### PR TITLE
osd/PG.cc: delay calculating pg_stats till flushing

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7087,11 +7087,14 @@ MPGStats* OSD::collect_pg_stats()
       continue;
     }
 
+    pg->lock();
+    pg->prepare_stats();
     pg->get_pg_stats([&](const pg_stat_t& s, epoch_t lec) {
 	m->pg_stat[pg->pg_id.pgid] = s;
 	min_last_epoch_clean = min(min_last_epoch_clean, lec);
 	min_last_epoch_clean_pgs.push_back(pg->pg_id.pgid);
       });
+    pg->unlock();
   }
 
   return m;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -315,8 +315,6 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   backfill_reserved(false),
   backfill_reserving(false),
   flushes_in_progress(0),
-  pg_stats_publish_lock("PG::pg_stats_publish_lock"),
-  pg_stats_publish_valid(false),
   finish_sync_event(NULL),
   backoff_lock("PG::backoff_lock"),
   scrub_after_recovery(false),
@@ -2775,12 +2773,10 @@ void PG::_update_blocked_by()
   }
 }
 
-void PG::publish_stats_to_osd()
+void PG::prepare_stats()
 {
-  if (!is_primary())
+  if (!is_primary() || !pg_stats_publish_valid) // save us some effort
     return;
-
-  pg_stats_publish_lock.Lock();
 
   if (info.stats.stats.sum.num_scrub_errors)
     state_set(PG_STATE_INCONSISTENT);
@@ -2845,15 +2841,11 @@ void PG::publish_stats_to_osd()
     dout(15) << "publish_stats_to_osd " << pg_stats_publish.reported_epoch
 	     << ":" << pg_stats_publish.reported_seq << dendl;
   }
-  pg_stats_publish_lock.Unlock();
 }
 
-void PG::clear_publish_stats()
+void PG::publish_stats_to_osd()
 {
-  dout(15) << "clear_stats" << dendl;
-  pg_stats_publish_lock.Lock();
-  pg_stats_publish_valid = false;
-  pg_stats_publish_lock.Unlock();
+  pg_stats_publish_valid = true;
 }
 
 /**
@@ -5327,9 +5319,7 @@ void PG::start_peering_interval(
     info.stats.mapping_epoch = osdmap->get_epoch();
   }
 
-  pg_stats_publish_lock.Lock();
   pg_stats_publish_valid = false;
-  pg_stats_publish_lock.Unlock();
 
   // This will now be remapped during a backfill in cases
   // that it would not have been before.
@@ -5447,7 +5437,7 @@ void PG::start_peering_interval(
     // did primary change?
     if (was_old_primary != is_primary()) {
       state_clear(PG_STATE_CLEAN);
-      clear_publish_stats();
+      pg_stats_publish_valid = false;
     }
 
     on_role_change();
@@ -8491,11 +8481,9 @@ void PG::dump_missing(Formatter *f)
 
 void PG::get_pg_stats(std::function<void(const pg_stat_t&, epoch_t lec)> f)
 {
-  pg_stats_publish_lock.Lock();
   if (pg_stats_publish_valid) {
     f(pg_stats_publish, pg_stats_publish.get_effective_last_epoch_clean());
   }
-  pg_stats_publish_lock.Unlock();
 }
 
 void PG::with_heartbeat_peers(std::function<void(int)> f)

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -467,6 +467,7 @@ public:
   void dump_pgstate_history(Formatter *f);
   void dump_missing(Formatter *f);
 
+  void prepare_stats();
   void get_pg_stats(std::function<void(const pg_stat_t&, epoch_t lec)> f);
   void with_heartbeat_peers(std::function<void(int)> f);
 
@@ -1210,14 +1211,12 @@ protected:
   object_stat_collection_t unstable_stats;
 
   // publish stats
-  Mutex pg_stats_publish_lock;
-  bool pg_stats_publish_valid;
+  std::atomic<bool> pg_stats_publish_valid = {false};
   pg_stat_t pg_stats_publish;
 
   void _update_calc_stats();
   void _update_blocked_by();
   void publish_stats_to_osd();
-  void clear_publish_stats();
 
   void clear_primary_state();
 


### PR DESCRIPTION
I believe this is good for performance, especially for normal
read/write paths.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>