### PR TITLE
osd/PrimaryLogPG: fix wrong comparison at evicting

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -13609,7 +13609,7 @@ bool PrimaryLogPG::agent_maybe_evict(ObjectContextRef& obc, bool after_flush)
     delete f;
     *_dout << dendl;
 
-    if (1000000 - temp_upper >= agent_state->evict_effort)
+    if (temp_lower >= agent_state->evict_effort)
       return false;
   }
 


### PR DESCRIPTION
Colder object gets lower temperature(smaller value).
Thus just use its ranking level in rating scale to
do comparison.

Signed-off-by: Yufan Chen <wiz.chen@gmail.com>