### PR TITLE
rgw: Fix the run-s3tests.sh run in build dir

### DIFF
--- a/qa/workunits/rgw/run-s3tests.sh
+++ b/qa/workunits/rgw/run-s3tests.sh
@@ -20,6 +20,7 @@ elif [ -e $root_path/../build/CMakeCache.txt ]; then
 fi
 PATH=$PATH:$BIN_PATH
 
+rm -rf tmp.s3-tests*
 dir=tmp.s3-tests.$$
 
 # clone and bootstrap
@@ -29,6 +30,13 @@ git clone https://github.com/ceph/s3-tests
 cd s3-tests
 git checkout ceph-$branch
 VIRTUALENV_PYTHON=/usr/bin/python2 ./bootstrap
+
+graphfile="./request_decision_graph.yml"
+if [ -e "$graphfile" ]
+then
+  cp $graphfile ../../
+fi
+
 cd ../..
 
 # users
@@ -78,6 +86,7 @@ EOF
 S3TEST_CONF=`pwd`/s3.conf $dir/s3-tests/virtualenv/bin/nosetests -a '!fails_on_rgw' -v 
 
 rm -rf $dir
+rm -rf $graphfile
 
 echo OK.
 


### PR DESCRIPTION
Fixes http://tracker.ceph.com/issues/22141
When run ../qa/workunits/rgw/run-s3tests.sh in ceph build dir,
s3tests.fuzz.test.test_fuzzer.test_load_grap need open
file request_decision_graph.yml,but cannot found as
"1623     graph_file = open('request_decision_graph.yml', 'r')
 1624 IOError: [Errno 2] No such file or directory:
 'request_decision_graph.yml'"

When run ../qa/workunits/rgw/run-s3tests.sh in ceph build dir, if
terminate the running script,leave the tmp s3-test dir exist.
Now if we again run this script,nosetests will find too many
testcase in previous tmp s3-test dir, and will have relative
import module error such as 'Failure: ImportError
(cannot import name realistic) ... ERROR'

Signed-off-by: baul <roidinev@gmail.com>