### PR TITLE
luminous: use user-defined literals for default sizes

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -697,7 +697,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("ms_rwthread_stack_bytes", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1024 << 10)
+    .set_default(1_M)
     .set_description(""),
 
     Option("ms_tcp_read_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
@@ -770,11 +770,11 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("ms_async_rdma_buffer_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(128 << 10)
+    .set_default(128_K)
     .set_description(""),
 
     Option("ms_async_rdma_send_buffers", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1024)
+    .set_default(1_K)
     .set_description(""),
 
     Option("ms_async_rdma_receive_buffers", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
@@ -1191,7 +1191,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_reweight_min_bytes_per_osd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(100*1024*1024)
+    .set_default(100_M)
     .set_description(""),
 
     Option("mon_reweight_max_osds", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -1245,7 +1245,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_data_size_warn", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(15ull*1024*1024*1024)
+    .set_default(15_G)
     .set_description(""),
 
     Option("mon_warn_not_scrubbed", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -1537,7 +1537,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("objecter_inflight_op_bytes", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1024*1024*100)
+    .set_default(100_M)
     .set_description(""),
 
     Option("objecter_inflight_ops", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
@@ -1665,7 +1665,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_client_message_size_cap", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(500*1024L*1024L)
+    .set_default(500_M)
     .set_description(""),
 
     Option("osd_client_message_cap", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
@@ -1813,7 +1813,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_tier_promote_max_bytes_sec", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(5 * 1024*1024)
+    .set_default(5_M)
     .set_description(""),
 
     Option("osd_tier_default_cache_mode", Option::TYPE_STR, Option::LEVEL_ADVANCED)
@@ -2779,11 +2779,11 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("leveldb_write_buffer_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(8 *1024*1024)
+    .set_default(8_M)
     .set_description(""),
 
     Option("leveldb_cache_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(128 *1024*1024)
+    .set_default(128_M)
     .set_description(""),
 
     Option("leveldb_block_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
@@ -2848,7 +2848,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("rocksdb_cache_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(128*1024*1024)
+    .set_default(128_M)
     .set_description(""),
 
     Option("rocksdb_cache_row_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
@@ -2864,7 +2864,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("rocksdb_block_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(4*1024)
+    .set_default(4_K)
     .set_description(""),
 
     Option("rocksdb_perf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -2974,7 +2974,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_max_object_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(128*1024L*1024L)
+    .set_default(128_M)
     .set_description(""),
 
     Option("osd_max_object_name_len", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
@@ -3042,7 +3042,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("memstore_device_bytes", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1024*1024*1024)
+    .set_default(1_G)
     .set_description(""),
 
     Option("memstore_page_set", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -3172,7 +3172,7 @@ std::vector<Option> get_global_options() {
     .set_description("Mirror bluefs data to file system for testing/validation"),
 
     Option("bluestore_bluefs_min", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1*1024*1024*1024)
+    .set_default(1_G)
     .set_description("minimum disk space allocated to BlueFS (e.g., at mkfs)"),
 
     Option("bluestore_bluefs_min_free", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
@@ -3217,7 +3217,7 @@ std::vector<Option> get_global_options() {
     .set_description("Path to block device/file"),
 
     Option("bluestore_block_size", Option::TYPE_UINT, Option::LEVEL_DEV)
-    .set_default(10ull * 1024*1024*1024)
+    .set_default(10_G)
     .add_tag("mkfs")
     .set_description("Size of file to create for backing bluestore"),
 
@@ -3250,7 +3250,7 @@ std::vector<Option> get_global_options() {
     .set_description("Path to block device/file backing bluefs wal"),
 
     Option("bluestore_block_wal_size", Option::TYPE_UINT, Option::LEVEL_DEV)
-    .set_default(96 * 1024*1024)
+    .set_default(96_M)
     .add_tag("mkfs")
     .set_description("Size of file to create for bluestore_block_wal_path"),
 
@@ -3281,7 +3281,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("bluestore_csum_max_block"),
 
     Option("bluestore_csum_max_block", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(64*1024)
+    .set_default(64_K)
     .set_safe()
     .set_description("Maximum block size to checksum")
     .add_see_also("bluestore_csum_min_block"),
@@ -3293,12 +3293,12 @@ std::vector<Option> get_global_options() {
     .set_long_description("A smaller allocation size generally means less data is read and then rewritten when a copy-on-write operation is triggered (e.g., when writing to something that was recently snapshotted).  Similarly, less data is journaled before performing an overwrite (writes smaller than min_alloc_size must first pass through the BlueStore journal).  Larger values of min_alloc_size reduce the amount of metadata required to describe the on-disk layout and reduce overall fragmentation."),
 
     Option("bluestore_min_alloc_size_hdd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(64*1024)
+    .set_default(64_K)
     .add_tag("mkfs")
     .set_description("Default min_alloc_size value for rotational media"),
 
     Option("bluestore_min_alloc_size_ssd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(16*1024)
+    .set_default(16_K)
     .add_tag("mkfs")
     .set_description("Default min_alloc_size value for non-rotational (solid state)  media"),
 
@@ -3342,12 +3342,12 @@ std::vector<Option> get_global_options() {
     .set_description("Chunks smaller than this are never compressed"),
 
     Option("bluestore_compression_min_blob_size_hdd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(128*1024)
+    .set_default(128_K)
     .set_safe()
     .set_description("Default value of bluestore_compression_min_blob_size for rotational media"),
 
     Option("bluestore_compression_min_blob_size_ssd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(8*1024)
+    .set_default(8_K)
     .set_safe()
     .set_description("Default value of bluestore_compression_min_blob_size for non-rotational (solid state) media"),
 
@@ -3357,12 +3357,12 @@ std::vector<Option> get_global_options() {
     .set_description("Chunks larger than this are broken into smaller chunks before being compressed"),
 
     Option("bluestore_compression_max_blob_size_hdd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(512*1024)
+    .set_default(512_K)
     .set_safe()
     .set_description("Default value of bluestore_compression_max_blob_size for rotational media"),
 
     Option("bluestore_compression_max_blob_size_ssd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(64*1024)
+    .set_default(64_K)
     .set_safe()
     .set_description("Default value of bluestore_compression_max_blob_size for non-rotational (solid state) media"),
 
@@ -3382,12 +3382,12 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("bluestore_max_blob_size_hdd", Option::TYPE_UINT, Option::LEVEL_DEV)
-    .set_default(512*1024)
+    .set_default(512_K)
     .set_safe()
     .set_description(""),
 
     Option("bluestore_max_blob_size_ssd", Option::TYPE_UINT, Option::LEVEL_DEV)
-    .set_default(64*1024)
+    .set_default(64_K)
     .set_safe()
     .set_description(""),
 
@@ -3444,11 +3444,11 @@ std::vector<Option> get_global_options() {
     .set_long_description("This includes data and metadata cached by BlueStore as well as memory devoted to rocksdb's cache(s)."),
 
     Option("bluestore_cache_size_hdd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1ull*1024*1024*1024)
+    .set_default(1_G)
     .set_description("Default bluestore_cache_size for rotational media"),
 
     Option("bluestore_cache_size_ssd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(3ull*1024*1024*1024)
+    .set_default(3_G)
     .set_description("Default bluestore_cache_size for non-rotational (solid state) media"),
 
     Option("bluestore_cache_meta_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
@@ -3460,7 +3460,7 @@ std::vector<Option> get_global_options() {
     .set_description("Ratio of bluestore cache to devote to kv database (rocksdb)"),
 
     Option("bluestore_cache_kv_max", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(512*1024*1024)
+    .set_default(512_M)
     .set_description("Max memory (bytes) to devote to kv database (rocksdb)"),
 
     Option("bluestore_kvbackend", Option::TYPE_STR, Option::LEVEL_DEV)
@@ -3522,12 +3522,12 @@ std::vector<Option> get_global_options() {
     .set_description("Try to submit metadata transaction to rocksdb in queuing thread context"),
 
     Option("bluestore_throttle_bytes", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(64*1024*1024)
+    .set_default(64_M)
     .set_safe()
     .set_description("Maximum bytes in flight before we throttle IO submission"),
 
     Option("bluestore_throttle_deferred_bytes", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(128*1024*1024)
+    .set_default(128_M)
     .set_safe()
     .set_description("Maximum bytes for deferred writes before we throttle IO submission"),
 
@@ -3649,7 +3649,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("kstore_max_bytes", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(64*1024*1024)
+    .set_default(64_M)
     .set_description(""),
 
     Option("kstore_backend", Option::TYPE_STR, Option::LEVEL_ADVANCED)
@@ -4251,23 +4251,23 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_max_chunk_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(4 * 1024 * 1024)
+    .set_default(4_M)
     .set_description(""),
 
     Option("rgw_put_obj_min_window_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(16 * 1024 * 1024)
+    .set_default(16_M)
     .set_description(""),
 
     Option("rgw_put_obj_max_window_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(64 * 1024 * 1024)
+    .set_default(64_M)
     .set_description(""),
 
     Option("rgw_max_put_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(5ULL*1024*1024*1024)
+    .set_default(5_G)
     .set_description(""),
 
     Option("rgw_max_put_param_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1 * 1024 * 1024)
+    .set_default(1_M)
     .set_description(""),
 
     Option("rgw_max_attr_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
@@ -4806,7 +4806,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_copy_obj_progress_every_bytes", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(1024 * 1024)
+    .set_default(1_M)
     .set_description(""),
 
     Option("rgw_obj_tombstone_cache_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -4886,7 +4886,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_multipart_min_part_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(5 * 1024 * 1024)
+    .set_default(5_M)
     .set_description(""),
 
     Option("rgw_multipart_part_upload_limit", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -5230,11 +5230,11 @@ static std::vector<Option> get_rbd_options() {
     .set_description("number of sequential requests necessary to trigger readahead"),
 
     Option("rbd_readahead_max_bytes", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(512 * 1024)
+    .set_default(512_K)
     .set_description("set to 0 to disable readahead"),
 
     Option("rbd_readahead_disable_after_bytes", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(50 * 1024 * 1024)
+    .set_default(50_M)
     .set_description("how many bytes are read in total before readahead is disabled"),
 
     Option("rbd_clone_copy_on_read", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -5955,15 +5955,15 @@ std::vector<Option> get_mds_client_options() {
     .set_description(""),
 
     Option("client_oc_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(1024*1024* 200)
+    .set_default(200_M)
     .set_description(""),
 
     Option("client_oc_max_dirty", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(1024*1024* 100)
+    .set_default(100_M)
     .set_description(""),
 
     Option("client_oc_target_dirty", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(1024*1024* 8)
+    .set_default(8_M)
     .set_description(""),
 
     Option("client_oc_max_dirty_age", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -132,6 +132,24 @@ void Option::dump(Formatter *f) const
   f->close_section();
 }
 
+constexpr unsigned long long operator"" _min (unsigned long long min) {
+  return min * 60;
+}
+constexpr unsigned long long operator"" _hr (unsigned long long hr) {
+  return hr * 60 * 60;
+}
+constexpr unsigned long long operator"" _day (unsigned long long day) {
+  return day * 60 * 60 * 24;
+}
+constexpr unsigned long long operator"" _K (unsigned long long n) {
+  return n << 10;
+}
+constexpr unsigned long long operator"" _M (unsigned long long n) {
+  return n << 20;
+}
+constexpr unsigned long long operator"" _G (unsigned long long n) {
+  return n << 30;
+}
 
 std::vector<Option> get_global_options() {
   return std::vector<Option>({
@@ -892,7 +910,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_subscribe_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(24*3600)
+    .set_default(1_day)
     .set_description(""),
 
     Option("mon_delta_reset_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
@@ -900,7 +918,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_osd_laggy_halflife", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(60*60)
+    .set_default(1_hr)
     .set_description(""),
 
     Option("mon_osd_laggy_weight", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
@@ -1193,7 +1211,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_health_to_clog_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(3600)
+    .set_default(1_hr)
     .set_description(""),
 
     Option("mon_health_to_clog_tick_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
@@ -1239,11 +1257,11 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_scrub_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(3600*24)
+    .set_default(1_day)
     .set_description(""),
 
     Option("mon_scrub_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(60*5)
+    .set_default(5_min)
     .set_description(""),
 
     Option("mon_scrub_max_keys", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -1359,7 +1377,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_osd_blacklist_default_expire", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(60*60)
+    .set_default(1_hr)
     .set_description(""),
 
     Option("mon_osd_crush_smoke_test", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -1443,11 +1461,11 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("auth_mon_ticket_ttl", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(60*60*12)
+    .set_default(12_hr)
     .set_description(""),
 
     Option("auth_service_ticket_ttl", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(60*60)
+    .set_default(1_hr)
     .set_description(""),
 
     Option("auth_debug", Option::TYPE_BOOL, Option::LEVEL_DEV)
@@ -2297,11 +2315,11 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_remove_thread_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(60*60)
+    .set_default(1_hr)
     .set_description(""),
 
     Option("osd_remove_thread_suicide_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(10*60*60)
+    .set_default(10_hr)
     .set_description(""),
 
     Option("osd_command_thread_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -2453,11 +2471,11 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_scrub_min_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(60*60*24)
+    .set_default(1_day)
     .set_description(""),
 
     Option("osd_scrub_max_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(7*60*60*24)
+    .set_default(7_day)
     .set_description(""),
 
     Option("osd_scrub_interval_randomize_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
@@ -2489,7 +2507,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_deep_scrub_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(60*60*24*7)
+    .set_default(7_day)
     .set_description(""),
 
     Option("osd_deep_scrub_randomize_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
@@ -2501,7 +2519,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_deep_scrub_update_digest_min_age", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(2*60*60)
+    .set_default(2_hr)
     .set_description(""),
 
     Option("osd_class_dir", Option::TYPE_STR, Option::LEVEL_ADVANCED)
@@ -4445,7 +4463,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_keystone_revocation_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(15 * 60)
+    .set_default(15_min)
     .set_description(""),
 
     Option("rgw_keystone_verify_ssl", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -4517,7 +4535,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_swift_token_expiration", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(24 * 3600)
+    .set_default(1_day)
     .set_description(""),
 
     Option("rgw_print_continue", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -4716,15 +4734,15 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_gc_obj_min_wait", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(2 * 3600)
+    .set_default(2_hr)
     .set_description(""),
 
     Option("rgw_gc_processor_max_time", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(3600)
+    .set_default(1_hr)
     .set_description(""),
 
     Option("rgw_gc_processor_period", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(3600)
+    .set_default(1_hr)
     .set_description(""),
 
     Option("rgw_s3_success_create_obj_status", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -4848,7 +4866,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_user_quota_sync_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(3600 * 24)
+    .set_default(1_day)
     .set_description(""),
 
     Option("rgw_user_quota_sync_idle_users", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -4856,7 +4874,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_user_quota_sync_wait_time", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(3600 * 24)
+    .set_default(1_day)
     .set_description(""),
 
     Option("rgw_user_default_quota_max_objects", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -4880,7 +4898,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_olh_pending_timeout_sec", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(3600)
+    .set_default(1_hr)
     .set_description(""),
 
     Option("rgw_user_max_buckets", Option::TYPE_INT, Option::LEVEL_ADVANCED)
@@ -4888,7 +4906,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_objexp_gc_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(60 * 10)
+    .set_default(10_min)
     .set_description(""),
 
     Option("rgw_objexp_time_step", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
@@ -5040,7 +5058,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_reshard_thread_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(60 * 10)
+    .set_default(10_min)
     .set_description(""),
   });
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/22309