### PR TITLE
mgr: prometheus: set metadata metrics value to '1' (#22717).

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -284,7 +284,7 @@ class Module(MgrModule):
             p_addr = osd['public_addr'].split(':')[0]
             c_addr = osd['cluster_addr'].split(':')[0]
             dev_class = next((osd for osd in osd_devices if osd['id'] == id_))
-            self.metrics['osd_metadata'].set(0, (
+            self.metrics['osd_metadata'].set(1, (
                 c_addr,
                 dev_class['class'],
                 id_,
@@ -308,7 +308,7 @@ class Module(MgrModule):
             if osd_dev_node and osd_hostname:
                 self.log.debug("Got dev for osd {0}: {1}/{2}".format(
                     id_, osd_hostname, osd_dev_node))
-                self.metrics['disk_occupation'].set(0, (
+                self.metrics['disk_occupation'].set(1, (
                     osd_hostname,
                     osd_dev_node,
                     "osd.{0}".format(id_)
@@ -320,7 +320,7 @@ class Module(MgrModule):
         for pool in osd_map['pools']:
             id_ = pool['pool']
             name = pool['pool_name']
-            self.metrics['pool_metadata'].set(0, (id_, name))
+            self.metrics['pool_metadata'].set(1, (id_, name))
 
     def collect(self):
         self.get_health()


### PR DESCRIPTION
By default we have pool metrics like this:

```python
ceph_pool_objects{pool_id="1"} 1075534
ceph_pool_metadata{name="name_of_pool_1",pool_id="1"} 0
```

When I was try to join `name` label from metadata series (to use label with Grafana) like this:

```python
ceph_pool_objects * on (pool_id) group_left(name) ceph_pool_metadata
```

Result returned without metric, only labels:

```python
{name="name_of_pool_1",pool_id="1"}
```

This is because metadata metric always have value '0'.
This behavior will be fixed if set value to '1'.

http://tracker.ceph.com/issues/22717