### PR TITLE
doc: Add introduction about different way to run rbd-mirror

### DIFF
--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -314,6 +314,10 @@ ID as the daemon instance::
 
   systemctl enable ceph-rbd-mirror@rbd-mirror.{unique id}
 
+The ``rbd-morror`` can also be run in foreground by ``rbd-mirror`` command::
+
+  rbd-mirror -f --log-file={log_path}
+
 .. _rbd: ../../man/8/rbd
 .. _ceph-conf: ../../rados/configuration/ceph-conf/#running-multiple-clusters
 .. _explicitly enabled: #enable-image-mirroring


### PR DESCRIPTION
Add a way to run rbd-mirror process in foregroup.
This way is useful to run rbd-mirror in a container when you don't
want to build a specified rbd-mirror image

Signed-off-by: Yu Shengzuo <yu.shengzuo@99cloud.net>