### PR TITLE
luminous: qa/workunits: silence py warnings for ceph-disk tests

### DIFF
--- a/qa/workunits/ceph-disk/ceph-disk.sh
+++ b/qa/workunits/ceph-disk/ceph-disk.sh
@@ -35,7 +35,7 @@ if ! ${PYTHON} -m pytest --version > /dev/null 2>&1; then
     exit 1
 fi
 
-sudo env PATH=$(dirname $0):$(dirname $0)/..:$PATH ${PYTHON} -m pytest -s -v $(dirname $0)/ceph-disk-test.py
+sudo env PATH=$(dirname $0):$(dirname $0)/..:$PATH PYTHONWARNINGS=ignore ${PYTHON} -m pytest -s -v $(dirname $0)/ceph-disk-test.py
 result=$?
 
 sudo rm -f /lib/udev/rules.d/60-ceph-by-partuuid.rules


### PR DESCRIPTION
http://tracker.ceph.com/issues/22212

ceph-disk now prints "depreacted" warning message when it starts. but
the tests parses its stdout and stderr for a json string. so we need to
silence the warnings for the tests.

Fixes: http://tracker.ceph.com/issues/22154
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit d44334f31704487ec3574738e75145872d9932cf)