### PR TITLE
osd: make sanity check warning more clear

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9520,7 +9520,7 @@ void OSD::check_config()
   // some sanity checks
   if (cct->_conf->osd_map_cache_size <= (int)cct->_conf->osd_pg_epoch_persisted_max_stale + 2) {
     clog->warn() << "osd_map_cache_size (" << cct->_conf->osd_map_cache_size << ")"
-		 << " is not > osd_pg_epoch_persisted_max_stale ("
+		 << " is not > osd_pg_epoch_persisted_max_stale + 2 ("
 		 << cct->_conf->osd_pg_epoch_persisted_max_stale << ")";
   }
 }


### PR DESCRIPTION
The sanity check warning `osd_map_cache_size (x) is not > osd_pg_epoch_persisted_max_stale (y)` is not correct when the difference between these variables is smaller than 3 - This commit adds a ` + 2` next to `osd_pg_epoch_persisted_max_stale` that should make it clear that the warning is printed because the difference between these two variables is too small and a larger one is recommended

Signed-off-by: Katie Holly <git@meo.ws>