### PR TITLE
osd: Initializing start_offset,last_offset,offset

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8032,7 +8032,7 @@ struct C_CopyChunk : public Context {
   epoch_t last_peering_reset;
   ceph_tid_t tid;
   PrimaryLogPG::CopyOpRef cop;
-  uint64_t offset;
+  uint64_t offset = 0;
   C_CopyChunk(PrimaryLogPG *p, hobject_t o, epoch_t lpr,
 	     const PrimaryLogPG::CopyOpRef& c)
     : pg(p), oid(o), last_peering_reset(lpr),

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -155,8 +155,8 @@ public:
     map<uint64_t, CopyOpRef> chunk_cops;
     int num_chunk;
     bool failed;
-    uint64_t start_offset;
-    uint64_t last_offset;
+    uint64_t start_offset = 0;
+    uint64_t last_offset = 0;
     vector<OSDOp> chunk_ops;
   
     CopyOp(CopyCallback *cb_, ObjectContextRef _obc, hobject_t s,


### PR DESCRIPTION
Fixes the coverity issues:

2. uninit_member: Non-static class member start_offset
is not initialized in this constructor nor in any functions
that it calls.

CID 1424396 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
4. uninit_member: Non-static class member last_offset is not
initialized in this constructor nor in any functions that it calls.

CID 1424658 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member offset is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>