### PR TITLE
osd/ECBackend.cc: prevent a assert when decode buffer is empty

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2264,7 +2264,7 @@ struct CallClientContexts :
 	ec->ec_impl,
 	to_decode,
 	&bl);
-      if (r < 0) {
+      if (r < 0 || bl.length() == 0) {
         res.r = r;
         goto out;
       }


### PR DESCRIPTION
In this situation, it is better to finish read io than cause a assert in
result.insert().

Signed-off-by: tangwenjun <tang.wenjun3@zte.com.cn>