### PR TITLE
mon: Add `ceph osd get-require-min-compat-client` command

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1410,6 +1410,7 @@ function test_mon_osd()
   # require-min-compat-client
   expect_false ceph osd set-require-min-compat-client dumpling  # firefly tunables
   ceph osd set-require-min-compat-client luminous
+  ceph osd get-require-min-compat-client | grep luminous
   ceph osd dump | grep 'require_min_compat_client luminous'
 
   #

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -709,6 +709,9 @@ COMMAND("osd set-nearfull-ratio " \
 	"name=ratio,type=CephFloat,range=0.0|1.0", \
 	"set usage ratio at which OSDs are marked near-full",
 	"osd", "rw", "cli,rest")
+COMMAND("osd get-require-min-compat-client",
+        "get the minimum client version we will maintain compatibility with",
+        "osd", "r", "cli,rest")
 COMMAND("osd set-require-min-compat-client " \
 	"name=version,type=CephString " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4940,6 +4940,11 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       rdata.append(ss.str());
       ss.str("");
     }
+  } else if (prefix == "osd get-require-min-compat-client") {
+    ss << ceph_release_name(osdmap.require_min_compat_client) << std::endl;
+    rdata.append(ss.str());
+    ss.str("");
+    goto reply;
   } else {
     // try prepare update
     return false;


### PR DESCRIPTION
As an antagonist to the already existing `set-require-min-compat-client`

