### PR TITLE
common: Remove ceph_clock_gettime, extern keyword

### DIFF
--- a/src/common/Clock.cc
+++ b/src/common/Clock.cc
@@ -23,13 +23,8 @@ utime_t ceph_clock_now()
   utime_t n(tp);
 #else
   struct timeval tv;
-  gettimeofday(&tv, NULL);
+  gettimeofday(&tv, nullptr);
   utime_t n(&tv);
 #endif
   return n;
-}
-
-time_t ceph_clock_gettime()
-{
-  return time(NULL);
 }

--- a/src/common/Clock.h
+++ b/src/common/Clock.h
@@ -19,7 +19,6 @@
 
 #include <time.h>
 
-extern utime_t ceph_clock_now();
-extern time_t ceph_clock_gettime();
+utime_t ceph_clock_now();
 
 #endif

--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -143,7 +143,7 @@ int execute_remove(const po::variables_map &vm) {
 }
 
 std::string delete_status(time_t deferment_end_time) {
-  time_t now = ceph_clock_gettime();
+  time_t now = time(nullptr);
 
   std::string time_str = ctime(&deferment_end_time);
   time_str = time_str.substr(0, time_str.length() - 1);


### PR DESCRIPTION
ceph_clock_gettime is only used in src/tools/rbd/action/Trash.cc

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>