### PR TITLE
rgw: fix s3 website redirection error

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -303,14 +303,13 @@ req_state::~req_state() {
   delete formatter;
 }
 
-bool search_err(rgw_http_errors& errs, int err_no, bool is_website_redirect, int& http_ret, string& code)
+bool search_err(rgw_http_errors& errs, int err_no, int& http_ret, string& code)
 {
   auto r = errs.find(err_no);
   if (r != errs.end()) {
-    if (! is_website_redirect)
-      http_ret = r->second.first;
-     code = r->second.second;
-     return true;
+    http_ret = r->second.first;
+    code = r->second.second;
+    return true;
   }
   return false;
 }
@@ -323,17 +322,14 @@ void set_req_state_err(struct rgw_err& err,	/* out */
     err_no = -err_no;
 
   err.ret = -err_no;
-  bool is_website_redirect = false;
 
   if (prot_flags & RGW_REST_SWIFT) {
-    if (search_err(rgw_http_swift_errors, err_no, is_website_redirect, err.http_ret, err.err_code))
+    if (search_err(rgw_http_swift_errors, err_no, err.http_ret, err.err_code))
       return;
   }
 
   //Default to searching in s3 errors
-  is_website_redirect |= (prot_flags & RGW_REST_WEBSITE)
-		&& err_no == ERR_WEBSITE_REDIRECT && err.is_clear();
-  if (search_err(rgw_http_s3_errors, err_no, is_website_redirect, err.http_ret, err.err_code))
+  if (search_err(rgw_http_s3_errors, err_no, err.http_ret, err.err_code))
       return;
   dout(0) << "WARNING: set_req_state_err err_no=" << err_no
 	<< " resorting to 500" << dendl;


### PR DESCRIPTION
when enable bucket static website as follow configure
```
<WebsiteConfiguration xmlns='http://s3.amazonaws.com/doc/2006-03-01/'>
  <IndexDocument>
    <Suffix>index.html</Suffix>
  </IndexDocument>
  <ErrorDocument>
    <Key>Error.html</Key>
  </ErrorDocument>
  <RoutingRules>
    <RoutingRule>
    <Condition>
      <KeyPrefixEquals>test/</KeyPrefixEquals>
    </Condition>
    <Redirect>
      <ReplaceKeyPrefixWith>tests/</ReplaceKeyPrefixWith>
    </Redirect>
    </RoutingRule>
  </RoutingRules>
</WebsiteConfiguration>
```
```
[root@dev build]# curl http://website01.eos-website.ecloud.today/test/1.html -v
* About to connect() to website01.eos-website.ecloud.today port 80 (#0)
*   Trying 192.168.153.165...
* Connected to website01.eos-website.ecloud.today (192.168.153.165) port 80 (#0)
> GET /test/1.html HTTP/1.1
> User-Agent: curl/7.29.0
> Host: website01.eos-website.ecloud.today
> Accept: */*
>
< HTTP/1.1 200 OK
< Location: http://website01.eos-website.ecloud.today/tests/1.html
< x-amz-request-id: tx000000000000000000001-005a1fb7c6-14882-default
< Content-Length: 0
< Date: Thu, 30 Nov 2017 08:57:25 GMT
<
```

it should return 301  rather  200

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>