### PR TITLE
mds: check metadata pool not cluster is full

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -55,7 +55,7 @@ MDSRank::MDSRank(
     Context *suicide_hook_)
   :
     whoami(whoami_), incarnation(0),
-    mds_lock(mds_lock_), clog(clog_), timer(timer_),
+    mds_lock(mds_lock_), cct(msgr->cct), clog(clog_), timer(timer_),
     mdsmap(mdsmap_),
     objecter(new Objecter(g_ceph_context, msgr, monc_, nullptr, 0, 0)),
     server(NULL), mdcache(NULL), locker(NULL), mdlog(NULL),
@@ -97,7 +97,7 @@ MDSRank::MDSRank(
 
   objecter->unset_honor_osdmap_full();
 
-  finisher = new Finisher(msgr->cct);
+  finisher = new Finisher(cct);
 
   mdcache = new MDCache(this, purge_queue);
   mdlog = new MDLog(this);
@@ -112,10 +112,10 @@ MDSRank::MDSRank(
   server = new Server(this);
   locker = new Locker(this, mdcache);
 
-  op_tracker.set_complaint_and_threshold(msgr->cct->_conf->mds_op_complaint_time,
-                                         msgr->cct->_conf->mds_op_log_threshold);
-  op_tracker.set_history_size_and_duration(msgr->cct->_conf->mds_op_history_size,
-                                           msgr->cct->_conf->mds_op_history_duration);
+  op_tracker.set_complaint_and_threshold(cct->_conf->mds_op_complaint_time,
+                                         cct->_conf->mds_op_log_threshold);
+  op_tracker.set_history_size_and_duration(cct->_conf->mds_op_history_size,
+                                           cct->_conf->mds_op_history_duration);
 }
 
 MDSRank::~MDSRank()

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -136,6 +136,8 @@ class MDSRank {
     // a separate lock here in future potentially.
     Mutex &mds_lock;
 
+    class CephContext *cct;
+
     bool is_daemon_stopping() const;
 
     // Reference to global cluster log client, just to avoid initialising

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1720,7 +1720,8 @@ void Server::handle_osd_map()
    * using osdmap_full_flag(), because we want to know "is the flag set"
    * rather than "does the flag apply to us?" */
   mds->objecter->with_osdmap([this](const OSDMap& o) {
-      is_full = o.test_flag(CEPH_OSDMAP_FULL);
+      auto pi = o.get_pg_pool(mds->mdsmap->get_metadata_pool());
+      is_full = pi && pi->has_flag(pg_pool_t::FLAG_FULL);
       dout(7) << __func__ << ": full = " << is_full << " epoch = "
 	      << o.get_epoch() << dendl;
     });


### PR DESCRIPTION
CEPH_OSDMAP_FULL flag was obsoleted by
b4ca5ae462c6f12ca48b787529938862646282cd. So, check if the metadata pool is
full instead which is a decent proxy (as metadata operations can still
proceed). However, the data pool may still be full which would result in some
operations still not completing (like inode backtrace updates).

Fixes: http://tracker.ceph.com/issues/22483

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>