### PR TITLE
rgw: remove unused cls_user_add_bucket

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3577,7 +3577,6 @@ public:
   int cls_user_update_buckets(rgw_raw_obj& obj, list<cls_user_bucket_entry>& entries, bool add);
   int cls_user_complete_stats_sync(rgw_raw_obj& obj);
   int complete_sync_user_stats(const rgw_user& user_id);
-  int cls_user_add_bucket(rgw_raw_obj& obj, list<cls_user_bucket_entry>& entries);
   int cls_user_remove_bucket(rgw_raw_obj& obj, const cls_user_bucket& bucket);
   int cls_user_get_bucket_stats(const rgw_bucket& bucket, cls_user_bucket_entry& entry);
 


### PR DESCRIPTION
the function
`int cls_user_add_bucket(rgw_raw_obj& obj, list<cls_user_bucket_entry>& entries);`
is unsed and not implemented, so remove it.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>