### PR TITLE
rgw: add xml output header in RGWCopyObj_ObjStore_S3 response msg

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2133,6 +2133,7 @@ void RGWCopyObj_ObjStore_S3::send_partial_response(off_t ofs)
     dump_errno(s);
 
     end_header(s, this, "application/xml");
+    dump_start(s);
     if (op_ret == 0) {
       s->formatter->open_object_section_in_ns("CopyObjectResult", XMLNS_AWS_S3);
     }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22416

When move object by `s3cmd mv`, s3cmd will do four things:

- get source object acl
- copy source object from source bucket to destination bucket and destination object
- put acl for destination object
- delete source object in source bucket

But in RGW now, the `s3cmd mv` will put a new object in destination bucket without deleting the 
source object in source bucket, this is not same with S3, eg:

s3cmd ls s3://bucket1
2017-12-13 04:04      1871   s3://bucket1/obj1
2017-12-13 04:04      8034   s3://bucket1/obj2

s3cmd mv s3://bucket1/obj1 s3://bucket1/obj3
move: 's3://bucket1/obj1' -> 's3://bucket1/obj3'

s3cmd ls s3://bucket1
2017-12-13 04:04      1871   s3://bucket1/obj1
2017-12-13 04:04      8034   s3://bucket1/obj2
2017-12-13 07:06      1871   s3://bucket1/obj3

By reading source code of s3cmd, I found s3cmd would parse the `data` field in response msg which should contain `<?xml version="1.0" encoding="UTF-8"?>` to decide whether send delete object request or not.

So now, the result is:

s3cmd ls s3://bucket1
2017-12-13 04:04      1871   s3://bucket1/obj1
2017-12-13 04:04      8034   s3://bucket1/obj2

s3cmd mv s3://bucket1/obj1 s3://bucket1/obj3
move: 's3://bucket1/obj1' -> 's3://bucket1/obj3'

s3cmd ls s3://bucket1
2017-12-13 04:04      8034   s3://bucket1/obj2
2017-12-13 07:06      1871   s3://bucket1/obj3

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>