### PR TITLE
rgw: fix s3website redirect location string length

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -103,7 +103,7 @@ int RGWGetObj_ObjStore_S3Website::send_response_data(bufferlist& bl, off_t bl_of
   iter = attrs.find(RGW_ATTR_AMZ_WEBSITE_REDIRECT_LOCATION);
   if (iter != attrs.end()) {
     bufferlist &bl = iter->second;
-    s->redirect = string(bl.c_str(), bl.length());
+    s->redirect = bl.c_str();
     s->err.http_ret = 301;
     ldout(s->cct, 20) << __CEPH_ASSERT_FUNCTION << " redirecting per x-amz-website-redirect-location=" << s->redirect << dendl;
     op_ret = -ERR_WEBSITE_REDIRECT;


### PR DESCRIPTION
when run s3test  test_website_xredirect_public_relative

redirect_dest = '/relative'

res = _website_request(bucket.name, '/page')

the length is 9 of redirect_dest   and the length of Location in res is is 10 ('/relative0')   so  redirect string returned  should not include the 0 in the end





  