### PR TITLE
rpm: adjust ceph-{osdomap,kvstore,monstore}-tool feature move

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -687,7 +687,7 @@ Summary:	Ceph benchmarks and test tools
 %if 0%{?suse_version}
 Group:		System/Benchmark
 %endif
-Requires:	ceph-common
+Requires:	ceph-common = %{_epoch_prefix}%{version}-%{release}
 Requires:	xmlstarlet
 Requires:	jq
 Requires:	socat


### PR DESCRIPTION
this is the rpm's counterpart of debian/control changes related to the
ceph-{osdomap,kvstore,monstore}-tool feature move. see #19328 and #19356.
the commit introducing this move is 6dba25e. and

$ git describe 6dba25e
v12.2.2-8-g6dba25e39d

so the first release that have this change is 12.2.2-8. in other words,
ceph-{base,osd,mon} >= 12.2.2.8 conflict with ceph-test < 12.2.2-8.

Fixes: http://tracker.ceph.com/issues/22558
Signed-off-by: Kefu Chai <kchai@redhat.com>