### PR TITLE
luminous: ceph_disk: allow "no fsid" on activate

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1258,7 +1258,8 @@ def get_fsid(cluster):
     :return: The fsid or raises Error.
     """
     fsid = get_conf_with_default(cluster=cluster, variable='fsid')
-    if fsid is None:
+    # uuids from boost always default to 'the empty uuid'
+    if fsid == '00000000-0000-0000-0000-000000000000':
         raise Error('getting cluster uuid from configuration failed')
     return fsid.lower()
 

--- a/src/ceph-disk/tests/test_prepare.py
+++ b/src/ceph-disk/tests/test_prepare.py
@@ -45,7 +45,8 @@ class Base(object):
 
 class TestPrepare(Base):
 
-    def test_init_filestore_dir(self):
+    @mock.patch('ceph_disk.main.get_fsid')
+    def test_init_filestore_dir(self, m_get_fsid):
         parser = argparse.ArgumentParser('ceph-disk')
         subparsers = parser.add_subparsers()
         main.Prepare.set_subparser(subparsers)
@@ -60,9 +61,11 @@ class TestPrepare(Base):
 
         def set_type(self):
             self.type = self.FILE
+        m_get_fsid.return_value = '571bb920-6d85-44d7-9eca-1bc114d1cd75'
         with mock.patch.multiple(main.PrepareData,
                                  set_type=set_type):
             prepare = main.Prepare.factory(args)
+        prepare = main.Prepare.factory(args)
         assert isinstance(prepare.data, main.PrepareFilestoreData)
         assert prepare.data.is_file()
         assert isinstance(prepare.journal, main.PrepareJournal)
@@ -73,7 +76,11 @@ class TestPrepare(Base):
 
     @mock.patch('stat.S_ISBLK')
     @mock.patch('ceph_disk.main.is_partition')
-    def test_init_filestore_dev(self, m_is_partition, m_s_isblk):
+    @mock.patch('ceph_disk.main.get_fsid')
+    def test_init_filestore_dev(self,
+                                m_get_fsid,
+                                m_is_partition,
+                                m_s_isblk):
         m_s_isblk.return_value = True
 
         parser = argparse.ArgumentParser('ceph-disk')
@@ -88,13 +95,15 @@ class TestPrepare(Base):
             data,
             '--filestore',
         ])
+        m_get_fsid.return_value = '571bb920-6d85-44d7-9eca-1bc114d1cd75'
         prepare = main.Prepare.factory(args)
         assert isinstance(prepare.data, main.PrepareData)
         assert prepare.data.is_device()
         assert isinstance(prepare.journal, main.PrepareJournal)
         assert prepare.journal.is_device()
 
-    def test_init_default_dir(self):
+    @mock.patch('ceph_disk.main.get_fsid')
+    def test_init_default_dir(self, m_get_fsid):
         parser = argparse.ArgumentParser('ceph-disk')
         subparsers = parser.add_subparsers()
         main.Prepare.set_subparser(subparsers)
@@ -108,6 +117,7 @@ class TestPrepare(Base):
 
         def set_type(self):
             self.type = self.FILE
+        m_get_fsid.return_value = '571bb920-6d85-44d7-9eca-1bc114d1cd75'
         with mock.patch.multiple(main.PrepareData,
                                  set_type=set_type):
             prepare = main.Prepare.factory(args)
@@ -376,7 +386,8 @@ class TestCryptHelpers(Base):
 
 class TestPrepareData(Base):
 
-    def test_set_variables(self):
+    @mock.patch('ceph_disk.main.get_fsid')
+    def test_set_variables(self, m_get_fsid):
         parser = argparse.ArgumentParser('ceph-disk')
         subparsers = parser.add_subparsers()
         main.Prepare.set_subparser(subparsers)
@@ -393,6 +404,7 @@ class TestPrepareData(Base):
 
         def set_type(self):
             self.type = self.FILE
+        m_get_fsid.return_value = cluster_uuid
         with mock.patch.multiple(main.PrepareData,
                                  set_type=set_type):
             data = main.PrepareData(args)

--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -6,6 +6,7 @@ skip_missing_interpreters = True
 setenv =
        VIRTUAL_ENV={envdir}
        CEPH_DISK={envbindir}/coverage run --append --source=ceph_disk -- {envbindir}/ceph-disk
+       PYTHONWARNINGS=ignore
 usedevelop = true
 deps =
   {env:NO_INDEX:}


### PR DESCRIPTION
backport of #19254 and #18991