### PR TITLE
osd: include new_pg_temp in creating_pgs

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1169,6 +1169,19 @@ OSDMonitor::update_pending_pgs(const OSDMap::Incremental& inc,
     pending_creatings.last_scan_epoch = osdmap.get_epoch();
   }
 
+  // process new pg_temp
+  auto total = pending_creatings.pgs.size();
+  // assuming the number of primed pgs cannot overload the cluster
+  for (auto& pg_temp : inc.new_pg_temp) {
+    pending_creatings.pgs.emplace(
+      pg_temp.first,
+      creating_pgs_t::pg_create_info{inc.epoch, inc.modified});
+  }
+  dout(10) << __func__
+           << " " << (pending_creatings.pgs.size() - total)
+           << "/" << pending_creatings.pgs.size()
+           << " pgs added from pg temp" << dendl;
+
   // filter out any pgs that shouldn't exist.
   {
     auto i = pending_creatings.pgs.begin();
@@ -1183,9 +1196,9 @@ OSDMonitor::update_pending_pgs(const OSDMap::Incremental& inc,
     }
   }
 
+  total = pending_creatings.pgs.size();
   // process queue
   unsigned max = std::max<int64_t>(1, g_conf()->mon_osd_max_creating_pgs);
-  const auto total = pending_creatings.pgs.size();
   while (pending_creatings.pgs.size() < max &&
 	 !pending_creatings.queue.empty()) {
     auto p = pending_creatings.queue.begin();


### PR DESCRIPTION
newly added pg_temp should be considered when sending creating-pgs
messages to interested OSD. otherwise the new primary OSD won't be
notified with this news, hence won't create the primed pg if the replica
OSDs fail to send the message to their primary.

Fixes: http://tracker.ceph.com/issues/22233
Signed-off-by: Kefu Chai <kchai@redhat.com>