### PR TITLE
osd: Sign in early SIGHUP signal

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -145,6 +145,9 @@ int main(int argc, const char **argv, const char *envp[]) {
 
   {
     common_init_finish(g_ceph_context);
+   
+    init_async_signal_handler();
+    register_async_signal_handler(SIGHUP, sighup_handler);
 
     //cout << "child, mounting" << std::endl;
     class RemountTest : public Thread {
@@ -239,9 +242,6 @@ int main(int argc, const char **argv, const char *envp[]) {
       cerr << "ceph-fuse[" << getpid() << "]: ceph messenger failed with " << cpp_strerror(-r) << std::endl;
       goto out_messenger_start_failed;
     }
-
-    init_async_signal_handler();
-    register_async_signal_handler(SIGHUP, sighup_handler);
 
     // start client
     r = client->init();

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -174,7 +174,11 @@ int main(int argc, const char **argv)
 
   global_init_daemonize(g_ceph_context);
   common_init_finish(g_ceph_context);
-
+  
+  // set up signal handlers, now that we've daemonized/forked.
+  init_async_signal_handler();
+  register_async_signal_handler(SIGHUP, sighup_handler);
+  
   // get monmap
   MonClient mc(g_ceph_context);
   if (mc.build_initial_monmap() < 0)
@@ -196,9 +200,6 @@ int main(int argc, const char **argv)
     goto shutdown;
   }
 
-  // set up signal handlers, now that we've daemonized/forked.
-  init_async_signal_handler();
-  register_async_signal_handler(SIGHUP, sighup_handler);
   register_async_signal_handler_oneshot(SIGINT, handle_mds_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_mds_signal);
 

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -512,6 +512,10 @@ int main(int argc, const char **argv)
 #endif
   }
 
+  // set up signal handlers, now that we've daemonized/forked.
+  init_async_signal_handler();
+  register_async_signal_handler(SIGHUP, sighup_handler);
+
   MonitorDBStore *store = new MonitorDBStore(g_conf->mon_data);
   {
     ostringstream oss;
@@ -789,9 +793,6 @@ int main(int argc, const char **argv)
 
   mon->init();
 
-  // set up signal handlers, now that we've daemonized/forked.
-  init_async_signal_handler();
-  register_async_signal_handler(SIGHUP, sighup_handler);
   register_async_signal_handler_oneshot(SIGINT, handle_mon_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_mon_signal);
 

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -599,6 +599,10 @@ flushjournal_out:
   global_init_daemonize(g_ceph_context);
   common_init_finish(g_ceph_context);
 
+  // install signal handlers
+  init_async_signal_handler();
+  register_async_signal_handler(SIGHUP, sighup_handler);
+
   TracepointProvider::initialize<osd_tracepoint_traits>(g_ceph_context);
   TracepointProvider::initialize<os_tracepoint_traits>(g_ceph_context);
 #ifdef WITH_OSD_INSTRUMENT_FUNCTIONS
@@ -658,9 +662,6 @@ flushjournal_out:
   cephd_preload_rados_classes(osd);
 #endif
 
-  // install signal handlers
-  init_async_signal_handler();
-  register_async_signal_handler(SIGHUP, sighup_handler);
   register_async_signal_handler_oneshot(SIGINT, handle_osd_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_osd_signal);
 

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -94,6 +94,9 @@ void MgrStandby::handle_conf_change(
 
 int MgrStandby::init()
 {
+  init_async_signal_handler();
+  register_async_signal_handler(SIGHUP, sighup_handler);
+
   Mutex::Locker l(lock);
 
   // Initialize Messenger
@@ -422,8 +425,6 @@ int MgrStandby::main(vector<const char *> args)
 {
   // Enable signal handlers
   signal_mgr = this;
-  init_async_signal_handler();
-  register_async_signal_handler(SIGHUP, sighup_handler);
   register_async_signal_handler_oneshot(SIGINT, handle_mgr_signal);
   register_async_signal_handler_oneshot(SIGTERM, handle_mgr_signal);
 

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -287,6 +287,9 @@ int main(int argc, const char **argv)
 
   common_init_finish(g_ceph_context);
 
+  init_async_signal_handler();
+  register_async_signal_handler(SIGHUP, sighup_handler);
+
   int r = rgw_tools_init(g_ceph_context);
   if (r < 0) {
     derr << "ERROR: unable to initialize rgw tools" << dendl;
@@ -427,8 +430,6 @@ int main(int argc, const char **argv)
     exit(1);
   }
 
-  init_async_signal_handler();
-  register_async_signal_handler(SIGHUP, sighup_handler);
   register_async_signal_handler(SIGTERM, handle_sigterm);
   register_async_signal_handler(SIGINT, handle_sigterm);
   register_async_signal_handler(SIGUSR1, handle_sigterm);


### PR DESCRIPTION
In the process of starting the osd process,if system just call the
logratote("killall -q -1 ceph-mon ceph-mgr ceph-mds ceph-osd ceph-fuse radosgw...")
it will cause osd'init failed to start,
in addition, osd init slower than before, will increase the chances of the error.
Other modules(mon\mds\mgr...) also have type problems, but the most serious osd problem,
I can then make other modules similar changes.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>