### PR TITLE
luminous: qa/suites/upgrade: disable broken kraken upgrade cls_rbd test

### DIFF
--- a/qa/suites/upgrade/kraken-x/parallel/2-workload/rados_api.yaml
+++ b/qa/suites/upgrade/kraken-x/parallel/2-workload/rados_api.yaml
@@ -8,4 +8,6 @@ workload:
         clients:
           client.0:
             - cls
+        env:
+          CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.snapshots_namespaces'
     - print: "**** done cls 2-workload"


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/22740
Signed-off-by: Jason Dillaman <dillaman@redhat.com>