### PR TITLE
 luminous: msg/async: unregister connection failed when racing happened

### DIFF
--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -356,9 +356,6 @@ public:
       Mutex::Locker l(deleted_lock);
       if (deleted_conns.erase(existing)) {
         existing->get_perf_counter()->dec(l_msgr_active_connections);
-        conns.erase(it);
-      } else if (conn != existing) {
-        return -1;
       }
     }
     conns[conn->peer_addr] = conn;


### PR DESCRIPTION
http://tracker.ceph.com/issues/22452