### PR TITLE
qa/stanalone: pass options using --<option-name>=<value>

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -728,9 +728,9 @@ function activate_osd() {
     ceph_args+=" --debug-osd=20"
     ceph_args+=" --log-file=$dir/\$name.log"
     ceph_args+=" --pid-file=$dir/\$name.pid"
-    ceph_args+=" --osd-max-object-name-len 460"
-    ceph_args+=" --osd-max-object-namespace-len 64"
-    ceph_args+=" --enable-experimental-unrecoverable-data-corrupting-features *"
+    ceph_args+=" --osd-max-object-name-len=460"
+    ceph_args+=" --osd-max-object-namespace-len=64"
+    ceph_args+=" --enable-experimental-unrecoverable-data-corrupting-features=*"
     ceph_args+=" "
     ceph_args+="$@"
     mkdir -p $osd_data

--- a/qa/standalone/osd/osd-config.sh
+++ b/qa/standalone/osd/osd-config.sh
@@ -44,9 +44,9 @@ function TEST_config_init() {
     local stale=1000
     local cache=500
     run_osd $dir 0 \
-        --osd-map-max-advance $advance \
-        --osd-map-cache-size $cache \
-        --osd-pg-epoch-persisted-max-stale $stale \
+        --osd-map-max-advance=$advance \
+        --osd-map-cache-size=$cache \
+        --osd-pg-epoch-persisted-max-stale=$stale \
         || return 1
     CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
     grep 'is not > osd_map_max_advance' $dir/osd.0.log || return 1


### PR DESCRIPTION
not `--<option-name> <value>`, otherwise `ceph-authtool` would error
out:
```
$ CEPH_ARGS='--osd-map-max-advance 1000' bin/ceph-authtool --gen-print-key
bin/ceph-authtool: unexpected '1000'
usage: ceph-authtool keyringfile [OPTIONS]...
....
```
but using the syntax of `--<option-name>=<value>`, it works:
```
$ CEPH_ARGS='--osd-map-max-advance=1000' bin/ceph-authtool --gen-print-key
AQBAhTNamf5+ABAASkAp/6IGq7LkUTEOMp/fgw==
```
Signed-off-by: Kefu Chai <kchai@redhat.com>