### PR TITLE
include/encoding: fix compat version error message

### DIFF
--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -1040,7 +1040,7 @@ decode(std::array<T, N>& v, bufferlist::iterator& p)
 #define ENCODE_FINISH(bl) ENCODE_FINISH_NEW_COMPAT(bl, 0)
 
 #define DECODE_ERR_OLDVERSION(func, v, compatv)					\
-  (std::string(func) + " no longer understand old encoding version " #v " < " #compatv)
+  (std::string(func) + " no longer understand old encoding version " #v " < " + std::to_string(compatv))
 
 #define DECODE_ERR_PAST(func) \
   (std::string(func) + " decode past end of struct encoding")


### PR DESCRIPTION
The compatv parameter can not behave as expected.
Using std::to_string instead of a macro pound sign.
Signed-off-by: Xinying Song <songxinying@cloudin.cn>