### PR TITLE
jewel: common: compute SimpleLRU's size with contents.size() instead of lru.…

### DIFF
--- a/src/common/simple_cache.hpp
+++ b/src/common/simple_cache.hpp
@@ -31,7 +31,7 @@ class SimpleLRU {
   map<K, V, C> pinned;
 
   void trim_cache() {
-    while (lru.size() > max_size) {
+    while (contents.size() > max_size) {
       contents.erase(lru.back().first);
       lru.pop_back();
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/22693