### PR TITLE
librbd: handle aio failure in ManagedLock and PreReleaseRequest

### DIFF
--- a/src/librbd/ManagedLock.cc
+++ b/src/librbd/ManagedLock.cc
@@ -762,8 +762,9 @@ void ManagedLock<I>::handle_shutdown_pre_release(int r) {
   using managed_lock::ReleaseRequest;
   ReleaseRequest<I>* req = ReleaseRequest<I>::create(m_ioctx, m_watcher,
       m_work_queue, m_oid, cookie,
-      new FunctionContext([this](int r) {
-        post_release_lock_handler(true, r, create_context_callback<
+      new FunctionContext([this, r](int l) {
+        int rst = r < 0 ? r : l;
+        post_release_lock_handler(true, rst, create_context_callback<
             ManagedLock<I>, &ManagedLock<I>::handle_shutdown_post_release>(this));
       }));
   req->send();


### PR DESCRIPTION
When I set osd_timeout and shutdown the only osd in cluster, client using librbd aborts. This pr fixes these aborts.

1. When aio operations fail, say if in `handle_block_writes` r < 0,
    `m_image_ctx->object_map` will not be deleted and the assert in
    `CloseRequest<I>::handle_shut_down_exclusive_lock` will fail.
2. when state go `STATE_SHUTTING_DOWN` in `handle_shutdown_pre_release`.
    The lock should be considered owned, otherwise, thread in objectCache
    will assert fail in `AbstractObjectWriteRequest::sen`d.
3. when r < 0 in handle_shutdown_pre_release, we should save the error result, otherwise, `post_release_lock_handler`
    will be called with result as 0(successful), and the `unblock_writes` will assert fail due to
    unlock has already been called in preReleaseRequest.

