### PR TITLE
osd/PG: [cleanup] Moves max to local variable like min

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4507,14 +4507,17 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	   * left end of the range if we are a tier because they may legitimately
 	   * not exist (see _scrub).
 	   */
-	  int min = MAX(3, cct->_conf->osd_scrub_chunk_min);
+	  int min = MAX(3, (int)cct->_conf->get_val<int64_t>(
+            "osd_scrub_chunk_min"));
+          int max = MAX(min, (int)cct->_conf->get_val<int64_t>(
+            "osd_scrub_chunk_max"));
           hobject_t start = scrubber.start;
 	  hobject_t candidate_end;
 	  vector<hobject_t> objects;
 	  ret = get_pgbackend()->objects_list_partial(
 	    start,
 	    min,
-	    MAX(min, cct->_conf->osd_scrub_chunk_max),
+	    max,
 	    &objects,
 	    &candidate_end);
 	  assert(ret >= 0);


### PR DESCRIPTION
 1.Create a new local variable for max
 2.Switch to new style config option
  - osd_scrub_chunk_min

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>