### PR TITLE
rgw: fix return value of auth v2/v4

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3923,16 +3923,18 @@ AWSGeneralAbstractor::get_auth_data_v2(const req_state* const s) const
     qsr = true;
 
     boost::string_view expires = s->info.args.get("Expires");
-    if (! expires.empty()) {
-      /* It looks we have the guarantee that expires is a null-terminated,
-       * and thus string_view::data() can be safely used. */
-      const time_t exp = atoll(expires.data());
-      time_t now;
-      time(&now);
+    if (expires.empty()) {
+      throw -EPERM;
+    }
 
-      if (now >= exp) {
-        throw -EPERM;
-      }
+    /* It looks we have the guarantee that expires is a null-terminated,
+     * and thus string_view::data() can be safely used. */
+    const time_t exp = atoll(expires.data());
+    time_t now;
+    time(&now);
+
+    if (now >= exp) {
+      throw -EPERM;
     }
   } else {
     /* The "Authorization" HTTP header is being used. */


### PR DESCRIPTION
 The return value of auth v2/v4 in RGW is different from that in AWS:
  1. When 'Expires' is missing in auth v2 query string request, AWS returns AccessDenied while RGW returns SignatureDoesNotMatch;
  2. When 'X-Amz-Expires' is missing in auth v4 query string request, AWS returns AuthorizationQueryParametersError while RGW returns RequestTimeTooSkewed;
 
Changes:
  1. When 'Expires' is missing in auth v2 query string request, change RGW's return value to AccessDenied;
  2. When 'X-Amz-Expires' is missing in auth v4 query string request, change RGW's return value to AccessDenied;
  3. Delete time skew check from parse_v4_query_string;