### PR TITLE
 luminous: cluster resource agent ocf:ceph:rbd - wrong permissions

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1481,7 +1481,7 @@ fi
 %dir %{_prefix}/lib/ocf
 %dir %{_prefix}/lib/ocf/resource.d
 %dir %{_prefix}/lib/ocf/resource.d/ceph
-%{_prefix}/lib/ocf/resource.d/ceph/rbd
+%attr(0755,-,-) %{_prefix}/lib/ocf/resource.d/ceph/rbd
 
 %endif
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/22454