### PR TITLE
rgw: re-creating bucket should return BucketAlreadyOwnedByYou/BucketAlreadyExists

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -98,6 +98,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_METHOD_NOT_ALLOWED, {405, "MethodNotAllowed" }},
     { ETIMEDOUT, {408, "RequestTimeout" }},
     { EEXIST, {409, "BucketAlreadyExists" }},
+    { ERR_BUCKET_EXISTS, {409, "BucketAlreadyOwnedByYou" }},
     { ERR_USER_EXIST, {409, "UserAlreadyExists" }},
     { ERR_EMAIL_EXIST, {409, "EmailExists" }},
     { ERR_KEY_EXIST, {409, "KeyExists"}},

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1192,8 +1192,6 @@ int RGWCreateBucket_ObjStore_S3::get_params()
 
 void RGWCreateBucket_ObjStore_S3::send_response()
 {
-  if (op_ret == -ERR_BUCKET_EXISTS)
-    op_ret = 0;
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);


### PR DESCRIPTION


At now, we will get HTTP response whose status code is 200, it should be 409.

Fixes: http://tracker.ceph.com/issues/22279

Signed-off-by: Chang Liu <liuchang0812@gmail.com>
Signed-off-by: lvshanchun <lvshanchun@gmail.com>