### PR TITLE
qa: add simple and dirty script to find ports being used

### DIFF
--- a/qa/find-used-ports.sh
+++ b/qa/find-used-ports.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+git --no-pager grep -n '127.0.0.1:[0-9]\+' | sed -n 's/.*127.0.0.1:\([0-9]\+\).*/\1/p' | sort -n | uniq -u


### PR DESCRIPTION
Seriously, having this is way better than realizing that one needs to
find an unused port each time a new test is created.

It's far from a perfect script. It's downright not elegant.

Signed-off-by: Joao Eduardo Luis `<joao@suse.de>`