### PR TITLE
osd_types.cc: reorder fields in serialized pg_stat_t

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2411,7 +2411,8 @@ void pg_stat_t::encode(bufferlist &bl) const
   encode(last_became_peered, bl);
   encode(pin_stats_invalid, bl);
   encode(snaptrimq_len, bl);
-  encode(state, bl);
+  __u32 top_state = (state >> 32);
+  encode(top_state, bl);
   encode(purged_snaps, bl);
   ENCODE_FINISH(bl);
 }
@@ -2470,7 +2471,9 @@ void pg_stat_t::decode(bufferlist::iterator &bl)
   if (struct_v >= 23) {
     decode(snaptrimq_len, bl);
     if (struct_v >= 24) {
-      decode(state, bl);
+      __u32 top_state;
+      decode(top_state, bl);
+      state = (uint64_t)old_state | ((uint64_t)top_state << 32);
       decode(purged_snaps, bl);
     } else {
       state = old_state;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2369,7 +2369,7 @@ void pg_stat_t::dump_brief(Formatter *f) const
 
 void pg_stat_t::encode(bufferlist &bl) const
 {
-  ENCODE_START(25, 22, bl);
+  ENCODE_START(24, 22, bl);
   encode(version, bl);
   encode(reported_seq, bl);
   encode(reported_epoch, bl);
@@ -2410,9 +2410,9 @@ void pg_stat_t::encode(bufferlist &bl) const
   encode(last_peered, bl);
   encode(last_became_peered, bl);
   encode(pin_stats_invalid, bl);
+  encode(snaptrimq_len, bl);
   encode(state, bl);
   encode(purged_snaps, bl);
-  encode(snaptrimq_len, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -2468,14 +2468,12 @@ void pg_stat_t::decode(bufferlist::iterator &bl)
   decode(tmp, bl);
   pin_stats_invalid = tmp;
   if (struct_v >= 23) {
-    decode(state, bl);
-  } else {
-    state = old_state;
-  }
-  if (struct_v >= 24) {
-    decode(purged_snaps, bl);
-    if (struct_v >= 25) {
-      decode(snaptrimq_len, bl);
+    decode(snaptrimq_len, bl);
+    if (struct_v >= 24) {
+      decode(state, bl);
+      decode(purged_snaps, bl);
+    } else {
+      state = old_state;
     }
   }
   DECODE_FINISH(bl);


### PR DESCRIPTION
Fields state (64-bit version), purged_snaps and snaptrimq_len are new to Mimic. Reorder them in a way that newest field (snaptrimq_len) is placed before two others and uses other encoding version, so the pull request #19520 can be backported to Luminous without breaking Luminous -> Mimic upgrade.
This also changes encoding/decoding version back to 24 as both state and purged snaps were added post-Luminous and pre-Mimic, so we can push it into a single struct version and keep snaptrimq_len into other version.

I'm using this opportunity to smuggle-in the change in how the new, 64-bit pg state is encoded, so the least significant 32 bits aren't encoded twice -- although I don't mind resubmitting that in separate PR once the reordering commit gets merged.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>