### PR TITLE
ceph-dencoder: moved RBD types outside of RGW preprocessor guard

### DIFF
--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -405,6 +405,8 @@ TYPE(rgw_data_sync_info)
 TYPE(rgw_data_sync_marker)
 TYPE(rgw_data_sync_status)
 
+#endif
+
 #ifdef WITH_RBD
 #include "cls/rbd/cls_rbd.h"
 TYPE(cls_rbd_parent)
@@ -414,8 +416,6 @@ TYPE(cls_rbd_snap)
 TYPE(cls::rbd::MirrorPeer)
 TYPE(cls::rbd::MirrorImage)
 TYPE(cls::rbd::MirrorImageMap)
-#endif
-
 #endif
 
 #include "cls/lock/cls_lock_types.h"


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22321
Signed-off-by: Jason Dillaman <dillaman@redhat.com>