### PR TITLE
osd: Move method declaration to header file

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2078,8 +2078,6 @@ OSD::~OSD()
   delete store;
 }
 
-void cls_initialize(ClassHandler *ch);
-
 void OSD::handle_signal(int signum)
 {
   assert(signum == SIGINT || signum == SIGTERM);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1174,6 +1174,8 @@ public:
   ~OSDService();
 };
 
+void cls_initialize(ClassHandler *ch);
+
 class OSD : public Dispatcher,
 	    public md_config_obs_t {
   /** OSD **/


### PR DESCRIPTION
There should be no obvious issue declaring method in implementation file without definition because it's defined in another location. But it's strange.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>