### PR TITLE
MDS: make sure that MDBalancer uses heartbeat info from the same epoch

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -415,8 +415,6 @@ void MDBalancer::handle_heartbeat(MHeartbeat *m)
                           << " : " << cpp_strerror(r);
       }
       prep_rebalance(m->get_beat());
-    
-      mds_load.clear();
     }
   }
 

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -300,9 +300,11 @@ void MDBalancer::send_heartbeat()
     return;
   }
 
-  mds_load.clear();
-  if (mds->get_nodeid() == 0)
+  if (mds->get_nodeid() == 0) {
     beat_epoch++;
+   
+    mds_load.clear();
+  }
 
   // my load
   mds_load_t load = get_load(now);
@@ -367,8 +369,19 @@ void MDBalancer::handle_heartbeat(MHeartbeat *m)
     goto out;
   }
 
+  if (mds->get_nodeid() != 0 && m->get_beat() > beat_epoch) {
+    dout(10) << "receive next epoch " << m->get_beat() << " from mds." << who << " before mds0" << dendl;
+
+    beat_epoch = m->get_beat();
+    // clear the mds load info whose epoch is less than beat_epoch 
+    mds_load.clear();
+  }
+
   if (who == 0) {
-    dout(20) << " from mds0, new epoch" << dendl;
+    dout(20) << " from mds0, new epoch " << m->get_beat() << dendl;
+    if (beat_epoch != m->get_beat()) {
+      mds_load.clear();
+    }
     beat_epoch = m->get_beat();
     send_heartbeat();
 
@@ -402,6 +415,8 @@ void MDBalancer::handle_heartbeat(MHeartbeat *m)
                           << " : " << cpp_strerror(r);
       }
       prep_rebalance(m->get_beat());
+    
+      mds_load.clear();
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Jianyu Li <joannyli@tencent.com>

Currently mds saves the heartbeat info from others in mds_load, once the mds_load.size( ) equals mds number, it considers that have received all heartbeats info and start the rebalance work. However, after prep_rebalance returns, it doesn't clear the mds_load immediately, but wait until receives the next round hearbeat from mds0. If there are mutiple mds(e.g. greater than 2), there is a chance for one mds receiving the first next round heartbeat other than mds0 due to the network delay. Below is the actual log output in our 3-mds test envrionment:

=====  on 17:02:02 ======
mds0:
2017-11-13 17:02:02.194263 7eff0c592700  0 mds.0.bal   mds.0 mdsload<[23.9135,6244.64 12513.2]/[23.9135,6244.64 12513.2], req 8539, hr 0, qlen 11, cpu 0.12> = 21162.2 ~ 12513.2

mds1:
2017-11-13 17:02:02.190062 7fc3aa429700  0 mds.1.bal   mds.1 mdsload<[0,0 0]/[0,0 0], req 0, hr 0, qlen 0, cpu 0.08>

mds2:
2017-11-13 17:02:02.190423 7efd63666700  0 mds.2.bal   mds.0 mdsload<[0,0 0]/[0,0 0], req 8539, hr 0, qlen 11, cpu 0.12>
2017-11-13 17:02:02.190444 7efd63666700  0 mds.2.bal   mds.1 mdsload<[0,0 0]/[0,0 0], req 0, hr 0, qlen 0, cpu 0.08>
2017-11-13 17:02:02.190455 7efd63666700  0 mds.2.bal   mds.2 mdsload<[0,0 0]/[0,0 0], req 0, hr 0, qlen 0, cpu 0.15>
<-----  on 17:02:02, mds2 receives heartbeat info from mds0  and mds1, now only mds0 has workloads (req -= 8539)

===== after 10s, on about 17:02:12  =====
mds0:
2017-11-13 17:02:13.025672 7eff0c592700  0 mds.0.bal   mds.0 mdsload<[14.6832,4222.36 8459.41]/[14.6832,4222.36 8459.41], req 51268, hr 0, qlen 7, cpu 1.77>

mds1:
2017-11-13 17:02:13.024683 7fc3aa429700  0 mds.1.bal   mds.1 mdsload<[0,7348.49 14697]/[0,7348.49 14697], req 4647, hr 0, qlen 0, cpu 2.39>

mds2:
2017-11-13 17:02:13.023597 7efd63666700  0 mds.2.bal   mds.0 mdsload<[0,0 0]/[0,0 0], req 8539, hr 0, qlen 11, cpu 0.12>
2017-11-13 17:02:13.023719 7efd63666700  0 mds.2.bal   mds.1 mdsload<[0,0 0]/[0,0 0], req 4647, hr 0, qlen 0, cpu 2.39>
2017-11-13 17:02:13.023756 7efd63666700  0 mds.2.bal   mds.2 mdsload<[0,0 0]/[0,0 0], req 0, hr 0, qlen 0, cpu 0.15>
<---- here mds2 receives next round heartbeat from mds1 before mds0, so it just update the mds1 load info in mds_load and call the prep_rebalance, trying to use the out-dated mds_load info of mds0/mds2 with the new mds1 load info to do the rebalance work, which leads the inconsistency decision results with other mds. This would bring adverse influence on the multi-mds balance effect.