### PR TITLE
rgw: add a brace for function "operator <<"

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -1208,9 +1208,9 @@ ostream& operator <<(ostream& m, const Condition& c) {
   if (c.ifexists) {
     m << "IfExists";
   }
-  m << ": { " << c.key;
+  m << ": { " << c.key << ": ";
   print_array(m, c.vals.cbegin(), c.vals.cend());
-  return m << "}";
+  return m << " } }";
 }
 
 Effect Statement::eval(const Environment& e,


### PR DESCRIPTION
* The braces in function "operator <<" of structure Condition are not
* matched.

Signed-off-by: Bingyin Zhang <zhangbingyin@cloudin.cn>