### PR TITLE
msg/async/AsyncConnection: unregister connection when racing happened

### DIFF
--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -356,9 +356,6 @@ public:
       Mutex::Locker l(deleted_lock);
       if (deleted_conns.erase(existing)) {
         existing->get_perf_counter()->dec(l_msgr_active_connections);
-        conns.erase(it);
-      } else if (conn != existing) {
-        return -1;
       }
     }
     conns[conn->peer_addr] = conn;


### PR DESCRIPTION
Signed-off-by: Haomai Wang <haomai@xsky.com>