### PR TITLE
mon: allow cluter and debug logs to go to stderr, with appropriate prefix

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -202,6 +202,7 @@ public:
       "log_max_recent",
       "log_to_syslog",
       "err_to_syslog",
+      "log_stderr_prefix",
       "log_to_stderr",
       "err_to_stderr",
       "log_to_graylog",
@@ -234,6 +235,10 @@ public:
     if (changed.count("log_file")) {
       log->set_log_file(conf->log_file);
       log->reopen_log_file();
+    }
+
+    if (changed.count("log_stderr_prefix")) {
+      log->set_log_stderr_prefix(conf->get_val<string>("log_stderr_prefix"));
     }
 
     if (changed.count("log_max_new")) {

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -345,6 +345,9 @@ std::vector<Option> get_global_options() {
     .set_daemon_default(true)
     .set_description("send critical error log lines to stderr"),
 
+    Option("log_stderr_prefix", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_description("String to prefix log messages with when sent to stderr"),
+
     Option("log_to_syslog", Option::TYPE_BOOL, Option::LEVEL_BASIC)
     .set_default(false)
     .set_description("send log lines to syslog facility"),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -430,6 +430,10 @@ std::vector<Option> get_global_options() {
     .set_default("12201")
     .set_description(""),
 
+    Option("mon_cluster_log_to_stderr", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Send cluster log messages to stderr (prefixed by channel)"),
+
     Option("mon_cluster_log_to_syslog", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("default=false")
     .set_description(""),

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -133,6 +133,11 @@ void Log::set_log_file(string fn)
   m_log_file = fn;
 }
 
+void Log::set_log_stderr_prefix(const std::string& p)
+{
+  m_log_stderr_prefix = p;
+}
+
 void Log::reopen_log_file()
 {
   pthread_mutex_lock(&m_flush_mutex);
@@ -336,7 +341,7 @@ void Log::_flush(EntryQueue *t, EntryQueue *requeue, bool crash)
       }
 
       if (do_stderr) {
-        cerr << buf << std::endl;
+        cerr << m_log_stderr_prefix << buf << std::endl;
       }
       if (do_fd) {
         buf[buflen] = '\n';

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -44,6 +44,8 @@ class Log : private Thread
   int m_stderr_log, m_stderr_crash;
   int m_graylog_log, m_graylog_crash;
 
+  std::string m_log_stderr_prefix;
+
   shared_ptr<Graylog> m_graylog;
 
   bool m_stop;
@@ -70,6 +72,7 @@ public:
   void set_log_file(std::string fn);
   void reopen_log_file();
   void chown_log_file(uid_t uid, gid_t gid);
+  void set_log_stderr_prefix(const std::string& p);
 
   void flush();
 

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -116,6 +116,10 @@ void LogMonitor::update_from_paxos(bool *need_bootstrap)
       if (channel.empty()) // keep retrocompatibility
         channel = CLOG_CHANNEL_CLUSTER;
 
+      if (g_conf->get_val<bool>("mon_cluster_log_to_stderr")) {
+	cerr << channel << " " << le << std::endl;
+      }
+
       if (channels.do_log_to_syslog(channel)) {
         string level = channels.get_level(channel);
         string facility = channels.get_facility(channel);


### PR DESCRIPTION
This would let us send both the debug log  and the mon's cluster logs to stderr, differentiated
by a prefix string.