### PR TITLE
luminous: ceph-disk flake8 test fails on very old, and very new, versions of flake8

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -25,4 +25,4 @@ commands = coverage run --append --source=ceph_disk {envbindir}/py.test -vv {tox
            coverage report --show-missing
 
 [testenv:flake8]
-commands = flake8 --ignore=H105,H405,E127 ceph_disk tests
+commands = flake8 --ignore=H105,H405,E127,E722 ceph_disk tests


### PR DESCRIPTION
http://tracker.ceph.com/issues/22235