### PR TITLE
include: xlist: Fix Clang error for missing string

### DIFF
--- a/src/include/xlist.h
+++ b/src/include/xlist.h
@@ -18,6 +18,7 @@
 #include "include/assert.h"
 #include <iterator>
 #include <cstdlib>
+#include <ostream>
 
 template<typename T>
 class xlist {


### PR DESCRIPTION
Clang complains:
```
home/jenkins/workspace/ceph-master/src/include/xlist.h:210:13: error: invalid operands to binary expression ('std::ostream' (aka 'basic_ostream<char>') and 'const char *')
        oss << ", ";
        ~~~ ^  ~~~~
1 error generated.
```
So make sure that a string is a string.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>