### PR TITLE
osd: async recovery

### DIFF
--- a/qa/standalone/osd/osd-recovery-stats.sh
+++ b/qa/standalone/osd/osd-recovery-stats.sh
@@ -211,13 +211,13 @@ function TEST_recovery_sizeup() {
     ceph osd out osd.$primary osd.$otherosd
     ceph osd pool set test size 4
     ceph osd unset norecover
-    ceph tell osd.$(get_primary $poolname obj1) debug kick_recovery_wq 0
+    # Get new primary
+    primary=$(get_primary $poolname obj1)
+
+    ceph tell osd.${primary} debug kick_recovery_wq 0
     sleep 2
 
     wait_for_clean || return 1
-
-    # Get new primary
-    primary=$(get_primary $poolname obj1)
 
     local degraded=$(expr $objects \* 2)
     local misplaced=$(expr $objects \* 2)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3126,6 +3126,10 @@ std::vector<Option> get_global_options() {
     .set_default(100)
     .set_description(""),
 
+    Option("osd_async_recovery_min_pg_log_entries", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(100)
+    .set_description("Number of entries difference above which to use asynchronous recovery when appropriate"),
+
     Option("osd_max_pg_per_osd_hard_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(2)
     .set_min(1)

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -890,7 +890,7 @@ void ECBackend::handle_sub_write(
   if (!op.temp_added.empty()) {
     add_temp_objs(op.temp_added);
   }
-  if (op.backfill) {
+  if (op.backfill_or_async_recovery) {
     for (set<hobject_t>::iterator i = op.temp_removed.begin();
 	 i != op.temp_removed.end();
 	 ++i) {
@@ -910,7 +910,7 @@ void ECBackend::handle_sub_write(
     op.updated_hit_set_history,
     op.trim_to,
     op.roll_forward_to,
-    !op.backfill,
+    !op.backfill_or_async_recovery,
     localt);
 
   if (!get_parent()->pg_is_undersized() &&

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -883,7 +883,6 @@ void ECBackend::handle_sub_write(
   if (msg)
     msg->mark_started();
   trace.event("handle_sub_write");
-  assert(!get_parent()->get_log().get_missing().is_missing(op.soid));
   if (!get_parent()->pgb_is_primary())
     get_parent()->update_stats(op.stats);
   ObjectStore::Transaction localt;

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -904,16 +904,14 @@ void ECBackend::handle_sub_write(
     }
   }
   clear_temp_objs(op.temp_removed);
-  dout(10) << __func__ << " missing before " << get_parent()->get_log().get_missing().get_items() << dendl;
+  dout(30) << __func__ << " missing before " << get_parent()->get_log().get_missing().get_items() << dendl;
   pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
   if (pmissing.is_missing(op.soid)) {
-    dout(10) << __func__ << " pmissing.is_missing(op.soid) " << pmissing.is_missing(op.soid) << dendl;
+    dout(30) << __func__ << " is_missing " << pmissing.is_missing(op.soid) << dendl;
     for (auto &&e: op.log_entries) {
-      dout(10) << " add_next_event entry " << e << dendl;
+      dout(30) << " add_next_event entry " << e << dendl;
       get_parent()->add_local_next_event(e);
-      dout(10) << " entry version " << e.version << dendl;
-      dout(10) << " entry prior version " << e.prior_version << dendl;
-      dout(10) << " entry is_delete " << e.is_delete() << dendl;
+      dout(30) << " entry is_delete " << e.is_delete() << dendl;
     }
   }
   get_parent()->log_operation(
@@ -940,7 +938,7 @@ void ECBackend::handle_sub_write(
   tls.push_back(std::move(op.t));
   tls.push_back(std::move(localt));
   get_parent()->queue_transactions(tls, msg);
-  dout(10) << __func__ << " missing after" << get_parent()->get_log().get_missing().get_items() << dendl;
+  dout(30) << __func__ << " missing after" << get_parent()->get_log().get_missing().get_items() << dendl;
 }
 
 void ECBackend::handle_sub_read(

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -904,6 +904,18 @@ void ECBackend::handle_sub_write(
     }
   }
   clear_temp_objs(op.temp_removed);
+  dout(10) << __func__ << " missing before " << get_parent()->get_log().get_missing().get_items() << dendl;
+  pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
+  if (pmissing.is_missing(op.soid)) {
+    dout(10) << __func__ << " pmissing.is_missing(op.soid) " << pmissing.is_missing(op.soid) << dendl;
+    for (auto &&e: op.log_entries) {
+      dout(10) << " add_next_event entry " << e << dendl;
+      get_parent()->add_local_next_event(e);
+      dout(10) << " entry version " << e.version << dendl;
+      dout(10) << " entry prior version " << e.prior_version << dendl;
+      dout(10) << " entry is_delete " << e.is_delete() << dendl;
+    }
+  }
   get_parent()->log_operation(
     op.log_entries,
     op.updated_hit_set_history,
@@ -928,6 +940,7 @@ void ECBackend::handle_sub_write(
   tls.push_back(std::move(op.t));
   tls.push_back(std::move(localt));
   get_parent()->queue_transactions(tls, msg);
+  dout(10) << __func__ << " missing after" << get_parent()->get_log().get_missing().get_items() << dendl;
 }
 
 void ECBackend::handle_sub_read(

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -728,8 +728,8 @@ int ECBackend::recover_object(
   }
   h->ops.back().recovery_progress.omap_complete = true;
   for (set<pg_shard_t>::const_iterator i =
-	 get_parent()->get_actingbackfill_shards().begin();
-       i != get_parent()->get_actingbackfill_shards().end();
+	 get_parent()->get_acting_recovery_backfill_shards().begin();
+       i != get_parent()->get_acting_recovery_backfill_shards().end();
        ++i) {
     dout(10) << "checking " << *i << dendl;
     if (get_parent()->get_shard_missing(*i).is_missing(hoid)) {
@@ -1848,8 +1848,8 @@ bool ECBackend::try_reads_to_commit()
 
   map<shard_id_t, ObjectStore::Transaction> trans;
   for (set<pg_shard_t>::const_iterator i =
-	 get_parent()->get_actingbackfill_shards().begin();
-       i != get_parent()->get_actingbackfill_shards().end();
+	 get_parent()->get_acting_recovery_backfill_shards().begin();
+       i != get_parent()->get_acting_recovery_backfill_shards().end();
        ++i) {
     trans[i->shard];
   }
@@ -1906,8 +1906,8 @@ bool ECBackend::try_reads_to_commit()
   bool should_write_local = false;
   ECSubWrite local_write_op;
   for (set<pg_shard_t>::const_iterator i =
-	 get_parent()->get_actingbackfill_shards().begin();
-       i != get_parent()->get_actingbackfill_shards().end();
+	 get_parent()->get_acting_recovery_backfill_shards().begin();
+       i != get_parent()->get_acting_recovery_backfill_shards().end();
        ++i) {
     op->pending_apply.insert(*i);
     op->pending_commit.insert(*i);

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1917,6 +1917,7 @@ bool ECBackend::try_reads_to_commit()
   ObjectStore::Transaction empty;
   bool should_write_local = false;
   ECSubWrite local_write_op;
+  set<pg_shard_t> backfill_shards = get_parent()->get_backfill_shards();
   for (set<pg_shard_t>::const_iterator i =
 	 get_parent()->get_acting_recovery_backfill_shards().begin();
        i != get_parent()->get_acting_recovery_backfill_shards().end();
@@ -1928,7 +1929,7 @@ bool ECBackend::try_reads_to_commit()
     assert(iter != trans.end());
     bool should_send = get_parent()->should_send_op(*i, op->hoid);
     const pg_stat_t &stats =
-      should_send ?
+      (should_send || !backfill_shards.count(*i)) ?
       get_info().stats :
       parent->get_shard_info().find(*i)->second.stats;
 

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -30,7 +30,7 @@ void ECSubWrite::encode(bufferlist &bl) const
   encode(temp_removed, bl);
   encode(updated_hit_set_history, bl);
   encode(roll_forward_to, bl);
-  encode(backfill, bl);
+  encode(backfill_or_async_recovery, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -57,10 +57,10 @@ void ECSubWrite::decode(bufferlist::iterator &bl)
     roll_forward_to = trim_to;
   }
   if (struct_v >= 4) {
-    decode(backfill, bl);
+    decode(backfill_or_async_recovery, bl);
   } else {
-    // The old protocol used an empty transaction to indicate backfill
-    backfill = t.empty();
+    // The old protocol used an empty transaction to indicate backfill or async_recovery
+    backfill_or_async_recovery = t.empty();
   }
   DECODE_FINISH(bl);
 }
@@ -75,8 +75,8 @@ std::ostream &operator<<(
       << ", roll_forward_to=" << rhs.roll_forward_to;
   if (rhs.updated_hit_set_history)
     lhs << ", has_updated_hit_set_history";
-  if (rhs.backfill)
-    lhs << ", backfill";
+  if (rhs.backfill_or_async_recovery)
+    lhs << ", backfill_or_async_recovery";
   return lhs <<  ")";
 }
 
@@ -89,7 +89,7 @@ void ECSubWrite::dump(Formatter *f) const
   f->dump_stream("roll_forward_to") << roll_forward_to;
   f->dump_bool("has_updated_hit_set_history",
       static_cast<bool>(updated_hit_set_history));
-  f->dump_bool("backfill", backfill);
+  f->dump_bool("backfill_or_async_recovery", backfill_or_async_recovery);
 }
 
 void ECSubWrite::generate_test_instances(list<ECSubWrite*> &o)

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -34,7 +34,7 @@ struct ECSubWrite {
   set<hobject_t> temp_added;
   set<hobject_t> temp_removed;
   boost::optional<pg_hit_set_history_t> updated_hit_set_history;
-  bool backfill = false;
+  bool backfill_or_async_recovery = false;
   ECSubWrite() : tid(0) {}
   ECSubWrite(
     pg_shard_t from,
@@ -50,7 +50,7 @@ struct ECSubWrite {
     boost::optional<pg_hit_set_history_t> updated_hit_set_history,
     const set<hobject_t> &temp_added,
     const set<hobject_t> &temp_removed,
-    bool backfill)
+    bool backfill_or_async_recovery)
     : from(from), tid(tid), reqid(reqid),
       soid(soid), stats(stats), t(t),
       at_version(at_version),
@@ -59,7 +59,7 @@ struct ECSubWrite {
       temp_added(temp_added),
       temp_removed(temp_removed),
       updated_hit_set_history(updated_hit_set_history),
-      backfill(backfill)
+      backfill_or_async_recovery(backfill_or_async_recovery)
     {}
   void claim(ECSubWrite &other) {
     from = other.from;
@@ -75,7 +75,7 @@ struct ECSubWrite {
     temp_added.swap(other.temp_added);
     temp_removed.swap(other.temp_removed);
     updated_hit_set_history = other.updated_hit_set_history;
-    backfill = other.backfill;
+    backfill_or_async_recovery = other.backfill_or_async_recovery;
   }
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &bl);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1706,8 +1706,9 @@ bool PG::choose_acting(pg_shard_t &auth_log_shard_id,
     // Caller is GetInfo
     backfill_targets = want_backfill;
   }
-  assert(async_recovery_targets.empty() || async_recovery_targets == want_async_recovery);
-  if (async_recovery_targets.empty()) {
+  // Adding !needs_recovery() to let the async_recovery_targets reset after recovery is complete
+  assert(async_recovery_targets.empty() || async_recovery_targets == want_async_recovery || !needs_recovery());
+  if (async_recovery_targets.empty() || !needs_recovery()) {
     async_recovery_targets = want_async_recovery;
   }
   // Will not change if already set because up would have had to change

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -458,9 +458,7 @@ void PG::proc_replica_log(
     dout(20) << " after missing " << i->first << " need " << i->second.need
 	     << " have " << i->second.have << dendl;
   }
-  dout(10) << __func__ << " peer_missing " << peer_missing[from].get_items() << dendl;
   peer_missing[from].claim(omissing);
-  dout(10) << __func__ << " peer_missing after claim" << peer_missing[from].get_items() << dendl;
 }
 
 bool PG::proc_replica_info(

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7719,10 +7719,14 @@ PG::RecoveryState::Recovered::Recovered(my_context ctx)
   // adjust acting set?  (e.g. because backfill completed...)
   bool history_les_bound = false;
   if (pg->acting != pg->up && !pg->choose_acting(auth_log_shard,
-						 true, &history_les_bound))
+						 true, &history_les_bound)) {
     assert(pg->want_acting.size());
+  } else if (!pg->async_recovery_targets.empty()) {
+    pg->choose_acting(auth_log_shard, true, &history_les_bound);
+  }
 
-  if (context< Active >().all_replicas_activated)
+  if (context< Active >().all_replicas_activated  &&
+      pg->async_recovery_targets.empty())
     post_event(GoClean());
 }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6047,6 +6047,10 @@ ostream& operator<<(ostream& out, const PG& pg)
     out << "/" << pg.acting;
   if (pg.is_ec_pg())
     out << "p" << pg.get_primary();
+  if (!pg.async_recovery_targets.empty())
+    out << " async=[" << pg.async_recovery_targets << "]";
+  if (!pg.backfill_targets.empty())
+    out << " backfill=[" << pg.backfill_targets << "]";
   out << " r=" << pg.get_role();
   out << " lpr=" << pg.get_last_peering_reset();
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1465,6 +1465,131 @@ void PG::calc_replicated_acting(
   }
 }
 
+bool PG::recoverable_and_ge_min_size(const vector<int> &want) const
+{
+  unsigned num_want_acting = 0;
+  set<pg_shard_t> have;
+  for (int i = 0; i < (int)want.size(); ++i) {
+    if (want[i] != CRUSH_ITEM_NONE) {
+      ++num_want_acting;
+      have.insert(
+        pg_shard_t(
+          want[i],
+          pool.info.is_erasure() ? shard_id_t(i) : shard_id_t::NO_SHARD));
+    }
+  }
+
+  // We go incomplete if below min_size for ec_pools since backfill
+  // does not currently maintain rollbackability
+  // Otherwise, we will go "peered", but not "active"
+  if (num_want_acting < pool.info.min_size &&
+      (pool.info.is_erasure() ||
+       !cct->_conf->osd_allow_recovery_below_min_size)) {
+    dout(10) << __func__ << "failed, below min size" << dendl;
+    return false;
+  }
+
+  /* Check whether we have enough acting shards to later perform recovery */
+  boost::scoped_ptr<IsPGRecoverablePredicate> recoverable_predicate(
+      get_pgbackend()->get_is_recoverable_predicate());
+  if (!(*recoverable_predicate)(have)) {
+    dout(10) << __func__ << "failed, not recoverable" << dendl;
+    return false;
+  }
+
+  return true;
+}
+
+void PG::choose_async_recovery_ec(const map<pg_shard_t, pg_info_t> &all_info,
+                                  const pg_info_t &auth_info,
+                                  vector<int> *want,
+                                  set<pg_shard_t> *async_recovery) const
+{
+  set<pair<int, pg_shard_t> > candidates_by_cost;
+  for (uint8_t i = 0; i < want->size(); ++i) {
+    if ((*want)[i] == CRUSH_ITEM_NONE)
+      continue;
+
+    // Considering log entries to recover is accurate enough for
+    // now. We could use minimum_to_decode_with_cost() later if
+    // necessary.
+    pg_shard_t shard_i((*want)[i], shard_id_t(i));
+    auto shard_info = all_info.find(shard_i)->second;
+    // for ec pools we rollback all entries past the authoritative
+    // last_update *before* activation. This is relatively inexpensive
+    // compared to recovery, since it is purely local, so treat shards
+    // past the authoritative last_update the same as those equal to it.
+    version_t auth_version = auth_info.last_update.version;
+    version_t candidate_version = shard_info.last_update.version;
+    if (auth_version > candidate_version &&
+        (auth_version - candidate_version) > cct->_conf->get_val<uint64_t>("osd_async_recovery_min_pg_log_entries")) {
+      candidates_by_cost.insert(make_pair(auth_version - candidate_version, shard_i));
+    }
+  }
+
+  dout(20) << __func__ << "candidates by cost are: " << candidates_by_cost
+           << dendl;
+
+  // take out as many osds as we can for async recovery, in order of cost
+  for (auto weighted_shard : candidates_by_cost) {
+    pg_shard_t cur_shard = weighted_shard.second;
+    vector<int> candidate_want(*want);
+    candidate_want[cur_shard.shard.id] = CRUSH_ITEM_NONE;
+    if (recoverable_and_ge_min_size(candidate_want)) {
+      want->swap(candidate_want);
+      async_recovery->insert(cur_shard);
+    }
+  }
+  dout(20) << __func__ << "result want=" << *want
+           << " async_recovery=" << *async_recovery << dendl;
+}
+
+void PG::choose_async_recovery_replicated(const map<pg_shard_t, pg_info_t> &all_info,
+                                          const pg_info_t &auth_info,
+                                          vector<int> *want,
+                                          set<pg_shard_t> *async_recovery) const
+{
+  set<pair<int, pg_shard_t> > candidates_by_cost;
+  for (auto osd_num : *want) {
+    pg_shard_t shard_i(osd_num, shard_id_t::NO_SHARD);
+    auto shard_info = all_info.find(shard_i)->second;
+    // use the approximate magnitude of the difference in length of
+    // logs as the cost of recovery
+    version_t auth_version = auth_info.last_update.version;
+    version_t candidate_version = shard_info.last_update.version;
+    size_t approx_entries;
+    if (auth_version > candidate_version) {
+      approx_entries = auth_version - candidate_version;
+    } else {
+      approx_entries = candidate_version - auth_version;
+    }
+    if (approx_entries > cct->_conf->get_val<uint64_t>("osd_async_recovery_min_pg_log_entries")) {
+      candidates_by_cost.insert(make_pair(approx_entries, shard_i));
+    }
+  }
+
+  dout(20) << __func__ << "candidates by cost are: " << candidates_by_cost
+           << dendl;
+
+  // take out as many osds as we can for async recovery, in order of cost
+  for (auto weighted_shard : candidates_by_cost) {
+    pg_shard_t cur_shard = weighted_shard.second;
+    vector<int> candidate_want(*want);
+    for (auto it = candidate_want.begin(); it != candidate_want.end(); ++it) {
+      if (*it == cur_shard.osd) {
+        candidate_want.erase(it);
+	async_recovery->insert(cur_shard);
+        break;
+      }
+    }
+    if (want->size() <= pool.info.min_size) {
+      break;
+    }
+  }
+  dout(20) << __func__ << "result want=" << *want
+           << " async_recovery=" << *async_recovery << dendl;
+}
+
 /**
  * choose acting
  *
@@ -1545,36 +1670,18 @@ bool PG::choose_acting(pg_shard_t &auth_log_shard_id,
       ss);
   dout(10) << ss.str() << dendl;
 
-  unsigned num_want_acting = 0;
-  set<pg_shard_t> have;
-  for (int i = 0; i < (int)want.size(); ++i) {
-    if (want[i] != CRUSH_ITEM_NONE) {
-      ++num_want_acting;
-      have.insert(
-        pg_shard_t(
-          want[i],
-          pool.info.is_erasure() ? shard_id_t(i) : shard_id_t::NO_SHARD));
+  if (!recoverable_and_ge_min_size(want)) {
+    want_acting.clear();
+    return false;
+  }
+
+  set<pg_shard_t> want_async_recovery;
+  if (HAVE_FEATURE(get_osdmap()->get_up_osd_features(), SERVER_MIMIC)) {
+    if (pool.info.is_erasure()) {
+      choose_async_recovery_ec(all_info, auth_log_shard->second, &want, &want_async_recovery);
+    } else {
+      choose_async_recovery_replicated(all_info, auth_log_shard->second, &want, &want_async_recovery);
     }
-  }
-
-  // We go incomplete if below min_size for ec_pools since backfill
-  // does not currently maintain rollbackability
-  // Otherwise, we will go "peered", but not "active"
-  if (num_want_acting < pool.info.min_size &&
-      (pool.info.is_erasure() ||
-       !cct->_conf->osd_allow_recovery_below_min_size)) {
-    want_acting.clear();
-    dout(10) << __func__ << " failed, below min size" << dendl;
-    return false;
-  }
-
-  /* Check whether we have enough acting shards to later perform recovery */
-  boost::scoped_ptr<IsPGRecoverablePredicate> recoverable_predicate(
-    get_pgbackend()->get_is_recoverable_predicate());
-  if (!(*recoverable_predicate)(have)) {
-    want_acting.clear();
-    dout(10) << __func__ << " failed, not recoverable" << dendl;
-    return false;
   }
 
   if (want != acting) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1571,9 +1571,11 @@ void PG::choose_async_recovery_replicated(const map<pg_shard_t, pg_info_t> &all_
 
   dout(20) << __func__ << " candidates by cost are: " << candidates_by_cost
            << dendl;
-
   // take out as many osds as we can for async recovery, in order of cost
   for (auto weighted_shard : candidates_by_cost) {
+    if (want->size() <= pool.info.min_size) {
+      break;
+    }
     pg_shard_t cur_shard = weighted_shard.second;
     vector<int> candidate_want(*want);
     for (auto it = candidate_want.begin(); it != candidate_want.end(); ++it) {
@@ -1583,9 +1585,6 @@ void PG::choose_async_recovery_replicated(const map<pg_shard_t, pg_info_t> &all_
 	async_recovery->insert(cur_shard);
         break;
       }
-    }
-    if (want->size() <= pool.info.min_size) {
-      break;
     }
   }
   dout(20) << __func__ << " result want=" << *want

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -458,7 +458,9 @@ void PG::proc_replica_log(
     dout(20) << " after missing " << i->first << " need " << i->second.need
 	     << " have " << i->second.have << dendl;
   }
+  dout(10) << __func__ << " peer_missing " << peer_missing[from].get_items() << dendl;
   peer_missing[from].claim(omissing);
+  dout(10) << __func__ << " peer_missing after claim" << peer_missing[from].get_items() << dendl;
 }
 
 bool PG::proc_replica_info(

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -800,8 +800,8 @@ protected:
       }
     }
 
-    void add_missing(const hobject_t &hoid, eversion_t need, eversion_t have) {
-      needs_recovery_map[hoid] = pg_missing_item(need, have);
+    void add_missing(const hobject_t &hoid, eversion_t need, eversion_t have, bool is_delete=false) {
+      needs_recovery_map[hoid] = pg_missing_item(need, have, is_delete);
     }
     void revise_need(const hobject_t &hoid, eversion_t need) {
       auto it = needs_recovery_map.find(hoid);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -782,6 +782,15 @@ protected:
 	_inc_count(p->second);
       }
     }
+
+    void clear_location(const hobject_t &hoid) {
+      auto p = missing_loc.find(hoid);
+      if (p != missing_loc.end()) {
+	_dec_count(p->second);
+        missing_loc.erase(p);
+      }
+    }
+
     void add_active_missing(const pg_missing_t &missing) {
       for (map<hobject_t, pg_missing_item>::const_iterator i =
 	     missing.get_items().begin();

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1434,6 +1434,16 @@ protected:
     set<pg_shard_t> *backfill,
     set<pg_shard_t> *acting_backfill,
     ostream &ss);
+  void choose_async_recovery_ec(const map<pg_shard_t, pg_info_t> &all_info,
+                                const pg_info_t &auth_info,
+                                vector<int> *want,
+                                set<pg_shard_t> *async_recovery) const;
+  void choose_async_recovery_replicated(const map<pg_shard_t, pg_info_t> &all_info,
+                                        const pg_info_t &auth_info,
+                                        vector<int> *want,
+                                        set<pg_shard_t> *async_recovery) const;
+
+  bool recoverable_and_ge_min_size(const vector<int> &want) const;
   bool choose_acting(pg_shard_t &auth_log_shard,
 		     bool restrict_to_up_acting,
 		     bool *history_les_bound);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -936,7 +936,9 @@ protected:
   pg_shard_t pg_whoami;
   pg_shard_t up_primary;
   vector<int> up, acting, want_acting;
-  set<pg_shard_t> actingbackfill, actingset, upset;
+  // acting_recovery_backfill contains shards that are acting,
+  // async recovery targets, or backfill targets.
+  set<pg_shard_t> acting_recovery_backfill, actingset, upset;
   map<pg_shard_t,eversion_t> peer_last_complete_ondisk;
   eversion_t  min_last_complete_ondisk;  // up: min over last_complete_ondisk, peer_last_complete_ondisk
   eversion_t  pg_trim_to;
@@ -1278,8 +1280,8 @@ protected:
 
   void clear_primary_state();
 
-  bool is_actingbackfill(pg_shard_t osd) const {
-    return actingbackfill.count(osd);
+  bool is_acting_recovery_backfill(pg_shard_t osd) const {
+    return acting_recovery_backfill.count(osd);
   }
   bool is_acting(pg_shard_t osd) const {
     return has_shard(pool.info.is_erasure(), acting, osd);
@@ -1334,9 +1336,9 @@ protected:
 
   bool calc_min_last_complete_ondisk() {
     eversion_t min = last_complete_ondisk;
-    assert(!actingbackfill.empty());
-    for (set<pg_shard_t>::iterator i = actingbackfill.begin();
-	 i != actingbackfill.end();
+    assert(!acting_recovery_backfill.empty());
+    for (set<pg_shard_t>::iterator i = acting_recovery_backfill.begin();
+	 i != acting_recovery_backfill.end();
 	 ++i) {
       if (*i == get_primary()) continue;
       if (peer_last_complete_ondisk.count(*i) == 0)
@@ -2930,7 +2932,7 @@ protected:
 
   /**
    * Merge entries updating missing as necessary on all
-   * actingbackfill logs and missings (also missing_loc)
+   * acting_recovery_backfill logs and missings (also missing_loc)
    */
   void merge_new_log_entries(
     const mempool::osd_pglog::list<pg_log_entry_t> &entries,

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1167,7 +1167,7 @@ protected:
   bool backfill_reserved;
   bool backfill_reserving;
 
-  set<pg_shard_t> backfill_targets;
+  set<pg_shard_t> backfill_targets,  async_recovery_targets;
 
   bool is_backfill_targets(pg_shard_t osd) {
     return backfill_targets.count(osd);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -876,6 +876,8 @@ protected:
       if (!missing.is_missing(hoid))
 	mliter->second.insert(self);
       for (auto &&i: pmissing) {
+	if (i.first == self)
+	  continue;
 	auto pinfoiter = pinfo.find(i.first);
 	assert(pinfoiter != pinfo.end());
 	if (item->need <= pinfoiter->second.last_update &&

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -42,8 +42,8 @@ static ostream& _prefix(std::ostream *_dout, PGBackend *pgb) {
 void PGBackend::recover_delete_object(const hobject_t &oid, eversion_t v,
 				      RecoveryHandle *h)
 {
-  assert(get_parent()->get_actingbackfill_shards().size() > 0);
-  for (const auto& shard : get_parent()->get_actingbackfill_shards()) {
+  assert(get_parent()->get_acting_recovery_backfill_shards().size() > 0);
+  for (const auto& shard : get_parent()->get_acting_recovery_backfill_shards()) {
     if (shard == get_parent()->whoami_shard())
       continue;
     if (get_parent()->get_shard_missing(shard).is_missing(oid)) {
@@ -159,7 +159,7 @@ void PGBackend::handle_recovery_delete_reply(OpRequestRef op)
     recovery_info.version = p.second;
     get_parent()->on_peer_recover(m->from, oid, recovery_info);
     bool peers_recovered = true;
-    for (const auto& shard : get_parent()->get_actingbackfill_shards()) {
+    for (const auto& shard : get_parent()->get_acting_recovery_backfill_shards()) {
       if (shard == get_parent()->whoami_shard())
 	continue;
       if (get_parent()->get_shard_missing(shard).is_missing(oid)) {

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -166,6 +166,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
        const = 0;
 
      virtual const pg_missing_tracker_t &get_local_missing() const = 0;
+     virtual void add_local_next_event(const pg_log_entry_t& e) = 0;
      virtual const map<pg_shard_t, pg_missing_t> &get_shard_missing()
        const = 0;
      virtual boost::optional<const pg_missing_const_i &> maybe_get_shard_missing(

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -156,7 +156,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      virtual epoch_t get_interval_start_epoch() const = 0;
      virtual epoch_t get_last_peering_reset_epoch() const = 0;
 
-     virtual const set<pg_shard_t> &get_actingbackfill_shards() const = 0;
+     virtual const set<pg_shard_t> &get_acting_recovery_backfill_shards() const = 0;
      virtual const set<pg_shard_t> &get_acting_shards() const = 0;
      virtual const set<pg_shard_t> &get_backfill_shards() const = 0;
 

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -663,8 +663,12 @@ public:
 
   const pg_missing_tracker_t& get_missing() const { return missing; }
 
-  void missing_add(const hobject_t& oid, eversion_t need, eversion_t have) {
-    missing.add(oid, need, have, false);
+  void missing_add(const hobject_t& oid, eversion_t need, eversion_t have, bool is_delete=false) {
+    missing.add(oid, need, have, is_delete);
+  }
+
+  void missing_add_next_entry(const pg_log_entry_t& e) {
+    missing.add_next_event(e);
   }
 
   //////////////////// get or set log ////////////////////

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1411,7 +1411,6 @@ public:
 	    }
 	  } else {
 	    ldpp_dout(dpp, 15) << "read_log_and_missing  missing " << *i << dendl;
-	    ldpp_dout(dpp, 15) << " missing set " << missing.get_items() << dendl;
 	    if (debug_verify_stored_missing) {
 	      auto miter = missing.get_items().find(i->soid);
 	      if (i->is_delete()) {

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1407,6 +1407,7 @@ public:
 	    }
 	  } else {
 	    ldpp_dout(dpp, 15) << "read_log_and_missing  missing " << *i << dendl;
+	    ldpp_dout(dpp, 15) << " missing set " << missing.get_items() << dendl;
 	    if (debug_verify_stored_missing) {
 	      auto miter = missing.get_items().find(i->soid);
 	      if (i->is_delete()) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10081,7 +10081,9 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     pg_shard_t peer(*i);
     if (peer == pg_whoami) continue;
     if (async_recovery_targets.count(peer) && peer_missing[peer].is_missing(soid)) {
-      missing_loc.add_missing(soid, ctx->at_version, eversion_t());
+      for (auto &&entry: ctx->log) {
+	missing_loc.add_missing(soid, ctx->at_version, eversion_t(), entry.is_delete());
+      }
     }
   }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -647,9 +647,27 @@ bool PrimaryLogPG::is_degraded_or_backfilling_object(const hobject_t& soid)
   return false;
 }
 
+bool PrimaryLogPG::is_degraded_on_async_recovery_target(const hobject_t& soid)
+{
+  for (set<pg_shard_t>::iterator i = acting_recovery_backfill.begin();
+       i != acting_recovery_backfill.end();
+       ++i) {
+    if (*i == get_primary()) continue;
+    pg_shard_t peer = *i;
+    auto peer_missing_entry = peer_missing.find(peer);
+    if (peer_missing_entry != peer_missing.end() &&
+        peer_missing_entry->second.get_items().count(soid) &&
+        async_recovery_targets.count(peer)) {
+      dout(10) << __func__ << " " << soid << dendl;
+      return true;
+    }
+  }
+  return false;
+}
+
 void PrimaryLogPG::wait_for_degraded_object(const hobject_t& soid, OpRequestRef op)
 {
-  assert(is_degraded_or_backfilling_object(soid));
+  assert(is_degraded_or_backfilling_object(soid) || is_degraded_on_async_recovery_target(soid));
 
   maybe_kick_recovery(soid);
   waiting_for_degraded_object[soid].push_back(op);
@@ -7524,22 +7542,18 @@ int PrimaryLogPG::_rollback_to(OpContext *ctx, ceph_osd_op& op)
   dout(10) << "_rollback_to " << soid << " snapid " << snapid << dendl;
 
   ObjectContextRef rollback_to;
+
   int ret = find_object_context(
     hobject_t(soid.oid, soid.get_key(), snapid, soid.get_hash(), info.pgid.pool(),
 	      soid.get_namespace()),
     &rollback_to, false, false, &missing_oid);
   if (ret == -EAGAIN) {
     /* clone must be missing */
-    assert(is_degraded_or_backfilling_object(missing_oid));
+    assert(is_degraded_or_backfilling_object(missing_oid) || is_degraded_on_async_recovery_target(missing_oid));
     dout(20) << "_rollback_to attempted to roll back to a missing or backfilling clone "
 	     << missing_oid << " (requested snapid: ) " << snapid << dendl;
     block_write_on_degraded_snap(missing_oid, ctx->op);
     return ret;
-  }
-  if(is_degraded_or_backfilling_object(soid)) {
-    dout(10) << __func__ << " " << soid << " is a degraded or backfilling object" << dendl;
-    block_write_on_degraded_snap(soid, ctx->op);
-    return -EAGAIN;
   }
   {
     ObjectContextRef promote_obc;
@@ -7597,7 +7611,8 @@ int PrimaryLogPG::_rollback_to(OpContext *ctx, ceph_osd_op& op)
     assert(0 == "unexpected error code in _rollback_to");
   } else { //we got our context, let's use it to do the rollback!
     hobject_t& rollback_to_sobject = rollback_to->obs.oi.soid;
-    if (is_degraded_or_backfilling_object(rollback_to_sobject)) {
+    if (is_degraded_or_backfilling_object(rollback_to_sobject) ||
+	is_degraded_on_async_recovery_target(rollback_to_sobject)) {
       dout(20) << "_rollback_to attempted to roll back to a degraded object "
 	       << rollback_to_sobject << " (requested snapid: ) " << snapid << dendl;
       block_write_on_degraded_snap(rollback_to_sobject, ctx->op);
@@ -10816,6 +10831,9 @@ int PrimaryLogPG::find_object_context(const hobject_t& oid,
     put_snapset_context(ssc);
     if (is_degraded_or_backfilling_object(soid)) {
       dout(20) << __func__ << " clone is degraded or backfilling " << soid << dendl;
+      return -EAGAIN;
+    } else if (is_degraded_on_async_recovery_target(soid)) {
+      dout(20) << __func__ << " clone is recovering " << soid << dendl;
       return -EAGAIN;
     } else {
       dout(20) << __func__ << " missing clone " << soid << dendl;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10125,13 +10125,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
 
   if (requires_missing_loc) {
     // clear out missing_loc
-    set<pg_shard_t> peers(missing_loc.get_locations(soid));
-    for (set<pg_shard_t>::iterator r = peers.begin();
-         r != peers.end();
-         ++r) {
-      pg_shard_t peer(*r);
-      missing_loc.remove_location(soid, peer);
-    }
+    missing_loc.clear_location(soid);
     for (set<pg_shard_t>::const_iterator i = actingset.begin();
          i != actingset.end();
          ++i) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7536,6 +7536,11 @@ int PrimaryLogPG::_rollback_to(OpContext *ctx, ceph_osd_op& op)
     block_write_on_degraded_snap(missing_oid, ctx->op);
     return ret;
   }
+  if(is_degraded_or_backfilling_object(soid)) {
+    dout(10) << __func__ << " " << soid << " is a degraded or backfilling object" << dendl;
+    block_write_on_degraded_snap(soid, ctx->op);
+    return -EAGAIN;
+  }
   {
     ObjectContextRef promote_obc;
     cache_result_t tier_mode_result;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10107,16 +10107,16 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
   }
 
   dout(10) << __func__ << " missing_loc before: " << missing_loc.get_locations(soid) << dendl;
-  // clear out missing_loc
-  set<pg_shard_t> peers(missing_loc.get_locations(soid));
-  for (set<pg_shard_t>::iterator r = peers.begin();
-       r != peers.end();
-       ++r) {
-    pg_shard_t peer(*r);
-    missing_loc.remove_location(soid, peer);
-  }
 
   if (requires_missing_loc) {
+    // clear out missing_loc
+    set<pg_shard_t> peers(missing_loc.get_locations(soid));
+    for (set<pg_shard_t>::iterator r = peers.begin();
+         r != peers.end();
+         ++r) {
+      pg_shard_t peer(*r);
+      missing_loc.remove_location(soid, peer);
+    }
     for (set<pg_shard_t>::const_iterator i = actingset.begin();
          i != actingset.end();
          ++i) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -940,6 +940,14 @@ int PrimaryLogPG::do_command(
         f->dump_stream("shard") << *p;
       f->close_section();
     }
+    if (!async_recovery_targets.empty()) {
+      f->open_array_section("async_recovery_targets");
+      for (set<pg_shard_t>::iterator p = async_recovery_targets.begin();
+	   p != async_recovery_targets.end();
+	   ++p)
+        f->dump_stream("shard") << *p;
+      f->close_section();
+    }
     if (!acting_recovery_backfill.empty()) {
       f->open_array_section("acting_recovery_backfill");
       for (set<pg_shard_t>::iterator p = acting_recovery_backfill.begin();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10067,6 +10067,11 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     projected_log.add(entry);
   }
 
+  for (map<pg_shard_t, pg_missing_t>::iterator i = peer_missing.begin();
+           i != peer_missing.end();
+           ++i) {
+    dout(10) << __func__ << " shard " << i->first << " before missing " << (i->second).get_items() << dendl;
+  }
   for (set<pg_shard_t>::iterator i = async_recovery_targets.begin();
        i != async_recovery_targets.end();
        ++i) {
@@ -10074,6 +10079,12 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     for (auto &&entry: ctx->log) {
       peer_missing[*i].add_next_event(entry);
     }
+  }
+
+  for (map<pg_shard_t, pg_missing_t>::iterator i = peer_missing.begin();
+           i != peer_missing.end();
+           ++i) {
+    dout(10) << __func__ << " shard " << i->first << " after add next missing " << (i->second).get_items() << dendl;
   }
 
   for (set<pg_shard_t>::const_iterator i = acting_recovery_backfill.begin();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -632,7 +632,7 @@ bool PrimaryLogPG::is_degraded_or_backfilling_object(const hobject_t& soid)
     if (peer_missing_entry != peer_missing.end() &&
 	peer_missing_entry->second.get_items().count(soid)) {
       if (async_recovery_targets.count(peer))
-	return false;
+	continue;
       else
 	return true;
     }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -658,7 +658,7 @@ bool PrimaryLogPG::is_degraded_on_async_recovery_target(const hobject_t& soid)
     if (peer_missing_entry != peer_missing.end() &&
         peer_missing_entry->second.get_items().count(soid) &&
         async_recovery_targets.count(peer)) {
-      dout(10) << __func__ << " " << soid << dendl;
+      dout(30) << __func__ << " " << soid << dendl;
       return true;
     }
   }
@@ -10087,11 +10087,6 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     projected_log.add(entry);
   }
 
-  for (map<pg_shard_t, pg_missing_t>::iterator i = peer_missing.begin();
-           i != peer_missing.end();
-           ++i) {
-    dout(10) << __func__ << " shard " << i->first << " before missing " << (i->second).get_items() << dendl;
-  }
   bool requires_missing_loc = false;
   for (set<pg_shard_t>::iterator i = async_recovery_targets.begin();
        i != async_recovery_targets.end();
@@ -10101,12 +10096,6 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     for (auto &&entry: ctx->log) {
       peer_missing[*i].add_next_event(entry);
     }
-  }
-
-  for (map<pg_shard_t, pg_missing_t>::iterator i = peer_missing.begin();
-           i != peer_missing.end();
-           ++i) {
-    dout(10) << __func__ << " shard " << i->first << " after add next missing " << (i->second).get_items() << dendl;
   }
 
   for (set<pg_shard_t>::const_iterator i = acting_recovery_backfill.begin();
@@ -10121,7 +10110,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     }
   }
 
-  dout(10) << __func__ << " missing_loc before: " << missing_loc.get_locations(soid) << dendl;
+  dout(30) << __func__ << " missing_loc before: " << missing_loc.get_locations(soid) << dendl;
 
   if (requires_missing_loc) {
     // clear out missing_loc
@@ -10134,7 +10123,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
         missing_loc.add_location(soid, peer);
     }
   }
-  dout(10) << __func__ << " missing_loc after: " << missing_loc.get_locations(soid) << dendl;
+  dout(30) << __func__ << " missing_loc after: " << missing_loc.get_locations(soid) << dendl;
 
   pgbackend->submit_transaction(
     soid,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10104,6 +10104,16 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     }
   }
 
+  dout(10) << __func__ << " missing_loc before: " << missing_loc.get_locations(soid) << dendl;
+  // clear out missing_loc
+  set<pg_shard_t> peers(missing_loc.get_locations(soid));
+  for (set<pg_shard_t>::iterator r = peers.begin();
+       r != peers.end();
+       ++r) {
+    pg_shard_t peer(*r);
+    missing_loc.remove_location(soid, peer);
+  }
+
   for (set<pg_shard_t>::const_iterator i = actingset.begin();
        i != actingset.end();
        ++i) {
@@ -10111,6 +10121,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     if (!peer_missing[peer].is_missing(soid))
       missing_loc.add_location(soid, peer);
   }
+  dout(10) << __func__ << " missing_loc after: " << missing_loc.get_locations(soid) << dendl;
 
   pgbackend->submit_transaction(
     soid,

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -355,6 +355,9 @@ public:
   const PGLog &get_log() const override {
     return pg_log;
   }
+  void add_local_next_event(const pg_log_entry_t& e) {
+    pg_log.missing_add_next_entry(e);
+  }
   bool pgb_is_primary() const override {
     return is_primary();
   }

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -416,18 +416,7 @@ public:
 
   bool should_send_op(
     pg_shard_t peer,
-    const hobject_t &hoid) override {
-    if (peer == get_primary())
-      return true;
-    assert(peer_info.count(peer));
-    bool should_send =
-      hoid.pool != (int64_t)info.pgid.pool() ||
-      hoid <= last_backfill_started ||
-      hoid <= peer_info[peer].last_backfill;
-    if (!should_send)
-      assert(is_backfill_targets(peer));
-    return should_send;
-  }
+    const hobject_t &hoid) override;
 
   bool pg_is_undersized() const override {
     return is_undersized();

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1084,7 +1084,8 @@ protected:
 				 PGBackend::RecoveryHandle *h,
 				 bool *work_started);
   int prep_object_replica_deletes(const hobject_t& soid, eversion_t v,
-				  PGBackend::RecoveryHandle *h);
+				  PGBackend::RecoveryHandle *h,
+				  bool *work_started);
 
   void finish_degraded_object(const hobject_t& oid);
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1078,7 +1078,8 @@ protected:
   bool new_backfill;
 
   int prep_object_replica_pushes(const hobject_t& soid, eversion_t v,
-				 PGBackend::RecoveryHandle *h);
+				 PGBackend::RecoveryHandle *h,
+				 bool *work_started);
   int prep_object_replica_deletes(const hobject_t& soid, eversion_t v,
 				  PGBackend::RecoveryHandle *h);
 
@@ -1207,7 +1208,8 @@ protected:
     ThreadPool::TPHandle &handle, uint64_t *started) override;
 
   uint64_t recover_primary(uint64_t max, ThreadPool::TPHandle &handle);
-  uint64_t recover_replicas(uint64_t max, ThreadPool::TPHandle &handle);
+  uint64_t recover_replicas(uint64_t max, ThreadPool::TPHandle &handle,
+		            bool *recovery_started);
   hobject_t earliest_peer_backfill() const;
   bool all_peer_done() const;
   /**

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1779,6 +1779,7 @@ public:
   void wait_for_all_missing(OpRequestRef op);
 
   bool is_degraded_or_backfilling_object(const hobject_t& oid);
+  bool is_degraded_on_async_recovery_target(const hobject_t& soid);
   void wait_for_degraded_object(const hobject_t& oid, OpRequestRef op);
 
   void block_write_on_full_cache(

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -325,8 +325,8 @@ public:
   epoch_t get_last_peering_reset_epoch() const override {
     return get_last_peering_reset();
   }
-  const set<pg_shard_t> &get_actingbackfill_shards() const override {
-    return actingbackfill;
+  const set<pg_shard_t> &get_acting_recovery_backfill_shards() const override {
+    return acting_recovery_backfill;
   }
   const set<pg_shard_t> &get_acting_shards() const override {
     return actingset;
@@ -878,7 +878,7 @@ protected:
   void simple_opc_submit(OpContextUPtr ctx);
 
   /**
-   * Merge entries atomically into all actingbackfill osds
+   * Merge entries atomically into all acting_recovery_backfill osds
    * adjusting missing and recovery state as necessary.
    *
    * Also used to store error log entries for dup detection.

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1004,7 +1004,7 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   // sanity checks
   assert(m->map_epoch >= get_info().history.same_interval_since);
 
-  dout(10) << __func__ << " missing before " << get_parent()->get_log().get_missing().get_items() << dendl;
+  dout(30) << __func__ << " missing before " << get_parent()->get_log().get_missing().get_items() << dendl;
   parent->maybe_preempt_replica_scrub(soid);
 
   int ackerosd = m->get_source().num();
@@ -1053,13 +1053,11 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
 
   pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
   if (pmissing.is_missing(soid)) {
-    dout(10) << __func__ << " j->second.is_missing(soid) " << pmissing.is_missing(soid) << dendl;
+    dout(30) << __func__ << " is_missing " << pmissing.is_missing(soid) << dendl;
     for (auto &&e: log) {
-      dout(10) << " add_next_event entry " << e << dendl;
+      dout(30) << " add_next_event entry " << e << dendl;
       get_parent()->add_local_next_event(e);
-      dout(10) << " entry version " << e.version << dendl;
-      dout(10) << " entry prior version " << e.prior_version << dendl;
-      dout(10) << " entry is_delete " << e.is_delete() << dendl;
+      dout(30) << " entry is_delete " << e.is_delete() << dendl;
     }
   }
 
@@ -1081,7 +1079,7 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   tls.push_back(std::move(rm->opt));
   parent->queue_transactions(tls, op);
   // op is cleaned up by oncommit/onapply when both are executed
-  dout(10) << __func__ << " missing after" << get_parent()->get_log().get_missing().get_items() << dendl;
+  dout(30) << __func__ << " missing after" << get_parent()->get_log().get_missing().get_items() << dendl;
 }
 
 void ReplicatedBackend::repop_commit(RepModifyRef rm)

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1004,9 +1004,6 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   // sanity checks
   assert(m->map_epoch >= get_info().history.same_interval_since);
 
-  // we better not be missing this.
-  assert(!parent->get_log().get_missing().is_missing(soid));
-
   parent->maybe_preempt_replica_scrub(soid);
 
   int ackerosd = m->get_source().num();

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1004,6 +1004,7 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   // sanity checks
   assert(m->map_epoch >= get_info().history.same_interval_since);
 
+  dout(10) << __func__ << " missing before " << get_parent()->get_log().get_missing().get_items() << dendl;
   parent->maybe_preempt_replica_scrub(soid);
 
   int ackerosd = m->get_source().num();
@@ -1049,6 +1050,19 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
     // collections now.  Otherwise, we do it later on push.
     update_snaps = true;
   }
+
+  pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
+  if (pmissing.is_missing(soid)) {
+    dout(10) << __func__ << " j->second.is_missing(soid) " << pmissing.is_missing(soid) << dendl;
+    for (auto &&e: log) {
+      dout(10) << " add_next_event entry " << e << dendl;
+      get_parent()->add_local_next_event(e);
+      dout(10) << " entry version " << e.version << dendl;
+      dout(10) << " entry prior version " << e.prior_version << dendl;
+      dout(10) << " entry is_delete " << e.is_delete() << dendl;
+    }
+  }
+
   parent->update_stats(m->pg_stats);
   parent->log_operation(
     log,
@@ -1067,6 +1081,7 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   tls.push_back(std::move(rm->opt));
   parent->queue_transactions(tls, op);
   // op is cleaned up by oncommit/onapply when both are executed
+  dout(10) << __func__ << " missing after" << get_parent()->get_log().get_missing().get_items() << dendl;
 }
 
 void ReplicatedBackend::repop_commit(RepModifyRef rm)

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -907,11 +907,6 @@ Message * ReplicatedBackend::generate_subop(
 
   // ship resulting transaction, log entries, and pg_stats
   if (!parent->should_send_op(peer, soid)) {
-    dout(10) << "issue_repop shipping empty opt to osd." << peer
-	     <<", object " << soid
-	     << " beyond std::max(last_backfill_started "
-	     << ", pinfo.last_backfill "
-	     << pinfo.last_backfill << ")" << dendl;
     ObjectStore::Transaction t;
     encode(t, wr->get_data());
   } else {


### PR DESCRIPTION
This PR adds asynchronous recovery capability, by performing recovery in the background on an OSD out of the acting set, similar to backfill, but still using the PG log to determine what needs recovery. We call such OSDs, async_recovery_targets. The idea is to not block writes to objects awaiting recovery in async_recovery_targets.

Signed-off-by: Neha Ojha <nojha@redhat.com>