### PR TITLE
ceph_volume_client: fix usage of get_mds_map()

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -391,7 +391,7 @@ class CephFSVolumeClient(object):
 
         log.info("evict clients with {0}".format(', '.join(client_spec)))
 
-        mds_map = get_mds_map()
+        mds_map = self.get_mds_map()
         up = {}
         for name, gid in mds_map['up'].items():
             # Quirk of the MDSMap JSON dump: keys in the up dict are like "mds_0"


### PR DESCRIPTION
get_mds_map() is an instance method, and not a global
function. Use it as such.

Fixes: http://tracker.ceph.com/issues/22524
Signed-off-by: Ramana Raja <rraja@redhat.com>