### PR TITLE
ceph_disk: allow "no fsid" on activate

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1258,7 +1258,8 @@ def get_fsid(cluster):
     :return: The fsid or raises Error.
     """
     fsid = get_conf_with_default(cluster=cluster, variable='fsid')
-    if fsid is None:
+    # uuids from boost always default to 'the empty uuid'
+    if fsid == '00000000-0000-0000-0000-000000000000':
         raise Error('getting cluster uuid from configuration failed')
     return fsid.lower()
 


### PR DESCRIPTION
The intent was to allow "no fsid" configurations when only one
conf file named 'ceph.conf' was present, but the code has a bug
in that ceph-osd --show-config-value will return a default all-0
uuid.  Allow either "None" or "all 0s" from get_fsid() to behave
the same way.

Signed-off-by: Dan Mick <dan.mick@redhat.com>