### PR TITLE
mds: avoid the assert failure when the inode for the cap_export from other MDS happened not in MDCache

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -4359,7 +4359,7 @@ void MDCache::handle_cache_rejoin_weak(MMDSCacheRejoin *weak)
 
     for (auto p = weak->cap_exports.begin(); p != weak->cap_exports.end(); ++p) {
       CInode *in = get_inode(p->first);
-      assert(in && in->is_auth());
+      assert(!in || in->is_auth());
       // note
       for (auto q = p->second.begin(); q != p->second.end(); ++q) {
 	dout(10) << " claiming cap import " << p->first << " client." << q->first << dendl;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22610
Signed-off-by: Jianyu Li <joannyli@tencent.com>