### PR TITLE
vstart.sh: drop .ceph_port and use randomly selected available port

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -22,7 +22,4 @@ plugin dir = lib
 erasure code dir = lib
 EOF
 
-# give vstart a (hopefully) unique mon port to start with
-echo $(( RANDOM % 1000 + 40000 )) > .ceph_port
-
 echo done.

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -805,9 +805,13 @@ if [ -n "$MON_ADDR" ]; then
 	CMDS_ARGS=" -m "$MON_ADDR
 fi
 
-if [ -z "$CEPH_PORT" ]; then
-    CEPH_PORT=6789
-    [ -e ".ceph_port" ] && CEPH_PORT=`cat .ceph_port`
+if [ -z "$CEPH_PORT" ]
+then
+  while [ true ]
+  do
+    CEPH_PORT="$(echo $(( RANDOM % 1000 + 40000 )))"
+    ss -a -n | egrep ":${CEPH_PORT} .+LISTEN" 1>/dev/null 2>&1 || break
+  done
 fi
 
 [ -z "$INIT_CEPH" ] && INIT_CEPH=$CEPH_BIN/init-ceph


### PR DESCRIPTION
vstart.sh becomes independent of do_cmake.sh

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>