### PR TITLE
jewel: doc: clarify Path Restriction instructions

### DIFF
--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -33,6 +33,7 @@ for example, to restrict client ``foo`` to ``bar`` directory, we will use. ::
 
 ./ceph auth get-or-create client.foo mon 'allow r' mds 'allow r, allow rw path=/bar' osd 'allow rw pool=data'
 
+See `User Management - Add a User to a Keyring`_. for additional details on user management
 
 To restrict a client to the specfied sub-directory only, we mention the specified
 directory while mounting following the undermentioned syntax. ::
@@ -105,3 +106,5 @@ for files, but client.1 cannot.
         caps: [mon] allow r
         caps: [osd] allow rw pool=data
 
+
+.. _User Management - Add a User to a Keyring: ../rados/operations/user-management/#add-a-user-to-a-keyring


### PR DESCRIPTION
http://tracker.ceph.com/issues/22569

Clarify Path Restriction instructions (write out client key to a keyring file), by specifying 'User Management - Add a User to a Keyring'.
    
Fixes: http://tracker.ceph.com/issues/22569
Signed-off-by: Jos Collin <jcollin@redhat.com>
  