### PR TITLE
client: emplace Cap in Inode caps map

### DIFF
--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -6,6 +6,7 @@
 
 #include <numeric>
 
+#include "include/assert.h"
 #include "include/types.h"
 #include "include/xlist.h"
 
@@ -13,14 +14,13 @@
 #include "mds/mdstypes.h" // hrm
 
 #include "osdc/ObjectCacher.h"
-#include "include/assert.h"
 
 #include "InodeRef.h"
+#include "MetaSession.h"
 #include "UserPerm.h"
 #include "Delegation.h"
 
 class Client;
-struct MetaSession;
 class Dentry;
 class Dir;
 struct SnapRealm;
@@ -29,11 +29,28 @@ class MetaRequest;
 class filepath;
 class Fh;
 
-struct Cap {
+class Cap {
+public:
+  Cap() = delete;
+  Cap(Inode *i, MetaSession *s) :
+      session(s), inode(i), cap_id(0), issued(0),
+      implemented(0), wanted(0), seq(0), issue_seq(0), mseq(0), gen(s->cap_gen),
+      latest_perms(), cap_item(this) {
+    s->caps.push_back(&cap_item);
+  }
+  ~Cap() {
+    cap_item.remove_myself();
+  }
+
+  void touch(void) {
+    // move to back of LRU
+    session->caps.push_back(&cap_item);
+  }
+
+  void dump(Formatter *f) const;
+
   MetaSession *session;
   Inode *inode;
-  xlist<Cap*>::item cap_item;
-
   uint64_t cap_id;
   unsigned issued;
   unsigned implemented;
@@ -43,11 +60,15 @@ struct Cap {
   __u32 gen;
   UserPerm latest_perms;
 
-  Cap() : session(NULL), inode(NULL), cap_item(this), cap_id(0), issued(0),
-	  implemented(0), wanted(0), seq(0), issue_seq(0), mseq(0), gen(0),
-	  latest_perms()  {}
-
-  void dump(Formatter *f) const;
+private:
+  /* Note that this Cap will not move (see Inode::caps):
+   *
+   * Section 23.1.2#8
+   * The insert members shall not affect the validity of iterators and
+   * references to the container, and the erase members shall invalidate only
+   * iterators and references to the erased elements.
+   */
+  xlist<Cap *>::item cap_item;
 };
 
 struct CapSnap {
@@ -168,7 +189,7 @@ struct Inode {
   bool dir_hashed, dir_replicated;
 
   // per-mds caps
-  map<mds_rank_t, Cap*> caps;            // mds -> Cap
+  std::map<mds_rank_t, Cap> caps;            // mds -> Cap
   Cap *auth_cap;
   int64_t cap_dirtier_uid;
   int64_t cap_dirtier_gid;
@@ -278,9 +299,8 @@ struct Inode {
   void get_cap_ref(int cap);
   int put_cap_ref(int cap);
   bool is_any_caps();
-  bool cap_is_valid(Cap* cap) const;
+  bool cap_is_valid(const Cap &cap) const;
   int caps_issued(int *implemented = 0) const;
-  void touch_cap(Cap *cap);
   void try_touch_cap(mds_rank_t mds);
   bool caps_issued_mask(unsigned mask);
   int caps_used();

--- a/src/client/MetaSession.cc
+++ b/src/client/MetaSession.cc
@@ -30,7 +30,7 @@ void MetaSession::dump(Formatter *f) const
   f->dump_stream("cap_ttl") << cap_ttl;
   f->dump_stream("last_cap_renew_request") << last_cap_renew_request;
   f->dump_unsigned("cap_renew_seq", cap_renew_seq);
-  f->dump_int("num_caps", num_caps);
+  f->dump_int("num_caps", caps.size());
   f->dump_string("state", get_state_name());
 }
 

--- a/src/client/MetaSession.h
+++ b/src/client/MetaSession.h
@@ -23,7 +23,6 @@ struct MetaSession {
   uint64_t cap_gen;
   utime_t cap_ttl, last_cap_renew_request;
   uint64_t cap_renew_seq;
-  int num_caps;
   entity_inst_t inst;
 
   enum {
@@ -51,7 +50,7 @@ struct MetaSession {
 
   MetaSession(mds_rank_t mds_num, ConnectionRef con, entity_inst_t inst)
     : mds_num(mds_num), con(con),
-      seq(0), cap_gen(0), cap_renew_seq(0), num_caps(0), inst(inst),
+      seq(0), cap_gen(0), cap_renew_seq(0), inst(inst),
       state(STATE_OPENING), mds_state(MDSMap::STATE_NULL), readonly(false)
   {}
 


### PR DESCRIPTION
Idea here is both to eliminate pointer management which avoids potential
leaks and to reduce memory fragmentation by putting the Cap in the map
itself.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>