### PR TITLE
osd,os/bluestore: Display current size of osd_max_object_size

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4013,9 +4013,11 @@ int BlueStore::get_block_device_fsid(CephContext* cct, const string& path,
 int BlueStore::_open_path()
 {
   // sanity check(s)
-  if (cct->_conf->get_val<uint64_t>("osd_max_object_size") >=
-      4*1024*1024*1024ull) {
-    derr << __func__ << " osd_max_object_size >= 4GB; BlueStore has hard limit of 4GB." << dendl;
+  auto osd_max_object_size =
+    cct->_conf->get_val<uint64_t>("osd_max_object_size");
+  if (osd_max_object_size >= 4*1024*1024*1024ull) {
+    derr << __func__ << " osd_max_object_size: " << osd_max_object_size
+      << "; BlueStore has hard limit of 4GB." << dendl;
     return -EINVAL;
   }
   assert(path_fd < 0);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4580,8 +4580,8 @@ static int check_offset_and_length(uint64_t offset, uint64_t length,
       length > max ||
       offset + length > max) {
     ldpp_dout(dpp, 10) << __func__ << " "
-      << "osd_max_object_size >= 4GB; Hard limit of object size is 4GB.\n"
-      << dendl;
+      << "osd_max_object_size: " << max
+      << "; Hard limit of object size is 4GB." << dendl;
     return -EFBIG;
   }
 


### PR DESCRIPTION
It is better to show current value than showing same value twice.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>