### PR TITLE
rgw/rgw_sync_log_trim: [Cleanup] Suppress warning because of uninitialization

### DIFF
--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -347,7 +347,7 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
                     std::vector<std::string> *status)
 {
   status->clear();
-  boost::optional<size_t> num_shards;
+  boost::optional<size_t> num_shards = 0;
   for (auto peer = first; peer != last; ++peer) {
     const size_t peer_shards = peer->size();
     if (!num_shards) {
@@ -370,6 +370,7 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
       }
     }
   }
+
   return 0;
 }
 


### PR DESCRIPTION
Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>