### PR TITLE
rgw: fix rewrite options usage text

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -434,17 +434,17 @@ Options
 
 .. option:: --min-rewrite-size
 
-    Specify the min object size condition for bucket rewrite (default 4M).
+    Specify the min object size for bucket rewrite (default 4M).
 
 .. option:: --max-rewrite-size
 
-    Specify the max object size condition for bucket rewrite (default ULLONG_MAX).
+    Specify the max object size for bucket rewrite (default ULLONG_MAX).
 
 .. option:: --min-rewrite-stripe-size
 
-    Specify the min stripe size condition for object rewrite,
-    default value is set to 0, in that case the specified object
-    will always be rewritten for restriping.
+    Specify the min stripe size for object rewrite (default 0). If the value
+    is set to 0, then the specified object will always be
+    rewritten for restriping.
 
 Quota Options
 =============

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -312,9 +312,9 @@ void usage()
   cout << "                             object deletions by not involving GC\n";
   cout << "   --inconsistent-index      when specified with bucket deletion and bypass-gc set to true,\n";
   cout << "                             ignores bucket index consistency\n";
-  cout << "   --min-rewrite-size        specify the min object size condition for bucket rewrite (default 4M)\n";
-  cout << "   --max-rewrite-size        specify the max object size condition for bucket rewrite (default ULLONG_MAX)\n";
-  cout << "   --min-rewrite-stripe-size specify the min stripe size condition for object rewrite (default 0)\n";
+  cout << "   --min-rewrite-size        min object size for bucket rewrite (default 4M)\n";
+  cout << "   --max-rewrite-size        max object size for bucket rewrite (default ULLONG_MAX)\n";
+  cout << "   --min-rewrite-stripe-size min stripe size for object rewrite (default 0)\n";
   cout << "\n";
   cout << "<date> := \"YYYY-MM-DD[ hh:mm:ss]\"\n";
   cout << "\nQuota options:\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -254,9 +254,9 @@
                                object deletions by not involving GC
      --inconsistent-index      when specified with bucket deletion and bypass-gc set to true,
                                ignores bucket index consistency
-     --min-rewrite-size        specify the min object size condition for bucket rewrite (default 4M)
-     --max-rewrite-size        specify the max object size condition for bucket rewrite (default ULLONG_MAX)
-     --min-rewrite-stripe-size specify the min stripe size condition for object rewrite (default 0)
+     --min-rewrite-size        min object size for bucket rewrite (default 4M)
+     --max-rewrite-size        max object size for bucket rewrite (default ULLONG_MAX)
+     --min-rewrite-stripe-size min stripe size for object rewrite (default 0)
   
   <date> := "YYYY-MM-DD[ hh:mm:ss]"
   


### PR DESCRIPTION
Fixed rewrite options usage text properly.
I thought I can fix it myself instead of giving many nits in https://github.com/ceph/ceph/pull/18918.

Signed-off-by: Jos Collin <jcollin@redhat.com>