### PR TITLE
osdc,os,osd: fix build on osx

### DIFF
--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -86,6 +86,7 @@ if(HAVE_LIBAIO)
 endif(HAVE_LIBAIO)
 
 if(WITH_FUSE)
+  target_include_directories(os SYSTEM PRIVATE ${FUSE_INCLUDE_DIRS})
   target_link_libraries(os ${FUSE_LIBRARIES})
 endif()
 

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1235,7 +1235,7 @@ int KStore::_do_read(
     _do_read_stripe(o, offset - stripe_off, &stripe);
     dout(30) << __func__ << " stripe " << offset - stripe_off << " got "
 	     << stripe.length() << dendl;
-    unsigned swant = std::min(stripe_size - stripe_off, length);
+    unsigned swant = std::min<unsigned>(stripe_size - stripe_off, length);
     if (stripe.length()) {
       if (swant == stripe.length()) {
 	bl.claim_append(stripe);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2808,7 +2808,7 @@ void PG::_update_blocked_by()
 {
   // set a max on the number of blocking peers we report. if we go
   // over, report a random subset.  keep the result sorted.
-  unsigned keep = std::min(blocked_by.size(), cct->_conf->osd_max_pg_blocked_by);
+  unsigned keep = std::min<unsigned>(blocked_by.size(), cct->_conf->osd_max_pg_blocked_by);
   unsigned skip = blocked_by.size() - keep;
   info.stats.blocked_by.clear();
   info.stats.blocked_by.resize(keep);

--- a/src/osdc/Striper.cc
+++ b/src/osdc/Striper.cc
@@ -287,7 +287,7 @@ void Striper::StripedReadResult::add_partial_sparse_result(
        p != buffer_extents.end();
        ++p) {
     uint64_t tofs = p->first;
-    uint64_t tlen = p->second;
+    size_t tlen = p->second;
     ldout(cct, 30) << " be " << tofs << "~" << tlen << dendl;
     while (tlen > 0) {
       ldout(cct, 20) << "  t " << tofs << "~" << tlen
@@ -314,7 +314,7 @@ void Striper::StripedReadResult::add_partial_sparse_result(
       if (s->first > bl_off) {
 	// gap in sparse read result
 	pair<bufferlist, uint64_t>& r = partial[tofs];
-	size_t gap = std::min(s->first - bl_off, tlen);
+	size_t gap = std::min<size_t>(s->first - bl_off, tlen);
 	ldout(cct, 20) << "  s gap " << gap << ", skipping" << dendl;
 	r.second = gap;
 	total_intended_len += r.second;


### PR DESCRIPTION
on clang on MacOS, size_t is not identical to uint64_t, so we need to do
specify the template parameter if the two parameters' types are
different.

Signed-off-by: Kefu Chai <kchai@redhat.com>