### PR TITLE
mon: osdmap prune

### DIFF
--- a/doc/dev/mon-osdmap-prune.rst
+++ b/doc/dev/mon-osdmap-prune.rst
@@ -1,0 +1,289 @@
+===========================
+FULL OSDMAP VERSION PRUNING
+===========================
+
+For each incremental osdmap epoch, the monitor will keep a full osdmap
+epoch in the store.
+
+While this is great when serving osdmap requests from clients, allowing
+us to fulfill their request without having to recompute the full osdmap
+from a myriad of incrementals, it can also become a burden once we start
+keeping an unbounded number of osdmaps.
+
+The monitors will attempt to keep a bounded number of osdmaps in the store.
+This number is defined (and configurable) via ``mon_min_osdmap_epochs``, and
+defaults to 500 epochs. Generally speaking, we will remove older osdmap
+epochs once we go over this limit.
+
+However, there are a few constraints to removing osdmaps. These are all
+defined in ``OSDMonitor::get_trim_to()``.
+
+In the event one of these conditions is not met, we may go over the bounds
+defined by ``mon_min_osdmap_epochs``. And if the cluster does not meet the
+trim criteria for some time (e.g., unclean pgs), the monitor may start
+keeping a lot of osdmaps. This can start putting pressure on the underlying
+key/value store, as well as on the available disk space.
+
+One way to mitigate this problem would be to stop keeping full osdmap
+epochs on disk. We would have to rebuild osdmaps on-demand, or grab them
+from cache if they had been recently served. We would still have to keep
+at least one osdmap, and apply all incrementals on top of either this
+oldest map epoch kept in the store or a more recent map grabbed from cache.
+While this would be feasible, it seems like a lot of cpu (and potentially
+IO) would be going into rebuilding osdmaps.
+
+Additionally, this would prevent the aforementioned problem going forward,
+but would do nothing for stores currently in a state that would truly
+benefit from not keeping osdmaps.
+
+This brings us to full osdmap pruning.
+
+Instead of not keeping full osdmap epochs, we are going to prune some of
+them when we have too many.
+
+Deciding whether we have too many will be dictated by a configurable option
+``mon_osdmap_full_prune_min`` (default: 10000). The pruning algorithm will be
+engaged once we go over this threshold.
+
+We will not remove all ``mon_osdmap_full_prune_min`` full osdmap epochs
+though. Instead, we are going to poke some holes in the sequence of full
+maps. By default, we will keep one full osdmap per 10 maps since the last
+map kept; i.e., if we keep epoch 1, we will also keep epoch 10 and remove
+full map epochs 2 to 9. The size of this interval is configurable with
+``mon_osdmap_full_prune_interval``.
+
+Essentially, we are proposing to keep ~10% of the full maps, but we will
+always honour the minimum number of osdmap epochs, as defined by
+``mon_min_osdmap_epochs``, and these won't be used for the count of the
+minimum versions to prune. For instance, if we have on-disk versions
+[1..50000], we would allow the pruning algorithm to operate only over
+osdmap epochs [1..49500); but, if have on-disk versions [1..10200], we
+won't be pruning because the algorithm would only operate on versions
+[1..700), and this interval contains less versions than the minimum
+required by ``mon_osdmap_full_prune_min``.
+
+
+ALGORITHM
+=========
+
+Say we have 50,000 osdmap epochs in the store, and we're using the
+defaults for all configurable options.
+
+::
+    -----------------------------------------------------------
+    |1|2|..|10|11|..|100|..|1000|..|10000|10001|..|49999|50000|
+    -----------------------------------------------------------
+     ^ first                                            last ^
+
+We will prune when all the following constraints are met:
+
+1. number of versions is greater than ``mon_min_osdmap_epochs``
+
+2. the number of versions between 'first' and 'prune_to' is greater than
+``mon_osdmap_full_prune_min``, with 'prune_to' being equal to 'last'
+minus ``mon_min_osdmap_epochs``.
+
+If any of these conditions fails, we will *not* prune any maps.
+
+Furthermore, if it is known that we have been pruning, but since then we
+are no longer satisfying at least one of the above constraints, we will
+not continue to prune. In essence, we only prune full osdmaps if the
+number of epochs in the store so warrants it.
+
+As pruning will create gaps in the sequence of full maps, we need to
+first decide which maps will be pinned for the pruning process; i.e.,
+which maps will not be removed, potentially being used in the future as
+the last known full state when rebuilding an osdmap. All pinned maps will
+be kept in a set (thus ensuring we get ordered, unique epochs).
+
+Deciding which maps to pin is straightforward and happens before pruning.::
+
+    first_to_pin = first
+    last_to_pin = last - mon_min_osdmap_epochs
+
+    for e in [first_to_pin .. last_to_pin]:
+      if pinned.empty() OR
+         e - pinned.last() == mon_osdmap_full_prune_interval:
+        pinned.insert(e)
+
+    pinned.insert(last_to_pin)
+
+The simplicity of the pinning process has the obvious drawback of not
+splitting the available versions uniformly. While we ensure that most
+pinned maps are ``mon_osdmap_full_prune_interval`` epochs apart, the last
+two pinned maps may very well be sequential. We are taking no further
+steps to resolve this particular corner case because we don't think it
+will nefariously affect the pruning process.
+
+With our maps pinned, we will now be able to remove the maps in-between.
+
+We could do the removal in one go, but we have no idea how long that would
+take. Therefore, we will perform several iterations, removing at most
+``mon_osdmap_full_prune_txsize`` osdmaps per iteration.
+
+In the end, our on-disk map sequence will look similar to::
+
+    ------------------------------------------
+    |1|10|20|30|..|49500|49501|..|49999|50000|
+    ------------------------------------------
+     ^ first                           last ^
+
+
+Because we are not pruning all versions in one go, we need to keep state
+about how far along on our pruning we are. With that in mind, we have
+created a data structure, ``osdmap_manifest_t``, that holds the set of pinned
+maps and the last pruned epoch: ::
+
+    struct osdmap_manifest_t:
+        set<version_t> pinned;
+        version_t      last_pruned;
+
+The osdmap manifest will be written to disk the first time we prune maps.
+We ensure that the manifest is written to disk with every transaction
+resulting from a pruning round, so that we always have an up-to-date
+manifest.
+
+We also rely on the manifest existing on disk to ascertain whether we are in
+the middle of pruning, or have pruned in the past. If we have pruned at
+least once, we will require the manifest so that we know which maps have
+been pinned, in order to rebuild osdmaps from incremental maps.
+Additionally, we need to know which maps we have pinned during osdmap
+trimming, but we will discuss that later; for now, let us focus on the
+prunning algorithm.
+
+For simplicity, we have decided that we shall not further along the pruning
+interval if a pruning is yet to be finished.
+
+Upon starting a full osdmap prune, we will pin all the maps we need (as
+discussed before), and will keep the pinned map vector in the osdmap manifest.
+The manifest will also be initiated with ``last_pruned`` at zero, denoting
+that there hasn't been a single version over ``first_committed`` that has been
+removed; in reality, these should be the criteria when ascertaining whether
+pruning has been started, not started, or has finished:
+
+* We will have not started pruning if ::
+  
+  invariant: first_committed > 1
+  last_pruned < first_committed
+
+* We will have started pruning if ::
+  
+  invariant: first_committed > 0
+  invariant: !pinned.empty())
+  invariant: pinned.count(first_committed) == 1
+  invariant: last_pruned > 0
+  invariant: last_pruned < last_committed
+  
+  precond:  last_pruned > first_committed AND
+  last_pruned < pinned.last() AND
+  !finished_pruning
+  
+  postcond: last_pruned > first_committed AND
+  last_pruned < pinned.last() AND
+  upper_pinned(last_pruned) C pinned AND
+  lower_pinned(last_pruned) C pinned AND
+  upper_pinned(last_pruned) != lower_pinned(last_pruned)
+
+* We will have finished pruning if ::
+  
+  invariant: first_committed > 0
+  invariant: !pinned.empty()
+  invariant: last_pruned > 0
+  invariant: last_pruned < last_committed
+  
+  (pinned.count(last_pruned + 1) AND (
+    last_pruned + 1 == pinned.last() OR
+    for each m1,m2 in pinned[last_pinned+1..pinned.last()]: m2 == m1+1
+  )) OR
+  last_pruned < first_committed
+
+Once we finish pruning maps, we will keep the manifest in the store, to
+allow us to easily find which maps have been pinned (instead of checking
+the store until we find a map), and to tell us which epoch did we last
+prune in case we need to prune again in the future. This doesn't however
+mean we will forever keep the osdmap manifest: the osdmap manifest will
+no longer be required once the monitor trims osdmaps and earliest available
+epoch in the store is greater than the last map we pruned.
+
+Pruning further maps may be cancelled at any point if the monitor trims
+osdmap epochs. The same conditions from ``OSDMonitor::get_trim_to()`` that
+force the monitor to keep a lot of osdmaps, thus requiring us to prune, may
+eventually change and allow the monitor to remove some of its oldest maps.
+
+If the monitor trims maps, we must then adjust the osdmap manifest to
+reflect our pruning status, or remove the manifest entirely if it no longer
+makes sense to keep it. For instance, take the map sequence from before, but
+let us assume we did not finish pruning all the maps. ::
+
+    -------------------------------------------------------------
+    |1|10|20|30|..|490|500|501|502|..|49500|49501|..|49999|50000|
+    -------------------------------------------------------------
+     ^ first          ^ last_pruned                       last ^
+                          (e 499)
+
+    pinned = {1, 10, 20, ..., 490, 500, 510, ..., 49500}
+
+Now let us assume that the monitor will trim up to epoch 501. This means
+removing all maps prior to epoch 501, and updating the ``first_committed``
+pointer to ``501``. Given removing all those maps would invalidate our
+current pruning process, we can consider our pruning has finished and drop
+our osdmap manifest. Doing so also simplifies starting a new prune, if all
+the starting conditions are met once we refreshed our state from the
+store.
+
+We would then have the following map sequence: ::
+
+    ---------------------------------------
+    |501|502|..|49500|49501|..|49999|50000|
+    ---------------------------------------
+     ^ first                        last ^
+
+However, imagine a slightly more convoluted scenario: the monitor will trim
+up to epoch 491. In this case, epoch 491 has been removed from the store.
+
+Given we will always need to have the oldest known map in the store, before
+we trim we will have to check whether that map is in the prune interval
+(i.e., if it's lower or equal than ``last_pruned``). If so, we need to check
+if this is a pinned map, in which case we don't have much to be concerned
+aside from removing lower epochs from the manifest's pinned set. On the
+other hand, if the map being trimmed to is not a pinned map, we will need
+to rebuild the map and pin it and remove the pinned maps prior to the this
+epoch. 
+
+In this case, we would end up with the following sequence:::
+
+    -----------------------------------------------
+    |491|500|501|502|..|49500|49501|..|49999|50000|
+    -----------------------------------------------
+     ^  ^- last_prunned (e 499)             last ^
+     `- first
+
+There is still an edge case that we should mention. Consider that we are
+going to trim up to epoch 499, which is the very last pruned epoch.
+
+Much like the scenario above, we would end up writing osdmap epoch 499 to
+the store; but what should we do about pinned maps and pruning?
+
+The simplest solution is to drop the osdmap manifest. After all, given we
+are trimming to the last pruned map, and we are rebuilding this map, we can
+guarantee that all maps greater than e 499 are sequential (because we have
+not pruned any of them). In essence, dropping the osdmap manifest in this
+case is essentially the same as if we were trimming over the last pruned
+epoch: we can prune again later if we meet the required conditions.
+
+Once we finish trimming maps, the following constraints need to be observed:::
+
+    if last_pruned <= first_committed:
+        postcond: !store.exists(osdmap_manifest)
+        postcond: store.exists_full(first_committed)
+        postcond: for v1,v2 in ondisk_full_osdmaps: v2 == v1 + 1
+
+    else:
+        postcond: last_pruned > first_committed
+        postcond: store.exists(osdmap_manifest)
+        postcond: manifest.pinned(first_committed)
+        postcond: manifest.pinned.first() == first_committed
+        postcond: store.exists_full(first_committed)
+
+And, with this, we have fully dwelled into full osdmap pruning. Enjoy.
+

--- a/qa/standalone/mon/mon-osdmap-prune.sh
+++ b/qa/standalone/mon/mon-osdmap-prune.sh
@@ -1,0 +1,180 @@
+#!/bin/bash
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+
+  local dir=$1
+  shift
+
+  export CEPH_MON="127.0.0.1:7115"
+  export CEPH_ARGS
+  CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none --mon-host=$CEPH_MON "
+
+  local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+  for func in $funcs; do
+    setup $dir || return 1
+    $func $dir || return 1
+    teardown $dir || return 1
+  done
+}
+
+
+function wait_for_osdmap_manifest() {
+
+  local what=${1:-"true"}
+
+  local -a delays=($(get_timeout_delays $TIMEOUT .1))
+  local -i loop=0
+
+  for ((i=0; i < ${#delays[*]}; ++i)); do
+    has_manifest=$(ceph report | jq 'has("osdmap_manifest")')
+    if [[ "$has_manifest" == "$what" ]]; then
+      return 0
+    fi
+
+    sleep ${delays[$i]}
+  done
+
+  echo "osdmap_manifest never outputted on report"
+  ceph report
+  return 1
+}
+
+function TEST_osdmap_prune() {
+
+  local dir=$1
+
+  run_mon $dir a || return 1
+  run_mgr $dir x || return 1
+  run_osd $dir 0 || return 1
+  run_osd $dir 1 || return 1
+  run_osd $dir 2 || return 1
+
+  sleep 5
+
+  # we are getting OSD_OUT_OF_ORDER_FULL health errors, and it's not clear
+  # why. so, to make the health checks happy, mask those errors.
+  ceph osd set-full-ratio 0.97
+  ceph osd set-backfillfull-ratio 0.97
+
+  ceph tell osd.* injectargs '--osd-beacon-report-interval 10' || return 1
+
+  create_pool foo 32
+  wait_for_clean || return 1
+  wait_for_health_ok || return 1
+
+  ceph tell mon.a injectargs \
+    '--mon-debug-block-osdmap-trim '\
+    '--mon-debug-extra-checks' || return 1
+
+  ceph daemon $(get_asok_path mon.a) test generate osdmap 1000 || return 1
+
+  report="$(ceph report)"
+  fc=$(jq '.first_committed' <<< $report)
+  lc=$(jq '.last_committed' <<< $report)
+
+  [[ $((lc-fc)) -ge 1000 ]] || return 1
+
+  ceph tell mon.a injectargs \
+    '--mon-osdmap-full-prune-enabled '\
+    '--mon-osdmap-full-prune-min 200 '\
+    '--mon-osdmap-full-prune-interval 10 '\
+    '--mon-osdmap-full-prune-txsize 100' || return 1
+
+  wait_for_osdmap_manifest || return 1
+
+  manifest="$(ceph report | jq '.osdmap_manifest')"
+
+  first_pinned=$(jq '.first_pinned' << $manifest)
+  last_pinned=$(jq '.last_pinned' <<< $manifest)
+  last_pruned=$(jq '.last_pruned' <<< $manifest)
+  pinned_maps=( $(jq '.pinned_maps' <<< $manifest | tr '\",' ' ') ) 
+
+  [[ $first_pinned -lt $last_pinned ]] || return 1
+  [[ $last_pruned -lt $last_pinned ]] || return 1
+  [[ $last_pruned -ge 0 ]] || return 1
+  [[ $last_pinned -lt $lc ]] || return 1
+  [[ $first_pinned -eq $fc ]] || return 1
+
+  # ensure all the maps are available, and work as expected
+  # this can take a while...
+
+  tmp_map=$(mktemp)
+  for ((i=$first_pinned; i <= $last_pinned; ++i)); do
+    ceph osd getmap -i $i -o $tmp_map || return 1
+    if ! osdmaptool --print $tmp_map | grep "epoch $i" ; then
+      echo "failed processing osdmap epoch $i"
+      return 1
+    fi
+  done
+  rm $tmp_map
+
+  # clean up maps
+  ceph tell mon.a injectargs \
+    '--mon-debug-block-osdmap-trim=false '\
+    '--paxos-service-trim-min=1'
+
+  wait_for_osdmap_manifest "false" || return 1
+
+  return 0
+}
+
+main mon-osdmap-prune "$@"
+
+exit 0
+
+ceph tell mon.a injectargs \
+  "--mon-debug-block-osdmap-trim " \
+  "--mon-debug-extra-checks" || exit 1
+
+ceph daemon mon.a test generate osdmap 1000 || exit 1
+
+init-ceph restart osd
+
+ceph tell osd.* injectargs \
+  "--osd-beacon-report-interval 10"
+
+ceph report | \
+  jq '{ "fc": .osdmap_first_committed, "lc": .osdmap_last_committed }'
+
+ceph tell mon.a injectargs \
+  "--mon-osdmap-full-prune-enabled "\
+  "--mon-osdmap-full-prune-min 200 "\
+  "--mon-osdmap-full-prune-interval 10 "\
+  "--mon-osdmap-full-prune-txsize 100 " || exit 1
+
+for ((i=0; i < 120; ++i)); do
+
+  ceph report | \
+    jq '{ "fc": .osdmap_first_committed, "lc": .osdmap_last_committed }'
+
+  has_manifest=$(ceph report | jq 'has("osdmap_manifest")')
+  if [[ "$has_manifest" == "true" ]]; then
+    ceph report | \
+      jq '{ "prune": .osdmap_manifest }'
+
+    break
+
+  else
+    echo "no manifest found :("
+  fi
+
+  sleep 2
+done
+
+ceph tell mon.a injectargs \
+  "--mon-debug-block-osdmap-trim=false"
+
+# 
+# report=$(ceph report 2>/dev/null)
+# first_v=$(echo $report | jq '.osdmap_first_committed')
+# last_v=$(echo $report | jq '.osdmap_last_committed')
+# 
+# has_manifest=$(echo $report | jq 'has("osdmap_manifest")')
+# [[ "$has_manifest" == "true" ]] && echo "unexpected manifest found!" && exit 1
+# 
+# ceph daemon mon.a osdmon_generate_maps 1000
+# report="$(ceph daemon mon.a report)"
+
+# how do we make a pg unclean?

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -897,6 +897,36 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description(""),
 
+    /* -- mon: osdmap prune (begin) -- */
+    Option("mon_osdmap_full_prune_enabled", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Enables pruning full osdmap versions when we go over a given number of maps")
+    .add_see_also("mon_osdmap_full_prune_min")
+    .add_see_also("mon_osdmap_full_prune_interval")
+    .add_see_also("mon_osdmap_full_prune_txsize"),
+
+    Option("mon_osdmap_full_prune_min", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(10000)
+    .set_description("Minimum number of versions in the store to trigger full map pruning")
+    .add_see_also("mon_osdmap_full_prune_enabled")
+    .add_see_also("mon_osdmap_full_prune_interval")
+    .add_see_also("mon_osdmap_full_prune_txsize"),
+
+    Option("mon_osdmap_full_prune_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(10)
+    .set_description("Interval between maps that will not be pruned; maps in the middle will be pruned.")
+    .add_see_also("mon_osdmap_full_prune_enabled")
+    .add_see_also("mon_osdmap_full_prune_interval")
+    .add_see_also("mon_osdmap_full_prune_txsize"),
+
+    Option("mon_osdmap_full_prune_txsize", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(100)
+    .set_description("Number of maps we will prune per iteration")
+    .add_see_also("mon_osdmap_full_prune_enabled")
+    .add_see_also("mon_osdmap_full_prune_interval")
+    .add_see_also("mon_osdmap_full_prune_txsize"),
+    /* -- mon: osdmap prune (end) -- */
+
     Option("mon_osd_cache_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(10)
     .set_description(""),
@@ -1331,6 +1361,14 @@ std::vector<Option> get_global_options() {
     Option("mon_mds_skip_sanity", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description(""),
+
+    Option("mon_debug_extra_checks", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("Enable some additional monitor checks")
+    .set_long_description(
+        "Enable some additional monitor checks that would be too expensive "
+        "to run on production systems, or would only be relevant while "
+        "testing or debugging."),
 
     Option("mon_debug_deprecated_as_obsolete", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1370,6 +1370,14 @@ std::vector<Option> get_global_options() {
         "to run on production systems, or would only be relevant while "
         "testing or debugging."),
 
+    Option("mon_debug_block_osdmap_trim", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("Block OSDMap trimming while the option is enabled.")
+    .set_long_description(
+        "Blocking OSDMap trimming may be quite helpful to easily reproduce "
+        "states in which the monitor keeps (hundreds of) thousands of "
+        "osdmaps."),
+
     Option("mon_debug_deprecated_as_obsolete", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description(""),

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -186,6 +186,7 @@ OSDMonitor::OSDMonitor(
    cct(cct),
    inc_osd_cache(g_conf->mon_osd_cache_size),
    full_osd_cache(g_conf->mon_osd_cache_size),
+   has_osdmap_manifest(false),
    last_attempted_minwait_time(utime_t()),
    mapper(mn->cct, &mn->cpu_tp),
    op_tracker(cct, true, 1)
@@ -274,6 +275,11 @@ void OSDMonitor::get_store_prefixes(std::set<string>& s) const
 
 void OSDMonitor::update_from_paxos(bool *need_bootstrap)
 {
+  // we really don't care if the version has been updated, because we may
+  // have trimmed without having increased the last committed; yet, we may
+  // need to update the in-memory manifest.
+  update_osdmap_manifest();
+
   version_t version = get_last_committed();
   if (version == osdmap.epoch)
     return;
@@ -883,6 +889,11 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   dout(10) << "encode_pending e " << pending_inc.epoch
 	   << dendl;
 
+  if (do_prune(t)) {
+    dout(1) << __func__ << " osdmap full prune encoded e"
+            << pending_inc.epoch << dendl;
+  }
+
   // finalize up pending_inc
   pending_inc.modified = ceph_clock_now();
 
@@ -1438,7 +1449,352 @@ void OSDMonitor::encode_trim_extra(MonitorDBStore::TransactionRef tx,
   bufferlist bl;
   get_version_full(first, bl);
   put_version_full(tx, first, bl);
+
+  if (has_osdmap_manifest &&
+      first > osdmap_manifest.get_first_pinned()) {
+    _prune_update_trimmed(tx, first);
+  }
 }
+
+
+/* full osdmap prune
+ *
+ * for more information, please refer to doc/dev/mon-osdmap-prune.rst
+ */
+
+void OSDMonitor::update_osdmap_manifest()
+{
+  bool store_has_manifest =
+    mon->store->exists(get_service_name(), "full_manifest");
+
+  if (!store_has_manifest) {
+    if (!has_osdmap_manifest) {
+      return;
+    }
+
+    dout(20) << __func__
+             << " dropping osdmap manifest from memory." << dendl;
+
+    osdmap_manifest = osdmap_manifest_t();
+    has_osdmap_manifest = false;
+    return;
+  }
+
+  dout(20) << __func__
+           << " osdmap manifest detected in store; reload." << dendl;
+
+  bufferlist manifest_bl;
+  int r = get_value("full_manifest", manifest_bl);
+  if (r < 0) {
+    derr << __func__ << " unable to read osdmap version manifest" << dendl;
+    ceph_assert(0 == "error reading manifest");
+  }
+  osdmap_manifest.decode(manifest_bl);
+  has_osdmap_manifest = true;
+
+  dout(10) << __func__ << " store osdmap manifest last pinned "
+           << osdmap_manifest.get_last_pinned()
+           << " last pruned " << osdmap_manifest.get_last_pruned()
+           << dendl;
+}
+
+bool OSDMonitor::is_prune_ongoing() const
+{
+  if (!has_osdmap_manifest)
+    return false;
+
+  version_t next = osdmap_manifest.get_next_prunable();
+
+  if (g_conf->get_val<bool>("mon_debug_extra_checks") && next > 0) {
+
+    version_t upper = osdmap_manifest.get_upper_closest_pinned(next);
+    version_t lower = osdmap_manifest.get_lower_closest_pinned(next);
+
+    ceph_assert(upper > 0);
+    ceph_assert(lower > 0);
+    ceph_assert(upper <= osdmap_manifest.get_last_pinned());
+    ceph_assert(lower >= osdmap_manifest.get_first_pinned());
+    ceph_assert(lower < upper);
+  }
+
+  return (next > 0);
+}
+
+bool OSDMonitor::should_prune() const
+{
+  version_t first = get_first_committed();
+  version_t last = get_last_committed();
+  version_t min_osdmap_epochs =
+    g_conf->get_val<int64_t>("mon_min_osdmap_epochs");
+  version_t prune_min =
+    g_conf->get_val<uint64_t>("mon_osdmap_full_prune_min");
+  version_t prune_interval =
+    g_conf->get_val<uint64_t>("mon_osdmap_full_prune_interval");
+  version_t prune_to = last - min_osdmap_epochs;
+  version_t last_pruned = osdmap_manifest.get_last_pruned();
+
+  if (prune_interval > prune_min) {
+    derr << __func__
+         << " impossible to ascertain proper prune interval because "
+         << " it is greater than the minimum prune epochs"
+         << " (min: " << prune_min << ", interval: " << prune_interval << ")"
+         << dendl;
+    return false;
+  }
+
+  // Make it or break it constraints.
+  //
+  // If any of these conditions fails, we will not prune, regardless of
+  // whether we have an on-disk manifest with an on-going pruning state.
+  //
+  if ((last - first) <= min_osdmap_epochs) {
+    // between the first and last committed epochs, we don't have
+    // enough epochs to trim, much less to prune.
+    dout(10) << __func__
+             << " currently holding only " << (last - first)
+             << " epochs (min osdmap epochs: " << min_osdmap_epochs
+             << "); do not prune."
+             << dendl;
+    return false;
+
+  } else if ((prune_to - first) < prune_min) {
+    // between the first committed epoch and the last epoch we would prune,
+    // we simply don't have enough versions over the minimum to prune maps.
+    dout(10) << __func__
+             << " could only prune " << (prune_to - first)
+             << " epochs (" << first << ".." << prune_to << "), which"
+                " is less than the required minimum (" << prune_min << ")"
+             << dendl;
+    return false;
+
+  } else if ((prune_to - last_pruned) < prune_min &&
+             !is_prune_ongoing()) {
+    // between the last pruned epoch and the last epoch we would prune,
+    // we don't have enough versions to trigger a *new* prune; however, if
+    // a prune is still going, we will finish pruning.
+    dout(10) << __func__
+             << " not enough epochs to prune (" << last_pruned << ".."
+             << prune_to << "), which is less than the required minimum ("
+             << prune_min << "); and there is no on-going prune."
+             << dendl;
+    return false;
+  }
+  dout(15) << __func__
+           << " should prune (" << last_pruned << ".." << prune_to << ")"
+           << " lc (" << first << ".." << last << ")"
+           << dendl;
+  return true;
+}
+
+version_t OSDMonitor::_prune_interval(
+    MonitorDBStore::TransactionRef t,
+    version_t first,
+    version_t last)
+{
+  dout(10) << __func__
+           << " interval [" << first << ".." << last << "]" << dendl;
+  for (version_t v = first; v <= last; ++v) {
+
+    dout(20) << __func__ << "    prunning osdmap full v" << v << dendl;
+    string full_key = mon->store->combine_strings("full", v);
+    t->erase(get_service_name(), full_key);
+  }
+
+  return last;
+}
+
+void OSDMonitor::_prune_update_trimmed(
+    MonitorDBStore::TransactionRef tx,
+    version_t first)
+{
+  dout(10) << __func__
+           << " first " << first
+           << " last_pinned " << osdmap_manifest.get_last_pinned()
+           << " last_pruned " << osdmap_manifest.get_last_pruned()
+           << dendl;
+
+  if (!osdmap_manifest.is_pinned(first)) {
+    osdmap_manifest.pinned.insert(first);
+  }
+
+  set<version_t>::iterator p_end = osdmap_manifest.pinned.find(first);
+  set<version_t>::iterator p = osdmap_manifest.pinned.begin();
+  osdmap_manifest.pinned.erase(p, p_end);
+  ceph_assert(osdmap_manifest.get_first_pinned() == first);
+
+  if (osdmap_manifest.pinned.size() == 1 &&
+      osdmap_manifest.get_last_pruned() <= first) {
+    // we reached the end of the line, as pinned maps go; clean up our
+    // manifest, and let `should_prune()` decide whether we should prune
+    // again.
+    osdmap_manifest.set_last_pruned(0);
+    tx->erase(get_service_name(), "full_manifest");
+    return;
+  }
+
+  bufferlist bl;
+  osdmap_manifest.encode(bl);
+  tx->put(get_service_name(), "full_manifest", bl);
+}
+
+void OSDMonitor::prune_pin_maps(version_t first, version_t last)
+{
+  version_t prune_interval =
+    g_conf->get_val<uint64_t>("mon_osdmap_full_prune_interval");
+
+  dout(10) << __func__
+           << " [" << first << ".." << last << "] interval "
+           << prune_interval << dendl;
+
+  ceph_assert(last - first >= prune_interval);
+
+  version_t p = first;
+  do {
+    dout(20) << __func__ << " pin epoch " << p << dendl;
+    osdmap_manifest.pin(p);
+    p += prune_interval;
+  } while (p <= last);
+
+  dout(20) << __func__ << " pin last version " << last << dendl;
+  osdmap_manifest.pin(last);
+}
+
+void OSDMonitor::prune_init()
+{
+  dout(1) << __func__ << dendl;
+
+  version_t pin_first;
+  version_t min_osdmap_epochs =
+    g_conf->get_val<int64_t>("mon_min_osdmap_epochs");
+  version_t last_to_prune = get_last_committed() - min_osdmap_epochs;
+
+  if (!has_osdmap_manifest) {
+    // we must have never pruned, OR if we pruned the state must no longer
+    // be relevant (i.e., the state must have been removed alongside with
+    // the trim that *must* have removed past the last pinned map in a
+    // previous prune).
+    ceph_assert(osdmap_manifest.pinned.empty());
+    ceph_assert(osdmap_manifest.get_last_pruned() == 0);
+
+    pin_first = get_first_committed();
+
+  } else {
+    // we must have pruned in the past AND its state is still relevant
+    // (i.e., even if we trimmed, we still hold pinned maps in the manifest,
+    // and thus we still hold a manifest in the store).
+    ceph_assert(!osdmap_manifest.pinned.empty());
+    ceph_assert(osdmap_manifest.get_last_pruned() > 0);
+    ceph_assert(!is_prune_ongoing());
+
+    ceph_assert(last_to_prune > 0);
+    ceph_assert(last_to_prune < get_last_committed());
+    ceph_assert(last_to_prune > get_first_committed());
+    ceph_assert(last_to_prune > osdmap_manifest.get_last_pruned());
+    ceph_assert(last_to_prune > osdmap_manifest.get_last_pinned());
+
+    dout(10) << __func__
+             << " last_pinned " << osdmap_manifest.get_last_pinned()
+             << " last_pruned " << osdmap_manifest.get_last_pruned()
+             << " last_to_prune " << last_to_prune
+             << dendl;
+
+    pin_first = osdmap_manifest.get_last_pinned();
+  }
+
+  prune_pin_maps(pin_first, last_to_prune);
+}
+
+/** do_prune
+ *
+ * @returns true if has side-effects; false otherwise.
+ */
+bool OSDMonitor::do_prune(MonitorDBStore::TransactionRef tx)
+{
+  bool enabled = g_conf->get_val<bool>("mon_osdmap_full_prune_enabled");
+
+  dout(1) << __func__ << " osdmap full prune "
+          << ( enabled ? "enabled" : "disabled")
+          << dendl;
+
+  if (!enabled || !should_prune()) {
+    return false;
+  }
+
+  version_t first = get_value(first_committed_name);
+  version_t last = get_value(last_committed_name);
+
+  // we are beyond the minimum prune versions, we need to remove maps because
+  // otherwise the store will grow unbounded and we may end up having issues
+  // with available disk space or store hangs.
+
+  // we will not pin all versions. We will leave a buffer number of versions.
+  // this allows us the monitor to trim maps without caring too much about
+  // pinned maps, and then allow us to use another ceph-mon without these
+  // capabilities, without having to repair the store.
+  version_t last_to_pin = last - g_conf->mon_min_osdmap_epochs;
+  version_t last_pinned = osdmap_manifest.get_last_pinned();
+  version_t last_pruned = osdmap_manifest.get_last_pruned();
+  uint64_t prune_interval =
+    g_conf->get_val<uint64_t>("mon_osdmap_full_prune_interval");
+  uint64_t prune_min = g_conf->get_val<uint64_t>("mon_osdmap_full_prune_min");
+
+  bool pin_maps = false;
+
+  if (!is_prune_ongoing()) {
+    // init pruning
+    prune_init();
+  }
+
+  // we need to get rid of some osdmaps
+
+  version_t last_to_prune = osdmap_manifest.get_last_pinned();
+  version_t next_to_prune = osdmap_manifest.get_next_prunable();
+  uint64_t num_pruned = 0;
+
+  dout(5) << __func__
+          << " last_pruned " << last_pruned
+          << " last_to_prune " << last_to_prune
+          << " next_to_prune " << next_to_prune
+          << dendl;
+
+  ceph_assert(next_to_prune > 0);
+  ceph_assert(last_pruned == 0 ||
+              (last_pruned < last_to_prune &&
+               last_pruned > osdmap_manifest.get_first_pinned()));
+
+  uint64_t max_prunes_per_tx =
+    g_conf->get_val<uint64_t>("mon_osdmap_full_prune_txsize");
+  version_t to_prune = next_to_prune;
+
+  while (to_prune > 0 && num_pruned < max_prunes_per_tx) {
+
+    ceph_assert(!osdmap_manifest.is_pinned(to_prune));
+    ceph_assert(to_prune > osdmap_manifest.get_first_pinned());
+    ceph_assert(to_prune < osdmap_manifest.get_last_pinned());
+
+    dout(20) << __func__ << "   pruning full osdmap e" << to_prune << dendl;
+    string full_key = mon->store->combine_strings("full", to_prune);
+    tx->erase(get_service_name(), full_key);
+
+    last_pruned = to_prune;
+    ++num_pruned;
+
+    to_prune = osdmap_manifest.get_next_prunable(to_prune);
+  }
+
+  ceph_assert(num_pruned > 0);
+  ceph_assert(last_pruned > 0);
+  ceph_assert(last_pruned > osdmap_manifest.get_first_pinned());
+  ceph_assert(last_pruned < osdmap_manifest.get_last_pinned());
+
+  osdmap_manifest.last_pruned = last_pruned;
+  bufferlist bl;
+  osdmap_manifest.encode(bl);
+  tx->put(get_service_name(), "full_manifest", bl);
+
+  return true;
+}
+
 
 // -------------
 
@@ -2994,16 +3350,133 @@ int OSDMonitor::get_version(version_t ver, bufferlist& bl)
     return ret;
 }
 
+int OSDMonitor::get_inc(version_t ver, OSDMap::Incremental& inc)
+{
+  bufferlist inc_bl;
+  int err = get_version(ver, inc_bl);
+  ceph_assert(err == 0);
+  ceph_assert(inc_bl.length());
+
+  bufferlist::iterator p = inc_bl.begin();
+  inc.decode(p);
+  dout(10) << __func__ << "     "
+           << " epoch " << inc.epoch
+           << " inc_crc " << inc.inc_crc
+           << " full_crc " << inc.full_crc
+           << " encode_features " << inc.encode_features << dendl;
+  return 0;
+}
+
+int OSDMonitor::get_full_from_pinned_map(version_t ver, bufferlist& bl)
+{
+  dout(10) << __func__ << " ver " << ver << dendl;
+
+  version_t closest_pinned = osdmap_manifest.get_lower_closest_pinned(ver);
+  if (closest_pinned == 0) {
+    return -ENOENT;
+  }
+  if (closest_pinned > ver) {
+    dout(0) << __func__ << " pinned: " << osdmap_manifest.pinned << dendl;
+  }
+  ceph_assert(closest_pinned <= ver);
+
+  dout(10) << __func__ << " closest pinned ver " << closest_pinned << dendl;
+
+  // get osdmap incremental maps and apply on top of this one.
+  bufferlist osdm_bl;
+  bool has_cached_osdmap = false;
+  for (version_t v = ver-1; v >= closest_pinned; --v) {
+    if (full_osd_cache.lookup(v, &osdm_bl)) {
+      dout(10) << __func__ << " found map in cache ver " << v << dendl;
+      closest_pinned = v;
+      has_cached_osdmap = true;
+      break;
+    }
+  }
+
+  if (!has_cached_osdmap) {
+    int err = PaxosService::get_version_full(closest_pinned, osdm_bl);
+    if (err != 0) {
+      derr << __func__ << " closest pinned map ver " << closest_pinned
+           << " not available! error: " << cpp_strerror(err) << dendl;
+    }
+    ceph_assert(err == 0);
+  }
+
+  ceph_assert(osdm_bl.length());
+
+  OSDMap *osdm = new OSDMap();
+  osdm->decode(osdm_bl);
+
+  dout(10) << __func__ << " loaded osdmap epoch " << closest_pinned
+           << " e" << osdm->epoch
+           << " crc " << osdm->get_crc()
+           << " -- applying incremental maps." << dendl;
+
+  uint64_t encode_features = 0;
+  for (version_t v = closest_pinned + 1; v <= ver; ++v) {
+    dout(20) << __func__ << "    applying inc epoch " << v << dendl;
+
+    OSDMap::Incremental inc;
+    int err = get_inc(v, inc);
+    ceph_assert(err == 0);
+
+    err = osdm->apply_incremental(inc);
+    ceph_assert(err == 0);
+
+    encode_features = inc.encode_features;
+    if (!encode_features) {
+      dout(10) << __func__
+               << " last incremental map didn't have features;"
+               << " defaulting to quorum's or all" << dendl;
+      encode_features =
+        (mon->quorum_con_features ? mon->quorum_con_features : -1);
+    }
+
+    if (!inc.full_crc) {
+      continue;
+    }
+
+    OSDMap *tosdm = new OSDMap();
+    bufferlist tbl;
+
+    osdm->encode(tbl, encode_features | CEPH_FEATURE_RESERVED);
+    tosdm->decode(tbl);
+    delete osdm;
+    osdm = tosdm;
+
+    if (inc.full_crc && osdm->get_crc() != inc.full_crc) {
+      derr << __func__
+           << "    osdmap crc mismatch! (osdmap crc " << osdm->get_crc()
+           << ", expected " << inc.full_crc << ")" << dendl;
+      ceph_assert(0 == "osdmap crc mismatch");
+    }
+  }
+
+  osdm->encode(bl, encode_features | CEPH_FEATURE_RESERVED);
+  delete osdm;
+
+  return 0;
+}
+
 int OSDMonitor::get_version_full(version_t ver, bufferlist& bl)
 {
     if (full_osd_cache.lookup(ver, &bl)) {
       return 0;
     }
     int ret = PaxosService::get_version_full(ver, bl);
-    if (!ret) {
-      full_osd_cache.add(ver, bl);
+    if (ret == -ENOENT) {
+      // build map?
+      ret = get_full_from_pinned_map(ver, bl);
+      if (ret != 0) {
+        return ret;
+      }
+    } else if (ret != 0) {
+      return ret;
     }
-    return ret;
+
+    full_osd_cache.add(ver, bl);
+    return 0;
 }
 
 epoch_t OSDMonitor::blacklist(const entity_addr_t& a, utime_t until)

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1408,6 +1408,15 @@ version_t OSDMonitor::get_trim_to() const
       return 0;
     }
   }
+
+  if (g_conf->get_val<bool>("mon_debug_block_osdmap_trim")) {
+    dout(0) << __func__
+            << " blocking osdmap trim"
+               " ('mon_debug_block_osdmap_trim' set to 'true')"
+            << dendl;
+    return 0;
+  }
+
   {
     epoch_t floor = get_min_last_epoch_clean();
     dout(10) << " min_last_epoch_clean " << floor << dendl;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3898,6 +3898,12 @@ void OSDMonitor::dump_info(Formatter *f)
   f->open_object_section("crushmap");
   osdmap.crush->dump(f);
   f->close_section();
+
+  if (has_osdmap_manifest) {
+    f->open_object_section("osdmap_manifest");
+    osdmap_manifest.dump(f);
+    f->close_section();
+  }
 }
 
 namespace {

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -124,6 +124,128 @@ public:
 };
 
 
+struct osdmap_manifest_t {
+  // all the maps we have pinned -- i.e., won't be removed unless
+  // they are inside a trim interval.
+  set<version_t> pinned;
+  // the last pruned version
+  version_t last_pruned;
+
+  osdmap_manifest_t() : last_pruned(0) { }
+
+  version_t get_last_pinned() const
+  {
+    set<version_t>::const_reverse_iterator it = pinned.crbegin();
+    if (it == pinned.crend()) {
+      ceph_assert(pinned.empty());
+      return 0;
+    }
+    return *it;
+  }
+
+  version_t get_first_pinned() const
+  {
+    set<version_t>::const_iterator it = pinned.cbegin();
+    if (it == pinned.cend()) {
+      ceph_assert(pinned.empty());
+      return 0;
+    }
+    return *it;
+  }
+
+  version_t get_last_pruned() const
+  {
+    return last_pruned;
+  }
+
+  void set_last_pruned(version_t v) {
+    last_pruned = v;
+  }
+
+  bool is_pinned(version_t v) const
+  {
+    return pinned.find(v) != pinned.end();
+  }
+
+  void pin(version_t v)
+  {
+    pinned.insert(v);
+  }
+
+  version_t get_lower_closest_pinned(version_t v) const
+  {
+    set<version_t>::const_iterator p = pinned.lower_bound(v);
+    if (p == pinned.cend()) {
+      return 0;
+    }
+
+    if (*p > v) {
+      if (p == pinned.cbegin()) {
+        return 0;
+      }
+      --p;
+    }
+
+    return *p;
+  }
+
+  version_t get_upper_closest_pinned(version_t v) const
+  {
+    set<version_t>::const_iterator p = pinned.upper_bound(v);
+    if (p == pinned.cend()) {
+      return 0;
+    }
+    return *p;
+  }
+
+  /* obtain the next prunable version
+   */
+  version_t get_next_prunable() const
+  {
+    return get_next_prunable(last_pruned);
+  }
+
+  version_t get_next_prunable(version_t v) const
+  {
+    version_t next = v;
+    if (next == 0) {
+      next = get_first_pinned();
+    }
+
+    while (++next < get_last_pinned()) {
+
+      if (is_pinned(next))
+        continue;
+
+      return next;
+    }
+    return 0;
+  }
+
+  void encode(bufferlist& bl) const
+  {
+    ENCODE_START(1, 1, bl);
+    ::encode(pinned, bl);
+    ::encode(last_pruned, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator& bl)
+  {
+    DECODE_START(1, bl);
+    ::decode(pinned, bl);
+    ::decode(last_pruned, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void decode(bufferlist& bl) {
+    bufferlist::iterator p = bl.begin();
+    decode(p);
+  }
+
+};
+WRITE_CLASS_ENCODER(osdmap_manifest_t);
+
 class OSDMonitor : public PaxosService {
   CephContext *cct;
 
@@ -141,6 +263,9 @@ public:
 
   SimpleLRU<version_t, bufferlist> inc_osd_cache;
   SimpleLRU<version_t, bufferlist> full_osd_cache;
+
+  bool has_osdmap_manifest;
+  osdmap_manifest_t osdmap_manifest;
 
   bool check_failures(utime_t now);
   bool check_failure(utime_t now, int target_osd, failure_info_t& fi);
@@ -160,7 +285,7 @@ public:
   };
 
   // svc
-public:  
+public:
   void create_initial() override;
   void get_store_prefixes(std::set<string>& s) const override;
 
@@ -171,6 +296,22 @@ private:
   void on_active() override;
   void on_restart() override;
   void on_shutdown() override;
+
+  /* osdmap full map prune */
+  void update_osdmap_manifest();
+  bool is_prune_ongoing() const;
+  bool should_prune() const;
+  version_t _prune_interval(
+      MonitorDBStore::TransactionRef t,
+      version_t first,
+      version_t last);
+  void _prune_update_trimmed(
+      MonitorDBStore::TransactionRef tx,
+      version_t first);
+  void prune_pin_maps(version_t first, version_t last);
+  void prune_init();
+  bool do_prune(MonitorDBStore::TransactionRef tx);
+
   /**
    * we haven't delegated full version stashing to paxosservice for some time
    * now, making this function useless in current context.
@@ -528,6 +669,8 @@ public:
 
   int get_version(version_t ver, bufferlist& bl) override;
   int get_version_full(version_t ver, bufferlist& bl) override;
+  int get_inc(version_t ver, OSDMap::Incremental& inc);
+  int get_full_from_pinned_map(version_t ver, bufferlist& bl);
 
   epoch_t blacklist(const entity_addr_t& a, utime_t until);
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -243,6 +243,12 @@ struct osdmap_manifest_t {
     decode(p);
   }
 
+  void dump(Formatter *f) {
+    f->dump_unsigned("first_pinned", get_first_pinned());
+    f->dump_unsigned("last_pinned", get_last_pinned());
+    f->dump_unsigned("last_pruned", get_last_pruned());
+    f->dump_stream("pinned_maps") << pinned;
+  }
 };
 WRITE_CLASS_ENCODER(osdmap_manifest_t);
 

--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -434,7 +434,6 @@ public:
   }
   void load_health();
 
- private:
   /**
    * @defgroup PaxosService_h_store_keys Set of keys that are usually used on
    *					 all the services implementing this
@@ -451,6 +450,7 @@ public:
    * @}
    */
 
+ private:
   /**
    * @defgroup PaxosService_h_version_cache Variables holding cached values
    *                                        for the most used versions (first


### PR DESCRIPTION
In the event of an unclean cluster for quite a while, the monitors may end up keeping quite a lot of maps (thousands to tens of thousands). When this happens, the monitors may be unstable due to the size of their store, which may lead to further unrest in the cluster -- and the whole situation can then become a catch-22 kind of thing.
This patch set introduces a new mechanism that will allow an administrator to prune maps. Unlike trim, prune will not be removing maps at the tail; instead, prune will be poking holes in the sequence of full osdmaps, reducing the usage of store space. Prune trades off performance for reduced store size, as the monitors will have to recompute pruned osdmaps from the last known full osdmap and all the incremental maps since.
The patch set also contains a dev doc describing the algorithm.

Signed-off-by: Joao Eduardo Luis `<joao@suse.de>`