### PR TITLE
rgw: remove needless judgement in generator::create_begin.

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2160,14 +2160,7 @@ int RGWObjManifest::generator::create_begin(CephContext *cct, RGWObjManifest *_m
     return -EIO;
   }
 
-  uint64_t head_size = manifest->get_head_size();
-
-  if (head_size > 0) {
-    cur_stripe_size = head_size;
-  } else {
-    cur_stripe_size = rule.stripe_max_size;
-  }
-  
+  cur_stripe_size = rule.stripe_max_size;
   cur_part_id = rule.start_part_num;
 
   manifest->get_implicit_location(cur_part_id, cur_stripe, 0, NULL, &cur_obj);


### PR DESCRIPTION
The head size is always zero. It has been set in:
 `manifest->set_head(placement_rule, _obj, 0);`

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>