### PR TITLE
rgw: User Type check for authentication

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1526,3 +1526,5 @@ OPTION(rgw_max_objs_per_shard, OPT_INT)
 OPTION(rgw_reshard_thread_interval, OPT_U32) // maximum time between rounds of reshard thread processing
 
 OPTION(rgw_acl_grants_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html), An ACL can have up to 100 grants.
+
+OPTION(rgw_check_user_type, OPT_BOOL)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6064,6 +6064,9 @@ std::vector<Option> get_rgw_options() {
 			  "of RGW instances under heavy use. If you would like "
 			  "to turn off cache expiry, set this value to zero."),
 
+    Option("rgw_check_user_type", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(false)
+    .set_description("Should User Type(local/ ldap/ Keystome) be checked while authentication."),
   });
 }
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -318,6 +318,7 @@ void usage()
   cout << "   --min-rewrite-size        min object size for bucket rewrite (default 4M)\n";
   cout << "   --max-rewrite-size        max object size for bucket rewrite (default ULLONG_MAX)\n";
   cout << "   --min-rewrite-stripe-size min stripe size for object rewrite (default 0)\n";
+  cout << "   --user-type               type of user (rgw/ldap/keystone)\n";
   cout << "\n";
   cout << "<date> := \"YYYY-MM-DD[ hh:mm:ss]\"\n";
   cout << "\nQuota options:\n";
@@ -2395,7 +2396,7 @@ int main(int argc, const char **argv)
 
   rgw_user user_id;
   string tenant;
-  std::string access_key, secret_key, user_email, display_name;
+  std::string access_key, secret_key, user_email, display_name, user_type;
   std::string bucket_name, pool_name, object;
   rgw_pool pool;
   std::string date, subuser, access, format;
@@ -2428,6 +2429,7 @@ int main(int argc, const char **argv)
   int key_type = KEY_TYPE_UNDEFINED;
   rgw_bucket bucket;
   uint32_t perm_mask = 0;
+  uint32_t type = 0;
   RGWUserInfo info;
   int opt_cmd = OPT_NO_CMD;
   bool need_more;
@@ -2860,6 +2862,10 @@ int main(int argc, const char **argv)
       perm_policy_doc = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--path-prefix", (char*)NULL)) {
       path_prefix = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--user-type", (char*)NULL)) {
+      user_type = val;
+      type = rgw_str_to_user_type(user_type.c_str());
+      user_op.set_user_type(type);
     } else if (strncmp(*i, "-", 1) == 0) {
       cerr << "ERROR: invalid flag " << *i << std::endl;
       return EINVAL;

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -352,6 +352,9 @@ class StrategyRegistry;
  * must be able to create it basing on data passed by an auth engine. Those
  * data will be used to fill RGWUserInfo structure. */
 class RemoteApplier : public IdentityApplier {
+
+  bool is_user_type(uint32_t& type) const;
+
 public:
   class AuthInfo {
     friend class RemoteApplier;
@@ -446,6 +449,7 @@ class LocalApplier : public IdentityApplier {
 protected:
   const RGWUserInfo user_info;
   const std::string subuser;
+  CephContext* const cct;
 
   uint32_t get_perm_mask(const std::string& subuser_name,
                          const RGWUserInfo &uinfo) const;
@@ -457,7 +461,8 @@ public:
                const RGWUserInfo& user_info,
                std::string subuser)
     : user_info(user_info),
-      subuser(std::move(subuser)) {
+      subuser(std::move(subuser)),
+      cct(cct) {
   }
 
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -572,6 +572,18 @@ uint32_t rgw_str_to_perm(const char *str)
   return RGW_PERM_INVALID;
 }
 
+uint32_t rgw_str_to_user_type(const char *str)
+{
+  if (strcasecmp(str, "rgw") == 0)
+    return TYPE_RGW;
+  else if (strcasecmp(str, "ldap") == 0)
+    return TYPE_LDAP;
+  else if (strcasecmp(str, "keystone") == 0)
+    return TYPE_KEYSTONE;
+
+  return TYPE_NONE;
+}
+
 int rgw_validate_tenant_name(const string& t)
 {
   struct tench {
@@ -2181,6 +2193,11 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
       return ret;
     }
     user_info.user_email = "";
+  }
+
+  // update user type, if given by user
+  if (op_state.has_user_type()) {
+    user_info.type = op_state.get_user_type();
   }
 
   // update the remaining user info

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -128,6 +128,7 @@ extern int rgw_remove_swift_name_index(RGWRados *store, string& swift_name);
 
 extern void rgw_perm_to_str(uint32_t mask, char *buf, int len);
 extern uint32_t rgw_str_to_perm(const char *str);
+extern uint32_t rgw_str_to_user_type(const char *str);
 
 extern int rgw_validate_tenant_name(const string& t);
 
@@ -222,6 +223,9 @@ struct RGWUserAdminOpState {
 
   RGWQuotaInfo bucket_quota;
   RGWQuotaInfo user_quota;
+
+  uint32_t user_type;
+  bool user_type_specified = false;
 
   void set_access_key(std::string& access_key) {
     if (access_key.empty())
@@ -389,6 +393,11 @@ struct RGWUserAdminOpState {
     user_quota_specified = true;
   }
 
+  void set_user_type(uint32_t type) {
+    user_type = type;
+    user_type_specified = true;
+  }
+
   bool is_populated() { return populated; }
   bool is_initialized() { return initialized; }
   bool has_existing_user() { return existing_user; }
@@ -409,6 +418,7 @@ struct RGWUserAdminOpState {
   bool will_generate_subuser() { return gen_subuser; }
   bool has_bucket_quota() { return bucket_quota_specified; }
   bool has_user_quota() { return user_quota_specified; }
+  bool has_user_type() {return user_type_specified; }
   void set_populated() { populated = true; }
   void clear_populated() { populated = false; }
   void set_initialized() { initialized = true; }
@@ -433,6 +443,7 @@ struct RGWUserAdminOpState {
   std::string get_caps() { return caps; }
   std::string get_user_email() { return user_email; }
   std::string get_display_name() { return display_name; }
+  uint32_t get_user_type() { return user_type; }
   map<int, std::string>& get_temp_url_keys() { return temp_url_keys; }
 
   RGWUserInfo&  get_user_info() { return info; }

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -261,6 +261,7 @@
      --min-rewrite-size        min object size for bucket rewrite (default 4M)
      --max-rewrite-size        max object size for bucket rewrite (default ULLONG_MAX)
      --min-rewrite-stripe-size min stripe size for object rewrite (default 0)
+     --user-type               type of user (rgw/ldap/keystone)
   
   <date> := "YYYY-MM-DD[ hh:mm:ss]"
   


### PR DESCRIPTION
This PR adds code for the following:
1. User type check for authentication
2. radosgw-admin modify user can be used to add user type to existing users which do not have a type,