### PR TITLE
luminous: MDSMonitor: monitor gives constant "is now active in filesystem cephfs as rank" cluster log info messages

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -755,20 +755,20 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
            << ceph_mds_state_name(state) << dendl;
       return true;
     } else {
-      // Made it through special cases and validations, record the
-      // daemon's reported state to the FSMap.
-      pending_fsmap.modify_daemon(gid, [state, seq](MDSMap::mds_info_t *info) {
-        info->state = state;
-        info->state_seq = seq;
-      });
-
-      if (state == MDSMap::STATE_ACTIVE) {
+      if (info.state != MDSMap::STATE_ACTIVE && state == MDSMap::STATE_ACTIVE) {
         auto fscid = pending_fsmap.mds_roles.at(gid);
         auto fs = pending_fsmap.get_filesystem(fscid);
         mon->clog->info() << info.human_name() << " is now active in "
                           << "filesystem " << fs->mds_map.fs_name << " as rank "
                           << info.rank;
       }
+
+      // Made it through special cases and validations, record the
+      // daemon's reported state to the FSMap.
+      pending_fsmap.modify_daemon(gid, [state, seq](MDSMap::mds_info_t *info) {
+        info->state = state;
+        info->state_seq = seq;
+      });
     }
   }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/22192