### PR TITLE
librbd: fix deep copy a child-image

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -81,6 +81,22 @@ test_others() {
     rbd snap ls testimg4 | grep -v 'SNAPID' | wc -l | grep 1
     rbd snap ls testimg4 | grep '.*snap1.*'
 
+    # deep copy clone-image
+    rbd snap rm testimg4@snap1
+    rbd snap rm testimg5@snap1
+    rbd rm testimg4
+    rbd rm testimg5
+    rbd snap protect testimg1@snap1
+    rbd clone testimg1@snap1 testimg4
+    rbd snap create testimg4@snap2
+    rbd deep copy testimg4 testimg5
+    rbd info testimg5 | grep 'size 256 MB'
+    rbd snap ls testimg5 | grep -v 'SNAPID' | wc -l | grep 1
+    rbd snap ls testimg5 | grep '.*snap2.*'
+    rbd flatten testimg4
+    rbd flatten testimg5
+    rbd snap unprotect testimg1@snap1
+
     rbd export testimg1 /tmp/img1.new
     rbd export testimg2 /tmp/img2.new
     rbd export testimg3 /tmp/img3.new


### PR DESCRIPTION
```
root@s222:/ceph-dev/build# rbd snap ls child
SNAPID NAME     SIZE TIMESTAMP                
     5 s1   10240 kB Wed Jan 23 13:47:58 2018 
root@s222:/ceph-dev/build# rbd deep cp child child-cp
2018-01-24 09:54:12.895 7f4953fff700 -1 librbd::deep_copy::SetHeadRequest: 0x7f49935464c0 handle_set_parent: failed to set parent: (22) Invalid argument
2018-01-24 09:54:12.895 7f4953fff700 -1 librbd::deep_copy::SnapshotCreateRequest: 0x7f4993545a10 handle_set_head: failed to set head: (22) Invalid argument
2018-01-24 09:54:12.895 7f4953fff700 -1 librbd::deep_copy::SnapshotCopyRequest: 0x7f4993545f70 handle_snap_create: failed to create snapshot 's1': (22) Invalid argument
2018-01-24 09:54:12.895 7f4953fff700 -1 librbd::DeepCopyRequest: 0x7f4993545cf0 handle_copy_snapshots: failed to copy snapshot metadata: (22) Invalid argument
Image deep copy: 0% complete...failed.
rbd: deep copy failed: (22) Invalid argument
```
This pull request (1)fix failed to set parent when deep copying a child-image which has snapshot(s) (2)update rbd_children object when deep copying a child-image.

I'm not sure if this is the right way to fix these issues, and the unittest still needs to be fixed.
@dillaman  @trociny  Please help to have a look, thank you in advance.