### PR TITLE
ceph-fuse: Porting the memory profiling function to ceph-fuse 

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -10,4 +10,5 @@ set(libclient_srcs
   posix_acl.cc
   Delegation.cc)
 add_library(client STATIC ${libclient_srcs})
-target_link_libraries(client osdc)
+
+target_link_libraries(client heap_profiler osdc ${ALLOC_LIBS})


### PR DESCRIPTION
Let ceph client can generate heap profiles using tcmalloc as the same as Ceph MON,
OSD and MDS.

Signed-off-by: Guan yunfei <yunfei.guan@xtaotech.com>