### PR TITLE
osd: Sanity check, if too full or not

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3824,6 +3824,7 @@ void PrimaryLogPG::do_scan(
       } else {
 	// we canceled backfill for a while due to a too full, and this
 	// is an extra response from a non-too-full peer
+	dout(20) << __func__ << " canceled backfill (too full?)" << dendl;
       }
     }
     break;


### PR DESCRIPTION
`too full` status is not trivial for users.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>