### PR TITLE
qa/standalone/osd/osd-mark-down: create pool to get updated osdmap faster

### DIFF
--- a/qa/standalone/osd/osd-markdown.sh
+++ b/qa/standalone/osd/osd-markdown.sh
@@ -59,6 +59,9 @@ function TEST_markdown_exceed_maxdown_count() {
     run_osd $dir 0 || return 1
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
+
+    create_rbd_pool || return 1
+
     # 3+1 times within 300s, osd should stay dead on the 4th time
     local count=3
     local sleeptime=10
@@ -79,6 +82,8 @@ function TEST_markdown_boot() {
     run_osd $dir 0 || return 1
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
+
+    create_rbd_pool || return 1
 
     # 3 times within 120s, should stay up
     local count=3
@@ -102,6 +107,7 @@ function TEST_markdown_boot_exceed_time() {
     run_osd $dir 1 || return 1
     run_osd $dir 2 || return 1
 
+    create_rbd_pool || return 1
 
     # 3+1 times, but over 40s, > 20s, so should stay up
     local count=3


### PR DESCRIPTION
Mon send osdmap to random osds after we mark osd down, the down osd
may use more than $sleep time to get updated osdmap if there is no
osd ping between osds. So create pool after setup cluster.

Signed-off-by: huangjun <huangjun@xsky.com>
(cherry picked from commit ee618a38a9ed06b3ea4d02e46cdeae6afb376b82)