### PR TITLE
cmake: update minimum boost version to 1.66

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,9 +37,6 @@
 	url = https://github.com/ceph/lua.git
 	branch = lua-5.3-ceph
 	ignore = dirty
-[submodule "src/Beast"]
-	path = src/Beast
-	url = https://github.com/ceph/Beast.git
 [submodule "src/dpdk"]
 	path = src/dpdk
 	url = https://github.com/ceph/dpdk

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -579,13 +579,13 @@ if(WITH_SYSTEM_BOOST)
   else()
     set(Boost_USE_STATIC_LIBS ON)
   endif()
-  find_package(Boost 1.61 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+  find_package(Boost 1.66 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 else()
   set(BOOST_J 1 CACHE STRING
     "max jobs for Boost build") # override w/-DBOOST_J=<n>
   set(Boost_USE_STATIC_LIBS ON)
   include(BuildBoost)
-  build_boost(1.63
+  build_boost(1.66
     COMPONENTS ${BOOST_COMPONENTS} ${BOOST_HEADER_COMPONENTS})
   include_directories(BEFORE SYSTEM ${Boost_INCLUDE_DIRS})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -390,6 +390,11 @@ if(WITH_BLKIN)
   include_directories(SYSTEM src/blkin/blkin-lib)
 endif(WITH_BLKIN)
 
+option(WITH_BOOST_CONTEXT "Enable boost::asio stackful coroutines" ON)
+if(WITH_BOOST_CONTEXT)
+  set(HAVE_BOOST_CONTEXT ON)
+endif()
+
 #option for RGW
 option(WITH_RADOSGW "Rados Gateway is enabled" ON)
 option(WITH_RADOSGW_FCGI_FRONTEND "Rados Gateway's FCGI frontend is enabled" OFF)
@@ -398,6 +403,10 @@ if(WITH_RADOSGW)
   find_package(EXPAT REQUIRED)
   if(WITH_RADOSGW_FCGI_FRONTEND)
     find_package(fcgi REQUIRED)
+  endif()
+  if(WITH_RADOSGW_BEAST_FRONTEND AND NOT WITH_BOOST_CONTEXT)
+    message(WARNING "disabling WITH_RADOSGW_BEAST_FRONTEND, which depends on WITH_BOOST_CONTEXT")
+    set(WITH_RADOSGW_BEAST_FRONTEND OFF)
   endif()
 endif(WITH_RADOSGW)
 
@@ -569,6 +578,9 @@ set(BOOST_HEADER_COMPONENTS container)
 
 if(WITH_MGR)
 	list(APPEND BOOST_COMPONENTS python)
+endif()
+if(WITH_BOOST_CONTEXT)
+  list(APPEND BOOST_COMPONENTS context coroutine)
 endif()
 
 set(Boost_USE_MULTITHREADED ON)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -862,9 +862,9 @@ cmake .. \
     -DWITH_OCF=ON \
 %endif
 %ifarch aarch64 armv7hl mips mipsel ppc ppc64 ppc64le %{ix86} x86_64
-    -DWITH_RADOSGW_BEAST_FRONTEND=ON \
+    -DWITH_BOOST_CONTEXT=ON \
 %else
-    -DWITH_RADOSGW_BEAST_FRONTEND=OFF \
+    -DWITH_BOOST_CONTEXT=OFF \
 %endif
     -DBOOST_J=%{_smp_ncpus}
 

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -79,14 +79,14 @@ function(do_build_boost version)
     message(STATUS "boost already in src")
     set(source_dir
       SOURCE_DIR "${PROJECT_SOURCE_DIR}/src/boost")
-  elseif(version VERSION_GREATER 1.63)
+  elseif(version VERSION_GREATER 1.66)
     message(FATAL_ERROR "Unknown BOOST_REQUESTED_VERSION: ${version}")
   else()
     message(STATUS "boost will be downloaded...")
     # NOTE: If you change this version number make sure the package is available
     # at the three URLs below (may involve uploading to download.ceph.com)
-    set(boost_version 1.63.0)
-    set(boost_md5 1c837ecd990bb022d07e7aab32b09847)
+    set(boost_version 1.66.0)
+    set(boost_md5 b2dfbd6c717be4a7bb2d88018eaccf75)
     string(REPLACE "." "_" boost_version_underscore ${boost_version} )
     set(boost_url 
       https://dl.bintray.com/boostorg/release/${boost_version}/source/boost_${boost_version_underscore}.tar.bz2)

--- a/debian/rules
+++ b/debian/rules
@@ -17,10 +17,10 @@ ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
 endif
 
 ifneq (,$(filter $(DEB_HOST_ARCH), arm armel armhf arm64 i386 amd64 mips mipsel powerpc ppc64))
-  # beast depends on libboost_context which only support the archs above
-  extraopts += -DWITH_RADOSGW_BEAST_FRONTEND=ON
+  # libboost_context only support the archs above
+  extraopts += -DWITH_BOOST_CONTEXT=ON
 else
-  extraopts += -DWITH_RADOSGW_BEAST_FRONTEND=OFF
+  extraopts += -DWITH_BOOST_CONTEXT=OFF
 endif
 
 %:

--- a/make-dist
+++ b/make-dist
@@ -100,8 +100,8 @@ ln -s . $outfile
 tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec $outfile/alpine/APKBUILD
 # NOTE: If you change this version number make sure the package is available
 # at the three URLs referenced below (may involve uploading to download.ceph.com)
-boost_version=1.63.0
-download_boost $boost_version 1c837ecd990bb022d07e7aab32b09847 \
+boost_version=1.66.0
+download_boost $boost_version b2dfbd6c717be4a7bb2d88018eaccf75 \
                https://dl.bintray.com/boostorg/release/$boost_version/source \
                https://downloads.sourceforge.net/project/boost/boost/$boost_version \
                https://download.ceph.com/qa

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -330,4 +330,7 @@
 /* Defined if getentropy() is available */
 #cmakedefine HAVE_GETENTROPY
 
+/* Defined if boost::context is available */
+#cmakedefine HAVE_BOOST_CONTEXT
+
 #endif /* CONFIG_H */

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -143,7 +143,6 @@ add_library(rgw_a STATIC ${rgw_a_srcs})
 add_dependencies(rgw_a civetweb_h)
 
 target_include_directories(rgw_a SYSTEM PUBLIC
-  "../Beast/include"
   ${FCGI_INCLUDE_DIR}
   "../rapidjson/include"
   )

--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -171,7 +171,7 @@ size_t ClientIO::complete_header()
     sent += txbuf.sputn(timestr, strlen(timestr));
   }
 
-  if (parser.is_keep_alive()) {
+  if (parser.keep_alive()) {
     constexpr char CONN_KEEP_ALIVE[] = "Connection: Keep-Alive\r\n";
     sent += txbuf.sputn(CONN_KEEP_ALIVE, sizeof(CONN_KEEP_ALIVE) - 1);
   } else {

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -64,7 +64,7 @@ namespace beast = boost::beast;
 
 class Connection {
   RGWProcessEnv& env;
-  boost::asio::strand strand;
+  boost::asio::io_service::strand strand;
   tcp::socket socket;
 
   // references are bound to callbacks for async operations. if a callback
@@ -169,7 +169,7 @@ class Connection {
     process_request(env.store, env.rest, &req, env.uri_prefix,
                     *env.auth_registry, &client, env.olog);
 
-    if (parser->is_keep_alive()) {
+    if (parser->keep_alive()) {
       // parse any unread bytes from the previous message (in case we replied
       // before reading the entire body) before reading the next
       discard_unread_message();


### PR DESCRIPTION
fixes compilation failures in radosgw with boost 1.66, and pins that as the required version so we don't have to continue supporting beast as a submodule

Fixes: http://tracker.ceph.com/issues/22600