### PR TITLE
rbd-mirror: rollback state transitions in image policy

### DIFF
--- a/src/tools/rbd_mirror/ImageMap.cc
+++ b/src/tools/rbd_mirror/ImageMap.cc
@@ -324,9 +324,7 @@ void ImageMap<I>::schedule_add_action(const std::string &global_image_id) {
 
   // in order of state-machine execution, so its easier to follow
   Context *on_update = new C_UpdateMap(this, global_image_id);
-  Context *on_acquire = new FunctionContext([this, global_image_id](int r) {
-      queue_acquire_image(global_image_id);
-    });
+  Context *on_acquire = new C_AcquireImage(this, global_image_id);
   Context *on_finish = new FunctionContext([this, global_image_id](int r) {
       handle_add_action(global_image_id, r);
     });
@@ -365,9 +363,7 @@ void ImageMap<I>::schedule_shuffle_action(const std::string &global_image_id) {
       queue_release_image(global_image_id);
     });
   Context *on_update = new C_UpdateMap(this, global_image_id);
-  Context *on_acquire = new FunctionContext([this, global_image_id](int r) {
-      queue_acquire_image(global_image_id);
-    });
+  Context *on_acquire = new C_AcquireImage(this, global_image_id);
   Context *on_finish = new FunctionContext([this, global_image_id](int r) {
       handle_shuffle_action(global_image_id, r);
     });

--- a/src/tools/rbd_mirror/ImageMap.h
+++ b/src/tools/rbd_mirror/ImageMap.h
@@ -155,6 +155,25 @@ private:
     }
   };
 
+  struct C_AcquireImage : Context {
+    ImageMap *image_map;
+    std::string global_image_id;
+
+    C_AcquireImage(ImageMap *image_map, const std::string &global_image_id)
+      : image_map(image_map),
+        global_image_id(global_image_id) {
+    }
+
+    void finish(int r) override {
+      image_map->queue_acquire_image(global_image_id);
+    }
+
+    // maybe called more than once
+    void complete(int r) override {
+      finish(r);
+    }
+  };
+
   // async op-tracker helper routines
   void start_async_op() {
     m_async_op_tracker.start_op();

--- a/src/tools/rbd_mirror/image_map/Action.cc
+++ b/src/tools/rbd_mirror/image_map/Action.cc
@@ -58,16 +58,10 @@ void Action::execute_state_callback(StateTransition::State state) {
   }
 }
 
-void Action::state_callback_complete(StateTransition::State state, bool delete_context) {
-  Context *on_state = nullptr;
-
+void Action::state_callback_complete(StateTransition::State state) {
   auto it = context_map.find(state);
   if (it != context_map.end()) {
-    std::swap(it->second, on_state);
-  }
-
-  if (on_state && delete_context) {
-    delete on_state;
+    it->second = nullptr;
   }
 }
 

--- a/src/tools/rbd_mirror/image_map/Action.h
+++ b/src/tools/rbd_mirror/image_map/Action.h
@@ -21,7 +21,7 @@ public:
                                       Context *on_finish);
 
   void execute_state_callback(StateTransition::State state);
-  void state_callback_complete(StateTransition::State state, bool delete_context);
+  void state_callback_complete(StateTransition::State state);
   void execute_completion_callback(int r);
 
   StateTransition::ActionType get_action_type() const;

--- a/src/tools/rbd_mirror/image_map/StateTransition.cc
+++ b/src/tools/rbd_mirror/image_map/StateTransition.cc
@@ -55,17 +55,17 @@ std::ostream &operator<<(std::ostream &os, const StateTransition::State &state) 
 const StateTransition::TransitionTable StateTransition::transition_table[] = {
   // action_type         current_state                   Transition
   // -------------------------------------------------------------------------------
-  ACTION_TYPE_ADD,     STATE_UNASSIGNED,      Transition(STATE_UPDATE_MAPPING, true),
-  ACTION_TYPE_ADD,     STATE_ASSOCIATED,      Transition(STATE_ASSOCIATED,     false),
-  ACTION_TYPE_ADD,     STATE_DISASSOCIATED,   Transition(STATE_UPDATE_MAPPING, true),
-  ACTION_TYPE_ADD,     STATE_UPDATE_MAPPING,  Transition(STATE_ASSOCIATED,     false),
+  ACTION_TYPE_ADD,     STATE_UNASSIGNED,      Transition(STATE_UPDATE_MAPPING),
+  ACTION_TYPE_ADD,     STATE_UPDATE_MAPPING,  Transition(STATE_ASSOCIATED, STATE_ASSOCIATED,
+                                                         STATE_UNASSIGNED),
 
-  ACTION_TYPE_REMOVE,  STATE_ASSOCIATED,      Transition(STATE_DISASSOCIATED,  false),
-  ACTION_TYPE_REMOVE,  STATE_DISASSOCIATED,   Transition(STATE_REMOVE_MAPPING, true),
+  ACTION_TYPE_REMOVE,  STATE_ASSOCIATED,      Transition(STATE_DISASSOCIATED),
+  ACTION_TYPE_REMOVE,  STATE_DISASSOCIATED,   Transition(STATE_REMOVE_MAPPING, STATE_UNASSIGNED),
 
-  ACTION_TYPE_SHUFFLE, STATE_ASSOCIATED,      Transition(STATE_DISASSOCIATED,  false),
-  ACTION_TYPE_SHUFFLE, STATE_DISASSOCIATED,   Transition(STATE_UPDATE_MAPPING, true),
-  ACTION_TYPE_SHUFFLE, STATE_UPDATE_MAPPING,  Transition(STATE_ASSOCIATED,     false),
+  ACTION_TYPE_SHUFFLE, STATE_ASSOCIATED,      Transition(STATE_DISASSOCIATED),
+  ACTION_TYPE_SHUFFLE, STATE_DISASSOCIATED,   Transition(STATE_UPDATE_MAPPING),
+  ACTION_TYPE_SHUFFLE, STATE_UPDATE_MAPPING,  Transition(STATE_ASSOCIATED, STATE_ASSOCIATED,
+                                                         STATE_DISASSOCIATED),
 };
 
 const StateTransition::Transition &StateTransition::transit(ActionType action_type, State state) {

--- a/src/tools/rbd_mirror/image_map/StateTransition.h
+++ b/src/tools/rbd_mirror/image_map/StateTransition.h
@@ -4,6 +4,8 @@
 #ifndef CEPH_RBD_MIRROR_IMAGE_MAP_STATE_TRANSITION_H
 #define CEPH_RBD_MIRROR_IMAGE_MAP_STATE_TRANSITION_H
 
+#include <boost/optional.hpp>
+
 namespace rbd {
 namespace mirror {
 namespace image_map {
@@ -27,13 +29,23 @@ public:
 
   struct Transition {
     State next_state;
-    bool retry_on_error;
+    boost::optional<State> final_state;
+    boost::optional<State> error_state;
 
-    Transition() {
+    Transition()
+      : Transition(STATE_UNASSIGNED, boost::none, boost::none) {
     }
-    Transition(State next_state, bool retry_on_error)
+    Transition(State next_state)
+      : Transition(next_state, boost::none, boost::none) {
+    }
+    Transition(State next_state, State final_state)
+      : Transition(next_state, final_state, boost::none) {
+    }
+    Transition(State next_state, boost::optional<State> final_state,
+               boost::optional<State> error_state)
       : next_state(next_state),
-        retry_on_error(retry_on_error) {
+        final_state(final_state),
+        error_state(error_state) {
     }
   };
 


### PR DESCRIPTION
Introduce cleanup (rollback) path for failed state transitions.
Rollback transitions should strictly be onn-disk map updates
(and in-memory if required).

Signed-off-by: Venky Shankar <vshankar@redhat.com>