### PR TITLE
mds/MDSMap : use arrary_section for mds stat

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -20,6 +20,8 @@
       - mds remove_data_pool -> fs rm_data_pool
       - mds rm_data_pool -> fs rm_data_pool
 
+  * The JSON format of `ceph fs status` and `ceph mds stat` has changed
+    for the "up" and "info" sections of the mds_map.
 
 >= 12.2.2
 ---------

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -64,7 +64,7 @@ class FSStatus(object):
         for info in self.get_standbys():
             yield info
         for fs in self.map['filesystems']:
-            for info in fs['mdsmap']['info'].values():
+            for info in fs['mdsmap']['info']:
                 yield info
 
     def get_standbys(self):
@@ -97,7 +97,7 @@ class FSStatus(object):
         Get the standby:replay MDS for the given FSCID.
         """
         fs = self.get_fsmap(fscid)
-        for info in fs['mdsmap']['info'].values():
+        for info in fs['mdsmap']['info']:
             if info['state'] == 'up:standby-replay':
                 yield info
 
@@ -106,7 +106,7 @@ class FSStatus(object):
         Get the ranks for the given FSCID.
         """
         fs = self.get_fsmap(fscid)
-        for info in fs['mdsmap']['info'].values():
+        for info in fs['mdsmap']['info']:
             if info['rank'] >= 0:
                 yield info
 
@@ -118,6 +118,14 @@ class FSStatus(object):
             if info['rank'] == rank:
                 return info
         raise RuntimeError("FSCID {0} has no rank {1}".format(fscid, rank))
+
+    def get_cluster(self, fscid):
+        """
+        Get the MDS cluster for the given FSCID.
+        """
+        fs = self.get_fsmap(fscid)
+        for info in fs['mdsmap']['info']:
+            yield info
 
     def get_mds(self, name):
         """
@@ -294,8 +302,8 @@ class MDSCluster(CephCluster):
             mdsmap = fs['mdsmap']
             metadata_pool = pool_id_name[mdsmap['metadata_pool']]
 
-            for gid in mdsmap['up'].values():
-                self.mon_manager.raw_cluster_cmd('mds', 'fail', gid.__str__())
+            for info in status.get_ranks(fs['id']):
+                self.mon_manager.raw_cluster_cmd('mds', 'fail', str(info['gid']))
 
             self.mon_manager.raw_cluster_cmd('fs', 'rm', mdsmap['fs_name'], '--yes-i-really-mean-it')
             self.mon_manager.raw_cluster_cmd('osd', 'pool', 'delete',
@@ -659,11 +667,11 @@ class Filesystem(MDSCluster):
 
         log.info("are_daemons_healthy: mds map: {0}".format(mds_map))
 
-        for mds_id, mds_status in mds_map['info'].items():
-            if mds_status['state'] not in ["up:active", "up:standby", "up:standby-replay"]:
-                log.warning("Unhealthy mds state {0}:{1}".format(mds_id, mds_status['state']))
+        for info in mds_map['info']:
+            if info['state'] not in ["up:active", "up:standby", "up:standby-replay"]:
+                log.warning("Unhealthy mds state {0}:{1}".format(info['gid'], info['state']))
                 return False
-            elif mds_status['state'] == 'up:active':
+            elif info['state'] == 'up:active':
                 active_count += 1
 
         log.info("are_daemons_healthy: {0}/{1}".format(
@@ -672,10 +680,10 @@ class Filesystem(MDSCluster):
 
         if active_count >= mds_map['max_mds']:
             # The MDSMap says these guys are active, but let's check they really are
-            for mds_id, mds_status in mds_map['info'].items():
-                if mds_status['state'] == 'up:active':
+            for info in mds_map['info']:
+                if info['state'] == 'up:active':
                     try:
-                        daemon_status = self.mds_asok(["status"], mds_id=mds_status['name'])
+                        daemon_status = self.mds_asok(["status"], mds_id=info['name'])
                     except CommandFailedError as cfe:
                         if cfe.exitstatus == errno.EINVAL:
                             # Old version, can't do this check
@@ -700,7 +708,7 @@ class Filesystem(MDSCluster):
         """
         status = self.get_mds_map()
         result = []
-        for mds_status in sorted(status['info'].values(), lambda a, b: cmp(a['rank'], b['rank'])):
+        for mds_status in sorted(status['info'], lambda a, b: cmp(a['rank'], b['rank'])):
             if mds_status['state'] == state or state is None:
                 result.append(mds_status['name'])
 
@@ -718,7 +726,7 @@ class Filesystem(MDSCluster):
     def get_all_mds_rank(self):
         status = self.get_mds_map()
         result = []
-        for mds_status in sorted(status['info'].values(), lambda a, b: cmp(a['rank'], b['rank'])):
+        for mds_status in sorted(status['info'], lambda a, b: cmp(a['rank'], b['rank'])):
             if mds_status['rank'] != -1 and mds_status['state'] != 'up:standby-replay':
                 result.append(mds_status['rank'])
 
@@ -733,7 +741,7 @@ class Filesystem(MDSCluster):
         """
         status = self.get_mds_map()
         result = []
-        for mds_status in sorted(status['info'].values(), lambda a, b: cmp(a['rank'], b['rank'])):
+        for mds_status in sorted(status['info'], lambda a, b: cmp(a['rank'], b['rank'])):
             if mds_status['rank'] != -1 and mds_status['state'] != 'up:standby-replay':
                 result.append(mds_status['name'])
 

--- a/qa/tasks/cephfs/test_failover.py
+++ b/qa/tasks/cephfs/test_failover.py
@@ -83,8 +83,7 @@ class TestFailover(CephFSTestCase):
 
         # Wait for everyone to go laggy
         def laggy():
-            mdsmap = self.fs.get_mds_map()
-            for info in mdsmap['info'].values():
+            for info in self.fs.status().get_cluster(self.fs.id):
                 if "laggy_since" not in info:
                     return False
 
@@ -469,7 +468,7 @@ class TestMultiFilesystems(CephFSTestCase):
 
         def get_info_by_name(fs, mds_name):
             mds_map = fs.get_mds_map()
-            for gid_str, info in mds_map['info'].items():
+            for info in mds_map['info']:
                 if info['name'] == mds_name:
                     return info
 

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -544,8 +544,7 @@ class TestStrays(CephFSTestCase):
                     time.sleep(1)
 
     def _is_stopped(self, rank):
-        mds_map = self.fs.get_mds_map()
-        return rank not in [i['rank'] for i in mds_map['info'].values()]
+        return rank not in self.fs.get_mds_map()['up']
 
     def test_purge_on_shutdown(self):
         """

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -153,11 +153,9 @@ void MDSMap::dump(Formatter *f) const
   for (set<mds_rank_t>::const_iterator p = in.begin(); p != in.end(); ++p)
     f->dump_int("mds", *p);
   f->close_section();
-  f->open_object_section("up");
+  f->open_array_section("up");
   for (map<mds_rank_t,mds_gid_t>::const_iterator p = up.begin(); p != up.end(); ++p) {
-    char s[14];
-    sprintf(s, "mds_%d", int(p->first));
-    f->dump_int(s, p->second);
+    f->dump_int("mds", p->first);
   }
   f->close_section();
   f->open_array_section("failed");
@@ -172,11 +170,9 @@ void MDSMap::dump(Formatter *f) const
   for (set<mds_rank_t>::const_iterator p = stopped.begin(); p != stopped.end(); ++p)
     f->dump_int("mds", *p);
   f->close_section();
-  f->open_object_section("info");
+  f->open_array_section("info");
   for (map<mds_gid_t,mds_info_t>::const_iterator p = mds_info.begin(); p != mds_info.end(); ++p) {
-    char s[25]; // 'gid_' + len(str(ULLONG_MAX)) + '\0'
-    sprintf(s, "gid_%llu", (long long unsigned)p->first);
-    f->open_object_section(s);
+    f->open_object_section("info_item");
     p->second.dump(f);
     f->close_section();
   }

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -114,14 +114,21 @@ class RankEvicter(threading.Thread):
 
         super(RankEvicter, self).__init__()
 
+    def _get_info(self, key, value):
+        for info in self._mds_map["info"]:
+            if info[key] == value:
+                return info
+        return {}
+
     def _ready_to_evict(self):
-        if self._mds_map['up'].get("mds_{0}".format(self.rank), None) != self.gid:
+        info = self._get_info('rank', self.rank)
+        if (self.rank not in self._mds_map['up']) or info.get('gid', None) != self.gid:
             log.info("Evicting {0} from {1}/{2}: rank no longer associated with gid, done.".format(
                 self._client_spec, self.rank, self.gid
             ))
             raise RankEvicter.GidGone()
 
-        info = self._mds_map['info']["gid_{0}".format(self.gid)]
+        info = self._get_info('gid', self.gid)
         log.debug("_ready_to_evict: state={0}".format(info['state']))
         return info['state'] in ["up:active", "up:clientreplay"]
 
@@ -393,10 +400,8 @@ class CephFSVolumeClient(object):
 
         mds_map = get_mds_map()
         up = {}
-        for name, gid in mds_map['up'].items():
-            # Quirk of the MDSMap JSON dump: keys in the up dict are like "mds_0"
-            assert name.startswith("mds_")
-            up[int(name[4:])] = gid
+        for rank in mds_map['up']:
+            up[rank] = self._get_info('rank', rank)['gid']
 
         # For all MDS ranks held by a daemon
         # Do the parallelism in python instead of using "tell mds.*", because


### PR DESCRIPTION
For `ceph mds stat -f json-pretty `, change the output of json from:

**up section**

The original `up` section take the `rank` as object's attributes, and `gid` as value.

```
       "up": {
            "mds_6": 335920,
            "mds_7": 292071,
            "mds_4": 289288,
            "mds_5": 289283,
            "mds_2": 289803,
            "mds_3": 289293,
            "mds_0": 335195,
            "mds_1": 289923,
            "mds_8": 292056
          },
```

I thnink it's better to change the `up` section to:

```
      "up": {
            6,
            7,
            4,
            5,
            2,
            3,
            0,
            1,
            8
          },
```

The change just contains the `rank` in the `up` section, and delete `gid`. The relationship between `gid` and `rank` can also be found in `info` section.

**info section**

```
          "info": {
            "gid_292071": {
              "standby_for_rank": -1,
              "export_targets": [],
              "name": "ceph-dev-mds-k-1380776",
              "incarnation": 114209,
              "standby_replay": false,
              "state_seq": 707405,
              "standby_for_fscid": -1,
              "state": "up:active",
              "gid": 292071,
              "features": 2305244844532236283,
              "rank": 7,
              "standby_for_name": "",
              "addr": "10.148.178.212:6800/2799316021" 
            },
            "gid_289283": {
              "standby_for_rank": -1,
              "export_targets": [],
              "name": "ceph-dev-mds-e-1378660",
              "incarnation": 114045,
              "standby_replay": false,
              "state_seq": 739977,
              "standby_for_fscid": -1,
              "state": "up:active",
              "gid": 289283,
              "features": 2305244844532236283,
              "rank": 5,
              "standby_for_name": "",
              "addr": "10.148.178.207:6800/1166382362" 
            }
         }
```

to

```
          "info": [
            {
              "standby_for_rank": -1,
              "export_targets": [],
              "name": "ceph-dev-mds-k-1380776",
              "incarnation": 114209,
              "standby_replay": false,
              "state_seq": 707405,
              "standby_for_fscid": -1,
              "state": "up:active",
              "gid": 292071,
              "features": 2305244844532236283,
              "rank": 7,
              "standby_for_name": "",
              "addr": "10.148.178.212:6800/2799316021" 
            },
            {
              "standby_for_rank": -1,
              "export_targets": [],
              "name": "ceph-dev-mds-e-1378660",
              "incarnation": 114045,
              "standby_replay": false,
              "state_seq": 739977,
              "standby_for_fscid": -1,
              "state": "up:active",
              "gid": 289283,
              "features": 2305244844532236283,
              "rank": 5,
              "standby_for_name": "",
              "addr": "10.148.178.207:6800/1166382362" 
            }
         ]
```

If the `Info` is not in `array_section`, it's hard to define json-decoder after get result from `ceph mds stat -f json-pretty`. After changed, it's easy to deal with.



http://tracker.ceph.com/issues/22338

Signed-off-by: You Ji <youji@ebay.com>