### PR TITLE
rgw: add detailed information for radosgw-admin lc list

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3408,7 +3408,7 @@ static int rgw_cls_lc_set_entry(cls_method_context_t hctx, bufferlist *in, buffe
   bufferlist bl;
   encode(op.entry, bl);
 
-  int ret = cls_cxx_map_set_val(hctx, op.entry.first, &bl);
+  int ret = cls_cxx_map_set_val(hctx, op.entry.bucket, &bl);
   return ret;
 }
 
@@ -3424,7 +3424,7 @@ static int rgw_cls_lc_rm_entry(cls_method_context_t hctx, bufferlist *in, buffer
     return -EINVAL;
   }
 
-  int ret = cls_cxx_map_remove_key(hctx, op.entry.first);
+  int ret = cls_cxx_map_remove_key(hctx, op.entry.bucket);
   return ret;
 }
 
@@ -3447,7 +3447,7 @@ static int rgw_cls_lc_get_next_entry(cls_method_context_t hctx, bufferlist *in, 
   if (ret < 0)
     return ret;
   map<string, bufferlist>::iterator it;
-  pair<string, int> entry;
+  cls_rgw_lc_entry entry;
   if (!vals.empty()) {
     it=vals.begin();
     in_iter = it->second.begin();
@@ -3482,7 +3482,7 @@ static int rgw_cls_lc_list_entries(cls_method_context_t hctx, bufferlist *in, bu
   if (ret < 0)
     return ret;
   map<string, bufferlist>::iterator it;
-  pair<string, int> entry;
+  cls_rgw_lc_entry entry;
   for (it = vals.begin(); it != vals.end(); ++it) {
     iter = it->second.begin();
     try {
@@ -3491,7 +3491,7 @@ static int rgw_cls_lc_list_entries(cls_method_context_t hctx, bufferlist *in, bu
     CLS_LOG(1, "ERROR: rgw_cls_lc_list_entries(): failed to decode entry\n");
     return -EIO;
    }
-   op_ret.entries.insert(entry);
+   op_ret.entries.push_back(entry);
   }
   encode(op_ret, *out);
   return 0;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -748,7 +748,7 @@ int cls_rgw_lc_put_head(IoCtx& io_ctx, string& oid, cls_rgw_lc_obj_head& head)
   return r;
 }
 
-int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, string& oid, string& marker, pair<string, int>& entry)
+int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, string& oid, string& marker, cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_get_next_entry_op call;
@@ -770,7 +770,7 @@ int cls_rgw_lc_get_next_entry(IoCtx& io_ctx, string& oid, string& marker, pair<s
  return r;
 }
 
-int cls_rgw_lc_rm_entry(IoCtx& io_ctx, string& oid, pair<string, int>& entry)
+int cls_rgw_lc_rm_entry(IoCtx& io_ctx, string& oid, cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_rm_entry_op call;
@@ -780,7 +780,7 @@ int cls_rgw_lc_rm_entry(IoCtx& io_ctx, string& oid, pair<string, int>& entry)
  return r;
 }
 
-int cls_rgw_lc_set_entry(IoCtx& io_ctx, string& oid, pair<string, int>& entry)
+int cls_rgw_lc_set_entry(IoCtx& io_ctx, string& oid, cls_rgw_lc_entry& entry)
 {
   bufferlist in, out;
   cls_rgw_lc_set_entry_op call;
@@ -793,7 +793,7 @@ int cls_rgw_lc_set_entry(IoCtx& io_ctx, string& oid, pair<string, int>& entry)
 int cls_rgw_lc_list(IoCtx& io_ctx, string& oid,
                     const string& marker,
                     uint32_t max_entries,
-                    map<string, int>& entries)
+                    vector<cls_rgw_lc_entry>& entries)
 {
   bufferlist in, out;
   cls_rgw_lc_list_entries_op op;
@@ -816,7 +816,7 @@ int cls_rgw_lc_list(IoCtx& io_ctx, string& oid,
   } catch (buffer::error& err) {
     return -EIO;
   }
-  entries.insert(ret.entries.begin(),ret.entries.end());
+  entries = ret.entries;
 
  return r;
 }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -520,13 +520,13 @@ void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const list<string>& t
 /* lifecycle */
 int cls_rgw_lc_get_head(librados::IoCtx& io_ctx, string& oid, cls_rgw_lc_obj_head& head);
 int cls_rgw_lc_put_head(librados::IoCtx& io_ctx, string& oid, cls_rgw_lc_obj_head& head);
-int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, string& oid, string& marker, pair<string, int>& entry);
-int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, string& oid, pair<string, int>& entry);
-int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, string& oid, pair<string, int>& entry);
+int cls_rgw_lc_get_next_entry(librados::IoCtx& io_ctx, string& oid, string& marker, cls_rgw_lc_entry& entry);
+int cls_rgw_lc_rm_entry(librados::IoCtx& io_ctx, string& oid, cls_rgw_lc_entry& entry);
+int cls_rgw_lc_set_entry(librados::IoCtx& io_ctx, string& oid, cls_rgw_lc_entry& entry);
 int cls_rgw_lc_list(librados::IoCtx& io_ctx, string& oid,
                     const string& marker,
                     uint32_t max_entries,
-                    map<string, int>& entries);
+                    vector<cls_rgw_lc_entry>& entries);
 
 /* resharding */
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1002,19 +1002,29 @@ struct cls_rgw_lc_get_next_entry_op {
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_next_entry_op)
 
 struct cls_rgw_lc_get_next_entry_ret {
-  pair<string, int> entry;
+  cls_rgw_lc_entry entry;
 
   cls_rgw_lc_get_next_entry_ret() {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
+    pair<string, int> compat_entry = make_pair(entry.bucket, entry.status);
+    encode(compat_entry, bl); 
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(1, bl);
-    decode(entry, bl);
+    DECODE_START(2, bl);
+    pair<string, int> compat_entry;
+    decode(compat_entry, bl);
+    if (struct_v < 2) {
+      entry.bucket = compat_entry.first;
+      entry.status = compat_entry.second;
+    }
+    if (struct_v >= 2) {
+      decode(entry, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -1022,36 +1032,56 @@ struct cls_rgw_lc_get_next_entry_ret {
 WRITE_CLASS_ENCODER(cls_rgw_lc_get_next_entry_ret)
 
 struct cls_rgw_lc_rm_entry_op {
-  pair<string, int> entry;
+  cls_rgw_lc_entry entry;
   cls_rgw_lc_rm_entry_op() {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
+    pair<string, int> compat_entry = make_pair(entry.bucket, entry.status);
+    encode(compat_entry, bl); 
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(1, bl);
-    decode(entry, bl);
+    DECODE_START(2, bl);
+    pair<string, int> compat_entry;
+    decode(compat_entry, bl);
+    if (struct_v < 2) {
+      entry.bucket = compat_entry.first;
+      entry.status = compat_entry.second;
+    }
+    if (struct_v >= 2) {
+      decode(entry, bl);
+    }
     DECODE_FINISH(bl);
   }
 };
 WRITE_CLASS_ENCODER(cls_rgw_lc_rm_entry_op)
 
 struct cls_rgw_lc_set_entry_op {
-  pair<string, int> entry;
+  cls_rgw_lc_entry entry;
   cls_rgw_lc_set_entry_op() {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
+    pair<string, int> compat_entry = make_pair(entry.bucket, entry.status);
+    encode(compat_entry, bl); 
     encode(entry, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(1, bl);
-    decode(entry, bl);
+    DECODE_START(2, bl);
+    pair<string, int> compat_entry;
+    decode(compat_entry, bl);
+    if (struct_v < 2) {
+      entry.bucket = compat_entry.first;
+      entry.status = compat_entry.second;
+    }
+    if (struct_v >= 2) {
+      decode(entry, bl);
+    }
     DECODE_FINISH(bl);
   }
 };
@@ -1122,23 +1152,38 @@ struct cls_rgw_lc_list_entries_op {
 WRITE_CLASS_ENCODER(cls_rgw_lc_list_entries_op)
 
 struct cls_rgw_lc_list_entries_ret {
-  map<string, int> entries;
+  vector<cls_rgw_lc_entry> entries;
   bool is_truncated{false};
 
   cls_rgw_lc_list_entries_ret() {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
-    encode(entries, bl);
+    ENCODE_START(3, 1, bl);
+    map<string, int> compat_entries;
+    for (auto& entry : entries) {
+      compat_entries[entry.bucket] = entry.status;
+    }
+    encode(compat_entries, bl);
     encode(is_truncated, bl);
+    encode(entries, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(2, bl);
-    decode(entries, bl);
+    DECODE_START(3, bl);
+    map<string, int> compat_entries;
+    decode(compat_entries, bl);
+    if (struct_v < 3) {
+      for (auto& compat_entry : compat_entries) {
+        cls_rgw_lc_entry entry(compat_entry.first, compat_entry.second);
+        entries.push_back(entry);
+      }
+    }
     if (struct_v >= 2) {
       decode(is_truncated, bl);
+    }
+    if (struct_v >= 3) {
+      decode(entries, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -629,7 +629,30 @@ void cls_rgw_bucket_instance_entry::generate_test_instances(list<cls_rgw_bucket_
   ls.back()->reshard_status = CLS_RGW_RESHARD_IN_PROGRESS;
   ls.back()->new_bucket_instance_id = "new_instance_id";
 }
-  
+
+const char* LC_STATUS[] = {
+      "UNINITIAL",
+      "PROCESSING",
+      "FAILED",
+      "COMPLETE"
+};
+
+void cls_rgw_lc_entry::dump(Formatter *f) const 
+{
+  encode_json("bucket", bucket, f);
+  string lc_status = LC_STATUS[status];
+  encode_json("status", lc_status, f);
+  encode_json("start_time", utime_t(start_time), f);
+  encode_json("finish_time", utime_t(finish_time), f);
+  encode_json("deleted_count", deleted_count, f);
+  encode_json("aborted_count", aborted_count, f);
+}
+
+void cls_rgw_lc_entry::generate_test_instances(list<cls_rgw_lc_entry*>& ls) 
+{
+  ls.push_back(new cls_rgw_lc_entry("test_bucket"));
+}
+
 void cls_rgw_lc_obj_head::dump(Formatter *f) const 
 {
   encode_json("start_date", start_date, f);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1046,6 +1046,55 @@ struct cls_rgw_gc_obj_info
 };
 WRITE_CLASS_ENCODER(cls_rgw_gc_obj_info)
 
+extern const char* LC_STATUS[];
+
+typedef enum {
+  lc_uninitial = 0,
+  lc_processing,
+  lc_failed,
+  lc_complete,
+} LC_BUCKET_STATUS;
+
+struct cls_rgw_lc_entry
+{
+  string bucket;
+  int status{lc_uninitial};
+  ceph::real_time start_time;
+  ceph::real_time finish_time;
+  uint64_t deleted_count{0};
+  uint64_t aborted_count{0};
+
+  cls_rgw_lc_entry() {}
+  explicit cls_rgw_lc_entry(const string& _bucket) : bucket(_bucket) {}
+  cls_rgw_lc_entry(const string& _bucket, int _status) : bucket(_bucket), status(_status) {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(bucket, bl);
+    encode(status, bl);
+    encode(start_time, bl);
+    encode(finish_time, bl);
+    encode(deleted_count, bl);
+    encode(aborted_count, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START(1, bl);
+    decode(bucket, bl);
+    decode(status, bl);
+    decode(start_time, bl);
+    decode(finish_time, bl);
+    decode(deleted_count, bl);
+    decode(aborted_count, bl);
+    DECODE_FINISH(bl);
+  }
+  
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<cls_rgw_lc_entry*>& ls);
+};
+WRITE_CLASS_ENCODER(cls_rgw_lc_entry)
+
 struct cls_rgw_lc_obj_head
 {
   time_t start_date = 0;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -26,15 +26,6 @@
 static string lc_oid_prefix = "lc";
 static string lc_index_lock_name = "lc_process";
 
-extern const char* LC_STATUS[];
-
-typedef enum {
-  lc_uninitial = 0,
-  lc_processing,
-  lc_failed,
-  lc_complete,
-}LC_BUCKET_STATUS;
-
 class LCExpiration
 {
 protected:
@@ -372,10 +363,10 @@ class RGWLC {
   int process();
   int process(int index, int max_secs);
   bool if_already_run_today(time_t& start_date);
-  int list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map);
+  int list_lc_progress(const string& marker, uint32_t max_entries, vector<cls_rgw_lc_entry> *progress_vec);
   int bucket_lc_prepare(int index);
-  int bucket_lc_process(string& shard_id);
-  int bucket_lc_post(int index, int max_lock_sec, pair<string, int >& entry, int& result);
+  int bucket_lc_process(string& shard_id, uint64_t* delected_count, uint64_t* aborted_count);
+  int bucket_lc_post(int index, int max_lock_sec, cls_rgw_lc_entry& entry, int& result);
   bool going_down();
   void start_processor();
   void stop_processor();
@@ -383,7 +374,8 @@ class RGWLC {
   private:
   int remove_expired_obj(RGWBucketInfo& bucket_info, rgw_obj_key obj_key, bool remove_indeed = true);
   bool obj_has_expired(ceph::real_time mtime, int days);
-  int handle_multipart_expiration(RGWRados::Bucket *target, const map<string, lc_op>& prefix_map);
+  int handle_multipart_expiration(RGWRados::Bucket *target, const map<string, lc_op>& prefix_map, 
+                                  uint64_t* aborted_count);
 };
 
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4897,7 +4897,7 @@ void RGWPutLC::execute()
   string shard_id = s->bucket.tenant + ':' + s->bucket.name + ':' + s->bucket.bucket_id;  
   string oid; 
   get_lc_oid(s, oid);
-  pair<string, int> entry(shard_id, lc_uninitial);
+  cls_rgw_lc_entry entry(shard_id, lc_uninitial);
   int max_lock_secs = s->cct->_conf->rgw_lc_lock_max_time;
   rados::cls::lock::Lock l(lc_index_lock_name); 
   utime_t time(max_lock_secs, 0);
@@ -4937,7 +4937,7 @@ void RGWDeleteLC::execute()
     return;
   }
   string shard_id = s->bucket.tenant + ':' + s->bucket.name + ':' + s->bucket.bucket_id;
-  pair<string, int> entry(shard_id, lc_uninitial);
+  cls_rgw_lc_entry entry(shard_id, lc_uninitial);
   string oid; 
   get_lc_oid(s, oid);
   int max_lock_secs = s->cct->_conf->rgw_lc_lock_max_time;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -12759,9 +12759,9 @@ int RGWRados::process_gc(bool expired_only)
   return gc->process(expired_only);
 }
 
-int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map)
+int RGWRados::list_lc_progress(const string& marker, uint32_t max_entries, vector<cls_rgw_lc_entry> *entries)
 {
-  return lc->list_lc_progress(marker, max_entries, progress_map);
+  return lc->list_lc_progress(marker, max_entries, entries);
 }
 
 int RGWRados::process_lc()

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3594,7 +3594,7 @@ public:
   int defer_gc(void *ctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj);
 
   int process_lc();
-  int list_lc_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map);
+  int list_lc_progress(const string& marker, uint32_t max_entries, vector<cls_rgw_lc_entry> *entries);
   
   int bucket_check_index(RGWBucketInfo& bucket_info,
                          map<RGWObjCategory, RGWStorageStats> *existing_stats,


### PR DESCRIPTION
Add start_time, finish_time, deleted_count and aborted_count for
radosgw-admin lc list, so we can know at which time the bucket's
lifecycle starts to process, at which time the process has finished
and how many objects have been deleted.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>