### PR TITLE
ceph-volume tests.devices.lvm prepare isn't bluestore specific anymore

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -35,7 +35,7 @@ class TestPrepare(object):
         stdout, stderr = capsys.readouterr()
         assert 'Use the filestore objectstore' in stdout
         assert 'Use the bluestore objectstore' in stdout
-        assert 'Bluestore: A physical device or logical' in stdout
+        assert 'A physical device or logical' in stdout
 
 
 class TestGetJournalLV(object):


### PR DESCRIPTION
this is a test-only change. The failure was introduced after updating the help menu.

PR #18973 will need this before backporting