### PR TITLE
mds: add dump_inode command

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11952,6 +11952,7 @@ void MDCache::dump_inode(std::string const &path, Formatter *f, std::ostream &ss
   CInode *in = cache_traverse(fp);
   if (NULL == in) {
     ss << "inode not in mds cache";
+    return;
   }
   f->open_object_section("inode");
   in->dump(f); 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11942,6 +11942,22 @@ int MDCache::cache_status(Formatter *f)
   return 0;
 }
 
+/**
+* use this function to dump a specific inode 
+*/
+void MDCache::dump_inode(std::string const &path, Formatter *f, std::ostream &ss)
+{
+  dout(1) << __func__ << path << dendl;
+  filepath fp(path.c_str());
+  CInode *in = cache_traverse(fp);
+  if (NULL == in) {
+    ss << "inode not in mds cache";
+  }
+  f->open_object_section("inode");
+  in->dump(f); 
+  f->close_section();
+}
+
 int MDCache::dump_cache(std::string const &file_name)
 {
   return dump_cache(file_name.c_str(), NULL);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1174,6 +1174,8 @@ protected:
 		  const std::string& dump_root = "",
 		  int depth = -1);
 public:
+  int dump_inode(const std::string &path, Formatter *f, std::ostream &ss);
+ 
   int dump_cache() { return dump_cache(NULL, NULL); }
   int dump_cache(const std::string &filename);
   int dump_cache(Formatter *f);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1174,7 +1174,7 @@ protected:
 		  const std::string& dump_root = "",
 		  int depth = -1);
 public:
-  int dump_inode(const std::string &path, Formatter *f, std::ostream &ss);
+  void dump_inode(const std::string &path, Formatter *f, std::ostream &ss);
  
   int dump_cache() { return dump_cache(NULL, NULL); }
   int dump_cache(const std::string &filename);

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -236,6 +236,11 @@ void MDSDaemon::set_up_admin_socket()
                                      "name=rank,type=CephInt",
                                      asok_hook,
                                      "migrate a subtree to named MDS");
+  r = admin_socket->register_command("dump inode",
+                                     "dump inode name=path,type=CephString,req=false",
+                                     asok_hook,
+                                     "dump a specific inode");
+                                     
   assert(r == 0);
   r = admin_socket->register_command("dump cache",
                                      "dump cache name=path,type=CephString,req=false",
@@ -325,6 +330,7 @@ void MDSDaemon::clean_up_admin_socket()
   admin_socket->unregister_command("tag path");
   admin_socket->unregister_command("flush_path");
   admin_socket->unregister_command("export dir");
+  admin_socket->unregister_command("dump inode");
   admin_socket->unregister_command("dump cache");
   admin_socket->unregister_command("cache status");
   admin_socket->unregister_command("dump tree");

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1936,6 +1936,14 @@ bool MDSRankDispatcher::handle_asok_command(
       return true;
     }
     command_export_dir(f, path, (mds_rank_t)rank);
+  } else if (command == "dump inode") {
+    Mutex::Locker l(mds_lock);
+    string path;
+    if (!cmd_getval(g_ceph_context, cmdmap, "path", path)) {
+      ss << "malformed path";
+      return true;
+    }
+    mdcache->dump_inode(path, f, ss); 
   } else if (command == "dump cache") {
     Mutex::Locker l(mds_lock);
     string path;


### PR DESCRIPTION
1 when the mds cache is really big. it's hard to dump all the cache
2 most of time, we only want to know a specific inode info.