### PR TITLE
luminous: mon/PGMap: Fix %USED calculation

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -824,8 +824,9 @@ void PGMapDigest::dump_object_stat_sum(
     curr_object_copies_rate = (float)(sum.num_object_copies - sum.num_objects_degraded) / sum.num_object_copies;
 
   float used = 0.0;
+  // note avail passed in is raw_avail, calc raw_used here.
   if (avail) {
-    used = sum.num_bytes * curr_object_copies_rate;
+    used = sum.num_bytes * raw_used_rate * curr_object_copies_rate;
     used /= used + avail;
   } else if (sum.num_bytes) {
     used = 1.0;

--- a/src/test/mon/PGMap.cc
+++ b/src/test/mon/PGMap.cc
@@ -175,7 +175,7 @@ TEST(pgmap, dump_object_stat_sum_0)
   float copies_rate =
     (static_cast<float>(sum.num_object_copies - sum.num_objects_degraded) /
      sum.num_object_copies);
-  float used_bytes = sum.num_bytes * copies_rate;
+  float used_bytes = sum.num_bytes * copies_rate * pool.get_size();
   float used_percent = used_bytes / (used_bytes + avail) * 100;
   unsigned col = 0;
   ASSERT_EQ(stringify(si_t(sum.num_bytes)), tbl.get(0, col++));


### PR DESCRIPTION
http://tracker.ceph.com/issues/22247

Previous code forgot to multiple raw_used_ratio to calculate
used byte.

Fixes: http://tracker.ceph.com/issues/22247
Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>
(cherry picked from commit d10c6c26f9ef7372e2c95da79d23b07ce5f4e0e5)