### PR TITLE
os/bluestore: no need to fsync when failed to write label

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4160,12 +4160,14 @@ int BlueStore::_write_bdev_label(CephContext *cct,
   if (r < 0) {
     derr << __func__ << " failed to write to " << path
 	 << ": " << cpp_strerror(r) << dendl;
+    goto out;
   }
   r = ::fsync(fd);
   if (r < 0) {
     derr << __func__ << " failed to fsync " << path
 	 << ": " << cpp_strerror(r) << dendl;
   }
+out:
   VOID_TEMP_FAILURE_RETRY(::close(fd));
   return r;
 }


### PR DESCRIPTION
Signed-off-by: tangwenjun <tang.wenjun3@zte.com.cn>