### PR TITLE
mgr: balancer: fixed mistype "AttributeError: 'Logger' object has no attribute 'err'"

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -675,7 +675,7 @@ class Module(MgrModule):
                     overlap[osd] = 1
                 visited[osd] = 1
         if len(overlap) > 0:
-            self.log.err('error: some osds belong to multiple subtrees: %s' %
+            self.log.error('error: some osds belong to multiple subtrees: %s' %
                          overlap)
             return False
 


### PR DESCRIPTION
Fixed this:

```python
# ceph balancer optimize balancer_plan
Error EINVAL: Traceback (most recent call last):
  File "/usr/lib64/ceph/mgr/balancer/module.py", line 303, in handle_command
    self.optimize(plan)
  File "/usr/lib64/ceph/mgr/balancer/module.py", line 598, in optimize
    return self.do_crush_compat(plan)
  File "/usr/lib64/ceph/mgr/balancer/module.py", line 678, in do_crush_compat
    self.log.err('error: some osds belong to multiple subtrees: %s' %
AttributeError: 'Logger' object has no attribute 'err'
```