### PR TITLE
qa/tests: create 4 lv's by default for ceph-volume tests

### DIFF
--- a/qa/suites/ceph-deploy/ceph-volume/cluster/4node.yaml
+++ b/qa/suites/ceph-deploy/ceph-volume/cluster/4node.yaml
@@ -1,3 +1,7 @@
+overrides:
+ ansible.cephlab: 
+  vars: 
+   quick_lvs_to_create: 4
 roles:
 - [mon.a, mgr.y, osd.0, osd.1]
 - [mon.b, osd.2, osd.3]


### PR DESCRIPTION
we need lvm's for ceph-volume tests

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>