### PR TITLE
cmake: only create sysctl file on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -604,7 +604,9 @@ if(WITH_SYSTEMD)
   add_subdirectory(systemd)
 endif()
 
-add_subdirectory(etc/sysctl)
+if(LINUX)
+  add_subdirectory(etc/sysctl)
+endif()
 
 include(CTags)
 option(CTAG_EXCLUDES "Exclude files/directories when running ctag.")

--- a/etc/sysctl/CMakeLists.txt
+++ b/etc/sysctl/CMakeLists.txt
@@ -1,8 +1,9 @@
-if(NOT CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i686|arm|ARM")
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   # 4194304 is the maximum limit possible on 64-bit CONFIG_BASE_FULL kernels.
   # Keep the default for 32-bit systems.
   set(sysctl_pid_max "kernel.pid_max = 4194304")
 endif()
 
 configure_file(90-ceph-osd.conf.in
-               ${CMAKE_CURRENT_SOURCE_DIR}/90-ceph-osd.conf @ONLY)
+  ${CMAKE_CURRENT_SOURCE_DIR}/90-ceph-osd.conf
+  @ONLY)


### PR DESCRIPTION
and check 64bit platform by looking at sizeof(void*)

Signed-off-by: Kefu Chai <kchai@redhat.com>