### PR TITLE
ceph-dencoder: add support for cls_rgw_lc_obj_head

### DIFF
--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -626,3 +626,13 @@ void cls_rgw_bucket_instance_entry::generate_test_instances(list<cls_rgw_bucket_
   ls.back()->reshard_status = CLS_RGW_RESHARD_IN_PROGRESS;
   ls.back()->new_bucket_instance_id = "new_instance_id";
 }
+  
+void cls_rgw_lc_obj_head::dump(Formatter *f) const 
+{
+  encode_json("start_date", start_date, f);
+  encode_json("marker", marker, f);
+}
+
+void cls_rgw_lc_obj_head::generate_test_instances(list<cls_rgw_lc_obj_head*>& ls)
+{
+}

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1067,6 +1067,8 @@ struct cls_rgw_lc_obj_head
     DECODE_FINISH(bl);
   }
 
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<cls_rgw_lc_obj_head*>& ls);
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_obj_head)
 

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -349,6 +349,7 @@ TYPE(cls_rgw_reshard_get_ret)
 TYPE(cls_rgw_reshard_remove_op)
 TYPE(cls_rgw_set_bucket_resharding_op)
 TYPE(cls_rgw_clear_bucket_resharding_op)
+TYPE(cls_rgw_lc_obj_head)
 
 #include "cls/rgw/cls_rgw_client.h"
 TYPE(rgw_bi_log_entry)


### PR DESCRIPTION
After adding cls_rgw_lc_obj_head, we can using the following command
to look into lc processing related information:
rados -p default.rgw.log getomapheader lc.0 ./header.bin --namespace=lc
ceph-dencoder type cls_rgw_lc_obj_head import ./header.bin decode dump_json

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>