### PR TITLE
build/ops: rpm: recommend chrony instead of ntp-daemon

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -281,7 +281,7 @@ Requires:      util-linux
 Requires:      xfsprogs
 Requires:      which
 %if 0%{?suse_version}
-Recommends:    ntp-daemon
+Recommends:    chrony
 %endif
 %description base
 Base is the package that includes all the files shared amongst ceph servers


### PR DESCRIPTION
References: https://tracker.ceph.com/issues/22751
Signed-off-by: Nathan Cutler <ncutler@suse.com>