### PR TITLE
osd: fix out of order caused by letting old msg from down osd be processed

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -538,6 +538,12 @@ public:
       }
     }
   }
+  OSDMapRef get_next_osdmap() {
+    Mutex::Locker l(pre_publish_lock);
+    if (!next_osdmap)
+      return OSDMapRef();
+    return next_osdmap;
+  }
 
 private:
   Mutex peer_map_epoch_lock;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5734,14 +5734,15 @@ bool PG::can_discard_replica_op(OpRequestRef& op)
   // connection to it when handling the new osdmap marking it down, and also
   // resets the messenger sesssion when the replica reconnects. to avoid the
   // out-of-order replies, the messages from that replica should be discarded.
-  if (osd->get_osdmap()->is_down(from))
+  OSDMapRef next_map = osd->get_next_osdmap();
+  if (next_map->is_down(from))
     return true;
   /* Mostly, this overlaps with the old_peering_msg
    * condition.  An important exception is pushes
    * sent by replicas not in the acting set, since
    * if such a replica goes down it does not cause
    * a new interval. */
-  if (get_osdmap()->get_down_at(from) >= m->map_epoch)
+  if (next_map->get_down_at(from) >= m->map_epoch)
     return true;
 
   // same pg?


### PR DESCRIPTION
fixes: http://tracker.ceph.com/issues/22570
if the down osd is primary, maybe cause http://tracker.ceph.com/issues/22050 ?

Signed-off-by: Mingxin Liu <mingxin@xsky.com>
  