### PR TITLE
mds,rgw: Initializing standby_reply, sync_tracer

### DIFF
--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -87,7 +87,7 @@ private:
   mds_rank_t standby_for_rank;
   std::string standby_for_name;
   fs_cluster_id_t standby_for_fscid;
-  bool standby_replay;
+  bool standby_replay = false;
   MDSMap::DaemonState want_state;
 
   // Internal beacon state

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2285,7 +2285,7 @@ class RGWRados
   RGWMetaNotifier *meta_notifier;
   RGWDataNotifier *data_notifier;
   RGWMetaSyncProcessorThread *meta_sync_processor_thread;
-  RGWSyncTraceManager *sync_tracer;
+  RGWSyncTraceManager *sync_tracer = nullptr;
   map<string, RGWDataSyncProcessorThread *> data_sync_processor_threads;
 
   boost::optional<rgw::BucketTrimManager> bucket_trim;


### PR DESCRIPTION
Fixes te coveity issue:

** 1396192 Uninitialized scalar field
>CID 1396192 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member standby_replay is
not initialized in this constructor nor in any functions that it calls.

** 717382 Uninitialized pointer field
>CID 717382 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member sync_tracer is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com