### PR TITLE
test/librbd: valgrind warning in TestMockManagedLockBreakRequest.DeadLockOwner

### DIFF
--- a/src/test/librbd/managed_lock/test_mock_BreakRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_BreakRequest.cc
@@ -82,6 +82,7 @@ public:
     } else {
       obj_watch_t watcher;
       strcpy(watcher.addr, (address + ":0/0").c_str());
+      watcher.watcher_id = 0;
       watcher.cookie = watch_handle;
 
       std::list<obj_watch_t> watchers;


### PR DESCRIPTION
When running with 'debug_rbd >= 20':
```
  Conditional jump or move depends on uninitialised value(s)
    by 0x94277B: operator<< (ostream:167)
    by 0x94277B: librbd::managed_lock::BreakRequest<librbd::(anonymous namespace)::MockTestImageCtx>::handle_get_watchers(int) (BreakRequest.cc:101)
```
Signed-off-by: Mykola Golub <to.my.trociny@gmail.com>