### PR TITLE
common/config: with_val

### DIFF
--- a/src/common/config.h
+++ b/src/common/config.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_CONFIG_H
 #define CEPH_CONFIG_H
 
+#include "common/backport14.h"
 #include "common/ConfUtils.h"
 #include "common/entity_name.h"
 #include "common/code_environment.h"
@@ -165,6 +166,13 @@ public:
   int _get_val(const std::string &key, char **buf, int len) const;
   Option::value_t get_val_generic(const std::string &key) const;
   template<typename T> const T get_val(const std::string &key) const;
+  template<typename T, typename Callback, typename...Args>
+  auto with_val(const string& key, Callback&& cb, Args&&... args) const ->
+    ceph::result_of_t<Callback(const T&, Args...)> {
+    return std::forward<Callback>(cb)(
+      boost::get<T>(this->get_val_generic(key)),
+      std::forward<Args>(args)...);
+  }
 
   void get_all_keys(std::vector<std::string> *keys) const;
 

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -423,11 +423,18 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
 	     << bloom_bits << dendl;
     bbt_opts.filter_policy.reset(rocksdb::NewBloomFilterPolicy(bloom_bits));
   }
-  if (g_conf->get_val<std::string>("rocksdb_index_type") == "binary_search")
+  using std::placeholders::_1;
+  if (g_conf->with_val<std::string>("rocksdb_index_type",
+				    std::bind(std::equal_to<std::string>(), _1,
+					      "binary_search")))
     bbt_opts.index_type = rocksdb::BlockBasedTableOptions::IndexType::kBinarySearch;
-  if (g_conf->get_val<std::string>("rocksdb_index_type") == "hash_search")
+  if (g_conf->with_val<std::string>("rocksdb_index_type",
+				    std::bind(std::equal_to<std::string>(), _1,
+					      "hash_search")))
     bbt_opts.index_type = rocksdb::BlockBasedTableOptions::IndexType::kHashSearch;
-  if (g_conf->get_val<std::string>("rocksdb_index_type") == "two_level")
+  if (g_conf->with_val<std::string>("rocksdb_index_type",
+				    std::bind(std::equal_to<std::string>(), _1,
+					      "two_level")))
     bbt_opts.index_type = rocksdb::BlockBasedTableOptions::IndexType::kTwoLevelIndexSearch;
   bbt_opts.cache_index_and_filter_blocks = 
       g_conf->get_val<bool>("rocksdb_cache_index_and_filter_blocks");

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -342,27 +342,38 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
   if (g_conf->rocksdb_separate_wal_dir) {
     opt.wal_dir = path + ".wal";
   }
-  if (g_conf->get_val<std::string>("rocksdb_db_paths").length()) {
-    list<string> paths;
-    get_str_list(g_conf->get_val<std::string>("rocksdb_db_paths"), "; \t", paths);
-    for (auto& p : paths) {
-      size_t pos = p.find(',');
-      if (pos == std::string::npos) {
-	derr << __func__ << " invalid db path item " << p << " in "
-	     << g_conf->get_val<std::string>("rocksdb_db_paths") << dendl;
-	return -EINVAL;
-      }
-      string path = p.substr(0, pos);
-      string size_str = p.substr(pos + 1);
-      uint64_t size = atoll(size_str.c_str());
-      if (!size) {
-	derr << __func__ << " invalid db path item " << p << " in "
-	     << g_conf->get_val<std::string>("rocksdb_db_paths") << dendl;
-	return -EINVAL;
-      }
-      opt.db_paths.push_back(rocksdb::DbPath(path, size));
-      dout(10) << __func__ << " db_path " << path << " size " << size << dendl;
-    }
+
+  // Since ceph::for_each_substr doesn't return a value and
+  // std::stoull does throw, we may as well just catch everything here.
+  try {
+    g_conf->with_val<std::string>(
+      "rocksdb_db_paths", [&opt, this](const std::string& paths) {
+	ceph::for_each_substr(
+	  paths, "; \t",
+	  [&paths, &opt, this](boost::string_view s) {
+	    size_t pos = s.find(',');
+	    if (pos == std::string::npos) {
+	      derr << __func__ << " invalid db path item " << s << " in "
+		   << paths << dendl;
+	      throw std::system_error(std::make_error_code(
+					std::errc::invalid_argument));
+	    }
+	    // And we have to use string because RocksDB doesn't know any better.
+	    auto path = string(s.substr(0, pos));
+	    auto size = std::stoull(string(s.substr(pos + 1)));
+	    if (!size) {
+	      derr << __func__ << " invalid db path item " << s << " in "
+		   << g_conf->get_val<std::string>("rocksdb_db_paths") << dendl;
+	      throw std::system_error(std::make_error_code(
+					std::errc::invalid_argument));
+	    }
+	    opt.db_paths.push_back(rocksdb::DbPath(path, size));
+	    dout(10) << __func__ << " db_path " << path << " size " << size
+		     << dendl;
+	  });
+      });
+  } catch (const std::system_error& e) {
+    return -e.code().value();
   }
 
   if (g_conf->rocksdb_log_to_ceph_log) {

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -481,6 +481,6 @@ static void _list_modules(
 
 void PyModuleRegistry::list_modules(std::set<std::string> *modules)
 {
-  _list_modules(g_conf->get_val<std::string>("mgr_module_path"), modules);
+  g_conf->with_val<std::string>("mgr_module_path",
+				&_list_modules, modules);
 }
-

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5457,9 +5457,11 @@ int OSDMonitor::parse_erasure_code_profile(const vector<string> &erasure_code_pr
 					   map<string,string> *erasure_code_profile_map,
 					   ostream *ss)
 {
-  int r = get_json_str_map(g_conf->get_val<string>("osd_pool_default_erasure_code_profile"),
-		           *ss,
-		           erasure_code_profile_map);
+  int r = g_conf->with_val<string>("osd_pool_default_erasure_code_profile",
+				   get_json_str_map,
+				   *ss,
+				   erasure_code_profile_map,
+				   true);
   if (r)
     return r;
   assert((*erasure_code_profile_map).count("plugin"));

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -159,11 +159,16 @@ AsyncConnection::~AsyncConnection()
 void AsyncConnection::maybe_start_delay_thread()
 {
   if (!delay_state) {
-    auto pos = async_msgr->cct->_conf->get_val<std::string>("ms_inject_delay_type").find(ceph_entity_type_name(peer_type));
-    if (pos != string::npos) {
-      ldout(msgr->cct, 1) << __func__ << " setting up a delay queue" << dendl;
-      delay_state = new DelayedDelivery(async_msgr, center, dispatch_queue, conn_id);
-    }
+    async_msgr->cct->_conf->with_val<std::string>(
+      "ms_inject_delay_type",
+      [this](const string& s) {
+	if (s.find(ceph_entity_type_name(peer_type)) != string::npos) {
+	  ldout(msgr->cct, 1) << __func__ << " setting up a delay queue"
+			      << dendl;
+	  delay_state = new DelayedDelivery(async_msgr, center, dispatch_queue,
+					    conn_id);
+	}
+      });
   }
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4785,8 +4785,10 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
     options = cct->_conf->bluestore_rocksdb_options;
 
     map<string,string> cf_map;
-    get_str_map(cct->_conf->get_val<string>("bluestore_rocksdb_cfs"), &cf_map,
-		" \t");
+    cct->_conf->with_val<string>("bluestore_rocksdb_cfs",
+                                 get_str_map,
+                                 &cf_map,
+                                 " \t");
     for (auto& i : cf_map) {
       dout(10) << "column family " << i.first << ": " << i.second << dendl;
       cfs.push_back(KeyValueDB::ColumnFamily(i.first, i.second));

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4727,8 +4727,11 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
       env->CreateDir(fn);
       if (cct->_conf->rocksdb_separate_wal_dir)
 	env->CreateDir(fn + ".wal");
-      if (cct->_conf->get_val<std::string>("rocksdb_db_paths").length())
-	env->CreateDir(fn + ".slow");
+
+      if (cct->_conf->with_val<std::string>(
+            "rocksdb_db_paths", [](const std::string& s) {
+              return s.length(); }))
+        env->CreateDir(fn + ".slow");
     }
   } else if (create) {
     int r = ::mkdir(fn.c_str(), 0755);

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -218,7 +218,7 @@ void RGWFormatter_Plain::write_data(const char *fmt, ...)
 done:
 #define LARGE_ENOUGH_BUF 4096
   if (!buf) {
-    max_len = max(LARGE_ENOUGH_BUF, size);
+    max_len = ceph::max(LARGE_ENOUGH_BUF, size);
     buf = (char *)malloc(max_len);
     if (!buf) {
       cerr << "ERROR: RGWFormatter_Plain::write_data: failed allocating " << max_len << " bytes" << std::endl;

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -82,7 +82,7 @@ public:
 
   void append(uint64_t ofs, const OldObjManifestPart& part) {
     objs[ofs] = part;
-    obj_size = max(obj_size, ofs + part.size);
+    obj_size = ceph::max(obj_size, ofs + part.size);
   }
 
   void encode(bufferlist& bl) const {


### PR DESCRIPTION
Minor performance patch. Since we can't return references to strings in `md_config_t`, let people call functions against string references under the lock. That way we can avoid copying an entire string just to find its length.