### PR TITLE
luminous: rbd-mirror: Allow a different data-pool to be used on the secondary cluster

### DIFF
--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -36,13 +36,6 @@ Ceph clusters.
    configuration file of the same name (e.g. /etc/ceph/remote.conf).  See the
    `ceph-conf`_ documentation for how to configure multiple clusters.
 
-.. note:: Images in a given pool will be mirrored to a pool with the same name
-   on the remote cluster. Images using a separate data-pool will use a data-pool
-   with the same name on the remote cluster. E.g., if an image being mirrored is
-   in the ``rbd`` pool on the local cluster and using a data-pool called
-   ``rbd-ec``, pools called ``rbd`` and ``rbd-ec`` must exist on the remote
-   cluster and will be used for mirroring the image.
-
 Enable Mirroring
 ----------------
 
@@ -108,6 +101,18 @@ For example::
 
         rbd --cluster local mirror pool peer remove image-pool 55672766-c02b-4729-8567-f13a66893445
         rbd --cluster remote mirror pool peer remove image-pool 60c0e299-b38f-4234-91f6-eed0a367be08
+
+Data Pools
+----------
+
+When creating images in the destination cluster, ``rbd-mirror`` selects a data
+pool as follows:
+
+#. If the destination cluster has a default data pool configured (with the
+   ``rbd_default_data_pool`` configuration option), it will be used.
+#. Otherwise, if the source image uses a separate data pool, and a pool with the
+   same name exists on the destination cluster, that pool will be used.
+#. If neither of the above is true, no data pool will be set.
 
 Image Configuration
 ===================


### PR DESCRIPTION
http://tracker.ceph.com/issues/21700