### PR TITLE
[RFC]osd/PrimaryLogPG: For bluestore no need call do_sparse_read.

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5655,7 +5655,10 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 		 op.extent.length, op.extent.truncate_size,
 		 op.extent.truncate_seq);
       if (op_finisher == nullptr) {
-	result = do_sparse_read(ctx, osd_op);
+	if (osd->store->get_type() == "bluestore")
+	  result = do_read(ctx, osd_op);
+	else
+	  result = do_sparse_read(ctx, osd_op);
       } else {
 	result = op_finisher->execute();
       }


### PR DESCRIPTION
Using sparse_read to avoid adding hole data from kernel to user space
for filestore. But bluestore know the hole and can avoid this problem.
So no need using sparse-read for bluestore.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>