### PR TITLE
Revert "common/config: return const reference instead of a copy"

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -873,21 +873,18 @@ int md_config_t::get_val(const std::string &key, char **buf, int len) const
   return _get_val(key, buf,len);
 }
 
-const Option::value_t&
-md_config_t::get_val_generic(const std::string &key) const
+Option::value_t md_config_t::get_val_generic(const std::string &key) const
 {
   Mutex::Locker l(lock);
   return _get_val_generic(key);
 }
 
-const Option::value_t&
-md_config_t::_get_val_generic(const std::string &key) const
+Option::value_t md_config_t::_get_val_generic(const std::string &key) const
 {
   assert(lock.is_locked());
 
-  static const Option::value_t empty{boost::blank()};
   if (key.empty()) {
-    return empty;
+    return Option::value_t(boost::blank());
   }
 
   // In key names, leading and trailing whitespace are not significant.
@@ -899,7 +896,7 @@ md_config_t::_get_val_generic(const std::string &key) const
     // entries in ::values
     return values.at(k);
   } else {
-    return empty;
+    return Option::value_t(boost::blank());
   }
 }
 
@@ -907,12 +904,12 @@ int md_config_t::_get_val(const std::string &key, std::string *value) const {
   assert(lock.is_locked());
 
   std::string normalized_key(ConfFile::normalize_key_name(key));
-  auto& config_value = _get_val_generic(normalized_key.c_str());
+  Option::value_t config_value = _get_val_generic(normalized_key.c_str());
   if (!boost::get<boost::blank>(&config_value)) {
     ostringstream oss;
-    if (auto *flag = boost::get<bool>(&config_value)) {
+    if (bool *flag = boost::get<bool>(&config_value)) {
       oss << (*flag ? "true" : "false");
-    } else if (auto *dp = boost::get<double>(&config_value)) {
+    } else if (double *dp = boost::get<double>(&config_value)) {
       oss << std::fixed << *dp;
     } else {
       oss << config_value;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -163,8 +163,8 @@ public:
   // No metavariables will be returned (they will have already been expanded)
   int get_val(const std::string &key, char **buf, int len) const;
   int _get_val(const std::string &key, char **buf, int len) const;
-  const Option::value_t& get_val_generic(const std::string &key) const;
-  template<typename T> const T& get_val(const std::string &key) const;
+  Option::value_t get_val_generic(const std::string &key) const;
+  template<typename T> const T get_val(const std::string &key) const;
 
   void get_all_keys(std::vector<std::string> *keys) const;
 
@@ -202,7 +202,7 @@ private:
   void validate_default_settings();
 
   int _get_val(const std::string &key, std::string *value) const;
-  const Option::value_t& _get_val_generic(const std::string &key) const;
+  Option::value_t _get_val_generic(const std::string &key) const;
   void _show_config(std::ostream *out, Formatter *f);
 
   void _get_my_sections(std::vector <std::string> &sections) const;
@@ -326,7 +326,7 @@ public:
 };
 
 template<typename T>
-const T& md_config_t::get_val(const std::string &key) const {
+const T md_config_t::get_val(const std::string &key) const {
   return boost::get<T>(this->get_val_generic(key));
 }
 


### PR DESCRIPTION
This reverts commit b248f8903b09f61f0bda1ead6c1ffb242dadd14e.

it's dangerous to return a reference of a variable which could be
changed by another thread.

Signed-off-by: Kefu Chai <kchai@redhat.com>