### PR TITLE
common:  RAII-styled mechanism for updating PerfCounters

### DIFF
--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -352,6 +352,24 @@ private:
 };
 
 
+class PerfGuard {
+  const ceph::real_clock::time_point start;
+  PerfCounters* const counters;
+  const int event;
+
+public:
+  PerfGuard(PerfCounters* const counters,
+            const int event)
+  : start(ceph::real_clock::now()),
+    counters(counters),
+    event(event) {
+  }
+
+  ~PerfGuard() {
+    counters->tinc(event, ceph::real_clock::now() - start);
+  }
+};
+
 
 class PerfCountersDeleter {
   CephContext* cct;


### PR DESCRIPTION
There are many places in e.g. BlueStore making use of the PerfCounters infrastructure. However, measuring  elapsed time and updating appropriate counter is made without any sugar and takes more code reader's attention than necessary, I think.

It might be useful to handle this common activity similarly to taking a mutex with the assistance of mutex guards. For instance:

```cpp
  // read raw blob data.  use aio if we have >1 blobs to read.
  {
    PerfGuard(logger, l_bluestore_read_wait_aio_lat);

    IOContext ioc(cct, nullptr, true);
    for (auto& p : blobs2read) {
      p.second->issue_io(...);
    }

    if (ioc.has_pending_aios()) {
      bdev->aio_submit(&ioc);
      ioc.aio_wait();

      // ...
    }
  }

```

The commit is a part of the BlueStore's read path rework. I'm sending it separately to get feedback earlier.