### PR TITLE
ceph-disk: fix signed integer is greater than maximum when call major

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -150,6 +150,13 @@ PTYPE = {
     },
 }
 
+try:
+    # see https://bugs.python.org/issue23098
+    os.major(0x80002b00)
+except OverflowError:
+    os.major = lambda devid: ((devid >> 8) & 0xfff) | ((devid >> 32) & ~0xfff)
+    os.minor = lambda devid: (devid & 0xff) | ((devid >> 12) & ~0xff)
+
 
 class Ptype(object):
 


### PR DESCRIPTION
  fix signed integer is greater than maximum when call os.major
  using python 2.7.5 in Centos 7
  
  when calling os.major  in block_path, it may broken due to already exist bugs in python 2.7.5 [1].
   
  As you see, this bug has been fixed in python after 2.7.14 (also teseted in my enviroment),  just   upgradeing python is Ok.
  but when i think 2.7.5 is largely used in Centos 7,  upgrading could have influenced to other applications.
  
  so i think implementing os.major and os.minor like major and minor in glibc [2] mayb be a good idea.
  
  but i'm not sure that if there is any other problems? please take a review, thanks

  [1] Dan MacDonald told me that "os.mknod()" should accept devices >32 bits.
       https://bugs.python.org/issue23098
  [2] https://github.com/lattera/glibc/blob/master/sysdeps/unix/sysv/linux/sys/sysmacros.h

Signed-off-by: Song Shun <song.shun3@zte.com.cn>