### PR TITLE
cls/rgw: trim all usage entries in cls_rgw

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2952,17 +2952,13 @@ static int usage_iterate_range(cls_method_context_t hctx, uint64_t start, uint64
 
     if (!by_user && key.compare(end_key) >= 0) {
       CLS_LOG(20, "usage_iterate_range reached key=%s, done", key.c_str());
-      if (truncated_status) {
-        key_iter = key;
-      }
+      key_iter = key;
       return 0;
     }
 
     if (by_user && key.compare(0, user_key.size(), user_key) != 0) {
       CLS_LOG(20, "usage_iterate_range reached key=%s, done", key.c_str());
-      if (truncated_status) {
-        key_iter = key;
-      }
+      key_iter = key;
       return 0;
     }
 
@@ -3077,6 +3073,9 @@ int rgw_user_usage_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlis
   ret = usage_iterate_range(hctx, op.start_epoch, op.end_epoch, op.user, iter, MAX_USAGE_TRIM_ENTRIES, &more, usage_log_trim_cb, NULL);
   if (ret < 0)
     return ret;
+
+  if (!more && iter.empty())
+    return -ENODATA;
 
   return 0;
 }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -503,7 +503,7 @@ int cls_rgw_usage_log_read(librados::IoCtx& io_ctx, string& oid, string& user,
                            string& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage,
                            bool *is_truncated);
 
-void cls_rgw_usage_log_trim(librados::ObjectWriteOperation& op, string& user,
+int cls_rgw_usage_log_trim(librados::IoCtx& io_ctx, const string& oid, string& user,
                            uint64_t start_epoch, uint64_t end_epoch);
 
 void cls_rgw_usage_log_add(librados::ObjectWriteOperation& op, rgw_usage_log_info& info);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5123,16 +5123,12 @@ int RGWRados::trim_usage(rgw_user& user, uint64_t start_epoch, uint64_t end_epoc
   usage_log_hash(cct, user_str, first_hash, index);
 
   hash = first_hash;
-
   do {
     int ret =  cls_obj_usage_log_trim(hash, user_str, start_epoch, end_epoch);
-    if (ret == -ENOENT)
-      goto next;
 
-    if (ret < 0)
+    if (ret < 0 && ret != -ENOENT)
       return ret;
 
-next:
     usage_log_hash(cct, user_str, hash, ++index);
   } while (hash != first_hash);
 
@@ -12881,10 +12877,7 @@ int RGWRados::cls_obj_usage_log_trim(string& oid, string& user, uint64_t start_e
     return r;
   }
 
-  ObjectWriteOperation op;
-  cls_rgw_usage_log_trim(op, user, start_epoch, end_epoch);
-
-  r = ref.ioctx.operate(ref.oid, &op);
+  r = cls_rgw_usage_log_trim(ref.ioctx, ref.oid, user, start_epoch, end_epoch);
   return r;
 }
 

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -629,6 +629,47 @@ TEST(cls_rgw, gc_defer)
   ASSERT_EQ(0, destroy_one_pool_pp(gc_pool_name, rados));
 }
 
+TEST(cls_rgw, usage_basic)
+{
+  string oid="usage.1";
+  string user="user1";
+  uint64_t start_epoch{0}, end_epoch{(uint64_t) -1};
+  constexpr auto total_usage_entries = 512;
+  uint64_t max_entries = 2000;
+
+  rgw_usage_log_info info;
+
+  for (int i=0; i < total_usage_entries; i++){
+    auto bucket = str_int("bucket", i);
+    string p; // we are not testing bucket payer here
+    info.entries.emplace_back(rgw_usage_log_entry(user, p, bucket));
+  }
+  ObjectWriteOperation op;
+  cls_rgw_usage_log_add(op, info);
+  ASSERT_EQ(0, ioctx.operate(oid, &op));
+
+  string read_iter;
+  map <rgw_user_bucket, rgw_usage_log_entry> usage, usage2;
+  bool truncated;
+
+
+  int ret = cls_rgw_usage_log_read(ioctx, oid, user, start_epoch, end_epoch,
+				   max_entries, read_iter, usage, &truncated);
+  // read the entries, and see that we have all the added entries
+  ASSERT_EQ(0, ret);
+  ASSERT_FALSE(truncated);
+  ASSERT_EQ(total_usage_entries, usage.size());
+
+  // delete and read to assert that we've deleted all the values
+  ASSERT_EQ(0, cls_rgw_usage_log_trim(ioctx, oid, user, start_epoch, end_epoch));
+
+
+  ret = cls_rgw_usage_log_read(ioctx, oid, user, start_epoch, end_epoch,
+			       max_entries, read_iter, usage2, &truncated);
+  ASSERT_EQ(0, ret);
+  ASSERT_EQ(0, usage2.size());
+
+}
 
 /* must be last test! */
 


### PR DESCRIPTION
Currently trim usage will only trim upto 128 omap entries, since we need
to run this in a loop until we're done, actually make the cls return
-ENODATA so that we know when to stop the loop (inspired by a similar
call in cls_log) this involves the following changes

* return -ENODATA when iterate entries goes through and the value of
  iter (which is set as the last value of key when succeeded)
* use IoCtx for calling the loop from within cls rather than in rgw
* drop the goto call in rgw_rados since we can return once we're done
  processing

Fixes: http://tracker.ceph.com/issues/22234

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>