### PR TITLE
 common: add streaming interfaces for json/xml escaping

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -425,7 +425,7 @@ set(libcommon_files
   common/bloom_filter.cc
   common/Readahead.cc
   common/cmdparse.cc
-  common/escape.c
+  common/escape.cc
   common/url_escape.cc
   common/io_priority.cc
   common/Clock.cc

--- a/src/common/escape.cc
+++ b/src/common/escape.cc
@@ -16,6 +16,8 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <iomanip>
+#include <boost/optional.hpp>
 
 /*
  * Some functions for escaping RGW responses
@@ -112,6 +114,60 @@ void escape_xml_attr(const char *buf, char *out)
 	*o = '\0';
 }
 
+// applies hex formatting on construction, restores on destruction
+struct hex_formatter {
+  std::ostream& out;
+  const char old_fill;
+  const std::ostream::fmtflags old_flags;
+
+  hex_formatter(std::ostream& out)
+    : out(out),
+      old_fill(out.fill('0')),
+      old_flags(out.setf(out.hex, out.basefield))
+  {}
+  ~hex_formatter() {
+    out.fill(old_fill);
+    out.flags(old_flags);
+  }
+};
+
+std::ostream& operator<<(std::ostream& out, const xml_stream_escaper& e)
+{
+  boost::optional<hex_formatter> fmt;
+
+  for (unsigned char c : e.str) {
+    switch (c) {
+    case '<':
+      out << LESS_THAN_XESCAPE;
+      break;
+    case '&':
+      out << AMPERSAND_XESCAPE;
+      break;
+    case '>':
+      out << GREATER_THAN_XESCAPE;
+      break;
+    case '\'':
+      out << SGL_QUOTE_XESCAPE;
+      break;
+    case '"':
+      out << DBL_QUOTE_XESCAPE;
+      break;
+    default:
+      // Escape control characters.
+      if (((c < 0x20) && (c != 0x09) && (c != 0x0a)) || (c == 0x7f)) {
+        if (!fmt) {
+          fmt.emplace(out); // enable hex formatting
+        }
+        out << "&#x" << std::setw(2) << static_cast<unsigned int>(c) << ';';
+      } else {
+        out << c;
+      }
+      break;
+    }
+  }
+  return out;
+}
+
 #define DBL_QUOTE_JESCAPE "\\\""
 #define BACKSLASH_JESCAPE "\\\\"
 #define TAB_JESCAPE "\\t"
@@ -196,3 +252,36 @@ void escape_json_attr(const char *buf, int src_len, char *out)
 	*o = '\0';
 }
 
+std::ostream& operator<<(std::ostream& out, const json_stream_escaper& e)
+{
+  boost::optional<hex_formatter> fmt;
+
+  for (unsigned char c : e.str) {
+    switch (c) {
+    case '"':
+      out << DBL_QUOTE_JESCAPE;
+      break;
+    case '\\':
+      out << BACKSLASH_JESCAPE;
+      break;
+    case '\t':
+      out << TAB_JESCAPE;
+      break;
+    case '\n':
+      out << NEWLINE_JESCAPE;
+      break;
+    default:
+      // Escape control characters.
+      if ((c < 0x20) || (c == 0x7f)) {
+        if (!fmt) {
+          fmt.emplace(out); // enable hex formatting
+        }
+        out << "\\u" << std::setw(4) << static_cast<unsigned int>(c);
+      } else {
+        out << c;
+      }
+      break;
+    }
+  }
+  return out;
+}

--- a/src/common/escape.h
+++ b/src/common/escape.h
@@ -15,9 +15,8 @@
 #ifndef CEPH_RGW_ESCAPE_H
 #define CEPH_RGW_ESCAPE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+#include <ostream>
+#include <boost/utility/string_view.hpp>
 
 /* Returns the length of a buffer that would be needed to escape 'buf'
  * as an XML attrribute
@@ -45,8 +44,21 @@ void escape_json_attr(const char *buf, int src_len, char *out);
  * require this, Amazon does it in their XML responses.
  */
 
-#ifdef __cplusplus
-}
-#endif
+// stream output operators that write escaped text without making a copy
+// usage:
+//   std::string xml_input = ...;
+//   std::cout << xml_stream_escaper(xml_input) << std::endl;
+
+struct xml_stream_escaper {
+  boost::string_view str;
+  xml_stream_escaper(boost::string_view str) : str(str) {}
+};
+std::ostream& operator<<(std::ostream& out, const xml_stream_escaper& e);
+
+struct json_stream_escaper {
+  boost::string_view str;
+  json_stream_escaper(boost::string_view str) : str(str) {}
+};
+std::ostream& operator<<(std::ostream& out, const json_stream_escaper& e);
 
 #endif

--- a/src/test/escape.cc
+++ b/src/test/escape.cc
@@ -37,21 +37,16 @@ TEST(EscapeXml, EntityRefs1) {
 }
 
 TEST(EscapeXml, ControlChars) {
-  uint8_t cc1[] = { 0x01, 0x02, 0x03, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((char*)cc1), "&#x01;&#x02;&#x03;");
+  ASSERT_EQ(escape_xml_attrs("\x01\x02\x03"), "&#x01;&#x02;&#x03;");
 
-  uint8_t cc2[] = { 0x61, 0x62, 0x63, 0x7f, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((char*)cc2), "abc&#x7f;");
+  ASSERT_EQ(escape_xml_attrs("abc\x7f"), "abc&#x7f;");
 }
 
 TEST(EscapeXml, Utf8) {
-  uint8_t cc1[] = { 0xe6, 0xb1, 0x89, 0xe5, 0xad, 0x97, 0x0a, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((const char*)cc1), (const char*)cc1);
+  const char *cc1 = "\xe6\xb1\x89\xe5\xad\x97\n";
+  ASSERT_EQ(escape_xml_attrs(cc1), cc1);
 
-  uint8_t cc2[] = { 0x3c, 0xe6, 0xb1, 0x89, 0xe5, 0xad, 0x97, 0x3e, 0x0a, 0x0 };
-  uint8_t cc2_out[] = { 0x26, 0x6c, 0x74, 0x3b, 0xe6, 0xb1, 0x89, 0xe5,
-			0xad, 0x97, 0x26, 0x67, 0x74, 0x3b, 0x0a, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((const char*)cc2), (const char*)cc2_out);
+  ASSERT_EQ(escape_xml_attrs("<\xe6\xb1\x89\xe5\xad\x97>\n"), "&lt;\xe6\xb1\x89\xe5\xad\x97&gt;\n");
 }
 
 static std::string escape_json_attrs(const char *str)
@@ -80,14 +75,11 @@ TEST(EscapeJson, Escapes1) {
 }
 
 TEST(EscapeJson, ControlChars) {
-  uint8_t cc1[] = { 0x01, 0x02, 0x03, 0x0 };
-  ASSERT_EQ(escape_json_attrs((char*)cc1), "\\u0001\\u0002\\u0003");
+  ASSERT_EQ(escape_json_attrs("\x01\x02\x03"), "\\u0001\\u0002\\u0003");
 
-  uint8_t cc2[] = { 0x61, 0x62, 0x63, 0x7f, 0x0 };
-  ASSERT_EQ(escape_json_attrs((char*)cc2), "abc\\u007f");
+  ASSERT_EQ(escape_json_attrs("abc\x7f"), "abc\\u007f");
 }
 
 TEST(EscapeJson, Utf8) {
-  uint8_t cc1[] = { 0xe6, 0xb1, 0x89, 0xe5, 0xad, 0x97, 0x0a, 0x0 };
-  ASSERT_EQ(escape_xml_attrs((const char*)cc1), (const char*)cc1);
+  EXPECT_EQ(escape_xml_attrs("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\n");
 }

--- a/src/test/escape.cc
+++ b/src/test/escape.cc
@@ -81,5 +81,5 @@ TEST(EscapeJson, ControlChars) {
 }
 
 TEST(EscapeJson, Utf8) {
-  EXPECT_EQ(escape_xml_attrs("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\n");
+  EXPECT_EQ(escape_json_attrs("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\\n");
 }

--- a/src/test/escape.cc
+++ b/src/test/escape.cc
@@ -22,31 +22,48 @@ static std::string escape_xml_attrs(const char *str)
   escape_xml_attr(str, out);
   return out;
 }
+static std::string escape_xml_stream(const char *str)
+{
+  std::stringstream ss;
+  ss << xml_stream_escaper(str);
+  return ss.str();
+}
 
 TEST(EscapeXml, PassThrough) {
   ASSERT_EQ(escape_xml_attrs("simplicity itself"), "simplicity itself");
+  ASSERT_EQ(escape_xml_stream("simplicity itself"), "simplicity itself");
   ASSERT_EQ(escape_xml_attrs(""), "");
+  ASSERT_EQ(escape_xml_stream(""), "");
   ASSERT_EQ(escape_xml_attrs("simple examples please!"), "simple examples please!");
+  ASSERT_EQ(escape_xml_stream("simple examples please!"), "simple examples please!");
 }
 
 TEST(EscapeXml, EntityRefs1) {
   ASSERT_EQ(escape_xml_attrs("The \"scare quotes\""), "The &quot;scare quotes&quot;");
+  ASSERT_EQ(escape_xml_stream("The \"scare quotes\""), "The &quot;scare quotes&quot;");
   ASSERT_EQ(escape_xml_attrs("I <3 XML"), "I &lt;3 XML");
+  ASSERT_EQ(escape_xml_stream("I <3 XML"), "I &lt;3 XML");
   ASSERT_EQ(escape_xml_attrs("Some 'single' \"quotes\" here"),
+	    "Some &apos;single&apos; &quot;quotes&quot; here");
+  ASSERT_EQ(escape_xml_stream("Some 'single' \"quotes\" here"),
 	    "Some &apos;single&apos; &quot;quotes&quot; here");
 }
 
 TEST(EscapeXml, ControlChars) {
   ASSERT_EQ(escape_xml_attrs("\x01\x02\x03"), "&#x01;&#x02;&#x03;");
+  ASSERT_EQ(escape_xml_stream("\x01\x02\x03"), "&#x01;&#x02;&#x03;");
 
   ASSERT_EQ(escape_xml_attrs("abc\x7f"), "abc&#x7f;");
+  ASSERT_EQ(escape_xml_stream("abc\x7f"), "abc&#x7f;");
 }
 
 TEST(EscapeXml, Utf8) {
   const char *cc1 = "\xe6\xb1\x89\xe5\xad\x97\n";
   ASSERT_EQ(escape_xml_attrs(cc1), cc1);
+  ASSERT_EQ(escape_xml_stream(cc1), cc1);
 
   ASSERT_EQ(escape_xml_attrs("<\xe6\xb1\x89\xe5\xad\x97>\n"), "&lt;\xe6\xb1\x89\xe5\xad\x97&gt;\n");
+  ASSERT_EQ(escape_xml_stream("<\xe6\xb1\x89\xe5\xad\x97>\n"), "&lt;\xe6\xb1\x89\xe5\xad\x97&gt;\n");
 }
 
 static std::string escape_json_attrs(const char *str)
@@ -57,29 +74,48 @@ static std::string escape_json_attrs(const char *str)
   escape_json_attr(str, src_len, out);
   return out;
 }
+static std::string escape_json_stream(const char *str)
+{
+  std::stringstream ss;
+  ss << json_stream_escaper(str);
+  return ss.str();
+}
 
 TEST(EscapeJson, PassThrough) {
   ASSERT_EQ(escape_json_attrs("simplicity itself"), "simplicity itself");
+  ASSERT_EQ(escape_json_stream("simplicity itself"), "simplicity itself");
   ASSERT_EQ(escape_json_attrs(""), "");
+  ASSERT_EQ(escape_json_stream(""), "");
   ASSERT_EQ(escape_json_attrs("simple examples please!"), "simple examples please!");
+  ASSERT_EQ(escape_json_stream("simple examples please!"), "simple examples please!");
 }
 
 TEST(EscapeJson, Escapes1) {
   ASSERT_EQ(escape_json_attrs("The \"scare quotes\""),
 			     "The \\\"scare quotes\\\"");
+  ASSERT_EQ(escape_json_stream("The \"scare quotes\""),
+			      "The \\\"scare quotes\\\"");
   ASSERT_EQ(escape_json_attrs("I <3 JSON"), "I <3 JSON");
+  ASSERT_EQ(escape_json_stream("I <3 JSON"), "I <3 JSON");
   ASSERT_EQ(escape_json_attrs("Some 'single' \"quotes\" here"),
       "Some 'single' \\\"quotes\\\" here");
+  ASSERT_EQ(escape_json_stream("Some 'single' \"quotes\" here"),
+      "Some 'single' \\\"quotes\\\" here");
   ASSERT_EQ(escape_json_attrs("tabs\tand\tnewlines\n, oh my"),
+      "tabs\\tand\\tnewlines\\n, oh my");
+  ASSERT_EQ(escape_json_stream("tabs\tand\tnewlines\n, oh my"),
       "tabs\\tand\\tnewlines\\n, oh my");
 }
 
 TEST(EscapeJson, ControlChars) {
   ASSERT_EQ(escape_json_attrs("\x01\x02\x03"), "\\u0001\\u0002\\u0003");
+  ASSERT_EQ(escape_json_stream("\x01\x02\x03"), "\\u0001\\u0002\\u0003");
 
   ASSERT_EQ(escape_json_attrs("abc\x7f"), "abc\\u007f");
+  ASSERT_EQ(escape_json_stream("abc\x7f"), "abc\\u007f");
 }
 
 TEST(EscapeJson, Utf8) {
   EXPECT_EQ(escape_json_attrs("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\\n");
+  EXPECT_EQ(escape_json_stream("\xe6\xb1\x89\xe5\xad\x97\n"), "\xe6\xb1\x89\xe5\xad\x97\\n");
 }


### PR DESCRIPTION
the existing c-style apis require the caller to query the resulting length via `escape_xml_attr_len()` and allocate an output buffer before before calling `escape_xml_attr()` to perform the escaping

this adds stream output operators that escape json/xml strings without having to allocate a separate output buffer