### PR TITLE
debian/rules: strip ceph-base libraries

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -763,6 +763,23 @@ Description: Python 2 libraries for the Ceph librados library
  This package contains Python 2 libraries for interacting with Ceph's
  RADOS object storage.
 
+Package: python-rados-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: python-rados (= ${binary:Version}),
+         python-dbg,
+         ${misc:Depends},
+Description: Python 2 libraries for the Ceph librados library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 2 libraries for interacting with Ceph's
+ RADOS object storage.
+ .
+ This package contains the debugging symbols for python-rados.
+
 Package: python3-rados
 Architecture: linux-any
 Section: python
@@ -777,6 +794,23 @@ Description: Python 3 libraries for the Ceph librados library
  .
  This package contains Python 3 libraries for interacting with Ceph's
  RADOS object storage.
+
+Package: python3-rados-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: python3-rados (= ${binary:Version}),
+         python3-dbg,
+         ${misc:Depends}
+Description: Python 3 libraries for the Ceph librados library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 3 libraries for interacting with Ceph's
+ RADOS object storage.
+ .
+ This package contains the debugging symbols for python-rados.
 
 Package: python-rbd
 Architecture: linux-any
@@ -795,6 +829,23 @@ Description: Python 2 libraries for the Ceph librbd library
  This package contains Python 2 libraries for interacting with Ceph's
  RBD block device library.
 
+Package: python-rbd-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: python-rbd (= ${binary:Version}),
+         python-dbg,
+         ${misc:Depends},
+Description: Python 2 libraries for the Ceph librbd library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 2 libraries for interacting with Ceph's
+ RBD block device library.
+ .
+ This package contains the debugging symbols for python-rbd.
+
 Package: python3-rbd
 Architecture: linux-any
 Section: python
@@ -809,6 +860,23 @@ Description: Python 3 libraries for the Ceph librbd library
  .
  This package contains Python 3 libraries for interacting with Ceph's
  RBD block device library.
+
+Package: python3-rbd-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: python3-rbd (= ${binary:Version}),
+         python3-dbg,
+         ${misc:Depends},
+Description: Python 3 libraries for the Ceph librbd library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 3 libraries for interacting with Ceph's
+ RBD block device library.
+ .
+ This package contains the debugging symbols for python-rbd.
 
 Package: python-rgw
 Architecture: linux-any
@@ -827,6 +895,23 @@ Description: Python 2 libraries for the Ceph librgw library
  This package contains Python 2 libraries for interacting with Ceph's
  RGW library.
 
+Package: python-rgw-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: python-rgw (= ${binary:Version}),
+         python-dbg,
+         ${misc:Depends},
+Description: Python 2 libraries for the Ceph librgw library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 2 libraries for interacting with Ceph's
+ RGW library.
+ .
+ This package contains the debugging symbols for python-rgw.
+
 Package: python3-rgw
 Architecture: linux-any
 Section: python
@@ -841,6 +926,23 @@ Description: Python 3 libraries for the Ceph librgw library
  .
  This package contains Python 3 libraries for interacting with Ceph's
  RGW library.
+
+Package: python3-rgw-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: python3-rgw (= ${binary:Version}),
+         python3-dbg,
+         ${misc:Depends},
+Description: Python 3 libraries for the Ceph librgw library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 3 libraries for interacting with Ceph's
+ RGW library.
+ .
+ This package contains the debugging symbols for python3-rgw.
 
 Package: python-cephfs
 Architecture: linux-any
@@ -859,6 +961,23 @@ Description: Python 2 libraries for the Ceph libcephfs library
  This package contains Python 2 libraries for interacting with Ceph's
  CephFS file system client library.
 
+Package: python-cephfs-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: python-cephfs (= ${binary:Version}),
+         python-dbg,
+         ${misc:Depends},
+Description: Python 2 libraries for the Ceph libcephfs library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 2 libraries for interacting with Ceph's
+ CephFS file system client library.
+ .
+ This package contains the debugging symbols for python-cephfs.
+
 Package: python3-cephfs
 Architecture: linux-any
 Section: python
@@ -873,6 +992,23 @@ Description: Python 3 libraries for the Ceph libcephfs library
  .
  This package contains Python 3 libraries for interacting with Ceph's
  CephFS file system client library.
+
+Package: python3-cephfs-dbg
+Architecture: linux-any
+Section: debug
+Priority: extra
+Depends: python3-cephfs (= ${binary:Version}),
+         python3-dbg,
+         ${misc:Depends},
+Description: Python 3 libraries for the Ceph libcephfs library
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains Python 3 libraries for interacting with Ceph's
+ CephFS file system client library.
+ .
+ This package contains the debugging symbols for python3-cephfs.
 
 Package: python3-ceph-argparse
 Architecture: linux-any

--- a/debian/rules
+++ b/debian/rules
@@ -156,6 +156,14 @@ override_dh_strip:
 	dh_strip -plibrgw2 --dbg-package=librgw2-dbg
 	dh_strip -pradosgw --dbg-package=radosgw-dbg
 	dh_strip -pceph-test --dbg-package=ceph-test-dbg
+	dh_strip -ppython-rados --dbg-package=python-rados-dbg
+	dh_strip -ppython3-rados --dbg-package=python3-rados-dbg
+	dh_strip -ppython-rbd --dbg-package=python-rbd-dbg
+	dh_strip -ppython3-rbd --dbg-package=python3-rbd-dbg
+	dh_strip -ppython-rgw --dbg-package=python-rgw-dbg
+	dh_strip -ppython3-rgw --dbg-package=python3-rgw-dbg
+	dh_strip -ppython-cephfs --dbg-package=python-cephfs-dbg
+	dh_strip -ppython3-cephfs --dbg-package=python3-cephfs-dbg
 
 override_dh_shlibdeps:
 	dh_shlibdeps -a --exclude=erasure-code --exclude=rados-classes --exclude=compressor

--- a/debian/rules
+++ b/debian/rules
@@ -143,6 +143,7 @@ override_dh_strip:
 	dh_strip -pceph-mgr --dbg-package=ceph-mgr-dbg
 	dh_strip -pceph-mon --dbg-package=ceph-mon-dbg
 	dh_strip -pceph-osd --dbg-package=ceph-osd-dbg
+	dh_strip -pceph-base --dbg-package=ceph-base-dbg
 	dh_strip -pceph-fuse --dbg-package=ceph-fuse-dbg
 	dh_strip -prbd-fuse --dbg-package=rbd-fuse-dbg
 	dh_strip -prbd-mirror --dbg-package=rbd-mirror-dbg


### PR DESCRIPTION
This includes rados classes and ec plugins.
http://tracker.ceph.com/issues/22640
  