### PR TITLE
rbd: properly pass ceph global command line args to subprocess

### DIFF
--- a/src/tools/rbd/Shell.cc
+++ b/src/tools/rbd/Shell.cc
@@ -5,8 +5,10 @@
 #include "tools/rbd/ArgumentTypes.h"
 #include "tools/rbd/IndentStream.h"
 #include "tools/rbd/OptionPrinter.h"
+#include "common/ceph_argparse.h"
 #include "common/config.h"
 #include "global/global_context.h"
+#include "global/global_init.h"
 #include "include/stringify.h"
 #include <algorithm>
 #include <iostream>
@@ -22,6 +24,40 @@ namespace {
 static const std::string APP_NAME("rbd");
 static const std::string HELP_SPEC("help");
 static const std::string BASH_COMPLETION_SPEC("bash-completion");
+
+boost::intrusive_ptr<CephContext> global_init(
+    int argc, const char **argv, std::vector<std::string> *command_args,
+    std::vector<std::string> *global_init_args) {
+  std::vector<const char*> cmd_args;
+  argv_to_vec(argc, argv, cmd_args);
+  std::vector<const char*> args(cmd_args);
+  env_to_vec(args);
+  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+                         CODE_ENVIRONMENT_UTILITY, 0);
+
+  *command_args = {args.begin(), args.end()};
+
+  // Scan command line arguments for ceph global init args (those are
+  // filtered out from args vector by global_init).
+
+  auto cursor = args.begin();
+  for (auto &arg : cmd_args) {
+    auto iter = cursor;
+    for (; iter != args.end(); iter++) {
+      if (*iter == arg) {
+        break;
+      }
+    }
+    if (iter == args.end()) {
+      // filtered out by global_init
+      global_init_args->push_back(arg);
+    } else {
+      cursor = ++iter;
+    }
+  }
+
+  return cct;
+}
 
 std::string format_command_spec(const Shell::CommandSpec &spec) {
   return joinify<std::string>(spec.begin(), spec.end(), " ");
@@ -66,10 +102,11 @@ std::set<std::string>& Shell::get_switch_arguments() {
   return switch_arguments;
 }
 
-int Shell::execute(const Arguments& cmdline_arguments) {
+int Shell::execute(int argc, const char **argv) {
+  std::vector<std::string> arguments;
+  std::vector<std::string> ceph_global_init_args;
+  auto cct = global_init(argc, argv, &arguments, &ceph_global_init_args);
 
-  std::vector<std::string> arguments(cmdline_arguments.begin(),
-                                     cmdline_arguments.end());
   std::vector<std::string> command_spec;
   get_command_spec(arguments, &command_spec);
   bool is_alias = true;
@@ -127,13 +164,9 @@ int Shell::execute(const Arguments& cmdline_arguments) {
       positional_options.add(at::POSITIONAL_ARGUMENTS.c_str(), max_count);
     }
 
-    po::options_description global_opts;
-    get_global_options(&global_opts);
-
     po::options_description group_opts;
     group_opts.add(command_opts)
-              .add(argument_opts)
-              .add(global_opts);
+              .add(argument_opts);
 
     po::store(po::command_line_parser(arguments)
       .style(po::command_line_style::default_style &
@@ -148,7 +181,7 @@ int Shell::execute(const Arguments& cmdline_arguments) {
       return EXIT_FAILURE;
     }
 
-    int r = (*action->execute)(vm);
+    int r = (*action->execute)(vm, ceph_global_init_args);
     if (r != 0) {
       return std::abs(r);
     }

--- a/src/tools/rbd/Shell.h
+++ b/src/tools/rbd/Shell.h
@@ -14,13 +14,13 @@ namespace rbd {
 
 class Shell {
 public:
-  typedef std::vector<const char *> Arguments;
   typedef std::vector<std::string> CommandSpec;
 
   struct Action {
     typedef void (*GetArguments)(boost::program_options::options_description *,
                                  boost::program_options::options_description *);
-    typedef int (*Execute)(const boost::program_options::variables_map &);
+    typedef int (*Execute)(const boost::program_options::variables_map &,
+                           const std::vector<std::string> &);
 
     CommandSpec command_spec;
     CommandSpec alias_command_spec;
@@ -49,7 +49,7 @@ public:
     }
   };
 
-  int execute(const Arguments &argument);
+  int execute(int argc, const char **argv);
 
 private:
   static std::vector<Action *>& get_actions();

--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -461,12 +461,14 @@ int bench_execute(const po::variables_map &vm, io_type_t bench_io_type) {
   return 0;
 }
 
-int execute_for_write(const po::variables_map &vm) {
+int execute_for_write(const po::variables_map &vm,
+                      const std::vector<std::string> &ceph_global_init_args) {
   std::cerr << "rbd: bench-write is deprecated, use rbd bench --io-type write ..." << std::endl;
   return bench_execute(vm, IO_TYPE_WRITE);
 }
 
-int execute_for_bench(const po::variables_map &vm) {
+int execute_for_bench(const po::variables_map &vm,
+                      const std::vector<std::string> &ceph_global_init_args) {
   io_type_t bench_io_type;
   if (vm.count("io-type")) {
     bench_io_type = vm["io-type"].as<io_type_t>();

--- a/src/tools/rbd/action/Children.cc
+++ b/src/tools/rbd/action/Children.cc
@@ -73,7 +73,8 @@ void get_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Clone.cc
+++ b/src/tools/rbd/action/Clone.cc
@@ -29,7 +29,8 @@ void get_arguments(po::options_description *positional,
   at::add_create_image_options(options, false);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Copy.cc
+++ b/src/tools/rbd/action/Copy.cc
@@ -40,7 +40,8 @@ void get_arguments(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Create.cc
+++ b/src/tools/rbd/action/Create.cc
@@ -28,7 +28,8 @@ void get_arguments(po::options_description *positional,
   at::add_size_option(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Diff.cc
+++ b/src/tools/rbd/action/Diff.cc
@@ -86,7 +86,8 @@ void get_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -245,7 +245,8 @@ void get_arguments(po::options_description *positional,
      "snapshot starting point");
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Export.cc
+++ b/src/tools/rbd/action/Export.cc
@@ -248,7 +248,8 @@ void get_arguments_diff(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute_diff(const po::variables_map &vm) {
+int execute_diff(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -587,7 +588,8 @@ void get_arguments(po::options_description *positional,
   at::add_export_format_option(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Feature.cc
+++ b/src/tools/rbd/action/Feature.cc
@@ -92,11 +92,13 @@ int execute(const po::variables_map &vm, bool enabled) {
   return 0;
 }
 
-int execute_disable(const po::variables_map &vm) {
+int execute_disable(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
   return execute(vm, false);
 }
 
-int execute_enable(const po::variables_map &vm) {
+int execute_enable(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   return execute(vm, true);
 }
 

--- a/src/tools/rbd/action/Flatten.cc
+++ b/src/tools/rbd/action/Flatten.cc
@@ -33,7 +33,8 @@ void get_arguments(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -19,7 +19,8 @@ namespace consgrp {
 namespace at = argument_types;
 namespace po = boost::program_options;
 
-int execute_create(const po::variables_map &vm) {
+int execute_create(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
 
   std::string group_name;
@@ -49,7 +50,8 @@ int execute_create(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_list(const po::variables_map &vm) {
+int execute_list(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
 
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
@@ -90,7 +92,8 @@ int execute_list(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_remove(const po::variables_map &vm) {
+int execute_remove(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
 
   std::string group_name;
@@ -121,7 +124,8 @@ int execute_remove(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_add(const po::variables_map &vm) {
+int execute_add(const po::variables_map &vm,
+                const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   // Parse group data.
   std::string group_name;
@@ -172,7 +176,8 @@ int execute_add(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_remove_image(const po::variables_map &vm) {
+int execute_remove_image(const po::variables_map &vm,
+                         const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
 
   std::string group_name;
@@ -245,7 +250,8 @@ int execute_remove_image(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_list_images(const po::variables_map &vm) {
+int execute_list_images(const po::variables_map &vm,
+                        const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string group_name;
   std::string pool_name;
@@ -326,7 +332,8 @@ int execute_list_images(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_group_snap_create(const po::variables_map &vm) {
+int execute_group_snap_create(const po::variables_map &vm,
+                              const std::vector<std::string> &global_args) {
   size_t arg_index = 0;
 
   std::string group_name;
@@ -357,7 +364,8 @@ int execute_group_snap_create(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_group_snap_remove(const po::variables_map &vm) {
+  int execute_group_snap_remove(const po::variables_map &vm,
+                                const std::vector<std::string> &global_args) {
   size_t arg_index = 0;
 
   std::string group_name;
@@ -385,7 +393,8 @@ int execute_group_snap_remove(const po::variables_map &vm) {
   return r;
 }
 
-int execute_group_snap_rename(const po::variables_map &vm) {
+int execute_group_snap_rename(const po::variables_map &vm,
+                              const std::vector<std::string> &global_args) {
   size_t arg_index = 0;
 
   std::string group_name;
@@ -433,7 +442,8 @@ int execute_group_snap_rename(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_group_snap_list(const po::variables_map &vm) {
+int execute_group_snap_list(const po::variables_map &vm,
+                            const std::vector<std::string> &ceph_global_args) {
   size_t arg_index = 0;
   std::string group_name;
   std::string pool_name;

--- a/src/tools/rbd/action/ImageMeta.cc
+++ b/src/tools/rbd/action/ImageMeta.cc
@@ -140,7 +140,8 @@ void get_list_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute_list(const po::variables_map &vm) {
+int execute_list(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -182,7 +183,8 @@ void get_get_arguments(po::options_description *positional,
   add_key_option(positional);
 }
 
-int execute_get(const po::variables_map &vm) {
+int execute_get(const po::variables_map &vm,
+                const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -226,7 +228,8 @@ void get_set_arguments(po::options_description *positional,
     ("value", "image meta value");
 }
 
-int execute_set(const po::variables_map &vm) {
+int execute_set(const po::variables_map &vm,
+                const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -274,7 +277,8 @@ void get_remove_arguments(po::options_description *positional,
   add_key_option(positional);
 }
 
-int execute_remove(const po::variables_map &vm) {
+int execute_remove(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -441,7 +441,8 @@ void get_arguments_diff(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute_diff(const po::variables_map &vm) {
+int execute_diff(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   std::string path;
   size_t arg_index = 0;
   int r = utils::get_path(vm, &arg_index, &path);
@@ -903,7 +904,8 @@ void get_arguments(po::options_description *positional,
   at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE, " (deprecated)");
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   std::string path;
   size_t arg_index = 0;
   int r = utils::get_path(vm, &arg_index, &path);

--- a/src/tools/rbd/action/Info.cc
+++ b/src/tools/rbd/action/Info.cc
@@ -326,7 +326,8 @@ void get_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Journal.cc
+++ b/src/tools/rbd/action/Journal.cc
@@ -810,7 +810,8 @@ void get_info_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute_info(const po::variables_map &vm) {
+int execute_info(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string journal_name;
@@ -848,7 +849,8 @@ void get_status_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute_status(const po::variables_map &vm) {
+int execute_status(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string journal_name;
@@ -884,7 +886,8 @@ void get_reset_arguments(po::options_description *positional,
   at::add_journal_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
 }
 
-int execute_reset(const po::variables_map &vm) {
+int execute_reset(const po::variables_map &vm,
+                  const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string journal_name;
@@ -917,7 +920,8 @@ void get_client_disconnect_arguments(po::options_description *positional,
      "client ID (or leave unspecified to disconnect all)");
 }
 
-int execute_client_disconnect(const po::variables_map &vm) {
+int execute_client_disconnect(const po::variables_map &vm,
+                              const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string journal_name;
@@ -954,7 +958,8 @@ void get_inspect_arguments(po::options_description *positional,
   at::add_verbose_option(options);
 }
 
-int execute_inspect(const po::variables_map &vm) {
+int execute_inspect(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string journal_name;
@@ -989,7 +994,8 @@ void get_export_arguments(po::options_description *positional,
   at::add_no_error_option(options);
 }
 
-int execute_export(const po::variables_map &vm) {
+int execute_export(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string journal_name;
@@ -1030,7 +1036,8 @@ void get_import_arguments(po::options_description *positional,
   at::add_no_error_option(options);
 }
 
-int execute_import(const po::variables_map &vm) {
+int execute_import(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   std::string path;
   size_t arg_index = 0;
   int r = utils::get_path(vm, &arg_index, &path);

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -376,7 +376,8 @@ void get_show_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute_show(const po::variables_map &vm) {
+int execute_show(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   at::Format::Formatter formatter;
   int r = utils::get_formatter(vm, &formatter);
   if (r < 0) {
@@ -403,7 +404,8 @@ void get_map_arguments(po::options_description *positional,
     ("exclusive", po::bool_switch(), "disable automatic exclusive lock transitions");
 }
 
-int execute_map(const po::variables_map &vm) {
+int execute_map(const po::variables_map &vm,
+                const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -471,7 +473,8 @@ void get_unmap_arguments(po::options_description *positional,
     ("options,o", po::value<std::string>(), "unmap options");
 }
 
-int execute_unmap(const po::variables_map &vm) {
+int execute_unmap(const po::variables_map &vm,
+                  const std::vector<std::string> &ceph_global_init_args) {
   std::string device_name = utils::get_positional_argument(vm, 0);
   if (!boost::starts_with(device_name, "/dev/")) {
     device_name.clear();

--- a/src/tools/rbd/action/List.cc
+++ b/src/tools/rbd/action/List.cc
@@ -280,7 +280,8 @@ void get_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 

--- a/src/tools/rbd/action/Lock.cc
+++ b/src/tools/rbd/action/Lock.cc
@@ -110,7 +110,8 @@ void get_list_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute_list(const po::variables_map &vm) {
+int execute_list(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -153,7 +154,8 @@ void get_add_arguments(po::options_description *positional,
     ("shared", po::value<std::string>(), "shared lock tag");
 }
 
-int execute_add(const po::variables_map &vm) {
+int execute_add(const po::variables_map &vm,
+                const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -211,7 +213,8 @@ void get_remove_arguments(po::options_description *positional,
     ("locker", "locker client");
 }
 
-int execute_remove(const po::variables_map &vm) {
+int execute_remove(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/MergeDiff.cc
+++ b/src/tools/rbd/action/MergeDiff.cc
@@ -414,7 +414,8 @@ void get_arguments(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   std::string first_diff = utils::get_positional_argument(vm, 0);
   if (first_diff.empty()) {
     std::cerr << "rbd: first diff was not specified" << std::endl;

--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -95,11 +95,13 @@ int execute_enable_disable(const po::variables_map &vm, bool enable,
   return 0;
 }
 
-int execute_disable(const po::variables_map &vm) {
+int execute_disable(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
   return execute_enable_disable(vm, false, vm["force"].as<bool>());
 }
 
-int execute_enable(const po::variables_map &vm) {
+int execute_enable(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   return execute_enable_disable(vm, true, false);
 }
 
@@ -110,7 +112,8 @@ void get_arguments_promote(po::options_description *positional,
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
 }
 
-int execute_promote(const po::variables_map &vm) {
+int execute_promote(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -148,7 +151,8 @@ int execute_promote(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_demote(const po::variables_map &vm) {
+int execute_demote(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -184,7 +188,8 @@ int execute_demote(const po::variables_map &vm) {
   return 0;
 }
 
-int execute_resync(const po::variables_map &vm) {
+int execute_resync(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -226,7 +231,8 @@ void get_status_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute_status(const po::variables_map &vm) {
+int execute_status(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   at::Format::Formatter formatter;
   int r = utils::get_formatter(vm, &formatter);
   if (r < 0) {

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -527,7 +527,8 @@ void get_peer_add_arguments(po::options_description *positional,
     ("remote-cluster", po::value<std::string>(), "remote cluster name");
 }
 
-int execute_peer_add(const po::variables_map &vm) {
+int execute_peer_add(const po::variables_map &vm,
+                     const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
@@ -588,7 +589,8 @@ void get_peer_remove_arguments(po::options_description *positional,
   add_uuid_option(positional);
 }
 
-int execute_peer_remove(const po::variables_map &vm) {
+int execute_peer_remove(const po::variables_map &vm,
+                        const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
@@ -628,7 +630,8 @@ void get_peer_set_arguments(po::options_description *positional,
     ("value", "new client or cluster name");
 }
 
-int execute_peer_set(const po::variables_map &vm) {
+int execute_peer_set(const po::variables_map &vm,
+                     const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
@@ -730,7 +733,8 @@ int execute_enable_disable(const std::string &pool_name,
   return 0;
 }
 
-int execute_disable(const po::variables_map &vm) {
+int execute_disable(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
@@ -738,7 +742,8 @@ int execute_disable(const po::variables_map &vm) {
                                 "disabled");
 }
 
-int execute_enable(const po::variables_map &vm) {
+int execute_enable(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
@@ -762,7 +767,8 @@ void get_info_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute_info(const po::variables_map &vm) {
+int execute_info(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
@@ -837,7 +843,8 @@ void get_status_arguments(po::options_description *positional,
   at::add_verbose_option(options);
 }
 
-int execute_status(const po::variables_map &vm) {
+int execute_status(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
@@ -948,7 +955,8 @@ void get_promote_arguments(po::options_description *positional,
   at::add_pool_options(positional, options);
 }
 
-int execute_promote(const po::variables_map &vm) {
+int execute_promote(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
@@ -978,7 +986,8 @@ void get_demote_arguments(po::options_description *positional,
   at::add_pool_options(positional, options);
 }
 
-int execute_demote(const po::variables_map &vm) {
+int execute_demote(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -19,8 +19,8 @@ namespace at = argument_types;
 namespace po = boost::program_options;
 
 static int call_nbd_cmd(const po::variables_map &vm,
-                        const std::vector<const char*> &args)
-{
+                        const std::vector<std::string> &args,
+                        const std::vector<std::string> &ceph_global_init_args) {
   char exe_path[PATH_MAX];
   ssize_t exe_path_bytes = readlink("/proc/self/exe", exe_path,
 				    sizeof(exe_path) - 1);
@@ -36,38 +36,13 @@ static int call_nbd_cmd(const po::variables_map &vm,
 
   SubProcess process(exe_path, SubProcess::KEEP, SubProcess::KEEP, SubProcess::KEEP);
 
-  if (vm.count("conf")) {
-    process.add_cmd_arg("--conf");
-    process.add_cmd_arg(vm["conf"].as<std::string>().c_str());
-  }
-  if (vm.count("cluster")) {
-    process.add_cmd_arg("--cluster");
-    process.add_cmd_arg(vm["cluster"].as<std::string>().c_str());
-  }
-  if (vm.count("id")) {
-    process.add_cmd_arg("--id");
-    process.add_cmd_arg(vm["id"].as<std::string>().c_str());
-  }
-  if (vm.count("name")) {
-    process.add_cmd_arg("--name");
-    process.add_cmd_arg(vm["name"].as<std::string>().c_str());
-  }
-  if (vm.count("mon_host")) {
-    process.add_cmd_arg("--mon_host");
-    process.add_cmd_arg(vm["mon_host"].as<std::string>().c_str());
-  }
-  if (vm.count("keyfile")) {
-    process.add_cmd_arg("--keyfile");
-    process.add_cmd_arg(vm["keyfile"].as<std::string>().c_str());
-  }
-  if (vm.count("keyring")) {
-    process.add_cmd_arg("--keyring");
-    process.add_cmd_arg(vm["keyring"].as<std::string>().c_str());
+  for (auto &arg : ceph_global_init_args) {
+    process.add_cmd_arg(arg.c_str());
   }
 
-  for (std::vector<const char*>::const_iterator p = args.begin();
-       p != args.end(); ++p)
-    process.add_cmd_arg(*p);
+  for (auto &arg : args) {
+    process.add_cmd_arg(arg.c_str());
+  }
 
   if (process.spawn()) {
     std::cerr << "rbd: failed to run rbd-nbd: " << process.err() << std::endl;
@@ -109,9 +84,9 @@ void get_show_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute_show(const po::variables_map &vm)
-{
-  std::vector<const char*> args;
+int execute_show(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
+  std::vector<std::string> args;
 
   args.push_back("list-mapped");
 
@@ -123,7 +98,7 @@ int execute_show(const po::variables_map &vm)
     args.push_back("--pretty-format");
   }
 
-  return call_nbd_cmd(vm, args);
+  return call_nbd_cmd(vm, args, ceph_global_init_args);
 }
 
 void get_map_arguments(po::options_description *positional,
@@ -140,9 +115,9 @@ void get_map_arguments(po::options_description *positional,
     ("timeout", po::value<std::string>(), "set nbd request timeout (seconds)");
 }
 
-int execute_map(const po::variables_map &vm)
-{
-  std::vector<const char*> args;
+int execute_map(const po::variables_map &vm,
+                const std::vector<std::string> &ceph_global_init_args) {
+  std::vector<std::string> args;
 
   args.push_back("map");
   std::string img;
@@ -150,7 +125,7 @@ int execute_map(const po::variables_map &vm)
   if (r < 0) {
     return r;
   }
-  args.push_back(img.c_str());
+  args.push_back(img);
 
   if (vm["read-only"].as<bool>())
     args.push_back("--read-only");
@@ -160,22 +135,22 @@ int execute_map(const po::variables_map &vm)
 
   if (vm.count("device")) {
     args.push_back("--device");
-    args.push_back(vm["device"].as<std::string>().c_str());
+    args.push_back(vm["device"].as<std::string>());
   }
   if (vm.count("nbds_max")) {
     args.push_back("--nbds_max");
-    args.push_back(vm["nbds_max"].as<std::string>().c_str());
+    args.push_back(vm["nbds_max"].as<std::string>());
   }
   if (vm.count("max_part")) {
     args.push_back("--max_part");
-    args.push_back(vm["max_part"].as<std::string>().c_str());
+    args.push_back(vm["max_part"].as<std::string>());
   }
   if (vm.count("timeout")) {
     args.push_back("--timeout");
-    args.push_back(vm["timeout"].as<std::string>().c_str());
+    args.push_back(vm["timeout"].as<std::string>());
   }
 
-  return call_nbd_cmd(vm, args);
+  return call_nbd_cmd(vm, args, ceph_global_init_args);
 }
 
 void get_unmap_arguments(po::options_description *positional,
@@ -190,8 +165,8 @@ void get_unmap_arguments(po::options_description *positional,
   at::add_snap_option(options, at::ARGUMENT_MODIFIER_NONE);
 }
 
-int execute_unmap(const po::variables_map &vm)
-{
+int execute_unmap(const po::variables_map &vm,
+                  const std::vector<std::string> &ceph_global_init_args) {
   std::string device_name = utils::get_positional_argument(vm, 0);
   if (!boost::starts_with(device_name, "/dev/")) {
     device_name.clear();
@@ -211,13 +186,12 @@ int execute_unmap(const po::variables_map &vm)
     return -EINVAL;
   }
 
-  std::vector<const char*> args;
+  std::vector<std::string> args;
 
   args.push_back("unmap");
-  args.push_back(device_name.empty() ? image_name.c_str() :
-                 device_name.c_str());
+  args.push_back(device_name.empty() ? image_name : device_name);
 
-  return call_nbd_cmd(vm, args);
+  return call_nbd_cmd(vm, args, ceph_global_init_args);
 }
 
 Shell::SwitchArguments switched_arguments({"read-only"});

--- a/src/tools/rbd/action/ObjectMap.cc
+++ b/src/tools/rbd/action/ObjectMap.cc
@@ -34,7 +34,8 @@ void get_rebuild_arguments(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute_rebuild(const po::variables_map &vm) {
+int execute_rebuild(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -84,7 +85,8 @@ void get_check_arguments(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute_check(const po::variables_map &vm) {
+int execute_check(const po::variables_map &vm,
+                  const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Pool.cc
+++ b/src/tools/rbd/action/Pool.cc
@@ -25,7 +25,8 @@ void get_arguments_init(po::options_description *positional,
        "force initialize pool for RBD use if registered by another application");
 }
 
-int execute_init(const po::variables_map &vm) {
+int execute_init(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 

--- a/src/tools/rbd/action/Remove.cc
+++ b/src/tools/rbd/action/Remove.cc
@@ -34,7 +34,8 @@ void get_arguments(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Rename.cc
+++ b/src/tools/rbd/action/Rename.cc
@@ -30,7 +30,8 @@ void get_arguments(po::options_description *positional,
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_DEST);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Resize.cc
+++ b/src/tools/rbd/action/Resize.cc
@@ -36,7 +36,8 @@ void get_arguments(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -242,7 +242,8 @@ void get_list_arguments(po::options_description *positional,
     (name.c_str(), po::bool_switch(), "list snapshots from all namespaces");
 }
 
-int execute_list(const po::variables_map &vm) {
+int execute_list(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -309,7 +310,8 @@ void get_create_arguments(po::options_description *positional,
   at::add_snap_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
 }
 
-int execute_create(const po::variables_map &vm) {
+int execute_create(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -349,7 +351,8 @@ void get_remove_arguments(po::options_description *positional,
     ("force", po::bool_switch(), "flatten children and unprotect snapshot if needed.");
 }
 
-int execute_remove(const po::variables_map &vm) {
+int execute_remove(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -426,7 +429,8 @@ void get_purge_arguments(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute_purge(const po::variables_map &vm) {
+int execute_purge(const po::variables_map &vm,
+                  const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -498,7 +502,8 @@ void get_rollback_arguments(po::options_description *positional,
   at::add_no_progress_option(options);
 }
 
-int execute_rollback(const po::variables_map &vm) {
+int execute_rollback(const po::variables_map &vm,
+                     const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -533,7 +538,8 @@ void get_protect_arguments(po::options_description *positional,
   at::add_snap_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
 }
 
-int execute_protect(const po::variables_map &vm) {
+int execute_protect(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -580,7 +586,8 @@ void get_unprotect_arguments(po::options_description *positional,
   at::add_image_id_option(options);
 }
 
-int execute_unprotect(const po::variables_map &vm) {
+int execute_unprotect(const po::variables_map &vm,
+                      const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -661,7 +668,8 @@ void get_set_limit_arguments(po::options_description *pos,
   at::add_limit_option(opt);
 }
 
-int execute_set_limit(const po::variables_map &vm) {
+int execute_set_limit(const po::variables_map &vm,
+                      const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -705,7 +713,8 @@ void get_clear_limit_arguments(po::options_description *pos,
   at::add_image_spec_options(pos, opt, at::ARGUMENT_MODIFIER_NONE);
 }
 
-int execute_clear_limit(const po::variables_map &vm) {
+int execute_clear_limit(const po::variables_map &vm,
+                        const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -742,7 +751,8 @@ void get_rename_arguments(po::options_description *positional,
   at::add_snap_spec_options(positional, options, at::ARGUMENT_MODIFIER_DEST);
 }
 
-int execute_rename(const po::variables_map &vm) {
+int execute_rename(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Status.cc
+++ b/src/tools/rbd/action/Status.cc
@@ -64,7 +64,8 @@ void get_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -40,7 +40,8 @@ void get_move_arguments(po::options_description *positional,
      "time delay in seconds until effectively remove the image");
 }
 
-int execute_move(const po::variables_map &vm) {
+int execute_move(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;
@@ -88,7 +89,8 @@ void get_remove_arguments(po::options_description *positional,
       ("force", po::bool_switch(), "force remove of non-expired delayed images");
 }
 
-int execute_remove(const po::variables_map &vm) {
+int execute_remove(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_id;
@@ -294,7 +296,8 @@ void get_list_arguments(po::options_description *positional,
   at::add_format_options(options);
 }
 
-int execute_list(const po::variables_map &vm) {
+int execute_list(const po::variables_map &vm,
+                 const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
@@ -331,7 +334,8 @@ void get_restore_arguments(po::options_description *positional,
   at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE, "");
 }
 
-int execute_restore(const po::variables_map &vm) {
+int execute_restore(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_id;

--- a/src/tools/rbd/action/Watch.cc
+++ b/src/tools/rbd/action/Watch.cc
@@ -94,7 +94,8 @@ void get_arguments(po::options_description *positional,
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
 }
 
-int execute(const po::variables_map &vm) {
+int execute(const po::variables_map &vm,
+            const std::vector<std::string> &ceph_global_init_args) {
   size_t arg_index = 0;
   std::string pool_name;
   std::string image_name;

--- a/src/tools/rbd/rbd.cc
+++ b/src/tools/rbd/rbd.cc
@@ -2,20 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "tools/rbd/Shell.h"
-#include "include/int_types.h"
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include <vector>
 
 int main(int argc, const char **argv)
 {
-  std::vector<const char*> args;
-  argv_to_vec(argc, argv, args);
-  env_to_vec(args);
-
-  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-                         CODE_ENVIRONMENT_UTILITY, 0);
-
   rbd::Shell shell;
-  return shell.execute(args);
+  return shell.execute(argc, argv);
 }


### PR DESCRIPTION
When initializing the global context, global_init parses command line
arguments and removes ceph global args from the list. As a result they
are not visible for rbd command line parser and global options were
ignored when passing them to subprocesses like nbd or ggate.

Fix this by keeping a list of ceph global init command line
arguments. To build the list we compare the list of initial command
line args and those that remain after global_init parsing.

After this fix it is possible to pass any ceph global option to a
subprocess.

Signed-off-by: Mykola Golub <mgolub@suse.com>