### PR TITLE
mds: don't delay processing completed requests in replay queue

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -235,7 +235,7 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
          lock->get_type() == CEPH_LOCK_IPOLICY) &&
 	mds->is_cluster_degraded() &&
 	mdr->is_master() &&
-	!mdr->is_replay()) {
+	!mdr->is_queued_for_replay()) {
       // waiting for recovering mds, to guarantee replayed requests and mksnap/setlayout
       // get processed in proper order.
       bool wait = false;
@@ -587,7 +587,7 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
       assert(mdr->is_master());
       if ((*p)->needs_recover()) {
 	if (mds->is_cluster_degraded()) {
-	  if (!mdr->is_replay()) {
+	  if (!mdr->is_queued_for_replay()) {
 	    // see comments in SimpleLock::set_state_rejoin() and
 	    // ScatterLock::encode_state_for_rejoin()
 	    drop_locks(mdr.get());

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -313,9 +313,9 @@ void MDRequestImpl::set_filepath2(const filepath& fp)
   more()->filepath2 = fp;
 }
 
-bool MDRequestImpl::is_replay() const
+bool MDRequestImpl::is_queued_for_replay() const
 {
-  return client_request ? client_request->is_replay() : false;
+  return client_request ? client_request->is_queued_for_replay() : false;
 }
 
 void MDRequestImpl::print(ostream &out) const

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -331,7 +331,7 @@ struct MDRequestImpl : public MutationImpl {
   const filepath& get_filepath2();
   void set_filepath(const filepath& fp);
   void set_filepath2(const filepath& fp);
-  bool is_replay() const;
+  bool is_queued_for_replay() const;
 
   void print(ostream &out) const override;
   void dump(Formatter *f) const override;


### PR DESCRIPTION
Completed requests can also be in replay queue, they need to be processed
(treated as lookup request) in clientreplay stage. MDS will be stuck at
clientreplay stage if it delays processing requests of this type.

Fixes: http://tracker.ceph.com/issues/22163
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>