### PR TITLE
luminous: client: avoid recursive lock in ll_get_vino

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12604,7 +12604,7 @@ int Client::ll_read_block(Inode *in, uint64_t blockid,
   if (unmounting)
     return -ENOTCONN;
 
-  vinodeno_t vino = ll_get_vino(in);
+  vinodeno_t vino = _get_vino(in);
   object_t oid = file_object_t(vino.ino, blockid);
   C_SaferCond onfinish;
   bufferlist bl;
@@ -12713,7 +12713,7 @@ int Client::ll_commit_blocks(Inode *in,
     Mutex::Locker lock(client_lock);
     /*
     BarrierContext *bctx;
-    vinodeno_t vino = ll_get_vino(in);
+    vinodeno_t vino = _get_vino(in);
     uint64_t ino = vino.ino;
 
     ldout(cct, 1) << "ll_commit_blocks for " << vino.ino << " from "


### PR DESCRIPTION
http://tracker.ceph.com/issues/22765