### PR TITLE
rgw: share time skew check between v2 and v4 auth

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -223,8 +223,20 @@ namespace rgw {
 namespace auth {
 namespace s3 {
 
-/* FIXME(rzarzynski): duplicated from rgw_rest_s3.h. */
-#define RGW_AUTH_GRACE_MINS 15
+bool is_time_skew_ok(time_t t)
+{
+  auto req_tp = ceph::coarse_real_clock::from_time_t(t);
+  auto cur_tp = ceph::coarse_real_clock::now();
+
+  if (std::chrono::abs(cur_tp - req_tp) > RGW_AUTH_GRACE) {
+    dout(10) << "NOTICE: request time skew too big." << dendl;
+    using ceph::operator<<;
+    dout(10) << "req_tp=" << req_tp << ", cur_tp=" << cur_tp << dendl;
+    return false;
+  }
+
+  return true;
+}
 
 static inline int parse_v4_query_string(const req_info& info,              /* in */
                                         boost::string_view& credential,    /* out */
@@ -391,13 +403,7 @@ static inline int parse_v4_auth_header(const req_info& info,               /* in
   }
   date = d;
 
-  auto req_tp = ceph::coarse_real_clock::from_time_t(internal_timegm(&t));
-  auto cur_tp = ceph::coarse_real_clock::now();
-  constexpr auto grace = std::chrono::minutes{RGW_AUTH_GRACE_MINS};
-  if (std::chrono::abs(cur_tp - req_tp) > grace) {
-    dout(10) << "NOTICE: request time skew too big." << dendl;
-    using ceph::operator<<;
-    dout(10) << "req_tp=" << req_tp << ", cur_tp=" << cur_tp << dendl;
+  if (!is_time_skew_ok(internal_timegm(&t))) {
     return -ERR_REQUEST_TIME_SKEWED;
   }
 

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -27,6 +27,11 @@ namespace rgw {
 namespace auth {
 namespace s3 {
 
+static constexpr auto RGW_AUTH_GRACE = std::chrono::minutes{15};
+
+// returns true if the request time is within RGW_AUTH_GRACE of the current time
+bool is_time_skew_ok(time_t t);
+
 class ExternalAuthStrategy : public rgw::auth::Strategy,
                              public rgw::auth::RemoteApplier::Factory {
   typedef rgw::auth::IdentityApplier::aplptr_t aplptr_t;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3660,33 +3660,6 @@ namespace rgw {
 namespace auth {
 namespace s3 {
 
-bool AWSGeneralAbstractor::is_time_skew_ok(const utime_t& header_time) const
-{
-  /* Check for time skew first. */
-  const time_t req_sec = header_time.sec();
-  time_t now;
-  time(&now);
-
-  if (req_sec < now - RGW_AUTH_GRACE_MINS * 60 ||
-      req_sec > now + RGW_AUTH_GRACE_MINS * 60) {
-    ldout(cct, 10) << "req_sec=" << req_sec << " now=" << now
-                   << "; now - RGW_AUTH_GRACE_MINS="
-                   << now - RGW_AUTH_GRACE_MINS * 60
-                   << "; now + RGW_AUTH_GRACE_MINS="
-                   << now + RGW_AUTH_GRACE_MINS * 60
-                   << dendl;
-
-    ldout(cct, 0)  << "NOTICE: request time skew too big now="
-                   << utime_t(now, 0)
-                   << " req_time=" << header_time
-                   << dendl;
-    return false;
-  }
-
-  return true;
-}
-
-
 static rgw::auth::Completer::cmplptr_t
 null_completer_factory(const boost::optional<std::string>& secret_key)
 {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -28,8 +28,6 @@
 #include "rgw_auth.h"
 #include "rgw_auth_filters.h"
 
-#define RGW_AUTH_GRACE_MINS 15
-
 struct rgw_http_error {
   int http_ret;
   const char *s3_code;
@@ -764,8 +762,6 @@ public:
 
 class AWSGeneralAbstractor : public AWSEngine::VersionAbstractor {
   CephContext* const cct;
-
-  bool is_time_skew_ok(const utime_t& header_time) const;
 
   virtual boost::optional<std::string>
   get_v4_canonical_headers(const req_info& info,


### PR DESCRIPTION
this moves the new std::chrono-based v4 time skew check into a common helper function, then uses that in place of the v2 check