### PR TITLE
jewel: install-deps.sh: readlink /usr/bin/gcc not /usr/bin/x86_64-linux-gnu-gcc

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -21,9 +21,13 @@ export LC_ALL=C # the following is vulnerable to i18n
 
 function ensure_decent_gcc_on_deb {
     # point gcc to the one offered by distro if the used one is different
-    local old=$(readlink -e /usr/bin/x86_64-linux-gnu-gcc | cut -d'-' -f2)
+    local old=$(readlink -e /usr/bin/gcc | cut -d'-' -f2)
     local new=$1
-    if dpkg --compare-versions $old eq $new; then
+    if [ ! -f /usr/bin/gcc-${old} ]; then
+        $SUDO rm -f /usr/bin/gcc-${old}
+        $SUDO ln -sf /usr/bin/gcc-${new} /usr/bin/gcc
+        return
+    elif dpkg --compare-versions $old eq $new; then
 	    return
     fi
 
@@ -31,8 +35,8 @@ function ensure_decent_gcc_on_deb {
     *i*)
         # interactive shell
         cat <<EOF
-/usr/bin/x86_64-linux-gnu-gcc now points to gcc-$old, which is not the version
-shipped with the distro: gcc-$new. Reverting...
+/usr/bin/gcc now points to gcc-$old, which is not the version shipped with the
+distro: gcc-$new. Reverting...
 EOF
     esac
 


### PR DESCRIPTION
See: http://tracker.ceph.com/issues/22220
Signed-off-by: Kefu Chai <kchai@redhat.com>