### PR TITLE
luminous: mds: fix return value of MDCache::dump_cache

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12004,6 +12004,7 @@ int MDCache::dump_cache(const char *fn, Formatter *f,
       f->close_section();  // inode
     }
   }
+  r = 0;
 
  out:
   if (f) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/22798