### PR TITLE
rgw: NULL check before use tagging

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1683,11 +1683,13 @@ int RGWPostObj_ObjStore_S3::get_tags()
       return -EINVAL;
     }
 
-    RGWObjTagSet_S3 *obj_tags_s3;
+    RGWObjTagSet_S3 *obj_tags_s3 = nullptr;
     RGWObjTagging_S3 *tagging;
 
     tagging = static_cast<RGWObjTagging_S3 *>(parser.find_first("Tagging"));
-    obj_tags_s3 = static_cast<RGWObjTagSet_S3 *>(tagging->find_first("TagSet"));
+    if (tagging) {
+      obj_tags_s3 = static_cast<RGWObjTagSet_S3 *>(tagging->find_first("TagSet"));
+    }
     if(!obj_tags_s3){
       return -ERR_MALFORMED_XML;
     }


### PR DESCRIPTION
Fixes the coverity issue:

>CID 1413796 (#1 of 1): Dereference null return value (NULL_RETURNS)
>6. dereference: Dereferencing a pointer that might be null tagging
when calling find_first.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>