### PR TITLE
qa/workunits/rados/test-upgrade-11.0.0: skip LibRadosMiscECPP.CompareExtentRange

### DIFF
--- a/qa/workunits/rados/test-upgrade-v11.0.0.sh
+++ b/qa/workunits/rados/test-upgrade-v11.0.0.sh
@@ -17,7 +17,7 @@ for f in \
     'api_list --gtest_filter=-LibRadosList*.EnumerateObjects*:*ListObjectsError*' \
     'api_io --gtest_filter=-*Checksum*:*CmpExt*' \
     api_lock \
-    'api_misc --gtest_filter=-*WriteSame*:*CmpExt*:*Checksum*:*CloneRange*' \
+    'api_misc --gtest_filter=-*WriteSame*:*CmpExt*:*Compare*:*Checksum*:*CloneRange*' \
     'api_watch_notify --gtest_filter=-*WatchNotify3*' \
     api_tier api_pool api_snapshots api_stat api_cmd \
     'api_c_write_operations --gtest_filter=-*WriteSame*:*CmpExt*' \


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>