### PR TITLE
jewel: rgw: Fix swift object expiry not deleting objects

### DIFF
--- a/src/cls/timeindex/cls_timeindex.cc
+++ b/src/cls/timeindex/cls_timeindex.cc
@@ -151,7 +151,6 @@ static int cls_timeindex_list(cls_method_context_t hctx,
     const string& index = iter->first;
     bufferlist& bl = iter->second;
 
-    marker = index;
     if (use_time_boundary && index.compare(0, to_index.size(), to_index) >= 0) {
       CLS_LOG(20, "DEBUG: cls_timeindex_list: finishing on to_index=%s",
               to_index.c_str());
@@ -170,6 +169,7 @@ static int cls_timeindex_list(cls_method_context_t hctx,
       e.value = bl;
       entries.push_back(e);
     }
+    marker = index;
   }
 
   if (iter == keys.end()) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/22180

Backport of PR #18821.
(cherry picked from commit 70adfaa)

In cls_timeindex_list() though `to_index` has expired for a timespan, the marker is set for a subsequent index during the time boundary check.
This marker is further returned to RGWObjectExpirer::process_single_shard(), where this out_marker is trimmed from the respective shard,
resulting in a lost removal hint and a leaked object.

Fixes: http://tracker.ceph.com/issues/22084
Signed-off-by: Pavan Rallabhandi <PRallabhandi@walmartlabs.com>