### PR TITLE
mgr/dashboard: Fix PG status coloring

### DIFF
--- a/src/pybind/mgr/dashboard/health.html
+++ b/src/pybind/mgr/dashboard/health.html
@@ -81,15 +81,33 @@
             };
 
             rivets.formatters.pg_status_style = function(pg_status) {
+                var warning = false;
+                var error = false;
+
                 $.each(pg_status, function(state, count) {
-                    if (state == "active+clean"
-                     || state == "active+clean+scrubbing"
-                     || state == "active+clean+scrubbing+deep") {
-                        return "color: #00bb00";
-                    } else {
-                        return "color: #FFC200";
+                    if (state.includes("inconsistent") ||
+                        state.includes("incomplete") ||
+                        !state.includes("active")
+                    ) {
+                        error = true;
+                    }
+
+                    if (state != "active+clean"
+                     && state != "active+clean+scrubbing"
+                     && state != "active+clean+scrubbing+deep") {
+                        warning = true;
                     }
                 });
+
+                if (error) {
+                    return "color: #FF0000";
+                }
+
+                if (warning) {
+                    return "color: #FFC200";
+                }
+
+                return "color: #00BB00";
             };
 
             rivets.formatters.pg_status = function(pg_status) {


### PR DESCRIPTION
This was broken in the 12.2.2 release and PGs would not get a
color anymore.

This commit also makes sure pools/PGs are marked as red when
one or more PGs are inactive, inconsistent, incomplete, down, etc.

Signed-off-by: Wido den Hollander <wido@42on.com>