### PR TITLE
config: lower default omap entries recovered at once

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2409,7 +2409,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_recovery_max_omap_entries_per_chunk", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(64000)
+    .set_default(8096)
     .set_description(""),
 
     Option("osd_copyfrom_max_chunk", Option::TYPE_UINT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
https://tracker.ceph.com/issues/22671