### PR TITLE
rgw: fix the two files with the same in the bucket when open/close version

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -825,7 +825,8 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   }
 
   entry.index_ver = header.ver;
-  entry.flags = (entry.key.instance.empty() ? 0 : RGW_BUCKET_DIRENT_FLAG_VER); /* resetting entry flags, entry might have been previously a delete marker */
+  bool is_version = !entry.key.instance.empty() || (entry.flags & RGW_BUCKET_DIRENT_FLAG_VER);
+  entry.flags = (is_version ? RGW_BUCKET_DIRENT_FLAG_VER : 0); /* resetting entry flags, entry might have been previously a delete marker */
 
   if (op.tag.size()) {
     map<string, struct rgw_bucket_pending_info>::iterator pinter = entry.pending_map.find(op.tag);


### PR DESCRIPTION

steps:
1.open version,  put the object.
2.close version, put the same object and set acl.
3.open version, put the same object.
4.list bucket

Signed-off-by: hechuang <hechuang@xsky.com>