### PR TITLE
os/bluestore: using macro OBJECT_MAX_SIZE to check osd_max_object_size.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4114,9 +4114,9 @@ int BlueStore::_open_path()
   // sanity check(s)
   auto osd_max_object_size =
     cct->_conf->get_val<uint64_t>("osd_max_object_size");
-  if (osd_max_object_size >= 4*1024*1024*1024ull) {
-    derr << __func__ << " osd_max_object_size: " << osd_max_object_size
-      << "; BlueStore has hard limit of 4GB." << dendl;
+  if (osd_max_object_size >= (uint64_t)OBJECT_MAX_SIZE) {
+    derr << __func__ << " osd_max_object_size >= 0x" << std::hex << OBJECT_MAX_SIZE
+      << "; BlueStore has hard limit of 0x" << OBJECT_MAX_SIZE << "." <<  std::dec << dendl;
     return -EINVAL;
   }
   assert(path_fd < 0);


### PR DESCRIPTION
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>