### PR TITLE
common/throttle: start using 64-bit values

### DIFF
--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -76,7 +76,7 @@ Throttle::~Throttle()
 void Throttle::_reset_max(int64_t m)
 {
   // lock must be held.
-  if (static_cast<int64_t>(max) == m)
+  if (max == m)
     return;
   if (!conds.empty())
     conds.front().notify_one();
@@ -222,7 +222,7 @@ int64_t Throttle::put(int64_t c)
     if (!conds.empty())
       conds.front().notify_one();
     // if count goes negative, we failed somewhere!
-    assert(static_cast<int64_t>(count) >= c);
+    assert(count >= c);
     count -= c;
     if (logger) {
       logger->inc(l_throttle_put);

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -29,7 +29,7 @@ class Throttle {
   CephContext *cct;
   const std::string name;
   PerfCountersRef logger;
-  std::atomic<unsigned> count = { 0 }, max = { 0 };
+  std::atomic<int64_t> count = { 0 }, max = { 0 };
   std::mutex lock;
   std::list<std::condition_variable> conds;
   const bool use_perf;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22539
Signed-off-by: Igor Fedotov <ifedotov@suse.com>