### PR TITLE
qa: preserve cbt task results

### DIFF
--- a/qa/tasks/cbt.py
+++ b/qa/tasks/cbt.py
@@ -118,6 +118,8 @@ class CBT(Task):
                 '{cbtdir}/cbt_config.yaml'.format(cbtdir=self.cbt_dir),
             ],
         )
+        preserve_file = os.path.join(self.ctx.archive, '.preserve')
+        open(preserve_file, 'a').close()
 
     def end(self):
         super(CBT, self).end()


### PR DESCRIPTION
Add '.preserve' file in the archive's top level directory. This ensures that the runs with the cbt results are preserved longer than usual. 

Signed-off-by: Neha Ojha <nojha@redhat.com>