### PR TITLE
test/rbd_mirror: "use of uninitialised value" valgrind warning

### DIFF
--- a/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
@@ -692,13 +692,13 @@ public:
     EXPECT_CALL(mock_image_sync_throttler, start_op(sync_id, _))
         .WillOnce(Invoke([on_call, on_start_ctx] (const std::string &,
                                                   Context *ctx) {
-                           if (on_call != nullptr) {
-                             on_call->complete(0);
-                           }
                            if (on_start_ctx != nullptr) {
                              *on_start_ctx = ctx;
                            } else {
                              ctx->complete(0);
+                           }
+                           if (on_call != nullptr) {
+                             on_call->complete(0);
                            }
                          }));
   }


### PR DESCRIPTION
The `on_call` context serves as a barrier and should be completed
after the `on_start_ctx` context is assigned.

The warning was observed sporadically e.g. by repeating
WaitingOnNonLeaderAcquireLeader test under valgrind.

Signed-off-by: Mykola Golub <to.my.trociny@gmail.com>