### PR TITLE
os/FuseStore: fix incorrect used space statistics for fuse's statfs interface

### DIFF
--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -1103,7 +1103,10 @@ static int os_statfs(const char *path, struct statvfs *stbuf)
   stbuf->f_bsize = 4096;   // LIES!
   stbuf->f_blocks = s.total / 4096;
   stbuf->f_bavail = s.available / 4096;
+  stbuf->f_bfree = stbuf->f_bavail;
 
+  ldout(fs->store->cct, 10) << __func__ << " " << path << ": " 
+    << stbuf->f_bavail << "/" << stbuf->f_blocks << dendl;
   return 0;
 }
 


### PR DESCRIPTION
This may be a regression issue happened on Luminous. It worked fine on Jewel.

After mounting bulestore data path as a fuse mountpoint, `df` displays the incorrect used space.

```
$ ceph-objectstore-tool --op fuse --data-path /var/lib/ceph/osd/ceph-33/ --mountpoint /mnt/test/ --type bluestore
$ df
Filesystem      1K-blocks       Used  Available Use% Mounted on
...
foo            1757709056 1757709056 1702329096  51% /mnt/test
```

The reason is that `statvfs f_bfree` is not set any more on Luminous. So set it as equal to f_bavail for simplify. 
```
$ df
Filesystem      1K-blocks       Used  Available Use% Mounted on
...
foo            1757709056 55426936 1702282120   4% /mnt/test
```

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>