### PR TITLE
osd: Use specializations, typedefs instead

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -774,7 +774,7 @@ public:
 
 private:
   /// throttle promotion attempts
-  std::atomic_uint promote_probability_millis{1000}; ///< probability thousands. one word.
+  std::atomic<unsigned int> promote_probability_millis{1000}; ///< probability thousands. one word.
   PromoteCounter promote_counter;
   utime_t last_recalibrate;
   unsigned long promote_max_objects, promote_max_bytes;
@@ -825,7 +825,7 @@ public:
 
   // -- tids --
   // for ops i issue
-  std::atomic_uint last_tid{0};
+  std::atomic<unsigned int> last_tid{0};
   ceph_tid_t get_tid() {
     return (ceph_tid_t)last_tid++;
   }
@@ -1119,7 +1119,7 @@ public:
     NOT_STOPPING,
     PREPARING_TO_STOP,
     STOPPING };
-  std::atomic_int state{NOT_STOPPING};
+  std::atomic<int> state{NOT_STOPPING};
   int get_state() const {
     return state;
   }
@@ -1313,7 +1313,7 @@ public:
   }
 
 private:
-  std::atomic_int state{STATE_INITIALIZING};
+  std::atomic<int> state{STATE_INITIALIZING};
 
 public:
   int get_state() const {
@@ -1460,7 +1460,7 @@ private:
   map<int, int> debug_heartbeat_drops_remaining;
   Cond heartbeat_cond;
   bool heartbeat_stop;
-  std::atomic_bool heartbeat_need_update;   
+  std::atomic<bool> heartbeat_need_update;   
   map<int,HeartbeatInfo> heartbeat_peers;  ///< map of osd id to HeartbeatInfo
   utime_t last_mon_heartbeat;
   Messenger *hb_front_client_messenger;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -542,7 +542,7 @@ protected:
   // unlock() when done with the current pointer (_most common_).
   mutable Mutex _lock = {"PG::_lock"};
 
-  std::atomic_uint ref{0};
+  std::atomic<unsigned int> ref{0};
 
 #ifdef PG_DEBUG_REFS
   Mutex _ref_id_lock = {"PG::_ref_id_lock"};

--- a/src/osd/Session.h
+++ b/src/osd/Session.h
@@ -73,7 +73,7 @@ struct Backoff : public RefCountedObject {
     STATE_ACKED = 2,   ///< backoff acked
     STATE_DELETING = 3 ///< backoff deleted, but un-acked
   };
-  std::atomic_int state = {STATE_NEW};
+  std::atomic<int> state = {STATE_NEW};
   spg_t pgid;          ///< owning pgid
   uint64_t id = 0;     ///< unique id (within the Session)
 
@@ -144,7 +144,7 @@ struct Session : public RefCountedObject {
 
   /// protects backoffs; orders inside Backoff::lock *and* PG::backoff_lock
   Mutex backoff_lock;
-  std::atomic_int backoff_count= {0};  ///< simple count of backoffs
+  std::atomic<int> backoff_count= {0};  ///< simple count of backoffs
   map<spg_t,map<hobject_t,set<BackoffRef>>> backoffs;
 
   std::atomic<uint64_t> backoff_seq = {0};

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -5211,9 +5211,9 @@ WRITE_CLASS_ENCODER(obj_list_snap_response_t)
 // PromoteCounter
 
 struct PromoteCounter {
-  std::atomic_ullong  attempts{0};
-  std::atomic_ullong  objects{0};
-  std::atomic_ullong  bytes{0};
+  std::atomic<unsigned long long>  attempts{0};
+  std::atomic<unsigned long long>  objects{0};
+  std::atomic<unsigned long long>  bytes{0};
 
   void attempt() {
     attempts++;


### PR DESCRIPTION
Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>