### PR TITLE
ceph-volume: Add linesep/newline at end of JSON file when writing

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -129,6 +129,7 @@ class Scan(object):
         else:
             with open(json_path, 'w') as fp:
                 json.dump(osd_metadata, fp, indent=4, sort_keys=True, ensure_ascii=False)
+                fp.write(os.linesep)
             terminal.success(
                 'OSD %s got scanned and metadata persisted to file: %s' % (
                     osd_id,


### PR DESCRIPTION
Instead of:

<pre>
    "systemd": "",
    "type": "bluestore",
    "whoami": "0"
  }root@alpha:~#
</pre>

A newline is added to the JSON file when writing:

<pre>
    "type": "bluestore",
    "whoami": "0"
  }
  root@alpha:~#
</pre>

Makes it a bit easier to read the JSON files on a terminal

Signed-off-by: Wido den Hollander <wido@42on.com>