### PR TITLE
WIP: mon: centralized config

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -57,3 +57,10 @@
 * The RBD C API's rbd_discard method now enforces a maximum length of
   2GB to match the C++ API's Image::discard method. This restriction
   prevents overflow of the result code.
+
+13.0.1
+------
+
+* The format of the 'config diff' output via the admin socket has changed.  It
+  now reflects the source of each config option (e.g., default, config file,
+  command line) as well as the final (active) value.

--- a/examples/rbd-replay/create-image
+++ b/examples/rbd-replay/create-image
@@ -3,6 +3,6 @@
 pool=rbd
 image=my-image
 size=10G
-export LD_LIBRARY_PATH=../../src/.libs
+export LD_LIBRARY_PATH=../../build/lib
 #qemu-img create -f raw rbd:$pool/$image:conf=../../src/ceph.conf $size
 qemu-img convert linux-0.2.img -O raw rbd:$pool/$image:conf=../../src/ceph.conf

--- a/examples/rbd-replay/trace
+++ b/examples/rbd-replay/trace
@@ -5,6 +5,6 @@ lttng create -o traces librbd
 lttng enable-event -u 'librbd:*'
 lttng add-context -u -t pthread_id
 lttng start
-LD_LIBRARY_PATH=../../src/.libs/ qemu-system-i386 -m 1024 rbd:rbd/my-image:conf=../../src/ceph.conf
+LD_LIBRARY_PATH=../../build/lib qemu-system-i386 -m 1024 rbd:rbd/my-image:conf=../../src/ceph.conf
 lttng stop
 lttng view > trace.log

--- a/qa/libceph/Makefile
+++ b/qa/libceph/Makefile
@@ -1,4 +1,4 @@
-CFLAGS = -Wall -Wextra -D_GNU_SOURCE -lcephfs -L../../src/.libs
+CFLAGS = -Wall -Wextra -D_GNU_SOURCE -lcephfs -L../../build/lib
 
 TARGETS = trivial_libceph 
 

--- a/qa/workunits/erasure-code/bench.sh
+++ b/qa/workunits/erasure-code/bench.sh
@@ -18,7 +18,7 @@
 # Test that it works from sources with:
 #
 #  CEPH_ERASURE_CODE_BENCHMARK=src/ceph_erasure_code_benchmark  \
-#  PLUGIN_DIRECTORY=src/.libs \
+#  PLUGIN_DIRECTORY=build/lib \
 #      qa/workunits/erasure-code/bench.sh fplot jerasure |
 #      tee qa/workunits/erasure-code/bench.js
 #
@@ -38,7 +38,7 @@
 #
 #  TOTAL_SIZE=$((4 * 1024 * 1024 * 1024)) \
 #  CEPH_ERASURE_CODE_BENCHMARK=src/ceph_erasure_code_benchmark  \
-#  PLUGIN_DIRECTORY=src/.libs \
+#  PLUGIN_DIRECTORY=build/lib \
 #      qa/workunits/erasure-code/bench.sh fplot jerasure |
 #      tee qa/workunits/erasure-code/bench.js
 #
@@ -182,7 +182,7 @@ fi
 # Local Variables:
 # compile-command: "\
 #   CEPH_ERASURE_CODE_BENCHMARK=../../../src/ceph_erasure_code_benchmark \
-#   PLUGIN_DIRECTORY=../../../src/.libs \
+#   PLUGIN_DIRECTORY=../../../build/lib \
 #   ./bench.sh
 # "
 # End:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -533,6 +533,7 @@ set(libcommon_files
   common/dns_resolve.cc
   common/hostname.cc
   common/util.cc
+  librbd/Features.cc
   arch/probe.cc
   ${auth_files}
   ${mds_files})

--- a/src/ceph-disk/tests/ceph-disk.sh
+++ b/src/ceph-disk/tests/ceph-disk.sh
@@ -23,7 +23,7 @@
 if [ -z "$CEPH_ROOT" ] || [ -z "$CEPH_BIN" ] || [ -z "$CEPH_LIB" ]; then
     CEPH_ROOT=`readlink -f $(dirname $0)/../../..`
     CEPH_BIN=$CEPH_ROOT
-    CEPH_LIB=$CEPH_ROOT/.libs
+    CEPH_LIB=$CEPH_ROOT/build/lib
 fi
 source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
 

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -79,9 +79,11 @@ int main(int argc, const char **argv, const char *envp[]) {
   }
   env_to_vec(args);
 
-  std::vector<const char*> def_args{"--pid-file="};
+  std::map<std::string,std::string> defaults = {
+    { "pid_file", "" }
+  };
 
-  auto cct = global_init(&def_args, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_DAEMON,
 			 CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
 

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -214,12 +214,13 @@ int main(int argc, const char **argv)
   //  leveldb_block_size        = 64*1024       = 65536     // 64KB
   //  leveldb_compression       = false
   //  leveldb_log               = ""
-  vector<const char*> def_args;
-  def_args.push_back("--leveldb-write-buffer-size=33554432");
-  def_args.push_back("--leveldb-cache-size=536870912");
-  def_args.push_back("--leveldb-block-size=65536");
-  def_args.push_back("--leveldb-compression=false");
-  def_args.push_back("--leveldb-log=");
+  map<string,string> defaults = {
+    { "leveldb_write_buffer_size", "33554432" },
+    { "leveldb_cache_size", "536870912" },
+    { "leveldb_block_size", "65536" },
+    { "leveldb_compression", "false"},
+    { "leveldb_log", "" }
+  };
 
   int flags = 0;
   {
@@ -241,7 +242,7 @@ int main(int argc, const char **argv)
     }
   }
 
-  auto cct = global_init(&def_args, args,
+  auto cct = global_init(&defaults, args,
 			 CEPH_ENTITY_TYPE_MON, CODE_ENVIRONMENT_DAEMON,
 			 flags, "mon_data");
   ceph_heap_profiler_init();

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -110,14 +110,16 @@ int main(int argc, const char **argv)
   argv_to_vec(argc, argv, args);
   env_to_vec(args);
 
-  vector<const char*> def_args;
-  // We want to enable leveldb's log, while allowing users to override this
-  // option, therefore we will pass it as a default argument to global_init().
-  def_args.push_back("--leveldb-log=");
-
-  auto cct = global_init(&def_args, args, CEPH_ENTITY_TYPE_OSD,
-			 CODE_ENVIRONMENT_DAEMON,
-			 0, "osd_data");
+  map<string,string> defaults = {
+    // We want to enable leveldb's log, while allowing users to override this
+    // option, therefore we will pass it as a default argument to global_init().
+    { "leveldb_log", "" }
+  };
+  auto cct = global_init(
+    &defaults,
+    args, CEPH_ENTITY_TYPE_OSD,
+    CODE_ENVIRONMENT_DAEMON,
+    0, "osd_data");
   ceph_heap_profiler_init();
 
   // osd specific args

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -481,66 +481,14 @@ void CephContext::do_command(std::string command, cmdmap_t& cmdmap,
         f->close_section();
       }
     } else if (command == "config diff") {
-      md_config_t def_conf;
-      def_conf.set_val("cluster", _conf->cluster);
-      def_conf.name = _conf->name;
-      def_conf.set_val("host", _conf->host);
-      def_conf.apply_changes(NULL);
-
-      map<string,pair<string,string> > diff;
-      set<string> unknown;
-      def_conf.diff(_conf, &diff, &unknown);
       f->open_object_section("diff");
-
-      f->open_object_section("current");
-      for (map<string,pair<string,string> >::iterator p = diff.begin();
-           p != diff.end(); ++p) {
-        f->dump_string(p->first.c_str(), p->second.second);
-      }
-      f->close_section(); // current
-      f->open_object_section("defaults");
-      for (map<string,pair<string,string> >::iterator p = diff.begin();
-           p != diff.end(); ++p) {
-        f->dump_string(p->first.c_str(), p->second.first);
-      }
-      f->close_section(); // defaults
-      f->close_section(); // diff
-
-      f->open_array_section("unknown");
-      for (set<string>::iterator p = unknown.begin();
-           p != unknown.end(); ++p) {
-        f->dump_string("option", *p);
-      }
+      _conf->diff(f);
       f->close_section(); // unknown
     } else if (command == "config diff get") {
       std::string setting;
-      if (!cmd_getval(this, cmdmap, "var", setting)) {
-        f->dump_string("error", "syntax error: 'config diff get <var>'");
-      } else {
-        md_config_t def_conf;
-        def_conf.set_val("cluster", _conf->cluster);
-        def_conf.name = _conf->name;
-        def_conf.set_val("host", _conf->host);
-        def_conf.apply_changes(NULL);
-
-        map<string, pair<string, string>> diff;
-        set<string> unknown;
-        def_conf.diff(_conf, &diff, &unknown, setting);
-        f->open_object_section("diff");
-        f->open_object_section("current");
-
-        for (const auto& p : diff) {
-          f->dump_string(p.first.c_str(), p.second.second);
-        } 
-        f->close_section();   //-- current
-
-        f->open_object_section("defaults");
-        for (const auto& p : diff) {
-          f->dump_string(p.first.c_str(), p.second.first);
-        } 
-        f->close_section();   //-- defaults
-        f->close_section();   //-- diff
-      } 
+      f->open_object_section("diff");
+      _conf->diff(f, setting);
+      f->close_section(); // unknown
     } else if (command == "log flush") {
       _log->flush();
     }

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -43,20 +43,20 @@ CephContext *common_preinit(const CephInitParameters &iparams,
   // for backward compatibility.  moving forward, we want all keyrings
   // in these locations.  the mon already forces $mon_data/keyring.
   if (conf->name.is_mds()) {
-    conf->set_val("keyring", "$mds_data/keyring", false);
+    conf->set_val_default("keyring", "$mds_data/keyring");
   } else if (conf->name.is_osd()) {
-    conf->set_val("keyring", "$osd_data/keyring", false);
+    conf->set_val_default("keyring", "$osd_data/keyring");
   }
 
   if (code_env == CODE_ENVIRONMENT_LIBRARY ||
       code_env == CODE_ENVIRONMENT_UTILITY_NODOUT) {
-    conf->set_val_or_die("log_to_stderr", "false");
-    conf->set_val_or_die("err_to_stderr", "false");
-    conf->set_val_or_die("log_flush_on_exit", "false");
+    conf->set_val_default("log_to_stderr", "false");
+    conf->set_val_default("err_to_stderr", "false");
+    conf->set_val_default("log_flush_on_exit", "false");
   }
   if (code_env != CODE_ENVIRONMENT_DAEMON) {
     // NOTE: disable ms subsystem gathering in clients by default
-    conf->set_val_or_die("debug_ms", "0/0");
+    conf->set_val_default("debug_ms", "0/0");
   }
 
   return cct;

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -911,14 +911,12 @@ Option::value_t md_config_t::_get_val_generic(const std::string &key) const
   // In key names, leading and trailing whitespace are not significant.
   string k(ConfFile::normalize_key_name(key));
 
-  const auto &opt_iter = schema.find(k);
-  if (opt_iter != schema.end()) {
-    // Using .at() is safe because all keys in the schema always have
-    // entries in ::values
-    return values.at(k);
-  } else {
-    return Option::value_t(boost::blank());
+  auto p = values.find(k);
+  if (p != values.end()) {
+    return p->second;
   }
+
+  return Option::value_t(boost::blank());
 }
 
 int md_config_t::_get_val_as_string(const std::string &key,

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -174,6 +174,15 @@ void md_config_t::validate_schema()
   }
 }
 
+const Option *md_config_t::find_option(const string& name) const
+{
+  auto p = schema.find(name);
+  if (p != schema.end()) {
+    return &p->second;
+  }
+  return nullptr;
+}
+
 void md_config_t::init_subsys()
 {
 #define SUBSYS(name, log, gather) \

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -227,6 +227,57 @@ const Option *md_config_t::find_option(const string& name) const
   return nullptr;
 }
 
+Option::value_t md_config_t::get_val_default(
+  const string& name,
+  bool meta) const
+{
+  Mutex::Locker l(lock);
+  const Option *o = find_option(name);
+  return _get_val_default(*o, meta);
+}
+
+Option::value_t md_config_t::_get_val_default(const Option& o, bool meta) const
+{
+  Option::value_t v;
+
+  auto p = default_values.find(o.name);
+  if (p != default_values.end()) {
+    // custom default
+    v = p->second;
+  } else {
+    // schema default
+    bool has_daemon_default = !boost::get<boost::blank>(&o.daemon_value);
+    if (is_daemon && has_daemon_default) {
+      v = o.daemon_value;
+    } else {
+      v = o.value;
+    }
+  }
+
+  if (meta) {
+    // expand meta fields
+    string *s = boost::get<std::string>(&v);
+    if (s) {
+      ostringstream oss;
+      expand_meta(*s, &oss);
+    }
+  }
+  return v;
+}
+
+void md_config_t::set_val_default(const string& name, const std::string& val)
+{
+  Mutex::Locker l(lock);
+  const Option *o = find_option(name);
+  assert(o);
+  string err;
+  Option::value_t v;
+  int r = o->parse_value(val, &v, &err);
+  assert(r == 0);
+  values[name] = v;
+  default_values[name] = v;
+}
+
 void md_config_t::init_subsys()
 {
 #define SUBSYS(name, log, gather) \

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -51,15 +51,6 @@ const char *CEPH_CONF_FILE_DEFAULT = "$data_dir/config, /etc/ceph/$cluster.conf,
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
 
-enum {
-  CONF_DEFAULT,
-  CONF_MON,
-  CONF_CONFFILE,
-  CONF_ENV,
-  CONF_OVERRIDE,
-  CONF_FINAL
-};
-
 const char *ceph_conf_level_name(int level)
 {
   switch (level) {
@@ -893,6 +884,23 @@ int md_config_t::rm_val(const std::string& key)
   return _rm_val(key, CONF_OVERRIDE);
 }
 
+void md_config_t::get_config_bl(bufferlist *bl)
+{
+  Mutex::Locker l(lock);
+  if (values_bl.length() == 0) {
+    ::encode((uint32_t)values.size(), values_bl);
+    for (auto& i : values) {
+      ::encode(i.first, values_bl);
+      ::encode((uint32_t)i.second.size(), values_bl);
+      for (auto& j : i.second) {
+	::encode(j.first, values_bl);
+	::encode(stringify(j.second), values_bl);
+      }
+    }
+  }
+  *bl = values_bl;
+}
+
 int md_config_t::get_val(const std::string &key, char **buf, int len) const
 {
   Mutex::Locker l(lock);
@@ -1237,11 +1245,13 @@ int md_config_t::_set_val(
     } else {
       p->second[level] = new_value;
     }
+    values_bl.clear();
     if (p->second.rbegin()->first > level) {
       // there was a higher priority value; no effect
       return 0;
     }
   } else {
+    values_bl.clear();
     values[opt.name][level] = new_value;
   }
 
@@ -1291,6 +1301,7 @@ int md_config_t::_rm_val(const std::string& key, int level)
   if (matters) {
     _refresh(*find_option(key));
   }
+  values_bl.clear();
   return 0;
 }
 

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1057,68 +1057,11 @@ int md_config_t::set_val_impl(const std::string &raw_val, const Option &opt,
 {
   assert(lock.is_locked());
 
-  std::string val = raw_val;
-
-  int r = opt.pre_validate(&val, error_message);
-  if (r != 0) {
-    return r;
-  }
-
   Option::value_t new_value;
-  if (opt.type == Option::TYPE_INT) {
-    int64_t f = strict_si_cast<int64_t>(val.c_str(), error_message);
-    if (!error_message->empty()) {
-      return -EINVAL;
-    }
-    new_value = f;
-  } else if (opt.type == Option::TYPE_UINT) {
-    uint64_t f = strict_si_cast<uint64_t>(val.c_str(), error_message);
-    if (!error_message->empty()) {
-      return -EINVAL;
-    }
-    new_value = f;
-  } else if (opt.type == Option::TYPE_STR) {
-    new_value = val;
-  } else if (opt.type == Option::TYPE_FLOAT) {
-    double f = strict_strtod(val.c_str(), error_message);
-    if (!error_message->empty()) {
-      return -EINVAL;
-    } else {
-      new_value = f;
-    }
-  } else if (opt.type == Option::TYPE_BOOL) {
-    if (strcasecmp(val.c_str(), "false") == 0) {
-      new_value = false;
-    } else if (strcasecmp(val.c_str(), "true") == 0) {
-      new_value = true;
-    } else {
-      int b = strict_strtol(val.c_str(), 10, error_message);
-      if (!error_message->empty()) {
-	return -EINVAL;
-      }
-      new_value = !!b;
-    }
-  } else if (opt.type == Option::TYPE_ADDR) {
-    entity_addr_t addr;
-    if (!addr.parse(val.c_str())){
-      return -EINVAL;
-    }
-    new_value = addr;
-  } else if (opt.type == Option::TYPE_UUID) {
-    uuid_d uuid;
-    if (!uuid.parse(val.c_str())) {
-      return -EINVAL;
-    }
-    new_value = uuid;
-  } else {
-    ceph_abort();
-  }
-
-  r = opt.validate(new_value, error_message);
-  if (r != 0) {
+  int r = opt.parse_value(raw_val, &new_value, error_message);
+  if (r < 0) {
     return r;
   }
-
 
   // Apply the value to its entry in the `values` map
   values[opt.name] = new_value;

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -22,18 +22,19 @@
 #include "osd/osd_types.h"
 #include "common/errno.h"
 #include "common/hostname.h"
+#include "common/dout.h"
 
 /* Don't use standard Ceph logging in this file.
  * We can't use logging until it's initialized, and a lot of the necessary
  * initialization happens here.
  */
 #undef dout
-#undef ldout
 #undef pdout
 #undef derr
-#undef lderr
 #undef generic_dout
-#undef dendl
+
+// set set_mon_vals()
+#define dout_subsys ceph_subsys_monc
 
 using std::map;
 using std::list;
@@ -271,13 +272,45 @@ void md_config_t::set_val_default(const string& name, const std::string& val)
   assert(r >= 0);
 }
 
-void md_config_t::set_val_mon(const string& name, const std::string& val)
+int md_config_t::set_mon_vals(CephContext *cct, const map<string,string>& kv)
 {
   Mutex::Locker l(lock);
-  const Option *o = find_option(name);
-  assert(o);
-  string err;
-  set_val_impl(val, *o, CONF_MON, &err);
+  for (auto& i : kv) {
+    const Option *o = find_option(i.first);
+    if (!o) {
+      ldout(cct,10) << __func__ << " " << i.first << " = " << i.second
+		    << " (unrecognized option)" << dendl;
+      continue;
+    }
+    if (o->has_flag(Option::FLAG_NO_MON_UPDATE)) {
+      continue;
+    }
+    std::string err;
+    int r = _set_val(i.second, *o, CONF_MON, &err);
+    if (r < 0) {
+      lderr(cct) << __func__ << " failed to set " << i.first << " = "
+		 << i.second << ": " << err << dendl;
+    } else if (r == 0) {
+      ldout(cct,20) << __func__ << " " << i.first << " = " << i.second
+		    << " (no change)" << dendl;
+    } else if (r == 1) {
+      ldout(cct,10) << __func__ << " " << i.first << " = " << i.second << dendl;
+    } else {
+      ceph_abort();
+    }
+  }
+  for (auto& i : values) {
+    auto j = i.second.find(CONF_MON);
+    if (j != i.second.end()) {
+      if (kv.find(i.first) == kv.end()) {
+	ldout(cct,10) << __func__ << " " << i.first
+		      << " cleared (was " << j->second << ")"
+		      << dendl;
+	_rm_val(i.first, CONF_MON);
+      }
+    }
+  }
+  return 0;
 }
 
 void md_config_t::init_subsys()

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -12,6 +12,8 @@
  *
  */
 
+#include <boost/type_traits.hpp>
+
 #include "common/ceph_argparse.h"
 #include "common/common_init.h"
 #include "common/config.h"
@@ -20,8 +22,6 @@
 #include "osd/osd_types.h"
 #include "common/errno.h"
 #include "common/hostname.h"
-
-#include <boost/type_traits.hpp>
 
 /* Don't use standard Ceph logging in this file.
  * We can't use logging until it's initialized, and a lot of the necessary
@@ -91,6 +91,49 @@ md_config_t::md_config_t(bool is_daemon)
       ceph_abort();
     }
     schema.insert({i.name, i});
+  }
+
+  // Define the debug_* options as well.
+  subsys_options.reserve(subsys.get_num());
+  for (unsigned i = 0; i < subsys.get_num(); ++i) {
+    string name = string("debug_") + subsys.get_name(i);
+    subsys_options.push_back(
+      Option(name, Option::TYPE_STR, Option::LEVEL_ADVANCED));
+    Option& opt = subsys_options.back();
+    opt.set_default(stringify(subsys.get_log_level(i)) + "/" +
+		    stringify(subsys.get_gather_level(i)));
+    string desc = string("Debug level for ") + subsys.get_name(i);
+    opt.set_description(desc.c_str());
+    opt.set_safe();
+    opt.set_long_description("The value takes the form 'N' or 'N/M' where N and M are values between 0 and 99.  N is the debug level to log (all values below this are included), and M is the level to gather and buffer in memory.  In the event of a crash, the most recent items <= M are dumped to the log file.");
+    opt.set_subsys(i);
+    opt.set_validator([](std::string *value, std::string *error_message) {
+	int m, n;
+	int r = sscanf(value->c_str(), "%d/%d", &m, &n);
+	if (r >= 1) {
+	  if (m < 0 || m > 99) {
+	    *error_message = "value must be in range [0, 99]";
+	    return -ERANGE;
+	  }
+	  if (r == 2) {
+	    if (n < 0 || n > 99) {
+	      *error_message = "value must be in range [0, 99]";
+	      return -ERANGE;
+	    }
+	  } else {
+	    // normalize to M/N
+	    n = m;
+	    *value = stringify(m) + "/" + stringify(n);
+	  }
+	} else {
+	  *error_message = "value must take the form N or N/M, where N and M are integers";
+	  return -EINVAL;
+	}
+	return 0;
+      });
+  }
+  for (auto& opt : subsys_options) {
+    schema.insert({opt.name, opt});
   }
 
   // Populate list of legacy_values according to the OPTION() definitions
@@ -336,25 +379,6 @@ int md_config_t::parse_config_files_impl(const std::list<std::string> &conf_file
     }
   }
 
-  // subsystems?
-  for (size_t o = 0; o < subsys.get_num(); o++) {
-    std::string as_option("debug_");
-    as_option += subsys.get_name(o);
-    std::string val;
-    int ret = _get_val_from_conf_file(my_sections, as_option.c_str(), val, false);
-    if (ret == 0) {
-      int log, gather;
-      int r = sscanf(val.c_str(), "%d/%d", &log, &gather);
-      if (r >= 1) {
-	if (r < 2)
-	  gather = log;
-	//	cout << "config subsys " << subsys.get_name(o) << " log " << log << " gather " << gather << std::endl;
-	subsys.set_log_level(o, log);
-	subsys.set_gather_level(o, gather);
-      }
-    }	
-  }
-
   // Warn about section names that look like old-style section names
   std::deque < std::string > old_style_section_names;
   for (ConfFile::const_section_iter_t s = cf.sections_begin();
@@ -410,20 +434,6 @@ void md_config_t::_show_config(std::ostream *out, Formatter *f)
   if (f) {
     f->dump_string("name", stringify(name));
     f->dump_string("cluster", cluster);
-  }
-  for (size_t o = 0; o < subsys.get_num(); o++) {
-    if (out)
-      *out << "debug_" << subsys.get_name(o)
-	   << " = " << subsys.get_log_level(o)
-	   << "/" << subsys.get_gather_level(o) << std::endl;
-    if (f) {
-      ostringstream ss;
-      std::string debug_name = "debug_";
-      debug_name += subsys.get_name(o);
-      ss << subsys.get_log_level(o)
-	 << "/" << subsys.get_gather_level(o);
-      f->dump_string(debug_name.c_str(), ss.str());
-    }
   }
   for (const auto& i: schema) {
     const Option &opt = i.second;
@@ -543,39 +553,6 @@ int md_config_t::parse_option(std::vector<const char*>& args,
   int ret = 0;
   size_t o = 0;
   std::string val;
-
-  // subsystems?
-  for (o = 0; o < subsys.get_num(); o++) {
-    std::string as_option("--");
-    as_option += "debug_";
-    as_option += subsys.get_name(o);
-    ostringstream err;
-    if (ceph_argparse_witharg(args, i, &val, err,
-			      as_option.c_str(), (char*)NULL)) {
-      if (err.tellp()) {
-        if (oss) {
-          *oss << err.str();
-        }
-        ret = -EINVAL;
-        break;
-      }
-      int log, gather;
-      int r = sscanf(val.c_str(), "%d/%d", &log, &gather);
-      if (r >= 1) {
-	if (r < 2)
-	  gather = log;
-	//	  cout << "subsys " << subsys.get_name(o) << " log " << log << " gather " << gather << std::endl;
-	subsys.set_log_level(o, log);
-	subsys.set_gather_level(o, gather);
-	if (oss)
-	  *oss << "debug_" << subsys.get_name(o) << "=" << log << "/" << gather << " ";
-      }
-      break;
-    }	
-  }
-  if (o < subsys.get_num()) {
-    return ret;
-  }
 
   std::string option_name;
   std::string error_message;
@@ -824,30 +801,6 @@ int md_config_t::set_val(const std::string &key, const char *val,
 
   string k(ConfFile::normalize_key_name(key));
 
-  // subsystems?
-  if (strncmp(k.c_str(), "debug_", 6) == 0) {
-    for (size_t o = 0; o < subsys.get_num(); o++) {
-      std::string as_option = "debug_" + subsys.get_name(o);
-      if (k == as_option) {
-	int log, gather;
-	int r = sscanf(v.c_str(), "%d/%d", &log, &gather);
-	if (r >= 1) {
-	  if (r < 2) {
-	    gather = log;
-          }
-	  subsys.set_log_level(o, log);
-	  subsys.set_gather_level(o, gather);
-          if (err_ss) *err_ss << "Set " << k << " to " << log << "/" << gather;
-	  return 0;
-	}
-        if (err_ss) {
-          *err_ss << "Invalid debug level, should be <int> or <int>/<int>";
-        }
-	return -EINVAL;
-      }
-    }	
-  }
-
   const auto &opt_iter = schema.find(k);
   if (opt_iter != schema.end()) {
     const Option &opt = opt_iter->second;
@@ -960,18 +913,6 @@ int md_config_t::_get_val(const std::string &key, char **buf, int len) const
   }
 
   string k(ConfFile::normalize_key_name(key));
-  // subsys?
-  for (size_t o = 0; o < subsys.get_num(); o++) {
-    std::string as_option = "debug_" + subsys.get_name(o);
-    if (k == as_option) {
-      if (len == -1) {
-	*buf = (char*)malloc(20);
-	len = 20;
-      }
-      int l = snprintf(*buf, len, "%d/%d", subsys.get_log_level(o), subsys.get_gather_level(o));
-      return (l == len) ? -ENAMETOOLONG : 0;
-    }
-  }
 
   // couldn't find a configuration option with key 'k'
   return -ENOENT;
@@ -988,9 +929,6 @@ void md_config_t::get_all_keys(std::vector<std::string> *keys) const {
     if (opt.type == Option::TYPE_BOOL) {
       keys->push_back(negative_flag_prefix + opt.name);
     }
-  }
-  for (size_t i = 0; i < subsys.get_num(); ++i) {
-    keys->push_back("debug_" + subsys.get_name(i));
   }
 }
 
@@ -1072,7 +1010,22 @@ int md_config_t::set_val_impl(const std::string &raw_val, const Option &opt,
     update_legacy_val(opt, legacy_ptr_iter->second);
   }
 
-  changed.insert(opt.name);
+  // Was this a debug_* option update?
+  if (opt.subsys >= 0) {
+    int log, gather;
+    int r = sscanf(raw_val.c_str(), "%d/%d", &log, &gather);
+    if (r >= 1) {
+      if (r < 2) {
+	gather = log;
+      }
+      subsys.set_log_level(opt.subsys, log);
+      subsys.set_gather_level(opt.subsys, gather);
+    }
+  } else {
+    // normal option, advertise the change.
+    changed.insert(opt.name);
+  }
+
   return 0;
 }
 

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -50,6 +50,28 @@ const char *CEPH_CONF_FILE_DEFAULT = "$data_dir/config, /etc/ceph/$cluster.conf,
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
 
+enum {
+  CONF_DEFAULT,
+  CONF_MON,
+  CONF_CONFFILE,
+  CONF_ENV,
+  CONF_OVERRIDE,
+  CONF_FINAL
+};
+
+const char *ceph_conf_level_name(int level)
+{
+  switch (level) {
+  case CONF_DEFAULT: return "default";
+  case CONF_MON: return "mon";
+  case CONF_ENV: return "env";
+  case CONF_CONFFILE: return "conffile";
+  case CONF_OVERRIDE: return "override";
+  case CONF_FINAL: return "final";
+  default: return "???";
+  }
+}
+
 int ceph_resolve_file_search(const std::string& filename_list,
 			     std::string& result)
 {
@@ -72,7 +94,24 @@ int ceph_resolve_file_search(const std::string& filename_list,
   return ret;
 }
 
-
+static int conf_stringify(const Option::value_t& v, string *out)
+{
+  if (boost::get<boost::blank>(&v)) {
+    return -ENOENT;
+  }
+  if (const bool *flag = boost::get<const bool>(&v)) {
+    *out = *flag ? "true" : "false";
+    return 0;
+  }
+  ostringstream oss;
+  if (const double *dp = boost::get<const double>(&v)) {
+    oss << std::fixed << *dp;
+  } else {
+    oss << v;
+  }
+  *out = oss.str();
+  return 0;
+}
 
 md_config_t::md_config_t(bool is_daemon)
   : is_daemon(is_daemon),
@@ -152,18 +191,17 @@ md_config_t::md_config_t(bool is_daemon)
 
   validate_schema();
 
-  // Load default values from the schema
+  // Validate default values from the schema
   for (const auto &i : schema) {
     const Option &opt = i.second;
-    bool has_daemon_default = !boost::get<boost::blank>(&opt.daemon_value);
-    Option::value_t default_val;
-    if (is_daemon && has_daemon_default) {
-      default_val = opt.daemon_value;
-    } else {
-      default_val = opt.value;
-    }
-
     if (opt.type == Option::TYPE_STR) {
+      bool has_daemon_default = !boost::get<boost::blank>(&opt.daemon_value);
+      Option::value_t default_val;
+      if (is_daemon && has_daemon_default) {
+	default_val = opt.daemon_value;
+      } else {
+	default_val = opt.value;
+      }
       // We call pre_validate as a sanity check, but also to get any
       // side effect (value modification) from the validator.
       std::string *def_str = boost::get<std::string>(&default_val);
@@ -178,18 +216,14 @@ md_config_t::md_config_t(bool is_daemon)
         ceph_abort();
       }
     }
-
-    values[i.first] = default_val;
   }
 
   // Copy out values (defaults) into any legacy (C struct member) fields
-  for (const auto &i : legacy_values) {
-    const auto &name = i.first;
-    const auto &option = schema.at(name);
-    auto ptr = i.second;
+  update_legacy_vals();
+}
 
-    update_legacy_val(option, ptr);
-  }
+md_config_t::~md_config_t()
+{
 }
 
 /**
@@ -227,55 +261,22 @@ const Option *md_config_t::find_option(const string& name) const
   return nullptr;
 }
 
-Option::value_t md_config_t::get_val_default(
-  const string& name,
-  bool meta) const
-{
-  Mutex::Locker l(lock);
-  const Option *o = find_option(name);
-  return _get_val_default(*o, meta);
-}
-
-Option::value_t md_config_t::_get_val_default(const Option& o, bool meta) const
-{
-  Option::value_t v;
-
-  auto p = default_values.find(o.name);
-  if (p != default_values.end()) {
-    // custom default
-    v = p->second;
-  } else {
-    // schema default
-    bool has_daemon_default = !boost::get<boost::blank>(&o.daemon_value);
-    if (is_daemon && has_daemon_default) {
-      v = o.daemon_value;
-    } else {
-      v = o.value;
-    }
-  }
-
-  if (meta) {
-    // expand meta fields
-    string *s = boost::get<std::string>(&v);
-    if (s) {
-      ostringstream oss;
-      expand_meta(*s, &oss);
-    }
-  }
-  return v;
-}
-
 void md_config_t::set_val_default(const string& name, const std::string& val)
 {
   Mutex::Locker l(lock);
   const Option *o = find_option(name);
   assert(o);
   string err;
-  Option::value_t v;
-  int r = o->parse_value(val, &v, &err);
-  assert(r == 0);
-  values[name] = v;
-  default_values[name] = v;
+  set_val_impl(val, *o, CONF_DEFAULT, &err);
+}
+
+void md_config_t::set_val_mon(const string& name, const std::string& val)
+{
+  Mutex::Locker l(lock);
+  const Option *o = find_option(name);
+  assert(o);
+  string err;
+  set_val_impl(val, *o, CONF_MON, &err);
 }
 
 void md_config_t::init_subsys()
@@ -287,10 +288,6 @@ void md_config_t::init_subsys()
 #include "common/subsys.h"
 #undef SUBSYS
 #undef DEFAULT_SUBSYS
-}
-
-md_config_t::~md_config_t()
-{
 }
 
 void md_config_t::add_observer(md_config_obs_t* observer_)
@@ -319,7 +316,7 @@ void md_config_t::remove_observer(md_config_obs_t* observer_)
   assert(found_obs);
 }
 
-int md_config_t::parse_config_files(const char *conf_files,
+int md_config_t::parse_config_files(const char *conf_files_str,
 				    std::ostream *warnings,
 				    int flags)
 {
@@ -328,7 +325,7 @@ int md_config_t::parse_config_files(const char *conf_files,
   if (safe_to_start_threads)
     return -ENOSYS;
 
-  if (!cluster.size() && !conf_files) {
+  if (!cluster.size() && !conf_files_str) {
     /*
      * set the cluster name to 'ceph' when neither cluster name nor
      * configuration file are specified.
@@ -336,51 +333,39 @@ int md_config_t::parse_config_files(const char *conf_files,
     cluster = "ceph";
   }
 
-  if (!conf_files) {
+  if (!conf_files_str) {
     const char *c = getenv("CEPH_CONF");
     if (c) {
-      conf_files = c;
+      conf_files_str = c;
     }
     else {
       if (flags & CINIT_FLAG_NO_DEFAULT_CONFIG_FILE)
 	return 0;
-      conf_files = CEPH_CONF_FILE_DEFAULT;
+      conf_files_str = CEPH_CONF_FILE_DEFAULT;
     }
   }
 
-  std::list<std::string> cfl;
-  get_str_list(conf_files, cfl);
-
-  auto p = cfl.begin();
-  while (p != cfl.end()) {
-    // expand $data_dir?
+  std::list<std::string> conf_files;
+  get_str_list(conf_files_str, conf_files);
+  auto p = conf_files.begin();
+  while (p != conf_files.end()) {
     string &s = *p;
-    if (s.find("$data_dir") != string::npos) {
-      if (data_dir_option.length()) {
-	list<const Option *> stack;
-	expand_meta(s, NULL, stack, warnings);
-	p++;
-      } else {
-	cfl.erase(p++);  // ignore this item
-      }
+    if (s.find("$data_dir") != string::npos &&
+	data_dir_option.empty()) {
+      // useless $data_dir item, skip
+      p = conf_files.erase(p);
     } else {
+      early_expand_meta(s, warnings);
       ++p;
     }
   }
-  return parse_config_files_impl(cfl, warnings);
-}
-
-int md_config_t::parse_config_files_impl(const std::list<std::string> &conf_files,
-					 std::ostream *warnings)
-{
-  assert(lock.is_locked());
 
   // open new conf
   list<string>::const_iterator c;
   for (c = conf_files.begin(); c != conf_files.end(); ++c) {
     cf.clear();
     string fn = *c;
-    expand_meta(fn, warnings);
+
     int ret = cf.parse_file(fn.c_str(), &parse_errors, warnings);
     if (ret == 0)
       break;
@@ -415,10 +400,10 @@ int md_config_t::parse_config_files_impl(const std::list<std::string> &conf_file
   for (const auto &i : schema) {
     const auto &opt = i.second;
     std::string val;
-    int ret = _get_val_from_conf_file(my_sections, opt.name, val, false);
+    int ret = _get_val_from_conf_file(my_sections, opt.name, val);
     if (ret == 0) {
       std::string error_message;
-      int r = set_val_impl(val, opt, &error_message);
+      int r = set_val_impl(val, opt, CONF_CONFFILE, &error_message);
       if (warnings != nullptr && (r != 0 || !error_message.empty())) {
         *warnings << "parse error setting '" << opt.name << "' to '" << val
                   << "'";
@@ -451,6 +436,9 @@ int md_config_t::parse_config_files_impl(const std::list<std::string> &conf_file
     }
     cerr << ". Please use the new style section names that include a period.";
   }
+
+  update_legacy_vals();
+
   return 0;
 }
 
@@ -460,7 +448,8 @@ void md_config_t::parse_env()
   if (safe_to_start_threads)
     return;
   if (getenv("CEPH_KEYRING")) {
-    set_val_or_die("keyring", getenv("CEPH_KEYRING"));
+    string k = getenv("CEPH_KEYRING");
+    values["keyring"][CONF_ENV] = Option::value_t(k);
   }
 }
 
@@ -488,13 +477,14 @@ void md_config_t::_show_config(std::ostream *out, Formatter *f)
   }
   for (const auto& i: schema) {
     const Option &opt = i.second;
-    char *buf;
-    _get_val(opt.name, &buf, -1);
-    if (out)
-      *out << opt.name << " = " << buf << std::endl;
-    if (f)
-      f->dump_string(opt.name.c_str(), buf);
-    free(buf);
+    string val;
+    conf_stringify(_get_val(opt), &val);
+    if (out) {
+      *out << opt.name << " = " << val << std::endl;
+    }
+    if (f) {
+      f->dump_string(opt.name.c_str(), val);
+    }
   }
 }
 
@@ -571,26 +561,24 @@ int md_config_t::parse_argv(std::vector<const char*>& args)
   }
 
   if (show_config) {
-    expand_all_meta();
     _show_config(&cout, NULL);
     _exit(0);
   }
 
   if (show_config_value) {
-    char *buf = 0;
-    int r = _get_val(show_config_value_arg.c_str(), &buf, -1);
+    string val;
+    int r = conf_stringify(_get_val(show_config_value_arg), &val);
     if (r < 0) {
       if (r == -ENOENT)
-	std::cerr << "failed to get config option '" <<
-	  show_config_value_arg << "': option not found" << std::endl;
+	std::cerr << "failed to get config option '"
+		  << show_config_value_arg << "': option not found" << std::endl;
       else
-	std::cerr << "failed to get config option '" <<
-	  show_config_value_arg << "': " << cpp_strerror(r) << std::endl;
+	std::cerr << "failed to get config option '"
+		  << show_config_value_arg << "': " << cpp_strerror(r)
+		  << std::endl;
       _exit(1);
     }
-    string s = buf;
-    expand_meta(s, &std::cerr);
-    std::cout << s << std::endl;
+    std::cout << val << std::endl;
     _exit(0);
   }
 
@@ -619,9 +607,9 @@ int md_config_t::parse_option(std::vector<const char*>& args,
       if (ceph_argparse_binary_flag(args, i, &res, oss, as_option.c_str(),
 				    (char*)NULL)) {
 	if (res == 0)
-	  ret = set_val_impl("false", opt, &error_message);
+	  ret = set_val_impl("false", opt, CONF_OVERRIDE, &error_message);
 	else if (res == 1)
-	  ret = set_val_impl("true", opt, &error_message);
+	  ret = set_val_impl("true", opt, CONF_OVERRIDE, &error_message);
 	else
 	  ret = res;
 	break;
@@ -629,7 +617,7 @@ int md_config_t::parse_option(std::vector<const char*>& args,
 	std::string no("--no-");
 	no += opt.name;
 	if (ceph_argparse_flag(args, i, no.c_str(), (char*)NULL)) {
-	  ret = set_val_impl("false", opt, &error_message);
+	  ret = set_val_impl("false", opt, CONF_OVERRIDE, &error_message);
 	  break;
 	}
       }
@@ -645,7 +633,7 @@ int md_config_t::parse_option(std::vector<const char*>& args,
 	*oss << "You cannot change " << opt.name << " using injectargs.\n";
         return -ENOSYS;
       }
-      ret = set_val_impl(val, opt, &error_message);
+      ret = set_val_impl(val, opt, CONF_OVERRIDE, &error_message);
       break;
     }
     ++o;
@@ -706,31 +694,21 @@ void md_config_t::_apply_changes(std::ostream *oss)
    * have changed. */
   typedef std::map < md_config_obs_t*, std::set <std::string> > rev_obs_map_t;
 
-  expand_all_meta();
-
-  // expand_all_meta could have modified anything.  Copy it all out again.
-  for (const auto &i : legacy_values) {
-    const auto &name = i.first;
-    const auto &option = schema.at(name);
-    auto ptr = i.second;
-
-    update_legacy_val(option, ptr);
-  }
+  // meta expands could have modified anything.  Copy it all out again.
+  update_legacy_vals();
 
   // create the reverse observer mapping, mapping observers to the set of
   // changed keys that they'll get.
   rev_obs_map_t robs;
   std::set <std::string> empty_set;
-  char buf[128];
-  char *bufptr = (char*)buf;
+  string val;
   for (changed_set_t::const_iterator c = changed.begin();
        c != changed.end(); ++c) {
     const std::string &key(*c);
     pair < obs_map_t::iterator, obs_map_t::iterator >
       range(observers.equal_range(key));
-    if ((oss) &&
-	!_get_val(key.c_str(), &bufptr, sizeof(buf))) {
-      (*oss) << key << " = '" << buf << "' ";
+    if ((oss) && !conf_stringify(_get_val(key), &val)) {
+      (*oss) << key << " = '" << val << "' ";
       if (range.first == range.second) {
 	(*oss) << "(not observed, change may require restart) ";
       }
@@ -766,9 +744,6 @@ void md_config_t::call_all_observers()
   // by reference and lock as appropriate.
   Mutex::Locker l(lock);
   {
-
-    expand_all_meta();
-
     for (auto r = observers.begin(); r != observers.end(); ++r) {
       obs[r->second].insert(r->first);
     }
@@ -823,11 +798,10 @@ int md_config_t::injectargs(const std::string& s, std::ostream *oss)
 }
 
 void md_config_t::set_val_or_die(const std::string &key,
-                                 const std::string &val,
-                                 bool meta)
+                                 const std::string &val)
 {
   std::stringstream err;
-  int ret = set_val(key, val, meta, &err);
+  int ret = set_val(key, val, &err);
   if (ret != 0) {
     std::cerr << "set_val_or_die(" << key << "): " << err.str();
   }
@@ -835,7 +809,7 @@ void md_config_t::set_val_or_die(const std::string &key,
 }
 
 int md_config_t::set_val(const std::string &key, const char *val,
-    bool meta, std::stringstream *err_ss)
+			 std::stringstream *err_ss)
 {
   Mutex::Locker l(lock);
   if (key.empty()) {
@@ -847,8 +821,6 @@ int md_config_t::set_val(const std::string &key, const char *val,
   }
 
   std::string v(val);
-  if (meta)
-    expand_meta(v, &std::cerr);
 
   string k(ConfFile::normalize_key_name(key));
 
@@ -867,7 +839,7 @@ int md_config_t::set_val(const std::string &key, const char *val,
     }
 
     std::string error_message;
-    int r = set_val_impl(v, opt, &error_message);
+    int r = set_val_impl(v, opt, CONF_OVERRIDE, &error_message);
     if (r == 0) {
       if (err_ss) *err_ss << "Set " << opt.name << " to " << v;
     } else {
@@ -884,26 +856,27 @@ int md_config_t::set_val(const std::string &key, const char *val,
 int md_config_t::get_val(const std::string &key, char **buf, int len) const
 {
   Mutex::Locker l(lock);
-  return _get_val(key, buf,len);
+  return _get_val_cstr(key, buf, len);
 }
 
-int md_config_t::get_val_as_string(const std::string &key,
-				   std::string *val) const
+int md_config_t::get_val(
+  const std::string &key,
+  std::string *val) const
 {
-  Mutex::Locker l(lock);
-  return _get_val_as_string(key, val);
+  return conf_stringify(get_val_generic(key), val);
 }
 
 Option::value_t md_config_t::get_val_generic(const std::string &key) const
 {
   Mutex::Locker l(lock);
-  return _get_val_generic(key);
+  return _get_val(key);
 }
 
-Option::value_t md_config_t::_get_val_generic(const std::string &key) const
+Option::value_t md_config_t::_get_val(
+  const std::string &key,
+  expand_stack_t *stack) const
 {
   assert(lock.is_locked());
-
   if (key.empty()) {
     return Option::value_t(boost::blank());
   }
@@ -911,44 +884,190 @@ Option::value_t md_config_t::_get_val_generic(const std::string &key) const
   // In key names, leading and trailing whitespace are not significant.
   string k(ConfFile::normalize_key_name(key));
 
-  auto p = values.find(k);
-  if (p != values.end()) {
-    return p->second;
+  const Option *o = find_option(key);
+  if (!o) {
+    // not a valid config option
+    return Option::value_t(boost::blank());
   }
 
-  return Option::value_t(boost::blank());
+  return _get_val(*o, stack);
 }
 
-int md_config_t::_get_val_as_string(const std::string &key,
-				    std::string *value) const {
-  assert(lock.is_locked());
+Option::value_t md_config_t::_get_val(
+  const Option& o,
+  expand_stack_t *stack,
+  std::ostream *err) const
+{
+  expand_stack_t a_stack;
+  if (!stack) {
+    stack = &a_stack;
+  }
 
-  std::string normalized_key(ConfFile::normalize_key_name(key));
-  Option::value_t config_value = _get_val_generic(normalized_key.c_str());
-  if (!boost::get<boost::blank>(&config_value)) {
-    ostringstream oss;
-    if (bool *flag = boost::get<bool>(&config_value)) {
-      oss << (*flag ? "true" : "false");
-    } else if (double *dp = boost::get<double>(&config_value)) {
-      oss << std::fixed << *dp;
-    } else {
-      oss << config_value;
+  auto p = values.find(o.name);
+  if (p != values.end() && !p->second.empty()) {
+    // use highest-priority value available (see CONF_*)
+    return _expand_meta(p->second.rbegin()->second, &o, stack, err);
+  }
+
+  return _expand_meta(_get_val_default(o), &o, stack, err);
+}
+
+const Option::value_t& md_config_t::_get_val_default(const Option& o) const
+{
+  bool has_daemon_default = !boost::get<boost::blank>(&o.daemon_value);
+  if (is_daemon && has_daemon_default) {
+    return o.daemon_value;
+  } else {
+    return o.value;
+  }
+}
+
+void md_config_t::early_expand_meta(
+  std::string &val,
+  std::ostream *err) const
+{
+  Mutex::Locker l(lock);
+  expand_stack_t stack;
+  Option::value_t v = _expand_meta(Option::value_t(val), nullptr, &stack, err);
+  conf_stringify(v, &val);
+}
+
+Option::value_t md_config_t::_expand_meta(
+  const Option::value_t& in,
+  const Option *o,
+  expand_stack_t *stack,
+  std::ostream *err) const
+{
+  //cout << __func__ << " in '" << in << "' stack " << stack << std::endl;
+  if (!stack) {
+    return in;
+  }
+  const std::string *str = boost::get<const std::string>(&in);
+  if (!str) {
+    // strings only!
+    return in;
+  }
+
+  auto pos = str->find('$');
+  if (pos == std::string::npos) {
+    // no substitutions!
+    return in;
+  }
+
+  if (o) {
+    stack->push_back(make_pair(o, &in));
+  }
+  string out;
+  decltype(pos) last_pos = 0;
+  while (pos != std::string::npos) {
+    assert((*str)[pos] == '$');
+    if (pos > last_pos) {
+      out += str->substr(last_pos, pos - last_pos);
     }
-    *value = oss.str();
-    return 0;
+
+    // try to parse the variable name into var, either \$\{(.+)\} or
+    // \$[a-z\_]+
+    const char *valid_chars = "abcdefghijklmnopqrstuvwxyz_";
+    string var;
+    size_t endpos = 0;
+    if ((*str)[pos+1] == '{') {
+      // ...${foo_bar}...
+      endpos = str->find_first_not_of(valid_chars, pos + 2);
+      if (endpos != std::string::npos &&
+	  (*str)[endpos] == '}') {
+	var = str->substr(pos + 2, endpos - pos - 2);
+	endpos++;
+      }
+    } else {
+      // ...$foo...
+      endpos = str->find_first_not_of(valid_chars, pos + 1);
+      if (endpos != std::string::npos)
+	var = str->substr(pos + 1, endpos - pos - 1);
+      else
+	var = str->substr(pos + 1);
+    }
+    last_pos = endpos;
+
+    if (!var.size()) {
+      out += '$';
+    } else {
+      //cout << " found var " << var << std::endl;
+      // special metavariable?
+      if (var == "type") {
+	out += name.get_type_name();
+      } else if (var == "cluster") {
+	out += cluster;
+      } else if (var == "name") {
+	out += name.to_cstr();
+      } else if (var == "host") {
+	if (host == "") {
+	  out += ceph_get_short_hostname();
+	} else {
+	  out += host;
+	}
+      } else if (var == "num") {
+	out += name.get_id().c_str();
+      } else if (var == "id") {
+	out += name.get_id();
+      } else if (var == "pid") {
+	out += stringify(getpid());
+      } else if (var == "cctid") {
+	out += stringify((unsigned long long)this);
+      } else {
+	if (var == "data_dir") {
+	  var = data_dir_option;
+	}
+	const Option *o = find_option(var);
+	if (!o) {
+	  out += str->substr(pos, endpos - pos);
+	} else {
+	  auto match = std::find_if(
+	    stack->begin(), stack->end(),
+	    [o](pair<const Option *,const Option::value_t*>& item) {
+	      return item.first == o;
+	    });
+	  if (match != stack->end()) {
+	    // substitution loop; break the cycle
+	    if (err) {
+	      *err << "variable expansion loop at " << var << "="
+		   << *match->second << "\n"
+		   << "expansion stack:\n";
+	      for (auto i = stack->rbegin(); i != stack->rend(); ++i) {
+		*err << i->first->name << "=" << *i->second << "\n";
+	      }
+	    }
+	    return Option::value_t(std::string("$") + o->name);
+	  } else {
+	    // recursively evaluate!
+	    string n;
+	    conf_stringify(_get_val(*o, stack, err), &n);
+	    out += n;
+	  }
+	}
+      }
+    }
+    pos = str->find('$', last_pos);
   }
-  return -ENOENT;
+  if (last_pos != std::string::npos) {
+    out += str->substr(last_pos);
+  }
+  if (o) {
+    stack->pop_back();
+  }
+
+  return Option::value_t(out);
 }
 
-int md_config_t::_get_val(const std::string &key, char **buf, int len) const
+int md_config_t::_get_val_cstr(
+  const std::string &key, char **buf, int len) const
 {
   assert(lock.is_locked());
 
   if (key.empty())
     return -EINVAL;
 
-  string val ;
-  if (_get_val_as_string(key, &val) == 0) {
+  string val;
+  if (conf_stringify(_get_val(key), &val) == 0) {
     int l = val.length() + 1;
     if (len == -1) {
       *buf = (char*)malloc(l);
@@ -1013,15 +1132,29 @@ int md_config_t::get_all_sections(std::vector <std::string> &sections) const
   return 0;
 }
 
-int md_config_t::get_val_from_conf_file(const std::vector <std::string> &sections,
-		    const std::string &key, std::string &out, bool emeta) const
+int md_config_t::get_val_from_conf_file(
+  const std::vector <std::string> &sections,
+  const std::string &key,
+  std::string &out,
+  bool emeta) const
 {
   Mutex::Locker l(lock);
-  return _get_val_from_conf_file(sections, key, out, emeta);
+  int r = _get_val_from_conf_file(sections, key, out);
+  if (r < 0) {
+    return r;
+  }
+  if (emeta) {
+    expand_stack_t stack;
+    auto v = _expand_meta(Option::value_t(out), nullptr, &stack, nullptr);
+    conf_stringify(v, &out);
+  }
+  return 0;
 }
 
-int md_config_t::_get_val_from_conf_file(const std::vector <std::string> &sections,
-					 const std::string &key, std::string &out, bool emeta) const
+int md_config_t::_get_val_from_conf_file(
+  const std::vector <std::string> &sections,
+  const std::string &key,
+  std::string &out) const
 {
   assert(lock.is_locked());
   std::vector <std::string>::const_iterator s = sections.begin();
@@ -1029,18 +1162,19 @@ int md_config_t::_get_val_from_conf_file(const std::vector <std::string> &sectio
   for (; s != s_end; ++s) {
     int ret = cf.read(s->c_str(), key, out);
     if (ret == 0) {
-      if (emeta)
-	expand_meta(out, &std::cerr);
       return 0;
-    }
-    else if (ret != -ENOENT)
+    } else if (ret != -ENOENT) {
       return ret;
+    }
   }
   return -ENOENT;
 }
 
-int md_config_t::set_val_impl(const std::string &raw_val, const Option &opt,
-                              std::string *error_message)
+int md_config_t::set_val_impl(
+  const std::string &raw_val,
+  const Option &opt,
+  int level,
+  std::string *error_message)
 {
   assert(lock.is_locked());
 
@@ -1051,7 +1185,7 @@ int md_config_t::set_val_impl(const std::string &raw_val, const Option &opt,
   }
 
   // Apply the value to its entry in the `values` map
-  values[opt.name] = new_value;
+  values[opt.name][level] = new_value;
 
   // Apply the value to its legacy field, if it has one
   auto legacy_ptr_iter = legacy_values.find(std::string(opt.name));
@@ -1061,8 +1195,10 @@ int md_config_t::set_val_impl(const std::string &raw_val, const Option &opt,
 
   // Was this a debug_* option update?
   if (opt.subsys >= 0) {
+    string actual_val;
+    conf_stringify(_get_val(opt), &actual_val);
     int log, gather;
-    int r = sscanf(raw_val.c_str(), "%d/%d", &log, &gather);
+    int r = sscanf(actual_val.c_str(), "%d/%d", &log, &gather);
     if (r >= 1) {
       if (r < 2) {
 	gather = log;
@@ -1100,249 +1236,52 @@ class assign_visitor : public boost::static_visitor<>
   }
 };
 
+void md_config_t::update_legacy_vals()
+{
+  for (const auto &i : legacy_values) {
+    const auto &name = i.first;
+    const auto &option = schema.at(name);
+    auto ptr = i.second;
+    update_legacy_val(option, ptr);
+  }
+}
+
 void md_config_t::update_legacy_val(const Option &opt,
                                     md_config_t::member_ptr_t member_ptr)
 {
-  if (boost::get<boost::blank>(&values.at(opt.name))) {
-    // This shouldn't happen, but if it does then just don't even
-    // try to assign to the legacy field.
-    return;
-  }
-
-  boost::apply_visitor(assign_visitor(this, values.at(opt.name)), member_ptr);
+  Option::value_t v = _get_val(opt);
+  boost::apply_visitor(assign_visitor(this, v), member_ptr);
 }
 
-
-static const char *CONF_METAVARIABLES[] = {
-  "data_dir", // put this first: it may contain some of the others
-  "cluster", "type", "name", "host", "num", "id", "pid", "cctid"
-};
-static const int NUM_CONF_METAVARIABLES =
-      (sizeof(CONF_METAVARIABLES) / sizeof(CONF_METAVARIABLES[0]));
-
-void md_config_t::expand_all_meta()
+static void dump(Formatter *f, int level, Option::value_t in)
 {
-  // Expand all metavariables
-  ostringstream oss;
-  for (const auto &i : schema) {
-    const Option &opt = i.second;
-
-    if (opt.type == Option::TYPE_STR) {
-      list<const Option*> stack;
-      std::string *str = boost::get<std::string>(&(values.at(opt.name)));
-      assert(str != nullptr);  // Non-string values should never get in
-      expand_meta(*str, &opt, stack, &oss);
-    }
+  if (const bool *v = boost::get<const bool>(&in)) {
+    f->dump_bool(ceph_conf_level_name(level), *v);
+  } else if (const int64_t *v = boost::get<const int64_t>(&in)) {
+    f->dump_int(ceph_conf_level_name(level), *v);
+  } else if (const uint64_t *v = boost::get<const uint64_t>(&in)) {
+    f->dump_unsigned(ceph_conf_level_name(level), *v);
+  } else if (const double *v = boost::get<const double>(&in)) {
+    f->dump_float(ceph_conf_level_name(level), *v);
+  } else {
+    f->dump_stream(ceph_conf_level_name(level)) << in;
   }
-  cerr << oss.str();
-}
-
-bool md_config_t::expand_meta(std::string &val,
-			      std::ostream *oss) const
-{
-  list<const Option*> stack;
-  return expand_meta(val, NULL, stack, oss);
-}
-
-bool md_config_t::expand_meta(std::string &origval,
-			      const Option *opt,
-			      std::list<const Option *> stack,
-			      std::ostream *oss) const
-{
-  assert(lock.is_locked());
-
-  // no $ means no variable expansion is necessary
-  if (origval.find("$") == string::npos)
-    return false;
-
-  // ignore an expansion loop and create a human readable
-  // message about it
-  if (opt) {
-    for (const auto stack_ptr : stack) {
-      if (opt->name == stack_ptr->name) {
-	*oss << "variable expansion loop at "
-	     << opt->name << "=" << origval << std::endl;
-	*oss << "expansion stack: " << std::endl;
-	for (const auto j : stack) {
-          std::string val;
-          _get_val_as_string(j->name, &val);
-	  *oss << j->name << "=" << val << std::endl;
-	}
-	return false;
-      }
-    }
-
-    stack.push_front(opt);
-  }
-
-  bool found_meta = false;
-  string out;
-  string val = origval;
-  for (string::size_type s = 0; s < val.size(); ) {
-    if (val[s] != '$') {
-      out += val[s++];
-      continue;
-    }
-
-    // try to parse the variable name into var, either \$\{(.+)\} or
-    // \$[a-z\_]+
-    const char *valid_chars = "abcdefghijklmnopqrstuvwxyz_";
-    string var;
-    size_t endpos = 0;
-    if (val[s+1] == '{') {
-      // ...${foo_bar}...
-      endpos = val.find_first_not_of(valid_chars, s+2);
-      if (endpos != std::string::npos &&
-	  val[endpos] == '}') {
-	var = val.substr(s+2, endpos-s-2);
-	endpos++;
-      }
-    } else {
-      // ...$foo...
-      endpos = val.find_first_not_of(valid_chars, s+1);
-      if (endpos != std::string::npos)
-	var = val.substr(s+1, endpos-s-1);
-      else
-	var = val.substr(s+1);
-    }
-
-    bool expanded = false;
-    if (var.length()) {
-      // special metavariable?
-      for (int i = 0; i < NUM_CONF_METAVARIABLES; ++i) {
-	if (var != CONF_METAVARIABLES[i])
-	  continue;
-	//cout << "  meta match of " << var << " " << CONF_METAVARIABLES[i] << std::endl;
-	if (var == "type")
-	  out += name.get_type_name();
-	else if (var == "cluster")
-	  out += cluster;
-	else if (var == "name")
-          out += name.to_cstr();
-	else if (var == "host")
-        {
-          if (host == "")
-            out += ceph_get_short_hostname();
-          else
-	    out += host;
-        }
-	else if (var == "num")
-	  out += name.get_id().c_str();
-	else if (var == "id")
-	  out += name.get_id().c_str();
-	else if (var == "pid")
-	  out += stringify(getpid());
-	else if (var == "cctid")
-	  out += stringify((unsigned long long)this);
-	else if (var == "data_dir") {
-	  if (data_dir_option.length()) {
-	    char *vv = NULL;
-	    _get_val(data_dir_option.c_str(), &vv, -1);
-	    string tmp = vv;
-	    free(vv);
-	    expand_meta(tmp, NULL, stack, oss);
-	    out += tmp;
-	  } else {
-	    // this isn't really right, but it'll result in a mangled
-	    // non-existent path that will fail any search list
-	    out += "$data_dir";
-	  }
-	} else
-	  ceph_abort(); // unreachable
-	expanded = true;
-      }
-
-      if (!expanded) {
-	// config option?
-        const auto other_opt_iter = schema.find(var);
-        if (other_opt_iter != schema.end()) {
-          const Option &other_opt = other_opt_iter->second;
-          if (other_opt.type == Option::TYPE_STR) {
-            // The referenced option is a string, it may need substitution
-            // before inserting.
-            Option::value_t *other_val_ptr = const_cast<Option::value_t*>(&(values.at(other_opt.name)));
-            std::string *other_opt_val = boost::get<std::string>(other_val_ptr);
-            expand_meta(*other_opt_val, &other_opt, stack, oss);
-            out += *other_opt_val;
-          } else {
-            // The referenced option is not a string: retrieve and insert
-            // its stringized form.
-            char *vv = NULL;
-            _get_val(other_opt.name, &vv, -1);
-            out += vv;
-            free(vv);
-          }
-          expanded = true;
-	}
-      }
-    }
-
-    if (expanded) {
-      found_meta = true;
-      s = endpos;
-    } else {
-      out += val[s++];
-    }
-  }
-  // override the original value with the expanded value
-  origval = out;
-  return found_meta;
 }
 
 void md_config_t::diff(
-  const md_config_t *other,
-  map<string, pair<string, string> > *diff,
-  set<string> *unknown) 
-{
-  diff_helper(other, diff, unknown);
-}
-void md_config_t::diff(
-  const md_config_t *other,
-  map<string, pair<string, string> > *diff,
-  set<string> *unknown, const string& setting) 
-{
-  diff_helper(other, diff, unknown, setting);
-}
-
-void md_config_t::diff_helper(
-    const md_config_t *other,
-    map<string,pair<string,string> > *diff,
-    set<string> *unknown, const string& setting)
+  Formatter *f,
+  string name) const
 {
   Mutex::Locker l(lock);
-
-  char local_buf[4096];
-  char other_buf[4096];
-  for (const auto &i : schema) {
-    const Option &opt = i.second;
-    if (!setting.empty()) {
-      if (setting != opt.name) {
-        continue;
-      }
+  for (auto& i : values) {
+    f->open_object_section(i.first.c_str());
+    const Option *o = find_option(i.first);
+    dump(f, CONF_DEFAULT, _get_val_default(*o));
+    for (auto& j : i.second) {
+      dump(f, j.first, j.second);
     }
-    memset(local_buf, 0, sizeof(local_buf));
-    memset(other_buf, 0, sizeof(other_buf));
-
-    char *other_val = other_buf;
-    int err = other->get_val(opt.name, &other_val, sizeof(other_buf));
-    if (err < 0) {
-      if (err == -ENOENT) {
-        unknown->insert(opt.name);
-      }
-      continue;
-    }
-
-    char *local_val = local_buf;
-    err = _get_val(opt.name, &local_val, sizeof(local_buf));
-    if (err != 0)
-      continue;
-
-    if (strcmp(local_val, other_val))
-      diff->insert(make_pair(opt.name, make_pair(local_val, other_val)));
-    else if (!setting.empty()) {
-        diff->insert(make_pair(opt.name, make_pair(local_val, other_val)));
-        break;
-    }
+    dump(f, CONF_FINAL, _get_val(*o));
+    f->close_section();
   }
 }
 

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -883,6 +883,13 @@ int md_config_t::get_val(const std::string &key, char **buf, int len) const
   return _get_val(key, buf,len);
 }
 
+int md_config_t::get_val_as_string(const std::string &key,
+				   std::string *val) const
+{
+  Mutex::Locker l(lock);
+  return _get_val_as_string(key, val);
+}
+
 Option::value_t md_config_t::get_val_generic(const std::string &key) const
 {
   Mutex::Locker l(lock);
@@ -910,7 +917,8 @@ Option::value_t md_config_t::_get_val_generic(const std::string &key) const
   }
 }
 
-int md_config_t::_get_val(const std::string &key, std::string *value) const {
+int md_config_t::_get_val_as_string(const std::string &key,
+				    std::string *value) const {
   assert(lock.is_locked());
 
   std::string normalized_key(ConfFile::normalize_key_name(key));
@@ -938,7 +946,7 @@ int md_config_t::_get_val(const std::string &key, char **buf, int len) const
     return -EINVAL;
 
   string val ;
-  if (_get_val(key, &val) == 0) {
+  if (_get_val_as_string(key, &val) == 0) {
     int l = val.length() + 1;
     if (len == -1) {
       *buf = (char*)malloc(l);
@@ -1212,7 +1220,7 @@ bool md_config_t::expand_meta(std::string &origval,
 	*oss << "expansion stack: " << std::endl;
 	for (const auto j : stack) {
           std::string val;
-          _get_val(j->name, &val);
+          _get_val_as_string(j->name, &val);
 	  *oss << j->name << "=" << val << std::endl;
 	}
 	return false;

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -75,8 +75,9 @@ int ceph_resolve_file_search(const std::string& filename_list,
 
 
 md_config_t::md_config_t(bool is_daemon)
-  : cluster(""),
-  lock("md_config_t", true, false)
+  : is_daemon(is_daemon),
+    cluster(""),
+    lock("md_config_t", true, false)
 {
   init_subsys();
 

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -267,7 +267,8 @@ void md_config_t::set_val_default(const string& name, const std::string& val)
   const Option *o = find_option(name);
   assert(o);
   string err;
-  set_val_impl(val, *o, CONF_DEFAULT, &err);
+  int r = _set_val(val, *o, CONF_DEFAULT, &err);
+  assert(r >= 0);
 }
 
 void md_config_t::set_val_mon(const string& name, const std::string& val)
@@ -403,8 +404,8 @@ int md_config_t::parse_config_files(const char *conf_files_str,
     int ret = _get_val_from_conf_file(my_sections, opt.name, val);
     if (ret == 0) {
       std::string error_message;
-      int r = set_val_impl(val, opt, CONF_CONFFILE, &error_message);
-      if (warnings != nullptr && (r != 0 || !error_message.empty())) {
+      int r = _set_val(val, opt, CONF_CONFFILE, &error_message);
+      if (warnings != nullptr && (r < 0 || !error_message.empty())) {
         *warnings << "parse error setting '" << opt.name << "' to '" << val
                   << "'";
         if (!error_message.empty()) {
@@ -607,9 +608,9 @@ int md_config_t::parse_option(std::vector<const char*>& args,
       if (ceph_argparse_binary_flag(args, i, &res, oss, as_option.c_str(),
 				    (char*)NULL)) {
 	if (res == 0)
-	  ret = set_val_impl("false", opt, CONF_OVERRIDE, &error_message);
+	  ret = _set_val("false", opt, CONF_OVERRIDE, &error_message);
 	else if (res == 1)
-	  ret = set_val_impl("true", opt, CONF_OVERRIDE, &error_message);
+	  ret = _set_val("true", opt, CONF_OVERRIDE, &error_message);
 	else
 	  ret = res;
 	break;
@@ -617,7 +618,7 @@ int md_config_t::parse_option(std::vector<const char*>& args,
 	std::string no("--no-");
 	no += opt.name;
 	if (ceph_argparse_flag(args, i, no.c_str(), (char*)NULL)) {
-	  ret = set_val_impl("false", opt, CONF_OVERRIDE, &error_message);
+	  ret = _set_val("false", opt, CONF_OVERRIDE, &error_message);
 	  break;
 	}
       }
@@ -633,13 +634,13 @@ int md_config_t::parse_option(std::vector<const char*>& args,
 	*oss << "You cannot change " << opt.name << " using injectargs.\n";
         return -ENOSYS;
       }
-      ret = set_val_impl(val, opt, CONF_OVERRIDE, &error_message);
+      ret = _set_val(val, opt, CONF_OVERRIDE, &error_message);
       break;
     }
     ++o;
   }
 
-  if (ret != 0 || !error_message.empty()) {
+  if (ret < 0 || !error_message.empty()) {
     assert(!option_name.empty());
     if (oss) {
       *oss << "Parse error setting " << option_name << " to '"
@@ -662,7 +663,7 @@ int md_config_t::parse_option(std::vector<const char*>& args,
     // ignore
     ++i;
   }
-  return ret;
+  return ret >= 0 ? 0 : ret;
 }
 
 int md_config_t::parse_injectargs(std::vector<const char*>& args,
@@ -839,9 +840,10 @@ int md_config_t::set_val(const std::string &key, const char *val,
     }
 
     std::string error_message;
-    int r = set_val_impl(v, opt, CONF_OVERRIDE, &error_message);
-    if (r == 0) {
+    int r = _set_val(v, opt, CONF_OVERRIDE, &error_message);
+    if (r >= 0) {
       if (err_ss) *err_ss << "Set " << opt.name << " to " << v;
+      r = 0;
     } else {
       if (err_ss) *err_ss << error_message;
     }
@@ -852,6 +854,11 @@ int md_config_t::set_val(const std::string &key, const char *val,
   return -ENOENT;
 }
 
+int md_config_t::rm_val(const std::string& key)
+{
+  Mutex::Locker l(lock);
+  return _rm_val(key, CONF_OVERRIDE);
+}
 
 int md_config_t::get_val(const std::string &key, char **buf, int len) const
 {
@@ -1170,7 +1177,7 @@ int md_config_t::_get_val_from_conf_file(
   return -ENOENT;
 }
 
-int md_config_t::set_val_impl(
+int md_config_t::_set_val(
   const std::string &raw_val,
   const Option &opt,
   int level,
@@ -1185,8 +1192,32 @@ int md_config_t::set_val_impl(
   }
 
   // Apply the value to its entry in the `values` map
-  values[opt.name][level] = new_value;
+  auto p = values.find(opt.name);
+  if (p != values.end()) {
+    auto q = p->second.find(level);
+    if (q != p->second.end()) {
+      if (new_value == q->second) {
+	// no change!
+	return 0;
+      }
+      q->second = new_value;
+    } else {
+      p->second[level] = new_value;
+    }
+    if (p->second.rbegin()->first > level) {
+      // there was a higher priority value; no effect
+      return 0;
+    }
+  } else {
+    values[opt.name][level] = new_value;
+  }
 
+  _refresh(opt);
+  return 1;
+}
+
+void md_config_t::_refresh(const Option& opt)
+{
   // Apply the value to its legacy field, if it has one
   auto legacy_ptr_iter = legacy_values.find(std::string(opt.name));
   if (legacy_ptr_iter != legacy_values.end()) {
@@ -1210,7 +1241,23 @@ int md_config_t::set_val_impl(
     // normal option, advertise the change.
     changed.insert(opt.name);
   }
+}
 
+int md_config_t::_rm_val(const std::string& key, int level)
+{
+  auto i = values.find(key);
+  if (i == values.end()) {
+    return -ENOENT;
+  }
+  auto j = i->second.find(level);
+  if (j == i->second.end()) {
+    return -ENOENT;
+  }
+  bool matters = (j->first == i->second.rbegin()->first);
+  i->second.erase(j);
+  if (matters) {
+    _refresh(*find_option(key));
+  }
   return 0;
 }
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -271,6 +271,8 @@ private:
   obs_map_t observers;
   changed_set_t changed;
 
+  vector<Option> subsys_options;
+
 public:
   ceph::logging::SubsystemMap subsys;
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -94,6 +94,9 @@ public:
    */
   std::map<std::string, const Option &> schema;
 
+  /// default values (if they vary from the schema)
+  std::map<std::string, Option::value_t> default_values;
+
   /**
    * The current values of all settings described by the schema
    */
@@ -146,6 +149,15 @@ public:
 
   /// Look up an option in the schema
   const Option *find_option(const string& name) const;
+
+  /// Look up the default value for an option by name
+  Option::value_t get_val_default(const string& name, bool meta) const;
+
+  /// Look up the default value for an option
+  Option::value_t _get_val_default(const Option& o, bool meta) const;
+
+  /// Set a default value
+  void set_val_default(const std::string& key, const std::string &val);
 
   // Called by the Ceph daemons to make configuration changes at runtime
   int injectargs(const std::string &s, std::ostream *oss);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_CONFIG_H
 #define CEPH_CONFIG_H
 
+#include <boost/container/small_vector.hpp>
 #include "common/ConfUtils.h"
 #include "common/entity_name.h"
 #include "common/code_environment.h"
@@ -94,13 +95,10 @@ public:
    */
   std::map<std::string, const Option &> schema;
 
-  /// default values (if they vary from the schema)
-  std::map<std::string, Option::value_t> default_values;
-
   /**
    * The current values of all settings described by the schema
    */
-  std::map<std::string, Option::value_t> values;
+  std::map<std::string, map<int,Option::value_t>> values;
 
   typedef enum {
     OPT_INT, OPT_LONGLONG, OPT_STR, OPT_DOUBLE, OPT_FLOAT, OPT_BOOL,
@@ -150,37 +148,32 @@ public:
   /// Look up an option in the schema
   const Option *find_option(const string& name) const;
 
-  /// Look up the default value for an option by name
-  Option::value_t get_val_default(const string& name, bool meta) const;
-
-  /// Look up the default value for an option
-  Option::value_t _get_val_default(const Option& o, bool meta) const;
-
   /// Set a default value
   void set_val_default(const std::string& key, const std::string &val);
 
+  /// Set a value from mon
+  void set_val_mon(const std::string& key, const std::string &val);
+  
   // Called by the Ceph daemons to make configuration changes at runtime
   int injectargs(const std::string &s, std::ostream *oss);
 
   // Set a configuration value, or crash
   // Metavariables will be expanded.
-  void set_val_or_die(const std::string &key, const std::string &val,
-                      bool meta=true);
+  void set_val_or_die(const std::string &key, const std::string &val);
 
   // Set a configuration value.
   // Metavariables will be expanded.
-  int set_val(const std::string &key, const char *val, bool meta=true,
+  int set_val(const std::string &key, const char *val,
               std::stringstream *err_ss=nullptr);
-  int set_val(const std::string &key, const string& s, bool meta=true,
+  int set_val(const std::string &key, const string& s,
               std::stringstream *err_ss=nullptr) {
-    return set_val(key, s.c_str(), meta, err_ss);
+    return set_val(key, s.c_str(), err_ss);
   }
 
   // Get a configuration value.
   // No metavariables will be returned (they will have already been expanded)
   int get_val(const std::string &key, char **buf, int len) const;
-  int get_val_as_string(const std::string &key, std::string *val) const;
-  int _get_val(const std::string &key, char **buf, int len) const;
+  int get_val(const std::string &key, std::string *val) const;
   Option::value_t get_val_generic(const std::string &key) const;
   template<typename T> const T get_val(const std::string &key) const;
 
@@ -202,70 +195,68 @@ public:
   /// dump all config values to a formatter
   void show_config(Formatter *f);
 
-  /// obtain a diff between our config values and another md_config_t values
-  void diff(const md_config_t *other,
-            map<string,pair<string,string> > *diff, set<string> *unknown);
-
-  /// obtain a diff between config values and another md_config_t 
-  /// values for a specific setting. 
-  void diff(const md_config_t *other,
-            map<string,pair<string,string>> *diff, set<string> *unknown, 
-            const string& setting);
+  /// dump config diff from default, conf, mon, etc.
+  void diff(Formatter *f, std::string name=string{}) const;
 
   /// print/log warnings/errors from parsing the config
   void complain_about_parse_errors(CephContext *cct);
 
 private:
+  // we use this to avoid variable expansion loops
+  typedef boost::container::small_vector<pair<const Option*,
+					      const Option::value_t*>,
+					 4> expand_stack_t;
+
   void validate_schema();
   void validate_default_settings();
 
-  int _get_val_as_string(const std::string &key, std::string *value) const;
-  Option::value_t _get_val_generic(const std::string &key) const;
+  int _get_val_cstr(const std::string &key, char **buf, int len) const;
+  Option::value_t _get_val(const std::string &key,
+			   expand_stack_t *stack=0) const;
+  Option::value_t _get_val(const Option& o,
+			   expand_stack_t *stack=0,
+			   std::ostream *err=0) const;
+  const Option::value_t& _get_val_default(const Option& o) const;
+
   void _show_config(std::ostream *out, Formatter *f);
 
   void _get_my_sections(std::vector <std::string> &sections) const;
 
   int _get_val_from_conf_file(const std::vector <std::string> &sections,
-			      const std::string &key, std::string &out, bool emeta) const;
+			      const std::string &key, std::string &out) const;
 
   int parse_option(std::vector<const char*>& args,
 		   std::vector<const char*>::iterator& i,
 		   std::ostream *oss);
   int parse_injectargs(std::vector<const char*>& args,
 		      std::ostream *oss);
-  int parse_config_files_impl(const std::list<std::string> &conf_files,
-			      std::ostream *warnings);
 
-  int set_val_impl(const std::string &val, const Option &opt,
-                   std::string *error_message);
+  int set_val_impl(
+    const std::string &val,
+    const Option &opt,
+    int level,  // CONF_*
+    std::string *error_message);
 
   template <typename T>
   void assign_member(member_ptr_t ptr, const Option::value_t &val);
 
 
+  void update_legacy_vals();
   void update_legacy_val(const Option &opt,
       md_config_t::member_ptr_t member);
 
   void init_subsys();
 
-  bool expand_meta(std::string &val,
-		   std::ostream *oss) const;
-
-  void diff_helper(const md_config_t* other,
-                   map<string, pair<string, string>>* diff,
-                   set<string>* unknown, const string& setting = string{});
+  Option::value_t _expand_meta(
+    const Option::value_t& in,
+    const Option *o,
+    expand_stack_t *stack,
+    std::ostream *err) const;
 
 public:  // for global_init
-  bool early_expand_meta(std::string &val,
-			 std::ostream *oss) const {
-    Mutex::Locker l(lock);
-    return expand_meta(val, oss);
-  }
+  void early_expand_meta(std::string &val,
+			 std::ostream *oss) const;
 private:
-  bool expand_meta(std::string &val,
-		   const Option *opt,
-		   std::list<const Option*> stack,
-		   std::ostream *oss) const;
 
   /// expand all metavariables in config structure.
   void expand_all_meta();

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -170,6 +170,9 @@ public:
     return set_val(key, s.c_str(), err_ss);
   }
 
+  /// clear override value
+  int rm_val(const std::string& key);
+
   // Get a configuration value.
   // No metavariables will be returned (they will have already been expanded)
   int get_val(const std::string &key, char **buf, int len) const;
@@ -218,6 +221,10 @@ private:
 			   std::ostream *err=0) const;
   const Option::value_t& _get_val_default(const Option& o) const;
 
+  int _rm_val(const std::string& key, int level);
+
+  void _refresh(const Option& opt);
+
   void _show_config(std::ostream *out, Formatter *f);
 
   void _get_my_sections(std::vector <std::string> &sections) const;
@@ -231,7 +238,7 @@ private:
   int parse_injectargs(std::vector<const char*>& args,
 		      std::ostream *oss);
 
-  int set_val_impl(
+  int _set_val(
     const std::string &val,
     const Option &opt,
     int level,  // CONF_*

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -167,6 +167,7 @@ public:
   // Get a configuration value.
   // No metavariables will be returned (they will have already been expanded)
   int get_val(const std::string &key, char **buf, int len) const;
+  int get_val_as_string(const std::string &key, std::string *val) const;
   int _get_val(const std::string &key, char **buf, int len) const;
   Option::value_t get_val_generic(const std::string &key) const;
   template<typename T> const T get_val(const std::string &key) const;
@@ -206,7 +207,7 @@ private:
   void validate_schema();
   void validate_default_settings();
 
-  int _get_val(const std::string &key, std::string *value) const;
+  int _get_val_as_string(const std::string &key, std::string *value) const;
   Option::value_t _get_val_generic(const std::string &key) const;
   void _show_config(std::ostream *out, Formatter *f);
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -102,10 +102,10 @@ public:
    */
   std::map<std::string, Option::value_t> values;
 
-   typedef enum {
-	OPT_INT, OPT_LONGLONG, OPT_STR, OPT_DOUBLE, OPT_FLOAT, OPT_BOOL,
-	OPT_ADDR, OPT_U32, OPT_U64, OPT_UUID
-   } opt_type_t;
+  typedef enum {
+    OPT_INT, OPT_LONGLONG, OPT_STR, OPT_DOUBLE, OPT_FLOAT, OPT_BOOL,
+    OPT_ADDR, OPT_U32, OPT_U64, OPT_UUID
+  } opt_type_t;
 
   // Create a new md_config_t structure.
   md_config_t(bool is_daemon=false);

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -151,9 +151,9 @@ public:
   /// Set a default value
   void set_val_default(const std::string& key, const std::string &val);
 
-  /// Set a value from mon
-  void set_val_mon(const std::string& key, const std::string &val);
-  
+  /// Set a values from mon
+  int set_mon_vals(CephContext *cct, const map<std::string,std::string>& kv);
+
   // Called by the Ceph daemons to make configuration changes at runtime
   int injectargs(const std::string &s, std::ostream *oss);
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -142,6 +142,9 @@ public:
   void set_safe_to_start_threads();
   void _clear_safe_to_start_threads();  // this is only used by the unit test
 
+  /// Look up an option in the schema
+  const Option *find_option(const string& name) const;
+
   // Called by the Ceph daemons to make configuration changes at runtime
   int injectargs(const std::string &s, std::ostream *oss);
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -73,6 +73,8 @@ public:
                          bool md_config_t::*,
                          entity_addr_t md_config_t::*,
                          uuid_d md_config_t::*> member_ptr_t;
+  /// true if we are a daemon (as per CephContext::code_env)
+  const bool is_daemon;
 
   /* Maps configuration options to the observer listening for them. */
   typedef std::multimap <std::string, md_config_obs_t*> obs_map_t;

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -36,6 +36,17 @@ extern const char *CEPH_CONF_FILE_DEFAULT;
 #define LOG_TO_STDERR_SOME 1
 #define LOG_TO_STDERR_ALL 2
 
+enum {
+  CONF_DEFAULT,
+  CONF_MON,
+  CONF_CONFFILE,
+  CONF_ENV,
+  CONF_OVERRIDE,
+  CONF_FINAL
+};
+
+extern const char *ceph_conf_level_name(int level);
+
 /** This class represents the current Ceph configuration.
  *
  * For Ceph daemons, this is the daemon configuration.  Log levels, caching
@@ -98,7 +109,10 @@ public:
   /**
    * The current values of all settings described by the schema
    */
-  std::map<std::string, map<int,Option::value_t>> values;
+  std::map<std::string, map<int32_t,Option::value_t>> values;
+
+  /// encoded, cached copy of of values
+  bufferlist values_bl;
 
   typedef enum {
     OPT_INT, OPT_LONGLONG, OPT_STR, OPT_DOUBLE, OPT_FLOAT, OPT_BOOL,
@@ -173,6 +187,9 @@ public:
   /// clear override value
   int rm_val(const std::string& key);
 
+  /// get encoded map<string,map<int32_t,string>> of entire config
+  void get_config_bl(bufferlist *bl);
+  
   // Get a configuration value.
   // No metavariables will be returned (they will have already been expanded)
   int get_val(const std::string &key, char **buf, int len) const;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -832,8 +832,6 @@ OPTION(kinetic_hmac_key, OPT_STR) // kinetic key to authenticate with
 OPTION(kinetic_use_ssl, OPT_BOOL) // whether to secure kinetic traffic with TLS
 
 
-OPTION(rocksdb_separate_wal_dir, OPT_BOOL) // use $path.wal for wal
-SAFE_OPTION(rocksdb_db_paths, OPT_STR)   // path,size( path,size)*
 OPTION(rocksdb_log_to_ceph_log, OPT_BOOL)  // log to ceph log
 OPTION(rocksdb_cache_size, OPT_U64)  // rocksdb cache size (unless set by bluestore/etc)
 OPTION(rocksdb_cache_row_ratio, OPT_FLOAT)   // ratio of cache for row (vs block)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -323,10 +323,6 @@ std::vector<Option> get_global_options() {
     .add_service("common")
     .add_see_also("admin_socket"),
 
-    Option("crushtool", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_description("name of the 'crushtool' utility")
-    .add_service("mon"),
-
     // daemon
     Option("daemonize", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -228,11 +228,13 @@ std::vector<Option> get_global_options() {
     Option("host", Option::TYPE_STR, Option::LEVEL_BASIC)
     .set_description("local hostname")
     .set_long_description("if blank, ceph assumes the short hostname (hostname -s)")
+    .set_flag(Option::FLAG_NO_MON_UPDATE)
     .add_service("common")
     .add_tag("network"),
 
     Option("fsid", Option::TYPE_UUID, Option::LEVEL_BASIC)
     .set_description("cluster fsid (uuid)")
+    .set_flag(Option::FLAG_NO_MON_UPDATE)
     .add_service("common")
     .add_tag("service"),
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2970,15 +2970,6 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
-    Option("rocksdb_separate_wal_dir", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
-    .set_description(""),
-
-    Option("rocksdb_db_paths", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("")
-    .set_description("")
-    .set_safe(),
-
     Option("rocksdb_log_to_ceph_log", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -85,6 +85,75 @@ int Option::validate(const Option::value_t &new_value, std::string *err) const
   return 0;
 }
 
+int Option::parse_value(
+  const std::string& raw_val,
+  value_t *out,
+  std::string *error_message) const
+{
+  std::string val = raw_val;
+
+  int r = pre_validate(&val, error_message);
+  if (r != 0) {
+    return r;
+  }
+
+  if (type == Option::TYPE_INT) {
+    int64_t f = strict_si_cast<int64_t>(val.c_str(), error_message);
+    if (!error_message->empty()) {
+      return -EINVAL;
+    }
+    *out = f;
+  } else if (type == Option::TYPE_UINT) {
+    uint64_t f = strict_si_cast<uint64_t>(val.c_str(), error_message);
+    if (!error_message->empty()) {
+      return -EINVAL;
+    }
+    *out = f;
+  } else if (type == Option::TYPE_STR) {
+    *out = val;
+  } else if (type == Option::TYPE_FLOAT) {
+    double f = strict_strtod(val.c_str(), error_message);
+    if (!error_message->empty()) {
+      return -EINVAL;
+    } else {
+      *out = f;
+    }
+  } else if (type == Option::TYPE_BOOL) {
+    if (strcasecmp(val.c_str(), "false") == 0) {
+      *out = false;
+    } else if (strcasecmp(val.c_str(), "true") == 0) {
+      *out = true;
+    } else {
+      int b = strict_strtol(val.c_str(), 10, error_message);
+      if (!error_message->empty()) {
+	return -EINVAL;
+      }
+      *out = !!b;
+    }
+  } else if (type == Option::TYPE_ADDR) {
+    entity_addr_t addr;
+    if (!addr.parse(val.c_str())){
+      return -EINVAL;
+    }
+    *out = addr;
+  } else if (type == Option::TYPE_UUID) {
+    uuid_d uuid;
+    if (!uuid.parse(val.c_str())) {
+      return -EINVAL;
+    }
+    *out = uuid;
+  } else {
+    ceph_abort();
+  }
+
+  r = validate(*out, error_message);
+  if (r != 0) {
+    return r;
+  }
+
+  return 0;
+}
+
 void Option::dump(Formatter *f) const
 {
   f->open_object_section("option");

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -14,6 +14,9 @@
 // Definitions for enums
 #include "common/perf_counters.h"
 
+// rbd feature validation
+#include "librbd/Features.h"
+
 
 void Option::dump_value(const char *field_name,
     const Option::value_t &v, Formatter *f) const
@@ -5661,62 +5664,15 @@ static std::vector<Option> get_rbd_options() {
         "+4 -> exclusive-lock, +8 -> object-map, +16 -> fast-diff, "
         "+32 -> deep-flatten, +64 -> journaling, +128 -> data-pool")
     .set_safe()
-    .set_validator([](std::string *value, std::string *error_message){
-      static const std::map<std::string, uint64_t> FEATURE_MAP = {
-        {RBD_FEATURE_NAME_LAYERING, RBD_FEATURE_LAYERING},
-        {RBD_FEATURE_NAME_STRIPINGV2, RBD_FEATURE_STRIPINGV2},
-        {RBD_FEATURE_NAME_EXCLUSIVE_LOCK, RBD_FEATURE_EXCLUSIVE_LOCK},
-        {RBD_FEATURE_NAME_OBJECT_MAP, RBD_FEATURE_OBJECT_MAP},
-        {RBD_FEATURE_NAME_FAST_DIFF, RBD_FEATURE_FAST_DIFF},
-        {RBD_FEATURE_NAME_DEEP_FLATTEN, RBD_FEATURE_DEEP_FLATTEN},
-        {RBD_FEATURE_NAME_JOURNALING, RBD_FEATURE_JOURNALING},
-        {RBD_FEATURE_NAME_DATA_POOL, RBD_FEATURE_DATA_POOL},
-      };
-      static_assert((RBD_FEATURE_DATA_POOL << 1) > RBD_FEATURES_ALL,
-                    "new RBD feature added");
-
-      // convert user-friendly comma delimited feature name list to a bitmask
-      // that is used by the librbd API
-      uint64_t features = 0;
-      error_message->clear();
-
-      try {
-        features = boost::lexical_cast<decltype(features)>(*value);
-
-        uint64_t unsupported_features = (features & ~RBD_FEATURES_ALL);
-        if (unsupported_features != 0ull) {
-          features &= RBD_FEATURES_ALL;
-
-          std::stringstream ss;
-          ss << "ignoring unknown feature mask 0x"
-             << std::hex << unsupported_features;
-          *error_message = ss.str();
-        }
-      } catch (const boost::bad_lexical_cast& ) {
-        int r = 0;
-        std::vector<std::string> feature_names;
-        boost::split(feature_names, *value, boost::is_any_of(","));
-        for (auto feature_name: feature_names) {
-          boost::trim(feature_name);
-          auto feature_it = FEATURE_MAP.find(feature_name);
-          if (feature_it != FEATURE_MAP.end()) {
-            features += feature_it->second;
-          } else {
-            if (!error_message->empty()) {
-              *error_message += ", ";
-            }
-            *error_message += "ignoring unknown feature " + feature_name;
-            r = -EINVAL;
-          }
-        }
-
-        if (features == 0 && r == -EINVAL) {
-          features = RBD_FEATURES_DEFAULT;
-        }
-      }
-      *value = stringify(features);
-      return 0;
-    }),
+    .set_validator([](std::string *value, std::string *error_message) {
+	ostringstream ss;
+	uint64_t features = librbd::rbd_features_from_string(*value, &ss);
+	*value = librbd::rbd_features_to_string(features, &ss);
+	if (ss.str().size()) {
+	  return -EINVAL;
+	}
+	return 0;
+      }),
 
     Option("rbd_op_threads", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1)

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -182,6 +182,12 @@ struct Option {
     return *this;
   }
 
+  /// parse and validate a string input
+  int parse_value(
+    const std::string& raw_val,
+    value_t *out,
+    std::string *error_message) const;
+
   template<typename T>
   Option& set_default(const T& v) {
     return set_value(value, v);

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -56,6 +56,7 @@ struct Option {
 
   enum flag_t {
     FLAG_SAFE = 1,
+    FLAG_NO_MON_UPDATE = 2,
   };
 
   using value_t = boost::variant<

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -76,6 +76,8 @@ struct Option {
 
   unsigned flags = 0;
 
+  int subsys = -1; // if >= 0, we are a subsys debug level
+
   value_t value;
   value_t daemon_value;
 
@@ -262,6 +264,11 @@ struct Option {
   Option &set_validator(const validator_fn_t  &validator_)
   {
     validator = validator_;
+    return *this;
+  }
+
+  Option &set_subsys(int s) {
+    subsys = s;
     return *this;
   }
 

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -684,6 +684,18 @@ map<string, string> CrushWrapper::get_full_location(int id) const
   return full_location;
 }
 
+int CrushWrapper::get_full_location(const string& name,
+				    map<string,string> *ploc)
+{
+  build_rmaps();
+  auto p = name_rmap.find(name);
+  if (p == name_rmap.end()) {
+    return -ENOENT;
+  }
+  *ploc = get_full_location(p->second);
+  return 0;
+}
+
 int CrushWrapper::get_full_location_ordered(int id, vector<pair<string, string> >& path) const
 {
   if (!item_exists(id))

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -696,6 +696,13 @@ public:
    */
   map<string, string> get_full_location(int id) const;
 
+  /**
+   * return location map for a item, by name
+   */
+  int get_full_location(
+    const string& name,
+    std::map<string,string> *ploc);
+
   /*
    * identical to get_full_location(int id) although it returns the type/name
    * pairs in the order they occur in the hierarchy.
@@ -896,6 +903,7 @@ public:
 			   std::map<string,string> *ploc);
   static int parse_loc_multimap(const std::vector<string>& args,
 				std::multimap<string,string> *ploc);
+
 
   /**
    * get an item's weight

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -81,10 +81,11 @@ static int chown_path(const std::string &pathname, const uid_t owner, const gid_
   return r;
 }
 
-void global_pre_init(std::vector < const char * > *alt_def_args,
-		     std::vector < const char* >& args,
-		     uint32_t module_type, code_environment_t code_env,
-		     int flags)
+void global_pre_init(
+  const std::map<std::string,std::string> *defaults,
+  std::vector < const char* >& args,
+  uint32_t module_type, code_environment_t code_env,
+  int flags)
 {
   std::string conf_file_list;
   std::string cluster = "";
@@ -95,8 +96,12 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
   global_init_set_globals(cct);
   md_config_t *conf = cct->_conf;
 
-  if (alt_def_args)
-    conf->parse_argv(*alt_def_args);  // alternative default args
+  // alternate defaults
+  if (defaults) {
+    for (auto& i : *defaults) {
+      conf->set_val_default(i.first, i.second);
+    }
+  }
 
   int ret = conf->parse_config_files(c_str_or_null(conf_file_list),
 				     &cerr, flags);
@@ -131,7 +136,7 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
 }
 
 boost::intrusive_ptr<CephContext>
-global_init(std::vector < const char * > *alt_def_args,
+global_init(const std::map<std::string,std::string> *defaults,
 	    std::vector < const char* >& args,
 	    uint32_t module_type, code_environment_t code_env,
 	    int flags,
@@ -142,7 +147,7 @@ global_init(std::vector < const char * > *alt_def_args,
   if (run_pre_init) {
     // We will run pre_init from here (default).
     assert(!g_ceph_context && first_run);
-    global_pre_init(alt_def_args, args, module_type, code_env, flags);
+    global_pre_init(defaults, args, module_type, code_env, flags);
   } else {
     // Caller should have invoked pre_init manually.
     assert(g_ceph_context && first_run);

--- a/src/global/global_init.h
+++ b/src/global/global_init.h
@@ -17,6 +17,7 @@
 
 #include <stdint.h>
 #include <vector>
+#include <map>
 #include <boost/intrusive_ptr.hpp>
 #include "include/assert.h"
 #include "common/code_environment.h"
@@ -30,20 +31,21 @@ class CephContext;
  * initialization, including setting up g_ceph_context.
  */
 boost::intrusive_ptr<CephContext>
-     global_init(std::vector < const char * > *alt_def_args,
-		 std::vector < const char* >& args,
-		 uint32_t module_type,
-		 code_environment_t code_env,
-		 int flags,
-		 const char *data_dir_option = 0,
-		 bool run_pre_init = true);
+global_init(
+  const std::map<std::string,std::string> *defaults,
+  std::vector < const char* >& args,
+  uint32_t module_type,
+  code_environment_t code_env,
+  int flags,
+  const char *data_dir_option = 0,
+  bool run_pre_init = true);
 
 void intrusive_ptr_add_ref(CephContext* cct);
 void intrusive_ptr_release(CephContext* cct);
 
 // just the first half; enough to get config parsed but doesn't start up the
 // cct or log.
-void global_pre_init(std::vector < const char * > *alt_def_args,
+void global_pre_init(const std::map<std::string,std::string> *defaults,
 		     std::vector < const char* >& args,
 		     uint32_t module_type, code_environment_t code_env,
 		     int flags);

--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -15,6 +15,7 @@
 
 KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 			       const string& dir,
+			       map<string,string> options,
 			       void *p)
 {
 #ifdef WITH_LEVELDB
@@ -30,7 +31,7 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 #endif
 #ifdef HAVE_LIBROCKSDB
   if (type == "rocksdb") {
-    return new RocksDBStore(cct, dir, p);
+    return new RocksDBStore(cct, dir, options, p);
   }
 #endif
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -151,6 +151,7 @@ public:
   /// create a new instance
   static KeyValueDB *create(CephContext *cct, const std::string& type,
 			    const std::string& dir,
+			    map<std::string,std::string> options = {},
 			    void *p = NULL);
 
   /// test whether we can successfully initialize; may have side effects (e.g., create)

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -339,17 +339,17 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
   }
 
   opt.create_if_missing = create_if_missing;
-  if (g_conf->rocksdb_separate_wal_dir) {
+  if (kv_options.count("separate_wal_dir")) {
     opt.wal_dir = path + ".wal";
   }
-  if (g_conf->get_val<std::string>("rocksdb_db_paths").length()) {
+  if (kv_options.count("db_paths")) {
     list<string> paths;
-    get_str_list(g_conf->get_val<std::string>("rocksdb_db_paths"), "; \t", paths);
+    get_str_list(kv_options["db_paths"], "; \t", paths);
     for (auto& p : paths) {
       size_t pos = p.find(',');
       if (pos == std::string::npos) {
 	derr << __func__ << " invalid db path item " << p << " in "
-	     << g_conf->get_val<std::string>("rocksdb_db_paths") << dendl;
+	     << kv_options["db_paths"] << dendl;
 	return -EINVAL;
       }
       string path = p.substr(0, pos);
@@ -357,7 +357,7 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
       uint64_t size = atoll(size_str.c_str());
       if (!size) {
 	derr << __func__ << " invalid db path item " << p << " in "
-	     << g_conf->get_val<std::string>("rocksdb_db_paths") << dendl;
+	     << kv_options["db_paths"] << dendl;
 	return -EINVAL;
       }
       opt.db_paths.push_back(rocksdb::DbPath(path, size));

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -71,6 +71,7 @@ class RocksDBStore : public KeyValueDB {
   CephContext *cct;
   PerfCounters *logger;
   string path;
+  map<string,string> kv_options;
   void *priv;
   rocksdb::DB *db;
   rocksdb::Env *env;
@@ -138,10 +139,11 @@ public:
     compact_range_async(combine_strings(prefix, start), combine_strings(prefix, end));
   }
 
-  RocksDBStore(CephContext *c, const string &path, void *p) :
+  RocksDBStore(CephContext *c, const string &path, map<string,string> opt, void *p) :
     cct(c),
     logger(NULL),
     path(path),
+    kv_options(opt),
     priv(p),
     db(NULL),
     env(static_cast<rocksdb::Env*>(p)),

--- a/src/librbd/Features.cc
+++ b/src/librbd/Features.cc
@@ -1,0 +1,91 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <boost/lexical_cast.hpp>
+#include <boost/algorithm/string.hpp>
+
+#include "librbd/Features.h"
+#include "include/rbd/features.h"
+
+#include <map>
+#include <vector>
+
+static const std::map<std::string, uint64_t> RBD_FEATURE_MAP = {
+  {RBD_FEATURE_NAME_LAYERING, RBD_FEATURE_LAYERING},
+  {RBD_FEATURE_NAME_STRIPINGV2, RBD_FEATURE_STRIPINGV2},
+  {RBD_FEATURE_NAME_EXCLUSIVE_LOCK, RBD_FEATURE_EXCLUSIVE_LOCK},
+  {RBD_FEATURE_NAME_OBJECT_MAP, RBD_FEATURE_OBJECT_MAP},
+  {RBD_FEATURE_NAME_FAST_DIFF, RBD_FEATURE_FAST_DIFF},
+  {RBD_FEATURE_NAME_DEEP_FLATTEN, RBD_FEATURE_DEEP_FLATTEN},
+  {RBD_FEATURE_NAME_JOURNALING, RBD_FEATURE_JOURNALING},
+  {RBD_FEATURE_NAME_DATA_POOL, RBD_FEATURE_DATA_POOL},
+};
+
+namespace librbd {
+
+std::string rbd_features_to_string(uint64_t features,
+				   std::ostream *err)
+{
+  std::string r;
+  for (auto& i : RBD_FEATURE_MAP) {
+    if (features & i.second) {
+      if (r.empty()) {
+	r += ",";
+      }
+      r += i.first;
+      features &= ~i.second;
+    }
+  }
+  if (err && features) {
+    *err << "ignoring unknown feature mask 0x"
+	 << std::hex << features << std::dec;
+  }
+  return r;
+}
+
+uint64_t rbd_features_from_string(const std::string& value,
+				  std::ostream *err)
+{
+  uint64_t features = 0;
+  try {
+    // numeric?
+    features = boost::lexical_cast<uint64_t>(value);
+
+    // drop unrecognized bits
+    uint64_t unsupported_features = (features & ~RBD_FEATURES_ALL);
+    if (unsupported_features != 0ull) {
+      features &= RBD_FEATURES_ALL;
+      if (err) {
+	*err << "ignoring unknown feature mask 0x"
+             << std::hex << unsupported_features << std::dec;
+      }
+    }
+  } catch (boost::bad_lexical_cast&) {
+    // feature name list?
+    bool errors = false;
+    int r = 0;
+    std::vector<std::string> feature_names;
+    boost::split(feature_names, value, boost::is_any_of(","));
+    for (auto feature_name: feature_names) {
+      boost::trim(feature_name);
+      auto feature_it = RBD_FEATURE_MAP.find(feature_name);
+      if (feature_it != RBD_FEATURE_MAP.end()) {
+	features += feature_it->second;
+      } else if (err) {
+	if (errors) {
+	  *err << ", ";
+	} else {
+	  errors = true;
+	}
+	*err << "ignoring unknown feature " << feature_name;
+      }
+    }
+    
+    if (features == 0 && r == -EINVAL) {
+      features = RBD_FEATURES_DEFAULT;
+    }
+  }
+  return features;
+}
+
+} // namespace librbd

--- a/src/librbd/Features.h
+++ b/src/librbd/Features.h
@@ -1,0 +1,17 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <string>
+#include <ostream>
+
+namespace librbd {
+
+  std::string rbd_features_to_string(uint64_t features,
+				     std::ostream *err);
+  uint64_t rbd_features_from_string(const std::string& value,
+				    std::ostream *err);
+
+} // librbd
+	

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -10,6 +10,7 @@
 #include "include/rbd/features.h"
 #include "common/dout.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/Features.h"
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -66,9 +67,10 @@ std::string generate_image_id(librados::IoCtx &ioctx) {
 
 uint64_t get_rbd_default_features(CephContext* cct)
 {
-  auto str_val = cct->_conf->get_val<std::string>("rbd_default_features");
-  return boost::lexical_cast<uint64_t>(str_val);
+  auto value = cct->_conf->get_val<std::string>("rbd_default_features");
+  return librbd::rbd_features_from_string(value, nullptr);
 }
+
 
 bool calc_sparse_extent(const bufferptr &bp,
                         size_t sparse_size,

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -16,6 +16,7 @@ namespace librbd {
 
 class ImageCtx;
 
+
 namespace util {
 
 namespace detail {
@@ -189,6 +190,7 @@ private:
   std::atomic<uint64_t> m_refs = { 0 };
   Context *m_on_finish = nullptr;
 };
+
 
 uint64_t get_rbd_default_features(CephContext* cct);
 

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -777,7 +777,7 @@ int MDSDaemon::_handle_command(
     cmd_getval(cct, cmdmap, "key", key);
     std::string val;
     cmd_getval(cct, cmdmap, "value", val);
-    r = cct->_conf->set_val(key, val, true, &ss);
+    r = cct->_conf->set_val(key, val, &ss);
     if (r == 0) {
       cct->_conf->apply_changes(nullptr);
     }

--- a/src/messages/MConfig.h
+++ b/src/messages/MConfig.h
@@ -1,0 +1,35 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "msg/Message.h"
+
+struct MConfig : public Message {
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+
+  map<string,string> config;
+
+  MConfig() : Message(MSG_CONFIG, HEAD_VERSION, COMPAT_VERSION) { }
+  MConfig(const map<string,string>& c)
+    : Message(MSG_CONFIG, HEAD_VERSION, COMPAT_VERSION),
+      config(c) {}
+
+  const char *get_type_name() const override {
+    return "config";
+  }
+  void print(ostream& o) const override {
+    o << "config(" << config.size() << " keys" << ")";
+  }
+
+  void decode_payload() override {
+    bufferlist::iterator p = payload.begin();
+    ::decode(config, p);
+  }
+
+  void encode_payload(uint64_t) override {
+    ::encode(config, payload);
+  }
+
+};

--- a/src/messages/MMgrOpen.h
+++ b/src/messages/MMgrOpen.h
@@ -19,7 +19,7 @@
 
 class MMgrOpen : public Message
 {
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -30,6 +30,9 @@ public:
   bool service_daemon = false;
   std::map<std::string,std::string> daemon_metadata;
   std::map<std::string,std::string> daemon_status;
+
+  // encode map<string,map<int32_t,string>> of current config
+  bufferlist config_bl;
 
   void decode_payload() override
   {
@@ -43,6 +46,9 @@ public:
 	::decode(daemon_status, p);
       }
     }
+    if (header.version >= 3) {
+      ::decode(config_bl, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
@@ -53,6 +59,7 @@ public:
       ::encode(daemon_metadata, payload);
       ::encode(daemon_status, payload);
     }
+    ::encode(config_bl, payload);
   }
 
   const char *get_type_name() const override { return "mgropen"; }

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -67,7 +67,7 @@ WRITE_CLASS_ENCODER(PerfCounterType)
 
 class MMgrReport : public Message
 {
-  static const int HEAD_VERSION = 5;
+  static const int HEAD_VERSION = 6;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -95,6 +95,9 @@ public:
 
   std::vector<OSDHealthMetric> osd_health_metrics;
 
+  // encode map<string,map<int32_t,string>> of current config
+  bufferlist config_bl;
+
   void decode_payload() override
   {
     bufferlist::iterator p = payload.begin();
@@ -110,6 +113,9 @@ public:
     if (header.version >= 5) {
       ::decode(osd_health_metrics, p);
     }
+    if (header.version >= 6) {
+      ::decode(config_bl, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
@@ -120,6 +126,7 @@ public:
     ::encode(service_name, payload);
     ::encode(daemon_status, payload);
     ::encode(osd_health_metrics, payload);
+    ::encode(config_bl, payload);
   }
 
   const char *get_type_name() const override { return "mgrreport"; }

--- a/src/messages/MMonSubscribe.h
+++ b/src/messages/MMonSubscribe.h
@@ -31,11 +31,13 @@ WRITE_RAW_ENCODER(ceph_mon_subscribe_item_old)
 
 struct MMonSubscribe : public Message {
 
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
+  static const int COMPAT_VERSION = 1;
 
+  string hostname;
   map<string, ceph_mon_subscribe_item> what;
   
-  MMonSubscribe() : Message(CEPH_MSG_MON_SUBSCRIBE, HEAD_VERSION) { }
+  MMonSubscribe() : Message(CEPH_MSG_MON_SUBSCRIBE, HEAD_VERSION, COMPAT_VERSION) { }
 private:
   ~MMonSubscribe() override {}
 
@@ -67,15 +69,15 @@ public:
 	if (q->second.onetime)
 	  what[q->first].flags |= CEPH_SUBSCRIBE_ONETIME;
       }
-    } else {
-      ::decode(what, p);
+      return;
+    }
+    ::decode(what, p);
+    if (header.version >= 3) {
+      ::decode(hostname, p);
     }
   }
   void encode_payload(uint64_t features) override {
-    if (features & CEPH_FEATURE_SUBSCRIBE2) {
-      ::encode(what, payload);
-      header.version = HEAD_VERSION;
-    } else {
+    if ((features & CEPH_FEATURE_SUBSCRIBE2) == 0) {
       header.version = 0;
       map<string, ceph_mon_subscribe_item_old> oldwhat;
       for (map<string, ceph_mon_subscribe_item>::iterator q = what.begin();
@@ -89,7 +91,11 @@ public:
 	oldwhat[q->first].onetime = q->second.flags & CEPH_SUBSCRIBE_ONETIME;
       }
       ::encode(oldwhat, payload);
+      return;
     }
+    header.version = HEAD_VERSION;
+    ::encode(what, payload);
+    ::encode(hostname, payload);
   }
 };
 

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -365,6 +365,12 @@ bool DaemonServer::handle_open(MMgrOpen *m)
     daemon->metadata = m->daemon_metadata;
     daemon->service_status = m->daemon_status;
 
+    auto p = m->config_bl.begin();
+    if (p != m->config_bl.end()) {
+      ::decode(daemon->config, p);
+      dout(20) << " got config " << daemon->config << dendl;
+    }
+
     utime_t now = ceph_clock_now();
     auto d = pending_service_map.get_daemon(m->service_name,
 					    m->daemon_name);
@@ -478,6 +484,12 @@ bool DaemonServer::handle_report(MMgrReport *m)
     Mutex::Locker l(daemon->lock);
     auto &daemon_counters = daemon->perf_counters;
     daemon_counters.update(m);
+
+    auto p = m->config_bl.begin();
+    if (p != m->config_bl.end()) {
+      ::decode(daemon->config, p);
+      dout(20) << " got config " << daemon->config << dendl;
+    }
 
     if (daemon->service_daemon) {
       utime_t now = ceph_clock_now();

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1329,7 +1329,71 @@ bool DaemonServer::handle_command(MCommand *m)
     ss << std::endl;
     cmdctx->reply(r, ss);
     return true;
+  } else if (prefix == "config show") {
+    string who;
+    cmd_getval(g_ceph_context, cmdctx->cmdmap, "who", who);
+    int r = 0;
+    if (who.size()) {
+      auto dot = who.find('.');
+      DaemonKey key;
+      key.first = who.substr(0, dot);
+      key.second = who.substr(dot + 1);
+      DaemonStatePtr daemon = daemon_state.get(key);
+      if (daemon) {
+	Mutex::Locker l(daemon->lock);
+	if (f) {
+	  f->open_array_section("config");
+	  for (auto& i : daemon->config) {
+	    dout(20) << " " << i.first << " -> " << i.second << dendl;
+	    if (i.second.empty()) {
+	      continue;
+	    }
+	    f->open_object_section("value");
+	    f->dump_string("name", i.first);
+	    f->dump_string("value", i.second.rbegin()->second);
+	    f->dump_string("source", ceph_conf_level_name(
+			     i.second.rbegin()->first));
+	    if (i.second.count(CONF_MON) &&
+		i.second.rbegin()->first > CONF_MON) {
+	      f->dump_bool("mon_overridden", true);
+	    }
+	    f->close_section();
+	  }
+	  f->close_section();
+	  f->flush(cmdctx->odata);
+	} else {
+	  TextTable tbl;
+	  tbl.define_column("NAME", TextTable::LEFT, TextTable::LEFT);
+	  tbl.define_column("VALUE", TextTable::LEFT, TextTable::LEFT);
+	  tbl.define_column("SOURCE", TextTable::LEFT, TextTable::LEFT);
+	  tbl.define_column("OVERRIDDEN", TextTable::LEFT, TextTable::LEFT);
+	  for (auto& i : daemon->config) {
+	    if (i.second.empty()) {
+	      continue;
+	    }
+	    dout(20) << " " << i.first << " -> " << i.second << dendl;
+	    tbl << i.first;
+	    tbl << i.second.rbegin()->second;
+	    tbl << ceph_conf_level_name(i.second.rbegin()->first);
+	    if (i.second.count(CONF_MON) &&
+		i.second.rbegin()->first > CONF_MON) {
+	      tbl << "*";
+	    }
+	    tbl << TextTable::endrow;
+	  }
+	  cmdctx->odata.append(stringify(tbl));
+	}
+      } else {
+	ss << "no state for daemon " << who;
+	r = -ENOENT;
+      }
+    } else {
+      // ...
+    }
+    cmdctx->reply(r, ss);
+    return true;
   } else {
+    // fall back to feeding command to PGMap
     r = cluster_state.with_pgmap([&](const PGMap& pg_map) {
 	return cluster_state.with_osdmap([&](const OSDMap& osdmap) {
 	    return process_pg_map_command(prefix, cmdctx->cmdmap, pg_map, osdmap,

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -791,7 +791,7 @@ bool DaemonServer::handle_command(MCommand *m)
     std::string val;
     cmd_getval(cct, cmdctx->cmdmap, "key", key);
     cmd_getval(cct, cmdctx->cmdmap, "value", val);
-    r = cct->_conf->set_val(key, val, true, &ss);
+    r = cct->_conf->set_val(key, val, &ss);
     if (r == 0) {
       cct->_conf->apply_changes(nullptr);
     }

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -106,6 +106,9 @@ class DaemonState
   std::map<std::string, std::string> service_status;
   utime_t last_service_beacon;
 
+  // running config
+  std::map<std::string,std::map<int32_t,std::string>> config;
+
   // The perf counters received in MMgrReport messages
   DaemonPerfCounters perf_counters;
 

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -174,6 +174,7 @@ void MgrClient::_send_open()
       open->service_daemon = service_daemon;
       open->daemon_metadata = daemon_metadata;
     }
+    cct->_conf->get_config_bl(&open->config_bl);
     session->con->send_message(open);
   }
 }
@@ -327,6 +328,9 @@ void MgrClient::send_report()
   }
 
   report->osd_health_metrics = std::move(osd_health_metrics);
+
+  cct->_conf->get_config_bl(&report->config_bl);
+
   session->con->send_message(report);
 }
 

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -136,3 +136,8 @@ COMMAND("config set " \
 	"name=key,type=CephString name=value,type=CephString",
 	"Set a configuration option at runtime (not persistent)",
 	"mgr", "rw", "cli,rest")
+
+COMMAND("config show " \
+	"name=who,type=CephString",
+	"Show running configuration",
+	"mgr", "r", "cli,rest")

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -14,6 +14,7 @@ set(lib_mon_srcs
   MonmapMonitor.cc
   LogMonitor.cc
   AuthMonitor.cc
+  ConfigMap.cc
   Elector.cc
   HealthMonitor.cc
   PGMap.cc

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -15,6 +15,7 @@ set(lib_mon_srcs
   LogMonitor.cc
   AuthMonitor.cc
   ConfigMap.cc
+  ConfigMonitor.cc
   Elector.cc
   HealthMonitor.cc
   PGMap.cc

--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -33,22 +33,22 @@ static ostream& _prefix(std::ostream *_dout, const Monitor *mon,
                 << "(" << service->get_epoch() << ") ";
 }
 
-const string ConfigKeyService::STORE_PREFIX = "mon_config_key";
+const string CONFIG_PREFIX = "mon_config_key";
 
 int ConfigKeyService::store_get(const string &key, bufferlist &bl)
 {
-  return mon->store->get(STORE_PREFIX, key, bl);
+  return mon->store->get(CONFIG_PREFIX, key, bl);
 }
 
 void ConfigKeyService::get_store_prefixes(set<string>& s) const
 {
-  s.insert(STORE_PREFIX);
+  s.insert(CONFIG_PREFIX);
 }
 
 void ConfigKeyService::store_put(const string &key, bufferlist &bl, Context *cb)
 {
   MonitorDBStore::TransactionRef t = paxos->get_pending_transaction();
-  t->put(STORE_PREFIX, key, bl);
+  t->put(CONFIG_PREFIX, key, bl);
   if (cb)
     paxos->queue_pending_finisher(cb);
   paxos->trigger_propose();
@@ -67,18 +67,18 @@ void ConfigKeyService::store_delete(
     MonitorDBStore::TransactionRef t,
     const string &key)
 {
-  t->erase(STORE_PREFIX, key);
+  t->erase(CONFIG_PREFIX, key);
 }
 
 bool ConfigKeyService::store_exists(const string &key)
 {
-  return mon->store->exists(STORE_PREFIX, key);
+  return mon->store->exists(CONFIG_PREFIX, key);
 }
 
 void ConfigKeyService::store_list(stringstream &ss)
 {
   KeyValueDB::Iterator iter =
-    mon->store->get_iterator(STORE_PREFIX);
+    mon->store->get_iterator(CONFIG_PREFIX);
 
   JSONFormatter f(true);
   f.open_array_section("keys");
@@ -95,7 +95,7 @@ void ConfigKeyService::store_list(stringstream &ss)
 bool ConfigKeyService::store_has_prefix(const string &prefix)
 {
   KeyValueDB::Iterator iter =
-    mon->store->get_iterator(STORE_PREFIX);
+    mon->store->get_iterator(CONFIG_PREFIX);
 
   while (iter->valid()) {
     string key(iter->key());
@@ -111,7 +111,7 @@ bool ConfigKeyService::store_has_prefix(const string &prefix)
 void ConfigKeyService::store_dump(stringstream &ss)
 {
   KeyValueDB::Iterator iter =
-    mon->store->get_iterator(STORE_PREFIX);
+    mon->store->get_iterator(CONFIG_PREFIX);
 
   JSONFormatter f(true);
   f.open_object_section("config-key store");
@@ -129,7 +129,7 @@ void ConfigKeyService::store_delete_prefix(
     const string &prefix)
 {
   KeyValueDB::Iterator iter =
-    mon->store->get_iterator(STORE_PREFIX);
+    mon->store->get_iterator(CONFIG_PREFIX);
 
   while (iter->valid()) {
     string key(iter->key());

--- a/src/mon/ConfigKeyService.h
+++ b/src/mon/ConfigKeyService.h
@@ -35,7 +35,7 @@ class ConfigKeyService : public QuorumService
       MonitorDBStore::TransactionRef t,
       const string &prefix);
   void store_list(stringstream &ss);
-  void store_dump(stringstream &ss);
+  void store_dump(stringstream &ss, const string& prefix);
   bool store_exists(const string &key);
   bool store_has_prefix(const string &prefix);
 

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -1,21 +1,24 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <boost/algorithm/string/split.hpp>
+
 #include "ConfigMap.h"
 #include "crush/CrushWrapper.h"
+#include "common/entity_name.h"
 
 int MaskedOption::get_precision(const CrushWrapper *crush)
 {
   // 0 = most precise
-  if (location_type.size()) {
-    int r = crush->get_type_id(location_type);
+  if (mask.location_type.size()) {
+    int r = crush->get_type_id(mask.location_type);
     if (r >= 0) {
       return r;
     }
     // bad type name, ignore it
   }
   int num_types = crush->get_num_type_names();
-  if (device_class.size()) {
+  if (mask.device_class.size()) {
     return num_types;
   }
   return num_types + 1;
@@ -25,23 +28,23 @@ void MaskedOption::dump(Formatter *f) const
 {
   f->dump_string("name", opt.name);
   f->dump_string("value", raw_value);
-  if (location_type.size()) {
-    f->dump_string("location_type", location_type);
-    f->dump_string("location_value", location_value);
+  if (mask.location_type.size()) {
+    f->dump_string("location_type", mask.location_type);
+    f->dump_string("location_value", mask.location_value);
   }
-  if (device_class.size()) {
-    f->dump_string("device_class", device_class);
+  if (mask.device_class.size()) {
+    f->dump_string("device_class", mask.device_class);
   }
 }
  
 ostream& operator<<(ostream& out, const MaskedOption& o)
 {
   out << o.opt.name;
-  if (o.location_type.size()) {
-    out << "@" << o.location_type << '=' << o.location_value;
+  if (o.mask.location_type.size()) {
+    out << "@" << o.mask.location_type << '=' << o.mask.location_value;
   }
-  if (o.device_class.size()) {
-    out << "@class=" << o.device_class;
+  if (o.mask.device_class.size()) {
+    out << "@class=" << o.mask.device_class;
   }
   return out;
 }
@@ -94,14 +97,14 @@ void ConfigMap::generate_entity_map(
     for (auto& i : s->options) {
       auto& o = i.second;
       // match against crush location, class
-      if (o.device_class.size() &&
-	  o.device_class != device_class) {
+      if (o.mask.device_class.size() &&
+	  o.mask.device_class != device_class) {
 	continue;
       }
-      if (o.location_type.size()) {
-	auto p = crush_location.find(o.location_type);
+      if (o.mask.location_type.size()) {
+	auto p = crush_location.find(o.mask.location_type);
 	if (p == crush_location.end() ||
-	    p->second != o.location_value) {
+	    p->second != o.mask.location_value) {
 	  continue;
 	}
       }
@@ -116,4 +119,43 @@ void ConfigMap::generate_entity_map(
       prev = &o;
     }
   }
+}
+
+bool ConfigMap::parse_mask(
+  const std::string& who,
+  std::string *section,
+  OptionMask *mask)
+{
+  vector<std::string> split;
+  boost::split(split, who, [](char c){ return c == '/'; });
+  for (unsigned j = 0; j < split.size(); ++j) {
+    auto& i = split[j];
+    if (i == "global") {
+      continue;
+    }
+    size_t delim = i.find(':');
+    if (delim != std::string::npos) {
+      string k = i.substr(0, delim);
+      if (k == "class") {
+	mask->device_class = i.substr(delim + 1);
+      } else {
+	mask->location_type = k;
+	mask->location_value = i.substr(delim + 1);
+      }
+      continue;
+    }
+    string type, id;
+    auto dotpos = i.find('.');
+    if (dotpos != std::string::npos) {
+      type = i.substr(0, dotpos);
+      id = i.substr(dotpos + 1);
+    } else {
+      type = i;
+    }
+    if (str_to_ceph_entity_type(type.c_str()) == CEPH_ENTITY_TYPE_ANY) {
+      return false;
+    }
+    *section = i;
+  }
+  return true;
 }

--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -1,0 +1,119 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "ConfigMap.h"
+#include "crush/CrushWrapper.h"
+
+int MaskedOption::get_precision(const CrushWrapper *crush)
+{
+  // 0 = most precise
+  if (location_type.size()) {
+    int r = crush->get_type_id(location_type);
+    if (r >= 0) {
+      return r;
+    }
+    // bad type name, ignore it
+  }
+  int num_types = crush->get_num_type_names();
+  if (device_class.size()) {
+    return num_types;
+  }
+  return num_types + 1;
+}
+
+void MaskedOption::dump(Formatter *f) const
+{
+  f->dump_string("name", opt.name);
+  f->dump_string("value", raw_value);
+  if (location_type.size()) {
+    f->dump_string("location_type", location_type);
+    f->dump_string("location_value", location_value);
+  }
+  if (device_class.size()) {
+    f->dump_string("device_class", device_class);
+  }
+}
+ 
+ostream& operator<<(ostream& out, const MaskedOption& o)
+{
+  out << o.opt.name;
+  if (o.location_type.size()) {
+    out << "@" << o.location_type << '=' << o.location_value;
+  }
+  if (o.device_class.size()) {
+    out << "@class=" << o.device_class;
+  }
+  return out;
+}
+
+// ----------
+
+void Section::dump(Formatter *f) const
+{
+  for (auto& i : options) {
+    f->dump_object(i.first.c_str(), i.second);
+  }
+}
+
+// ------------
+
+void ConfigMap::dump(Formatter *f) const
+{
+  f->dump_object("global", global);
+  f->open_object_section("by_type");
+  for (auto& i : by_type) {
+    f->dump_object(i.first.c_str(), i.second);
+  }
+  f->close_section();
+  f->open_object_section("by_id");
+  for (auto& i : by_id) {
+    f->dump_object(i.first.c_str(), i.second);
+  }
+  f->close_section();
+}
+
+void ConfigMap::generate_entity_map(
+  const EntityName& name,
+  const map<std::string,std::string>& crush_location,
+  const CrushWrapper *crush,
+  const std::string& device_class,
+  std::map<std::string,std::string> *out)
+{
+  // global, then by type, then by full name.
+  vector<Section*> sections = { &global };
+  auto p = by_type.find(name.get_type_name());
+  if (p != by_type.end()) {
+    sections.push_back(&p->second);
+  }
+  auto q = by_id.find(name.to_str());
+  if (q != by_id.end()) {
+    sections.push_back(&q->second);
+  }
+  MaskedOption *prev = nullptr;
+  for (auto s : sections) {
+    for (auto& i : s->options) {
+      auto& o = i.second;
+      // match against crush location, class
+      if (o.device_class.size() &&
+	  o.device_class != device_class) {
+	continue;
+      }
+      if (o.location_type.size()) {
+	auto p = crush_location.find(o.location_type);
+	if (p == crush_location.end() ||
+	    p->second != o.location_value) {
+	  continue;
+	}
+      }
+      if (prev && prev->opt.name != i.first) {
+	prev = nullptr;
+      }
+      if (prev &&
+	  prev->get_precision(crush) < o.get_precision(crush)) {
+	continue;
+      }
+      (*out)[i.first] = o.raw_value;
+      prev = &o;
+    }
+  }
+}

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -30,11 +30,29 @@ class CrushWrapper;
 // is less precise than host, because the crush limiters are only
 // resolved within a section (global, per-daemon, per-instance).
 
+struct OptionMask {
+  std::string location_type, location_value; ///< matches crush_location
+  std::string device_class;                  ///< matches device class
+
+  std::string to_str() const {
+    std::string r;
+    if (location_type.size()) {
+      r += location_type + ":" + location_value;
+    }
+    if (device_class.size()) {
+      if (r.size()) {
+	r += "/";
+      }
+      r += "class:" + device_class;
+    }
+    return r;
+  }
+};
+
 struct MaskedOption {
   string raw_value;                          ///< raw, unparsed, unvalidated value
   Option opt;                                ///< the option
-  std::string location_type, location_value; ///< matches crush_location
-  std::string device_class;                  ///< matches device class
+  OptionMask mask;
 
   MaskedOption(const Option& o) : opt(o) {}
 
@@ -64,4 +82,9 @@ struct ConfigMap {
     const CrushWrapper *crush,
     const std::string& device_class,
     std::map<std::string,std::string> *out);
+
+  static bool parse_mask(
+    const std::string& in,
+    std::string *section,
+    OptionMask *mask);
 };

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -1,0 +1,67 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <map>
+#include <ostream>
+#include <string>
+
+#include "common/options.h"
+#include "common/entity_name.h"
+
+class CrushWrapper;
+
+// the precedence is thus:
+//
+//  global
+//   crush location (coarse to fine, ordered by type id)
+//  daemon type (e.g., osd)
+//   device class (osd only)
+//   crush location (coarse to fine, ordered by type id)
+//  daemon name (e.g., mds.foo)
+//
+// Note that this means that if we have
+//
+//  config/host:foo/a = 1
+//  config/osd/rack:foo/a = 2
+//
+// then we get a = 2.  The osd-level config wins, even though rack
+// is less precise than host, because the crush limiters are only
+// resolved within a section (global, per-daemon, per-instance).
+
+struct MaskedOption {
+  string raw_value;                          ///< raw, unparsed, unvalidated value
+  Option opt;                                ///< the option
+  std::string location_type, location_value; ///< matches crush_location
+  std::string device_class;                  ///< matches device class
+
+  MaskedOption(const Option& o) : opt(o) {}
+
+  /// return a precision metric (smaller is more precise)
+  int get_precision(const CrushWrapper *crush);
+
+  friend ostream& operator<<(ostream& out, const MaskedOption& o);
+
+  void dump(Formatter *f) const;
+};
+
+struct Section {
+  std::multimap<std::string,MaskedOption> options;
+
+  void dump(Formatter *f) const;
+};
+
+struct ConfigMap {
+  Section global;
+  std::map<std::string,Section> by_type;
+  std::map<std::string,Section> by_id;
+
+  void dump(Formatter *f) const;
+  void generate_entity_map(
+    const EntityName& name,
+    const map<std::string,std::string>& crush_location,
+    const CrushWrapper *crush,
+    const std::string& device_class,
+    std::map<std::string,std::string> *out);
+};

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -169,6 +169,21 @@ void ConfigMonitor::load_config()
   jf.close_section();
   jf.flush(*_dout);
   *_dout << dendl;
+
+  // refresh our own config
+  {
+    const OSDMap& osdmap = mon->osdmon()->osdmap;
+    map<string,string> crush_location;
+    osdmap.crush->get_full_location(g_conf->host, &crush_location);
+    map<string,string> out;
+    config_map.generate_entity_map(
+      g_conf->name,
+      crush_location,
+      osdmap.crush.get(),
+      string(), // no device class
+      &out);
+    g_conf->set_mon_vals(g_ceph_context, out);
+  }
 }
 
 bool ConfigMonitor::refresh_config(MonSession *s)

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -1,0 +1,281 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <boost/algorithm/string/split.hpp>
+
+#include "mon/Monitor.h"
+#include "mon/ConfigMonitor.h"
+#include "mon/OSDMonitor.h"
+#include "messages/MConfig.h"
+#include "common/Formatter.h"
+
+#define dout_subsys ceph_subsys_mon
+#undef dout_prefix
+#define dout_prefix _prefix(_dout, mon, this)
+static ostream& _prefix(std::ostream *_dout, const Monitor *mon,
+                        const ConfigMonitor *hmon) {
+  return *_dout << "mon." << mon->name << "@" << mon->rank
+		<< "(" << mon->get_state_name() << ").config ";
+}
+
+const string KEY_PREFIX("config/");
+
+ConfigMonitor::ConfigMonitor(Monitor *m, Paxos *p, const string& service_name)
+  : PaxosService(m, p, service_name) {
+}
+
+void ConfigMonitor::init()
+{
+  dout(10) << __func__ << dendl;
+}
+
+void ConfigMonitor::create_initial()
+{
+  dout(10) << __func__ << dendl;
+  version = 0;
+  pending.clear();
+}
+
+void ConfigMonitor::update_from_paxos(bool *need_bootstrap)
+{
+  version = get_last_committed();
+  dout(10) << __func__ << dendl;
+  load_config();
+
+#warning fixme: load changed sections to hint load_config()
+}
+
+void ConfigMonitor::create_pending()
+{
+  dout(10) << " " << version << dendl;
+  pending.clear();
+}
+
+void ConfigMonitor::encode_pending(MonitorDBStore::TransactionRef t)
+{
+  ++version;
+  dout(10) << " " << version << dendl;
+  put_last_committed(t, version);
+
+#warning fixme: record changed sections (osd, mds.foo, rack:bar, ...)
+
+  for (auto& p : pending) {
+    string key = KEY_PREFIX + p.first;
+    if (p.second) {
+      t->put(CONFIG_PREFIX, key, *p.second);
+    } else {
+      t->erase(CONFIG_PREFIX, key);
+    }
+  }
+}
+
+version_t ConfigMonitor::get_trim_to() const
+{
+  // we don't actually need *any* old states, but keep a few.
+  if (version > 5) {
+    return version - 5;
+  }
+  return 0;
+}
+
+bool ConfigMonitor::preprocess_query(MonOpRequestRef op)
+{
+  return false;
+}
+
+bool ConfigMonitor::prepare_update(MonOpRequestRef op)
+{
+  Message *m = op->get_req();
+  dout(7) << "prepare_update " << *m
+	  << " from " << m->get_orig_source_inst() << dendl;
+  return false;
+}
+
+void ConfigMonitor::tick()
+{
+  if (!is_active()) {
+    return;
+  }
+  dout(10) << __func__ << dendl;
+  bool changed = false;
+  if (changed) {
+    propose_pending();
+  }
+
+#warning temp hack
+  check_all_subs();
+}
+
+void ConfigMonitor::load_config()
+{
+  unsigned num = 0;
+  KeyValueDB::Iterator it = mon->store->get_iterator(CONFIG_PREFIX);
+  it->lower_bound(KEY_PREFIX);
+  while (it->valid() &&
+	 it->key().compare(0, KEY_PREFIX.size(), KEY_PREFIX) == 0) {
+    string key = it->key().substr(KEY_PREFIX.size());
+    string value = it->value().to_str();
+    vector<string> split;
+    boost::split(split, key, [](char c){return c == '/';});
+    string name = split.back();
+    split.pop_back();
+    Section *section = &config_map.global;
+
+    Option fake_opt(name, Option::TYPE_STR, Option::LEVEL_DEV);
+    const Option *opt = g_conf->find_option(name);
+    if (!opt) {
+      dout(10) << __func__ << " unrecognized option '" << name << "'" << dendl;
+      opt = &fake_opt;
+    }
+    string err;
+    int r = opt->pre_validate(&value, &err);
+    if (r < 0) {
+      dout(10) << __func__ << " pre-validate failed on '" << name << "' = '"
+	       << value << "' for " << split << dendl;
+    }
+
+    MaskedOption mopt(*opt);
+    mopt.raw_value = value;
+    string device_class;
+    string loc_type, loc_value;
+    for (unsigned j = 0; j < split.size(); ++j) {
+      auto& i = split[j];
+      size_t delim = i.find(':');
+      if (delim != std::string::npos) {
+	string k = i.substr(0, delim);
+	if (k == "class") {
+	  mopt.device_class = i.substr(delim + 1);
+	} else {
+	  mopt.location_type = k;
+	  mopt.location_value = i.substr(delim + 1);
+	}
+	continue;
+      }
+      if (split.front().find('.') != std::string::npos) {
+	section = &config_map.by_id[i];
+      } else {
+	section = &config_map.by_type[i];
+      }
+    }
+    section->options.insert(make_pair(name, mopt));
+    ++num;
+    it->next();
+  }
+  dout(10) << __func__ << " got " << num << " keys" << dendl;
+  dout(20) << __func__ << " config map:\n";
+  JSONFormatter jf(true);
+  jf.open_object_section("config_map");
+  config_map.dump(&jf);
+  jf.close_section();
+  jf.flush(*_dout);
+  *_dout << dendl;
+}
+
+bool ConfigMonitor::refresh_config(MonSession *s)
+{
+  const OSDMap& osdmap = mon->osdmon()->osdmap;
+
+  map<string,string> crush_location;
+  if (s->remote_host.size()) {
+    osdmap.crush->get_full_location(s->remote_host, &crush_location);
+    dout(10) << __func__ << " crush_location for remote_host " << s->remote_host
+	     << " is " << crush_location << dendl;
+  }
+
+  string device_class;
+  if (s->inst.name.is_osd()) {
+    const char *c = osdmap.crush->get_item_class(s->inst.name.num());
+    if (c) {
+      device_class = c;
+      dout(10) << __func__ << " device_class " << device_class << dendl;
+    }
+  }
+
+  dout(20) << __func__ << " " << s->entity_name << " crush " << crush_location
+	   << " device_class " << device_class << dendl;
+  map<string,string> out;
+  config_map.generate_entity_map(
+    s->entity_name,
+    crush_location,
+    osdmap.crush.get(),
+    device_class,
+    &out);
+
+  if (out == s->last_config) {
+    dout(20) << __func__ << " no change, " << out << dendl;
+    return false;
+  }
+
+  dout(20) << __func__ << " " << out << dendl;  
+  s->last_config = out;
+  return true;
+}
+
+bool ConfigMonitor::maybe_send_config(MonSession *s)
+{
+  bool changed = refresh_config(s);
+  dout(10) << __func__ << " to " << s->inst << " "
+	   << (changed ? "(changed)" : "(unchanged)")
+	   << dendl;
+  if (changed) {
+    send_config(s);
+  }
+  return changed;
+}
+
+void ConfigMonitor::send_config(MonSession *s)
+{
+  dout(10) << __func__ << " to " << s->inst << dendl;
+  auto m = new MConfig(s->last_config);
+  s->con->send_message(m);
+}
+
+void ConfigMonitor::check_sub(MonSession *s)
+{
+  if (!s->is_capable(s->entity_name.get_type_str(), MON_CAP_R)) {
+    dout(20) << __func__ << " not capable for " << s->entity_name << " with "
+	     << s->caps << dendl;
+    return;
+  }
+  auto p = s->sub_map.find("config");
+  if (p != s->sub_map.end()) {
+    check_sub(p->second);
+  }
+}
+
+void ConfigMonitor::check_sub(Subscription *sub)
+{
+  dout(10) << __func__
+	   << " next " << sub->next
+	   << " have " << version << dendl;
+  if (sub->next <= version) {
+    maybe_send_config(sub->session);
+    if (sub->onetime) {
+      mon->with_session_map([this, sub](MonSessionMap& session_map) {
+	  session_map.remove_sub(sub);
+	});
+    } else {
+      sub->next = version + 1;
+    }
+  }
+}
+
+void ConfigMonitor::check_all_subs()
+{
+  dout(10) << __func__ << dendl;
+  auto subs = mon->session_map.subs.find("config");
+  if (subs == mon->session_map.subs.end()) {
+    return;
+  }
+  int updated = 0, total = 0;
+  auto p = subs->second->begin();
+  while (!p.end()) {
+    auto sub = *p;
+    ++p;
+    ++total;
+    if (maybe_send_config(sub->session)) {
+      ++updated;
+    }
+  }
+  dout(10) << __func__ << " updated " << updated << " / " << total << dendl;
+}

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -115,11 +115,17 @@ void ConfigMonitor::load_config()
 	 it->key().compare(0, KEY_PREFIX.size(), KEY_PREFIX) == 0) {
     string key = it->key().substr(KEY_PREFIX.size());
     string value = it->value().to_str();
-    vector<string> split;
-    boost::split(split, key, [](char c){return c == '/';});
-    string name = split.back();
-    split.pop_back();
-    Section *section = &config_map.global;
+
+    auto last_slash = key.rfind('/');
+    string name;
+    string who;
+    if (last_slash == std::string::npos) {
+      name = key;
+    } else {
+      name = key.substr(last_slash + 1);
+      who = key.substr(0, last_slash);
+    }
+    string section_name;
 
     Option fake_opt(name, Option::TYPE_STR, Option::LEVEL_DEV);
     const Option *opt = g_conf->find_option(name);
@@ -131,34 +137,26 @@ void ConfigMonitor::load_config()
     int r = opt->pre_validate(&value, &err);
     if (r < 0) {
       dout(10) << __func__ << " pre-validate failed on '" << name << "' = '"
-	       << value << "' for " << split << dendl;
+	       << value << "' for " << name << dendl;
     }
 
     MaskedOption mopt(*opt);
     mopt.raw_value = value;
-    string device_class;
-    string loc_type, loc_value;
-    for (unsigned j = 0; j < split.size(); ++j) {
-      auto& i = split[j];
-      size_t delim = i.find(':');
-      if (delim != std::string::npos) {
-	string k = i.substr(0, delim);
-	if (k == "class") {
-	  mopt.device_class = i.substr(delim + 1);
+
+    if (ConfigMap::parse_mask(who, &section_name, &mopt.mask)) {
+      Section *section = &config_map.global;;
+      if (section_name.size()) {
+	if (section_name.find('.') != std::string::npos) {
+	  section = &config_map.by_id[section_name];
 	} else {
-	  mopt.location_type = k;
-	  mopt.location_value = i.substr(delim + 1);
+	  section = &config_map.by_type[section_name];
 	}
-	continue;
       }
-      if (split.front().find('.') != std::string::npos) {
-	section = &config_map.by_id[i];
-      } else {
-	section = &config_map.by_type[i];
-      }
+      section->options.insert(make_pair(name, mopt));
+      ++num;
+    } else {
+      derr << __func__ << " ignoring key " << key << dendl;
     }
-    section->options.insert(make_pair(name, mopt));
-    ++num;
     it->next();
   }
   dout(10) << __func__ << " got " << num << " keys" << dendl;

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -101,8 +101,10 @@ void ConfigMonitor::tick()
   if (changed) {
     propose_pending();
   }
+}
 
-#warning temp hack
+void ConfigMonitor::on_active()
+{
   check_all_subs();
 }
 

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -26,6 +26,8 @@ public:
   bool preprocess_query(MonOpRequestRef op) override;
   bool prepare_update(MonOpRequestRef op) override;
 
+  bool prepare_command(MonOpRequestRef op);
+
   void create_initial() override;
   void update_from_paxos(bool *need_bootstrap) override;
   void create_pending() override;

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -1,0 +1,45 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <boost/optional.hpp>
+
+#include "ConfigMap.h"
+#include "mon/PaxosService.h"
+
+class MonSession;
+
+class ConfigMonitor : public PaxosService
+{
+  version_t version = 0;
+  ConfigMap config_map;
+  map<string,boost::optional<bufferlist>> pending;
+
+public:
+  ConfigMonitor(Monitor *m, Paxos *p, const string& service_name);
+
+  void init() override;
+
+  void load_config();
+
+  bool preprocess_query(MonOpRequestRef op) override;
+  bool prepare_update(MonOpRequestRef op) override;
+
+  void create_initial() override;
+  void update_from_paxos(bool *need_bootstrap) override;
+  void create_pending() override;
+  void encode_pending(MonitorDBStore::TransactionRef t) override;
+  version_t get_trim_to() const override;
+
+  void encode_full(MonitorDBStore::TransactionRef t) override { }
+
+  void tick() override;
+
+  bool refresh_config(MonSession *s);
+  bool maybe_send_config(MonSession *s);
+  void send_config(MonSession *s);
+  void check_sub(MonSession *s);
+  void check_sub(Subscription *sub);
+  void check_all_subs();
+};

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -34,6 +34,7 @@ public:
 
   void encode_full(MonitorDBStore::TransactionRef t) override { }
 
+  void on_active() override;
   void tick() override;
 
   bool refresh_config(MonSession *s);

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -15,11 +15,13 @@
 #include <random>
 
 #include "include/scope_guard.h"
+#include "include/stringify.h"
 
 #include "messages/MMonGetMap.h"
 #include "messages/MMonGetVersion.h"
 #include "messages/MMonGetVersionReply.h"
 #include "messages/MMonMap.h"
+#include "messages/MConfig.h"
 #include "messages/MAuth.h"
 #include "messages/MLogAck.h"
 #include "messages/MAuthReply.h"
@@ -244,6 +246,7 @@ bool MonClient::ms_dispatch(Message *m)
   case CEPH_MSG_MON_GET_VERSION_REPLY:
   case MSG_MON_COMMAND_ACK:
   case MSG_LOGACK:
+  case MSG_CONFIG:
     break;
   default:
     return false;
@@ -299,6 +302,9 @@ bool MonClient::ms_dispatch(Message *m)
       m->put();
     }
     break;
+  case MSG_CONFIG:
+    handle_config(static_cast<MConfig*>(m));
+    break;
   }
   return true;
 }
@@ -347,6 +353,13 @@ void MonClient::handle_monmap(MMonMap *m)
 
   map_cond.Signal();
   want_monmap = false;
+}
+
+void MonClient::handle_config(MConfig *m)
+{
+  ldout(cct,10) << __func__ << " " << *m << dendl;
+  cct->_conf->set_mon_vals(cct, m->config);
+  m->put();
 }
 
 // ----------------------
@@ -452,6 +465,7 @@ int MonClient::authenticate(double timeout)
   }
 
   _sub_want("monmap", monmap.get_epoch() ? monmap.get_epoch() + 1 : 0, 0);
+  _sub_want("config", 0, 0);
   if (!_opened())
     _reopen_session();
 

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -27,6 +27,7 @@
 
 
 class MMonMap;
+class MConfig;
 class MMonGetVersionReply;
 struct MMonSubscribeAck;
 class MMonCommandAck;
@@ -177,6 +178,7 @@ private:
   bool ms_handle_refused(Connection *con) override { return false; }
 
   void handle_monmap(MMonMap *m);
+  void handle_config(MConfig *m);
 
   void handle_auth(MAuthReply *m);
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1050,7 +1050,8 @@ COMMAND("config-key exists " \
 COMMAND_WITH_FLAG("config-key list ", "list keys", "config-key", "r", "cli,rest",
 		  FLAG(DEPRECATED))
 COMMAND("config-key ls ", "list keys", "config-key", "r", "cli,rest")
-COMMAND("config-key dump", "dump keys and values", "config-key", "r", "cli,rest")
+COMMAND("config-key dump " \
+	"name=key,type=CephString,req=false", "dump keys and values (with optional prefix)", "config-key", "r", "cli,rest")
 
 
 /*

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1084,3 +1084,11 @@ COMMAND("mgr count-metadata name=property,type=CephString",
 COMMAND("mgr versions", \
 	"check running versions of ceph-mgr daemons",
 	"mgr", "r", "cli,rest")
+
+// ConfigMonitor
+COMMAND("config set" \
+	" name=who,type=CephString" \
+	" name=name,type=CephString" \
+	" name=value,type=CephString", \
+	"set a config option",
+	"config", "rw", "cli,rest")

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3167,7 +3167,7 @@ void Monitor::handle_command(MonOpRequestRef op)
     cmd_getval(cct, cmdmap, "key", key);
     std::string val;
     cmd_getval(cct, cmdmap, "value", val);
-    r = g_conf->set_val(key, val, true, &ss);
+    r = g_conf->set_val(key, val, &ss);
     if (r == 0) {
       g_conf->apply_changes(nullptr);
     }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -74,6 +74,7 @@
 #include "AuthMonitor.h"
 #include "MgrMonitor.h"
 #include "MgrStatMonitor.h"
+#include "ConfigMonitor.h"
 #include "mon/QuorumService.h"
 #include "mon/HealthMonitor.h"
 #include "mon/ConfigKeyService.h"
@@ -188,6 +189,7 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   paxos_service[PAXOS_MGR] = new MgrMonitor(this, paxos, "mgr");
   paxos_service[PAXOS_MGRSTAT] = new MgrStatMonitor(this, paxos, "mgrstat");
   paxos_service[PAXOS_HEALTH] = new HealthMonitor(this, paxos, "health");
+  paxos_service[PAXOS_CONFIG] = new ConfigMonitor(this, paxos, "config");
 
   config_key_service = new ConfigKeyService(this, paxos);
 
@@ -4777,6 +4779,8 @@ void Monitor::handle_subscribe(MonOpRequestRef op)
       mgrmon()->check_sub(s->sub_map[p->first]);
     } else if (p->first == "servicemap") {
       mgrstatmon()->check_sub(s->sub_map[p->first]);
+    } else if (p->first == "config") {
+      configmon()->check_sub(s);
     }
   }
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3042,6 +3042,10 @@ void Monitor::handle_command(MonOpRequestRef op)
     osdmon()->dispatch(op);
     return;
   }
+  if (module == "config") {
+    configmon()->dispatch(op);
+    return;
+  }
 
   if (module == "mon" &&
       /* Let the Monitor class handle the following commands:

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -639,6 +639,10 @@ public:
     return (class HealthMonitor*) paxos_service[PAXOS_HEALTH];
   }
 
+  class ConfigMonitor *configmon() {
+    return (class ConfigMonitor*) paxos_service[PAXOS_CONFIG];
+  }
+
   friend class Paxos;
   friend class OSDMonitor;
   friend class MDSMonitor;

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -60,6 +60,9 @@ struct MonSession : public RefCountedObject {
   ConnectionRef proxy_con;
   uint64_t proxy_tid;
 
+  string remote_host;                ///< remote host name
+  map<string,string> last_config;    ///< most recently shared config
+
   MonSession(const entity_inst_t& i, Connection *c) :
     RefCountedObject(g_ceph_context),
     con(c),

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -49,6 +49,8 @@ inline const char *get_paxos_name(int p) {
 
 #define CEPH_MON_ONDISK_MAGIC "ceph mon volume v012"
 
+extern const string CONFIG_PREFIX;
+
 // map of entity_type -> features -> count
 struct FeatureMap {
   std::map<uint32_t,std::map<uint64_t,uint64_t>> m;

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -31,7 +31,8 @@
 #define PAXOS_MGR        5
 #define PAXOS_MGRSTAT    6
 #define PAXOS_HEALTH     7
-#define PAXOS_NUM        8
+#define PAXOS_CONFIG     8
+#define PAXOS_NUM        9
 
 inline const char *get_paxos_name(int p) {
   switch (p) {
@@ -43,6 +44,7 @@ inline const char *get_paxos_name(int p) {
   case PAXOS_MGR: return "mgr";
   case PAXOS_MGRSTAT: return "mgrstat";
   case PAXOS_HEALTH: return "health";
+  case PAXOS_CONFIG: return "config";
   default: ceph_abort(); return 0;
   }
 }

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -34,6 +34,7 @@
 #include "messages/MMonCommand.h"
 #include "messages/MMonCommandAck.h"
 #include "messages/MMonPaxos.h"
+#include "messages/MConfig.h"
 
 #include "messages/MMonProbe.h"
 #include "messages/MMonJoin.h"
@@ -359,6 +360,9 @@ Message *decode_message(CephContext *cct, int crcflags,
     break;
   case MSG_MON_PAXOS:
     m = new MMonPaxos;
+    break;
+  case MSG_CONFIG:
+    m = new MConfig;
     break;
 
   case MSG_MON_PROBE:

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -59,6 +59,8 @@
 
 #define MSG_PAXOS                  40
 
+#define MSG_CONFIG           62
+
 
 // osd internal
 #define MSG_OSD_PING         70

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4558,6 +4558,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
   }
   dout(10) << __func__ << " do_bluefs = " << do_bluefs << dendl;
 
+  map<string,string> kv_options;
   rocksdb::Env *env = NULL;
   if (do_bluefs) {
     dout(10) << __func__ << " initializing bluefs" << dendl;
@@ -4671,10 +4672,10 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
 	  bluefs->get_block_device_size(BlueFS::BDEV_WAL) -
 	   BDEV_LABEL_BLOCK_SIZE);
       }
-      cct->_conf->set_val("rocksdb_separate_wal_dir", "true");
+      kv_options["separate_wal_dir"] = "1";
       bluefs_single_shared_device = false;
     } else if (::lstat(bfn.c_str(), &st) == -1) {
-      cct->_conf->set_val("rocksdb_separate_wal_dir", "false");
+      kv_options.erase("separate_wal_dir");
     } else {
       //symlink exist is bug
       derr << __func__ << " " << bfn << " link target doesn't exist" << dendl;
@@ -4718,16 +4719,15 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
                << (uint64_t)(db_size * 95 / 100) << " "
                << fn + ".slow" << ","
                << (uint64_t)(slow_size * 95 / 100);
-      cct->_conf->set_val("rocksdb_db_paths", db_paths.str(), false);
-      dout(10) << __func__ << " set rocksdb_db_paths to "
-	       << cct->_conf->get_val<std::string>("rocksdb_db_paths") << dendl;
+      kv_options["db_paths"] = db_paths.str();
+      dout(10) << __func__ << " set db_paths to " << db_paths.str() << dendl;
     }
 
     if (create) {
       env->CreateDir(fn);
-      if (cct->_conf->rocksdb_separate_wal_dir)
+      if (kv_options.count("separate_wal_dir"))
 	env->CreateDir(fn + ".wal");
-      if (cct->_conf->get_val<std::string>("rocksdb_db_paths").length())
+      if (kv_options.count("rocksdb_db_paths"))
 	env->CreateDir(fn + ".slow");
     }
   } else if (create) {
@@ -4741,7 +4741,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
     }
 
     // wal_dir, too!
-    if (cct->_conf->rocksdb_separate_wal_dir) {
+    if (kv_options.count("separate_wal_dir")) {
       string walfn = path + "/db.wal";
       r = ::mkdir(walfn.c_str(), 0755);
       if (r < 0)
@@ -4758,6 +4758,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
   db = KeyValueDB::create(cct,
 			  kv_backend,
 			  fn,
+			  kv_options,
 			  static_cast<void*>(env));
   if (!db) {
     derr << __func__ << " error creating db" << dendl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6089,7 +6089,7 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
     cmd_getval(cct, cmdmap, "key", key);
     cmd_getval(cct, cmdmap, "value", val);
     osd_lock.Unlock();
-    r = cct->_conf->set_val(key, val, true, &ss);
+    r = cct->_conf->set_val(key, val, &ss);
     if (r == 0) {
       cct->_conf->apply_changes(nullptr);
     }

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -461,12 +461,13 @@ namespace rgw {
     int r = 0;
 
     /* alternative default for module */
-    vector<const char *> def_args;
-    def_args.push_back("--debug-rgw=1/5");
-    def_args.push_back("--keyring=$rgw_data/keyring");
-    def_args.push_back("--log-file=/var/log/radosgw/$cluster-$name.log");
+    map<string,string> defaults = {
+      { "debug_rgw", "1/5" },
+      { "keyring", "$rgw_data/keyring" },
+      { "log_file", "/var/log/radosgw/$cluster-$name.log" }
+    };
 
-    cct = global_init(&def_args, args,
+    cct = global_init(&defaults, args,
 		      CEPH_ENTITY_TYPE_CLIENT,
 		      CODE_ENVIRONMENT_DAEMON,
 		      CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -183,9 +183,10 @@ int main(int argc, const char **argv)
   }
 
   /* alternative default for module */
-  vector<const char *> def_args;
-  def_args.push_back("--debug-rgw=1/5");
-  def_args.push_back("--keyring=$rgw_data/keyring");
+  map<string,string> defaults = {
+    { "debug_rgw", "1/5" },
+    { "keyring", "$rgw_data/keyring" }
+  };
 
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
@@ -193,8 +194,9 @@ int main(int argc, const char **argv)
 
   // First, let's determine which frontends are configured.
   int flags = CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS;
-  global_pre_init(&def_args, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_DAEMON,
-          flags);
+  global_pre_init(
+    &defaults, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_DAEMON,
+    flags);
 
   list<string> frontends;
   get_str_list(g_conf->rgw_frontends, ",", frontends);
@@ -239,7 +241,7 @@ int main(int argc, const char **argv)
   // initialization. Passing false as the final argument ensures that
   // global_pre_init() is not invoked twice.
   // claim the reference and release it after subsequent destructors have fired
-  auto cct = global_init(&def_args, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_DAEMON,
 			 flags, "rgw_data", false);
 

--- a/src/test/bench/small_io_bench_dumb.cc
+++ b/src/test/bench/small_io_bench_dumb.cc
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
     std::cerr << e.what() << std::endl;
     return 1;
   }
-  vector<const char *> ceph_options, def_args;
+  vector<const char *> ceph_options;
   ceph_options.reserve(ceph_option_strings.size());
   for (vector<string>::iterator i = ceph_option_strings.begin();
        i != ceph_option_strings.end();
@@ -96,7 +96,7 @@ int main(int argc, char **argv)
   }
 
   auto cct = global_init(
-    &def_args, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
+    NULL, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
     CODE_ENVIRONMENT_UTILITY,
     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/bench/small_io_bench_fs.cc
+++ b/src/test/bench/small_io_bench_fs.cc
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
     std::cerr << e.what() << std::endl;
     return 1;
   }
-  vector<const char *> ceph_options, def_args;
+  vector<const char *> ceph_options;
   ceph_options.reserve(ceph_option_strings.size());
   for (vector<string>::iterator i = ceph_option_strings.begin();
        i != ceph_option_strings.end();
@@ -107,7 +107,7 @@ int main(int argc, char **argv)
   }
 
   auto cct = global_init(
-    &def_args, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
+    NULL, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
     CODE_ENVIRONMENT_UTILITY,
     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/bench/tp_bench.cc
+++ b/src/test/bench/tp_bench.cc
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
     std::cerr << e.what() << std::endl;
     return 1;
   }
-  vector<const char *> ceph_options, def_args;
+  vector<const char *> ceph_options;
   ceph_options.reserve(ceph_option_strings.size());
   for (vector<string>::iterator i = ceph_option_strings.begin();
        i != ceph_option_strings.end();
@@ -143,7 +143,7 @@ int main(int argc, char **argv)
   }
 
   auto cct = global_init(
-    &def_args, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
+    NULL, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
     CODE_ENVIRONMENT_UTILITY,
     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -41,7 +41,7 @@ public:
       std::string after = " AFTER ";
 
       std::string val(before + "$run_dir${run_dir}" + after);
-      EXPECT_TRUE(expand_meta(val, &oss));
+      early_expand_meta(val, &oss);
       EXPECT_EQ(before + "/var/run/ceph/var/run/ceph" + after, val);
       EXPECT_EQ("", oss.str());
     }
@@ -49,8 +49,18 @@ public:
       ostringstream oss;
       std::string before = " BEFORE ";
       std::string after = " AFTER ";
+
+      std::string val(before + "$$1$run_dir$2${run_dir}$3$" + after);
+      early_expand_meta(val, &oss);
+      EXPECT_EQ(before + "$$1/var/run/ceph$2/var/run/ceph$3$" + after, val);
+      EXPECT_EQ("", oss.str());
+    }
+    {
+      ostringstream oss;
+      std::string before = " BEFORE ";
+      std::string after = " AFTER ";
       std::string val(before + "$host${host}" + after);
-      EXPECT_TRUE(expand_meta(val, &oss));
+      early_expand_meta(val, &oss);
       std::string hostname = exec("hostname -s");
       EXPECT_EQ(before + hostname + hostname + after, val);
       EXPECT_EQ("", oss.str());
@@ -60,30 +70,30 @@ public:
       ostringstream oss;
       std::string expected = "expect $foo and ${bar} to not expand";
       std::string val = expected;
-      EXPECT_FALSE(expand_meta(val, &oss));
+      early_expand_meta(val, &oss);
       EXPECT_EQ(expected, val);
       EXPECT_EQ("", oss.str());
     }
     // recursive variable expansion
     {
       std::string host = "localhost";
-      EXPECT_EQ(0, set_val("host", host.c_str(), false));
+      EXPECT_EQ(0, set_val("host", host.c_str()));
 
       std::string mon_host = "$cluster_network";
-      EXPECT_EQ(0, set_val("mon_host", mon_host.c_str(), false));
+      EXPECT_EQ(0, set_val("mon_host", mon_host.c_str()));
 
       std::string lockdep = "true";
-      EXPECT_EQ(0, set_val("lockdep", lockdep.c_str(), false));
+      EXPECT_EQ(0, set_val("lockdep", lockdep.c_str()));
 
       std::string cluster_network = "$public_network $public_network $lockdep $host";
-      EXPECT_EQ(0, set_val("cluster_network", cluster_network.c_str(), false));
+      EXPECT_EQ(0, set_val("cluster_network", cluster_network.c_str()));
 
       std::string public_network = "NETWORK";
-      EXPECT_EQ(0, set_val("public_network", public_network.c_str(), false));
+      EXPECT_EQ(0, set_val("public_network", public_network.c_str()));
 
       ostringstream oss;
       std::string val = "$mon_host";
-      EXPECT_TRUE(expand_meta(val, &oss));
+      early_expand_meta(val, &oss);
       EXPECT_EQ(public_network + " " +
                 public_network + " " +
                 lockdep + " " +
@@ -93,64 +103,26 @@ public:
     // variable expansion loops are non fatal
     {
       std::string mon_host = "$cluster_network";
-      EXPECT_EQ(0, set_val("mon_host", mon_host.c_str(), false));
+      EXPECT_EQ(0, set_val("mon_host", mon_host.c_str()));
 
       std::string cluster_network = "$public_network";
-      EXPECT_EQ(0, set_val("cluster_network", cluster_network.c_str(), false));
+      EXPECT_EQ(0, set_val("cluster_network", cluster_network.c_str()));
 
       std::string public_network = "$mon_host";
-      EXPECT_EQ(0, set_val("public_network", public_network.c_str(), false));
+      EXPECT_EQ(0, set_val("public_network", public_network.c_str()));
 
       ostringstream oss;
       std::string val = "$mon_host";
-      EXPECT_TRUE(expand_meta(val, &oss));
-      EXPECT_EQ("$cluster_network", val);
+      early_expand_meta(val, &oss);
+      EXPECT_EQ("$mon_host", val);
       const char *expected_oss =
         "variable expansion loop at mon_host=$cluster_network\n"
-        "expansion stack: \n"
+        "expansion stack:\n"
         "public_network=$mon_host\n"
         "cluster_network=$public_network\n"
         "mon_host=$cluster_network\n";
       EXPECT_EQ(expected_oss, oss.str());
     }
-  }
-
-  void test_expand_all_meta() {
-    Mutex::Locker l(lock);
-    int before_count = 0, data_dir = 0;
-    for (const auto &i : schema) {
-      const Option &opt = i.second;
-      if (opt.type == Option::TYPE_STR) {
-        const auto &str = boost::get<std::string>(opt.value);
-        if (str.find("$") != string::npos)
-          before_count++;
-        if (str.find("$data_dir") != string::npos)
-          data_dir++;
-      }
-    }
-
-    // if there are no meta variables in the default configuration,
-    // something must be done to check the expected side effect
-    // of expand_all_meta
-    ASSERT_LT(0, before_count);
-    expand_all_meta();
-    int after_count = 0;
-    for (auto& i : values) {
-      const auto &opt = schema.at(i.first);
-      if (opt.type == Option::TYPE_STR) {
-        const std::string &str = boost::get<std::string>(i.second);
-        size_t pos = 0;
-        while ((pos = str.find("$", pos)) != string::npos) {
-          if (str.substr(pos, 8) != "$channel") {
-            std::cout << "unexpected meta-variable found at pos " << pos
-                      << " of '" << str << "'" << std::endl;
-            after_count++;
-          }
-          pos++;
-        }
-      }
-    }
-    ASSERT_EQ(data_dir, after_count);
   }
 };
 
@@ -159,25 +131,10 @@ TEST_F(test_md_config_t, expand_meta)
   test_expand_meta();
 }
 
-TEST_F(test_md_config_t, expand_all_meta)
-{
-  test_expand_all_meta();
-}
-
 TEST(md_config_t, set_val)
 {
   int buf_size = 1024;
   md_config_t conf;
-  // disable meta variable expansion
-  {
-    char *buf = (char*)malloc(buf_size);
-    std::string expected = "$host";
-    EXPECT_EQ(0, conf.set_val("mon_host", expected.c_str(), false));
-    EXPECT_EQ(0, conf.get_val("mon_host", &buf, buf_size));
-    EXPECT_EQ(expected, buf);
-    free(buf);
-  }
-  // meta variable expansion is enabled by default
   {
     char *run_dir = (char*)malloc(buf_size);
     EXPECT_EQ(0, conf.get_val("run_dir", &run_dir, buf_size));

--- a/src/test/common/test_context.cc
+++ b/src/test/common/test_context.cc
@@ -34,7 +34,7 @@ TEST(CephContext, do_command)
 
   string key("key");
   string value("value");
-  cct->_conf->set_val(key.c_str(), value.c_str(), false);
+  cct->_conf->set_val(key.c_str(), value.c_str());
   cmdmap_t cmdmap;
   cmdmap["var"] = key;
 
@@ -56,8 +56,7 @@ TEST(CephContext, do_command)
     bufferlist out;
     cct->do_command("config diff get", cmdmap, "xml", &out);
     string s(out.c_str(), out.length());
-    EXPECT_EQ("<config_diff_get><diff><current><key>" + value + 
-      "</key></current><defaults><key></key></defaults></diff></config_diff_get>", s);
+    EXPECT_EQ("<config_diff_get><diff><key><default></default><override>" + value + "</override><final>value</final></key></diff></config_diff_get>", s);
   }
   cct->put();
 }

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -379,7 +379,7 @@ TEST(ZlibCompressor, zlib_isal_compatibility)
 TEST(CompressionPlugin, all)
 {
   const char* env = getenv("CEPH_LIB");
-  std::string directory(env ? env : ".libs");
+  std::string directory(env ? env : "lib");
   CompressorRef compressor;
   PluginRegistry *reg = g_ceph_context->get_plugin_registry();
   EXPECT_TRUE(reg);

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1423,9 +1423,10 @@ int main(int argc, char **argv) {
   argv_to_vec(argc, (const char **)argv, args);
   env_to_vec(args);
 
-  vector<const char*> def_args;
-  def_args.push_back("--debug-crush=0");
-  auto cct = global_init(&def_args, args, CEPH_ENTITY_TYPE_CLIENT,
+  map<string,string> defaults = {
+    { "debug_crush", "0" }
+  };
+  auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/test/daemon_config.cc
+++ b/src/test/daemon_config.cc
@@ -47,7 +47,7 @@ TEST(DaemonConfig, Substitution) {
   g_conf->_clear_safe_to_start_threads();
   ret = g_ceph_context->_conf->set_val("host", "foo");
   ASSERT_EQ(0, ret);
-  ret = g_ceph_context->_conf->set_val("public_network", "bar$host.baz", false);
+  ret = g_ceph_context->_conf->set_val("public_network", "bar$host.baz");
   ASSERT_EQ(0, ret);
   g_ceph_context->_conf->apply_changes(NULL);
   char buf[128];
@@ -63,7 +63,7 @@ TEST(DaemonConfig, SubstitutionTrailing) {
   g_conf->_clear_safe_to_start_threads();
   ret = g_ceph_context->_conf->set_val("host", "foo");
   ASSERT_EQ(0, ret);
-  ret = g_ceph_context->_conf->set_val("public_network", "bar$host", false);
+  ret = g_ceph_context->_conf->set_val("public_network", "bar$host");
   ASSERT_EQ(0, ret);
   g_ceph_context->_conf->apply_changes(NULL);
   char buf[128];
@@ -79,7 +79,7 @@ TEST(DaemonConfig, SubstitutionBraces) {
   g_conf->_clear_safe_to_start_threads();
   ret = g_ceph_context->_conf->set_val("host", "foo");
   ASSERT_EQ(0, ret);
-  ret = g_ceph_context->_conf->set_val("public_network", "bar${host}baz", false);
+  ret = g_ceph_context->_conf->set_val("public_network", "bar${host}baz");
   ASSERT_EQ(0, ret);
   g_ceph_context->_conf->apply_changes(NULL);
   char buf[128];
@@ -94,7 +94,7 @@ TEST(DaemonConfig, SubstitutionBracesTrailing) {
   g_conf->_clear_safe_to_start_threads();
   ret = g_ceph_context->_conf->set_val("host", "foo");
   ASSERT_EQ(0, ret);
-  ret = g_ceph_context->_conf->set_val("public_network", "bar${host}", false);
+  ret = g_ceph_context->_conf->set_val("public_network", "bar${host}");
   ASSERT_EQ(0, ret);
   g_ceph_context->_conf->apply_changes(NULL);
   char buf[128];
@@ -108,9 +108,9 @@ TEST(DaemonConfig, SubstitutionBracesTrailing) {
 // config: variable substitution happen only once http://tracker.ceph.com/issues/7103
 TEST(DaemonConfig, SubstitutionMultiple) {
   int ret;
-  ret = g_ceph_context->_conf->set_val("mon_host", "localhost", false);
+  ret = g_ceph_context->_conf->set_val("mon_host", "localhost");
   ASSERT_EQ(0, ret);
-  ret = g_ceph_context->_conf->set_val("keyring", "$mon_host/$cluster.keyring,$mon_host/$cluster.mon.keyring", false);
+  ret = g_ceph_context->_conf->set_val("keyring", "$mon_host/$cluster.keyring,$mon_host/$cluster.mon.keyring");
   ASSERT_EQ(0, ret);
   g_ceph_context->_conf->apply_changes(NULL);
   char buf[512];

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -403,7 +403,7 @@ TEST(ErasureCodeLrc, layers_init)
     ErasureCodeProfile profile;
 
     const char* env = getenv("CEPH_LIB");
-    string directory(env ? env : ".libs");
+    string directory(env ? env : "lib");
     string description_string = 
       "[ " 
       "  [ \"_cDDD_cDD_\", \"directory=" + directory + "\" ]," 

--- a/src/test/erasure-code/TestErasureCodePlugin.cc
+++ b/src/test/erasure-code/TestErasureCodePlugin.cc
@@ -83,7 +83,7 @@ TEST_F(ErasureCodePluginRegistryTest, all)
 {
   ErasureCodeProfile profile;
   const char* env = getenv("CEPH_LIB");
-  string directory(env ? env : ".libs");
+  string directory(env ? env : "lib");
   ErasureCodeInterfaceRef erasure_code;
   ErasureCodePluginRegistry &instance = ErasureCodePluginRegistry::instance();
   EXPECT_FALSE(erasure_code);

--- a/src/test/erasure-code/TestErasureCodeShec_all.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_all.cc
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
 
   const char* env = getenv("CEPH_LIB");
   string directory(env ? env : ".libs");
-  g_conf->set_val_or_die("erasure_code_dir", directory, false);
+  g_conf->set_val_or_die("erasure_code_dir", directory);
 
   ::testing::InitGoogleTest(&argc, argv);
 

--- a/src/test/erasure-code/TestErasureCodeShec_arguments.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_arguments.cc
@@ -401,7 +401,7 @@ int main(int argc, char **argv)
 
   const char* env = getenv("CEPH_LIB");
   std::string directory(env ? env : ".libs");
-  g_conf->set_val_or_die("erasure_code_dir", directory, false);
+  g_conf->set_val_or_die("erasure_code_dir", directory);
 
   ::testing::InitGoogleTest(&argc, argv);
 

--- a/src/test/erasure-code/TestErasureCodeShec_arguments.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_arguments.cc
@@ -400,7 +400,7 @@ int main(int argc, char **argv)
   common_init_finish(g_ceph_context);
 
   const char* env = getenv("CEPH_LIB");
-  std::string directory(env ? env : ".libs");
+  std::string directory(env ? env : "lib");
   g_conf->set_val_or_die("erasure_code_dir", directory);
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/test/erasure-code/ceph_erasure_code.cc
+++ b/src/test/erasure-code/ceph_erasure_code.cc
@@ -90,7 +90,7 @@ int ErasureCodeCommand::setup(int argc, char** argv) {
   common_init_finish(g_ceph_context);
   g_ceph_context->_conf->apply_changes(NULL);
   const char* env = getenv("CEPH_LIB");
-  string directory(env ? env : ".libs");
+  string directory(env ? env : "lib");
   g_conf->set_val_or_die("erasure_code_dir", directory);
 
   if (vm.count("help")) {

--- a/src/test/erasure-code/ceph_erasure_code.cc
+++ b/src/test/erasure-code/ceph_erasure_code.cc
@@ -91,7 +91,7 @@ int ErasureCodeCommand::setup(int argc, char** argv) {
   g_ceph_context->_conf->apply_changes(NULL);
   const char* env = getenv("CEPH_LIB");
   string directory(env ? env : ".libs");
-  g_conf->set_val_or_die("erasure_code_dir", directory, false);
+  g_conf->set_val_or_die("erasure_code_dir", directory);
 
   if (vm.count("help")) {
     cout << desc << std::endl;

--- a/src/test/erasure-code/ceph_erasure_code.cc
+++ b/src/test/erasure-code/ceph_erasure_code.cc
@@ -73,7 +73,7 @@ int ErasureCodeCommand::setup(int argc, char** argv) {
     vm);
   po::notify(vm);
 
-  vector<const char *> ceph_options, def_args;
+  vector<const char *> ceph_options;
   vector<string> ceph_option_strings = po::collect_unrecognized(
     parsed.options, po::include_positional);
   ceph_options.reserve(ceph_option_strings.size());
@@ -84,7 +84,7 @@ int ErasureCodeCommand::setup(int argc, char** argv) {
   }
 
   cct = global_init(
-    &def_args, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
+    NULL, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
     CODE_ENVIRONMENT_UTILITY,
     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -71,7 +71,7 @@ int ErasureCodeBench::setup(int argc, char** argv) {
     vm);
   po::notify(vm);
 
-  vector<const char *> ceph_options, def_args;
+  vector<const char *> ceph_options;
   vector<string> ceph_option_strings = po::collect_unrecognized(
     parsed.options, po::include_positional);
   ceph_options.reserve(ceph_option_strings.size());
@@ -82,7 +82,7 @@ int ErasureCodeBench::setup(int argc, char** argv) {
   }
 
   cct = global_init(
-    &def_args, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
+    NULL, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
     CODE_ENVIRONMENT_UTILITY,
     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -345,7 +345,7 @@ int main(int argc, char** argv) {
  *   valgrind --tool=memcheck --leak-check=full \
  *      ./ceph_erasure_code_benchmark \
  *      --plugin jerasure \
- *      --parameter directory=.libs \
+ *      --parameter directory=lib \
  *      --parameter technique=reed_sol_van \
  *      --parameter k=2 \
  *      --parameter m=2 \

--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -98,7 +98,7 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
   g_ceph_context->_conf->apply_changes(NULL);
   const char* env = getenv("CEPH_LIB");
   std::string libs_dir(env ? env : ".libs");
-  g_conf->set_val_or_die("erasure_code_dir", libs_dir, false);
+  g_conf->set_val_or_die("erasure_code_dir", libs_dir);
 
   if (vm.count("help")) {
     cout << desc << std::endl;

--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -81,7 +81,7 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
     vm);
   po::notify(vm);
 
-  vector<const char *> ceph_options, def_args;
+  vector<const char *> ceph_options;
   vector<string> ceph_option_strings = po::collect_unrecognized(
     parsed.options, po::include_positional);
   ceph_options.reserve(ceph_option_strings.size());
@@ -91,7 +91,7 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
     ceph_options.push_back(i->c_str());
   }
 
-  cct = global_init(&def_args, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
+  cct = global_init(NULL, ceph_options, CEPH_ENTITY_TYPE_CLIENT,
 		    CODE_ENVIRONMENT_UTILITY,
 		    CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -97,7 +97,7 @@ int ErasureCodeNonRegression::setup(int argc, char** argv) {
   common_init_finish(g_ceph_context);
   g_ceph_context->_conf->apply_changes(NULL);
   const char* env = getenv("CEPH_LIB");
-  std::string libs_dir(env ? env : ".libs");
+  std::string libs_dir(env ? env : "lib");
   g_conf->set_val_or_die("erasure_code_dir", libs_dir);
 
   if (vm.count("help")) {

--- a/src/test/librados/librados_config.cc
+++ b/src/test/librados/librados_config.cc
@@ -75,7 +75,7 @@ TEST(LibRadosConfig, DebugLevels) {
   memset(buf, 0, sizeof(buf));
   ret = rados_conf_get(cl, "debug_rados", buf, sizeof(buf));
   ASSERT_EQ(ret, 0);
-  ASSERT_EQ(0, strncmp("3/", buf, 2));
+  ASSERT_EQ(0, strcmp("3/3", buf));
 
   ret = rados_conf_set(cl, "debug_rados", "7/8");
   ASSERT_EQ(ret, 0);

--- a/src/test/librados_test_stub/TestClassHandler.cc
+++ b/src/test/librados_test_stub/TestClassHandler.cc
@@ -47,7 +47,7 @@ void TestClassHandler::open_all_classes() {
   assert(m_class_handles.empty());
 
   const char* env = getenv("CEPH_LIB");
-  std::string CEPH_LIB(env ? env : ".libs");
+  std::string CEPH_LIB(env ? env : "lib");
   DIR *dir = ::opendir(CEPH_LIB.c_str());
   if (dir == NULL) {
     ceph_abort();;

--- a/src/test/mon/MonMap.cc
+++ b/src/test/mon/MonMap.cc
@@ -97,7 +97,7 @@ TEST_F(MonMapTest, build_initial_config_from_dns) {
 
 
   CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_MON))->get();
-  cct->_conf->set_val("mon_dns_srv_name", "cephmon", false);
+  cct->_conf->set_val("mon_dns_srv_name", "cephmon");
   MonMap monmap;
   int r = monmap.build_initial(cct, std::cerr);
 
@@ -195,7 +195,7 @@ TEST_F(MonMapTest, build_initial_config_from_dns_with_domain) {
 
 
   CephContext *cct = (new CephContext(CEPH_ENTITY_TYPE_MON))->get();
-  cct->_conf->set_val("mon_dns_srv_name", "cephmon_ceph.com", false);
+  cct->_conf->set_val("mon_dns_srv_name", "cephmon_ceph.com");
   MonMap monmap;
   int r = monmap.build_initial(cct, std::cerr);
 

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -995,12 +995,11 @@ int get_id_interval(int &first, int &last, string &str)
 
 int main(int argc, const char *argv[])
 {
-  vector<const char*> def_args;
   vector<const char*> args;
   our_name = argv[0];
   argv_to_vec(argc, argv, args);
 
-  auto cct = global_init(&def_args, args,
+  auto cct = global_init(NULL, args,
 			 CEPH_ENTITY_TYPE_OSD, CODE_ENVIRONMENT_UTILITY,
 			 0);
 

--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -41,17 +41,17 @@ class NetworkWorkerTest : public ::testing::TestWithParam<const char*> {
   void SetUp() override {
     cerr << __func__ << " start set up " << GetParam() << std::endl;
     if (strncmp(GetParam(), "dpdk", 4)) {
-      g_ceph_context->_conf->set_val("ms_type", "async+posix", false);
+      g_ceph_context->_conf->set_val("ms_type", "async+posix");
       addr = "127.0.0.1:15000";
       port_addr = "127.0.0.1:15001";
     } else {
-      g_ceph_context->_conf->set_val("ms_type", "async+dpdk", false);
-      g_ceph_context->_conf->set_val("ms_dpdk_debug_allow_loopback", "true", false);
-      g_ceph_context->_conf->set_val("ms_async_op_threads", "2", false);
-      g_ceph_context->_conf->set_val("ms_dpdk_coremask", "0x7", false);
-      g_ceph_context->_conf->set_val("ms_dpdk_host_ipv4_addr", "172.16.218.3", false);
-      g_ceph_context->_conf->set_val("ms_dpdk_gateway_ipv4_addr", "172.16.218.2", false);
-      g_ceph_context->_conf->set_val("ms_dpdk_netmask_ipv4_addr", "255.255.255.0", false);
+      g_ceph_context->_conf->set_val("ms_type", "async+dpdk");
+      g_ceph_context->_conf->set_val("ms_dpdk_debug_allow_loopback", "true");
+      g_ceph_context->_conf->set_val("ms_async_op_threads", "2");
+      g_ceph_context->_conf->set_val("ms_dpdk_coremask", "0x7");
+      g_ceph_context->_conf->set_val("ms_dpdk_host_ipv4_addr", "172.16.218.3");
+      g_ceph_context->_conf->set_val("ms_dpdk_gateway_ipv4_addr", "172.16.218.2");
+      g_ceph_context->_conf->set_val("ms_dpdk_netmask_ipv4_addr", "255.255.255.0");
       addr = "172.16.218.3:15000";
       port_addr = "172.16.218.3:15001";
     }

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -1329,7 +1329,7 @@ TEST_P(MessengerTest, SyntheticInjectTest4) {
   g_ceph_context->_conf->set_val("ms_inject_socket_failures", "30");
   g_ceph_context->_conf->set_val("ms_inject_internal_delays", "0.1");
   g_ceph_context->_conf->set_val("ms_inject_delay_probability", "1");
-  g_ceph_context->_conf->set_val("ms_inject_delay_type", "client osd", false);
+  g_ceph_context->_conf->set_val("ms_inject_delay_type", "client osd");
   g_ceph_context->_conf->set_val("ms_inject_delay_max", "5");
   SyntheticWorkload test_msg(16, 32, GetParam(), 100,
                              Messenger::Policy::lossless_peer(0),
@@ -1360,7 +1360,7 @@ TEST_P(MessengerTest, SyntheticInjectTest4) {
   g_ceph_context->_conf->set_val("ms_inject_socket_failures", "0");
   g_ceph_context->_conf->set_val("ms_inject_internal_delays", "0");
   g_ceph_context->_conf->set_val("ms_inject_delay_probability", "0");
-  g_ceph_context->_conf->set_val("ms_inject_delay_type", "", false);
+  g_ceph_context->_conf->set_val("ms_inject_delay_type", "");
   g_ceph_context->_conf->set_val("ms_inject_delay_max", "0");
 }
 

--- a/src/test/objectstore/TestRocksdbOptionParse.cc
+++ b/src/test/objectstore/TestRocksdbOptionParse.cc
@@ -13,7 +13,8 @@ const string dir("rocksdb.test_temp_dir");
 TEST(RocksDBOption, simple) {
   rocksdb::Options options;
   rocksdb::Status status;
-  RocksDBStore *db = new RocksDBStore(g_ceph_context, dir, NULL);
+  map<string,string> kvoptions;
+  RocksDBStore *db = new RocksDBStore(g_ceph_context, dir, kvoptions, NULL);
   string options_string = ""
 			  "write_buffer_size=536870912;"
 			  "create_if_missing=true;"
@@ -42,7 +43,8 @@ TEST(RocksDBOption, simple) {
 TEST(RocksDBOption, interpret) {
   rocksdb::Options options;
   rocksdb::Status status;
-  RocksDBStore *db = new RocksDBStore(g_ceph_context, dir, NULL);
+  map<string,string> kvoptions;
+  RocksDBStore *db = new RocksDBStore(g_ceph_context, dir, kvoptions, NULL);
   string options_string = "compact_on_mount = true; compaction_threads=10;flusher_threads=5;";
   
   int r = db->ParseOptionsFromString(options_string, options);

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -572,11 +572,12 @@ int main(int argc, char **argv) {
   argv_to_vec(argc, (const char **)argv, args);
   env_to_vec(args);
 
-  vector<const char *> def_args;
-  def_args.push_back("--debug-bluefs=1/20");
-  def_args.push_back("--debug-bdev=1/20");
+  map<string,string> defaults = {
+    { "debug_bluefs", "1/20" },
+    { "debug_bdev", "1/20" }
+  };
 
-  auto cct = global_init(&def_args, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 0);
   common_init_finish(g_ceph_context);

--- a/src/test/objectstore/test_idempotent_sequence.cc
+++ b/src/test/objectstore/test_idempotent_sequence.cc
@@ -201,12 +201,11 @@ int run_command(std::string& command, std::vector<std::string>& args)
 
 int main(int argc, const char *argv[])
 {
-  vector<const char*> def_args;
   vector<const char*> args;
   our_name = argv[0];
   argv_to_vec(argc, argv, args);
 
-  auto cct = global_init(&def_args, args,
+  auto cct = global_init(NULL, args,
 			 CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/objectstore/test_memstore_clone.cc
+++ b/src/test/objectstore/test_memstore_clone.cc
@@ -178,10 +178,10 @@ TEST_F(MemStoreClone, CloneRangeHoleEnd)
 int main(int argc, char** argv)
 {
   // default to memstore
-  vector<const char*> defaults{
-    "--osd_objectstore", "memstore",
-    "--osd_data", "msc.test_temp_dir",
-    "--memstore_page_size", "4",
+  map<string,string> defaults = {
+    { "osd_objectstore", "memstore" },
+    { "osd_data", "msc.test_temp_dir" },
+    { "memstore_page_size", "4" }
   };
 
   vector<const char*> args;

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -562,15 +562,16 @@ int main(int argc, const char *argv[])
 
   our_name = argv[0];
 
-  def_args.push_back("--osd-journal-size");
-  def_args.push_back("400");
+  map<string,string> defaults = {
+    { "osd_journal_size", "400" }
+  };
 //  def_args.push_back("--osd-data");
 //  def_args.push_back("workload_gen_dir");
 //  def_args.push_back("--osd-journal");
 //  def_args.push_back("workload_gen_dir/journal");
   argv_to_vec(argc, argv, args);
 
-  auto cct = global_init(&def_args, args,
+  auto cct = global_init(&defaults, args,
 			 CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -20,9 +20,9 @@ int main(int argc, char **argv) {
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
   // make sure we have 3 copies, or some tests won't work
-  g_ceph_context->_conf->set_val("osd_pool_default_size", "3", false);
+  g_ceph_context->_conf->set_val("osd_pool_default_size", "3");
   // our map is flat, so just try and split across OSDs, not hosts or whatever
-  g_ceph_context->_conf->set_val("osd_crush_chooseleaf_type", "0", false);
+  g_ceph_context->_conf->set_val("osd_crush_chooseleaf_type", "0");
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/src/test/perf_counters.cc
+++ b/src/test/perf_counters.cc
@@ -46,11 +46,11 @@
 #include "common/common_init.h"
 
 int main(int argc, char **argv) {
-  std::vector<const char *> preargs;
-  preargs.push_back("--admin-socket");
-  preargs.push_back(get_rand_socket_path());
+  map<string,string> defaults = {
+    { "admin_socket", get_rand_socket_path() }
+  };
   std::vector<const char*> args;
-  auto cct = global_init(&preargs, args, CEPH_ENTITY_TYPE_CLIENT,
+  auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);

--- a/src/test/unit.cc
+++ b/src/test/unit.cc
@@ -43,8 +43,8 @@ int main(int argc, char **argv) {
 
   const char* env = getenv("CEPH_LIB");
   if (env) {
-    g_conf->set_val_or_die("erasure_code_dir", env, false);
-    g_conf->set_val_or_die("plugin_dir", env, false);
+    g_conf->set_val_or_die("erasure_code_dir", env);
+    g_conf->set_val_or_die("plugin_dir", env);
   }
 
   ::testing::InitGoogleTest(&argc, argv);

--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -824,7 +824,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  vector<const char *> ceph_options, def_args;
+  vector<const char *> ceph_options;
   ceph_options.reserve(ceph_option_strings.size());
   for (vector<string>::iterator i = ceph_option_strings.begin();
        i != ceph_option_strings.end();
@@ -833,7 +833,7 @@ int main(int argc, char **argv) {
   }
 
   auto cct = global_init(
-    &def_args, ceph_options, CEPH_ENTITY_TYPE_MON,
+    NULL, ceph_options, CEPH_ENTITY_TYPE_MON,
     CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
   g_ceph_context->_conf->apply_changes(NULL);

--- a/src/tools/ceph_osdomap_tool.cc
+++ b/src/tools/ceph_osdomap_tool.cc
@@ -60,7 +60,7 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  vector<const char *> ceph_options, def_args;
+  vector<const char *> ceph_options;
   ceph_options.reserve(ceph_option_strings.size());
   for (vector<string>::iterator i = ceph_option_strings.begin();
        i != ceph_option_strings.end();
@@ -71,7 +71,7 @@ int main(int argc, char **argv) {
   if (vm.count("debug")) debug = true;
 
   auto cct = global_init(
-    &def_args, ceph_options, CEPH_ENTITY_TYPE_OSD,
+    NULL, ceph_options, CEPH_ENTITY_TYPE_OSD,
     CODE_ENVIRONMENT_UTILITY_NODOUT, 0);
   common_init_finish(g_ceph_context);
   g_ceph_context->_conf->apply_changes(NULL);

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -430,13 +430,7 @@ EOF
         lockdep = true
 EOF
 	fi
-	if [ "$cephx" -eq 1 ] ; then
-		wconf <<EOF
-        auth cluster required = cephx
-        auth service required = cephx
-        auth client required = cephx
-EOF
-	else
+	if [ "$cephx" -ne 1 ] ; then
 		wconf <<EOF
 	auth cluster required = none
 	auth service required = none

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -510,7 +510,6 @@ $extra_conf
         mon osd allow primary affinity = true
         mon reweight min pgs per osd = 4
         mon osd prime pg temp = true
-        crushtool = $CEPH_BIN/crushtool
         mon allow pool delete = true
 $DAEMONOPTS
 $CMONDEBUG

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -405,21 +405,12 @@ prepare_conf() {
 
 [global]
         fsid = $(uuidgen)
-        osd pg bits = 3
-        osd pgp bits = 5  ; (invalid, but ceph should cope!)
-        osd pool default size = $OSD_POOL_DEFAULT_SIZE
-        osd crush chooseleaf type = 0
-        osd pool default min size = 1
         osd failsafe full ratio = .99
+        mon osd full ratio = .99
         mon osd nearfull ratio = .99
         mon osd backfillfull ratio = .99
-        mon osd reporter subtree level = osd
-        mon osd full ratio = .99
-        mon data avail warn = 2
-        mon data avail crit = 1
         erasure code dir = $EC_PATH
         plugin dir = $CEPH_LIB
-        osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd
         filestore fd cache size = 32
         run dir = $CEPH_OUT_DIR
         enable experimental unrecoverable data corrupting features = *
@@ -457,9 +448,6 @@ $extra_conf
 [mds]
 $DAEMONOPTS
 $CMDSDEBUG
-        mds debug frag = true
-        mds debug auth pins = true
-        mds debug subtrees = true
         mds data = $CEPH_DEV_DIR/mds.\$id
         mds root ino uid = `id -u`
         mds root ino gid = `id -g`
@@ -467,8 +455,6 @@ $extra_conf
 [mgr]
         mgr data = $CEPH_DEV_DIR/mgr.\$id
         mgr module path = $MGR_PYTHON_PATH
-        mon reweight min pgs per osd = 4
-        mon pg warn min per osd = 3
 $DAEMONOPTS
 $CMGRDEBUG
 $extra_conf
@@ -482,16 +468,13 @@ $DAEMONOPTS
         osd class dir = $OBJCLASS_PATH
         osd class load list = *
         osd class default list = *
-        osd scrub load threshold = 2000.0
-        osd debug op order = true
-        osd debug misdirected ops = true
+
         filestore wbthrottle xfs ios start flusher = 10
         filestore wbthrottle xfs ios hard limit = 20
         filestore wbthrottle xfs inodes hard limit = 30
         filestore wbthrottle btrfs ios start flusher = 10
         filestore wbthrottle btrfs ios hard limit = 20
         filestore wbthrottle btrfs inodes hard limit = 30
-        osd copyfrom max chunk = 524288
         bluestore fsck on mount = true
         bluestore block create = true
 	bluestore block db path = $CEPH_DEV_DIR/osd\$id/block.db.file
@@ -506,11 +489,6 @@ $COSDSHORT
 $extra_conf
 [mon]
         mgr initial modules = restful status dashboard balancer
-        mon pg warn min per osd = 3
-        mon osd allow primary affinity = true
-        mon reweight min pgs per osd = 4
-        mon osd prime pg temp = true
-        mon allow pool delete = true
 $DAEMONOPTS
 $CMONDEBUG
 $extra_conf
@@ -855,6 +833,26 @@ fi
 
 if [ $CEPH_NUM_MON -gt 0 ]; then
     start_mon
+
+    $CEPH_BIN/ceph config set global osd_pool_default_size $OSD_POOL_DEFAULT_SIZE
+    $CEPH_BIN/ceph config set global crush_chooseleaf_type 0
+    $CEPH_BIN/ceph config set global osd_pool_default_min_size 1
+    $CEPH_BIN/ceph config set global mon_pg_warn_min_per_osd 3
+
+    $CEPH_BIN/ceph config set mon mon_osd_reporter_subtree_level osd
+    $CEPH_BIN/ceph config set mon mon_data_avail_warn 2
+    $CEPH_BIN/ceph config set mon mon_data_avail_crit 1
+    $CEPH_BIN/ceph config set mon osd_pool_default_erasure_code_profile 'plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd'
+    $CEPH_BIN/ceph config set mon mon_allow_pool_deletes true
+
+    $CEPH_BIN/ceph config set osd osd_scrub_load_threshold 2000
+    $CEPH_BIN/ceph config set osd osd_debug_op_order true
+    $CEPH_BIN/ceph config set osd osd_debug_misdirected_ops true
+    $CEPH_BIN/ceph config set osd osd_copyfrom_max_chunk 524288
+
+    $CEPH_BIN/ceph config set mds mds_debug_frag true
+    $CEPH_BIN/ceph config set mds mds_debug_auth_pins true
+    $CEPH_BIN/ceph config set mds mds_debug_subtrees true
 fi
 
 if [ $CEPH_NUM_MGR -gt 0 ]; then


### PR DESCRIPTION
The basics are kind of working!

- [x] use normal monclient auth for initial config
- [x] incorporate into global_init/common_init infrastructure
- [x] --no-mon-config argument
- [x] ceph config set WHO KEY VALUE
- [x] ceph config get WHO
- [x] ceph config get WHO KEY (includes default value)
- [x] ceph config dump
- [x] ceph config show WHO
- [x] ceph config show-with-defaults WHO
- [x] ceph config show WHO KEY
- [x] ceph config help
- [x] report mgr running config to mgr
- [x] annotate conf-only options (paxos_* maybe?)
- [x] make ConfigMonitor refresh more efficient than reparsing all config
- [x] show config option level in dump, get output
- [x] ceph config assimilate-conf -i old-ceph.conf -o new-ceph.conf
- [x] sort out ceph-conf behavior
- [x] 'option can be changed' in get and/or show (json?) output
- [x] docs
- [ ] clean up tell|daemon config set output (gross json that makes no sense)
- [x] tests