### PR TITLE
cmake: link against ceph-common instead of common

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -753,7 +753,7 @@ if (WITH_MGR)
   add_executable(ceph-mgr ${mgr_srcs}
                  $<TARGET_OBJECTS:heap_profiler_objs>)
   target_include_directories(ceph-mgr SYSTEM PRIVATE "${PYTHON_INCLUDE_DIRS}")
-  target_link_libraries(ceph-mgr osdc client global-static common
+  target_link_libraries(ceph-mgr osdc client global-static ceph-common
       Boost::python ${PYTHON_LIBRARIES} ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} ${ALLOC_LIBS})
   install(TARGETS ceph-mgr DESTINATION bin)
 endif (WITH_MGR)
@@ -840,7 +840,7 @@ set(ceph_mon_srcs
 add_executable(ceph-mon ${ceph_mon_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
 add_dependencies(ceph-mon erasure_code_plugins)
-target_link_libraries(ceph-mon mon os global-static common
+target_link_libraries(ceph-mon mon os global-static ceph-common
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS})
 install(TARGETS ceph-mon DESTINATION bin)
@@ -871,7 +871,7 @@ set(ceph_osd_srcs
   ceph_osd.cc)
 add_executable(ceph-osd ${ceph_osd_srcs})
 add_dependencies(ceph-osd erasure_code_plugins)
-target_link_libraries(ceph-osd osd os global-static common
+target_link_libraries(ceph-osd osd os global-static ceph-common
   ${BLKID_LIBRARIES} ${RDMA_LIBRARIES})
 if(WITH_FUSE)
   target_link_libraries(ceph-osd ${FUSE_LIBRARIES})
@@ -882,7 +882,7 @@ add_subdirectory(mds)
 set(ceph_mds_srcs
   ceph_mds.cc)
 add_executable(ceph-mds ${ceph_mds_srcs})
-target_link_libraries(ceph-mds mds ${CMAKE_DL_LIBS} global-static common
+target_link_libraries(ceph-mds mds ${CMAKE_DL_LIBS} global-static ceph-common
   Boost::thread)
 install(TARGETS ceph-mds DESTINATION bin)
 


### PR DESCRIPTION
this change repeats e6695bb and partially reverts df9a598.
it's always nice to reuse shared library: smaller size of executable,
less debug symbol, and smaller memory footprints at run-time, if the
shared library is "shared" by multiple executables.

See-also: http://tracker.ceph.com/issues/22438
See-also: https://github.com/ceph/teuthology/pull/1143
Signed-off-by: Kefu Chai <kchai@redhat.com>