### PR TITLE
config: lower default omap entries recovered at once

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2594,7 +2594,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_recovery_max_omap_entries_per_chunk", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(64000)
+    .set_default(8096)
     .set_description(""),
 
     Option("osd_copyfrom_max_chunk", Option::TYPE_UINT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
For large omap DBs, reading 64k leads to heartbeat timeouts.  There
are numerous callchains leading to this recovery step, many of which
do not have heartbeat handles, so for an easily backported version
just change the default number of entries read. DBs approaching 100GB
may require an even lower setting, but this should be good enough for
most clusters, without sacrificing recovery speed.

Fixes: http://tracker.ceph.com/issues/21897
Signed-off-by: Josh Durgin <jdurgin@redhat.com>