### PR TITLE
doc/man remove deprecation of ceph-disk man page title

### DIFF
--- a/doc/man/8/ceph-disk.rst
+++ b/doc/man/8/ceph-disk.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 ===================================================================
- [DEPRECATED] ceph-disk -- Ceph disk utility for OSD
+ ceph-disk -- Ceph disk utility for OSD
 ===================================================================
 
 .. program:: ceph-disk


### PR DESCRIPTION
Seems like this broke not only Sphinx builds, but actual package builds. The deprecation notice still stands, but the title has been reverted.