### PR TITLE
BlueStore: Remove bluefs fsck

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5700,12 +5700,6 @@ int BlueStore::_fsck(bool deep, bool repair)
         }
 	);
     }
-    r = bluefs->fsck();
-    if (r < 0) {
-      goto out_scan;
-    }
-    if (r > 0)
-      errors += r;
   }
 
   // get expected statfs; fill unaffected fields to be able to compare


### PR DESCRIPTION
BlueFS:fsck returns always 0 and it holds lock which is not free. Calling its fcsk without any reason would not make sense.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>