### PR TITLE
.githubmap: Add cbodley

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -14,6 +14,7 @@ badone Brad Hubbard <bhubbard@redhat.com>
 bassamtabbara Bassam Tabbara <bassam.tabbara@quantum.com>
 batrick Patrick Donnelly <pdonnell@redhat.com>
 branch-predictor Piotr Dałek <piotr.dalek@corp.ovh.com>
+cbodley Casey Bodley <cbodley@redhat.com>
 chhabaramesh Ramesh Chander <Ramesh.Chander@sandisk.com>
 dragonylffly Li Wang <laurence.liwang@gmail.com>
 dvanders Dan van der Ster <daniel.vanderster@cern.ch>


### PR DESCRIPTION
Added cbodley to .githubmap. Found during the merge of https://github.com/ceph/ceph/pull/18921.

Signed-off-by: Jos Collin <jcollin@redhat.com>