### PR TITLE
ceph.spec: use devtoolset-6-gcc-c++ on aarch64

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -122,7 +122,12 @@ BuildRequires:	fuse-devel
 %if 0%{?rhel} == 7
 # devtoolset offers newer make and valgrind-devel, but the old ones are good
 # enough.
+%ifarch x86_64
 BuildRequires:	devtoolset-7-gcc-c++
+%endif
+%ifarch aarch64
+BuildRequires:	devtoolset-6-gcc-c++
+%endif
 %else
 BuildRequires:	gcc-c++
 %endif
@@ -789,7 +794,12 @@ python-rbd, python-rgw or python-cephfs instead.
 %build
 
 %if 0%{?rhel} == 7
+%ifarch x86_64
 . /opt/rh/devtoolset-7/enable
+%endif
+%ifarch aarch64
+. /opt/rh/devtoolset-6/enable
+%endif
 %endif
 
 %if 0%{with cephfs_java}

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -167,7 +167,12 @@ else
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
                 if test $(lsb_release -si) = CentOS -a $MAJOR_VERSION = 7 ; then
                     $SUDO yum-config-manager --enable cr
-                    $SUDO yum install centos-release-scl
+		    case $(uname -m) in
+			x86_64)
+			    $SUDO yum install centos-release-scl;;
+			aarch64)
+			    $SUDO yum install centos-release-scl-rh;;
+		    esac
                 elif test $(lsb_release -si) = RedHatEnterpriseServer -a $MAJOR_VERSION = 7 ; then
                     $SUDO yum-config-manager --enable rhel-server-rhscl-7-rpms
                 elif test $(lsb_release -si) = VirtuozzoLinux -a $MAJOR_VERSION = 7 ; then


### PR DESCRIPTION
see https://github.com/sclorg/centos-release-scl
see https://buildlogs.centos.org/centos/7/sclo/aarch64/rh/

Fixes: http://tracker.ceph.com/issues/22301
Signed-off-by: Kefu Chai <kchai@redhat.com>