### PR TITLE
mgr/influx: PEP-8 and other fixes to Influx module

### DIFF
--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from threading import Event
 import json
 import errno
+import time
 
 from mgr_module import MgrModule
 
@@ -163,6 +164,8 @@ class Module(MgrModule):
 
         # If influx server has authentication turned off then
         # missing username/password is valid.
+        self.log.debug("Sending data to Influx host: %s",
+                       self.config['hostname'])
         client = InfluxDBClient(self.config['hostname'], self.config['port'],
                                 self.config['username'],
                                 self.config['password'],
@@ -232,7 +235,10 @@ class Module(MgrModule):
         self.run = True
 
         while self.run:
+            start = time.time()
             self.send_to_influx()
-            self.log.debug("Running interval loop")
-            self.log.debug("sleeping for %d seconds", self.config['interval'])
+            runtime = time.time() - start
+            self.log.debug('Finished sending data in Influx in %.3f seconds',
+                           runtime)
+            self.log.debug("Sleeping for %d seconds", self.config['interval'])
             self.event.wait(self.config['interval'])

--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -26,6 +26,9 @@ class Module(MgrModule):
         self.event = Event()
         self.run = True
 
+    def get_fsid(self):
+        return self.get('mon_map')['fsid']
+
     def get_latest(self, daemon_type, daemon_name, stat):
         data = self.get_counter(daemon_type, daemon_name, stat)[stat]
         if data:
@@ -55,7 +58,7 @@ class Module(MgrModule):
                         "pool_name": pool['name'],
                         "pool_id": pool['id'],
                         "type_instance": df_type,
-                        "mgr_id": self.get_mgr_id(),
+                        "fsid": self.get_fsid()
                     },
                     "time": datetime.utcnow().isoformat() + 'Z',
                     "fields": {
@@ -83,7 +86,8 @@ class Module(MgrModule):
                     "tags": {
                         "ceph_daemon": daemon,
                         "type_instance": path,
-                        "host": metadata['hostname']
+                        "host": metadata['hostname'],
+                        "fsid": self.get_fsid()
                     },
                     "time": datetime.utcnow().isoformat() + 'Z',
                     "fields": {


### PR DESCRIPTION
This PR fixes two things:

- PEP-8 fixes to Influx module
- Send fsid as a tag to Influx
- Update module configuration
- Updated logging of module

By sending the fsid as a tag to Influx we can have multiple clusters send their data to the same Influx database.