### PR TITLE
luminous: ceph-volume correctly fallback to bluestore when no objectstore is specified

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -212,6 +212,6 @@ class Activate(object):
         args = parser.parse_args(self.argv)
         # Default to bluestore here since defaulting it in add_argument may
         # cause both to be True
-        if args.bluestore is None and args.filestore is None:
+        if not args.bluestore and not args.filestore:
             args.bluestore = True
         self.activate(args)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -46,3 +46,33 @@ class TestActivate(object):
         args = Args(osd_id=None, osd_fsid='1234')
         with pytest.raises(RuntimeError):
             activate.Activate([]).activate(args)
+
+
+class TestActivateFlags(object):
+
+    def test_default_objectstore(self, capture):
+        args = ['0', 'asdf-ljh-asdf']
+        activation = activate.Activate(args)
+        activation.activate = capture
+        activation.main()
+        parsed_args = capture.calls[0]['args'][0]
+        assert parsed_args.filestore is False
+        assert parsed_args.bluestore is True
+
+    def test_uses_filestore(self, capture):
+        args = ['--filestore', '0', 'asdf-ljh-asdf']
+        activation = activate.Activate(args)
+        activation.activate = capture
+        activation.main()
+        parsed_args = capture.calls[0]['args'][0]
+        assert parsed_args.filestore is True
+        assert parsed_args.bluestore is False
+
+    def test_uses_bluestore(self, capture):
+        args = ['--bluestore', '0', 'asdf-ljh-asdf']
+        activation = activate.Activate(args)
+        activation.activate = capture
+        activation.main()
+        parsed_args = capture.calls[0]['args'][0]
+        assert parsed_args.filestore is False
+        assert parsed_args.bluestore is True


### PR DESCRIPTION
Merged in master at https://github.com/ceph/ceph/pull/19213

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1518264