### PR TITLE
rgw: silence warning from -Wmaybe-uninitialized

### DIFF
--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -347,7 +347,7 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
                     std::vector<std::string> *status)
 {
   status->clear();
-  boost::optional<size_t> num_shards;
+  boost::optional<size_t> num_shards{0};
   for (auto peer = first; peer != last; ++peer) {
     const size_t peer_shards = peer->size();
     if (!num_shards) {


### PR DESCRIPTION
Found in Jenkins build.

Fixes:
```
/home/jenkins-build/build/workspace/ceph-pull-requests/src/rgw/rgw_sync_log_trim.cc:356:12: warning: ‘*((void*)& num_shards +8)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     } else if (*num_shards != peer_shards) {
```
Signed-off-by: Jos Collin <jcollin@redhat.com>