### PR TITLE
 luminous: Pool Compression type option doesn't apply to new OSD's

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5999,6 +5999,13 @@ PG::RecoveryState::Initial::Initial(my_context ctx)
   context< RecoveryMachine >().log_enter(state_name);
 }
 
+boost::statechart::result PG::RecoveryState::Initial::react(const Initialize& l)
+{
+  PG *pg = context< RecoveryMachine >().pg;
+  pg->update_store_with_options();
+  return transit< Reset >();
+}
+
 boost::statechart::result PG::RecoveryState::Initial::react(const Load& l)
 {
   PG *pg = context< RecoveryMachine >().pg;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1706,13 +1706,14 @@ public:
       void exit();
 
       typedef boost::mpl::list <
-	boost::statechart::transition< Initialize, Reset >,
+	boost::statechart::custom_reaction< Initialize >,
 	boost::statechart::custom_reaction< Load >,
 	boost::statechart::custom_reaction< NullEvt >,
 	boost::statechart::transition< boost::statechart::event_base, Crashed >
 	> reactions;
 
       boost::statechart::result react(const Load&);
+      boost::statechart::result react(const Initialize&);
       boost::statechart::result react(const MNotifyRec&);
       boost::statechart::result react(const MInfoRec&);
       boost::statechart::result react(const MLogRec&);


### PR DESCRIPTION
http://tracker.ceph.com/issues/22502