### PR TITLE
rgw: check read_op.read return value in RGWRados::copy_obj_data

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8229,6 +8229,10 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
   do {
     bufferlist bl;
     ret = read_op.read(ofs, end, bl);
+    if (ret < 0) {
+      ldout(cct, 0) << "ERROR: fail to read object data, ret = " << ret << dendl;
+      return ret;
+    }
 
     uint64_t read_len = ret;
     bool again;


### PR DESCRIPTION
The return-value-type of RGWRados::Object::Read::read is int, and
the return value of RGWRados::Object::Read::read is either the
length of object data which has been read if everything is OK,
or the error value which is a negative value if something is wrong.

If a negative error value is assigned to read_len whose value type is
unsigned long long, the read_len will be a very large value,
which will cause an error during RGWPutObjProcessor processing.

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>