### PR TITLE
rgw: Stop warning in take_min_status

### DIFF
--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -347,7 +347,7 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
                     std::vector<std::string> *status)
 {
   status->clear();
-  boost::optional<size_t> num_shards;
+  auto num_shards = boost::make_optional(false, (size_t)(0));
   for (auto peer = first; peer != last; ++peer) {
     const size_t peer_shards = peer->size();
     if (!num_shards) {


### PR DESCRIPTION
`/git/ceph/src/rgw/rgw_sync_log_trim.cc: In function ‘int take_min_status(CephContext*, Iter, Iter, std::vector<std::basic_string<char> >*) [with Iter = __gnu_cxx::__normal_iterator<std::vector<rgw_bucket_shard_sync_info>*, std::vector<std::vector<rgw_bucket_shard_sync_info> > >]’: /git/ceph/src/rgw/rgw_sync_log_trim.cc:356:12: warning: ‘*((void*)&
num_shards +8)’ may be used uninitialized in this function
[-Wmaybe-uninitialized]
     } else if (*num_shards != peer_shards) {`

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>