### PR TITLE
common: change routines to public access

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1867,8 +1867,10 @@ protected:
 
   TrivialEvent(IntervalFlush)
 
+  public:
   TrivialEvent(DeleteStart)
   TrivialEvent(DeleteSome)
+  protected:
   TrivialEvent(DeleteReserved)
   TrivialEvent(DeleteInterrupted)
 


### PR DESCRIPTION
Clang complains tafter recent changes:
/home/jenkins/workspace/ceph-master/src/osd/OSD.cc:8787:8: error: 'DeleteStart' is a protected member of 'PG'
          PG::DeleteStart())));
              ^
/home/jenkins/workspace/ceph-master/src/osd/PG.h:1870:16: note: declared protected here
  TrivialEvent(DeleteStart)
               ^
/home/jenkins/workspace/ceph-master/src/osd/OSD.cc:9136:6: error: 'DeleteSome' is a protected member of 'PG'
        PG::DeleteSome())),
            ^
/home/jenkins/workspace/ceph-master/src/osd/PG.h:1871:16: note: declared protected here
  TrivialEvent(DeleteSome)
               ^
2 errors generated.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>