### PR TITLE
rgw: add rewrite cmd and options into radosgw-admin usage and doc

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -89,11 +89,17 @@ which are as follows:
 :command:`bucket check`
   Check bucket index.
 
+:command:`bucket rewrite`
+  Rewrite all objects in the specified bucket.
+
 :command:`object rm`
   Remove an object.
 
 :command:`object unlink`
   Unlink object from bucket index.
+
+:command:`object rewrite`
+  Rewrite the specified object.
 
 :command:`quota set`
   Set quota params.
@@ -404,6 +410,19 @@ Options
 
 	Required for certain operations.
 
+.. option:: --min-rewrite-size
+
+    Specify the min object size condition for bucket rewrite (default 4M).
+
+.. option:: --max-rewrite-size
+
+    Specify the max object size condition for bucket rewrite (default ULLONG_MAX).
+
+.. option:: --min-rewrite-stripe-size
+
+    Specify the min stripe size condition for object rewrite,
+    default value is set to 0, in that case the specified object
+    will always be rewritten for restriping.
 
 Quota Options
 =============

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -82,6 +82,7 @@ void usage()
   cout << "  bucket rm                  remove bucket\n";
   cout << "  bucket check               check bucket index\n";
   cout << "  bucket reshard             reshard bucket\n";
+  cout << "  bucket rewrite             rewrite all objects in the specified bucket\n";
   cout << "  bucket sync disable        disable bucket sync\n";
   cout << "  bucket sync enable         enable bucket sync\n";
   cout << "  bi get                     retrieve bucket index object entries\n";
@@ -91,6 +92,7 @@ void usage()
   cout << "  object rm                  remove object\n";
   cout << "  object stat                stat an object for its metadata\n";
   cout << "  object unlink              unlink object from bucket index\n";
+  cout << "  object rewrite             rewrite the specified object\n";
   cout << "  objects expire             run expired objects cleanup\n";
   cout << "  period delete              delete a period\n";
   cout << "  period get                 get period info\n";
@@ -303,6 +305,9 @@ void usage()
   cout << "                             object deletions by not involving GC\n";
   cout << "   --inconsistent-index      when specified with bucket deletion and bypass-gc set to true,\n";
   cout << "                             ignores bucket index consistency\n";
+  cout << "   --min-rewrite-size        specify the min object size condition for bucket rewrite (default 4M)\n";
+  cout << "   --max-rewrite-size        specify the max object size condition for bucket rewrite (default ULLONG_MAX)\n";
+  cout << "   --min-rewrite-stripe-size specify the min stripe size condition for object rewrite (default 0)\n";
   cout << "\n";
   cout << "<date> := \"YYYY-MM-DD[ hh:mm:ss]\"\n";
   cout << "\nQuota options:\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -25,6 +25,7 @@
     bucket rm                  remove bucket
     bucket check               check bucket index
     bucket reshard             reshard bucket
+    bucket rewrite             rewrite all objects in the specified bucket
     bucket sync disable        disable bucket sync
     bucket sync enable         enable bucket sync
     bi get                     retrieve bucket index object entries
@@ -34,6 +35,7 @@
     object rm                  remove object
     object stat                stat an object for its metadata
     object unlink              unlink object from bucket index
+    object rewrite             rewrite the specified object
     objects expire             run expired objects cleanup
     period delete              delete a period
     period get                 get period info
@@ -246,6 +248,9 @@
                                object deletions by not involving GC
      --inconsistent-index      when specified with bucket deletion and bypass-gc set to true,
                                ignores bucket index consistency
+     --min-rewrite-size        specify the min object size condition for bucket rewrite (default 4M)
+     --max-rewrite-size        specify the max object size condition for bucket rewrite (default ULLONG_MAX)
+     --min-rewrite-stripe-size specify the min stripe size condition for object rewrite (default 0)
   
   <date> := "YYYY-MM-DD[ hh:mm:ss]"
   


### PR DESCRIPTION
+ radosgw-admin object rewrite
+ radosgw-admin bucket rewrite
+ --min-rewrite-size
+ --max-rewrite-size
+ --min-rewrite-stripe-size

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>