### PR TITLE
luminous: bluestore: OSD crash on boot with assert caused by Bluefs on flush write

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1760,9 +1760,15 @@ static std::atomic_flag buffer_debug_lock = ATOMIC_FLAG_INIT;
   }
   
   bool buffer::list::rebuild_aligned_size_and_memory(unsigned align_size,
-  						   unsigned align_memory)
+						    unsigned align_memory,
+						    unsigned max_buffers)
   {
     unsigned old_memcopy_count = _memcopy_count;
+
+    if (max_buffers && _buffers.size() > max_buffers
+	&& _len > (max_buffers * align_size)) {
+      align_size = ROUND_UP_TO(ROUND_UP_TO(_len, max_buffers) / max_buffers, align_size);
+    }
     std::list<ptr>::iterator p = _buffers.begin();
     while (p != _buffers.end()) {
       // keep anything that's already align and sized aligned

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -781,8 +781,11 @@ namespace buffer CEPH_BUFFER_API {
     void rebuild();
     void rebuild(ptr& nb);
     bool rebuild_aligned(unsigned align);
+    // max_buffers = 0 mean don't care _buffers.size(), other
+    // must make _buffers.size() <= max_buffers after rebuilding.
     bool rebuild_aligned_size_and_memory(unsigned align_size,
-					 unsigned align_memory);
+					 unsigned align_memory,
+					 unsigned max_buffers = 0);
     bool rebuild_page_aligned();
 
     void reserve(size_t prealloc);

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -580,7 +580,7 @@ int KernelDevice::write(
   assert(off + len <= size);
 
   if ((!buffered || bl.get_num_buffers() >= IOV_MAX) &&
-      bl.rebuild_aligned_size_and_memory(block_size, block_size)) {
+      bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
   dout(40) << "data: ";
@@ -607,7 +607,7 @@ int KernelDevice::aio_write(
   assert(off + len <= size);
 
   if ((!buffered || bl.get_num_buffers() >= IOV_MAX) &&
-      bl.rebuild_aligned_size_and_memory(block_size, block_size)) {
+      bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
   dout(40) << "data: ";


### PR DESCRIPTION
http://tracker.ceph.com/issues/22193