### PR TITLE
osd: use the sum of max allowed backfill and recovery as max_allowed

### DIFF
--- a/qa/suites/rados/singleton/all/recovery-preemption.yaml
+++ b/qa/suites/rados/singleton/all/recovery-preemption.yaml
@@ -19,6 +19,7 @@ tasks:
         osd recovery sleep: .1
         osd min pg log entries: 100
         osd max pg log entries: 1000
+        osd recovery max active: 20
     log-whitelist:
       - \(POOL_APP_NOT_ENABLED\)
       - \(OSDMAP_FLAGS\)
@@ -43,7 +44,7 @@ tasks:
       - rados -p foo bench 3 write -b 4096 --no-cleanup
       - ceph osd unset noup
       - sleep 10
-      - for f in 0 1 2 3 ; do sudo ceph daemon osd.$f config set osd_recovery_sleep 0 ; sudo ceph daemon osd.$f config set osd_recovery_max_active 20 ; done
+      - for f in 0 1 2 3 ; do sudo ceph daemon osd.$f config set osd_recovery_sleep 0 ; sudo ceph daemon osd.$f config set osd_recovery_max_active 3 ; done
 - ceph.healthy:
 - exec:
     osd.0:

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -831,7 +831,7 @@ public:
     return (ceph_tid_t)last_tid++;
   }
 
-  // -- backfill_reservation --
+  // -- recovery and backfill reservation --
   Finisher reserver_finisher;
   AsyncReserver<spg_t> local_reserver;
   AsyncReserver<spg_t> remote_reserver;


### PR DESCRIPTION
…ax_allowed

also, it would be easier to trigger the preemption of recovery by
decreasing the reserver's max_allowed.

Fixes: http://tracker.ceph.com/issues/22043
Signed-off-by: Kefu Chai <kchai@redhat.com>