### PR TITLE
mon: align lspools output

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4040,7 +4040,10 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  f->dump_string("poolname", osdmap.pool_name[p->first]);
 	  f->close_section();
 	} else {
-	  ds << p->first << ' ' << osdmap.pool_name[p->first] << ',';
+	  ds << p->first << ' ' << osdmap.pool_name[p->first];
+	  if (next(p) != osdmap.pools.end()) {
+	    ds << '\n';
+	  }
 	}
       }
     }


### PR DESCRIPTION
Aligned 'osd lspools' output

Signed-off-by: Jos Collin <jcollin@redhat.com>