### PR TITLE
luminous: mgr[zabbix] float division by zero (osd['kb'] = 0)

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -174,6 +174,8 @@ class Module(MgrModule):
 
         osd_stats = self.get('osd_stats')
         for osd in osd_stats['osd_stats']:
+            if osd['kb'] == 0:
+                continue
             osd_fill.append((float(osd['kb_used']) / float(osd['kb'])) * 100)
             osd_apply_latency.append(osd['perf_stat']['apply_latency_ms'])
             osd_commit_latency.append(osd['perf_stat']['commit_latency_ms'])


### PR DESCRIPTION
http://tracker.ceph.com/issues/22196