### PR TITLE
pybind/mgr/dashboard: fix reverse proxy support

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -151,7 +151,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
     are not permitted to implement commands and they do not receive
     any notifications.
 
-    They only have access to the mgrmap (for acecssing service URI info
+    They only have access to the mgrmap (for accessing service URI info
     from their active peer), and to configuration settings (read only).
     """
 


### PR DESCRIPTION
Changes in 4f7007d break support for reverse http proxies by always redirecting to / on standby MGRs. This patch should fix it.

Fixes: http://tracker.ceph.com/issues/22557
Signed-off-by: Nick Erdmann <n@nirf.de>
  