### PR TITLE
ceph.in: Drop printing invalid command

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -1075,8 +1075,6 @@ def main():
 
         if ret < 0:
             ret = -ret
-            errstr = errno.errorcode.get(ret, 'Unknown')
-            print(u'Error {0}: {1}'.format(errstr, outs), file=sys.stderr)
             if len(targets) > 1:
                 final_ret = ret
             else:


### PR DESCRIPTION
Dropped printing `Error EINVAL: invalid command`. As the commands are printing `no valid command found; <num> closest matches` from ceph_argparse.py, this seems to be unnecessary.

There is one more instance here: https://github.com/ceph/ceph/blob/5043e4b494ec8ea0227af3506c4e5e3428599151/src/ceph.in#L1070 But I'm not sure how to test this one. So leaving it for the reviewer's suggestion.

Signed-off-by: Jos Collin <jcollin@redhat.com>