### PR TITLE
rbd-mirror: support deferred deletions of mirrored images

### DIFF
--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -354,9 +354,11 @@ struct TrashImageSpec {
 
   TrashImageSpec() {}
   TrashImageSpec(TrashImageSource source, const std::string &name,
-                   utime_t deletion_time, utime_t deferment_end_time) :
-    source(source), name(name), deletion_time(deletion_time),
-    deferment_end_time(deferment_end_time) {}
+                 const utime_t& deletion_time,
+                 const utime_t& deferment_end_time)
+    : source(source), name(name), deletion_time(deletion_time),
+      deferment_end_time(deferment_end_time) {
+  }
 
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator& it);

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -363,6 +363,13 @@ struct TrashImageSpec {
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator& it);
   void dump(Formatter *f) const;
+
+  inline bool operator==(const TrashImageSpec& rhs) const {
+    return (source == rhs.source &&
+            name == rhs.name &&
+            deletion_time == rhs.deletion_time &&
+            deferment_end_time == rhs.deferment_end_time);
+  }
 };
 WRITE_CLASS_ENCODER(TrashImageSpec);
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5873,6 +5873,10 @@ static std::vector<Option> get_rbd_options() {
     .set_default(false)
     .set_description("automatically start image resync after mirroring is disconnected due to being laggy"),
 
+    Option("rbd_mirroring_delete_delay", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("time-delay in seconds for rbd-mirror delete propagation"),
+
     Option("rbd_mirroring_replay_delay", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description("time-delay in seconds for rbd-mirror asynchronous replication"),

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -65,6 +65,7 @@ set(librbd_internal_srcs
   journal/PromoteRequest.cc
   journal/RemoveRequest.cc
   journal/Replay.cc
+  journal/ResetRequest.cc
   journal/StandardPolicy.cc
   journal/Utils.cc
   managed_lock/AcquireRequest.cc

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -107,6 +107,7 @@ set(librbd_internal_srcs
   operation/SnapshotUnprotectRequest.cc
   operation/SnapshotLimitRequest.cc
   operation/TrimRequest.cc
+  trash/MoveRequest.cc
   watcher/Notifier.cc
   watcher/RewatchRequest.cc
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc)

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(rbd_types STATIC
   journal/Types.cc
   mirroring_watcher/Types.cc
+  trash_watcher/Types.cc
   watcher/Types.cc
   WatchNotifyTypes.cc)
 
@@ -20,6 +21,7 @@ set(librbd_internal_srcs
   MirroringWatcher.cc
   ObjectMap.cc
   Operations.cc
+  TrashWatcher.cc
   Utils.cc
   Watcher.cc
   api/DiffIterate.cc

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1020,6 +1020,7 @@ struct C_InvalidateCache : public Context {
         "rbd_journal_max_payload_bytes", false)(
         "rbd_journal_max_concurrent_object_sets", false)(
         "rbd_mirroring_resync_after_disconnect", false)(
+        "rbd_mirroring_delete_delay", false)(
         "rbd_mirroring_replay_delay", false)(
         "rbd_skip_partial_discard", false)(
 	"rbd_qos_iops_limit", false);
@@ -1080,6 +1081,7 @@ struct C_InvalidateCache : public Context {
     ASSIGN_OPTION(journal_max_payload_bytes, uint64_t);
     ASSIGN_OPTION(journal_max_concurrent_object_sets, int64_t);
     ASSIGN_OPTION(mirroring_resync_after_disconnect, bool);
+    ASSIGN_OPTION(mirroring_delete_delay, uint64_t);
     ASSIGN_OPTION(mirroring_replay_delay, int64_t);
     ASSIGN_OPTION(skip_partial_discard, bool);
     ASSIGN_OPTION(blkin_trace_all, bool);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -196,6 +196,7 @@ namespace librbd {
     uint32_t journal_max_payload_bytes;
     int journal_max_concurrent_object_sets;
     bool mirroring_resync_after_disconnect;
+    uint64_t mirroring_delete_delay;
     int mirroring_replay_delay;
     bool skip_partial_discard;
     bool blkin_trace_all;

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -20,6 +20,7 @@
 #include "librbd/journal/DemoteRequest.h"
 #include "librbd/journal/OpenRequest.h"
 #include "librbd/journal/RemoveRequest.h"
+#include "librbd/journal/ResetRequest.h"
 #include "librbd/journal/Replay.h"
 #include "librbd/journal/PromoteRequest.h"
 
@@ -405,54 +406,17 @@ int Journal<I>::reset(librados::IoCtx &io_ctx, const std::string &image_id) {
   CephContext *cct = reinterpret_cast<CephContext *>(io_ctx.cct());
   ldout(cct, 5) << __func__ << ": image=" << image_id << dendl;
 
-  Journaler journaler(io_ctx, image_id, IMAGE_CLIENT_ID, {});
+  ThreadPool *thread_pool;
+  ContextWQ *op_work_queue;
+  ImageCtx::get_thread_pool_instance(cct, &thread_pool, &op_work_queue);
 
   C_SaferCond cond;
-  journaler.init(&cond);
-  BOOST_SCOPE_EXIT_ALL(&journaler) {
-    journaler.shut_down();
-  };
+  auto req = journal::ResetRequest<I>::create(io_ctx, image_id, IMAGE_CLIENT_ID,
+                                              Journal<>::LOCAL_MIRROR_UUID,
+                                              op_work_queue, &cond);
+  req->send();
 
-  int r = cond.wait();
-  if (r == -ENOENT) {
-    return 0;
-  } else if (r < 0) {
-    lderr(cct) << __func__ << ": "
-               << "failed to initialize journal: " << cpp_strerror(r) << dendl;
-    return r;
-  }
-
-  uint8_t order, splay_width;
-  int64_t pool_id;
-  journaler.get_metadata(&order, &splay_width, &pool_id);
-
-  std::string pool_name;
-  if (pool_id != -1) {
-    librados::Rados rados(io_ctx);
-    r = rados.pool_reverse_lookup(pool_id, &pool_name);
-    if (r < 0) {
-      lderr(cct) << __func__ << ": "
-                 << "failed to lookup data pool: " << cpp_strerror(r) << dendl;
-      return r;
-    }
-  }
-
-  C_SaferCond ctx1;
-  journaler.remove(true, &ctx1);
-  r = ctx1.wait();
-  if (r < 0) {
-    lderr(cct) << __func__ << ": "
-               << "failed to reset journal: " << cpp_strerror(r) << dendl;
-    return r;
-  }
-
-  r = create(io_ctx, image_id, order, splay_width, pool_name);
-  if (r < 0) {
-    lderr(cct) << __func__ << ": "
-               << "failed to create journal: " << cpp_strerror(r) << dendl;
-    return r;
-  }
-  return 0;
+  return cond.wait();
 }
 
 template <typename I>

--- a/src/librbd/TrashWatcher.cc
+++ b/src/librbd/TrashWatcher.cc
@@ -1,0 +1,115 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/TrashWatcher.h"
+#include "include/rbd_types.h"
+#include "include/rados/librados.hpp"
+#include "common/errno.h"
+#include "librbd/Utils.h"
+#include "librbd/watcher/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::TrashWatcher: " << __func__ << ": "
+
+namespace librbd {
+
+using namespace trash_watcher;
+using namespace watcher;
+
+using librbd::util::create_rados_callback;
+
+namespace {
+
+static const uint64_t NOTIFY_TIMEOUT_MS = 5000;
+
+} // anonymous namespace
+
+template <typename I>
+TrashWatcher<I>::TrashWatcher(librados::IoCtx &io_ctx, ContextWQ *work_queue)
+  : Watcher(io_ctx, work_queue, RBD_TRASH) {
+}
+
+template <typename I>
+void TrashWatcher<I>::notify_image_added(
+    librados::IoCtx &io_ctx, const std::string& image_id,
+    const cls::rbd::TrashImageSpec& trash_image_spec, Context *on_finish) {
+  CephContext *cct = reinterpret_cast<CephContext*>(io_ctx.cct());
+  ldout(cct, 20) << dendl;
+
+  bufferlist bl;
+  ::encode(NotifyMessage{ImageAddedPayload{image_id, trash_image_spec}}, bl);
+
+  librados::AioCompletion *comp = create_rados_callback(on_finish);
+  int r = io_ctx.aio_notify(RBD_TRASH, comp, bl, NOTIFY_TIMEOUT_MS, nullptr);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void TrashWatcher<I>::notify_image_removed(librados::IoCtx &io_ctx,
+                                           const std::string& image_id,
+                                           Context *on_finish) {
+  CephContext *cct = reinterpret_cast<CephContext*>(io_ctx.cct());
+  ldout(cct, 20) << dendl;
+
+  bufferlist bl;
+  ::encode(NotifyMessage{ImageRemovedPayload{image_id}}, bl);
+
+  librados::AioCompletion *comp = create_rados_callback(on_finish);
+  int r = io_ctx.aio_notify(RBD_TRASH, comp, bl, NOTIFY_TIMEOUT_MS, nullptr);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+void TrashWatcher<I>::handle_notify(uint64_t notify_id, uint64_t handle,
+                                    uint64_t notifier_id, bufferlist &bl) {
+  CephContext *cct = this->m_cct;
+  ldout(cct, 15) << "notify_id=" << notify_id << ", "
+                 << "handle=" << handle << dendl;
+
+
+  NotifyMessage notify_message;
+  try {
+    bufferlist::iterator iter = bl.begin();
+    ::decode(notify_message, iter);
+  } catch (const buffer::error &err) {
+    lderr(cct) << "error decoding image notification: " << err.what()
+               << dendl;
+    Context *ctx = new C_NotifyAck(this, notify_id, handle);
+    ctx->complete(0);
+    return;
+  }
+
+  apply_visitor(watcher::util::HandlePayloadVisitor<TrashWatcher<I>>(
+    this, notify_id, handle), notify_message.payload);
+}
+
+template <typename I>
+bool TrashWatcher<I>::handle_payload(const ImageAddedPayload &payload,
+                                     Context *on_notify_ack) {
+  CephContext *cct = this->m_cct;
+  ldout(cct, 20) << dendl;
+  handle_image_added(payload.image_id, payload.trash_image_spec);
+  return true;
+}
+
+template <typename I>
+bool TrashWatcher<I>::handle_payload(const ImageRemovedPayload &payload,
+                                     Context *on_notify_ack) {
+  CephContext *cct = this->m_cct;
+  ldout(cct, 20) << dendl;
+  handle_image_removed(payload.image_id);
+  return true;
+}
+
+template <typename I>
+bool TrashWatcher<I>::handle_payload(const UnknownPayload &payload,
+                                     Context *on_notify_ack) {
+  return true;
+}
+
+} // namespace librbd
+
+template class librbd::TrashWatcher<librbd::ImageCtx>;

--- a/src/librbd/TrashWatcher.h
+++ b/src/librbd/TrashWatcher.h
@@ -1,0 +1,58 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_TRASH_WATCHER_H
+#define CEPH_LIBRBD_TRASH_WATCHER_H
+
+#include "include/int_types.h"
+#include "cls/rbd/cls_rbd_types.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Watcher.h"
+#include "librbd/trash_watcher/Types.h"
+
+namespace librados { class IoCtx; }
+
+namespace librbd {
+
+namespace watcher {
+namespace util {
+template <typename> struct HandlePayloadVisitor;
+} // namespace util
+} // namespace watcher
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class TrashWatcher : public Watcher {
+  friend struct watcher::util::HandlePayloadVisitor<TrashWatcher<ImageCtxT>>;
+public:
+  TrashWatcher(librados::IoCtx &io_ctx, ContextWQ *work_queue);
+
+  static void notify_image_added(librados::IoCtx &io_ctx,
+                                 const std::string& image_id,
+                                 const cls::rbd::TrashImageSpec& spec,
+                                 Context *on_finish);
+  static void notify_image_removed(librados::IoCtx &io_ctx,
+                                   const std::string& image_id,
+                                   Context *on_finish);
+
+protected:
+  virtual void handle_image_added(const std::string &image_id,
+                                  const cls::rbd::TrashImageSpec& spec) = 0;
+  virtual void handle_image_removed(const std::string &image_id) = 0;
+
+private:
+  void handle_notify(uint64_t notify_id, uint64_t handle,
+                     uint64_t notifier_id, bufferlist &bl) override;
+
+  bool handle_payload(const trash_watcher::ImageAddedPayload &payload,
+                      Context *on_notify_ack);
+  bool handle_payload(const trash_watcher::ImageRemovedPayload &payload,
+                      Context *on_notify_ack);
+  bool handle_payload(const trash_watcher::UnknownPayload &payload,
+                      Context *on_notify_ack);
+};
+
+} // namespace librbd
+
+extern template class librbd::TrashWatcher<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_TRASH_WATCHER_H

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -45,6 +45,7 @@
 #include "librbd/managed_lock/Types.h"
 #include "librbd/mirror/EnableRequest.h"
 #include "librbd/operation/TrimRequest.h"
+#include "librbd/trash/MoveRequest.h"
 
 #include "journal/Journaler.h"
 
@@ -1351,102 +1352,59 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
     ldout(cct, 20) << "trash_move " << &io_ctx << " " << image_name
                    << dendl;
 
+    // try to get image id from the directory
     std::string image_id;
-    ImageCtx *ictx = new ImageCtx(image_name, "", nullptr, io_ctx, false);
-    int r = ictx->state->open(true);
-    if (r < 0) {
-      ictx = nullptr;
-
-      if (r != -ENOENT) {
-        ldout(cct, 2) << "error opening image: " << cpp_strerror(-r) << dendl;
-        return r;
-      }
-
-      // try to get image id from the directory
-      r = cls_client::dir_get_id(&io_ctx, RBD_DIRECTORY, image_name, &image_id);
-      if (r < 0) {
-        if (r != -ENOENT) {
-          ldout(cct, 2) << "error reading image id from dirctory: "
-                        << cpp_strerror(-r) << dendl;
-        }
-        return r;
-      }
-    } else {
-      if (ictx->old_format) {
-        ictx->state->close();
-        return -EOPNOTSUPP;
-      }
-
-      image_id = ictx->id;
-      ictx->owner_lock.get_read();
-      if (ictx->exclusive_lock != nullptr) {
-        r = ictx->operations->prepare_image_update(false);
-        if (r < 0) {
-	  lderr(cct) << "cannot obtain exclusive lock - not removing" << dendl;
-	  ictx->owner_lock.put_read();
-	  ictx->state->close();
-          return -EBUSY;
-        }
-      }
-    }
-
-    BOOST_SCOPE_EXIT_ALL(ictx, cct) {
-      if (ictx == nullptr)
-        return;
-
-      bool is_locked = ictx->exclusive_lock != nullptr &&
-                       ictx->exclusive_lock->is_lock_owner();
-      if (is_locked) {
-        C_SaferCond ctx;
-        auto exclusive_lock = ictx->exclusive_lock;
-        exclusive_lock->shut_down(&ctx);
-        ictx->owner_lock.put_read();
-        int r = ctx.wait();
-        if (r < 0) {
-          lderr(cct) << "error shutting down exclusive lock" << dendl;
-        }
-        delete exclusive_lock;
-      } else {
-        ictx->owner_lock.put_read();
-      }
-      ictx->state->close();
-    };
-
-    ldout(cct, 2) << "adding image entry to rbd_trash" << dendl;
-    utime_t ts = ceph_clock_now();
-    utime_t deferment_end_time = ts;
-    deferment_end_time += (double)delay;
-    cls::rbd::TrashImageSource trash_source =
-        static_cast<cls::rbd::TrashImageSource>(source);
-    cls::rbd::TrashImageSpec trash_spec(trash_source, image_name, ts,
-                                        deferment_end_time);
-    r = cls_client::trash_add(&io_ctx, image_id, trash_spec);
-    if (r < 0 && r != -EEXIST) {
-      lderr(cct) << "error adding image " << image_name << " to rbd_trash"
-                 << dendl;
-      return r;
-    } else if (r == -EEXIST) {
-      ldout(cct, 10) << "found previous unfinished deferred remove for image:"
-                     << image_id << dendl;
-      // continue with removing image from directory
-    }
-
-    ldout(cct, 2) << "removing id object..." << dendl;
-    r = io_ctx.remove(util::id_obj_name(image_name));
+    int r = cls_client::dir_get_id(&io_ctx, RBD_DIRECTORY, image_name,
+                                   &image_id);
     if (r < 0 && r != -ENOENT) {
-      lderr(cct) << "error removing id object: " << cpp_strerror(r)
-                 << dendl;
+      lderr(cct) << "failed to retrieve image id: " << cpp_strerror(r) << dendl;
       return r;
     }
 
-    ldout(cct, 2) << "removing rbd image from v2 directory..." << dendl;
-    r = cls_client::dir_remove_image(&io_ctx, RBD_DIRECTORY, image_name,
-                                     image_id);
-    if (r < 0) {
-      if (r != -ENOENT) {
-        lderr(cct) << "error removing image from v2 directory: "
-                   << cpp_strerror(-r) << dendl;
+    ImageCtx *ictx = new ImageCtx((image_id.empty() ? image_name : ""),
+                                  image_id, nullptr, io_ctx, false);
+    r = ictx->state->open(true);
+    if (r == -ENOENT) {
+      return r;
+    } else if (r < 0) {
+      lderr(cct) << "failed to open image: " << cpp_strerror(r) << dendl;
+      return r;
+    } else if (ictx->old_format) {
+      ldout(cct, 10) << "cannot move v1 image to trash" << dendl;
+      ictx->state->close();
+      return -EOPNOTSUPP;
+    }
+
+    image_id = ictx->id;
+    ictx->owner_lock.get_read();
+    if (ictx->exclusive_lock != nullptr) {
+      ictx->exclusive_lock->block_requests(0);
+
+      r = ictx->operations->prepare_image_update(false);
+      if (r < 0) {
+        lderr(cct) << "cannot obtain exclusive lock - not removing" << dendl;
+        ictx->owner_lock.put_read();
+        ictx->state->close();
+        return -EBUSY;
       }
+    }
+    ictx->owner_lock.put_read();
+
+    utime_t delete_time{ceph_clock_now()};
+    utime_t deferment_end_time{delete_time};
+    deferment_end_time += delay;
+    cls::rbd::TrashImageSpec trash_image_spec{
+      static_cast<cls::rbd::TrashImageSource>(source), ictx->name,
+      delete_time, deferment_end_time};
+
+    C_SaferCond ctx;
+    auto req = trash::MoveRequest<>::create(io_ctx, ictx->id, trash_image_spec,
+                                            &ctx);
+    req->send();
+
+    r = ctx.wait();
+    ictx->state->close();
+    if (r < 0) {
       return r;
     }
 

--- a/src/librbd/journal/ResetRequest.cc
+++ b/src/librbd/journal/ResetRequest.cc
@@ -1,0 +1,162 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/journal/ResetRequest.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "common/Timer.h"
+#include "common/WorkQueue.h"
+#include "journal/Journaler.h"
+#include "journal/Settings.h"
+#include "include/assert.h"
+#include "librbd/Journal.h"
+#include "librbd/Utils.h"
+#include "librbd/journal/CreateRequest.h"
+#include "librbd/journal/RemoveRequest.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::journal::ResetRequest: " << this << " " \
+                           << __func__ << ": "
+
+namespace librbd {
+namespace journal {
+
+using util::create_async_context_callback;
+using util::create_context_callback;
+
+template<typename I>
+void ResetRequest<I>::send() {
+   init_journaler();
+}
+
+template<typename I>
+void ResetRequest<I>::init_journaler() {
+  ldout(m_cct, 10) << dendl;
+
+  m_journaler = new Journaler(m_io_ctx, m_image_id, m_client_id, {});
+  Context *ctx = create_context_callback<
+     ResetRequest<I>, &ResetRequest<I>::handle_init_journaler>(this);
+  m_journaler->init(ctx);
+}
+
+template<typename I>
+void ResetRequest<I>::handle_init_journaler(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r == -ENOENT) {
+    ldout(m_cct, 5) << "journal does not exist" << dendl;
+    m_ret_val = r;
+  } else if (r < 0) {
+    lderr(m_cct) << "failed to init journaler: " << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+  } else {
+    int64_t pool_id;
+    m_journaler->get_metadata(&m_order, &m_splay_width, &pool_id);
+
+    if (pool_id != -1) {
+      librados::Rados rados(m_io_ctx);
+      r = rados.pool_reverse_lookup(pool_id, &m_object_pool_name);
+      if (r < 0) {
+        lderr(m_cct) << "failed to lookup data pool: " << cpp_strerror(r)
+                     << dendl;
+        m_ret_val = r;
+      }
+    }
+  }
+
+  shut_down_journaler();
+}
+
+template<typename I>
+void ResetRequest<I>::shut_down_journaler() {
+  ldout(m_cct, 10) << dendl;
+
+  Context *ctx = create_async_context_callback(
+    m_op_work_queue, create_context_callback<
+      ResetRequest<I>, &ResetRequest<I>::handle_journaler_shutdown>(this));
+  m_journaler->shut_down(ctx);
+}
+
+template<typename I>
+void ResetRequest<I>::handle_journaler_shutdown(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  delete m_journaler;
+  if (r < 0) {
+    lderr(m_cct) << "failed to shut down journaler: " << cpp_strerror(r)
+                 << dendl;
+    if (m_ret_val == 0) {
+      m_ret_val = r;
+    }
+  }
+
+  if (m_ret_val < 0) {
+    finish(m_ret_val);
+    return;
+  }
+
+  remove_journal();
+}
+
+template<typename I>
+void ResetRequest<I>::remove_journal() {
+  ldout(m_cct, 10) << dendl;
+
+  Context *ctx = create_context_callback<
+    ResetRequest<I>, &ResetRequest<I>::handle_remove_journal>(this);
+  auto req = RemoveRequest<I>::create(m_io_ctx, m_image_id, m_client_id,
+                                      m_op_work_queue, ctx);
+  req->send();
+}
+
+template<typename I>
+void ResetRequest<I>::handle_remove_journal(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to remove journal: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  create_journal();
+}
+
+template<typename I>
+void ResetRequest<I>::create_journal() {
+  ldout(m_cct, 10) << dendl;
+
+  Context *ctx = create_context_callback<
+    ResetRequest<I>, &ResetRequest<I>::handle_create_journal>(this);
+  journal::TagData tag_data(m_mirror_uuid);
+  auto req = CreateRequest<I>::create(m_io_ctx, m_image_id, m_order,
+                                      m_splay_width, m_object_pool_name,
+                                      cls::journal::Tag::TAG_CLASS_NEW,
+                                      tag_data, m_client_id, m_op_work_queue,
+                                      ctx);
+  req->send();
+}
+
+template<typename I>
+void ResetRequest<I>::handle_create_journal(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to create journal: " << cpp_strerror(r) << dendl;
+  }
+  finish(r);
+}
+
+template<typename I>
+void ResetRequest<I>::finish(int r) {
+   ldout(m_cct, 10) << "r=" << r << dendl;
+
+   m_on_finish->complete(r);
+   delete this;
+}
+
+} // namespace journal
+} // namespace librbd
+
+template class librbd::journal::ResetRequest<librbd::ImageCtx>;

--- a/src/librbd/journal/ResetRequest.h
+++ b/src/librbd/journal/ResetRequest.h
@@ -1,0 +1,111 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_JOURNAL_RESET_REQUEST_H
+#define CEPH_LIBRBD_JOURNAL_RESET_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+#include "include/rados/librados.hpp"
+#include "include/rbd/librbd.hpp"
+#include "common/Mutex.h"
+#include "librbd/journal/TypeTraits.h"
+#include <string>
+
+class Context;
+class ContextWQ;
+class SafeTimer;
+
+namespace journal { class Journaler; }
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace journal {
+
+template<typename ImageCtxT = ImageCtx>
+class ResetRequest {
+public:
+  static ResetRequest *create(librados::IoCtx &io_ctx,
+                              const std::string &image_id,
+                              const std::string &client_id,
+                              const std::string &mirror_uuid,
+                              ContextWQ *op_work_queue, Context *on_finish) {
+    return new ResetRequest(io_ctx, image_id, client_id, mirror_uuid,
+                            op_work_queue, on_finish);
+  }
+
+  ResetRequest(librados::IoCtx &io_ctx, const std::string &image_id,
+               const std::string &client_id, const std::string &mirror_uuid,
+               ContextWQ *op_work_queue, Context *on_finish)
+    : m_io_ctx(io_ctx), m_image_id(image_id), m_client_id(client_id),
+      m_mirror_uuid(mirror_uuid), m_op_work_queue(op_work_queue),
+      m_on_finish(on_finish),
+      m_cct(reinterpret_cast<CephContext *>(m_io_ctx.cct())) {
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * INIT_JOURNALER
+   *    |
+   *    v
+   * SHUT_DOWN_JOURNALER
+   *    |
+   *    v
+   * REMOVE_JOURNAL
+   *    |
+   *    v
+   * CREATE_JOURNAL
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+  typedef typename TypeTraits<ImageCtxT>::Journaler Journaler;
+
+  librados::IoCtx &m_io_ctx;
+  std::string m_image_id;
+  std::string m_client_id;
+  std::string m_mirror_uuid;
+  ContextWQ *m_op_work_queue;
+  Context *m_on_finish;
+
+  CephContext *m_cct;
+  Journaler *m_journaler = nullptr;
+  int m_ret_val = 0;
+
+  uint8_t m_order = 0;
+  uint8_t m_splay_width = 0;
+  std::string m_object_pool_name;
+
+  void init_journaler();
+  void handle_init_journaler(int r);
+
+  void shut_down_journaler();
+  void handle_journaler_shutdown(int r);
+
+  void remove_journal();
+  void handle_remove_journal(int r);
+
+  void create_journal();
+  void handle_create_journal(int r);
+
+  void finish(int r);
+
+};
+
+} // namespace journal
+} // namespace librbd
+
+extern template class librbd::journal::ResetRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_JOURNAL_REMOVE_REQUEST_H

--- a/src/librbd/trash/MoveRequest.cc
+++ b/src/librbd/trash/MoveRequest.cc
@@ -1,0 +1,124 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/trash/MoveRequest.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::trash::MoveRequest: " << this \
+                           << " " << __func__ << ": "
+
+namespace librbd {
+namespace trash {
+
+using util::create_context_callback;
+using util::create_rados_callback;
+
+template <typename I>
+void MoveRequest<I>::send() {
+  trash_add();
+}
+
+template <typename I>
+void MoveRequest<I>::trash_add() {
+  ldout(m_cct, 10) << dendl;
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::trash_add(&op, m_image_id, m_trash_image_spec);
+
+  auto aio_comp = create_rados_callback<
+    MoveRequest<I>, &MoveRequest<I>::handle_trash_add>(this);
+  int r = m_io_ctx.aio_operate(RBD_TRASH, aio_comp, &op);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void MoveRequest<I>::handle_trash_add(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r == -EEXIST) {
+    ldout(m_cct, 10) << "previous unfinished deferred remove for image: "
+                     << m_image_id << dendl;
+  } else if (r < 0) {
+    lderr(m_cct) << "failed to add image to trash: " << cpp_strerror(r)
+                 << dendl;
+    finish(r);
+    return;
+  }
+
+  remove_id();
+}
+
+template <typename I>
+void MoveRequest<I>::remove_id() {
+  ldout(m_cct, 10) << dendl;
+
+  auto aio_comp = create_rados_callback<
+    MoveRequest<I>, &MoveRequest<I>::handle_remove_id>(this);
+  int r = m_io_ctx.aio_remove(util::id_obj_name(m_trash_image_spec.name),
+                              aio_comp);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void MoveRequest<I>::handle_remove_id(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "failed to remove image id object: " << cpp_strerror(r)
+                 << dendl;
+    finish(r);
+    return;
+  }
+
+  directory_remove();
+}
+
+template <typename I>
+void MoveRequest<I>::directory_remove() {
+  ldout(m_cct, 10) << dendl;
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::dir_remove_image(&op, m_trash_image_spec.name,
+                                       m_image_id);
+
+  auto aio_comp = create_rados_callback<
+    MoveRequest<I>, &MoveRequest<I>::handle_directory_remove>(this);
+  int r = m_io_ctx.aio_operate(RBD_DIRECTORY, aio_comp, &op);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void MoveRequest<I>::handle_directory_remove(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "failed to remove image from directory: " << cpp_strerror(r)
+                 << dendl;
+  }
+
+  finish(r);
+}
+
+template <typename I>
+void MoveRequest<I>::finish(int r) {
+  ldout(m_cct, 10) << "r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace trash
+} // namespace librbd
+
+template class librbd::trash::MoveRequest<librbd::ImageCtx>;

--- a/src/librbd/trash/MoveRequest.h
+++ b/src/librbd/trash/MoveRequest.h
@@ -1,0 +1,88 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_TRASH_MOVE_REQUEST_H
+#define CEPH_LIBRBD_TRASH_MOVE_REQUEST_H
+
+#include "include/utime.h"
+#include "include/rados/librados.hpp"
+#include "cls/rbd/cls_rbd_types.h"
+#include <string>
+
+struct CephContext;
+struct Context;
+namespace librados { struct IoCtx; }
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace trash {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class MoveRequest {
+public:
+  static MoveRequest* create(librados::IoCtx& io_ctx,
+                             const std::string& image_id,
+                             const cls::rbd::TrashImageSpec& trash_image_spec,
+                             Context* on_finish) {
+    return new MoveRequest(io_ctx, image_id, trash_image_spec, on_finish);
+  }
+
+  MoveRequest(librados::IoCtx& io_ctx, const std::string& image_id,
+              const cls::rbd::TrashImageSpec& trash_image_spec,
+              Context* on_finish)
+    : m_io_ctx(io_ctx), m_image_id(image_id),
+      m_trash_image_spec(trash_image_spec), m_on_finish(on_finish),
+      m_cct(reinterpret_cast<CephContext *>(io_ctx.cct())) {
+  }
+
+  void send();
+
+private:
+  /*
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * TRASH_ADD
+   *    |
+   *    v
+   * REMOVE_ID
+   *    |
+   *    v
+   * DIRECTORY_REMOVE
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  librados::IoCtx &m_io_ctx;
+  std::string m_image_id;
+  cls::rbd::TrashImageSpec m_trash_image_spec;
+  Context *m_on_finish;
+
+  CephContext *m_cct;
+
+  void trash_add();
+  void handle_trash_add(int r);
+
+  void remove_id();
+  void handle_remove_id(int r);
+
+  void directory_remove();
+  void handle_directory_remove(int r);
+
+  void finish(int r);
+
+};
+
+} // namespace trash
+} // namespace librbd
+
+extern template class librbd::trash::MoveRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_TRASH_MOVE_REQUEST_H

--- a/src/librbd/trash_watcher/Types.cc
+++ b/src/librbd/trash_watcher/Types.cc
@@ -1,0 +1,126 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/Formatter.h"
+#include "include/assert.h"
+#include "include/stringify.h"
+#include "librbd/trash_watcher/Types.h"
+#include "librbd/watcher/Utils.h"
+
+namespace librbd {
+namespace trash_watcher {
+
+namespace {
+
+class DumpPayloadVisitor : public boost::static_visitor<void> {
+public:
+  explicit DumpPayloadVisitor(Formatter *formatter) : m_formatter(formatter) {}
+
+  template <typename Payload>
+  inline void operator()(const Payload &payload) const {
+    NotifyOp notify_op = Payload::NOTIFY_OP;
+    m_formatter->dump_string("notify_op", stringify(notify_op));
+    payload.dump(m_formatter);
+  }
+
+private:
+  ceph::Formatter *m_formatter;
+};
+
+} // anonymous namespace
+
+void ImageAddedPayload::encode(bufferlist &bl) const {
+  ::encode(image_id, bl);
+  ::encode(trash_image_spec, bl);
+}
+
+void ImageAddedPayload::decode(__u8 version, bufferlist::iterator &iter) {
+  ::decode(image_id, iter);
+  ::decode(trash_image_spec, iter);
+}
+
+void ImageAddedPayload::dump(Formatter *f) const {
+  f->dump_string("image_id", image_id);
+  f->open_object_section("trash_image_spec");
+  trash_image_spec.dump(f);
+  f->close_section();
+}
+
+void ImageRemovedPayload::encode(bufferlist &bl) const {
+  ::encode(image_id, bl);
+}
+
+void ImageRemovedPayload::decode(__u8 version, bufferlist::iterator &iter) {
+  ::decode(image_id, iter);
+}
+
+void ImageRemovedPayload::dump(Formatter *f) const {
+  f->dump_string("image_id", image_id);
+}
+
+void UnknownPayload::encode(bufferlist &bl) const {
+  ceph_abort();
+}
+
+void UnknownPayload::decode(__u8 version, bufferlist::iterator &iter) {
+}
+
+void UnknownPayload::dump(Formatter *f) const {
+}
+
+void NotifyMessage::encode(bufferlist& bl) const {
+  ENCODE_START(1, 1, bl);
+  boost::apply_visitor(watcher::util::EncodePayloadVisitor(bl), payload);
+  ENCODE_FINISH(bl);
+}
+
+void NotifyMessage::decode(bufferlist::iterator& iter) {
+  DECODE_START(1, iter);
+
+  uint32_t notify_op;
+  ::decode(notify_op, iter);
+
+  // select the correct payload variant based upon the encoded op
+  switch (notify_op) {
+  case NOTIFY_OP_IMAGE_ADDED:
+    payload = ImageAddedPayload();
+    break;
+  case NOTIFY_OP_IMAGE_REMOVED:
+    payload = ImageRemovedPayload();
+    break;
+  default:
+    payload = UnknownPayload();
+    break;
+  }
+
+  apply_visitor(watcher::util::DecodePayloadVisitor(struct_v, iter), payload);
+  DECODE_FINISH(iter);
+}
+
+void NotifyMessage::dump(Formatter *f) const {
+  apply_visitor(DumpPayloadVisitor(f), payload);
+}
+
+void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
+  o.push_back(new NotifyMessage{ImageAddedPayload{
+    "id", {cls::rbd::TRASH_IMAGE_SOURCE_USER, "name", {}, {}}}});
+  o.push_back(new NotifyMessage{ImageRemovedPayload{"id"}});
+}
+
+std::ostream &operator<<(std::ostream &out, const NotifyOp &op) {
+  switch (op) {
+  case NOTIFY_OP_IMAGE_ADDED:
+    out << "ImageAdded";
+    break;
+  case NOTIFY_OP_IMAGE_REMOVED:
+    out << "ImageRemoved";
+    break;
+  default:
+    out << "Unknown (" << static_cast<uint32_t>(op) << ")";
+    break;
+  }
+  return out;
+}
+
+} // namespace trash_watcher
+} // namespace librbd

--- a/src/librbd/trash_watcher/Types.h
+++ b/src/librbd/trash_watcher/Types.h
@@ -1,0 +1,97 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_TRASH_WATCHER_TYPES_H
+#define CEPH_LIBRBD_TRASH_WATCHER_TYPES_H
+
+#include "include/int_types.h"
+#include "include/buffer_fwd.h"
+#include "include/encoding.h"
+#include "cls/rbd/cls_rbd_types.h"
+#include <iosfwd>
+#include <list>
+#include <string>
+#include <boost/variant.hpp>
+
+
+namespace librbd {
+namespace trash_watcher {
+
+enum NotifyOp {
+  NOTIFY_OP_IMAGE_ADDED = 0,
+  NOTIFY_OP_IMAGE_REMOVED = 1
+};
+
+struct ImageAddedPayload {
+  static const NotifyOp NOTIFY_OP = NOTIFY_OP_IMAGE_ADDED;
+
+  std::string image_id;
+  cls::rbd::TrashImageSpec trash_image_spec;
+
+  ImageAddedPayload() {
+  }
+  ImageAddedPayload(const std::string& image_id,
+                    const cls::rbd::TrashImageSpec& trash_image_spec)
+    : image_id(image_id), trash_image_spec(trash_image_spec) {
+  }
+
+  void encode(bufferlist &bl) const;
+  void decode(__u8 version, bufferlist::iterator &iter);
+  void dump(Formatter *f) const;
+};
+
+struct ImageRemovedPayload {
+  static const NotifyOp NOTIFY_OP = NOTIFY_OP_IMAGE_REMOVED;
+
+  std::string image_id;
+
+  ImageRemovedPayload() {
+  }
+  ImageRemovedPayload(const std::string& image_id)
+    : image_id(image_id) {
+  }
+
+  void encode(bufferlist &bl) const;
+  void decode(__u8 version, bufferlist::iterator &iter);
+  void dump(Formatter *f) const;
+};
+
+struct UnknownPayload {
+  static const NotifyOp NOTIFY_OP = static_cast<NotifyOp>(-1);
+
+  UnknownPayload() {
+  }
+
+  void encode(bufferlist &bl) const;
+  void decode(__u8 version, bufferlist::iterator &iter);
+  void dump(Formatter *f) const;
+};
+
+typedef boost::variant<ImageAddedPayload,
+                       ImageRemovedPayload,
+                       UnknownPayload> Payload;
+
+struct NotifyMessage {
+  NotifyMessage(const Payload &payload = UnknownPayload()) : payload(payload) {
+  }
+
+  Payload payload;
+
+  void encode(bufferlist& bl) const;
+  void decode(bufferlist::iterator& it);
+  void dump(Formatter *f) const;
+
+  static void generate_test_instances(std::list<NotifyMessage *> &o);
+};
+
+WRITE_CLASS_ENCODER(NotifyMessage);
+
+std::ostream &operator<<(std::ostream &out, const NotifyOp &op);
+
+} // namespace trash_watcher
+} // namespace librbd
+
+using librbd::trash_watcher::encode;
+using librbd::trash_watcher::decode;
+
+#endif // CEPH_LIBRBD_TRASH_WATCHER_TYPES_H

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -274,6 +274,8 @@ TYPE(librbd::journal::ClientData)
 TYPE(librbd::journal::TagData)
 #include "librbd/mirroring_watcher/Types.h"
 TYPE(librbd::mirroring_watcher::NotifyMessage)
+#include "librbd/trash_watcher/Types.h"
+TYPE(librbd::mirroring_watcher::NotifyMessage)
 #include "librbd/WatchNotifyTypes.h"
 TYPE(librbd::watch_notify::NotifyMessage)
 TYPE(librbd::watch_notify::ResponseMessage)

--- a/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
@@ -60,6 +60,11 @@ public:
     return TestMemIoCtxImpl::assert_exists(oid);
   }
 
+  MOCK_METHOD2(create, int(const std::string&, bool));
+  int do_create(const std::string& oid, bool exclusive) {
+    return TestMemIoCtxImpl::create(oid, exclusive);
+  }
+
   MOCK_METHOD3(cmpext, int(const std::string&, uint64_t, bufferlist&));
   int do_cmpext(const std::string& oid, uint64_t off, bufferlist& cmp_bl) {
     return TestMemIoCtxImpl::cmpext(oid, off, cmp_bl);
@@ -193,6 +198,7 @@ public:
     ON_CALL(*this, aio_watch(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_watch));
     ON_CALL(*this, aio_unwatch(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_unwatch));
     ON_CALL(*this, assert_exists(_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_assert_exists));
+    ON_CALL(*this, create(_,_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_create));
     ON_CALL(*this, cmpext(_,_,_)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_cmpext));
     ON_CALL(*this, exec(_, _, _, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_exec));
     ON_CALL(*this, get_instance_id()).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_get_instance_id));

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -33,6 +33,7 @@ set(unittest_librbd_srcs
   test_mock_Journal.cc
   test_mock_ManagedLock.cc
   test_mock_ObjectMap.cc
+  test_mock_TrashWatcher.cc
   deep_copy/test_mock_ImageCopyRequest.cc
   deep_copy/test_mock_MetadataCopyRequest.cc
   deep_copy/test_mock_ObjectCopyRequest.cc

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -51,6 +51,7 @@ set(unittest_librbd_srcs
   journal/test_mock_OpenRequest.cc
   journal/test_mock_PromoteRequest.cc
   journal/test_mock_Replay.cc
+  journal/test_mock_ResetRequest.cc
   managed_lock/test_mock_AcquireRequest.cc
   managed_lock/test_mock_BreakRequest.cc
   managed_lock/test_mock_GetLockerRequest.cc

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -75,6 +75,7 @@ set(unittest_librbd_srcs
   operation/test_mock_SnapshotRollbackRequest.cc
   operation/test_mock_SnapshotUnprotectRequest.cc
   operation/test_mock_TrimRequest.cc
+  trash/test_mock_MoveRequest.cc
   watcher/test_mock_RewatchRequest.cc
   )
 add_executable(unittest_librbd

--- a/src/test/librbd/journal/test_mock_ResetRequest.cc
+++ b/src/test/librbd/journal/test_mock_ResetRequest.cc
@@ -1,0 +1,264 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/journal/mock/MockJournaler.h"
+#include "common/Mutex.h"
+#include "cls/journal/cls_journal_types.h"
+#include "librbd/journal/CreateRequest.h"
+#include "librbd/journal/RemoveRequest.h"
+#include "librbd/journal/ResetRequest.h"
+
+namespace librbd {
+
+namespace {
+
+struct MockTestImageCtx : public MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx& image_ctx) : MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+
+namespace journal {
+
+template <>
+struct TypeTraits<MockTestImageCtx> {
+  typedef ::journal::MockJournalerProxy Journaler;
+};
+
+template <>
+struct CreateRequest<MockTestImageCtx> {
+  static CreateRequest* s_instance;
+  Context* on_finish = nullptr;
+
+  static CreateRequest* create(IoCtx &ioctx, const std::string &imageid,
+                               uint8_t order, uint8_t splay_width,
+                               const std::string &object_pool,
+                               uint64_t tag_class, TagData &tag_data,
+                               const std::string &client_id,
+                               ContextWQ *op_work_queue, Context *on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  MOCK_METHOD0(send, void());
+
+  CreateRequest() {
+    s_instance = this;
+  }
+};
+
+template <>
+struct RemoveRequest<MockTestImageCtx> {
+  static RemoveRequest* s_instance;
+  Context* on_finish = nullptr;
+
+  static RemoveRequest* create(IoCtx &ioctx, const std::string &image_id,
+                               const std::string &client_id,
+                               ContextWQ *op_work_queue, Context *on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  MOCK_METHOD0(send, void());
+
+  RemoveRequest() {
+    s_instance = this;
+  }
+};
+
+CreateRequest<MockTestImageCtx>* CreateRequest<MockTestImageCtx>::s_instance = nullptr;
+RemoveRequest<MockTestImageCtx>* RemoveRequest<MockTestImageCtx>::s_instance = nullptr;
+
+} // namespace journal
+} // namespace librbd
+
+#include "librbd/journal/ResetRequest.cc"
+
+namespace librbd {
+namespace journal {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::WithArg;
+
+class TestMockJournalResetRequest : public TestMockFixture {
+public:
+  typedef ResetRequest<MockTestImageCtx> MockResetRequest;
+  typedef CreateRequest<MockTestImageCtx> MockCreateRequest;
+  typedef RemoveRequest<MockTestImageCtx> MockRemoveRequest;
+
+  void expect_construct_journaler(::journal::MockJournaler &mock_journaler) {
+    EXPECT_CALL(mock_journaler, construct());
+  }
+
+  void expect_init_journaler(::journal::MockJournaler &mock_journaler, int r) {
+    EXPECT_CALL(mock_journaler, init(_))
+      .WillOnce(CompleteContext(r, static_cast<ContextWQ*>(NULL)));
+  }
+
+  void expect_get_metadata(::journal::MockJournaler& mock_journaler) {
+    EXPECT_CALL(mock_journaler, get_metadata(_, _, _))
+      .WillOnce(Invoke([](uint8_t* order, uint8_t* splay_width,
+                          int64_t* pool_id) {
+                  *order = 24;
+                  *splay_width = 4;
+                  *pool_id = -1;
+                }));
+  }
+
+  void expect_shut_down_journaler(::journal::MockJournaler &mock_journaler,
+                                  int r) {
+    EXPECT_CALL(mock_journaler, shut_down(_))
+      .WillOnce(CompleteContext(r, static_cast<ContextWQ*>(NULL)));
+  }
+
+  void expect_remove(MockRemoveRequest& mock_remove_request, int r) {
+    EXPECT_CALL(mock_remove_request, send())
+      .WillOnce(Invoke([&mock_remove_request, r]() {
+                  mock_remove_request.on_finish->complete(r);
+                }));
+  }
+
+  void expect_create(MockCreateRequest& mock_create_request, int r) {
+    EXPECT_CALL(mock_create_request, send())
+      .WillOnce(Invoke([&mock_create_request, r]() {
+                  mock_create_request.on_finish->complete(r);
+                }));
+  }
+};
+
+TEST_F(TestMockJournalResetRequest, Success) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  ::journal::MockJournaler mock_journaler;
+  expect_construct_journaler(mock_journaler);
+  expect_init_journaler(mock_journaler, 0);
+  expect_get_metadata(mock_journaler);
+  expect_shut_down_journaler(mock_journaler, 0);
+
+  MockRemoveRequest mock_remove_request;
+  expect_remove(mock_remove_request, 0);
+
+  MockCreateRequest mock_create_request;
+  expect_create(mock_create_request, 0);
+
+  C_SaferCond ctx;
+  auto req = MockResetRequest::create(m_ioctx, "image id",
+                                      Journal<>::IMAGE_CLIENT_ID,
+                                      Journal<>::LOCAL_MIRROR_UUID,
+                                      ictx->op_work_queue , &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockJournalResetRequest, InitError) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  ::journal::MockJournaler mock_journaler;
+  expect_construct_journaler(mock_journaler);
+  expect_init_journaler(mock_journaler, -EINVAL);
+  expect_shut_down_journaler(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  auto req = MockResetRequest::create(m_ioctx, "image id",
+                                      Journal<>::IMAGE_CLIENT_ID,
+                                      Journal<>::LOCAL_MIRROR_UUID,
+                                      ictx->op_work_queue , &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockJournalResetRequest, ShutDownError) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  ::journal::MockJournaler mock_journaler;
+  expect_construct_journaler(mock_journaler);
+  expect_init_journaler(mock_journaler, 0);
+  expect_get_metadata(mock_journaler);
+  expect_shut_down_journaler(mock_journaler, -EINVAL);
+
+  C_SaferCond ctx;
+  auto req = MockResetRequest::create(m_ioctx, "image id",
+                                      Journal<>::IMAGE_CLIENT_ID,
+                                      Journal<>::LOCAL_MIRROR_UUID,
+                                      ictx->op_work_queue , &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockJournalResetRequest, RemoveError) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  ::journal::MockJournaler mock_journaler;
+  expect_construct_journaler(mock_journaler);
+  expect_init_journaler(mock_journaler, 0);
+  expect_get_metadata(mock_journaler);
+  expect_shut_down_journaler(mock_journaler, 0);
+
+  MockRemoveRequest mock_remove_request;
+  expect_remove(mock_remove_request, -EINVAL);
+
+  C_SaferCond ctx;
+  auto req = MockResetRequest::create(m_ioctx, "image id",
+                                      Journal<>::IMAGE_CLIENT_ID,
+                                      Journal<>::LOCAL_MIRROR_UUID,
+                                      ictx->op_work_queue , &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockJournalResetRequest, CreateError) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  InSequence seq;
+  ::journal::MockJournaler mock_journaler;
+  expect_construct_journaler(mock_journaler);
+  expect_init_journaler(mock_journaler, 0);
+  expect_get_metadata(mock_journaler);
+  expect_shut_down_journaler(mock_journaler, 0);
+
+  MockRemoveRequest mock_remove_request;
+  expect_remove(mock_remove_request, 0);
+
+  MockCreateRequest mock_create_request;
+  expect_create(mock_create_request, -EINVAL);
+
+  C_SaferCond ctx;
+  auto req = MockResetRequest::create(m_ioctx, "image id",
+                                      Journal<>::IMAGE_CLIENT_ID,
+                                      Journal<>::LOCAL_MIRROR_UUID,
+                                      ictx->op_work_queue , &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+} // namespace journal
+} // namespace librbd

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -106,6 +106,7 @@ struct MockImageCtx {
           image_ctx.journal_max_concurrent_object_sets),
       mirroring_resync_after_disconnect(
           image_ctx.mirroring_resync_after_disconnect),
+      mirroring_delete_delay(image_ctx.mirroring_delete_delay),
       mirroring_replay_delay(image_ctx.mirroring_replay_delay),
       non_blocking_aio(image_ctx.non_blocking_aio),
       blkin_trace_all(image_ctx.blkin_trace_all),
@@ -314,6 +315,7 @@ struct MockImageCtx {
   uint32_t journal_max_payload_bytes;
   int journal_max_concurrent_object_sets;
   bool mirroring_resync_after_disconnect;
+  uint64_t mirroring_delete_delay;
   int mirroring_replay_delay;
   bool non_blocking_aio;
   bool blkin_trace_all;

--- a/src/test/librbd/test_mock_TrashWatcher.cc
+++ b/src/test/librbd/test_mock_TrashWatcher.cc
@@ -1,0 +1,95 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "include/rbd_types.h"
+#include "librbd/TrashWatcher.h"
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include <list>
+
+namespace librbd {
+namespace {
+
+struct MockTrashWatcher : public TrashWatcher<> {
+  MockTrashWatcher(ImageCtx &image_ctx)
+    : TrashWatcher<>(image_ctx.md_ctx, image_ctx.op_work_queue) {
+  }
+
+  MOCK_METHOD2(handle_image_added, void(const std::string&,
+                                        const cls::rbd::TrashImageSpec&));
+  MOCK_METHOD1(handle_image_removed, void(const std::string&));
+};
+
+} // anonymous namespace
+
+using ::testing::_;
+using ::testing::AtLeast;
+using ::testing::StrEq;
+
+class TestTrashWatcher : public TestMockFixture {
+public:
+  void SetUp() override {
+    TestFixture::SetUp();
+
+    bufferlist bl;
+    ASSERT_EQ(0, m_ioctx.write_full(RBD_TRASH, bl));
+
+    librbd::ImageCtx *ictx;
+    ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+    m_trash_watcher = new MockTrashWatcher(*ictx);
+
+    C_SaferCond ctx;
+    m_trash_watcher->register_watch(&ctx);
+    if (ctx.wait() != 0) {
+      delete m_trash_watcher;
+      m_trash_watcher = nullptr;
+      FAIL();
+    }
+  }
+
+  void TearDown() override {
+    if (m_trash_watcher != nullptr) {
+      C_SaferCond ctx;
+      m_trash_watcher->unregister_watch(&ctx);
+      ASSERT_EQ(0, ctx.wait());
+      delete m_trash_watcher;
+    }
+
+    TestFixture::TearDown();
+  }
+
+  MockTrashWatcher *m_trash_watcher = nullptr;
+};
+
+TEST_F(TestTrashWatcher, ImageAdded) {
+  REQUIRE_FORMAT_V2();
+
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name",
+    ceph_clock_now(), ceph_clock_now()};
+
+  EXPECT_CALL(*m_trash_watcher, handle_image_added(StrEq("image id"),
+                                                   trash_image_spec))
+    .Times(AtLeast(1));
+
+  C_SaferCond ctx;
+  MockTrashWatcher::notify_image_added(m_ioctx, "image id", trash_image_spec,
+                                       &ctx);
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestTrashWatcher, ImageRemoved) {
+  REQUIRE_FORMAT_V2();
+
+  EXPECT_CALL(*m_trash_watcher, handle_image_removed(StrEq("image id")))
+    .Times(AtLeast(1));
+
+  C_SaferCond ctx;
+  MockTrashWatcher::notify_image_removed(m_ioctx, "image id", &ctx);
+  ASSERT_EQ(0, ctx.wait());
+}
+
+} // namespace librbd

--- a/src/test/librbd/trash/test_mock_MoveRequest.cc
+++ b/src/test/librbd/trash/test_mock_MoveRequest.cc
@@ -1,0 +1,230 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockExclusiveLock.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/MockImageState.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "include/rbd/librbd.hpp"
+#include "librbd/Utils.h"
+#include "librbd/trash/MoveRequest.h"
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public MockImageCtx {
+  static MockTestImageCtx *s_instance;
+  static MockTestImageCtx *create(const std::string &image_name,
+                                  const std::string &image_id,
+                                  const char *snap, librados::IoCtx& p,
+                                  bool read_only) {
+    assert(s_instance != nullptr);
+    s_instance->construct(image_name, image_id);
+    return s_instance;
+  }
+
+  MOCK_METHOD2(construct, void(const std::string&, const std::string&));
+
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+      : librbd::MockImageCtx(image_ctx) {
+    s_instance = this;
+  }
+};
+
+MockTestImageCtx *MockTestImageCtx::s_instance = nullptr;
+
+} // anonymous namespace
+} // namespace librbd
+
+#include "librbd/trash/MoveRequest.cc"
+
+namespace librbd {
+namespace trash {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::WithArg;
+
+struct TestMockTrashMoveRequest : public TestMockFixture {
+  typedef MoveRequest<librbd::MockTestImageCtx> MockMoveRequest;
+
+  void expect_trash_add(MockTestImageCtx &mock_image_ctx,
+                        const std::string& image_id,
+                        cls::rbd::TrashImageSource trash_image_source,
+                        const std::string& name,
+                        const utime_t& end_time,
+                        int r) {
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(StrEq("rbd_trash"), _, StrEq("rbd"), StrEq("trash_add"),
+                     _, _, _))
+      .WillOnce(WithArg<4>(Invoke([=](bufferlist& in_bl) {
+                             std::string id;
+                             cls::rbd::TrashImageSpec trash_image_spec;
+
+                             bufferlist::iterator bl_it = in_bl.begin();
+                             ::decode(id, bl_it);
+                             ::decode(trash_image_spec, bl_it);
+
+                             EXPECT_EQ(id, image_id);
+                             EXPECT_EQ(trash_image_spec.source,
+                                       trash_image_source);
+                             EXPECT_EQ(trash_image_spec.name, name);
+                             EXPECT_EQ(trash_image_spec.deferment_end_time,
+                                       end_time);
+                             return r;
+                           })));
+  }
+
+  void expect_aio_remove(MockTestImageCtx &mock_image_ctx,
+                         const std::string& oid, int r) {
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx), remove(oid, _))
+      .WillOnce(Return(r));
+  }
+
+  void expect_dir_remove(MockTestImageCtx& mock_image_ctx,
+                         const std::string& name, const std::string& id,
+                         int r) {
+    bufferlist in_bl;
+    ::encode(name, in_bl);
+    ::encode(id, in_bl);
+
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(StrEq("rbd_directory"), _, StrEq("rbd"), StrEq("dir_remove_image"),
+                     ContentsEqual(in_bl), _, _))
+      .WillOnce(Return(r));
+  }
+};
+
+TEST_F(TestMockTrashMoveRequest, Success) {
+  REQUIRE_FORMAT_V2();
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock mock_exclusive_lock;
+  if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+    mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  }
+
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  utime_t delete_time{ceph_clock_now()};
+  expect_trash_add(mock_image_ctx, "image id",
+                   cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name", delete_time,
+                   0);
+  expect_aio_remove(mock_image_ctx, util::id_obj_name("image name"), 0);
+  expect_dir_remove(mock_image_ctx, "image name", "image id", 0);
+
+  C_SaferCond ctx;
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name", delete_time,
+    delete_time};
+  auto req = MockMoveRequest::create(mock_image_ctx.md_ctx, "image id",
+                                     trash_image_spec, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockTrashMoveRequest, TrashAddError) {
+  REQUIRE_FORMAT_V2();
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock mock_exclusive_lock;
+  if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+    mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  }
+
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  utime_t delete_time{ceph_clock_now()};
+  expect_trash_add(mock_image_ctx, "image id",
+                   cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name", delete_time,
+                   -EPERM);
+
+  C_SaferCond ctx;
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name", delete_time,
+    delete_time};
+  auto req = MockMoveRequest::create(mock_image_ctx.md_ctx, "image id",
+                                     trash_image_spec, &ctx);
+  req->send();
+  ASSERT_EQ(-EPERM, ctx.wait());
+}
+
+TEST_F(TestMockTrashMoveRequest, RemoveIdError) {
+  REQUIRE_FORMAT_V2();
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock mock_exclusive_lock;
+  if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+    mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  }
+
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  utime_t delete_time{ceph_clock_now()};
+  expect_trash_add(mock_image_ctx, "image id",
+                   cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name", delete_time,
+                   0);
+  expect_aio_remove(mock_image_ctx, util::id_obj_name("image name"), -EPERM);
+
+  C_SaferCond ctx;
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name", delete_time,
+    delete_time};
+  auto req = MockMoveRequest::create(mock_image_ctx.md_ctx, "image id",
+                                     trash_image_spec, &ctx);
+  req->send();
+  ASSERT_EQ(-EPERM, ctx.wait());
+}
+
+TEST_F(TestMockTrashMoveRequest, DirectoryRemoveError) {
+  REQUIRE_FORMAT_V2();
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockExclusiveLock mock_exclusive_lock;
+  if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+    mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  }
+
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  utime_t delete_time{ceph_clock_now()};
+  expect_trash_add(mock_image_ctx, "image id",
+                   cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name", delete_time,
+                   0);
+  expect_aio_remove(mock_image_ctx, util::id_obj_name("image name"), 0);
+  expect_dir_remove(mock_image_ctx, "image name", "image id", -EPERM);
+
+  C_SaferCond ctx;
+  cls::rbd::TrashImageSpec trash_image_spec{
+    cls::rbd::TRASH_IMAGE_SOURCE_USER, "image name", delete_time,
+    delete_time};
+  auto req = MockMoveRequest::create(mock_image_ctx.md_ctx, "image id",
+                                     trash_image_spec, &ctx);
+  req->send();
+  ASSERT_EQ(-EPERM, ctx.wait());
+}
+
+} // namespace trash
+} // namespace librbd

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(unittest_rbd_mirror
   test_mock_PoolWatcher.cc
   image_deleter/test_mock_RemoveRequest.cc
   image_deleter/test_mock_SnapshotPurgeRequest.cc
+  image_deleter/test_mock_TrashWatcher.cc
   image_replayer/test_mock_BootstrapRequest.cc
   image_replayer/test_mock_CreateImageRequest.cc
   image_replayer/test_mock_EventPreprocessor.cc

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -26,6 +26,7 @@ add_executable(unittest_rbd_mirror
   test_mock_PoolWatcher.cc
   image_deleter/test_mock_RemoveRequest.cc
   image_deleter/test_mock_SnapshotPurgeRequest.cc
+  image_deleter/test_mock_TrashMoveRequest.cc
   image_deleter/test_mock_TrashWatcher.cc
   image_replayer/test_mock_BootstrapRequest.cc
   image_replayer/test_mock_CreateImageRequest.cc

--- a/src/test/rbd_mirror/image_deleter/test_mock_RemoveRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_RemoveRequest.cc
@@ -4,7 +4,6 @@
 #include "test/rbd_mirror/test_mock_fixture.h"
 #include "cls/rbd/cls_rbd_types.h"
 #include "librbd/ImageCtx.h"
-#include "librbd/Journal.h"
 #include "librbd/Utils.h"
 #include "librbd/image/RemoveRequest.h"
 #include "tools/rbd_mirror/Threads.h"
@@ -25,29 +24,6 @@ struct MockTestImageCtx : public librbd::MockImageCtx {
 
 } // anonymous namespace
 
-template <>
-struct Journal<librbd::MockTestImageCtx> {
-  static Journal *s_instance;
-
-  static void get_tag_owner(librados::IoCtx &io_ctx,
-                            const std::string &image_id,
-                            std::string *mirror_uuid,
-                            ContextWQ *work_queue,
-                            Context *on_finish) {
-    assert(s_instance != nullptr);
-    s_instance->get_tag_owner(image_id, mirror_uuid, on_finish);
-  }
-
-  MOCK_METHOD3(get_tag_owner, void(const std::string &, std::string *,
-                                   Context *));
-
-  Journal() {
-    s_instance = this;
-  }
-};
-
-Journal<librbd::MockTestImageCtx>* Journal<librbd::MockTestImageCtx>::s_instance = nullptr;
-
 namespace image {
 
 template <>
@@ -66,7 +42,7 @@ struct RemoveRequest<librbd::MockTestImageCtx> {
     assert(s_instance != nullptr);
     EXPECT_TRUE(image_name.empty());
     EXPECT_TRUE(force);
-    EXPECT_FALSE(remove_from_trash);
+    EXPECT_TRUE(remove_from_trash);
     s_instance->construct(image_id);
     s_instance->on_finish = on_finish;
     return s_instance;
@@ -135,30 +111,7 @@ class TestMockImageDeleterRemoveRequest : public TestMockFixture {
 public:
   typedef RemoveRequest<librbd::MockTestImageCtx> MockRemoveRequest;
   typedef SnapshotPurgeRequest<librbd::MockTestImageCtx> MockSnapshotPurgeRequest;
-  typedef librbd::Journal<librbd::MockTestImageCtx> MockJournal;
   typedef librbd::image::RemoveRequest<librbd::MockTestImageCtx> MockImageRemoveRequest;
-
-  void expect_mirror_image_get_image_id(const std::string& image_id, int r) {
-    bufferlist bl;
-    ::encode(image_id, bl);
-
-    EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
-                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_get_image_id"), _, _, _))
-      .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
-                                          *out_bl = bl;
-                                        })),
-                      Return(r)));
-  }
-
-  void expect_get_tag_owner(MockJournal &mock_journal,
-                            const std::string &image_id,
-                            const std::string &tag_owner, int r) {
-    EXPECT_CALL(mock_journal, get_tag_owner(image_id, _, _))
-      .WillOnce(WithArgs<1, 2>(Invoke([this, tag_owner, r](std::string *owner, Context *on_finish) {
-                                        *owner = tag_owner;
-                                        m_threads->work_queue->queue(on_finish, r);
-                                      })));
-  }
 
   void expect_get_snapcontext(const std::string& image_id,
                               const ::SnapContext &snapc, int r) {
@@ -172,24 +125,6 @@ public:
                                           *out_bl = bl;
                                         })),
                       Return(r)));
-  }
-
-  void expect_mirror_image_set(const std::string& image_id,
-                               const std::string& global_image_id,
-                               cls::rbd::MirrorImageState mirror_image_state,
-                               int r) {
-    cls::rbd::MirrorImage mirror_image;
-    mirror_image.global_image_id = global_image_id;
-    mirror_image.state = mirror_image_state;
-
-    bufferlist bl;
-    ::encode(image_id, bl);
-    ::encode(mirror_image, bl);
-
-    EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
-                exec(RBD_MIRRORING, _, StrEq("rbd"),
-                     StrEq("mirror_image_set"), ContentsEqual(bl), _, _))
-      .WillOnce(Return(r));
   }
 
   void expect_snapshot_purge(MockSnapshotPurgeRequest &snapshot_purge_request,
@@ -209,29 +144,11 @@ public:
                   m_threads->work_queue->queue(image_remove_request.on_finish, r);
                 }));
   }
-
-  void expect_mirror_image_remove(const std::string& image_id,
-                                  int r) {
-    bufferlist bl;
-    ::encode(image_id, bl);
-
-    EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
-                exec(RBD_MIRRORING, _, StrEq("rbd"),
-                     StrEq("mirror_image_remove"), ContentsEqual(bl), _, _))
-      .WillOnce(Return(r));
-  }
 };
 
 TEST_F(TestMockImageDeleterRemoveRequest, Success) {
   InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", 0);
-
   expect_get_snapcontext("image id", {1, {1}}, 0);
-  expect_mirror_image_set("image id", "global image id",
-                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
 
   MockSnapshotPurgeRequest mock_snapshot_purge_request;
   expect_snapshot_purge(mock_snapshot_purge_request, "image id", 0);
@@ -239,140 +156,25 @@ TEST_F(TestMockImageDeleterRemoveRequest, Success) {
   MockImageRemoveRequest mock_image_remove_request;
   expect_image_remove(mock_image_remove_request, "image id", 0);
 
-  expect_mirror_image_remove("image id", 0);
-
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
+  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
                                        &error_result, m_threads->work_queue,
                                        &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
-}
-
-TEST_F(TestMockImageDeleterRemoveRequest, GetImageIdDNE) {
-  InSequence seq;
-  expect_mirror_image_get_image_id("image id", -ENOENT);
-
-  C_SaferCond ctx;
-  ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
-  req->send();
-  ASSERT_EQ(-ENOENT, ctx.wait());
-  ASSERT_EQ(ERROR_RESULT_COMPLETE, error_result);
-}
-
-TEST_F(TestMockImageDeleterRemoveRequest, GetImageIdError) {
-  InSequence seq;
-  expect_mirror_image_get_image_id("image id", -EINVAL);
-
-  C_SaferCond ctx;
-  ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
-  req->send();
-  ASSERT_EQ(-EINVAL, ctx.wait());
-}
-
-TEST_F(TestMockImageDeleterRemoveRequest, GetTagOwnerLocalPrimary) {
-  InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id",
-                       librbd::Journal<>::LOCAL_MIRROR_UUID, 0);
-
-  C_SaferCond ctx;
-  ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
-  req->send();
-  ASSERT_EQ(-EPERM, ctx.wait());
-  ASSERT_EQ(ERROR_RESULT_COMPLETE, error_result);
-}
-
-TEST_F(TestMockImageDeleterRemoveRequest, GetTagOwnerOrphan) {
-  InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id",
-                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
-
-  C_SaferCond ctx;
-  ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", false,
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
-  req->send();
-  ASSERT_EQ(-EPERM, ctx.wait());
-  ASSERT_EQ(ERROR_RESULT_COMPLETE, error_result);
-}
-
-TEST_F(TestMockImageDeleterRemoveRequest, GetTagOwnerDNE) {
-  InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", -ENOENT);
-
-  expect_get_snapcontext("image id", {1, {1}}, -ENOENT);
-  expect_mirror_image_set("image id", "global image id",
-                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
-
-  MockImageRemoveRequest mock_image_remove_request;
-  expect_image_remove(mock_image_remove_request, "image id", 0);
-
-  expect_mirror_image_remove("image id", 0);
-
-  C_SaferCond ctx;
-  ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
-  req->send();
-  ASSERT_EQ(0, ctx.wait());
-}
-
-TEST_F(TestMockImageDeleterRemoveRequest, GetTagOwnerError) {
-  InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", -EINVAL);
-
-  C_SaferCond ctx;
-  ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
-  req->send();
-  ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
 TEST_F(TestMockImageDeleterRemoveRequest, GetSnapContextDNE) {
   InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", 0);
-
   expect_get_snapcontext("image id", {1, {1}}, -ENOENT);
-  expect_mirror_image_set("image id", "global image id",
-                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
 
   MockImageRemoveRequest mock_image_remove_request;
   expect_image_remove(mock_image_remove_request, "image id", 0);
 
-  expect_mirror_image_remove("image id", 0);
-
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
+  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
                                        &error_result, m_threads->work_queue,
                                        &ctx);
   req->send();
@@ -381,57 +183,11 @@ TEST_F(TestMockImageDeleterRemoveRequest, GetSnapContextDNE) {
 
 TEST_F(TestMockImageDeleterRemoveRequest, GetSnapContextError) {
   InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", 0);
-
   expect_get_snapcontext("image id", {1, {1}}, -EINVAL);
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
-  req->send();
-  ASSERT_EQ(-EINVAL, ctx.wait());
-}
-
-TEST_F(TestMockImageDeleterRemoveRequest, SetMirrorDNE) {
-  InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", 0);
-
-  expect_get_snapcontext("image id", {1, {1}}, 0);
-  expect_mirror_image_set("image id", "global image id",
-                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, -ENOENT);
-
-  C_SaferCond ctx;
-  ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
-  req->send();
-  ASSERT_EQ(-ENOENT, ctx.wait());
-  ASSERT_EQ(ERROR_RESULT_COMPLETE, error_result);
-}
-
-TEST_F(TestMockImageDeleterRemoveRequest, SetMirrorError) {
-  InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", 0);
-
-  expect_get_snapcontext("image id", {1, {1}}, 0);
-  expect_mirror_image_set("image id", "global image id",
-                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, -EINVAL);
-
-  C_SaferCond ctx;
-  ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
+  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
                                        &error_result, m_threads->work_queue,
                                        &ctx);
   req->send();
@@ -440,21 +196,14 @@ TEST_F(TestMockImageDeleterRemoveRequest, SetMirrorError) {
 
 TEST_F(TestMockImageDeleterRemoveRequest, PurgeSnapshotBusy) {
   InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", 0);
-
   expect_get_snapcontext("image id", {1, {1}}, 0);
-  expect_mirror_image_set("image id", "global image id",
-                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
 
   MockSnapshotPurgeRequest mock_snapshot_purge_request;
   expect_snapshot_purge(mock_snapshot_purge_request, "image id", -EBUSY);
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
+  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
                                        &error_result, m_threads->work_queue,
                                        &ctx);
   req->send();
@@ -464,21 +213,14 @@ TEST_F(TestMockImageDeleterRemoveRequest, PurgeSnapshotBusy) {
 
 TEST_F(TestMockImageDeleterRemoveRequest, PurgeSnapshotError) {
   InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", 0);
-
   expect_get_snapcontext("image id", {1, {1}}, 0);
-  expect_mirror_image_set("image id", "global image id",
-                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
 
   MockSnapshotPurgeRequest mock_snapshot_purge_request;
   expect_snapshot_purge(mock_snapshot_purge_request, "image id", -EINVAL);
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
+  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
                                        &error_result, m_threads->work_queue,
                                        &ctx);
   req->send();
@@ -487,14 +229,7 @@ TEST_F(TestMockImageDeleterRemoveRequest, PurgeSnapshotError) {
 
 TEST_F(TestMockImageDeleterRemoveRequest, RemoveError) {
   InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", 0);
-
   expect_get_snapcontext("image id", {1, {1}}, 0);
-  expect_mirror_image_set("image id", "global image id",
-                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
 
   MockSnapshotPurgeRequest mock_snapshot_purge_request;
   expect_snapshot_purge(mock_snapshot_purge_request, "image id", 0);
@@ -504,35 +239,7 @@ TEST_F(TestMockImageDeleterRemoveRequest, RemoveError) {
 
   C_SaferCond ctx;
   ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
-                                       &error_result, m_threads->work_queue,
-                                       &ctx);
-  req->send();
-  ASSERT_EQ(-EINVAL, ctx.wait());
-}
-
-TEST_F(TestMockImageDeleterRemoveRequest, RemoveMirrorError) {
-  InSequence seq;
-  expect_mirror_image_get_image_id("image id", 0);
-
-  MockJournal mock_journal;
-  expect_get_tag_owner(mock_journal, "image id", "remote uuid", 0);
-
-  expect_get_snapcontext("image id", {1, {1}}, 0);
-  expect_mirror_image_set("image id", "global image id",
-                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
-
-  MockSnapshotPurgeRequest mock_snapshot_purge_request;
-  expect_snapshot_purge(mock_snapshot_purge_request, "image id", 0);
-
-  MockImageRemoveRequest mock_image_remove_request;
-  expect_image_remove(mock_image_remove_request, "image id", 0);
-
-  expect_mirror_image_remove("image id", -EINVAL);
-
-  C_SaferCond ctx;
-  ErrorResult error_result;
-  auto req = MockRemoveRequest::create(m_local_io_ctx, "global image id", true,
+  auto req = MockRemoveRequest::create(m_local_io_ctx, "image id",
                                        &error_result, m_threads->work_queue,
                                        &ctx);
   req->send();

--- a/src/test/rbd_mirror/image_deleter/test_mock_SnapshotPurgeRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_SnapshotPurgeRequest.cc
@@ -218,6 +218,7 @@ TEST_F(TestMockImageDeleterSnapshotPurgeRequest, OpenError) {
   InSequence seq;
   expect_set_journal_policy(mock_image_ctx);
   expect_open(mock_image_ctx, -EPERM);
+  expect_destroy(mock_image_ctx);
 
   C_SaferCond ctx;
   auto req = MockSnapshotPurgeRequest::create(m_local_io_ctx, mock_image_ctx.id,

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashMoveRequest.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashMoveRequest.cc
@@ -1,0 +1,671 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Operations.h"
+#include "librbd/TrashWatcher.h"
+#include "librbd/journal/ResetRequest.h"
+#include "librbd/trash/MoveRequest.h"
+#include "tools/rbd_mirror/Threads.h"
+#include "tools/rbd_mirror/image_deleter/TrashMoveRequest.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librbd/mock/MockExclusiveLock.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/MockImageState.h"
+#include "test/librbd/mock/MockOperations.h"
+
+namespace librbd {
+
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  static MockTestImageCtx *s_instance;
+  static MockTestImageCtx *create(const std::string &image_name,
+                                  const std::string &image_id,
+                                  const char *snap, librados::IoCtx& p,
+                                  bool read_only) {
+    assert(s_instance != nullptr);
+    return s_instance;
+  }
+
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+      : librbd::MockImageCtx(image_ctx) {
+    s_instance = this;
+  }
+};
+
+MockTestImageCtx *MockTestImageCtx::s_instance = nullptr;
+
+} // anonymous namespace
+
+template <>
+struct Journal<librbd::MockTestImageCtx> {
+  static Journal *s_instance;
+
+  static void get_tag_owner(librados::IoCtx &io_ctx,
+                            const std::string &image_id,
+                            std::string *mirror_uuid,
+                            ContextWQ *work_queue,
+                            Context *on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->get_tag_owner(image_id, mirror_uuid, on_finish);
+  }
+
+  MOCK_METHOD3(get_tag_owner, void(const std::string &, std::string *,
+                                   Context *));
+
+  Journal() {
+    s_instance = this;
+  }
+};
+
+Journal<librbd::MockTestImageCtx>* Journal<librbd::MockTestImageCtx>::s_instance = nullptr;
+
+template<>
+struct TrashWatcher<MockTestImageCtx> {
+  static TrashWatcher* s_instance;
+  static void notify_image_added(librados::IoCtx&, const std::string& image_id,
+                                 const cls::rbd::TrashImageSpec& spec,
+                                 Context *ctx) {
+    assert(s_instance != nullptr);
+    s_instance->notify_image_added(image_id, spec, ctx);
+  }
+
+  MOCK_METHOD3(notify_image_added, void(const std::string&,
+                                        const cls::rbd::TrashImageSpec&,
+                                        Context*));
+
+  TrashWatcher() {
+    s_instance = this;
+  }
+};
+
+TrashWatcher<MockTestImageCtx>* TrashWatcher<MockTestImageCtx>::s_instance = nullptr;
+
+namespace journal {
+
+template <>
+struct ResetRequest<MockTestImageCtx> {
+  static ResetRequest* s_instance;
+  Context* on_finish = nullptr;
+
+  static ResetRequest* create(librados::IoCtx &io_ctx,
+                              const std::string &image_id,
+                              const std::string &client_id,
+                              const std::string &mirror_uuid,
+                              ContextWQ *op_work_queue, Context *on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  MOCK_METHOD0(send, void());
+
+  ResetRequest() {
+    s_instance = this;
+  }
+};
+
+ResetRequest<MockTestImageCtx>* ResetRequest<MockTestImageCtx>::s_instance = nullptr;
+
+} // namespace journal
+
+namespace trash {
+
+template <>
+struct MoveRequest<MockTestImageCtx> {
+  static MoveRequest* s_instance;
+  Context* on_finish = nullptr;
+
+  typedef boost::optional<utime_t> DefermentEndTime;
+
+  static MoveRequest* create(librados::IoCtx& io_ctx,
+                             const std::string& image_id,
+                             const cls::rbd::TrashImageSpec& trash_image_spec,
+                             Context* on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  MOCK_METHOD0(send, void());
+
+  MoveRequest() {
+    s_instance = this;
+  }
+};
+
+MoveRequest<MockTestImageCtx>* MoveRequest<MockTestImageCtx>::s_instance = nullptr;
+
+} // namespace trash
+} // namespace librbd
+
+#include "tools/rbd_mirror/image_deleter/TrashMoveRequest.cc"
+
+namespace rbd {
+namespace mirror {
+namespace image_deleter {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::WithArg;
+using ::testing::WithArgs;
+
+class TestMockImageDeleterTrashMoveRequest : public TestMockFixture {
+public:
+  typedef TrashMoveRequest<librbd::MockTestImageCtx> MockTrashMoveRequest;
+  typedef librbd::Journal<librbd::MockTestImageCtx> MockJournal;
+  typedef librbd::journal::ResetRequest<librbd::MockTestImageCtx> MockJournalResetRequest;
+  typedef librbd::trash::MoveRequest<librbd::MockTestImageCtx> MockLibrbdTrashMoveRequest;
+  typedef librbd::TrashWatcher<librbd::MockTestImageCtx> MockTrashWatcher;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+  }
+
+  void expect_mirror_image_get_image_id(const std::string& image_id, int r) {
+    bufferlist bl;
+    ::encode(image_id, bl);
+
+    EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
+                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_get_image_id"), _, _, _))
+      .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
+                                          *out_bl = bl;
+                                        })),
+                      Return(r)));
+  }
+
+  void expect_get_tag_owner(MockJournal &mock_journal,
+                            const std::string &image_id,
+                            const std::string &tag_owner, int r) {
+    EXPECT_CALL(mock_journal, get_tag_owner(image_id, _, _))
+      .WillOnce(WithArgs<1, 2>(Invoke([this, tag_owner, r](std::string *owner, Context *on_finish) {
+                                        *owner = tag_owner;
+                                        m_threads->work_queue->queue(on_finish, r);
+                                      })));
+  }
+
+  void expect_set_journal_policy(librbd::MockTestImageCtx &mock_image_ctx) {
+    EXPECT_CALL(mock_image_ctx, set_journal_policy(_))
+      .WillOnce(Invoke([](librbd::journal::Policy* policy) {
+                  delete policy;
+                }));
+  }
+
+  void expect_open(librbd::MockTestImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(*mock_image_ctx.state, open(true, _))
+      .WillOnce(WithArg<1>(Invoke([this, r](Context* ctx) {
+                             m_threads->work_queue->queue(ctx, r);
+                           })));
+  }
+
+  void expect_close(librbd::MockTestImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(*mock_image_ctx.state, close(_))
+      .WillOnce(Invoke([this, r](Context* ctx) {
+                  m_threads->work_queue->queue(ctx, r);
+                }));
+  }
+
+  void expect_block_requests(librbd::MockTestImageCtx &mock_image_ctx) {
+    EXPECT_CALL(*mock_image_ctx.exclusive_lock, block_requests(0)).Times(1);
+  }
+
+  void expect_acquire_lock(librbd::MockTestImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(*mock_image_ctx.exclusive_lock, acquire_lock(_))
+      .WillOnce(Invoke([this, r](Context* ctx) {
+                  m_threads->work_queue->queue(ctx, r);
+                }));
+  }
+
+  void expect_destroy(librbd::MockTestImageCtx& mock_image_ctx) {
+    EXPECT_CALL(mock_image_ctx, destroy());
+  }
+
+  void expect_mirror_image_set(const std::string& image_id,
+                               const std::string& global_image_id,
+                               cls::rbd::MirrorImageState mirror_image_state,
+                               int r) {
+    cls::rbd::MirrorImage mirror_image;
+    mirror_image.global_image_id = global_image_id;
+    mirror_image.state = mirror_image_state;
+
+    bufferlist bl;
+    ::encode(image_id, bl);
+    ::encode(mirror_image, bl);
+
+    EXPECT_CALL(get_mock_io_ctx(m_local_io_ctx),
+                exec(RBD_MIRRORING, _, StrEq("rbd"),
+                     StrEq("mirror_image_set"), ContentsEqual(bl), _, _))
+      .WillOnce(Return(r));
+  }
+
+  void expect_mirror_image_remove(librados::IoCtx &ioctx, int r) {
+    EXPECT_CALL(get_mock_io_ctx(ioctx),
+                exec(StrEq("rbd_mirroring"), _, StrEq("rbd"), StrEq("mirror_image_remove"),
+                     _, _, _))
+      .WillOnce(Return(r));
+  }
+
+  void expect_journal_reset(MockJournalResetRequest& mock_journal_reset_request,
+                            int r) {
+    EXPECT_CALL(mock_journal_reset_request, send())
+      .WillOnce(Invoke([this, &mock_journal_reset_request, r]() {
+                  m_threads->work_queue->queue(mock_journal_reset_request.on_finish, r);
+                }));
+  }
+
+  void expect_trash_move(MockLibrbdTrashMoveRequest& mock_trash_move_request,
+                         int r) {
+    EXPECT_CALL(mock_trash_move_request, send())
+      .WillOnce(Invoke([this, &mock_trash_move_request, r]() {
+                  m_threads->work_queue->queue(mock_trash_move_request.on_finish, r);
+                }));
+  }
+
+  void expect_notify_image_added(MockTrashWatcher& mock_trash_watcher,
+                                 const std::string& image_id) {
+    EXPECT_CALL(mock_trash_watcher, notify_image_added(image_id, _, _))
+      .WillOnce(WithArg<2>(Invoke([this](Context *ctx) {
+                             m_threads->work_queue->queue(ctx, 0);
+                           })));
+  }
+
+  librbd::ImageCtx *m_local_image_ctx;
+};
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, Success) {
+  librbd::MockTestImageCtx mock_image_ctx(*m_local_image_ctx);
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
+  expect_mirror_image_set("image id", "global image id",
+                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
+
+  MockJournalResetRequest mock_journal_reset_request;
+  expect_journal_reset(mock_journal_reset_request, 0);
+
+  expect_set_journal_policy(mock_image_ctx);
+  expect_open(mock_image_ctx, 0);
+  expect_block_requests(mock_image_ctx);
+  expect_acquire_lock(mock_image_ctx, 0);
+
+  MockLibrbdTrashMoveRequest mock_librbd_trash_move_request;
+  expect_trash_move(mock_librbd_trash_move_request, 0);
+  expect_mirror_image_remove(m_local_io_ctx, 0);
+
+  expect_close(mock_image_ctx, 0);
+  expect_destroy(mock_image_ctx);
+
+  MockTrashWatcher mock_trash_watcher;
+  expect_notify_image_added(mock_trash_watcher, "image id");
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, GetImageIdDNE) {
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", -ENOENT);
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-ENOENT, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, GetImageIdError) {
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", -EINVAL);
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, GetTagOwnerLocalPrimary) {
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::LOCAL_MIRROR_UUID, 0);
+
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EPERM, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, GetTagOwnerOrphan) {
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
+
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          false,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EPERM, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, GetTagOwnerDNE) {
+  librbd::MockTestImageCtx mock_image_ctx(*m_local_image_ctx);
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id", "remote uuid", -ENOENT);
+  expect_mirror_image_set("image id", "global image id",
+                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
+
+  MockJournalResetRequest mock_journal_reset_request;
+  expect_journal_reset(mock_journal_reset_request, 0);
+
+  expect_set_journal_policy(mock_image_ctx);
+  expect_open(mock_image_ctx, 0);
+  expect_block_requests(mock_image_ctx);
+  expect_acquire_lock(mock_image_ctx, 0);
+
+  MockLibrbdTrashMoveRequest mock_librbd_trash_move_request;
+  expect_trash_move(mock_librbd_trash_move_request, 0);
+  expect_mirror_image_remove(m_local_io_ctx, 0);
+
+  expect_close(mock_image_ctx, 0);
+  expect_destroy(mock_image_ctx);
+
+  MockTrashWatcher mock_trash_watcher;
+  expect_notify_image_added(mock_trash_watcher, "image id");
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, GetTagOwnerError) {
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id", "remote uuid", -EINVAL);
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, DisableMirrorImageError) {
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
+  expect_mirror_image_set("image id", "global image id",
+                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, -EINVAL);
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, ResetJournalError) {
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
+  expect_mirror_image_set("image id", "global image id",
+                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
+
+  MockJournalResetRequest mock_journal_reset_request;
+  expect_journal_reset(mock_journal_reset_request, -EINVAL);
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, OpenImageError) {
+  librbd::MockTestImageCtx mock_image_ctx(*m_local_image_ctx);
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
+  expect_mirror_image_set("image id", "global image id",
+                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
+
+  MockJournalResetRequest mock_journal_reset_request;
+  expect_journal_reset(mock_journal_reset_request, 0);
+
+  expect_set_journal_policy(mock_image_ctx);
+  expect_open(mock_image_ctx, -EINVAL);
+  expect_destroy(mock_image_ctx);
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, AcquireLockError) {
+  librbd::MockTestImageCtx mock_image_ctx(*m_local_image_ctx);
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
+  expect_mirror_image_set("image id", "global image id",
+                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
+
+  MockJournalResetRequest mock_journal_reset_request;
+  expect_journal_reset(mock_journal_reset_request, 0);
+
+  expect_set_journal_policy(mock_image_ctx);
+  expect_open(mock_image_ctx, 0);
+  expect_block_requests(mock_image_ctx);
+  expect_acquire_lock(mock_image_ctx, -EINVAL);
+
+  expect_close(mock_image_ctx, 0);
+  expect_destroy(mock_image_ctx);
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, TrashMoveError) {
+  librbd::MockTestImageCtx mock_image_ctx(*m_local_image_ctx);
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
+  expect_mirror_image_set("image id", "global image id",
+                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
+
+  MockJournalResetRequest mock_journal_reset_request;
+  expect_journal_reset(mock_journal_reset_request, 0);
+
+  expect_set_journal_policy(mock_image_ctx);
+  expect_open(mock_image_ctx, 0);
+  expect_block_requests(mock_image_ctx);
+  expect_acquire_lock(mock_image_ctx, 0);
+
+  MockLibrbdTrashMoveRequest mock_librbd_trash_move_request;
+  expect_trash_move(mock_librbd_trash_move_request, -EINVAL);
+
+  expect_close(mock_image_ctx, 0);
+  expect_destroy(mock_image_ctx);
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, RemoveMirrorImageError) {
+  librbd::MockTestImageCtx mock_image_ctx(*m_local_image_ctx);
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
+  expect_mirror_image_set("image id", "global image id",
+                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
+
+  MockJournalResetRequest mock_journal_reset_request;
+  expect_journal_reset(mock_journal_reset_request, 0);
+
+  expect_set_journal_policy(mock_image_ctx);
+  expect_open(mock_image_ctx, 0);
+  expect_block_requests(mock_image_ctx);
+  expect_acquire_lock(mock_image_ctx, 0);
+
+  MockLibrbdTrashMoveRequest mock_librbd_trash_move_request;
+  expect_trash_move(mock_librbd_trash_move_request, 0);
+  expect_mirror_image_remove(m_local_io_ctx, -EINVAL);
+
+  expect_close(mock_image_ctx, 0);
+  expect_destroy(mock_image_ctx);
+
+  MockTrashWatcher mock_trash_watcher;
+  expect_notify_image_added(mock_trash_watcher, "image id");
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageDeleterTrashMoveRequest, CloseImageError) {
+  librbd::MockTestImageCtx mock_image_ctx(*m_local_image_ctx);
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  InSequence seq;
+  expect_mirror_image_get_image_id("image id", 0);
+
+  MockJournal mock_journal;
+  expect_get_tag_owner(mock_journal, "image id",
+                       librbd::Journal<>::ORPHAN_MIRROR_UUID, 0);
+  expect_mirror_image_set("image id", "global image id",
+                          cls::rbd::MIRROR_IMAGE_STATE_DISABLING, 0);
+
+  MockJournalResetRequest mock_journal_reset_request;
+  expect_journal_reset(mock_journal_reset_request, 0);
+
+  expect_set_journal_policy(mock_image_ctx);
+  expect_open(mock_image_ctx, 0);
+  expect_block_requests(mock_image_ctx);
+  expect_acquire_lock(mock_image_ctx, 0);
+
+  MockLibrbdTrashMoveRequest mock_librbd_trash_move_request;
+  expect_trash_move(mock_librbd_trash_move_request, 0);
+  expect_mirror_image_remove(m_local_io_ctx, 0);
+
+  expect_close(mock_image_ctx, -EINVAL);
+  expect_destroy(mock_image_ctx);
+
+  MockTrashWatcher mock_trash_watcher;
+  expect_notify_image_added(mock_trash_watcher, "image id");
+
+  C_SaferCond ctx;
+  auto req = MockTrashMoveRequest::create(m_local_io_ctx, "global image id",
+                                          true,
+                                          m_local_image_ctx->op_work_queue,
+                                          &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+} // namespace image_deleter
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/image_deleter/test_mock_TrashWatcher.cc
+++ b/src/test/rbd_mirror/image_deleter/test_mock_TrashWatcher.cc
@@ -1,0 +1,480 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/rbd_mirror/mock/MockContextWQ.h"
+#include "test/rbd_mirror/mock/MockSafeTimer.h"
+#include "librbd/TrashWatcher.h"
+#include "tools/rbd_mirror/Threads.h"
+#include "tools/rbd_mirror/image_deleter/TrashWatcher.h"
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+
+struct MockTrashWatcher {
+  static MockTrashWatcher *s_instance;
+  static MockTrashWatcher &get_instance() {
+    assert(s_instance != nullptr);
+    return *s_instance;
+  }
+
+  MockTrashWatcher() {
+    s_instance = this;
+  }
+
+  MOCK_CONST_METHOD0(is_unregistered, bool());
+  MOCK_METHOD1(register_watch, void(Context*));
+  MOCK_METHOD1(unregister_watch, void(Context*));
+};
+
+template <>
+struct TrashWatcher<MockTestImageCtx> {
+  static TrashWatcher *s_instance;
+
+  TrashWatcher(librados::IoCtx &io_ctx, ::MockContextWQ *work_queue) {
+    s_instance = this;
+  }
+  virtual ~TrashWatcher() {
+  }
+
+  static TrashWatcher<MockTestImageCtx> &get_instance() {
+    assert(s_instance != nullptr);
+    return *s_instance;
+  }
+
+  virtual void handle_rewatch_complete(int r) = 0;
+
+  virtual void handle_image_added(const std::string &image_id,
+                                  const cls::rbd::TrashImageSpec& spec) = 0;
+  virtual void handle_image_removed(const std::string &image_id) = 0;
+
+  bool is_unregistered() const {
+    return MockTrashWatcher::get_instance().is_unregistered();
+  }
+  void register_watch(Context *ctx) {
+    MockTrashWatcher::get_instance().register_watch(ctx);
+  }
+  void unregister_watch(Context *ctx) {
+    MockTrashWatcher::get_instance().unregister_watch(ctx);
+  }
+};
+
+MockTrashWatcher *MockTrashWatcher::s_instance = nullptr;
+TrashWatcher<MockTestImageCtx> *TrashWatcher<MockTestImageCtx>::s_instance = nullptr;
+
+} // namespace librbd
+
+namespace rbd {
+namespace mirror {
+
+template <>
+struct Threads<librbd::MockTestImageCtx> {
+  MockSafeTimer *timer;
+  Mutex &timer_lock;
+
+  MockContextWQ *work_queue;
+
+  Threads(Threads<librbd::ImageCtx> *threads)
+    : timer(new MockSafeTimer()),
+      timer_lock(threads->timer_lock),
+      work_queue(new MockContextWQ()) {
+  }
+  ~Threads() {
+    delete timer;
+    delete work_queue;
+  }
+};
+
+} // namespace mirror
+} // namespace rbd
+
+#include "tools/rbd_mirror/image_deleter/TrashWatcher.cc"
+
+namespace rbd {
+namespace mirror {
+namespace image_deleter {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnArg;
+using ::testing::StrEq;
+using ::testing::WithArg;
+
+class TestMockImageDeleterTrashWatcher : public TestMockFixture {
+public:
+  typedef TrashWatcher<librbd::MockTestImageCtx> MockTrashWatcher;
+  typedef Threads<librbd::MockTestImageCtx> MockThreads;
+  typedef librbd::MockTrashWatcher MockLibrbdTrashWatcher;
+  typedef librbd::TrashWatcher<librbd::MockTestImageCtx> LibrbdTrashWatcher;
+
+  struct MockListener : TrashListener {
+    MOCK_METHOD2(handle_trash_image, void(const std::string&, const utime_t&));
+  };
+
+  void expect_work_queue(MockThreads &mock_threads) {
+    EXPECT_CALL(*mock_threads.work_queue, queue(_, _))
+      .WillRepeatedly(Invoke([this](Context *ctx, int r) {
+          m_threads->work_queue->queue(ctx, r);
+        }));
+  }
+
+  void expect_trash_watcher_is_unregistered(MockLibrbdTrashWatcher &mock_trash_watcher,
+                                            bool unregistered) {
+    EXPECT_CALL(mock_trash_watcher, is_unregistered())
+      .WillOnce(Return(unregistered));
+  }
+
+  void expect_trash_watcher_register(MockLibrbdTrashWatcher &mock_trash_watcher,
+                                     int r) {
+    EXPECT_CALL(mock_trash_watcher, register_watch(_))
+      .WillOnce(CompleteContext(r));
+  }
+
+  void expect_trash_watcher_unregister(MockLibrbdTrashWatcher &mock_trash_watcher,
+                                       int r) {
+    EXPECT_CALL(mock_trash_watcher, unregister_watch(_))
+      .WillOnce(CompleteContext(r));
+  }
+
+  void expect_create_trash(librados::IoCtx &io_ctx, int r) {
+    EXPECT_CALL(get_mock_io_ctx(io_ctx), create(RBD_TRASH, false))
+      .WillOnce(Return(r));
+  }
+
+  void expect_trash_list(librados::IoCtx &io_ctx,
+                         const std::string& last_image_id,
+                         std::map<std::string, cls::rbd::TrashImageSpec>&& images,
+                         int r) {
+    bufferlist bl;
+    ::encode(last_image_id, bl);
+    ::encode(static_cast<size_t>(1024), bl);
+
+    bufferlist out_bl;
+    ::encode(images, out_bl);
+
+    EXPECT_CALL(get_mock_io_ctx(io_ctx),
+                exec(RBD_TRASH, _, StrEq("rbd"), StrEq("trash_list"),
+                     ContentsEqual(bl), _, _))
+      .WillOnce(DoAll(WithArg<5>(Invoke([this, out_bl](bufferlist *bl) {
+                          *bl = out_bl;
+                        })),
+                      Return(r)));
+  }
+
+  void expect_timer_add_event(MockThreads &mock_threads) {
+    EXPECT_CALL(*mock_threads.timer, add_event_after(_, _))
+      .WillOnce(DoAll(WithArg<1>(Invoke([this](Context *ctx) {
+                        auto wrapped_ctx =
+			  new FunctionContext([this, ctx](int r) {
+			      Mutex::Locker timer_locker(m_threads->timer_lock);
+			      ctx->complete(r);
+			    });
+			m_threads->work_queue->queue(wrapped_ctx, 0);
+                      })),
+                      ReturnArg<1>()));
+  }
+
+  void expect_handle_trash_image(MockListener& mock_listener,
+                                 const std::string& global_image_id) {
+    EXPECT_CALL(mock_listener, handle_trash_image(global_image_id, _));
+  }
+
+  int when_shut_down(MockTrashWatcher &mock_trash_watcher) {
+    C_SaferCond ctx;
+    mock_trash_watcher.shut_down(&ctx);
+    return ctx.wait();
+  }
+
+};
+
+TEST_F(TestMockImageDeleterTrashWatcher, EmptyPool) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, 0);
+  expect_trash_list(m_local_io_ctx, "", {}, 0);
+
+  MockListener mock_listener;
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(0, ctx.wait());
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+TEST_F(TestMockImageDeleterTrashWatcher, NonEmptyPool) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  MockListener mock_listener;
+  expect_handle_trash_image(mock_listener, "image0");
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, 0);
+
+  std::map<std::string, cls::rbd::TrashImageSpec> images;
+  images["image0"] = {cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "name", {}, {}};
+  for (auto idx = 1; idx < 1024; ++idx) {
+    images["image" + stringify(idx)] = {};
+  }
+  expect_trash_list(m_local_io_ctx, "", std::move(images), 0);
+
+  images.clear();
+  for (auto idx = 1024; idx < 2000; ++idx) {
+    images["image" + stringify(idx)] = {};
+  }
+  expect_trash_list(m_local_io_ctx, "image999", std::move(images), 0);
+
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(0, ctx.wait());
+  m_threads->work_queue->drain();
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+TEST_F(TestMockImageDeleterTrashWatcher, Notify) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  MockListener mock_listener;
+  expect_handle_trash_image(mock_listener, "image1");
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, 0);
+  expect_trash_list(m_local_io_ctx, "", {}, 0);
+
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(0, ctx.wait());
+
+  LibrbdTrashWatcher::get_instance().handle_image_added(
+    "image1", {cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, "name", {}, {}});
+  m_threads->work_queue->drain();
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+TEST_F(TestMockImageDeleterTrashWatcher, CreateError) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, -EINVAL);
+
+  expect_timer_add_event(mock_threads);
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, 0);
+
+  MockListener mock_listener;
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(0, ctx.wait());
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+TEST_F(TestMockImageDeleterTrashWatcher, RegisterWatcherBlacklist) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, -EBLACKLISTED);
+
+  MockListener mock_listener;
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(-EBLACKLISTED, ctx.wait());
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+TEST_F(TestMockImageDeleterTrashWatcher, RegisterWatcherError) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, -EINVAL);
+  expect_timer_add_event(mock_threads);
+
+  expect_create_trash(m_local_io_ctx, 0);
+
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, 0);
+
+  MockListener mock_listener;
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(0, ctx.wait());
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+TEST_F(TestMockImageDeleterTrashWatcher, TrashListBlacklist) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, 0);
+  expect_trash_list(m_local_io_ctx, "", {}, -EBLACKLISTED);
+
+  MockListener mock_listener;
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(-EBLACKLISTED, ctx.wait());
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+TEST_F(TestMockImageDeleterTrashWatcher, TrashListError) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, 0);
+  expect_trash_list(m_local_io_ctx, "", {}, -EINVAL);
+
+  expect_timer_add_event(mock_threads);
+  expect_create_trash(m_local_io_ctx, 0);
+
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, false);
+  expect_trash_list(m_local_io_ctx, "", {}, 0);
+
+  MockListener mock_listener;
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(0, ctx.wait());
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+TEST_F(TestMockImageDeleterTrashWatcher, Rewatch) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, 0);
+  expect_trash_list(m_local_io_ctx, "", {}, 0);
+
+  MockListener mock_listener;
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(0, ctx.wait());
+
+  expect_timer_add_event(mock_threads);
+  expect_create_trash(m_local_io_ctx, 0);
+
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, false);
+  expect_trash_list(m_local_io_ctx, "", {}, 0);
+  LibrbdTrashWatcher::get_instance().handle_rewatch_complete(0);
+  m_threads->work_queue->drain();
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+TEST_F(TestMockImageDeleterTrashWatcher, RewatchBlacklist) {
+  MockThreads mock_threads(m_threads);
+  expect_work_queue(mock_threads);
+
+  InSequence seq;
+  expect_create_trash(m_local_io_ctx, 0);
+
+  MockLibrbdTrashWatcher mock_librbd_trash_watcher;
+  expect_trash_watcher_is_unregistered(mock_librbd_trash_watcher, true);
+  expect_trash_watcher_register(mock_librbd_trash_watcher, 0);
+  expect_trash_list(m_local_io_ctx, "", {}, 0);
+
+  MockListener mock_listener;
+  MockTrashWatcher mock_trash_watcher(m_local_io_ctx, &mock_threads,
+                                      mock_listener);
+  C_SaferCond ctx;
+  mock_trash_watcher.init(&ctx);
+  ASSERT_EQ(0, ctx.wait());
+
+  LibrbdTrashWatcher::get_instance().handle_rewatch_complete(-EBLACKLISTED);
+  m_threads->work_queue->drain();
+
+  expect_trash_watcher_unregister(mock_librbd_trash_watcher, 0);
+  ASSERT_EQ(0, when_shut_down(mock_trash_watcher));
+}
+
+} // namespace image_deleter
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/test_ImageDeleter.cc
+++ b/src/test/rbd_mirror/test_ImageDeleter.cc
@@ -214,120 +214,61 @@ public:
                                                     &mirror_image));
   }
 
+  int trash_move(const std::string& global_image_id) {
+    C_SaferCond ctx;
+    rbd::mirror::ImageDeleter<>::trash_move(m_local_io_ctx, global_image_id,
+                                            true, m_threads->work_queue, &ctx);
+    return ctx.wait();
+  }
+
   librbd::RBD rbd;
   std::string m_local_image_id;
   std::unique_ptr<rbd::mirror::ServiceDaemon<>> m_service_daemon;
   rbd::mirror::ImageDeleter<> *m_deleter;
 };
 
-TEST_F(TestImageDeleter, Delete_NonPrimary_Image) {
-  init_image_deleter();
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, nullptr);
+TEST_F(TestImageDeleter, ExistingTrashMove) {
+  ASSERT_EQ(0, trash_move(GLOBAL_IMAGE_ID));
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx);
-  EXPECT_EQ(0, ctx.wait());
+  m_deleter->wait_for_deletion(m_local_image_id, false, &ctx);
+  init_image_deleter();
 
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-
-  check_image_deleted();
+  ASSERT_EQ(0, ctx.wait());
 }
 
-TEST_F(TestImageDeleter, Delete_Split_Brain_Image) {
+TEST_F(TestImageDeleter, LiveTrashMove) {
   init_image_deleter();
-  promote_image();
-  demote_image();
-
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, true, nullptr);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx);
-  EXPECT_EQ(0, ctx.wait());
+  m_deleter->wait_for_deletion(m_local_image_id, false, &ctx);
 
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-
-  check_image_deleted();
+  ASSERT_EQ(0, trash_move(GLOBAL_IMAGE_ID));
+  ASSERT_EQ(0, ctx.wait());
 }
 
-TEST_F(TestImageDeleter, Fail_Delete_Primary_Image) {
-  init_image_deleter();
-  promote_image();
-
-  C_SaferCond ctx;
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, &ctx);
-  EXPECT_EQ(-EPERM, ctx.wait());
-
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-}
-
-TEST_F(TestImageDeleter, Fail_Delete_Orphan_Image) {
-  init_image_deleter();
-  promote_image();
-  demote_image();
-
-  C_SaferCond ctx;
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, &ctx);
-  EXPECT_EQ(-EPERM, ctx.wait());
-
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-}
-
-TEST_F(TestImageDeleter, Delete_Image_With_Child) {
-  init_image_deleter();
-  create_snapshot();
-
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, nullptr);
-
-  C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx);
-  EXPECT_EQ(0, ctx.wait());
-
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-}
-
-TEST_F(TestImageDeleter, Delete_Image_With_Children) {
+TEST_F(TestImageDeleter, Delete_Image_With_Snapshots) {
   init_image_deleter();
   create_snapshot("snap1");
   create_snapshot("snap2");
 
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, nullptr);
-
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx);
+  m_deleter->wait_for_deletion(m_local_image_id, false, &ctx);
+  ASSERT_EQ(0, trash_move(GLOBAL_IMAGE_ID));
   EXPECT_EQ(0, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
   ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
 }
 
-TEST_F(TestImageDeleter, Delete_Image_With_ProtectedChild) {
-  init_image_deleter();
-  create_snapshot("snap1", true);
-
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, nullptr);
-
-  C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx);
-  EXPECT_EQ(0, ctx.wait());
-
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-}
-
-TEST_F(TestImageDeleter, Delete_Image_With_ProtectedChildren) {
+TEST_F(TestImageDeleter, Delete_Image_With_ProtectedSnapshots) {
   init_image_deleter();
   create_snapshot("snap1", true);
   create_snapshot("snap2", true);
 
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, nullptr);
-
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx);
+  m_deleter->wait_for_deletion(m_local_image_id, false, &ctx);
+  ASSERT_EQ(0, trash_move(GLOBAL_IMAGE_ID));
   EXPECT_EQ(0, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -338,114 +279,22 @@ TEST_F(TestImageDeleter, Delete_Image_With_Clone) {
   init_image_deleter();
   std::string clone_id = create_clone();
 
-  C_SaferCond ctx;
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, &ctx);
+  C_SaferCond ctx1;
   m_deleter->set_busy_timer_interval(0.1);
-  EXPECT_EQ(-EBUSY, ctx.wait());
+  m_deleter->wait_for_deletion(m_local_image_id, false, &ctx1);
+  ASSERT_EQ(0, trash_move(GLOBAL_IMAGE_ID));
+  EXPECT_EQ(-EBUSY, ctx1.wait());
 
   C_SaferCond ctx2;
-  m_deleter->schedule_image_delete(GLOBAL_CLONE_IMAGE_ID, false, &ctx2);
+  m_deleter->wait_for_deletion(clone_id, false, &ctx2);
+  ASSERT_EQ(0, trash_move(GLOBAL_CLONE_IMAGE_ID));
   EXPECT_EQ(0, ctx2.wait());
 
   C_SaferCond ctx3;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx3);
+  m_deleter->wait_for_deletion(m_local_image_id, true, &ctx3);
   EXPECT_EQ(0, ctx3.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
   ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
 }
 
-TEST_F(TestImageDeleter, Delete_NonExistent_Image) {
-  init_image_deleter();
-  remove_image();
-
-  cls::rbd::MirrorImage mirror_image(GLOBAL_IMAGE_ID,
-                              MirrorImageState::MIRROR_IMAGE_STATE_ENABLED);
-  EXPECT_EQ(0, cls_client::mirror_image_set(&m_local_io_ctx, m_local_image_id,
-                                            mirror_image));
-
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, nullptr);
-
-  C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx);
-  EXPECT_EQ(0, ctx.wait());
-
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-
-  check_image_deleted();
-}
-
-TEST_F(TestImageDeleter, Delete_NonExistent_Image_With_MirroringState) {
-  init_image_deleter();
-  remove_image(true);
-
-  cls::rbd::MirrorImage mirror_image(GLOBAL_IMAGE_ID,
-                              MirrorImageState::MIRROR_IMAGE_STATE_ENABLED);
-  EXPECT_EQ(0, cls_client::mirror_image_set(&m_local_io_ctx, m_local_image_id,
-                                            mirror_image));
-  mirror_image.state = MirrorImageState::MIRROR_IMAGE_STATE_DISABLING;
-  EXPECT_EQ(0, cls_client::mirror_image_set(&m_local_io_ctx, m_local_image_id,
-                                            mirror_image));
-
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, nullptr);
-
-  C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx);
-  EXPECT_EQ(0, ctx.wait());
-
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-
-  check_image_deleted();
-}
-
-TEST_F(TestImageDeleter, Delete_NonExistent_Image_Without_MirroringState) {
-  init_image_deleter();
-  remove_image();
-
-  C_SaferCond ctx;
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, &ctx);
-  EXPECT_EQ(-ENOENT, ctx.wait());
-
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-
-  check_image_deleted();
-}
-
-TEST_F(TestImageDeleter, Fail_Delete_NonPrimary_Image) {
-  init_image_deleter();
-  ImageCtx *ictx = new ImageCtx("", m_local_image_id, "", m_local_io_ctx,
-                                false);
-  EXPECT_EQ(0, ictx->state->open(false));
-
-  C_SaferCond ctx;
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, &ctx);
-  EXPECT_EQ(-EBUSY, ctx.wait());
-
-  EXPECT_EQ(0, ictx->state->close());
-}
-
-TEST_F(TestImageDeleter, Retry_Failed_Deletes) {
-  init_image_deleter();
-  EXPECT_EQ(0, g_ceph_context->_conf->set_val("rbd_mirror_delete_retry_interval", "0.1"));
-  ImageCtx *ictx = new ImageCtx("", m_local_image_id, "", m_local_io_ctx,
-                                false);
-  EXPECT_EQ(0, ictx->state->open(false));
-
-  C_SaferCond ctx;
-  m_deleter->schedule_image_delete(GLOBAL_IMAGE_ID, false, &ctx);
-  EXPECT_EQ(-EBUSY, ctx.wait());
-
-  EXPECT_EQ(0, ictx->state->close());
-
-  C_SaferCond ctx2;
-  m_deleter->wait_for_scheduled_deletion(GLOBAL_IMAGE_ID, &ctx2);
-  EXPECT_EQ(0, ctx2.wait());
-
-  ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
-  ASSERT_EQ(0u, m_deleter->get_failed_queue_items().size());
-
-  check_image_deleted();
-}

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -125,6 +125,11 @@ public:
                                                             m_threads.get()));
     m_image_deleter.reset(new rbd::mirror::ImageDeleter<>(
       m_local_ioctx, m_threads.get(), m_service_daemon.get()));
+
+    C_SaferCond ctx;
+    m_image_deleter->init(&ctx);
+    EXPECT_EQ(0, ctx.wait());
+
     m_instance_watcher = rbd::mirror::InstanceWatcher<>::create(
         m_local_ioctx, m_threads->work_queue, nullptr);
     m_instance_watcher->handle_acquire_leader();

--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -87,8 +87,8 @@ template <>
 struct ImageDeleter<librbd::MockTestImageCtx> {
   MOCK_METHOD3(schedule_image_delete, void(const std::string&, bool,
                                            Context*));
-  MOCK_METHOD3(wait_for_scheduled_deletion,
-               void(const std::string&, Context*, bool));
+  MOCK_METHOD2(wait_for_scheduled_deletion,
+               void(const std::string&, Context*));
   MOCK_METHOD1(cancel_waiter, void(const std::string&));
 };
 
@@ -385,7 +385,7 @@ public:
                                           const std::string& global_image_id,
                                           int r) {
     EXPECT_CALL(mock_image_deleter,
-                wait_for_scheduled_deletion(global_image_id, _, false))
+                wait_for_scheduled_deletion(global_image_id, _))
       .WillOnce(WithArg<1>(Invoke([this, r](Context *ctx) {
                              m_threads->work_queue->queue(ctx, r);
                            })));

--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -85,11 +85,11 @@ struct Threads<librbd::MockTestImageCtx> {
 
 template <>
 struct ImageDeleter<librbd::MockTestImageCtx> {
-  MOCK_METHOD4(schedule_image_delete, void(IoCtxRef, const std::string&, bool,
+  MOCK_METHOD3(schedule_image_delete, void(const std::string&, bool,
                                            Context*));
-  MOCK_METHOD4(wait_for_scheduled_deletion,
-               void(int64_t, const std::string&, Context*, bool));
-  MOCK_METHOD2(cancel_waiter, void(int64_t, const std::string&));
+  MOCK_METHOD3(wait_for_scheduled_deletion,
+               void(const std::string&, Context*, bool));
+  MOCK_METHOD1(cancel_waiter, void(const std::string&));
 };
 
 template<>
@@ -385,22 +385,21 @@ public:
                                           const std::string& global_image_id,
                                           int r) {
     EXPECT_CALL(mock_image_deleter,
-                wait_for_scheduled_deletion(_, global_image_id, _, false))
-      .WillOnce(WithArg<2>(Invoke([this, r](Context *ctx) {
+                wait_for_scheduled_deletion(global_image_id, _, false))
+      .WillOnce(WithArg<1>(Invoke([this, r](Context *ctx) {
                              m_threads->work_queue->queue(ctx, r);
                            })));
   }
 
   void expect_cancel_waiter(MockImageDeleter& mock_image_deleter) {
-    EXPECT_CALL(mock_image_deleter, cancel_waiter(m_local_io_ctx.get_id(),
-                                                  "global image id"));
+    EXPECT_CALL(mock_image_deleter, cancel_waiter("global image id"));
   }
 
   void expect_schedule_image_delete(MockImageDeleter& mock_image_deleter,
                                     const std::string& global_image_id,
                                     bool ignore_orphan) {
     EXPECT_CALL(mock_image_deleter,
-                schedule_image_delete(_, global_image_id, ignore_orphan, nullptr));
+                schedule_image_delete(global_image_id, ignore_orphan, nullptr));
   }
 
   bufferlist encode_tag_data(const librbd::journal::TagData &tag_data) {

--- a/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
@@ -5,7 +5,6 @@
 #include "test/rbd_mirror/test_mock_fixture.h"
 #include "test/rbd_mirror/mock/MockContextWQ.h"
 #include "test/rbd_mirror/mock/MockSafeTimer.h"
-#include "tools/rbd_mirror/ImageDeleter.h"
 #include "tools/rbd_mirror/ImageReplayer.h"
 #include "tools/rbd_mirror/InstanceWatcher.h"
 #include "tools/rbd_mirror/InstanceReplayer.h"
@@ -49,10 +48,6 @@ struct Threads<librbd::MockTestImageCtx> {
   }
 };
 
-template <>
-struct ImageDeleter<librbd::MockTestImageCtx> {
-};
-
 template<>
 struct ServiceDaemon<librbd::MockTestImageCtx> {
   MOCK_METHOD3(add_or_update_attribute,
@@ -71,7 +66,6 @@ struct ImageReplayer<librbd::MockTestImageCtx> {
 
   static ImageReplayer *create(
     Threads<librbd::MockTestImageCtx> *threads,
-    ImageDeleter<librbd::MockTestImageCtx>* image_deleter,
     InstanceWatcher<librbd::MockTestImageCtx> *instance_watcher,
     RadosRef local, const std::string &local_mirror_uuid, int64_t local_pool_id,
     const std::string &global_image_id) {
@@ -132,7 +126,6 @@ using ::testing::WithArg;
 class TestMockInstanceReplayer : public TestMockFixture {
 public:
   typedef Threads<librbd::MockTestImageCtx> MockThreads;
-  typedef ImageDeleter<librbd::MockTestImageCtx> MockImageDeleter;
   typedef ImageReplayer<librbd::MockTestImageCtx> MockImageReplayer;
   typedef InstanceReplayer<librbd::MockTestImageCtx> MockInstanceReplayer;
   typedef InstanceWatcher<librbd::MockTestImageCtx> MockInstanceWatcher;
@@ -174,11 +167,10 @@ public:
 TEST_F(TestMockInstanceReplayer, AcquireReleaseImage) {
   MockThreads mock_threads(m_threads);
   MockServiceDaemon mock_service_daemon;
-  MockImageDeleter mock_image_deleter;
   MockInstanceWatcher mock_instance_watcher;
   MockImageReplayer mock_image_replayer;
   MockInstanceReplayer instance_replayer(
-    &mock_threads, &mock_service_daemon, &mock_image_deleter,
+    &mock_threads, &mock_service_daemon,
     rbd::mirror::RadosRef(new librados::Rados(m_local_io_ctx)),
     "local_mirror_uuid", m_local_io_ctx.get_id());
   std::string global_image_id("global_image_id");
@@ -245,11 +237,10 @@ TEST_F(TestMockInstanceReplayer, AcquireReleaseImage) {
 TEST_F(TestMockInstanceReplayer, RemoveFinishedImage) {
   MockThreads mock_threads(m_threads);
   MockServiceDaemon mock_service_daemon;
-  MockImageDeleter mock_image_deleter;
   MockInstanceWatcher mock_instance_watcher;
   MockImageReplayer mock_image_replayer;
   MockInstanceReplayer instance_replayer(
-    &mock_threads, &mock_service_daemon, &mock_image_deleter,
+    &mock_threads, &mock_service_daemon,
     rbd::mirror::RadosRef(new librados::Rados(m_local_io_ctx)),
     "local_mirror_uuid", m_local_io_ctx.get_id());
   std::string global_image_id("global_image_id");

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -23,6 +23,7 @@ set(rbd_mirror_internal
   types.cc
   image_deleter/RemoveRequest.cc
   image_deleter/SnapshotPurgeRequest.cc
+  image_deleter/TrashWatcher.cc
   image_map/Action.cc
   image_map/LoadRequest.cc
   image_map/Policy.cc

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -23,6 +23,7 @@ set(rbd_mirror_internal
   types.cc
   image_deleter/RemoveRequest.cc
   image_deleter/SnapshotPurgeRequest.cc
+  image_deleter/TrashMoveRequest.cc
   image_deleter/TrashWatcher.cc
   image_map/Action.cc
   image_map/LoadRequest.cc

--- a/src/tools/rbd_mirror/ImageDeleter.h
+++ b/src/tools/rbd_mirror/ImageDeleter.h
@@ -61,21 +61,11 @@ public:
   void init(Context* on_finish);
   void shut_down(Context* on_finish);
 
-  void schedule_image_delete(const std::string& global_image_id,
-                             bool ignore_orphaned,
-                             Context *on_finish);
-  void wait_for_deletion(const std::string &global_image_id,
-                         bool scheduled_only, Context* on_finish);
-  void wait_for_scheduled_deletion(const std::string &global_image_id,
-                                   Context* on_finish) {
-    wait_for_deletion(global_image_id, true, on_finish);
-  }
-
-  void cancel_waiter(const std::string &global_image_id);
-
   void print_status(Formatter *f, std::stringstream *ss);
 
   // for testing purposes
+  void wait_for_deletion(const std::string &image_id,
+                         bool scheduled_only, Context* on_finish);
 
   std::vector<std::string> get_delete_queue_items();
   std::vector<std::pair<std::string, int> > get_failed_queue_items();
@@ -98,28 +88,23 @@ private:
   };
 
   struct DeleteInfo {
-    std::string global_image_id;
-    bool ignore_orphaned = false;
+    std::string image_id;
 
     image_deleter::ErrorResult error_result = {};
     int error_code = 0;
     utime_t retry_time = {};
     int retries = 0;
 
-    DeleteInfo(const std::string& global_image_id)
-      : global_image_id(global_image_id) {
-    }
-
-    DeleteInfo(const std::string& global_image_id, bool ignore_orphaned)
-      : global_image_id(global_image_id), ignore_orphaned(ignore_orphaned) {
+    DeleteInfo(const std::string& image_id)
+      : image_id(image_id) {
     }
 
     inline bool operator==(const DeleteInfo& delete_info) const {
-      return (global_image_id == delete_info.global_image_id);
+      return (image_id == delete_info.image_id);
     }
 
     friend std::ostream& operator<<(std::ostream& os, DeleteInfo& delete_info) {
-      os << "[global_image_id=" << delete_info.global_image_id << "]";
+      os << "[image_id=" << delete_info.image_id << "]";
     return os;
     }
 
@@ -160,7 +145,7 @@ private:
   void enqueue_failed_delete(DeleteInfoRef* delete_info, int error_code,
                              double retry_delay);
 
-  DeleteInfoRef find_delete_info(const std::string &global_image_id);
+  DeleteInfoRef find_delete_info(const std::string &image_id);
 
   void remove_images();
   void remove_image(DeleteInfoRef delete_info);
@@ -177,7 +162,7 @@ private:
   void wait_for_ops(Context* on_finish);
   void cancel_all_deletions(Context* on_finish);
 
-  void notify_on_delete(const std::string& global_image_id, int r);
+  void notify_on_delete(const std::string& image_id, int r);
 
 };
 

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -258,14 +258,12 @@ void ImageReplayer<I>::RemoteJournalerListener::handle_update(
 
 template <typename I>
 ImageReplayer<I>::ImageReplayer(Threads<I> *threads,
-                                ImageDeleter<I>* image_deleter,
                                 InstanceWatcher<I> *instance_watcher,
                                 RadosRef local,
                                 const std::string &local_mirror_uuid,
                                 int64_t local_pool_id,
                                 const std::string &global_image_id) :
   m_threads(threads),
-  m_image_deleter(image_deleter),
   m_instance_watcher(instance_watcher),
   m_local(local),
   m_local_mirror_uuid(local_mirror_uuid),
@@ -388,30 +386,6 @@ void ImageReplayer<I>::start(Context *on_finish, bool manual)
     derr << "error opening ioctx for local pool " << m_local_pool_id
          << ": " << cpp_strerror(r) << dendl;
     on_start_fail(r, "error opening local pool");
-    return;
-  }
-
-  wait_for_deletion();
-}
-
-template <typename I>
-void ImageReplayer<I>::wait_for_deletion() {
-  dout(20) << dendl;
-
-  Context *ctx = create_context_callback<
-    ImageReplayer, &ImageReplayer<I>::handle_wait_for_deletion>(this);
-  m_image_deleter->wait_for_scheduled_deletion(m_global_image_id, ctx);
-}
-
-template <typename I>
-void ImageReplayer<I>::handle_wait_for_deletion(int r) {
-  dout(20) << "r=" << r << dendl;
-
-  if (r == -ECANCELED) {
-    on_start_fail(0, "");
-    return;
-  } else if (r < 0) {
-    on_start_fail(r, "error waiting for image deletion");
     return;
   }
 
@@ -742,8 +716,6 @@ void ImageReplayer<I>::stop(Context *on_finish, bool manual, int r,
 {
   dout(20) << "on_finish=" << on_finish << ", manual=" << manual
 	   << ", desc=" << desc << dendl;
-
-  m_image_deleter->cancel_waiter(m_global_image_id);
 
   image_replayer::BootstrapRequest<I> *bootstrap_request = nullptr;
   bool shut_down_replay = false;
@@ -1632,6 +1604,8 @@ template <typename I>
 void ImageReplayer<I>::handle_shut_down(int r) {
   reschedule_update_status_task(-1);
 
+  bool resync_requested = false;
+  bool delete_requested = false;
   bool unregister_asok_hook = false;
   {
     Mutex::Locker locker(m_lock);
@@ -1649,22 +1623,16 @@ void ImageReplayer<I>::handle_shut_down(int r) {
       return;
     }
 
-    bool delete_requested = false;
     if (m_delete_requested && !m_local_image_id.empty()) {
       assert(m_remote_image.image_id.empty());
       dout(0) << "remote image no longer exists: scheduling deletion" << dendl;
-      delete_requested = true;
+      unregister_asok_hook = true;
+      std::swap(delete_requested, m_delete_requested);
     }
-    if (delete_requested || m_resync_requested) {
-      m_image_deleter->schedule_image_delete(m_global_image_id,
-                                             m_resync_requested, nullptr);
 
+    std::swap(resync_requested, m_resync_requested);
+    if (delete_requested || resync_requested) {
       m_local_image_id = "";
-      m_resync_requested = false;
-      if (m_delete_requested) {
-        unregister_asok_hook = true;
-        m_delete_requested = false;
-      }
     } else if (m_last_r == -ENOENT &&
                m_local_image_id.empty() && m_remote_image.image_id.empty()) {
       dout(0) << "mirror image no longer exists" << dendl;
@@ -1675,6 +1643,16 @@ void ImageReplayer<I>::handle_shut_down(int r) {
 
   if (unregister_asok_hook) {
     unregister_admin_socket_hook();
+  }
+
+  if (delete_requested || resync_requested) {
+    dout(5) << "moving image to trash" << dendl;
+    auto ctx = new FunctionContext([this, r](int) {
+      handle_shut_down(r);
+    });
+    ImageDeleter<I>::trash_move(*m_local_ioctx, m_global_image_id,
+                                resync_requested, m_threads->work_queue, ctx);
+    return;
   }
 
   dout(20) << "stop complete" << dendl;

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -400,8 +400,7 @@ void ImageReplayer<I>::wait_for_deletion() {
 
   Context *ctx = create_context_callback<
     ImageReplayer, &ImageReplayer<I>::handle_wait_for_deletion>(this);
-  m_image_deleter->wait_for_scheduled_deletion(
-    m_global_image_id, ctx, false);
+  m_image_deleter->wait_for_scheduled_deletion(m_global_image_id, ctx);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -454,7 +454,7 @@ void ImageReplayer<I>::handle_prepare_remote_image(int r) {
     dout(20) << "remote image does not exist" << dendl;
 
     // TODO need to support multiple remote images
-    if (!m_local_image_id.empty() &&
+    if (m_remote_image.image_id.empty() && !m_local_image_id.empty() &&
         m_local_image_tag_owner == m_remote_image.mirror_uuid) {
       // local image exists and is non-primary and linked to the missing
       // remote image

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -401,7 +401,7 @@ void ImageReplayer<I>::wait_for_deletion() {
   Context *ctx = create_context_callback<
     ImageReplayer, &ImageReplayer<I>::handle_wait_for_deletion>(this);
   m_image_deleter->wait_for_scheduled_deletion(
-    m_local_pool_id, m_global_image_id, ctx, false);
+    m_global_image_id, ctx, false);
 }
 
 template <typename I>
@@ -744,7 +744,7 @@ void ImageReplayer<I>::stop(Context *on_finish, bool manual, int r,
   dout(20) << "on_finish=" << on_finish << ", manual=" << manual
 	   << ", desc=" << desc << dendl;
 
-  m_image_deleter->cancel_waiter(m_local_pool_id, m_global_image_id);
+  m_image_deleter->cancel_waiter(m_global_image_id);
 
   image_replayer::BootstrapRequest<I> *bootstrap_request = nullptr;
   bool shut_down_replay = false;
@@ -1657,7 +1657,7 @@ void ImageReplayer<I>::handle_shut_down(int r) {
       delete_requested = true;
     }
     if (delete_requested || m_resync_requested) {
-      m_image_deleter->schedule_image_delete(m_local_ioctx, m_global_image_id,
+      m_image_deleter->schedule_image_delete(m_global_image_id,
                                              m_resync_requested, nullptr);
 
       m_local_image_id = "";

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -47,7 +47,6 @@ namespace journal { template <typename> class Replay; }
 namespace rbd {
 namespace mirror {
 
-template <typename> struct ImageDeleter;
 template <typename> struct InstanceWatcher;
 template <typename> struct Threads;
 
@@ -62,20 +61,17 @@ template <typename ImageCtxT = librbd::ImageCtx>
 class ImageReplayer {
 public:
   static ImageReplayer *create(
-    Threads<ImageCtxT> *threads, ImageDeleter<ImageCtxT>* image_deleter,
-    InstanceWatcher<ImageCtxT> *instance_watcher,
+    Threads<ImageCtxT> *threads, InstanceWatcher<ImageCtxT> *instance_watcher,
     RadosRef local, const std::string &local_mirror_uuid, int64_t local_pool_id,
     const std::string &global_image_id) {
-    return new ImageReplayer(threads, image_deleter, instance_watcher,
-                             local, local_mirror_uuid, local_pool_id,
-                             global_image_id);
+    return new ImageReplayer(threads, instance_watcher, local,
+                             local_mirror_uuid, local_pool_id, global_image_id);
   }
   void destroy() {
     delete this;
   }
 
   ImageReplayer(Threads<ImageCtxT> *threads,
-                ImageDeleter<ImageCtxT>* image_deleter,
                 InstanceWatcher<ImageCtxT> *instance_watcher,
                 RadosRef local, const std::string &local_mirror_uuid,
                 int64_t local_pool_id, const std::string &global_image_id);
@@ -137,9 +133,6 @@ protected:
    *    |                                                   ^
    *    v                                                   *
    * <starting>                                             *
-   *    |                                                   *
-   *    v                                                   *
-   * WAIT_FOR_DELETION                                      *
    *    |                                                   *
    *    v                                           (error) *
    * PREPARE_LOCAL_IMAGE  * * * * * * * * * * * * * * * * * *
@@ -276,7 +269,6 @@ private:
   };
 
   Threads<ImageCtxT> *m_threads;
-  ImageDeleter<ImageCtxT>* m_image_deleter;
   InstanceWatcher<ImageCtxT> *m_instance_watcher;
 
   Peers m_peers;
@@ -389,9 +381,6 @@ private:
   void shut_down(int r);
   void handle_shut_down(int r);
   void handle_remote_journal_metadata_updated();
-
-  void wait_for_deletion();
-  void handle_wait_for_deletion(int r);
 
   void prepare_local_image();
   void handle_prepare_local_image(int r);

--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -34,11 +34,11 @@ using librbd::util::create_context_callback;
 template <typename I>
 InstanceReplayer<I>::InstanceReplayer(
     Threads<I> *threads, ServiceDaemon<I>* service_daemon,
-    ImageDeleter<I>* image_deleter, RadosRef local_rados,
-    const std::string &local_mirror_uuid, int64_t local_pool_id)
+    RadosRef local_rados, const std::string &local_mirror_uuid,
+    int64_t local_pool_id)
   : m_threads(threads), m_service_daemon(service_daemon),
-    m_image_deleter(image_deleter), m_local_rados(local_rados),
-    m_local_mirror_uuid(local_mirror_uuid), m_local_pool_id(local_pool_id),
+    m_local_rados(local_rados), m_local_mirror_uuid(local_mirror_uuid),
+    m_local_pool_id(local_pool_id),
     m_lock("rbd::mirror::InstanceReplayer " + stringify(local_pool_id)) {
 }
 
@@ -142,7 +142,7 @@ void InstanceReplayer<I>::acquire_image(InstanceWatcher<I> *instance_watcher,
   auto it = m_image_replayers.find(global_image_id);
   if (it == m_image_replayers.end()) {
     auto image_replayer = ImageReplayer<I>::create(
-        m_threads, m_image_deleter, instance_watcher, m_local_rados,
+        m_threads, instance_watcher, m_local_rados,
         m_local_mirror_uuid, m_local_pool_id, global_image_id);
 
     dout(20) << global_image_id << ": creating replayer " << image_replayer

--- a/src/tools/rbd_mirror/InstanceReplayer.h
+++ b/src/tools/rbd_mirror/InstanceReplayer.h
@@ -17,7 +17,6 @@ namespace librbd { class ImageCtx; }
 namespace rbd {
 namespace mirror {
 
-template <typename> class ImageDeleter;
 template <typename> class ImageReplayer;
 template <typename> class InstanceWatcher;
 template <typename> class ServiceDaemon;
@@ -29,11 +28,10 @@ public:
   static InstanceReplayer* create(
       Threads<ImageCtxT> *threads,
       ServiceDaemon<ImageCtxT>* service_daemon,
-      ImageDeleter<ImageCtxT>* image_deleter,
       RadosRef local_rados, const std::string &local_mirror_uuid,
       int64_t local_pool_id) {
-    return new InstanceReplayer(threads, service_daemon, image_deleter,
-                                local_rados, local_mirror_uuid, local_pool_id);
+    return new InstanceReplayer(threads, service_daemon, local_rados,
+                                local_mirror_uuid, local_pool_id);
   }
   void destroy() {
     delete this;
@@ -41,7 +39,6 @@ public:
 
   InstanceReplayer(Threads<ImageCtxT> *threads,
                    ServiceDaemon<ImageCtxT>* service_daemon,
-		   ImageDeleter<ImageCtxT>* image_deleter,
 		   RadosRef local_rados, const std::string &local_mirror_uuid,
 		   int64_t local_pool_id);
   ~InstanceReplayer();
@@ -86,7 +83,6 @@ private:
 
   Threads<ImageCtxT> *m_threads;
   ServiceDaemon<ImageCtxT>* m_service_daemon;
-  ImageDeleter<ImageCtxT>* m_image_deleter;
   RadosRef m_local_rados;
   std::string m_local_mirror_uuid;
   int64_t m_local_pool_id;

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -245,11 +245,6 @@ int Mirror::init()
 
   m_local_cluster_watcher.reset(new ClusterWatcher(m_local, m_lock,
                                                    m_service_daemon.get()));
-
-  m_image_deleter.reset(new ImageDeleter<>(m_threads->work_queue,
-                                           m_threads->timer,
-                                           &m_threads->timer_lock,
-                                           m_service_daemon.get()));
   return r;
 }
 
@@ -296,10 +291,7 @@ void Mirror::print_status(Formatter *f, stringstream *ss)
 
   if (f) {
     f->close_section();
-    f->open_object_section("image_deleter");
   }
-
-  m_image_deleter->print_status(f, ss);
 }
 
 void Mirror::start()
@@ -419,8 +411,7 @@ void Mirror::update_pool_replayers(const PoolPeers &pool_peers)
       } else {
         dout(20) << "starting pool replayer for " << peer << dendl;
         unique_ptr<PoolReplayer> pool_replayer(new PoolReplayer(
-	  m_threads, m_service_daemon.get(), m_image_deleter.get(), kv.first,
-          peer, m_args));
+	  m_threads, m_service_daemon.get(), kv.first, peer, m_args));
 
         // TODO: make async
         pool_replayer->init();

--- a/src/tools/rbd_mirror/Mirror.h
+++ b/src/tools/rbd_mirror/Mirror.h
@@ -9,7 +9,6 @@
 #include "include/rados/librados.hpp"
 #include "ClusterWatcher.h"
 #include "PoolReplayer.h"
-#include "ImageDeleter.h"
 #include "types.h"
 
 #include <set>
@@ -66,7 +65,6 @@ private:
 
   // monitor local cluster for config changes in peers
   std::unique_ptr<ClusterWatcher> m_local_cluster_watcher;
-  std::unique_ptr<ImageDeleter<>> m_image_deleter;
   std::map<PoolPeer, std::unique_ptr<PoolReplayer> > m_pool_replayers;
   std::atomic<bool> m_stopping = { false };
   bool m_manual_stop = false;

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -319,8 +319,8 @@ void PoolReplayer::init()
   image_deleter_ctx.wait();
 
   m_instance_replayer.reset(InstanceReplayer<>::create(
-    m_threads, m_service_daemon, m_image_deleter.get(), m_local_rados,
-    local_mirror_uuid, m_local_pool_id));
+    m_threads, m_service_daemon, m_local_rados, local_mirror_uuid,
+    m_local_pool_id));
   m_instance_replayer->init();
   m_instance_replayer->add_peer(m_peer.uuid, m_remote_io_ctx);
 

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -311,13 +311,6 @@ void PoolReplayer::init()
 
   dout(20) << "connected to " << m_peer << dendl;
 
-  // TODO
-  C_SaferCond image_deleter_ctx;
-  m_image_deleter.reset(new ImageDeleter<>(m_local_io_ctx, m_threads,
-                                           m_service_daemon));
-  m_image_deleter->init(&image_deleter_ctx);
-  image_deleter_ctx.wait();
-
   m_instance_replayer.reset(InstanceReplayer<>::create(
     m_threads, m_service_daemon, m_local_rados, local_mirror_uuid,
     m_local_pool_id));
@@ -376,13 +369,7 @@ void PoolReplayer::shut_down() {
     m_instance_replayer.reset();
   }
 
-  // TODO
-  if (m_image_deleter) {
-    C_SaferCond image_deleter_ctx;
-    m_image_deleter->shut_down(&image_deleter_ctx);
-    image_deleter_ctx.wait();
-  }
-
+  assert(!m_image_deleter);
   assert(!m_local_pool_watcher);
   assert(!m_remote_pool_watcher);
   m_local_rados.reset();
@@ -566,9 +553,11 @@ void PoolReplayer::print_status(Formatter *f, stringstream *ss)
 
   m_instance_replayer->print_status(f, ss);
 
-  f->open_object_section("image_deleter");
-  m_image_deleter->print_status(f, ss);
-  f->close_section();
+  if (m_image_deleter) {
+    f->open_object_section("image_deleter");
+    m_image_deleter->print_status(f, ss);
+    f->close_section();
+  }
 
   f->close_section();
   f->flush(*ss);
@@ -709,7 +698,7 @@ void PoolReplayer::handle_pre_release_leader(Context *on_finish) {
 
   m_service_daemon->remove_attribute(m_local_pool_id, SERVICE_DAEMON_LEADER_KEY);
   m_instance_watcher->handle_release_leader();
-  shut_down_pool_watchers(on_finish);
+  shut_down_image_deleter(on_finish);
 }
 
 void PoolReplayer::init_local_pool_watcher(Context *on_finish) {
@@ -747,10 +736,64 @@ void PoolReplayer::init_remote_pool_watcher(Context *on_finish) {
   assert(!m_remote_pool_watcher);
   m_remote_pool_watcher.reset(new PoolWatcher<>(
     m_threads, m_remote_io_ctx, m_remote_pool_watcher_listener));
-  m_remote_pool_watcher->init(create_async_context_callback(
-    m_threads->work_queue, on_finish));
 
+  auto ctx = new FunctionContext([this, on_finish](int r) {
+      handle_init_remote_pool_watcher(r, on_finish);
+    });
+  m_remote_pool_watcher->init(create_async_context_callback(
+    m_threads->work_queue, ctx));
+}
+
+void PoolReplayer::handle_init_remote_pool_watcher(int r, Context *on_finish) {
+  dout(20) << "r=" << r << dendl;
+  if (r < 0) {
+    derr << "failed to retrieve remote images: " << cpp_strerror(r) << dendl;
+    on_finish->complete(r);
+    return;
+  }
+
+  init_image_deleter(on_finish);
+}
+
+void PoolReplayer::init_image_deleter(Context *on_finish) {
+  dout(20) << dendl;
+
+  Mutex::Locker locker(m_lock);
+  assert(!m_image_deleter);
+
+  m_image_deleter.reset(new ImageDeleter<>(m_local_io_ctx, m_threads,
+                                           m_service_daemon));
+  m_image_deleter->init(on_finish);
   m_cond.Signal();
+}
+
+void PoolReplayer::shut_down_image_deleter(Context* on_finish) {
+  dout(20) << dendl;
+  {
+    Mutex::Locker locker(m_lock);
+    if (m_image_deleter) {
+      Context *ctx = new FunctionContext([this, on_finish](int r) {
+          handle_shut_down_image_deleter(r, on_finish);
+	});
+      ctx = create_async_context_callback(m_threads->work_queue, ctx);
+
+      m_image_deleter->shut_down(ctx);
+      return;
+    }
+  }
+  shut_down_pool_watchers(on_finish);
+}
+
+void PoolReplayer::handle_shut_down_image_deleter(int r, Context* on_finish) {
+  dout(20) << "r=" << r << dendl;
+
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_image_deleter);
+    m_image_deleter.reset();
+  }
+
+  shut_down_pool_watchers(on_finish);
 }
 
 void PoolReplayer::shut_down_pool_watchers(Context *on_finish) {

--- a/src/tools/rbd_mirror/PoolReplayer.h
+++ b/src/tools/rbd_mirror/PoolReplayer.h
@@ -42,7 +42,6 @@ class PoolReplayer {
 public:
   PoolReplayer(Threads<librbd::ImageCtx> *threads,
                ServiceDaemon<librbd::ImageCtx>* service_daemon,
-	       ImageDeleter<>* image_deleter,
 	       int64_t local_pool_id, const peer_t &peer,
 	       const std::vector<const char*> &args);
   ~PoolReplayer();
@@ -110,7 +109,6 @@ private:
 
   Threads<librbd::ImageCtx> *m_threads;
   ServiceDaemon<librbd::ImageCtx>* m_service_daemon;
-  ImageDeleter<>* m_image_deleter;
   int64_t m_local_pool_id = -1;
   peer_t m_peer;
   std::vector<const char*> m_args;
@@ -134,6 +132,7 @@ private:
   std::unique_ptr<PoolWatcher<> > m_remote_pool_watcher;
 
   std::unique_ptr<InstanceReplayer<librbd::ImageCtx>> m_instance_replayer;
+  std::unique_ptr<ImageDeleter<>> m_image_deleter;
 
   std::string m_asok_hook_name;
   AdminSocketHook *m_asok_hook = nullptr;

--- a/src/tools/rbd_mirror/PoolReplayer.h
+++ b/src/tools/rbd_mirror/PoolReplayer.h
@@ -98,6 +98,12 @@ private:
   void handle_init_local_pool_watcher(int r, Context *on_finish);
 
   void init_remote_pool_watcher(Context *on_finish);
+  void handle_init_remote_pool_watcher(int r, Context *on_finish);
+
+  void init_image_deleter(Context* on_finish);
+
+  void shut_down_image_deleter(Context* on_finish);
+  void handle_shut_down_image_deleter(int r, Context* on_finish);
 
   void shut_down_pool_watchers(Context *on_finish);
   void handle_shut_down_pool_watchers(int r, Context *on_finish);

--- a/src/tools/rbd_mirror/image_deleter/RemoveRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/RemoveRequest.cc
@@ -30,84 +30,6 @@ template <typename I>
 void RemoveRequest<I>::send() {
   *m_error_result = ERROR_RESULT_RETRY;
 
-  get_mirror_image_id();
-}
-
-template <typename I>
-void RemoveRequest<I>::get_mirror_image_id() {
-  dout(10) << dendl;
-
-  librados::ObjectReadOperation op;
-  librbd::cls_client::mirror_image_get_image_id_start(&op, m_global_image_id);
-
-  auto aio_comp = create_rados_callback<
-    RemoveRequest<I>, &RemoveRequest<I>::handle_get_mirror_image_id>(this);
-  m_out_bl.clear();
-  int r = m_io_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op, &m_out_bl);
-  assert(r == 0);
-  aio_comp->release();
-}
-
-template <typename I>
-void RemoveRequest<I>::handle_get_mirror_image_id(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  if (r == 0) {
-    auto bl_it = m_out_bl.begin();
-    r = librbd::cls_client::mirror_image_get_image_id_finish(&bl_it,
-                                                             &m_image_id);
-  }
-  if (r == -ENOENT) {
-    dout(10) << "image " << m_global_image_id << " is not mirrored" << dendl;
-    *m_error_result = ERROR_RESULT_COMPLETE;
-    finish(r);
-    return;
-  } else if (r < 0) {
-    derr << "error retrieving local id for image " << m_global_image_id
-         << ": " << cpp_strerror(r) << dendl;
-    finish(r);
-    return;
-  }
-
-  get_tag_owner();
-}
-
-template <typename I>
-void RemoveRequest<I>::get_tag_owner() {
-  dout(10) << dendl;
-
-  auto ctx = create_context_callback<
-    RemoveRequest<I>, &RemoveRequest<I>::handle_get_tag_owner>(this);
-  librbd::Journal<I>::get_tag_owner(m_io_ctx, m_image_id, &m_mirror_uuid,
-                                    m_op_work_queue, ctx);
-}
-
-template <typename I>
-void RemoveRequest<I>::handle_get_tag_owner(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  if (r < 0 && r != -ENOENT) {
-    derr << "error retrieving image primary info for image "
-         << m_global_image_id << ": " << cpp_strerror(r) << dendl;
-    finish(r);
-    return;
-  } else if (r != -ENOENT) {
-    if (m_mirror_uuid == librbd::Journal<>::LOCAL_MIRROR_UUID) {
-      dout(10) << "image " << m_global_image_id << " is local primary" << dendl;
-
-      *m_error_result = ERROR_RESULT_COMPLETE;
-      finish(-EPERM);
-      return;
-    } else if (m_mirror_uuid == librbd::Journal<>::ORPHAN_MIRROR_UUID &&
-               !m_ignore_orphaned) {
-      dout(10) << "image " << m_global_image_id << " is orphaned" << dendl;
-
-      *m_error_result = ERROR_RESULT_COMPLETE;
-      finish(-EPERM);
-      return;
-    }
-  }
-
   get_snap_context();
 }
 
@@ -139,57 +61,12 @@ void RemoveRequest<I>::handle_get_snap_context(int r) {
   }
   if (r < 0 && r != -ENOENT) {
     derr << "error retrieving snapshot context for image "
-         << m_global_image_id << ": " << cpp_strerror(r) << dendl;
+         << m_image_id << ": " << cpp_strerror(r) << dendl;
     finish(r);
     return;
   }
 
   m_has_snapshots = (!snapc.empty());
-  set_mirror_image_disabling();
-}
-
-template <typename I>
-void RemoveRequest<I>::set_mirror_image_disabling() {
-  dout(10) << dendl;
-
-  cls::rbd::MirrorImage mirror_image;
-  mirror_image.global_image_id = m_global_image_id;
-  mirror_image.state = cls::rbd::MIRROR_IMAGE_STATE_DISABLING;
-
-  librados::ObjectWriteOperation op;
-  librbd::cls_client::mirror_image_set(&op, m_image_id, mirror_image);
-
-  auto aio_comp = create_rados_callback<
-    RemoveRequest<I>,
-    &RemoveRequest<I>::handle_set_mirror_image_disabling>(this);
-  int r = m_io_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op);
-  assert(r == 0);
-  aio_comp->release();
-}
-
-template <typename I>
-void RemoveRequest<I>::handle_set_mirror_image_disabling(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  if (r == -ENOENT) {
-    dout(10) << "local image is not mirrored, aborting deletion." << dendl;
-    *m_error_result = ERROR_RESULT_COMPLETE;
-    finish(r);
-    return;
-  } else if (r == -EEXIST || r == -EINVAL) {
-    derr << "cannot disable mirroring for image " << m_global_image_id
-         << ": global_image_id has changed/reused: "
-         << cpp_strerror(r) << dendl;
-    *m_error_result = ERROR_RESULT_COMPLETE;
-    finish(r);
-    return;
-  } else if (r < 0) {
-    derr << "cannot disable mirroring for image " << m_global_image_id
-         << ": " << cpp_strerror(r) << dendl;
-    finish(r);
-    return;
-  }
-
   purge_snapshots();
 }
 
@@ -232,7 +109,7 @@ void RemoveRequest<I>::remove_image() {
   auto ctx = create_context_callback<
     RemoveRequest<I>, &RemoveRequest<I>::handle_remove_image>(this);
   auto req = librbd::image::RemoveRequest<I>::create(
-    m_io_ctx, "", m_image_id, true, false, m_progress_ctx, m_op_work_queue,
+    m_io_ctx, "", m_image_id, true, true, m_progress_ctx, m_op_work_queue,
     ctx);
   req->send();
 }
@@ -241,36 +118,9 @@ template <typename I>
 void RemoveRequest<I>::handle_remove_image(int r) {
   dout(10) << "r=" << r << dendl;
   if (r < 0 && r != -ENOENT) {
-    derr << "error removing image " << m_global_image_id << " "
+    derr << "error removing image " << m_image_id << " "
          << "(" << m_image_id << ") from local pool: "
          << cpp_strerror(r) << dendl;
-    finish(r);
-    return;
-  }
-
-  remove_mirror_image();
-}
-
-template <typename I>
-void RemoveRequest<I>::remove_mirror_image() {
-  dout(10) << dendl;
-
-  librados::ObjectWriteOperation op;
-  librbd::cls_client::mirror_image_remove(&op, m_image_id);
-
-  auto aio_comp = create_rados_callback<
-    RemoveRequest<I>, &RemoveRequest<I>::handle_remove_mirror_image>(this);
-  int r = m_io_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op);
-  assert(r == 0);
-  aio_comp->release();
-}
-
-template <typename I>
-void RemoveRequest<I>::handle_remove_mirror_image(int r) {
-  dout(10) << "r=" << r << dendl;
-  if (r < 0 && r != -ENOENT) {
-    derr << "error removing image " << m_global_image_id << " from mirroring "
-         << "directory: " << cpp_strerror(r) << dendl;
     finish(r);
     return;
   }

--- a/src/tools/rbd_mirror/image_deleter/RemoveRequest.h
+++ b/src/tools/rbd_mirror/image_deleter/RemoveRequest.h
@@ -23,18 +23,17 @@ template <typename ImageCtxT = librbd::ImageCtx>
 class RemoveRequest {
 public:
   static RemoveRequest* create(librados::IoCtx &io_ctx,
-                               const std::string &global_image_id,
-                               bool ignore_orphaned, ErrorResult *error_result,
+                               const std::string &image_id,
+                               ErrorResult *error_result,
                                ContextWQ *op_work_queue, Context *on_finish) {
-    return new RemoveRequest(io_ctx, global_image_id, ignore_orphaned,
-                             error_result, op_work_queue, on_finish);
+    return new RemoveRequest(io_ctx, image_id, error_result, op_work_queue,
+                             on_finish);
   }
 
-  RemoveRequest(librados::IoCtx &io_ctx, const std::string &global_image_id,
-                bool ignore_orphaned, ErrorResult *error_result,
-                ContextWQ *op_work_queue, Context *on_finish)
-    : m_io_ctx(io_ctx), m_global_image_id(global_image_id),
-      m_ignore_orphaned(ignore_orphaned), m_error_result(error_result),
+  RemoveRequest(librados::IoCtx &io_ctx, const std::string &image_id,
+                ErrorResult *error_result, ContextWQ *op_work_queue,
+                Context *on_finish)
+    : m_io_ctx(io_ctx), m_image_id(image_id), m_error_result(error_result),
       m_op_work_queue(op_work_queue), m_on_finish(on_finish) {
   }
 
@@ -47,16 +46,7 @@ private:
    * <start>
    *    |
    *    v
-   * GET_MIRROR_IMAGE_ID
-   *    |
-   *    v
-   * GET_TAG_OWNER
-   *    |
-   *    v
    * GET_SNAP_CONTEXT
-   *    |
-   *    v
-   * SET_MIRROR_IMAGE_DISABLING
    *    |
    *    v
    * PURGE_SNAPSHOTS
@@ -65,47 +55,29 @@ private:
    * REMOVE_IMAGE
    *    |
    *    v
-   * REMOVE_MIRROR_IMAGE
-   *    |
-   *    v
    * <finish>
    *
    * @endverbatim
    */
 
   librados::IoCtx &m_io_ctx;
-  std::string m_global_image_id;
-  bool m_ignore_orphaned;
+  std::string m_image_id;
   ErrorResult *m_error_result;
   ContextWQ *m_op_work_queue;
   Context *m_on_finish;
 
   ceph::bufferlist m_out_bl;
-  std::string m_image_id;
-  std::string m_mirror_uuid;
   bool m_has_snapshots = false;
   librbd::NoOpProgressContext m_progress_ctx;
 
-  void get_mirror_image_id();
-  void handle_get_mirror_image_id(int r);
-
-  void get_tag_owner();
-  void handle_get_tag_owner(int r);
-
   void get_snap_context();
   void handle_get_snap_context(int r);
-
-  void set_mirror_image_disabling();
-  void handle_set_mirror_image_disabling(int r);
 
   void purge_snapshots();
   void handle_purge_snapshots(int r);
 
   void remove_image();
   void handle_remove_image(int r);
-
-  void remove_mirror_image();
-  void handle_remove_mirror_image(int r);
 
   void finish(int r);
 

--- a/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
@@ -9,6 +9,7 @@
 #include "librbd/Operations.h"
 #include "librbd/Utils.h"
 #include "librbd/journal/Policy.h"
+#include "tools/rbd_mirror/image_deleter/Types.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
@@ -19,23 +20,6 @@
 namespace rbd {
 namespace mirror {
 namespace image_deleter {
-
-namespace {
-
-struct DeleteJournalPolicy : public librbd::journal::Policy {
-  bool append_disabled() const override {
-    return true;
-  }
-  bool journal_disabled() const override {
-    return false;
-  }
-
-  void allocate_tag_on_lock(Context *on_finish) override {
-    on_finish->complete(0);
-  }
-};
-
-} // anonymous namespace
 
 using librbd::util::create_context_callback;
 
@@ -51,7 +35,7 @@ void SnapshotPurgeRequest<I>::open_image() {
 
   {
     RWLock::WLocker snap_locker(m_image_ctx->snap_lock);
-    m_image_ctx->set_journal_policy(new DeleteJournalPolicy());
+    m_image_ctx->set_journal_policy(new JournalPolicy());
   }
 
   Context *ctx = create_context_callback<

--- a/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
@@ -67,6 +67,9 @@ void SnapshotPurgeRequest<I>::handle_open_image(int r) {
   if (r < 0) {
     derr << "failed to open image '" << m_image_id << "': " << cpp_strerror(r)
          << dendl;
+    m_image_ctx->destroy();
+    m_image_ctx = nullptr;
+
     finish(r);
     return;
   }

--- a/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
@@ -1,0 +1,382 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "tools/rbd_mirror/image_deleter/TrashMoveRequest.h"
+#include "include/rbd_types.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "common/debug.h"
+#include "common/errno.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Journal.h"
+#include "librbd/TrashWatcher.h"
+#include "librbd/Utils.h"
+#include "librbd/journal/ResetRequest.h"
+#include "librbd/trash/MoveRequest.h"
+#include "tools/rbd_mirror/image_deleter/Types.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_deleter::TrashMoveRequest: " \
+                           << this << " " << __func__ << ": "
+namespace rbd {
+namespace mirror {
+namespace image_deleter {
+
+using librbd::util::create_context_callback;
+using librbd::util::create_rados_callback;
+
+template <typename I>
+void TrashMoveRequest<I>::send() {
+  get_mirror_image_id();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::get_mirror_image_id() {
+  dout(10) << dendl;
+
+  librados::ObjectReadOperation op;
+  librbd::cls_client::mirror_image_get_image_id_start(&op, m_global_image_id);
+
+  auto aio_comp = create_rados_callback<
+    TrashMoveRequest<I>,
+    &TrashMoveRequest<I>::handle_get_mirror_image_id>(this);
+  m_out_bl.clear();
+  int r = m_io_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op, &m_out_bl);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_get_mirror_image_id(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r == 0) {
+    auto bl_it = m_out_bl.begin();
+    r = librbd::cls_client::mirror_image_get_image_id_finish(&bl_it,
+                                                             &m_image_id);
+  }
+  if (r == -ENOENT) {
+    dout(10) << "image " << m_global_image_id << " is not mirrored" << dendl;
+    finish(r);
+    return;
+  } else if (r < 0) {
+    derr << "error retrieving local id for image " << m_global_image_id << ": "
+         << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  get_tag_owner();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::get_tag_owner() {
+  dout(10) << dendl;
+
+  auto ctx = create_context_callback<
+    TrashMoveRequest<I>, &TrashMoveRequest<I>::handle_get_tag_owner>(this);
+  librbd::Journal<I>::get_tag_owner(m_io_ctx, m_image_id, &m_mirror_uuid,
+                                    m_op_work_queue, ctx);
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_get_tag_owner(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    derr << "error retrieving image primary info for image "
+         << m_global_image_id << ": " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  } else if (r != -ENOENT) {
+    if (m_mirror_uuid == librbd::Journal<>::LOCAL_MIRROR_UUID) {
+      dout(10) << "image " << m_global_image_id << " is local primary" << dendl;
+      finish(-EPERM);
+      return;
+    } else if (m_mirror_uuid == librbd::Journal<>::ORPHAN_MIRROR_UUID &&
+               !m_resync) {
+      dout(10) << "image " << m_global_image_id << " is orphaned" << dendl;
+      finish(-EPERM);
+      return;
+    }
+  }
+
+  disable_mirror_image();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::disable_mirror_image() {
+  dout(10) << dendl;
+
+  cls::rbd::MirrorImage mirror_image;
+  mirror_image.global_image_id = m_global_image_id;
+  mirror_image.state = cls::rbd::MIRROR_IMAGE_STATE_DISABLING;
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::mirror_image_set(&op, m_image_id, mirror_image);
+
+  auto aio_comp = create_rados_callback<
+    TrashMoveRequest<I>,
+    &TrashMoveRequest<I>::handle_disable_mirror_image>(this);
+  int r = m_io_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_disable_mirror_image(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r == -ENOENT) {
+    dout(10) << "local image is not mirrored, aborting deletion." << dendl;
+    finish(r);
+    return;
+  } else if (r == -EEXIST || r == -EINVAL) {
+    derr << "cannot disable mirroring for image " << m_global_image_id
+         << ": global_image_id has changed/reused: "
+         << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  } else if (r < 0) {
+    derr << "cannot disable mirroring for image " << m_global_image_id
+         << ": " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  reset_journal();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::reset_journal() {
+  dout(10) << dendl;
+
+  // ensure that if the image is recovered any peers will split-brain
+  auto ctx = create_context_callback<
+    TrashMoveRequest<I>, &TrashMoveRequest<I>::handle_reset_journal>(this);
+  auto req = librbd::journal::ResetRequest<I>::create(
+    m_io_ctx, m_image_id, librbd::Journal<>::IMAGE_CLIENT_ID,
+    m_mirror_uuid, m_op_work_queue, ctx);
+  req->send();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_reset_journal(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0 && r != -ENOENT) {
+    derr << "failed to reset journal: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  open_image();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::open_image() {
+  dout(10) << dendl;
+
+  m_image_ctx = I::create("", m_image_id, nullptr, m_io_ctx, false);
+
+  {
+    // don't attempt to open the journal
+    RWLock::WLocker snap_locker(m_image_ctx->snap_lock);
+    m_image_ctx->set_journal_policy(new JournalPolicy());
+  }
+
+  Context *ctx = create_context_callback<
+    TrashMoveRequest<I>, &TrashMoveRequest<I>::handle_open_image>(this);
+  m_image_ctx->state->open(true, ctx);
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_open_image(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to open image: " << cpp_strerror(r) << dendl;
+    m_image_ctx->destroy();
+    m_image_ctx = nullptr;
+    finish(r);
+    return;
+  }
+
+  if (m_image_ctx->old_format) {
+    derr << "cannot move v1 image to trash" << dendl;
+    m_ret_val = -EINVAL;
+    close_image();
+    return;
+  }
+
+  acquire_lock();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::acquire_lock() {
+  m_image_ctx->owner_lock.get_read();
+  if (m_image_ctx->exclusive_lock == nullptr) {
+    derr << "exclusive lock feature not enabled" << dendl;
+    m_image_ctx->owner_lock.put_read();
+    m_ret_val = -EINVAL;
+    close_image();
+    return;
+  }
+
+  dout(10) << dendl;
+
+  Context *ctx = create_context_callback<
+    TrashMoveRequest<I>, &TrashMoveRequest<I>::handle_acquire_lock>(this);
+  m_image_ctx->exclusive_lock->block_requests(0);
+  m_image_ctx->exclusive_lock->acquire_lock(ctx);
+  m_image_ctx->owner_lock.put_read();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_acquire_lock(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to acquire exclusive lock: " << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    close_image();
+    return;
+  }
+
+  trash_move();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::trash_move() {
+  dout(10) << dendl;
+
+  // TODO support configurable "deletion delay"
+  utime_t delete_time{ceph_clock_now()};
+  utime_t deferment_end_time{delete_time};
+  m_trash_image_spec = {
+    cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, m_image_ctx->name, delete_time,
+    deferment_end_time};
+
+  Context *ctx = create_context_callback<
+    TrashMoveRequest<I>, &TrashMoveRequest<I>::handle_trash_move>(this);
+  auto req = librbd::trash::MoveRequest<I>::create(
+    m_io_ctx, m_image_id, m_trash_image_spec, ctx);
+  req->send();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_trash_move(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to move image to trash: " << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+    close_image();
+    return;
+  }
+
+  m_moved_to_trash = true;
+  remove_mirror_image();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::remove_mirror_image() {
+  dout(10) << dendl;
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::mirror_image_remove(&op, m_image_id);
+
+  auto aio_comp = create_rados_callback<
+    TrashMoveRequest<I>,
+    &TrashMoveRequest<I>::handle_remove_mirror_image>(this);
+  int r = m_io_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_remove_mirror_image(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r == -ENOENT) {
+    dout(10) << "local image is not mirrored" << dendl;
+  } else if (r < 0) {
+    derr << "failed to remove mirror image state for " << m_global_image_id
+         << ": " << cpp_strerror(r) << dendl;
+    m_ret_val = r;
+  }
+
+  close_image();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::close_image() {
+  dout(10) << dendl;
+
+  Context *ctx = create_context_callback<
+    TrashMoveRequest<I>, &TrashMoveRequest<I>::handle_close_image>(this);
+  m_image_ctx->state->close(ctx);
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_close_image(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  m_image_ctx->destroy();
+  m_image_ctx = nullptr;
+
+  if (r < 0) {
+    derr << "failed to close image: " << cpp_strerror(r) << dendl;
+  }
+
+  // don't send notification if we failed
+  if (!m_moved_to_trash) {
+    finish(0);
+    return;
+  }
+
+  notify_trash_add();
+}
+
+template <typename I>
+void TrashMoveRequest<I>::notify_trash_add() {
+  dout(10) << dendl;
+
+  Context *ctx = create_context_callback<
+    TrashMoveRequest<I>, &TrashMoveRequest<I>::handle_notify_trash_add>(this);
+  librbd::TrashWatcher<I>::notify_image_added(m_io_ctx, m_image_id,
+                                              m_trash_image_spec, ctx);
+}
+
+template <typename I>
+void TrashMoveRequest<I>::handle_notify_trash_add(int r) {
+  dout(10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to notify trash watchers: " << cpp_strerror(r) << dendl;
+  }
+
+  finish(0);
+}
+
+template <typename I>
+void TrashMoveRequest<I>::finish(int r) {
+  if (m_ret_val < 0) {
+    r = m_ret_val;
+  }
+
+  dout(10) << "r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_deleter
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_deleter::TrashMoveRequest<librbd::ImageCtx>;
+

--- a/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.cc
@@ -253,9 +253,10 @@ template <typename I>
 void TrashMoveRequest<I>::trash_move() {
   dout(10) << dendl;
 
-  // TODO support configurable "deletion delay"
   utime_t delete_time{ceph_clock_now()};
   utime_t deferment_end_time{delete_time};
+  deferment_end_time += m_image_ctx->mirroring_delete_delay;
+
   m_trash_image_spec = {
     cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING, m_image_ctx->name, delete_time,
     deferment_end_time};

--- a/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.h
+++ b/src/tools/rbd_mirror/image_deleter/TrashMoveRequest.h
@@ -1,0 +1,136 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RBD_MIRROR_IMAGE_DELETE_TRASH_MOVE_REQUEST_H
+#define CEPH_RBD_MIRROR_IMAGE_DELETE_TRASH_MOVE_REQUEST_H
+
+#include "include/buffer.h"
+#include "include/rados/librados.hpp"
+#include "cls/rbd/cls_rbd_types.h"
+#include <boost/optional.hpp>
+#include <string>
+
+struct Context;
+class ContextWQ;
+namespace librbd { struct ImageCtx; }
+
+namespace rbd {
+namespace mirror {
+namespace image_deleter {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class TrashMoveRequest {
+public:
+  static TrashMoveRequest* create(librados::IoCtx& io_ctx,
+                                  const std::string& global_image_id,
+                                  bool resync, ContextWQ* op_work_queue,
+                                  Context* on_finish) {
+    return new TrashMoveRequest(io_ctx, global_image_id, resync, op_work_queue,
+                                on_finish);
+  }
+
+  TrashMoveRequest(librados::IoCtx& io_ctx, const std::string& global_image_id,
+                   bool resync, ContextWQ* op_work_queue, Context* on_finish)
+    : m_io_ctx(io_ctx), m_global_image_id(global_image_id), m_resync(resync),
+      m_op_work_queue(op_work_queue), m_on_finish(on_finish) {
+  }
+
+  void send();
+
+private:
+  /*
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * GET_MIRROR_IMAGE_ID
+   *    |
+   *    v
+   * GET_TAG_OWNER
+   *    |
+   *    v
+   * DISABLE_MIRROR_IMAGE
+   *    |
+   *    v
+   * RESET_JOURNAL
+   *    |
+   *    v
+   * OPEN_IMAGE
+   *    |
+   *    v
+   * ACQUIRE_LOCK
+   *    |
+   *    v
+   * TRASH_MOVE
+   *    |
+   *    v
+   * REMOVE_MIRROR_IMAGE
+   *    |
+   *    v
+   * CLOSE_IMAGE
+   *    |
+   *    v
+   * NOTIFY_TRASH_ADD
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  librados::IoCtx &m_io_ctx;
+  std::string m_global_image_id;
+  bool m_resync;
+  ContextWQ *m_op_work_queue;
+  Context *m_on_finish;
+
+  ceph::bufferlist m_out_bl;
+  std::string m_image_id;
+  std::string m_mirror_uuid;
+  cls::rbd::TrashImageSpec m_trash_image_spec;
+  ImageCtxT *m_image_ctx = nullptr;;
+  int m_ret_val = 0;
+  bool m_moved_to_trash = false;
+
+  void get_mirror_image_id();
+  void handle_get_mirror_image_id(int r);
+
+  void get_tag_owner();
+  void handle_get_tag_owner(int r);
+
+  void disable_mirror_image();
+  void handle_disable_mirror_image(int r);
+
+  void reset_journal();
+  void handle_reset_journal(int r);
+
+  void open_image();
+  void handle_open_image(int r);
+
+  void acquire_lock();
+  void handle_acquire_lock(int r);
+
+  void trash_move();
+  void handle_trash_move(int r);
+
+  void remove_mirror_image();
+  void handle_remove_mirror_image(int r);
+
+  void close_image();
+  void handle_close_image(int r);
+
+  void notify_trash_add();
+  void handle_notify_trash_add(int r);
+
+  void finish(int r);
+
+};
+
+} // namespace image_deleter
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_deleter::TrashMoveRequest<librbd::ImageCtx>;
+
+#endif // CEPH_RBD_MIRROR_IMAGE_DELETE_TRASH_WATCHER_H

--- a/src/tools/rbd_mirror/image_deleter/TrashWatcher.cc
+++ b/src/tools/rbd_mirror/image_deleter/TrashWatcher.cc
@@ -1,0 +1,370 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "tools/rbd_mirror/image_deleter/TrashWatcher.h"
+#include "include/rbd_types.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "common/debug.h"
+#include "common/errno.h"
+#include "common/Timer.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "tools/rbd_mirror/Threads.h"
+#include "tools/rbd_mirror/image_deleter/Types.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_deleter::TrashWatcher: " \
+                           << this << " " << __func__ << ": "
+
+using librbd::util::create_context_callback;
+using librbd::util::create_rados_callback;
+
+namespace rbd {
+namespace mirror {
+namespace image_deleter {
+
+namespace {
+
+const size_t MAX_RETURN = 1024;
+
+} // anonymous namespace
+
+template <typename I>
+TrashWatcher<I>::TrashWatcher(librados::IoCtx &io_ctx, Threads<I> *threads,
+                              TrashListener& trash_listener)
+  : librbd::TrashWatcher<I>(io_ctx, threads->work_queue),
+    m_io_ctx(io_ctx), m_threads(threads), m_trash_listener(trash_listener),
+    m_lock(librbd::util::unique_lock_name(
+      "rbd::mirror::image_deleter::TrashWatcher", this)) {
+}
+
+template <typename I>
+void TrashWatcher<I>::init(Context *on_finish) {
+  dout(5) << dendl;
+
+  {
+    Mutex::Locker locker(m_lock);
+    m_on_init_finish = on_finish;
+
+    assert(!m_trash_list_in_progress);
+    m_trash_list_in_progress = true;
+  }
+
+  create_trash();
+}
+
+template <typename I>
+void TrashWatcher<I>::shut_down(Context *on_finish) {
+  dout(5) << dendl;
+
+  {
+    Mutex::Locker timer_locker(m_threads->timer_lock);
+    Mutex::Locker locker(m_lock);
+
+    assert(!m_shutting_down);
+    m_shutting_down = true;
+    if (m_timer_ctx != nullptr) {
+      m_threads->timer->cancel_event(m_timer_ctx);
+      m_timer_ctx = nullptr;
+    }
+  }
+
+  auto ctx = new FunctionContext([this, on_finish](int r) {
+      unregister_watcher(on_finish);
+    });
+  m_async_op_tracker.wait_for_ops(ctx);
+}
+
+template <typename I>
+void TrashWatcher<I>::handle_image_added(const std::string &image_id,
+                                         const cls::rbd::TrashImageSpec& spec) {
+  dout(10) << "image_id=" << image_id << dendl;
+
+  Mutex::Locker locker(m_lock);
+  add_image(image_id, spec);
+}
+
+template <typename I>
+void TrashWatcher<I>::handle_image_removed(const std::string &image_id) {
+  // ignore removals -- the image deleter will ignore -ENOENTs
+}
+
+template <typename I>
+void TrashWatcher<I>::handle_rewatch_complete(int r) {
+  dout(5) << "r=" << r << dendl;
+
+  if (r == -EBLACKLISTED) {
+    dout(0) << "detected client is blacklisted" << dendl;
+    return;
+  } else if (r == -ENOENT) {
+    dout(5) << "trash directory deleted" << dendl;
+  } else if (r < 0) {
+    derr << "unexpected error re-registering trash directory watch: "
+         << cpp_strerror(r) << dendl;
+  }
+  schedule_trash_list(30);
+}
+
+template <typename I>
+void TrashWatcher<I>::create_trash() {
+  dout(20) << dendl;
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_trash_list_in_progress);
+  }
+
+  librados::ObjectWriteOperation op;
+  op.create(false);
+
+  m_async_op_tracker.start_op();
+  auto aio_comp = create_rados_callback<
+    TrashWatcher<I>, &TrashWatcher<I>::handle_create_trash>(this);
+  int r = m_io_ctx.aio_operate(RBD_TRASH, aio_comp, &op);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void TrashWatcher<I>::handle_create_trash(int r) {
+  dout(20) << "r=" << r << dendl;
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_trash_list_in_progress);
+  }
+
+  if (r < 0 && r != -EEXIST) {
+    derr << "failed to create trash object: " << cpp_strerror(r) << dendl;
+    {
+      Mutex::Locker locker(m_lock);
+      m_trash_list_in_progress = false;
+    }
+
+    schedule_trash_list(30);
+  } else {
+    register_watcher();
+  }
+
+  m_async_op_tracker.finish_op();
+}
+
+template <typename I>
+void TrashWatcher<I>::register_watcher() {
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_trash_list_in_progress);
+  }
+
+  // if the watch registration is in-flight, let the watcher
+  // handle the transition -- only (re-)register if it's not registered
+  if (!this->is_unregistered()) {
+    trash_list(true);
+    return;
+  }
+
+  // first time registering or the watch failed
+  dout(5) << dendl;
+  m_async_op_tracker.start_op();
+
+  Context *ctx = create_context_callback<
+    TrashWatcher, &TrashWatcher<I>::handle_register_watcher>(this);
+  this->register_watch(ctx);
+}
+
+template <typename I>
+void TrashWatcher<I>::handle_register_watcher(int r) {
+  dout(5) << "r=" << r << dendl;
+
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_trash_list_in_progress);
+    if (r < 0) {
+      m_trash_list_in_progress = false;
+    }
+  }
+
+  Context *on_init_finish = nullptr;
+  if (r >= 0) {
+    trash_list(true);
+  } else if (r == -EBLACKLISTED) {
+    dout(0) << "detected client is blacklisted" << dendl;
+
+    Mutex::Locker locker(m_lock);
+    std::swap(on_init_finish, m_on_init_finish);
+  } else {
+    derr << "unexpected error registering trash directory watch: "
+         << cpp_strerror(r) << dendl;
+    schedule_trash_list(10);
+  }
+
+  m_async_op_tracker.finish_op();
+  if (on_init_finish != nullptr) {
+    on_init_finish->complete(r);
+  }
+}
+
+template <typename I>
+void TrashWatcher<I>::unregister_watcher(Context* on_finish) {
+  dout(5) << dendl;
+
+  m_async_op_tracker.start_op();
+  Context *ctx = new FunctionContext([this, on_finish](int r) {
+      handle_unregister_watcher(r, on_finish);
+    });
+  this->unregister_watch(ctx);
+}
+
+template <typename I>
+void TrashWatcher<I>::handle_unregister_watcher(int r, Context* on_finish) {
+  dout(5) << "unregister_watcher: r=" << r << dendl;
+  if (r < 0) {
+    derr << "error unregistering watcher for trash directory: "
+         << cpp_strerror(r) << dendl;
+  }
+  m_async_op_tracker.finish_op();
+  on_finish->complete(0);
+}
+
+template <typename I>
+void TrashWatcher<I>::trash_list(bool initial_request) {
+  if (initial_request) {
+    m_async_op_tracker.start_op();
+    m_last_image_id = "";
+  }
+
+  dout(5) << "last_image_id=" << m_last_image_id << dendl;
+
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_trash_list_in_progress);
+  }
+
+  librados::ObjectReadOperation op;
+  librbd::cls_client::trash_list_start(&op, m_last_image_id, MAX_RETURN);
+
+  librados::AioCompletion *aio_comp = create_rados_callback<
+    TrashWatcher<I>, &TrashWatcher<I>::handle_trash_list>(this);
+  m_out_bl.clear();
+  int r = m_io_ctx.aio_operate(RBD_TRASH, aio_comp, &op, &m_out_bl);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void TrashWatcher<I>::handle_trash_list(int r) {
+  dout(5) << "r=" << r << dendl;
+
+  std::map<std::string, cls::rbd::TrashImageSpec> images;
+  if (r >= 0) {
+    auto bl_it = m_out_bl.begin();
+    r = librbd::cls_client::trash_list_finish(&bl_it, &images);
+  }
+
+  Context *on_init_finish = nullptr;
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_trash_list_in_progress);
+    if (r >= 0) {
+      for (auto& image : images) {
+        add_image(image.first, image.second);
+      }
+    } else if (r == -ENOENT) {
+      r = 0;
+    }
+
+    if (r == -EBLACKLISTED) {
+      dout(0) << "detected client is blacklisted during trash refresh" << dendl;
+      m_trash_list_in_progress = false;
+      std::swap(on_init_finish, m_on_init_finish);
+    } else if (r >= 0 && images.size() < MAX_RETURN) {
+      m_trash_list_in_progress = false;
+      std::swap(on_init_finish, m_on_init_finish);
+    } else if (r < 0) {
+      m_trash_list_in_progress = false;
+    }
+  }
+
+  if (r >= 0 && images.size() == MAX_RETURN) {
+    m_last_image_id = images.rbegin()->first;
+    trash_list(false);
+    return;
+  } else if (r < 0 && r != -EBLACKLISTED) {
+    derr << "failed to retrieve trash directory: " << cpp_strerror(r) << dendl;
+    schedule_trash_list(10);
+  }
+
+  m_async_op_tracker.finish_op();
+  if (on_init_finish != nullptr) {
+    on_init_finish->complete(r);
+  }
+}
+
+template <typename I>
+void TrashWatcher<I>::schedule_trash_list(double interval) {
+  Mutex::Locker timer_locker(m_threads->timer_lock);
+  Mutex::Locker locker(m_lock);
+  if (m_shutting_down || m_trash_list_in_progress || m_timer_ctx != nullptr) {
+    if (m_trash_list_in_progress && !m_deferred_trash_list) {
+      dout(5) << "deferring refresh until in-flight refresh completes" << dendl;
+      m_deferred_trash_list = true;
+    }
+    return;
+  }
+
+  dout(5) << dendl;
+  m_timer_ctx = m_threads->timer->add_event_after(
+    interval,
+    new FunctionContext([this](int r) {
+	process_trash_list();
+      }));
+}
+
+template <typename I>
+void TrashWatcher<I>::process_trash_list() {
+  dout(5) << dendl;
+
+  assert(m_threads->timer_lock.is_locked());
+  assert(m_timer_ctx != nullptr);
+  m_timer_ctx = nullptr;
+
+  {
+    Mutex::Locker locker(m_lock);
+    assert(!m_trash_list_in_progress);
+    m_trash_list_in_progress = true;
+  }
+
+  // execute outside of the timer's lock
+  m_async_op_tracker.start_op();
+  Context *ctx = new FunctionContext([this](int r) {
+      create_trash();
+      m_async_op_tracker.finish_op();
+    });
+  m_threads->work_queue->queue(ctx, 0);
+}
+
+template <typename I>
+void TrashWatcher<I>::add_image(const std::string& image_id,
+                                const cls::rbd::TrashImageSpec& spec) {
+  if (spec.source != cls::rbd::TRASH_IMAGE_SOURCE_MIRRORING) {
+    return;
+  }
+
+  assert(m_lock.is_locked());
+  auto& deferment_end_time = spec.deferment_end_time;
+  dout(10) << "image_id=" << image_id << ", "
+           << "deferment_end_time=" << deferment_end_time << dendl;
+
+  m_async_op_tracker.start_op();
+  auto ctx = new FunctionContext([this, image_id, deferment_end_time](int r) {
+      m_trash_listener.handle_trash_image(image_id, deferment_end_time);
+      m_async_op_tracker.finish_op();
+    });
+  m_threads->work_queue->queue(ctx, 0);
+}
+
+} // namespace image_deleter;
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_deleter::TrashWatcher<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_deleter/TrashWatcher.h
+++ b/src/tools/rbd_mirror/image_deleter/TrashWatcher.h
@@ -1,0 +1,133 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RBD_MIRROR_IMAGE_DELETE_TRASH_WATCHER_H
+#define CEPH_RBD_MIRROR_IMAGE_DELETE_TRASH_WATCHER_H
+
+#include "include/rados/librados.hpp"
+#include "common/AsyncOpTracker.h"
+#include "common/Mutex.h"
+#include "librbd/TrashWatcher.h"
+#include <set>
+#include <string>
+
+struct Context;
+namespace librbd { struct ImageCtx; }
+
+namespace rbd {
+namespace mirror {
+
+template <typename> struct Threads;
+
+namespace image_deleter {
+
+struct TrashListener;
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class TrashWatcher : public librbd::TrashWatcher<ImageCtxT> {
+public:
+  TrashWatcher(librados::IoCtx &io_ctx, Threads<ImageCtxT> *threads,
+               TrashListener& trash_listener);
+  TrashWatcher(const TrashWatcher&) = delete;
+  TrashWatcher& operator=(const TrashWatcher&) = delete;
+
+  void init(Context *on_finish);
+  void shut_down(Context *on_finish);
+
+protected:
+  void handle_image_added(const std::string &image_id,
+                          const cls::rbd::TrashImageSpec& spec) override;
+
+  void handle_image_removed(const std::string &image_id) override;
+
+  void handle_rewatch_complete(int r) override;
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   *  INIT
+   *    |
+   *    v
+   * CREATE_TRASH
+   *    |
+   *    v
+   * REGISTER_WATCHER
+   *    |
+   *    |/--------------------------------\
+   *    |                                 |
+   *    |/---------\                      |
+   *    |          |                      |
+   *    v          | (more images)        |
+   * TRASH_LIST ---/                      |
+   *    |                                 |
+   *    |/----------------------------\   |
+   *    |                             |   |
+   *    v                             |   |
+   * <idle> --\                       |   |
+   *    |     |                       |   |
+   *    |     |\---> IMAGE_ADDED -----/   |
+   *    |     |                           |
+   *    |     \----> WATCH_ERROR ---------/
+   *    v
+   * SHUT_DOWN
+   *    |
+   *    v
+   * UNREGISTER_WATCHER
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  librados::IoCtx m_io_ctx;
+  Threads<ImageCtxT> *m_threads;
+  TrashListener& m_trash_listener;
+
+  std::string m_last_image_id;
+  bufferlist m_out_bl;
+
+  mutable Mutex m_lock;
+
+  Context *m_on_init_finish = nullptr;
+  Context *m_timer_ctx = nullptr;
+
+  AsyncOpTracker m_async_op_tracker;
+  bool m_trash_list_in_progress = false;
+  bool m_deferred_trash_list = false;
+  bool m_shutting_down = false;
+
+  void register_watcher();
+  void handle_register_watcher(int r);
+
+  void create_trash();
+  void handle_create_trash(int r);
+
+  void unregister_watcher(Context* on_finish);
+  void handle_unregister_watcher(int r, Context* on_finish);
+
+  void trash_list(bool initial_request);
+  void handle_trash_list(int r);
+
+  void schedule_trash_list(double interval);
+  void process_trash_list();
+
+  void get_mirror_uuid();
+  void handle_get_mirror_uuid(int r);
+
+  void add_image(const std::string& image_id,
+                 const cls::rbd::TrashImageSpec& spec);
+
+};
+
+} // namespace image_deleter
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_deleter::TrashWatcher<librbd::ImageCtx>;
+
+#endif // CEPH_RBD_MIRROR_IMAGE_DELETE_TRASH_WATCHER_H

--- a/src/tools/rbd_mirror/image_deleter/TrashWatcher.h
+++ b/src/tools/rbd_mirror/image_deleter/TrashWatcher.h
@@ -26,6 +26,12 @@ struct TrashListener;
 template <typename ImageCtxT = librbd::ImageCtx>
 class TrashWatcher : public librbd::TrashWatcher<ImageCtxT> {
 public:
+  static TrashWatcher* create(librados::IoCtx &io_ctx,
+                              Threads<ImageCtxT> *threads,
+                              TrashListener& trash_listener) {
+    return new TrashWatcher(io_ctx, threads, trash_listener);
+  }
+
   TrashWatcher(librados::IoCtx &io_ctx, Threads<ImageCtxT> *threads,
                TrashListener& trash_listener);
   TrashWatcher(const TrashWatcher&) = delete;

--- a/src/tools/rbd_mirror/image_deleter/Types.h
+++ b/src/tools/rbd_mirror/image_deleter/Types.h
@@ -4,6 +4,10 @@
 #ifndef CEPH_RBD_MIRROR_IMAGE_DELETER_TYPES_H
 #define CEPH_RBD_MIRROR_IMAGE_DELETER_TYPES_H
 
+#include <string>
+
+struct utime_t;
+
 namespace rbd {
 namespace mirror {
 namespace image_deleter {
@@ -12,6 +16,20 @@ enum ErrorResult {
   ERROR_RESULT_COMPLETE,
   ERROR_RESULT_RETRY,
   ERROR_RESULT_RETRY_IMMEDIATELY
+};
+
+struct TrashListener {
+  TrashListener() {
+  }
+  TrashListener(const TrashListener&) = delete;
+  TrashListener& operator=(const TrashListener&) = delete;
+
+  virtual ~TrashListener() {
+  }
+
+  virtual void handle_trash_image(const std::string& image_id,
+                                  const utime_t& deferment_end_time) = 0;
+
 };
 
 } // namespace image_deleter

--- a/src/tools/rbd_mirror/image_deleter/Types.h
+++ b/src/tools/rbd_mirror/image_deleter/Types.h
@@ -4,6 +4,8 @@
 #ifndef CEPH_RBD_MIRROR_IMAGE_DELETER_TYPES_H
 #define CEPH_RBD_MIRROR_IMAGE_DELETER_TYPES_H
 
+#include "include/Context.h"
+#include "librbd/journal/Policy.h"
 #include <string>
 
 struct utime_t;
@@ -30,6 +32,19 @@ struct TrashListener {
   virtual void handle_trash_image(const std::string& image_id,
                                   const utime_t& deferment_end_time) = 0;
 
+};
+
+struct JournalPolicy : public librbd::journal::Policy {
+  bool append_disabled() const override {
+    return true;
+  }
+  bool journal_disabled() const override {
+    return true;
+  }
+
+  void allocate_tag_on_lock(Context *on_finish) override {
+    on_finish->complete(0);
+  }
 };
 
 } // namespace image_deleter

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -466,7 +466,11 @@ void BootstrapRequest<I>::handle_create_local_image(int r) {
   dout(20) << ": r=" << r << dendl;
 
   if (r < 0) {
-    derr << ": failed to create local image: " << cpp_strerror(r) << dendl;
+    if (r == -ENOENT) {
+      dout(10) << ": parent image does not exist" << dendl;
+    } else {
+      derr << ": failed to create local image: " << cpp_strerror(r) << dendl;
+    }
     m_ret_val = r;
     close_remote_image();
     return;

--- a/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
@@ -125,8 +125,12 @@ void OpenLocalImageRequest<I>::handle_open_image(int r) {
   dout(20) << ": r=" << r << dendl;
 
   if (r < 0) {
-    derr << ": failed to open image '" << m_local_image_id << "': "
-         << cpp_strerror(r) << dendl;
+    if (r == -ENOENT) {
+      dout(10) << ": local image does not exist" << dendl;
+    } else {
+      derr << ": failed to open image '" << m_local_image_id << "': "
+           << cpp_strerror(r) << dendl;
+    }
     (*m_local_image_ctx)->destroy();
     *m_local_image_ctx = nullptr;
     finish(r);


### PR DESCRIPTION
All deleted images are first moved to the trash, and once in the trash, the image deleter will detect the new image and schedule it from removal based upon its deferment end time. 