### PR TITLE
build: do_cmake: allow ARGS to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@ Build instructions:
 
 This assumes you make your build dir a subdirectory of the ceph.git
 checkout. If you put it elsewhere, just replace `..` in do_cmake.sh with a
-correct path to the checkout.
+correct path to the checkout. Any additional CMake args can be specified
+setting ARGS before invoking do_cmake. See [cmake options](#cmake-options) 
+for more details. Eg.
+
+    ARGS="-DCMAKE_C_COMPILER=gcc-7" ./do_cmake.sh
 
 To build only certain targets use:
 

--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -5,7 +5,6 @@ if test -e build; then
     exit 1
 fi
 
-ARGS=""
 if which ccache ; then
     echo "enabling ccache"
     ARGS="$ARGS -DWITH_CCACHE=ON"


### PR DESCRIPTION
so that one can do stuff like
ARGS="-DCMAKE_C_COMPILER=gcc-7 -D.." ./do_cmake.sh

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>