### PR TITLE
rgw: fix RGWLibIO did not init RGWEnv

### DIFF
--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -63,7 +63,9 @@ namespace rgw {
     RGWLibIO(const RGWUserInfo &_user_info)
       : user_info(_user_info) {}
 
-    void init_env(CephContext *cct) override {}
+    void init_env(CephContext *cct) override {
+      env.init(cct);
+    }
 
     const RGWUserInfo& get_user() {
       return user_info;


### PR DESCRIPTION
enable_ops_log and enable_usage_log was init in RGWEnv.init

Signed-off-by: Tianshan Qu <tianshan@xsky.com>