### PR TITLE
mgr/balancer: fix KeyError in balancer rm

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -303,7 +303,7 @@ class Module(MgrModule):
             self.optimize(plan)
             return (0, '', '')
         elif command['prefix'] == 'balancer rm':
-            self.plan_rm(command['name'])
+            self.plan_rm(command['plan'])
             return (0, '', '')
         elif command['prefix'] == 'balancer reset':
             self.plans = {}


### PR DESCRIPTION
Fix the typo in the plan name which leads to a KeyError in balancer
rm.

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>
Fixes: http://tracker.ceph.com/issues/22470