### PR TITLE
librados: getter for min compatible client versions

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -707,6 +707,20 @@ CEPH_RADOS_API rados_config_t rados_cct(rados_t cluster);
 CEPH_RADOS_API uint64_t rados_get_instance_id(rados_t cluster);
 
 /**
+ * Gets the minimum compatible client version
+ *
+ * @param cluster cluster handle
+ * @param[out] min_compat_client minimum compatible client version
+ *  based upon the current features
+ * @param[out] require_min_compat_client required minimum client version
+ *  based upon explicit setting
+ * @returns 0 on sucess, negative error code on failure
+ */
+CEPH_RADOS_API int rados_get_min_compatible_client(rados_t cluster,
+                                                   int8_t* min_compat_client,
+                                                   int8_t* require_min_compat_client);
+
+/**
  * Create an io context
  *
  * The io context allows you to perform operations within a particular

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1337,6 +1337,9 @@ namespace librados
 
     uint64_t get_instance_id();
 
+    int get_min_compatible_client(int8_t* min_compat_client,
+                                  int8_t* require_min_compat_client);
+
     int mon_command(std::string cmd, const bufferlist& inbl,
 		    bufferlist *outbl, std::string *outs);
     int mgr_command(std::string cmd, const bufferlist& inbl,

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -441,6 +441,22 @@ uint64_t librados::RadosClient::get_instance_id()
   return instance_id;
 }
 
+int librados::RadosClient::get_min_compatible_client(int8_t* min_compat_client,
+                                                     int8_t* require_min_compat_client)
+{
+  int r = wait_for_osdmap();
+  if (r < 0) {
+    return r;
+  }
+
+  objecter->with_osdmap(
+    [min_compat_client, require_min_compat_client](const OSDMap& o) {
+      *min_compat_client = o.get_min_compat_client();
+      *require_min_compat_client = o.get_require_min_compat_client();
+    });
+  return 0;
+}
+
 librados::RadosClient::~RadosClient()
 {
   if (messenger)

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -99,6 +99,9 @@ public:
 
   uint64_t get_instance_id();
 
+  int get_min_compatible_client(int8_t* min_compat_client,
+                                int8_t* require_min_compat_client);
+
   int wait_for_latest_osdmap();
 
   int create_ioctx(const char *name, IoCtxImpl **io);

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2323,6 +2323,13 @@ uint64_t librados::Rados::get_instance_id()
   return client->get_instance_id();
 }
 
+int librados::Rados::get_min_compatible_client(int8_t* min_compat_client,
+                                               int8_t* require_min_compat_client)
+{
+  return client->get_min_compatible_client(min_compat_client,
+                                           require_min_compat_client);
+}
+
 int librados::Rados::conf_read_file(const char * const path) const
 {
   return rados_conf_read_file((rados_t)client, path);
@@ -2886,6 +2893,15 @@ extern "C" uint64_t rados_get_instance_id(rados_t cluster)
   uint64_t retval = client->get_instance_id();
   tracepoint(librados, rados_get_instance_id_exit, retval);
   return retval;
+}
+
+extern "C" int rados_get_min_compatible_client(rados_t cluster,
+                                               int8_t* min_compat_client,
+                                               int8_t* require_min_compat_client)
+{
+  librados::RadosClient *client = (librados::RadosClient *)cluster;
+  return client->get_min_compatible_client(min_compat_client,
+                                           require_min_compat_client);
 }
 
 extern "C" void rados_version(int *major, int *minor, int *extra)

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1451,6 +1451,11 @@ uint8_t OSDMap::get_min_compat_client() const
   return CEPH_RELEASE_ARGONAUT;    // v0.48argonaut-206-g6f381af
 }
 
+uint8_t OSDMap::get_require_min_compat_client() const
+{
+  return require_min_compat_client;
+}
+
 void OSDMap::_calc_up_osd_features()
 {
   bool first = true;

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -979,6 +979,11 @@ public:
   uint8_t get_min_compat_client() const;
 
   /**
+   * gets the required minimum *client* version that can connect to the cluster.
+   */
+  uint8_t get_require_min_compat_client() const;
+
+  /**
    * get intersection of features supported by up osds
    */
   uint64_t get_up_osd_features() const;

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -6,6 +6,7 @@
 #include "include/err.h"
 #include "include/buffer.h"
 #include "include/rbd_types.h"
+#include "include/rados.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
 #include "include/stringify.h"
@@ -1378,4 +1379,29 @@ TEST_F(LibRadosMiscECPP, CompareExtentRange) {
   ObjectReadOperation read2;
   read2.cmpext(2097152, bl3, nullptr);
   ASSERT_EQ(0, ioctx.operate("foo", &read2, nullptr));
+}
+
+TEST_F(LibRadosMisc, MinCompatClient) {
+  int8_t min_compat_client;
+  int8_t require_min_compat_client;
+  ASSERT_EQ(0, rados_get_min_compatible_client(cluster,
+                                               &min_compat_client,
+                                               &require_min_compat_client));
+  ASSERT_LE(-1, min_compat_client);
+  ASSERT_GT(CEPH_RELEASE_MAX, min_compat_client);
+
+  ASSERT_LE(-1, require_min_compat_client);
+  ASSERT_GT(CEPH_RELEASE_MAX, require_min_compat_client);
+}
+
+TEST_F(LibRadosMiscPP, MinCompatClient) {
+  int8_t min_compat_client;
+  int8_t require_min_compat_client;
+  ASSERT_EQ(0, cluster.get_min_compatible_client(&min_compat_client,
+                                                 &require_min_compat_client));
+  ASSERT_LE(-1, min_compat_client);
+  ASSERT_GT(CEPH_RELEASE_MAX, min_compat_client);
+
+  ASSERT_LE(-1, require_min_compat_client);
+  ASSERT_GT(CEPH_RELEASE_MAX, require_min_compat_client);
 }


### PR DESCRIPTION
librbd would like to automatically enable the new clone v2 feature (by default) if all clients are known to be mimic or later. This new API method avoids the need to send a mon command to dump the OSD map and parse the JSON for the client compat settings.