### PR TITLE
rgw: fix RGWCompletionManager get_next stuck after going down

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -68,10 +68,10 @@ int RGWCompletionManager::get_next(void **user_info)
 {
   Mutex::Locker l(lock);
   while (complete_reqs.empty()) {
-    cond.Wait(lock);
     if (going_down) {
       return -ECANCELED;
     }
+    cond.Wait(lock);
   }
   *user_info = complete_reqs.front();
   complete_reqs.pop_front();


### PR DESCRIPTION
fix the situation cond.Signal() fist then we go into cond.wait()

Signed-off-by: Tianshan Qu <tianshan@xsky.com>