### PR TITLE
librgw: fix shutdown err with resources uncleaned

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -24,6 +24,7 @@
 #include "include/str_list.h"
 #include "include/stringify.h"
 #include "global/global_init.h"
+#include "global/signal_handler.h"
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/Timer.h"
@@ -60,6 +61,11 @@
 #define dout_subsys ceph_subsys_rgw
 
 bool global_stop = false;
+
+static void handle_sigterm(int signum)
+{
+  dout(20) << __func__ << " SIGUSR1 ignored" << dendl;
+}
 
 namespace rgw {
 
@@ -544,6 +550,9 @@ namespace rgw {
     fec = new RGWFrontendConfig("rgwlib");
     fe = new RGWLibFrontend(env, fec);
 
+    init_async_signal_handler();
+    register_async_signal_handler(SIGUSR1, handle_sigterm);
+
     map<string, string> service_map_meta;
     service_map_meta["pid"] = stringify(getpid());
     service_map_meta["frontend_type#" + fe_count] = "rgw-nfs";
@@ -577,6 +586,9 @@ namespace rgw {
     delete fe;
     delete fec;
     delete ldh;
+
+    unregister_async_signal_handler(SIGUSR1, handle_sigterm);
+    shutdown_async_signal_handler();
 
     rgw_log_usage_finalize();
 


### PR DESCRIPTION
Fixed: http://tracker.ceph.com/issues/22296

Signed-off-by : Tao CHEN <chentao@umcloud.com>