### PR TITLE
mon: fix structure of 'features' command

### DIFF
--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -104,7 +104,7 @@ struct FeatureMap {
 
   void dump(Formatter *f) const {
     for (auto& p : m) {
-      f->open_object_section(ceph_entity_type_name(p.first));
+      f->open_array_section(ceph_entity_type_name(p.first));
       for (auto& q : p.second) {
 	f->open_object_section("group");
         std::stringstream ss;


### PR DESCRIPTION
I wonder if we should also restrict this to just client features.. the 'versions' command already tells us the code version for daemons, which implies what features they support, so it's not really new or useful information for the operator...
