### PR TITLE
kv/RocksDB: get index and filter blocks memory usage

### DIFF
--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -723,6 +723,9 @@ void RocksDBStore::get_statistics(Formatter *f)
     str.clear();
     db->GetProperty("rocksdb.cur-size-all-mem-tables", &str);
     f->dump_string("rocksdb_memtable_usage", str);
+    str.clear();
+    db->GetProperty("rocksdb.estimate-table-readers-mem", &str);
+    f->dump_string("rocksdb_index_filter_blocks_usage", str);
     f->close_section();
   }
 }


### PR DESCRIPTION
RocksDB has following major components to use memory:

1. Block cache
2. Indexes and bloom filters
3. Memtables
4. Blocks pinned by iterators

Now RockDBStore gets memory statistics for 3 of them, except indexes and bloom filters. So add it into RockDBStore, which can help user to monitor and tune RocksDB memory usage for some cases. 

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>