### PR TITLE
ceph-volume: adds --crush-device-class flag for lvm prepare and create

### DIFF
--- a/doc/ceph-volume/lvm/prepare.rst
+++ b/doc/ceph-volume/lvm/prepare.rst
@@ -227,6 +227,15 @@ a volume group and a logical volume using the following convention:
 * logical volume name: ``osd-block-{osd_fsid}``
 
 
+Crush device class
+------------------
+
+To set the crush device class for the OSD, use the ``--crush-device-class`` flag. This will
+work for both bluestore and filestore OSDs::
+
+    ceph-volume lvm prepare --bluestore --data vg/lv --crush-device-class foo
+
+
 Storing metadata
 ----------------
 The following tags will get applied as part of the preparation process
@@ -236,6 +245,7 @@ regardless of the type of volume (journal or data) or OSD objectstore:
 * ``encrypted``
 * ``osd_fsid``
 * ``osd_id``
+* ``crush_device_class``
 
 For :term:`filestore` these tags will be added:
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -54,6 +54,7 @@ def activate_filestore(lvs):
 
     # start the OSD
     systemctl.start_osd(osd_id)
+    terminal.success("ceph-volume lvm activate successful for osd ID: %s" % osd_id)
 
 
 def get_osd_device_path(osd_lv, lvs, device_type):
@@ -126,6 +127,7 @@ def activate_bluestore(lvs):
 
     # start the OSD
     systemctl.start_osd(osd_id)
+    terminal.success("ceph-volume lvm activate successful for osd ID: %s" % osd_id)
 
 
 class Activate(object):
@@ -161,7 +163,6 @@ class Activate(object):
             activate_bluestore(lvs)
         elif args.filestore:
             activate_filestore(lvs)
-        terminal.success("ceph-volume lvm activate successful for osd ID: %s" % args.osd_id)
 
     def main(self):
         sub_command_help = dedent("""

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -94,6 +94,11 @@ def common_parser(prog, description):
         dest='block_wal',
         help='(bluestore) Path to bluestore block.wal logical volume or device',
     )
+    parser.add_argument(
+        '--crush-device-class',
+        dest='crush_device_class',
+        help='Crush device class to assign this OSD to',
+    )
     # Do not parse args, so that consumers can do something before the args get
     # parsed triggering argparse behavior
     return parser

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -190,6 +190,9 @@ class Prepare(object):
 
         cluster_fsid = conf.ceph.get('global', 'fsid')
         osd_fsid = args.osd_fsid or system.generate_uuid()
+        crush_device_class = args.crush_device_class
+        if crush_device_class:
+            secrets['crush_device_class'] = crush_device_class
         # allow re-using an id, in case a prepare failed
         self.osd_id = args.osd_id or prepare_utils.create_id(osd_fsid, json.dumps(secrets))
         tags = {
@@ -197,7 +200,7 @@ class Prepare(object):
             'ceph.osd_id': self.osd_id,
             'ceph.cluster_fsid': cluster_fsid,
             'ceph.cluster_name': conf.cluster,
-            'ceph.crush_device_class': args.crush_device_class,
+            'ceph.crush_device_class': crush_device_class,
         }
         if args.filestore:
             if not args.journal:

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -192,6 +192,13 @@ class Prepare(object):
         osd_fsid = args.osd_fsid or system.generate_uuid()
         # allow re-using an id, in case a prepare failed
         self.osd_id = args.osd_id or prepare_utils.create_id(osd_fsid, json.dumps(secrets))
+        tags = {
+            'ceph.osd_fsid': osd_fsid,
+            'ceph.osd_id': self.osd_id,
+            'ceph.cluster_fsid': cluster_fsid,
+            'ceph.cluster_name': conf.cluster,
+            'ceph.crush_device_class': args.crush_device_class,
+        }
         if args.filestore:
             if not args.journal:
                 raise RuntimeError('--journal is required when using --filestore')
@@ -200,14 +207,8 @@ class Prepare(object):
             if not data_lv:
                 data_lv = self.prepare_device(args.data, 'data', cluster_fsid, osd_fsid)
 
-            tags = {
-                'ceph.osd_fsid': osd_fsid,
-                'ceph.osd_id': self.osd_id,
-                'ceph.cluster_fsid': cluster_fsid,
-                'ceph.cluster_name': conf.cluster,
-                'ceph.data_device': data_lv.lv_path,
-                'ceph.data_uuid': data_lv.lv_uuid,
-            }
+            tags['ceph.data_device'] = data_lv.lv_path
+            tags['ceph.data_uuid'] = data_lv.lv_uuid
 
             journal_device, journal_uuid, tags = self.setup_device('journal', args.journal, tags)
 
@@ -226,14 +227,8 @@ class Prepare(object):
             if not block_lv:
                 block_lv = self.prepare_device(args.data, 'block', cluster_fsid, osd_fsid)
 
-            tags = {
-                'ceph.osd_fsid': osd_fsid,
-                'ceph.osd_id': self.osd_id,
-                'ceph.cluster_fsid': cluster_fsid,
-                'ceph.cluster_name': conf.cluster,
-                'ceph.block_device': block_lv.lv_path,
-                'ceph.block_uuid': block_lv.lv_uuid,
-            }
+            tags['ceph.block_device'] = block_lv.lv_path
+            tags['ceph.block_uuid'] = block_lv.lv_uuid
 
             wal_device, wal_uuid, tags = self.setup_device('wal', args.block_wal, tags)
             db_device, db_uuid, tags = self.setup_device('db', args.block_db, tags)

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/group_vars/all
@@ -14,6 +14,7 @@ copy_admin_key: true
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group
+    crush_device_class: test
   - data: data-lv2
     data_vg: test_group
     db: journal1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/group_vars/all
@@ -16,6 +16,7 @@ lvm_volumes:
   - data: data-lv1
     journal: /dev/sdc1
     data_vg: test_group
+    crush_device_class: test
   - data: data-lv2
     journal: journal1
     data_vg: test_group

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/group_vars/all
@@ -14,6 +14,7 @@ copy_admin_key: true
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group
+    crush_device_class: test
   - data: data-lv2
     data_vg: test_group
     db: journal1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/group_vars/all
@@ -16,6 +16,7 @@ lvm_volumes:
   - data: data-lv1
     journal: /dev/sdc1
     data_vg: test_group
+    crush_device_class: test
   - data: data-lv2
     journal: journal1
     data_vg: test_group


### PR DESCRIPTION
This supports the new method of setting the crush device class through the json given to the ``osd new`` command. Introduced here: https://github.com/ceph/ceph/pull/19939

Needs this for ceph-ansible support and for CI testing: https://github.com/ceph/ceph-ansible/pull/2318

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1498521