### PR TITLE
DNM: common: ceph_clock for replacement of ceph_clock method

### DIFF
--- a/src/common/Clock.cc
+++ b/src/common/Clock.cc
@@ -11,20 +11,22 @@
  * Foundation.  See file COPYING.
  *
  */
+#include "common/ceph_clock.h"
 
+utime_t ceph_clock_now() {
+  return ceph_clock<utime_t>();
+}
 
-#include "common/Clock.h"
+template <>
+coarse_mono_time ceph_clock_now() {
+  return ceph_clock<coarse_mono_time>();
+}
 
-utime_t ceph_clock_now()
-{
-#if defined(__linux__)
-  struct timespec tp;
-  clock_gettime(CLOCK_REALTIME, &tp);
-  utime_t n(tp);
-#else
-  struct timeval tv;
-  gettimeofday(&tv, nullptr);
-  utime_t n(&tv);
-#endif
-  return n;
+utime_t get_duration(utime_t start) {
+  return ceph_clock<utime_t>() - start;
+}
+
+template <>
+ceph::time_detail::signedspan get_duration(coarse_mono_time start) {
+  return ceph_clock<coarse_mono_time>() - start;
 }

--- a/src/common/Clock.h
+++ b/src/common/Clock.h
@@ -12,12 +12,10 @@
  *
  */
 
-#ifndef CEPH_CLOCK_H
-#define CEPH_CLOCK_H
+#ifndef CLOCK_H
+#define CLOCK_H
 
 #include "include/utime.h"
-
-#include <time.h>
 
 utime_t ceph_clock_now();
 

--- a/src/common/ceph_clock.h
+++ b/src/common/ceph_clock.h
@@ -1,0 +1,64 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * Author: Shinobu Kinjo <shinobu@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#ifndef CEPH_CLOCK_H
+#define CEPH_CLOCK_H
+
+#include "common/ceph_time.h"
+#include "include/utime.h"
+#include <time.h>
+#include <type_traits>
+
+template <typename T>
+T ceph_clock();
+
+template <>
+coarse_mono_time ceph_clock() {
+  return ceph::coarse_mono_clock::now();
+}
+
+template <>
+utime_t ceph_clock() {
+#if defined(CLOCK_REALTIME)
+    struct timespec tp;
+    clock_gettime(CLOCK_REALTIME, &tp);
+    utime_t n(tp);
+#else
+    struct timeval tv;
+    gettimeofday(&tv, nullptr);
+    utime_t n(&tv);
+#endif
+  return n;
+}
+
+template <typename T,
+  typename std::enable_if_t<
+    std::is_same<T, coarse_mono_time>::value>* = nullptr>
+auto get_duration(T start) -> ceph::time_detail::signedspan {
+  return ceph_clock<T>() - start;
+}
+
+template <typename T,
+  typename std::enable_if_t<
+    std::is_same<T, utime_t>::value>* =nullptr>
+T get_duration(T start) {
+  return ceph_clock<T>() - start;
+}
+
+template <typename T = utime_t>
+T ceph_clock_now() {
+  return ceph_clock<T>();
+}
+#endif


### PR DESCRIPTION
The purposes of this PR is:
 1) Replace utime_t with coarse_mono_time
 2) Provide single interface to get timestamp
 3) Minimize migration cost as much as possible
  