### PR TITLE
mon/OSDMonitor: fix forgetting clear pending_inc.new_state

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2131,6 +2131,10 @@ bool OSDMonitor::prepare_failure(MonOpRequestRef op)
 	dout(10) << " removing last failure_info for osd." << target_osd
 		 << dendl;
 	failure_info.erase(target_osd);
+	if (pending_inc.pending_osd_state_clear(target_osd, CEPH_OSD_UP)) {
+	  dout(10) << " cancel pending osd." << target_osd << " failure"
+		   << dendl;
+        }
       } else {
 	dout(10) << " failure_info for osd." << target_osd << " now "
 		 << fi.reporters.size() << " reporters" << dendl;


### PR DESCRIPTION

  fix forgetting clear pending_inc.new_state when cancel failure_info

Signed-off-by: shun-s <song.shun3@zte.com.cn>