### PR TITLE
tests - Replaced requests for "centos 7.3" to centos_latest

### DIFF
--- a/qa/suites/rbd/valgrind/centos_latest.yaml
+++ b/qa/suites/rbd/valgrind/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../distros/supported/centos_latest.yaml

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
@@ -1,5 +1,3 @@
-os_type: centos
-os_version: "7.3"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
@@ -1,5 +1,3 @@
-os_type: centos
-os_version: "7.3"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
@@ -1,5 +1,3 @@
-os_type: centos
-os_version: "7.3"
 tasks:
 - workunit:
     clients:


### PR DESCRIPTION
Needs backport for `luminous` and `jewel`

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>