### PR TITLE
qa/tests: use 'stable-2.1' branch for jewel testing

### DIFF
--- a/qa/suites/ceph-ansible/smoke/basic/2-config/ceph_ansible.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/2-config/ceph_ansible.yaml
@@ -1,20 +1,21 @@
 meta:
 - desc: "Build the ceph cluster using ceph-ansible"
 
-overrides:                                                                                                                                                                                                  
-   ceph_ansible:                                                                                                                                                                                            
-     vars:                                                                                                                                                                                                  
-        ceph_conf_overrides:                                                                                                                                                                                
-          global:                                                                                                                                                                                           
-            osd default pool size: 2                                                                                                                                                                        
-            mon pg warn min per osd: 2                                                                                                                                                                      
-        ceph_dev: true                                                                                                                                                                                      
-        ceph_dev_key: https://download.ceph.com/keys/autobuild.asc                                                                                                                                          
-        ceph_origin: upstream                                                                                                                                                                               
-        ceph_test: true                                                                                                                                                                                     
-        journal_collocation: true                                                                                                                                                                           
-        journal_size: 1024                                                                                                                                                                                  
-        osd_auto_discovery: false 
+overrides:
+   ceph_ansible:
+     branch: 'stable-2.1'                                                                                                                                                                                           
+     vars:
+        ceph_conf_overrides:
+          global:
+            osd default pool size: 2
+            mon pg warn min per osd: 2
+        ceph_dev: true
+        ceph_dev_key: https://download.ceph.com/keys/autobuild.asc
+        ceph_origin: upstream
+        ceph_test: true
+        journal_collocation: true
+        journal_size: 1024
+        osd_auto_discovery: false
 
 tasks:
 - ssh-keys:


### PR DESCRIPTION
use stable-2.1 branch to test ceph-ansible for jewel branch

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>