### PR TITLE
rgw: AWS v4 authorization work when INIT_MULTIPART is chunked

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3826,6 +3826,7 @@ AWSGeneralAbstractor::get_auth_data_v4(const req_state* const s,
         case RGW_OP_PUT_OBJ:
         case RGW_OP_PUT_ACLS:
         case RGW_OP_PUT_CORS:
+        case RGW_OP_INIT_MULTIPART: // in case that Init Multipart uses CHUNK encoding
         case RGW_OP_COMPLETE_MULTIPART:
         case RGW_OP_SET_BUCKET_VERSIONING:
         case RGW_OP_DELETE_MULTI_OBJ:


### PR DESCRIPTION
Add RGW_OP_INIT_MULTIPART as a the single chunk special case
like RGW_OP_COMPLETE_MULTIPART.

Fixes: http://tracker.ceph.com/issues/22129
Signed-off-by: Jeegn Chen <jeegnchen@gmail.com>