### PR TITLE
cephfs: potential adjust failure in lru_expire

### DIFF
--- a/src/include/lru.h
+++ b/src/include/lru.h
@@ -157,6 +157,7 @@ public:
 
   // expire -- expire a single item
   LRUObject *lru_get_next_expire() {
+    adjust();
     // look through tail of bot
     while (bottom.size()) {
       LRUObject *p = bottom.back();
@@ -164,7 +165,6 @@ public:
 
       // move to pintail
       pintail.push_front(&p->lru_link);
-      adjust();
     }
 
     // ok, try head then
@@ -174,7 +174,6 @@ public:
 
       // move to pintail
       pintail.push_front(&p->lru_link);
-      adjust();
     }
     
     // no luck!


### PR DESCRIPTION
Fix: the first 'adjust' is not needed,it will never take real effect.
     the second 'adjust' may never get the chance to be executed
     suppose we can reach the second 'adjust', it will crash because the bottom list is empty here.

Signed-off-by: dongdong tao <tdd21151186@gmail.com>