### PR TITLE
jewel: OSD/PGLog: store extra duo ops beyond the log + write only changed dup entries

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -794,8 +794,9 @@ OPTION(osd_kill_backfill_at, OPT_INT, 0)
 // Bounds how infrequently a new map epoch will be persisted for a pg
 OPTION(osd_pg_epoch_persisted_max_stale, OPT_U32, 150) // make this < map_cache_size!
 
-OPTION(osd_min_pg_log_entries, OPT_U32, 3000)  // number of entries to keep in the pg log when trimming it
-OPTION(osd_max_pg_log_entries, OPT_U32, 10000) // max entries, say when degraded, before we trim
+OPTION(osd_min_pg_log_entries, OPT_U32, 1500)  // minimum number of entries to maintain in the PG log
+OPTION(osd_max_pg_log_entries, OPT_U32, 10000) // maximum number of entries to maintain in the PG log when degraded before we trim
+OPTION(osd_pg_log_dups_tracked, OPT_U32, 3000) // how many versions back to track in order to detect duplicate ops; this is combined with both the regular pg log entries and additional minimal dup detection entries
 OPTION(osd_pg_log_trim_min, OPT_U32, 100)
 OPTION(osd_op_complaint_time, OPT_FLOAT, 30) // how many seconds old makes an op complaint-worthy
 OPTION(osd_command_max_records, OPT_INT, 256)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -150,6 +150,7 @@ void PG::dump_live_ids()
 }
 #endif
 
+
 void PGPool::update(OSDMapRef map)
 {
   const pg_pool_t *pi = map->get_pg_pool(id);
@@ -220,7 +221,8 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   deleting(false), dirty_info(false), dirty_big_info(false),
   info(p),
   info_struct_v(0),
-  coll(p), pg_log(cct),
+  coll(p),
+  pg_log(cct),
   pgmeta_oid(p.make_pgmeta_oid()),
   missing_loc(this),
   recovery_item(this), stat_queue_item(this),

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -85,6 +85,10 @@ void PGLog::IndexedLog::split_into(
     oldlog.erase(i++);
   }
 
+  // osd_reqid is unique, so it doesn't matter if there are extra
+  // dup entries in each pg. To avoid storing oid with the dup
+  // entries, just copy the whole list.
+  olog->dups = dups;
 
   olog->can_rollback_to = can_rollback_to;
 
@@ -95,7 +99,8 @@ void PGLog::IndexedLog::split_into(
 void PGLog::IndexedLog::trim(
   LogEntryHandler *handler,
   eversion_t s,
-  set<eversion_t> *trimmed)
+  set<eversion_t> *trimmed,
+  set<string> *trimmed_dups)
 {
   if (complete_to != log.end() &&
       complete_to->version <= s) {
@@ -118,6 +123,18 @@ void PGLog::IndexedLog::trim(
 
     unindex(e);         // remove from index,
 
+    // add to dup list
+    if (e.version.version + 1000 > s.version) {
+      dirty_dups = true;
+      dups.push_back(pg_log_dup_t(e));
+      dup_index[e.reqid] = &(dups.back());
+      for (const auto& extra : e.extra_reqids) {
+	dups.push_back(pg_log_dup_t(e.version, extra.second,
+				    extra.first, e.return_code));
+	dup_index[extra->first] = &(dups.back());
+      }
+    }
+
     if (rollback_info_trimmed_to_riter == log.rend() ||
 	e.version == rollback_info_trimmed_to_riter->version) {
       log.pop_front();
@@ -125,6 +142,17 @@ void PGLog::IndexedLog::trim(
     } else {
       log.pop_front();
     }
+  }
+
+  while (!dups.empty()) {
+    auto &e = *dups.begin();
+    if (e.version.version + 1000 > s.version)
+      break;
+    generic_dout(20) << "trim dup " << e << dendl;
+    if (trimmed_dups)
+      trimmed_dups->insert(e.get_key_name());
+    dup_index.erase(e.reqid);
+    dups.pop_front();
   }
 
   // raise tail?
@@ -186,7 +214,7 @@ void PGLog::trim(
     assert(trim_to <= info.last_complete);
 
     dout(10) << "trim " << log << " to " << trim_to << dendl;
-    log.trim(handler, trim_to, &trimmed);
+    log.trim(handler, trim_to, &trimmed, &trimmed_dups);
     info.log_tail = log.tail;
   }
 }
@@ -807,6 +835,7 @@ void PGLog::write_log(
 	     << ", divergent_priors: " << divergent_priors.size()
 	     << ", writeout_from: " << writeout_from
 	     << ", trimmed: " << trimmed
+	     << ", trimmed_dups: " << trimmed_dups
 	     << dendl;
     _write_log(
       t, km, log, coll, log_oid, divergent_priors,
@@ -815,6 +844,7 @@ void PGLog::write_log(
       writeout_from,
       trimmed,
       dirty_divergent_priors,
+      trimmed_dups,
       !touched_log,
       require_rollback,
       (pg_log_debug ? &log_keys_debug : 0));
@@ -835,7 +865,7 @@ void PGLog::write_log(
   _write_log(
     t, km, log, coll, log_oid,
     divergent_priors, eversion_t::max(), eversion_t(), eversion_t(),
-    set<eversion_t>(),
+    set<eversion_t>(), set<string>(),
     true, true, require_rollback, 0);
 }
 
@@ -849,13 +879,14 @@ void PGLog::_write_log(
   eversion_t dirty_from,
   eversion_t writeout_from,
   const set<eversion_t> &trimmed,
+  const set<string> &trimmed_dups,
   bool dirty_divergent_priors,
   bool touch_log,
   bool require_rollback,
   set<string> *log_keys_debug
   )
 {
-  set<string> to_remove;
+  set<string> to_remove(trimmed_dups);
   for (set<eversion_t>::const_iterator i = trimmed.begin();
        i != trimmed.end();
        ++i) {
@@ -899,6 +930,18 @@ void PGLog::_write_log(
     bufferlist bl(sizeof(*p) * 2);
     p->encode_with_checksum(bl);
     (*km)[p->get_key_name()].claim(bl);
+  }
+
+  if (dirty_dups) {
+    pg_log_dup_t min;
+    t.omap_rmkeyrange(
+      coll, log_oid,
+      min.get_key_name(), log.dups.begin()->get_key_name());
+    for (const auto& entry : log.dups) {
+      bufferlist bl;
+      ::encode(entry, bl);
+      (*km)[entry.get_key_name()].claim(bl);
+    }
   }
 
   if (log_keys_debug) {
@@ -967,6 +1010,13 @@ void PGLog::read_log(ObjectStore *store, coll_t pg_coll,
         ::decode(log.can_rollback_to, bp);
       } else if (p->key() == "rollback_info_trimmed_to") {
         ::decode(log.rollback_info_trimmed_to, bp);
+      } else if (p->key().substr(0, 4) == string("dup_")) {
+	pg_log_dup_t dup;
+	::decode(dup, bp);
+	if (!log.dups.empty()) {
+	  assert(log.dups.back().version < dup.version);
+	}
+	log.dups.push_back(dup);
       } else {
 	pg_log_entry_t e;
 	e.decode_with_checksum(bp);

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -104,7 +104,7 @@ void PGLog::IndexedLog::trim(
   eversion_t s,
   set<eversion_t> *trimmed,
   set<string>* trimmed_dups,
-  bool* dirty_dups)
+  eversion_t *write_from_dups)
 {
   if (complete_to != log.end() &&
       complete_to->version <= s) {
@@ -133,8 +133,12 @@ void PGLog::IndexedLog::trim(
     unindex(e);         // remove from index,
 
     // add to dup list
+    generic_dout(20) << "earliest_dup_version = " << earliest_dup_version << dendl;
     if (e.version.version >= earliest_dup_version) {
-      if (dirty_dups) *dirty_dups = true;
+      if (write_from_dups != nullptr && *write_from_dups > e.version) {
+	generic_dout(20) << "updating write_from_dups from " << *write_from_dups << " to " << e.version << dendl;
+	*write_from_dups = e.version;
+      }
       dups.push_back(pg_log_dup_t(e));
       index(dups.back());
       for (const auto& extra : e.extra_reqids) {
@@ -235,7 +239,7 @@ void PGLog::trim(
     assert(trim_to <= info.last_complete);
 
     dout(10) << "trim " << log << " to " << trim_to << dendl;
-    log.trim(cct, handler, trim_to, &trimmed, &trimmed_dups, &dirty_dups);
+    log.trim(cct, handler, trim_to, &trimmed, &trimmed_dups, &write_from_dups);
     info.log_tail = log.tail;
   }
 }
@@ -809,7 +813,6 @@ void PGLog::merge_log(ObjectStore::Transaction& t,
 
   // now handle dups
   if (merge_log_dups(olog)) {
-    dirty_dups = true;
     changed = true;
   }
 
@@ -833,6 +836,8 @@ bool PGLog::merge_log_dups(const pg_log_t& olog) {
 	olog.dups.front().version << " to " <<
 	olog.dups.back().version << dendl;
       changed = true;
+      dirty_from_dups = eversion_t();
+      dirty_to_dups = eversion_t::max();
       // since our log.dups is empty just copy them
       for (const auto& i : olog.dups) {
 	log.dups.push_back(i);
@@ -850,9 +855,11 @@ bool PGLog::merge_log_dups(const pg_log_t& olog) {
 	auto log_tail_version = log.dups.back().version;
 
 	auto insert_cursor = log.dups.end();
+	eversion_t last_shared = eversion_t::max();
 	for (auto i = olog.dups.crbegin(); i != olog.dups.crend(); ++i) {
 	  if (i->version <= log_tail_version) break;
 	  log.dups.insert(insert_cursor, *i);
+	  last_shared = i->version;
 
 	  auto prev = insert_cursor;
 	  --prev;
@@ -861,6 +868,7 @@ bool PGLog::merge_log_dups(const pg_log_t& olog) {
 
 	  --insert_cursor; // make sure we insert in reverse order
 	}
+	mark_dirty_from_dups(last_shared);
       }
 
       if (olog.dups.front().version < log.dups.front().version) {
@@ -869,15 +877,18 @@ bool PGLog::merge_log_dups(const pg_log_t& olog) {
 	  olog.dups.front().version << dendl;
 	changed = true;
 
+	eversion_t last;
 	auto insert_cursor = log.dups.begin();
 	for (auto i = olog.dups.cbegin(); i != olog.dups.cend(); ++i) {
 	  if (i->version >= insert_cursor->version) break;
 	  log.dups.insert(insert_cursor, *i);
+	  last = i->version;
 	  auto prev = insert_cursor;
 	  --prev;
 	  // be sure to pass address of copy in log.dups
 	  log.index(*prev);
 	}
+	mark_dirty_to_dups(last);
       }
     }
   }
@@ -890,6 +901,7 @@ bool PGLog::merge_log_dups(const pg_log_t& olog) {
 
     while (!log.dups.empty() && log.dups.back().version >= log.tail) {
       log.unindex(log.dups.back());
+      mark_dirty_from_dups(log.dups.back().version);
       log.dups.pop_back();
     }
   }
@@ -951,7 +963,9 @@ void PGLog::write_log(
       dirty_divergent_priors,
       !touched_log,
       require_rollback,
-      dirty_dups,
+      dirty_to_dups,
+      dirty_from_dups,
+      write_from_dups,
       (pg_log_debug ? &log_keys_debug : 0));
     undirty();
   } else {
@@ -965,14 +979,14 @@ void PGLog::write_log(
     pg_log_t &log,
     const coll_t& coll, const ghobject_t &log_oid,
     map<eversion_t, hobject_t> &divergent_priors,
-    bool require_rollback,
-    bool dirty_dups)
+    bool require_rollback
+    )
 {
   _write_log(
     t, km, log, coll, log_oid,
     divergent_priors, eversion_t::max(), eversion_t(), eversion_t(),
     set<eversion_t>(), set<string>(),
-    true, true, require_rollback, true, nullptr);
+    true, true, require_rollback, eversion_t::max(), eversion_t(), eversion_t(), nullptr);
 }
 
 void PGLog::_write_log(
@@ -989,7 +1003,9 @@ void PGLog::_write_log(
   bool dirty_divergent_priors,
   bool touch_log,
   bool require_rollback,
-  bool dirty_dups,
+  eversion_t dirty_to_dups,
+  eversion_t dirty_from_dups,
+  eversion_t write_from_dups,
   set<string> *log_keys_debug
   )
 {
@@ -1050,18 +1066,40 @@ void PGLog::_write_log(
     }
   }
 
-  // process dirty_dups after log_keys_debug is filled, so dups do not
+  // process dups after log_keys_debug is filled, so dups do not
   // end up in that set
-  if (dirty_dups) {
-    pg_log_dup_t min;
+  if (dirty_to_dups != eversion_t()) {
+    pg_log_dup_t min, dirty_to_dup;
+    dirty_to_dup.version = dirty_to_dups;
     t.omap_rmkeyrange(
       coll, log_oid,
-      min.get_key_name(), log.dups.begin()->get_key_name());
-    for (const auto& entry : log.dups) {
-      bufferlist bl;
-      ::encode(entry, bl);
-      (*km)[entry.get_key_name()].claim(bl);
-    }
+      min.get_key_name(), dirty_to_dup.get_key_name());
+  }
+  if (dirty_to_dups != eversion_t::max() && dirty_from_dups != eversion_t::max()) {
+    pg_log_dup_t max, dirty_from_dup;
+    max.version = eversion_t::max();
+    dirty_from_dup.version = dirty_from_dups;
+    t.omap_rmkeyrange(
+      coll, log_oid,
+      dirty_from_dup.get_key_name(), max.get_key_name());
+  }
+
+  for (const auto& entry : log.dups) {
+    if (entry.version > dirty_to_dups)
+      break;
+    bufferlist bl;
+    ::encode(entry, bl);
+    (*km)[entry.get_key_name()].claim(bl);
+  }
+
+  for (list<pg_log_dup_t>::reverse_iterator p = log.dups.rbegin();
+       p != log.dups.rend() &&
+	 (p->version >= dirty_from_dups || p->version >= write_from_dups) &&
+	 p->version >= dirty_to_dups;
+       ++p) {
+    bufferlist bl;
+    ::encode(*p, bl);
+    (*km)[p->get_key_name()].claim(bl);
   }
 
   if (dirty_divergent_priors) {

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -10,9 +10,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #include "PGLog.h"
@@ -46,7 +46,9 @@ void PGLog::IndexedLog::advance_rollback_info_trimmed_to(
       ++rollback_info_trimmed_to_riter;
       break;
     }
-    h->trim(*rollback_info_trimmed_to_riter);
+    if (h) {
+      h->trim(*rollback_info_trimmed_to_riter);
+    }
   }
 }
 
@@ -97,10 +99,12 @@ void PGLog::IndexedLog::split_into(
 }
 
 void PGLog::IndexedLog::trim(
+  CephContext* cct,
   LogEntryHandler *handler,
   eversion_t s,
   set<eversion_t> *trimmed,
-  set<string> *trimmed_dups)
+  set<string>* trimmed_dups,
+  bool* dirty_dups)
 {
   if (complete_to != log.end() &&
       complete_to->version <= s) {
@@ -113,8 +117,13 @@ void PGLog::IndexedLog::trim(
     can_rollback_to = s;
   advance_rollback_info_trimmed_to(s, handler);
 
+  auto earliest_dup_version =
+    log.rbegin()->version.version < cct->_conf->osd_pg_log_dups_tracked
+    ? 0u
+    : log.rbegin()->version.version - cct->_conf->osd_pg_log_dups_tracked;
+
   while (!log.empty()) {
-    pg_log_entry_t &e = *log.begin();
+    const pg_log_entry_t &e = *log.begin();
     if (e.version > s)
       break;
     generic_dout(20) << "trim " << e << dendl;
@@ -124,14 +133,15 @@ void PGLog::IndexedLog::trim(
     unindex(e);         // remove from index,
 
     // add to dup list
-    if (e.version.version + 1000 > s.version) {
-      dirty_dups = true;
+    if (e.version.version >= earliest_dup_version) {
+      if (dirty_dups) *dirty_dups = true;
       dups.push_back(pg_log_dup_t(e));
-      dup_index[e.reqid] = &(dups.back());
+      index(dups.back());
       for (const auto& extra : e.extra_reqids) {
+	// note: extras have the same version as outer op
 	dups.push_back(pg_log_dup_t(e.version, extra.second,
-				    extra.first, e.return_code));
-	dup_index[extra->first] = &(dups.back());
+				    extra.first, 0));
+	index(dups.back());
       }
     }
 
@@ -145,13 +155,15 @@ void PGLog::IndexedLog::trim(
   }
 
   while (!dups.empty()) {
-    auto &e = *dups.begin();
-    if (e.version.version + 1000 > s.version)
+    const auto& e = *dups.begin();
+    if (e.version.version >= earliest_dup_version)
       break;
     generic_dout(20) << "trim dup " << e << dendl;
     if (trimmed_dups)
       trimmed_dups->insert(e.get_key_name());
-    dup_index.erase(e.reqid);
+    if (indexed_data & PGLOG_INDEXED_DUPS) {
+      dup_index.erase(e.reqid);
+    }
     dups.pop_front();
   }
 
@@ -166,9 +178,18 @@ ostream& PGLog::IndexedLog::print(ostream& out) const
   for (list<pg_log_entry_t>::const_iterator p = log.begin();
        p != log.end();
        ++p) {
-    out << *p << " " << (logged_object(p->soid) ? "indexed":"NOT INDEXED") << std::endl;
+    out << *p << " " <<
+      (logged_object(p->soid) ? "indexed" : "NOT INDEXED") <<
+      std::endl;
     assert(!p->reqid_is_indexed() || logged_req(p->reqid));
   }
+
+  for (list<pg_log_dup_t>::const_iterator p = dups.begin();
+       p != dups.end();
+       ++p) {
+    out << *p << std::endl;
+  }
+
   return out;
 }
 
@@ -214,7 +235,7 @@ void PGLog::trim(
     assert(trim_to <= info.last_complete);
 
     dout(10) << "trim " << log << " to " << trim_to << dendl;
-    log.trim(handler, trim_to, &trimmed, &trimmed_dups);
+    log.trim(cct, handler, trim_to, &trimmed, &trimmed_dups, &dirty_dups);
     info.log_tail = log.tail;
   }
 }
@@ -340,7 +361,7 @@ void PGLog::proc_replica_log(
   } else {
     oinfo.last_complete = oinfo.last_update;
   }
-}
+} // proc_replica_log
 
 /**
  * _merge_object_divergent_entries
@@ -684,7 +705,7 @@ void PGLog::merge_log(ObjectStore::Transaction& t,
     // splice into our log.
     log.log.splice(log.log.begin(),
 		   olog.log, from, to);
-      
+
     info.log_tail = log.tail = olog.tail;
     changed = true;
   }
@@ -707,7 +728,7 @@ void PGLog::merge_log(ObjectStore::Transaction& t,
   // extend on head?
   if (olog.head > log.head) {
     dout(10) << "merge_log extending head to " << olog.head << dendl;
-      
+
     // find start point in olog
     list<pg_log_entry_t>::iterator to = olog.log.end();
     list<pg_log_entry_t>::iterator from = olog.log.end();
@@ -785,13 +806,95 @@ void PGLog::merge_log(ObjectStore::Transaction& t,
 
     changed = true;
   }
-  
-  dout(10) << "merge_log result " << log << " " << missing << " changed=" << changed << dendl;
+
+  // now handle dups
+  if (merge_log_dups(olog)) {
+    dirty_dups = true;
+    changed = true;
+  }
+
+  dout(10) << "merge_log result " << log << " " << missing <<
+    " changed=" << changed << dendl;
 
   if (changed) {
     dirty_info = true;
     dirty_big_info = true;
   }
+}
+
+
+// returns true if any changes were made to log.dups
+bool PGLog::merge_log_dups(const pg_log_t& olog) {
+  bool changed = false;
+
+  if (!olog.dups.empty()) {
+    if (log.dups.empty()) {
+      dout(10) << "merge_log copying olog dups to log " <<
+	olog.dups.front().version << " to " <<
+	olog.dups.back().version << dendl;
+      changed = true;
+      // since our log.dups is empty just copy them
+      for (const auto& i : olog.dups) {
+	log.dups.push_back(i);
+	log.index(log.dups.back());
+      }
+    } else {
+      // since our log.dups is not empty try to extend on each end
+
+      if (olog.dups.back().version > log.dups.back().version) {
+	// extend the dups's tail (i.e., newer dups)
+	dout(10) << "merge_log extending dups tail to " <<
+	  olog.dups.back().version << dendl;
+	changed = true;
+
+	auto log_tail_version = log.dups.back().version;
+
+	auto insert_cursor = log.dups.end();
+	for (auto i = olog.dups.crbegin(); i != olog.dups.crend(); ++i) {
+	  if (i->version <= log_tail_version) break;
+	  log.dups.insert(insert_cursor, *i);
+
+	  auto prev = insert_cursor;
+	  --prev;
+	  // be sure to pass reference of copy in log.dups
+	  log.index(*prev);
+
+	  --insert_cursor; // make sure we insert in reverse order
+	}
+      }
+
+      if (olog.dups.front().version < log.dups.front().version) {
+	// extend the dups's head (i.e., older dups)
+	dout(10) << "merge_log extending dups head to " <<
+	  olog.dups.front().version << dendl;
+	changed = true;
+
+	auto insert_cursor = log.dups.begin();
+	for (auto i = olog.dups.cbegin(); i != olog.dups.cend(); ++i) {
+	  if (i->version >= insert_cursor->version) break;
+	  log.dups.insert(insert_cursor, *i);
+	  auto prev = insert_cursor;
+	  --prev;
+	  // be sure to pass address of copy in log.dups
+	  log.index(*prev);
+	}
+      }
+    }
+  }
+
+  // remove any dup entries that overlap with pglog
+  if (!log.dups.empty() && log.dups.back().version >= log.tail) {
+    dout(10) << "merge_log removed dups overlapping log entries [" <<
+      log.tail << "," << log.dups.back().version << "]" << dendl;
+    changed = true;
+
+    while (!log.dups.empty() && log.dups.back().version >= log.tail) {
+      log.unindex(log.dups.back());
+      log.dups.pop_back();
+    }
+  }
+
+  return changed;
 }
 
 void PGLog::check() {
@@ -823,7 +926,8 @@ void PGLog::check() {
 void PGLog::write_log(
   ObjectStore::Transaction& t,
   map<string,bufferlist> *km,
-  const coll_t& coll, const ghobject_t &log_oid,
+  const coll_t& coll,
+  const ghobject_t &log_oid,
   bool require_rollback)
 {
   if (is_dirty()) {
@@ -843,10 +947,11 @@ void PGLog::write_log(
       dirty_from,
       writeout_from,
       trimmed,
-      dirty_divergent_priors,
       trimmed_dups,
+      dirty_divergent_priors,
       !touched_log,
       require_rollback,
+      dirty_dups,
       (pg_log_debug ? &log_keys_debug : 0));
     undirty();
   } else {
@@ -860,13 +965,14 @@ void PGLog::write_log(
     pg_log_t &log,
     const coll_t& coll, const ghobject_t &log_oid,
     map<eversion_t, hobject_t> &divergent_priors,
-    bool require_rollback)
+    bool require_rollback,
+    bool dirty_dups)
 {
   _write_log(
     t, km, log, coll, log_oid,
     divergent_priors, eversion_t::max(), eversion_t(), eversion_t(),
     set<eversion_t>(), set<string>(),
-    true, true, require_rollback, 0);
+    true, true, require_rollback, true, nullptr);
 }
 
 void PGLog::_write_log(
@@ -883,6 +989,7 @@ void PGLog::_write_log(
   bool dirty_divergent_priors,
   bool touch_log,
   bool require_rollback,
+  bool dirty_dups,
   set<string> *log_keys_debug
   )
 {
@@ -932,6 +1039,19 @@ void PGLog::_write_log(
     (*km)[p->get_key_name()].claim(bl);
   }
 
+  if (log_keys_debug) {
+    for (map<string, bufferlist>::iterator i = (*km).begin();
+	 i != (*km).end();
+	 ++i) {
+      if (i->first[0] == '_')
+	continue;
+      assert(!log_keys_debug->count(i->first));
+      log_keys_debug->insert(i->first);
+    }
+  }
+
+  // process dirty_dups after log_keys_debug is filled, so dups do not
+  // end up in that set
   if (dirty_dups) {
     pg_log_dup_t min;
     t.omap_rmkeyrange(
@@ -941,17 +1061,6 @@ void PGLog::_write_log(
       bufferlist bl;
       ::encode(entry, bl);
       (*km)[entry.get_key_name()].claim(bl);
-    }
-  }
-
-  if (log_keys_debug) {
-    for (map<string, bufferlist>::iterator i = (*km).begin();
-	 i != (*km).end();
-	 ++i) {
-      if (i->first[0] == '_')
-	continue;
-      assert(!log_keys_debug->count(i->first));
-      log_keys_debug->insert(i->first);
     }
   }
 

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -464,7 +464,7 @@ struct PGLog : DoutPrefixProvider {
       eversion_t s,
       set<eversion_t> *trimmed,
       set<string>* trimmed_dups,
-      bool* dirty_dups);
+      eversion_t *write_from_dups);
 
     ostream& print(ostream& out) const;
 
@@ -483,13 +483,15 @@ protected:
   eversion_t dirty_from;       ///< must clear/writeout all keys >= dirty_from
   eversion_t writeout_from;    ///< must writout keys >= writeout_from
   set<eversion_t> trimmed;     ///< must clear keys in trimmed
+  eversion_t dirty_to_dups;    ///< must clear/writeout all dups <= dirty_to_dups
+  eversion_t dirty_from_dups;  ///< must clear/writeout all dups >= dirty_from_dups
+  eversion_t write_from_dups;  ///< must write keys >= write_from_dups
   set<string> trimmed_dups;    ///< must clear keys in trimmed_dups
   CephContext *cct;
   bool pg_log_debug;
   /// Log is clean on [dirty_to, dirty_from)
   bool touched_log;
   bool dirty_divergent_priors;
-  bool dirty_dups; /// log.dups is updated
 
   bool is_dirty() const {
     return !touched_log ||
@@ -498,7 +500,9 @@ protected:
       dirty_divergent_priors ||
       (writeout_from != eversion_t::max()) ||
       !(trimmed_dups.empty()) ||
-      dirty_dups ||
+      (dirty_to_dups != eversion_t()) ||
+      (dirty_from_dups != eversion_t::max()) ||
+      (write_from_dups != eversion_t::max()) ||
       !(trimmed.empty());
   }
   void mark_dirty_to(eversion_t to) {
@@ -513,6 +517,14 @@ protected:
     if (from < writeout_from)
       writeout_from = from;
   }
+  void mark_dirty_to_dups(eversion_t to) {
+    if (to > dirty_to_dups)
+      dirty_to_dups = to;
+  }
+  void mark_dirty_from_dups(eversion_t from) {
+    if (from < dirty_from_dups)
+      dirty_from_dups = from;
+  }
   void add_divergent_prior(eversion_t version, hobject_t obj) {
     divergent_priors.insert(make_pair(version, obj));
     dirty_divergent_priors = true;
@@ -521,6 +533,8 @@ public:
   void mark_log_for_rewrite() {
     mark_dirty_to(eversion_t::max());
     mark_dirty_from(eversion_t());
+    mark_dirty_to_dups(eversion_t::max());
+    mark_dirty_from_dups(eversion_t());
     touched_log = false;
   }
 protected:
@@ -552,7 +566,9 @@ protected:
     trimmed_dups.clear();
     writeout_from = eversion_t::max();
     check();
-    dirty_dups = false;
+    dirty_to_dups = eversion_t();
+    dirty_from_dups = eversion_t::max();
+    write_from_dups = eversion_t::max();
   }
 public:
 
@@ -560,10 +576,12 @@ public:
   PGLog(CephContext *cct, DoutPrefixProvider *dpp = nullptr) :
     prefix_provider(dpp),
     dirty_from(eversion_t::max()),
-    writeout_from(eversion_t::max()), 
-    cct(cct), 
+    writeout_from(eversion_t::max()),
+    dirty_from_dups(eversion_t::max()),
+    write_from_dups(eversion_t::max()),
+    cct(cct),
     pg_log_debug(!(cct && !(cct->_conf->osd_debug_pg_log_writeout))),
-    touched_log(false), dirty_divergent_priors(false), dirty_dups(false) {}
+    touched_log(false), dirty_divergent_priors(false) {}
 
   void reset_backfill();
 
@@ -667,6 +685,7 @@ public:
     log.claim_log_and_clear_rollback_info(o);
     missing.clear();
     mark_dirty_to(eversion_t::max());
+    mark_dirty_to_dups(eversion_t::max());
   }
 
   void split_into(
@@ -676,7 +695,9 @@ public:
     log.split_into(child_pgid, split_bits, &(opg_log->log));
     missing.split_into(child_pgid, split_bits, &(opg_log->missing));
     opg_log->mark_dirty_to(eversion_t::max());
+    opg_log->mark_dirty_to_dups(eversion_t::max());
     mark_dirty_to(eversion_t::max());
+    mark_dirty_to_dups(eversion_t::max());
 
     unsigned mask = ~((~0)<<split_bits);
     for (map<eversion_t, hobject_t>::iterator i = divergent_priors.begin();
@@ -872,8 +893,7 @@ public:
     pg_log_t &log,
     const coll_t& coll,
     const ghobject_t &log_oid, map<eversion_t, hobject_t> &divergent_priors,
-    bool require_rollback,
-    bool dirty_dups);
+    bool require_rollback);
 
   static void _write_log(
     ObjectStore::Transaction& t,
@@ -889,7 +909,9 @@ public:
     bool dirty_divergent_priors,
     bool touch_log,
     bool require_rollback,
-    bool dirty_dups,
+    eversion_t dirty_to_dups,
+    eversion_t dirty_from_dups,
+    eversion_t write_from_dups,
     set<string> *log_keys_debug
     );
 

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -78,6 +78,7 @@ struct PGLog : DoutPrefixProvider {
     mutable ceph::unordered_map<hobject_t,pg_log_entry_t*> objects;  // ptrs into log.  be careful!
     mutable ceph::unordered_map<osd_reqid_t,pg_log_entry_t*> caller_ops;
     mutable ceph::unordered_multimap<osd_reqid_t,pg_log_entry_t*> extra_caller_ops;
+    mutable ceph::unordered_map<osd_reqid_t, pg_log_dup_t*> dup_index;
 
     // recovery pointers
     list<pg_log_entry_t>::iterator complete_to;  // not inclusive of referenced item
@@ -339,6 +340,7 @@ struct PGLog : DoutPrefixProvider {
       objects.clear();
       caller_ops.clear();
       extra_caller_ops.clear();
+      dup_index.clear();
       indexed_data = 0;
     }
     void unindex(pg_log_entry_t& e) {
@@ -414,7 +416,8 @@ struct PGLog : DoutPrefixProvider {
     void trim(
       LogEntryHandler *handler,
       eversion_t s,
-      set<eversion_t> *trimmed);
+      set<eversion_t> *trimmed,
+      set<string> *trimmed_dups);
 
     ostream& print(ostream& out) const;
 
@@ -433,11 +436,13 @@ protected:
   eversion_t dirty_from;       ///< must clear/writeout all keys >= dirty_from
   eversion_t writeout_from;    ///< must writout keys >= writeout_from
   set<eversion_t> trimmed;     ///< must clear keys in trimmed
+  set<string> trimmed_dups; ///< must clear keys in trimmed_dups
   CephContext *cct;
   bool pg_log_debug;
   /// Log is clean on [dirty_to, dirty_from)
   bool touched_log;
   bool dirty_divergent_priors;
+  bool dirty_dups; /// log.dups is updated
 
   bool is_dirty() const {
     return !touched_log ||
@@ -445,6 +450,7 @@ protected:
       (dirty_from != eversion_t::max()) ||
       dirty_divergent_priors ||
       (writeout_from != eversion_t::max()) ||
+      !(trimmed_dups.empty()) ||
       !(trimmed.empty());
   }
   void mark_dirty_to(eversion_t to) {
@@ -495,8 +501,10 @@ protected:
     dirty_divergent_priors = false;
     touched_log = true;
     trimmed.clear();
+    trimmed_dups.clear();
     writeout_from = eversion_t::max();
     check();
+    dirty_dups = false;
   }
 public:
   // cppcheck-suppress noExplicitConstructor
@@ -825,6 +833,7 @@ public:
     eversion_t dirty_from,
     eversion_t writeout_from,
     const set<eversion_t> &trimmed,
+    const set<string> &trimmed_dups,
     bool dirty_divergent_priors,
     bool touch_log,
     bool require_rollback,

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -28,7 +28,11 @@ using namespace std;
 #define PGLOG_INDEXED_OBJECTS          (1 << 0)
 #define PGLOG_INDEXED_CALLER_OPS       (1 << 1)
 #define PGLOG_INDEXED_EXTRA_CALLER_OPS (1 << 2)
-#define PGLOG_INDEXED_ALL              (PGLOG_INDEXED_OBJECTS | PGLOG_INDEXED_CALLER_OPS | PGLOG_INDEXED_EXTRA_CALLER_OPS)
+#define PGLOG_INDEXED_DUPS             (1 << 3)
+#define PGLOG_INDEXED_ALL              (PGLOG_INDEXED_OBJECTS | \
+					PGLOG_INDEXED_CALLER_OPS | \
+					PGLOG_INDEXED_EXTRA_CALLER_OPS | \
+					PGLOG_INDEXED_DUPS)
 
 struct PGLog : DoutPrefixProvider {
   DoutPrefixProvider *prefix_provider;
@@ -78,7 +82,7 @@ struct PGLog : DoutPrefixProvider {
     mutable ceph::unordered_map<hobject_t,pg_log_entry_t*> objects;  // ptrs into log.  be careful!
     mutable ceph::unordered_map<osd_reqid_t,pg_log_entry_t*> caller_ops;
     mutable ceph::unordered_multimap<osd_reqid_t,pg_log_entry_t*> extra_caller_ops;
-    mutable ceph::unordered_map<osd_reqid_t, pg_log_dup_t*> dup_index;
+    mutable ceph::unordered_map<osd_reqid_t,pg_log_dup_t*> dup_index;
 
     // recovery pointers
     list<pg_log_entry_t>::iterator complete_to;  // not inclusive of referenced item
@@ -104,7 +108,7 @@ struct PGLog : DoutPrefixProvider {
       last_requested(0),
       indexed_data(0),
       rollback_info_trimmed_to_riter(log.rbegin())
-      {}
+    { }
 
     void claim_log_and_clear_rollback_info(const pg_log_t& o) {
       // we must have already trimmed the old entries
@@ -199,6 +203,17 @@ struct PGLog : DoutPrefixProvider {
 	}
 	assert(0 == "in extra_caller_ops but not extra_reqids");
       }
+
+      if (!(indexed_data & PGLOG_INDEXED_DUPS)) {
+        index_dups();
+      }
+      auto q = dup_index.find(r);
+      if (q != dup_index.end()) {
+	*replay_version = q->second->version;
+	*user_version = q->second->user_version;
+	return true;
+      }
+
       return false;
     }
 
@@ -266,6 +281,11 @@ struct PGLog : DoutPrefixProvider {
             extra_caller_ops.insert(make_pair(j->first, &(*i)));
         }
       }
+
+      dup_index.clear();
+      for (auto& i : dups) {
+	dup_index[i.reqid] = const_cast<pg_log_dup_t*>(&i);
+      }
         
       reset_riter();
       indexed_data = PGLOG_INDEXED_ALL;
@@ -315,6 +335,14 @@ struct PGLog : DoutPrefixProvider {
       indexed_data |= PGLOG_INDEXED_EXTRA_CALLER_OPS;        
     }
 
+    void index_dups() const {
+      dup_index.clear();
+      for (auto& i : dups) {
+	dup_index[i.reqid] = const_cast<pg_log_dup_t*>(&i);
+      }
+      indexed_data |= PGLOG_INDEXED_DUPS;
+    }
+
     void index(pg_log_entry_t& e) {
       if (indexed_data & PGLOG_INDEXED_OBJECTS) {
         if (objects.count(e.soid) == 0 || 
@@ -336,6 +364,7 @@ struct PGLog : DoutPrefixProvider {
         }
       }
     }
+
     void unindex() {
       objects.clear();
       caller_ops.clear();
@@ -343,7 +372,8 @@ struct PGLog : DoutPrefixProvider {
       dup_index.clear();
       indexed_data = 0;
     }
-    void unindex(pg_log_entry_t& e) {
+
+    void unindex(const pg_log_entry_t& e) {
       // NOTE: this only works if we remove from the _tail_ of the log!
       if (indexed_data & PGLOG_INDEXED_OBJECTS) {
         if (objects.count(e.soid) && objects[e.soid]->version == e.version)
@@ -371,6 +401,21 @@ struct PGLog : DoutPrefixProvider {
             }
           }
         }
+      }
+    }
+
+    void index(pg_log_dup_t& e) {
+      if (PGLOG_INDEXED_DUPS) {
+	dup_index[e.reqid] = &e;
+      }
+    }
+
+    void unindex(const pg_log_dup_t& e) {
+      if (PGLOG_INDEXED_DUPS) {
+	auto i = dup_index.find(e.reqid);
+	if (i != dup_index.end()) {
+	  dup_index.erase(i);
+	}
       }
     }
 
@@ -402,7 +447,7 @@ struct PGLog : DoutPrefixProvider {
     caller_ops[e.reqid] = &(log.back());
         }
       }
-      
+
       if (indexed_data & PGLOG_INDEXED_EXTRA_CALLER_OPS) {
         for (vector<pair<osd_reqid_t, version_t> >::const_iterator j =
          e.extra_reqids.begin();
@@ -414,10 +459,12 @@ struct PGLog : DoutPrefixProvider {
     }
 
     void trim(
+      CephContext *cct,
       LogEntryHandler *handler,
       eversion_t s,
       set<eversion_t> *trimmed,
-      set<string> *trimmed_dups);
+      set<string>* trimmed_dups,
+      bool* dirty_dups);
 
     ostream& print(ostream& out) const;
 
@@ -436,7 +483,7 @@ protected:
   eversion_t dirty_from;       ///< must clear/writeout all keys >= dirty_from
   eversion_t writeout_from;    ///< must writout keys >= writeout_from
   set<eversion_t> trimmed;     ///< must clear keys in trimmed
-  set<string> trimmed_dups; ///< must clear keys in trimmed_dups
+  set<string> trimmed_dups;    ///< must clear keys in trimmed_dups
   CephContext *cct;
   bool pg_log_debug;
   /// Log is clean on [dirty_to, dirty_from)
@@ -451,6 +498,7 @@ protected:
       dirty_divergent_priors ||
       (writeout_from != eversion_t::max()) ||
       !(trimmed_dups.empty()) ||
+      dirty_dups ||
       !(trimmed.empty());
   }
   void mark_dirty_to(eversion_t to) {
@@ -507,15 +555,15 @@ protected:
     dirty_dups = false;
   }
 public:
+
   // cppcheck-suppress noExplicitConstructor
-  PGLog(CephContext *cct, DoutPrefixProvider *dpp = 0) :
+  PGLog(CephContext *cct, DoutPrefixProvider *dpp = nullptr) :
     prefix_provider(dpp),
     dirty_from(eversion_t::max()),
     writeout_from(eversion_t::max()), 
     cct(cct), 
     pg_log_debug(!(cct && !(cct->_conf->osd_debug_pg_log_writeout))),
-    touched_log(false), dirty_divergent_priors(false) {}
-
+    touched_log(false), dirty_divergent_priors(false), dirty_dups(false) {}
 
   void reset_backfill();
 
@@ -647,7 +695,7 @@ public:
   void recover_got(hobject_t oid, eversion_t v, pg_info_t &info) {
     if (missing.is_missing(oid, v)) {
       missing.got(oid, v);
-      
+
       // raise last_complete?
       if (missing.missing.empty()) {
 	log.complete_to = log.log.end();
@@ -773,6 +821,9 @@ protected:
 	(*new_divergent_prior).first,
 	(*new_divergent_prior).second);
   }
+
+  bool merge_log_dups(const pg_log_t& olog);
+
 public:
   void rewind_divergent_log(ObjectStore::Transaction& t, eversion_t newhead,
                             pg_info_t &info, LogEntryHandler *rollbacker,
@@ -821,7 +872,8 @@ public:
     pg_log_t &log,
     const coll_t& coll,
     const ghobject_t &log_oid, map<eversion_t, hobject_t> &divergent_priors,
-    bool require_rollback);
+    bool require_rollback,
+    bool dirty_dups);
 
   static void _write_log(
     ObjectStore::Transaction& t,
@@ -837,6 +889,7 @@ public:
     bool dirty_divergent_priors,
     bool touch_log,
     bool require_rollback,
+    bool dirty_dups,
     set<string> *log_keys_debug
     );
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3653,17 +3653,21 @@ void pg_log_dup_t::dump(Formatter *f) const
 void pg_log_dup_t::generate_test_instances(list<pg_log_dup_t*>& o)
 {
   o.push_back(new pg_log_dup_t());
-  o.push_back(new pg_log_dup_t(osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
-			       eversion_t(1,2), 1, 0);
-  o.push_back(new pg_log_dup_t(osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
-			       eversion_t(1,2), 2, -ENOENT);
+  o.push_back(new pg_log_dup_t(eversion_t(1,2),
+			       1,
+			       osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
+			       0));
+  o.push_back(new pg_log_dup_t(eversion_t(1,2),
+			       2,
+			       osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
+			       -ENOENT));
 }
 
-ostream& operator<<(ostream& out, const pg_log_dup_t& e)
-{
-  out << e.reqid << " v" << e.version << " uv" << e.user_version
-      << " rc=" << e.return_code;
-  return out;
+
+std::ostream& operator<<(std::ostream& out, const pg_log_dup_t& e) {
+  return out << "log_dup(reqid=" << e.reqid <<
+    " v=" << e.version << " uv=" << e.user_version <<
+    " rc=" << e.return_code << ")";
 }
 
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3615,6 +3615,57 @@ ostream& operator<<(ostream& out, const pg_log_entry_t& e)
   return out;
 }
 
+// -- pg_log_dup_t --
+
+string pg_log_dup_t::get_key_name() const
+{
+  return "dup_" + version.get_key_name();
+}
+
+void pg_log_dup_t::encode(bufferlist &bl) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(reqid, bl);
+  ::encode(version, bl);
+  ::encode(user_version, bl);
+  ::encode(return_code, bl);
+  ENCODE_FINISH(bl);
+}
+
+void pg_log_dup_t::decode(bufferlist::iterator &bl)
+{
+  DECODE_START(1, bl);
+  ::decode(reqid, bl);
+  ::decode(version, bl);
+  ::decode(user_version, bl);
+  ::decode(return_code, bl);
+  DECODE_FINISH(bl);
+}
+
+void pg_log_dup_t::dump(Formatter *f) const
+{
+  f->dump_stream("reqid") << reqid;
+  f->dump_stream("version") << version;
+  f->dump_stream("user_version") << user_version;
+  f->dump_stream("return_code") << return_code;
+}
+
+void pg_log_dup_t::generate_test_instances(list<pg_log_dup_t*>& o)
+{
+  o.push_back(new pg_log_dup_t());
+  o.push_back(new pg_log_dup_t(osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
+			       eversion_t(1,2), 1, 0);
+  o.push_back(new pg_log_dup_t(osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
+			       eversion_t(1,2), 2, -ENOENT);
+}
+
+ostream& operator<<(ostream& out, const pg_log_dup_t& e)
+{
+  out << e.reqid << " v" << e.version << " uv" << e.user_version
+      << " rc=" << e.return_code;
+  return out;
+}
+
 
 // -- pg_log_t --
 
@@ -3656,18 +3707,19 @@ void pg_log_t::filter_log(spg_t import_pgid, const OSDMap &curmap,
 
 void pg_log_t::encode(bufferlist& bl) const
 {
-  ENCODE_START(6, 3, bl);
+  ENCODE_START(7, 3, bl);
   ::encode(head, bl);
   ::encode(tail, bl);
   ::encode(log, bl);
   ::encode(can_rollback_to, bl);
   ::encode(rollback_info_trimmed_to, bl);
+  ::encode(dups, bl);
   ENCODE_FINISH(bl);
 }
  
 void pg_log_t::decode(bufferlist::iterator &bl, int64_t pool)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(6, 3, 3, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(7, 3, 3, bl);
   ::decode(head, bl);
   ::decode(tail, bl);
   if (struct_v < 2) {
@@ -3682,6 +3734,10 @@ void pg_log_t::decode(bufferlist::iterator &bl, int64_t pool)
     ::decode(rollback_info_trimmed_to, bl);
   else
     rollback_info_trimmed_to = tail;
+
+  if (struct_v >= 7)
+    ::decode(dups, bl);
+
   DECODE_FINISH(bl);
 
   // handle hobject_t format change
@@ -3703,6 +3759,13 @@ void pg_log_t::dump(Formatter *f) const
   for (list<pg_log_entry_t>::const_iterator p = log.begin(); p != log.end(); ++p) {
     f->open_object_section("entry");
     p->dump(f);
+    f->close_section();
+  }
+  f->close_section();
+  f->open_array_section("dups");
+  for (const auto& entry : dups) {
+    f->open_object_section("entry");
+    entry.dump(f);
     f->close_section();
   }
   f->close_section();
@@ -3777,13 +3840,16 @@ void pg_log_t::copy_up_to(const pg_log_t &other, int max)
   }
 }
 
-ostream& pg_log_t::print(ostream& out) const 
+ostream& pg_log_t::print(ostream& out) const
 {
   out << *this << std::endl;
   for (list<pg_log_entry_t>::const_iterator p = log.begin();
        p != log.end();
-       ++p) 
+       ++p)
     out << *p << std::endl;
+  for (const auto& entry : dups) {
+    out << " dup entry: " << entry << std::endl;
+  }
   return out;
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -732,7 +732,7 @@ public:
   eversion_t(epoch_t e, version_t v) : version(v), epoch(e), __pad(0) {}
 
   // cppcheck-suppress noExplicitConstructor
-  eversion_t(const ceph_eversion& ce) : 
+  eversion_t(const ceph_eversion& ce) :
     version(ce.version),
     epoch(ce.epoch),
     __pad(0) { }
@@ -2644,13 +2644,18 @@ struct pg_log_dup_t {
     : reqid(rid), version(v), user_version(uv),
       return_code(return_code)
   {}
+
   string get_key_name() const;
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<pg_log_dup_t*>& o);
+
+  friend std::ostream& operator<<(std::ostream& out, const pg_log_dup_t& e);
 };
 WRITE_CLASS_ENCODER(pg_log_dup_t)
+
+std::ostream& operator<<(std::ostream& out, const pg_log_dup_t& e);
 
 /**
  * pg_log_t - incremental log of recent pg changes.
@@ -2772,7 +2777,7 @@ struct pg_log_t {
 };
 WRITE_CLASS_ENCODER(pg_log_t)
 
-inline ostream& operator<<(ostream& out, const pg_log_t& log) 
+inline ostream& operator<<(ostream& out, const pg_log_t& log)
 {
   out << "log((" << log.tail << "," << log.head << "], crt="
       << log.can_rollback_to << ")";
@@ -3133,10 +3138,6 @@ inline ostream& operator<<(ostream& out, const ObjectExtent &ex)
 	     << " -> " << ex.buffer_extents
              << ")";
 }
-
-
-
-
 
 
 // ---------------------------------------

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2627,7 +2627,30 @@ WRITE_CLASS_ENCODER(pg_log_entry_t)
 
 ostream& operator<<(ostream& out, const pg_log_entry_t& e);
 
+struct pg_log_dup_t {
+  osd_reqid_t reqid;  // caller+tid to uniquely identify request
+  eversion_t version;
+  version_t user_version; // the user version for this entry
+  int32_t return_code; // only stored for ERRORs for dup detection
 
+  pg_log_dup_t()
+   : user_version(0), return_code(0) {}
+  explicit pg_log_dup_t(const pg_log_entry_t &entry)
+    : reqid(entry.reqid), version(entry.version),
+      user_version(entry.user_version), return_code(0)
+  {}
+  pg_log_dup_t(const eversion_t& v, version_t uv,
+	       const osd_reqid_t& rid, int return_code)
+    : reqid(rid), version(v), user_version(uv),
+      return_code(return_code)
+  {}
+  string get_key_name() const;
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &bl);
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<pg_log_dup_t*>& o);
+};
+WRITE_CLASS_ENCODER(pg_log_dup_t)
 
 /**
  * pg_log_t - incremental log of recent pg changes.
@@ -2652,13 +2675,15 @@ struct pg_log_t {
   eversion_t rollback_info_trimmed_to;
 
   list<pg_log_entry_t> log;  // the actual log.
-  
+  list<pg_log_dup_t> dups;  // entries just for dup op detection
+
   pg_log_t() {}
 
   void clear() {
     eversion_t z;
     can_rollback_to = head = tail = z;
     log.clear();
+    dups.clear();
   }
 
   bool empty() const {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2651,6 +2651,16 @@ struct pg_log_dup_t {
   void dump(Formatter *f) const;
   static void generate_test_instances(list<pg_log_dup_t*>& o);
 
+  bool operator==(const pg_log_dup_t &rhs) const {
+    return reqid == rhs.reqid &&
+      version == rhs.version &&
+      user_version == rhs.user_version &&
+      return_code == rhs.return_code;
+  }
+  bool operator!=(const pg_log_dup_t &rhs) const {
+    return !(*this == rhs);
+  }
+
   friend std::ostream& operator<<(std::ostream& out, const pg_log_dup_t& e);
 };
 WRITE_CLASS_ENCODER(pg_log_dup_t)

--- a/src/test/Makefile-server.am
+++ b/src/test/Makefile-server.am
@@ -194,7 +194,7 @@ if LINUX
 unittest_osdscrub_LDADD += -ldl
 endif # LINUX
 
-unittest_pglog_SOURCES = test/osd/TestPGLog.cc
+unittest_pglog_SOURCES = test/osd/TestPGLog.cc test/objectstore/store_test_fixture.cc
 unittest_pglog_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 unittest_pglog_LDADD = $(LIBOSD) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 check_TESTPROGRAMS += unittest_pglog

--- a/src/test/objectstore/store_test_fixture.cc
+++ b/src/test/objectstore/store_test_fixture.cc
@@ -1,0 +1,55 @@
+#include <stdlib.h>
+#include <string>
+#include <iostream>
+#include <gtest/gtest.h>
+
+#include "common/errno.h"
+#include "os/ObjectStore.h"
+#if defined(HAVE_LIBAIO)
+#include "os/bluestore/BlueStore.h"
+#endif
+#include "store_test_fixture.h"
+
+static void rm_r(const string& path) {
+  string cmd = string("rm -r ") + path;
+  cout << "==> " << cmd << std::endl;
+  int r = ::system(cmd.c_str());
+  if (r) {
+    if (r == -1) {
+      r = errno;
+      cerr << "system() failed to fork() " << cpp_strerror(r)
+           << ", continuing anyway" << std::endl;
+    } else {
+      cerr << "failed with exit code " << r
+           << ", continuing anyway" << std::endl;
+    }
+  }
+}
+
+void StoreTestFixture::SetUp() {
+  int r = ::mkdir(data_dir.c_str(), 0777);
+  if (r < 0) {
+    r = -errno;
+    cerr << __func__ << ": unable to create " << data_dir << ": " << cpp_strerror(r) << std::endl;
+  }
+  ASSERT_EQ(0, r);
+
+  store.reset(ObjectStore::create(g_ceph_context,
+                                  type,
+                                  data_dir,
+                                  string("store_test_temp_journal")));
+  if (!store) {
+    cerr << __func__ << ": objectstore type " << type << " doesn't exist yet!" << std::endl;
+  }
+  ASSERT_FALSE(!store);
+  ASSERT_EQ(0, store->mkfs());
+  ASSERT_EQ(0, store->mount());
+}
+
+void StoreTestFixture::TearDown() {
+  if (store) {
+    int r = store->umount();
+    EXPECT_EQ(0, r);
+    rm_r(data_dir);
+  }
+}

--- a/src/test/objectstore/store_test_fixture.h
+++ b/src/test/objectstore/store_test_fixture.h
@@ -1,0 +1,19 @@
+#include <string>
+#include <boost/scoped_ptr.hpp>
+#include <gtest/gtest.h>
+
+class ObjectStore;
+
+class StoreTestFixture : virtual public ::testing::Test {
+  const std::string type;
+  const std::string data_dir;
+
+public:
+  boost::scoped_ptr<ObjectStore> store;
+
+  StoreTestFixture(const std::string& type)
+    : type(type), data_dir(type + ".test_temp_dir")
+  {}
+  void SetUp() override;
+  void TearDown() override;
+};

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -25,15 +25,8 @@
 #include "osd/OSDMap.h"
 #include "test/unit.h"
 
-class PGLogTest : public ::testing::Test, protected PGLog {
-public:
-  PGLogTest() : PGLog(g_ceph_context) {}
-  virtual void SetUp() { }
 
-  virtual void TearDown() {
-    clear();
-  }
-
+struct PGLogTestBase {
   static hobject_t mk_obj(unsigned id) {
     hobject_t hoid;
     stringstream ss;
@@ -46,43 +39,78 @@ public:
     return eversion_t(ep, v);
   }
   static pg_log_entry_t mk_ple_mod(
-    const hobject_t &hoid, eversion_t v, eversion_t pv) {
+    const hobject_t &hoid, eversion_t v, eversion_t pv, osd_reqid_t reqid) {
     pg_log_entry_t e;
     e.mod_desc.mark_unrollbackable();
     e.op = pg_log_entry_t::MODIFY;
     e.soid = hoid;
     e.version = v;
     e.prior_version = pv;
+    e.reqid = reqid;
     return e;
   }
   static pg_log_entry_t mk_ple_dt(
-    const hobject_t &hoid, eversion_t v, eversion_t pv) {
+    const hobject_t &hoid, eversion_t v, eversion_t pv, osd_reqid_t reqid) {
     pg_log_entry_t e;
     e.mod_desc.mark_unrollbackable();
     e.op = pg_log_entry_t::DELETE;
     e.soid = hoid;
     e.version = v;
     e.prior_version = pv;
+    e.reqid = reqid;
     return e;
   }
   static pg_log_entry_t mk_ple_mod_rb(
-    const hobject_t &hoid, eversion_t v, eversion_t pv) {
+    const hobject_t &hoid, eversion_t v, eversion_t pv, osd_reqid_t reqid) {
     pg_log_entry_t e;
     e.op = pg_log_entry_t::MODIFY;
     e.soid = hoid;
     e.version = v;
     e.prior_version = pv;
+    e.reqid = reqid;
     return e;
   }
   static pg_log_entry_t mk_ple_dt_rb(
-    const hobject_t &hoid, eversion_t v, eversion_t pv) {
+    const hobject_t &hoid, eversion_t v, eversion_t pv, osd_reqid_t reqid) {
     pg_log_entry_t e;
     e.op = pg_log_entry_t::DELETE;
     e.soid = hoid;
     e.version = v;
     e.prior_version = pv;
+    e.reqid = reqid;
     return e;
   }
+  static pg_log_entry_t mk_ple_mod(
+    const hobject_t &hoid, eversion_t v, eversion_t pv) {
+    return mk_ple_mod(hoid, v, pv, osd_reqid_t());
+  }
+  static pg_log_entry_t mk_ple_dt(
+    const hobject_t &hoid, eversion_t v, eversion_t pv) {
+    return mk_ple_dt(hoid, v, pv, osd_reqid_t());
+  }
+  static pg_log_entry_t mk_ple_mod_rb(
+    const hobject_t &hoid, eversion_t v, eversion_t pv) {
+    return mk_ple_mod_rb(hoid, v, pv, osd_reqid_t());
+  }
+  static pg_log_entry_t mk_ple_dt_rb(
+    const hobject_t &hoid, eversion_t v, eversion_t pv) {
+    return mk_ple_dt_rb(hoid, v, pv, osd_reqid_t());
+  }
+}; // PGLogTestBase
+
+
+class PGLogTest : virtual public ::testing::Test, protected PGLog, public PGLogTestBase  {
+public:
+  PGLogTest() : PGLog(g_ceph_context) {}
+  void SetUp() override {}
+
+#include "common/ceph_context.h"
+#include "common/config.h"
+
+  void TearDown() override {
+    clear();
+  }
+
 
   struct TestCase {
     list<pg_log_entry_t> base;
@@ -150,12 +178,12 @@ public:
     const IndexedLog &get_fulldiv() const { return fulldiv; }
     const pg_info_t &get_authinfo() const { return authinfo; }
     const pg_info_t &get_divinfo() const { return divinfo; }
-  };
+  }; // struct TestCase
 
   struct LogHandler : public PGLog::LogEntryHandler {
     set<hobject_t, hobject_t::BitwiseComparator> removed;
     list<pg_log_entry_t> rolledback;
-    
+
     void rollback(
       const pg_log_entry_t &entry) {
       rolledback.push_back(entry);
@@ -230,7 +258,8 @@ public:
     ASSERT_EQ(info.last_update, oinfo.last_update);
     verify_missing(tcase, missing);
     verify_sideeffects(tcase, h);
-  };
+  }
+
   void test_proc_replica_log(const TestCase &tcase) {
     clear();
     ObjectStore::Transaction t;
@@ -258,12 +287,13 @@ public:
       omissing.add_next_event(*i);
     }
     verify_missing(tcase, omissing);
-  }
+  } // test_proc_replica_log
+
   void run_test_case(const TestCase &tcase) {
     test_merge_log(tcase);
     test_proc_replica_log(tcase);
   }
-};
+}; // class PGLogTest
 
 struct TestHandler : public PGLog::LogEntryHandler {
   list<hobject_t> &removed;
@@ -686,7 +716,7 @@ TEST_F(PGLogTest, merge_old_entry) {
   // the old entry (from the log entry given in argument) is not a CLONE and
   // the old entry (from the log entry given in argument) is not a DELETE and
   // the old entry prior_version is lower than the tail of the log :
-  //   add the old object to the remove_snap list and 
+  //   add the old object to the remove_snap list and
   //   add the old object to divergent priors and
   //   add or update the prior_version of the object to missing and
   //   return false
@@ -1355,11 +1385,11 @@ TEST_F(PGLogTest, proc_replica_log) {
             |        |       |  DELETE |
             |        |       |         |
             +--------+-------+---------+
-	    
+
       The log entry (1,3) deletes the object x9 and the olog entry
       (2,3) also deletes it : do nothing. The olog tail is ignored
       because it is before the log tail.
-      
+
   */
   {
     clear();
@@ -2044,6 +2074,550 @@ TEST_F(PGLogTest, filter_log_1) {
     EXPECT_EQ(count, num_internal);
   }
 }
+
+int main(int argc, char **argv) {
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+
+  auto x = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+		       CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+
+class PGLogMergeDupsTest : public ::testing::Test, protected PGLog {
+
+public:
+
+  PGLogMergeDupsTest() : PGLog(g_ceph_context) { }
+
+  void SetUp() override { }
+
+  void TearDown() override {
+    clear();
+  }
+
+  static pg_log_dup_t create_dup_entry(uint a, uint b) {
+    // make each dup_entry unique by using different client id's
+    static uint client_id = 777;
+    return pg_log_dup_t(eversion_t(a, b),
+			a,
+			osd_reqid_t(entity_name_t::CLIENT(client_id++), 8, 1),
+			0);
+  }
+
+  static std::vector<pg_log_dup_t> example_dups_1() {
+    std::vector<pg_log_dup_t> result = {
+      create_dup_entry(10, 11),
+      create_dup_entry(10, 12),
+      create_dup_entry(11, 1),
+      create_dup_entry(12, 3),
+      create_dup_entry(13, 99)
+    };
+    return result;
+  }
+
+  static std::vector<pg_log_dup_t> example_dups_2() {
+    std::vector<pg_log_dup_t> result = {
+      create_dup_entry(12, 3),
+      create_dup_entry(13, 99),
+      create_dup_entry(15, 11),
+      create_dup_entry(16, 14),
+      create_dup_entry(16, 32)
+    };
+    return result;
+  }
+
+  void add_dups(uint a, uint b) {
+    log.dups.push_back(create_dup_entry(a, b));
+  }
+
+  void add_dups(const std::vector<pg_log_dup_t>& l) {
+    for (auto& i : l) {
+      log.dups.push_back(i);
+    }
+  }
+
+  static void add_dups(IndexedLog& log, const std::vector<pg_log_dup_t>& dups) {
+    for (auto& i : dups) {
+      log.dups.push_back(i);
+    }
+  }
+
+  void check_order() {
+    eversion_t prev(0, 0);
+
+    for (auto& i : log.dups) {
+      EXPECT_LT(prev, i.version) << "verify versions monotonically increase";
+      prev = i.version;
+    }
+  }
+
+  void check_index() {
+    EXPECT_EQ(log.dups.size(), log.dup_index.size());
+    for (auto& i : log.dups) {
+      EXPECT_EQ(1u, log.dup_index.count(i.reqid));
+    }
+  }
+};
+
+TEST_F(PGLogMergeDupsTest, OtherEmpty) {
+  log.tail = eversion_t(14, 5);
+
+  IndexedLog olog;
+
+  add_dups(example_dups_1());
+  index();
+
+  bool changed = merge_log_dups(olog);
+
+  EXPECT_FALSE(changed);
+  EXPECT_EQ(5u, log.dups.size());
+
+  if (5 == log.dups.size()) {
+    EXPECT_EQ(10u, log.dups.front().version.epoch);
+    EXPECT_EQ(11u, log.dups.front().version.version);
+    EXPECT_EQ(13u, log.dups.back().version.epoch);
+    EXPECT_EQ(99u, log.dups.back().version.version);
+  }
+
+  check_order();
+  check_index();
+}
+
+TEST_F(PGLogMergeDupsTest, AmEmpty) {
+  log.tail = eversion_t(14, 5);
+  index();
+
+  IndexedLog olog;
+
+  add_dups(olog, example_dups_1());
+
+  bool changed = merge_log_dups(olog);
+
+  EXPECT_TRUE(changed);
+  EXPECT_EQ(5u, log.dups.size());
+
+  if (5 == log.dups.size()) {
+    EXPECT_EQ(10u, log.dups.front().version.epoch);
+    EXPECT_EQ(11u, log.dups.front().version.version);
+
+    EXPECT_EQ(13u, log.dups.back().version.epoch);
+    EXPECT_EQ(99u, log.dups.back().version.version);
+  }
+
+  check_order();
+  check_index();
+}
+
+TEST_F(PGLogMergeDupsTest, AmEmptyOverlap) {
+  log.tail = eversion_t(12, 3);
+  index();
+
+  IndexedLog olog;
+
+  add_dups(olog, example_dups_1());
+
+  bool changed = merge_log_dups(olog);
+
+  EXPECT_TRUE(changed);
+  EXPECT_EQ(3u, log.dups.size());
+
+  if (3 == log.dups.size()) {
+    EXPECT_EQ(10u, log.dups.front().version.epoch);
+    EXPECT_EQ(11u, log.dups.front().version.version);
+
+    EXPECT_EQ(11u, log.dups.back().version.epoch);
+    EXPECT_EQ(1u, log.dups.back().version.version);
+  }
+
+  check_order();
+  check_index();
+}
+
+TEST_F(PGLogMergeDupsTest, Same) {
+  log.tail = eversion_t(14, 1);
+
+  IndexedLog olog;
+
+  add_dups(example_dups_1());
+  index();
+  add_dups(olog, example_dups_1());
+
+  bool changed = merge_log_dups(olog);
+
+  EXPECT_FALSE(changed);
+  EXPECT_EQ(5u, log.dups.size());
+
+  if (5 == log.dups.size()) {
+    EXPECT_EQ(10u, log.dups.front().version.epoch);
+    EXPECT_EQ(11u, log.dups.front().version.version);
+
+    EXPECT_EQ(13u, log.dups.back().version.epoch);
+    EXPECT_EQ(99u, log.dups.back().version.version);
+  }
+
+  check_order();
+  check_index();
+}
+
+
+TEST_F(PGLogMergeDupsTest, Later) {
+  log.tail = eversion_t(16, 14);
+
+  IndexedLog olog;
+
+  add_dups(example_dups_1());
+  index();
+  add_dups(olog, example_dups_2());
+
+  bool changed = merge_log_dups(olog);
+
+  EXPECT_TRUE(changed);
+  EXPECT_EQ(6u, log.dups.size());
+
+  if (6 == log.dups.size()) {
+    EXPECT_EQ(10u, log.dups.front().version.epoch);
+    EXPECT_EQ(11u, log.dups.front().version.version);
+
+    EXPECT_EQ(15u, log.dups.back().version.epoch);
+    EXPECT_EQ(11u, log.dups.back().version.version);
+  }
+
+  check_order();
+  check_index();
+}
+
+
+TEST_F(PGLogMergeDupsTest, Earlier) {
+  log.tail = eversion_t(17, 2);
+
+  IndexedLog olog;
+
+  add_dups(example_dups_2());
+  index();
+  add_dups(olog, example_dups_1());
+
+  bool changed = merge_log_dups(olog);
+
+  EXPECT_TRUE(changed);
+  EXPECT_EQ(8u, log.dups.size());
+
+  if (6 == log.dups.size()) {
+    EXPECT_EQ(10u, log.dups.front().version.epoch);
+    EXPECT_EQ(11u, log.dups.front().version.version);
+
+    EXPECT_EQ(16u, log.dups.back().version.epoch);
+    EXPECT_EQ(32u, log.dups.back().version.version);
+  }
+
+  check_order();
+  check_index();
+}
+
+
+TEST_F(PGLogMergeDupsTest, Superset) {
+  log.tail = eversion_t(17, 2);
+
+  IndexedLog olog;
+
+  add_dups(example_dups_1());
+  index();
+
+  olog.dups.push_back(create_dup_entry(9, 5));
+  olog.dups.push_back(create_dup_entry(15, 11));
+
+  bool changed = merge_log_dups(olog);
+
+  EXPECT_TRUE(changed);
+  EXPECT_EQ(7u, log.dups.size());
+
+  if (7 == log.dups.size()) {
+    EXPECT_EQ(9u, log.dups.front().version.epoch);
+    EXPECT_EQ(5u, log.dups.front().version.version);
+
+    EXPECT_EQ(15u, log.dups.back().version.epoch);
+    EXPECT_EQ(11u, log.dups.back().version.version);
+  }
+
+  check_order();
+  check_index();
+}
+
+
+struct PGLogTrimTest :
+  public ::testing::Test,
+  public PGLogTestBase,
+  public PGLog::IndexedLog
+{
+  std::list<hobject_t*> test_hobjects;
+  CephContext *cct;
+
+  void SetUp() override {
+    cct = (new CephContext(CEPH_ENTITY_TYPE_OSD))->get();
+
+    hobject_t::generate_test_instances(test_hobjects);
+  }
+
+  void SetUp(unsigned min_entries, unsigned max_entries, unsigned dup_track) {
+    constexpr size_t size = 10;
+
+    char min_entries_s[size];
+    char max_entries_s[size];
+    char dup_track_s[size];
+
+    snprintf(min_entries_s, size, "%u", min_entries);
+    snprintf(max_entries_s, size, "%u", max_entries);
+    snprintf(dup_track_s, size, "%u", dup_track);
+
+    cct->_conf->set_val_or_die("osd_min_pg_log_entries", min_entries_s);
+    cct->_conf->set_val_or_die("osd_max_pg_log_entries", max_entries_s);
+    cct->_conf->set_val_or_die("osd_pg_log_dups_tracked", dup_track_s);
+}
+
+  void TearDown() override {
+    while (!test_hobjects.empty()) {
+      delete test_hobjects.front();
+      test_hobjects.pop_front();
+    }
+
+    cct->put();
+  }
+}; // struct PGLogTrimTest
+
+
+# if 0
+TEST_F(PGLogTest, Trim1) {
+  TestCase t;
+
+  t.auth.push_back(mk_ple_mod(mk_obj(1), mk_evt(10, 100), mk_evt(8, 70)));
+  t.auth.push_back(mk_ple_mod(mk_obj(1), mk_evt(15, 150), mk_evt(10, 100)));
+  t.auth.push_back(mk_ple_mod(mk_obj(1), mk_evt(15, 155), mk_evt(15, 150)));
+  t.auth.push_back(mk_ple_mod(mk_obj(1), mk_evt(20, 160), mk_evt(25, 152)));
+  t.auth.push_back(mk_ple_mod(mk_obj(1), mk_evt(21, 165), mk_evt(26, 160)));
+  t.auth.push_back(mk_ple_mod(mk_obj(1), mk_evt(21, 165), mk_evt(31, 171)));
+
+  t.setup();
+}
+#endif
+
+
+TEST_F(PGLogTrimTest, TestMakingCephContext)
+{
+  SetUp(1, 2, 5);
+
+  EXPECT_EQ(1u, cct->_conf->osd_min_pg_log_entries);
+  EXPECT_EQ(2u, cct->_conf->osd_max_pg_log_entries);
+  EXPECT_EQ(5u, cct->_conf->osd_pg_log_dups_tracked);
+}
+
+
+TEST_F(PGLogTrimTest, TestPartialTrim)
+{
+  SetUp(1, 2, 20);
+  PGLog::IndexedLog log;
+  log.head = mk_evt(24, 0);
+  //  log.skip_can_rollback_to_to_head();
+  log.head = mk_evt(9, 0);
+
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(10, 100), mk_evt(8, 70)));
+  log.add(mk_ple_dt(mk_obj(2), mk_evt(15, 150), mk_evt(10, 100)));
+  log.add(mk_ple_mod_rb(mk_obj(3), mk_evt(15, 155), mk_evt(15, 150)));
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(19, 160), mk_evt(25, 152)));
+  log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160)));
+  log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166)));
+
+  std::set<eversion_t> trimmed;
+  std::set<std::string> trimmed_dups;
+  bool dirty_dups = false;
+
+  log.trim(cct, nullptr, mk_evt(19, 157), &trimmed, &trimmed_dups, &dirty_dups);
+
+  EXPECT_TRUE(dirty_dups);
+  EXPECT_EQ(3u, log.log.size());
+  EXPECT_EQ(3u, trimmed.size());
+  EXPECT_EQ(2u, log.dups.size());
+  EXPECT_EQ(0u, trimmed_dups.size());
+
+  SetUp(1, 2, 15);
+
+  std::set<eversion_t> trimmed2;
+  std::set<std::string> trimmed_dups2;
+  bool dirty_dups2 = false;
+  
+  log.trim(cct, nullptr, mk_evt(20, 164), &trimmed2, &trimmed_dups2, &dirty_dups2);
+
+  EXPECT_TRUE(dirty_dups2);
+  EXPECT_EQ(2u, log.log.size());
+  EXPECT_EQ(1u, trimmed2.size());
+  EXPECT_EQ(2u, log.dups.size());
+  EXPECT_EQ(1u, trimmed_dups2.size());
+}
+
+
+TEST_F(PGLogTrimTest, TestTrimNoTrimmed) {
+  SetUp(1, 2, 20);
+  PGLog::IndexedLog log;
+  log.head = mk_evt(20, 0);
+  //  log.skip_can_rollback_to_to_head();
+  log.head = mk_evt(9, 0);
+
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(10, 100), mk_evt(8, 70)));
+  log.add(mk_ple_dt(mk_obj(2), mk_evt(15, 150), mk_evt(10, 100)));
+  log.add(mk_ple_mod_rb(mk_obj(3), mk_evt(15, 155), mk_evt(15, 150)));
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(20, 160), mk_evt(25, 152)));
+  log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160)));
+  log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166)));
+
+  bool dirty_dups = false;
+
+  log.trim(cct, nullptr, mk_evt(19, 157), nullptr, nullptr, &dirty_dups);
+
+  EXPECT_TRUE(dirty_dups);
+  EXPECT_EQ(3u, log.log.size());
+  EXPECT_EQ(2u, log.dups.size());
+}
+
+
+TEST_F(PGLogTrimTest, TestTrimNoDups)
+{
+  SetUp(1, 2, 10);
+  PGLog::IndexedLog log;
+  log.head = mk_evt(20, 0);
+  //  log.skip_can_rollback_to_to_head();
+  log.head = mk_evt(9, 0);
+
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(10, 100), mk_evt(8, 70)));
+  log.add(mk_ple_dt(mk_obj(2), mk_evt(15, 150), mk_evt(10, 100)));
+  log.add(mk_ple_mod_rb(mk_obj(3), mk_evt(15, 155), mk_evt(15, 150)));
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(20, 160), mk_evt(25, 152)));
+  log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160)));
+  log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166)));
+
+  std::set<eversion_t> trimmed;
+  std::set<std::string> trimmed_dups;
+  bool dirty_dups = false;
+
+  log.trim(cct, nullptr, mk_evt(19, 157), &trimmed, &trimmed_dups, &dirty_dups);
+
+  EXPECT_FALSE(dirty_dups);
+  EXPECT_EQ(3u, log.log.size());
+  EXPECT_EQ(3u, trimmed.size());
+  EXPECT_EQ(0u, log.dups.size());
+  EXPECT_EQ(0u, trimmed_dups.size());
+}
+
+TEST_F(PGLogTrimTest, TestNoTrim)
+{
+  SetUp(1, 2, 20);
+  PGLog::IndexedLog log;
+  log.head = mk_evt(24, 0);
+  //  log.skip_can_rollback_to_to_head();
+  log.head = mk_evt(9, 0);
+
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(10, 100), mk_evt(8, 70)));
+  log.add(mk_ple_dt(mk_obj(2), mk_evt(15, 150), mk_evt(10, 100)));
+  log.add(mk_ple_mod_rb(mk_obj(3), mk_evt(15, 155), mk_evt(15, 150)));
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(19, 160), mk_evt(25, 152)));
+  log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160)));
+  log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166)));
+
+  std::set<eversion_t> trimmed;
+  std::set<std::string> trimmed_dups;
+  bool dirty_dups = false;
+
+  log.trim(cct, nullptr, mk_evt(9, 99), &trimmed, &trimmed_dups, &dirty_dups);
+
+  EXPECT_FALSE(dirty_dups);
+  EXPECT_EQ(6u, log.log.size());
+  EXPECT_EQ(0u, trimmed.size());
+  EXPECT_EQ(0u, log.dups.size());
+  EXPECT_EQ(0u, trimmed_dups.size());
+}
+
+TEST_F(PGLogTrimTest, TestTrimAll)
+{
+  SetUp(1, 2, 20);
+  PGLog::IndexedLog log;
+  log.head = mk_evt(24, 0);
+  //  log.skip_can_rollback_to_to_head();
+  log.head = mk_evt(9, 0);
+
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(10, 100), mk_evt(8, 70)));
+  log.add(mk_ple_dt(mk_obj(2), mk_evt(15, 150), mk_evt(10, 100)));
+  log.add(mk_ple_mod_rb(mk_obj(3), mk_evt(15, 155), mk_evt(15, 150)));
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(19, 160), mk_evt(25, 152)));
+  log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160)));
+  log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166)));
+
+  std::set<eversion_t> trimmed;
+  std::set<std::string> trimmed_dups;
+  bool dirty_dups = false;
+
+  log.trim(cct, nullptr, mk_evt(22, 180), &trimmed, &trimmed_dups, &dirty_dups);
+
+  EXPECT_TRUE(dirty_dups);
+  EXPECT_EQ(0u, log.log.size());
+  EXPECT_EQ(6u, trimmed.size());
+  EXPECT_EQ(5u, log.dups.size());
+  EXPECT_EQ(0u, trimmed_dups.size());
+}
+
+
+TEST_F(PGLogTrimTest, TestGetRequest) {
+  SetUp(1, 2, 20);
+  PGLog::IndexedLog log;
+  log.head = mk_evt(20, 0);
+  //  log.skip_can_rollback_to_to_head();
+  log.head = mk_evt(9, 0);
+
+  entity_name_t client = entity_name_t::CLIENT(777);
+
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(10, 100), mk_evt(8, 70),
+		     osd_reqid_t(client, 8, 1)));
+  log.add(mk_ple_dt(mk_obj(2), mk_evt(15, 150), mk_evt(10, 100),
+		    osd_reqid_t(client, 8, 2)));
+  log.add(mk_ple_mod_rb(mk_obj(3), mk_evt(15, 155), mk_evt(15, 150),
+			osd_reqid_t(client, 8, 3)));
+  log.add(mk_ple_mod(mk_obj(1), mk_evt(20, 160), mk_evt(25, 152),
+		     osd_reqid_t(client, 8, 4)));
+  log.add(mk_ple_mod(mk_obj(4), mk_evt(21, 165), mk_evt(26, 160),
+		     osd_reqid_t(client, 8, 5)));
+  log.add(mk_ple_dt_rb(mk_obj(5), mk_evt(21, 167), mk_evt(31, 166),
+		       osd_reqid_t(client, 8, 6)));
+
+  bool dirty_dups = false;
+
+  log.trim(cct, nullptr, mk_evt(19, 157), nullptr, nullptr, &dirty_dups);
+
+  EXPECT_TRUE(dirty_dups);
+  EXPECT_EQ(3u, log.log.size());
+  EXPECT_EQ(2u, log.dups.size());
+
+  eversion_t version;
+  version_t user_version;
+
+  osd_reqid_t log_reqid = osd_reqid_t(client, 8, 5);
+  osd_reqid_t dup_reqid = osd_reqid_t(client, 8, 3);
+  osd_reqid_t bad_reqid = osd_reqid_t(client, 8, 1);
+
+  bool result;
+
+  result = log.get_request(log_reqid, &version, &user_version);
+  EXPECT_TRUE(result);
+  EXPECT_EQ(mk_evt(21, 165), version);
+
+  result = log.get_request(dup_reqid, &version, &user_version);
+  EXPECT_TRUE(result);
+  EXPECT_EQ(mk_evt(15, 155), version);
+
+  result = log.get_request(bad_reqid, &version, &user_version);
+  EXPECT_FALSE(result);
+}
+
 
 // Local Variables:
 // compile-command: "cd ../.. ; make unittest_pglog ; ./unittest_pglog --log-to-stderr=true  --debug-osd=20 # --gtest_filter=*.* "

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -488,7 +488,7 @@ int write_pg(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
     return ret;
   coll_t coll(info.pgid);
   map<string,bufferlist> km;
-  PGLog::write_log(t, &km, log, coll, info.pgid.make_pgmeta_oid(), divergent_priors, true);
+  PGLog::write_log(t, &km, log, coll, info.pgid.make_pgmeta_oid(), divergent_priors, true, true);
   t.omap_setkeys(coll, info.pgid.make_pgmeta_oid(), km);
   return 0;
 }

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -488,7 +488,7 @@ int write_pg(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
     return ret;
   coll_t coll(info.pgid);
   map<string,bufferlist> km;
-  PGLog::write_log(t, &km, log, coll, info.pgid.make_pgmeta_oid(), divergent_priors, true, true);
+  PGLog::write_log(t, &km, log, coll, info.pgid.make_pgmeta_oid(), divergent_priors, true);
   t.omap_setkeys(coll, info.pgid.make_pgmeta_oid(), km);
   return 0;
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/22400
http://tracker.ceph.com/issues/22405

This helps us avoid replaying non-idempotent client operations when the pg log is very short, e.g. in an effort to force OSDs to use backfill rather than regular recovery. This can be advantageous to avoid blocking i/o to objects, at the cost of longer total time to become clean (since backfill requires scanning the objects to see what is missing).

PLUS

Writing all of the dup entries whenever one is changed causes a large regression in performance.
    
Instead, keep track of ranges that need to be cleared and written after log merging (dirty_{to,from}_dups) and the earliest dup entry we haven't written yet during normal operation (write_from_dups). This parallels the way we track unpersisted log entries.
    
Check that the correct set of dups is persisted by adding a roundtrip through memstore to each merge_log unit test.

jewel backport of  http://tracker.ceph.com/issues/22405

Credit goes to Josh Durgin <jdurgin@redhat.com> for doing the heavy lifting with the backport.