### PR TITLE
librbd: Add a function to list image watchers

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -204,6 +204,12 @@ typedef struct {
   time_t deferment_end_time;
 } rbd_trash_image_info_t;
 
+typedef struct {
+  char *addr;
+  int64_t id;
+  uint64_t cookie;
+} rbd_image_watcher_t;
+
 CEPH_RBD_API void rbd_image_options_create(rbd_image_options_t* opts);
 CEPH_RBD_API void rbd_image_options_destroy(rbd_image_options_t opts);
 CEPH_RBD_API int rbd_image_options_set_string(rbd_image_options_t opts,
@@ -870,6 +876,29 @@ CEPH_RBD_API int rbd_update_watch(rbd_image_t image, uint64_t *handle,
  */
 CEPH_RBD_API int rbd_update_unwatch(rbd_image_t image, uint64_t handle);
 
+/**
+ * List any watchers of an image.
+ *
+ * Watchers will be allocated and stored in the passed watchers array. If there
+ * are more watchers than max_watchers, -ERANGE will be returned and the number
+ * of watchers will be stored in max_watchers.
+ *
+ * The caller should call rbd_watchers_list_cleanup when finished with the list
+ * of watchers.
+ *
+ * @param image the image to list watchers for.
+ * @param watchers an array to store watchers in.
+ * @param max_watchers capacity of the watchers array.
+ * @returns 0 on success, negative error code on failure.
+ * @returns -ERANGE if there are too many watchers for the passed array.
+ * @returns the number of watchers in max_watchers.
+ */
+CEPH_RBD_API int rbd_watchers_list(rbd_image_t image,
+				   rbd_image_watcher_t *watchers,
+				   size_t *max_watchers);
+
+CEPH_RBD_API void rbd_watchers_list_cleanup(rbd_image_watcher_t *watchers,
+					    size_t num_watchers);
 
 CEPH_RBD_API int rbd_group_image_add(
 				rados_ioctx_t group_p, const char *group_name,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -108,6 +108,12 @@ namespace librbd {
     bool trash;
   } child_info_t;
 
+  typedef struct {
+    std::string addr;
+    int64_t id;
+    uint64_t cookie;
+  } image_watcher_t;
+
 class CEPH_RBD_API RBD
 {
 public:
@@ -475,6 +481,8 @@ public:
 
   int update_watch(UpdateWatchCtx *ctx, uint64_t *handle);
   int update_unwatch(uint64_t handle);
+
+  int list_watchers(std::list<image_watcher_t> &watchers);
 
 private:
   friend class RBD;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2356,7 +2356,35 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
     }
   }
 
+  int list_watchers(ImageCtx *ictx,
+		    std::list<librbd::image_watcher_t> &watchers)
+  {
+    int r;
+    std::string header_oid;
+    std::list<obj_watch_t> obj_watchers;
 
+    if (ictx->old_format) {
+      header_oid = ictx->name + RBD_SUFFIX;
+    } else {
+      header_oid = RBD_HEADER_PREFIX + ictx->id;
+    }
+
+    r = ictx->md_ctx.list_watchers(header_oid, &obj_watchers);
+    if (r < 0) {
+      return r;
+    }
+
+    for (auto i = obj_watchers.begin(); i != obj_watchers.end(); ++i) {
+      librbd::image_watcher_t watcher;
+      watcher.addr = i->addr;
+      watcher.id = i->watcher_id;
+      watcher.cookie = i->cookie;
+
+      watchers.push_back(watcher);
+    }
+
+    return 0;
+  }
 
 }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2364,9 +2364,9 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
     std::list<obj_watch_t> obj_watchers;
 
     if (ictx->old_format) {
-      header_oid = ictx->name + RBD_SUFFIX;
+      header_oid = util::old_header_name(ictx->name);
     } else {
-      header_oid = RBD_HEADER_PREFIX + ictx->id;
+      header_oid = util::header_name(ictx->id);
     }
 
     r = ictx->md_ctx.list_watchers(header_oid, &obj_watchers);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -170,6 +170,7 @@ namespace librbd {
   int metadata_list(ImageCtx *ictx, const string &last, uint64_t max, map<string, bufferlist> *pairs);
   int metadata_get(ImageCtx *ictx, const std::string &key, std::string *value);
 
+  int list_watchers(ImageCtx *ictx, std::list<librbd::image_watcher_t> &watchers);
 }
 
 std::ostream &operator<<(std::ostream &os, const librbd::ImageOptions &opts);

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -154,6 +154,11 @@ cdef extern from "rbd/librbd.h" nogil:
         time_t deletion_time
         time_t deferment_end_time
 
+    ctypedef struct rbd_image_watcher_t:
+        char *addr
+        int64_t id
+        uint64_t cookie
+
     ctypedef void (*rbd_callback_t)(rbd_completion_t cb, void *arg)
     ctypedef int (*librbd_progress_fn_t)(uint64_t offset, uint64_t total, void* ptr)
 
@@ -348,6 +353,11 @@ cdef extern from "rbd/librbd.h" nogil:
     int rbd_metadata_list(rbd_image_t image, const char *start, uint64_t max,
                           char *keys, size_t *key_len, char *values,
                           size_t *vals_len)
+
+    int rbd_watchers_list(rbd_image_t image, rbd_image_watcher_t *watchers,
+                          size_t *max_watchers)
+    void rbd_watchers_list_cleanup(rbd_image_watcher_t *watchers,
+                                   size_t num_watchers)
 
 RBD_FEATURE_LAYERING = _RBD_FEATURE_LAYERING
 RBD_FEATURE_STRIPINGV2 = _RBD_FEATURE_STRIPINGV2
@@ -2755,6 +2765,16 @@ written." % (self.name, ret, length))
         """
         return MetadataIterator(self)
 
+
+    def watchers_list(self):
+        """
+        List image watchers.
+
+        :returns: :class:`WatcherIterator`
+        """
+        return WatcherIterator(self)
+
+
 cdef class LockOwnerIterator(object):
     """
     Iterator over managed lock owners for an image
@@ -3026,3 +3046,50 @@ cdef class ChildIterator(object):
         if self.children:
             rbd_list_children_cleanup(self.children, self.num_children)
             free(self.children)
+
+cdef class WatcherIterator(object):
+    """
+    Iterator over watchers of an image.
+
+    Yields a dictionary containing information about a watcher.
+
+    Keys are:
+
+    * ``addr`` (str) - address of the watcher
+
+    * ``id`` (int) - id of the watcher
+
+    * ``cookie`` (int) - the watcher's cookie
+    """
+
+    cdef rbd_image_watcher_t *watchers
+    cdef size_t num_watchers
+    cdef object image
+
+    def __init__(self, Image image):
+        self.image = image
+        self.watchers = NULL
+        self.num_watchers = 10
+        while True:
+            self.watchers = <rbd_image_watcher_t*>realloc_chk(self.watchers,
+                                                              self.num_watchers *
+                                                              sizeof(rbd_image_watcher_t))
+            with nogil:
+                ret = rbd_watchers_list(image.image, self.watchers, &self.num_watchers)
+            if ret >= 0:
+                break
+            elif ret != -errno.ERANGE:
+                raise make_ex(ret, 'error listing watchers.')
+
+    def __iter__(self):
+        for i in range(self.num_watchers):
+            yield {
+                'addr'   : decode_cstr(self.watchers[i].addr),
+                'id'     : self.watchers[i].id,
+                'cookie' : self.watchers[i].cookie
+                }
+
+    def __dealloc__(self):
+        if self.watchers:
+            rbd_watchers_list_cleanup(self.watchers, self.num_watchers)
+            free(self.watchers)

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -6497,6 +6497,33 @@ TEST_F(TestLibRBD, TestTrashMoveAndRestore) {
   ASSERT_TRUE(found);
 }
 
+TEST_F(TestLibRBD, TestListWatchers) {
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
+
+  librbd::RBD rbd;
+  std::string name = get_temp_image_name();
+
+  uint64_t size = 1 << 18;
+  int order = 12;
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, name.c_str(), size, &order));
+
+  librbd::Image image;
+  std::list<librbd::image_watcher_t> watchers;
+
+  // No watchers
+  ASSERT_EQ(0, rbd.open_read_only(ioctx, image, name.c_str(), nullptr));
+  ASSERT_EQ(0, image.list_watchers(watchers));
+  ASSERT_EQ(0, watchers.size());
+  ASSERT_EQ(0, image.close());
+
+  // One watcher
+  ASSERT_EQ(0, rbd.open(ioctx, image, name.c_str(), nullptr));
+  ASSERT_EQ(0, image.list_watchers(watchers));
+  ASSERT_EQ(1, watchers.size());
+  ASSERT_EQ(0, image.close());
+}
+
 // poorman's assert()
 namespace ceph {
   void __ceph_assert_fail(const char *assertion, const char *file, int line,

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -854,6 +854,12 @@ class TestImage(object):
             metadata = list(self.image.metadata_list())
             eq(len(metadata), N - i - 1)
 
+    def test_watchers_list(self):
+        watchers = list(self.image.watchers_list())
+        # The image is open (in r/w mode) from setup, so expect there to be one
+        # watcher.
+        eq(len(watchers), 1)
+
 def check_diff(image, offset, length, from_snapshot, expected):
     extents = []
     def cb(offset, length, exists):

--- a/src/tools/rbd/action/Status.cc
+++ b/src/tools/rbd/action/Status.cc
@@ -17,32 +17,12 @@ namespace status {
 namespace at = argument_types;
 namespace po = boost::program_options;
 
-static int do_show_status(librados::IoCtx &io_ctx, librbd::Image &image,
-                          const char *imgname, Formatter *f)
+static int do_show_status(librbd::Image &image, Formatter *f)
 {
-  uint8_t old_format;
   int r;
-  std::string header_oid;
-  std::list<obj_watch_t> watchers;
+  std::list<librbd::image_watcher_t> watchers;
 
-  r = image.old_format(&old_format);
-  if (r < 0)
-    return r;
-
-  if (old_format) {
-    header_oid = imgname;
-    header_oid += RBD_SUFFIX;
-  } else {
-    std::string id;
-    r = image.get_id(&id);
-    if (r < 0) {
-      return r;
-    }
-
-    header_oid = RBD_HEADER_PREFIX + id;
-  }
-
-  r = io_ctx.list_watchers(header_oid, &watchers);
+  r = image.list_watchers(watchers);
   if (r < 0)
     return r;
 
@@ -51,21 +31,20 @@ static int do_show_status(librados::IoCtx &io_ctx, librbd::Image &image,
 
   if (f) {
     f->open_array_section("watchers");
-    for (std::list<obj_watch_t>::iterator i = watchers.begin(); i != watchers.end(); ++i) {
+    for (auto &watcher : watchers) {
       f->open_object_section("watcher");
-      f->dump_string("address", i->addr);
-      f->dump_unsigned("client", i->watcher_id);
-      f->dump_unsigned("cookie", i->cookie);
+      f->dump_string("address", watcher.addr);
+      f->dump_unsigned("client", watcher.id);
+      f->dump_unsigned("cookie", watcher.cookie);
       f->close_section();
     }
     f->close_section();
   } else {
     if (watchers.size()) {
       std::cout << "Watchers:" << std::endl;
-      for (std::list<obj_watch_t>::iterator i = watchers.begin();
-           i != watchers.end(); ++i) {
-        std::cout << "\twatcher=" << i->addr << " client." << i->watcher_id
-                  << " cookie=" << i->cookie << std::endl;
+      for (auto &watcher : watchers) {
+        std::cout << "\twatcher=" << watcher.addr << " client." << watcher.id
+                  << " cookie=" << watcher.cookie << std::endl;
       }
     } else {
       std::cout << "Watchers: none" << std::endl;
@@ -112,7 +91,7 @@ int execute(const po::variables_map &vm) {
     return r;
   }
 
-  r = do_show_status(io_ctx, image, image_name.c_str(), formatter.get());
+  r = do_show_status(image, formatter.get());
   if (r < 0) {
     std::cerr << "rbd: show status failed: " << cpp_strerror(r) << std::endl;
     return r;

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -2530,3 +2530,39 @@ TRACEPOINT_EVENT(librbd, image_get_group_exit,
         ctf_integer(int, retval, retval)
     )
 )
+
+TRACEPOINT_EVENT(librbd, list_watchers_enter,
+    TP_ARGS(
+        void*, imagectx,
+        const char*, name,
+        const char*, snap_name,
+        char, read_only),
+    TP_FIELDS(
+        ctf_integer_hex(void*, imagectx, imagectx)
+        ctf_string(name, name)
+        ctf_string(snap_name, snap_name)
+        ctf_integer(char, read_only, read_only)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, list_watchers_entry,
+    TP_ARGS(
+        const char*, addr,
+        int64_t, id,
+        uint64_t, cookie),
+    TP_FIELDS(
+        ctf_string(addr, addr)
+        ctf_integer(int64_t, id, id)
+        ctf_integer(uint64_t, cookie, cookie)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, list_watchers_exit,
+    TP_ARGS(
+        int, retval,
+        size_t, num_watchers),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+        ctf_integer(size_t, num_watchers, num_watchers)
+    )
+)


### PR DESCRIPTION
Currently the only way to see an image's watchers is the `rbd status` command. Add a function to the librbd API that provides the same information, and refactor `rbd status` to use the API call.