### PR TITLE
doc/rbd: correct the path of librbd python APIs

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -24,7 +24,7 @@ Ceph Block Device APIs
 
 See `librbdpy`_.
 
-.. _librbdpy: ../rbd/librbdpy
+.. _librbdpy: ../rbd/api/librbdpy
 
 Ceph RADOS Gateway APIs
 =======================

--- a/doc/rbd/api/index.rst
+++ b/doc/rbd/api/index.rst
@@ -5,4 +5,4 @@
 .. toctree::
    :maxdepth: 2
 
-   librados (Python) <librbdpy>
+   librbd (Python) <librbdpy>


### PR DESCRIPTION
In this page - [API DOCUMENTATION](http://docs.ceph.com/docs/master/api/), the link of ['librbdpy'](http://docs.ceph.com/docs/master/rbd/librbdpy) returns '404 Not Found' error.

Signed-off-by: songweibin <song.weibin@zte.com.cn>