### PR TITLE
rgw: the metavariables in frontends-related config won't be expanded

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -197,6 +197,7 @@ int main(int argc, const char **argv)
           flags);
 
   list<string> frontends;
+  g_conf->early_expand_meta(g_conf->rgw_frontends, &cerr);
   get_str_list(g_conf->rgw_frontends, ",", frontends);
   multimap<string, RGWFrontendConfig *> fe_map;
   list<RGWFrontendConfig *> configs;


### PR DESCRIPTION
When using metavariables in frontends-related config, I found that metavariables won't be expanded. Such as:
The `name` variable won't be expanded.
```
[client.rgw]
rgw frontends = civetweb port=8000 access_log_file=/path/$name.access.log
```

The reason is as follows:

In `rgw_main.cc/main` function, program uses frontends-related config before the `expand_all_meta` function call that is called in the `global_init` function.

Signed-off-by: chnmagnus chnmagnus@qq.com