### PR TITLE
luminous: cluster [ERR] Unhandled exception from module 'balancer' while running on mgr.x: 'NoneType' object has no attribute 'iteritems'" in cluster log

### DIFF
--- a/qa/suites/rados/thrash/workloads/cache-agent-small.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-agent-small.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    crush_tunables: firefly
     log-whitelist:
       - must scrub before tier agent can activate
 tasks:

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -656,6 +656,8 @@ class Module(MgrModule):
 
         # get current compat weight-set weights
         orig_ws = self.get_compat_weight_set_weights()
+        if orig_ws is None:
+            return False
         orig_ws = { a: b for a, b in orig_ws.iteritems() if a >= 0 }
 
         # Make sure roots don't overlap their devices.  If so, we

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -11,6 +11,7 @@ import random
 import time
 from mgr_module import MgrModule, CommandResult
 from threading import Event
+from mgr_module import CRUSHMap
 
 # available modes: 'none', 'crush', 'crush-compat', 'upmap', 'osd_weight'
 default_mode = 'none'
@@ -18,7 +19,6 @@ default_sleep_interval = 60   # seconds
 default_max_misplaced = .05    # max ratio of pgs replaced at a time
 
 TIME_FORMAT = '%Y-%m-%d_%H:%M:%S'
-
 
 class MappingState:
     def __init__(self, osdmap, pg_dump, desc=''):
@@ -451,6 +451,8 @@ class Module(MgrModule):
                     bytes_by_osd[osd] = 0
             for pgid, up in pm.iteritems():
                 for osd in [int(osd) for osd in up]:
+                    if osd == CRUSHMap.ITEM_NONE:
+                        continue
                     pgs_by_osd[osd] += 1
                     objects_by_osd[osd] += ms.pg_stat[pgid]['num_objects']
                     bytes_by_osd[osd] += ms.pg_stat[pgid]['num_bytes']

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -126,6 +126,8 @@ class OSDMapIncremental(ceph_module.BasePyOSDMapIncremental):
         return self._set_crush_compat_weight_set_weights(weightmap)
 
 class CRUSHMap(ceph_module.BasePyCRUSH):
+    ITEM_NONE = 0x7fffffff
+
     def dump(self):
         return self._dump()
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/22164