### PR TITLE
cmake: do not find bzip2/lz4 for rocksdb

### DIFF
--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -12,13 +12,3 @@ add_library(kv STATIC $<TARGET_OBJECTS:kv_objs>)
 target_include_directories(kv_objs SYSTEM BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
 target_include_directories(kv SYSTEM BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
 target_link_libraries(kv ${LEVELDB_LIBRARIES} ${ROCKSDB_LIBRARIES} ${ALLOC_LIBS} ${SNAPPY_LIBRARIES} ${ZLIB_LIBRARIES})
-
-# rocksdb detects bzlib and lz4 in its Makefile, which forces us to do the same.
-find_package(BZip2 QUIET)
-if (BZIP2_FOUND)
-  target_link_libraries(kv ${BZIP2_LIBRARIES})
-endif (BZIP2_FOUND)
-find_package(LZ4 QUIET)
-if (LZ4_FOUND)
-  target_link_libraries(kv ${LZ4_LIBRARY})
-endif (LZ4_FOUND)


### PR DESCRIPTION
Rocksdb has compression disabled by default[1] and it's never been enabled[2], so do not link these compression libraries implicitly

[1] https://github.com/ceph/rocksdb/blob/master/CMakeLists.txt#L76
[2] https://github.com/ceph/ceph/blob/master/cmake/modules/BuildRocksDB.cmake

Signed-off-by: runsisi <runsisi@zte.com.cn>