### PR TITLE
rgw: no need to deal with md5 header in get_data.

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1157,9 +1157,6 @@ int RGWPutObj_ObjStore::get_data(bufferlist& bl)
     return -ERR_TOO_LARGE;
   }
 
-  if (!ofs)
-    supplied_md5_b64 = s->info.env->get("HTTP_CONTENT_MD5");
-
   return len;
 }
 


### PR DESCRIPTION
supplied_md5_b64 has been initiated in RGWPutObj_ObjStore::get_params().

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>