### PR TITLE
rgw: improve sync status: display behind bucket shards 

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -566,8 +566,12 @@ Options
 
 .. option:: --shard-id=<shard-id>
 
-	Optional for mdlog list. Required for ``mdlog trim``,
+	Optional for mdlog list, data sync status. Required for ``mdlog trim``,
 	``replica mdlog get/delete``, ``replica datalog get/delete``.
+
+.. option:: --max-entries=<entries>
+
+	Optional for listing operations to specify the max entires
 
 .. option:: --auth-uid=auid
 

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -132,7 +132,19 @@ struct rgw_data_sync_marker {
   }
 
   void dump(Formatter *f) const {
-    encode_json("state", (int)state, f);
+    const char *s{nullptr};
+    switch ((SyncState)state) {
+      case FullSync:
+        s = "full-sync";
+        break;
+      case IncrementalSync:
+        s = "incremental-sync";
+        break;
+      default:
+        s = "unknown";
+        break;
+    }
+    encode_json("status", s, f);
     encode_json("marker", marker, f);
     encode_json("next_step_marker", next_step_marker, f);
     encode_json("total_entries", total_entries, f);
@@ -140,9 +152,13 @@ struct rgw_data_sync_marker {
     encode_json("timestamp", utime_t(timestamp), f);
   }
   void decode_json(JSONObj *obj) {
-    int s;
-    JSONDecoder::decode_json("state", s, obj);
-    state = s;
+    std::string s;
+    JSONDecoder::decode_json("status", s, obj);
+    if (s == "full-sync") {
+      state = FullSync;
+    } else if (s == "incremental-sync") {
+      state = IncrementalSync;
+    }
     JSONDecoder::decode_json("marker", marker, obj);
     JSONDecoder::decode_json("next_step_marker", next_step_marker, obj);
     JSONDecoder::decode_json("total_entries", total_entries, obj);

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -284,6 +284,7 @@ public:
   int read_source_log_shards_next(map<int, string> shard_markers, map<int, rgw_datalog_shard_data> *result);
   int read_sync_status(rgw_data_sync_status *sync_status);
   int read_recovering_shards(const int num_shards, set<int>& recovering_shards);
+  int read_shard_status(int shard_id, set<string>& lagging_buckets,set<string>& recovering_buckets, rgw_data_sync_marker* sync_marker, const int max_entries);
   int init_sync_status(int num_shards);
   int run_sync(int num_shards);
 
@@ -338,6 +339,9 @@ public:
     return source_log.read_recovering_shards(num_shards, recovering_shards);
   }
 
+  int read_shard_status(int shard_id, set<string>& lagging_buckets, set<string>& recovering_buckets, rgw_data_sync_marker *sync_marker, const int max_entries) {
+    return source_log.read_shard_status(shard_id, lagging_buckets, recovering_buckets,sync_marker, max_entries);
+  }
   int init_sync_status() { return source_log.init_sync_status(num_shards); }
 
   int read_log_info(rgw_datalog_info *log_info) {

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -178,11 +178,14 @@
      --start-date=<date>       start date in the format yyyy-mm-dd
      --end-date=<date>         end date in the format yyyy-mm-dd
      --bucket-id=<bucket-id>   bucket id
-     --shard-id=<shard-id>     optional for mdlog list
+     --shard-id=<shard-id>     optional for: 
+                                 mdlog list
+                                 data sync status
                                required for: 
                                  mdlog trim
                                  replica mdlog get/delete
                                  replica datalog get/delete
+     --max-entries=<entries>   max entries for listing operations
      --metadata-key=<key>      key to retrieve metadata from with metadata get
      --remote=<remote>         zone or zonegroup id of remote gateway
      --period=<id>             period id


### PR DESCRIPTION
This PR is together with my last PR(#19573), it's mainly about to display the lagging bucket shards that are belong to a specified datalog shards, the overall work flow to get lagging bucket shards is as below:
- use sync status command to get the behind or recovering datalog shards(see #19573)
- use data sync status --shard-id=x command to lists which bucket shards are left to process 

**The mainly modifications of are as below：**
-  ~~use active_repo(```RGWOmapAppend```) to record the active bucket shards, when find some log left to process, record the related bucket shards in sync status datalog~~
- use ```RGWReadLaggingBucketShardsCoroutine``` to read lagging bucket shards and sync marker of a specified datalog shard
-  ~~since the logic of list remote bucket instance info has invoked in several place, I move it form ```RGWListBucketIndexesCR``` to ```RGWListBucketInstanceInfoCR```, so that it can be widely used.~~
-  ~~use ```RGWBuildFullSyncMapsCR``` instead of ```RGWListBucketIndexesCR``` to build full sync maps, and remove the related logic about list remote bucket instance from it~~
 
~~**The work flow of ```RGWReadLaggingBucketShardsCoroutine```  is as below:**~~
- get active bucket shards have been recorded in related sync status datalog
- get the rest bucket shards that are belong to this data log shard
- read the bucket shards that are in ```StateInit```
- read the sync marker of this data log shard

Signed-off-by: lvshanchun lvshanchun@gmail.com