### PR TITLE
osd/mClockOpClassSupport: Use get_val<> to get configs values

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -657,23 +657,6 @@ OPTION(osd_op_queue, OPT_STR)
 
 OPTION(osd_op_queue_cut_off, OPT_STR) // Min priority to go to strict queue. (low, high)
 
-// mClock priority queue parameters for five types of ops
-OPTION(osd_op_queue_mclock_client_op_res, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_client_op_wgt, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_client_op_lim, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_osd_rep_op_res, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_osd_rep_op_wgt, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_osd_rep_op_lim, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_snap_res, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_snap_wgt, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_snap_lim, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_recov_res, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_recov_wgt, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_recov_lim, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_scrub_res, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_scrub_wgt, OPT_DOUBLE)
-OPTION(osd_op_queue_mclock_scrub_lim, OPT_DOUBLE)
-
 OPTION(osd_ignore_stale_divergent_priors, OPT_BOOL) // do not assert on divergent_prior entries which aren't in the log and whose on-disk objects are newer
 
 // Set to true for testing.  Users should NOT set this.

--- a/src/osd/mClockOpClassSupport.cc
+++ b/src/osd/mClockOpClassSupport.cc
@@ -24,21 +24,26 @@ namespace ceph {
   namespace mclock {
 
     OpClassClientInfoMgr::OpClassClientInfoMgr(CephContext *cct) :
-      client_op(cct->_conf->osd_op_queue_mclock_client_op_res,
-		cct->_conf->osd_op_queue_mclock_client_op_wgt,
-		cct->_conf->osd_op_queue_mclock_client_op_lim),
-      osd_rep_op(cct->_conf->osd_op_queue_mclock_osd_rep_op_res,
-		 cct->_conf->osd_op_queue_mclock_osd_rep_op_wgt,
-		 cct->_conf->osd_op_queue_mclock_osd_rep_op_lim),
-      snaptrim(cct->_conf->osd_op_queue_mclock_snap_res,
-	       cct->_conf->osd_op_queue_mclock_snap_wgt,
-	       cct->_conf->osd_op_queue_mclock_snap_lim),
-      recov(cct->_conf->osd_op_queue_mclock_recov_res,
-	    cct->_conf->osd_op_queue_mclock_recov_wgt,
-	    cct->_conf->osd_op_queue_mclock_recov_lim),
-      scrub(cct->_conf->osd_op_queue_mclock_scrub_res,
-	    cct->_conf->osd_op_queue_mclock_scrub_wgt,
-	    cct->_conf->osd_op_queue_mclock_scrub_lim)
+      client_op(
+        cct->_conf->get_val<double>("osd_op_queue_mclock_client_op_res"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_client_op_wgt"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_client_op_lim")),
+      osd_rep_op(
+        cct->_conf->get_val<double>("osd_op_queue_mclock_osd_rep_op_res"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_osd_rep_op_wgt"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_osd_rep_op_lim")),
+      snaptrim(
+        cct->_conf->get_val<double>("osd_op_queue_mclock_snap_res"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_snap_wgt"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_snap_lim")),
+      recov(
+        cct->_conf->get_val<double>("osd_op_queue_mclock_recov_res"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_recov_wgt"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_recov_lim")),
+      scrub(
+        cct->_conf->get_val<double>("osd_op_queue_mclock_scrub_res"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_scrub_wgt"),
+        cct->_conf->get_val<double>("osd_op_queue_mclock_scrub_lim"))
     {
       constexpr int rep_ops[] = {
 	MSG_OSD_REPOP,


### PR DESCRIPTION
Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>