### PR TITLE
msg/simple: pass a char for reading from shutdown_rd_fd

### DIFF
--- a/src/msg/simple/Accepter.cc
+++ b/src/msg/simple/Accepter.cc
@@ -295,7 +295,6 @@ void *Accepter::entry()
   ldout(msgr->cct,1) << __func__ << " start" << dendl;
   
   int errors = 0;
-  int ch;
 
   struct pollfd pfd[2];
   memset(pfd, 0, sizeof(pfd));
@@ -327,7 +326,8 @@ void *Accepter::entry()
     if (pfd[1].revents & (POLLIN | POLLERR | POLLNVAL | POLLHUP)) {
       // We got "signaled" to exit the poll
       // clean the selfpipe
-      if (::read(shutdown_rd_fd, &ch, 1) == -1) {
+      char ch;
+      if (::read(shutdown_rd_fd, &ch, sizeof(ch)) == -1) {
         if (errno != EAGAIN)
           ldout(msgr->cct,1) << __func__ << " Cannot read selfpipe: "
  			      << " errno " << errno << " " << cpp_strerror(errno) << dendl;
@@ -379,8 +379,8 @@ void Accepter::stop()
     return;
 
   // Send a byte to the shutdown pipe that the thread is listening to
-  char buf[1] = { 0x0 };
-  int ret = safe_write(shutdown_wr_fd, buf, 1);
+  char ch = 0x0;
+  int ret = safe_write(shutdown_wr_fd, &ch, sizeof(ch));
   if (ret < 0) {
     ldout(msgr->cct,1) << __func__ << "close failed: "
              << " errno " << errno << " " << cpp_strerror(errno) << dendl;


### PR DESCRIPTION
Fixes the coverity issue:

> CID 1395794 (#1 of 1): Wrong size argument (SIZEOF_MISMATCH)
> suspicious_sizeof: Passing argument &ch of type int * and
> argument 1UL to function read is suspicious because sizeof
> (int) /*4*/ is expected.

Signed-off-by: Kefu Chai <kchai@redhat.com>