### PR TITLE
osd: no need to remove mapping for non-snap objects

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3659,10 +3659,12 @@ void OSD::recursive_remove_collection(CephContext* cct,
   for (vector<ghobject_t>::iterator p = objects.begin();
        p != objects.end();
        ++p, removed++) {
-    OSDriver::OSTransaction _t(driver.get_transaction(&t));
-    int r = mapper.remove_oid(p->hobj, &_t);
-    if (r != 0 && r != -ENOENT)
-      ceph_abort();
+    if (p->hobj->snap < CEPH_MAXSNAP) {
+      OSDriver::OSTransaction _t(driver.get_transaction(&t));
+      int r = mapper.remove_oid(p->hobj, &_t);
+      if (r != 0 && r != -ENOENT)
+        ceph_abort();
+    }
     t.remove(tmp, *p);
     if (removed > cct->_conf->osd_target_transaction_size) {
       int r = store->apply_transaction(osr.get(), std::move(t));

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -8509,10 +8509,12 @@ void PG::with_heartbeat_peers(std::function<void(int)> f)
 
 void PG::pg_remove_object(const ghobject_t& oid, ObjectStore::Transaction *t)
 {
-  OSDriver::OSTransaction _t(osdriver.get_transaction(t));
-  int r = snap_mapper.remove_oid(oid.hobj, &_t);
-  if (r != 0 && r != -ENOENT) {
-    ceph_abort();
+  if (oid.hobj.snap < CEPH_MAXSNAP) {
+    OSDriver::OSTransaction _t(osdriver.get_transaction(t));
+    int r = snap_mapper.remove_oid(oid.hobj, &_t);
+    if (r != 0 && r != -ENOENT) {
+      ceph_abort();
+    }
   }
   t->remove(coll, oid);
 }


### PR DESCRIPTION
Sometimes removing a pool with many many objects is quite slow, and most of the time is spent in SnapMapper::_remove_oid() in remove_dir() of OSD.cc. And for a non-cloned object, the method will always return -ENOENT with nothing todo. So check the object first, and only call SnapMapper::_remove_oid() if it's a clone.

Signed-off-by: wumingqiao <wumingqiao@inspur.com>