### PR TITLE
admin/build-doc: svg peering diagram instead of graphviz

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -51,6 +51,7 @@ fi
 set -e
 
 cat $TOPDIR/src/osd/PG.h $TOPDIR/src/osd/PG.cc | $TOPDIR/doc/scripts/gen_state_diagram.py > $TOPDIR/doc/dev/peering_graph.generated.dot
+dot -Tsvg $TOPDIR/doc/dev/peering_graph.generated.dot -o $TOPDIR/doc/dev/peering_graph.generated.svg -Gratio=fill
 
 cd build-doc
 

--- a/doc/dev/peering.rst
+++ b/doc/dev/peering.rst
@@ -256,4 +256,5 @@ The high level process is for the current PG primary to:
 State Model
 -----------
 
-.. graphviz:: peering_graph.generated.dot
+.. image:: peering_graph.generated.svg
+   :target: peering_graph.generated.svg


### PR DESCRIPTION
Theoretically this may make the peering diagram readable.  Testable with jenkins?

Signed-off-by: Mark Nelson <mnelson@redhat.com>