### PR TITLE
cmake: move ceph-osdomap-tool, ceph-monstore-tool out of ceph-test

### DIFF
--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -22,6 +22,11 @@ add_executable(ceph_radosacl radosacl.cc)
 target_link_libraries(ceph_radosacl librados global)
 install(TARGETS ceph_radosacl DESTINATION bin)
 
+install(PROGRAMS
+  ceph-monstore-update-crush.sh
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/ceph)
+endif(WITH_TESTS)
+
 add_executable(ceph-osdomap-tool ceph_osdomap_tool.cc)
 target_link_libraries(ceph-osdomap-tool os global Boost::program_options)
 install(TARGETS ceph-osdomap-tool DESTINATION bin)
@@ -31,10 +36,6 @@ add_executable(ceph-monstore-tool
   ../mgr/mgr_commands.cc)
 target_link_libraries(ceph-monstore-tool os global Boost::program_options)
 install(TARGETS ceph-monstore-tool DESTINATION bin)
-install(PROGRAMS
-  ceph-monstore-update-crush.sh
-  DESTINATION ${CMAKE_INSTALL_LIBDIR}/ceph)
-endif(WITH_TESTS)
 
 add_executable(ceph-objectstore-tool
   ceph_objectstore_tool.cc

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -43,7 +43,7 @@ add_executable(ceph-objectstore-tool
   RadosDump.cc)
 target_link_libraries(ceph-objectstore-tool osd os global Boost::program_options ${CMAKE_DL_LIBS})
 if(WITH_FUSE)
-  target_link_libraries(ceph-objectstore-tool fuse)
+  target_link_libraries(ceph-objectstore-tool ${FUSE_LIBRARIES})
 endif(WITH_FUSE)
 install(TARGETS ceph-objectstore-tool DESTINATION bin)
 


### PR DESCRIPTION
build rpm with `--without ceph_test_package` should fail[1][2] since `-DWITH_TESTS=OFF` is defined.

and do not use `-lfuse` directly

[1] https://github.com/ceph/ceph/blob/master/ceph.spec.in#L1254
[2] https://github.com/ceph/ceph/blob/master/ceph.spec.in#L1423

Signed-off-by: runsisi runsisi@zte.com.cn