### PR TITLE
jewel: tests: rbd_mirror_helpers.sh request_resync_image function saves image id to wrong variable

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -780,7 +780,7 @@ request_resync_image()
     local cluster=$1
     local pool=$2
     local image=$3
-    local image_id_var_name=$1
+    local image_id_var_name=$4
 
     eval "${image_id_var_name}='$(get_image_id ${cluster} ${pool} ${image})'"
     eval 'test -n "$'${image_id_var_name}'"'


### PR DESCRIPTION
http://tracker.ceph.com/issues/21691