### PR TITLE
ceph-volume: allow using a device or partition for `lvm --data`

### DIFF
--- a/doc/ceph-volume/lvm/prepare.rst
+++ b/doc/ceph-volume/lvm/prepare.rst
@@ -33,19 +33,24 @@ the back end can be specified with:
 This is the OSD backend that allows preparation of logical volumes for
 a :term:`filestore` objectstore OSD.
 
-The process is *very* strict, it requires an existing logical volume for the
-OSD data and a partitioned physical device or logical volume for the journal.
-No special preparation is needed for these volumes other than following the
-minimum size requirements for data and journal.
+It can use a logical volume for the OSD data and a partitioned physical device
+or logical volume for the journal.  No special preparation is needed for these
+volumes other than following the minimum size requirements for data and
+journal.
 
 The API call looks like::
 
     ceph-volume prepare --filestore --data volume_group/lv_name --journal journal
 
-The ``--data`` value *must* be a volume group name and a logical volume name
-separated by a ``/``. Since logical volume names are not enforced for
-uniqueness, this prevents using the wrong volume. The ``--journal`` can be
-either a logical volume *or* a partition.
+There is flexibility to use a raw device or partition as well for ``--data``
+that will be converted to a logical volume. This is not ideal in all situations
+since ``ceph-volume`` is just going to create a unique volume group and
+a logical volume from that device.
+
+When using logical volumes for ``--data``, the  value *must* be a volume group
+name and a logical volume name separated by a ``/``. Since logical volume names
+are not enforced for uniqueness, this prevents using the wrong volume. The
+``--journal`` can be either a logical volume *or* a partition.
 
 When using a partition, it *must* contain a ``PARTUUID`` discoverable by
 ``blkid``, so that it can later be identified correctly regardless of the
@@ -171,11 +176,10 @@ more flexibility for devices. Bluestore supports the following configurations:
 * A block device and a block.db device
 * A single block device
 
-It can accept a whole device (not a partition, otherwise it will raise an
-error) or a logical volume for ``block``. If a physical device is provided it
-will then be turned into a logical volume. This allows a simpler approach at
-using LVM but at the cost of flexibility: there are no options or
-configurations to change how the LV is created.
+It can accept a whole device (or partition), or a logical volume for ``block``.
+If a physical device is provided it will then be turned into a logical volume.
+This allows a simpler approach at using LVM but at the cost of flexibility:
+there are no options or configurations to change how the LV is created.
 
 The ``block`` is specified with the ``--data`` flag, and in its simplest use
 case it looks like::

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -21,7 +21,7 @@ def common_parser(prog, description):
         '--data',
         required=True,
         type=arg_validators.LVPath(),
-        help='OSD data path. Bluestore: A physical device or logical volume. Filestore: A logical volume (vg_name/lv_name)',
+        help='OSD data path. A physical device or logical volume',
     )
     parser.add_argument(
         '--journal-size',

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -128,6 +128,39 @@ class Prepare(object):
             tags['ceph.%s_device' % device_type] = path
         return path, uuid, tags
 
+    def prepare_device(self, arg, device_type, cluster_fsid, osd_fsid):
+        """
+        Check if ``arg`` is a device or partition to create an LV out of it
+        with a distinct volume group name, assigning LV tags on it and
+        ultimately, returning the logical volume object.  Failing to detect
+        a device or partition will result in error.
+
+        :param arg: The value of ``--data`` when parsing args
+        :param device_type: Usually, either ``data`` or ``block`` (filestore vs. bluestore)
+        :param cluster_fsid: The cluster fsid/uuid
+        :param osd_fsid: The OSD fsid/uuid
+        """
+        if disk.is_partition(arg) or disk.is_device(arg):
+            # we must create a vg, and then a single lv
+            vg_name = "ceph-%s" % cluster_fsid
+            if api.get_vg(vg_name=vg_name):
+                # means we already have a group for this, make a different one
+                # XXX this could end up being annoying for an operator, maybe?
+                vg_name = "ceph-%s" % str(uuid.uuid4())
+            api.create_vg(vg_name, arg)
+            lv_name = "osd-%s-%s" % (device_type, osd_fsid)
+            return api.create_lv(
+                lv_name,
+                vg_name,  # the volume group
+                tags={'ceph.type': device_type})
+        else:
+            error = [
+                'Cannot use device (%s).',
+                'A vg/lv path or an existing device is needed' % arg]
+            raise RuntimeError(' '.join(error))
+
+        raise RuntimeError('no data logical volume found with: %s' % arg)
+
     @decorators.needs_root
     def prepare(self, args):
         # FIXME we don't allow re-using a keyring, we always generate one for the
@@ -146,7 +179,7 @@ class Prepare(object):
 
             data_lv = self.get_lv(args.data)
             if not data_lv:
-                raise RuntimeError('no data logical volume found with: %s' % args.data)
+                data_lv = self.prepare_device(args.data, 'data', cluster_fsid, osd_fsid)
 
             tags = {
                 'ceph.osd_fsid': osd_fsid,
@@ -172,25 +205,7 @@ class Prepare(object):
         elif args.bluestore:
             block_lv = self.get_lv(args.data)
             if not block_lv:
-                if disk.is_partition(args.data) or disk.is_device(args.data):
-                    # we must create a vg, and then a single lv
-                    vg_name = "ceph-%s" % cluster_fsid
-                    if api.get_vg(vg_name=vg_name):
-                        # means we already have a group for this, make a different one
-                        # XXX this could end up being annoying for an operator, maybe?
-                        vg_name = "ceph-%s" % str(uuid.uuid4())
-                    api.create_vg(vg_name, args.data)
-                    block_name = "osd-block-%s" % osd_fsid
-                    block_lv = api.create_lv(
-                        block_name,
-                        vg_name,  # the volume group
-                        tags={'ceph.type': 'block'})
-                else:
-                    error = [
-                        'Cannot use device (%s) for bluestore. ' % args.data,
-                        'A vg/lv path or an existing device is needed'
-                    ]
-                    raise RuntimeError(' '.join(error))
+                block_lv = self.prepare_device(args.data, 'block', cluster_fsid, osd_fsid)
 
             tags = {
                 'ceph.osd_fsid': osd_fsid,

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -254,6 +254,10 @@ class Prepare(object):
 
               ceph-volume lvm prepare --filestore --data {vg/lv} --journal {vg/lv}
 
+          Existing block device, that will be made a group and logical volume:
+
+              ceph-volume lvm prepare --filestore --data /path/to/device --journal {vg/lv}
+
         Bluestore
         ---------
 

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/group_vars/all
@@ -18,6 +18,7 @@ lvm_volumes:
     data_vg: test_group
     db: journal1
     db_vg: journals
+  - data: /dev/sdd1
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/setup.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/setup.yml
@@ -1,0 +1,1 @@
+../../../playbooks/setup_partitions.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/group_vars/all
@@ -20,6 +20,8 @@ lvm_volumes:
     journal: journal1
     data_vg: test_group
     journal_vg: journals
+  - data: /dev/sdd1
+    journal: /dev/sdd2
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/setup.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/setup.yml
@@ -1,0 +1,1 @@
+../../../playbooks/setup_partitions.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/setup_partitions.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/setup_partitions.yml
@@ -1,0 +1,27 @@
+---
+
+- hosts: osds
+  gather_facts: false
+  become: yes
+  tasks:
+
+    - name: partition /dev/sdd for lvm data usage
+      parted:
+        device: /dev/sdd
+        number: 1
+        part_start: 0%
+        part_end: 50%
+        unit: '%'
+        label: gpt
+        state: present
+
+    - name: partition /dev/sdd lvm journals
+      parted:
+        device: /dev/sdd
+        number: 2
+        part_start: 50%
+        part_end: 100%
+        unit: '%'
+        state: present
+        label: gpt
+

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -38,6 +38,9 @@ commands=
   # create logical volumes to test with on the vms
   ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/lvm_setup.yml
 
+  # ad-hoc/local test setup for lvm
+  ansible-playbook -vv -i {changedir}/hosts {changedir}/setup.yml
+
   # use ceph-ansible to deploy a ceph cluster on the vms
   ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/site.yml.sample --extra-vars "fetch_directory={changedir}/fetch ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}"
 

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/group_vars/all
@@ -18,6 +18,7 @@ lvm_volumes:
     data_vg: test_group
     db: journal1
     db_vg: journals
+  - data: /dev/sdd1
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/setup.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/setup.yml
@@ -1,0 +1,1 @@
+../../../playbooks/setup_partitions.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/group_vars/all
@@ -20,6 +20,8 @@ lvm_volumes:
     journal: journal1
     data_vg: test_group
     journal_vg: journals
+  - data: /dev/sdd1
+    journal: /dev/sdd2
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/setup.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/setup.yml
@@ -1,0 +1,1 @@
+../../../playbooks/setup_partitions.yml


### PR DESCRIPTION
When bluestore functionality was added for `ceph-volume lvm`, there was a feature that got in where a partition or device could be used as part of `--data`, whereas the filestore implementation strictly required a logical volume.

This PR removes the disparity by allowing both objectstore scenarios to consume a partition or raw device, from where a logical group and logical volume will be created.

The approach is naive, because there are numerous ways to create a logical volume, and the tooling is not trying to attempt to provide all bells and whistles to do so, but rather, allow a simpler approach for users who don't care or don't want to deal with lvm at all, at the expense of a 1:1 ratio of device-to-lv

This PR requires this branch from ceph-ansible to test: https://github.com/ceph/ceph-ansible/compare/lvm-raw-device

It passes locally against that branch. 