### PR TITLE
OSD: add get_mapped_pools asok command

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1944,6 +1944,8 @@ public:
     return pg_map.size();
   }
 
+  std::set<int> get_mapped_pools();
+
 protected:
   PG   *_open_lock_pg(OSDMapRef createmap,
 		      spg_t pg, bool no_lockdep_check=false);


### PR DESCRIPTION
get_mapped_pools will return all pool_id that
mapped to the paticular OSD.

It is super useful for monitoring system that want to
**group** OSDs based on application. PoolID is a nature
grouping tag to be attached to OSDs.

Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>