### PR TITLE
osd: fix unordered read bug (for chunked object)

### DIFF
--- a/qa/suites/rados/thrash/workloads/set-chunks.yaml
+++ b/qa/suites/rados/thrash/workloads/set-chunks.yaml
@@ -6,4 +6,3 @@ tasks:
     set_chunk: true
     op_weights:
       chunk_read: 100
-      write: 30

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3214,6 +3214,9 @@ bool PrimaryLogPG::can_proxy_chunked_read(OpRequestRef op, ObjectContextRef obc)
 	/* requested chunks exist in chunk_map ? */
 	for (auto &p : obc->obs.oi.manifest.chunk_map) {
 	  if (p.first <= cursor && p.first + p.second.length > cursor) {
+	    if (p.second.flags != chunk_info_t::FLAG_MISSING) {
+	      return false;
+	    }
 	    if (p.second.length >= remain) {
 	      remain = 0;
 	      break; 

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2247,22 +2247,6 @@ public:
     context->oid_not_in_use.erase(oid);
 
     context->find_object(oid, &src_value); 
-
-    comp = context->rados.aio_create_completion();
-    rd_op.stat(NULL, NULL, NULL);
-    context->io_ctx.aio_operate(context->prefix+oid, comp, &rd_op,
-     			  librados::OPERATION_ORDER_READS_WRITES,
-     			  NULL);
-    comp->wait_for_safe();
-    if ((r = comp->get_return_value()) && !src_value.deleted()) {
-      cerr << "Error: oid " << oid << " stat returned error code "
-	   << r << std::endl;
-      ceph_abort();
-    }
-    context->update_object_version(oid, comp->get_version64());
-    comp->release();
-
-    context->find_object(oid, &src_value); 
     context->find_object(oid_tgt, &tgt_value);
 
     if (src_value.version != 0 && !src_value.deleted())


### PR DESCRIPTION
The current implementation for chunked object only supports
proxy_read(if offset is within range) and write(local write)
In this case, a read request can be handled before a write request.
This commit prevents unordered read processing because
proxy_read() will be executed if the chunk is missing state.
If chunked object has been overwritten, its state will not be missing.


Fixes: http://tracker.ceph.com/issues/22369
Signed-off-by: Myoungwon Oh <omwmw@sk.com>