### PR TITLE
mds: fix scrub crash

### DIFF
--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -256,8 +256,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     utime_t last_scrub_stamp;
     scrub_stamp_info_t() : scrub_start_version(0), last_scrub_version(0) {}
     void reset() {
-      scrub_start_version = 0;
-      scrub_start_stamp = utime_t();
+      scrub_start_version = last_scrub_version = 0;
+      scrub_start_stamp = last_scrub_stamp = utime_t();
     }
   };
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22730
if we don't reset the last_scrub_version, will got assertion failure in "CInode::scrub_finish"