### PR TITLE
DNM osd, os/bluestore: bring support for asynchronous reads

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -475,7 +475,7 @@ void CephContext::do_command(std::string command, cmdmap_t& cmdmap,
           msg << "Setting not found: '" << key << "'";
           f->dump_string("error", msg.str());
         } else {
-          i->second.dump(f);
+          static_cast<const Option&>(i->second).dump(f);
         }
       } else {
         // Output all

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -89,7 +89,7 @@ md_config_t::md_config_t(bool is_daemon)
                 << std::endl;
       ceph_abort();
     }
-    schema.insert({i.name, i});
+    schema.emplace(i.name, i);
   }
 
   // Populate list of legacy_values according to the OPTION() definitions
@@ -155,7 +155,7 @@ md_config_t::md_config_t(bool is_daemon)
 void md_config_t::validate_schema()
 {
   for (const auto &i : schema) {
-    const auto &opt = i.second;
+    const Option &opt = i.second;
     for (const auto &see_also_key : opt.see_also) {
       if (schema.count(see_also_key) == 0) {
         std::cerr << "Non-existent see-also key '" << see_also_key
@@ -309,7 +309,7 @@ int md_config_t::parse_config_files_impl(const std::list<std::string> &conf_file
   std::vector <std::string> my_sections;
   _get_my_sections(my_sections);
   for (const auto &i : schema) {
-    const auto &opt = i.second;
+    const Option &opt = i.second;
     std::string val;
     int ret = _get_val_from_conf_file(my_sections, opt.name, val, false);
     if (ret == 0) {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -15,6 +15,8 @@
 #ifndef CEPH_CONFIG_H
 #define CEPH_CONFIG_H
 
+#include <boost/container/flat_map.hpp>
+
 #include "common/backport_std.h"
 #include "common/ConfUtils.h"
 #include "common/entity_name.h"
@@ -90,8 +92,15 @@ public:
   /**
    * The configuration schema, in the form of Option objects describing
    * possible settings.
+   *
+   * flat_map<> is employed to lower memory fragmentation and reduce
+   * CPU cache misses. It still offers logarithmic search complexity
+   * while the extra overhead on insert isn't a problem as modifying
+   * the schema is intended to be rare.
    */
-  std::map<std::string, const Option &> schema;
+  boost::container::flat_map<
+    std::string,
+    std::reference_wrapper<const Option>> schema;
 
   /**
    * The current values of all settings described by the schema

--- a/src/common/config_cacher.h
+++ b/src/common/config_cacher.h
@@ -1,0 +1,59 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_CONFIG_CACHER_H
+#define CEPH_CONFIG_CACHER_H
+
+#include "common/config_obs.h"
+#include "common/config.h"
+
+template <typename ValueT>
+class md_config_cacher_t : public md_config_obs_t {
+  md_config_t& conf;
+  const char* const option_name;
+  std::atomic<ValueT> value_cache;
+
+  const char** get_tracked_conf_keys() const override {
+    const static char* keys[] = { option_name, nullptr };
+    return keys;
+  }
+
+  void handle_conf_change(const md_config_t* conf,
+                          const std::set<std::string>& changed) override {
+    if (changed.count(option_name)) {
+      value_cache.store(conf->get_val<ValueT>(option_name));
+    }
+  }
+
+public:
+  md_config_cacher_t(md_config_t& conf,
+                     const char* const option_name)
+    : conf(conf),
+      option_name(option_name) {
+    conf.add_observer(this);
+    std::atomic_init(&value_cache,
+                     conf.get_val<ValueT>(option_name));
+  }
+
+  ~md_config_cacher_t() {
+    conf.remove_observer(this);
+  }
+
+  ValueT get_val() const {
+    return value_cache.load();
+  }
+};
+
+#endif // CEPH_CONFIG_CACHER_H
+

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -804,6 +804,9 @@ OPTION(osd_fast_info, OPT_BOOL) // use fast info attr, if we can
 // determines whether PGLog::check() compares written out log to stored log
 OPTION(osd_debug_pg_log_writeout, OPT_BOOL)
 OPTION(osd_loop_before_reset_tphandle, OPT_U32) // Max number of loop before we reset thread-pool's handle
+OPTION(osd_skip_data_digest, OPT_BOOL)
+OPTION(osd_max_snap_prune_intervals_per_epoch, OPT_U64) // Max number of snap intervals to report to mgr in pg_stat_t
+
 // default timeout while caling WaitInterval on an empty queue
 OPTION(threadpool_default_timeout, OPT_INT)
 // default wait time for an empty queue before pinging the hb timeout

--- a/src/common/tiny_vector.hpp
+++ b/src/common/tiny_vector.hpp
@@ -1,0 +1,141 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+//
+// Ceph - scalable distributed file system
+//
+// Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+//
+// This is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1, as published by the Free Software
+// Foundation.  See file COPYING.
+//
+
+#ifndef CEPH_COMMON_TINY_VECTOR_H
+#define CEPH_COMMON_TINY_VECTOR_H
+
+#include <type_traits>
+
+namespace ceph {
+
+// tiny_vector - a CPU-friendly container for non-movable objects.
+//
+// The purpose of the container is store arbitrary number of objects
+// with absolutely minimal requirements regarding constructibility
+// and with minimized memory indirection.
+// There is no obligation for MoveConstructibility, CopyConstructibility
+// nor even DefaultConstructibility which allows to handle std::mutexes,
+// std::atomics or any type embedding them.
+//
+// Few requirements translate into tiny interface. The container isn't
+// Copy- nor MoveConstructible. Although it does offer random access
+// iterator, insertion in the middle is not allowed. The maximum number
+// of elements must be known in run-time. This shouldn't be an issue in
+// the intended use case: sharding.
+//
+// Alternatives:
+//  1. std::vector<boost::optional<ValueT>> initialized with the known
+//     known size and emplace_backed(). boost::optional inside provides
+//     the DefaultConstructibility. Imposes extra memory indirection.
+//  2. boost::container::small_vector + boost::optional doesn't work.
+//  3. boost::container::static_vector feed via emplace_back().
+//     Good for performance but enforces upper limit on elements count.
+//     For sharding this means we can't handle arbitrary number of
+//     shards (weird configs).
+//  4. std::unique_ptr<ValueT>: extra indirection together with memory
+//     fragmentation.
+
+template<typename Value, std::size_t Capacity>
+class tiny_vector {
+  using storage_unit_t = \
+    std::aligned_storage_t<sizeof(Value), alignof(Value)>;
+
+  std::size_t _size = 0;
+  storage_unit_t* const data = nullptr;
+  storage_unit_t internal[Capacity];
+
+public:
+  typedef std::size_t size_type;
+  typedef std::add_lvalue_reference_t<Value> reference;
+  typedef std::add_const_t<reference> const_reference;
+  typedef std::add_pointer_t<Value> pointer;
+
+  class emplacer {
+    friend class tiny_vector;
+
+    tiny_vector* parent;
+    emplacer(tiny_vector* const parent)
+      : parent(parent) {
+    }
+
+  public:
+    template<class... Args>
+    void emplace(Args&&... args) {
+      if (!parent) {
+        return;
+      }
+      new (&parent->data[parent->_size++]) Value(std::forward<Args>(args)...);
+      parent = nullptr;
+    }
+  };
+
+  template<typename F>
+  tiny_vector(const std::size_t count, F&& f)
+    : data(count <= Capacity ? internal
+                             : new storage_unit_t[count]) {
+    for (std::size_t i = 0; i < count; ++i) {
+      // caller MAY emplace up to count elements but it IS NOT
+      // obliged to do so.
+      f(i, emplacer(this));
+    }
+  }
+
+  ~tiny_vector() {
+    for (auto& elem : *this) {
+      reinterpret_cast<Value&>(elem).~Value();
+    }
+
+    const auto data_addr = reinterpret_cast<uintptr_t>(data);
+    const auto this_addr = reinterpret_cast<uintptr_t>(this);
+    if (data_addr < this_addr ||
+        data_addr >= this_addr + sizeof(*this)) {
+      delete[] data;
+    }
+  }
+
+  reference       operator[](size_type pos) {
+    return reinterpret_cast<reference>(data[pos]);
+  }
+  const_reference operator[](size_type pos) const {
+    return reinterpret_cast<const_reference>(data[pos]);
+  }
+
+  size_type size() const {
+    return _size;
+  }
+
+  pointer begin() {
+    return reinterpret_cast<pointer>(&data[0]);
+  }
+  pointer end() {
+    return reinterpret_cast<pointer>(&data[_size]);
+  }
+
+  const pointer begin() const {
+    return reinterpret_cast<pointer>(&data[0]);
+  }
+  const pointer end() const {
+    return reinterpret_cast<pointer>(&data[_size]);
+  }
+
+  const pointer cbegin() const {
+    return reinterpret_cast<pointer>(&data[0]);
+  }
+  const pointer cend() const {
+    return reinterpret_cast<pointer>(&data[_size]);
+  }
+};
+
+} // namespace ceph
+
+#endif // CEPH_COMMON_TINY_VECTOR_H

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1770,6 +1770,32 @@ public:
       ceph::bufferlist& destbl,
       Context* on_complete) = 0;
 
+    /**
+     * read_sparse -- read a byte range of data from an object using
+     * the formatting of CEPH_OSD_OP_SPARSE_READ for output.
+     *
+     * The operation can be performed synchronously or asynchronously
+     * solely depnding on the implementation's decision.
+     *
+     * Note: if reading from an offset past the end of the object, we
+     * return 0 (not, say, -EINVAL).
+     *
+     * @param offset location offset of first byte to be read
+     * @param len number of bytes to be read
+     * @param op_flags is CEPH_OSD_OP_FLAG_*
+     * @param destbl output bufferlist
+     * @param on_complete callback to be called
+     * @returns number of bytes read on success,
+     *          or negative error code on failure,
+     *          or -EINPROGESS if implementations decided to go async.
+     */
+    virtual int read_sparse(
+      uint64_t offset,
+      uint64_t length,
+      uint32_t flags,
+      ceph::bufferlist& destbl,
+      Context* on_complete) = 0;
+
     virtual bool empty() const = 0;
     virtual int apply(Context* on_complete) = 0;
   };

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1793,6 +1793,27 @@ public:
     return false;
   }
 
+  struct async_read_params_t {
+    uint64_t offset = 0;
+    uint64_t length = 0;
+    ceph::bufferlist* outbl = nullptr;
+    Context* on_complete = nullptr;
+    uint32_t flags = 0;
+
+    async_read_params_t(
+      const uint64_t offset,
+      const uint64_t length,
+      ceph::bufferlist* const outbl,
+      Context* const on_complete,
+      const uint32_t flags)
+    : offset(offset),
+      length(length),
+      outbl(outbl),
+      on_complete(on_complete),
+      flags(flags) {
+    }
+  };
+
   /**
    * fiemap -- get extent map of data of an object
    *

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1718,22 +1718,22 @@ public:
    * @param op_flags is CEPH_OSD_OP_FLAG_*
    * @returns number of bytes read on success, or negative error code on failure.
    */
-   virtual int read(
-    const coll_t& cid,
+  virtual int read(
+   const coll_t& cid,
+   const ghobject_t& oid,
+   uint64_t offset,
+   size_t len,
+   bufferlist& bl,
+   uint32_t op_flags = 0) = 0;
+  virtual int read(
+    CollectionHandle &c,
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
     bufferlist& bl,
-    uint32_t op_flags = 0) = 0;
-   virtual int read(
-     CollectionHandle &c,
-     const ghobject_t& oid,
-     uint64_t offset,
-     size_t len,
-     bufferlist& bl,
-     uint32_t op_flags = 0) {
-     return read(c->get_cid(), oid, offset, len, bl, op_flags);
-   }
+    uint32_t op_flags = 0) {
+    return read(c->get_cid(), oid, offset, len, bl, op_flags);
+  }
 
   /*********************************
    * ReadTransaction
@@ -1830,19 +1830,19 @@ public:
    * @param bl output bufferlist for extent map information.
    * @returns 0 on success, negative error code on failure.
    */
-   virtual int fiemap(const coll_t& cid, const ghobject_t& oid,
- 		     uint64_t offset, size_t len, bufferlist& bl) = 0;
-   virtual int fiemap(const coll_t& cid, const ghobject_t& oid,
- 		     uint64_t offset, size_t len,
- 		     map<uint64_t, uint64_t>& destmap) = 0;
-   virtual int fiemap(CollectionHandle& c, const ghobject_t& oid,
- 		     uint64_t offset, size_t len, bufferlist& bl) {
-     return fiemap(c->get_cid(), oid, offset, len, bl);
-   }
-   virtual int fiemap(CollectionHandle& c, const ghobject_t& oid,
- 		     uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) {
-     return fiemap(c->get_cid(), oid, offset, len, destmap);
-   }
+  virtual int fiemap(const coll_t& cid, const ghobject_t& oid,
+       	     uint64_t offset, size_t len, bufferlist& bl) = 0;
+  virtual int fiemap(const coll_t& cid, const ghobject_t& oid,
+       	     uint64_t offset, size_t len,
+       	     map<uint64_t, uint64_t>& destmap) = 0;
+  virtual int fiemap(CollectionHandle& c, const ghobject_t& oid,
+       	     uint64_t offset, size_t len, bufferlist& bl) {
+    return fiemap(c->get_cid(), oid, offset, len, bl);
+  }
+  virtual int fiemap(CollectionHandle& c, const ghobject_t& oid,
+       	     uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) {
+    return fiemap(c->get_cid(), oid, offset, len, destmap);
+  }
 
   /**
    * getattr -- get an xattr of an object

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1735,6 +1735,10 @@ public:
      return read(c->get_cid(), oid, offset, len, bl, op_flags);
    }
 
+  virtual bool has_async_read() const {
+    return false;
+  }
+
   /**
    * fiemap -- get extent map of data of an object
    *

--- a/src/os/bluestore/BlockDevice.cc
+++ b/src/os/bluestore/BlockDevice.cc
@@ -84,7 +84,8 @@ void IOContext::release_running_aios()
 }
 
 BlockDevice *BlockDevice::create(CephContext* cct, const string& path,
-				 aio_callback_t cb, void *cbpriv)
+				 aio_callback_t cb, void *cbpriv,
+                                 size_t max_shard_num)
 {
   string type = "kernel";
   char buf[PATH_MAX + 1];
@@ -117,7 +118,7 @@ BlockDevice *BlockDevice::create(CephContext* cct, const string& path,
 #endif
 #if defined(HAVE_LIBAIO)
   if (type == "kernel") {
-    return new KernelDevice(cct, cb, cbpriv);
+    return new KernelDevice(cct, cb, cbpriv, max_shard_num);
   }
 #endif
 #if defined(HAVE_SPDK)

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -47,6 +47,7 @@ private:
 public:
   CephContext* cct;
   void *priv;
+  size_t shard_hint = 0;
 #ifdef HAVE_SPDK
   void *nvme_task_first = nullptr;
   void *nvme_task_last = nullptr;
@@ -61,7 +62,9 @@ public:
   std::atomic_int num_running = {0};
   bool allow_eio;
 
-  explicit IOContext(CephContext* cct, void *p, bool allow_eio = false)
+  explicit IOContext(CephContext* cct,
+                     void *p,
+                     bool allow_eio = false)
     : cct(cct), priv(p), allow_eio(allow_eio)
     {}
 
@@ -129,7 +132,11 @@ public:
   virtual ~BlockDevice() = default;
 
   static BlockDevice *create(
-    CephContext* cct, const std::string& path, aio_callback_t cb, void *cbpriv);
+    CephContext* cct,
+    const std::string& path,
+    aio_callback_t cb,
+    void *cbpriv,
+    size_t max_shard_num = 1 /* no sharding */);
   virtual bool supported_bdev_label() { return true; }
   virtual bool is_rotational() { return rotational; }
 

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -205,6 +205,11 @@ public:
     bufferlist& bl,
     IOContext *ioc,
     bool buffered) = 0;
+  virtual int aio_write(
+    uint64_t off,
+    bufferlist& bl,
+    RDOnlyIOContext *ioc,
+    bool buffered) = delete;
   virtual int flush() = 0;
 
   void queue_reap_ioc(IOContext *ioc);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3884,9 +3884,10 @@ int BlueStore::BlueReadTrans::_do_read(
   if (!cr.blobs2read.empty()) {
     // yes, at least one region isn't in cache
     if (!aio) {
-      aio = std::make_unique<AioReadBatch>(store->cct);
-      Collection *c = static_cast<Collection *>(this->c.get());
-      aio->ioc.shard_hint = c->get_cid().hash_to_shard(store->cache_shards.size());
+      Collection* const c = static_cast<Collection *>(this->c.get());
+      const auto shard_hint = \
+        c->get_cid().hash_to_shard(store->cache_shards.size());
+      aio = std::make_unique<AioReadBatch>(store->cct, shard_hint);
     }
 
     aio->queue_read_ctx(std::move(cr),

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3524,7 +3524,7 @@ void BlueStore::AioReadBatch::aio_finish(BlueStore* const store)
   }
 
   on_all_complete->complete(0);
-  delete this;
+  delete static_cast<AioReadBatch*>(this);
 }
 
 // =======================================================

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6844,9 +6844,21 @@ int BlueStore::_do_read(
   }
 
   // generate a resulting buffer
+  bl = _do_read_compose_result(ready_regions, offset, length);
+
+  assert(bl.length() == length);
+  return bl.length();
+}
+
+ceph::bufferlist BlueStore::_do_read_compose_result(
+  BlueStore::ready_regions_t& ready_regions,
+  const size_t offset,
+  const size_t length)
+{
   auto pr = ready_regions.begin();
-  auto pr_end = ready_regions.end();
+  const auto pr_end = ready_regions.end();
   uint64_t pos = 0;
+  ceph::bufferlist bl;
   while (pos < length) {
     if (pr != pr_end && pr->first == pos + offset) {
       dout(30) << __func__ << " assemble 0x" << std::hex << pos
@@ -6868,10 +6880,9 @@ int BlueStore::_do_read(
       pos += l;
     }
   }
-  assert(bl.length() == length);
   assert(pos == length);
   assert(pr == pr_end);
-  return bl.length();
+  return bl;
 }
 
 int BlueStore::RegionReader::_verify_csum(

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1749,9 +1749,9 @@ public:
       regions2read.emplace_back(logical_offset, blob_offset, length);
     }
 
-    int _decompress(
-      ceph::bufferlist& source,
-      ceph::bufferlist* result);
+    boost::optional<ceph::bufferlist> _decompress(
+      ceph::bufferlist& source);
+
   public:
     using RegionReader::RegionReader;
     int issue_io(io_issuer_t) override;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <condition_variable>
 
+#include <boost/container/small_vector.hpp>
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/unordered_set.hpp>
 #include <boost/intrusive/set.hpp>
@@ -1723,7 +1724,7 @@ public:
       using region_t::region_t;
     };
 
-    std::vector<plain_region_t> regions2read;
+    boost::container::small_vector<plain_region_t, 1> regions2read;
 
     void add_region_hint(
       const uint64_t logical_offset,
@@ -1739,7 +1740,7 @@ public:
   };
 
   class CompressedRegionReader : public RegionReader {
-    std::vector<region_t> regions2read;
+    boost::container::small_vector<region_t, 1> regions2read;
     ceph::bufferlist compressed_bl;
    
     void add_region_hint(
@@ -1794,7 +1795,7 @@ public:
       }
     };
 
-    std::vector<read_ctx_t> read_ctx_batch;
+    boost::container::small_vector<read_ctx_t, 1> read_ctx_batch;
     Context* on_all_complete;
     IOContext ioc;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1797,17 +1797,11 @@ public:
 
     boost::container::small_vector<read_ctx_t, 1> read_ctx_batch;
     Context* on_all_complete;
-    IOContext ioc;
+    RDOnlyIOContext ioc;
 
-    AioReadBatch(CephContext* const cct,
-                 Context* const on_all_complete)
-      : on_all_complete(on_all_complete),
-        ioc(cct, this, true) { // allow EIO
-    }
-
-    AioReadBatch(CephContext* const cct)
+    AioReadBatch(CephContext* const cct, const size_t shard_hint)
       : on_all_complete(nullptr),
-        ioc(cct, this, true) { // allow EIO
+        ioc(cct, this, shard_hint, true) { // allow EIO
     }
 
     read_ctx_t& create_read_ctx(async_read_params_t params) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1761,11 +1761,13 @@ public:
   typedef std::map<BlobRef,
                    RegionReaderRef> blobs2read_t;
 
+  struct cache_response_t {
+    ready_regions_t ready_regions;
+    blobs2read_t blobs2read;
+    size_t num_all_regions;
+  };
   
-  std::tuple<BlueStore::ready_regions_t,
-             BlueStore::blobs2read_t,
-             size_t>
-  _consult_cache(
+  cache_response_t _consult_cache(
     BlueStore::OnodeRef o,
     const uint64_t offset,
     const size_t length);
@@ -1773,10 +1775,7 @@ public:
   struct AioReadBatch : public AioContext {
     struct read_ctx_t {
       async_read_params_t params;
-
-      ready_regions_t ready_regions;
-      blobs2read_t blobs2read;
-      size_t num_all_regions = 0;
+      cache_response_t cache_response;
 
       read_ctx_t(async_read_params_t params)
         : params(std::move(params)) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1780,10 +1780,16 @@ public:
       read_ctx_t(async_read_params_t params)
         : params(std::move(params)) {
       }
+
+      read_ctx_t(async_read_params_t&& params,
+                 cache_response_t&& cache_response)
+        : params(std::move(params)),
+          cache_response(std::move(cache_response)) {
+      }
     };
 
     std::vector<read_ctx_t> read_ctx_batch;
-    Context* const on_all_complete;
+    Context* on_all_complete;
     IOContext ioc;
 
     AioReadBatch(CephContext* const cct,
@@ -1792,8 +1798,20 @@ public:
         ioc(cct, this, true) { // allow EIO
     }
 
+    AioReadBatch(CephContext* const cct)
+      : on_all_complete(nullptr),
+        ioc(cct, this, true) { // allow EIO
+    }
+
     read_ctx_t& create_read_ctx(async_read_params_t params) {
       read_ctx_batch.push_back(std::move(params));
+      return read_ctx_batch.back();
+    }
+
+    read_ctx_t& queue_read_ctx(cache_response_t&& cache_response,
+                               async_read_params_t&& params) {
+      read_ctx_batch.emplace_back(std::move(params),
+                                  std::move(cache_response));
       return read_ctx_batch.back();
     }
 
@@ -2405,6 +2423,47 @@ public:
     size_t len,
     bufferlist& bl,
     uint32_t op_flags = 0);
+
+  class BlueReadTrans : public ObjectStore::ReadTransaction {
+    BlueStore* const store;
+    CollectionHandle c;
+    OnodeRef o;
+    std::unique_ptr<AioReadBatch> aio;
+
+    int _do_read(
+      uint64_t offset,
+      uint64_t length,
+      uint32_t flags,
+      ceph::bufferlist& destbl,
+      Context* on_complete);
+
+  public:
+    BlueReadTrans(BlueStore* const store,
+                  CollectionHandle&& c,
+                  OnodeRef&& o)
+    : store(store),
+      c(std::move(c)),
+      o(std::move(o)) {
+    }
+
+    int read(
+      uint64_t offset,
+      uint64_t length,
+      uint32_t flags,
+      ceph::bufferlist& destbl,
+      Context* on_complete) override;
+
+    bool empty() const override {
+      return !aio || aio->read_ctx_batch.empty();
+    }
+
+    int apply(Context* on_complete) override;
+  };
+
+  std::unique_ptr<ReadTransaction> create_read_transaction(
+    const CollectionHandle& c,
+    const ghobject_t& oid
+  ) override;
 
   bool has_async_read() const override {
     return true;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1475,7 +1475,7 @@ public:
     }
   };
 
-  struct TransContext : public AioContext {
+  struct TransContext final : public AioContext {
     MEMPOOL_CLASS_HELPERS();
 
     typedef enum {
@@ -1617,7 +1617,7 @@ public:
       boost::intrusive::list_member_hook<>,
       &TransContext::deferred_queue_item> > deferred_queue_t;
 
-  struct DeferredBatch : public AioContext {
+  struct DeferredBatch final : public AioContext {
     OpSequencer *osr;
     struct deferred_io {
       bufferlist bl;    ///< data

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1778,7 +1778,7 @@ public:
     INDEX
   };
 
-  struct AioReadBatch : public AioContext {
+  struct AioReadBatch final : public AioContext {
     struct read_ctx_t {
       async_read_params_t params;
       cache_response_t cache_response;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2578,7 +2578,12 @@ private:
 
   // --------------------------------------------------------
   // read processing internal methods
-  bool _do_read_is_buffered(const uint32_t op_flags) const;
+  bool _do_read_is_buffered(
+    const uint32_t op_flags) const;
+  ceph::bufferlist _do_read_compose_result(
+    BlueStore::ready_regions_t& ready_regions,
+    size_t offset,
+    size_t length);
 
 
   // --------------------------------------------------------

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -61,10 +61,11 @@ class KernelDevice : public BlockDevice {
     int start(CephContext* cct);
     void stop(CephContext* cct);
   };
+  aio_service_t aio_main_service;
   static constexpr size_t expected_max_shard_num = 16;
   boost::container::static_vector<
     aio_service_t,
-    expected_max_shard_num> aio_services;
+    expected_max_shard_num> aio_rdonly_services;
 
   void _aio_thread(aio_queue_t& aio_queue, const bool& aio_stop);
   int _aio_start();
@@ -93,6 +94,7 @@ public:
                size_t max_shard_num);
 
   void aio_submit(IOContext *ioc) override;
+  void aio_submit(RDOnlyIOContext *ioc) override;
 
   int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;
   int get_devname(std::string *s) override {

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -114,6 +114,7 @@ public:
   int read_random(uint64_t off, uint64_t len, char *buf, bool buffered) override;
 
   int write(uint64_t off, bufferlist& bl, bool buffered) override;
+  using BlockDevice::aio_write;
   int aio_write(uint64_t off, bufferlist& bl,
 		IOContext *ioc,
 		bool buffered) override;

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -68,6 +68,7 @@ class NVMEDevice : public BlockDevice {
     uint64_t len,
     bufferlist *pbl,
     IOContext *ioc) override;
+  using BlockDevice::aio_write;
   int aio_write(uint64_t off, bufferlist& bl,
                 IOContext *ioc,
                 bool buffered) override;

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -57,6 +57,7 @@ class NVMEDevice : public BlockDevice {
 
   bool supported_bdev_label() override { return false; }
 
+  using BlockDevice::aio_submit;
   void aio_submit(IOContext *ioc) override;
 
   int read(uint64_t off, uint64_t len, bufferlist *pbl,

--- a/src/os/bluestore/PMEMDevice.h
+++ b/src/os/bluestore/PMEMDevice.h
@@ -39,6 +39,7 @@ public:
   PMEMDevice(CephContext *cct, aio_callback_t cb, void *cbpriv);
 
 
+  using BlockDevice::aio_submit;
   void aio_submit(IOContext *ioc) override;
 
   int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;

--- a/src/os/bluestore/PMEMDevice.h
+++ b/src/os/bluestore/PMEMDevice.h
@@ -52,6 +52,7 @@ public:
 
   int read_random(uint64_t off, uint64_t len, char *buf, bool buffered) override;
   int write(uint64_t off, bufferlist& bl, bool buffered) override;
+  using BlockDevice::aio_write;
   int aio_write(uint64_t off, bufferlist& bl,
 		IOContext *ioc,
 		bool buffered) override;

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1368,7 +1368,7 @@ void ECBackend::filter_read_op(
 
   if (op.in_progress.empty()) {
     get_parent()->schedule_recovery_work(
-      get_parent()->bless_gencontext(
+      get_parent()->bless_unlocked_gencontext(
 	new FinishReadOp(this, op.tid)));
   }
 }

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2125,6 +2125,18 @@ int ECBackend::ECReadTransaction::read(
   return -EINPROGRESS;
 }
 
+int ECBackend::ECReadTransaction::read_sparse(
+  uint64_t offset,
+  uint64_t length,
+  uint32_t flags,
+  ceph::bufferlist& destbl,
+  Context* on_complete)
+{
+  pending_async_reads.emplace_back(offset, length, &destbl,
+                                   on_complete, flags);
+  return -EINPROGRESS;
+}
+
 int ECBackend::ECReadTransaction::apply(Context *on_complete)
 {
   std::vector<ObjectStore::async_read_params_t> to_read;

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -197,6 +197,13 @@ public:
       ceph::bufferlist& destbl,
       Context* on_complete) override;
 
+    int read_sparse(
+      uint64_t offset,
+      uint64_t length,
+      uint32_t flags,
+      ceph::bufferlist& destbl,
+      Context* on_complete) override;
+
     bool empty() const override {
       return pending_async_reads.empty();
     }

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -177,8 +177,7 @@ public:
   list<ClientAsyncReadStatus> in_progress_client_reads;
   void objects_read_async(
     const hobject_t &hoid,
-    const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
-		    pair<bufferlist*, Context*> > > &to_read,
+    std::vector<async_read_params_t> to_read,
     Context *on_complete,
     bool fast_read = false) override;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1716,6 +1716,22 @@ void OSDService::enqueue_front(OpQueueItem&& qi)
   osd->op_shardedwq.queue_front(std::move(qi));
 }
 
+void OSDService::queue_recovery_context(
+  PG *pg,
+  GenContext<ThreadPool::TPHandle&> *c)
+{
+  epoch_t e = get_osdmap()->get_epoch();
+  enqueue_back(
+    OpQueueItem(
+      unique_ptr<OpQueueItem::OpQueueable>(
+	new PGRecoveryContext(pg->get_pgid(), c, e)),
+      cct->_conf->osd_recovery_cost,
+      cct->_conf->osd_recovery_priority,
+      ceph_clock_now(),
+      0,
+      e));
+}
+
 void OSDService::queue_for_snap_trim(PG *pg)
 {
   dout(10) << "queueing " << *pg << " for snaptrim" << dendl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9770,14 +9770,14 @@ int OSD::init_op_flags(OpRequestRef& op)
 
 void OSD::ShardedOpWQ::wake_pg_waiters(spg_t pgid)
 {
-  uint32_t shard_index = pgid.hash_to_shard(shard_list.size());
-  auto sdata = shard_list[shard_index];
+  uint32_t shard_index = pgid.hash_to_shard(shards.size());
+  auto& sdata = shards[shard_index];
   bool queued = false;
   unsigned pushes_to_free = 0;
   {
-    Mutex::Locker l(sdata->sdata_op_ordering_lock);
-    auto p = sdata->pg_slots.find(pgid);
-    if (p != sdata->pg_slots.end()) {
+    Mutex::Locker l(sdata.sdata_op_ordering_lock);
+    auto p = sdata.pg_slots.find(pgid);
+    if (p != sdata.pg_slots.end()) {
       dout(20) << __func__ << " " << pgid
 	       << " to_process " << p->second.to_process
 	       << " waiting_for_pg=" << (int)p->second.waiting_for_pg << dendl;
@@ -9787,7 +9787,7 @@ void OSD::ShardedOpWQ::wake_pg_waiters(spg_t pgid)
       for (auto i = p->second.to_process.rbegin();
 	   i != p->second.to_process.rend();
 	   ++i) {
-	sdata->_enqueue_front(std::move(*i), osd->op_prio_cutoff);
+	sdata._enqueue_front(std::move(*i), osd->op_prio_cutoff);
       }
       p->second.to_process.clear();
       p->second.waiting_for_pg = false;
@@ -9799,20 +9799,20 @@ void OSD::ShardedOpWQ::wake_pg_waiters(spg_t pgid)
     osd->service.release_reserved_pushes(pushes_to_free);
   }
   if (queued) {
-    sdata->sdata_lock.Lock();
-    sdata->sdata_cond.SignalOne();
-    sdata->sdata_lock.Unlock();
+    sdata.sdata_lock.Lock();
+    sdata.sdata_cond.SignalOne();
+    sdata.sdata_lock.Unlock();
   }
 }
 
 void OSD::ShardedOpWQ::prune_pg_waiters(OSDMapRef osdmap, int whoami)
 {
   unsigned pushes_to_free = 0;
-  for (auto sdata : shard_list) {
-    Mutex::Locker l(sdata->sdata_op_ordering_lock);
-    sdata->waiting_for_pg_osdmap = osdmap;
-    auto p = sdata->pg_slots.begin();
-    while (p != sdata->pg_slots.end()) {
+  for (auto& sdata : shards) {
+    Mutex::Locker l(sdata.sdata_op_ordering_lock);
+    sdata.waiting_for_pg_osdmap = osdmap;
+    auto p = sdata.pg_slots.begin();
+    while (p != sdata.pg_slots.end()) {
       ShardData::pg_slot& slot = p->second;
       if (!slot.to_process.empty() && slot.num_running == 0) {
 	if (osdmap->is_up_acting_osd_shard(p->first, whoami)) {
@@ -9837,7 +9837,7 @@ void OSD::ShardedOpWQ::prune_pg_waiters(OSDMapRef osdmap, int whoami)
 	  slot.num_running == 0 &&
 	  !slot.pg) {
 	dout(20) << __func__ << "  " << p->first << " empty, pruning" << dendl;
-	p = sdata->pg_slots.erase(p);
+	p = sdata.pg_slots.erase(p);
       } else {
 	++p;
       }
@@ -9850,11 +9850,11 @@ void OSD::ShardedOpWQ::prune_pg_waiters(OSDMapRef osdmap, int whoami)
 
 void OSD::ShardedOpWQ::clear_pg_pointer(spg_t pgid)
 {
-  uint32_t shard_index = pgid.hash_to_shard(shard_list.size());
-  auto sdata = shard_list[shard_index];
-  Mutex::Locker l(sdata->sdata_op_ordering_lock);
-  auto p = sdata->pg_slots.find(pgid);
-  if (p != sdata->pg_slots.end()) {
+  uint32_t shard_index = pgid.hash_to_shard(shards.size());
+  auto& sdata = shards[shard_index];
+  Mutex::Locker l(sdata.sdata_op_ordering_lock);
+  auto p = sdata.pg_slots.find(pgid);
+  if (p != sdata.pg_slots.end()) {
     auto& slot = p->second;
     dout(20) << __func__ << " " << pgid << " pg " << slot.pg << dendl;
     assert(!slot.pg || slot.pg->is_deleting());
@@ -9864,10 +9864,10 @@ void OSD::ShardedOpWQ::clear_pg_pointer(spg_t pgid)
 
 void OSD::ShardedOpWQ::clear_pg_slots()
 {
-  for (auto sdata : shard_list) {
-    Mutex::Locker l(sdata->sdata_op_ordering_lock);
-    sdata->pg_slots.clear();
-    sdata->waiting_for_pg_osdmap.reset();
+  for (auto& sdata : shards) {
+    Mutex::Locker l(sdata.sdata_op_ordering_lock);
+    sdata.pg_slots.clear();
+    sdata.waiting_for_pg_osdmap.reset();
     // don't bother with reserved pushes; we are shutting down
   }
 }
@@ -9877,43 +9877,42 @@ void OSD::ShardedOpWQ::clear_pg_slots()
 
 void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 {
-  uint32_t shard_index = thread_index % num_shards;
-  auto& sdata = shard_list[shard_index];
-  assert(sdata);
+  uint32_t shard_index = thread_index % shards.size();
+  auto& sdata = shards[shard_index];
   // peek at spg_t
-  sdata->sdata_op_ordering_lock.Lock();
-  if (sdata->pqueue->empty()) {
-    sdata->sdata_lock.Lock();
-    if (!sdata->stop_waiting) {
+  sdata.sdata_op_ordering_lock.Lock();
+  if (sdata.pqueue->empty()) {
+    sdata.sdata_lock.Lock();
+    if (!sdata.stop_waiting) {
       dout(20) << __func__ << " empty q, waiting" << dendl;
       osd->cct->get_heartbeat_map()->clear_timeout(hb);
-      sdata->sdata_op_ordering_lock.Unlock();
-      sdata->sdata_cond.Wait(sdata->sdata_lock);
-      sdata->sdata_lock.Unlock();
-      sdata->sdata_op_ordering_lock.Lock();
-      if (sdata->pqueue->empty()) {
-	sdata->sdata_op_ordering_lock.Unlock();
+      sdata.sdata_op_ordering_lock.Unlock();
+      sdata.sdata_cond.Wait(sdata.sdata_lock);
+      sdata.sdata_lock.Unlock();
+      sdata.sdata_op_ordering_lock.Lock();
+      if (sdata.pqueue->empty()) {
+	sdata.sdata_op_ordering_lock.Unlock();
 	return;
       }
       osd->cct->get_heartbeat_map()->reset_timeout(hb,
 	  osd->cct->_conf->threadpool_default_timeout, 0);
     } else {
       dout(0) << __func__ << " need return immediately" << dendl;
-      sdata->sdata_lock.Unlock();
-      sdata->sdata_op_ordering_lock.Unlock();
+      sdata.sdata_lock.Unlock();
+      sdata.sdata_op_ordering_lock.Unlock();
       return;
     }
   }
-  OpQueueItem item = sdata->pqueue->dequeue();
+  OpQueueItem item = sdata.pqueue->dequeue();
   if (osd->is_stopping()) {
-    sdata->sdata_op_ordering_lock.Unlock();
+    sdata.sdata_op_ordering_lock.Unlock();
     return;    // OSD shutdown, discard.
   }
   PGRef pg;
   uint64_t requeue_seq;
   const auto token = item.get_ordering_token();
   {
-    auto& slot = sdata->pg_slots[token];
+    auto& slot = sdata.pg_slots[token];
     dout(30) << __func__ << " " << token
 	     << " to_process " << slot.to_process
 	     << " waiting_for_pg=" << (int)slot.waiting_for_pg << dendl;
@@ -9924,7 +9923,7 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
       // save ourselves a bit of effort
       dout(20) << __func__ << slot.to_process.back()
 	       << " queued, waiting_for_pg" << dendl;
-      sdata->sdata_op_ordering_lock.Unlock();
+      sdata.sdata_op_ordering_lock.Unlock();
       return;
     }
     pg = slot.pg;
@@ -9932,7 +9931,7 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 	     << " queued" << dendl;
     ++slot.num_running;
   }
-  sdata->sdata_op_ordering_lock.Unlock();
+  sdata.sdata_op_ordering_lock.Unlock();
 
   osd->service.maybe_inject_dispatch_delay();
 
@@ -9947,10 +9946,10 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 
   // we don't use a Mutex::Locker here because of the
   // osd->service.release_reserved_pushes() call below
-  sdata->sdata_op_ordering_lock.Lock();
+  sdata.sdata_op_ordering_lock.Lock();
 
-  auto q = sdata->pg_slots.find(token);
-  assert(q != sdata->pg_slots.end());
+  auto q = sdata.pg_slots.find(token);
+  assert(q != sdata.pg_slots.end());
   auto& slot = q->second;
   --slot.num_running;
 
@@ -9961,7 +9960,7 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
     if (pg) {
       pg->unlock();
     }
-    sdata->sdata_op_ordering_lock.Unlock();
+    sdata.sdata_op_ordering_lock.Unlock();
     return;
   }
   if (requeue_seq != slot.requeue_seq) {
@@ -9972,7 +9971,7 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
     if (pg) {
       pg->unlock();
     }
-    sdata->sdata_op_ordering_lock.Unlock();
+    sdata.sdata_op_ordering_lock.Unlock();
     return;
   }
   if (pg && !slot.pg && !pg->is_deleting()) {
@@ -9990,7 +9989,7 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
     if (pg) {
       pg->unlock();
     }
-    sdata->sdata_op_ordering_lock.Unlock();
+    sdata.sdata_op_ordering_lock.Unlock();
     return;
   }
 
@@ -10001,7 +10000,7 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 
   if (!pg) {
     // should this pg shard exist on this osd in this (or a later) epoch?
-    OSDMapRef osdmap = sdata->waiting_for_pg_osdmap;
+    OSDMapRef osdmap = sdata.waiting_for_pg_osdmap;
     if (osdmap->is_up_acting_osd_shard(token,
 				       osd->whoami)) {
       dout(20) << __func__ << " " << token
@@ -10024,21 +10023,21 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 	Session *session = static_cast<Session *>(
 	  (*_op)->get_req()->get_connection()->get_priv());
 	if (session) {
-	  osd->maybe_share_map(session, *_op, sdata->waiting_for_pg_osdmap);
+	  osd->maybe_share_map(session, *_op, sdata.waiting_for_pg_osdmap);
 	  session->put();
 	}
       }
       unsigned pushes_to_free = qi.get_reserved_pushes();
       if (pushes_to_free > 0) {
-	sdata->sdata_op_ordering_lock.Unlock();
+	sdata.sdata_op_ordering_lock.Unlock();
 	osd->service.release_reserved_pushes(pushes_to_free);
 	return;
       }
     }
-    sdata->sdata_op_ordering_lock.Unlock();
+    sdata.sdata_op_ordering_lock.Unlock();
     return;
   }
-  sdata->sdata_op_ordering_lock.Unlock();
+  sdata.sdata_op_ordering_lock.Unlock();
 
 
   // osd_opwq_process marks the point at which an operation has been dequeued
@@ -10081,37 +10080,35 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 
 void OSD::ShardedOpWQ::_enqueue(OpQueueItem&& item) {
   uint32_t shard_index =
-    item.get_ordering_token().hash_to_shard(shard_list.size());
+    item.get_ordering_token().hash_to_shard(shards.size());
 
-  ShardData* sdata = shard_list[shard_index];
-  assert (NULL != sdata);
+  auto& sdata = shards[shard_index];
   unsigned priority = item.get_priority();
   unsigned cost = item.get_cost();
-  sdata->sdata_op_ordering_lock.Lock();
+  sdata.sdata_op_ordering_lock.Lock();
 
   dout(20) << __func__ << " " << item << dendl;
   if (priority >= osd->op_prio_cutoff)
-    sdata->pqueue->enqueue_strict(
+    sdata.pqueue->enqueue_strict(
       item.get_owner(), priority, std::move(item));
   else
-    sdata->pqueue->enqueue(
+    sdata.pqueue->enqueue(
       item.get_owner(), priority, cost, std::move(item));
-  sdata->sdata_op_ordering_lock.Unlock();
+  sdata.sdata_op_ordering_lock.Unlock();
 
-  sdata->sdata_lock.Lock();
-  sdata->sdata_cond.SignalOne();
-  sdata->sdata_lock.Unlock();
+  sdata.sdata_lock.Lock();
+  sdata.sdata_cond.SignalOne();
+  sdata.sdata_lock.Unlock();
 
 }
 
 void OSD::ShardedOpWQ::_enqueue_front(OpQueueItem&& item)
 {
-  auto shard_index = item.get_ordering_token().hash_to_shard(shard_list.size());
-  auto& sdata = shard_list[shard_index];
-  assert(sdata);
-  sdata->sdata_op_ordering_lock.Lock();
-  auto p = sdata->pg_slots.find(item.get_ordering_token());
-  if (p != sdata->pg_slots.end() && !p->second.to_process.empty()) {
+  auto shard_index = item.get_ordering_token().hash_to_shard(shards.size());
+  auto& sdata = shards[shard_index];
+  sdata.sdata_op_ordering_lock.Lock();
+  auto p = sdata.pg_slots.find(item.get_ordering_token());
+  if (p != sdata.pg_slots.end() && !p->second.to_process.empty()) {
     // we may be racing with _process, which has dequeued a new item
     // from pqueue, put it on to_process, and is now busy taking the
     // pg lock.  ensure this old requeued item is ordered before any
@@ -10125,11 +10122,11 @@ void OSD::ShardedOpWQ::_enqueue_front(OpQueueItem&& item)
   } else {
     dout(20) << __func__ << " " << item << dendl;
   }
-  sdata->_enqueue_front(std::move(item), osd->op_prio_cutoff);
-  sdata->sdata_op_ordering_lock.Unlock();
-  sdata->sdata_lock.Lock();
-  sdata->sdata_cond.SignalOne();
-  sdata->sdata_lock.Unlock();
+  sdata._enqueue_front(std::move(item), osd->op_prio_cutoff);
+  sdata.sdata_op_ordering_lock.Unlock();
+  sdata.sdata_lock.Lock();
+  sdata.sdata_cond.SignalOne();
+  sdata.sdata_lock.Unlock();
 }
 
 namespace ceph { 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1624,7 +1624,7 @@ private:
   friend class PGPeeringItem;
   friend class PGRecovery;
 
-  class ShardedOpWQ
+  class ShardedOpWQ final
     : public ShardedThreadPool::ShardedWQ<OpQueueItem>
   {
     struct ShardData {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -876,6 +876,7 @@ public:
   SafeTimer scrub_sleep_timer;
 
   AsyncReserver<spg_t> snap_reserver;
+  void queue_recovery_context(PG *pg, GenContext<ThreadPool::TPHandle&> *c);
   void queue_for_snap_trim(PG *pg);
   void queue_for_scrub(PG *pg, bool with_high_priority);
 

--- a/src/osd/OpQueueItem.cc
+++ b/src/osd/OpQueueItem.cc
@@ -55,4 +55,11 @@ void PGRecovery::run(OSD *osd,
   pg->unlock();
 }
 
-
+void PGRecoveryContext::run(
+  OSD *osd,
+  PGRef& pg,
+  ThreadPool::TPHandle &handle)
+{
+  c.release()->complete(handle);
+  pg->unlock();
+}

--- a/src/osd/OpQueueItem.h
+++ b/src/osd/OpQueueItem.h
@@ -276,3 +276,23 @@ public:
   virtual void run(
     OSD *osd, PGRef& pg, ThreadPool::TPHandle &handle) override final;
 };
+
+class PGRecoveryContext : public PGOpQueueable {
+  unique_ptr<GenContext<ThreadPool::TPHandle&>> c;
+  epoch_t epoch;
+public:
+  PGRecoveryContext(spg_t pgid,
+		    GenContext<ThreadPool::TPHandle&> *c, epoch_t epoch)
+    : PGOpQueueable(pgid),
+      c(c), epoch(epoch) {}
+  op_type_t get_op_type() const override final {
+    return op_type_t::bg_recovery;
+  }
+  ostream &print(ostream &rhs) const override final {
+    return rhs << "PGRecoveryContext(pgid=" << get_pgid()
+	       << " c=" << c.get() << " epoch=" << epoch
+	       << ")";
+  }
+  void run(
+    OSD *osd, PGRef& pg, ThreadPool::TPHandle &handle) override final;
+};

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2866,7 +2866,7 @@ void PG::publish_stats_to_osd()
   if (get_osdmap()->require_osd_release >= CEPH_RELEASE_MIMIC) {
     // share (some of) our purged_snaps via the pg_stats. limit # of intervals
     // because we don't want to make the pg_stat_t structures too expensive.
-    unsigned max = cct->_conf->get_val<uint64_t>("osd_max_snap_prune_intervals_per_epoch");
+    unsigned max = cct->_conf->osd_max_snap_prune_intervals_per_epoch;
     unsigned num = 0;
     auto i = info.purged_snaps.begin();
     while (num < max && i != info.purged_snaps.end()) {

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -550,11 +550,8 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      uint32_t op_flags,
      bufferlist *bl) = 0;
 
-   using async_read_params_t = ObjectStore::async_read_params_t;
-   virtual void objects_read_async(
-     const hobject_t &hoid,
-     std::vector<async_read_params_t> to_read,
-     Context *on_complete, bool fast_read = false) = 0;
+   virtual std::unique_ptr<ObjectStore::ReadTransaction>
+   create_read_transaction(const hobject_t &hoid) = 0;
 
    virtual bool auto_repair_supported() const = 0;
    void be_scan_list(

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -141,6 +141,8 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      virtual Context *bless_context(Context *c) = 0;
      virtual GenContext<ThreadPool::TPHandle&> *bless_gencontext(
        GenContext<ThreadPool::TPHandle&> *c) = 0;
+     virtual GenContext<ThreadPool::TPHandle&> *bless_unlocked_gencontext(
+       GenContext<ThreadPool::TPHandle&> *c) = 0;
 
      virtual void send_message(int to_osd, Message *m) = 0;
      virtual void queue_transaction(

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -550,10 +550,10 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      uint32_t op_flags,
      bufferlist *bl) = 0;
 
+   using async_read_params_t = ObjectStore::async_read_params_t;
    virtual void objects_read_async(
      const hobject_t &hoid,
-     const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
-		pair<bufferlist*, Context*> > > &to_read,
+     std::vector<async_read_params_t> to_read,
      Context *on_complete, bool fast_read = false) = 0;
 
    virtual bool auto_repair_supported() const = 0;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -318,11 +318,9 @@ void PrimaryLogPG::OpContext::start_async_reads(PrimaryLogPG *pg)
 
     // called by recovery workers
     void finish(ThreadPool::TPHandle&) override {
-      pg->lock();
       if (!pg->pg_has_reset_since(e)) {
         opcontext->finish_read(pg.get());
       }
-      pg->unlock();
     }
   };
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3516,7 +3516,6 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
   if (result == -EINPROGRESS || pending_async_reads) {
     // come back later.
     if (pending_async_reads) {
-      assert(pool.info.is_erasure());
       in_progress_async_reads.push_back(make_pair(op, ctx));
       ctx->start_async_reads(this);
     }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -25,6 +25,7 @@
 #include "Session.h"
 #include "objclass/objclass.h"
 
+#include "common/config_cacher.h"
 #include "common/errno.h"
 #include "common/scrub_types.h"
 #include "common/perf_counters.h"
@@ -5321,8 +5322,10 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   ObjectState& obs = ctx->new_obs;
   object_info_t& oi = obs.oi;
   const hobject_t& soid = oi.soid;
+  static md_config_cacher_t<bool> data_digest_proxy(
+    *g_conf, "osd_skip_data_digest");
   bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->osd_skip_data_digest;
+    data_digest_proxy.get_val();
 
   PGTransaction* t = ctx->op_t.get();
   if (!oi.has_extents() &&

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -198,18 +198,6 @@ class PrimaryLogPG::C_OSD_OndiskWriteUnlock : public Context {
   }
 };
 
-struct OnReadComplete : public Context {
-  PrimaryLogPG *pg;
-  PrimaryLogPG::OpContext *opcontext;
-  OnReadComplete(
-    PrimaryLogPG *pg,
-    PrimaryLogPG::OpContext *ctx) : pg(pg), opcontext(ctx) {}
-  void finish(int r) override {
-    opcontext->finish_read(pg);
-  }
-  ~OnReadComplete() override {}
-};
-
 class PrimaryLogPG::C_OSD_AppliedRecoveredObject : public Context {
   PrimaryLogPGRef pg;
   ObjectContextRef obc;
@@ -246,16 +234,108 @@ class PrimaryLogPG::C_OSD_AppliedRecoveredObjectReplica : public Context {
 };
 
 // OpContext
+int PrimaryLogPG::OpContext::read_maybe_async(
+  const hobject_t &hoid,
+  const OSDOp& osd_op,
+  const uint64_t offset,
+  const uint64_t length,
+  ceph::bufferlist* const destbl,
+  Context* const on_complete,
+  const uint32_t flags)
+{
+  struct ReadFinisher : public PrimaryLogPG::OpFinisher {
+    const OSDOp& osd_op;
+
+    ReadFinisher(const OSDOp& osd_op)
+      : osd_op(osd_op) {
+    }
+
+    int execute() override {
+      return osd_op.rval;
+    }
+  };
+
+  if (!read_transaction) {
+    read_transaction = pg->pgbackend->create_read_transaction(hoid);
+  }
+
+  const int ret = read_transaction->read(offset, length, flags,
+                                         *destbl, on_complete);
+  if (ret == -EINPROGRESS) {
+    // if the underlying implementation decides to go async,
+    // then it returns -EINPROGRESS
+    //dout(10) << " async_read noted for " << soid << dendl;
+
+    op_finishers[current_osd_subop_num] = \
+      std::make_unique<ReadFinisher>(osd_op);
+  } else if (ret < 0) {
+    on_complete->complete(ret);
+  }
+  return ret;
+}
+
 void PrimaryLogPG::OpContext::start_async_reads(PrimaryLogPG *pg)
 {
+  struct OnReadComplete : public Context {
+    PrimaryLogPG *pg;
+    PrimaryLogPG::OpContext *opcontext;
+    OnReadComplete(
+      PrimaryLogPG *pg,
+      PrimaryLogPG::OpContext *ctx) : pg(pg), opcontext(ctx) {}
+    void finish(int r) override {
+      opcontext->finish_read(pg);
+    }
+    ~OnReadComplete() override {}
+  };
+
+
+  struct BlessedReadCompleter : public Context,
+                                public GenContext<ThreadPool::TPHandle&> {
+    PrimaryLogPGRef pg;
+    PrimaryLogPG::OpContext *opcontext;
+    epoch_t e;
+
+    BlessedReadCompleter(PrimaryLogPG* const pg,
+                         PrimaryLogPG::OpContext* const opcontext)
+      : pg(pg),
+        opcontext(opcontext),
+        // I would prefer to bless the context later but holding
+        // the PG::lock is a must due to the get_osdmap() call.
+        e(pg->get_epoch()) {
+    }
+
+    void finish(const int) override {
+      pg->schedule_recovery_work(this);
+    }
+
+    /* the purpose of this override is to avoid disposing the object on
+     * the complete() call from ReadTransaction::apply(), and thus let
+     * reuse the GenContext<...> subobject in the recovery work queue. */
+    void complete(const int r) override {
+      finish(r);
+      /* DON'T delete this; */
+    }
+
+    // called by recovery workers
+    void finish(ThreadPool::TPHandle&) override {
+      pg->lock();
+      if (!pg->pg_has_reset_since(e)) {
+        opcontext->finish_read(pg.get());
+      }
+      pg->unlock();
+    }
+  };
+
   inflightreads = 1;
-  std::vector<async_read_params_t> in;
-  in.swap(pending_async_reads);
-  pg->pgbackend->objects_read_async(
-    obc->obs.oi.soid,
-    std::move(in),
-    new OnReadComplete(pg, this), pg->get_pool().fast_read);
+
+  if (pg->pool.info.is_erasure()) {
+    // the EC backend handles blessing contexts on its own
+    read_transaction->apply(new OnReadComplete(pg, this));
+  } else {
+    read_transaction->apply(new BlessedReadCompleter(pg, this));
+  }
 }
+
 void PrimaryLogPG::OpContext::finish_read(PrimaryLogPG *pg)
 {
   // We're called under PG::lock.
@@ -3518,7 +3598,8 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
     obc->ondisk_read_unlock();
   }
 
-  bool pending_async_reads = !ctx->pending_async_reads.empty();
+  bool const pending_async_reads = \
+    ctx->read_transaction && !ctx->read_transaction->empty();
   if (result == -EINPROGRESS || pending_async_reads) {
     // come back later.
     if (pending_async_reads) {
@@ -4666,17 +4747,6 @@ void PrimaryLogPG::maybe_create_new_object(
   }
 }
 
-struct ReadFinisher : public PrimaryLogPG::OpFinisher {
-  OSDOp& osd_op;
-
-  ReadFinisher(OSDOp& osd_op) : osd_op(osd_op) {
-  }
-
-  int execute() override {
-    return osd_op.rval;
-  }
-};
-
 struct C_ChecksumRead : public Context {
   PrimaryLogPG *primary_log_pg;
   OSDOp &osd_op;
@@ -4794,17 +4864,14 @@ int PrimaryLogPG::do_checksum(OpContext *ctx, OSDOp& osd_op,
 					   std::move(init_value_bl), maybe_crc,
 					   oi.size, osd, soid, op.flags);
 
-    ctx->pending_async_reads.emplace_back(
+    return ctx->read_maybe_async(
+      soid,
+      osd_op,
       op.checksum.offset,
       op.checksum.length,
       &checksum_ctx->read_bl,
       checksum_ctx,
       op.flags);
-
-    dout(10) << __func__ << ": async_read noted for " << soid << dendl;
-    ctx->op_finishers[ctx->current_osd_subop_num].reset(
-      new ReadFinisher(osd_op));
-    return -EINPROGRESS;
   }
 
   // sync read
@@ -4967,18 +5034,14 @@ int PrimaryLogPG::do_extent_cmp(OpContext *ctx, OSDOp& osd_op)
     auto& soid = oi.soid;
     auto extent_cmp_ctx = new C_ExtentCmpRead(this, osd_op, maybe_crc, oi.size,
 					      osd, soid, op.flags);
-    ctx->pending_async_reads.emplace_back(
+    return ctx->read_maybe_async(
+      soid,
+      osd_op,
       op.extent.offset,
       op.extent.length,
       &extent_cmp_ctx->read_bl,
       extent_cmp_ctx,
       op.flags);
-
-    dout(10) << __func__ << ": async_read noted for " << soid << dendl;
-
-    ctx->op_finishers[ctx->current_osd_subop_num].reset(
-      new ReadFinisher(osd_op));
-    return -EINPROGRESS;
   }
 
   // sync read
@@ -5051,7 +5114,9 @@ int PrimaryLogPG::do_read(OpContext *ctx, OSDOp& osd_op, bool sync) {
     if (oi.is_data_digest() && op.extent.offset == 0 &&
         op.extent.length >= oi.size)
       maybe_crc = oi.data_digest;
-    ctx->pending_async_reads.emplace_back(
+    ctx->read_maybe_async(
+      soid,
+      osd_op,
       op.extent.offset,
       op.extent.length,
       &osd_op.outdata,
@@ -5059,10 +5124,6 @@ int PrimaryLogPG::do_read(OpContext *ctx, OSDOp& osd_op, bool sync) {
                              &osd_op.outdata, maybe_crc, oi.size,
                              osd, soid, op.flags),
       op.flags);
-    dout(10) << " async_read noted for " << soid << dendl;
-
-    ctx->op_finishers[ctx->current_osd_subop_num].reset(
-      new ReadFinisher(osd_op));
   } else {
     int r = pgbackend->objects_read_sync(
       soid, op.extent.offset, op.extent.length, op.flags, &osd_op.outdata);
@@ -5120,17 +5181,15 @@ int PrimaryLogPG::do_sparse_read(OpContext *ctx, OSDOp& osd_op) {
     }
 
     if (length > 0) {
-      ctx->pending_async_reads.emplace_back(
+      ctx->read_maybe_async(
+        soid,
+        osd_op,
         offset,
         length,
         &osd_op.outdata,
         new ToSparseReadResult(&osd_op.rval, &osd_op.outdata, offset,
                                &op.extent.length),
         op.flags);
-      dout(10) << " async_read (was sparse_read) noted for " << soid << dendl;
-
-      ctx->op_finishers[ctx->current_osd_subop_num].reset(
-        new ReadFinisher(osd_op));
     } else {
       dout(10) << " sparse read ended up empty for " << soid << dendl;
       map<uint64_t, uint64_t> extents;
@@ -7799,7 +7858,7 @@ int PrimaryLogPG::prepare_transaction(OpContext *ctx)
 
   // read-op?  write-op noop? done?
   if (ctx->op_t->empty() && !ctx->modify) {
-    if (ctx->pending_async_reads.empty())
+    if (!ctx->read_transaction || ctx->read_transaction->empty())
       unstable_stats.add(ctx->delta_stats);
     if (ctx->op->may_write() &&
 	get_osdmap()->require_osd_release >= CEPH_RELEASE_KRAKEN) {
@@ -8148,16 +8207,13 @@ int PrimaryLogPG::do_copy_get(OpContext *ctx, bufferlist::iterator& bp,
     if (cursor.data_offset < oi.size) {
       uint64_t max_read = MIN(oi.size - cursor.data_offset, (uint64_t)left);
       if (cb) {
-	async_read_started = true;
-	ctx->pending_async_reads.emplace_back(cursor.data_offset, max_read,
-                                              &bl, cb, osd_op.op.flags);
+	result =  ctx->read_maybe_async(soid, osd_op, cursor.data_offset,
+                                        max_read, &bl, cb, osd_op.op.flags);
 	cb->len = max_read;
-
-        ctx->op_finishers[ctx->current_osd_subop_num].reset(
-          new ReadFinisher(osd_op));
-	result = -EINPROGRESS;
-
-	dout(10) << __func__ << ": async_read noted for " << soid << dendl;
+	async_read_started = true;
+        if (result < 0) {
+          return result;
+        }
       } else {
 	result = pgbackend->objects_read_sync(
 	  oi.soid, cursor.data_offset, max_read, osd_op.op.flags, &bl);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -583,7 +583,7 @@ void PrimaryLogPG::begin_peer_recover(
 void PrimaryLogPG::schedule_recovery_work(
   GenContext<ThreadPool::TPHandle&> *c)
 {
-  osd->recovery_gen_wq.queue(c);
+  osd->queue_recovery_context(this, c);
 }
 
 void PrimaryLogPG::send_message_osd_cluster(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5322,7 +5322,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   object_info_t& oi = obs.oi;
   const hobject_t& soid = oi.soid;
   bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->get_val<bool>("osd_skip_data_digest");
+    g_conf->osd_skip_data_digest;
 
   PGTransaction* t = ctx->op_t.get();
   if (!oi.has_extents() &&

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5097,7 +5097,7 @@ int PrimaryLogPG::do_sparse_read(OpContext *ctx, OSDOp& osd_op) {
   }
 
   ++ctx->num_read;
-  if (pool.info.is_erasure()) {
+  if (pool.info.is_erasure() || osd->store->has_async_read()) {
     // translate sparse read to a normal one if not supported
     uint64_t offset = op.extent.offset;
     uint64_t length = op.extent.length;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -299,10 +299,13 @@ public:
 			     Context *on_complete) override;
 
   template<class T> class BlessedGenContext;
+  template<class T> class UnlockedBlessedGenContext;
   class BlessedContext;
   Context *bless_context(Context *c) override;
 
   GenContext<ThreadPool::TPHandle&> *bless_gencontext(
+    GenContext<ThreadPool::TPHandle&> *c) override;
+  GenContext<ThreadPool::TPHandle&> *bless_unlocked_gencontext(
     GenContext<ThreadPool::TPHandle&> *c) override;
     
   void send_message(int to_osd, Message *m) override {

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1223,7 +1223,7 @@ protected:
     );
 
   int prepare_transaction(OpContext *ctx);
-  list<pair<OpRequestRef, OpContext*> > in_progress_async_reads;
+  std::unordered_map<OpContext*, OpRequestRef> in_progress_async_reads;
   void complete_read_ctx(int result, OpContext *ctx);
   
   // pg on-disk content

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1373,7 +1373,7 @@ protected:
 
   friend class C_ExtentCmpRead;
 
-  int do_read(OpContext *ctx, OSDOp& osd_op);
+  int do_read(OpContext *ctx, OSDOp& osd_op, bool sync);
   int do_sparse_read(OpContext *ctx, OSDOp& osd_op);
   int do_writesame(OpContext *ctx, OSDOp& osd_op);
 

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -867,7 +867,7 @@ void ReplicatedBackend::_do_pull_response(OpRequestRef op)
     t.register_on_complete(
       new PG_RecoveryQueueAsync(
 	get_parent(),
-	get_parent()->bless_gencontext(c)));
+	get_parent()->bless_unlocked_gencontext(c)));
   }
   replies.erase(replies.end() - 1);
 

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -262,6 +262,18 @@ int ReplicatedBackend::objects_read_sync(
   return store->read(ch, ghobject_t(hoid), off, len, *bl, op_flags);
 }
 
+struct AsyncReadCallback : public GenContext<ThreadPool::TPHandle&> {
+  int r;
+  Context *c;
+  AsyncReadCallback(int r, Context *c) : r(r), c(c) {}
+  void finish(ThreadPool::TPHandle&) override {
+    c->complete(r);
+    c = NULL;
+  }
+  ~AsyncReadCallback() override {
+    delete c;
+  }
+};
 void ReplicatedBackend::objects_read_async(
   const hobject_t &hoid,
   const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
@@ -269,7 +281,29 @@ void ReplicatedBackend::objects_read_async(
   Context *on_complete,
   bool fast_read)
 {
-  assert(0 == "async read is not used by replica pool");
+  // There is no fast read implementation for replication backend yet
+  assert(!fast_read);
+
+  int r = 0;
+  for (list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
+		 pair<bufferlist*, Context*> > >::const_iterator i =
+	   to_read.begin();
+       i != to_read.end() && r >= 0;
+       ++i) {
+    int _r = store->read(ch, ghobject_t(hoid), i->first.get<0>(),
+			 i->first.get<1>(), *(i->second.first),
+			 i->first.get<2>());
+    if (i->second.second) {
+      get_parent()->schedule_recovery_work(
+	get_parent()->bless_gencontext(
+	  new AsyncReadCallback(_r, i->second.second)));
+    }
+    if (_r < 0)
+      r = _r;
+  }
+  get_parent()->schedule_recovery_work(
+    get_parent()->bless_gencontext(
+      new AsyncReadCallback(r, on_complete)));
 }
 
 class C_OSD_OnOpCommit : public Context {

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -151,11 +151,10 @@ public:
     uint32_t op_flags,
     bufferlist *bl) override;
 
-  void objects_read_async(
-    const hobject_t &hoid,
-    std::vector<async_read_params_t> to_read,
-    Context *on_complete,
-    bool fast_read = false) override;
+  std::unique_ptr<ObjectStore::ReadTransaction>
+  create_read_transaction(const hobject_t &hoid) override {
+    return store->create_read_transaction(ch, ghobject_t(hoid));
+  }
 
 private:
   // push

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -153,10 +153,9 @@ public:
 
   void objects_read_async(
     const hobject_t &hoid,
-    const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
-	       pair<bufferlist*, Context*> > > &to_read,
-               Context *on_complete,
-               bool fast_read = false) override;
+    std::vector<async_read_params_t> to_read,
+    Context *on_complete,
+    bool fast_read = false) override;
 
 private:
   // push

--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -136,7 +136,7 @@ public:
     expand_all_meta();
     int after_count = 0;
     for (auto& i : values) {
-      const auto &opt = schema.at(i.first);
+      const Option &opt = schema.at(i.first);
       if (opt.type == Option::TYPE_STR) {
         const std::string &str = boost::get<std::string>(i.second);
         size_t pos = 0;


### PR DESCRIPTION
To make testing and performance comparisons easier, the branch starts from the same (pretty old) `master` as PR #18986.

The reference point (caching in `librbd` and BlueStore disabled) taken directly from #18986:
```
rbd_iodepth32: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=rbd, iodepth=32
fio-3.0-32-g83070
Starting 1 process
2017-11-17 15:55:44.574289 7f64799b4a40 -1 WARNING: the following dangerous and experimental features are enabled: *

rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=6695: Fri Nov 17 15:56:44 2017
   read: IOPS=10.4k, BW=40.5MiB/s (42.5MB/s)(2431MiB/60004msec)
    slat (nsec): min=634, max=111104, avg=2810.27, stdev=2417.64
    clat (usec): min=138, max=19830, avg=3081.28, stdev=1681.88
     lat (usec): min=140, max=19833, avg=3084.09, stdev=1681.84
    clat percentiles (usec):
     |  1.00th=[ 1012],  5.00th=[ 1631], 10.00th=[ 1729], 20.00th=[ 1827],
     | 30.00th=[ 2008], 40.00th=[ 2147], 50.00th=[ 2311], 60.00th=[ 2966],
     | 70.00th=[ 3818], 80.00th=[ 4146], 90.00th=[ 4883], 95.00th=[ 6456],
     | 99.00th=[ 9372], 99.50th=[10421], 99.90th=[12780], 99.95th=[13566],
     | 99.99th=[16057]
   bw (  KiB/s): min=27208, max=67256, per=100.00%, avg=41493.62, stdev=12617.76, samples=120
   iops        : min= 6802, max=16814, avg=10373.38, stdev=3154.45, samples=120
  lat (usec)   : 250=0.04%, 500=0.37%, 750=0.31%, 1000=0.27%
  lat (msec)   : 2=28.49%, 4=45.26%, 10=24.66%, 20=0.61%
  cpu          : usr=30.13%, sys=69.13%, ctx=462715, majf=0, minf=6
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=622444,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=40.5MiB/s (42.5MB/s), 40.5MiB/s-40.5MiB/s (42.5MB/s-42.5MB/s), io=2431MiB (2550MB), run=60004-60004msec

Disk stats (read/write):
  nvme0n1: ios=621391/560, merge=0/14, ticks=30396/600, in_queue=31000, util=49.72%
```

After the changes (caching in `librbd` and BlueStore disabled):
```
rbd_iodepth32: (g=0): rw=read, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=rbd, iodepth=32
fio-3.0-32-g83070
Starting 1 process
2017-12-07 13:51:17.356017 7f912be5ea40 -1 WARNING: the following dangerous and experimental features are enabled: *

rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=9626: Thu Dec  7 13:52:17 2017
   read: IOPS=17.8k, BW=69.5MiB/s (72.8MB/s)(4168MiB/60001msec)
    slat (nsec): min=638, max=433712, avg=2447.17, stdev=2618.79
    clat (usec): min=217, max=12588, avg=1796.44, stdev=565.18
     lat (usec): min=220, max=12590, avg=1798.89, stdev=565.09
    clat percentiles (usec):
     |  1.00th=[  832],  5.00th=[ 1106], 10.00th=[ 1254], 20.00th=[ 1434],
     | 30.00th=[ 1549], 40.00th=[ 1647], 50.00th=[ 1745], 60.00th=[ 1844],
     | 70.00th=[ 1942], 80.00th=[ 2073], 90.00th=[ 2278], 95.00th=[ 2507],
     | 99.00th=[ 4293], 99.50th=[ 5080], 99.90th=[ 6325], 99.95th=[ 7242],
     | 99.99th=[ 8717]
   bw (  KiB/s): min=58960, max=74288, per=100.00%, avg=71126.64, stdev=2006.03, samples=120
   iops        : min=14740, max=18572, avg=17781.63, stdev=501.51, samples=120
  lat (usec)   : 250=0.01%, 500=0.11%, 750=0.48%, 1000=2.02%
  lat (msec)   : 2=72.57%, 4=23.59%, 10=1.22%, 20=0.01%
  cpu          : usr=31.48%, sys=67.11%, ctx=691243, majf=0, minf=6
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=1066967,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=69.5MiB/s (72.8MB/s), 69.5MiB/s-69.5MiB/s (72.8MB/s-72.8MB/s), io=4168MiB (4370MB), run=60001-60001msec

Disk stats (read/write):
  nvme0n1: ios=1064545/891, merge=0/66, ticks=47656/1444, in_queue=49136, util=36.35%
```