### PR TITLE
tests: ceph-disk: ignore E722 in flake8 test

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -25,4 +25,4 @@ commands = coverage run --append --source=ceph_disk {envbindir}/py.test -vv {tox
            coverage report --show-missing
 
 [testenv:flake8]
-commands = flake8 --ignore=H105,H405,E127 ceph_disk tests
+commands = flake8 --ignore=H105,H405,E127,E722 ceph_disk tests


### PR DESCRIPTION
Very old, and very new, versions of flake8 treat E722 as an error:

```
flake8 runtests: commands[0] | flake8 --ignore=H105,H405,E127 ceph_disk tests
ceph_disk/main.py:1575:9: E722 do not use bare except'
ceph_disk/main.py:1582:9: E722 do not use bare except'
ceph_disk/main.py:3252:5: E722 do not use bare except'
ceph_disk/main.py:3288:21: E722 do not use bare except'
ceph_disk/main.py:3296:17: E722 do not use bare except'
ceph_disk/main.py:4358:5: E722 do not use bare except'
tests/test_main.py:26:1: E722 do not use bare except'
ERROR: InvocationError: '/opt/j/ws/mkck/src/ceph-disk/.tox/flake8/bin/flake8 --ignore=H105,H405,E127 ceph_disk tests'
```

Fixes: http://tracker.ceph.com/issues/22207
References: https://gitlab.com/pycqa/flake8/issues/361

Signed-off-by: Nathan Cutler <ncutler@suse.com>