### PR TITLE
mgr/dashboard: performance counter browsers

### DIFF
--- a/src/pybind/mgr/dashboard/monitors.html
+++ b/src/pybind/mgr/dashboard/monitors.html
@@ -67,7 +67,7 @@
 			    <th>Open Sessions</th>
 			</thead>
 			<tr rv-each-mon="in_quorum" style="font-size:15px;height:80px">
-			    <td style="font-weight:bold">{mon.name}</td>
+			    <td style="font-weight:bold"><a rv-href="mon.url_perf">{mon.name}</a></td>
 			    <td>{mon.rank}</td>
 			    <td>{mon.public_addr}</td>
 			    <td><span class="inlinesparkline" style="font-size:30px">{ mon.stats.num_sessions | sparkline_data }</span></td>
@@ -87,7 +87,7 @@
 		    <th>Public Addr</th>
 		</thead>
 		<tr rv-each-mon="out_quorum" class="font-size:15px;height:80px">
-		    <td style="font-weight:bold">{mon.name}</td>
+		    <td style="font-weight:bold"><a rv-href="mon.url_perf">{mon.name}</a></td>
 		    <td>{mon.rank}</td>
 		    <td>{mon.public_addr}</td>
 		</tr>

--- a/src/pybind/mgr/dashboard/osd_perf.html
+++ b/src/pybind/mgr/dashboard/osd_perf.html
@@ -104,11 +104,12 @@
                     post_load();
                     setTimeout(refresh, 3000);
                 });
-            };
+	    };
 
             // Wait 1s to load irrespective of normal frequency,
             // to promptly load our first delta
-            setTimeout(refresh, 1000);
+	    setTimeout(refresh, 1000);
+				    
         });
 </script>
 
@@ -116,11 +117,12 @@
 <section class="content-header">
     <h1>
         osd.{osd.osd}
+        <button class="pull-right btn btn-default"><a rv-href="url_perf">Performance Counters</a></button>
     </h1>
 </section>
 
 <section class="content">
-
+  
     <table>
         <tr>
             <td>
@@ -150,7 +152,7 @@
             <tbody>
             <tr rv-each-item="osd_list">
                 <td>{item.key}</td>
-                <td>{item.value}</td>
+                <td>{item.value}</td>		
             </tr>
             </tbody>
         </table>

--- a/src/pybind/mgr/dashboard/perf_counters.html
+++ b/src/pybind/mgr/dashboard/perf_counters.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<script>
+        $(document).ready(function(){
+            // Pre-populated initial data at page load
+            var content_data = {{ content_data }};
+
+            rivets.bind($("div#content"), content_data);
+	
+            var refresh = function() {
+                $.get("{{ url_prefix }}/perf_counters/" + content_data.service_type  + "/" + content_data.service_id, function(data) {
+                    _.extend(content_data, data);
+                    setTimeout(refresh, 3000);
+                });
+            };
+        
+            setTimeout(refresh, 1000);
+        });
+</script>
+
+
+<section class="content-header">
+    <h1>
+        {service_type}.{service_id}
+    </h1>
+</section>
+
+<section class="content">
+<div class="box">
+    <div class="box-header">
+        <h3 class="box-title">Performance Counters</h3>
+    </div>
+    <div class="box-body">
+        <table class="table table-bordered">
+            <thead>
+            <tr>
+                <th>Name</th>
+                <th>Description</th>
+		<th>Value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr rv-each-item="counters">
+                <td>{item.name}</td>
+                <td>{item.description}</td>
+		<td>{item.value | dimless} {item.unit}</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+</section>
+<!-- /.content -->
+
+{% endblock %}

--- a/src/pybind/mgr/dashboard/rgw_detail.html
+++ b/src/pybind/mgr/dashboard/rgw_detail.html
@@ -20,6 +20,7 @@
 </script>
 
 <section class="content-header">
+    <button class="pull-right btn btn-default"><a rv-href="url_perf">Performance Counters</a></button>
     <h1 rv-text="rgw_id"></h1>
 </section>
 

--- a/src/pybind/mgr/dashboard/servers.html
+++ b/src/pybind/mgr/dashboard/servers.html
@@ -16,11 +16,12 @@
             setTimeout(refresh, 5000);
 
             rivets.formatters.service_list = function(services) {
-                var strings = [];
+ 	         var result = ""
                 $.each(services, function(i, svc) {
-                    strings.push(svc.type + "." + svc.id);
+	             result += "<a href={{url_prefix}}/perf_counters/" + svc.type + "/" + svc.id + ">" + svc.type + "." + svc.id + "</a>, " ;
                 });
-                return strings.join(", ");
+	         result = result.slice(0, -2);
+                return result;
             };
 
             rivets.bind($("#content"), content_data);
@@ -55,8 +56,7 @@
                     <td>
                         {server.hostname}
                     </td>
-                    <td>
-                        {server.services | service_list}
+                    <td rv-html="server.services | service_list">
                     </td>
                     <td>
                         {server.ceph_version | short_version}

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -308,6 +308,21 @@ class MgrModule(ceph_module.BaseMgrModule):
         """
         return self._ceph_get(data_name)
 
+    def _stattype_to_str(self, stattype):
+        
+        typeonly = stattype & self.PERFCOUNTER_TYPE_MASK
+        if typeonly == 0:
+            return 'gauge'
+        if typeonly == self.PERFCOUNTER_LONGRUNAVG:
+            # this lie matches the DaemonState decoding: only val, no counts
+            return 'counter'
+        if typeonly == self.PERFCOUNTER_COUNTER:
+            return 'counter'
+        if typeonly == self.PERFCOUNTER_HISTOGRAM:
+            return 'histogram'
+        
+        return ''
+
     def get_server(self, hostname):
         """
         Called by the plugin to fetch metadata about a particular hostname from

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -144,21 +144,6 @@ class Module(MgrModule):
         self.schema = OrderedDict()
         _global_instance['plugin'] = self
 
-    def _stattype_to_str(self, stattype):
-
-        typeonly = stattype & self.PERFCOUNTER_TYPE_MASK
-        if typeonly == 0:
-            return 'gauge'
-        if typeonly == self.PERFCOUNTER_LONGRUNAVG:
-            # this lie matches the DaemonState decoding: only val, no counts
-            return 'counter'
-        if typeonly == self.PERFCOUNTER_COUNTER:
-            return 'counter'
-        if typeonly == self.PERFCOUNTER_HISTOGRAM:
-            return 'histogram'
-
-        return ''
-
     def _setup_static_metrics(self):
         metrics = {}
         metrics['health_status'] = Metric(


### PR DESCRIPTION
http://tracker.ceph.com/issues/22521

This PR adds performance counter links for: osd, mon and rgw from their individual detail page as well as from "servers" page.