### PR TITLE
systemd: fix rbd-mirror reboot

### DIFF
--- a/systemd/ceph-rbd-mirror@.service
+++ b/systemd/ceph-rbd-mirror@.service
@@ -2,7 +2,7 @@
 Description=Ceph rbd mirror daemon
 After=network-online.target local-fs.target
 Wants=network-online.target local-fs.target
-PartOf=ceph-rbd-mirror.target
+Requires=ceph-rbd-mirror.target
 
 [Service]
 LimitNOFILE=1048576


### PR DESCRIPTION
As mentioned in
https://www.freedesktop.org/software/systemd/man/systemd.unit.html#PartOf=

> is a one-way dependency — changes to this unit do not affect the
listed units.

Therefore, adding `PartOf=ceph-rbd-mirror.target` won't enable
`ceph-rbd-mirror.target` when
`ceph-rbd-mirror@rbd-mirror.ceph-rbd-mirror0` gets enabled.

What we need here is `Requires=ceph-rbd-mirror.target` to achieve that:

https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Requires=
> If this unit gets activated, the units listed here will be activated
as well.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>