### PR TITLE
install-deps: do not download unmirrored arch

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -40,8 +40,8 @@ function ensure_decent_gcc_on_deb {
     if [ ! -f /usr/bin/g++-${new} ]; then
 	$SUDO tee /etc/apt/sources.list.d/ubuntu-toolchain-r.list <<EOF
 deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu $dist main
-deb http://mirror.cs.uchicago.edu/ubuntu-toolchain-r $dist main
-deb http://mirror.yandex.ru/mirrors/launchpad/ubuntu-toolchain-r $dist main
+deb [arch=amd64] http://mirror.cs.uchicago.edu/ubuntu-toolchain-r $dist main
+deb [arch=amd64,i386] http://mirror.yandex.ru/mirrors/launchpad/ubuntu-toolchain-r $dist main
 EOF
 	# import PPA's signing key into APT's keyring
 	$SUDO apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E9377A2BA9EF27F


### PR DESCRIPTION
On Ubuntu amd64 installations, i386 is enabled as an additional
architecture by default. apt & co. expect repositories to provide all
configured architectures, which causes the error above. And also there
is no i386 release in this repository.

Signed-off-by: Songbo Wang wangsongbo@cloudin.cn