### PR TITLE
mds: properly execute scrub finish context

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12114,7 +12114,7 @@ void MDCache::enqueue_scrub_work(MDRequestRef& mdr)
 
   Context *fin = nullptr;
   if (!header->get_recursive()) {
-    cs->take_finisher();
+    fin = cs->take_finisher();
   }
 
   // If the scrub did some repair, then flush the journal at the end of


### PR DESCRIPTION
Bug was introduced by commit 7e52729699 (mds: flush after scrub repairs)

Fixes: http://tracker.ceph.com/issues/22058
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>