### PR TITLE
osd: pull latest dmclock subtree

### DIFF
--- a/src/dmclock/src/dmclock_recs.h
+++ b/src/dmclock/src/dmclock_recs.h
@@ -17,7 +17,7 @@ namespace crimson {
   namespace dmclock {
     using Counter = uint64_t;
 
-    enum class PhaseType { reservation, priority };
+    enum class PhaseType : uint8_t { reservation, priority };
 
     inline std::ostream& operator<<(std::ostream& out, const PhaseType& phase) {
       out << (PhaseType::reservation == phase ? "reservation" : "priority");


### PR DESCRIPTION
This includes @TaewoongKim 's reduction of phasetype size and synchronizes the changes surrounding @adamemerson 's mark dependency includes as SYSTEM in dmclock.