### PR TITLE
githubmap: Add ktdreyer

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -26,6 +26,7 @@ ivancich J. Eric Ivancich <ivancich@redhat.com>
 jcsp John Spray <john.spray@redhat.com>
 jlayton Jeff Layton <jlayton@redhat.com>
 joscollin Jos Collin <jcollin@redhat.com>
+ktdreyer Ken Dreyer <kdreyer@redhat.com>
 leseb Sébastien Han <seb@redhat.com>
 liewegas Sage Weil <sage@redhat.com>
 liupan1111 Pan Liu <liupan1111@gmail.com>


### PR DESCRIPTION
Added ktdreyer to .githubmap. Found during the merge of https://github.com/ceph/ceph/pull/19172.

Signed-off-by: Jos Collin <jcollin@redhat.com>