### PR TITLE
mon/MgrMonitor: limit mgrmap history

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1139,6 +1139,10 @@ std::vector<Option> get_global_options() {
     .set_default(500)
     .set_description(""),
 
+    Option("mon_max_mgrmap_epochs", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(500)
+    .set_description(""),
+
     Option("mon_max_osd", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(10000)
     .set_description(""),

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -41,6 +41,15 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon,
 const static std::string command_descs_prefix = "mgr_command_descs";
 
 
+version_t MgrMonitor::get_trim_to()
+{
+  int64_t max = g_conf->get_val<int64_t>("mon_max_mgrmap_epochs");
+  if (map.epoch > max) {
+    return map.epoch - max;
+  }
+  return 0;
+}
+
 void MgrMonitor::create_initial()
 {
   // Take a local copy of initial_modules for tokenizer to iterate over.

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -78,6 +78,8 @@ public:
 
   bool in_use() const { return map.epoch > 0; }
 
+  version_t get_trim_to() override;
+
   void create_initial() override;
   void get_store_prefixes(std::set<string>& s) override;
   void update_from_paxos(bool *need_bootstrap) override;


### PR DESCRIPTION
http://tracker.ceph.com/issues/22258

Keep 500 by default (like we do osdmaps and mdsmaps).

Fixes: http://tracker.ceph.com/issues/22257
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 00fa8b10990f945f3e875c9850eedeb65af3fd2e)