### PR TITLE
rgw: bucket resharding should rewrite bucket attrs after link

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -400,11 +400,11 @@ int rgw_bucket_parse_bucket_key(CephContext *cct, const string& key,
   return 0;
 }
 
-int rgw_bucket_set_attrs(RGWRados *store, RGWBucketInfo& bucket_info,
+int rgw_bucket_set_attrs(RGWRados *store, const RGWBucketInfo& bucket_info,
                          map<string, bufferlist>& attrs,
                          RGWObjVersionTracker *objv_tracker)
 {
-  rgw_bucket& bucket = bucket_info.bucket;
+  const rgw_bucket& bucket = bucket_info.bucket;
 
   if (!bucket_info.has_instance_obj) {
     /* an old bucket object, need to convert it */

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -191,7 +191,7 @@ extern int rgw_remove_object(RGWRados *store, RGWBucketInfo& bucket_info, rgw_bu
 extern int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children);
 extern int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket, int concurrent_max);
 
-extern int rgw_bucket_set_attrs(RGWRados *store, RGWBucketInfo& bucket_info,
+extern int rgw_bucket_set_attrs(RGWRados *store, const RGWBucketInfo& bucket_info,
                                 map<string, bufferlist>& attrs,
                                 RGWObjVersionTracker *objv_tracker);
 

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -482,6 +482,12 @@ int RGWBucketReshard::do_reshard(
     return -ret;
   }
 
+  ret = rgw_bucket_set_attrs(store, new_bucket_info, bucket_attrs, &new_bucket_info.objv_tracker);
+  if (ret < 0) {
+    lderr(store->ctx()) << "failed to reset attrs for bucket " << new_bucket_info.bucket.name << " instance (bucket_id=" << new_bucket_info.bucket.bucket_id << ": " << err << "; " << cpp_strerror(-ret) << ")" << dendl;
+    /* don't error out, reshard process succeeded */
+  }
+
   ret = bucket_info_updater.complete();
   if (ret < 0) {
     ldout(store->ctx(), 0) << __func__ << ": failed to update bucket info ret=" << ret << dendl;


### PR DESCRIPTION
 bucket link op resets bucket ACL attr.
    
 Fixes: http://tracker.ceph.com/issues/22703
