### PR TITLE
qa: configure zabbix properly before selftest

### DIFF
--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -47,6 +47,12 @@ class MgrCluster(CephCluster):
     def get_standby_ids(self):
         return [s['name'] for s in self.get_mgr_map()["standbys"]]
 
+    def set_module_conf(self, module, key, val):
+        self.mon_manager.raw_cluster_cmd("config-key", "set",
+                                         "mgr/{0}/{1}".format(
+                                             module, key
+                                         ), val)
+
     def set_module_localized_conf(self, module, mgr_id, key, val):
         self.mon_manager.raw_cluster_cmd("config-key", "set",
                                          "mgr/{0}/{1}/{2}".format(

--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -24,6 +24,10 @@ class TestModuleSelftest(MgrTestCase):
         self.mgr_cluster.mon_manager.raw_cluster_cmd(module_name, "self-test")
 
     def test_zabbix(self):
+        # Set these mandatory config fields so that the zabbix module
+        # won't trigger health/log errors on load/serve.
+        self.mgr_cluster.set_module_conf("zabbix", "zabbix_host", "localhost")
+        self.mgr_cluster.set_module_conf("zabbix", "identifier", "foo")
         self._selftest_plugin("zabbix")
 
     def test_prometheus(self):


### PR DESCRIPTION
Even though the selftest routine doesn't care about
the settings, we should set them to avoid emitting
nasty log/health messages when enabling the module.

Fixes: http://tracker.ceph.com/issues/22514
Signed-off-by: John Spray <john.spray@redhat.com>