### PR TITLE
rgw: release RGWDataSyncControlCR in destory RGWRemoteDataLog

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1749,16 +1749,21 @@ int RGWRemoteDataLog::run_sync(int num_shards)
 
   int r = run(data_sync_cr);
 
-  lock.get_write();
-  data_sync_cr->put();
-  data_sync_cr = NULL;
-  lock.unlock();
-
   if (r < 0) {
     ldout(store->ctx(), 0) << "ERROR: failed to run sync" << dendl;
     return r;
   }
   return 0;
+}
+
+RGWRemoteDataLog::~RGWRemoteDataLog()
+{
+  lock.get_write();
+  if (data_sync_cr) {
+    data_sync_cr->put();
+    data_sync_cr = NULL;
+  }
+  lock.unlock();
 }
 
 int RGWDataSyncStatusManager::init()

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -275,6 +275,9 @@ public:
       http_manager(store->ctx(), completion_mgr),
       lock("RGWRemoteDataLog::lock"), data_sync_cr(NULL),
       initialized(false) {}
+
+  ~RGWRemoteDataLog() override;
+
   int init(const string& _source_zone, RGWRESTConn *_conn, RGWSyncErrorLogger *_error_logger,
            RGWSyncTraceManager *_sync_tracer, RGWSyncModuleInstanceRef& module);
   void finish();


### PR DESCRIPTION
the release sequence in RGWRados::finalize() is stop sync thread, then
stop async rados, and last release sync thread. But RGWDataSyncControlCR
is released right after RGWRemoteDataLog stop, and some async op send by
RGWDataSyncControlCR is still rely some resources, so we need wait async
op reaped then destroy the RGWDataSyncControlCR.

Signed-off-by: Tianshan Qu <tianshan@xsky.com>