### PR TITLE
jewel: tools/ceph-conf: dump parsed config in plain text or as json

### DIFF
--- a/src/test/cli/ceph-conf/help.t
+++ b/src/test/cli/ceph-conf/help.t
@@ -17,10 +17,14 @@
     -r|--resolve-search             search for the first file that exists and
                                     can be opened in the resulted comma
                                     delimited search list.
+    -D|--dump-all                   dump all variables.
   
   FLAGS
     --name name                     Set type.id
     [-s <section>]                  Add to list of sections to search
+    [--format plain|json|json-pretty]
+                                    dump variables in plain text, json or pretty
+                                    json
   
   If there is no action given, the action will default to --lookup.
   


### PR DESCRIPTION
This is useful for finding differences between ceph.conf on disk and in osd/mon memory.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>
(cherry picked from commit 951434f3a40fd697e5eae8fbcbf779abceb3ba34)