### PR TITLE
osd/PG: Update blocked_by with _update_calc_stats

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -780,7 +780,6 @@ OPTION(osd_force_recovery_pg_log_entries_factor, OPT_FLOAT) // max entries facto
 OPTION(osd_pg_log_trim_min, OPT_U32)
 OPTION(osd_op_complaint_time, OPT_FLOAT) // how many seconds old makes an op complaint-worthy
 OPTION(osd_command_max_records, OPT_INT)
-OPTION(osd_max_pg_blocked_by, OPT_U32)    // max peer osds to report that are blocking our progress
 OPTION(osd_op_log_threshold, OPT_INT) // how many op log messages to show in one go
 OPTION(osd_verify_sparse_read_holes, OPT_BOOL)  // read fiemap-reported holes and verify they are zeros
 OPTION(osd_backoff_on_unfound, OPT_BOOL)   // object unfound

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2679,7 +2679,7 @@ std::vector<Option> get_global_options() {
 
     Option("osd_max_pg_blocked_by", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(16)
-    .set_description(""),
+    .set_description("max peer osds to report that are blocking our progress"),
 
     Option("osd_op_log_threshold", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(5)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2752,13 +2752,16 @@ void PG::_update_calc_stats()
     info.stats.stats.sum.num_objects_unfound = get_num_unfound();
     info.stats.stats.sum.num_objects_misplaced = misplaced;
   }
+
+  _update_blocked_by();
 }
 
 void PG::_update_blocked_by()
 {
-  // set a max on the number of blocking peers we report. if we go
-  // over, report a random subset.  keep the result sorted.
-  unsigned keep = MIN(blocked_by.size(), cct->_conf->osd_max_pg_blocked_by);
+  // set a max on the number of blocking peers (16 by default)  we report. if we
+  // go over, report a random subset.  keep the result sorted.
+  unsigned keep = MIN(blocked_by.size(),
+    cct->_conf->get_val<uint64_t>("osd_max_pg_blocked_by"));
   unsigned skip = blocked_by.size() - keep;
   info.stats.blocked_by.clear();
   info.stats.blocked_by.resize(keep);
@@ -2810,7 +2813,6 @@ void PG::publish_stats_to_osd()
   }
 
   _update_calc_stats();
-  _update_blocked_by();
 
   pg_stat_t pre_publish = info.stats;
   pre_publish.stats.add(unstable_stats);


### PR DESCRIPTION
It would be better to update blocked_by info with PG info stats always.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>