### PR TITLE
luminous: rbd ls -l crashes with SIGABRT

### DIFF
--- a/src/librbd/image/RefreshParentRequest.cc
+++ b/src/librbd/image/RefreshParentRequest.cc
@@ -69,12 +69,13 @@ void RefreshParentRequest<I>::send() {
 
 template <typename I>
 void RefreshParentRequest<I>::apply() {
+  assert(m_child_image_ctx.cache_lock.is_locked());
+  assert(m_child_image_ctx.snap_lock.is_wlocked());
+  assert(m_child_image_ctx.parent_lock.is_wlocked());
   if (m_child_image_ctx.parent != nullptr) {
     // closing parent image
     m_child_image_ctx.clear_nonexistence_cache();
   }
-  assert(m_child_image_ctx.snap_lock.is_wlocked());
-  assert(m_child_image_ctx.parent_lock.is_wlocked());
   std::swap(m_child_image_ctx.parent, m_parent_image_ctx);
 }
 

--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -326,6 +326,7 @@ int SetSnapRequest<I>::apply() {
   ldout(cct, 10) << __func__ << dendl;
 
   RWLock::WLocker owner_locker(m_image_ctx.owner_lock);
+  Mutex::Locker cache_locker(m_image_ctx.cache_lock);
   RWLock::WLocker snap_locker(m_image_ctx.snap_lock);
   RWLock::WLocker parent_locker(m_image_ctx.parent_lock);
   if (m_snap_id != CEPH_NOSNAP) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/21641