### PR TITLE
rgw: make radosgw object stat RGW_ATTR_COMPRESSION dump readable

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5886,6 +5886,8 @@ next:
         handled = dump_string("tag", bl, formatter);
       } else if (iter->first == RGW_ATTR_ETAG) {
         handled = dump_string("etag", bl, formatter);
+      } else if (iter->first == RGW_ATTR_COMPRESSION) {
+        handled = decode_dump<RGWCompressionInfo>("compression", bl, formatter);
       }
 
       if (!handled)

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1634,3 +1634,17 @@ void RGWLifecycleConfiguration::dump(Formatter *f) const
   }
   f->close_section();
 }
+
+void compression_block::dump(Formatter *f) const
+{
+  f->dump_unsigned("old_ofs", old_ofs);
+  f->dump_unsigned("new_ofs", new_ofs);
+  f->dump_unsigned("len", len);
+}
+
+void RGWCompressionInfo::dump(Formatter *f) const
+{
+  f->dump_string("compression_type", compression_type);
+  f->dump_unsigned("orig_size", orig_size);
+  ::encode_json("blocks", blocks, f);
+}

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -196,6 +196,7 @@ struct compression_block {
      ::decode(len, bl);
      DECODE_FINISH(bl);
   }
+  void dump(Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(compression_block)
 
@@ -223,7 +224,8 @@ struct RGWCompressionInfo {
      ::decode(orig_size, bl);
      ::decode(blocks, bl);
      DECODE_FINISH(bl);
-  }
+  } 
+  void dump(Formatter *f) const;
 };
 WRITE_CLASS_ENCODER(RGWCompressionInfo)
 


### PR DESCRIPTION
RGW_ATTR_COMPRESSION is not readable when doing "radosgw object stat", and codes in pr #15599 even truncate the RGW_ATTR_COMPRESSION attr bufferlist.

Signed-off-by: fang yuxiang fang.yuxiang@eisoo.com