### PR TITLE
mgr/prometheus: Load metrics configuration from a separate file

### DIFF
--- a/src/pybind/mgr/prometheus/metric.py
+++ b/src/pybind/mgr/prometheus/metric.py
@@ -1,4 +1,39 @@
+import copy
 import math
+
+import static_metrics
+
+
+def get_metrics_spec():
+    """
+    Load the metrics configuration, and build a spec representing the set of
+    metrics we'll use.
+    """
+    metrics_spec = copy.deepcopy(static_metrics.groups)
+    for name, group in metrics_spec.items():
+        templates = group.pop('templates', dict())
+        defaults = group.pop('defaults', dict())
+        for name, item in group.get('metrics', dict()).items():
+            apply_defaults(defaults, item)
+            apply_templates(templates, name, item)
+            if 'name' not in item:
+                item['name'] = name
+    return metrics_spec
+
+
+def apply_defaults(defaults, item):
+    for name, value in defaults.items():
+        if name not in item:
+            item[name] = value
+    return item
+
+
+def apply_templates(templates, item_name, item):
+    for name, value in templates.items():
+        new_value = value.format(item_name)
+        if name not in item:
+            item[name] = new_value
+    return item
 
 
 class Metric(object):

--- a/src/pybind/mgr/prometheus/metric.py
+++ b/src/pybind/mgr/prometheus/metric.py
@@ -1,0 +1,67 @@
+import math
+
+
+class Metric(object):
+    def __init__(self, mtype, name, desc, labels=None):
+        self.mtype = mtype
+        self.name = name
+        self.desc = desc
+        self.labelnames = labels    # tuple if present
+        self.value = dict()         # indexed by label values
+
+    def set(self, value, labelvalues=None):
+        # labelvalues must be a tuple
+        labelvalues = labelvalues or ('',)
+        self.value[labelvalues] = value
+
+    def str_expfmt(self):
+
+        def promethize(path):
+            ''' replace illegal metric name characters '''
+            result = path.replace('.', '_').replace('+', '_plus')\
+                .replace('::', '_')
+
+            # Hyphens usually turn into underscores, unless they are
+            # trailing
+            if result.endswith("-"):
+                result = result[0:-1] + "_minus"
+            else:
+                result = result.replace("-", "_")
+
+            return "ceph_{0}".format(result)
+
+        def floatstr(value):
+            ''' represent as Go-compatible float '''
+            if value == float('inf'):
+                return '+Inf'
+            if value == float('-inf'):
+                return '-Inf'
+            if math.isnan(value):
+                return 'NaN'
+            return repr(float(value))
+
+        name = promethize(self.name)
+        expfmt = '''
+# HELP {name} {desc}
+# TYPE {name} {mtype}'''.format(
+            name=name,
+            desc=self.desc,
+            mtype=self.mtype,
+        )
+
+        for labelvalues, value in self.value.items():
+            if self.labelnames:
+                labels = zip(self.labelnames, labelvalues)
+                labels = ','.join('%s="%s"' % (k, v) for k, v in labels)
+            else:
+                labels = ''
+            if labels:
+                fmtstr = '\n{name}{{{labels}}} {value}'
+            else:
+                fmtstr = '\n{name} {value}'
+            expfmt += fmtstr.format(
+                name=name,
+                labels=labels,
+                value=floatstr(value),
+            )
+        return expfmt

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -1,11 +1,12 @@
 import cherrypy
 import json
 import errno
-import math
 import os
 import socket
 from collections import OrderedDict
 from mgr_module import MgrModule, MgrStandbyModule
+
+from metric import Metric
 
 # Defaults for the Prometheus HTTP server.  Can also set in config-key
 # see https://github.com/prometheus/prometheus/wiki/Default-port-allocations
@@ -62,71 +63,6 @@ OSD_STATS = ['apply_latency_ms', 'commit_latency_ms']
 POOL_METADATA = ('pool_id', 'name')
 
 DISK_OCCUPATION = ('instance', 'device', 'ceph_daemon')
-
-
-class Metric(object):
-    def __init__(self, mtype, name, desc, labels=None):
-        self.mtype = mtype
-        self.name = name
-        self.desc = desc
-        self.labelnames = labels    # tuple if present
-        self.value = dict()         # indexed by label values
-
-    def set(self, value, labelvalues=None):
-        # labelvalues must be a tuple
-        labelvalues = labelvalues or ('',)
-        self.value[labelvalues] = value
-
-    def str_expfmt(self):
-
-        def promethize(path):
-            ''' replace illegal metric name characters '''
-            result = path.replace('.', '_').replace('+', '_plus').replace('::', '_')
-
-            # Hyphens usually turn into underscores, unless they are
-            # trailing
-            if result.endswith("-"):
-                result = result[0:-1] + "_minus"
-            else:
-                result = result.replace("-", "_")
-
-            return "ceph_{0}".format(result)
-
-        def floatstr(value):
-            ''' represent as Go-compatible float '''
-            if value == float('inf'):
-                return '+Inf'
-            if value == float('-inf'):
-                return '-Inf'
-            if math.isnan(value):
-                return 'NaN'
-            return repr(float(value))
-
-        name = promethize(self.name)
-        expfmt = '''
-# HELP {name} {desc}
-# TYPE {name} {mtype}'''.format(
-            name=name,
-            desc=self.desc,
-            mtype=self.mtype,
-        )
-
-        for labelvalues, value in self.value.items():
-            if self.labelnames:
-                labels = zip(self.labelnames, labelvalues)
-                labels = ','.join('%s="%s"' % (k, v) for k, v in labels)
-            else:
-                labels = ''
-            if labels:
-                fmtstr = '\n{name}{{{labels}}} {value}'
-            else:
-                fmtstr = '\n{name} {value}'
-            expfmt += fmtstr.format(
-                name=name,
-                labels=labels,
-                value=floatstr(value),
-            )
-        return expfmt
 
 
 class Module(MgrModule):

--- a/src/pybind/mgr/prometheus/static_metrics.py
+++ b/src/pybind/mgr/prometheus/static_metrics.py
@@ -1,0 +1,95 @@
+groups = {
+    'df_cluster': {
+        'defaults': {'type': 'gauge'},
+        'templates': {'desc': 'DF {}', 'name': 'cluster_{}'},
+        'metrics': {
+            'total_bytes': {},
+            'total_objects': {},
+            'total_used_bytes': {},
+        },
+    },
+    'df_pool': {
+        'defaults': {'labels': ['pool_id'], 'type': 'gauge'},
+        'templates': {'desc': 'DF Pool {}', 'name': 'pool_{}'},
+        'metrics': {
+            'bytes_used': {},
+            'dirty': {},
+            'max_avail': {},
+            'objects': {},
+            'quota_bytes': {},
+            'quota_objects': {},
+            'raw_bytes_used': {},
+            'rd': {},
+            'rd_bytes': {},
+            'wr': {},
+            'wr_bytes': {}
+        },
+    },
+    'metadata': {
+        'defaults': {'type': 'untyped'},
+        'metrics': {
+            'disk_occupation': {
+                'desc': 'Associate Ceph daemon with disk used',
+                'labels': ['instance', 'device', 'ceph_daemon'],
+            },
+            'health_status': {'desc': 'Cluster health status'},
+            'mon_quorum_count': {
+                'desc': 'Monitors in quorum',
+                'type': 'gauge',
+            },
+            'osd_metadata': {
+                'desc': 'OSD Metadata',
+                'labels': ['cluster_addr', 'device_class', 'id',
+                           'public_addr'],
+            },
+            'pool_metadata': {
+                'desc': 'POOL Metadata',
+                'labels': ['pool_id', 'name'],
+            },
+        },
+    },
+    'osd_status': {
+        'defaults': {'labels': ['ceph_daemon'], 'type': 'untyped'},
+        'templates': {'desc': 'OSD Status {}', 'name': 'osd_{}'},
+        'metrics': {
+            'in': {},
+            'up': {},
+            'weight': {},
+        },
+    },
+    'osd_stats': {
+        'defaults': {'labels': ['ceph_daemon'], 'type': 'gauge'},
+        'templates': {'desc': 'OSD stat {}', 'name': 'osd_{}'},
+        'metrics': {
+            'apply_latency_ms': {},
+            'commit_latency_ms': {},
+        },
+    },
+    'pg_states': {
+        'defaults': {'type': 'gauge'},
+        'templates': {'desc': 'PG {}', 'name': 'pg_{}'},
+        'metrics': {
+            'active': {},
+            'backfill': {},
+            'backfill-toofull': {},
+            'clean': {},
+            'creating': {},
+            'deep': {},
+            'degraded': {},
+            'down': {},
+            'forced-backfill': {},
+            'forced-recovery': {},
+            'incomplete': {},
+            'inconsistent': {},
+            'peered': {},
+            'peering': {},
+            'recovering': {},
+            'remapped': {},
+            'repair': {},
+            'scrubbing': {},
+            'stale': {},
+            'undersized': {},
+            'wait-backfill': {},
+        },
+    },
+}


### PR DESCRIPTION
This PR attempts to lay the groundwork for some future development on the prometheus side as we try to reconcile what cephmetrics collects vs. ceph itself.

One thing I quickly noticed when looking at the current module was that it was quite difficult to discover the list of metrics that would be used, as well as all their labels. I think reading them from a separate file helps. I put a good amount of thought into defining a format that would support everything the existing Python code is doing, while also leaving room for future improvement. I'm of course open to changing the approach, though.

I also wanted to nudge things in the direction of being testable outside the context of a running Ceph cluster, but this PR alone won't get us there.

Speaking of testing, all I've done so far is use `vstart.sh` to run a `master` cluster, scrape the endpoint, and repeat using this branch. Here is the [old](https://paste.fedoraproject.org/paste/mIKpfOuliquIg0~SRiNSZA) vs [new](https://paste.fedoraproject.org/paste/8Mc8g8ad-OnqZqwF-qf50w) output.

Bearing all of the above in mind, I should mention that whatever happens with this PR, I'll want to backport it to luminous as well. Thoughts?