### PR TITLE
luminous: rgw: Fix swift object expiry not deleting objects

### DIFF
--- a/src/cls/timeindex/cls_timeindex.cc
+++ b/src/cls/timeindex/cls_timeindex.cc
@@ -137,7 +137,6 @@ static int cls_timeindex_list(cls_method_context_t hctx,
     const string& index = iter->first;
     bufferlist& bl = iter->second;
 
-    marker = index;
     if (use_time_boundary && index.compare(0, to_index.size(), to_index) >= 0) {
       CLS_LOG(20, "DEBUG: cls_timeindex_list: finishing on to_index=%s",
               to_index.c_str());
@@ -156,6 +155,7 @@ static int cls_timeindex_list(cls_method_context_t hctx,
       e.value = bl;
       entries.push_back(e);
     }
+    marker = index;
   }
 
   ret.marker = marker;


### PR DESCRIPTION
In cls_timeindex_list() though `to_index` has expired for a timespan, the marker is set for a subsequent index during the time boundary check.
This marker is further returned to RGWObjectExpirer::process_single_shard(), where this out_marker is trimmed from the respective shard,
resulting in a lost removal hint and a leaked object.

Fixes: http://tracker.ceph.com/issues/22084
Signed-off-by: Pavan Rallabhandi <PRallabhandi@walmartlabs.com>
(cherry picked from commit 70adfaae5073d2680a9722526a6a19795dd18780)