### PR TITLE
ceph-volume: Try to cast OSD metadata to int while scanning directory

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -74,7 +74,11 @@ class Scan(object):
             if system.is_binary(file_path):
                 continue
             if os.path.isfile(file_path):
-                osd_metadata[_file] = self.get_contents(file_path)
+                content = self.get_contents(file_path)
+                try:
+                    osd_metadata[_file] = int(content)
+                except ValueError:
+                    osd_metadata[_file] = content
 
         device = path_mounts.get(path)
         # it is possible to have more than one device, pick the first one, and


### PR DESCRIPTION
By doing so values like 'whoami' and 'bluefs' will be stored as a
integer in the resulting JSON rather then a String.

Signed-off-by: Wido den Hollander <wido@42on.com>