### PR TITLE
Add noreturn attribute to silence uninitialized warning

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -235,7 +235,7 @@ void usage(ostream& out)
 
 unsigned default_op_size = 1 << 22;
 
-static void usage_exit()
+[[noreturn]] static void usage_exit()
 {
   usage(cerr);
   exit(1);


### PR DESCRIPTION
Marking the `usage_exit` function as noreturn lets the compiler know
that execution won't continue beyond the statement where it's called,
so the path that would lead to the variables being used uninitialized
doesn't count.