### PR TITLE
Revert "msg/async/AsyncConnection: unregister connection when racing happened"

### DIFF
--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -355,6 +355,9 @@ public:
       Mutex::Locker l(deleted_lock);
       if (deleted_conns.erase(existing)) {
         existing->get_perf_counter()->dec(l_msgr_active_connections);
+        conns.erase(it);
+      } else if (conn != existing) {
+        return -1;
       }
     }
     conns[conn->peer_addr] = conn;


### PR DESCRIPTION
This reverts commit 5216309c25522e9e4a3c3a03ceb927079de91e9b.  Seeing many
many instances of

     0> 2017-12-19 00:04:34.146 7fed2ebc1700 -1 /build/ceph-13.0.0-4128-gc27b472/src/msg/async/AsyncConnection.cc: In function 'void AsyncConnection::process()' thread 7fed2ebc1700 time 2017-12-19 00:04:34.147015
/build/ceph-13.0.0-4128-gc27b472/src/msg/async/AsyncConnection.cc: 726: FAILED assert(0 == "old msgs despite reconnect_seq feature")

 ceph version 13.0.0-4128-gc27b472 (c27b4726c18322825fbc2a58de2759766e332fa6) mimic (dev)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x102) [0x55ce15c5bab2]
 2: (AsyncConnection::process()+0x25f6) [0x55ce15f347e6]
 3: (EventCenter::process_events(int, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >*)+0x6e8) [0x55ce15cf5988]
 4: (()+0xb7b965) [0x55ce15cf8965]
 5: (()+0xb8c80) [0x7fed30e02c80]
 6: (()+0x76ba) [0x7fed314f16ba]
 7: (clone()+0x6d) [0x7fed305683dd]

See http://tracker.ceph.com/issues/22231
Signed-off-by: Sage Weil <sage@redhat.com>

For example, /a/sage-2017-12-18_22:56:18-rados-wip-sage-testing-2017-12-18-1406-distro-basic-smithi/1976806