### PR TITLE
mgr: improved module loading for error reporting etc

### DIFF
--- a/doc/mgr/plugins.rst
+++ b/doc/mgr/plugins.rst
@@ -124,6 +124,19 @@ the monitor cluster, use this function:
 
 .. automethod:: MgrModule.have_mon_connection
 
+Reporting if your module cannot run
+-----------------------------------
+
+If your module cannot be run for any reason (such as a missing dependency),
+then you can report that by implementing the ``can_run`` function.
+
+.. automethod:: MgrModule.can_run
+
+Note that this will only work properly if your module can always be imported:
+if you are importing a dependency that may be absent, then do it in a
+try/except block so that your module can be loaded far enough to use
+``can_run`` even if the dependency is absent.
+
 Sending commands
 ----------------
 

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -21,6 +21,38 @@ that are defined by ceph-mgr python modules.
 Definitions
 ===========
 
+Manager
+-------
+
+MGR_MODULE_DEPENDENCY
+_____________________
+
+An enabled manager module is failing its dependency check.  This health check
+should come with an explanatory message from the module about the problem.
+
+For example, a module might report that a required package is not installed:
+install the required package and restart your manager daemons.
+
+This health check is only applied to enabled modules.  If a module is
+not enabled, you can see whether it is reporting dependency issues in
+the output of `ceph module ls`.
+
+
+MGR_MODULE_ERROR
+________________
+
+A manager module has experienced an unexpected error.  Typically,
+this means an unhandled exception was raised from the module's `serve`
+function.  The human readable description of the error may be obscurely
+worded if the exception did not provide a useful description of itself.
+
+This health check may indicate a bug: please open a Ceph bug report if you
+think you have encountered a bug.
+
+If you believe the error is transient, you may restart your manager
+daemon(s), or use `ceph mgr fail` on the active daemon to prompt
+a failover to another daemon.
+
 
 OSDs
 ----

--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -14,6 +14,8 @@ tasks:
         - Reduced data availability
         - Degraded data redundancy
         - objects misplaced
+        - Synthetic exception in serve
+        - influxdb python module not found
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest

--- a/qa/suites/rados/upgrade/luminous-x-singleton/0-cluster/start.yaml
+++ b/qa/suites/rados/upgrade/luminous-x-singleton/0-cluster/start.yaml
@@ -6,6 +6,9 @@ meta:
 overrides:
   ceph:
     fs: xfs
+    conf:
+      global:
+        ms dump corrupt message level: 0
 roles:
 - - mon.a
   - mon.b

--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -119,3 +119,14 @@ class TestModuleSelftest(MgrTestCase):
                 "mgr", "self-test", "run"
             )
         self.assertEqual(exc_raised.exception.exitstatus, errno.EIO)
+
+        # A health alert should be raised for a module that has thrown
+        # an exception from its serve() method
+        self.wait_for_health(
+            "Module 'selftest' has failed: Synthetic exception in serve",
+            timeout=30)
+
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            "mgr", "module", "disable", "selftest")
+
+        self.wait_for_health_clear(timeout=30)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -733,6 +733,7 @@ if (WITH_MGR)
       mgr/ActivePyModules.cc
       mgr/OSDHealthMetricCollector.cc
       mgr/StandbyPyModules.cc
+      mgr/PyModule.cc
       mgr/PyModuleRegistry.cc
       mgr/PyModuleRunner.cc
       mgr/PyFormatter.cc

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -34,25 +34,10 @@
 class ActivePyModule;
 class ActivePyModules;
 
-/**
- * A Ceph CLI command description provided from a Python module
- */
-class ModuleCommand {
-public:
-  std::string cmdstring;
-  std::string helpstring;
-  std::string perm;
-  ActivePyModule *handler;
-};
-
 class ActivePyModule : public PyModuleRunner
 {
 private:
   health_check_map_t health_checks;
-
-  std::vector<ModuleCommand> commands;
-
-  int load_commands();
 
   // Optional, URI exposed by plugins that implement serve()
   std::string uri;
@@ -66,11 +51,6 @@ public:
   int load(ActivePyModules *py_modules);
   void notify(const std::string &notify_type, const std::string &notify_id);
   void notify_clog(const LogEntry &le);
-
-  const std::vector<ModuleCommand> &get_commands() const
-  {
-    return commands;
-  }
 
   int handle_command(
     const cmdmap_t &cmdmap,

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -58,11 +58,9 @@ private:
   std::string uri;
 
 public:
-  ActivePyModule(const std::string &module_name_,
-      PyObject *pClass_,
-      const SafeThreadState &my_ts_,
+  ActivePyModule(PyModuleRef py_module_,
       LogChannelRef clog_)
-    : PyModuleRunner(module_name_, pClass_, my_ts_, clog_)
+    : PyModuleRunner(py_module_, clog_)
   {}
 
   int load(ActivePyModules *py_modules);

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -90,11 +90,11 @@ public:
 
   void set_uri(const std::string& module_name, const std::string &uri);
 
-  // Python command definitions, including callback
-  std::vector<ModuleCommand> get_py_commands() const;
-
-  // Monitor command definitions, suitable for CLI
-  std::vector<MonCommand> get_commands() const;
+  int handle_command(
+    const std::string &module_name,
+    const cmdmap_t &cmdmap,
+    std::stringstream *ds,
+    std::stringstream *ss);
 
   std::map<std::string, std::string> get_services() const;
 

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -108,9 +108,7 @@ public:
   int init();
   void shutdown();
 
-  int start_one(std::string const &module_name,
-                PyObject *pClass,
-                const SafeThreadState &pMyThreadState);
+  int start_one(PyModuleRef py_module);
 
   void dump_server(const std::string &hostname,
                    const DaemonStateCollection &dmc,

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -22,9 +22,7 @@
 #include "global/signal_handler.h"
 
 #include "mgr/MgrContext.h"
-#include "mgr/mgr_commands.h"
 
-//#include "MgrPyModule.h"
 #include "DaemonServer.h"
 #include "messages/MMgrBeacon.h"
 #include "messages/MMgrDigest.h"
@@ -218,8 +216,8 @@ void Mgr::init()
 
   // assume finisher already initialized in background_init
   dout(4) << "starting python modules..." << dendl;
-  py_module_registry->active_start(loaded_config, daemon_state, cluster_state, *monc,
-      clog, *objecter, *client, finisher);
+  py_module_registry->active_start(loaded_config, daemon_state, cluster_state,
+      *monc, clog, *objecter, *client, finisher);
 
   dout(4) << "Complete." << dendl;
   initializing = false;
@@ -622,16 +620,6 @@ void Mgr::tick()
 {
   dout(10) << dendl;
   server.send_report();
-}
-
-std::vector<MonCommand> Mgr::get_command_set() const
-{
-  Mutex::Locker l(lock);
-
-  std::vector<MonCommand> commands = mgr_commands;
-  std::vector<MonCommand> py_commands = py_module_registry->get_commands();
-  commands.insert(commands.end(), py_commands.begin(), py_commands.end());
-  return commands;
 }
 
 std::map<std::string, std::string> Mgr::get_services() const

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -101,7 +101,6 @@ public:
   void background_init(Context *completion);
   void shutdown();
 
-  std::vector<MonCommand> get_command_set() const;
   std::map<std::string, std::string> get_services() const;
 };
 

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -152,7 +152,7 @@ void MgrStandby::send_beacon()
   dout(1) << state_str() << dendl;
 
   set<string> modules;
-  PyModuleRegistry::list_modules(&modules);
+  py_module_registry.list_modules(&modules);
 
   // Whether I think I am available (request MgrMonitor to set me
   // as available in the map)

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -157,9 +157,9 @@ void MgrStandby::send_beacon()
 
   // Construct a list of the info about each loaded module
   // which we will transmit to the monitor.
-  std::vector<MMgrBeacon::ModuleInfo> module_info;
+  std::vector<MgrMap::ModuleInfo> module_info;
   for (const auto &module : modules) {
-    MMgrBeacon::ModuleInfo info;
+    MgrMap::ModuleInfo info;
     info.name = module->get_name();
     info.error_string = module->get_error_string();
     info.can_run = module->get_can_run();

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -152,8 +152,7 @@ void MgrStandby::send_beacon()
   assert(lock.is_locked_by_me());
   dout(1) << state_str() << dendl;
 
-  std::list<PyModuleRef> modules;
-  py_module_registry.get_modules(&modules);
+  std::list<PyModuleRef> modules = py_module_registry.get_modules();
 
   // Construct a list of the info about each loaded module
   // which we will transmit to the monitor.

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -22,6 +22,7 @@
 #include "global/signal_handler.h"
 
 #include "mgr/MgrContext.h"
+#include "mgr/mgr_commands.h"
 
 #include "messages/MMgrBeacon.h"
 #include "messages/MMgrMap.h"
@@ -189,7 +190,10 @@ void MgrStandby::send_beacon()
       // We are informing the mon that we are done initializing: inform
       // it of our command set.  This has to happen after init() because
       // it needs the python modules to have loaded.
-      m->set_command_descs(active_mgr->get_command_set());
+      std::vector<MonCommand> commands = mgr_commands;
+      std::vector<MonCommand> py_commands = py_module_registry.get_commands();
+      commands.insert(commands.end(), py_commands.begin(), py_commands.end());
+      m->set_command_descs(commands);
       dout(4) << "going active, including " << m->get_command_descs().size()
               << " commands in beacon" << dendl;
     }

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -1,0 +1,306 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 John Spray <john.spray@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "BaseMgrModule.h"
+#include "BaseMgrStandbyModule.h"
+#include "PyOSDMap.h"
+
+#include "PyModule.h"
+
+#include "common/debug.h"
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_mgr
+
+#undef dout_prefix
+#define dout_prefix *_dout << "mgr[py] "
+
+// Courtesy of http://stackoverflow.com/questions/1418015/how-to-get-python-exception-text
+#include <boost/python.hpp>
+#include "include/assert.h"  // boost clobbers this
+// decode a Python exception into a string
+std::string handle_pyerror()
+{
+    using namespace boost::python;
+    using namespace boost;
+
+    PyObject *exc, *val, *tb;
+    object formatted_list, formatted;
+    PyErr_Fetch(&exc, &val, &tb);
+    handle<> hexc(exc), hval(allow_null(val)), htb(allow_null(tb));
+    object traceback(import("traceback"));
+    if (!tb) {
+        object format_exception_only(traceback.attr("format_exception_only"));
+        formatted_list = format_exception_only(hexc, hval);
+    } else {
+        object format_exception(traceback.attr("format_exception"));
+        formatted_list = format_exception(hexc,hval, htb);
+    }
+    formatted = str("").join(formatted_list);
+    return extract<std::string>(formatted);
+}
+
+
+namespace {
+  PyObject* log_write(PyObject*, PyObject* args) {
+    char* m = nullptr;
+    if (PyArg_ParseTuple(args, "s", &m)) {
+      auto len = strlen(m);
+      if (len && m[len-1] == '\n') {
+	m[len-1] = '\0';
+      }
+      dout(4) << m << dendl;
+    }
+    Py_RETURN_NONE;
+  }
+
+  PyObject* log_flush(PyObject*, PyObject*){
+    Py_RETURN_NONE;
+  }
+
+  static PyMethodDef log_methods[] = {
+    {"write", log_write, METH_VARARGS, "write stdout and stderr"},
+    {"flush", log_flush, METH_VARARGS, "flush"},
+    {nullptr, nullptr, 0, nullptr}
+  };
+}
+
+
+std::string PyModule::get_site_packages()
+{
+  std::stringstream site_packages;
+
+  // CPython doesn't auto-add site-packages dirs to sys.path for us,
+  // but it does provide a module that we can ask for them.
+  auto site_module = PyImport_ImportModule("site");
+  assert(site_module);
+
+  auto site_packages_fn = PyObject_GetAttrString(site_module, "getsitepackages");
+  if (site_packages_fn != nullptr) {
+    auto site_packages_list = PyObject_CallObject(site_packages_fn, nullptr);
+    assert(site_packages_list);
+
+    auto n = PyList_Size(site_packages_list);
+    for (Py_ssize_t i = 0; i < n; ++i) {
+      if (i != 0) {
+        site_packages << ":";
+      }
+      site_packages << PyString_AsString(PyList_GetItem(site_packages_list, i));
+    }
+
+    Py_DECREF(site_packages_list);
+    Py_DECREF(site_packages_fn);
+  } else {
+    // Fall back to generating our own site-packages paths by imitating
+    // what the standard site.py does.  This is annoying but it lets us
+    // run inside virtualenvs :-/
+
+    auto site_packages_fn = PyObject_GetAttrString(site_module, "addsitepackages");
+    assert(site_packages_fn);
+
+    auto known_paths = PySet_New(nullptr);
+    auto pArgs = PyTuple_Pack(1, known_paths);
+    PyObject_CallObject(site_packages_fn, pArgs);
+    Py_DECREF(pArgs);
+    Py_DECREF(known_paths);
+    Py_DECREF(site_packages_fn);
+
+    auto sys_module = PyImport_ImportModule("sys");
+    assert(sys_module);
+    auto sys_path = PyObject_GetAttrString(sys_module, "path");
+    assert(sys_path);
+
+    dout(1) << "sys.path:" << dendl;
+    auto n = PyList_Size(sys_path);
+    bool first = true;
+    for (Py_ssize_t i = 0; i < n; ++i) {
+      dout(1) << "  " << PyString_AsString(PyList_GetItem(sys_path, i)) << dendl;
+      if (first) {
+        first = false;
+      } else {
+        site_packages << ":";
+      }
+      site_packages << PyString_AsString(PyList_GetItem(sys_path, i));
+    }
+
+    Py_DECREF(sys_path);
+    Py_DECREF(sys_module);
+  }
+
+  Py_DECREF(site_module);
+
+  return site_packages.str();
+}
+
+
+int PyModule::load(PyThreadState *pMainThreadState)
+{
+  assert(pMainThreadState != nullptr);
+
+  // Configure sub-interpreter and construct C++-generated python classes
+  {
+    SafeThreadState sts(pMainThreadState);
+    Gil gil(sts);
+
+    auto thread_state = Py_NewInterpreter();
+    if (thread_state == nullptr) {
+      derr << "Failed to create python sub-interpreter for '" << module_name << '"' << dendl;
+      return -EINVAL;
+    } else {
+      pMyThreadState.set(thread_state);
+      // Some python modules do not cope with an unpopulated argv, so lets
+      // fake one.  This step also picks up site-packages into sys.path.
+      const char *argv[] = {"ceph-mgr"};
+      PySys_SetArgv(1, (char**)argv);
+
+      if (g_conf->daemonize) {
+        auto py_logger = Py_InitModule("ceph_logger", log_methods);
+#if PY_MAJOR_VERSION >= 3
+        PySys_SetObject("stderr", py_logger);
+        PySys_SetObject("stdout", py_logger);
+#else
+        PySys_SetObject(const_cast<char*>("stderr"), py_logger);
+        PySys_SetObject(const_cast<char*>("stdout"), py_logger);
+#endif
+      }
+
+      // Configure sys.path to include mgr_module_path
+      std::string sys_path = std::string(Py_GetPath()) + ":" + get_site_packages()
+                             + ":" + g_conf->get_val<std::string>("mgr_module_path");
+      dout(10) << "Computed sys.path '" << sys_path << "'" << dendl;
+
+      PySys_SetPath(const_cast<char*>(sys_path.c_str()));
+    }
+
+    PyMethodDef ModuleMethods[] = {
+      {nullptr}
+    };
+
+    // Initialize module
+    PyObject *ceph_module = Py_InitModule("ceph_module", ModuleMethods);
+    assert(ceph_module != nullptr);
+
+    auto load_class = [ceph_module](const char *name, PyTypeObject *type)
+    {
+      type->tp_new = PyType_GenericNew;
+      if (PyType_Ready(type) < 0) {
+          assert(0);
+      }
+      Py_INCREF(type);
+
+      PyModule_AddObject(ceph_module, name, (PyObject *)type);
+    };
+
+    load_class("BaseMgrModule", &BaseMgrModuleType);
+    load_class("BaseMgrStandbyModule", &BaseMgrStandbyModuleType);
+    load_class("BasePyOSDMap", &BasePyOSDMapType);
+    load_class("BasePyOSDMapIncremental", &BasePyOSDMapIncrementalType);
+    load_class("BasePyCRUSH", &BasePyCRUSHType);
+  }
+
+  // Environment is all good, import the external module
+  {
+    Gil gil(pMyThreadState);
+    int r;
+    r = load_subclass_of("MgrModule", &pClass);
+    if (r) {
+      derr << "Class not found in module '" << module_name << "'" << dendl;
+      return r;
+    }
+
+    // We've imported the module and found a MgrModule subclass, at this
+    // point the module is considered loaded.  It might still not be
+    // runnable though, can_run populated later...
+    loaded = true;
+
+    r = load_subclass_of("MgrStandbyModule", &pStandbyClass);
+    if (!r) {
+      dout(4) << "Standby mode available in module '" << module_name
+              << "'" << dendl;
+    } else {
+      dout(4) << "Standby mode not provided by module '" << module_name
+              << "'" << dendl;
+    }
+
+    // Populate can_run by interrogating the module's callback that
+    // may check for dependencies etc
+    // TODO
+
+  }
+  return 0;
+}
+
+int PyModule::load_subclass_of(const char* base_class, PyObject** py_class)
+{
+  // load the base class
+  PyObject *mgr_module = PyImport_ImportModule("mgr_module");
+  if (!mgr_module) {
+    derr << "Module not found: 'mgr_module'" << dendl;
+    derr << handle_pyerror() << dendl;
+    return -EINVAL;
+  }
+  auto mgr_module_type = PyObject_GetAttrString(mgr_module, base_class);
+  Py_DECREF(mgr_module);
+  if (!mgr_module_type) {
+    derr << "Unable to import MgrModule from mgr_module" << dendl;
+    derr << handle_pyerror() << dendl;
+    return -EINVAL;
+  }
+
+  // find the sub class
+  PyObject *plugin_module = PyImport_ImportModule(module_name.c_str());
+  if (!plugin_module) {
+    derr << "Module not found: '" << module_name << "'" << dendl;
+    derr << handle_pyerror() << dendl;
+    return -ENOENT;
+  }
+  auto locals = PyModule_GetDict(plugin_module);
+  Py_DECREF(plugin_module);
+  PyObject *key, *value;
+  Py_ssize_t pos = 0;
+  *py_class = nullptr;
+  while (PyDict_Next(locals, &pos, &key, &value)) {
+    if (!PyType_Check(value)) {
+      continue;
+    }
+    if (!PyObject_IsSubclass(value, mgr_module_type)) {
+      continue;
+    }
+    if (PyObject_RichCompareBool(value, mgr_module_type, Py_EQ)) {
+      continue;
+    }
+    auto class_name = PyString_AsString(key);
+    if (*py_class) {
+      derr << __func__ << ": ignoring '"
+	   << module_name << "." << class_name << "'"
+	   << ": only one '" << base_class
+	   << "' class is loaded from each plugin" << dendl;
+      continue;
+    }
+    *py_class = value;
+    dout(4) << __func__ << ": found class: '"
+	    << module_name << "." << class_name << "'" << dendl;
+  }
+  Py_DECREF(mgr_module_type);
+
+  return *py_class ? 0 : -EINVAL;
+}
+
+PyModule::~PyModule()
+{
+  if (pMyThreadState.ts != nullptr) {
+    Gil gil(pMyThreadState, true);
+    Py_XDECREF(pClass);
+    Py_XDECREF(pStandbyClass);
+  }
+}
+

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -45,6 +45,9 @@ private:
   // (e.g. throwing an exception from serve())
   bool failed = false;
 
+  // Populated if loaded, can_run or failed indicates a problem
+  std::string error_string;
+
 public:
   SafeThreadState pMyThreadState;
   PyObject *pClass = nullptr;
@@ -59,9 +62,27 @@ public:
 
   int load(PyThreadState *pMainThreadState);
 
+  /**
+   * Mark the module as failed, recording the reason in the error
+   * string.
+   */
+  void fail(const std::string &reason)
+  {
+    Mutex::Locker l(lock);
+    failed = true;
+    error_string = reason;
+  }
+
   bool is_enabled() const { Mutex::Locker l(lock) ; return enabled; }
-  const std::string &get_name() const
-    { Mutex::Locker l(lock) ; return module_name; }
+  const std::string &get_name() const {
+    Mutex::Locker l(lock) ; return module_name;
+  }
+  const std::string &get_error_string() const {
+    Mutex::Locker l(lock) ; return error_string;
+  }
+  bool get_can_run() const {
+    Mutex::Locker l(lock) ; return can_run;
+  }
 };
 
 typedef std::shared_ptr<PyModule> PyModuleRef;

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -1,0 +1,68 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 John Spray <john.spray@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#pragma once
+
+#include "Python.h"
+#include "Gil.h"
+
+#include <string>
+#include "common/Mutex.h"
+#include <memory>
+
+std::string handle_pyerror();
+
+class PyModule
+{
+  mutable Mutex lock{"PyModule::lock"};
+private:
+  const std::string module_name;
+  std::string get_site_packages();
+  int load_subclass_of(const char* class_name, PyObject** py_class);
+
+  // Did the MgrMap identify this module as one that should run?
+  bool enabled = false;
+
+  // Did we successfully import this python module and look up symbols?
+  // (i.e. is it possible to instantiate a MgrModule subclass instance?)
+  bool loaded = false;
+
+  // Did the module identify itself as being able to run?
+  // (i.e. should we expect instantiating and calling serve() to work?)
+  bool can_run = false;
+
+  // Did the module encounter an unexpected error while running?
+  // (e.g. throwing an exception from serve())
+  bool failed = false;
+
+public:
+  SafeThreadState pMyThreadState;
+  PyObject *pClass = nullptr;
+  PyObject *pStandbyClass = nullptr;
+
+  PyModule(const std::string &module_name_, bool const enabled_)
+    : module_name(module_name_), enabled(enabled_)
+  {
+  }
+
+  ~PyModule();
+
+  int load(PyThreadState *pMainThreadState);
+
+  bool is_enabled() const { Mutex::Locker l(lock) ; return enabled; }
+  const std::string &get_name() const
+    { Mutex::Locker l(lock) ; return module_name; }
+};
+
+typedef std::shared_ptr<PyModule> PyModuleRef;
+

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -130,11 +130,26 @@ public:
     return modules.at(module_name);
   }
 
+  /**
+   * Pass through command to the named module for execution.
+   *
+   * The command must exist in the COMMANDS reported by the module.  If it
+   * doesn't then this will abort.
+   *
+   * If ActivePyModules has not been instantiated yet then this will
+   * return EAGAIN.
+   */
   int handle_command(
     std::string const &module_name,
     const cmdmap_t &cmdmap,
     std::stringstream *ds,
     std::stringstream *ss);
+
+  /**
+   * Pass through health checks reported by modules, and report any
+   * modules that have failed (i.e. unhandled exceptions in serve())
+   */
+  void get_health_checks(health_check_map_t *checks);
 
   // FIXME: breaking interface so that I don't have to go rewrite all
   // the places that call into these (for now)
@@ -154,11 +169,6 @@ public:
     }
   }
 
-  void get_health_checks(health_check_map_t *checks)
-  {
-    assert(active_modules);
-    active_modules->get_health_checks(checks);
-  }
   std::map<std::string, std::string> get_services() const
   {
     assert(active_modules);

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -54,17 +54,27 @@ private:
   // before ClusterState exists.
   MgrMap mgr_map;
 
+  /**
+   * Discover python modules from local disk
+   */
+  std::set<std::string> probe_modules() const;
+
 public:
   static std::string config_prefix;
 
-  void list_modules(std::set<std::string> *modules);
-
-  void get_modules(std::list<PyModuleRef> *modules_out)
+  /**
+   * Get references to all modules (whether they have loaded and/or
+   * errored) or not.
+   */
+  std::list<PyModuleRef> get_modules() const
   {
     Mutex::Locker l(lock);
+    std::list<PyModuleRef> modules_out;
     for (const auto &i : modules) {
-      modules_out->push_back(i.second);
+      modules_out.push_back(i.second);
     }
+
+    return modules_out;
   }
 
   PyModuleRegistry(LogChannelRef clog_)

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -117,6 +117,25 @@ public:
     std::forward<Callback>(cb)(*active_modules, std::forward<Args>(args)...);
   }
 
+  std::vector<MonCommand> get_commands() const;
+  std::vector<ModuleCommand> get_py_commands() const;
+
+  /**
+   * module_name **must** exist, but does not have to be loaded
+   * or runnable.
+   */
+  PyModuleRef get_module(const std::string &module_name)
+  {
+    Mutex::Locker l(lock);
+    return modules.at(module_name);
+  }
+
+  int handle_command(
+    std::string const &module_name,
+    const cmdmap_t &cmdmap,
+    std::stringstream *ds,
+    std::stringstream *ss);
+
   // FIXME: breaking interface so that I don't have to go rewrite all
   // the places that call into these (for now)
   // >>>
@@ -135,16 +154,6 @@ public:
     }
   }
 
-  std::vector<MonCommand> get_commands() const
-  {
-    assert(active_modules);
-    return active_modules->get_commands();
-  }
-  std::vector<ModuleCommand> get_py_commands() const
-  {
-    assert(active_modules);
-    return active_modules->get_py_commands();
-  }
   void get_health_checks(health_check_map_t *checks)
   {
     assert(active_modules);

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -59,6 +59,14 @@ public:
 
   void list_modules(std::set<std::string> *modules);
 
+  void get_modules(std::list<PyModuleRef> *modules_out)
+  {
+    Mutex::Locker l(lock);
+    for (const auto &i : modules) {
+      modules_out->push_back(i.second);
+    }
+  }
+
   PyModuleRegistry(LogChannelRef clog_)
     : clog(clog_)
   {}

--- a/src/mgr/PyModuleRunner.cc
+++ b/src/mgr/PyModuleRunner.cc
@@ -70,6 +70,9 @@ int PyModuleRunner::serve()
                   << ": " << exc_msg;
     derr << get_name() << ".serve:" << dendl;
     derr << handle_pyerror() << dendl;
+
+    py_module->fail(exc_msg);
+
     return -EINVAL;
   }
 

--- a/src/mgr/StandbyPyModules.h
+++ b/src/mgr/StandbyPyModules.h
@@ -89,12 +89,10 @@ class StandbyPyModule : public PyModuleRunner
 
   StandbyPyModule(
       StandbyPyModuleState &state_,
-      const std::string &module_name_,
-      PyObject *pClass_,
-      const SafeThreadState &pMyThreadState_,
+      PyModuleRef py_module_,
       LogChannelRef clog_)
     :
-      PyModuleRunner(module_name_, pClass_, pMyThreadState_, clog_),
+      PyModuleRunner(py_module_, clog_),
       state(state_)
   {
   }
@@ -139,9 +137,7 @@ public:
       const MgrMap &mgr_map_,
       LogChannelRef clog_);
 
-  int start_one(std::string const &module_name,
-                PyObject *pClass,
-                const SafeThreadState &pMyThreadState);
+  int start_one(PyModuleRef py_module);
 
   void shutdown();
 

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -28,7 +28,7 @@ public:
   std::set<std::string> available_modules;
 
   StandbyInfo(uint64_t gid_, const std::string &name_,
-	      std::set<std::string>& am)
+	      const std::set<std::string>& am)
     : gid(gid_), name(name_), available_modules(am)
   {}
 

--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -58,6 +58,13 @@ class Module(MgrModule):
     def get_fsid(self):
         return self.get('mon_map')['fsid']
 
+    @staticmethod
+    def can_run():
+        if InfluxDBClient is not None:
+            return True, ""
+        else:
+            return False, "influxdb python module not found"
+
     def get_latest(self, daemon_type, daemon_name, stat):
         data = self.get_counter(daemon_type, daemon_name, stat)[stat]
         if data:

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -633,3 +633,19 @@ class MgrModule(ceph_module.BaseMgrModule):
         self._rados.connect()
 
         return self._rados
+
+    @staticmethod
+    def can_run():
+        """
+        Implement this function to report whether the module's dependencies
+        are met.  For example, if the module needs to import a particular
+        dependency to work, then use a try/except around the import at
+        file scope, and then report here if the import failed.
+
+        This will be called in a blocking way from the C++ code, so do not
+        do any I/O that could block in this function.
+
+        :return a 2-tuple consisting of a boolean and explanatory string
+        """
+
+        return True, ""

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -17,10 +17,13 @@ class Module(MgrModule):
     activities in its serve() thread.
     """
 
+    # These workloads are things that can be requested to run inside the
+    # serve() function
     WORKLOAD_COMMAND_SPAM = "command_spam"
+    WORKLOAD_THROW_EXCEPTION = "throw_exception"
     SHUTDOWN = "shutdown"
 
-    WORKLOADS = (WORKLOAD_COMMAND_SPAM, )
+    WORKLOADS = (WORKLOAD_COMMAND_SPAM, WORKLOAD_THROW_EXCEPTION)
 
     COMMANDS = [
             {
@@ -211,6 +214,8 @@ class Module(MgrModule):
             elif self._workload == self.SHUTDOWN:
                 self.log.info("Shutting down...")
                 break
+            elif self._workload == self.WORKLOAD_THROW_EXCEPTION:
+                raise RuntimeError("Synthetic exception in serve")
             else:
                 self.log.info("Waiting for workload request...")
                 self._event.wait()


### PR DESCRIPTION
- Fixes the case where commands are unfound immediately after loading module (http://tracker.ceph.com/issues/21683)
- Adds helpful message when someones tries to use a command from a module that is not enabled.
- Adds health checks for modules in a failed state (e.g. exceptions from serve), follows on from http://tracker.ceph.com/issues/21999
- Adds ``can_run`` method to module interface to enable reporting missing dependencies (http://tracker.ceph.com/issues/21502), and expose health check if any can_run=false modules are enabled.

There is scope for some follow on work after this:
- prompting user during "ceph mgr module enable" if they're enabling a can_run=false module
- automatically restarting mgr (perhaps with backoff, perhaps only once) when a module fails, rather than requiring admin intervention

Happy to have feedback about some of the naming etc, I've gone back and forth about about whether the ``can_run`` bit should be called something with "dependency" in the name to make it more obvious.