### PR TITLE
luminous: mds: change the type of "num_rdlock" to __s32

### DIFF
--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -167,7 +167,7 @@ protected:
   __s16 state;
 
 private:
-  __s16 num_rdlock;
+  __s32 num_rdlock;
   __s32 num_client_lease;
 
   struct unstable_bits_t {


### PR DESCRIPTION
This should be able to avoid overloads of SimpleLock::num_rdlock

Fixes: http://tracker.ceph.com/issues/22374
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>