### PR TITLE
luminous: osd: Pool Compression type option doesn't apply to new OSDs

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5949,6 +5949,10 @@ void PG::handle_create(RecoveryCtx *rctx)
   recovery_state.handle_event(evt, rctx);
   ActMap evt2;
   recovery_state.handle_event(evt2, rctx);
+
+  rctx->on_applied->add(make_lambda_context([this]() {
+    update_store_with_options();
+  }));
 }
 
 void PG::handle_query_state(Formatter *f)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5966,7 +5966,7 @@ void PG::update_store_with_options()
 {
   auto r = osd->store->set_collection_opts(coll, pool.info.opts);
   if(r < 0 && r != -EOPNOTSUPP) {
-    derr << __func__ << "set_collection_opts returns error:" << r << dendl;
+    derr << __func__ << " set_collection_opts returns error:" << r << dendl;
   }
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/22502