### PR TITLE
rgw: do not add cancel op in squash_map

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2692,6 +2692,9 @@ int RGWBucketShardIncrementalSyncCR::operate()
           syncstopped = false;
           continue;
         }
+        if (e.op == CLS_RGW_OP_CANCEL) {
+          continue;
+        }
         if (e.state != CLS_RGW_STATE_COMPLETE) {
           continue;
         }


### PR DESCRIPTION
quickly PUT obj twice, and second PUT canceled by some reason.
the two bilogs will have same timestamp, and squash_map will keep the
cancel op, which lead to skip the first normal op because of squash_map
value not equal.

Signed-off-by: Tianshan Qu <tianshan@xsky.com>