### PR TITLE
ceph-volume should be able to handle multiple LVM (VG/LV) tags

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -63,6 +63,8 @@ def parse_tags(lv_tags):
     tag_mapping = {}
     tags = lv_tags.split(',')
     for tag_assignment in tags:
+        if not tag_assignment.startswith('ceph.'):
+            continue
         key, value = tag_assignment.split('=', 1)
         tag_mapping[key] = value
 

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -13,6 +13,14 @@ class TestParseTags(object):
         result = api.parse_tags('ceph.osd_something=1')
         assert result == {'ceph.osd_something': '1'}
 
+    def test_non_ceph_tags_are_skipped(self):
+        result = api.parse_tags('foo')
+        assert result == {}
+
+    def test_mixed_non_ceph_tags(self):
+        result = api.parse_tags('foo,ceph.bar=1')
+        assert result == {'ceph.bar': '1'}
+
     def test_multiple_csv_expands_in_dict(self):
         result = api.parse_tags('ceph.osd_something=1,ceph.foo=2,ceph.fsid=0000')
         # assert them piecemeal to avoid the un-ordered dict nature


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22305