### PR TITLE
jewel: doc: clarify Path Restriction instructions

### DIFF
--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -107,4 +107,4 @@ for files, but client.1 cannot.
         caps: [osd] allow rw pool=data
 
 
-.. _User Management - Add a User to a Keyring: ../rados/operations/user-management/#add-a-user-to-a-keyring
+.. _User Management - Add a User to a Keyring: ../../rados/operations/user-management/#add-a-user-to-a-keyring


### PR DESCRIPTION
Commit 85ac1cd38756435e6c9eadd6abb2f73546feef04 which was a cherry-pick of d1277f116cd297bae8da7b3e1a7000d3f99c6a51 fixing tracker issue http://tracker.ceph.com/issues/16906 introduced a regression. The path `../rados/operations/user-management/#add-a-user-to-a-keyring` is not correct.

References: http://tracker.ceph.com/issues/22569
Signed-off-by: Jos Collin <jcollin@redhat.com>