### PR TITLE
tools/ceph_monstore_tool: include mgrmap in initial paxos epoch

### DIFF
--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -591,6 +591,9 @@ static int update_monitor(MonitorDBStore& st)
   return 0;
 }
 
+// rebuild
+//  - mgr
+//  - mgr_command_desc
 static int update_mgrmap(MonitorDBStore& st)
 {
   auto t = make_shared<MonitorDBStore::Transaction>();
@@ -731,6 +734,9 @@ int rebuild_monstore(const char* progname,
   if ((r = update_pgmap_meta(st))) {
     return r;
   }
+  if ((r = update_mgrmap(st))) {
+    return r;
+  }
   if ((r = update_paxos(st))) {
     return r;
   }
@@ -738,9 +744,6 @@ int rebuild_monstore(const char* progname,
     return r;
   }
   if ((r = update_monitor(st))) {
-    return r;
-  }
-  if ((r = update_mgrmap(st))) {
     return r;
   }
   return 0;


### PR DESCRIPTION
before this change, the "mgr" map is not included paxos, thus why the
peon mon fails to have the mgr map after it is sync'ed with its leader.
and hence there is chance that ceph-mgr is unable to get a mgr map from
the monitor it is connected to.

Fixes: http://tracker.ceph.com/issues/22266
Signed-off-by: Kefu Chai <kchai@redhat.com>