### PR TITLE
rgw: fix issues in bucket policy of SourceIp

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -1038,7 +1038,7 @@ optional<MaskedIP> Condition::as_network(const string& s) {
     return none;
   }
 
-  m.v6 = s.find(':');
+  m.v6 = (s.find(':') == string::npos) ? false : true;
   auto slash = s.find('/');
   if (slash == string::npos) {
     m.prefix = m.v6 ? 128 : 32;
@@ -1061,7 +1061,7 @@ optional<MaskedIP> Condition::as_network(const string& s) {
 
   if (m.v6) {
     struct sockaddr_in6 a;
-    if (inet_pton(AF_INET6, p->c_str(), static_cast<void*>(&a)) != 1) {
+    if (inet_pton(AF_INET6, p->c_str(), &(a.sin6_addr)) != 1) {
       return none;
     }
 
@@ -1083,13 +1083,13 @@ optional<MaskedIP> Condition::as_network(const string& s) {
     m.addr |= Address(a.sin6_addr.s6_addr[15]) << 120;
   } else {
     struct sockaddr_in a;
-    if (inet_pton(AF_INET, p->c_str(), static_cast<void*>(&a)) != 1) {
+    if (inet_pton(AF_INET, p->c_str(), &(a.sin_addr)) != 1) {
       return none;
     }
     m.addr = ntohl(a.sin_addr.s_addr);
   }
 
-  return none;
+  return m;
 }
 
 namespace {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -603,7 +603,7 @@ rgw::IAM::Environment rgw_build_iam_environment(RGWRados* store,
     e.emplace("aws:SecureTransport", "true");
   }
 
-  i = m.find("HTTP_HOST");
+  i = m.find("REMOTE_ADDR");
   if (i != m.end()) {
     e.emplace("aws:SourceIp", i->second);
   }


### PR DESCRIPTION
* Restricting access to specific ip addresses is not working because of
* the following issues:
     1. 'aws:SourceIp' corresponds to REMOTE_ADDR, not HTTP_HOST;
     2. Function 'Condition::as_network' has several bugs.

Signed-off-by: Bingyin Zhang <zhangbingyin@cloudin.cn>