### PR TITLE
osd: support class method whitelisting within caps

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -21,7 +21,7 @@ if command -v dpkg >/dev/null; then
     fi
 elif command -v yum >/dev/null; then
     for package in python-devel python-pip python-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel Cython graphviz; do
-	if ! rpm -q $package >/dev/null ; then
+	if ! rpm -q --whatprovides $package >/dev/null ; then
 		missing="${missing:+$missing }$package"
 	fi
     done

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -99,20 +99,38 @@ a user.
 
 Capability syntax follows the form::
 
-	{daemon-type} '{capspec}[, {capspec} ...]'
+	{daemon-type} '{cap-spec}[, {cap-spec} ...]'
 
 - **Monitor Caps:** Monitor capabilities include ``r``, ``w``, ``x`` access
   settings or ``profile {name}``. For example::
 
-	mon 'allow rwx'
-	mon 'profile osd'
+	mon 'allow {access-spec}'
+
+	mon 'profile {name}'
+
+  The ``{access-spec}`` syntax is as follows: ::
+
+        * | all | [r][w][x]
 
 - **OSD Caps:** OSD capabilities include ``r``, ``w``, ``x``, ``class-read``,
   ``class-write`` access settings or ``profile {name}``. Additionally, OSD
   capabilities also allow for pool and namespace settings. ::
 
-	osd 'allow {access} [pool={pool-name} [namespace={namespace-name}]] [tag {application} {key}={value}]'
+	osd 'allow {access-spec} [{match-spec}]'
+
 	osd 'profile {name} [pool={pool-name} [namespace={namespace-name}]]'
+
+  The ``{access-spec}`` syntax is either of the following: ::
+
+        * | all | [r][w][x] [class-read] [class-write]
+
+        class {class name} [{method name}]
+
+  The optional ``{match-spec}`` syntax is either of the following: ::
+
+        pool={pool-name} [namespace={namespace-name}] [object_prefix {prefix}]
+
+        [namespace={namespace-name}] tag {application} {key}={value}
 
 - **Metadata Server Caps:** For administrators, use ``allow *``.  For all
   other users, such as CephFS clients, consult :doc:`/cephfs/client-auth`
@@ -122,7 +140,7 @@ Capability syntax follows the form::
           Ceph Storage Cluster, so it is not represented as a Ceph Storage
           Cluster daemon type.
 
-The following entries describe each capability.
+The following entries describe each access capability.
 
 ``allow``
 
@@ -160,12 +178,13 @@ The following entries describe each capability.
               Subset of ``x``.
 
 
-``*``
+``*``, ``all``
 
 :Description: Gives the user read, write and execute permissions for a
               particular daemon/pool, and the ability to execute
               admin commands.
 
+The following entries describe valid capability profiles:
 
 ``profile osd`` (Monitor only)
 
@@ -204,7 +223,7 @@ The following entries describe each capability.
 
 ``profile rbd-read-only`` (OSD only)
 
-:Description: Gives a user read-only permissions to an RBD image.
+:Description: Gives a user read-only permissions to RBD images.
 
 
 Pool

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9676,7 +9676,8 @@ int OSD::init_op_flags(OpRequestRef& op)
 	  op->set_class_write();
         if (is_promote)
           op->set_promote();
-        op->add_class(cname, is_read, is_write, cls->whitelisted);
+        op->add_class(std::move(cname), std::move(mname), is_read, is_write,
+                      cls->whitelisted);
 	break;
       }
 

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -49,8 +49,12 @@ ostream& operator<<(ostream& out, const OSDCapSpec& s)
 {
   if (s.allow)
     return out << s.allow;
-  if (s.class_name.length())
-    return out << "class '" << s.class_name << "' '" << s.class_allow << "'";
+  if (s.class_name.length()) {
+    out << "class '" << s.class_name << "'";
+    if (!s.method_name.empty()) {
+      out << " '" << s.method_name << "'";
+    }
+  }
   return out;
 }
 
@@ -271,9 +275,11 @@ bool OSDCapGrant::is_capable(const string& pool_name, const string& ns,
 
         // compare this grant to each class in the operation
         for (size_t i = 0; i < classes.size(); ++i) {
-          // check 'allow class foo'
+          // check 'allow class foo [method_name]'
           if (!spec.class_name.empty() &&
-              classes[i].class_name == spec.class_name) {
+              classes[i].class_name == spec.class_name &&
+              (spec.method_name.empty() ||
+               classes[i].method_name == spec.method_name)) {
             (*class_allowed)[i] = true;
             continue;
           }
@@ -434,12 +440,12 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
 	( (spaces >> lit("class-read")[_val |= OSD_CAP_CLS_R]) ||
 	  (spaces >> lit("class-write")[_val |= OSD_CAP_CLS_W]) ));
 
-    // capspec := * | rwx | class <name> [classcap]
+    // capspec := * | rwx | class <name> [<method name>]
     class_name %= (spaces >> lit("class") >> spaces >> str);
-    class_cap %= -(spaces >> str);
+    method_name %= -(spaces >> str);
     capspec = (
-      (rwxa)                    [_val = phoenix::construct<OSDCapSpec>(_1)] |
-      (class_name >> class_cap) [_val = phoenix::construct<OSDCapSpec>(_1, _2)]);
+      (rwxa)                      [_val = phoenix::construct<OSDCapSpec>(_1)] |
+      (class_name >> method_name) [_val = phoenix::construct<OSDCapSpec>(_1, _2)]);
 
     // profile := profile <name> [pool[=]<pool> [namespace[=]<namespace>]]
     profile_name %= (lit("profile") >> (lit('=') | spaces) >> str);
@@ -465,7 +471,7 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
   qi::rule<Iterator, string()> wildcard;
   qi::rule<Iterator, int()> auid;
   qi::rule<Iterator, string()> class_name;
-  qi::rule<Iterator, string()> class_cap;
+  qi::rule<Iterator, string()> method_name;
   qi::rule<Iterator, OSDCapSpec()> capspec;
   qi::rule<Iterator, string()> pool_name;
   qi::rule<Iterator, string()> nspace;

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -272,7 +272,8 @@ bool OSDCapGrant::is_capable(const string& pool_name, const string& ns,
         // compare this grant to each class in the operation
         for (size_t i = 0; i < classes.size(); ++i) {
           // check 'allow class foo'
-          if (!spec.class_name.empty() && classes[i].name == spec.class_name) {
+          if (!spec.class_name.empty() &&
+              classes[i].class_name == spec.class_name) {
             (*class_allowed)[i] = true;
             continue;
           }

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -64,13 +64,13 @@ ostream& operator<<(ostream& out, const osd_rwxa_t& p);
 struct OSDCapSpec {
   osd_rwxa_t allow;
   std::string class_name;
-  std::string class_allow;
+  std::string method_name;
 
   OSDCapSpec() : allow(0) {}
   explicit OSDCapSpec(osd_rwxa_t v) : allow(v) {}
-  explicit OSDCapSpec(std::string n) : allow(0), class_name(std::move(n)) {}
-  OSDCapSpec(std::string n, std::string a) :
-    allow(0), class_name(std::move(n)), class_allow(std::move(a)) {}
+  OSDCapSpec(std::string class_name, std::string method_name)
+    : allow(0), class_name(std::move(class_name)),
+      method_name(std::move(method_name)) {}
 
   bool allow_all() const {
     return allow == OSD_CAP_ANY;

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -194,7 +194,7 @@ bool OpRequest::filter_out(const set<string>& filters)
 
 ostream& operator<<(ostream& out, const OpRequest::ClassInfo& i)
 {
-  out << "class " << i.name << " rd " << i.read
-    << " wr " << i.write << " wl " << i.whitelisted;
+  out << "class " << i.class_name << " method " << i.method_name
+      << " rd " << i.read << " wr " << i.write << " wl " << i.whitelisted;
   return out;
 }

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -52,17 +52,20 @@ struct OpRequest : public TrackedOp {
   void set_force_rwordered();
 
   struct ClassInfo {
-    ClassInfo(const std::string& name, bool read, bool write,
-        bool whitelisted) :
-      name(name), read(read), write(write), whitelisted(whitelisted)
+    ClassInfo(std::string&& class_name, std::string&& method_name,
+              bool read, bool write, bool whitelisted) :
+      class_name(std::move(class_name)), method_name(std::move(method_name)),
+      read(read), write(write), whitelisted(whitelisted)
     {}
-    const std::string name;
+    const std::string class_name;
+    const std::string method_name;
     const bool read, write, whitelisted;
   };
 
-  void add_class(const std::string& name, bool read, bool write,
-      bool whitelisted) {
-    classes_.emplace_back(name, read, write, whitelisted);
+  void add_class(std::string&& class_name, std::string&& method_name,
+                 bool read, bool write, bool whitelisted) {
+    classes_.emplace_back(std::move(class_name), std::move(method_name),
+                          read, write, whitelisted);
   }
 
   std::vector<ClassInfo> classes() const {

--- a/src/test/osd/osdcap.cc
+++ b/src/test/osd/osdcap.cc
@@ -947,6 +947,33 @@ TEST(OSDCap, AllowClass) {
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}));
 }
 
+TEST(OSDCap, AllowClassMethod) {
+  OSDCap cap;
+  ASSERT_TRUE(cap.parse("allow class foo xyz", NULL));
+
+  // can call the xyz method on class foo regardless of whitelist status
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, false, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", false, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, true, false}}));
+
+  // does not permit invoking class bar
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, true, false}}));
+}
+
 TEST(OSDCap, AllowClass2) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class foo, allow class bar", NULL));

--- a/src/test/osd/osdcap.cc
+++ b/src/test/osd/osdcap.cc
@@ -162,23 +162,23 @@ TEST(OSDCap, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}));
   // 'allow *' overrides whitelist
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}));
 }
 
 TEST(OSDCap, AllowPool) {
@@ -186,21 +186,21 @@ TEST(OSDCap, AllowPool) {
   bool r = cap.parse("allow rwx pool foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
   // true->false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}));
 
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
 }
 
 TEST(OSDCap, AllowPools) {
@@ -208,25 +208,25 @@ TEST(OSDCap, AllowPools) {
   bool r = cap.parse("allow rwx pool foo, allow r pool bar", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}));
 
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "", true, false, {}));
   ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "", true, false, {}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
   ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
 
   ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "", true, false, {}));
   ASSERT_FALSE(cap.is_capable("baz", "ns", 0, {}, "", true, false, {}));
@@ -239,10 +239,10 @@ TEST(OSDCap, AllowPools2) {
   bool r = cap.parse("allow r, allow rwx pool foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
 
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "", true, false, {}));
 }
@@ -252,17 +252,17 @@ TEST(OSDCap, ObjectPrefix) {
   bool r = cap.parse("allow rwx object_prefix foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, true}}));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "_foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, " foo ", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "fo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "_foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, " foo ", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "fo", true, true, {{"cls", "", true, true, true}}));
 }
 
 TEST(OSDCap, ObjectPoolAndPrefix) {
@@ -270,17 +270,17 @@ TEST(OSDCap, ObjectPoolAndPrefix) {
   bool r = cap.parse("allow rwx pool bar object_prefix foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, true}}));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "food", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "fo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "food", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "fo", true, true, {{"cls", "", true, true, true}}));
 }
 
 TEST(OSDCap, Namespace) {
@@ -309,10 +309,10 @@ TEST(OSDCap, BasicR) {
 
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
 }
 
@@ -322,9 +322,9 @@ TEST(OSDCap, BasicW) {
 
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
 }
@@ -333,13 +333,13 @@ TEST(OSDCap, BasicX) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow x", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
   // true->false when class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
 
 
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
@@ -355,23 +355,23 @@ TEST(OSDCap, BasicRW) {
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
 }
 
 TEST(OSDCap, BasicRX) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, true, true}}));
   // true->false for class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, true, false}}));
 
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
@@ -382,13 +382,13 @@ TEST(OSDCap, BasicWX) {
   ASSERT_TRUE(cap.parse("allow wx", NULL));
 
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
   // true->false for class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
 
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
@@ -399,20 +399,20 @@ TEST(OSDCap, BasicRWX) {
   ASSERT_TRUE(cap.parse("allow rwx", NULL));
 
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
   // true->false for class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
 }
 
 TEST(OSDCap, BasicRWClassRClassW) {
@@ -420,97 +420,97 @@ TEST(OSDCap, BasicRWClassRClassW) {
   ASSERT_TRUE(cap.parse("allow rw class-read class-write", NULL));
 
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
 }
 
 TEST(OSDCap, ClassR) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class-read", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
 
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
 }
 
 TEST(OSDCap, ClassW) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class-write", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}));
 
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
 }
 
 TEST(OSDCap, ClassRW) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class-read class-write", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
 
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
 }
 
 TEST(OSDCap, BasicRClassR) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow r class-read", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
   ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "any", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
@@ -520,150 +520,150 @@ TEST(OSDCap, PoolClassR) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow pool bar r class-read, allow pool foo rwx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
   ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {}));
   ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
   ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
 
   ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
 
   ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
 }
 
 TEST(OSDCap, PoolClassRNS) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow pool bar namespace='' r class-read, allow pool foo namespace=ns rwx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {}));
   ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", false, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", true, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "other", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
   ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
 
   ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
 
   ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
 }
 
 TEST(OSDCap, NSClassR) {
@@ -671,64 +671,64 @@ TEST(OSDCap, NSClassR) {
   ASSERT_TRUE(cap.parse("allow namespace '' rw class-read class-write, allow namespace test r", NULL));
 
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
 
   ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
   ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
 
   ASSERT_TRUE(cap.is_capable("bar", "test", 0, {}, "foo", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
   ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, true, {}));
   ASSERT_FALSE(cap.is_capable("bar", "test", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
   ASSERT_TRUE(cap.is_capable("foo", "test", 0, {}, "foo", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
   ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, true, {}));
   ASSERT_FALSE(cap.is_capable("foo", "test", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
   ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", true, false, {}));
   ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {{"application", {{"key", "value"}}}}, "foo", false, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {{"application", {{"key", "value"}}}}, "foo", false, false, {{"cls", "", false, true, true}}));
 }
 
 TEST(OSDCap, PoolTagBasic)
@@ -761,20 +761,20 @@ TEST(OSDCap, PoolTagBasic)
   ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
   ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {}));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", false, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", false, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", false, false, true}}));
 }
 
 TEST(OSDCap, PoolTagWildK)
@@ -931,39 +931,39 @@ TEST(OSDCap, AllowClass) {
   ASSERT_TRUE(cap.parse("allow class foo", NULL));
 
   // can call any method on class foo regardless of whitelist status
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}}));
 
   // does not permit invoking class bar
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}));
 }
 
 TEST(OSDCap, AllowClass2) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class foo, allow class bar", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}));
 }
 
 TEST(OSDCap, AllowClassRWX) {
@@ -971,22 +971,22 @@ TEST(OSDCap, AllowClassRWX) {
   ASSERT_TRUE(cap.parse("allow rwx, allow class foo", NULL));
 
   // can call any method on class foo regardless of whitelist status
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}}));
 
   // does not permit invoking class bar
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}));
 
   // allows class bar if it is whitelisted
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}));
 }
 
 TEST(OSDCap, AllowClassMulti) {
@@ -995,155 +995,155 @@ TEST(OSDCap, AllowClassMulti) {
 
   // can call any method on foo, but not bar, so the entire op is rejected
   // bar with whitelist is rejected because it still needs rwx/class-read,write
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}));
 
   // these are OK because 'bar' is on the whitelist BUT the calls don't read or write
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}));
 
   // can call any method on foo or bar regardless of whitelist status
   OSDCap cap2;
   ASSERT_TRUE(cap2.parse("allow class foo, allow class bar", NULL));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}));
 }
 
 TEST(OSDCap, AllowClassMultiRWX) {
@@ -1151,86 +1151,86 @@ TEST(OSDCap, AllowClassMultiRWX) {
   ASSERT_TRUE(cap.parse("allow rwx, allow class foo", NULL));
 
   // can call anything on foo, but only whitelisted methods on bar
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}));
 
   // fails because bar not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}));
 }
 
 TEST(OSDCap, AllowProfile) {
@@ -1248,15 +1248,15 @@ TEST(OSDCap, AllowProfile) {
   ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {}));
   ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "rbd_children", true, false, {}));
   ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "rbd_children", false, false,
-                             {{"rbd", true, false, true}}));
+                             {{"rbd", "", true, false, true}}));
   ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "asdf", true, true,
-                             {{"rbd", true, true, true}}));
+                             {{"rbd", "", true, true, true}}));
 
   cap.grants.clear();
   ASSERT_TRUE(cap.parse("profile rbd-read-only pool abc", NULL));
   ASSERT_FALSE(cap.allow_all());
   ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "rbd_children", true, false, {}));
   ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "asdf", true, false,
-                             {{"rbd", true, false, true}}));
+                             {{"rbd", "", true, false, true}}));
 }
 


### PR DESCRIPTION
RBD is planning to utilize this to support simplified cloning by allowing users with read-only access to a pool to be able to execute a read/write class method to manage the child clone references.
  