### PR TITLE
cls/rgw: fix bi_log_iterate_entries return wrong truncated

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2602,6 +2602,9 @@ static int bi_log_iterate_entries(cls_method_context_t hctx, const string& marke
 
     if (key.compare(end_key) > 0) {
       key_iter = key;
+      if (truncated) {
+        *truncated = false;
+      }
       return 0;
     }
 


### PR DESCRIPTION
if there are over 1000 entries of instance keys, cls_cxx_map_get_vals
will get truncated=true, but bilogs already reach the end.

Signed-off-by: Tianshan Qu <tianshan@xsky.com>