### PR TITLE
Revert "rgw: reshard should not update stats when linking new bucket instance"

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -182,8 +182,7 @@ int rgw_link_bucket(RGWRados* const store,
                     const rgw_user& user_id,
                     rgw_bucket& bucket,
                     ceph::real_time creation_time,
-                    bool update_entrypoint,
-                    bool update_stats)
+                    bool update_entrypoint)
 {
   int ret;
   string& tenant_name = bucket.tenant;
@@ -216,7 +215,7 @@ int rgw_link_bucket(RGWRados* const store,
   rgw_get_buckets_obj(user_id, buckets_obj_id);
 
   rgw_raw_obj obj(store->get_zone_params().user_uid_pool, buckets_obj_id);
-  ret = store->cls_user_add_bucket(obj, new_bucket, update_stats);
+  ret = store->cls_user_add_bucket(obj, new_bucket);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: error adding bucket to directory: "
                            << cpp_strerror(-ret) << dendl;
@@ -890,7 +889,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
     }
 
     r = rgw_link_bucket(store, user_info.user_id, bucket_info.bucket,
-                        ceph::real_time(),true, op_state.will_update_stats());
+                        ceph::real_time());
     if (r < 0) {
       return r;
     }

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -182,8 +182,7 @@ extern int rgw_link_bucket(RGWRados* store,
                            const rgw_user& user_id,
                            rgw_bucket& bucket,
                            ceph::real_time creation_time,
-                           bool update_entrypoint = true,
-                           bool update_stats = true);
+                           bool update_entrypoint = true);
 extern int rgw_unlink_bucket(RGWRados *store, const rgw_user& user_id,
                              const string& tenant_name, const string& bucket_name, bool update_entrypoint = true);
 
@@ -211,7 +210,6 @@ struct RGWBucketAdminOpState {
   bool delete_child_objects;
   bool bucket_stored;
   int max_aio = 0;
-  bool update_stats;
 
   rgw_bucket bucket;
 
@@ -223,7 +221,6 @@ struct RGWBucketAdminOpState {
   void set_delete_children(bool value) { delete_child_objects = value; }
 
   void set_max_aio(int value) { max_aio = value; }
-  void set_update_stats(bool value) { update_stats = value; }
 
   void set_user_id(const rgw_user& user_id) {
     if (!user_id.empty())
@@ -264,11 +261,10 @@ struct RGWBucketAdminOpState {
   bool is_system_op() { return uid.empty(); }
   bool has_bucket_stored() { return bucket_stored; }
   int get_max_aio() { return max_aio; }
-  bool will_update_stats() { return update_stats;}
 
   RGWBucketAdminOpState() : list_buckets(false), stat_buckets(false), check_objects(false), 
                             fix_index(false), delete_child_objects(false),
-                            bucket_stored(false), update_stats(true)  {}
+                            bucket_stored(false)  {}
 };
 
 /*

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -13361,13 +13361,12 @@ int RGWRados::cls_user_complete_stats_sync(rgw_raw_obj& obj)
   return 0;
 }
 
-int RGWRados::cls_user_add_bucket(rgw_raw_obj& obj, const cls_user_bucket_entry& entry,
-  bool update_stats)
+int RGWRados::cls_user_add_bucket(rgw_raw_obj& obj, const cls_user_bucket_entry& entry)
 {
   list<cls_user_bucket_entry> l;
   l.push_back(entry);
 
-  return cls_user_update_buckets(obj, l, update_stats);
+  return cls_user_update_buckets(obj, l, true);
 }
 
 int RGWRados::cls_user_remove_bucket(rgw_raw_obj& obj, const cls_user_bucket& bucket)

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3571,7 +3571,7 @@ public:
                             list<cls_user_bucket_entry>& entries,
                             string *out_marker,
                             bool *truncated);
-  int cls_user_add_bucket(rgw_raw_obj& obj, const cls_user_bucket_entry& entry, bool update_stats);
+  int cls_user_add_bucket(rgw_raw_obj& obj, const cls_user_bucket_entry& entry);
   int cls_user_update_buckets(rgw_raw_obj& obj, list<cls_user_bucket_entry>& entries, bool add);
   int cls_user_complete_stats_sync(rgw_raw_obj& obj);
   int complete_sync_user_stats(const rgw_user& user_id);

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -474,12 +474,11 @@ int RGWBucketReshard::do_reshard(
   bucket_op.set_bucket_name(new_bucket_info.bucket.name);
   bucket_op.set_bucket_id(new_bucket_info.bucket.bucket_id);
   bucket_op.set_user_id(new_bucket_info.owner);
-  bucket_op.set_update_stats(false);
   string err;
-  ret = RGWBucketAdminOp::link(store, bucket_op, &err);
-  if (ret < 0) {
-    lderr(store->ctx()) << "failed to link new bucket instance (bucket_id=" << new_bucket_info.bucket.bucket_id << ": " << err << "; " << cpp_strerror(-ret) << ")" << dendl;
-    return -ret;
+  int r = RGWBucketAdminOp::link(store, bucket_op, &err);
+  if (r < 0) {
+    lderr(store->ctx()) << "failed to link new bucket instance (bucket_id=" << new_bucket_info.bucket.bucket_id << ": " << err << "; " << cpp_strerror(-r) << ")" << dendl;
+    return -r;
   }
 
   ret = bucket_info_updater.complete();


### PR DESCRIPTION
reverting due to regression causing the bucket not to be displayed in user bucket list
Reverts ceph/ceph#19253