### PR TITLE
rgw: change ObjectCache::lru from deque back to list

### DIFF
--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -209,7 +209,7 @@ void ObjectCache::remove(string& name)
 }
 
 void ObjectCache::touch_lru(string& name, ObjectCacheEntry& entry,
-			    std::deque<string>::iterator& lru_iter)
+			    std::list<string>::iterator& lru_iter)
 {
   while (lru_size > (size_t)cct->_conf->rgw_cache_lru_size) {
     auto iter = lru.begin();
@@ -249,7 +249,7 @@ void ObjectCache::touch_lru(string& name, ObjectCacheEntry& entry,
 }
 
 void ObjectCache::remove_lru(string& name,
-			     std::deque<string>::iterator& lru_iter)
+			     std::list<string>::iterator& lru_iter)
 {
   if (lru_iter == lru.end())
     return;

--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -134,6 +134,8 @@ void ObjectCache::put(string& name, ObjectCacheInfo& info, rgw_cache_entry_info 
   ObjectCacheEntry& entry = iter->second;
   ObjectCacheInfo& target = entry.info;
 
+  invalidate_lru(entry);
+
   entry.chained_entries.clear();
   entry.gen++;
 

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -128,7 +128,7 @@ WRITE_CLASS_ENCODER(RGWCacheNotifyInfo)
 
 struct ObjectCacheEntry {
   ObjectCacheInfo info;
-  std::deque<string>::iterator lru_iter;
+  std::list<string>::iterator lru_iter;
   uint64_t lru_promotion_ts;
   uint64_t gen;
   std::vector<pair<RGWChainedCache *, string> > chained_entries;
@@ -138,7 +138,7 @@ struct ObjectCacheEntry {
 
 class ObjectCache {
   std::unordered_map<string, ObjectCacheEntry> cache_map;
-  std::deque<string> lru;
+  std::list<string> lru;
   unsigned long lru_size;
   unsigned long lru_counter;
   unsigned long lru_window;
@@ -151,8 +151,8 @@ class ObjectCache {
   ceph::timespan expiry;
 
   void touch_lru(string& name, ObjectCacheEntry& entry,
-		 std::deque<string>::iterator& lru_iter);
-  void remove_lru(string& name, std::deque<string>::iterator& lru_iter);
+		 std::list<string>::iterator& lru_iter);
+  void remove_lru(string& name, std::list<string>::iterator& lru_iter);
   void invalidate_lru(ObjectCacheEntry& entry);
 
   void do_invalidate_all();


### PR DESCRIPTION
ObjectCacheEntry stores an lru_iter into this lru, and depends on that iterator remaining valid as other entries are inserted/erased

Fixes: http://tracker.ceph.com/issues/22560