### PR TITLE
rgw: NULL check before use astate

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -10139,7 +10139,7 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl)
   else
     len = end - ofs + 1;
 
-  if (astate->has_manifest && astate->manifest.has_tail()) {
+  if (astate && astate->has_manifest && astate->manifest.has_tail()) {
     /* now get the relevant object part */
     RGWObjManifest::obj_iterator iter = astate->manifest.obj_find(ofs);
 


### PR DESCRIPTION
Fixes the coverity issue:

>CID undefined (#1 of 1): Dereference before null check (REVERSE_INULL)
>check_after_deref: Null-checking astate suggests that it may be null,
but it has already been dereferenced on all paths leading to the check.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>