### PR TITLE
rgw: RGWRadosGetOmapKeysCR takes shared_ptr to map

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -249,11 +249,13 @@ int RGWRadosSetOmapKeysCR::request_complete()
 RGWRadosGetOmapKeysCR::RGWRadosGetOmapKeysCR(RGWRados *_store,
                       const rgw_raw_obj& _obj,
                       const string& _marker,
-                      map<string, bufferlist> *_entries, int _max_entries) : RGWSimpleCoroutine(_store->ctx()),
-                                                store(_store),
-                                                marker(_marker),
-                                                entries(_entries), max_entries(_max_entries), rval(0),
-                                                obj(_obj), cn(NULL)
+                      omap_ptr _entries,
+                      int _max_entries)
+  : RGWSimpleCoroutine(_store->ctx()),
+    store(_store),
+    marker(_marker),
+    entries(std::move(_entries)), max_entries(_max_entries), rval(0),
+    obj(_obj), cn(NULL)
 {
   set_description() << "set omap keys dest=" << obj << " marker=" << marker;
 }
@@ -268,7 +270,7 @@ int RGWRadosGetOmapKeysCR::send_request() {
   set_status() << "send request";
 
   librados::ObjectReadOperation op;
-  op.omap_get_vals2(marker, max_entries, entries, nullptr, &rval);
+  op.omap_get_vals2(marker, max_entries, entries.get(), nullptr, &rval);
 
   cn = stack->create_completion_notifier();
   return ref.ioctx.aio_operate(ref.oid, cn->completion(), &op, NULL);

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -410,7 +410,8 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   RGWRados *store;
 
   string marker;
-  map<string, bufferlist> *entries;
+  using omap_ptr = std::shared_ptr<std::map<std::string, bufferlist>>;
+  omap_ptr entries;
   int max_entries;
 
   int rval;
@@ -424,7 +425,7 @@ public:
   RGWRadosGetOmapKeysCR(RGWRados *_store,
 		      const rgw_raw_obj& _obj,
 		      const string& _marker,
-		      map<string, bufferlist> *_entries, int _max_entries);
+		      omap_ptr _entries, int _max_entries);
 
   int send_request() override;
 


### PR DESCRIPTION
parent coroutines that spawn RGWRadosGetOmapKeysCR as a child can't
guarantee that they will outlive the child coroutine, so it's not safe
for them to pass in pointers to member variables. use a shared_ptr to
extend the lifetime of this shared data

Fixes: http://tracker.ceph.com/issues/21154