### PR TITLE
rgw: retry resuming when curl receive data timeout

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1440,6 +1440,7 @@ OPTION(rgw_md_log_max_shards, OPT_INT) // max shards for metadata log
 OPTION(rgw_curl_wait_timeout_ms, OPT_INT) // timeout for certain curl calls
 OPTION(rgw_curl_low_speed_limit, OPT_INT) // low speed limit for certain curl calls
 OPTION(rgw_curl_low_speed_time, OPT_INT) // low speed time for certain curl calls
+OPTION(rgw_curl_timeout_retry_num, OPT_INT) // retry num when timeout
 OPTION(rgw_copy_obj_progress, OPT_BOOL) // should dump progress during long copy operations?
 OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT) // min bytes between copy progress output
 OPTION(rgw_obj_tombstone_cache_size, OPT_INT) // how many objects in tombstone cache, which is used in multi-zone sync to keep

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5920,6 +5920,10 @@ std::vector<Option> get_rgw_options() {
         "the rgw_curl_low_speed_limit for the library to consider it too slow and abort. "
         "Set it zero to disable this."),
 
+    Option("rgw_curl_timeout_retry_num", Option::TYPE_INT, Option::LEVEL_DEV)
+    .set_default(3)
+    .set_description("The max times allowed to retry connecting other when network connection is timeout"),
+
     Option("rgw_copy_obj_progress", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("Send progress report through copy operation")

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -510,6 +510,9 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data, bool send_data_hin
   if (has_send_len) {
     curl_easy_setopt(easy_handle, CURLOPT_INFILESIZE, (void *)send_len); 
   }
+  if (has_receive_len) {
+    curl_easy_setopt(easy_handle, CURLOPT_RESUME_FROM_LARGE, receive_len);
+  }
   if (!verify_ssl) {
     curl_easy_setopt(easy_handle, CURLOPT_SSL_VERIFYPEER, 0L);
     curl_easy_setopt(easy_handle, CURLOPT_SSL_VERIFYHOST, 0L);
@@ -518,6 +521,17 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data, bool send_data_hin
   curl_easy_setopt(easy_handle, CURLOPT_PRIVATE, (void *)req_data);
 
   return 0;
+}
+
+bool RGWHTTPClient::resume()
+{
+  size_t rl_threshold = 1<<8;
+  CURL *easy_handle = req_data->get_easy_handle();
+  if (has_receive_len && receive_len > rl_threshold) {
+    curl_easy_setopt(easy_handle, CURLOPT_RESUME_FROM_LARGE, receive_len);
+    return true;
+  }
+  return false;
 }
 
 bool RGWHTTPClient::is_done()
@@ -1152,10 +1166,22 @@ void *RGWHTTPManager::reqs_thread_entry()
           case CURLE_OPERATION_TIMEDOUT:
             dout(0) << "WARNING: curl operation timed out, network average transfer speed less than " 
               << cct->_conf->rgw_curl_low_speed_limit << " Bytes per second during " << cct->_conf->rgw_curl_low_speed_time << " seconds." << dendl;
+            status = -ETIMEDOUT;
           default:
             dout(20) << "ERROR: msg->data.result=" << result << " req_data->id=" << id << " http_status=" << http_status << dendl;
 	    break;
         }
+
+        if (req_data->client->method.compare("GET") == 0 && status == -ETIMEDOUT &&
+            req_data->client->retry_num < cct->_conf->rgw_curl_timeout_retry_num) {
+          if (req_data->client->resume()) {
+            req_data->client->retry_num++;
+            dout(10) << "ERROR: req_data->id=" << id << " will try to resume GET" << dendl;
+            continue;
+          }
+        }
+
+	finish_request(req_data, status);
       }
     }
   }

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -75,6 +75,7 @@ class RGWHTTPClient : public RGWIOProvider
   bufferlist send_bl;
   bufferlist::iterator send_iter;
   bool has_send_len;
+  bool has_receive_len;
   long http_status;
   size_t receive_pause_skip{0}; /* how many bytes to skip next time receive_data is called
                                    due to being paused */
@@ -93,7 +94,10 @@ protected:
   string method;
   string url;
 
+  int retry_num{0};
+
   size_t send_len{0};
+  size_t receive_len{0};
 
   param_vec_t headers;
 
@@ -101,6 +105,8 @@ protected:
 
   int init_request(rgw_http_req_data *req_data,
                    bool send_data_hint = false);
+
+  bool resume();
 
   virtual int receive_header(void *ptr, size_t len) {
     return 0;
@@ -148,6 +154,7 @@ public:
                          const string& _method,
                          const string& _url)
     : has_send_len(false),
+      has_receive_len(false),
       http_status(HTTP_STATUS_NOSTATUS),
       req_data(nullptr),
       verify_ssl(cct->_conf->rgw_verify_ssl),
@@ -165,6 +172,11 @@ public:
     has_send_len = true;
   }
 
+
+  void set_receive_length(size_t len) {
+    receive_len = len;
+    has_receive_len = true;
+  }
 
   long get_http_status() const {
     return http_status;

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -108,6 +108,7 @@ private:
   bufferlist in_data;
   size_t chunk_ofs{0};
   size_t ofs{0};
+  size_t extra_len{0};
   uint64_t write_ofs{0};
   bool read_paused{false};
   bool send_paused{false};


### PR DESCRIPTION
When the network is not stable, the request will time out sometime. The huge object sync process will be very slow in this situation. This fix will be helpful.

Fix http://tracker.ceph.com/issues/22775