### PR TITLE
osd,os,io: Initializing C_ProxyChunkRead members,queue,request

### DIFF
--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -61,7 +61,7 @@ public:
 
   template <typename ImageCtxT = ImageCtx>
   struct C_SparseReadRequest : public C_SparseReadRequestBase {
-    ObjectReadRequest<ImageCtxT> *request;
+    ObjectReadRequest<ImageCtxT> *request = nullptr;
     Extents buffer_extents;
 
     C_SparseReadRequest(AioCompletion *aio_completion, Extents&& buffer_extents,

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -227,7 +227,7 @@ struct Task {
   IORequest io_request;
   std::mutex lock;
   std::condition_variable cond;
-  SharedDriverQueueData *queue;
+  SharedDriverQueueData *queue = nullptr;
   Task(NVMEDevice *dev, IOCommand c, uint64_t off, uint64_t l, int64_t rc = 0)
     : device(dev), command(c), offset(off), len(l),
       return_code(rc),

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2756,10 +2756,10 @@ struct C_ProxyChunkRead : public Context {
   PrimaryLogPG::ProxyReadOpRef prdop;
   utime_t start;
   ObjectOperation *obj_op;
-  int op_index;
-  uint64_t req_offset;
+  int op_index = 0;
+  uint64_t req_offset = 0;
   ObjectContextRef obc;
-  uint64_t req_total_len;
+  uint64_t req_total_len = 0;
   C_ProxyChunkRead(PrimaryLogPG *p, hobject_t o, epoch_t lpr,
 		   const PrimaryLogPG::ProxyReadOpRef& prd)
     : pg(p), oid(o), last_peering_reset(lpr),


### PR DESCRIPTION
Fixes the coverity issue:

>2. uninit_member: Non-static class member op_index is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member req_offset is not initialized
in this constructor nor in any functions that it calls.

CID 1424845 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member req_total_len is not
initialized in this constructor nor in any functions that it calls.

CID 1422461 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member queue is not initialized
in this constructor nor in any functions that it calls.

CID 1422362 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member request is not initialized
in this constructor nor in any functions that it calls

Signed-off-by: Amit Kumar amitkuma@redhat.com