### PR TITLE
debian/control: adjust ceph-{osdomap,kvstore,monstore}-tool feature move

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -105,10 +105,10 @@ Recommends: btrfs-tools,
             ntp | time-daemon,
 Replaces: ceph (<< 10),
           ceph-common (<< 0.78-500),
-          ceph-test (<< 12.2.3),
+          ceph-test (<< 12.2.2-14),
           python-ceph (<< 0.92-1223),
 Breaks: ceph (<< 10),
-        ceph-test (<< 12.2.3),
+        ceph-test (<< 12.2.2-14),
         python-ceph (<< 0.92-1223),
 Description: common ceph daemon libraries and management tools
  Ceph is a massively scalable, open-source, distributed
@@ -206,8 +206,8 @@ Depends: ceph-base (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},
 Recommends: ceph-common,
-Replaces: ceph (<< 10), ceph-test (<< 12.2.3)
-Breaks: ceph (<< 10), ceph-test (<< 12.2.3)
+Replaces: ceph (<< 10), ceph-test (<< 12.2.2-14)
+Breaks: ceph (<< 10), ceph-test (<< 12.2.2-14)
 Description: monitor server for the ceph storage system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,
@@ -239,8 +239,8 @@ Depends: ceph-base (= ${binary:Version}),
          ${python:Depends},
          ${shlibs:Depends},
 Recommends: ceph-common (= ${binary:Version}),
-Replaces: ceph (<< 10), ceph-test (<< 12.2.3)
-Breaks: ceph (<< 10), ceph-test (<< 12.2.3)
+Replaces: ceph (<< 10), ceph-test (<< 12.2.2-14)
+Breaks: ceph (<< 10), ceph-test (<< 12.2.2-14)
 Description: OSD server for the ceph storage system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,

--- a/debian/control
+++ b/debian/control
@@ -105,10 +105,10 @@ Recommends: btrfs-tools,
             ntp | time-daemon,
 Replaces: ceph (<< 10),
           ceph-common (<< 0.78-500),
-          ceph-test (<< 12.2.2),
+          ceph-test (<< 12.2.3),
           python-ceph (<< 0.92-1223),
 Breaks: ceph (<< 10),
-        ceph-test (<< 12.2.2),
+        ceph-test (<< 12.2.3),
         python-ceph (<< 0.92-1223),
 Description: common ceph daemon libraries and management tools
  Ceph is a massively scalable, open-source, distributed
@@ -206,8 +206,8 @@ Depends: ceph-base (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},
 Recommends: ceph-common,
-Replaces: ceph (<< 10), ceph-test (<< 12.2.2)
-Breaks: ceph (<< 10), ceph-test (<< 12.2.2)
+Replaces: ceph (<< 10), ceph-test (<< 12.2.3)
+Breaks: ceph (<< 10), ceph-test (<< 12.2.3)
 Description: monitor server for the ceph storage system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,
@@ -239,8 +239,8 @@ Depends: ceph-base (= ${binary:Version}),
          ${python:Depends},
          ${shlibs:Depends},
 Recommends: ceph-common (= ${binary:Version}),
-Replaces: ceph (<< 10), ceph-test (<< 12.2.2)
-Breaks: ceph (<< 10), ceph-test (<< 12.2.2)
+Replaces: ceph (<< 10), ceph-test (<< 12.2.3)
+Breaks: ceph (<< 10), ceph-test (<< 12.2.3)
 Description: OSD server for the ceph storage system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,


### PR DESCRIPTION
it's a forward port of #19328 and #19356. without it, the rados upgrade test fails: http://pulpito.ceph.com/kchai-2017-12-06_15:52:24-rados-wip-kefu-testing-2017-12-06-1717-distro-basic-mira/1939633/