### PR TITLE
common: Do not use unique_lock, if manual lock/unlock are not necessary

### DIFF
--- a/src/common/mempool.cc
+++ b/src/common/mempool.cc
@@ -100,7 +100,7 @@ void mempool::pool_t::get_stats(
     total->bytes += shard[i].bytes;
   }
   if (debug_mode) {
-    std::unique_lock<std::mutex> shard_lock(lock);
+    std::lock_guard<std::mutex> shard_lock(lock);
     for (auto &p : type_map) {
       std::string n = ceph_demangle(p.second.type_name);
       stats_t &s = (*by_type)[n];


### PR DESCRIPTION
Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>