### PR TITLE
mailmap: update affiliation for Mykola Golub

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -38,7 +38,7 @@ renhwztetecs huanwen ren <ren.huanwen@zte.com.cn>
 smithfarm Nathan Cutler <ncutler@suse.com>
 tchaikov Kefu Chai <kchai@redhat.com>
 theanalyst Abhishek Lekshmanan <abhishek.lekshmanan@gmail.com>
-trociny Mykola Golub <to.my.trociny@gmail.com>
+trociny Mykola Golub <mgolub@suse.com>
 ukernel Zheng Yan <zyan@redhat.com>
 vasukulkarni Vasu Kulkarni <vasu@redhat.com>
 vuhuong Vu Pham <vuhuong@mellanox.com>

--- a/.mailmap
+++ b/.mailmap
@@ -278,6 +278,7 @@ Mingqiao Wu <wumingqiao@inspur.com>
 Mingyue Zhao <zhao.mingyue@h3c.com>
 Mykola Golub <mgolub@mirantis.com> <mgolub@zhuzha.mirantis.lviv.net>
 Mykola Golub <to.my.trociny@gmail.com>
+Mykola Golub <mgolub@suse.com>
 Myoungwon Oh <omwmw@sk.com>
 Nathan Cutler <ncutler@suse.com>
 Nathan Cutler <ncutler@suse.com> <nculter@suse.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -506,6 +506,7 @@ SUSE <contact@suse.com> Karol Mroz <kmroz@suse.com>
 SUSE <contact@suse.com> Kapil Sharma <ksharma@suse.com>
 SUSE <contact@suse.com> Mohamad Gebai <mgebai@suse.com>
 SUSE <contact@suse.com> Michal Koutný <mkoutny@suse.com>
+SUSE <contact@suse.com> Mykola Golub <mgolub@suse.com>
 SUSE <contact@suse.com> Nathan Cutler <ncutler@suse.com>
 SUSE <contact@suse.com> Owen Synge <osynge@suse.com>
 SUSE <contact@suse.com> Ricardo Dias <rdias@suse.com>

--- a/.peoplemap
+++ b/.peoplemap
@@ -36,7 +36,8 @@ Loic Dachary <ldachary@redhat.com> Loic Dachary <loic-201408@dachary.org>
 Loic Dachary <ldachary@redhat.com> Loic Dachary <loic@dachary.org>
 Mark Nelson <mnelson@redhat.com> Mark Nelson <mark.nelson@inktank.com>
 Mark Nelson <mnelson@redhat.com> Mark Nelson <mark.nelson@dreamhost.com>
-Mykola Golub <to.my.trociny@gmail.com> Mykola Golub <mgolub@mirantis.com>
+Mykola Golub <mgolub@suse.com> Mykola Golub <mgolub@mirantis.com>
+Mykola Golub <mgolub@suse.com> Mykola Golub <to.my.trociny@gmail.com>
 Neil Levine <nlevine@redhat.com> Neil Levine <neil.levine@inktank.com>
 Noah Watkins <nwatkins@redhat.com> Noah Watkins <noah.watkins@inktank.com>
 Patrick McGarry <pmcgarry@redhat.com> Patrick McGarry <patrick@inktank.com>


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@suse.com>