### PR TITLE
rgw: correct log output for metadata section name in RGWListBucketIndexesCR

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -763,7 +763,7 @@ public:
                                                       entrypoint, NULL, &result));
       }
       if (retcode < 0) {
-        ldout(sync_env->cct, 0) << "ERROR: failed to fetch metadata for section bucket.index" << dendl;
+        ldout(sync_env->cct, 0) << "ERROR: failed to fetch metadata for section bucket.instance" << dendl;
         return set_cr_error(retcode);
       }
       entries_index = new RGWShardedOmapCRManager(sync_env->async_rados, store, this, num_shards,
@@ -771,7 +771,7 @@ public:
                                                   oid_prefix);
       yield; // yield so OmapAppendCRs can start
       for (iter = result.begin(); iter != result.end(); ++iter) {
-        ldout(sync_env->cct, 20) << "list metadata: section=bucket.index key=" << *iter << dendl;
+        ldout(sync_env->cct, 20) << "list metadata: section=bucket.instance key=" << *iter << dendl;
 
         key = *iter;
 


### PR DESCRIPTION
There are three named metadata sections:

- user
- bucket.instance
- bucket

no section named "bucket-index"

Signed-off-by: Xinying Song <songxinying@cloudin.cn>