### PR TITLE
src/test/osd: add two pool test for manifest objects

### DIFF
--- a/qa/suites/rados/thrash/workloads/redirect.yaml
+++ b/qa/suites/rados/thrash/workloads/redirect.yaml
@@ -1,6 +1,10 @@
 tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
 - rados:
     clients: [client.0]
+    low_tier_pool: 'low_tier'
     ops: 4000
     objects: 500
     set_redirect: true

--- a/qa/suites/rados/thrash/workloads/redirect_promote_tests.yaml
+++ b/qa/suites/rados/thrash/workloads/redirect_promote_tests.yaml
@@ -1,6 +1,10 @@
 tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
 - rados:
     clients: [client.0]
+    low_tier_pool: 'low_tier'
     ops: 4000
     objects: 500
     set_redirect: true

--- a/qa/suites/rados/thrash/workloads/redirect_set_object.yaml
+++ b/qa/suites/rados/thrash/workloads/redirect_set_object.yaml
@@ -1,6 +1,10 @@
 tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
 - rados:
     clients: [client.0]
+    low_tier_pool: 'low_tier'
     ops: 4000
     objects: 500
     set_redirect: true

--- a/qa/suites/rados/thrash/workloads/set-chunks-read.yaml
+++ b/qa/suites/rados/thrash/workloads/set-chunks-read.yaml
@@ -1,6 +1,10 @@
 tasks:
+- exec:
+    client.0:
+      - sudo ceph osd pool create low_tier 4
 - rados:
     clients: [client.0]
+    low_tier_pool: 'low_tier'
     ops: 4000
     objects: 300
     set_chunk: true

--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -147,6 +147,8 @@ def task(ctx, config):
         args.extend(['--set_redirect'])
     if config.get('set_chunk', False):
         args.extend(['--set_chunk'])
+    if config.get('low_tier_pool', None):
+        args.extend(['--low_tier_pool', config.get('low_tier_pool', None)])
     if config.get('pool_snaps', False):
         args.extend(['--pool-snaps'])
     args.extend([

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2328,12 +2328,15 @@ public:
     context->oid_in_use.insert(oid);
     context->oid_not_in_use.erase(oid);
 
+    if (tgt_pool_name.empty()) ceph_abort();
+
     context->find_object(oid, &src_value); 
     context->find_object(oid_tgt, &tgt_value);
 
     if (src_value.version != 0 && !src_value.deleted())
       op.assert_version(src_value.version);
-    op.set_chunk(offset, length, context->io_ctx, context->prefix+oid_tgt, tgt_offset);
+    op.set_chunk(offset, length, context->low_tier_io_ctx, 
+		 context->prefix+oid_tgt, tgt_offset);
 
     pair<TestOp*, TestOp::CallbackInfo*> *cb_arg =
       new pair<TestOp*, TestOp::CallbackInfo*>(this,

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -571,6 +571,10 @@ int main(int argc, char **argv)
     } else if (strcmp(argv[i], "--set_chunk") == 0) {
       set_chunk = true;
     } else if (strcmp(argv[i], "--low_tier_pool") == 0) {
+      /*
+       * disallow redirect or chunk object into the same pool
+       * to prevent the race. see https://github.com/ceph/ceph/pull/20096
+       */
       low_tier_pool_name = argv[++i];
     } else {
       cerr << "unknown arg " << argv[i] << std::endl;

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -234,7 +234,7 @@ public:
 	     << " length: " << rand_length <<  " target oid " << oid2.str() 
 	     << " tgt_offset: " << rand_tgt_offset << std::endl;
 	op = new SetChunkOp(m_op, &context, oid.str(), rand_offset, rand_length, oid2.str(), 
-			      context.pool_name, rand_tgt_offset, m_stats);
+			      context.low_tier_pool_name, rand_tgt_offset, m_stats);
 	return true;
       }
     } else if (m_op == make_manifest_end + 1) {


### PR DESCRIPTION
This PR changed existing test (manifest) based on single pool to the test based on two pools 
As discussed in the https://github.com/ceph/ceph/pull/19362

Signed-off-by: Myoungwon Oh <omwmw@sk.com>