### PR TITLE
test/rbd_mirror: fix valgrind warnings in unittest

### DIFF
--- a/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
@@ -239,8 +239,10 @@ public:
   }
 
   void expect_ioctx_create(librados::IoCtx &io_ctx) {
+    librados::MockTestMemIoCtxImpl &io_ctx_impl = get_mock_io_ctx(io_ctx);
     EXPECT_CALL(*get_mock_io_ctx(io_ctx).get_mock_rados_client(), create_ioctx(_, _))
-      .WillOnce(Return(&get_mock_io_ctx(io_ctx)));
+      .WillOnce(DoAll(GetReference(&io_ctx_impl),
+                      Return(&get_mock_io_ctx(io_ctx))));
   }
 
   void expect_get_parent_global_image_id(librados::IoCtx &io_ctx,

--- a/src/test/rbd_mirror/image_replayer/test_mock_PrepareRemoteImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_PrepareRemoteImageRequest.cc
@@ -192,6 +192,7 @@ TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, Success) {
   ASSERT_EQ(std::string("remote image id"), remote_image_id);
   ASSERT_TRUE(remote_journaler != nullptr);
   ASSERT_EQ(cls::journal::CLIENT_STATE_DISCONNECTED, client_state);
+  delete remote_journaler;
 }
 
 TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, SuccessNotRegistered) {
@@ -239,6 +240,7 @@ TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, SuccessNotRegistered) {
   ASSERT_EQ(std::string("remote image id"), remote_image_id);
   ASSERT_TRUE(remote_journaler != nullptr);
   ASSERT_EQ(cls::journal::CLIENT_STATE_CONNECTED, client_state);
+  delete remote_journaler;
 }
 
 TEST_F(TestMockImageReplayerPrepareRemoteImageRequest, MirrorUuidError) {

--- a/src/test/rbd_mirror/test_mock_fixture.h
+++ b/src/test/rbd_mirror/test_mock_fixture.h
@@ -34,6 +34,10 @@ ACTION_P2(CompleteContext, wq, r) {
   context_wq->queue(arg0, r);
 }
 
+ACTION_P(GetReference, ref_object) {
+  ref_object->get();
+}
+
 MATCHER_P(ContentsEqual, bl, "") {
   // TODO fix const-correctness of bufferlist
   return const_cast<bufferlist &>(arg).contents_equal(


### PR DESCRIPTION
Signed-off-by: Mykola Golub <to.my.trociny@gmail.com>