### PR TITLE
mon/OSDMonitor: list osd tree in named bucket

### DIFF
--- a/src/crush/CrushTreeDumper.h
+++ b/src/crush/CrushTreeDumper.h
@@ -167,6 +167,14 @@ namespace CrushTreeDumper {
 
     bool is_touched(int id) const { return touched.count(id) > 0; }
 
+    void set_root(const string& bucket) {
+      roots.clear();
+      if (crush->name_exists(bucket)) {
+	int i = crush->get_item_id(bucket);
+	roots.insert(i);
+      }
+    }
+
   protected:
     virtual void dump_item(const Item &qi, F *f) = 0;
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -453,6 +453,11 @@ COMMAND("osd tree " \
 	"name=epoch,type=CephInt,range=0,req=false " \
 	"name=states,type=CephChoices,strings=up|down|in|out|destroyed,n=N,req=false", \
 	"print OSD tree", "osd", "r", "cli,rest")
+COMMAND("osd tree-from " \
+	"name=epoch,type=CephInt,range=0,req=false " \
+	"name=bucket,type=CephString " \
+	"name=states,type=CephChoices,strings=up|down|in|out|destroyed,n=N,req=false", \
+	"print OSD tree in bucket", "osd", "r", "cli,rest")
 COMMAND("osd ls " \
 	"name=epoch,type=CephInt,range=0,req=false", \
 	"show all OSD ids", "osd", "r", "cli,rest")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3497,6 +3497,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   }
   else if (prefix == "osd dump" ||
 	   prefix == "osd tree" ||
+	   prefix == "osd tree-from" ||
 	   prefix == "osd ls" ||
 	   prefix == "osd getmap" ||
 	   prefix == "osd getcrushmap" ||
@@ -3567,7 +3568,11 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	}
       }
       rdata.append(ds);
-    } else if (prefix == "osd tree") {
+    } else if (prefix == "osd tree" || prefix == "osd tree-from") {
+      string bucket;
+      if (prefix == "osd tree-from")
+	cmd_getval(cct, cmdmap, "bucket", bucket);
+
       vector<string> states;
       cmd_getval(cct, cmdmap, "states", states);
       unsigned filter = 0;
@@ -3606,11 +3611,11 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       }
       if (f) {
 	f->open_object_section("tree");
-	p->print_tree(f.get(), NULL, filter);
+	p->print_tree(f.get(), NULL, filter, bucket);
 	f->close_section();
 	f->flush(ds);
       } else {
-	p->print_tree(NULL, &ds, filter);
+	p->print_tree(NULL, &ds, filter, bucket);
       }
       rdata.append(ds);
     } else if (prefix == "osd getmap") {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3051,7 +3051,7 @@ public:
     return !filter;
   }
 
-  void dump(TextTable *tbl) {
+  void init_table(TextTable *tbl) {
     tbl->define_column("ID", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("CLASS", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("WEIGHT", TextTable::LEFT, TextTable::RIGHT);
@@ -3059,12 +3059,19 @@ public:
     tbl->define_column("STATUS", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("REWEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("PRI-AFF", TextTable::LEFT, TextTable::RIGHT);
+  }
+  void dump(TextTable *tbl, string& bucket) {
+    init_table(tbl);
 
-    Parent::dump(tbl);
-
-    for (int i = 0; i < osdmap->get_max_osd(); i++) {
-      if (osdmap->exists(i) && !is_touched(i) && should_dump_leaf(i)) {
-	dump_item(CrushTreeDumper::Item(i, 0, 0, 0), tbl);
+    if (!bucket.empty()) {
+      set_root(bucket);
+      Parent::dump(tbl);
+    } else {
+      Parent::dump(tbl);
+      for (int i = 0; i < osdmap->get_max_osd(); i++) {
+	if (osdmap->exists(i) && !is_touched(i) && should_dump_leaf(i)) {
+	  dump_item(CrushTreeDumper::Item(i, 0, 0, 0), tbl);
+	}
       }
     }
   }
@@ -3141,16 +3148,23 @@ public:
     return !filter;
   }
 
-  void dump(Formatter *f) {
-    f->open_array_section("nodes");
-    Parent::dump(f);
-    f->close_section();
-    f->open_array_section("stray");
-    for (int i = 0; i < osdmap->get_max_osd(); i++) {
-      if (osdmap->exists(i) && !is_touched(i) && should_dump_leaf(i))
-	dump_item(CrushTreeDumper::Item(i, 0, 0, 0), f);
+  void dump(Formatter *f, string& bucket) {
+    if (!bucket.empty()) {
+      set_root(bucket);
+      f->open_array_section("nodes");
+      Parent::dump(f);
+      f->close_section();
+    } else {
+      f->open_array_section("nodes");
+      Parent::dump(f);
+      f->close_section();
+      f->open_array_section("stray");
+      for (int i = 0; i < osdmap->get_max_osd(); i++) {
+	if (osdmap->exists(i) && !is_touched(i) && should_dump_leaf(i))
+	  dump_item(CrushTreeDumper::Item(i, 0, 0, 0), f);
+      }
+      f->close_section();
     }
-    f->close_section();
   }
 
 protected:
@@ -3178,14 +3192,14 @@ private:
   const unsigned filter;
 };
 
-void OSDMap::print_tree(Formatter *f, ostream *out, unsigned filter) const
+void OSDMap::print_tree(Formatter *f, ostream *out, unsigned filter, string bucket) const
 {
   if (f) {
-    OSDTreeFormattingDumper(crush.get(), this, filter).dump(f);
+    OSDTreeFormattingDumper(crush.get(), this, filter).dump(f, bucket);
   } else {
     assert(out);
     TextTable tbl;
-    OSDTreePlainDumper(crush.get(), this, filter).dump(&tbl);
+    OSDTreePlainDumper(crush.get(), this, filter).dump(&tbl, bucket);
     *out << tbl;
   }
 }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1347,7 +1347,7 @@ public:
     DUMP_DOWN = 8,       // only 'down' osds
     DUMP_DESTROYED = 16, // only 'destroyed' osds
   };
-  void print_tree(Formatter *f, ostream *out, unsigned dump_flags=0) const;
+  void print_tree(Formatter *f, ostream *out, unsigned dump_flags=0, string bucket="") const;
 
   int summarize_mapping_stats(
     OSDMap *newmap,


### PR DESCRIPTION
easy to get osd status in named bucket.
eg.
"ceph osd tree-ls node-1" will only show osds in bucket node-1,


Signed-off-by: kungf <yang.wang@easystack.cn>
@yangdongsheng 