### PR TITLE
qa/suites/upgrade/jewel-x/point-to-point: skip ec tests when mons may be old

### DIFF
--- a/qa/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
@@ -161,7 +161,7 @@ workload_x:
        branch: jewel
        clients:
          client.1:
-         - rados/test-upgrade-v11.0.0.sh
+         - rados/test-upgrade-v11.0.0-noec.sh
          - cls
        env:
          CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.mirror_image'
@@ -170,7 +170,7 @@ workload_x:
        branch: jewel
        clients:
          client.0:
-         - rados/test-upgrade-v11.0.0.sh
+         - rados/test-upgrade-v11.0.0-noec.sh
          - cls
    - print: "**** done rados/test-upgrade-v11.0.0.sh &  cls workload_x upgraded client"
    - rgw: [client.1]


### PR DESCRIPTION
Early point release mons don't handle legacy ruleset-* ec profiles, new
ones do.  Skip the ec tests that may trigger this when we are doing a
workload that races with mon upgrades.

Signed-off-by: Sage Weil <sage@redhat.com>