### PR TITLE
mds: Print error messages when _handle_command() returns error

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -823,18 +823,19 @@ int MDSDaemon::_handle_command(
     cpu_profiler_handle_command(argvec, ds);
   } else {
     // Give MDSRank a shot at the command
-    if (mds_rank) {
+    if (!mds_rank) {
+      ss << "MDS not active";
+      r = -EINVAL;
+    }
+    else {
       bool handled = mds_rank->handle_command(cmdmap, m, &r, &ds, &ss,
 					      need_reply);
-      if (handled) {
-        goto out;
+      if (!handled) {
+        // MDSDaemon doesn't know this command
+        ss << "unrecognized command! " << prefix;
+        r = -EINVAL;
       }
     }
-
-    // Neither MDSDaemon nor MDSRank know this command
-    std::ostringstream ss;
-    ss << "unrecognized command! " << prefix;
-    r = -EINVAL;
   }
 
 out:

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -962,10 +962,10 @@ cdef class LibCephFS(object):
             char *_inbuf = input_data
             size_t _inbuf_len = len(input_data)
 
-            char *_outbuf
-            size_t _outbuf_len
-            char *_outs
-            size_t _outs_len
+            char *_outbuf = NULL
+            size_t _outbuf_len = 0
+            char *_outs = NULL
+            size_t _outs_len = 0
 
         try:
             with nogil:
@@ -974,15 +974,12 @@ cdef class LibCephFS(object):
                                        <const char*>_inbuf, _inbuf_len,
                                        &_outbuf, &_outbuf_len,
                                        &_outs, &_outs_len)
-            if ret == 0:
-                my_outs = decode_cstr(_outs[:_outs_len])
-                my_outbuf = _outbuf[:_outbuf_len]
-                if _outs_len:
-                    ceph_buffer_free(_outs)
-                if _outbuf_len:
-                    ceph_buffer_free(_outbuf)
-                return (ret, my_outbuf, my_outs)
-            else:
-                return (ret, b"", "")
+            my_outs = decode_cstr(_outs[:_outs_len])
+            my_outbuf = _outbuf[:_outbuf_len]
+            if _outs_len:
+                ceph_buffer_free(_outs)
+            if _outbuf_len:
+                ceph_buffer_free(_outbuf)
+            return (ret, my_outbuf, my_outs)
         finally:
             free(_cmd)


### PR DESCRIPTION
Print error messages when _handle_command() returns error values. Also given appropriate error message when mds is not active.

Fixes: http://tracker.ceph.com/issues/21991
Signed-off-by: Jos Collin <jcollin@redhat.com>