### PR TITLE
osd: introduce shared-exclusive locking for PGs

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2675,11 +2675,14 @@ void BlueStore::ExtentMap::fault_range(
           }
         }
       );
-      p->extents = decode_some(v);
-      p->loaded = true;
-      dout(20) << __func__ << " open shard 0x" << std::hex
+      {
+        std::lock_guard<std::mutex> l(em_lock);
+        p->extents = decode_some(v);
+        p->loaded = true;
+        dout(20) << __func__ << " open shard 0x" << std::hex
 	       << p->shard_info->offset << std::dec
 	       << " (" << v.length() << " bytes)" << dendl;
+      }
       assert(p->dirty == false);
       assert(v.length() == p->shard_info->bytes);
       onode->c->store->logger->inc(l_bluestore_onode_shard_misses);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -730,6 +730,7 @@ public:
   struct ExtentMap {
     Onode *onode;
     extent_map_t extent_map;        ///< map of Extents to Blobs
+    std::mutex em_lock;             ///< protects extent_map during BS::read
     blob_map_t spanning_blob_map;   ///< blobs that span shards
 
     struct Shard {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9802,16 +9802,24 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
     dout(20) << __func__ << " " << slot.to_process.back()
 	     << " queued" << dendl;
     ++slot.num_running;
+    sdata->sdata_op_ordering_lock.Unlock();
+
+    osd->service.maybe_inject_dispatch_delay();
+
+    // take the transition lock. this is intermediary step before dropping
+    // the shard lock and PG::lock()ing. there are situations where PG can
+    // be locked in shared manner (reads) but they can be determined on qi
+    // that isn't available yet.
+    slot.transition_lock.Lock();
   }
-  sdata->sdata_op_ordering_lock.Unlock();
 
-  osd->service.maybe_inject_dispatch_delay();
-
-  // [lookup +] lock pg (if we have it)
+  // [lookup pg]. locking is deferred
   if (!pg) {
-    pg = osd->_lookup_lock_pg(token);
-  } else {
-    pg->lock();
+    RWLock::RLocker l(osd->pg_map_lock);
+    const auto pg_map_entry = osd->pg_map.find(token);
+    if (pg_map_entry != osd->pg_map.end()) {
+      pg = pg_map_entry->second;
+    }
   }
 
   osd->service.maybe_inject_dispatch_delay();
@@ -9825,13 +9833,15 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
   auto& slot = q->second;
   --slot.num_running;
 
+  if (!pg) {
+    // no pg means no need to lock it in the future
+    slot.transition_lock.Unlock();
+  }
+
   if (slot.to_process.empty()) {
     // raced with wake_pg_waiters or prune_pg_waiters
     dout(20) << __func__ << " " << token
 	     << " nothing queued" << dendl;
-    if (pg) {
-      pg->unlock();
-    }
     sdata->sdata_op_ordering_lock.Unlock();
     return;
   }
@@ -9840,9 +9850,6 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 	     << " requeue_seq " << slot.requeue_seq << " > our "
 	     << requeue_seq << ", we raced with wake_pg_waiters"
 	     << dendl;
-    if (pg) {
-      pg->unlock();
-    }
     sdata->sdata_op_ordering_lock.Unlock();
     return;
   }
@@ -9858,9 +9865,6 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
   if (slot.waiting_for_pg) {
     dout(20) << __func__ << " " << token
 	     << " slot is waiting_for_pg" << dendl;
-    if (pg) {
-      pg->unlock();
-    }
     sdata->sdata_op_ordering_lock.Unlock();
     return;
   }
@@ -9911,6 +9915,10 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
   }
   sdata->sdata_op_ordering_lock.Unlock();
 
+  // exchange the transition lock on PG::_lock in appropriate mode
+  pg->lock_in_mode(qi.needs_exclusive_pglock(osd));
+  osd->service.maybe_inject_dispatch_delay();
+  slot.transition_lock.Unlock();
 
   // osd_opwq_process marks the point at which an operation has been dequeued
   // and will begin to be handled by a worker thread.

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1608,6 +1608,7 @@ private:
       OSDMapRef waiting_for_pg_osdmap;
       struct pg_slot {
 	PGRef pg;                     ///< cached pg reference [optional]
+	Mutex transition_lock;        ///< order items for this slot
 	deque<OpQueueItem> to_process; ///< order items for this slot
 	int num_running = 0;          ///< _process threads doing pg lookup/lock
 
@@ -1618,6 +1619,8 @@ private:
 	/// incremented by wake_pg_waiters; indicates racing _process threads
 	/// should bail out (their op has been requeued)
 	uint64_t requeue_seq = 0;
+
+        pg_slot() : transition_lock("transition_lock") {}
       };
 
       /// map of slots for each spg_t.  maintains ordering of items dequeued

--- a/src/osd/OpQueueItem.cc
+++ b/src/osd/OpQueueItem.cc
@@ -22,6 +22,17 @@ void PGOpItem::run(OSD *osd,
   osd->dequeue_op(pg, op, handle);
 }
 
+bool PGOpItem::needs_exclusive_pglock(OSD *osd)
+{
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
+  // This is **buggy**. Sorry. We can't use op::may_write() and friends.
+  // OSD::init_op_flags() hasn't been called yet and there is very good
+  // reason for that: the MOSDop isn't fully parsed at this stage!
+  // Maybe a bit assistance from a client would be needed. Will see.
+  return !m->has_flag(CEPH_OSD_FLAG_READ) ||
+          m->has_flag(CEPH_OSD_FLAG_WRITE);
+}
+
 void PGSnapTrim::run(OSD *osd,
                    PGRef& pg,
                    ThreadPool::TPHandle &handle)

--- a/src/osd/OpQueueItem.h
+++ b/src/osd/OpQueueItem.h
@@ -61,6 +61,10 @@ public:
       return 0;
     }
 
+    virtual bool needs_exclusive_pglock(OSD *osd) {
+      return true;
+    }
+
     virtual ostream &print(ostream &rhs) const = 0;
 
     virtual void run(OSD *osd, PGRef& pg, ThreadPool::TPHandle &handle) = 0;
@@ -116,6 +120,9 @@ public:
   }
   uint64_t get_reserved_pushes() const {
     return qitem->get_reserved_pushes();
+  }
+  bool needs_exclusive_pglock(OSD *osd) {
+    return qitem->needs_exclusive_pglock(osd);
   }
   void run(OSD *osd, PGRef& pg, ThreadPool::TPHandle &handle) {
     qitem->run(osd, pg, handle);
@@ -182,6 +189,7 @@ public:
   boost::optional<OpRequestRef> maybe_get_op() const override final {
     return op;
   }
+  bool needs_exclusive_pglock(OSD *osd) override final;
   void run(OSD *osd, PGRef& pg, ThreadPool::TPHandle &handle) override final;
 };
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -356,6 +356,16 @@ void PG::lock(bool no_lockdep) const
   dout(30) << "lock" << dendl;
 }
 
+void PG::lock_in_mode(bool exclusive, bool no_lockdep) const
+{
+  _lock.get(exclusive);
+  // if we have unrecorded dirty state with the lock dropped, there is a bug
+  assert(!dirty_info);
+  assert(!dirty_big_info);
+
+  dout(30) << "lock" << dendl;
+}
+
 std::string PG::gen_prefix() const
 {
   stringstream out;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -348,7 +348,7 @@ PG::~PG()
 
 void PG::lock(bool no_lockdep) const
 {
-  _lock.Lock(no_lockdep);
+  _lock.get_write(!no_lockdep);
   // if we have unrecorded dirty state with the lock dropped, there is a bug
   assert(!dirty_info);
   assert(!dirty_big_info);
@@ -360,7 +360,7 @@ std::string PG::gen_prefix() const
 {
   stringstream out;
   OSDMapRef mapref = osdmap_ref;
-  if (_lock.is_locked_by_me()) {
+  if (_lock.is_wlocked()) {
     out << "osd." << osd->whoami
 	<< " pg_epoch: " << (mapref ? mapref->get_epoch():0)
 	<< " " << *this << " ";

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -310,8 +310,9 @@ public:
     //generic_dout(0) << this << " " << info.pgid << " unlock" << dendl;
     assert(!dirty_info);
     assert(!dirty_big_info);
-    _lock.Unlock();
+    _lock.unlock();
   }
+
   bool is_locked() const {
     return _lock.is_locked();
   }
@@ -541,7 +542,7 @@ protected:
   // get() should be called on pointer copy (to another thread, etc.).
   // put() should be called on destruction of some previously copied pointer.
   // unlock() when done with the current pointer (_most common_).
-  mutable Mutex _lock = {"PG::_lock"};
+  mutable RWLock _lock;
 
   std::atomic_uint ref{0};
 
@@ -585,17 +586,16 @@ protected:
   void requeue_map_waiters();
 
   void update_osdmap_ref(OSDMapRef newmap) {
-    assert(_lock.is_locked_by_me());
+    // FIXME: is_locked_by_me()
+    assert(_lock.is_locked());
     osdmap_ref = std::move(newmap);
   }
 
 protected:
 
-
   bool deleting;  // true while in removing or OSD is shutting down
 
   ZTracer::Endpoint trace_endpoint;
-
 
 protected:
   bool dirty_info, dirty_big_info;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -306,6 +306,8 @@ public:
     handle.reset_tp_timeout();
   }
   void lock(bool no_lockdep = false) const;
+  void lock_in_mode(bool exclusive, bool no_lockdep = false) const;
+
   void unlock() const {
     //generic_dout(0) << this << " " << info.pgid << " unlock" << dendl;
     assert(!dirty_info);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -544,7 +544,7 @@ protected:
   // get() should be called on pointer copy (to another thread, etc.).
   // put() should be called on destruction of some previously copied pointer.
   // unlock() when done with the current pointer (_most common_).
-  mutable RWLock _lock;
+  mutable RWLock _lock = {"PG::lock"};
 
   std::atomic_uint ref{0};
 


### PR DESCRIPTION
Currently, the PG lock is taken always exclusively blocking any other operation targeting the same PG. This restriction applies even to a series of reads across the same PG which is a typical case for accessing RBD images sequentially.

The patchset tries to deal with the problem by introducing `shared-exlusive` locking manner for `PG::_lock`. I treat it rather as a proof-of-concept showing potential benefits from parallel reads and allowing to discover issues earlier.  Still, reads in `ObjectStore` are synchronous while we have only 2 threads per shard (`osd_op_num_threads_per_shard`) in default configuration on SSDs. Introducing asynchronous mode looks like a preferred way. Thus, the PR gets the *DNM* label. T

The reference point (caching in `librbd` and BlueStore disabled):
```
rbd_iodepth32: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=rbd, iodepth=32
fio-3.0-32-g83070
Starting 1 process
2017-11-17 15:55:44.574289 7f64799b4a40 -1 WARNING: the following dangerous and experimental features are enabled: *

rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=6695: Fri Nov 17 15:56:44 2017
   read: IOPS=10.4k, BW=40.5MiB/s (42.5MB/s)(2431MiB/60004msec)
    slat (nsec): min=634, max=111104, avg=2810.27, stdev=2417.64
    clat (usec): min=138, max=19830, avg=3081.28, stdev=1681.88
     lat (usec): min=140, max=19833, avg=3084.09, stdev=1681.84
    clat percentiles (usec):
     |  1.00th=[ 1012],  5.00th=[ 1631], 10.00th=[ 1729], 20.00th=[ 1827],
     | 30.00th=[ 2008], 40.00th=[ 2147], 50.00th=[ 2311], 60.00th=[ 2966],
     | 70.00th=[ 3818], 80.00th=[ 4146], 90.00th=[ 4883], 95.00th=[ 6456],
     | 99.00th=[ 9372], 99.50th=[10421], 99.90th=[12780], 99.95th=[13566],
     | 99.99th=[16057]
   bw (  KiB/s): min=27208, max=67256, per=100.00%, avg=41493.62, stdev=12617.76, samples=120
   iops        : min= 6802, max=16814, avg=10373.38, stdev=3154.45, samples=120
  lat (usec)   : 250=0.04%, 500=0.37%, 750=0.31%, 1000=0.27%
  lat (msec)   : 2=28.49%, 4=45.26%, 10=24.66%, 20=0.61%
  cpu          : usr=30.13%, sys=69.13%, ctx=462715, majf=0, minf=6
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=622444,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=40.5MiB/s (42.5MB/s), 40.5MiB/s-40.5MiB/s (42.5MB/s-42.5MB/s), io=2431MiB (2550MB), run=60004-60004msec

Disk stats (read/write):
  nvme0n1: ios=621391/560, merge=0/14, ticks=30396/600, in_queue=31000, util=49.72%
```

After the changes (caching in `librbd` and BlueStore disabled):
```
rbd_iodepth32: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=rbd, iodepth=32
fio-3.0-32-g83070
Starting 1 process
2017-11-17 15:27:13.313920 7f4ed6465a40 -1 WARNING: the following dangerous and experimental features are enabled: *

rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=29841: Fri Nov 17 15:28:13 2017
   read: IOPS=18.9k, BW=73.0MiB/s (77.6MB/s)(4439MiB/60003msec)
    slat (nsec): min=633, max=189327, avg=2769.45, stdev=2394.62
    clat (usec): min=155, max=17775, avg=1686.20, stdev=768.27
     lat (usec): min=157, max=17778, avg=1688.97, stdev=768.30
    clat percentiles (usec):
     |  1.00th=[  873],  5.00th=[ 1057], 10.00th=[ 1123], 20.00th=[ 1172],
     | 30.00th=[ 1221], 40.00th=[ 1287], 50.00th=[ 1369], 60.00th=[ 1565],
     | 70.00th=[ 1893], 80.00th=[ 2147], 90.00th=[ 2507], 95.00th=[ 3228],
     | 99.00th=[ 4621], 99.50th=[ 5342], 99.90th=[ 6783], 99.95th=[ 7308],
     | 99.99th=[ 8979]
   bw (  KiB/s): min=54024, max=103344, per=100.00%, avg=75756.22, stdev=15965.96, samples=120
   iops        : min=13506, max=25836, avg=18939.04, stdev=3991.50, samples=120
  lat (usec)   : 250=0.01%, 500=0.24%, 750=0.45%, 1000=1.78%
  lat (msec)   : 2=71.44%, 4=24.01%, 10=2.08%, 20=0.01%
  cpu          : usr=33.50%, sys=65.34%, ctx=669492, majf=0, minf=6
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=1136350,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=73.0MiB/s (77.6MB/s), 73.0MiB/s-73.0MiB/s (77.6MB/s-77.6MB/s), io=4439MiB (4654MB), run=60003-60003msec

Disk stats (read/write):
  nvme0n1: ios=1134440/571, merge=0/21, ticks=53020/684, in_queue=54192, util=58.45%
```