### PR TITLE
os/bluestore: type of min_alloc_size should be uint64_t

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1829,7 +1829,7 @@ bool BlueStore::Blob::put_ref(
   return b.release_extents(empty, logical, r);
 }
 
-bool BlueStore::Blob::can_reuse_blob(uint32_t min_alloc_size,
+bool BlueStore::Blob::can_reuse_blob(uint64_t min_alloc_size,
                 		     uint32_t target_blob_size,
 		                     uint32_t b_offset,
 		                     uint32_t *length0) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -520,7 +520,7 @@ public:
              get_blob().can_split_at(blob_offset);
     }
 
-    bool can_reuse_blob(uint32_t min_alloc_size,
+    bool can_reuse_blob(uint64_t min_alloc_size,
 			uint32_t target_blob_size,
 			uint32_t b_offset,
 			uint32_t *length0);


### PR DESCRIPTION
Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>