### PR TITLE
qa/rgw: disable log trim in multisite suite

### DIFF
--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -6,5 +6,6 @@ overrides:
         debug rgw: 20
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo=
         rgw crypt require ssl: false
+        rgw sync log trim interval: 0
   rgw:
     compression type: random


### PR DESCRIPTION
the multisite tests run manual trim operations with radosgw-admin, which can race with internal log trimming to produce tests failures