### PR TITLE
ceph_test_objectstore: flush() before collection_empty()

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2388,6 +2388,7 @@ TEST_P(StoreTest, SimpleAttrTest) {
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
   }
+  osr.flush();
   {
     bool empty;
     int r = store->collection_empty(cid, &empty);
@@ -2407,6 +2408,7 @@ TEST_P(StoreTest, SimpleAttrTest) {
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
   }
+  osr.flush();
   {
     bool empty;
     int r = store->collection_empty(cid, &empty);


### PR DESCRIPTION
see also 8dae6d1

Fixes: http://tracker.ceph.com/issues/22409
Signed-off-by: Kefu Chai <kchai@redhat.com>