### PR TITLE
luminous: mon: reenable timer to send digest when paxos is temporarily inactive

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -453,14 +453,15 @@ void MgrMonitor::send_digests()
 {
   cancel_timer();
 
-  if (!is_active()) {
-    return;
-  }
-  dout(10) << __func__ << dendl;
-
   const std::string type = "mgrdigest";
   if (mon->session_map.subs.count(type) == 0)
     return;
+
+  if (!is_active()) {
+    // if paxos is currently not active, don't send a digest but reenable timer
+    goto timer;
+  }
+  dout(10) << __func__ << dendl;
 
   for (auto sub : *(mon->session_map.subs[type])) {
     dout(10) << __func__ << " sending digest to subscriber " << sub->session->con
@@ -480,6 +481,7 @@ void MgrMonitor::send_digests()
     sub->session->con->send_message(mdigest);
   }
 
+timer:
   digest_event = mon->timer.add_event_after(
     g_conf->get_val<int64_t>("mon_mgr_digest_period"),
     new C_MonContext(mon, [this](int) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/22421