### PR TITLE
osd/OSDMap.h: toss osd out if it has no more pending states

### DIFF
--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -480,6 +480,10 @@ public:
       }
 
       new_state[osd] &= ~state;
+      if (!new_state[osd]) {
+        // all flags cleared
+        new_state.erase(osd);
+      }
       return true;
     }
 


### PR DESCRIPTION
So we don't push an empty entry into new_state map,
which is inefficient.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>