### PR TITLE
cryptopp: compilation fixes for c++17

### DIFF
--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -12,7 +12,7 @@
  */
 
 #include <sstream>
-#include "Crypto.h"
+#include "common/ceph_crypto.h"
 #ifdef USE_CRYPTOPP
 # include <cryptopp/modes.h>
 # include <cryptopp/aes.h>
@@ -23,10 +23,10 @@
 # include <pk11pub.h>
 #endif
 
+#include "Crypto.h"
 #include "include/assert.h"
 #include "common/Clock.h"
 #include "common/armor.h"
-#include "common/ceph_crypto.h"
 #include "common/hex.h"
 #include "common/safe_io.h"
 #include "include/ceph_fs.h"
@@ -150,9 +150,9 @@ public:
     secret = s;
 
     enc_key = new CryptoPP::AES::Encryption(
-      (byte*)secret.c_str(), CryptoPP::AES::DEFAULT_KEYLENGTH);
+      (::byte*)secret.c_str(), CryptoPP::AES::DEFAULT_KEYLENGTH);
     dec_key = new CryptoPP::AES::Decryption(
-      (byte*)secret.c_str(), CryptoPP::AES::DEFAULT_KEYLENGTH);
+      (::byte*)secret.c_str(), CryptoPP::AES::DEFAULT_KEYLENGTH);
 
     return 0;
   }
@@ -162,7 +162,7 @@ public:
     string ciphertext;
     CryptoPP::StringSink *sink = new CryptoPP::StringSink(ciphertext);
     CryptoPP::CBC_Mode_ExternalCipher::Encryption cbc(
-      *enc_key, (const byte*)CEPH_AES_IV);
+      *enc_key, (const ::byte*)CEPH_AES_IV);
     CryptoPP::StreamTransformationFilter stfEncryptor(cbc, sink);
 
     for (std::list<bufferptr>::const_iterator it = in.buffers().begin();
@@ -189,7 +189,7 @@ public:
     string decryptedtext;
     CryptoPP::StringSink *sink = new CryptoPP::StringSink(decryptedtext);
     CryptoPP::CBC_Mode_ExternalCipher::Decryption cbc(
-      *dec_key, (const byte*)CEPH_AES_IV );
+      *dec_key, (const ::byte*)CEPH_AES_IV );
     CryptoPP::StreamTransformationFilter stfDecryptor(cbc, sink);
     for (std::list<bufferptr>::const_iterator it = in.buffers().begin();
 	 it != in.buffers().end(); ++it) {

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -20,11 +20,11 @@
 
 #include <boost/algorithm/string.hpp>
 
+#include "common/ceph_crypto.h"
 #include "include/mempool.h"
 #include "common/admin_socket.h"
 #include "common/perf_counters.h"
 #include "common/code_environment.h"
-#include "common/ceph_crypto.h"
 #include "common/HeartbeatMap.h"
 #include "common/errno.h"
 #include "common/Graylog.h"

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -12,8 +12,8 @@
  *
  */
 
-#include "common/config.h"
 #include "ceph_crypto.h"
+#include "common/config.h"
 
 #ifdef USE_CRYPTOPP
 void ceph::crypto::init(CephContext *cct)

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -2,10 +2,10 @@
 #include <time.h>
 
 #include "gtest/gtest.h"
+#include "common/ceph_crypto.h"
 #include "include/types.h"
 #include "auth/Crypto.h"
 #include "common/Clock.h"
-#include "common/ceph_crypto.h"
 #include "common/ceph_context.h"
 #include "global/global_context.h"
 


### PR DESCRIPTION
cryptopp adds a `typedef unsigned char byte` to the global namespace, which conflicts with c++17's `std::byte` when `using namespace std` has been used

this shuffles around the #include order in some sources as a workaround, and adds the `::byte` qualifier when used in ceph sources

(see https://github.com/weidai11/cryptopp/pull/438 for more background)