### PR TITLE
mds: respect mds_client_writeable_range_max_inc_objs config

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2298,7 +2298,7 @@ uint64_t Locker::calc_new_max_size(inode_t *pi, uint64_t size)
   uint64_t new_max = (size + 1) << 1;
   uint64_t max_inc = g_conf->mds_client_writeable_range_max_inc_objs;
   if (max_inc > 0) {
-    max_inc *= pi->get_layout_size_increment();
+    max_inc *= pi->layout.object_size;
     new_max = std::min(new_max, size + max_inc);
   }
   return ROUND_UP_TO(new_max, pi->get_layout_size_increment());


### PR DESCRIPTION
get_layout_size_increment() return layout.get_period(). A period
contain layout.stripe_count objects.

The config is for limiting number of objects need to probe when
recovering a file.

Fixes: http://tracker.ceph.com/issues/22492
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>