### PR TITLE
luminous: common/dns, erasure-code: fix mem leaks

### DIFF
--- a/src/common/dns_resolve.cc
+++ b/src/common/dns_resolve.cc
@@ -197,6 +197,9 @@ int DNSResolver::resolve_ip_addr(CephContext *cct, const string& hostname,
   if (r < 0) {
     return r;
   }
+  auto put_state = make_scope_guard([res, this] {
+      this->put_state(res);
+    });
   return this->resolve_ip_addr(cct, &res, hostname, addr);
 #else
   return this->resolve_ip_addr(cct, NULL, hostname, addr);

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -302,6 +302,14 @@ void ErasureCodeJerasureCauchy::prepare_schedule(int *matrix)
   schedule = jerasure_smart_bitmatrix_to_schedule(k, m, w, bitmatrix);
 }
 
+ErasureCodeJerasureCauchy::~ErasureCodeJerasureCauchy() 
+{
+  if (bitmatrix)
+    free(bitmatrix);
+  if (schedule)
+    jerasure_free_schedule(schedule);
+}
+
 // 
 // ErasureCodeJerasureCauchyOrig
 //

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -156,12 +156,7 @@ public:
     DEFAULT_M = "3";
     DEFAULT_W = "8";
   }
-  ~ErasureCodeJerasureCauchy() override {
-    if (bitmatrix)
-      free(bitmatrix);
-    if (schedule)
-      free(schedule);
-  }
+  ~ErasureCodeJerasureCauchy() override;
 
   void jerasure_encode(char **data,
                                char **coding,


### PR DESCRIPTION
backport of #19649 and #19650