### PR TITLE
osd: cancel removing pgs if osd is stopping

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2001,8 +2001,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
     cct->_conf->osd_command_thread_suicide_timeout,
     &command_tp),
   remove_wq(
-    cct,
-    store,
+    this,
     cct->_conf->osd_remove_thread_timeout,
     cct->_conf->osd_remove_thread_suicide_timeout,
     &disk_tp),
@@ -5335,7 +5334,7 @@ void OSD::RemoveWQ::_process(
   if (!cont)
     return;
   if (!finished) {
-    if (item.second->pause_clearing())
+    if (item.second->pause_clearing() && !osd->is_stopping())
       queue_front(item);
     return;
   }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2192,13 +2192,14 @@ protected:
   // -- removing --
   struct RemoveWQ :
     public ThreadPool::WorkQueueVal<pair<PGRef, DeletingStateRef> > {
+    OSD *osd;
     CephContext* cct;
     ObjectStore *&store;
     list<pair<PGRef, DeletingStateRef> > remove_queue;
-    RemoveWQ(CephContext* cct, ObjectStore *&o, time_t ti, time_t si,
+    RemoveWQ(OSD *o, time_t ti, time_t si,
 	     ThreadPool *tp)
       : ThreadPool::WorkQueueVal<pair<PGRef, DeletingStateRef> >(
-	"OSD::RemoveWQ", ti, si, tp), cct(cct), store(o) {}
+	"OSD::RemoveWQ", ti, si, tp), osd(o), cct(o->cct), store(o->store) {}
 
     bool _empty() override {
       return remove_queue.empty();


### PR DESCRIPTION
Removing large pg(s) will spend lots of time, stop an osd with this may get timed out.

Signed-off-by: wumingqiao <wumingqiao@inspur.com>