### PR TITLE
os/bluestore: avoid unneeded BlobRefing in _do_read().

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6613,7 +6613,7 @@ int BlueStore::_do_read(
       pos += hole;
       left -= hole;
     }
-    BlobRef bptr = lp->blob;
+    BlobRef& bptr = lp->blob;
     unsigned l_off = pos - lp->logical_offset;
     unsigned b_off = l_off + lp->blob_offset;
     unsigned b_len = std::min(left, lp->length - l_off);
@@ -6663,7 +6663,7 @@ int BlueStore::_do_read(
   vector<bufferlist> compressed_blob_bls;
   IOContext ioc(cct, NULL, true); // allow EIO
   for (auto& p : blobs2read) {
-    BlobRef bptr = p.first;
+    const BlobRef& bptr = p.first;
     dout(20) << __func__ << "  blob " << *bptr << std::hex
 	     << " need " << p.second << std::dec << dendl;
     if (bptr->get_blob().is_compressed()) {
@@ -6762,7 +6762,7 @@ int BlueStore::_do_read(
   auto p = compressed_blob_bls.begin();
   blobs2read_t::iterator b2r_it = blobs2read.begin();
   while (b2r_it != blobs2read.end()) {
-    BlobRef bptr = b2r_it->first;
+    const BlobRef& bptr = b2r_it->first;
     dout(20) << __func__ << "  blob " << *bptr << std::hex
 	     << " need 0x" << b2r_it->second << std::dec << dendl;
     if (bptr->get_blob().is_compressed()) {


### PR DESCRIPTION
The hottest place in the terms of CPU cycles according to `perf annotate`:
```
       |          intrusive_ptr(intrusive_ptr const & rhs): px( rhs.px )
  0,04 | 365:   mov    0x28(%rax),%r12
       |          {
       |              if( px != 0 ) intrusive_ptr_add_ref( px );
  0,41 |        test   %r12,%r12
       |      ↓ je     37c
       |      _ZNSt13__atomic_baseIiEppEv():
  0,04 |        lock   addl   $0x1,(%r12)
 19,75 |        mov    0xa8(%rsp),%rax
       |      _ZN9BlueStore8_do_readEPNS_10CollectionEN5boost13intrusive_ptrINS_5OnodeEEEmmRN4ceph6buffer4listEj():
       |          }
       |          BlobRef bptr = lp->blob;
       |          unsigned l_off = pos - lp->logical_offset
       | 37c:   mov    0xa0(%rsp),%rdx
       |        sub    0x18(%rax),%edx
       |          unsigned b_off = l_off + lp->blob_offset;
  0,08 |        mov    0x1c(%rax),%ecx
```

With the patch applied:

```
       |          T * operator->() const
       |          {
       |              BOOST_ASSERT( px != 0 );
       |              return px;
       |        mov    0x28(%rcx),%rax
       |        mov    0x8(%rax),%rax
       |      _ZN9BlueStore8_do_readEPNS_10CollectionEN5boost13intrusive_ptrINS
       |          unsigned b_len = std::min(left, lp->length - l_off);
       |
       |          ready_regions_t cache_res;
       |          interval_set<uint32_t> cache_interval;
       |          bptr->shared_blob->bc.read(
 17,78 |        lea    0x18(%rax),%rdi
       |      _ZNK5boost13intrusive_ptrIN9BlueStore10CollectionEEcvbEv():
       |      #if !defined( BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS ) && !
       |          && !(defined(__SUNPRO_CC) && BOOST_WORKAROUND(__SUNPRO_CC, <=
       |
       |          explicit operator bool () const BOOST_NOEXCEPT
       |          {
       |              return px != 0;
  0,07 |        mov    0x8(%rax),%rax
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>