### PR TITLE
mon/PGMap: calculate %used based on usable used and avail, not raw

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -847,7 +847,7 @@ void PGMapDigest::dump_object_stat_sum(
   float used = 0.0;
   if (avail) {
     used = sum.num_bytes * curr_object_copies_rate;
-    used /= used + avail;
+    used /= used + avail / raw_used_rate;
   } else if (sum.num_bytes) {
     used = 1.0;
   }

--- a/src/test/mon/PGMap.cc
+++ b/src/test/mon/PGMap.cc
@@ -79,7 +79,7 @@ TEST(pgmap, dump_object_stat_sum_0)
     (static_cast<float>(sum.num_object_copies - sum.num_objects_degraded) /
      sum.num_object_copies);
   float used_bytes = sum.num_bytes * copies_rate;
-  float used_percent = used_bytes / (used_bytes + avail) * 100;
+  float used_percent = used_bytes / (used_bytes + avail / pool.size) * 100;
   unsigned col = 0;
   ASSERT_EQ(stringify(si_t(sum.num_bytes)), tbl.get(0, col++));
   ASSERT_EQ(percentify(used_percent), tbl.get(0, col++));


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22232

Signed-off-by: Jan Fajerski <jfajerski@suse.com>