### PR TITLE
[RPC] mds: lookup snapped inodes by vinodeno_t

### DIFF
--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -549,6 +549,12 @@ union ceph_mds_request_args {
 		__le64 length; /* num bytes to lock from start */
 		__u8 wait; /* will caller wait for lock to become available? */
 	} __attribute__ ((packed)) filelock_change;
+	struct {
+		__le32 mask;                 /* CEPH_CAP_* */
+		__le64 snapid;
+		__le64 parent;
+		__le32 hash;
+	} __attribute__ ((packed)) lookupino;
 } __attribute__ ((packed));
 
 #define CEPH_MDS_REQUEST_HEAD_VERSION	1

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2593,6 +2593,24 @@ void CInode::pre_cow_old_inode()
     cow_old_inode(follows, true);
 }
 
+bool CInode::has_snap_data(snapid_t snapid)
+{
+  bool found = snapid >= first && snapid <= last;
+  if (!found && is_multiversion()) {
+    auto p = old_inodes.lower_bound(snapid);
+    if (p != old_inodes.end()) {
+      if (p->second.first > snapid) {
+	if  (p != old_inodes.begin())
+	  --p;
+      }
+      if (p->second.first <= snapid && snapid <= p->first) {
+	found = true;
+      }
+    }
+  }
+  return found;
+}
+
 void CInode::purge_stale_snap_data(const set<snapid_t>& snaps)
 {
   dout(10) << "purge_stale_snap_data " << snaps << dendl;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -515,6 +515,7 @@ public:
   void split_old_inode(snapid_t snap);
   old_inode_t *pick_old_inode(snapid_t last);
   void pre_cow_old_inode();
+  bool has_snap_data(snapid_t s);
   void purge_stale_snap_data(const std::set<snapid_t>& snaps);
 
   // -- cache infrastructure --

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -788,6 +788,13 @@ public:
   CInode* get_inode(inodeno_t ino, snapid_t s=CEPH_NOSNAP) {
     return get_inode(vinodeno_t(ino, s));
   }
+  CInode* lookup_snap_inode(vinodeno_t vino) {
+    auto p = snap_inode_map.lower_bound(vino);
+    if (p != snap_inode_map.end() &&
+	p->second->ino() == vino.ino && p->second->first <= vino.snapid)
+      return p->second;
+    return NULL;
+  }
 
   CDir* get_dirfrag(dirfrag_t df) {
     CInode *in = get_inode(df.ino);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -192,6 +192,7 @@ public:
   void handle_client_getattr(MDRequestRef& mdr, bool is_lookup);
   void handle_client_lookup_ino(MDRequestRef& mdr,
 				bool want_parent, bool want_dentry);
+  void _lookup_snap_ino(MDRequestRef& mdr);
   void _lookup_ino_2(MDRequestRef& mdr, int r);
   void handle_client_readdir(MDRequestRef& mdr);
   void handle_client_file_setlock(MDRequestRef& mdr);


### PR DESCRIPTION
Directory inodes are always multiversion, snapped metadata are stored
together with head inode. lookup snapped directory inodes is basically
the same as lookup head inodes.

For non-directory inode, there can be multiple version of snapped inodes,
and they can be stored in different dirfrags. To lookup a snapped inode,
client need to tell mds from which dirfrag it got the snapped inode.

Fixes: http://tracker.ceph.com/issues/22105
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>