### PR TITLE
pybind/mgr/prometheus: fix metric type undef -> untyped

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -181,7 +181,7 @@ class Module(MgrModule):
         # so that we can stably use the same tag names that
         # the Prometheus node_exporter does
         metrics['disk_occupation'] = Metric(
-            'undef',
+            'untyped',
             'disk_occupation',
             'Associate Ceph daemon with disk used',
             DISK_OCCUPATION


### PR DESCRIPTION
Fixes "Prometheus exporter can't get metrics after update to 12.2.2" http://tracker.ceph.com/issues/22313

Signed-off-by: Ilya Margolin <listen@ulani.de>