### PR TITLE
rbd-mirror: ensure unique service daemon name is utilized

### DIFF
--- a/src/pybind/mgr/dashboard/rbd_ls.py
+++ b/src/pybind/mgr/dashboard/rbd_ls.py
@@ -10,20 +10,8 @@ class RbdPoolLs(RemoteViewCache):
 
 
         osd_map = self._module.get_sync_object(OsdMap).data
-        osd_pools = [pool['pool_name'] for pool in osd_map['pools']]
-
-        rbd_pools = []
-        for pool in osd_pools:
-            self.log.debug("Constructing IOCtx " + pool)
-            try:
-                ioctx = self._module.rados.open_ioctx(pool)
-                ioctx.stat("rbd_directory")
-                rbd_pools.append(pool)
-            except (rados.PermissionError, rados.ObjectNotFound):
-                self.log.debug("No RBD directory in " + pool)
-            except:
-                self.log.exception("Failed to open pool " + pool)
-
+        rbd_pools = [pool['pool_name'] for pool in osd_map['pools'] if \
+                        'rbd' in pool.get('application_metadata', {})]
         return rbd_pools
 
 class RbdLs(RemoteViewCache):

--- a/src/pybind/mgr/dashboard/rbd_mirroring.html
+++ b/src/pybind/mgr/dashboard/rbd_mirroring.html
@@ -78,8 +78,8 @@
                     <table id="daemons" class="table table-condensed">
                         <thead>
                         <tr>
-                            <th>ID</th>
                             <th>Instance</th>
+                            <th>ID</th>
                             <th>Hostname</th>
                             <th>Version</th>
                             <th>Health</th>
@@ -87,8 +87,8 @@
                         </thead>
                         <tbody>
                             <tr rv-each-daemon="daemons">
-                                <td>{daemon.id}</td>
                                 <td>{daemon.instance_id}</td>
+                                <td>{daemon.id}</td>
                                 <td>{daemon.server_hostname}</td>
                                 <td>{daemon.version | short_version}</td>
                                 <td><span rv-class="daemon.health_color | mirror_health_color">{daemon.health}</span></td>

--- a/src/pybind/mgr/dashboard/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/rbd_mirroring.py
@@ -18,19 +18,23 @@ class DaemonsAndPools(RemoteViewCache):
         for server in self._module.list_servers():
             for service in server['services']:
                 if service['type'] == 'rbd-mirror':
-                    metadata = self._module.get_metadata('rbd-mirror',
-                                                         service['id'])
-                    status = self._module.get_daemon_status('rbd-mirror',
-                                                            service['id'])
+                    id = service['id']
+                    metadata = self._module.get_metadata('rbd-mirror', id)
+                    status = self._module.get_daemon_status('rbd-mirror', id)
                     try:
                         status = json.loads(status['json'])
                     except:
                         status = {}
 
+                    instance_id = metadata['instance_id']
+                    if (id == instance_id):
+                        # new version that supports per-cluster leader elections
+                        id = metadata['id']
+
                     # extract per-daemon service data and health
                     daemon = {
-                        'id': service['id'],
-                        'instance_id': metadata['instance_id'],
+                        'id': id,
+                        'instance_id': instance_id,
                         'version': metadata['ceph_version'],
                         'server_hostname': server['hostname'],
                         'service': service,
@@ -41,7 +45,7 @@ class DaemonsAndPools(RemoteViewCache):
                     daemon = dict(daemon, **self.get_daemon_health(daemon))
                     daemons.append(daemon)
 
-        return sorted(daemons, key=lambda k: k['id'])
+        return sorted(daemons, key=lambda k: k['instance_id'])
 
     def get_daemon_health(self, daemon):
         health = {

--- a/src/tools/rbd_mirror/ServiceDaemon.cc
+++ b/src/tools/rbd_mirror/ServiceDaemon.cc
@@ -71,15 +71,15 @@ template <typename I>
 int ServiceDaemon<I>::init() {
   dout(20) << dendl;
 
-  std::string name = m_cct->_conf->name.get_id();
-  if (name.find(RBD_MIRROR_AUTH_ID_PREFIX) == 0) {
-    name = name.substr(RBD_MIRROR_AUTH_ID_PREFIX.size());
+  std::string id = m_cct->_conf->name.get_id();
+  if (id.find(RBD_MIRROR_AUTH_ID_PREFIX) == 0) {
+    id = id.substr(RBD_MIRROR_AUTH_ID_PREFIX.size());
   }
 
+  std::string instance_id = stringify(m_rados->get_instance_id());
   std::map<std::string, std::string> service_metadata = {
-      {"instance_id", stringify(m_rados->get_instance_id())}
-    };
-  int r = m_rados->service_daemon_register("rbd-mirror", name,
+    {"id", id}, {"instance_id", instance_id}};
+  int r = m_rados->service_daemon_register("rbd-mirror", instance_id,
                                            service_metadata);
   if (r < 0) {
     return r;


### PR DESCRIPTION
The librados instance id is uniquely assigned from the monitors so it can ensure each rbd-mirror daemon instance is properly displayed within the dashboard. Also clean-up the dashboard handling of RBD pools and rbd-mirror daemons.