### PR TITLE
mgr/zabbix: set default parameters zabbix_port, zabbix_sender, interval

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -86,14 +86,23 @@ class Module(MgrModule):
         self.event = Event()
 
     def init_module_config(self):
+        firste = None
         for key, default in self.config_keys.items():
-            value = self.get_localized_config(key, default)
-            if value is None:
-                raise RuntimeError('Configuration key {0} not set; "ceph '
+            try:
+                value = self.get_localized_config(key, default)
+                if value is not None:
+                    self.set_config_option(key, value)
+                if value is None:
+                    raise RuntimeError('Configuration key {0} not set; "ceph '
                                    'config-key set mgr/zabbix/{0} '
                                    '<value>"'.format(key))
+            except Exception as e:
+                if firste is None:
+                   firste = e
+                continue
 
-            self.set_config_option(key, value)
+        if firste is not None:
+           raise firste
 
     def set_config_option(self, option, value):
         if option not in self.config_keys.keys():


### PR DESCRIPTION
According the wiki ,'Additional configuration keys which can be configured and their default values:

zabbix_port: 10051
zabbix_sender: /usr/bin/zabbix_sender
interval: 60
'
But on master,these three key cannot got default value
Set defaule parameters zabbix_port, zabbix_sender, interval when zabbix module init

Signed-off-by: baul <roidinev@gmail.com>