### PR TITLE
build/ops: deb: drop redundant ceph-common recommends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -206,7 +206,6 @@ Depends: ceph-base (= ${binary:Version}),
          python-flask,
          ${misc:Depends},
          ${shlibs:Depends},
-Recommends: ceph-common,
 Replaces: ceph (<< 10), ceph-test (<< 12.2.2-14)
 Breaks: ceph (<< 10), ceph-test (<< 12.2.2-14)
 Description: monitor server for the ceph storage system
@@ -240,7 +239,6 @@ Depends: ceph-base (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
-Recommends: ceph-common (= ${binary:Version}),
 Replaces: ceph (<< 10), ceph-test (<< 12.2.2-14)
 Breaks: ceph (<< 10), ceph-test (<< 12.2.2-14)
 Description: OSD server for the ceph storage system


### PR DESCRIPTION
Since ceph-common is a hard dependency of ceph-base, packages that
require ceph-base do not need to recommend ceph-common.

Signed-off-by: Nathan Cutler <ncutler@suse.com>