### PR TITLE
os: data race condition for aio_stop

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -632,7 +632,11 @@ int FileJournal::_fdump(Formatter &f, bool simple)
 void FileJournal::start_writer()
 {
   write_stop = false;
+  aio_lock.Lock();
   aio_stop = false;
+  aio_cond.Signal();
+  write_finish_cond.Signal();
+  aio_lock.Unlock();
   write_thread.create("journal_write");
 #ifdef HAVE_LIBAIO
   if (aio)


### PR DESCRIPTION
Fixes the coverity issue:

** 1251447 Data race condition
>CID 1251447 (#1 of 1): Data race condition (MISSING_LOCK)
>1. missing_lock: Accessing this->aio_stop without holding lock Mutex._m.
>Elsewhere, "FileJournal.aio_stop" is accessed with Mutex._m held 1 out
>of 2 times (1 of these accesses strongly imply that it is necessary).

Signed-off-by: Amit Kumar <amitkuma@redhat.com>