### PR TITLE
githubmap: Add oritwas

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -31,6 +31,7 @@ liewegas Sage Weil <sage@redhat.com>
 liupan1111 Pan Liu <liupan1111@gmail.com>
 majianpeng Jianpeng Ma <jianpeng.ma@intel.com>
 markhpc Mark Nelson <mnelson@redhat.com>
+oritwas Orit Wasserman <owasserm@redhat.com>
 rchagam Anjaneya Chagam <anjaneya.chagam@intel.com>
 renhwztetecs huanwen ren <ren.huanwen@zte.com.cn>
 smithfarm Nathan Cutler <ncutler@suse.com>


### PR DESCRIPTION
Added oritwas to .githubmap. Found during the testing of https://github.com/ceph/ceph/pull/18302.

Signed-off-by: Jos Collin <jcollin@redhat.com>