### PR TITLE
cephfs-journal-tool: Fix Dumper destroyed before shutdown

### DIFF
--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -570,7 +570,6 @@ int JournalTool::journal_export(std::string const &path, bool import)
     } else {
       r = dumper.dump(path.c_str());
     }
-    dumper.shutdown();
   }
 
   return r;
@@ -595,7 +594,6 @@ int JournalTool::journal_reset(bool hard)
   } else {
     r = resetter.reset(mds_role_t(role_selector.get_ns(), rank));
   }
-  resetter.shutdown();
 
   return r;
 }

--- a/src/tools/cephfs/MDSUtility.cc
+++ b/src/tools/cephfs/MDSUtility.cc
@@ -23,7 +23,8 @@ MDSUtility::MDSUtility() :
   objecter(NULL),
   lock("MDSUtility::lock"),
   finisher(g_ceph_context, "MDSUtility", "fn_mds_utility"),
-  waiting_for_mds_map(NULL)
+  waiting_for_mds_map(NULL),
+  inited(false)
 {
   monc = new MonClient(g_ceph_context);
   messenger = Messenger::create_client_messenger(g_ceph_context, "mds");
@@ -34,6 +35,9 @@ MDSUtility::MDSUtility() :
 
 MDSUtility::~MDSUtility()
 {
+  if (inited) {
+    shutdown();
+  }
   delete objecter;
   delete monc;
   delete messenger;
@@ -107,6 +111,7 @@ int MDSUtility::init()
 
   finisher.start();
 
+  inited = true;
   return 0;
 }
 

--- a/src/tools/cephfs/MDSUtility.h
+++ b/src/tools/cephfs/MDSUtility.h
@@ -41,6 +41,7 @@ protected:
 
   Context *waiting_for_mds_map;
 
+  bool inited;
 public:
   MDSUtility();
   ~MDSUtility() override;

--- a/src/tools/cephfs/cephfs-data-scan.cc
+++ b/src/tools/cephfs/cephfs-data-scan.cc
@@ -39,7 +39,6 @@ int main(int argc, const char **argv)
     std::cerr << "Error (" << cpp_strerror(rc) << ")" << std::endl;
   }
 
-  data_scan.shutdown();
 
   return rc;
 }

--- a/src/tools/cephfs/cephfs-journal-tool.cc
+++ b/src/tools/cephfs/cephfs-journal-tool.cc
@@ -52,8 +52,6 @@ int main(int argc, const char **argv)
     std::cerr << "Error (" << cpp_strerror(rc) << ")" << std::endl;
   }
 
-  jt.shutdown();
-
   return rc;
 }
 

--- a/src/tools/cephfs/cephfs-table-tool.cc
+++ b/src/tools/cephfs/cephfs-table-tool.cc
@@ -39,8 +39,6 @@ int main(int argc, const char **argv)
     std::cerr << "Error (" << cpp_strerror(rc) << ")" << std::endl;
   }
 
-  tt.shutdown();
-
   return rc;
 }
 


### PR DESCRIPTION
it may got assertion failure in deconstructor if it's not been shutdown.
Signed-off-by: dongdong tao <tdd21151186@gmail.com>