### PR TITLE
rgw: optimize next start time for lifecycle

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -783,8 +783,10 @@ bool RGWLC::LCWorker::should_work(utime_t& now)
 
 int RGWLC::LCWorker::schedule_next_start_time(utime_t &start, utime_t& now)
 {
+  int secs;
+
   if (cct->_conf->rgw_lc_debug_interval > 0) {
-	int secs = start + cct->_conf->rgw_lc_debug_interval - now;
+	secs = start + cct->_conf->rgw_lc_debug_interval - now;
 	if (secs < 0)
 	  secs = 0;
 	return (secs);
@@ -804,8 +806,9 @@ int RGWLC::LCWorker::schedule_next_start_time(utime_t &start, utime_t& now)
   bdt.tm_min = start_minute;
   bdt.tm_sec = 0;
   nt = mktime(&bdt);
+  secs = nt - tt;
 
-  return (nt+24*60*60 - tt);
+  return secs>0 ? secs : secs+24*60*60;
 }
 
 void RGWLifecycleConfiguration::generate_test_instances(list<RGWLifecycleConfiguration*>& o)


### PR DESCRIPTION
If the scheduling time of lifecycle is after the current time, the processing of lifecycle should not be postponed for a day.