### PR TITLE
test: Initializing ChunkReadOp members

### DIFF
--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1992,11 +1992,11 @@ public:
 
   vector<bufferlist> checksums;
   vector<int> checksum_retvals;
-  uint32_t offset;
-  uint32_t length;
+  uint32_t offset = 0;
+  uint32_t length = 0;
   string tgt_oid;
   string tgt_pool_name;
-  uint32_t tgt_offset;
+  uint32_t tgt_offset = 0;
 
   ChunkReadOp(int n,
 	 RadosTestContext *context,


### PR DESCRIPTION
Fixes the coverity issue:

>2. uninit_member: Non-static class member offset is not
initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member length is not
initialized in this constructor nor in any functions that it calls.

CID 1424433 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member tgt_offset is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com