### PR TITLE
mon/OSDMonitor: add option to fix up ruleset-* to crush-* for ec profiles

### DIFF
--- a/qa/releases/luminous-with-mgr.yaml
+++ b/qa/releases/luminous-with-mgr.yaml
@@ -8,3 +8,5 @@ overrides:
     conf:
       mon:
         mon warn on osd down out interval zero: false
+    log-whitelist:
+      - ruleset-

--- a/qa/releases/luminous.yaml
+++ b/qa/releases/luminous.yaml
@@ -19,3 +19,4 @@ overrides:
         mon warn on osd down out interval zero: false
     log-whitelist:
       - no active mgr
+      - ruleset-

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -2153,8 +2153,8 @@ function test_mon_osd_erasure_code()
   ceph osd erasure-code-profile set fooprofile a=b c=d e=f --force
   ceph osd erasure-code-profile set fooprofile a=b c=d e=f
   expect_false ceph osd erasure-code-profile set fooprofile a=b c=d e=f g=h
-  # make sure ruleset-foo doesn't work anymore
-  expect_false ceph osd erasure-code-profile set barprofile ruleset-failure-domain=host
+  # ruleset-foo will work for luminous only
+  ceph osd erasure-code-profile set barprofile ruleset-failure-domain=host
   ceph osd erasure-code-profile set barprofile crush-failure-domain=host
   # clean up
   ceph osd erasure-code-profile rm fooprofile

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1298,6 +1298,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("mon_fixup_legacy_erasure_code_profiles", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("Automatically adjust ruleset-* to crush-* so that legacy apps can set modern erasure code profiles without modification"),
+
     Option("mon_debug_deprecated_as_obsolete", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description(""),


### PR DESCRIPTION
The jewel->luminous upgrade test will fail if we finish the upgrade while
a workload setting old-style ec profiles is running.  Add option to
automatically fix them up.  Warn to the cluster log when this happens.

For now, enable this option to ease upgrades and whitelist the warning.

Only include this option in luminous so that we implicitly sunset this
compatibility kludge immediately.

Fixes: http://tracker.ceph.com/issues/22128
Signed-off-by: Sage Weil <sage@redhat.com>