### PR TITLE
rbd: add parent info when moving child into trash bin

### DIFF
--- a/src/cls/journal/cls_journal.cc
+++ b/src/cls/journal/cls_journal.cc
@@ -388,7 +388,7 @@ int journal_get_order(cls_method_context_t hctx, bufferlist *in,
  * none
  *
  * Output:
- * order (uint8_t)
+ * splay_width (uint8_t)
  * @returns 0 on success, negative error code on failure
  */
 int journal_get_splay_width(cls_method_context_t hctx, bufferlist *in,

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -980,7 +980,7 @@ class RBD(object):
         with nogil:
             ret = rbd_trash_get(_ioctx, _image_id, &c_info)
         if ret != 0:
-            raise make_ex(ret, 'error restoring image from trash')
+            raise make_ex(ret, 'error retrieving image from trash')
 
         __source_string = ['USER', 'MIRRORING']
         info = {


### PR DESCRIPTION
We can get child's parent info even it's in trash bin if --long flag is specified:
```
root@ceph:/home/ceph-build/ceph-dev/build# ./bin/rbd trash ls -l
ID           NAME SOURCE DELETED_AT               STATUS                                   PARENT    
10423d1b58ba i2   USER   Fri Dec  1 17:22:20 2017                                          rbd/i1@s1 
10513d1b58ba i3   USER   Fri Dec  1 17:56:22 2017 protected until Fri Dec  1 17:58:02 2017 rbd/i1@s1
root@ceph:/home/ceph-build/ceph-dev/build#
```

Signed-off-by: songweibin <song.weibin@zte.com.cn>