### PR TITLE
osd: Step down RecoveryCtx from class to struct

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -259,7 +259,7 @@ public:
 
   ObjectStore::CollectionHandle ch;
 
-  class RecoveryCtx;
+  struct RecoveryCtx;
 
   // -- methods --
   std::string gen_prefix() const override;


### PR DESCRIPTION
Because we don't have defined `class RecoveryCtx`

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>