### PR TITLE
osd: enable/test discontiguous log entry versions in preparation for pg merging

### DIFF
--- a/qa/suites/rados/thrash/thrashers/pggrow.yaml
+++ b/qa/suites/rados/thrash/thrashers/pggrow.yaml
@@ -10,6 +10,7 @@ overrides:
         filestore odsync write: true
         osd max backfills: 2
         osd snap trim sleep: .5
+        osd debug randomize version offsets: true
 tasks:
 - thrashosds:
     timeout: 1200

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2773,6 +2773,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("osd_debug_randomize_version_offsets", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("Randomly vary the interval between pg_log_entry_t version to stress test peering code"),
+
     Option("osd_enable_op_tracker", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5431,9 +5431,28 @@ void PG::start_peering_interval(
   }
   clear_primary_state();
 
-    
   // pg->on_*
   on_change(t);
+
+  // choose version alignment
+  {
+    unsigned num_pgs;
+    info.pgid.pgid.calc_merge_alignment(
+      pool.info.get_pg_num(),
+      pool.info.get_pgp_num(),
+      &num_pgs,
+      &version_offset);
+    assert(num_pgs > 0);
+    version_mask = num_pgs - 1;  // make it a bit mask. num_pgs is a power of 2.
+    if (!version_mask &&
+	cct->_conf->get_val<bool>("osd_debug_randomize_version_offsets")) {
+      dout(10) << __func__ << " randomizing version mask and offset" << dendl;
+      version_mask = 15;
+      version_offset = rand() % 16;
+    }
+    dout(10) << __func__ << " version_mask " << version_mask << " version_offset "
+	     << version_offset << dendl;
+  }
 
   projected_last_update = eversion_t();
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1004,6 +1004,9 @@ protected:
                                        // which are unfound on the primary
   epoch_t last_peering_reset;
 
+  unsigned version_mask = 0;   ///< mask for low bits that must remain fixed
+  unsigned version_offset = 0; ///< fixed value of low bits
+
   epoch_t get_last_peering_reset() const {
     return last_peering_reset;
   }
@@ -2754,7 +2757,7 @@ protected:
   eversion_t get_next_version() const {
     eversion_t at_version(
       get_osdmap()->get_epoch(),
-      projected_last_update.version+1);
+      ((projected_last_update.version + version_mask + 1) & ~version_mask) + version_offset);
     assert(at_version > info.last_update);
     assert(at_version > pg_log.get_head());
     assert(at_version > projected_last_update);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -414,6 +414,13 @@ struct pg_t {
    */
   unsigned get_split_bits(unsigned pg_num) const;
 
+  /// calculate position of pg for potential merge
+  void calc_merge_alignment(
+    unsigned pg_num,    ///< from
+    unsigned pgp_num,   ///< to
+    unsigned *num,      ///< number of merging pgs
+    unsigned *offset);  ///< position of this pg among merging pgs
+
   bool contains(int bits, const ghobject_t& oid) {
     return oid.match(bits, ps());
   }

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -564,6 +564,35 @@ TEST(pg_t, get_ancestor)
   ASSERT_EQ(pg_t(3, 0, -1), pg_t(1323, 0, -1).get_ancestor(8));
 }
 
+TEST(pg_t, calc_merge_alignment)
+{
+  unsigned num, offset;
+
+  pg_t(0, 1).calc_merge_alignment(8, 8, &num, &offset);
+  ASSERT_EQ(1u, num);
+  ASSERT_EQ(0u, offset);
+
+  pg_t(0, 1).calc_merge_alignment(16, 8, &num, &offset);
+  ASSERT_EQ(2u, num);
+  ASSERT_EQ(0u, offset);
+
+  pg_t(8, 1).calc_merge_alignment(16, 8, &num, &offset);
+  ASSERT_EQ(2u, num);
+  ASSERT_EQ(1u, offset);
+
+  pg_t(0, 1).calc_merge_alignment(12, 8, &num, &offset);
+  ASSERT_EQ(2u, num);
+  ASSERT_EQ(0u, offset);
+
+  pg_t(8, 1).calc_merge_alignment(12, 8, &num, &offset);
+  ASSERT_EQ(2u, num);
+  ASSERT_EQ(1u, offset);
+
+  pg_t(4, 1).calc_merge_alignment(12, 8, &num, &offset);
+  ASSERT_EQ(1u, num);
+  ASSERT_EQ(0u, offset);
+}
+
 TEST(pg_t, split)
 {
   pg_t pgid(0, 0, -1);


### PR DESCRIPTION
This just allows pg versions to be discontiguous but non-overlapping so that we
can get lots of testing that there aren't hidden dependencies on consecutive versions
hidden in the code.