### PR TITLE
doc: update ceph iscsi kernel and package info

### DIFF
--- a/doc/rbd/iscsi-target-ansible.rst
+++ b/doc/rbd/iscsi-target-ansible.rst
@@ -11,7 +11,7 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
 -  A running Ceph Luminous (12.2.x) cluster or newer
 
--  RHEL/CentOS 7.5; Linux kernel v4.17 or newer; or the `Ceph iSCSI client kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-stable>`_
+-  RHEL/CentOS 7.5; Linux kernel v4.17 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
 
 -  The ``ceph-iscsi-config`` package installed on all the iSCSI gateway nodes
 

--- a/doc/rbd/iscsi-target-cli-manual-install.rst
+++ b/doc/rbd/iscsi-target-cli-manual-install.rst
@@ -34,13 +34,19 @@ on each machine that will be a iSCSI gateway:
 -  Linux Kernel
 
    If not using a distro kernel that contains the required Ceph iSCSI patches,
-   then Linux kernel v4.17 or newer or the ceph-client ceph-iscsi-stable
-   branch must be used. To get the ceph-iscsi-stable branch run:
+   then Linux kernel v4.17 or newer or the ceph-client ceph-iscsi-test
+   branch must be used. To get the branch run:
 
    ::
 
        > git clone https://github.com/ceph/ceph-client.git
-       > git checkout ceph-iscsi-stable
+       > git checkout ceph-iscsi-test
+
+   .. warning::
+       ceph-iscsi-test is not for production use. It should only be used
+       for proof of concept setups and testing. The kernel is only updated
+       with Ceph iSCSI patches. General security and bug fixes from upstream
+       are not applied.
 
    Check your distro's docs for specific instructions on how to build a
    kernel. The only Ceph iSCSI specific requirements are the following

--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -21,7 +21,7 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
    -  ``tcmu-runner-1.3.0`` or newer package
 
-   -  ``ceph-iscsi-config-2.3`` or newer package
+   -  ``ceph-iscsi-config-2.4`` or newer package
 
    -  ``ceph-iscsi-cli-2.5`` or newer package
 

--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -11,7 +11,7 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
 -  A running Ceph Luminous or later storage cluster
 
--  RHEL/CentOS 7.5; Linux kernel v4.17 or newer; or the `Ceph iSCSI client kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-stable>`_
+-  RHEL/CentOS 7.5; Linux kernel v4.17 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
 
 -  The following packages must be installed from your Linux distribution's software repository:
 
@@ -183,7 +183,7 @@ to create a iSCSI target and export a RBD image as LUN 0.
        > /iscsi-target...-igw/gateways>  create ceph-gw-1 10.172.19.21
        > /iscsi-target...-igw/gateways>  create ceph-gw-2 10.172.19.22
 
-   If not using RHEL/CentOS or using an upstream or ceph-iscsi-stable kernel,
+   If not using RHEL/CentOS or using an upstream or ceph-iscsi-test kernel,
    the skipchecks=true argument must be used. This will avoid the Red Hat kernel
    and rpm checks:
 

--- a/doc/rbd/iscsi-targets.rst
+++ b/doc/rbd/iscsi-targets.rst
@@ -8,7 +8,7 @@ within OpenStack environments. Starting with the Ceph Luminous release,
 block-level access is expanding to offer standard iSCSI support allowing
 wider platform usage, and potentially opening new use cases.
 
--  RHEL/CentOS 7.5; Linux kernel v4.17 or newer; or the `Ceph iSCSI client kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-stable>`_
+-  RHEL/CentOS 7.5; Linux kernel v4.17 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
 
 -  A working Ceph Storage cluster, deployed with ``ceph-ansible`` or using the command-line interface
 


### PR DESCRIPTION
This updates the ceph iscsi doc's kernel info to make sure users know the ceph iscsi client kernel is not like the stable and LTS upstream kernels. It is only temporary until the patches get released into a upstream kernel. We will not be back porting non ceph iscsi related security and bug fixes, so the kernel should only be used for non production setups like testing, proof of concepts, devel etc.

[edit]
Added second patch to also bump the required package info.