### PR TITLE
mon: add osd crush unset-device-class

### DIFF
--- a/doc/rados/operations/crush-map.rst
+++ b/doc/rados/operations/crush-map.rst
@@ -218,6 +218,10 @@ The device class for one or more OSDs can be explicitly set with::
 
   ceph osd crush set-device-class <class> <osd-name> [...]
 
+All OSDs belonging to the specific device class can be explicitly unset with::
+
+  ceph osd crush unset-device-class <class>
+
 Once a device class is set, it cannot be changed to another class
 until the old class is unset with::
 

--- a/qa/standalone/crush/crush-classes.sh
+++ b/qa/standalone/crush/crush-classes.sh
@@ -214,6 +214,22 @@ function TEST_mon_classes() {
     ceph osd crush tree --show-shadow | grep 'class_1' && return 1
     ceph osd crush class ls | grep 'class_2' || return 1
     ceph osd crush tree --show-shadow | grep 'class_2' || return 1
+
+    # test class unset-device-class
+    ceph osd crush set-device-class aaa osd.0 || return 1
+    ceph osd tree | grep -q 'aaa' || return 1
+    ceph osd crush dump | grep -q '~aaa' || return 1
+    ceph osd crush tree --show-shadow | grep -q '~aaa' || return 1
+    ceph osd crush unset-device-class aaa || return 1
+    ceph osd tree | grep -q 'aaa' && return 1
+    ceph osd crush class ls | grep -q 'aaa' && return 1
+    ceph osd crush set-device-class abc all || return 1
+    ceph osd tree | grep -q 'abc' || return 1
+    ceph osd crush dump | grep -q '~abc' || return 1
+    ceph osd crush tree --show-shadow | grep -q '~abc' || return 1
+    ceph osd crush unset-device-class abc || return 1
+    ceph osd tree | grep -q 'abc' && return 1
+    ceph osd crush class ls | grep -q 'abc' && return 1
 }
 
 main crush-classes "$@"

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -543,6 +543,10 @@ COMMAND("osd crush set-device-class " \
 	"set the <class> of the osd(s) <id> [<id>...]," \
         "or use <all|any|*> to set all.", \
 	"osd", "rw", "cli,rest")
+COMMAND("osd crush unset-device-class " \
+        "name=class,type=CephString,goodchars=[A-Za-z0-9-_] ", \
+        "remove class of all osds belonging to the specific <class>", \
+        "osd", "rw", "cli,rest")
 COMMAND("osd crush rm-device-class " \
         "name=ids,type=CephString,n=N", \
         "remove class of the osd(s) <id> [<id>...]," \


### PR DESCRIPTION
This command can remove class of all osds that belongs to the specific class

Signed-off-by: songweibin <song.weibin@zte.com.cn>