### PR TITLE
luminous: rgw: fix chained cache invalidation to prevent cache size growth

### DIFF
--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -136,11 +136,7 @@ void ObjectCache::put(string& name, ObjectCacheInfo& info, rgw_cache_entry_info 
   ObjectCacheEntry& entry = iter->second;
   ObjectCacheInfo& target = entry.info;
 
-  for (list<pair<RGWChainedCache *, string> >::iterator iiter = entry.chained_entries.begin();
-       iiter != entry.chained_entries.end(); ++iiter) {
-    RGWChainedCache *chained_cache = iiter->first;
-    chained_cache->invalidate(iiter->second);
-  }
+  invalidate_lru(entry);
 
   entry.chained_entries.clear();
   entry.gen++;
@@ -231,8 +227,11 @@ void ObjectCache::touch_lru(string& name, ObjectCacheEntry& entry, std::list<str
     }
     map<string, ObjectCacheEntry>::iterator map_iter = cache_map.find(*iter);
     ldout(cct, 10) << "removing entry: name=" << *iter << " from cache LRU" << dendl;
-    if (map_iter != cache_map.end())
+    if (map_iter != cache_map.end()) {
+      ObjectCacheEntry& entry = map_iter->second;
+      invalidate_lru(entry);
       cache_map.erase(map_iter);
+    }
     lru.pop_front();
     lru_size--;
   }
@@ -262,6 +261,15 @@ void ObjectCache::remove_lru(string& name, std::list<string>::iterator& lru_iter
   lru.erase(lru_iter);
   lru_size--;
   lru_iter = lru.end();
+}
+
+void ObjectCache::invalidate_lru(ObjectCacheEntry& entry)
+{
+  for (list<pair<RGWChainedCache *, string> >::iterator iter = entry.chained_entries.begin();
+       iter != entry.chained_entries.end(); ++iter) {
+    RGWChainedCache *chained_cache = iter->first;
+    chained_cache->invalidate(iter->second);
+  }
 }
 
 void ObjectCache::set_enabled(bool status)

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -149,6 +149,7 @@ class ObjectCache {
 
   void touch_lru(string& name, ObjectCacheEntry& entry, std::list<string>::iterator& lru_iter);
   void remove_lru(string& name, std::list<string>::iterator& lru_iter);
+  void invalidate_lru(ObjectCacheEntry& entry);
 
   void do_invalidate_all();
 public:


### PR DESCRIPTION
above the rgw_cache_lru_size limit

Fixes: http://tracker.ceph.com/issues/22410

Signed-off-by: Mark Kogan <mkogan@redhat.com>
(cherry picked from commit a6a1b664d313a54ad9d2f64b859296b1352b1ce4)