### PR TITLE
os/bluestore: fix potential assert when splitting collection.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8337,7 +8337,7 @@ void BlueStore::_osr_drain_preceding(TransContext *txc)
   {
     // submit anything pending
     deferred_lock.lock();
-    if (osr->deferred_pending) {
+    if (osr->deferred_pending && !osr->deferred_running) {
       _deferred_submit_unlock(osr);
     } else {
       deferred_lock.unlock();


### PR DESCRIPTION
This bug caused occasional failures when running ceph_test_objectstore's ObjectStore/StoreTest.ColSplitTest1Clones/2 test case:
/home/if/ssd/ceph.i/src/os/bluestore/BlueStore.cc: 8864: FAILED assert(!osr->deferred_running)

 ceph version 13.0.0-4008-g807152af2c (807152af2c680ee89da8bf956c6130a1a5a849e3) mimic (dev)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0xf5) [0x7f1f3ecd2ff5]
 2: (BlueStore::_deferred_submit_unlock(BlueStore::OpSequencer*)+0x783) [0x55f80d418373]
 3: (BlueStore::_osr_drain_preceding(BlueStore::TransContext*)+0x9e) [0x55f80d41843e]
 4: (BlueStore::_split_collection(BlueStore::TransContext*, boost::intrusive_ptr<BlueStore::Collection>&, boost::intrusive_ptr<BlueStore::Collection>&, unsigned int, int)+0x8e) [0x55f80
d43cd1e]
 5: (BlueStore::_txc_add_transaction(BlueStore::TransContext*, ObjectStore::Transaction*)+0xa61) [0x55f80d4696e1]
 6: (BlueStore::queue_transactions(ObjectStore::Sequencer*, std::vector<ObjectStore::Transaction, std::allocator<ObjectStore::Transaction> >&, boost::intrusive_ptr<TrackedOp>, ThreadPoo
l::TPHandle*)+0x519) [0x55f80d46b379]
 7: (ObjectStore::apply_transactions(ObjectStore::Sequencer*, std::vector<ObjectStore::Transaction, std::allocator<ObjectStore::Transaction> >&, Context*)+0x1e6) [0x55f80d343166]
 8: (ObjectStore::apply_transaction(ObjectStore::Sequencer*, ObjectStore::Transaction&&, Context*)+0x52) [0x55f80d3232e2]
 9: (int apply_transaction<ObjectStore*>(ObjectStore*&, ObjectStore::Sequencer*, ObjectStore::Transaction&&)+0xa1) [0x55f80d32adf1]
 10: (colsplittest(ObjectStore*, unsigned int, unsigned int, bool)+0x8b7) [0x55f80d302de7]
 11: (void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)+0x4a) [0x55f80d59aeda]
 12: (testing::Test::Run()+0xba) [0x55f80d58d8ea]
 13: (testing::TestInfo::Run()+0xaf) [0x55f80d58d9cf]
 14: (testing::TestCase::Run()+0xe5) [0x55f80d58db35]
 15: (testing::internal::UnitTestImpl::RunAllTests()+0x468) [0x55f80d58e228]
 16: (testing::UnitTest::Run()+0x69) [0x55f80d58e389]
 17: (main()+0x5da) [0x55f80d1c82ba]
 18: (__libc_start_main()+0xea) [0x7f1f3cb9af4a]
 19: (_start()+0x2a) [0x55f80d2947fa]

Signed-off-by: Igor Fedotov <ifedotov@suse.com>