### PR TITLE
rgw: remove unused param in AWSGeneralAbstractor::get_auth_data_v4

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -417,13 +417,10 @@ int parse_credentials(const req_info& info,                     /* in */
                       boost::string_view& signedheaders,        /* out */
                       boost::string_view& signature,            /* out */
                       boost::string_view& date,                 /* out */
-                      bool& using_qs)                           /* out */
+                      const bool using_qs)                      /* in */
 {
-  const char* const http_auth = info.env->get("HTTP_AUTHORIZATION");
-  using_qs = http_auth == nullptr || http_auth[0] == '\0';
-
-  int ret;
   boost::string_view credential;
+  int ret;
   if (using_qs) {
     ret = parse_v4_query_string(info, credential, signedheaders,
                                 signature, date);

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -344,7 +344,7 @@ int parse_credentials(const req_info& info,                     /* in */
                       boost::string_view& signedheaders,        /* out */
                       boost::string_view& signature,            /* out */
                       boost::string_view& date,                 /* out */
-                      bool& using_qs);                          /* out */
+                      const bool using_qs);                     /* in */
 
 static inline std::string get_v4_canonical_uri(const req_info& info) {
   /* The code should normalize according to RFC 3986 but S3 does NOT do path

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3724,8 +3724,7 @@ AWSGeneralAbstractor::get_v4_canonical_headers(
 
 AWSEngine::VersionAbstractor::auth_data_t
 AWSGeneralAbstractor::get_auth_data_v4(const req_state* const s,
-                                       /* FIXME: const. */
-                                       bool using_qs) const
+                                       const bool using_qs) const
 {
   boost::string_view access_key_id;
   boost::string_view signed_hdrs;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -776,7 +776,7 @@ class AWSGeneralAbstractor : public AWSEngine::VersionAbstractor {
                            const bool using_qs) const;
 
   auth_data_t get_auth_data_v2(const req_state* s) const;
-  auth_data_t get_auth_data_v4(const req_state* s, bool using_qs) const;
+  auth_data_t get_auth_data_v4(const req_state* s, const bool using_qs) const;
 
 public:
   AWSGeneralAbstractor(CephContext* const cct)


### PR DESCRIPTION
* 'using_qs' is initialized by parse_credentials, not passed in by the
* caller.

Signed-off-by: Bingyin Zhang <zhangbingyin@cloudin.cn>