### PR TITLE
rgw: remove redundant parenthesis in logs

### DIFF
--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -1009,7 +1009,7 @@ int RGWMetadataManager::store_in_heap(RGWMetadataHandler *handler, const string&
                                bl.c_str(), bl.length(), false,
                                &otracker, mtime, pattrs);
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "ERROR: rgw_put_system_obj() oid=" << oid << ") returned ret=" << ret << dendl;
+    ldout(store->ctx(), 0) << "ERROR: rgw_put_system_obj() oid=" << oid << " returned ret=" << ret << dendl;
     return ret;
   }
 
@@ -1032,7 +1032,7 @@ int RGWMetadataManager::remove_from_heap(RGWMetadataHandler *handler, const stri
   rgw_raw_obj obj(heap_pool, oid);
   int ret = store->delete_system_obj(obj);
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "ERROR: store->delete_system_obj()=" << oid << ") returned ret=" << ret << dendl;
+    ldout(store->ctx(), 0) << "ERROR: store->delete_system_obj() oid=" << oid << " returned ret=" << ret << dendl;
     return ret;
   }
 


### PR DESCRIPTION
Signed-off-by: Bingyin Zhang <zhangbingyin@cloudin.cn>