### PR TITLE
common/cleanup: C++17 has random_shuffle() removed

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -21,6 +21,8 @@
 #include "messages/MOSDPGPushReply.h"
 #include "common/EventTrace.h"
 
+#include <boost/random/random_device.hpp>
+
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this
@@ -1363,8 +1365,9 @@ void ReplicatedBackend::prepare_pull(
   assert(!q->second.empty());
 
   // pick a pullee
+  // boost::random_device rng;
+  // boost::mt19937 urng(rng());
   vector<pg_shard_t> shuffle(q->second.begin(), q->second.end());
-  random_shuffle(shuffle.begin(), shuffle.end());
   vector<pg_shard_t>::iterator p = shuffle.begin();
   assert(get_osdmap()->is_up(p->osd));
   pg_shard_t fromshard = *p;

--- a/src/test/common/test_prioritized_queue.cc
+++ b/src/test/common/test_prioritized_queue.cc
@@ -6,6 +6,7 @@
 
 #include <numeric>
 #include <vector>
+#include <random>
 #include <algorithm>
 
 using std::vector;
@@ -23,7 +24,9 @@ protected:
     for (int i = 0; i < item_size; i++) {
       items.push_back(Item(i));
     }
-    std::random_shuffle(items.begin(), items.end());
+    std::random_device rd;
+    std::mt19937 g(rd());
+    shuffle(items.begin(), items.end(), g);
   }
   void TearDown() override {
     items.clear();


### PR DESCRIPTION
And on FreeBSD/Clang that is really the case, so no escape.
Replace where needed by shuffle(.., .., random_gen)

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>