### PR TITLE
osd: refcount for manifest object (redirect, chunked)

### DIFF
--- a/src/cls/refcount/cls_refcount.cc
+++ b/src/cls/refcount/cls_refcount.cc
@@ -13,6 +13,26 @@ CLS_NAME(refcount)
 
 
 #define REFCOUNT_ATTR "refcount"
+#define CHUNK_REFCOUNT_ATTR "chunk_refcount"
+
+struct chunk_obj_refcount {
+  set<hobject_t> refs;
+
+  chunk_obj_refcount() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(refs, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START(1, bl);
+    decode(refs, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(chunk_obj_refcount)
 
 struct obj_refcount {
   map<string, bool> refs;
@@ -217,6 +237,163 @@ static int cls_rc_refcount_read(cls_method_context_t hctx, bufferlist *in, buffe
   return 0;
 }
 
+static int chunk_read_refcount(cls_method_context_t hctx, chunk_obj_refcount *objr)
+{
+  bufferlist bl;
+  objr->refs.clear();
+  int ret = cls_cxx_getxattr(hctx, CHUNK_REFCOUNT_ATTR, &bl);
+  if (ret == -ENODATA) {
+    return 0;
+  }
+  if (ret < 0)
+    return ret;
+
+  try {
+    bufferlist::iterator iter = bl.begin();
+    decode(*objr, iter);
+  } catch (buffer::error& err) {
+    CLS_LOG(0, "ERROR: chunk_read_refcount(): failed to decode refcount entry\n");
+    return -EIO;
+  }
+
+  return 0;
+}
+
+static int chunk_set_refcount(cls_method_context_t hctx, const struct chunk_obj_refcount& objr)
+{
+  bufferlist bl;
+
+  encode(objr, bl);
+
+  int ret = cls_cxx_setxattr(hctx, CHUNK_REFCOUNT_ATTR, &bl);
+  if (ret < 0)
+    return ret;
+
+  return 0;
+}
+
+static int cls_rc_chunk_refcount_get(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  bufferlist::iterator in_iter = in->begin();
+
+  cls_chunk_refcount_get_op op;
+  try {
+    decode(op, in_iter);
+  } catch (buffer::error& err) {
+    CLS_LOG(1, "ERROR: cls_rc_refcount_get(): failed to decode entry\n");
+    return -EINVAL;
+  }
+
+  chunk_obj_refcount objr;
+  int ret = chunk_read_refcount(hctx, &objr);
+  if (ret < 0)
+    return ret;
+
+  CLS_LOG(10, "cls_rc_chunk_refcount_get() oid=%s\n", op.source.oid.name.c_str());
+
+  objr.refs.insert(op.source);
+
+  ret = chunk_set_refcount(hctx, objr);
+  if (ret < 0)
+    return ret;
+
+  return 0;
+}
+
+static int cls_rc_chunk_refcount_put(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  bufferlist::iterator in_iter = in->begin();
+
+  cls_chunk_refcount_put_op op;
+  try {
+    decode(op, in_iter);
+  } catch (buffer::error& err) {
+    CLS_LOG(1, "ERROR: cls_rc_chunk_refcount_put(): failed to decode entry\n");
+    return -EINVAL;
+  }
+
+  chunk_obj_refcount objr;
+  int ret = chunk_read_refcount(hctx, &objr);
+  if (ret < 0)
+    return ret;
+
+  if (objr.refs.empty()) {// shouldn't happen!
+    CLS_LOG(0, "ERROR: cls_rc_chunk_refcount_put() was called without any references!\n");
+    return -EINVAL;
+  }
+
+  CLS_LOG(10, "cls_rc_chunk_refcount_put() oid=%s\n", op.source.oid.name.c_str());
+
+  bool found = false;
+  for (auto &p : objr.refs) {
+    if (p == op.source) {
+      found = true;
+      break;
+    }
+  }
+
+  if (!found) {
+    return 0;
+  }
+
+  auto p = objr.refs.find(op.source);
+  objr.refs.erase(p);
+
+  if (objr.refs.empty()) {
+    return cls_cxx_remove(hctx);
+  }
+
+  ret = chunk_set_refcount(hctx, objr);
+  if (ret < 0)
+    return ret;
+
+  return 0;
+}
+
+static int cls_rc_chunk_refcount_set(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  bufferlist::iterator in_iter = in->begin();
+
+  cls_chunk_refcount_set_op op;
+  try {
+    decode(op, in_iter);
+  } catch (buffer::error& err) {
+    CLS_LOG(1, "ERROR: cls_chunk_refcount_set(): failed to decode entry\n");
+    return -EINVAL;
+  }
+
+  if (!op.refs.size()) {
+    return cls_cxx_remove(hctx);
+  }
+
+  chunk_obj_refcount objr;
+  objr.refs = op.refs;
+
+  int ret = chunk_set_refcount(hctx, objr);
+  if (ret < 0)
+    return ret;
+
+  return 0;
+}
+
+static int cls_rc_chunk_refcount_read(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  chunk_obj_refcount objr;
+
+  cls_chunk_refcount_read_ret read_ret;
+  int ret = chunk_read_refcount(hctx, &objr);
+  if (ret < 0)
+    return ret;
+
+  for (auto &p : objr.refs) {
+    read_ret.refs.insert(p);
+  }
+
+  encode(read_ret, *out);
+
+  return 0;
+}
+
 CLS_INIT(refcount)
 {
   CLS_LOG(1, "Loaded refcount class!");
@@ -227,6 +404,11 @@ CLS_INIT(refcount)
   cls_method_handle_t h_refcount_set;
   cls_method_handle_t h_refcount_read;
 
+  cls_method_handle_t h_chunk_refcount_get;
+  cls_method_handle_t h_chunk_refcount_put;
+  cls_method_handle_t h_chunk_refcount_set;
+  cls_method_handle_t h_chunk_refcount_read;
+
   cls_register("refcount", &h_class);
 
   /* refcount */
@@ -234,6 +416,15 @@ CLS_INIT(refcount)
   cls_register_cxx_method(h_class, "put", CLS_METHOD_RD | CLS_METHOD_WR, cls_rc_refcount_put, &h_refcount_put);
   cls_register_cxx_method(h_class, "set", CLS_METHOD_RD | CLS_METHOD_WR, cls_rc_refcount_set, &h_refcount_set);
   cls_register_cxx_method(h_class, "read", CLS_METHOD_RD, cls_rc_refcount_read, &h_refcount_read);
+  /* chunk refcount */
+  cls_register_cxx_method(h_class, "chunk_get", CLS_METHOD_RD | CLS_METHOD_WR, cls_rc_chunk_refcount_get, 
+			  &h_chunk_refcount_get);
+  cls_register_cxx_method(h_class, "chunk_put", CLS_METHOD_RD | CLS_METHOD_WR, cls_rc_chunk_refcount_put, 
+			  &h_chunk_refcount_put);
+  cls_register_cxx_method(h_class, "chunk_set", CLS_METHOD_RD | CLS_METHOD_WR, cls_rc_chunk_refcount_set, 
+			  &h_chunk_refcount_set);
+  cls_register_cxx_method(h_class, "chunk_read", CLS_METHOD_RD, cls_rc_chunk_refcount_read, 
+			  &h_chunk_refcount_read);
 
   return;
 }

--- a/src/cls/refcount/cls_refcount_client.cc
+++ b/src/cls/refcount/cls_refcount_client.cc
@@ -58,3 +58,50 @@ int cls_refcount_read(librados::IoCtx& io_ctx, string& oid, list<string> *refs, 
 
   return r;
 }
+
+void cls_chunk_refcount_get(librados::ObjectWriteOperation& op, const hobject_t& soid)
+{
+  bufferlist in;
+  cls_chunk_refcount_get_op call;
+  call.source = soid;
+  encode(call, in);
+  op.exec("refcount", "chunk_get", in);
+}
+
+void cls_chunk_refcount_put(librados::ObjectWriteOperation& op, const hobject_t& soid)
+{
+  bufferlist in;
+  cls_chunk_refcount_put_op call;
+  call.source = soid;
+  encode(call, in);
+  op.exec("refcount", "chunk_put", in);
+}
+
+void cls_chunk_refcount_set(librados::ObjectWriteOperation& op, set<hobject_t>& refs)
+{
+  bufferlist in;
+  cls_chunk_refcount_set_op call;
+  call.refs = refs;
+  encode(call, in);
+  op.exec("refcount", "chunk_set", in);
+}
+
+int cls_chunk_refcount_read(librados::IoCtx& io_ctx, string& oid, set<hobject_t> *refs)
+{
+  bufferlist in, out;
+  int r = io_ctx.exec(oid, "refcount", "chunk_read", in, out);
+  if (r < 0)
+    return r;
+
+  cls_chunk_refcount_read_ret ret;
+  try {
+    bufferlist::iterator iter = out.begin();
+    decode(ret, iter);
+  } catch (buffer::error& err) {
+    return -EIO;
+  }
+
+  *refs = ret.refs;
+
+  return r;
+}

--- a/src/cls/refcount/cls_refcount_ops.h
+++ b/src/cls/refcount/cls_refcount_ops.h
@@ -5,6 +5,7 @@
 #define CEPH_CLS_REFCOUNT_OPS_H
 
 #include "include/types.h"
+#include "common/hobject.h"
 
 struct cls_refcount_get_op {
   string tag;
@@ -123,5 +124,90 @@ struct cls_refcount_read_ret {
 };
 WRITE_CLASS_ENCODER(cls_refcount_read_ret)
 
+struct cls_chunk_refcount_get_op {
+  hobject_t source;
 
+  cls_chunk_refcount_get_op() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(source, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START(1, bl);
+    decode(source, bl);
+    DECODE_FINISH(bl);
+  }
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(list<cls_chunk_refcount_get_op*>& ls);
+};
+WRITE_CLASS_ENCODER(cls_chunk_refcount_get_op)
+
+struct cls_chunk_refcount_put_op {
+  hobject_t source;
+
+  cls_chunk_refcount_put_op() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(source, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START(1, bl);
+    decode(source, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(list<cls_chunk_refcount_put_op*>& ls);
+};
+WRITE_CLASS_ENCODER(cls_chunk_refcount_put_op)
+
+struct cls_chunk_refcount_set_op {
+  set<hobject_t> refs;
+
+  cls_chunk_refcount_set_op() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(refs, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START(1, bl);
+    decode(refs, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(list<cls_chunk_refcount_set_op*>& ls);
+};
+WRITE_CLASS_ENCODER(cls_chunk_refcount_set_op)
+
+struct cls_chunk_refcount_read_ret {
+  set<hobject_t> refs;
+
+  cls_chunk_refcount_read_ret() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(refs, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START(1, bl);
+    decode(refs, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(list<cls_chunk_refcount_read_ret*>& ls);
+};
+WRITE_CLASS_ENCODER(cls_chunk_refcount_read_ret)
 #endif

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -468,6 +468,7 @@ enum {
 	CEPH_OSD_OP_FLAG_FADVISE_WILLNEED   = 0x10,/* data will be accessed in the near future */
 	CEPH_OSD_OP_FLAG_FADVISE_DONTNEED   = 0x20,/* data will not be accessed in the near future */
 	CEPH_OSD_OP_FLAG_FADVISE_NOCACHE   = 0x40, /* data will be accessed only once by this client */
+	CEPH_OSD_OP_FLAG_WITH_REFERENCE   = 0x80, /* need reference couting */
 };
 
 #define EOLDSNAPC    85  /* ORDERSNAP flag set; writer has old snapc*/

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -469,9 +469,9 @@ namespace librados
      * Set redirect target
      */
     void set_redirect(const std::string& tgt_obj, const IoCtx& tgt_ioctx,
-		      uint64_t tgt_version);
+		      uint64_t tgt_version, int flag = 0);
     void set_chunk(uint64_t src_offset, uint64_t src_length, const IoCtx& tgt_ioctx,
-                   std::string tgt_oid, uint64_t tgt_offset);
+                   std::string tgt_oid, uint64_t tgt_offset, int flag = 0);
     void tier_promote();
 
 

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -607,22 +607,24 @@ void librados::ObjectReadOperation::cache_evict()
 
 void librados::ObjectWriteOperation::set_redirect(const std::string& tgt_obj, 
 						  const IoCtx& tgt_ioctx,
-						  uint64_t tgt_version)
+						  uint64_t tgt_version,
+						  int flag)
 {
   ::ObjectOperation *o = &impl->o;
   o->set_redirect(object_t(tgt_obj), tgt_ioctx.io_ctx_impl->snap_seq,
-			  tgt_ioctx.io_ctx_impl->oloc, tgt_version);
+			  tgt_ioctx.io_ctx_impl->oloc, tgt_version, flag);
 }
 
 void librados::ObjectWriteOperation::set_chunk(uint64_t src_offset,
 					       uint64_t src_length,
 					       const IoCtx& tgt_ioctx,
 					       string tgt_oid,
-					       uint64_t tgt_offset)
+					       uint64_t tgt_offset,
+					       int flag)
 {
   ::ObjectOperation *o = &impl->o;
   o->set_chunk(src_offset, src_length, 
-	       tgt_ioctx.io_ctx_impl->oloc, object_t(tgt_oid), tgt_offset);
+	       tgt_ioctx.io_ctx_impl->oloc, object_t(tgt_oid), tgt_offset, flag);
 }
 
 void librados::ObjectWriteOperation::tier_promote()

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3393,6 +3393,45 @@ void PrimaryLogPG::do_proxy_chunked_op(OpRequestRef op, const hobject_t& missing
   } 
 }
 
+struct RefCountCallback : public Context {
+public:
+  PrimaryLogPG *pg;
+  PrimaryLogPG::OpContext *ctx;
+  OSDOp& osd_op;
+  epoch_t last_peering_reset;
+    
+  RefCountCallback(PrimaryLogPG *pg, PrimaryLogPG::OpContext *ctx,
+                  OSDOp &osd_op, epoch_t lpr) 
+    : pg(pg), ctx(ctx), osd_op(osd_op), last_peering_reset(lpr)
+  {}
+  void finish(int r) override {
+    pg->lock();
+    if (last_peering_reset == pg->get_last_peering_reset()) {
+      if (r >= 0) {
+       osd_op.rval = 0;
+       pg->execute_ctx(ctx);
+      } else {
+       if (ctx->op) {
+         pg->osd->reply_op_error(ctx->op, r);
+       }
+       pg->close_op_ctx(ctx);
+      }
+    }
+    pg->unlock();
+  }
+};
+
+struct SetManifestFinisher : public PrimaryLogPG::OpFinisher {
+  OSDOp& osd_op;
+
+  SetManifestFinisher(OSDOp& osd_op) : osd_op(osd_op) {
+  }
+
+  int execute() override {
+    return osd_op.rval;
+  }
+};
+
 void PrimaryLogPG::refcount_manifest(ObjectContextRef obc, object_locator_t oloc, hobject_t soid,
                                      SnapContext snapc, bool get, Context *cb, uint64_t offset)
 {
@@ -6699,36 +6738,63 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  result = -EINVAL;
 	  break;
 	}
-	if (!oi.has_manifest() && !oi.manifest.is_redirect())
-	  ctx->delta_stats.num_objects_manifest++;
 
-        oi.set_flag(object_info_t::FLAG_MANIFEST);
-	oi.manifest.redirect_target = target;
-	oi.manifest.type = object_manifest_t::TYPE_REDIRECT;
-	t->truncate(soid, 0);
-	if (oi.is_omap() && pool.info.supports_omap()) {
-	  t->omap_clear(soid);
-	  obs.oi.clear_omap_digest();
-	  obs.oi.clear_flag(object_info_t::FLAG_OMAP);
+	bool need_reference = (osd_op.op.flags & CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+	bool has_reference = (oi.flags & object_info_t::FLAG_REDIRECT_HAS_REFERENCE);
+	if (has_reference) {
+	  result = -EINVAL;
+	  dout(5) << " the object is already a manifest " << dendl;
+	  break;
 	}
-        ctx->delta_stats.num_bytes -= oi.size;
-	oi.size = 0;
-	oi.new_object();
-	oi.user_version = target_version;
-	ctx->user_at_version = target_version;
-	/* rm_attrs */
-	map<string,bufferlist> rmattrs;
-	result = getattrs_maybe_cache(ctx->obc,
-		    &rmattrs);
-	if (result < 0) {
-	  return result;
+	if (op_finisher == nullptr && need_reference) {
+	  // start
+	  ctx->op_finishers[ctx->current_osd_subop_num].reset(
+	    new SetManifestFinisher(osd_op));
+	  RefCountCallback *fin = new RefCountCallback(
+	    this, ctx, osd_op, get_last_peering_reset());
+	  refcount_manifest(ctx->obc, target_oloc, target, SnapContext(),
+			    true, fin, 0);
+	  result = -EINPROGRESS;
+	} else {
+	  // finish
+	  if (op_finisher) {
+	    result = op_finisher->execute();
+	    assert(result == 0);
+	  }
+
+	  if (!oi.has_manifest() && !oi.manifest.is_redirect())
+	    ctx->delta_stats.num_objects_manifest++;
+
+	  oi.set_flag(object_info_t::FLAG_MANIFEST);
+	  oi.manifest.redirect_target = target;
+	  oi.manifest.type = object_manifest_t::TYPE_REDIRECT;
+	  t->truncate(soid, 0);
+	  if (oi.is_omap() && pool.info.supports_omap()) {
+	    t->omap_clear(soid);
+	    obs.oi.clear_omap_digest();
+	    obs.oi.clear_flag(object_info_t::FLAG_OMAP);
+	  }
+	  ctx->delta_stats.num_bytes -= oi.size;
+	  oi.size = 0;
+	  oi.new_object();
+	  oi.user_version = target_version;
+	  ctx->user_at_version = target_version;
+	  /* rm_attrs */
+	  map<string,bufferlist> rmattrs;
+	  result = getattrs_maybe_cache(ctx->obc, &rmattrs);
+	  if (result < 0) {
+	    return result;
+	  }
+	  map<string, bufferlist>::iterator iter;
+	  for (iter = rmattrs.begin(); iter != rmattrs.end(); ++iter) {
+	    const string& name = iter->first;
+	    t->rmattr(soid, name);
+	  }
+	  dout(10) << "set-redirect oid:" << oi.soid << " user_version: " << oi.user_version << dendl;
+	  if (op_finisher) {
+	    ctx->op_finishers.erase(ctx->current_osd_subop_num);
+	  }
 	}
-	map<string, bufferlist>::iterator iter;
-	for (iter = rmattrs.begin(); iter != rmattrs.end(); ++iter) {
-	  const string& name = iter->first;
-	  t->rmattr(soid, name);
-	}
-	dout(10) << "set-redirect oid:" << oi.soid << " user_version: " << oi.user_version << dendl;
       }
 
       break;
@@ -6789,20 +6855,47 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	hobject_t target(tgt_name, tgt_oloc.key, snapid_t(),
 			 raw_pg.ps(), raw_pg.pool(),
 			 tgt_oloc.nspace);
-	chunk_info.flags = chunk_info_t::FLAG_MISSING;
-	chunk_info.oid = target;
-	chunk_info.offset = tgt_offset;
-	chunk_info.length= src_length;
-	oi.manifest.chunk_map[src_offset] = chunk_info;
-	if (!oi.has_manifest() && !oi.manifest.is_chunked()) 
-	  ctx->delta_stats.num_objects_manifest++;
+	bool need_reference = (osd_op.op.flags & CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+	bool has_reference = (oi.manifest.chunk_map.find(src_offset) != oi.manifest.chunk_map.end()) &&
+			     (oi.manifest.chunk_map[src_offset].flags & chunk_info_t::FLAG_HAS_REFERENCE);
+	if (has_reference) {
+	  result = -EINVAL;
+	  dout(5) << " the object is already a manifest " << dendl;
+	  break;
+	}
+	if (op_finisher == nullptr && need_reference) {
+	  // start
+	  ctx->op_finishers[ctx->current_osd_subop_num].reset(
+	    new SetManifestFinisher(osd_op));
+	  RefCountCallback *fin = new RefCountCallback(
+	    this, ctx, osd_op, get_last_peering_reset());
+	  refcount_manifest(ctx->obc, tgt_oloc, target, SnapContext(),
+			    true, fin, src_offset);
+	  result = -EINPROGRESS;
+	} else {
+	  if (op_finisher) {
+	    result = op_finisher->execute();
+	    assert(result == 0);
+	  }
 
-        oi.set_flag(object_info_t::FLAG_MANIFEST);
-        oi.manifest.type = object_manifest_t::TYPE_CHUNKED;
-        ctx->modify = true;
+	  chunk_info_t chunk_info;
+	  chunk_info.flags = chunk_info_t::FLAG_MISSING;
+	  chunk_info.oid = target;
+	  chunk_info.offset = tgt_offset;
+	  chunk_info.length= src_length;
+	  oi.manifest.chunk_map[src_offset] = chunk_info;
+	  if (!oi.has_manifest() && !oi.manifest.is_chunked()) 
+	    ctx->delta_stats.num_objects_manifest++;
+	  oi.set_flag(object_info_t::FLAG_MANIFEST);
+	  oi.manifest.type = object_manifest_t::TYPE_CHUNKED;
+	  ctx->modify = true;
 
-	dout(10) << "set-chunked oid:" << oi.soid << " user_version: " << oi.user_version 
-		 << " chunk_info: " << chunk_info << dendl;
+	  dout(10) << "set-chunked oid:" << oi.soid << " user_version: " << oi.user_version 
+		   << " chunk_info: " << chunk_info << dendl;
+	  if (op_finisher) {
+	    ctx->op_finishers.erase(ctx->current_osd_subop_num);
+	  }
+	}
       }
 
       break;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -27,6 +27,7 @@
 #include "common/sharedptr_registry.hpp"
 #include "ReplicatedBackend.h"
 #include "PGTransaction.h"
+#include "cls/refcount/cls_refcount_ops.h"
 
 class CopyFromCallback;
 class PromoteCallback;
@@ -1406,7 +1407,7 @@ protected:
   void handle_manifest_flush(hobject_t oid, ceph_tid_t tid, int r,
 			     uint64_t offset, uint64_t last_offset);
   void refcount_manifest(ObjectContextRef obc, object_locator_t oloc, hobject_t soid,
-                        SnapContext snapc, bool get, Context *cb, uint64_t offset);
+                         SnapContext snapc, bool get, Context *cb, uint64_t offset);
 
   friend struct C_ProxyChunkRead;
   friend class PromoteManifestCallback;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1412,6 +1412,7 @@ protected:
   friend class PromoteManifestCallback;
   friend class C_CopyChunk;
   friend struct C_ManifestFlush;
+  friend struct RefCountCallback;
 
 public:
   PrimaryLogPG(OSDService *o, OSDMapRef curmap,

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1405,6 +1405,8 @@ protected:
 			     uint64_t last_offset);
   void handle_manifest_flush(hobject_t oid, ceph_tid_t tid, int r,
 			     uint64_t offset, uint64_t last_offset);
+  void refcount_manifest(ObjectContextRef obc, object_locator_t oloc, hobject_t soid,
+                        SnapContext snapc, bool get, Context *cb, uint64_t offset);
 
   friend struct C_ProxyChunkRead;
   friend class PromoteManifestCallback;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4567,6 +4567,7 @@ struct chunk_info_t {
   enum {
     FLAG_DIRTY = 1, 
     FLAG_MISSING = 2,
+    FLAG_HAS_REFERENCE = 4,
   };
   uint32_t offset;
   uint32_t length;
@@ -4582,6 +4583,9 @@ struct chunk_info_t {
     }
     if (flags & FLAG_MISSING) {
       r += "|missing";
+    }
+    if (flags & FLAG_HAS_REFERENCE) {
+      r += "|has_reference";
     }
     if (r.length())
       return r.substr(1);
@@ -4666,6 +4670,7 @@ struct object_info_t {
     FLAG_CACHE_PIN   = 1<<6, // pin the object in cache tier
     FLAG_MANIFEST    = 1<<7, // has manifest
     FLAG_USES_TMAP   = 1<<8, // deprecated; no longer used
+    FLAG_REDIRECT_HAS_REFERENCE = 1<<9, // has reference
   } flag_t;
 
   flag_t flags;
@@ -4700,6 +4705,8 @@ struct object_info_t {
       sv.insert(sv.end(), "cache_pin");
     if (flags & FLAG_MANIFEST)
       sv.insert(sv.end(), "manifest");
+    if (flags & FLAG_REDIRECT_HAS_REFERENCE)
+      sv.insert(sv.end(), "redirect_has_reference");
     return sv;
   }
   string get_flag_string() const {

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1134,22 +1134,24 @@ struct ObjectOperation {
    * Extensible tier
    */
   void set_redirect(object_t tgt, snapid_t snapid, object_locator_t tgt_oloc, 
-		    version_t tgt_version) {
+		    version_t tgt_version, int flag) {
     OSDOp& osd_op = add_op(CEPH_OSD_OP_SET_REDIRECT);
     osd_op.op.copy_from.snapid = snapid;
     osd_op.op.copy_from.src_version = tgt_version;
     encode(tgt, osd_op.indata);
     encode(tgt_oloc, osd_op.indata);
+    set_last_op_flags(flag);
   }
 
   void set_chunk(uint64_t src_offset, uint64_t src_length, object_locator_t tgt_oloc,
-		 object_t tgt_oid, uint64_t tgt_offset) {
+		 object_t tgt_oid, uint64_t tgt_offset, int flag) {
     OSDOp& osd_op = add_op(CEPH_OSD_OP_SET_CHUNK);
     encode(src_offset, osd_op.indata);
     encode(src_length, osd_op.indata);
     encode(tgt_oloc, osd_op.indata);
     encode(tgt_oid, osd_op.indata);
     encode(tgt_offset, osd_op.indata);
+    set_last_op_flags(flag);
   }
 
   void tier_promote() {

--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -14,6 +14,7 @@
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
 #include "json_spirit/json_spirit.h"
+#include "cls/refcount/cls_refcount_ops.h"
 
 #include "osd/HitSet.h"
 
@@ -3155,6 +3156,104 @@ TEST_F(LibRadosTwoPoolsPP, ManifestPromoteRead) {
     "{\"prefix\": \"osd tier remove\", \"pool\": \"" + pool_name +
     "\", \"tierpool\": \"" + cache_pool_name + "\"}",
     inbl, NULL, NULL));
+
+  // wait for maps to settle before next test
+  cluster.wait_for_latest_osdmap();
+}
+
+TEST_F(LibRadosTwoPoolsPP, ManifestRefRead) {
+  // skip test if not yet mimic
+  {
+    bufferlist inbl, outbl;
+    ASSERT_EQ(0, cluster.mon_command(
+		"{\"prefix\": \"osd dump\"}",
+		inbl, &outbl, NULL));
+    string s(outbl.c_str(), outbl.length());
+    if (s.find("mimic") == std::string::npos) {
+      cout << "cluster is not yet mimic, skipping test" << std::endl;
+      return;
+    }
+  }
+
+  // create object
+  {
+    bufferlist bl;
+    bl.append("hi there");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, ioctx.operate("foo", &op));
+  }
+  {
+    bufferlist bl;
+    bl.append("base chunk");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, ioctx.operate("foo-chunk", &op));
+  }
+  {
+    bufferlist bl;
+    bl.append("there");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, cache_ioctx.operate("bar", &op));
+  }
+  {
+    bufferlist bl;
+    bl.append("CHUNK");
+    ObjectWriteOperation op;
+    op.write_full(bl);
+    ASSERT_EQ(0, cache_ioctx.operate("bar-chunk", &op));
+  }
+
+  // wait for maps to settle
+  cluster.wait_for_latest_osdmap();
+
+  // set-redirect
+  {
+    ObjectWriteOperation op;
+    op.set_redirect("bar", cache_ioctx, 0, CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
+    completion->wait_for_safe();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+  // set-chunk
+  {
+    ObjectWriteOperation op;
+    op.set_chunk(0, 2, cache_ioctx, "bar-chunk", 0, CEPH_OSD_OP_FLAG_WITH_REFERENCE);
+    librados::AioCompletion *completion = cluster.aio_create_completion();
+    ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
+    completion->wait_for_safe();
+    ASSERT_EQ(0, completion->get_return_value());
+    completion->release();
+  }
+  // redirect's refcount 
+  {
+    bufferlist in, out;
+    cache_ioctx.exec("bar", "refcount", "chunk_read", in, out);
+    cls_chunk_refcount_read_ret read_ret;
+    try {
+      bufferlist::iterator iter = out.begin();
+      decode(read_ret, iter);
+    } catch (buffer::error& err) {
+      ASSERT_TRUE(0);
+    }
+    ASSERT_EQ(1, read_ret.refs.size());
+  }
+  // chunk's refcount 
+  {
+    bufferlist in, out;
+    cache_ioctx.exec("bar-chunk", "refcount", "chunk_read", in, out);
+    cls_chunk_refcount_read_ret read_ret;
+    try {
+      bufferlist::iterator iter = out.begin();
+      decode(read_ret, iter);
+    } catch (buffer::error& err) {
+      ASSERT_TRUE(0);
+    }
+    ASSERT_EQ(1, read_ret.refs.size());
+  }
 
   // wait for maps to settle before next test
   cluster.wait_for_latest_osdmap();


### PR DESCRIPTION
This PR introduces refcount operations for redirect and chunked object.
(please refer to https://github.com/ceph/ceph/pull/19294, https://github.com/ceph/ceph/pull/15482)

Signed-off-by: Myoungwon Oh <omwmw@sk.com>