### PR TITLE
common: fix RWLock set perfer_writer not work

### DIFF
--- a/src/common/RWLock.h
+++ b/src/common/RWLock.h
@@ -42,7 +42,7 @@ public:
   RWLock(const std::string &n, bool track_lock=true, bool ld=true, bool prioritize_write=false)
     : name(n), id(-1), track(track_lock),
       lockdep(ld) {
-#if defined(PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP)
+#if !defined(__FreeBSD__) && !defined(__APPLE__)
     if (prioritize_write) {
       pthread_rwlockattr_t attr;
       pthread_rwlockattr_init(&attr);


### PR DESCRIPTION
PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP is defined as enum in pthread.h,
the check will never be true.

Signed-off-by: Tianshan Qu <tianshan@xsky.com>