### PR TITLE
osd: s/random_shuffle()/shuffle()/

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -20,6 +20,7 @@
 #include "messages/MOSDPGPull.h"
 #include "messages/MOSDPGPushReply.h"
 #include "common/EventTrace.h"
+#include "include/random.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
@@ -1363,9 +1364,10 @@ void ReplicatedBackend::prepare_pull(
   assert(!q->second.empty());
 
   // pick a pullee
-  vector<pg_shard_t> shuffle(q->second.begin(), q->second.end());
-  random_shuffle(shuffle.begin(), shuffle.end());
-  vector<pg_shard_t>::iterator p = shuffle.begin();
+  auto p = q->second.begin();
+  std::advance(p,
+               util::generate_random_number<int>(0,
+                                                 q->second.size() - 1));
   assert(get_osdmap()->is_up(p->osd));
   pg_shard_t fromshard = *p;
 

--- a/src/test/common/test_prioritized_queue.cc
+++ b/src/test/common/test_prioritized_queue.cc
@@ -7,6 +7,7 @@
 #include <numeric>
 #include <vector>
 #include <algorithm>
+#include <random>
 
 using std::vector;
 
@@ -23,7 +24,9 @@ protected:
     for (int i = 0; i < item_size; i++) {
       items.push_back(Item(i));
     }
-    std::random_shuffle(items.begin(), items.end());
+    std::random_device rd;
+    std::default_random_engine rng(rd());
+    std::shuffle(items.begin(), items.end(), rng);
   }
   void TearDown() override {
     items.clear();


### PR DESCRIPTION
random_shuffle() is deprecated in C++14, and is removed in C++17

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>
Signed-off-by: Kefu Chai <kchai@redhat.com>