### PR TITLE
luminous ceph-volume: warn on missing ceph.conf file

### DIFF
--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -136,10 +136,18 @@ Ceph Conf: {ceph_path}
         if os.path.isdir(conf.log_path):
             conf.log_path = os.path.join(args.log_path, 'ceph-volume.log')
         log.setup()
+        logger = logging.getLogger(__name__)
         # set all variables from args and load everything needed according to
         # them
         self.load_ceph_conf_path(cluster_name=args.cluster)
-        conf.ceph = configuration.load(conf.path)
+        try:
+            conf.ceph = configuration.load(conf.path)
+        except exceptions.ConfigurationError as error:
+            # we warn only here, because it is possible that the configuration
+            # file is not needed, or that it will be loaded by some other means
+            # (like reading from lvm tags)
+            logger.exception('ignoring inability to load ceph.conf')
+            terminal.red(error)
         # dispatch to sub-commands
         terminal.dispatch(self.mapper, subcommand_args)
 

--- a/src/ceph-volume/ceph_volume/tests/test_main.py
+++ b/src/ceph-volume/ceph_volume/tests/test_main.py
@@ -28,3 +28,12 @@ class TestVolume(object):
         stdout, stderr = capsys.readouterr()
         assert '--cluster' in stdout
         assert '--log-path' in stdout
+
+    def test_log_ignoring_missing_ceph_conf(self, caplog):
+        with pytest.raises(SystemExit) as error:
+            main.Volume(argv=['ceph-volume', '--cluster', 'barnacle', 'lvm', '--help'])
+        # make sure we aren't causing an actual error
+        assert error.value.code == 0
+        log = caplog.records[0]
+        assert log.message == 'ignoring inability to load ceph.conf'
+        assert log.levelname == 'ERROR'


### PR DESCRIPTION
Avoid exiting early, this would cause OSDs not come up after a reboot.

Fixes: http://tracker.ceph.com/issues/22326
Master PR: https://github.com/ceph/ceph/pull/19347