### PR TITLE
buffer: zero bufferptr improvements

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9289,9 +9289,7 @@ int Client::_read_sync(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
 	int64_t some = in->size - pos;
 	if (some > left)
 	  some = left;
-	auto z = buffer::ptr_node::create(some);
-	z->zero();
-	bl->push_back(std::move(z));
+	bl->append_zero(some);
 	read += some;
 	pos += some;
 	left -= some;

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1184,10 +1184,14 @@ inline namespace v14_2_0 {
     void append(std::istream& in);
     contiguous_filler append_hole(unsigned len);
     void append_zero(unsigned len);
+    void append_zero_precalc_crc(unsigned len, unsigned crc);
     void prepend_zero(unsigned len);
 
     reserve_t obtain_contiguous_space(unsigned len);
 
+    void append_zero_static(unsigned len);
+    void append_zero_static_precalc_crc(unsigned len, unsigned crc);
+    
     /*
      * get a char
      */

--- a/src/messages/MOSDPing.h
+++ b/src/messages/MOSDPing.h
@@ -107,14 +107,7 @@ public:
       // we are targeting jumbo ethernet frames around 9000 bytes, 16k should
       // be more than sufficient!  the compiler will statically zero this so
       // that at runtime we are only adding a bufferptr reference to it.
-      static char zeros[16384] = {};
-      while (s > sizeof(zeros)) {
-        payload.append(buffer::create_static(sizeof(zeros), zeros));
-        s -= sizeof(zeros);
-      }
-      if (s) {
-        payload.append(buffer::create_static(s, zeros));
-      }
+      payload.append_zero_static_precalc_crc(s, 0);
     }
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4535,9 +4535,7 @@ int BlueStore::_write_bdev_label(CephContext *cct,
   uint32_t crc = bl.crc32c(-1);
   encode(crc, bl);
   ceph_assert(bl.length() <= BDEV_LABEL_BLOCK_SIZE);
-  bufferptr z(BDEV_LABEL_BLOCK_SIZE - bl.length());
-  z.zero();
-  bl.append(std::move(z));
+  bl.append_zero_static(BDEV_LABEL_BLOCK_SIZE - bl.length());
 
   int fd = TEMP_FAILURE_RETRY(::open(path.c_str(), O_WRONLY|O_CLOEXEC));
   if (fd < 0) {

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -241,7 +241,6 @@ public:
 private:
   string fn;
 
-  char *zero_buf;
   off64_t max_size;
   size_t block_size;
   bool directio, aio, force_aio;
@@ -408,7 +407,6 @@ private:
     completions_lock(
       "FileJournal::completions_lock", false, true, false),
     fn(f),
-    zero_buf(NULL),
     max_size(0), block_size(0),
     directio(dio), aio(ai), force_aio(faio),
     must_write_header(false),
@@ -449,7 +447,6 @@ private:
   }
   ~FileJournal() override {
     ceph_assert(fd == -1);
-    delete[] zero_buf;
     cct->_conf.remove_observer(this);
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6777,9 +6777,7 @@ int OSD::_do_command(
     }
 
     bufferlist bl;
-    bufferptr bp(bsize);
-    bp.zero();
-    bl.push_back(std::move(bp));
+    bl.append_zero(bsize);
     bl.rebuild_page_aligned();
 
     {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -236,9 +236,9 @@ struct PGTempMap {
     using ceph::encode;
     size_t need = sizeof(int32_t) * (1 + v.size());
     if (need < data.get_append_buffer_unused_tail_length()) {
-      ceph::buffer::ptr z(data.get_append_buffer_unused_tail_length());
-      z.zero();
-      data.append(z.c_str(), z.length());
+      bufferlist tmpbl;
+      tmpbl.append_zero_static(data.get_append_buffer_unused_tail_length());
+      data.append(tmpbl.c_str(), tmpbl.length());
     }
     encode(v, data);
     map[pgid] = (int32_t*)(data.back().end_c_str()) - (1 + v.size());


### PR DESCRIPTION
This PR improves different parts of code that use zeroed bufferptrs. Changes include faster calculation of CRC for bufferptrs that consist only of zeros, using static buffer for zeros, duplicate/redundant code removal, etc.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>