### PR TITLE
MDS: make rebalancer evaluate the overload state of each mds with the same criterion

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -338,7 +338,7 @@ void MDBalancer::send_heartbeat()
   for (set<mds_rank_t>::iterator p = up.begin(); p != up.end(); ++p) {
     if (*p == mds->get_nodeid())
       continue;
-    MHeartbeat *hb = new MHeartbeat(load, beat_epoch);
+    MHeartbeat *hb = new MHeartbeat(load, beat_epoch, last_epoch_under);
     hb->get_import_map() = import_map;
     messenger->send_message(hb,
                             mds->mdsmap->get_inst(*p));
@@ -384,6 +384,7 @@ void MDBalancer::handle_heartbeat(MHeartbeat *m)
     }
   }
   mds_import_map[ who ] = m->get_import_map();
+  mds_last_epoch_under_info[who] = m->get_last_epoch_under();
 
   //dout(0) << "  load is " << load << " have " << mds_load.size() << dendl;
 
@@ -663,7 +664,8 @@ void MDBalancer::prep_rebalance(int beat)
 	dout(15) << "   mds." << it->second << " is importer" << dendl;
 	importers.insert(pair<double,mds_rank_t>(it->first,it->second));
 	importer_set.insert(it->second);
-      } else {
+      } else if ((it->first > target_load * (1.0 + g_conf->mds_bal_min_rebalance)) && 
+        (it->second == whoami || !mds_last_epoch_under_info[it->second] || beat_epoch - mds_last_epoch_under_info[it->second] >= 2)){
 	dout(15) << "   mds." << it->second << " is exporter" << dendl;
 	exporters.insert(pair<double,mds_rank_t>(it->first,it->second));
 	exporter_set.insert(it->second);

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -664,11 +664,13 @@ void MDBalancer::prep_rebalance(int beat)
 	dout(15) << "   mds." << it->second << " is importer" << dendl;
 	importers.insert(pair<double,mds_rank_t>(it->first,it->second));
 	importer_set.insert(it->second);
-      } else if ((it->first > target_load * (1.0 + g_conf->mds_bal_min_rebalance)) && 
-        (it->second == whoami || !mds_last_epoch_under_info[it->second] || beat_epoch - mds_last_epoch_under_info[it->second] >= 2)){
-	dout(15) << "   mds." << it->second << " is exporter" << dendl;
-	exporters.insert(pair<double,mds_rank_t>(it->first,it->second));
-	exporter_set.insert(it->second);
+      } else if (it->first > target_load * (1.0 + g_conf->mds_bal_min_rebalance)) {
+        int mds_last_epoch_under = (it->second == whoami) ? 0 : mds_last_epoch_under_info[it->second];
+        if (!mds_last_epoch_under || beat_epoch - mds_last_epoch_under >= 2) {
+	  dout(15) << "   mds." << it->second << " is exporter" << dendl;
+	  exporters.insert(pair<double,mds_rank_t>(it->first,it->second));
+	  exporter_set.insert(it->second);
+        }
       }
     }
 

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -142,6 +142,7 @@ private:
   map<mds_rank_t, mds_load_t>  mds_load;
   map<mds_rank_t, double>       mds_meta_load;
   map<mds_rank_t, map<mds_rank_t, float> > mds_import_map;
+  map<mds_rank_t, int> mds_last_epoch_under_info;
 
   // per-epoch state
   double          my_load, target_load;

--- a/src/messages/MHeartbeat.h
+++ b/src/messages/MHeartbeat.h
@@ -20,24 +20,29 @@
 #include "msg/Message.h"
 
 class MHeartbeat : public Message {
+  static const int HEAD_VERSION = 2;
+  static const int COMPAT_VERSION = 1;
   mds_load_t load;
   __s32        beat = 0;
+  __s32        last_epoch_under = 0;
   map<mds_rank_t, float> import_map;
 
  public:
   mds_load_t& get_load() { return load; }
   int get_beat() { return beat; }
+  int get_last_epoch_under() { return last_epoch_under; }
 
   map<mds_rank_t, float>& get_import_map() {
     return import_map;
   }
 
   MHeartbeat()
-    : Message(MSG_MDS_HEARTBEAT), load(utime_t()) { }
-  MHeartbeat(mds_load_t& load, int beat)
-    : Message(MSG_MDS_HEARTBEAT),
+    : Message(MSG_MDS_HEARTBEAT, HEAD_VERSION, COMPAT_VERSION), load(utime_t()) { }
+  MHeartbeat(mds_load_t& load, int beat, int last_epoch_under)
+    : Message(MSG_MDS_HEARTBEAT, HEAD_VERSION, COMPAT_VERSION),
       load(load) {
     this->beat = beat;
+    this->last_epoch_under = last_epoch_under;
   }
 private:
   ~MHeartbeat() override {}
@@ -49,6 +54,7 @@ public:
     ::encode(load, payload);
     ::encode(beat, payload);
     ::encode(import_map, payload);
+    ::encode(last_epoch_under, payload);
   }
   void decode_payload() override {
     bufferlist::iterator p = payload.begin();
@@ -56,6 +62,11 @@ public:
     ::decode(load, now, p);
     ::decode(beat, p);
     ::decode(import_map, p);
+    if (header.version >= 2) {
+      ::decode(last_epoch_under, p);
+    } else {
+      last_epoch_under = 0;
+    }
   }
 
 };


### PR DESCRIPTION
Signed-off-by: Jianyu Li <joannyli@tencent.com>

Currently, the prep_rebalancer requires the mds_load of itself being greater than average level  mds_bal_min_rebalance percent to be counted as exporter, however, for the other mds, as long as their mdsload is greater than average level, they could be consider as exporter. This inconsistent standard would cause gray area in the rebalance activity: one may expect the other do some work, but it didn't. Below is the actual log snip:

======  mds0  =======
2017-11-30 15:06:36.812943 7fdf03c6f700  5 mds.0.bal  prep_rebalance: cluster loads are
2017-11-30 15:06:36.812949 7fdf03c6f700  0 mds.0.bal   mds.0 mdsload<[0.461638,4366.5 8733.46]/[0.461888,4366.5 8733.46], req 12832.5, hr 0, qlen 3, cpu 29.93> = 21595.9 ~ 8733.46
2017-11-30 15:06:36.812979 7fdf03c6f700  0 mds.0.bal   mds.1 mdsload<[0,0 0]/[0,0 0], req 13169.8, hr 0, qlen 0, cpu 7.34> = 16327 ~ 6602.68
2017-11-30 15:06:36.813007 7fdf03c6f700  0 mds.0.bal   mds.2 mdsload<[0,0 0]/[0,0 0], req 13274.8, hr 0, qlen 0, cpu 25.47> = 20636.8 ~ 8345.58
2017-11-30 15:06:36.813022 7fdf03c6f700  5 mds.0.bal prep_rebalance:  my load 8733.46   target 7893.91   total 23681.7
2017-11-30 15:06:36.813026 7fdf03c6f700  5 mds.0.bal   i am sufficiently overloaded // based on above mds load info, mds0 itself is considered as overloaded, since its load 8733.46 > target_load(7893.91) * (1+mds_bal_min_rebalance=10% )
2017-11-30 15:06:36.813039 7fdf03c6f700  5 mds.0.bal    mds.1 is importer
2017-11-30 15:06:36.813041 7fdf03c6f700  5 mds.0.bal    mds.2 is exporter   // here mds2 load is 8345.58, which is greater than target_load=7893.91, so mds2 is considered as a overloaded mds
2017-11-30 15:06:36.813042 7fdf03c6f700  5 mds.0.bal    mds.0 is exporter
2017-11-30 15:06:36.813052 7fdf03c6f700  5 mds.0.bal    - mds.0 exports 839.555 to mds.1
2017-11-30 15:06:36.813057 7fdf03c6f700  5 mds.0.bal    - mds.2 exports 451.676 to mds.1  // and besides mds0, mds2 also be expected to export (8345.58 - 7893.91) = 451.67 to mds1

======  mds2  =======
2017-11-30 15:06:36.811258 7f7ae3d9e700  5 mds.2.bal  prep_rebalance: cluster loads are
2017-11-30 15:06:36.811266 7f7ae3d9e700  0 mds.2.bal   mds.0 mdsload<[0,0 0]/[0,0 0], req 12832.5, hr 0, qlen 3, cpu 29.93> = 21595.9 ~ 7704.16
2017-11-30 15:06:36.811287 7f7ae3d9e700  0 mds.2.bal   mds.1 mdsload<[0,0 0]/[0,0 0], req 13169.8, hr 0, qlen 0, cpu 7.34> = 16327 ~ 5824.5
2017-11-30 15:06:36.811304 7f7ae3d9e700  0 mds.2.bal   mds.2 mdsload<[0,3681 7361.99]/[0,3681 7361.99], req 13274.8, hr 0, qlen 0, cpu 25.47> = 20636.8 ~ 7361.99
2017-11-30 15:06:36.811318 7f7ae3d9e700  5 mds.2.bal prep_rebalance:  my load 7361.99   target 6963.55   total 20890.6
2017-11-30 15:06:36.811329 7f7ae3d9e700  5 mds.2.bal   i am underloaded or barely overloaded, doing nothing. // however, for mds2 itself, since its load 8345.58 isn't greater than target_load(7893.91) * (1+mds_bal_min_rebalance=10% ), so it doesn't consider itself as exporter, and doing nothing!

Besides above case, since we also have the requirement that overloaded mds should last at least for two epoches, we should take it into consideration too, otherwise we will meet the below bad case:

======  mds0  =======
2017-11-30 15:06:26.833284 7fdf03c6f700  5 mds.0.bal  prep_rebalance: cluster loads are
2017-11-30 15:06:26.833290 7fdf03c6f700  0 mds.0.bal   mds.0 mdsload<[1.84021,3990.87 7983.57]/[1.8412,3990.87 7983.57], req 16169.3, hr 0, qlen 3, cpu 31.32> = 24182.9 ~ 7983.57
2017-11-30 15:06:26.833332 7fdf03c6f700  0 mds.0.bal   mds.1 mdsload<[0,0 0]/[0,0 0], req 8704.57, hr 0, qlen 0, cpu 7.09> = 10734.3 ~ 3543.74
2017-11-30 15:06:26.833383 7fdf03c6f700  0 mds.0.bal   mds.2 mdsload<[0,0 0]/[0,0 0], req 15544.7, hr 0, qlen 0, cpu 24.19> = 23420.4 ~ 7731.84
2017-11-30 15:06:26.833417 7fdf03c6f700  5 mds.0.bal prep_rebalance:  my load 7983.57   target 6419.72   total 19259.2
2017-11-30 15:06:26.833433 7fdf03c6f700  5 mds.0.bal   i am overloaded, but only for 1 epochs // just overloaded for 1 epoch, doing nothing

======  mds2  =======
2017-11-30 15:06:26.830542 7f7ae3d9e700  5 mds.2.bal  prep_rebalance: cluster loads are
2017-11-30 15:06:26.830546 7f7ae3d9e700  0 mds.2.bal   mds.0 mdsload<[0,0 0]/[0,0 0], req 16169.3, hr 0, qlen 3, cpu 31.32> = 24182.9 ~ 8132.12
2017-11-30 15:06:26.830580 7f7ae3d9e700  0 mds.2.bal   mds.1 mdsload<[0,0 0]/[0,0 0], req 8704.57, hr 0, qlen 0, cpu 7.09> = 10734.3 ~ 3609.68
2017-11-30 15:06:26.830602 7f7ae3d9e700  0 mds.2.bal   mds.2 mdsload<[0,3937.85 7875.71]/[0,3937.85 7875.71], req 15544.7, hr 0, qlen 0, cpu 24.19> = 23420.4 ~ 7875.71
2017-11-30 15:06:26.830616 7f7ae3d9e700  5 mds.2.bal prep_rebalance:  my load 7875.71   target 6539.17   total 19617.5
2017-11-30 15:06:26.830626 7f7ae3d9e700  5 mds.2.bal   i am sufficiently overloaded
2017-11-30 15:06:26.830627 7f7ae3d9e700  5 mds.2.bal    mds.1 is importer
2017-11-30 15:06:26.830638 7f7ae3d9e700  5 mds.2.bal    mds.2 is exporter
2017-11-30 15:06:26.830646 7f7ae3d9e700  5 mds.2.bal    mds.0 is exporter
2017-11-30 15:06:26.830658 7f7ae3d9e700  5 mds.2.bal    - mds.2 exports 1336.54 to mds.1
2017-11-30 15:06:26.830673 7f7ae3d9e700  5 mds.2.bal    - mds.0 exports 1592.95 to mds.1  // but mds2 expects mds.0 could export its overload part: 8132.12 - target_load(6539.17) = 1592.95 to importer mds.1
2017-11-30 15:06:26.830690 7f7ae3d9e700  5 mds.2.bal want to send 1336.54 to mds.1 -> 1336.54
2017-11-30 15:06:26.977395 7f7ae3d9e700  5 mds.2.bal rebalance done

Here jut is the situation in three-mds configuration, with the increasing amount of mds, this inconsistent decision would get worse and affects the optimization effect of rebalancer.