### PR TITLE
luminous: rgw: fix GET website response error code

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2119,7 +2119,7 @@ void RGWGetBucketWebsite::pre_exec()
 void RGWGetBucketWebsite::execute()
 {
   if (!s->bucket_info.has_website) {
-    op_ret = -ENOENT;
+    op_ret = -ERR_NO_SUCH_WEBSITE_CONFIGURATION;
   }
 }
 


### PR DESCRIPTION
Change NoSuchKey error code to NoSuchWebsiteConfiguration, when bucket doesn't have website configuration.

Fixes: http://tracker.ceph.com/issues/22426
Signed-off-by: Dmitry Plyakin <dplyakin@gmail.com>
(cherry picked from commit 56344f0e147e1781bb359bfde6878511b077487f)