### PR TITLE
qa/suites/rados/thrash: extend mgr beacon grace when many msgr failures injected

### DIFF
--- a/qa/suites/rados/multimon/msgr-failures/many.yaml
+++ b/qa/suites/rados/multimon/msgr-failures/many.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       global:
         ms inject socket failures: 500
+        mon mgr beacon grace: 90

--- a/qa/suites/rados/singleton/msgr-failures/many.yaml
+++ b/qa/suites/rados/singleton/msgr-failures/many.yaml
@@ -3,6 +3,7 @@ overrides:
     conf:
       global:
         ms inject socket failures: 500
+        mon mgr beacon grace: 90
       mgr:
         debug monc: 10
         mon client hunt interval max multiple: 2


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21147
Signed-off-by: Sage Weil <sage@redhat.com>