### PR TITLE
mon: fix mgr using auth_client_required policy

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -72,9 +72,13 @@ DaemonServer::DaemonServer(MonClient *monc_,
       py_modules(py_modules_),
       clog(clog_),
       audit_clog(audit_clog_),
-      auth_registry(g_ceph_context,
+      auth_cluster_registry(g_ceph_context,
                     g_conf->auth_supported.empty() ?
                       g_conf->auth_cluster_required :
+                      g_conf->auth_supported),
+      auth_service_registry(g_ceph_context,
+                   g_conf->auth_supported.empty() ?
+                      g_conf->auth_service_required :
                       g_conf->auth_supported),
       lock("DaemonServer"),
       pgmap_ready(false)
@@ -145,7 +149,15 @@ bool DaemonServer::ms_verify_authorizer(Connection *con,
     bool& is_valid,
     CryptoKey& session_key)
 {
-  auto handler = auth_registry.get_handler(protocol);
+  AuthAuthorizeHandler *handler = nullptr;
+  if (peer_type == CEPH_ENTITY_TYPE_OSD ||
+      peer_type == CEPH_ENTITY_TYPE_MON ||
+      peer_type == CEPH_ENTITY_TYPE_MDS ||
+      peer_type == CEPH_ENTITY_TYPE_MGR) {
+    handler = auth_cluster_registry.get_handler(protocol);
+  } else {
+    handler = auth_service_registry.get_handler(protocol);
+  }
   if (!handler) {
     dout(0) << "No AuthAuthorizeHandler found for protocol " << protocol << dendl;
     is_valid = false;

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -62,7 +62,10 @@ protected:
   PyModuleRegistry &py_modules;
   LogChannelRef clog, audit_clog;
 
-  AuthAuthorizeHandlerRegistry auth_registry;
+  // Authentication methods for cluster peers
+  AuthAuthorizeHandlerRegistry auth_cluster_registry;
+  // Authentication methods for clients
+  AuthAuthorizeHandlerRegistry auth_service_registry;
 
   // Connections for daemons, and clients with service names set
   // (i.e. those MgrClients that are allowed to send MMgrReports)

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -366,7 +366,8 @@ int MonClient::init()
     method = cct->_conf->auth_supported;
   else if (entity_name.get_type() == CEPH_ENTITY_TYPE_OSD ||
 	   entity_name.get_type() == CEPH_ENTITY_TYPE_MDS ||
-	   entity_name.get_type() == CEPH_ENTITY_TYPE_MON)
+	   entity_name.get_type() == CEPH_ENTITY_TYPE_MON ||
+	   entity_name.get_type() == CEPH_ENTITY_TYPE_MGR)
     method = cct->_conf->auth_cluster_required;
   else
     method = cct->_conf->auth_client_required;


### PR DESCRIPTION
This caused mgr daemons to fail to authenticate
when auth_client_required was set to something
different to auth_cluster_required.

Fixes: https://tracker.ceph.com/issues/22096
Signed-off-by: John Spray <john.spray@redhat.com>