### PR TITLE
test: Incorrect conversion to double

### DIFF
--- a/src/test/kv_store_bench.cc
+++ b/src/test/kv_store_bench.cc
@@ -117,7 +117,7 @@ int KvStoreBench::setup(int argc, const char** argv) {
       } else if (strcmp(args[i], "--cache-refresh") == 0) {
 	auto temp = atoi(args[i+1]);
 	assert (temp != 0);
-	cache_refresh = 100 / temp;
+	cache_refresh = 100 / (double)temp;
       } else if (strcmp(args[i], "-t") == 0) {
 	max_ops_in_flight = atoi(args[i+1]);
       } else if (strcmp(args[i], "--clients") == 0) {


### PR DESCRIPTION
Fixes the coverity issue:

>CID 1417062 (#1 of 1): Result is not floating-point
>(UNINTENDED_INTEGER_DIVISION)
>integer_division: Dividing integer expressions 100 and temp
>, and then converting the integer quotient to type double.
>Any remainder, or fractional part of the quotient, is ignored.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>