### PR TITLE
mds: open file table

### DIFF
--- a/qa/tasks/cephfs/test_damage.py
+++ b/qa/tasks/cephfs/test_damage.py
@@ -141,7 +141,9 @@ class TestDamage(CephFSTestCase):
                 # Missing dirfrags for non-system dirs result in empty directory
                 "10000000000.00000000",
                 # PurgeQueue is auto-created if not found on startup
-                "500.00000000"
+                "500.00000000",
+                # open file table is auto-created if not found on startup
+                "mds0_openfiles.0"
             ]:
                 expectation = NO_DAMAGE
             else:

--- a/src/mds/Anchor.cc
+++ b/src/mds/Anchor.cc
@@ -1,0 +1,60 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "mds/Anchor.h"
+
+#include "common/Formatter.h"
+
+void Anchor::encode(bufferlist &bl) const
+{
+  ENCODE_START(1, 1, bl);
+  encode(ino, bl);
+  encode(dirino, bl);
+  encode(d_name, bl);
+  encode(d_type, bl);
+  ENCODE_FINISH(bl);
+}
+
+void Anchor::decode(bufferlist::iterator &bl)
+{
+  DECODE_START(1, bl);
+  decode(ino, bl);
+  decode(dirino, bl);
+  decode(d_name, bl);
+  decode(d_type, bl);
+  DECODE_FINISH(bl);
+}
+
+void Anchor::dump(Formatter *f) const
+{
+  f->dump_unsigned("ino", ino);
+  f->dump_unsigned("dirino", dirino);
+  f->dump_string("d_name", d_name);
+  f->dump_unsigned("d_type", d_type);
+}
+
+void Anchor::generate_test_instances(list<Anchor*>& ls)
+{
+  ls.push_back(new Anchor);
+  ls.push_back(new Anchor);
+  ls.back()->ino = 1;
+  ls.back()->dirino = 2;
+  ls.back()->d_name = "hello";
+  ls.back()->d_type = DT_DIR;
+}
+
+ostream& operator<<(ostream& out, const Anchor &a)
+{
+  return out << "a(" << a.ino << " " << a.dirino << "/'" << a.d_name << "' " << a.d_type << ")";
+}

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -31,15 +31,11 @@ public:
   inodeno_t ino;	// anchored ino
   inodeno_t dirino;
   std::string d_name;
-  __u8 d_type;
-  union {
-    mutable int nref;		// how many children
-    mutable mds_rank_t auth;	// auth hint
-  };
+  __u8 d_type = 0;
 
-  Anchor() : d_type(0), nref(0) {}
-  Anchor(inodeno_t i, inodeno_t di, std::string_view str, __u8 tp, int nr) :
-    ino(i), dirino(di), d_name(str), d_type(tp), nref(nr) { }
+  Anchor() {}
+  Anchor(inodeno_t i, inodeno_t di, std::string_view str, __u8 tp) :
+    ino(i), dirino(di), d_name(str), d_type(tp) {}
 
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &bl);
@@ -54,5 +50,22 @@ inline bool operator==(const Anchor &l, const Anchor &r) {
 }
 
 ostream& operator<<(ostream& out, const Anchor &a);
+
+class RecoveredAnchor : public Anchor {
+public:
+  RecoveredAnchor() {}
+
+  mds_rank_t auth = MDS_RANK_NONE; // auth hint
+};
+
+class OpenedAnchor : public Anchor {
+public:
+  OpenedAnchor(inodeno_t i, inodeno_t di, std::string_view str, __u8 tp, int nr) :
+      Anchor(i, di, str, tp),
+      nref(nr)
+  {}
+
+  mutable int nref = 0; // how many children
+};
 
 #endif

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -33,6 +33,8 @@ public:
   std::string d_name;
   __u8 d_type = 0;
 
+  int omap_idx = -1;	// stored in which omap object
+
   Anchor() {}
   Anchor(inodeno_t i, inodeno_t di, std::string_view str, __u8 tp) :
     ino(i), dirino(di), d_name(str), d_type(tp) {}

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -32,7 +32,10 @@ public:
   inodeno_t dirino;
   std::string d_name;
   __u8 d_type;
-  mutable int nref;	// how many children
+  union {
+    mutable int nref;		// how many children
+    mutable mds_rank_t auth;	// auth hint
+  };
 
   Anchor() : d_type(0), nref(0) {}
   Anchor(inodeno_t i, inodeno_t di, std::string_view str, __u8 tp, int nr) :

--- a/src/mds/Anchor.h
+++ b/src/mds/Anchor.h
@@ -1,0 +1,55 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_ANCHOR_H
+#define CEPH_ANCHOR_H
+
+#include <string>
+
+#include "include/types.h"
+#include "mdstypes.h"
+#include "include/buffer.h"
+
+/*
+ * Anchor represents primary linkage of an inode. When adding inode to an
+ * anchor table, MDS ensures that the table also contains inode's ancestor
+ * inodes. MDS can get inode's path by looking up anchor table recursively.
+ */
+class Anchor {
+public:
+  inodeno_t ino;	// anchored ino
+  inodeno_t dirino;
+  std::string d_name;
+  __u8 d_type;
+  mutable int nref;	// how many children
+
+  Anchor() : d_type(0), nref(0) {}
+  Anchor(inodeno_t i, inodeno_t di, std::string_view str, __u8 tp, int nr) :
+    ino(i), dirino(di), d_name(str), d_type(tp), nref(nr) { }
+
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &bl);
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<Anchor*>& ls);
+};
+WRITE_CLASS_ENCODER(Anchor)
+
+inline bool operator==(const Anchor &l, const Anchor &r) {
+  return l.ino == r.ino && l.dirino == r.dirino &&
+	 l.d_name == r.d_name && l.d_type == r.d_type;
+}
+
+ostream& operator<<(ostream& out, const Anchor &a);
+
+#endif

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -566,6 +566,9 @@ void CDir::link_inode_work( CDentry *dn, CInode *in)
   // pin dentry?
   if (in->get_num_ref())
     dn->get(CDentry::PIN_INODEPIN);
+
+  if (in->state_test(CInode::STATE_TRACKEDBYOFT))
+    inode->mdcache->open_file_table.notify_link(in);
   
   // adjust auth pin count
   if (in->auth_pins + in->nested_auth_pins)
@@ -642,6 +645,9 @@ void CDir::unlink_inode_work( CDentry *dn )
     // unpin dentry?
     if (in->get_num_ref())
       dn->put(CDentry::PIN_INODEPIN);
+
+    if (in->state_test(CInode::STATE_TRACKEDBYOFT))
+      inode->mdcache->open_file_table.notify_unlink(in);
     
     // unlink auth_pin count
     if (in->auth_pins + in->nested_auth_pins)

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -91,7 +91,8 @@ public:
   static const unsigned STATE_ASSIMRSTAT =    (1<<15);  // assimilating inode->frag rstats
   static const unsigned STATE_DIRTYDFT =      (1<<16);  // dirty dirfragtree
   static const unsigned STATE_BADFRAG =       (1<<17);  // bad dirfrag
-  static const unsigned STATE_AUXSUBTREE =    (1<<18);  // no subtree merge
+  static const unsigned STATE_TRACKEDBYOFT =  (1<<18);  // tracked by open file table
+  static const unsigned STATE_AUXSUBTREE =    (1<<19);  // no subtree merge
 
   // common states
   static const unsigned STATE_CLEAN =  0;
@@ -106,14 +107,16 @@ public:
    STATE_IMPORTBOUND |
    STATE_EXPORTBOUND |
    STATE_FROZENTREE |
-   STATE_STICKY);
+   STATE_STICKY |
+   STATE_TRACKEDBYOFT);
   static const unsigned MASK_STATE_EXPORT_KEPT = 
   (STATE_EXPORTING |
    STATE_IMPORTBOUND |
    STATE_EXPORTBOUND |
    STATE_FROZENTREE |
    STATE_FROZENDIR |
-   STATE_STICKY);
+   STATE_STICKY |
+   STATE_TRACKEDBYOFT);
   static const unsigned MASK_STATE_FRAGMENT_KEPT = 
   (STATE_DIRTY |
    STATE_EXPORTBOUND |
@@ -337,6 +340,8 @@ protected:
 
   int num_dirty;
 
+  int num_inodes_with_caps = 0;
+
   // state
   version_t committing_version;
   version_t committed_version;
@@ -428,6 +433,8 @@ protected:
   int get_num_dirty() const {
     return num_dirty;
   }
+
+  void adjust_num_inodes_with_caps(int d);
 
   int64_t get_frag_size() const {
     return get_projected_fnode()->fragstat.size();

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -73,25 +73,25 @@ public:
   }
 
   // -- state --
-  static const unsigned STATE_COMPLETE =      (1<< 1);   // the complete contents are in cache
-  static const unsigned STATE_FROZENTREE =    (1<< 2);   // root of tree (bounded by exports)
-  static const unsigned STATE_FREEZINGTREE =  (1<< 3);   // in process of freezing 
-  static const unsigned STATE_FROZENDIR =     (1<< 4);
-  static const unsigned STATE_FREEZINGDIR =   (1<< 5);
-  static const unsigned STATE_COMMITTING =    (1<< 6);   // mid-commit
-  static const unsigned STATE_FETCHING =      (1<< 7);   // currenting fetching
-  static const unsigned STATE_CREATING =      (1<< 8);
-  static const unsigned STATE_IMPORTBOUND =   (1<<10);
-  static const unsigned STATE_EXPORTBOUND =   (1<<11);
-  static const unsigned STATE_EXPORTING =     (1<<12);
-  static const unsigned STATE_IMPORTING =     (1<<13);
-  static const unsigned STATE_FRAGMENTING =   (1<<14);
-  static const unsigned STATE_STICKY =        (1<<15);  // sticky pin due to inode stickydirs
-  static const unsigned STATE_DNPINNEDFRAG =  (1<<16);  // dir is refragmenting
-  static const unsigned STATE_ASSIMRSTAT =    (1<<17);  // assimilating inode->frag rstats
-  static const unsigned STATE_DIRTYDFT =      (1<<18);  // dirty dirfragtree
-  static const unsigned STATE_BADFRAG =       (1<<19);  // bad dirfrag
-  static const unsigned STATE_AUXSUBTREE =    (1<<20);  // no subtree merge
+  static const unsigned STATE_COMPLETE =      (1<< 0);   // the complete contents are in cache
+  static const unsigned STATE_FROZENTREE =    (1<< 1);   // root of tree (bounded by exports)
+  static const unsigned STATE_FREEZINGTREE =  (1<< 2);   // in process of freezing
+  static const unsigned STATE_FROZENDIR =     (1<< 3);
+  static const unsigned STATE_FREEZINGDIR =   (1<< 4);
+  static const unsigned STATE_COMMITTING =    (1<< 5);   // mid-commit
+  static const unsigned STATE_FETCHING =      (1<< 6);   // currenting fetching
+  static const unsigned STATE_CREATING =      (1<< 7);
+  static const unsigned STATE_IMPORTBOUND =   (1<< 8);
+  static const unsigned STATE_EXPORTBOUND =   (1<< 9);
+  static const unsigned STATE_EXPORTING =     (1<<10);
+  static const unsigned STATE_IMPORTING =     (1<<11);
+  static const unsigned STATE_FRAGMENTING =   (1<<12);
+  static const unsigned STATE_STICKY =        (1<<13);  // sticky pin due to inode stickydirs
+  static const unsigned STATE_DNPINNEDFRAG =  (1<<14);  // dir is refragmenting
+  static const unsigned STATE_ASSIMRSTAT =    (1<<15);  // assimilating inode->frag rstats
+  static const unsigned STATE_DIRTYDFT =      (1<<16);  // dirty dirfragtree
+  static const unsigned STATE_BADFRAG =       (1<<17);  // bad dirfrag
+  static const unsigned STATE_AUXSUBTREE =    (1<<18);  // no subtree merge
 
   // common states
   static const unsigned STATE_CLEAN =  0;
@@ -102,18 +102,20 @@ public:
   (STATE_COMPLETE|STATE_DIRTY|STATE_DIRTYDFT|STATE_BADFRAG);
   static const unsigned MASK_STATE_IMPORT_KEPT = 
   (						  
-   STATE_IMPORTING
-   |STATE_IMPORTBOUND|STATE_EXPORTBOUND
-   |STATE_FROZENTREE
-   |STATE_STICKY);
+   STATE_IMPORTING |
+   STATE_IMPORTBOUND |
+   STATE_EXPORTBOUND |
+   STATE_FROZENTREE |
+   STATE_STICKY);
   static const unsigned MASK_STATE_EXPORT_KEPT = 
-  (STATE_EXPORTING
-   |STATE_IMPORTBOUND|STATE_EXPORTBOUND
-   |STATE_FROZENTREE
-   |STATE_FROZENDIR
-   |STATE_STICKY);
+  (STATE_EXPORTING |
+   STATE_IMPORTBOUND |
+   STATE_EXPORTBOUND |
+   STATE_FROZENTREE |
+   STATE_FROZENDIR |
+   STATE_STICKY);
   static const unsigned MASK_STATE_FRAGMENT_KEPT = 
-  (STATE_DIRTY|
+  (STATE_DIRTY |
    STATE_EXPORTBOUND |
    STATE_IMPORTBOUND |
    STATE_AUXSUBTREE |

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2873,9 +2873,9 @@ void CInode::set_mds_caps_wanted(mds_rank_t mds, int32_t wanted)
 void CInode::adjust_num_caps_wanted(int d)
 {
   if (!num_caps_wanted && d > 0)
-    ; // add 'this' to open file table
+    mdcache->open_file_table.add_inode(this);
   else if (num_caps_wanted > 0 && num_caps_wanted == -d)
-    ; // remove 'this' from open file table
+    mdcache->open_file_table.remove_inode(this);
 
   num_caps_wanted +=d;
   assert(num_caps_wanted >= 0);

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2935,7 +2935,6 @@ void CInode::remove_client_cap(client_t client)
     put(PIN_CAPS);
     item_caps.remove_myself();
     containing_realm = NULL;
-    item_open_file.remove_myself();  // unpin logsegment
     mdcache->num_inodes_with_caps--;
   }
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2892,10 +2892,11 @@ Capability *CInode::add_client_cap(client_t client, Session *session, SnapRealm 
       containing_realm = find_snaprealm();
     containing_realm->inodes_with_caps.push_back(&item_caps);
     dout(10) << __func__ << " first cap, joining realm " << *containing_realm << dendl;
-  }
 
-  if (client_caps.empty())
     mdcache->num_inodes_with_caps++;
+    if (parent)
+      parent->dir->adjust_num_inodes_with_caps(1);
+  }
   
   Capability *cap = new Capability(this, ++mdcache->last_cap_id, client);
   assert(client_caps.count(client) == 0);
@@ -2936,6 +2937,8 @@ void CInode::remove_client_cap(client_t client)
     item_caps.remove_myself();
     containing_realm = NULL;
     mdcache->num_inodes_with_caps--;
+    if (parent)
+      parent->dir->adjust_num_inodes_with_caps(-1);
   }
 
   //clean up advisory locks

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -564,7 +564,8 @@ protected:
   using cap_map = mempool::mds_co::map<client_t, Capability*>;
   cap_map client_caps;         // client -> caps
   mempool::mds_co::compact_map<int32_t, int32_t>      mds_caps_wanted;     // [auth] mds -> caps wanted
-  int                   replica_caps_wanted = 0; // [replica] what i've requested from auth
+  int replica_caps_wanted = 0; // [replica] what i've requested from auth
+  int num_caps_wanted = 0;
 
 public:
   mempool::mds_co::compact_map<int, mempool::mds_co::set<client_t> > client_snap_caps;     // [auth] [snap] dirty metadata we still need from the head
@@ -689,6 +690,7 @@ public:
     clear_file_locks();
     assert(num_projected_xattrs == 0);
     assert(num_projected_srnodes == 0);
+    assert(num_caps_wanted == 0);
   }
   
 
@@ -973,7 +975,8 @@ public:
   bool is_any_nonstale_caps() { return count_nonstale_caps(); }
 
   const mempool::mds_co::compact_map<int32_t,int32_t>& get_mds_caps_wanted() const { return mds_caps_wanted; }
-  mempool::mds_co::compact_map<int32_t,int32_t>& get_mds_caps_wanted() { return mds_caps_wanted; }
+  void set_mds_caps_wanted(mempool::mds_co::compact_map<int32_t,int32_t>& m);
+  void set_mds_caps_wanted(mds_rank_t mds, int32_t wanted);
 
   const cap_map& get_client_caps() const { return client_caps; }
   Capability *get_client_cap(client_t client) {
@@ -990,6 +993,9 @@ public:
       return 0;
     }
   }
+
+  int get_num_caps_wanted() const { return num_caps_wanted; }
+  void adjust_num_caps_wanted(int d);
 
   Capability *add_client_cap(client_t client, Session *session, SnapRealm *conrealm=0);
   void remove_client_cap(client_t client);

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -232,13 +232,15 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int STATE_MISSINGOBJS		= (1<<15);
   static const int STATE_EVALSTALECAPS		= (1<<16);
   static const int STATE_QUEUEDEXPORTPIN	= (1<<17);
+  static const int STATE_TRACKEDBYOFT		= (1<<18);  // tracked by open file table
   // orphan inode needs notification of releasing reference
   static const int STATE_ORPHAN =	STATE_NOTIFYREF;
 
   static const int MASK_STATE_EXPORTED =
     (STATE_DIRTY|STATE_NEEDSRECOVER|STATE_DIRTYPARENT|STATE_DIRTYPOOL);
   static const int MASK_STATE_EXPORT_KEPT =
-    (STATE_FROZEN|STATE_AMBIGUOUSAUTH|STATE_EXPORTINGCAPS|STATE_QUEUEDEXPORTPIN);
+    (STATE_FROZEN|STATE_AMBIGUOUSAUTH|STATE_EXPORTINGCAPS|
+     STATE_QUEUEDEXPORTPIN|STATE_TRACKEDBYOFT);
 
   // -- waiters --
   static const uint64_t WAIT_DIR         = (1<<0);

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -214,24 +214,24 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int DUMP_DEFAULT = DUMP_ALL & (~DUMP_PATH);
 
   // -- state --
-  static const int STATE_EXPORTING =   (1<<2);   // on nonauth bystander.
-  static const int STATE_OPENINGDIR =  (1<<5);
-  static const int STATE_FREEZING =    (1<<7);
-  static const int STATE_FROZEN =      (1<<8);
-  static const int STATE_AMBIGUOUSAUTH = (1<<9);
-  static const int STATE_EXPORTINGCAPS = (1<<10);
-  static const int STATE_NEEDSRECOVER = (1<<11);
-  static const int STATE_RECOVERING =   (1<<12);
-  static const int STATE_PURGING =     (1<<13);
-  static const int STATE_DIRTYPARENT =  (1<<14);
-  static const int STATE_DIRTYRSTAT =  (1<<15);
-  static const int STATE_STRAYPINNED = (1<<16);
-  static const int STATE_FROZENAUTHPIN = (1<<17);
-  static const int STATE_DIRTYPOOL =   (1<<18);
-  static const int STATE_REPAIRSTATS = (1<<19);
-  static const int STATE_MISSINGOBJS = (1<<20);
-  static const int STATE_EVALSTALECAPS = (1<<21);
-  static const int STATE_QUEUEDEXPORTPIN = (1<<22);
+  static const int STATE_EXPORTING 		= (1<<0);   // on nonauth bystander.
+  static const int STATE_OPENINGDIR		= (1<<1);
+  static const int STATE_FREEZING		= (1<<2);
+  static const int STATE_FROZEN			= (1<<3);
+  static const int STATE_AMBIGUOUSAUTH		= (1<<4);
+  static const int STATE_EXPORTINGCAPS		= (1<<5);
+  static const int STATE_NEEDSRECOVER		= (1<<6);
+  static const int STATE_RECOVERING		= (1<<7);
+  static const int STATE_PURGING		= (1<<8);
+  static const int STATE_DIRTYPARENT		= (1<<9);
+  static const int STATE_DIRTYRSTAT		= (1<<10);
+  static const int STATE_STRAYPINNED		= (1<<11);
+  static const int STATE_FROZENAUTHPIN		= (1<<12);
+  static const int STATE_DIRTYPOOL		= (1<<13);
+  static const int STATE_REPAIRSTATS		= (1<<14);
+  static const int STATE_MISSINGOBJS		= (1<<15);
+  static const int STATE_EVALSTALECAPS		= (1<<16);
+  static const int STATE_QUEUEDEXPORTPIN	= (1<<17);
   // orphan inode needs notification of releasing reference
   static const int STATE_ORPHAN =	STATE_NOTIFYREF;
 

--- a/src/mds/CMakeLists.txt
+++ b/src/mds/CMakeLists.txt
@@ -36,6 +36,8 @@ set(mds_srcs
   MDLog.cc
   MDSCacheObject.cc
   Mantle.cc
+  Anchor.cc
+  OpenFileTable.cc
   ${CMAKE_SOURCE_DIR}/src/common/TrackedOp.cc
   ${CMAKE_SOURCE_DIR}/src/common/MemoryModel.cc
   ${CMAKE_SOURCE_DIR}/src/osdc/Journaler.cc)

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -257,10 +257,7 @@ public:
 
   // caps this client wants to hold
   int wanted() { return _wanted; }
-  void set_wanted(int w) {
-    _wanted = w;
-    //check_rdcaps_list();
-  }
+  void set_wanted(int w);
 
   void inc_last_seq() { last_sent++; }
   ceph_seq_t get_last_seq() { return last_sent; }
@@ -291,7 +288,7 @@ public:
     client_follows = other.client_follows;
 
     // wanted
-    _wanted = _wanted | other.wanted;
+    set_wanted(wanted() | other.wanted);
     if (auth_cap)
       mseq = other.mseq;
   }
@@ -308,7 +305,7 @@ public:
     }
 
     // wanted
-    _wanted = _wanted | otherwanted;
+    set_wanted(wanted() | otherwanted);
   }
 
   void revoke() {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8379,8 +8379,8 @@ struct C_MDC_OpenInoTraverseDir : public MDCacheContext {
       mdcache->handle_open_ino(msg, r);
       return;
     }
-    assert(mdcache->opening_inodes.count(ino));
-    mdcache->_open_ino_traverse_dir(ino, mdcache->opening_inodes[ino], r);
+    auto& info = mdcache->opening_inodes.at(ino);
+    mdcache->_open_ino_traverse_dir(ino, info, r);
   }
 };
 
@@ -8397,8 +8397,7 @@ void MDCache::_open_ino_backtrace_fetched(inodeno_t ino, bufferlist& bl, int err
 {
   dout(10) << "_open_ino_backtrace_fetched ino " << ino << " errno " << err << dendl;
 
-  assert(opening_inodes.count(ino));
-  open_ino_info_t& info = opening_inodes[ino];
+  open_ino_info_t& info = opening_inodes.at(ino);
 
   CInode *in = get_inode(ino);
   if (in) {
@@ -8473,8 +8472,7 @@ void MDCache::_open_ino_parent_opened(inodeno_t ino, int ret)
 {
   dout(10) << "_open_ino_parent_opened ino " << ino << " ret " << ret << dendl;
 
-  assert(opening_inodes.count(ino));
-  open_ino_info_t& info = opening_inodes[ino];
+  open_ino_info_t& info = opening_inodes.at(ino);
 
   CInode *in = get_inode(ino);
   if (in) {
@@ -8830,8 +8828,9 @@ void MDCache::open_ino(inodeno_t ino, int64_t pool, MDSInternalContextBase* fin,
   dout(10) << "open_ino " << ino << " pool " << pool << " want_replica "
 	   << want_replica << dendl;
 
-  if (opening_inodes.count(ino)) {
-    open_ino_info_t& info = opening_inodes[ino];
+  auto it = opening_inodes.find(ino);
+  if (it != opening_inodes.end()) {
+    open_ino_info_t& info = it->second;
     if (want_replica) {
       info.want_replica = true;
       if (want_xlocked && !info.want_xlocked) {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8555,6 +8555,8 @@ void MDCache::_open_ino_fetch_dir(inodeno_t ino, MMDSOpenIno *m, CDir *dir, bool
   if (dir->state_test(CDir::STATE_REJOINUNDEF))
     assert(dir->get_inode()->dirfragtree.is_leaf(dir->get_frag()));
   dir->fetch(new C_MDC_OpenInoTraverseDir(this, ino, m, parent));
+  if (mds->logger)
+    mds->logger->inc(l_mds_openino_dir_fetch);
 }
 
 int MDCache::open_ino_traverse_dir(inodeno_t ino, MMDSOpenIno *m,
@@ -8745,6 +8747,8 @@ void MDCache::do_open_ino_peer(inodeno_t ino, open_ino_info_t& info)
     if (info.discover || !info.fetch_backtrace)
       pa = &info.ancestors;
     mds->send_message_mds(new MMDSOpenIno(info.tid, ino, pa), peer);
+    if (mds->logger)
+      mds->logger->inc(l_mds_openino_peer_discover);
   }
 }
 
@@ -9619,6 +9623,8 @@ void MDCache::fetch_backtrace(inodeno_t ino, int64_t pool, bufferlist& bl, Conte
 {
   object_t oid = CInode::get_object_name(ino, frag_t(), "");
   mds->objecter->getxattr(oid, object_locator_t(pool), "parent", CEPH_NOSNAP, &bl, 0, fin);
+  if (mds->logger)
+    mds->logger->inc(l_mds_openino_backtrace_fetch);
 }
 
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -171,7 +171,8 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
   filer(m->objecter, m->finisher),
   exceeded_size_limit(false),
   recovery_queue(m),
-  stray_manager(m, purge_queue_)
+  stray_manager(m, purge_queue_),
+  open_file_table(m)
 {
   migrator.reset(new Migrator(mds, this));
   root = NULL;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -4803,7 +4803,7 @@ void MDCache::handle_cache_rejoin_strong(MMDSCacheRejoin *strong)
 
     // caps_wanted
     if (is.caps_wanted) {
-      in->mds_caps_wanted[from] = is.caps_wanted;
+      in->set_mds_caps_wanted(from, is.caps_wanted);
       dout(15) << " inode caps_wanted " << ccap_string(is.caps_wanted)
 	       << " on " << *in << dendl;
     }
@@ -7413,7 +7413,7 @@ void MDCache::inode_remove_replica(CInode *in, mds_rank_t from, bool rejoin,
 				   set<SimpleLock *>& gather_locks)
 {
   in->remove_replica(from);
-  in->mds_caps_wanted.erase(from);
+  in->set_mds_caps_wanted(from, 0);
   
   // note: this code calls _eval more often than it needs to!
   // fix lock

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5634,10 +5634,8 @@ void MDCache::clean_open_file_lists()
       CInode *in = *q;
       ++q;
       if (in->last == CEPH_NOSNAP) {
-	if (!in->is_any_caps_wanted()) {
-	  dout(10) << " unlisting unwanted/capless inode " << *in << dendl;
-	  in->item_open_file.remove_myself();
-	}
+	dout(10) << " unlisting unwanted/capless inode " << *in << dendl;
+	in->item_open_file.remove_myself();
       } else {
 	if (in->client_snap_caps.empty()) {
 	  dout(10) << " unlisting flushed snap inode " << *in << dendl;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -597,6 +597,9 @@ public:
 			     mds_rank_t frommds=MDS_RANK_NONE) {
     cap_imports[ino][client][frommds] = icr;
   }
+  bool rejoin_has_cap_reconnect(inodeno_t ino) const {
+    return cap_imports.count(ino);
+  }
   const cap_reconnect_t *get_replay_cap_reconnect(inodeno_t ino, client_t client) {
     if (cap_imports.count(ino) &&
 	cap_imports[ino].count(client) &&
@@ -644,6 +647,7 @@ public:
   friend class C_MDC_RejoinOpenInoFinish;
   friend class C_MDC_RejoinSessionsOpened;
   void rejoin_open_ino_finish(inodeno_t ino, int ret);
+  void rejoin_prefetch_ino_finish(inodeno_t ino, int ret);
   void rejoin_open_sessions_finish(map<client_t,entity_inst_t> client_map,
 				   map<client_t,uint64_t>& sseqmap);
   bool process_imported_caps();

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -600,6 +600,9 @@ public:
   bool rejoin_has_cap_reconnect(inodeno_t ino) const {
     return cap_imports.count(ino);
   }
+  void add_replay_ino_alloc(inodeno_t ino) {
+    cap_imports_missing.insert(ino); // avoid opening ino during cache rejoin
+  }
   const cap_reconnect_t *get_replay_cap_reconnect(inodeno_t ino, client_t client) {
     if (cap_imports.count(ino) &&
 	cap_imports[ino].count(client) &&

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -31,6 +31,7 @@
 #include "events/EMetaBlob.h"
 #include "RecoveryQueue.h"
 #include "StrayManager.h"
+#include "OpenFileTable.h"
 #include "MDSContext.h"
 #include "MDSMap.h"
 #include "Mutation.h"
@@ -1227,6 +1228,8 @@ public:
 public:
   /* Because exports may fail, this set lets us keep track of inodes that need exporting. */
   std::set<CInode *> export_pin_queue;
+
+  OpenFileTable open_file_table;
 };
 
 class C_MDS_RetryRequest : public MDSInternalContext {

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -1468,6 +1468,9 @@ void MDLog::standby_trim_segments()
   dout(10) << "standby_trim_segments" << dendl;
   uint64_t expire_pos = journaler->get_expire_pos();
   dout(10) << " expire_pos=" << expire_pos << dendl;
+
+  mds->mdcache->open_file_table.trim_destroyed_inos(expire_pos);
+
   bool removed_segment = false;
   while (have_any_segments()) {
     LogSegment *seg = get_oldest_segment();

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -715,7 +715,8 @@ int MDLog::trim_all()
   uint64_t last_seq = 0;
   if (!segments.empty()) {
     last_seq = get_last_segment_seq();
-    if (last_seq > mds->mdcache->open_file_table.get_committing_log_seq()) {
+    if (!mds->mdcache->open_file_table.is_any_committing() &&
+	last_seq > mds->mdcache->open_file_table.get_committing_log_seq()) {
       submit_mutex.Unlock();
       mds->mdcache->open_file_table.commit(new C_OFT_Committed(this, last_seq),
 					   last_seq, CEPH_MSG_PRIO_DEFAULT);

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -566,6 +566,17 @@ void MDLog::_journal_segment_subtree_map(MDSInternalContextBase *onsync)
   _submit_entry(sle, new C_MDL_Flushed(this, onsync));
 }
 
+class C_OFT_Committed : public MDSInternalContext {
+  MDLog *mdlog;
+  uint64_t seq;
+public:
+  C_OFT_Committed(MDLog *l, uint64_t s) :
+    MDSInternalContext(l->mds), mdlog(l), seq(s) {}
+  void finish(int ret) override {
+    mdlog->trim_expired_segments();
+  }
+};
+
 void MDLog::trim(int m)
 {
   unsigned max_segments = g_conf->mds_log_max_segments;
@@ -636,6 +647,7 @@ void MDLog::trim(int m)
 	      << journaler->get_write_safe_pos() << " < end " << ls->end << dendl;
       break;
     }
+
     if (expiring_segments.count(ls)) {
       dout(5) << "trim already expiring segment " << ls->seq << "/" << ls->offset
 	      << ", " << ls->num_events << " events" << dendl;
@@ -654,6 +666,18 @@ void MDLog::trim(int m)
 
       submit_mutex.Lock();
       p = segments.lower_bound(last_seq + 1);
+    }
+  }
+
+  if (!capped &&
+      !mds->mdcache->open_file_table.is_any_committing()) {
+    uint64_t last_seq = get_last_segment_seq();
+    if (mds->mdcache->open_file_table.is_any_dirty() ||
+	last_seq > mds->mdcache->open_file_table.get_committed_log_seq()) {
+      submit_mutex.Unlock();
+      mds->mdcache->open_file_table.commit(new C_OFT_Committed(this, last_seq),
+					   last_seq, CEPH_MSG_PRIO_HIGH);
+      submit_mutex.Lock();
     }
   }
 
@@ -689,8 +713,15 @@ int MDLog::trim_all()
            << "/" << expired_segments.size() << dendl;
 
   uint64_t last_seq = 0;
-  if (!segments.empty())
+  if (!segments.empty()) {
     last_seq = get_last_segment_seq();
+    if (last_seq > mds->mdcache->open_file_table.get_committing_log_seq()) {
+      submit_mutex.Unlock();
+      mds->mdcache->open_file_table.commit(new C_OFT_Committed(this, last_seq),
+					   last_seq, CEPH_MSG_PRIO_DEFAULT);
+      submit_mutex.Lock();
+    }
+  }
 
   map<uint64_t,LogSegment*>::iterator p = segments.begin();
   while (p != segments.end() &&
@@ -770,6 +801,8 @@ void MDLog::_trim_expired_segments()
 {
   assert(submit_mutex.is_locked_by_me());
 
+  uint64_t oft_committed_seq = mds->mdcache->open_file_table.get_committed_log_seq();
+
   // trim expired segments?
   bool trimmed = false;
   while (!segments.empty()) {
@@ -777,6 +810,12 @@ void MDLog::_trim_expired_segments()
     if (!expired_segments.count(ls)) {
       dout(10) << "_trim_expired_segments waiting for " << ls->seq << "/" << ls->offset
 	       << " to expire" << dendl;
+      break;
+    }
+
+    if (!capped && ls->seq >= oft_committed_seq) {
+      dout(10) << "_trim_expired_segments open file table committedseq " << oft_committed_seq
+	       << " <= " << ls->seq << "/" << ls->offset << dendl;
       break;
     }
     

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -306,6 +306,7 @@ private:
 
   friend class C_MaybeExpiredSegment;
   friend class C_MDL_Flushed;
+  friend class C_OFT_Committed;
 
 public:
   void trim_expired_segments();

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2630,6 +2630,12 @@ void MDSRank::create_logger()
     mds_plb.add_u64_counter(
       l_mds_imported_inodes, "imported_inodes", "Imported inodes", "imi",
       PerfCountersBuilder::PRIO_INTERESTING);
+    mds_plb.add_u64_counter(l_mds_openino_dir_fetch, "openino_dir_fetch",
+			    "OpenIno incomplete directory fetchings");
+    mds_plb.add_u64_counter(l_mds_openino_backtrace_fetch, "openino_backtrace_fetch",
+			    "OpenIno backtrace fetchings");
+    mds_plb.add_u64_counter(l_mds_openino_peer_discover, "openino_peer_discover",
+			    "OpenIno peer inode discovers");
     logger = mds_plb.create_perf_counters();
     g_ceph_context->get_perfcounters_collection()->add(logger);
   }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1075,6 +1075,8 @@ void MDSRank::boot_start(BootStep step, int r)
 	} else if (!standby_replaying) {
 	  dout(2) << "boot_start " << step << ": opening purge queue (async)" << dendl;
 	  purge_queue.open(NULL);
+	  dout(2) << "boot_start " << step << ": loading open file table (async)" << dendl;
+	  mdcache->open_file_table.load(nullptr);
 	}
 
         if (mdsmap->get_tableserver() == whoami) {
@@ -1274,8 +1276,10 @@ void MDSRank::standby_replay_restart()
           this,
 	  mdlog->get_journaler()->get_read_pos()));
 
-      dout(1) << " opening purge queue (async)" << dendl;
+      dout(1) << " opening purge_queue (async)" << dendl;
       purge_queue.open(NULL);
+      dout(1) << " opening open_file_table (async)" << dendl;
+      mdcache->open_file_table.load(nullptr);
     } else {
       dout(1) << " waiting for osdmap " << mdsmap->get_last_failure_osd_epoch()
               << " (which blacklists prior instance)" << dendl;

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -71,6 +71,9 @@ enum {
   l_mds_exported_inodes,
   l_mds_imported,
   l_mds_imported_inodes,
+  l_mds_openino_dir_fetch,
+  l_mds_openino_backtrace_fetch,
+  l_mds_openino_peer_discover,
   l_mds_last,
 };
 

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -1553,8 +1553,6 @@ void Migrator::finish_export_inode(CInode *in, utime_t now, mds_rank_t peer,
   if (!in->has_subtree_root_dirfrag(mds->get_nodeid()))
     in->clear_scatter_dirty();
 
-  in->item_open_file.remove_myself();
-
   in->clear_dirty_parent();
 
   in->clear_file_locks();

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -3047,7 +3047,12 @@ void Migrator::decode_import_inode_caps(CInode *in, bool auth_cap,
   map<client_t,Capability::Export> cap_map;
   decode(cap_map, blp);
   if (auth_cap)
-    decode(in->get_mds_caps_wanted(), blp);
+  if (auth_cap) {
+    mempool::mds_co::compact_map<int32_t,int32_t> mds_wanted;
+    decode(mds_wanted, blp);
+    mds_wanted.erase(mds->get_nodeid());
+    in->set_mds_caps_wanted(mds_wanted);
+  }
   if (!cap_map.empty() ||
       (auth_cap && (in->get_caps_wanted() & ~CEPH_CAP_PIN))) {
     peer_exports[in].swap(cap_map);

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -483,7 +483,7 @@ void OpenFileTable::_load_finish(int op_r, int header_r, int values_r,
 					    std::piecewise_construct,
 					    std::make_tuple(ino),
 					    std::make_tuple());
-    Anchor& anchor = it->second;
+    RecoveredAnchor& anchor = it->second;
     decode(anchor, p);
     assert(ino == anchor.ino);
     anchor.auth = MDS_RANK_NONE;

--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -1,0 +1,432 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "mds/CInode.h"
+#include "mds/MDSRank.h"
+#include "mds/MDCache.h"
+#include "osdc/Objecter.h"
+#include "OpenFileTable.h"
+
+#include "common/config.h"
+#include "common/errno.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_mds
+#undef dout_prefix
+#define dout_prefix _prefix(_dout, mds)
+static ostream& _prefix(std::ostream *_dout, MDSRank *mds) {
+  return *_dout << "mds." << mds->get_nodeid() << ".openfiles ";
+}
+
+void OpenFileTable::get_ref(CInode *in)
+{
+  do {
+    auto p = anchor_map.find(in->ino());
+    if (p != anchor_map.end()) {
+      assert(in->state_test(CInode::STATE_TRACKEDBYOFT));
+      assert(p->second.nref > 0);
+      p->second.nref++;
+      break;
+    }
+
+    CDentry *dn = in->get_parent_dn();
+    CInode *pin = dn ? dn->get_dir()->get_inode() : nullptr;
+
+    auto ret = anchor_map.emplace(std::piecewise_construct, std::forward_as_tuple(in->ino()),
+				  std::forward_as_tuple(in->ino(), (pin ? pin->ino() : inodeno_t(0)),
+				  (dn ? dn->get_name() : string()), in->d_type(), 1));
+    assert(ret.second == true);
+    in->state_set(CInode::STATE_TRACKEDBYOFT);
+
+    dirty_items.emplace(in->ino(), DIRTY_NEW);
+
+    in = pin;
+  } while (in);
+}
+
+void OpenFileTable::put_ref(CInode *in)
+{
+  do {
+    assert(in->state_test(CInode::STATE_TRACKEDBYOFT));
+    auto p = anchor_map.find(in->ino());
+    assert(p != anchor_map.end());
+    assert(p->second.nref > 0);
+
+    if (p->second.nref > 1) {
+      p->second.nref--;
+      break;
+    }
+
+    CDentry *dn = in->get_parent_dn();
+    CInode *pin = dn ? dn->get_dir()->get_inode() : nullptr;
+    if (dn) {
+      assert(p->second.dirino == pin->ino());
+      assert(p->second.d_name == dn->get_name());
+    } else {
+      assert(p->second.dirino == inodeno_t(0));
+      assert(p->second.d_name == "");
+    }
+
+    anchor_map.erase(p);
+    in->state_clear(CInode::STATE_TRACKEDBYOFT);
+
+    auto ret = dirty_items.emplace(in->ino(), 0);
+    if (!ret.second && (ret.first->second & DIRTY_NEW))
+      dirty_items.erase(ret.first);
+
+    in = pin;
+  } while (in);
+}
+
+void OpenFileTable::add_inode(CInode *in)
+{
+  dout(10) << __func__ << " " << *in << dendl;
+  if (!in->is_dir()) {
+    auto p = anchor_map.find(in->ino());
+    assert(p == anchor_map.end());
+  }
+  get_ref(in);
+}
+
+void OpenFileTable::remove_inode(CInode *in)
+{
+  dout(10) << __func__ << " " << *in << dendl;
+  if (!in->is_dir()) {
+    auto p = anchor_map.find(in->ino());
+    assert(p != anchor_map.end());
+    assert(p->second.nref == 1);
+  }
+  put_ref(in);
+}
+
+void OpenFileTable::notify_link(CInode *in)
+{
+  dout(10) << __func__ << " " << *in << dendl;
+  auto p = anchor_map.find(in->ino());
+  assert(p != anchor_map.end());
+  assert(p->second.nref > 0);
+  assert(p->second.dirino == inodeno_t(0));
+  assert(p->second.d_name == "");
+
+  CDentry *dn = in->get_parent_dn();
+  CInode *pin = dn->get_dir()->get_inode();
+
+  p->second.dirino = pin->ino();
+  p->second.d_name = dn->get_name();
+  dirty_items.emplace(in->ino(), 0);
+
+  get_ref(pin);
+}
+
+void OpenFileTable::notify_unlink(CInode *in)
+{
+  dout(10) << __func__ << " " << *in << dendl;
+  auto p = anchor_map.find(in->ino());
+  assert(p != anchor_map.end());
+  assert(p->second.nref > 0);
+
+  CDentry *dn = in->get_parent_dn();
+  CInode *pin = dn->get_dir()->get_inode();
+  assert(p->second.dirino == pin->ino());
+  assert(p->second.d_name == dn->get_name());
+
+  p->second.dirino = inodeno_t(0);
+  p->second.d_name = "";
+  dirty_items.emplace(in->ino(), 0);
+
+  put_ref(pin);
+}
+
+object_t OpenFileTable::get_object_name() const
+{
+  char s[30];
+  snprintf(s, sizeof(s), "mds%d_openfiles", int(mds->get_nodeid()));
+  return object_t(s);
+}
+
+class C_IO_OFT_Save : public MDSIOContextBase {
+protected:
+  OpenFileTable *oft;
+  uint64_t log_seq;
+  MDSInternalContextBase *fin;
+  MDSRank *get_mds() override { return oft->mds; }
+public:
+  C_IO_OFT_Save(OpenFileTable *t, uint64_t s, MDSInternalContextBase *c) :
+    oft(t), log_seq(s), fin(c) {}
+  void finish(int r) {
+    oft->_commit_finish(r, log_seq, fin);
+  }
+};
+
+void OpenFileTable::_commit_finish(int r, uint64_t log_seq, MDSInternalContextBase *fin)
+{
+  dout(10) << __func__ << " log_seq " << log_seq << dendl;
+  if (r < 0) {
+    mds->handle_write_error(r);
+    return;
+  }
+
+  assert(log_seq <= committing_log_seq);
+  assert(log_seq >= committed_log_seq);
+  committed_log_seq = log_seq;
+  num_pending_commit--;
+
+  if (fin)
+    fin->complete(r);
+}
+
+void OpenFileTable::commit(MDSInternalContextBase *c, uint64_t log_seq, int op_prio)
+{
+  dout(10) << __func__ << " log_seq " << log_seq << dendl;
+  const unsigned max_write_size = mds->mdcache->max_dir_commit_size;
+
+  assert(log_seq >= committing_log_seq);
+  committing_log_seq = log_seq;
+
+  C_GatherBuilder gather(g_ceph_context,
+			 new C_OnFinisher(new C_IO_OFT_Save(this, log_seq, c),
+					  mds->finisher));
+
+  SnapContext snapc;
+  object_t oid = get_object_name();
+  object_locator_t oloc(mds->mdsmap->get_metadata_pool());
+
+  bool first = true;
+  unsigned write_size = 0;
+  std::map<string, bufferlist> to_update;
+  std::set<string> to_remove;
+
+  auto commit_func = [&](bool last) {
+    ObjectOperation op;
+    op.priority = op_prio;
+
+    if (clear_on_commit) {
+      op.omap_clear();
+      op.set_last_op_flags(CEPH_OSD_OP_FLAG_FAILOK);
+      clear_on_commit = false;
+    }
+
+    if (last) {
+      bufferlist header;
+      encode(log_seq, header);
+      op.omap_set_header(header);
+    } else if (first) {
+      // make incomplete
+      bufferlist header;
+      encode((uint64_t)0, header);
+      op.omap_set_header(header);
+    }
+
+    if (!to_update.empty())
+      op.omap_set(to_update);
+    if (!to_remove.empty())
+      op.omap_rm_keys(to_remove);
+
+    mds->objecter->mutate(oid, oloc, op, snapc, ceph::real_clock::now(), 0,
+			  gather.new_sub());
+
+    first = false;
+    write_size = 0;
+    to_update.clear();
+    to_remove.clear();
+  };
+
+  bool first_commit = !loaded_anchor_map.empty();
+
+  using ceph::encode;
+  for (auto& it : dirty_items) {
+    auto p = anchor_map.find(it.first);
+    if (first_commit) {
+      auto q = loaded_anchor_map.find(it.first);
+      if (q != loaded_anchor_map.end()) {
+	bool same = (p != anchor_map.end() && p->second == q->second);
+	loaded_anchor_map.erase(q);
+	if (same)
+	  continue;
+      }
+    }
+
+    char key[32];
+    int len = snprintf(key, sizeof(key), "%llx", (unsigned long long)it.first.val);
+    write_size += len + sizeof(__u32);
+
+    if (p != anchor_map.end()) {
+      bufferlist bl;
+      encode(p->second, bl);
+
+      write_size += bl.length() + sizeof(__u32);
+
+      to_update[key].swap(bl);
+    } else {
+      to_remove.emplace(key);
+    }
+
+    if (write_size >= max_write_size) {
+      commit_func(false);
+    }
+  }
+  dirty_items.clear();
+
+  if (first_commit) {
+    for (auto& it : loaded_anchor_map) {
+      char key[32];
+      int len = snprintf(key, sizeof(key), "%llx", (unsigned long long)it.first.val);
+      write_size += len + sizeof(__u32);
+      to_remove.emplace(key);
+
+      if (write_size >= max_write_size) {
+	commit_func(false);
+      }
+    }
+    loaded_anchor_map.clear();
+  }
+
+  commit_func(true);
+
+  num_pending_commit++;
+  gather.activate();
+}
+
+class C_IO_OFT_Load : public MDSIOContextBase {
+protected:
+  OpenFileTable *oft;
+  MDSRank *get_mds() override { return oft->mds; }
+
+public:
+  int header_r = 0;  //< Return value from OMAP header read
+  int values_r = 0;  //< Return value from OMAP value read
+  bufferlist header_bl;
+  std::map<std::string, bufferlist> values;
+  bool more = false;
+  bool first;
+
+  C_IO_OFT_Load(OpenFileTable *t, bool f) : oft(t), first(f) {}
+  void finish(int r) {
+    oft->_load_finish(r, header_r, values_r, first, more, header_bl, values);
+  }
+};
+
+void OpenFileTable::_load_finish(int op_r, int header_r, int values_r,
+				 bool first, bool more,
+				 bufferlist &header_bl,
+				 std::map<std::string, bufferlist> &values)
+{
+  if (op_r < 0) {
+    derr << __func__ << " got " << cpp_strerror(op_r) << dendl;
+    clear_on_commit = true;
+    if (!first)
+      loaded_anchor_map.clear();
+    goto out;
+  }
+
+  try {
+    using ceph::decode;
+    if (first) {
+      bufferlist::iterator p = header_bl.begin();
+      uint64_t log_seq;
+      decode(log_seq, p);
+      committed_log_seq = committing_log_seq = log_seq;
+      if (log_seq == 0) {
+	dout(1) << __func__ << ": incomplete values" << dendl;
+	goto out;
+      }
+    }
+
+    for (auto& it : values) {
+      inodeno_t ino;
+      sscanf(it.first.c_str(), "%llx", (unsigned long long*)&ino.val);
+
+      auto r = loaded_anchor_map.emplace_hint(loaded_anchor_map.end(),
+					      std::piecewise_construct,
+					      std::make_tuple(ino),
+					      std::make_tuple());
+      Anchor& anchor = r->second;
+
+      bufferlist::iterator p = it.second.begin();
+      decode(anchor, p);
+      assert(ino == anchor.ino);
+    }
+  } catch (buffer::error &e) {
+    derr << __func__ << ": corrupted header/values: " << e.what() << dendl;
+    clear_on_commit = true;
+    loaded_anchor_map.clear();
+    goto out;
+  }
+
+  if (more) {
+    // Issue another read if we're not at the end of the omap
+    const std::string last_key = values.rbegin()->first;
+    dout(10) << __func__ << ": continue to load from '" << last_key << "'" << dendl;
+    object_t oid = get_object_name();
+    object_locator_t oloc(mds->mdsmap->get_metadata_pool());
+    C_IO_OFT_Load *c = new C_IO_OFT_Load(this, false);
+    ObjectOperation op;
+    op.omap_get_vals(last_key, "", uint64_t(-1),
+		     &c->values, &c->more, &c->values_r);
+    mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, nullptr, 0,
+			new C_OnFinisher(c, mds->finisher));
+    return;
+  }
+
+  dout(10) << __func__ << ": load complete" << dendl;
+out:
+  load_done = true;
+  finish_contexts(g_ceph_context, waiting_for_load);
+  waiting_for_load.clear();
+}
+
+void OpenFileTable::load(MDSInternalContextBase *onload)
+{
+  dout(10) << __func__ << dendl;
+  assert(!load_done);
+  if (onload)
+    waiting_for_load.push_back(onload);
+
+  C_IO_OFT_Load *c = new C_IO_OFT_Load(this, true);
+  object_t oid = get_object_name();
+  object_locator_t oloc(mds->mdsmap->get_metadata_pool());
+
+  ObjectOperation op;
+  op.omap_get_header(&c->header_bl, &c->header_r);
+  op.omap_get_vals("", "", uint64_t(-1),
+		   &c->values, &c->more, &c->values_r);
+
+  mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, nullptr, 0,
+		      new C_OnFinisher(c, mds->finisher));
+}
+
+bool OpenFileTable::get_ancestors(inodeno_t ino, vector<inode_backpointer_t>& ancestors)
+{
+  auto p = loaded_anchor_map.find(ino);
+  if (p == loaded_anchor_map.end())
+    return false;
+
+  inodeno_t dirino = p->second.dirino;
+  if (dirino == inodeno_t(0))
+    return false;
+
+  ancestors.clear();
+  while (true) {
+    ancestors.push_back(inode_backpointer_t(dirino, p->second.d_name, 0));
+
+    p = loaded_anchor_map.find(dirino);
+    if (p == loaded_anchor_map.end())
+      break;
+
+    dirino = p->second.dirino;
+    if (dirino == inodeno_t(0))
+      break;
+  }
+  return true;
+}

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -58,6 +58,9 @@ public:
 
   bool should_log_open(CInode *in);
 
+  void note_destroyed_inos(uint64_t seq, const vector<inodeno_t>& inos);
+  void trim_destroyed_inos(uint64_t seq);
+
 protected:
   MDSRank *mds;
 
@@ -97,6 +100,9 @@ protected:
   list<MDSInternalContextBase*> waiting_for_prefetch;
   void _open_ino_finish(inodeno_t ino, int r);
   void _prefetch_inodes();
+
+  std::map<uint64_t, vector<inodeno_t> > logseg_destroyed_inos;
+  std::set<inodeno_t> destroyed_inos_set;
 
   friend class C_IO_OFT_Load;
   friend class C_IO_OFT_Save;

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -56,6 +56,7 @@ public:
     waiting_for_prefetch.push_back(c);
   }
 
+  bool should_log_open(CInode *in);
 
 protected:
   MDSRank *mds;

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -1,0 +1,85 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef OPEN_FILE_TABLE_H
+#define OPEN_FILE_TABLE_H
+
+#include "mdstypes.h"
+#include "Anchor.h"
+
+class CDir;
+class CInode;
+class MDSRank;
+class MDSInternalContextBase;
+
+class OpenFileTable
+{
+public:
+  OpenFileTable(MDSRank *m) : mds(m) {}
+
+  void add_inode(CInode *in);
+  void remove_inode(CInode *in);
+  void notify_link(CInode *in);
+  void notify_unlink(CInode *in);
+  bool is_any_dirty() const { return !dirty_items.empty(); }
+
+  void commit(MDSInternalContextBase *c, uint64_t log_seq, int op_prio);
+  uint64_t get_committed_log_seq() const { return committed_log_seq; }
+  uint64_t get_committing_log_seq() const { return committing_log_seq; }
+  bool is_any_committing() const { return num_pending_commit > 0; }
+
+  void load(MDSInternalContextBase *c);
+  bool is_loaded() const { return load_done; }
+  void wait_for_load(MDSInternalContextBase *c) {
+    assert(!load_done);
+    waiting_for_load.push_back(c);
+  }
+
+  bool get_ancestors(inodeno_t ino, vector<inode_backpointer_t>& ancestors);
+
+protected:
+  MDSRank *mds;
+
+  map<inodeno_t, Anchor> anchor_map;
+
+  std::map<inodeno_t, unsigned> dirty_items; // ino -> dirty state
+  static const unsigned DIRTY_NEW = 1;
+
+  uint64_t committed_log_seq = 0;
+  uint64_t committing_log_seq = 0;
+
+  void get_ref(CInode *in);
+  void put_ref(CInode *in);
+
+  object_t get_object_name() const;
+
+  bool clear_on_commit = false;
+  unsigned num_pending_commit = 0;
+  void _commit_finish(int r, uint64_t log_seq, MDSInternalContextBase *fin);
+
+  map<inodeno_t, Anchor> loaded_anchor_map;
+  list<MDSInternalContextBase*> waiting_for_load;
+  bool load_done = false;
+
+  void _load_finish(int op_r, int header_r, int values_r,
+		    bool first, bool more,
+                    bufferlist &header_bl,
+		    std::map<std::string, bufferlist> &values);
+
+
+  friend class C_IO_OFT_Load;
+  friend class C_IO_OFT_Save;
+};
+
+#endif

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -30,6 +30,8 @@ public:
 
   void add_inode(CInode *in);
   void remove_inode(CInode *in);
+  void add_dirfrag(CDir *dir);
+  void remove_dirfrag(CDir *dir);
   void notify_link(CInode *in);
   void notify_unlink(CInode *in);
   bool is_any_dirty() const { return !dirty_items.empty(); }
@@ -65,6 +67,7 @@ protected:
   MDSRank *mds;
 
   map<inodeno_t, Anchor> anchor_map;
+  set<dirfrag_t> dirfrags;
 
   std::map<inodeno_t, unsigned> dirty_items; // ino -> dirty state
   static const unsigned DIRTY_NEW = 1;
@@ -82,6 +85,7 @@ protected:
   void _commit_finish(int r, uint64_t log_seq, MDSInternalContextBase *fin);
 
   map<inodeno_t, Anchor> loaded_anchor_map;
+  set<dirfrag_t> loaded_dirfrags;
   list<MDSInternalContextBase*> waiting_for_load;
   bool load_done = false;
 
@@ -92,14 +96,16 @@ protected:
 
   enum {
     DIR_INODES = 1,
-    FILE_INODES = 2,
-    DONE = 3,
+    DIRFRAGS = 2,
+    FILE_INODES = 3,
+    DONE = 4,
   };
   unsigned prefetch_state = 0;
   unsigned num_opening_inodes = 0;
   list<MDSInternalContextBase*> waiting_for_prefetch;
   void _open_ino_finish(inodeno_t ino, int r);
   void _prefetch_inodes();
+  void _prefetch_dirfrags();
 
   std::map<uint64_t, vector<inodeno_t> > logseg_destroyed_inos;
   std::set<inodeno_t> destroyed_inos_set;

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -68,7 +68,7 @@ protected:
 
   version_t omap_version = 0;
 
-  map<inodeno_t, Anchor> anchor_map;
+  map<inodeno_t, OpenedAnchor> anchor_map;
   set<dirfrag_t> dirfrags;
 
   std::map<inodeno_t, unsigned> dirty_items; // ino -> dirty state
@@ -95,7 +95,7 @@ protected:
   void _commit_finish(int r, uint64_t log_seq, MDSInternalContextBase *fin);
 
   std::map<std::string, bufferlist> loaded_journal;
-  map<inodeno_t, Anchor> loaded_anchor_map;
+  map<inodeno_t, RecoveredAnchor> loaded_anchor_map;
   set<dirfrag_t> loaded_dirfrags;
   list<MDSInternalContextBase*> waiting_for_load;
   bool load_done = false;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -214,6 +214,10 @@ void Server::dispatch(Message *m)
       if (req->is_replay()) {
 	dout(3) << "queuing replayed op" << dendl;
 	queue_replay = true;
+	if (req->head.ino &&
+	    !session->have_completed_request(req->get_reqid().tid, nullptr)) {
+	  mdcache->add_replay_ino_alloc(inodeno_t(req->head.ino));
+	}
       } else if (req->get_retry_attempt()) {
 	// process completed request in clientreplay stage. The completed request
 	// might have created new file/directorie. This guarantees MDS sends a reply


### PR DESCRIPTION
The table records pathes of inodes that are potentially opened by clients. During mds recovery, It can reduce the time mds takes to load inodes for client caps. 

here is result of a simple test

Two client open all files of 50 kernel source trees
<pre>
zhyan-alpha:~ zhyan$ ceph daemon mds.b session ls
[
    {
        "id": 19324254,
        "num_leases": 0,
        "num_caps": 1113562,
        "state": "open",
        "replay_requests": 0,
        "completed_requests": 0,
        "reconnecting": false,
        "inst": "client.19324254 10.8.1.2:0/1733406068",
        "client_metadata": {
            "entity_id": "admin",
            "hostname": "kvm1-beta",
            "kernel_version": "4.15.0-rc9+",
            "root": "/"
        }
    },
    {
        "id": 19324248,
        "num_leases": 0,
        "num_caps": 1670343,
        "state": "open",
        "replay_requests": 0,
        "completed_requests": 0,
        "reconnecting": false,
        "inst": "client.19324248 10.8.1.2:0/84053815",
        "client_metadata": {
            "entity_id": "admin",
            "hostname": "kvm2-beta",
            "kernel_version": "4.15.0-rc9+",
            "root": "/"
        }
    }
]
</pre>

MDS took 37 seconds to load all these inodes during recovery. (3 OSDs, SSD disk cluster) 
<pre>
2018-01-26 20:19:22.461 7fffe877d700  1 mds.1.2913760 rejoin_start
2018-01-26 20:19:22.687 7fffe877d700  1 mds.1.2913760 rejoin_joint_start
2018-01-26 20:19:59.913 7fffe3470700  0 log_channel(cluster) log [WRN] : open_snaprealms has:
2018-01-26 20:19:59.913 7fffe3470700  0 log_channel(cluster) log [WRN] :  unconnected snaprealm 0x1000d43381b
2018-01-26 20:19:59.913 7fffe3470700  0 log_channel(cluster) log [WRN] :   client.19324248 snapid 36a101
2018-01-26 20:19:59.913 7fffe3470700  0 log_channel(cluster) log [WRN] :   client.19324254 snapid 36a101
2018-01-26 20:19:59.913 7fffe3470700  1 mds.1.2913760 rejoin_done
</pre>