### PR TITLE
luminous: build/ops: luminous build fails with --without-radosgw

### DIFF
--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -399,6 +399,8 @@ TYPE(rgw_data_sync_info)
 TYPE(rgw_data_sync_marker)
 TYPE(rgw_data_sync_status)
 
+#endif
+
 #ifdef WITH_RBD
 #include "cls/rbd/cls_rbd.h"
 TYPE(cls_rbd_parent)
@@ -407,8 +409,6 @@ TYPE(cls_rbd_snap)
 #include "cls/rbd/cls_rbd_types.h"
 TYPE(cls::rbd::MirrorPeer)
 TYPE(cls::rbd::MirrorImage)
-#endif
-
 #endif
 
 #include "cls/lock/cls_lock_types.h"


### PR DESCRIPTION
http://tracker.ceph.com/issues/22375