### PR TITLE
common: preliminary crypto cleanup and refactoring

### DIFF
--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -22,7 +22,7 @@ class Cond;
 
 struct EntityAuth {
   uint64_t auid;
-  CryptoKey key;
+  ceph::crypto::Key key;
   map<string, bufferlist> caps;
 
   EntityAuth() : auid(CEPH_AUTH_UID_DEFAULT) {}
@@ -137,7 +137,7 @@ WRITE_CLASS_ENCODER(AuthTicket)
 struct AuthAuthorizer {
   __u32 protocol;
   bufferlist bl;
-  CryptoKey session_key;
+  ceph::crypto::Key session_key;
 
   explicit AuthAuthorizer(__u32 p) : protocol(p) {}
   virtual ~AuthAuthorizer() {}
@@ -151,7 +151,7 @@ struct AuthAuthorizer {
 #define KEY_ROTATE_NUM 3   /* prev, current, next */
 
 struct ExpiringCryptoKey {
-  CryptoKey key;
+  ceph::crypto::Key key;
   utime_t expiration;
 
   void encode(bufferlist& bl) const {
@@ -240,9 +240,9 @@ WRITE_CLASS_ENCODER(RotatingSecrets)
 class KeyStore {
 public:
   virtual ~KeyStore() {}
-  virtual bool get_secret(const EntityName& name, CryptoKey& secret) const = 0;
+  virtual bool get_secret(const EntityName& name, ceph::crypto::Key& secret) const = 0;
   virtual bool get_service_secret(uint32_t service_id, uint64_t secret_id,
-				  CryptoKey& secret) const = 0;
+				  ceph::crypto::Key& secret) const = 0;
 };
 
 inline bool auth_principal_needs_rotating_keys(EntityName& name)

--- a/src/auth/AuthAuthorizeHandler.h
+++ b/src/auth/AuthAuthorizeHandler.h
@@ -34,7 +34,7 @@ struct AuthAuthorizeHandler {
   virtual bool verify_authorizer(CephContext *cct, KeyStore *keys,
 				 bufferlist& authorizer_data, bufferlist& authorizer_reply,
                                  EntityName& entity_name, uint64_t& global_id,
-				 AuthCapsInfo& caps_info, CryptoKey& session_key, uint64_t *auid = NULL) = 0;
+				 AuthCapsInfo& caps_info, ceph::crypto::Key& session_key, uint64_t *auid = NULL) = 0;
   virtual int authorizer_session_crypto() = 0;
 };
 

--- a/src/auth/AuthSessionHandler.cc
+++ b/src/auth/AuthSessionHandler.cc
@@ -21,7 +21,7 @@
 #define dout_subsys ceph_subsys_auth
 
 
-AuthSessionHandler *get_auth_session_handler(CephContext *cct, int protocol, CryptoKey key, uint64_t features)
+AuthSessionHandler *get_auth_session_handler(CephContext *cct, int protocol, ceph::crypto::Key key, uint64_t features)
 {
 
   // Should add code to only print the SHA1 hash of the key, unless in secure debugging mode

--- a/src/auth/AuthSessionHandler.h
+++ b/src/auth/AuthSessionHandler.h
@@ -31,12 +31,12 @@ struct AuthSessionHandler {
 protected:
   CephContext *cct;
   int protocol;
-  CryptoKey key;
+  ceph::crypto::Key key;
 
 public:
   explicit AuthSessionHandler(CephContext *cct_) : cct(cct_), protocol(CEPH_AUTH_UNKNOWN) {}
 
-  AuthSessionHandler(CephContext *cct_, int protocol_, CryptoKey key_) : cct(cct_), 
+  AuthSessionHandler(CephContext *cct_, int protocol_, ceph::crypto::Key key_) : cct(cct_), 
     protocol(protocol_), key(key_) {}
   virtual ~AuthSessionHandler() { }
 
@@ -47,11 +47,11 @@ public:
   virtual int decrypt_message(Message *message) = 0;
 
   int get_protocol() {return protocol;}
-  CryptoKey get_key() {return key;}
+  ceph::crypto::Key get_key() {return key;}
 
 };
 
-extern AuthSessionHandler *get_auth_session_handler(CephContext *cct, int protocol, CryptoKey key,
+extern AuthSessionHandler *get_auth_session_handler(CephContext *cct, int protocol, ceph::crypto::Key key,
 						    uint64_t features);
 
 #endif

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -118,7 +118,7 @@ public:
   CryptoAES() { }
   ~CryptoAES() override {}
   int get_type() const override {
-    return CEPH_CRYPTO_AES;
+    return CEPH_CRYPTO_AES128;
   }
   int create(CryptoRandom *random, bufferptr& secret) override;
   int validate_secret(const bufferptr& secret) override;
@@ -413,7 +413,7 @@ CryptoHandler *CryptoHandler::create(int type)
   switch (type) {
   case CEPH_CRYPTO_NONE:
     return new CryptoNone;
-  case CEPH_CRYPTO_AES:
+  case CEPH_CRYPTO_AES128:
     return new CryptoAES;
   default:
     return NULL;

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -52,10 +52,8 @@ public:
 
   virtual ~KeyHandler() {}
 
-  virtual int encrypt(const bufferlist& in,
-		       bufferlist& out, std::string *error) const = 0;
-  virtual int decrypt(const bufferlist& in,
-		       bufferlist& out, std::string *error) const = 0;
+  virtual void encrypt(const bufferlist& in, bufferlist& out) const = 0;
+  virtual void decrypt(const bufferlist& in, bufferlist& out) const = 0;
 };
 
 /*
@@ -120,15 +118,13 @@ public:
 
   // --
   int create(CephContext *cct, int type);
-  int encrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
-	       std::string *error) const {
+  void encrypt(CephContext *cct, const bufferlist& in, bufferlist& out) const {
     assert(ckh); // Bad key?
-    return ckh->encrypt(in, out, error);
+    ckh->encrypt(in, out);
   }
-  int decrypt(CephContext *cct, const bufferlist& in, bufferlist& out,
-	       std::string *error) const {
+  void decrypt(CephContext *cct, const bufferlist& in, bufferlist& out) const {
     assert(ckh); // Bad key?
-    return ckh->decrypt(in, out, error);
+    ckh->decrypt(in, out);
   }
 
   void to_str(std::string& s) const;
@@ -154,8 +150,7 @@ public:
   virtual int get_type() const = 0;
   virtual int create(Random *random, bufferptr& secret) = 0;
   virtual int validate_secret(const bufferptr& secret) = 0;
-  virtual std::unique_ptr<KeyHandler> get_key_handler(const bufferptr& secret,
-                                                      string& error) = 0;
+  virtual std::unique_ptr<KeyHandler> get_key_handler(const bufferptr& secret) = 0;
 
   static std::unique_ptr<Handler> create(int type);
 };

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -15,12 +15,12 @@
 #ifndef CEPH_AUTH_CRYPTO_H
 #define CEPH_AUTH_CRYPTO_H
 
+#include <memory>
+#include <string>
+
 #include "include/types.h"
 #include "include/utime.h"
-#include "include/memory.h"
 #include "include/buffer.h"
-
-#include <string>
 
 class CephContext;
 
@@ -154,10 +154,10 @@ public:
   virtual int get_type() const = 0;
   virtual int create(Random *random, bufferptr& secret) = 0;
   virtual int validate_secret(const bufferptr& secret) = 0;
-  virtual KeyHandler *get_key_handler(const bufferptr& secret,
-                                      string& error) = 0;
+  virtual std::unique_ptr<KeyHandler> get_key_handler(const bufferptr& secret,
+                                                      string& error) = 0;
 
-  static Handler *create(int type);
+  static std::unique_ptr<Handler> create(int type);
 };
 
 } // namespace crypto

--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -92,7 +92,7 @@ int KeyRing::set_modifier(const char *type, const char *val, EntityName& name, m
     return -EINVAL;
 
   if (strcmp(type, "key") == 0) {
-    CryptoKey key;
+    ceph::crypto::Key key;
     string l(val);
     try {
       key.decode_base64(l);

--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -45,7 +45,7 @@ public:
     a = k->second;
     return true;
   }
-  bool get_secret(const EntityName& name, CryptoKey& secret) const override {
+  bool get_secret(const EntityName& name, ceph::crypto::Key& secret) const override {
     map<EntityName, EntityAuth>::const_iterator k = keys.find(name);
     if (k == keys.end())
       return false;
@@ -53,7 +53,7 @@ public:
     return true;
   }
   bool get_service_secret(uint32_t service_id, uint64_t secret_id,
-			  CryptoKey& secret) const override {
+			  ceph::crypto::Key& secret) const override {
     return false;
   }
   bool get_caps(const EntityName& name,
@@ -72,7 +72,7 @@ public:
   void add(const EntityName& name, EntityAuth &a) {
     keys[name] = a;
   }
-  void add(const EntityName& name, CryptoKey &k) {
+  void add(const EntityName& name, ceph::crypto::Key &k) {
     EntityAuth a;
     a.key = k;
     keys[name] = a;
@@ -86,7 +86,7 @@ public:
   void set_uid(EntityName& ename, uint64_t auid) {
     keys[ename].auid = auid;
   }
-  void set_key(EntityName& ename, CryptoKey& key) {
+  void set_key(EntityName& ename, ceph::crypto::Key& key) {
     keys[ename].key = key;
   }
   void import(CephContext *cct, KeyRing& other);

--- a/src/auth/RotatingKeyRing.cc
+++ b/src/auth/RotatingKeyRing.cc
@@ -37,14 +37,14 @@ void RotatingKeyRing::dump_rotating() const
     ldout(cct, 10) << " id " << iter->first << " " << iter->second << dendl;
 }
 
-bool RotatingKeyRing::get_secret(const EntityName& name, CryptoKey& secret) const
+bool RotatingKeyRing::get_secret(const EntityName& name, ceph::crypto::Key& secret) const
 {
   Mutex::Locker l(lock);
   return keyring->get_secret(name, secret);
 }
 
 bool RotatingKeyRing::get_service_secret(uint32_t service_id_, uint64_t secret_id,
-					 CryptoKey& secret) const
+					 ceph::crypto::Key& secret) const
 {
   Mutex::Locker l(lock);
 

--- a/src/auth/RotatingKeyRing.h
+++ b/src/auth/RotatingKeyRing.h
@@ -43,9 +43,9 @@ public:
   bool need_new_secrets(utime_t now) const;
   void set_secrets(RotatingSecrets&& s);
   void dump_rotating() const;
-  bool get_secret(const EntityName& name, CryptoKey& secret) const override;
+  bool get_secret(const EntityName& name, ceph::crypto::Key& secret) const override;
   bool get_service_secret(uint32_t service_id, uint64_t secret_id,
-			  CryptoKey& secret) const override;
+			  ceph::crypto::Key& secret) const override;
   KeyRing *get_keyring();
 };
 

--- a/src/auth/cephx/CephxAuthorizeHandler.cc
+++ b/src/auth/cephx/CephxAuthorizeHandler.cc
@@ -8,7 +8,8 @@
 
 bool CephxAuthorizeHandler::verify_authorizer(CephContext *cct, KeyStore *keys,
 					      bufferlist& authorizer_data, bufferlist& authorizer_reply,
-                                              EntityName& entity_name, uint64_t& global_id, AuthCapsInfo& caps_info, CryptoKey& session_key,  uint64_t *auid)
+					      EntityName& entity_name, uint64_t& global_id, AuthCapsInfo& caps_info,
+					      ceph::crypto::Key& session_key,  uint64_t *auid)
 {
   bufferlist::iterator iter = authorizer_data.begin();
 

--- a/src/auth/cephx/CephxAuthorizeHandler.h
+++ b/src/auth/cephx/CephxAuthorizeHandler.h
@@ -23,7 +23,8 @@ struct CephxAuthorizeHandler : public AuthAuthorizeHandler {
   bool verify_authorizer(CephContext *cct, KeyStore *keys,
 			 bufferlist& authorizer_data, bufferlist& authorizer_reply,
                          EntityName& entity_name, uint64_t& global_id,
-			 AuthCapsInfo& caps_info, CryptoKey& session_key, uint64_t *auid = NULL) override;
+			 AuthCapsInfo& caps_info, ceph::crypto::Key& session_key,
+			 uint64_t *auid = NULL) override;
   int authorizer_session_crypto() override;
 };
 

--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -40,7 +40,7 @@ int CephxClientHandler::build_request(bufferlist& bl) const
     header.request_type = CEPHX_GET_AUTH_SESSION_KEY;
     encode(header, bl);
 
-    CryptoKey secret;
+    ceph::crypto::Key secret;
     const bool got = keyring->get_secret(cct->_conf->name, secret);
     if (!got) {
       ldout(cct, 20) << "no secret found for entity: " << cct->_conf->name << dendl;
@@ -134,7 +134,7 @@ int CephxClientHandler::handle_response(int ret, bufferlist::iterator& indata)
   case CEPHX_GET_AUTH_SESSION_KEY:
     {
       ldout(cct, 10) << " get_auth_session_key" << dendl;
-      CryptoKey secret;
+      ceph::crypto::Key secret;
       const bool got = keyring->get_secret(cct->_conf->name, secret);
       if (!got) {
 	ldout(cct, 0) << "key not found for " << cct->_conf->name << dendl;
@@ -175,7 +175,7 @@ int CephxClientHandler::handle_response(int ret, bufferlist::iterator& indata)
       ldout(cct, 10) << " get_rotating_key" << dendl;
       if (rotating_secrets) {
 	RotatingSecrets secrets;
-	CryptoKey secret_key;
+	ceph::crypto::Key secret_key;
 	const bool got = keyring->get_secret(cct->_conf->name, secret_key);
         if (!got) {
           ldout(cct, 0) << "key not found for " << cct->_conf->name << dendl;

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -260,14 +260,14 @@ bool KeyServer::get_service_secret(uint32_t service_id,
 bool KeyServer::generate_secret(CryptoKey& secret)
 {
   bufferptr bp;
-  CryptoHandler *crypto = cct->get_crypto_handler(CEPH_CRYPTO_AES);
+  CryptoHandler *crypto = cct->get_crypto_handler(CEPH_CRYPTO_AES128);
   if (!crypto)
     return false;
 
   if (crypto->create(cct->random(), bp) < 0)
     return false;
 
-  secret.set_secret(CEPH_CRYPTO_AES, bp, ceph_clock_now());
+  secret.set_secret(CEPH_CRYPTO_AES128, bp, ceph_clock_now());
 
   return true;
 }

--- a/src/auth/cephx/CephxKeyServer.cc
+++ b/src/auth/cephx/CephxKeyServer.cc
@@ -399,10 +399,11 @@ bool KeyServer::get_rotating_encrypted(const EntityName& name,
 
   RotatingSecrets secrets = rotate_iter->second;
 
-  std::string error;
-  if (encode_encrypt(cct, secrets, specific_key, enc_bl, error))
+  try {
+    encode_encrypt(cct, secrets, specific_key, enc_bl);
+  } catch (...) {
     return false;
-
+  }
   return true;
 }
 

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -95,11 +95,11 @@ struct KeyServerData {
   bool get_service_secret(CephContext *cct, uint32_t service_id,
 			  ExpiringCryptoKey& secret, uint64_t& secret_id) const;
   bool get_service_secret(CephContext *cct, uint32_t service_id,
-			  CryptoKey& secret, uint64_t& secret_id) const;
+			  ceph::crypto::Key& secret, uint64_t& secret_id) const;
   bool get_service_secret(CephContext *cct, uint32_t service_id,
-			  uint64_t secret_id, CryptoKey& secret) const;
+			  uint64_t secret_id, ceph::crypto::Key& secret) const;
   bool get_auth(const EntityName& name, EntityAuth& auth) const;
-  bool get_secret(const EntityName& name, CryptoKey& secret) const;
+  bool get_secret(const EntityName& name, ceph::crypto::Key& secret) const;
   bool get_caps(CephContext *cct, const EntityName& name,
 		const std::string& type, AuthCapsInfo& caps) const;
 
@@ -204,28 +204,28 @@ class KeyServer : public KeyStore {
 	AuthCapsInfo& caps) const;
 public:
   KeyServer(CephContext *cct_, KeyRing *extra_secrets);
-  bool generate_secret(CryptoKey& secret);
+  bool generate_secret(ceph::crypto::Key& secret);
 
-  bool get_secret(const EntityName& name, CryptoKey& secret) const override;
+  bool get_secret(const EntityName& name, ceph::crypto::Key& secret) const override;
   bool get_auth(const EntityName& name, EntityAuth& auth) const;
   bool get_caps(const EntityName& name, const string& type, AuthCapsInfo& caps) const;
-  bool get_active_rotating_secret(const EntityName& name, CryptoKey& secret) const;
+  bool get_active_rotating_secret(const EntityName& name, ceph::crypto::Key& secret) const;
   int start_server();
   void rotate_timeout(double timeout);
 
   int build_session_auth_info(uint32_t service_id, CephXServiceTicketInfo& auth_ticket_info, CephXSessionAuthInfo& info);
   int build_session_auth_info(uint32_t service_id, CephXServiceTicketInfo& auth_ticket_info, CephXSessionAuthInfo& info,
-                                        CryptoKey& service_secret, uint64_t secret_id);
+                                        ceph::crypto::Key& service_secret, uint64_t secret_id);
 
   /* get current secret for specific service type */
   bool get_service_secret(uint32_t service_id, ExpiringCryptoKey& service_key,
 			  uint64_t& secret_id) const;
-  bool get_service_secret(uint32_t service_id, CryptoKey& service_key, 
+  bool get_service_secret(uint32_t service_id, ceph::crypto::Key& service_key, 
 			  uint64_t& secret_id) const;
   bool get_service_secret(uint32_t service_id, uint64_t secret_id,
-			  CryptoKey& secret) const override;
+			  ceph::crypto::Key& secret) const override;
 
-  bool generate_secret(EntityName& name, CryptoKey& secret);
+  bool generate_secret(EntityName& name, ceph::crypto::Key& secret);
 
   void encode(bufferlist& bl) const {
     using ceph::encode;

--- a/src/auth/cephx/CephxProtocol.cc
+++ b/src/auth/cephx/CephxProtocol.cc
@@ -24,7 +24,7 @@
 
 
 
-void cephx_calc_client_server_challenge(CephContext *cct, CryptoKey& secret, uint64_t server_challenge, 
+void cephx_calc_client_server_challenge(CephContext *cct, ceph::crypto::Key& secret, uint64_t server_challenge, 
 		  uint64_t client_challenge, uint64_t *key, std::string &error)
 {
   CephXChallengeBlob b;
@@ -81,10 +81,10 @@ bool cephx_build_service_ticket_blob(CephContext *cct, CephXSessionAuthInfo& inf
  * {principal_ticket, session key}^service_secret  ... "enc_ticket"
  */
 bool cephx_build_service_ticket_reply(CephContext *cct,
-                     CryptoKey& principal_secret,
+                     ceph::crypto::Key& principal_secret,
                      vector<CephXSessionAuthInfo> ticket_info_vec,
                      bool should_encrypt_ticket,
-                     CryptoKey& ticket_enc_key,
+                     ceph::crypto::Key& ticket_enc_key,
                      bufferlist& reply)
 {
   __u8 service_ticket_reply_v = 1;
@@ -141,7 +141,7 @@ bool cephx_build_service_ticket_reply(CephContext *cct,
  * PRINCIPAL: verify our attempt to authenticate succeeded.  fill out
  * this ServiceTicket with the result.
  */
-bool CephXTicketHandler::verify_service_ticket_reply(CryptoKey& secret,
+bool CephXTicketHandler::verify_service_ticket_reply(ceph::crypto::Key& secret,
 						     bufferlist::iterator& indata)
 {
   __u8 service_ticket_v;
@@ -260,7 +260,7 @@ void CephXTicketManager::invalidate_ticket(uint32_t service_id)
  * PRINCIPAL: verify our attempt to authenticate succeeded.  fill out
  * this ServiceTicket with the result.
  */
-bool CephXTicketManager::verify_service_ticket_reply(CryptoKey& secret,
+bool CephXTicketManager::verify_service_ticket_reply(ceph::crypto::Key& secret,
 						     bufferlist::iterator& indata)
 {
   __u8 service_ticket_reply_v;
@@ -352,7 +352,7 @@ bool cephx_decode_ticket(CephContext *cct, KeyStore *keys, uint32_t service_id,
 	      CephXTicketBlob& ticket_blob, CephXServiceTicketInfo& ticket_info)
 {
   uint64_t secret_id = ticket_blob.secret_id;
-  CryptoKey service_secret;
+  ceph::crypto::Key service_secret;
 
   if (!ticket_blob.blob.length()) {
     return false;
@@ -395,7 +395,7 @@ bool cephx_verify_authorizer(CephContext *cct, KeyStore *keys,
   __u8 authorizer_v;
   uint32_t service_id;
   uint64_t global_id;
-  CryptoKey service_secret;
+  ceph::crypto::Key service_secret;
   // ticket blob
   CephXTicketBlob ticket;
 

--- a/src/auth/cephx/CephxProtocol.h
+++ b/src/auth/cephx/CephxProtocol.h
@@ -212,7 +212,7 @@ struct CephXChallengeBlob {
 WRITE_CLASS_ENCODER(CephXChallengeBlob)
 
 void cephx_calc_client_server_challenge(CephContext *cct, 
-					CryptoKey& secret, uint64_t server_challenge, uint64_t client_challenge,
+					ceph::crypto::Key& secret, uint64_t server_challenge, uint64_t client_challenge,
 					uint64_t *key, std::string &error);
 
 
@@ -223,8 +223,8 @@ struct CephXSessionAuthInfo {
   uint32_t service_id;
   uint64_t secret_id;
   AuthTicket ticket;
-  CryptoKey session_key;
-  CryptoKey service_secret;
+  ceph::crypto::Key session_key;
+  ceph::crypto::Key service_secret;
   utime_t validity;
 };
 
@@ -237,10 +237,10 @@ extern void cephx_build_service_ticket_request(CephContext *cct,
 					       bufferlist& request);
 
 extern bool cephx_build_service_ticket_reply(CephContext *cct,
-					     CryptoKey& principal_secret,
+					     ceph::crypto::Key& principal_secret,
 					     vector<CephXSessionAuthInfo> ticket_info,
                                              bool should_encrypt_ticket,
-                                             CryptoKey& ticket_enc_key,
+                                             ceph::crypto::Key& ticket_enc_key,
 					     bufferlist& reply);
 
 struct CephXServiceTicketRequest {
@@ -304,7 +304,7 @@ public:
  */
 struct CephXTicketHandler {
   uint32_t service_id;
-  CryptoKey session_key;
+  ceph::crypto::Key session_key;
   CephXTicketBlob ticket;        // opaque to us
   utime_t renew_after, expires;
   bool have_key_flag;
@@ -313,7 +313,7 @@ struct CephXTicketHandler {
     : service_id(service_id_), have_key_flag(false), cct(cct_) { }
 
   // to build our ServiceTicket
-  bool verify_service_ticket_reply(CryptoKey& principal_secret,
+  bool verify_service_ticket_reply(ceph::crypto::Key& principal_secret,
 				 bufferlist::iterator& indata);
   // to access the service
   CephXAuthorizer *build_authorizer(uint64_t global_id) const;
@@ -335,7 +335,7 @@ struct CephXTicketManager {
 
   explicit CephXTicketManager(CephContext *cct_) : global_id(0), cct(cct_) {}
 
-  bool verify_service_ticket_reply(CryptoKey& principal_secret,
+  bool verify_service_ticket_reply(ceph::crypto::Key& principal_secret,
 				 bufferlist::iterator& indata);
 
   CephXTicketHandler& get_handler(uint32_t type) {
@@ -362,7 +362,7 @@ private:
 
 /* A */
 struct CephXServiceTicket {
-  CryptoKey session_key;
+  ceph::crypto::Key session_key;
   utime_t validity;
 
   void encode(bufferlist& bl) const {
@@ -385,7 +385,7 @@ WRITE_CLASS_ENCODER(CephXServiceTicket)
 /* B */
 struct CephXServiceTicketInfo {
   AuthTicket ticket;
-  CryptoKey session_key;
+  ceph::crypto::Key session_key;
 
   void encode(bufferlist& bl) const {
     using ceph::encode;
@@ -446,7 +446,7 @@ extern bool cephx_verify_authorizer(CephContext *cct, KeyStore *keys,
 static constexpr uint64_t AUTH_ENC_MAGIC = 0xff009cad8826aa55ull;
 
 template <typename T>
-void decode_decrypt_enc_bl(CephContext *cct, T& t, CryptoKey key, bufferlist& bl_enc, 
+void decode_decrypt_enc_bl(CephContext *cct, T& t, ceph::crypto::Key key, bufferlist& bl_enc, 
 			   std::string &error)
 {
   uint64_t magic;
@@ -470,7 +470,7 @@ void decode_decrypt_enc_bl(CephContext *cct, T& t, CryptoKey key, bufferlist& bl
 }
 
 template <typename T>
-void encode_encrypt_enc_bl(CephContext *cct, const T& t, const CryptoKey& key,
+void encode_encrypt_enc_bl(CephContext *cct, const T& t, const ceph::crypto::Key& key,
 			   bufferlist& out, std::string &error)
 {
   bufferlist bl;
@@ -484,7 +484,7 @@ void encode_encrypt_enc_bl(CephContext *cct, const T& t, const CryptoKey& key,
 }
 
 template <typename T>
-int decode_decrypt(CephContext *cct, T& t, const CryptoKey& key,
+int decode_decrypt(CephContext *cct, T& t, const ceph::crypto::Key& key,
 		    bufferlist::iterator& iter, std::string &error)
 {
   bufferlist bl_enc;
@@ -501,7 +501,7 @@ int decode_decrypt(CephContext *cct, T& t, const CryptoKey& key,
 }
 
 template <typename T>
-int encode_encrypt(CephContext *cct, const T& t, const CryptoKey& key,
+int encode_encrypt(CephContext *cct, const T& t, const ceph::crypto::Key& key,
 		    bufferlist& out, std::string &error)
 {
   bufferlist bl_enc;

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -71,11 +71,11 @@ int CephxServiceHandler::handle_request(bufferlist::iterator& indata, bufferlist
       }      
 
       uint64_t expected_key;
-      std::string error;
-      cephx_calc_client_server_challenge(cct, secret, server_challenge,
-					 req.client_challenge, &expected_key, error);
-      if (!error.empty()) {
-	ldout(cct, 0) << " cephx_calc_client_server_challenge error: " << error << dendl;
+      try {
+        cephx_calc_client_server_challenge(cct, secret, server_challenge,
+                                           req.client_challenge, &expected_key);
+      } catch (const std::exception& e) {
+	ldout(cct, 0) << " cephx_calc_client_server_challenge error: " << e.what() << dendl;
 	ret = -EPERM;
 	break;
       }

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -58,7 +58,7 @@ int CephxServiceHandler::handle_request(bufferlist::iterator& indata, bufferlist
       CephXAuthenticate req;
       decode(req, indata);
 
-      CryptoKey secret;
+      ceph::crypto::Key secret;
       if (!key_server->get_secret(entity_name, secret)) {
         ldout(cct, 0) << "couldn't find entity name: " << entity_name << dendl;
 	ret = -EPERM;
@@ -89,7 +89,7 @@ int CephxServiceHandler::handle_request(bufferlist::iterator& indata, bufferlist
 	break;
       }
 
-      CryptoKey session_key;
+      ceph::crypto::Key session_key;
       CephXSessionAuthInfo info;
       bool should_enc_ticket = false;
 
@@ -190,7 +190,7 @@ int CephxServiceHandler::handle_request(bufferlist::iterator& indata, bufferlist
 	ldout(cct, 10) << __func__ << " did not find any service keys" << dendl;
 	ret = service_err;
       }
-      CryptoKey no_key;
+      ceph::crypto::Key no_key;
       build_cephx_response_header(cephx_header.request_type, ret, result_bl);
       cephx_build_service_ticket_reply(cct, auth_ticket_info.session_key, info_vec, false, no_key, result_bl);
     }

--- a/src/auth/cephx/CephxSessionHandler.cc
+++ b/src/auth/cephx/CephxSessionHandler.cc
@@ -49,7 +49,9 @@ int CephxSessionHandler::_calc_signature(Message *m, uint64_t *psig)
   bl_plaintext.append(buffer::create_static(sizeof(sigblock), (char*)&sigblock));
 
   bufferlist bl_ciphertext;
-  if (key.encrypt(cct, bl_plaintext, bl_ciphertext, NULL) < 0) {
+  try {
+    key.encrypt(cct, bl_plaintext, bl_ciphertext);
+  } catch (const std::exception& e) {
     lderr(cct) << __func__ << " failed to encrypt signature block" << dendl;
     return -1;
   }

--- a/src/auth/cephx/CephxSessionHandler.h
+++ b/src/auth/cephx/CephxSessionHandler.h
@@ -23,7 +23,7 @@ class CephxSessionHandler  : public AuthSessionHandler {
   uint64_t features;
 
 public:
-  CephxSessionHandler(CephContext *cct_, CryptoKey session_key, uint64_t features)
+  CephxSessionHandler(CephContext *cct_, ceph::crypto::Key session_key, uint64_t features)
     : AuthSessionHandler(cct_, CEPH_AUTH_CEPHX, session_key),
       features(features) {}
   ~CephxSessionHandler() override {}

--- a/src/auth/none/AuthNoneAuthorizeHandler.cc
+++ b/src/auth/none/AuthNoneAuthorizeHandler.cc
@@ -19,7 +19,7 @@
 
 bool AuthNoneAuthorizeHandler::verify_authorizer(CephContext *cct, KeyStore *keys,
 						 bufferlist& authorizer_data, bufferlist& authorizer_reply,
-						 EntityName& entity_name, uint64_t& global_id, AuthCapsInfo& caps_info, CryptoKey& session_key,
+						 EntityName& entity_name, uint64_t& global_id, AuthCapsInfo& caps_info, ceph::crypto::Key& session_key,
 uint64_t *auid)
 {
   bufferlist::iterator iter = authorizer_data.begin();

--- a/src/auth/none/AuthNoneAuthorizeHandler.h
+++ b/src/auth/none/AuthNoneAuthorizeHandler.h
@@ -23,7 +23,8 @@ struct AuthNoneAuthorizeHandler : public AuthAuthorizeHandler {
   bool verify_authorizer(CephContext *cct, KeyStore *keys,
 			 bufferlist& authorizer_data, bufferlist& authorizer_reply,
                          EntityName& entity_name, uint64_t& global_id,
-			 AuthCapsInfo& caps_info, CryptoKey& session_key, uint64_t *auid=NULL) override;
+			 AuthCapsInfo& caps_info, ceph::crypto::Key& session_key,
+			 uint64_t *auid=NULL) override;
   int authorizer_session_crypto() override;
 };
 

--- a/src/auth/none/AuthNoneSessionHandler.h
+++ b/src/auth/none/AuthNoneSessionHandler.h
@@ -19,7 +19,7 @@ class CephContext;
 
 class AuthNoneSessionHandler  : public AuthSessionHandler {
 public:
-  AuthNoneSessionHandler(CephContext *cct_, CryptoKey session_key)
+  AuthNoneSessionHandler(CephContext *cct_, ceph::crypto::Key session_key)
     : AuthSessionHandler(cct_, CEPH_AUTH_NONE, session_key) {}
   ~AuthNoneSessionHandler() override {}
   

--- a/src/auth/unknown/AuthUnknownAuthorizeHandler.cc
+++ b/src/auth/unknown/AuthUnknownAuthorizeHandler.cc
@@ -16,7 +16,7 @@
 
 bool AuthUnknownAuthorizeHandler::verify_authorizer(CephContext *cct, KeyStore *keys,
 						 bufferlist& authorizer_data, bufferlist& authorizer_reply,
-						 EntityName& entity_name, uint64_t& global_id, AuthCapsInfo& caps_info, CryptoKey& session_key,
+						 EntityName& entity_name, uint64_t& global_id, AuthCapsInfo& caps_info, ceph::crypto::Key& session_key,
 uint64_t *auid)
 {
   // For unknown authorizers, there's nothing to verify.  They're "OK" by definition.  PLR

--- a/src/auth/unknown/AuthUnknownAuthorizeHandler.h
+++ b/src/auth/unknown/AuthUnknownAuthorizeHandler.h
@@ -23,7 +23,8 @@ struct AuthUnknownAuthorizeHandler : public AuthAuthorizeHandler {
   bool verify_authorizer(CephContext *cct, KeyStore *keys,
 			 bufferlist& authorizer_data, bufferlist& authorizer_reply,
                          EntityName& entity_name, uint64_t& global_id,
-			 AuthCapsInfo& caps_info, CryptoKey& session_key, uint64_t *auid=NULL) override;
+			 AuthCapsInfo& caps_info, ceph::crypto::Key& session_key,
+			 uint64_t *auid=NULL) override;
   int authorizer_session_crypto() override;
 };
 

--- a/src/auth/unknown/AuthUnknownSessionHandler.h
+++ b/src/auth/unknown/AuthUnknownSessionHandler.h
@@ -21,7 +21,7 @@ class CephContext;
 
 class AuthUnknownSessionHandler  : public AuthSessionHandler {
 public:
-  AuthUnknownSessionHandler(CephContext *cct_, CryptoKey session_key)
+  AuthUnknownSessionHandler(CephContext *cct_, ceph::crypto::Key session_key)
     : AuthSessionHandler(cct_, CEPH_AUTH_UNKNOWN, session_key) {}
   ~AuthUnknownSessionHandler() override {}
   

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -289,7 +289,7 @@ int main(int argc, const char **argv)
 	keyring->get_auth(ename, eauth)) {
       derr << "already have key in keyring " << keyring_path << dendl;
     } else {
-      eauth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
+      eauth.key.create(g_ceph_context, CEPH_CRYPTO_AES128);
       keyring->add(ename, eauth);
       bufferlist bl;
       keyring->encode_plaintext(bl);

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -585,8 +585,6 @@ CephContext::CephContext(uint32_t module_type_,
     _perf_counters_collection(NULL),
     _perf_counters_conf_obs(NULL),
     _heartbeat_map(NULL),
-    _crypto_none(NULL),
-    _crypto_aes(NULL),
     _plugin_registry(NULL),
     _lockdep_obs(NULL),
     crush_location(this),
@@ -706,8 +704,8 @@ CephContext::~CephContext()
 
   delete _conf;
   
-  delete _crypto_none;
-  delete _crypto_aes;
+  _crypto_none.reset();
+  _crypto_aes.reset();
   if (_crypto_inited)
     ceph::crypto::shutdown(g_code_env == CODE_ENVIRONMENT_LIBRARY);
 }
@@ -843,9 +841,9 @@ ceph::crypto::Handler *CephContext::get_crypto_handler(int type)
 {
   switch (type) {
   case CEPH_CRYPTO_NONE:
-    return _crypto_none;
+    return _crypto_none.get();
   case CEPH_CRYPTO_AES128:
-    return _crypto_aes;
+    return _crypto_aes.get();
   default:
     return NULL;
   }

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -635,9 +635,9 @@ CephContext::CephContext(uint32_t module_type_,
   _admin_socket->register_command("log dump", "log dump", _admin_hook, "dump recent log entries to log file");
   _admin_socket->register_command("log reopen", "log reopen", _admin_hook, "reopen log file");
 
-  _crypto_none = CryptoHandler::create(CEPH_CRYPTO_NONE);
-  _crypto_aes = CryptoHandler::create(CEPH_CRYPTO_AES128);
-  _crypto_random.reset(new CryptoRandom());
+  _crypto_none = ceph::crypto::Handler::create(CEPH_CRYPTO_NONE);
+  _crypto_aes = ceph::crypto::Handler::create(CEPH_CRYPTO_AES128);
+  _crypto_random.reset(new ceph::crypto::Random());
 
   MempoolObs *mempool_obs = 0;
   lookup_or_create_singleton_object(mempool_obs, "mempool_obs");
@@ -839,7 +839,7 @@ AdminSocket *CephContext::get_admin_socket()
   return _admin_socket;
 }
 
-CryptoHandler *CephContext::get_crypto_handler(int type)
+ceph::crypto::Handler *CephContext::get_crypto_handler(int type)
 {
   switch (type) {
   case CEPH_CRYPTO_NONE:

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -636,7 +636,7 @@ CephContext::CephContext(uint32_t module_type_,
   _admin_socket->register_command("log reopen", "log reopen", _admin_hook, "reopen log file");
 
   _crypto_none = CryptoHandler::create(CEPH_CRYPTO_NONE);
-  _crypto_aes = CryptoHandler::create(CEPH_CRYPTO_AES);
+  _crypto_aes = CryptoHandler::create(CEPH_CRYPTO_AES128);
   _crypto_random.reset(new CryptoRandom());
 
   MempoolObs *mempool_obs = 0;
@@ -844,7 +844,7 @@ CryptoHandler *CephContext::get_crypto_handler(int type)
   switch (type) {
   case CEPH_CRYPTO_NONE:
     return _crypto_none;
-  case CEPH_CRYPTO_AES:
+  case CEPH_CRYPTO_AES128:
     return _crypto_aes;
   default:
     return NULL;

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -37,10 +37,12 @@ class md_config_obs_t;
 struct md_config_t;
 class CephContextHook;
 class CephContextObs;
-class CryptoHandler;
-class CryptoRandom;
 
 namespace ceph {
+namespace crypto {
+class Handler;
+class Random;
+}
   class PluginRegistry;
   class HeartbeatMap;
   namespace logging {
@@ -146,9 +148,9 @@ public:
   /**
    * get a crypto handler
    */
-  CryptoHandler *get_crypto_handler(int type);
+  ceph::crypto::Handler* get_crypto_handler(int type);
 
-  CryptoRandom* random() const { return _crypto_random.get(); }
+  ceph::crypto::Random* random() const { return _crypto_random.get(); }
 
   /// check if experimental feature is enable, and emit appropriate warnings
   bool check_experimental_feature_enabled(const std::string& feature);
@@ -267,9 +269,9 @@ private:
   std::vector<ForkWatcher*> _fork_watchers;
 
   // crypto
-  CryptoHandler *_crypto_none;
-  CryptoHandler *_crypto_aes;
-  std::unique_ptr<CryptoRandom> _crypto_random;
+  ceph::crypto::Handler *_crypto_none;
+  ceph::crypto::Handler *_crypto_aes;
+  std::unique_ptr<ceph::crypto::Random> _crypto_random;
 
   // experimental
   CephContextObs *_cct_obs;

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -269,8 +269,8 @@ private:
   std::vector<ForkWatcher*> _fork_watchers;
 
   // crypto
-  ceph::crypto::Handler *_crypto_none;
-  ceph::crypto::Handler *_crypto_aes;
+  std::unique_ptr<ceph::crypto::Handler> _crypto_none;
+  std::unique_ptr<ceph::crypto::Handler> _crypto_aes;
   std::unique_ptr<ceph::crypto::Random> _crypto_random;
 
   // experimental

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -63,8 +63,9 @@ struct ceph_dir_layout {
 } __attribute__ ((packed));
 
 /* crypto algorithms */
-#define CEPH_CRYPTO_NONE 0x0
-#define CEPH_CRYPTO_AES  0x1
+#define CEPH_CRYPTO_NONE        0x0
+#define CEPH_CRYPTO_AES128      0x1
+#define CEPH_CRYPTO_AES         CEPH_CRYPTO_AES128 /* alias for AES128 */
 
 #define CEPH_AES_IV "cephsageyudagreg"
 

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -146,7 +146,7 @@ static int build_map_buf(CephContext *cct, const char *pool, const char *image,
     }
   }
 
-  CryptoKey secret;
+  ceph::crypto::Key secret;
   string key_name = string("client.") + cct->_conf->name.get_id();
   if (keyring.get_secret(cct->_conf->name, secret)) {
     string secret_str;

--- a/src/libcephd/libcephd.cc
+++ b/src/libcephd/libcephd.cc
@@ -87,7 +87,7 @@ extern "C" int cephd_generate_secret_key(char *buf, size_t len)
     cct->init_crypto();
 
     CryptoKey key;
-    key.create(cct, CEPH_CRYPTO_AES);
+    key.create(cct, CEPH_CRYPTO_AES128);
 
     cct->put();
 

--- a/src/libcephd/libcephd.cc
+++ b/src/libcephd/libcephd.cc
@@ -86,7 +86,7 @@ extern "C" int cephd_generate_secret_key(char *buf, size_t len)
     cct->_conf->apply_changes(NULL);
     cct->init_crypto();
 
-    CryptoKey key;
+    ceph::crypto::Key key;
     key.create(cct, CEPH_CRYPTO_AES128);
 
     cct->put();

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1264,7 +1264,7 @@ bool MDSDaemon::ms_handle_refused(Connection *con)
 
 bool MDSDaemon::ms_verify_authorizer(Connection *con, int peer_type,
 			       int protocol, bufferlist& authorizer_data, bufferlist& authorizer_reply,
-			       bool& is_valid, CryptoKey& session_key)
+			       bool& is_valid, ceph::crypto::Key& session_key)
 {
   Mutex::Locker l(mds_lock);
   if (stopping) {

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -97,7 +97,7 @@ class MDSDaemon : public Dispatcher, public md_config_obs_t {
   bool ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer, bool force_new) override;
   bool ms_verify_authorizer(Connection *con, int peer_type,
 			       int protocol, bufferlist& authorizer_data, bufferlist& authorizer_reply,
-			       bool& isvalid, CryptoKey& session_key) override;
+			       bool& isvalid, ceph::crypto::Key& session_key) override;
   void ms_handle_accept(Connection *con) override;
   void ms_handle_connect(Connection *con) override;
   bool ms_handle_reset(Connection *con) override;

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -148,7 +148,7 @@ bool DaemonServer::ms_verify_authorizer(Connection *con,
     ceph::bufferlist& authorizer_data,
     ceph::bufferlist& authorizer_reply,
     bool& is_valid,
-    CryptoKey& session_key)
+    ceph::crypto::Key& session_key)
 {
   AuthAuthorizeHandler *handler = nullptr;
   if (peer_type == CEPH_ENTITY_TYPE_OSD ||

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -129,7 +129,7 @@ public:
       ceph::bufferlist& authorizer,
       ceph::bufferlist& authorizer_reply,
       bool& isvalid,
-      CryptoKey& session_key) override;
+      ceph::crypto::Key& session_key) override;
 
   bool handle_open(MMgrOpen *m);
   bool handle_report(MMgrReport *m);

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1159,7 +1159,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     if (!has_keyring) {
       dout(10) << "AuthMonitor::prepare_command generating random key for "
         << auth_inc.name << dendl;
-      new_inc.key.create(g_ceph_context, CEPH_CRYPTO_AES);
+      new_inc.key.create(g_ceph_context, CEPH_CRYPTO_AES128);
     }
     new_inc.caps = new_caps;
 
@@ -1246,7 +1246,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     KeyServerData::Incremental auth_inc;
     auth_inc.op = KeyServerData::AUTH_INC_ADD;
     auth_inc.name = entity;
-    auth_inc.auth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
+    auth_inc.auth.key.create(g_ceph_context, CEPH_CRYPTO_AES128);
     auth_inc.auth.caps = wanted_caps;
 
     push_cephx_inc(auth_inc);
@@ -1347,7 +1347,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     KeyServerData::Incremental auth_inc;
     auth_inc.op = KeyServerData::AUTH_INC_ADD;
     auth_inc.name = entity;
-    auth_inc.auth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
+    auth_inc.auth.key.create(g_ceph_context, CEPH_CRYPTO_AES128);
     auth_inc.auth.caps = wanted_caps;
 
     push_cephx_inc(auth_inc);
@@ -1563,7 +1563,7 @@ void AuthMonitor::upgrade_format()
       encode("allow profile bootstrap-mgr", auth_inc.auth.caps["mon"]);
       auth_inc.op = KeyServerData::AUTH_INC_ADD;
       // generate key
-      auth_inc.auth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
+      auth_inc.auth.key.create(g_ceph_context, CEPH_CRYPTO_AES128);
       push_cephx_inc(auth_inc);
     }
     changed = true;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -5605,7 +5605,7 @@ bool Monitor::ms_get_authorizer(int service_id, AuthAuthorizer **authorizer,
   if (service_id == CEPH_ENTITY_TYPE_MON) {
     // mon to mon authentication uses the private monitor shared key and not the
     // rotating key
-    CryptoKey secret;
+    ceph::crypto::Key secret;
     if (!keyring.get_secret(name, secret) &&
 	!key_server.get_secret(name, secret)) {
       dout(0) << " couldn't get secret for mon service from keyring or keyserver"
@@ -5661,7 +5661,7 @@ bool Monitor::ms_get_authorizer(int service_id, AuthAuthorizer **authorizer,
 bool Monitor::ms_verify_authorizer(Connection *con, int peer_type,
 				   int protocol, bufferlist& authorizer_data,
 				   bufferlist& authorizer_reply,
-				   bool& isvalid, CryptoKey& session_key)
+				   bool& isvalid, ceph::crypto::Key& session_key)
 {
   dout(10) << "ms_verify_authorizer " << con->get_peer_addr()
 	   << " " << ceph_entity_type_name(peer_type)

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -879,7 +879,7 @@ public:
   bool ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer, bool force_new) override;
   bool ms_verify_authorizer(Connection *con, int peer_type,
 			    int protocol, bufferlist& authorizer_data, bufferlist& authorizer_reply,
-			    bool& isvalid, CryptoKey& session_key) override;
+			    bool& isvalid, ceph::crypto::Key& session_key) override;
   bool ms_handle_reset(Connection *con) override;
   void ms_handle_remote_reset(Connection *con) override {}
   bool ms_handle_refused(Connection *con) override;

--- a/src/msg/Dispatcher.h
+++ b/src/msg/Dispatcher.h
@@ -23,8 +23,12 @@ class Messenger;
 class Message;
 class Connection;
 class AuthAuthorizer;
-class CryptoKey;
 class CephContext;
+namespace ceph {
+namespace crypto {
+class Key;
+} // namespace crypto
+} // namespace ceph
 
 class Dispatcher {
 public:
@@ -203,7 +207,7 @@ public:
 				    ceph::bufferlist& authorizer,
 				    ceph::bufferlist& authorizer_reply,
 				    bool& isvalid,
-				    CryptoKey& session_key) { return false; }
+				    ceph::crypto::Key& session_key) { return false; }
   /**
    * @} //Authentication
    */

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -805,7 +805,7 @@ public:
    */
   bool ms_deliver_verify_authorizer(Connection *con, int peer_type,
 				    int protocol, bufferlist& authorizer, bufferlist& authorizer_reply,
-				    bool& isvalid, CryptoKey& session_key) {
+				    bool& isvalid, ceph::crypto::Key& session_key) {
     for (list<Dispatcher*>::iterator p = dispatchers.begin();
 	 p != dispatchers.end();
 	 ++p) {

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -351,7 +351,7 @@ class AsyncConnection : public Connection {
   ceph_msg_connect_reply connect_reply;
   // Accepting state
   entity_addr_t socket_addr;
-  CryptoKey session_key;
+  ceph::crypto::Key session_key;
   bool replacing;    // when replacing process happened, we will reply connect
                      // side with RETRY tag and accept side will clear replaced
                      // connection. So when connect side reissue connect_msg,

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -383,7 +383,7 @@ public:
    * This wraps ms_deliver_verify_authorizer; we use it for AsyncConnection.
    */
   bool verify_authorizer(Connection *con, int peer_type, int protocol, bufferlist& auth, bufferlist& auth_reply,
-                         bool& isvalid, CryptoKey& session_key) {
+                         bool& isvalid, ceph::crypto::Key& session_key) {
     return ms_deliver_verify_authorizer(con, peer_type, protocol, auth,
                                         auth_reply, isvalid, session_key);
   }

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -340,7 +340,7 @@ int Pipe::accept()
   // reset or not, it is true if there is an existing connection and the
   // connection sequence from peer is equal to zero
   bool is_reset_from_peer = false;
-  CryptoKey session_key;
+  ceph::crypto::Key session_key;
   int removed; // single-use down below
 
   // this should roughly mirror pseudocode at

--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -413,7 +413,7 @@ AuthAuthorizer *SimpleMessenger::get_authorizer(int peer_type, bool force_new)
 
 bool SimpleMessenger::verify_authorizer(Connection *con, int peer_type,
 					int protocol, bufferlist& authorizer, bufferlist& authorizer_reply,
-					bool& isvalid,CryptoKey& session_key)
+					bool& isvalid, ceph::crypto::Key& session_key)
 {
   return ms_deliver_verify_authorizer(con, peer_type, protocol, authorizer, authorizer_reply, isvalid,session_key);
 }

--- a/src/msg/simple/SimpleMessenger.h
+++ b/src/msg/simple/SimpleMessenger.h
@@ -348,7 +348,7 @@ public:
    * This wraps ms_deliver_verify_authorizer; we use it for Pipe.
    */
   bool verify_authorizer(Connection *con, int peer_type, int protocol, bufferlist& auth, bufferlist& auth_reply,
-                         bool& isvalid,CryptoKey& session_key);
+                         bool& isvalid, ceph::crypto::Key& session_key);
   /**
    * Increment the global sequence for this SimpleMessenger and return it.
    * This is for the connect protocol, although it doesn't hurt if somebody

--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -218,7 +218,7 @@ int XioConnection::passive_setup()
   /* XXX passive setup is a placeholder for (potentially active-side
      initiated) feature and auth* negotiation */
   static bufferlist authorizer_reply; /* static because fake */
-  static CryptoKey session_key; /* ditto */
+  static ceph::crypto::Key session_key; /* ditto */
   bool authorizer_valid;
 
   XioMessenger *msgr = static_cast<XioMessenger*>(get_messenger());

--- a/src/msg/xio/XioConnection.h
+++ b/src/msg/xio/XioConnection.h
@@ -131,7 +131,7 @@ private:
     uint64_t features;
     Messenger::Policy policy;
 
-    CryptoKey session_key;
+    ceph::crypto::Key session_key;
     ceph::shared_ptr<AuthSessionHandler> session_security;
     AuthAuthorizer *authorizer;
     XioConnection *xcon;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1938,9 +1938,9 @@ int OSD::write_meta(CephContext *cct, ObjectStore *store, uuid_d& cluster_fsid, 
       string err;
       if (keyfile == "-") {
 	static_assert(1024 * 1024 >
-		      (sizeof(CryptoKey) - sizeof(bufferptr) +
+		      (sizeof(ceph::crypto::Key) - sizeof(bufferptr) +
 		       sizeof(__u16) + 16 /* AES_KEY_LEN */ + 3 - 1) / 3. * 4.,
-		      "1MB should be enough for a base64 encoded CryptoKey");
+		      "1MB should be enough for a base64 encoded ceph::crypto::Key");
 	r = keybl.read_fd(STDIN_FILENO, 1024 * 1024);
       } else {
 	r = keybl.read_file(keyfile.c_str(), &err);
@@ -6517,7 +6517,7 @@ bool OSD::ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer, bool for
 
 bool OSD::ms_verify_authorizer(Connection *con, int peer_type,
 			       int protocol, bufferlist& authorizer_data, bufferlist& authorizer_reply,
-			       bool& isvalid, CryptoKey& session_key)
+			       bool& isvalid, ceph::crypto::Key& session_key)
 {
   AuthAuthorizeHandler *authorize_handler = 0;
   switch (peer_type) {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1500,7 +1500,7 @@ public:
     }
     bool ms_verify_authorizer(Connection *con, int peer_type,
 			      int protocol, bufferlist& authorizer_data, bufferlist& authorizer_reply,
-			      bool& isvalid, CryptoKey& session_key) override {
+			      bool& isvalid, ceph::crypto::Key& session_key) override {
       isvalid = true;
       return true;
     }
@@ -2143,7 +2143,7 @@ private:
   bool ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer, bool force_new) override;
   bool ms_verify_authorizer(Connection *con, int peer_type,
 			    int protocol, bufferlist& authorizer, bufferlist& authorizer_reply,
-			    bool& isvalid, CryptoKey& session_key) override;
+			    bool& isvalid, ceph::crypto::Key& session_key) override;
   void ms_handle_connect(Connection *con) override;
   void ms_handle_fast_connect(Connection *con) override;
   void ms_handle_fast_accept(Connection *con) override;

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -71,8 +71,6 @@ TEST(AES, Encrypt) {
   int err;
   err = memcmp(cipher_s, want_cipher, sizeof(want_cipher));
   ASSERT_EQ(0, err);
-
-  delete kh;
 }
 
 TEST(AES, Decrypt) {
@@ -111,8 +109,6 @@ TEST(AES, Decrypt) {
   int err;
   err = memcmp(plaintext_s, want_plaintext, sizeof(want_plaintext));
   ASSERT_EQ(0, err);
-
-  delete kh;
 }
 
 TEST(AES, Loop) {
@@ -137,8 +133,6 @@ TEST(AES, Loop) {
       int r = kh->encrypt(plaintext, cipher, &error);
       ASSERT_EQ(r, 0);
       ASSERT_EQ(error, "");
-
-      delete kh;
     }
     plaintext.clear();
 
@@ -149,8 +143,6 @@ TEST(AES, Loop) {
       int r = ckh->decrypt(cipher, plaintext, &error);
       ASSERT_EQ(r, 0);
       ASSERT_EQ(error, "");
-
-      delete ckh;
     }
   }
 

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -17,7 +17,7 @@ public:
 };
 
 TEST(AES, ValidateSecret) {
-  CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES);
+  CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
   int l;
 
   for (l=0; l<16; l++) {
@@ -36,7 +36,7 @@ TEST(AES, ValidateSecret) {
 }
 
 TEST(AES, Encrypt) {
-  CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES);
+  CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
   char secret_s[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -76,7 +76,7 @@ TEST(AES, Encrypt) {
 }
 
 TEST(AES, Decrypt) {
-  CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES);
+  CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
   char secret_s[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -130,7 +130,7 @@ TEST(AES, Loop) {
   for (int i=0; i<10000; i++) {
     bufferlist cipher;
     {
-      CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES);
+      CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
 
       std::string error;
       CryptoKeyHandler *kh = h->get_key_handler(secret, error);
@@ -143,7 +143,7 @@ TEST(AES, Loop) {
     plaintext.clear();
 
     {
-      CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES);
+      CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
       std::string error;
       CryptoKeyHandler *ckh = h->get_key_handler(secret, error);
       int r = ckh->decrypt(cipher, plaintext, &error);
@@ -163,7 +163,7 @@ TEST(AES, LoopKey) {
   CryptoRandom random;
   bufferptr k(16);
   random.get_bytes(k.c_str(), k.length());
-  CryptoKey key(CEPH_CRYPTO_AES, ceph_clock_now(), k);
+  CryptoKey key(CEPH_CRYPTO_AES128, ceph_clock_now(), k);
 
   bufferlist data;
   bufferptr r(128);

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -17,7 +17,7 @@ public:
 };
 
 TEST(AES, ValidateSecret) {
-  CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
+  auto h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
   int l;
 
   for (l=0; l<16; l++) {
@@ -36,7 +36,7 @@ TEST(AES, ValidateSecret) {
 }
 
 TEST(AES, Encrypt) {
-  CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
+  auto h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
   char secret_s[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -52,7 +52,7 @@ TEST(AES, Encrypt) {
 
   bufferlist cipher;
   std::string error;
-  CryptoKeyHandler *kh = h->get_key_handler(secret, error);
+  auto kh = h->get_key_handler(secret, error);
   int r = kh->encrypt(plaintext, cipher, &error);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(error, "");
@@ -76,7 +76,7 @@ TEST(AES, Encrypt) {
 }
 
 TEST(AES, Decrypt) {
-  CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
+  auto h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
   char secret_s[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
@@ -100,7 +100,7 @@ TEST(AES, Decrypt) {
 
   std::string error;
   bufferlist plaintext;
-  CryptoKeyHandler *kh = h->get_key_handler(secret, error);
+  auto kh = h->get_key_handler(secret, error);
   int r = kh->decrypt(cipher, plaintext, &error);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(error, "");
@@ -116,7 +116,7 @@ TEST(AES, Decrypt) {
 }
 
 TEST(AES, Loop) {
-  CryptoRandom random;
+  ceph::crypto::Random random;
 
   bufferptr secret(16);
   random.get_bytes(secret.c_str(), secret.length());
@@ -130,10 +130,10 @@ TEST(AES, Loop) {
   for (int i=0; i<10000; i++) {
     bufferlist cipher;
     {
-      CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
+      auto h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
 
       std::string error;
-      CryptoKeyHandler *kh = h->get_key_handler(secret, error);
+      auto kh = h->get_key_handler(secret, error);
       int r = kh->encrypt(plaintext, cipher, &error);
       ASSERT_EQ(r, 0);
       ASSERT_EQ(error, "");
@@ -143,9 +143,9 @@ TEST(AES, Loop) {
     plaintext.clear();
 
     {
-      CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
+      auto h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES128);
       std::string error;
-      CryptoKeyHandler *ckh = h->get_key_handler(secret, error);
+      auto ckh = h->get_key_handler(secret, error);
       int r = ckh->decrypt(cipher, plaintext, &error);
       ASSERT_EQ(r, 0);
       ASSERT_EQ(error, "");
@@ -160,10 +160,10 @@ TEST(AES, Loop) {
 }
 
 TEST(AES, LoopKey) {
-  CryptoRandom random;
+  ceph::crypto::Random random;
   bufferptr k(16);
   random.get_bytes(k.c_str(), k.length());
-  CryptoKey key(CEPH_CRYPTO_AES128, ceph_clock_now(), k);
+  ceph::crypto::Key key(CEPH_CRYPTO_AES128, ceph_clock_now(), k);
 
   bufferlist data;
   bufferptr r(128);

--- a/src/test/messenger/simple_dispatcher.h
+++ b/src/test/messenger/simple_dispatcher.h
@@ -115,7 +115,7 @@ public:
   bool ms_verify_authorizer(Connection *con, int peer_type,
 				    int protocol, bufferlist& authorizer,
 				    bufferlist& authorizer_reply,
-				    bool& isvalid, CryptoKey& session_key) override {
+				    bool& isvalid, ceph::crypto::Key& session_key) override {
     /* always succeed */
     isvalid = true;
     return true;

--- a/src/test/messenger/xio_dispatcher.h
+++ b/src/test/messenger/xio_dispatcher.h
@@ -115,7 +115,7 @@ public:
   virtual bool ms_verify_authorizer(Connection *con, int peer_type,
 				    int protocol, bufferlist& authorizer,
 				    bufferlist& authorizer_reply,
-				    bool& isvalid, CryptoKey& session_key) {
+				    bool& isvalid, ceph::crypto::Key& session_key) {
     /* always succeed */
     isvalid = true;
     return true;

--- a/src/test/msgr/perf_msgr_client.cc
+++ b/src/test/msgr/perf_msgr_client.cc
@@ -58,7 +58,7 @@ class MessengerClient {
     bool ms_handle_refused(Connection *con) override { return false; }
     bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
                               bufferlist& authorizer, bufferlist& authorizer_reply,
-                              bool& isvalid, CryptoKey& session_key) override {
+                              bool& isvalid, ceph::crypto::Key& session_key) override {
       isvalid = true;
       return true;
     }

--- a/src/test/msgr/perf_msgr_server.cc
+++ b/src/test/msgr/perf_msgr_server.cc
@@ -100,7 +100,7 @@ class ServerDispatcher : public Dispatcher {
   }
   bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
                             bufferlist& authorizer, bufferlist& authorizer_reply,
-                            bool& isvalid, CryptoKey& session_key) override {
+                            bool& isvalid, ceph::crypto::Key& session_key) override {
     isvalid = true;
     return true;
   }

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -203,7 +203,7 @@ class FakeDispatcher : public Dispatcher {
 
   bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
                             bufferlist& authorizer, bufferlist& authorizer_reply,
-                            bool& isvalid, CryptoKey& session_key) override {
+                            bool& isvalid, ceph::crypto::Key& session_key) override {
     isvalid = true;
     return true;
   }
@@ -893,7 +893,7 @@ class SyntheticDispatcher : public Dispatcher {
 
   bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
                             bufferlist& authorizer, bufferlist& authorizer_reply,
-                            bool& isvalid, CryptoKey& session_key) override {
+                            bool& isvalid, ceph::crypto::Key& session_key) override {
     isvalid = true;
     return true;
   }
@@ -1436,7 +1436,7 @@ class MarkdownDispatcher : public Dispatcher {
   }
   bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
                             bufferlist& authorizer, bufferlist& authorizer_reply,
-                            bool& isvalid, CryptoKey& session_key) override {
+                            bool& isvalid, ceph::crypto::Key& session_key) override {
     isvalid = true;
     return true;
   }

--- a/src/test/testcrypto.cc
+++ b/src/test/testcrypto.cc
@@ -26,10 +26,10 @@ int main(int argc, char *argv[])
   enc_in.append(msg, strlen(msg));
 
   bufferlist enc_out;
-  std::string error;
-  if (key.encrypt(g_ceph_context, enc_in, enc_out, &error) < 0) {
-    assert(!error.empty());
-    dout(0) << "couldn't encode! error " << error << dendl;
+  try {
+    key.encrypt(g_ceph_context, enc_in, enc_out);
+  } catch (const std::exception& e) {
+    dout(0) << "couldn't encode! error " << e.what() << dendl;
     exit(1);
   }
 
@@ -44,9 +44,10 @@ int main(int argc, char *argv[])
 
   dec_in = enc_out;
 
-  if (key.decrypt(g_ceph_context, dec_in, dec_out, &error) < 0) {
-    assert(!error.empty());
-    dout(0) << "couldn't decode! error " << error << dendl;
+  try {
+    key.decrypt(g_ceph_context, dec_in, dec_out);
+  } catch (const std::exception& e) {
+    dout(0) << "couldn't decode! error " << e.what() << dendl;
     exit(1);
   }
 

--- a/src/test/testcrypto.cc
+++ b/src/test/testcrypto.cc
@@ -15,7 +15,7 @@ int main(int argc, char *argv[])
   char aes_key[AES_KEY_LEN];
   memset(aes_key, 0x77, sizeof(aes_key));
   bufferptr keybuf(aes_key, sizeof(aes_key));
-  CryptoKey key(CEPH_CRYPTO_AES128, ceph_clock_now(), keybuf);
+  ceph::crypto::Key key(CEPH_CRYPTO_AES128, ceph_clock_now(), keybuf);
 
   const char *msg="hello! this is a message\n";
   char pad[16];

--- a/src/test/testcrypto.cc
+++ b/src/test/testcrypto.cc
@@ -15,7 +15,7 @@ int main(int argc, char *argv[])
   char aes_key[AES_KEY_LEN];
   memset(aes_key, 0x77, sizeof(aes_key));
   bufferptr keybuf(aes_key, sizeof(aes_key));
-  CryptoKey key(CEPH_CRYPTO_AES, ceph_clock_now(), keybuf);
+  CryptoKey key(CEPH_CRYPTO_AES128, ceph_clock_now(), keybuf);
 
   const char *msg="hello! this is a message\n";
   char pad[16];

--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -161,7 +161,7 @@ int main(int argc, const char **argv)
 
   if (gen_print_key) {
     CryptoKey key;
-    key.create(g_ceph_context, CEPH_CRYPTO_AES);
+    key.create(g_ceph_context, CEPH_CRYPTO_AES128);
     cout << key << std::endl;
     return 0;
   }
@@ -229,7 +229,7 @@ int main(int argc, const char **argv)
   }
   if (gen_key) {
     EntityAuth eauth;
-    eauth.key.create(g_ceph_context, CEPH_CRYPTO_AES);
+    eauth.key.create(g_ceph_context, CEPH_CRYPTO_AES128);
     keyring.add(ename, eauth);
     modified = true;
   }

--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -160,7 +160,7 @@ int main(int argc, const char **argv)
   }
 
   if (gen_print_key) {
-    CryptoKey key;
+    ceph::crypto::Key key;
     key.create(g_ceph_context, CEPH_CRYPTO_AES128);
     cout << key << std::endl;
     return 0;
@@ -195,7 +195,7 @@ int main(int argc, const char **argv)
   // Validate that "name" actually has an existing key in this keyring if we
   // have not given gen-key or add-key options
   if (!gen_key && add_key.empty() && !caps.empty()) {
-    CryptoKey key;
+    ceph::crypto::Key key;
     if (!keyring.get_secret(ename, key)) {
       cerr << "can't find existing key for " << ename 
            << " and neither gen-key nor add-key specified" << std::endl;
@@ -286,7 +286,7 @@ int main(int argc, const char **argv)
     }
   }
   if (print_key) {
-    CryptoKey key;
+    ceph::crypto::Key key;
     if (keyring.get_secret(ename, key)) {
       cout << key << std::endl;
     } else {


### PR DESCRIPTION
some cleanup and refactoring of Crypto interfaces that was motivated by the work in https://github.com/ceph/ceph/pull/14498 to add new handlers for AES256 modes used in radosgw encryption. posting as a separate pr for early review

each commit is distinct and can be reviewed on its own if that's easier:
* add `CEPH_CRYPTO_AES128` as an alias for `CEPH_CRYPTO_AES`
* use `namespace ceph::crypto`
* use `unique_ptr` for factory functions
* use exceptions instead of strings/streams for error handling
* use raii wrappers to manage resources from the NSS c api