### PR TITLE
RGW/gperf: Gperf generates register keywords, invalid in C++17

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 function(gperf_generate input output)
   add_custom_command(
     OUTPUT ${output}
-    COMMAND ${GPERF} ${input} > ${output}
+    COMMAND ${GPERF} ${input} | sed 's/register//g' > ${output}
     DEPENDS ${input}
     COMMENT "Generate ${output}"
     )


### PR DESCRIPTION
And Clang enforces this.
2 options:
1)    Use -Wno-register
2)    Fix gperf output, and keep warning for other registers.

Chose to do the last one.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>
  