### PR TITLE
librbd,librados: do not include stdbool.h in C++ headers

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1,7 +1,6 @@
 #ifndef __LIBRADOS_HPP
 #define __LIBRADOS_HPP
 
-#include <stdbool.h>
 #include <string>
 #include <list>
 #include <map>

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -15,7 +15,6 @@
 #ifndef __LIBRBD_HPP
 #define __LIBRBD_HPP
 
-#include <stdbool.h>
 #include <string>
 #include <list>
 #include <map>

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -34,7 +34,6 @@
 #include <err.h>
 #endif
 #include <signal.h>
-#include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
stdbool.h is offered to provide C++ keywords for C source file.

Signed-off-by: Kefu Chai <kchai@redhat.com>