### PR TITLE
tools/ceph_monstore_tool: include mgrmap in initial paxos epoch

### DIFF
--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -592,6 +592,9 @@ static int update_monitor(MonitorDBStore& st)
   return 0;
 }
 
+// rebuild
+//  - mgr
+//  - mgr_command_desc
 static int update_mgrmap(MonitorDBStore& st)
 {
   auto t = make_shared<MonitorDBStore::Transaction>();
@@ -732,6 +735,9 @@ int rebuild_monstore(const char* progname,
   if ((r = update_pgmap_meta(st))) {
     return r;
   }
+  if ((r = update_mgrmap(st))) {
+    return r;
+  }
   if ((r = update_paxos(st))) {
     return r;
   }
@@ -739,9 +745,6 @@ int rebuild_monstore(const char* progname,
     return r;
   }
   if ((r = update_monitor(st))) {
-    return r;
-  }
-  if ((r = update_mgrmap(st))) {
     return r;
   }
   return 0;


### PR DESCRIPTION
Note: this is a backport of #19780 to Luminous

There is no backport tracker because this is a follow-on fix for https://tracker.ceph.com/issues/22266 (for which an earlier fix was already backported in the v12.2.2 cycle).