### PR TITLE
blkin: Fix unconditional tracing in OSD

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1042,7 +1042,7 @@ void ReplicatedBackend::issue_op(
       op_t,
       peer,
       pinfo);
-    if (op->op)
+    if (op->op && op->op->pg_trace)
       wr->trace.init("replicated op", nullptr, &op->op->pg_trace);
     get_parent()->send_message_osd_cluster(
       peer.osd, wr, get_osdmap()->get_epoch());


### PR DESCRIPTION
Blkin trace will be triggered unconditionally at OSD `issue_op`, even if
op->pg_trace is not initialized. This issue introduces unnecessary
overhead and confusing tracing records when blkin tracing is ON.

Signed-off-by: Yingxin <yingxin.cheng@intel.com>