### PR TITLE
Revert "ceph-disk add deprecation warnings in favor of ceph-volume"

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -42,22 +42,11 @@ import pwd
 import grp
 import textwrap
 import glob
-import warnings
 
 CEPH_OSD_ONDISK_MAGIC = 'ceph osd volume v026'
 CEPH_LOCKBOX_ONDISK_MAGIC = 'ceph lockbox volume v001'
 
 KEY_MANAGEMENT_MODE_V1 = 'ceph-mon v1'
-
-DEPRECATION_WARNING = """
-*******************************************************************************
-This tool is now deprecated in favor of ceph-volume.
-It is recommended to use ceph-volume for OSD deployments. For details see:
-
-    http://docs.ceph.com/docs/master/ceph-volume/#migrating
-
-*******************************************************************************
-"""
 
 PTYPE = {
     'regular': {
@@ -5656,8 +5645,6 @@ def make_zap_parser(subparsers):
 
 
 def main(argv):
-    # Deprecate from the very beginning
-    warnings.warn(DEPRECATION_WARNING)
     args = parse_args(argv)
 
     setup_logging(args.verbose, args.log_stdout)
@@ -5677,19 +5664,9 @@ def main(argv):
     CEPH_PREF_GROUP = args.setgroup
 
     if args.verbose:
-        try:
-            args.func(args)
-        except Exception:
-            # warn on any exception when running with verbosity
-            warnings.warn(DEPRECATION_WARNING)
-            # but still raise the original issue
-            raise
-
+        args.func(args)
     else:
         main_catch(args.func, args)
-
-    # if there aren't any errors, still log again at the very bottom
-    warnings.warn(DEPRECATION_WARNING)
 
 
 def setup_logging(verbose, log_stdout):
@@ -5717,8 +5694,6 @@ def main_catch(func, args):
         func(args)
 
     except Error as e:
-        # warn on generic 'error' exceptions
-        warnings.warn(DEPRECATION_WARNING)
         raise SystemExit(
             '{prog}: {msg}'.format(
                 prog=args.prog,
@@ -5727,8 +5702,6 @@ def main_catch(func, args):
         )
 
     except CephDiskException as error:
-        # warn on ceph-disk exceptions
-        warnings.warn(DEPRECATION_WARNING)
         exc_name = error.__class__.__name__
         raise SystemExit(
             '{prog} {exc_name}: {msg}'.format(


### PR DESCRIPTION
This reverts commit b8bf0d047868054135592188c7ebe186181310c5.

Deprecation warnings for ceph-disk will no longer be present in any
Luminous release beyond 12.2.2 - but are still present in master and any
newer release.

Signed-off-by: Alfredo Deza <adeza@redhat.com>