### PR TITLE
rgw: cancel event if not wakenup by timer in RGWCompletionManager

### DIFF
--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -44,6 +44,7 @@ class RGWCompletionManager : public RefCountedObject {
   std::atomic<bool> going_down = { false };
 
   map<void *, void *> waiters;
+  map<void *, Context *> timer_callbacks;
 
   class WaitContext;
 


### PR DESCRIPTION
the timer and notify will both wakenup the stack, so the actual run
interval maybe less than 20s

Signed-off-by: Tianshan Qu <tianshan@xsky.com>