### PR TITLE
rgw: lease_cr->go_down is called twice, remove the needless one.

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1298,7 +1298,6 @@ public:
       }
       if (retcode < 0) {
         tn->log(0, SSTR("ERROR: failed to set sync marker: retcode=" << retcode));
-        lease_cr->go_down();
         return set_cr_error(retcode);
       }
     }


### PR DESCRIPTION
Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>