### PR TITLE
qa/suites/rados/singleton: more whitelist

### DIFF
--- a/qa/suites/rados/singleton/all/osd-recovery.yaml
+++ b/qa/suites/rados/singleton/all/osd-recovery.yaml
@@ -20,6 +20,7 @@ tasks:
       - \(OSD_
       - \(PG_
       - \(OBJECT_DEGRADED\)
+      - \(SLOW_OPS\)
     conf:
       osd:
         osd min pg log entries: 5

--- a/qa/suites/rados/singleton/all/thrash-eio.yaml
+++ b/qa/suites/rados/singleton/all/thrash-eio.yaml
@@ -29,6 +29,7 @@ tasks:
     - \(REQUEST_SLOW\)
     - \(SLOW_OPS\)
     - \(PG_
+    - \(OBJECT_MISPLACED\)
     - \(OSD_
 - thrashosds:
     op_delay: 30


### PR DESCRIPTION
* SLOW_OPS is normal in a cluster with flattering OSDs
* so is OBJECT_MISPLACED.

Signed-off-by: Kefu Chai <kchai@redhat.com>