### PR TITLE
librbd: Do not instantiate TrimRequest template class

### DIFF
--- a/src/test/librbd/operation/test_mock_ResizeRequest.cc
+++ b/src/test/librbd/operation/test_mock_ResizeRequest.cc
@@ -44,7 +44,6 @@ TrimRequest<MockImageCtx> *TrimRequest<MockImageCtx>::s_instance = nullptr;
 
 // template definitions
 #include "librbd/operation/ResizeRequest.cc"
-#include "librbd/operation/TrimRequest.cc"
 
 namespace librbd {
 namespace operation {


### PR DESCRIPTION
We include TrimRequest.cc in librbd tests at two places:
 - operation/test_mock_TrimRequest.cc
 - operation/test_mock_ResizeRequest.cc

That causes linking errors when doing the builds because some of the
instantiated classes are defined twice.

We can fix this by not instantiating the template class in the
TrimReqeust.cc file when including it in the tests.

Signed-off-by: Boris Ranto <branto@redhat.com>