### PR TITLE
rgw: add admin rest api for bucket sync

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -7320,29 +7320,19 @@ next:
     if (bucket_name.empty()) {
       cerr << "ERROR: bucket not specified" << std::endl;
       return EINVAL;
+    } 
+    if (opt_cmd == OPT_BUCKET_SYNC_DISABLE) {
+      bucket_op.set_sync_bucket(false);
+    } else {
+      bucket_op.set_sync_bucket(true);
     }
-
+    bucket_op.set_tenant(tenant);
+    string err_msg;
+    ret = RGWBucketAdminOp::sync_bucket(store, bucket_op, &err_msg);
     if (ret < 0) {
-      cerr << "could not init realm " << ": " << cpp_strerror(-ret) << std::endl;
-      return ret;
-    }
-    RGWPeriod period;
-    ret = period.init(g_ceph_context, store->svc()->sysobj, realm_id, realm_name, true);
-    if (ret < 0) {
-      cerr << "failed to init period " << ": " << cpp_strerror(-ret) << std::endl;
-      return ret;
-    }
-
-    if (!store->svc()->zone->is_meta_master()) {
-      cerr << "failed to update bucket sync: only allowed on meta master zone "  << std::endl;
-      cerr << period.get_master_zone() << " | " << period.get_realm() << std::endl;
-      return EINVAL;
-    }
-
-    rgw_obj obj(bucket, object);
-    ret = set_bucket_sync_enabled(store, opt_cmd, tenant, bucket_name);
-    if (ret < 0)
+      cerr << err_msg << std::endl;
       return -ret;
+    }
   }
 
   if (opt_cmd == OPT_BUCKET_SYNC_STATUS) {

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -599,7 +599,7 @@ int RGWBucket::init(RGWRadosStore *storage, RGWBucketAdminOpState& op_state,
 
   if (bucket.name.empty() && user_id.empty())
     return -EINVAL;
-
+  
   // split possible tenant/name
   auto pos = bucket.name.find('/');
   if (pos != string::npos) {

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1070,7 +1070,7 @@ int RGWBucket::check_index(RGWBucketAdminOpState& op_state,
 
 int RGWBucket::sync(RGWBucketAdminOpState& op_state, std::string *err_msg)
 {
-  if (!store->getRados()->is_meta_master()) {
+  if (!store->getRados()->svc.zone->is_meta_master()) {
     set_err_msg(err_msg, "ERROR: failed to update bucket sync: only allowed on meta master zone");
     return EINVAL;
   }

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -359,7 +359,7 @@ public:
   int remove_object(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
   int policy_bl_to_stream(bufferlist& bl, ostream& o);
   int get_policy(RGWBucketAdminOpState& op_state, RGWAccessControlPolicy& policy, optional_yield y);
-  int sync(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
+  int sync(RGWBucketAdminOpState& op_state, map<string, bufferlist> *attrs, std::string *err_msg = NULL);
 
   void clear_failure() { failure = false; }
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -243,6 +243,7 @@ struct RGWBucketAdminOpState {
   bool fix_index;
   bool delete_child_objects;
   bool bucket_stored;
+  bool sync_bucket;
   int max_aio = 0;
 
   rgw_bucket bucket;
@@ -260,6 +261,9 @@ struct RGWBucketAdminOpState {
     if (!user_id.empty())
       uid = user_id;
   }
+  void set_tenant(const std::string& tenant_str) {
+    uid.tenant = tenant_str;
+  }
   void set_bucket_name(const std::string& bucket_str) {
     bucket_name = bucket_str; 
   }
@@ -274,10 +278,13 @@ struct RGWBucketAdminOpState {
   }
 
 
+  void set_sync_bucket(bool value) { sync_bucket = value; }
+
   rgw_user& get_user_id() { return uid; }
   std::string& get_user_display_name() { return display_name; }
   std::string& get_bucket_name() { return bucket_name; }
   std::string& get_object_name() { return object_name; }
+  std::string& get_tenant() { return uid.tenant; }
 
   rgw_bucket& get_bucket() { return bucket; }
   void set_bucket(rgw_bucket& _bucket) {
@@ -298,10 +305,11 @@ struct RGWBucketAdminOpState {
   bool is_system_op() { return uid.empty(); }
   bool has_bucket_stored() { return bucket_stored; }
   int get_max_aio() { return max_aio; }
+  bool will_sync_bucket() { return sync_bucket; }
 
   RGWBucketAdminOpState() : list_buckets(false), stat_buckets(false), check_objects(false), 
                             fix_index(false), delete_child_objects(false),
-                            bucket_stored(false)  {}
+                            bucket_stored(false), sync_bucket(true)  {}
 };
 
 /*
@@ -351,6 +359,7 @@ public:
   int remove_object(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
   int policy_bl_to_stream(bufferlist& bl, ostream& o);
   int get_policy(RGWBucketAdminOpState& op_state, RGWAccessControlPolicy& policy, optional_yield y);
+  int sync(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
 
   void clear_failure() { failure = false; }
 
@@ -392,6 +401,8 @@ public:
                            RGWFormatterFlusher& flusher);
   static int fix_obj_expiry(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state,
 			    RGWFormatterFlusher& flusher, bool dry_run = false);
+
+  static int sync_bucket(rgw::sal::RGWRadosStore *store, RGWBucketAdminOpState& op_state, string *err_msg = NULL);
 };
 
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -957,8 +957,8 @@ void RGWHTTPArgs::append(const string& name, const string& val)
               (name.compare("policy") == 0) ||
               (name.compare("quota") == 0) ||
               (name.compare("list") == 0) ||
-              (name.compare("object") == 0)) {
-
+              (name.compare("object") == 0) ||
+              (name.compare("sync") == 0)) {
     if (!admin_subresource_added) {
       sub_resources[name] = "";
       admin_subresource_added = true;

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -289,6 +289,38 @@ void RGWOp_Set_Bucket_Quota::execute()
   http_ret = RGWBucketAdminOp::set_quota(store, op_state);
 }
 
+class RGWOp_Sync_Bucket : public RGWRESTOp {
+
+public:
+  RGWOp_Sync_Bucket() {}
+
+  int check_caps(RGWUserCaps& caps) override {
+    return caps.check_cap("buckets", RGW_CAP_WRITE);
+  }
+
+  void execute() override;
+
+  const char* name() const override { return "sync_bucket"; }
+}
+
+void RGWOp_Sync_Bucket::execute()
+{
+  std::string bucket;
+  std::string tenant;
+  bool sync_bucket;
+
+  RGWBucketAdminOpState op_state;
+  RESTArgs::get_string(s, "bucket", bucket, &bucket);
+  RESTArgs::get_string(s, "tenant", tenant, &tenant);
+  RESTArgs::get_bool(s, "sync", true, &sync_bucket);
+
+  op_state.set_bucket_name(bucket);
+  op_state.set_tenant(tenant);
+  op_state.set_sync_bucket(sync_bucket);
+
+  http_ret = RGWBucketAdminOp::sync_bucket(store, op_state);
+}
+
 class RGWOp_Object_Remove: public RGWRESTOp {
 
 public:
@@ -318,6 +350,7 @@ void RGWOp_Object_Remove::execute()
 
   http_ret = RGWBucketAdminOp::remove_object(store, op_state);
 }
+
 
 RGWOp *RGWHandler_Bucket::op_get()
 {

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -368,6 +368,10 @@ RGWOp *RGWHandler_Bucket::op_put()
 {
   if (s->info.args.sub_resource_exists("quota"))
     return new RGWOp_Set_Bucket_Quota;
+
+  if (s->info.args.sub_resource_exists("sync"))
+    return new RGWOp_Sync_Bucket;
+  
   return new RGWOp_Bucket_Link;
 }
 

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -301,7 +301,7 @@ public:
   void execute() override;
 
   const char* name() const override { return "sync_bucket"; }
-}
+};
 
 void RGWOp_Sync_Bucket::execute()
 {


### PR DESCRIPTION
Add admin rest api for enable/disable bucket sync:

> PUT /admin/bucket?sync&format=json
> parameters:
> bucket: 
>   Description: The bucket name;
>   Type: String
>   Required: Yes
> sync: 
>   Description: Flag of enable/disable sync. 
>   Type: bool
>   Required: No. Default value is true.


Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>