### PR TITLE
common: fix BoundedKeyCounter const_pointer_iterator

### DIFF
--- a/src/common/bounded_key_counter.h
+++ b/src/common/bounded_key_counter.h
@@ -73,7 +73,11 @@ class BoundedKeyCounter {
   struct const_pointer_iterator : public map_type::const_iterator {
     const_pointer_iterator(typename map_type::const_iterator i)
       : map_type::const_iterator(i) {}
-    const value_type* operator*() const {
+
+    using value_type = typename map_type::const_iterator::value_type*;
+    using reference = const typename map_type::const_iterator::value_type*;
+
+    reference operator*() const {
       return &map_type::const_iterator::operator*();
     }
   };


### PR DESCRIPTION
with libc++, clang fails to compile a call to:
```c++
  vector::assign(const_pointer_iterator, const_pointer_iterator)
```
because `const_pointer_iterator` does not satisfy the `InputIterator` concept. added the necessary typedefs for `value_type` and `reference` to reflect the pointer type

Fixes: http://tracker.ceph.com/issues/22139