### PR TITLE
build: fix dpdk deps result in do_cmake.sh error

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -136,6 +136,7 @@ else
                 if test $(lsb_release -si) = VirtuozzoLinux -a $MAJOR_VERSION = 7 ; then
                     $SUDO yum-config-manager --enable cr
                 fi
+                $SUDO yum install -y CUnit-devel # dpdk deps
                 ;;
         esac
         munge_ceph_spec_in $DIR/ceph.spec


### PR DESCRIPTION
do_cmake.sh error log:

-- Found aio: /lib64/libaio.so
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find CUnit (missing: CUNIT_LIBRARY CUNIT_INCLUDE_DIR)
  Call Stack (most recent call first):
    /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:315 (_FPHSA_FAILURE_MESSAGE)
      cmake/modules/FindCUnit.cmake:15 (find_package_handle_standard_args)
        cmake/modules/BuildSPDK.cmake:6 (find_package)
	  CMakeLists.txt:232 (build_spdk)

env info:

[root@ceph-node1]~# cat /etc/centos-release
CentOS Linux release 7.3.1611 (Core)

