### PR TITLE
osd: don't clear mapping for non-clone objects when removing pg.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3659,10 +3659,12 @@ void OSD::recursive_remove_collection(CephContext* cct,
   for (vector<ghobject_t>::iterator p = objects.begin();
        p != objects.end();
        ++p, removed++) {
-    OSDriver::OSTransaction _t(driver.get_transaction(&t));
-    int r = mapper.remove_oid(p->hobj, &_t);
-    if (r != 0 && r != -ENOENT)
-      ceph_abort();
+    if (p->hobj.snap < CEPH_MAXSNAP) {
+      OSDriver::OSTransaction _t(driver.get_transaction(&t));
+      int r = mapper.remove_oid(p->hobj, &_t);
+      if (r != 0 && r != -ENOENT)
+        ceph_abort();
+    }
     t.remove(tmp, *p);
     if (removed > cct->_conf->osd_target_transaction_size) {
       int r = store->apply_transaction(osr.get(), std::move(t));

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -8509,10 +8509,12 @@ void PG::with_heartbeat_peers(std::function<void(int)> f)
 
 void PG::pg_remove_object(const ghobject_t& oid, ObjectStore::Transaction *t)
 {
-  OSDriver::OSTransaction _t(osdriver.get_transaction(t));
-  int r = snap_mapper.remove_oid(oid.hobj, &_t);
-  if (r != 0 && r != -ENOENT) {
-    ceph_abort();
+  if (oid.hobj.snap < CEPH_MAXSNAP) {
+    OSDriver::OSTransaction _t(osdriver.get_transaction(t));
+    int r = snap_mapper.remove_oid(oid.hobj, &_t);
+    if (r != 0 && r != -ENOENT) {
+      ceph_abort();
+    }
   }
   t->remove(coll, oid);
 }


### PR DESCRIPTION
clear snap-mapping for a non-snapped object is no need and always return -ENOENT, so jump over it to fast the pg removing. 

Signed-off-by: wumingqiao <wumingqiao@inspur.com>