### PR TITLE
qa/tasks/ceph_manager: tolerate tell osd.* error

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -888,9 +888,12 @@ class Thrasher:
                 osd_state = "false"
             else:
                 osd_state = "true"
-            self.ceph_manager.inject_args('osd', '*',
-                                          'osd_enable_op_tracker',
-                                          osd_state)
+            try:
+                self.ceph_manager.inject_args('osd', '*',
+                                              'osd_enable_op_tracker',
+                                              osd_state)
+            except CommandFailedError:
+                self.log('Failed to tell all osds, ignoring')
             gevent.sleep(delay)
 
     @log_exc


### PR DESCRIPTION
It's possible for tell osd.* to race against an osd we stopped but the
cluster doesn't know is down yet.  In tha case we'll get ENXIO on that
osd and the command will fail.
    
In this context, we don't care.