### PR TITLE
jewel: ceph-disk flake8 test fails on very old, and very new, versions of flake8

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -20,4 +20,4 @@ commands = coverage run --append --source=ceph_disk {envbindir}/py.test -vv test
            coverage report --omit=*test*,*tox* --show-missing
 
 [testenv:flake8]
-commands = flake8 --ignore=H105,H405,E127 ceph_disk tests
+commands = flake8 --ignore=H105,H405,E127,E722 ceph_disk tests


### PR DESCRIPTION
http://tracker.ceph.com/issues/22236