### PR TITLE
ceph-dencoder: add support for RGWObjTags

### DIFF
--- a/src/rgw/rgw_tag.cc
+++ b/src/rgw/rgw_tag.cc
@@ -54,3 +54,8 @@ int RGWObjTags::set_from_string(const string& input){
   }
   return ret;
 }
+
+void RGWObjTags::generate_test_instances(list<RGWObjTags*>& o)
+{
+  o.push_back(new RGWObjTags);
+}

--- a/src/rgw/rgw_tag.h
+++ b/src/rgw/rgw_tag.h
@@ -37,6 +37,7 @@ class RGWObjTags
   void clear() { tag_map.clear(); }
   bool empty() const noexcept { return tag_map.empty(); }
   const tag_map_t& get_tags() const {return tag_map;}
+  static void generate_test_instances(list<RGWObjTags*>& o);
 };
 WRITE_CLASS_ENCODER(RGWObjTags)
 

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -312,6 +312,9 @@ TYPE(RGWCacheNotifyInfo)
 #include "rgw/rgw_lc.h"
 TYPE(RGWLifecycleConfiguration)
 
+#include "rgw/rgw_gc.h"
+TYPE(RGWObjTags)
+
 #include "cls/rgw/cls_rgw_types.h"
 TYPE(rgw_bucket_pending_info)
 TYPE(rgw_bucket_dir_entry_meta)


### PR DESCRIPTION
Signed-off-by: Songbo Wang wangsongbo@cloudin.cn