### PR TITLE
rgw: use static_ptr for IdentityApplier

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -18,8 +18,7 @@
 namespace rgw {
 namespace auth {
 
-std::unique_ptr<rgw::auth::Identity>
-transform_old_authinfo(const req_state* const s)
+IdentityPtr transform_old_authinfo(const req_state* const s)
 {
   /* This class is not intended for public use. Should be removed altogether
    * with this function after moving all our APIs to the new authentication
@@ -82,13 +81,11 @@ transform_old_authinfo(const req_state* const s)
     }
   };
 
-  return std::unique_ptr<rgw::auth::Identity>(
-        new DummyIdentityApplier(s->cct,
-                                 s->user->user_id,
-                                 s->perm_mask,
+  return ceph::make_static<DummyIdentityApplier>(
+      s->cct, s->user->user_id, s->perm_mask,
   /* System user has admin permissions by default - it's supposed to pass
    * through any security check. */
-                                 s->system_request));
+      s->system_request);
 }
 
 } /* namespace auth */

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -77,7 +77,7 @@ inline std::ostream& operator<<(std::ostream& out,
 }
 
 
-std::unique_ptr<Identity> transform_old_authinfo(const req_state* const s);
+IdentityPtr transform_old_authinfo(const req_state* const s);
 
 
 /* Interface for classes applying changes to request state/RADOS store
@@ -91,7 +91,7 @@ std::unique_ptr<Identity> transform_old_authinfo(const req_state* const s);
  * policy (ACLs, account's ownership and entitlement). */
 class IdentityApplier : public Identity {
 public:
-  typedef std::unique_ptr<IdentityApplier> aplptr_t;
+  using aplptr_t = ceph::static_ptr<IdentityApplier, MaxIdentitySize>;
 
   virtual ~IdentityApplier() {};
 

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -47,8 +47,7 @@ class ExternalAuthStrategy : public rgw::auth::Strategy,
     auto apl = rgw::auth::add_sysreq(cct, store, s,
       rgw::auth::RemoteApplier(cct, store, std::move(acl_alg), info,
                                cct->_conf->rgw_keystone_implicit_tenants));
-    /* TODO(rzarzynski): replace with static_ptr. */
-    return aplptr_t(new decltype(apl)(std::move(apl)));
+    return ceph::make_static<decltype(apl)>(std::move(apl));
   }
 
 public:
@@ -105,8 +104,7 @@ class AWSAuthStrategy : public rgw::auth::Strategy,
                             const std::string& subuser) const override {
     auto apl = rgw::auth::add_sysreq(cct, store, s,
       rgw::auth::LocalApplier(cct, user_info, subuser));
-    /* TODO(rzarzynski): replace with static_ptr. */
-    return aplptr_t(new decltype(apl)(std::move(apl)));
+    return ceph::make_static<decltype(apl)>(std::move(apl));
   }
 
 public:

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -22,6 +22,7 @@
 
 #include "common/ceph_crypto.h"
 #include "common/perf_counters.h"
+#include "common/static_ptr.h"
 #include "rgw_acl.h"
 #include "rgw_cors.h"
 #include "rgw_iam_policy.h"
@@ -1435,6 +1436,11 @@ class RGWEnv;
 /* Namespaced forward declarations. */
 namespace rgw {
   namespace auth {
+    class Identity;
+    // size of static storage needed to fit any derived Identity
+    static constexpr size_t MaxIdentitySize = 704;
+    using IdentityPtr = ceph::static_ptr<Identity, MaxIdentitySize>;
+
     namespace s3 {
       class AWSBrowserUploadAbstractor;
     }
@@ -1816,13 +1822,11 @@ struct req_state {
   RGWUserInfo *user;
 
   struct {
-    /* TODO(rzarzynski): switch out to the static_ptr for both members. */
-
     /* Object having the knowledge about an authenticated identity and allowing
      * to apply it during the authorization phase (verify_permission() methods
      * of a given RGWOp). Thus, it bounds authentication and authorization steps
      * through a well-defined interface. For more details, see rgw_auth.h. */
-    std::unique_ptr<rgw::auth::Identity> identity;
+    rgw::auth::IdentityPtr identity;
 
     std::shared_ptr<rgw::auth::Completer> completer;
 

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -218,7 +218,7 @@ void RGWFormatter_Plain::write_data(const char *fmt, ...)
 done:
 #define LARGE_ENOUGH_BUF 4096
   if (!buf) {
-    max_len = max(LARGE_ENOUGH_BUF, size);
+    max_len = std::max(LARGE_ENOUGH_BUF, size);
     buf = (char *)malloc(max_len);
     if (!buf) {
       cerr << "ERROR: RGWFormatter_Plain::write_data: failed allocating " << max_len << " bytes" << std::endl;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -911,17 +911,15 @@ public:
                              rgw::auth::RemoteApplier::acl_strategy_t&& acl_alg,
                              const rgw::auth::RemoteApplier::AuthInfo info
                             ) const override {
-    return aplptr_t(
-      new rgw::auth::RemoteApplier(cct, store, std::move(acl_alg), info,
-                                   cct->_conf->rgw_keystone_implicit_tenants));
+    return ceph::make_static<RemoteApplier>(cct, store, std::move(acl_alg), info,
+                                            cct->_conf->rgw_keystone_implicit_tenants);
   }
 
   aplptr_t create_apl_local(CephContext* const cct,
                             const req_state* const s,
                             const RGWUserInfo& user_info,
                             const std::string& subuser) const override {
-      return aplptr_t(
-        new rgw::auth::LocalApplier(cct, user_info, subuser));
+      return ceph::make_static<LocalApplier>(cct, user_info, subuser);
   }
 };
 

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -193,8 +193,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
         rgw::auth::add_sysreq(cct, store, s,
           rgw::auth::RemoteApplier(cct, store, std::move(extra_acl_strategy), info,
                                    cct->_conf->rgw_keystone_implicit_tenants)));
-    /* TODO(rzarzynski): replace with static_ptr. */
-    return aplptr_t(new decltype(apl)(std::move(apl)));
+    return ceph::make_static<decltype(apl)>(std::move(apl));
   }
 
   aplptr_t create_apl_local(CephContext* const cct,
@@ -205,8 +204,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
       rgw::auth::add_3rdparty(store, s->account_name,
         rgw::auth::add_sysreq(cct, store, s,
           rgw::auth::LocalApplier(cct, user_info, subuser)));
-    /* TODO(rzarzynski): replace with static_ptr. */
-    return aplptr_t(new decltype(apl)(std::move(apl)));
+    return ceph::make_static<decltype(apl)>(std::move(apl));
   }
 
   aplptr_t create_apl_turl(CephContext* const cct,
@@ -215,7 +213,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
     /* TempURL doesn't need any user account override. It's a Swift-specific
      * mechanism that requires  account name internally, so there is no
      * business with delegating the responsibility outside. */
-    return aplptr_t(new rgw::auth::swift::TempURLApplier(cct, user_info));
+    return ceph::make_static<TempURLApplier>(cct, user_info);
   }
 
 public:


### PR DESCRIPTION
uses the new `ceph::static_ptr` instead of `std::unique_ptr` to store the `rgw::auth::Identity` in `req_state`. this saves an allocation, at the cost of ~700 extra bytes in `req_state` (now up to 4416 bytes)