### PR TITLE
luminous: qa/tasks: prolong revive_osd() timeout to 6 min

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -111,7 +111,7 @@ class Thrasher:
         self.stopping = False
         self.logger = logger
         self.config = config
-        self.revive_timeout = self.config.get("revive_timeout", 150)
+        self.revive_timeout = self.config.get("revive_timeout", 360)
         self.pools_to_fix_pgp_num = set()
         if self.config.get('powercycle'):
             self.revive_timeout += 120


### PR DESCRIPTION
backport of #19024 

http://tracker.ceph.com/issues/22166