### PR TITLE
rgw: fix handling of ENOENT in RGWRadosGetOmapKeysCR

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -252,7 +252,7 @@ RGWRadosGetOmapKeysCR::RGWRadosGetOmapKeysCR(RGWRados *_store,
                       map<string, bufferlist> *_entries, int _max_entries) : RGWSimpleCoroutine(_store->ctx()),
                                                 store(_store),
                                                 marker(_marker),
-                                                entries(_entries), max_entries(_max_entries), rval(0),
+                                                entries(_entries), max_entries(_max_entries),
                                                 obj(_obj), cn(NULL)
 {
   set_description() << "get omap keys dest=" << obj << " marker=" << marker;
@@ -268,10 +268,19 @@ int RGWRadosGetOmapKeysCR::send_request() {
   set_status() << "send request";
 
   librados::ObjectReadOperation op;
-  op.omap_get_vals2(marker, max_entries, entries, nullptr, &rval);
+  op.omap_get_vals2(marker, max_entries, entries, nullptr, nullptr);
 
   cn = stack->create_completion_notifier();
   return ref.ioctx.aio_operate(ref.oid, cn->completion(), &op, NULL);
+}
+
+int RGWRadosGetOmapKeysCR::request_complete()
+{
+  int r = cn->completion()->get_return_value();
+
+  set_status() << "request complete; ret=" << r;
+
+  return r;
 }
 
 RGWRadosRemoveOmapKeysCR::RGWRadosRemoveOmapKeysCR(RGWRados *_store,

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -249,7 +249,7 @@ int RGWRadosSetOmapKeysCR::request_complete()
 RGWRadosGetOmapKeysCR::RGWRadosGetOmapKeysCR(RGWRados *_store,
                       const rgw_raw_obj& _obj,
                       const string& _marker,
-                      map<string, bufferlist> *_entries, int _max_entries) : RGWSimpleCoroutine(_store->ctx()),
+                      std::set<std::string> *_entries, int _max_entries) : RGWSimpleCoroutine(_store->ctx()),
                                                 store(_store),
                                                 marker(_marker),
                                                 entries(_entries), max_entries(_max_entries),
@@ -268,7 +268,7 @@ int RGWRadosGetOmapKeysCR::send_request() {
   set_status() << "send request";
 
   librados::ObjectReadOperation op;
-  op.omap_get_vals2(marker, max_entries, entries, nullptr, nullptr);
+  op.omap_get_keys2(marker, max_entries, entries, nullptr, nullptr);
 
   cn = stack->create_completion_notifier();
   return ref.ioctx.aio_operate(ref.oid, cn->completion(), &op, NULL);

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -410,7 +410,7 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   RGWRados *store;
 
   string marker;
-  map<string, bufferlist> *entries;
+  std::set<std::string> *entries;
   int max_entries;
 
   rgw_rados_ref ref;
@@ -423,7 +423,7 @@ public:
   RGWRadosGetOmapKeysCR(RGWRados *_store,
 		      const rgw_raw_obj& _obj,
 		      const string& _marker,
-		      map<string, bufferlist> *_entries, int _max_entries);
+		      std::set<std::string> *_entries, int _max_entries);
 
   int send_request() override;
   int request_complete() override;

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -413,7 +413,6 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   map<string, bufferlist> *entries;
   int max_entries;
 
-  int rval;
   rgw_rados_ref ref;
 
   rgw_raw_obj obj;
@@ -427,10 +426,7 @@ public:
 		      map<string, bufferlist> *_entries, int _max_entries);
 
   int send_request() override;
-
-  int request_complete() override {
-    return rval;
-  }
+  int request_complete() override;
 };
 
 class RGWRadosRemoveOmapKeysCR : public RGWSimpleCoroutine {


### PR DESCRIPTION
when this operates on a nonexistent object, the osd will reject the request with ENOENT before trying to process the subops. so Objecter will get back a subop return code of 0, try to decode an empty bufferlist into the result and map that subop return code to EIO. by using the AioCompletion's return code, we get the correct result of ENOENT instead

separately, it now calls omap_get_keys2() instead of omap_get_vals2(), and uses set\<string> instead of map<string, bufferlist> accordingly
  