### PR TITLE
rbd: disk usage on empty pool no longer returns an error message

### DIFF
--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -208,7 +208,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
       ++count;
     }
   }
-  if (!found) {
+  if (imgname != nullptr && !found) {
     std::cerr << "specified image " << imgname << " is not found." << std::endl;
     return -ENOENT;
   }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22200
Signed-off-by: Jason Dillaman <dillaman@redhat.com>