### PR TITLE
common: Struct ceph_clock, successor of ceph_clock_now

### DIFF
--- a/src/common/Clock.h
+++ b/src/common/Clock.h
@@ -12,8 +12,8 @@
  *
  */
 
-#ifndef CEPH_CLOCK_H
-#define CEPH_CLOCK_H
+#ifndef CLOCK_H
+#define CLOCK_H
 
 #include "include/utime.h"
 

--- a/src/common/ceph_clock.h
+++ b/src/common/ceph_clock.h
@@ -1,0 +1,116 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * Author: Shinobu Kinjo <shinobu@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#ifndef CEPH_CLOCK_H
+#define CEPH_CLOCK_H
+
+#include "common/ceph_time.h"
+#include "include/utime.h"
+#include <type_traits>
+#include <time.h>
+
+struct ceph_clock {
+  ceph_clock() :
+    mc_start_(ceph::mono_clock::now()),
+    ut_start_(ceph_clock_now_()) {} 
+
+  /* mono_clock */
+  template <typename T,
+    typename std::enable_if_t<
+      std::is_same<T, ceph::mono_time>::value>* = nullptr>
+  T now() {
+    mc_now_ = get_time_point_();
+    return mc_now_;
+  }
+
+  template <typename T,
+    typename std::enable_if_t<
+      std::is_same<T, ceph::mono_time>::value>* = nullptr>
+  void reset() {
+    mc_now_ = get_time_point_();
+  }
+
+  template <typename T,
+    typename std::enable_if_t<
+      std::is_same<T, ceph::timespan>::value>* = nullptr>
+  T elapsed_from_start() {
+    mc_end_ = get_time_point_();
+    return mc_end_ - mc_start_;
+  }
+
+  template <typename T,
+    typename std::enable_if_t<
+      std::is_same<T, ceph::timespan>::value>* = nullptr>
+  T elapsed_from_now() {
+    mc_end_ = get_time_point_();
+    return mc_end_ - mc_now_;
+  }
+
+  template <typename T,
+    typename std::enable_if_t<
+      std::is_same<T, std::chrono::seconds>::value>* = nullptr>
+  void set_duration(ceph::mono_clock::duration& d, int64_t s) {
+    d = std::chrono::seconds(s);
+  }
+
+  /* Compatibility: utime_t */
+  template <typename T,
+    typename std::enable_if_t<
+      std::is_same<T, utime_t>::value>* = nullptr>
+  T now() {
+    ut_now_ = ceph_clock_now_();
+    return ut_now_;
+  }
+
+  template <typename T,
+    typename std::enable_if_t<
+      std::is_same<T, utime_t>::value>* = nullptr>
+  void reset() {
+    ut_now_ = ceph_clock_now_();
+  }
+
+  ostream& set_localtime(ostream& out, utime_t& ut) const {
+    return ut.localtime(out);
+  }
+
+private:
+  /** mono_clock **/
+  ceph::mono_time mc_start_;
+  ceph::mono_time mc_now_;
+  ceph::mono_time mc_end_;
+
+  /** Compatibility: utime_t **/
+  utime_t ut_start_;
+  utime_t ut_now_;
+  utime_t ut_end_;
+
+  ceph::mono_time get_time_point_() {
+    return ceph::mono_clock::now();
+  }
+
+  utime_t ceph_clock_now_() {
+#if defined(CLOCK_REALTIME)
+    struct timespec tp;
+    clock_gettime(CLOCK_REALTIME, &tp);
+    utime_t n(tp);
+#else
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+    utime_t n(&tv);
+#endif
+  return n;
+  }
+};
+#endif

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -17,6 +17,7 @@
  */
 #include "include/compat.h"
 #include <pthread.h>
+#include "common/ceph_clock.h"
 #include "common/Cond.h"
 #include "obj_bencher.h"
 
@@ -83,17 +84,19 @@ void *ObjBencher::status_printer(void *_bencher) {
   int cycleSinceChange = 0;
   double bandwidth;
   int iops = 0;
-  mono_clock::duration ONE_SECOND = std::chrono::seconds(1);
+  ceph_clock cc;
+  ceph::mono_clock::duration ONE_SECOND;
+  cc.set_duration<std::chrono::seconds>(ONE_SECOND, (int64_t)1);
   bencher->lock.Lock();
   if (formatter)
     formatter->open_array_section("datas");
   while(!data.done) {
-    mono_time cur_time = mono_clock::now();
-    utime_t t = ceph_clock_now();
+    cc.reset<ceph::mono_time>();
+    utime_t t = cc.now<utime_t>();
 
     if (i % 20 == 0 && !formatter) {
       if (i > 0)
-        t.localtime(cout)
+        cc.set_localtime(cout, t)
           << " min lat: " << data.min_latency
           << " max lat: " << data.max_latency
           << " avg lat: " << data.avg_latency << std::endl;
@@ -144,7 +147,7 @@ void *ObjBencher::status_printer(void *_bencher) {
       formatter->open_object_section("data");
 
     // elapsed will be in seconds, by default
-    std::chrono::duration<double> elapsed = cur_time - data.start_time;
+    auto elapsed = cc.elapsed_from_now<ceph::timespan>();
     double avg_bandwidth = (double) (data.op_size) * (data.finished)
       / elapsed.count() / (1024*1024);
     if (previous_writes != data.finished) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -25,6 +25,7 @@
 #include "include/intarith.h"
 #include "include/stringify.h"
 #include "include/str_map.h"
+#include "common/ceph_clock.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "Allocator.h"
@@ -6482,7 +6483,7 @@ int BlueStore::read(
   bufferlist& bl,
   uint32_t op_flags)
 {
-  utime_t start = ceph_clock_now();
+  ceph_clock cc1;
   Collection *c = static_cast<Collection *>(c_.get());
   const coll_t &cid = c->get_cid();
   dout(15) << __func__ << " " << cid << " " << oid
@@ -6495,9 +6496,9 @@ int BlueStore::read(
   int r;
   {
     RWLock::RLocker l(c->lock);
-    utime_t start1 = ceph_clock_now();
+    ceph_clock cc2;
     OnodeRef o = c->get_onode(oid, false);
-    logger->tinc(l_bluestore_read_onode_meta_lat, ceph_clock_now() - start1);
+    logger->tinc(l_bluestore_read_onode_meta_lat, cc2.elapsed_from_start<ceph::timespan>());
     if (!o || !o->exists) {
       r = -ENOENT;
       goto out;
@@ -6524,7 +6525,7 @@ int BlueStore::read(
   dout(10) << __func__ << " " << cid << " " << oid
 	   << " 0x" << std::hex << offset << "~" << length << std::dec
 	   << " = " << r << dendl;
-  logger->tinc(l_bluestore_read_lat, ceph_clock_now() - start);
+  logger->tinc(l_bluestore_read_lat, cc1.elapsed_from_start<ceph::timespan>());
   return r;
 }
 


### PR DESCRIPTION
This PR is not completed. This is for getting opinions for changes in this PR. Example use cases are in `ObjectCacher.cc`, `BlueStore.cc` and `obj_bencher.cc`.