### PR TITLE
os/bluestore: _dump_onode() don't prolongate Onode anymore.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9471,7 +9471,7 @@ int BlueStore::_touch(TransContext *txc,
   return r;
 }
 
-void BlueStore::_dump_onode(OnodeRef o, int log_level)
+void BlueStore::_dump_onode(const OnodeRef& o, int log_level)
 {
   if (!cct->_conf->subsys.should_gather(ceph_subsys_bluestore, log_level))
     return;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2017,7 +2017,7 @@ private:
   void _assign_nid(TransContext *txc, OnodeRef o);
   uint64_t _assign_blobid(TransContext *txc);
 
-  void _dump_onode(OnodeRef o, int log_level=30);
+  void _dump_onode(const OnodeRef& o, int log_level=30);
   void _dump_extent_map(ExtentMap& em, int log_level=30);
   void _dump_transaction(Transaction *t, int log_level = 30);
 


### PR DESCRIPTION
Before the patch `BlueStore::_dump_onode()` takes `OnodeRef` by value effectively extending the object's life time.

This is unnecessary and can be costly as `BlueStore::OnodeRef` is ref-counted with `boost::intrusive_ptr`. Moreover, callers are supposed to already hold a reference, so the optimization for `count == 0` case stays without effect of inhibiting call to `BlueStore::Onode::put()` and atomic integer increment.

    ```
    0000000000907d70 <BlueStore::_do_read(BlueStore::Collection*, boost::intrusive_ptr<BlueStore::Onode>, unsigned long, unsigned long, ceph::buffer::list&, unsigned int)>:
      907d70:       41 57                   push   %r15
      907d72:       41 56                   push   %r14

    ...

      907f1f:       48 8b 44 24 78          mov    0x78(%rsp),%rax
      907f24:       48 8b 00                mov    (%rax),%rax
      907f27:       48 85 c0                test   %rax,%rax
      907f2a:       48 89 84 24 a0 01 00    mov    %rax,0x1a0(%rsp)
      907f31:       00
      907f32:       74 04                   je     907f38 <BlueStore::_do_read(BlueStore::Collection*, boost::intrusive_ptr<BlueStore::Onode>, unsigned long, unsigned long, ceph::buffer::list&, unsigned int)+0x1c8>
      907f34:       f0 83 00 01             lock addl $0x1,(%rax)
      907f38:       48 8d 84 24 a0 01 00    lea    0x1a0(%rsp),%rax
      907f3f:       00
      907f40:       ba 1e 00 00 00          mov    $0x1e,%edx
      907f45:       4c 89 ff                mov    %r15,%rdi
      907f48:       48 89 c6                mov    %rax,%rsi
      907f4b:       48 89 44 24 20          mov    %rax,0x20(%rsp)
      907f50:       e8 9b bc fb ff          callq  8c3bf0 <BlueStore::_dump_onode(boost::intrusive_ptr<BlueStore::Onode>, int)>
      907f55:       48 8b bc 24 a0 01 00    mov    0x1a0(%rsp),%rdi
      907f5c:       00
      907f5d:       48 85 ff                test   %rdi,%rdi
      907f60:       74 05                   je     907f67 <BlueStore::_do_read(BlueStore::Collection*, boost::intrusive_ptr<BlueStore::Onode>, unsigned long, unsigned long, ceph::buffer::list&, unsigned int)+0x1f7>
      907f62:       e8 99 14 02 00          callq  929400 <BlueStore::Onode::put()>
      907f67:       48 8d 84 24 d0 00 00    lea    0xd0(%rsp),%rax
    ```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>