### PR TITLE
msg: Wrong argument passed to read()

### DIFF
--- a/src/msg/simple/Accepter.cc
+++ b/src/msg/simple/Accepter.cc
@@ -295,7 +295,7 @@ void *Accepter::entry()
   ldout(msgr->cct,1) << __func__ << " start" << dendl;
   
   int errors = 0;
-  int ch;
+  char *ch;
 
   struct pollfd pfd[2];
   memset(pfd, 0, sizeof(pfd));
@@ -327,7 +327,7 @@ void *Accepter::entry()
     if (pfd[1].revents & (POLLIN | POLLERR | POLLNVAL | POLLHUP)) {
       // We got "signaled" to exit the poll
       // clean the selfpipe
-      if (::read(shutdown_rd_fd, &ch, 1) == -1) {
+      if (::read(shutdown_rd_fd, ch, 1) == -1) {
         if (errno != EAGAIN)
           ldout(msgr->cct,1) << __func__ << " Cannot read selfpipe: "
  			      << " errno " << errno << " " << cpp_strerror(errno) << dendl;


### PR DESCRIPTION
Fixes the coverity issue:
>CID 1395794 (#1 of 1): Wrong size argument (SIZEOF_MISMATCH)
>suspicious_sizeof: Passing argument &ch of type int * and
>argument 1UL to function read is suspicious because sizeof
>(int) /*4*/ is expected.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>