### PR TITLE
mds: NULL check before use srcdn

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1456,6 +1456,8 @@ void Server::reply_client_request(MDRequestRef& mdr, MClientReply *reply)
     req->get_connection()->send_message(reply);
   }
 
+  assert (reply);
+
   if (req->is_queued_for_replay() &&
       (mdr->has_completed || reply->get_result() < 0)) {
     if (reply->get_result() < 0) {
@@ -2317,7 +2319,8 @@ void Server::handle_slave_auth_pin(MDRequestRef& mdr)
 
   // ack!
   MMDSSlaveRequest *reply = new MMDSSlaveRequest(mdr->reqid, mdr->attempt, MMDSSlaveRequest::OP_AUTHPINACK);
-  
+
+  assert (auth_pin_freeze);
   // return list of my auth_pins (if any)
   for (set<MDSCacheObject*>::iterator p = mdr->auth_pins.begin();
        p != mdr->auth_pins.end();
@@ -8322,6 +8325,8 @@ void Server::_rename_rollback_finish(MutationRef& mut, MDRequestRef& mdr, CDentr
     if (root)
       mdcache->try_trim_non_auth_subtree(root);
   }
+
+  assert (srcdn);
 
   if (mdr) {
     list<MDSInternalContextBase*> finished;


### PR DESCRIPTION
Fixes the coverity issue:

** 1405293 Dereference after null check
>CID 1405293 (#1 of 1): Dereference after null check (FORWARD_NULL)
>18. var_deref_model: Passing null pointer srcdn to is_auth, which dereferences it.

** 1405288 Explicit null dereferenced
>CID 1405288 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)
>13. var_deref_model: Passing null pointer auth_pin_freeze to set_object_info, which dereferences it.

** 1405283 Explicit null dereferenced
>CID 1405283 (#2 of 2): Explicit null dereferenced (FORWARD_NULL)
>20. var_deref_model: Passing null pointer reply to get_result, which dereferences it.

Signed-off-by: Amit Kumar amitkuma@redhat.com