### PR TITLE
common: compute SimpleLRU's size with contents.size() instead of lru.size()

### DIFF
--- a/src/common/simple_cache.hpp
+++ b/src/common/simple_cache.hpp
@@ -27,7 +27,7 @@ class SimpleLRU {
   map<K, V, C> pinned;
 
   void trim_cache() {
-    while (lru.size() > max_size) {
+    while (contents.size() > max_size) {
       contents.erase(lru.back().first);
       lru.pop_back();
     }


### PR DESCRIPTION
As libstdc++ earlier than version 5 implement the list::size() as a O(n) operation,
this should be needed to avoid regression of various ceph component's performance.

Signed-off-by: Xuehan Xu <xuxuehan@360.cn>
  
http://tracker.ceph.com/issues/22613
