### PR TITLE
health.h: display only health status

### DIFF
--- a/src/include/health.h
+++ b/src/include/health.h
@@ -55,13 +55,13 @@ struct denc_traits<health_status_t> {
 inline std::ostream& operator<<(std::ostream &oss, const health_status_t status) {
   switch (status) {
     case HEALTH_ERR:
-      oss << "HEALTH_ERR";
+      oss << "ERR";
       break;
     case HEALTH_WARN:
-      oss << "HEALTH_WARN";
+      oss << "WARN";
       break;
     case HEALTH_OK:
-      oss << "HEALTH_OK";
+      oss << "OK";
       break;
   }
   return oss;


### PR DESCRIPTION
./bin/ceph -c ceph.conf -s
```
  cluster:
    id:     7c2aabb7-8e86-4f11-b552-413653fae2e3
    health: OK
```
Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>