### PR TITLE
luminous: qa/ceph-disk: enlarge the simulated SCSI disk

### DIFF
--- a/qa/workunits/ceph-disk/ceph-disk-test.py
+++ b/qa/workunits/ceph-disk/ceph-disk-test.py
@@ -113,7 +113,7 @@ class CephDisk:
         LOG.debug(self.unused_disks('sd.'))
         if self.unused_disks('sd.'):
             return
-        modprobe = "modprobe scsi_debug vpd_use_hostno=0 add_host=1 dev_size_mb=200 ; udevadm settle"
+        modprobe = "modprobe scsi_debug vpd_use_hostno=0 add_host=1 dev_size_mb=300 ; udevadm settle"
         try:
             self.sh(modprobe)
         except:


### PR DESCRIPTION
backport of #19199

100MB will be allocated for journal, and the remaining 100MB is for data
device. taking the inode into consideration, there will be approximately
87988 kB available for the activated OSD. and it will complain with a
"nearfull" state.

Fixes: http://tracker.ceph.com/issues/22136
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit b3c159e9fb8c31d0acd75f0702080f18959f672e)