### PR TITLE
rbd: replace positional_path parameter with arg_index in get_path()

### DIFF
--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -805,11 +805,14 @@ int get_image_size(const boost::program_options::variables_map &vm,
 }
 
 int get_path(const boost::program_options::variables_map &vm,
-             const std::string &positional_path, std::string *path) {
-  if (!positional_path.empty()) {
-    *path = positional_path;
-  } else if (vm.count(at::PATH)) {
+             size_t *arg_index, std::string *path) {
+  if (vm.count(at::PATH)) {
     *path = vm[at::PATH].as<std::string>();
+  } else {
+    *path = get_positional_argument(vm, *arg_index);
+    if (!path->empty()) {
+      ++(*arg_index);
+    }
   }
 
   if (path->empty()) {

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -161,7 +161,7 @@ int get_image_size(const boost::program_options::variables_map &vm,
                    uint64_t *size);
 
 int get_path(const boost::program_options::variables_map &vm,
-             const std::string &positional_path, std::string *path);
+             size_t *arg_index, std::string *path);
 
 int get_formatter(const boost::program_options::variables_map &vm,
                   argument_types::Format::Formatter *formatter);

--- a/src/tools/rbd/action/Export.cc
+++ b/src/tools/rbd/action/Export.cc
@@ -262,7 +262,7 @@ int execute_diff(const po::variables_map &vm) {
   }
 
   std::string path;
-  r = utils::get_path(vm, utils::get_positional_argument(vm, 1), &path);
+  r = utils::get_path(vm, &arg_index, &path);
   if (r < 0) {
     return r;
   }
@@ -601,7 +601,7 @@ int execute(const po::variables_map &vm) {
   }
 
   std::string path;
-  r = utils::get_path(vm, utils::get_positional_argument(vm, 1), &path);
+  r = utils::get_path(vm, &arg_index, &path);
   if (r < 0) {
     return r;
   }

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -443,12 +443,12 @@ void get_arguments_diff(po::options_description *positional,
 
 int execute_diff(const po::variables_map &vm) {
   std::string path;
-  int r = utils::get_path(vm, utils::get_positional_argument(vm, 0), &path);
+  size_t arg_index = 0;
+  int r = utils::get_path(vm, &arg_index, &path);
   if (r < 0) {
     return r;
   }
 
-  size_t arg_index = 1;
   std::string pool_name;
   std::string image_name;
   std::string snap_name;
@@ -906,7 +906,8 @@ void get_arguments(po::options_description *positional,
 
 int execute(const po::variables_map &vm) {
   std::string path;
-  int r = utils::get_path(vm, utils::get_positional_argument(vm, 0), &path);
+  size_t arg_index = 0;
+  int r = utils::get_path(vm, &arg_index, &path);
   if (r < 0) {
     return r;
   }
@@ -941,7 +942,6 @@ int execute(const po::variables_map &vm) {
     sparse_size = vm[at::IMAGE_SPARSE_SIZE].as<size_t>();
   }
 
-  size_t arg_index = 1;
   std::string pool_name = deprecated_pool_name;
   std::string image_name;
   std::string snap_name = deprecated_snap_name;

--- a/src/tools/rbd/action/Journal.cc
+++ b/src/tools/rbd/action/Journal.cc
@@ -1000,7 +1000,7 @@ int execute_export(const po::variables_map &vm) {
   }
 
   std::string path;
-  r = utils::get_path(vm, utils::get_positional_argument(vm, 1), &path);
+  r = utils::get_path(vm, &arg_index, &path);
   if (r < 0) {
     return r;
   }
@@ -1032,12 +1032,12 @@ void get_import_arguments(po::options_description *positional,
 
 int execute_import(const po::variables_map &vm) {
   std::string path;
-  int r = utils::get_path(vm, utils::get_positional_argument(vm, 0), &path);
+  size_t arg_index = 0;
+  int r = utils::get_path(vm, &arg_index, &path);
   if (r < 0) {
     return r;
   }
 
-  size_t arg_index = 1;
   std::string pool_name;
   std::string journal_name;
   r = utils::get_pool_journal_names(vm, at::ARGUMENT_MODIFIER_DEST,

--- a/src/tools/rbd/action/MergeDiff.cc
+++ b/src/tools/rbd/action/MergeDiff.cc
@@ -428,8 +428,8 @@ int execute(const po::variables_map &vm) {
   }
 
   std::string path;
-  int r = utils::get_path(vm, utils::get_positional_argument(vm, 2),
-                          &path);
+  size_t arg_index = 2;
+  int r = utils::get_path(vm, &arg_index, &path);
   if (r < 0) {
     return r;
   }


### PR DESCRIPTION
fix:
```
[root@ ~]# rbd import --path export_img1 pool1/img2
rbd: error opening pool1/img2
rbd: import failed: (2) No such file or directory
```
Signed-off-by: songweibin <song.weibin@zte.com.cn>