### PR TITLE
build/ops: rpm: conditionalize Python 2 availability to enable Ceph build on Python 3-only system

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -42,6 +42,10 @@
   This functionality is provided by the systemd target units (ceph-osd.target,
   ceph-mon.target, etc.).
 
+* The python-ceph-compat package is declared deprecated, and will be dropped
+  when all supported distros have completed the move to Python 3. It has
+  already been dropped from those supported distros where Python 3 is standard
+  and Python 2 is optional (currently only SUSE).
 
 >= 12.2.2
 ---------

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -112,33 +112,6 @@ BuildRequires:	sharutils
 BuildRequires:	checkpolicy
 BuildRequires:	selinux-policy-devel
 %endif
-%if 0%{with make_check}
-%if 0%{?fedora} || 0%{?rhel}
-%if 0%{with python2}
-BuildRequires:	python-cherrypy
-BuildRequires:	python-pecan
-BuildRequires:	python-werkzeug
-%else
-BuildRequires:	python%{python3_pkgversion}-cherrypy
-BuildRequires:	python%{python3_pkgversion}-pecan
-BuildRequires:	python%{python3_pkgversion}-werkzeug
-%endif
-%endif
-%if 0%{?suse_version}
-%if 0%{with python2}
-BuildRequires:	python-CherryPy
-BuildRequires:	python-Werkzeug
-BuildRequires:	python-pecan
-BuildRequires:	python-numpy-devel
-%else
-BuildRequires:	python%{python3_pkgversion}-CherryPy
-BuildRequires:	python%{python3_pkgversion}-Werkzeug
-BuildRequires:	python%{python3_pkgversion}-pecan
-BuildRequires:	python%{python3_pkgversion}-numpy-devel
-%endif
-%endif
-BuildRequires:	socat
-%endif
 BuildRequires:	bc
 BuildRequires:	gperf
 BuildRequires:  cmake
@@ -186,6 +159,9 @@ BuildRequires:	python%{python3_pkgversion}-requests
 BuildRequires:	python%{python3_pkgversion}-virtualenv
 %endif
 BuildRequires:	snappy-devel
+%if 0%{with make_check}
+BuildRequires:	socat
+%endif
 BuildRequires:	udev
 BuildRequires:	util-linux
 BuildRequires:	valgrind-devel
@@ -254,6 +230,33 @@ BuildRequires:	python34-Cython
 BuildRequires:	python3-devel
 BuildRequires:	python3-setuptools
 BuildRequires:	python3-Cython
+%endif
+# distro-conditional make check dependencies
+%if 0%{with make_check}
+%if 0%{?fedora} || 0%{?rhel}
+%if 0%{with python2}
+BuildRequires:	python-cherrypy
+BuildRequires:	python-pecan
+BuildRequires:	python-werkzeug
+%else
+BuildRequires:	python%{python3_pkgversion}-cherrypy
+BuildRequires:	python%{python3_pkgversion}-pecan
+BuildRequires:	python%{python3_pkgversion}-werkzeug
+%endif
+%endif
+%if 0%{?suse_version}
+%if 0%{with python2}
+BuildRequires:	python-CherryPy
+BuildRequires:	python-Werkzeug
+BuildRequires:	python-pecan
+BuildRequires:	python-numpy-devel
+%else
+BuildRequires:	python%{python3_pkgversion}-CherryPy
+BuildRequires:	python%{python3_pkgversion}-Werkzeug
+BuildRequires:	python%{python3_pkgversion}-pecan
+BuildRequires:	python%{python3_pkgversion}-numpy-devel
+%endif
+%endif
 %endif
 # lttng and babeltrace for rbd-replay-prep
 %if %{with lttng}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -519,7 +519,7 @@ that use RADOS gateway client library.
 %package -n python-rgw
 Summary:	Python 2 libraries for the RADOS gateway
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 Requires:	librgw2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python-rados = %{_epoch_prefix}%{version}-%{release}
@@ -532,7 +532,7 @@ gateway.
 %package -n python%{python3_pkgversion}-rgw
 Summary:	Python 3 libraries for the RADOS gateway
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 Requires:	librgw2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
@@ -544,7 +544,7 @@ gateway.
 %package -n python-rados
 Summary:	Python 2 libraries for the RADOS object store
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-ceph < %{_epoch_prefix}%{version}-%{release}
@@ -556,7 +556,7 @@ object store.
 %package -n python%{python3_pkgversion}-rados
 Summary:	Python 3 libraries for the RADOS object store
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 Requires:	python%{python3_pkgversion}
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
@@ -625,7 +625,7 @@ that use RADOS block device.
 %package -n python-rbd
 Summary:	Python 2 libraries for the RADOS block device
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python-rados = %{_epoch_prefix}%{version}-%{release}
@@ -638,7 +638,7 @@ block device.
 %package -n python%{python3_pkgversion}-rbd
 Summary:	Python 3 libraries for the RADOS block device
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
@@ -680,7 +680,7 @@ that use Cephs distributed file system.
 %package -n python-cephfs
 Summary:	Python 2 libraries for Ceph distributed file system
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?suse_version}
@@ -695,7 +695,7 @@ file system.
 %package -n python%{python3_pkgversion}-cephfs
 Summary:	Python 3 libraries for Ceph distributed file system
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
@@ -707,7 +707,7 @@ file system.
 %package -n python%{python3_pkgversion}-ceph-argparse
 Summary:	Python 3 utility libraries for Ceph CLI
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 %description -n python%{python3_pkgversion}-ceph-argparse
 This package contains types and routines for Python 3 used by the Ceph CLI as
@@ -804,7 +804,7 @@ populated file-systems.
 %package -n python-ceph-compat
 Summary:	Compatibility package for Cephs python libraries
 %if 0%{?suse_version}
-Group:		Development/Languages/Python
+Group:		Development/Libraries/Python
 %endif
 Obsoletes:	python-ceph
 Requires:	python-rados = %{_epoch_prefix}%{version}-%{release}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1379,7 +1379,12 @@ fi
 %{_bindir}/ceph-monstore-tool
 %{_mandir}/man8/ceph-mon.8*
 %{_mandir}/man8/ceph-rest-api.8*
+%if 0%{with python2}
 %{python_sitelib}/ceph_rest_api.py*
+%else
+%{python3_sitelib}/ceph_rest_api.py
+%{python3_sitelib}/__pycache__/ceph_rest_api.cpython*.py*
+%endif
 %{_unitdir}/ceph-mon@.service
 %{_unitdir}/ceph-mon.target
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/mon

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -780,6 +780,7 @@ Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{relea
 This package contains Python 3 libraries for interacting with Cephs distributed
 file system.
 
+%if 0%{with python2}
 %package -n python%{python3_pkgversion}-ceph-argparse
 Summary:	Python 3 utility libraries for Ceph CLI
 %if 0%{?suse_version}
@@ -790,6 +791,7 @@ This package contains types and routines for Python 3 used by the Ceph CLI as
 well as the RESTful interface. These have to do with querying the daemons for
 command-description information, validating user command input against those
 descriptions, and submitting the command to the appropriate daemon.
+%endif
 
 %if 0%{with ceph_test_package}
 %package -n ceph-test
@@ -1232,8 +1234,15 @@ fi
 %config %{_sysconfdir}/bash_completion.d/radosgw-admin
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{_unitdir}/rbdmap.service
+%if 0%{with python2}
 %{python_sitelib}/ceph_argparse.py*
 %{python_sitelib}/ceph_daemon.py*
+%else
+%{python3_sitelib}/ceph_argparse.py
+%{python3_sitelib}/__pycache__/ceph_argparse.cpython*.py*
+%{python3_sitelib}/ceph_daemon.py
+%{python3_sitelib}/__pycache__/ceph_daemon.cpython*.py*
+%endif
 %dir %{_udevrulesdir}
 %{_udevrulesdir}/50-rbd.rules
 %attr(3770,ceph,ceph) %dir %{_localstatedir}/log/ceph/
@@ -1762,11 +1771,13 @@ fi
 %{python3_sitelib}/ceph_volume_client.py
 %{python3_sitelib}/__pycache__/ceph_volume_client.cpython*.py*
 
+%if 0%{with python2}
 %files -n python%{python3_pkgversion}-ceph-argparse
 %{python3_sitelib}/ceph_argparse.py
 %{python3_sitelib}/__pycache__/ceph_argparse.cpython*.py*
 %{python3_sitelib}/ceph_daemon.py
 %{python3_sitelib}/__pycache__/ceph_daemon.cpython*.py*
+%endif
 
 %if 0%{with ceph_test_package}
 %files -n ceph-test

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -48,6 +48,7 @@
 %endif
 %if 0%{?suse_version} >= 1500
 %bcond_with python2
+%global _defined_if_python2_absent 1
 %else
 %bcond_without python2
 %endif
@@ -60,6 +61,9 @@
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}
 %{!?tmpfiles_create: %global tmpfiles_create systemd-tmpfiles --create}
 %{!?python3_pkgversion: %global python3_pkgversion 3}
+# define _python_buildid macro which will expand to the empty string when
+# building with python2
+%global _python_buildid %{?_defined_if_python2_absent:%{python3_pkgversion}}
 
 # unify libexec for all targets
 %global _libexecdir %{_exec_prefix}/lib
@@ -142,22 +146,11 @@ BuildRequires:	parted
 BuildRequires:	perl
 BuildRequires:	pkgconfig
 BuildRequires:  procps
-%if 0%{with python2}
-BuildRequires:	python
-BuildRequires:	python-devel
-BuildRequires:	python-nose
-BuildRequires:	python-requests
-BuildRequires:	python-virtualenv
-%else
-BuildRequires:	python%{python3_pkgversion}
-%if 0%{?suse_version}
-BuildRequires:	python%{python3_pkgversion}-base
-%endif
-BuildRequires:	python%{python3_pkgversion}-devel
-BuildRequires:	python%{python3_pkgversion}-nose
-BuildRequires:	python%{python3_pkgversion}-requests
-BuildRequires:	python%{python3_pkgversion}-virtualenv
-%endif
+BuildRequires:	python%{_python_buildid}
+BuildRequires:	python%{_python_buildid}-devel
+BuildRequires:	python%{_python_buildid}-nose
+BuildRequires:	python%{_python_buildid}-requests
+BuildRequires:	python%{_python_buildid}-virtualenv
 BuildRequires:	snappy-devel
 %if 0%{with make_check}
 BuildRequires:	socat
@@ -189,15 +182,10 @@ BuildRequires:  libopenssl-devel
 BuildRequires:  lsb-release
 BuildRequires:  openldap2-devel
 BuildRequires:  cunit-devel
-%if 0%{with python2}
-BuildRequires:	python-Cython
-BuildRequires:	python-PrettyTable
-BuildRequires:	python-Sphinx
-%else
-BuildRequires:	python%{python3_pkgversion}-Cython
-BuildRequires:	python%{python3_pkgversion}-PrettyTable
-BuildRequires:	python%{python3_pkgversion}-Sphinx
-%endif
+BuildRequires:	python%{_python_buildid}-base
+BuildRequires:	python%{_python_buildid}-Cython
+BuildRequires:	python%{_python_buildid}-PrettyTable
+BuildRequires:	python%{_python_buildid}-Sphinx
 BuildRequires:  rdma-core-devel
 %endif
 %if 0%{?fedora} || 0%{?rhel}
@@ -211,15 +199,9 @@ BuildRequires:  openldap-devel
 BuildRequires:  openssl-devel
 BuildRequires:  CUnit-devel
 BuildRequires:  redhat-lsb-core
-%if 0%{with python2}
-BuildRequires:	Cython
-BuildRequires:	python-prettytable
-BuildRequires:	python-sphinx
-%else
-BuildRequires:	Cython%{python3_pkgversion}
-BuildRequires:	python%{python3_pkgversion}-prettytable
-BuildRequires:	python%{python3_pkgversion}-sphinx
-%endif
+BuildRequires:	Cython%{_python_buildid}
+BuildRequires:	python%{_python_buildid}-prettytable
+BuildRequires:	python%{_python_buildid}-sphinx
 %endif
 # python34-... for RHEL, python3-... for all other supported distros
 %if 0%{?rhel}
@@ -234,28 +216,15 @@ BuildRequires:	python3-Cython
 # distro-conditional make check dependencies
 %if 0%{with make_check}
 %if 0%{?fedora} || 0%{?rhel}
-%if 0%{with python2}
-BuildRequires:	python-cherrypy
-BuildRequires:	python-pecan
-BuildRequires:	python-werkzeug
-%else
-BuildRequires:	python%{python3_pkgversion}-cherrypy
-BuildRequires:	python%{python3_pkgversion}-pecan
-BuildRequires:	python%{python3_pkgversion}-werkzeug
-%endif
+BuildRequires:	python%{_python_buildid}-cherrypy
+BuildRequires:	python%{_python_buildid}-pecan
+BuildRequires:	python%{_python_buildid}-werkzeug
 %endif
 %if 0%{?suse_version}
-%if 0%{with python2}
-BuildRequires:	python-CherryPy
-BuildRequires:	python-Werkzeug
-BuildRequires:	python-pecan
-BuildRequires:	python-numpy-devel
-%else
-BuildRequires:	python%{python3_pkgversion}-CherryPy
-BuildRequires:	python%{python3_pkgversion}-Werkzeug
-BuildRequires:	python%{python3_pkgversion}-pecan
-BuildRequires:	python%{python3_pkgversion}-numpy-devel
-%endif
+BuildRequires:	python%{_python_buildid}-CherryPy
+BuildRequires:	python%{_python_buildid}-Werkzeug
+BuildRequires:	python%{_python_buildid}-pecan
+BuildRequires:	python%{_python_buildid}-numpy-devel
 %endif
 %endif
 # lttng and babeltrace for rbd-replay-prep
@@ -301,22 +270,15 @@ Requires:      librgw2 = %{_epoch_prefix}%{version}-%{release}
 %if 0%{with selinux}
 Requires:      ceph-selinux = %{_epoch_prefix}%{version}-%{release}
 %endif
-%if 0%{with python2}
-Requires:      python
-Requires:      python-requests
-Requires:      python-setuptools
-%else
-Requires:      python%{python3_pkgversion}
-Requires:      python%{python3_pkgversion}-requests
-Requires:      python%{python3_pkgversion}-setuptools
-%endif
-Requires:      grep
-Requires:      xfsprogs
-Requires:      logrotate
-Requires:      util-linux
 Requires:      cryptsetup
 Requires:      findutils
+Requires:      grep
+Requires:      logrotate
 Requires:      psmisc
+Requires:      python%{_python_buildid}-requests
+Requires:      python%{_python_buildid}-setuptools
+Requires:      util-linux
+Requires:      xfsprogs
 Requires:      which
 %if 0%{?suse_version}
 Recommends:    ntp-daemon
@@ -332,34 +294,17 @@ Group:		System/Filesystems
 Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
-%if 0%{with python2}
-Requires:	python-rados = %{_epoch_prefix}%{version}-%{release}
-Requires:	python-rbd = %{_epoch_prefix}%{version}-%{release}
-Requires:	python-cephfs = %{_epoch_prefix}%{version}-%{release}
-Requires:	python-rgw = %{_epoch_prefix}%{version}-%{release}
-%else
-Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rbd = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-cephfs = %{_epoch_prefix}%{version}-%{release}
-Requires:	python%{python3_pkgversion}-rgw = %{_epoch_prefix}%{version}-%{release}
-%endif
+Requires:	python%{_python_buildid}-rados = %{_epoch_prefix}%{version}-%{release}
+Requires:	python%{_python_buildid}-rbd = %{_epoch_prefix}%{version}-%{release}
+Requires:	python%{_python_buildid}-cephfs = %{_epoch_prefix}%{version}-%{release}
+Requires:	python%{_python_buildid}-rgw = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel}
-%if 0%{with python2}
-Requires:	python-prettytable
-Requires:	python-requests
-%else
-Requires:	python%{python3_pkgversion}-prettytable
-Requires:	python%{python3_pkgversion}-requests
-%endif
+Requires:	python%{_python_buildid}-prettytable
+Requires:	python%{_python_buildid}-requests
 %endif
 %if 0%{?suse_version}
-%if 0%{with python2}
-Requires:	python-PrettyTable
-Requires:	python-requests
-%else
-Requires:	python%{python3_pkgversion}-PrettyTable
-Requires:	python%{python3_pkgversion}-requests
-%endif
+Requires:	python%{_python_buildid}-PrettyTable
+Requires:	python%{_python_buildid}-requests
 %endif
 %{?systemd_requires}
 %if 0%{?suse_version}
@@ -388,18 +333,10 @@ Group:		System/Filesystems
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 # For ceph-rest-api
 %if 0%{?fedora} || 0%{?rhel}
-%if 0%{with python2}
-Requires:      python-flask
-%else
-Requires:      python%{python3_pkgversion}-flask
-%endif
+Requires:      python%{_python_buildid}-flask
 %endif
 %if 0%{?suse_version}
-%if 0%{with python2}
-Requires:      python-Flask
-%else
-Requires:      python%{python3_pkgversion}-Flask
-%endif
+Requires:      python%{_python_buildid}-Flask
 %endif
 %description mon
 ceph-mon is the cluster monitor daemon for the Ceph distributed file
@@ -414,36 +351,19 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-base = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel}
-%if 0%{with python2}
-Requires:       python-cherrypy
-Requires:       python-jinja2
-Requires:       python-pecan
-Requires:       python-werkzeug
-Requires:       pyOpenSSL
-%else
-Requires:       python%{python3_pkgversion}-cherrypy
-Requires:       python%{python3_pkgversion}-jinja2
-Requires:       python%{python3_pkgversion}-pecan
-Requires:       python%{python3_pkgversion}-werkzeug
-Requires:       pyOpenSSL%{python3_pkgversion}
-%endif
+Requires:       python%{_python_buildid}-cherrypy
+Requires:       python%{_python_buildid}-jinja2
+Requires:       python%{_python_buildid}-pecan
+Requires:       python%{_python_buildid}-werkzeug
+Requires:       pyOpenSSL%{_python_buildid}
 %endif
 %if 0%{?suse_version}
-%if 0%{with python2}
-Requires:       python-CherryPy
-Requires:       python-Jinja2
-Requires:       python-Werkzeug
-Requires:       python-pecan
-Requires:       python-pyOpenSSL
-Recommends:     python-influxdb
-%else
-Requires:       python%{python3_pkgversion}-CherryPy
-Requires:       python%{python3_pkgversion}-Jinja2
-Requires:       python%{python3_pkgversion}-Werkzeug
-Requires:       python%{python3_pkgversion}-pecan
-Requires:       python%{python3_pkgversion}-pyOpenSSL
-Recommends:     python%{python3_pkgversion}-influxdb
-%endif
+Requires:       python%{_python_buildid}-CherryPy
+Requires:       python%{_python_buildid}-Jinja2
+Requires:       python%{_python_buildid}-Werkzeug
+Requires:       python%{_python_buildid}-pecan
+Requires:       python%{_python_buildid}-pyOpenSSL
+Recommends:     python%{_python_buildid}-influxdb
 %endif
 %description mgr
 ceph-mgr enables python modules that provide services (such as the REST

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -46,6 +46,11 @@
 %endif
 %endif
 %endif
+%if 0%{?suse_version} >= 1500
+%bcond_with python2
+%else
+%bcond_without python2
+%endif
 
 %if %{with selinux}
 # get selinux policy version
@@ -109,15 +114,29 @@ BuildRequires:	selinux-policy-devel
 %endif
 %if 0%{with make_check}
 %if 0%{?fedora} || 0%{?rhel}
+%if 0%{with python2}
 BuildRequires:	python-cherrypy
+BuildRequires:	python-pecan
 BuildRequires:	python-werkzeug
+%else
+BuildRequires:	python%{python3_pkgversion}-cherrypy
+BuildRequires:	python%{python3_pkgversion}-pecan
+BuildRequires:	python%{python3_pkgversion}-werkzeug
+%endif
 %endif
 %if 0%{?suse_version}
+%if 0%{with python2}
 BuildRequires:	python-CherryPy
 BuildRequires:	python-Werkzeug
-BuildRequires:	python-numpy-devel
-%endif
 BuildRequires:	python-pecan
+BuildRequires:	python-numpy-devel
+%else
+BuildRequires:	python%{python3_pkgversion}-CherryPy
+BuildRequires:	python%{python3_pkgversion}-Werkzeug
+BuildRequires:	python%{python3_pkgversion}-pecan
+BuildRequires:	python%{python3_pkgversion}-numpy-devel
+%endif
+%endif
 BuildRequires:	socat
 %endif
 BuildRequires:	bc
@@ -150,11 +169,22 @@ BuildRequires:	parted
 BuildRequires:	perl
 BuildRequires:	pkgconfig
 BuildRequires:  procps
+%if 0%{with python2}
 BuildRequires:	python
 BuildRequires:	python-devel
 BuildRequires:	python-nose
 BuildRequires:	python-requests
 BuildRequires:	python-virtualenv
+%else
+BuildRequires:	python%{python3_pkgversion}
+%if 0%{?suse_version}
+BuildRequires:	python%{python3_pkgversion}-base
+%endif
+BuildRequires:	python%{python3_pkgversion}-devel
+BuildRequires:	python%{python3_pkgversion}-nose
+BuildRequires:	python%{python3_pkgversion}-requests
+BuildRequires:	python%{python3_pkgversion}-virtualenv
+%endif
 BuildRequires:	snappy-devel
 BuildRequires:	udev
 BuildRequires:	util-linux
@@ -183,9 +213,15 @@ BuildRequires:  libopenssl-devel
 BuildRequires:  lsb-release
 BuildRequires:  openldap2-devel
 BuildRequires:  cunit-devel
+%if 0%{with python2}
 BuildRequires:	python-Cython
 BuildRequires:	python-PrettyTable
 BuildRequires:	python-Sphinx
+%else
+BuildRequires:	python%{python3_pkgversion}-Cython
+BuildRequires:	python%{python3_pkgversion}-PrettyTable
+BuildRequires:	python%{python3_pkgversion}-Sphinx
+%endif
 BuildRequires:  rdma-core-devel
 %endif
 %if 0%{?fedora} || 0%{?rhel}
@@ -199,9 +235,15 @@ BuildRequires:  openldap-devel
 BuildRequires:  openssl-devel
 BuildRequires:  CUnit-devel
 BuildRequires:  redhat-lsb-core
+%if 0%{with python2}
 BuildRequires:	Cython
 BuildRequires:	python-prettytable
 BuildRequires:	python-sphinx
+%else
+BuildRequires:	Cython%{python3_pkgversion}
+BuildRequires:	python%{python3_pkgversion}-prettytable
+BuildRequires:	python%{python3_pkgversion}-sphinx
+%endif
 %endif
 # python34-... for RHEL, python3-... for all other supported distros
 %if 0%{?rhel}
@@ -256,9 +298,15 @@ Requires:      librgw2 = %{_epoch_prefix}%{version}-%{release}
 %if 0%{with selinux}
 Requires:      ceph-selinux = %{_epoch_prefix}%{version}-%{release}
 %endif
+%if 0%{with python2}
 Requires:      python
 Requires:      python-requests
 Requires:      python-setuptools
+%else
+Requires:      python%{python3_pkgversion}
+Requires:      python%{python3_pkgversion}-requests
+Requires:      python%{python3_pkgversion}-setuptools
+%endif
 Requires:      grep
 Requires:      xfsprogs
 Requires:      logrotate
@@ -281,17 +329,35 @@ Group:		System/Filesystems
 Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
+%if 0%{with python2}
 Requires:	python-rados = %{_epoch_prefix}%{version}-%{release}
 Requires:	python-rbd = %{_epoch_prefix}%{version}-%{release}
 Requires:	python-cephfs = %{_epoch_prefix}%{version}-%{release}
 Requires:	python-rgw = %{_epoch_prefix}%{version}-%{release}
+%else
+Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
+Requires:	python%{python3_pkgversion}-rbd = %{_epoch_prefix}%{version}-%{release}
+Requires:	python%{python3_pkgversion}-cephfs = %{_epoch_prefix}%{version}-%{release}
+Requires:	python%{python3_pkgversion}-rgw = %{_epoch_prefix}%{version}-%{release}
+%endif
 %if 0%{?fedora} || 0%{?rhel}
+%if 0%{with python2}
 Requires:	python-prettytable
+Requires:	python-requests
+%else
+Requires:	python%{python3_pkgversion}-prettytable
+Requires:	python%{python3_pkgversion}-requests
+%endif
 %endif
 %if 0%{?suse_version}
+%if 0%{with python2}
 Requires:	python-PrettyTable
-%endif
 Requires:	python-requests
+%else
+Requires:	python%{python3_pkgversion}-PrettyTable
+Requires:	python%{python3_pkgversion}-requests
+%endif
+%endif
 %{?systemd_requires}
 %if 0%{?suse_version}
 Requires(pre):	pwdutils
@@ -319,10 +385,18 @@ Group:		System/Filesystems
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 # For ceph-rest-api
 %if 0%{?fedora} || 0%{?rhel}
+%if 0%{with python2}
 Requires:      python-flask
+%else
+Requires:      python%{python3_pkgversion}-flask
+%endif
 %endif
 %if 0%{?suse_version}
+%if 0%{with python2}
 Requires:      python-Flask
+%else
+Requires:      python%{python3_pkgversion}-Flask
+%endif
 %endif
 %description mon
 ceph-mon is the cluster monitor daemon for the Ceph distributed file
@@ -337,19 +411,37 @@ Group:          System/Filesystems
 %endif
 Requires:       ceph-base = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel}
+%if 0%{with python2}
 Requires:       python-cherrypy
 Requires:       python-jinja2
+Requires:       python-pecan
 Requires:       python-werkzeug
 Requires:       pyOpenSSL
+%else
+Requires:       python%{python3_pkgversion}-cherrypy
+Requires:       python%{python3_pkgversion}-jinja2
+Requires:       python%{python3_pkgversion}-pecan
+Requires:       python%{python3_pkgversion}-werkzeug
+Requires:       pyOpenSSL%{python3_pkgversion}
+%endif
 %endif
 %if 0%{?suse_version}
-Requires: 	python-CherryPy
+%if 0%{with python2}
+Requires:       python-CherryPy
 Requires:       python-Jinja2
 Requires:       python-Werkzeug
+Requires:       python-pecan
 Requires:       python-pyOpenSSL
 Recommends:     python-influxdb
+%else
+Requires:       python%{python3_pkgversion}-CherryPy
+Requires:       python%{python3_pkgversion}-Jinja2
+Requires:       python%{python3_pkgversion}-Werkzeug
+Requires:       python%{python3_pkgversion}-pecan
+Requires:       python%{python3_pkgversion}-pyOpenSSL
+Recommends:     python%{python3_pkgversion}-influxdb
 %endif
-Requires:       python-pecan
+%endif
 %description mgr
 ceph-mgr enables python modules that provide services (such as the REST
 module derived from Calamari) and expose CLI hooks.  ceph-mgr gathers
@@ -500,6 +592,7 @@ Obsoletes:	librgw2-devel < %{_epoch_prefix}%{version}-%{release}
 This package contains libraries and headers needed to develop programs
 that use RADOS gateway client library.
 
+%if 0%{with python2}
 %package -n python-rgw
 Summary:	Python 2 libraries for the RADOS gateway
 %if 0%{?suse_version}
@@ -511,6 +604,7 @@ Obsoletes:	python-ceph < %{_epoch_prefix}%{version}-%{release}
 %description -n python-rgw
 This package contains Python 2 libraries for interacting with Cephs RADOS
 gateway.
+%endif
 
 %package -n python%{python3_pkgversion}-rgw
 Summary:	Python 3 libraries for the RADOS gateway
@@ -523,6 +617,7 @@ Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{relea
 This package contains Python 3 libraries for interacting with Cephs RADOS
 gateway.
 
+%if 0%{with python2}
 %package -n python-rados
 Summary:	Python 2 libraries for the RADOS object store
 %if 0%{?suse_version}
@@ -533,6 +628,7 @@ Obsoletes:	python-ceph < %{_epoch_prefix}%{version}-%{release}
 %description -n python-rados
 This package contains Python 2 libraries for interacting with Cephs RADOS
 object store.
+%endif
 
 %package -n python%{python3_pkgversion}-rados
 Summary:	Python 3 libraries for the RADOS object store
@@ -602,6 +698,7 @@ Obsoletes:	librbd1-devel < %{_epoch_prefix}%{version}-%{release}
 This package contains libraries and headers needed to develop programs
 that use RADOS block device.
 
+%if 0%{with python2}
 %package -n python-rbd
 Summary:	Python 2 libraries for the RADOS block device
 %if 0%{?suse_version}
@@ -613,6 +710,7 @@ Obsoletes:	python-ceph < %{_epoch_prefix}%{version}-%{release}
 %description -n python-rbd
 This package contains Python 2 libraries for interacting with Cephs RADOS
 block device.
+%endif
 
 %package -n python%{python3_pkgversion}-rbd
 Summary:	Python 3 libraries for the RADOS block device
@@ -655,6 +753,7 @@ Obsoletes:	libcephfs2-devel < %{_epoch_prefix}%{version}-%{release}
 This package contains libraries and headers needed to develop programs
 that use Cephs distributed file system.
 
+%if 0%{with python2}
 %package -n python-cephfs
 Summary:	Python 2 libraries for Ceph distributed file system
 %if 0%{?suse_version}
@@ -668,6 +767,7 @@ Obsoletes:	python-ceph < %{_epoch_prefix}%{version}-%{release}
 %description -n python-cephfs
 This package contains Python 2 libraries for interacting with Cephs distributed
 file system.
+%endif
 
 %package -n python%{python3_pkgversion}-cephfs
 Summary:	Python 3 libraries for Ceph distributed file system
@@ -775,6 +875,7 @@ populated file-systems.
 
 %endif
 
+%if 0%{with python2}
 %package -n python-ceph-compat
 Summary:	Compatibility package for Cephs python libraries
 %if 0%{?suse_version}
@@ -791,6 +892,7 @@ This is a compatibility package to accommodate python-ceph split into
 python-rados, python-rbd, python-rgw and python-cephfs. Packages still
 depending on python-ceph should be fixed to depend on python-rados,
 python-rbd, python-rgw or python-cephfs instead.
+%endif
 
 #################################################################################
 # common
@@ -859,6 +961,12 @@ cmake .. \
     -DWITH_EMBEDDED=OFF \
     -DWITH_MANPAGE=ON \
     -DWITH_PYTHON3=ON \
+%if %{with python2}
+    -DWITH_PYTHON2=ON \
+%else
+    -DWITH_PYTHON2=OFF \
+    -DMGR_PYTHON_VERSION=3 \
+%endif
     -DWITH_SYSTEMD=ON \
 %if 0%{?rhel} && ! 0%{?centos}
     -DWITH_SUBMAN=ON \
@@ -1547,9 +1655,11 @@ fi
 %{_bindir}/librados-config
 %{_mandir}/man8/librados-config.8*
 
+%if 0%{with python2}
 %files -n python-rados
 %{python_sitearch}/rados.so
 %{python_sitearch}/rados-*.egg-info
+%endif
 
 %files -n python%{python3_pkgversion}-rados
 %{python3_sitearch}/rados.cpython*.so
@@ -1601,17 +1711,21 @@ fi
 %{_includedir}/rados/rgw_file.h
 %{_libdir}/librgw.so
 
+%if 0%{with python2}
 %files -n python-rgw
 %{python_sitearch}/rgw.so
 %{python_sitearch}/rgw-*.egg-info
+%endif
 
 %files -n python%{python3_pkgversion}-rgw
 %{python3_sitearch}/rgw.cpython*.so
 %{python3_sitearch}/rgw-*.egg-info
 
+%if 0%{with python2}
 %files -n python-rbd
 %{python_sitearch}/rbd.so
 %{python_sitearch}/rbd-*.egg-info
+%endif
 
 %files -n python%{python3_pkgversion}-rbd
 %{python3_sitearch}/rbd.cpython*.so
@@ -1630,10 +1744,12 @@ fi
 %{_includedir}/cephfs/ceph_statx.h
 %{_libdir}/libcephfs.so
 
+%if 0%{with python2}
 %files -n python-cephfs
 %{python_sitearch}/cephfs.so
 %{python_sitearch}/cephfs-*.egg-info
 %{python_sitelib}/ceph_volume_client.py*
+%endif
 
 %files -n python%{python3_pkgversion}-cephfs
 %{python3_sitearch}/cephfs.cpython*.so
@@ -1793,9 +1909,11 @@ exit 0
 
 %endif # with selinux
 
+%if 0%{with python2}
 %files -n python-ceph-compat
 # We need an empty %%files list for python-ceph-compat, to tell rpmbuild to
 # actually build this meta package.
+%endif
 
 
 %changelog

--- a/make-dist
+++ b/make-dist
@@ -96,6 +96,14 @@ for spec in ceph.spec.in alpine/APKBUILD.in; do
         sed "s/@RPM_RELEASE@/$rpm_release/g" |
         sed "s/@TARBALL_BASENAME@/ceph-$version/g" > `echo $spec | sed 's/.in$//'`
 done
+
+. /etc/os-release
+case $ID in
+    opensuse|suse|sles)
+        sed -i -e "s/^Release:.*/&.<B_CNT>/" ceph.spec
+        ;;
+esac
+
 ln -s . $outfile
 tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec $outfile/alpine/APKBUILD
 # NOTE: If you change this version number make sure the package is available

--- a/src/compressor/zstd/CMakeLists.txt
+++ b/src/compressor/zstd/CMakeLists.txt
@@ -35,7 +35,10 @@ set(zstd_sources
 add_library(ceph_zstd SHARED ${zstd_sources})
 add_dependencies(ceph_zstd ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ceph_zstd zstd)
-set_target_properties(ceph_zstd PROPERTIES VERSION 2.0.0 SOVERSION 2)
+set_target_properties(ceph_zstd PROPERTIES
+  VERSION 2.0.0
+  SOVERSION 2
+  INSTALL_RPATH "")
 install(TARGETS ceph_zstd DESTINATION ${compressor_plugin_dir})
 
 if(WITH_EMBEDDED)


### PR DESCRIPTION
Not all build targets have Python 2 available. Allow the build
to succeed on pure Python 3 systems.

~~Note: this depends on #19122, #20064, and #20077 so let's merge those, first.~~ (all merged now)