### PR TITLE
doc: doc/radosgw/s3.rst: Adding AWS S3 `Storage Class` as `Not Supported`

### DIFF
--- a/doc/radosgw/s3.rst
+++ b/doc/radosgw/s3.rst
@@ -74,6 +74,8 @@ The following table describes the support status for current Amazon S3 functiona
 +---------------------------------+-----------------+----------------------------------------+
 | **Object Tagging**              | Supported       | Not supported in bucket policy/LC rules|
 +---------------------------------+-----------------+----------------------------------------+
+| **Storage Class**               | Not Supported   | Use **Bucket Location** as alternative |
++--------------------------------------------------------------------------------------------+
 
 
 Unsupported Header Fields


### PR DESCRIPTION
[Amazon S3 Storage Classes](https://aws.amazon.com/s3/storage-classes/) aren't supported by radosgw and the header is silently ignored