### PR TITLE
rgw: silence not allow register storage class specifier warning

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 function(gperf_generate input output)
   add_custom_command(
     OUTPUT ${output}
-    COMMAND ${GPERF} ${input} > ${output}
+    COMMAND ${GPERF} ${input} | sed "s/register //g" > ${output}
     DEPENDS ${input}
     COMMENT "Generate ${output}"
     )


### PR DESCRIPTION
The register keyword was deprecated in C++11, so remove it.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>