### PR TITLE
client: drop duplicate friend

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -761,7 +761,6 @@ private:
   void _put_fh(Fh *fh);
 
   int _do_remount(void);
-  friend class C_Client_Remount;
 
   struct C_Readahead : public Context {
     Client *client;


### PR DESCRIPTION
Dropped duplicate friend access providing, as the below warning appears:
```
ceph/src/client/Client.h:764:16: warning: ‘C_Client_Remount’ is already a friend of ‘Client’ [enabled by default]
   friend class C_Client_Remount;
```
Signed-off-by: Jos Collin <jcollin@redhat.com>