### PR TITLE
rgw: remove redundant S3AnonymousEngine

### DIFF
--- a/src/rgw/rgw_auth_registry.h
+++ b/src/rgw/rgw_auth_registry.h
@@ -30,7 +30,7 @@ class StrategyRegistry {
     using s3_main_strategy_plain_t = \
       s3_strategy_t<rgw::auth::s3::AWSGeneralAbstractor, true>;
     using s3_main_strategy_boto2_t = \
-      s3_strategy_t<rgw::auth::s3::AWSGeneralBoto2Abstractor, true>;
+      s3_strategy_t<rgw::auth::s3::AWSGeneralBoto2Abstractor>;
 
     s3_main_strategy_plain_t s3_main_strategy_plain;
     s3_main_strategy_boto2_t s3_main_strategy_boto2;


### PR DESCRIPTION
When receives unauthorized requests, RGW(rados auth only) runs four engines as follows:
  1. anonymous engine in s3_main_strategy_plain
  2. local engine in s3_main_strategy_plain
  3. anonymous engine in s3_main_strategy_boto2
  4. local engine in s3_main_strategy_boto2

The third engine which is exactly the same with the first one is redundant.