### PR TITLE
luminous: rgw: check going_down() when lifecycle processing

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -311,6 +311,8 @@ int RGWLC::handle_multipart_expiration(RGWRados::Bucket *target, const map<strin
             ldout(cct, 0) << "ERROR: abort_multipart_upload failed, ret=" << ret <<dendl;
             return ret;
           }
+          if (going_down())
+            return 0;
         }
       }
     } while(is_truncated);
@@ -414,6 +416,9 @@ int RGWLC::bucket_lc_process(string& shard_id)
             } else {
               ldout(cct, 10) << "DELETED:" << bucket_name << ":" << key << dendl;
             }
+
+            if (going_down())
+              return 0;
           }
         }
       } while (is_truncated);
@@ -517,6 +522,9 @@ int RGWLC::bucket_lc_process(string& shard_id)
             } else {
               ldout(cct, 10) << "DELETED:" << bucket_name << ":" << obj_iter->key << dendl;
             }
+
+            if (going_down())
+              return 0;
           }
         }
       } while (is_truncated);


### PR DESCRIPTION
http://tracker.ceph.com/issues/22177