### PR TITLE
osd: make memory release rate gettable and settable from admin_socket

### DIFF
--- a/src/perfglue/disabled_heap_profiler.cc
+++ b/src/perfglue/disabled_heap_profiler.cc
@@ -39,5 +39,15 @@ bool ceph_heap_set_numeric_property(const char *property, size_t value)
   return false;
 }
 
+double ceph_heap_get_memory_release_rate()
+{
+  return 0.0;
+}
+
+void ceph_heap_set_memory_release_rate(double rate)
+{
+  return;
+}
+
 void ceph_heap_profiler_handle_command(const std::vector<std::string>& cmd,
                                        ostream& out) { return; }

--- a/src/perfglue/heap_profiler.cc
+++ b/src/perfglue/heap_profiler.cc
@@ -68,6 +68,16 @@ bool ceph_heap_set_numeric_property(
     value);
 }
 
+double ceph_heap_get_memory_release_rate()
+{
+  return MallocExtension::instance()->GetMemoryReleaseRate();
+}
+
+void ceph_heap_set_memory_release_rate(double rate)
+{
+  return MallocExtension::instance()->SetMemoryReleaseRate(rate);
+}
+
 bool ceph_heap_profiler_running()
 {
 #ifdef HAVE_LIBTCMALLOC

--- a/src/perfglue/heap_profiler.h
+++ b/src/perfglue/heap_profiler.h
@@ -47,6 +47,10 @@ bool ceph_heap_get_numeric_property(const char *property, size_t *value);
 
 bool ceph_heap_set_numeric_property(const char *property, size_t value);
 
+double ceph_heap_get_memory_release_rate();
+
+void ceph_heap_set_memory_release_rate(double rate);
+
 void ceph_heap_profiler_handle_command(const std::vector<std::string> &cmd,
                                        ostream& out);
 


### PR DESCRIPTION
Add get_memory_release_rate and set_memory_release_rate admin_socket
command for controlling memory release rate.  According to the tcmalloc
's doc https://gperftools.github.io/gperftools/tcmalloc.html, the
reasonable rates are in the range [0,10].

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>