### PR TITLE
jewel: rgw: fix doubled underscore with s3/swift server-side copy

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7360,8 +7360,14 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
   string tag;
   append_rand_alpha(cct, tag, tag, 32);
 
+  string dest_obj_name = dest_obj.get_object();
+  if (dest_obj_name.size() > 2
+	&& dest_obj_name[0] == '_' && dest_obj_name[1] == '_') {
+    dest_obj_name.erase(0,1);
+  }
+
   RGWPutObjProcessor_Atomic processor(obj_ctx,
-                                      dest_bucket_info, dest_obj.bucket, dest_obj.get_object(),
+                                      dest_bucket_info, dest_obj.bucket, dest_obj_name,
                                       cct->_conf->rgw_obj_stripe_size, tag, dest_bucket_info.versioning_enabled());
   if (version_id) {
     processor.set_version_id(*version_id);


### PR DESCRIPTION
https://tracker.ceph.com/issues/22709

A name is almost an oid.  Except that if a name starts
with a _, the corresponding oid starts with a double _.
The copy logic passes the oid straight in as a name,
which results in a triple _ on the oid, resulting in
an object name with a double __.

Fix: remove one _ when converting an oid back into
a name, so that the final oid only has a double _.

Fixes: http://tracker.ceph.com/issues/22529

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>