### PR TITLE
rgw: release completion in RGWCompletionManager going down

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -94,6 +94,7 @@ void RGWCompletionManager::go_down()
   Mutex::Locker l(lock);
   for (auto cn : cns) {
     cn->unregister();
+    cn->put();
   }
   going_down = true;
   cond.Signal();


### PR DESCRIPTION
if RGWRadosGetOmapKeysCR in data sync error retry happened before reload
which triggered RGWCompletionManager going down, the get-omap's
reply will crash in complete callback

Signed-off-by: Tianshan Qu <tianshan@xsky.com>