### PR TITLE
WIP: os: remove on_applied/on_readable from ObjectStore

### DIFF
--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -760,10 +760,7 @@ static int os_mkdir(const char *path, mode_t mode)
   }
 
   if (!t.empty()) {
-    fs->store->apply_transaction(ch, std::move(t));
-    C_SaferCond waiter;
-    if (!ch->flush_commit(&waiter))
-      waiter.wait();
+    fs->store->queue_transaction(ch, std::move(t));
   }
 
   return 0;
@@ -837,10 +834,7 @@ static int os_create(const char *path, mode_t mode, struct fuse_file_info *fi)
   }
 
   if (!t.empty()) {
-    fs->store->apply_transaction(ch, std::move(t));
-    C_SaferCond waiter;
-    if (!ch->flush_commit(&waiter))
-      waiter.wait();
+    fs->store->queue_transaction(ch, std::move(t));
   }
 
   if (pbl) {
@@ -972,10 +966,7 @@ int os_flush(const char *path, struct fuse_file_info *fi)
     return 0;
   }
 
-  fs->store->apply_transaction(ch, std::move(t));
-  C_SaferCond waiter;
-  if (!ch->flush_commit(&waiter))
-    waiter.wait();
+  fs->store->queue_transaction(ch, std::move(t));
 
   return 0;
 }
@@ -1049,10 +1040,7 @@ static int os_unlink(const char *path)
     return -EPERM;
   }
 
-  fs->store->apply_transaction(ch, std::move(t));
-  C_SaferCond waiter;
-  if (!ch->flush_commit(&waiter))
-    waiter.wait();
+  fs->store->queue_transaction(ch, std::move(t));
 
   return 0;
 }
@@ -1095,10 +1083,7 @@ static int os_truncate(const char *path, off_t size)
   ObjectStore::CollectionHandle ch = fs->store->open_collection(cid);
   ObjectStore::Transaction t;
   t.truncate(cid, oid, size);
-  fs->store->apply_transaction(ch, std::move(t));
-  C_SaferCond waiter;
-  if (!ch->flush_commit(&waiter))
-    waiter.wait();
+  fs->store->queue_transaction(ch, std::move(t));
   return 0;
 }
 

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -250,6 +250,8 @@ static int os_getattr(const char *path, struct stat *stbuf)
   stbuf->st_gid = 0;
   stbuf->st_mode = S_IFREG | 0700;
 
+  auto ch = fs->store->open_collection(cid);
+
   switch (t) {
   case FN_OBJECT_OMAP:
   case FN_OBJECT_ATTR:
@@ -260,7 +262,7 @@ static int os_getattr(const char *path, struct stat *stbuf)
     {
       spg_t pgid;
       if (cid.is_pg(&pgid)) {
-	int bits = fs->store->collection_bits(cid);
+	int bits = fs->store->collection_bits(ch);
 	if (bits >= 0 && !oid.match(bits, pgid.ps())) {
 	  // sorry, not part of this PG
 	  return -ENOENT;
@@ -274,7 +276,7 @@ static int os_getattr(const char *path, struct stat *stbuf)
   case FN_OBJECT_OMAP:
   case FN_OBJECT_ATTR:
   case FN_OBJECT:
-    if (!fs->store->exists(cid, oid))
+    if (!fs->store->exists(ch, oid))
       return -ENOENT;
     // fall-thru
   case FN_ALL:
@@ -293,15 +295,15 @@ static int os_getattr(const char *path, struct stat *stbuf)
     break;
 
   case FN_OBJECT_HASH:
-    if (!fs->store->exists(cid, oid))
+    if (!fs->store->exists(ch, oid))
       return -ENOENT;
     stbuf->st_size = 9;
     return 0;
 
   case FN_HASH_END:
-    if (!fs->store->collection_exists(cid))
+    if (!ch)
       return -ENOENT;
-    if (fs->store->collection_bits(cid) < 0)
+    if (fs->store->collection_bits(ch) < 0)
       return -ENOENT;
     // fall-thru
   case FN_HASH_START:
@@ -310,9 +312,9 @@ static int os_getattr(const char *path, struct stat *stbuf)
 
   case FN_HASH_BITS:
     {
-      if (!fs->store->collection_exists(cid))
+      if (!ch)
 	return -ENOENT;
-      int bits = fs->store->collection_bits(cid);
+      int bits = fs->store->collection_bits(ch);
       if (bits < 0)
 	return -ENOENT;
       char buf[8];
@@ -323,9 +325,9 @@ static int os_getattr(const char *path, struct stat *stbuf)
 
   case FN_OBJECT_DATA:
     {
-      if (!fs->store->exists(cid, oid))
+      if (!fs->store->exists(ch, oid))
 	return -ENOENT;
-      int r = fs->store->stat(cid, oid, stbuf);
+      int r = fs->store->stat(ch, oid, stbuf);
       if (r < 0)
 	return r;
     }
@@ -333,22 +335,22 @@ static int os_getattr(const char *path, struct stat *stbuf)
 
   case FN_OBJECT_OMAP_HEADER:
     {
-      if (!fs->store->exists(cid, oid))
+      if (!fs->store->exists(ch, oid))
 	return -ENOENT;
       bufferlist bl;
-      fs->store->omap_get_header(cid, oid, &bl);
+      fs->store->omap_get_header(ch, oid, &bl);
       stbuf->st_size = bl.length();
     }
     break;
 
   case FN_OBJECT_OMAP_VAL:
     {
-      if (!fs->store->exists(cid, oid))
+      if (!fs->store->exists(ch, oid))
 	return -ENOENT;
       set<string> k;
       k.insert(key);
       map<string,bufferlist> v;
-      fs->store->omap_get_values(cid, oid, k, &v);
+      fs->store->omap_get_values(ch, oid, k, &v);
       if (!v.count(key)) {
 	return -ENOENT;
       }
@@ -358,10 +360,10 @@ static int os_getattr(const char *path, struct stat *stbuf)
 
   case FN_OBJECT_ATTR_VAL:
     {
-      if (!fs->store->exists(cid, oid))
+      if (!fs->store->exists(ch, oid))
 	return -ENOENT;
       bufferptr v;
-      int r = fs->store->getattr(cid, oid, key.c_str(), v);
+      int r = fs->store->getattr(ch, oid, key.c_str(), v);
       if (r == -ENODATA)
 	r = -ENOENT;
       if (r < 0)
@@ -398,6 +400,8 @@ static int os_readdir(const char *path,
 
   std::lock_guard<std::mutex> l(fs->lock);
 
+  auto ch = fs->store->open_collection(cid);
+
   // we can't shift 32 bits or else off_t will go negative
   const int hash_shift = 31;
 
@@ -418,7 +422,7 @@ static int os_readdir(const char *path,
   case FN_COLLECTION:
     {
       filler(buf, "bitwise_hash_start", NULL, 0);
-      if (fs->store->collection_bits(cid) >= 0) {
+      if (fs->store->collection_bits(ch) >= 0) {
 	filler(buf, "bitwise_hash_end", NULL, 0);
 	filler(buf, "bitwise_hash_bits", NULL, 0);
       }
@@ -426,7 +430,7 @@ static int os_readdir(const char *path,
       filler(buf, "by_bitwise_hash", NULL, 0);
       spg_t pgid;
       if (cid.is_pg(&pgid) &&
-	  fs->store->exists(cid, pgid.make_pgmeta_oid())) {
+	  fs->store->exists(ch, pgid.make_pgmeta_oid())) {
 	filler(buf, "pgmeta", NULL, 0);
       }
     }
@@ -476,7 +480,7 @@ static int os_readdir(const char *path,
       while (true) {
 	vector<ghobject_t> ls;
 	int r = fs->store->collection_list(
-	  cid, next, last, 1000, &ls, &next);
+	  ch, next, last, 1000, &ls, &next);
 	if (r < 0)
 	  return r;
 	for (auto p : ls) {
@@ -508,7 +512,7 @@ static int os_readdir(const char *path,
   case FN_OBJECT_OMAP:
     {
       set<string> keys;
-      fs->store->omap_get_keys(cid, oid, &keys);
+      fs->store->omap_get_keys(ch, oid, &keys);
       unsigned skip = offset;
       for (auto k : keys) {
 	if (skip) {
@@ -526,7 +530,7 @@ static int os_readdir(const char *path,
   case FN_OBJECT_ATTR:
     {
       map<string,bufferptr> aset;
-      fs->store->getattrs(cid, oid, aset);
+      fs->store->getattrs(ch, oid, aset);
       unsigned skip = offset;
       for (auto a : aset) {
 	if (skip) {
@@ -560,6 +564,8 @@ static int os_open(const char *path, struct fuse_file_info *fi)
 
   std::lock_guard<std::mutex> l(fs->lock);
 
+  auto ch = fs->store->open_collection(cid);
+
   bufferlist *pbl = 0;
   switch (t) {
   case FN_TYPE:
@@ -589,7 +595,7 @@ static int os_open(const char *path, struct fuse_file_info *fi)
       spg_t pgid;
       unsigned long h;
       if (cid.is_pg(&pgid)) {
-	int hash_bits = fs->store->collection_bits(cid);
+	int hash_bits = fs->store->collection_bits(ch);
 	if (hash_bits >= 0) {
 	  uint64_t rev_start = hobject_t::_reverse_bits(pgid.ps());
 	  uint64_t rev_end = (rev_start | (0xffffffff >> hash_bits));
@@ -609,7 +615,7 @@ static int os_open(const char *path, struct fuse_file_info *fi)
 
   case FN_HASH_BITS:
     {
-      int r = fs->store->collection_bits(cid);
+      int r = fs->store->collection_bits(ch);
       if (r < 0)
         return r;
       char buf[8];
@@ -634,7 +640,7 @@ static int os_open(const char *path, struct fuse_file_info *fi)
       int r = fs->open_file(
 	path, fi,
 	[&](bufferlist *pbl) {
-	  return fs->store->read(cid, oid, 0, 0, *pbl);
+	  return fs->store->read(ch, oid, 0, 0, *pbl);
 	});
       if (r < 0) {
         return r;
@@ -648,7 +654,7 @@ static int os_open(const char *path, struct fuse_file_info *fi)
 	path, fi,
 	[&](bufferlist *pbl) {
 	  bufferptr bp;
-	  int r = fs->store->getattr(cid, oid, key.c_str(), bp);
+	  int r = fs->store->getattr(ch, oid, key.c_str(), bp);
 	  if (r < 0)
 	    return r;
 	  pbl->append(bp);
@@ -667,7 +673,7 @@ static int os_open(const char *path, struct fuse_file_info *fi)
 	  set<string> k;
 	  k.insert(key);
 	  map<string,bufferlist> v;
-	  int r = fs->store->omap_get_values(cid, oid, k, &v);
+	  int r = fs->store->omap_get_values(ch, oid, k, &v);
 	  if (r < 0)
 	    return r;
 	  *pbl = v[key];
@@ -683,7 +689,7 @@ static int os_open(const char *path, struct fuse_file_info *fi)
       int r = fs->open_file(
 	path, fi,
 	[&](bufferlist *pbl) {
-	  return fs->store->omap_get_header(cid, oid, pbl);
+	  return fs->store->omap_get_header(ch, oid, pbl);
 	});
       if (r < 0)
        return r;
@@ -723,7 +729,7 @@ static int os_mkdir(const char *path, mode_t mode)
     {
       spg_t pgid;
       if (cid.is_pg(&pgid)) {
-	int bits = fs->store->collection_bits(cid);
+	int bits = fs->store->collection_bits(ch);
 	if (bits >= 0 && !oid.match(bits, pgid.ps())) {
 	  // sorry, not part of this PG
 	  return -EINVAL;
@@ -795,7 +801,7 @@ static int os_create(const char *path, mode_t mode, struct fuse_file_info *fi)
   case FN_OBJECT_DATA:
     {
       pbl = new bufferlist;
-      fs->store->read(cid, oid, 0, 0, *pbl);
+      fs->store->read(ch, oid, 0, 0, *pbl);
     }
     break;
 
@@ -803,7 +809,7 @@ static int os_create(const char *path, mode_t mode, struct fuse_file_info *fi)
     {
       pbl = new bufferlist;
       bufferptr bp;
-      int r = fs->store->getattr(cid, oid, key.c_str(), bp);
+      int r = fs->store->getattr(ch, oid, key.c_str(), bp);
       if (r == -ENODATA) {
 	bufferlist empty;
 	t.setattr(cid, oid, key.c_str(), empty);
@@ -818,7 +824,7 @@ static int os_create(const char *path, mode_t mode, struct fuse_file_info *fi)
       set<string> k;
       k.insert(key);
       map<string,bufferlist> v;
-      fs->store->omap_get_values(cid, oid, k, &v);
+      fs->store->omap_get_values(ch, oid, k, &v);
       if (v.count(key) == 0) {
 	map<string,bufferlist> aset;
 	aset[key] = bufferlist();
@@ -1024,7 +1030,7 @@ static int os_unlink(const char *path)
   case FN_COLLECTION:
     {
       bool empty;
-      int r = fs->store->collection_empty(cid, &empty);
+      int r = fs->store->collection_empty(ch, &empty);
       if (r < 0)
         return r;
       if (!empty)

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -155,17 +155,12 @@ int ObjectStore::read_meta(const std::string& key,
 
 
 
-ostream& operator<<(ostream& out, const ObjectStore::Sequencer& s)
-{
-  return out << "osr(" << s.get_name() << " " << &s << ")";
-}
-
 ostream& operator<<(ostream& out, const ObjectStore::Transaction& tx) {
 
   return out << "Transaction(" << &tx << ")"; 
 }
 
-unsigned ObjectStore::apply_transactions(Sequencer *osr,
+unsigned ObjectStore::apply_transactions(CollectionHandle& ch,
 					 vector<Transaction>& tls,
 					 Context *ondisk)
 {
@@ -176,7 +171,7 @@ unsigned ObjectStore::apply_transactions(Sequencer *osr,
   bool done;
   C_SafeCond *onreadable = new C_SafeCond(&my_lock, &my_cond, &done, &r);
 
-  queue_transactions(osr, tls, onreadable, ondisk);
+  queue_transactions(ch, tls, onreadable, ondisk);
 
   my_lock.Lock();
   while (!done)
@@ -186,7 +181,7 @@ unsigned ObjectStore::apply_transactions(Sequencer *osr,
 }
 
 int ObjectStore::queue_transactions(
-  Sequencer *osr,
+  CollectionHandle& ch,
   vector<Transaction>& tls,
   Context *onreadable,
   Context *oncommit,
@@ -199,6 +194,6 @@ int ObjectStore::queue_transactions(
     onreadable, _complete);
   Context *_oncommit = new Wrapper<RunOnDeleteRef>(
     oncommit, _complete);
-  return queue_transactions(osr, tls, _onreadable, _oncommit,
+  return queue_transactions(ch, tls, _onreadable, _oncommit,
 			    onreadable_sync, op);
 }

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -159,27 +159,6 @@ ostream& operator<<(ostream& out, const ObjectStore::Transaction& tx) {
 
   return out << "Transaction(" << &tx << ")"; 
 }
-
-unsigned ObjectStore::apply_transactions(CollectionHandle& ch,
-					 vector<Transaction>& tls,
-					 Context *ondisk)
-{
-  // use op pool
-  Cond my_cond;
-  Mutex my_lock("ObjectStore::apply_transaction::my_lock");
-  int r = 0;
-  bool done;
-  C_SafeCond *onreadable = new C_SafeCond(&my_lock, &my_cond, &done, &r);
-
-  queue_transactions(ch, tls, onreadable, ondisk);
-
-  my_lock.Lock();
-  while (!done)
-    my_cond.Wait(my_lock);
-  my_lock.Unlock();
-  return r;
-}
-
 int ObjectStore::queue_transactions(
   CollectionHandle& ch,
   vector<Transaction>& tls,

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -159,20 +159,3 @@ ostream& operator<<(ostream& out, const ObjectStore::Transaction& tx) {
 
   return out << "Transaction(" << &tx << ")"; 
 }
-int ObjectStore::queue_transactions(
-  CollectionHandle& ch,
-  vector<Transaction>& tls,
-  Context *onreadable,
-  Context *oncommit,
-  Context *onreadable_sync,
-  Context *oncomplete,
-  TrackedOpRef op = TrackedOpRef())
-{
-  RunOnDeleteRef _complete (std::make_shared<RunOnDelete>(oncomplete));
-  Context *_onreadable = new Wrapper<RunOnDeleteRef>(
-    onreadable, _complete);
-  Context *_oncommit = new Wrapper<RunOnDeleteRef>(
-    oncommit, _complete);
-  return queue_transactions(ch, tls, _onreadable, _oncommit,
-			    onreadable_sync, op);
-}

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1655,10 +1655,7 @@ public:
    * @param oid oid of object
    * @returns true if object exists, false otherwise
    */
-  virtual bool exists(const coll_t& cid, const ghobject_t& oid) = 0; // useful?
-  virtual bool exists(CollectionHandle& c, const ghobject_t& oid) {
-    return exists(c->get_cid(), oid);
-  }
+  virtual bool exists(CollectionHandle& c, const ghobject_t& oid) = 0;
   /**
    * set_collection_opts -- set pool options for a collectioninformation for an object
    *
@@ -1667,7 +1664,7 @@ public:
    * @returns 0 on success, negative error code on failure.
    */
   virtual int set_collection_opts(
-    const coll_t& cid,
+    CollectionHandle& c,
     const pool_opts_t& opts) = 0;
 
   /**
@@ -1680,18 +1677,10 @@ public:
    * @returns 0 on success, negative error code on failure.
    */
   virtual int stat(
-    const coll_t& cid,
-    const ghobject_t& oid,
-    struct stat *st,
-    bool allow_eio = false) = 0; // struct stat?
-  virtual int stat(
     CollectionHandle &c,
     const ghobject_t& oid,
     struct stat *st,
-    bool allow_eio = false) {
-    return stat(c->get_cid(), oid, st, allow_eio);
-  }
-
+    bool allow_eio = false) = 0;
   /**
    * read -- read a byte range of data from an object
    *
@@ -1707,21 +1696,12 @@ public:
    * @returns number of bytes read on success, or negative error code on failure.
    */
    virtual int read(
-    const coll_t& cid,
-    const ghobject_t& oid,
-    uint64_t offset,
-    size_t len,
-    bufferlist& bl,
-    uint32_t op_flags = 0) = 0;
-   virtual int read(
      CollectionHandle &c,
      const ghobject_t& oid,
      uint64_t offset,
      size_t len,
      bufferlist& bl,
-     uint32_t op_flags = 0) {
-     return read(c->get_cid(), oid, offset, len, bl, op_flags);
-   }
+     uint32_t op_flags = 0) = 0;
 
   /**
    * fiemap -- get extent map of data of an object
@@ -1739,19 +1719,10 @@ public:
    * @param bl output bufferlist for extent map information.
    * @returns 0 on success, negative error code on failure.
    */
-   virtual int fiemap(const coll_t& cid, const ghobject_t& oid,
- 		     uint64_t offset, size_t len, bufferlist& bl) = 0;
-   virtual int fiemap(const coll_t& cid, const ghobject_t& oid,
- 		     uint64_t offset, size_t len,
- 		     map<uint64_t, uint64_t>& destmap) = 0;
    virtual int fiemap(CollectionHandle& c, const ghobject_t& oid,
- 		     uint64_t offset, size_t len, bufferlist& bl) {
-     return fiemap(c->get_cid(), oid, offset, len, bl);
-   }
+		      uint64_t offset, size_t len, bufferlist& bl) = 0;
    virtual int fiemap(CollectionHandle& c, const ghobject_t& oid,
- 		     uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) {
-     return fiemap(c->get_cid(), oid, offset, len, destmap);
-   }
+		      uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) = 0;
 
   /**
    * getattr -- get an xattr of an object
@@ -1762,12 +1733,8 @@ public:
    * @param value place to put output result.
    * @returns 0 on success, negative error code on failure.
    */
-  virtual int getattr(const coll_t& cid, const ghobject_t& oid,
-		      const char *name, bufferptr& value) = 0;
   virtual int getattr(CollectionHandle &c, const ghobject_t& oid,
-		      const char *name, bufferptr& value) {
-    return getattr(c->get_cid(), oid, name, value);
-  }
+		      const char *name, bufferptr& value) = 0;
 
   /**
    * getattr -- get an xattr of an object
@@ -1778,21 +1745,6 @@ public:
    * @param value place to put output result.
    * @returns 0 on success, negative error code on failure.
    */
-  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name, bufferlist& value) {
-    bufferptr bp;
-    int r = getattr(cid, oid, name, bp);
-    if (bp.length())
-      value.push_back(bp);
-    return r;
-  }
-  int getattr(
-    coll_t cid, const ghobject_t& oid,
-    const string& name, bufferlist& value) {
-    bufferptr bp;
-    int r = getattr(cid, oid, name.c_str(), bp);
-    value.push_back(bp);
-    return r;
-  }
   int getattr(
     CollectionHandle &c, const ghobject_t& oid,
     const string& name, bufferlist& value) {
@@ -1810,12 +1762,8 @@ public:
    * @param aset place to put output result.
    * @returns 0 on success, negative error code on failure.
    */
-  virtual int getattrs(const coll_t& cid, const ghobject_t& oid,
-		       map<string,bufferptr>& aset) = 0;
   virtual int getattrs(CollectionHandle &c, const ghobject_t& oid,
-		       map<string,bufferptr>& aset) {
-    return getattrs(c->get_cid(), oid, aset);
-  }
+		       map<string,bufferptr>& aset) = 0;
 
   /**
    * getattrs -- get all of the xattrs of an object
@@ -1825,16 +1773,6 @@ public:
    * @param aset place to put output result.
    * @returns 0 on success, negative error code on failure.
    */
-  int getattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferlist>& aset) {
-    map<string,bufferptr> bmap;
-    int r = getattrs(cid, oid, bmap);
-    for (map<string,bufferptr>::iterator i = bmap.begin();
-	i != bmap.end();
-	++i) {
-      aset[i->first].append(i->second);
-    }
-    return r;
-  }
   int getattrs(CollectionHandle &c, const ghobject_t& oid,
 	       map<string,bufferlist>& aset) {
     map<string,bufferptr> bmap;
@@ -1873,7 +1811,7 @@ public:
    * @param empty true if the specified collection is empty, false otherwise
    * @returns 0 on success, negative error code on failure.
    */
-  virtual int collection_empty(const coll_t& c, bool *empty) = 0;
+  virtual int collection_empty(CollectionHandle& c, bool *empty) = 0;
 
   /**
    * return the number of significant bits of the coll_t::pgid.
@@ -1882,7 +1820,7 @@ public:
    * set.  A legacy backend may return -EAGAIN if the value is unavailable
    * (because we upgraded from an older version, e.g., FileStore).
    */
-  virtual int collection_bits(const coll_t& c) = 0;
+  virtual int collection_bits(CollectionHandle& c) = 0;
 
 
   /**
@@ -1897,96 +1835,51 @@ public:
    * @param next [out] next item sorts >= this value
    * @return zero on success, or negative error
    */
-  virtual int collection_list(const coll_t& c,
-			      const ghobject_t& start, const ghobject_t& end,
-			      int max,
-			      vector<ghobject_t> *ls, ghobject_t *next) = 0;
   virtual int collection_list(CollectionHandle &c,
 			      const ghobject_t& start, const ghobject_t& end,
 			      int max,
-			      vector<ghobject_t> *ls, ghobject_t *next) {
-    return collection_list(c->get_cid(), start, end, max, ls, next);
-  }
+			      vector<ghobject_t> *ls, ghobject_t *next) = 0;
 
 
   /// OMAP
   /// Get omap contents
   virtual int omap_get(
-    const coll_t& c,                ///< [in] Collection containing oid
-    const ghobject_t &oid,   ///< [in] Object containing omap
-    bufferlist *header,      ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
-    ) = 0;
-  virtual int omap_get(
     CollectionHandle &c,     ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     map<string, bufferlist> *out /// < [out] Key to value map
-    ) {
-    return omap_get(c->get_cid(), oid, header, out);
-  }
+    ) = 0;
 
   /// Get omap header
   virtual int omap_get_header(
-    const coll_t& c,                ///< [in] Collection containing oid
-    const ghobject_t &oid,   ///< [in] Object containing omap
-    bufferlist *header,      ///< [out] omap header
-    bool allow_eio = false ///< [in] don't assert on eio
-    ) = 0;
-  virtual int omap_get_header(
     CollectionHandle &c,     ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     bool allow_eio = false ///< [in] don't assert on eio
-    ) {
-    return omap_get_header(c->get_cid(), oid, header, allow_eio);
-  }
+    ) = 0;
 
   /// Get keys defined on oid
-  virtual int omap_get_keys(
-    const coll_t& c,              ///< [in] Collection containing oid
-    const ghobject_t &oid, ///< [in] Object containing omap
-    set<string> *keys      ///< [out] Keys defined on oid
-    ) = 0;
   virtual int omap_get_keys(
     CollectionHandle &c,   ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
     set<string> *keys      ///< [out] Keys defined on oid
-    ) {
-    return omap_get_keys(c->get_cid(), oid, keys);
-  }
+    ) = 0;
 
   /// Get key values
-  virtual int omap_get_values(
-    const coll_t& c,                    ///< [in] Collection containing oid
-    const ghobject_t &oid,       ///< [in] Object containing omap
-    const set<string> &keys,     ///< [in] Keys to get
-    map<string, bufferlist> *out ///< [out] Returned keys and values
-    ) = 0;
   virtual int omap_get_values(
     CollectionHandle &c,         ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
     map<string, bufferlist> *out ///< [out] Returned keys and values
-    ) {
-    return omap_get_values(c->get_cid(), oid, keys, out);
-  }
+    ) = 0;
 
   /// Filters keys into out which are defined on oid
-  virtual int omap_check_keys(
-    const coll_t& c,                ///< [in] Collection containing oid
-    const ghobject_t &oid,   ///< [in] Object containing omap
-    const set<string> &keys, ///< [in] Keys to check
-    set<string> *out         ///< [out] Subset of keys defined on oid
-    ) = 0;
   virtual int omap_check_keys(
     CollectionHandle &c,     ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     const set<string> &keys, ///< [in] Keys to check
     set<string> *out         ///< [out] Subset of keys defined on oid
-    ) {
-    return omap_check_keys(c->get_cid(), oid, keys, out);
-  }
+    ) = 0;
 
   /**
    * Returns an object map iterator
@@ -1998,15 +1891,9 @@ public:
    * @return iterator, null on error
    */
   virtual ObjectMap::ObjectMapIterator get_omap_iterator(
-    const coll_t& c,              ///< [in] collection
-    const ghobject_t &oid  ///< [in] object
-    ) = 0;
-  virtual ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle &c,   ///< [in] collection
     const ghobject_t &oid  ///< [in] object
-    ) {
-    return get_omap_iterator(c->get_cid(), oid);
-  }
+    ) = 0;
 
   virtual int flush_journal() { return -EOPNOTSUPP; }
 

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -504,6 +504,11 @@ public:
     Transaction(const Transaction& other) = default;
     Transaction& operator=(const Transaction& other) = default;
 
+    // expose object_index for FileStore::Op's benefit
+    const map<ghobject_t, __le32>& get_object_index() const {
+      return object_index;
+    }
+
     /* Operations on callback contexts */
     void register_on_applied(Context *c) {
       if (!c) return;

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1434,25 +1434,12 @@ public:
     static void generate_test_instances(list<Transaction*>& o);
   };
 
-  int queue_transaction(CollectionHandle& ch, Transaction&& t, Context *onreadable, Context *ondisk=0,
-				Context *onreadable_sync=0,
-				TrackedOpRef op = TrackedOpRef(),
-				ThreadPool::TPHandle *handle = NULL) {
+  int queue_transaction(CollectionHandle& ch,
+			Transaction&& t,
+			TrackedOpRef op = TrackedOpRef(),
+			ThreadPool::TPHandle *handle = NULL) {
     vector<Transaction> tls;
     tls.push_back(std::move(t));
-    return queue_transactions(ch, tls, onreadable, ondisk, onreadable_sync,
-	                      op, handle);
-  }
-
-  int queue_transactions(CollectionHandle& ch, vector<Transaction>& tls,
-			 Context *onreadable, Context *ondisk=0,
-			 Context *onreadable_sync=0,
-			 TrackedOpRef op = TrackedOpRef(),
-			 ThreadPool::TPHandle *handle = NULL) {
-    assert(!tls.empty());
-    tls.back().register_on_applied(onreadable);
-    tls.back().register_on_commit(ondisk);
-    tls.back().register_on_applied_sync(onreadable_sync);
     return queue_transactions(ch, tls, op, handle);
   }
 
@@ -1461,30 +1448,6 @@ public:
     TrackedOpRef op = TrackedOpRef(),
     ThreadPool::TPHandle *handle = NULL) = 0;
 
-
-  int queue_transactions(
-    CollectionHandle& ch,
-    vector<Transaction>& tls,
-    Context *onreadable,
-    Context *oncommit,
-    Context *onreadable_sync,
-    Context *oncomplete,
-    TrackedOpRef op);
-
-  int queue_transaction(
-    CollectionHandle& ch,
-    Transaction&& t,
-    Context *onreadable,
-    Context *oncommit,
-    Context *onreadable_sync,
-    Context *oncomplete,
-    TrackedOpRef op) {
-
-    vector<Transaction> tls;
-    tls.push_back(std::move(t));
-    return queue_transactions(
-      ch, tls, onreadable, oncommit, onreadable_sync, oncomplete, op);
-  }
 
  public:
   ObjectStore(CephContext* cct,

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1434,14 +1434,6 @@ public:
     static void generate_test_instances(list<Transaction*>& o);
   };
 
-  // synchronous wrappers
-  unsigned apply_transaction(CollectionHandle& ch, Transaction&& t, Context *ondisk=0) {
-    vector<Transaction> tls;
-    tls.push_back(std::move(t));
-    return apply_transactions(ch, tls, ondisk);
-  }
-  unsigned apply_transactions(CollectionHandle& ch, vector<Transaction>& tls, Context *ondisk=0);
-
   int queue_transaction(CollectionHandle& ch, Transaction&& t, Context *onreadable, Context *ondisk=0,
 				Context *onreadable_sync=0,
 				TrackedOpRef op = TrackedOpRef(),

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8986,14 +8986,14 @@ int BlueStore::queue_transactions(
   ThreadPool::TPHandle *handle)
 {
   FUNCTRACE(cct);
-  list<Context *> on_applied, on_commit, on_applied_sync;
+  list<Context *> on_applied, on_commit;
   ObjectStore::Transaction::collect_contexts(
-    tls, &on_applied, &on_commit, &on_applied_sync);
+    tls, &on_applied, &on_commit);
 
   if (cct->_conf->objectstore_blackhole) {
     dout(0) << __func__ << " objectstore_blackhole = TRUE, dropping transaction"
 	    << dendl;
-    for (auto& l : { on_applied, on_commit, on_applied_sync }) {
+    for (auto& l : { on_applied, on_commit }) {
       for (auto c : l) {
 	delete c;
       }
@@ -9062,9 +9062,6 @@ int BlueStore::queue_transactions(
   _txc_state_proc(txc);
 
   // we're immediately readable (unlike FileStore)
-  for (auto c : on_applied_sync) {
-    c->complete(0);
-  }
   for (auto c : on_applied) {
     // NOTE: these may complete out of order since some may be sync and some
     // may be async.

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6514,14 +6514,6 @@ ObjectStore::CollectionHandle BlueStore::create_new_collection(
   return c;
 }
 
-bool BlueStore::exists(const coll_t& cid, const ghobject_t& oid)
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return false;
-  return exists(c, oid);
-}
-
 bool BlueStore::exists(CollectionHandle &c_, const ghobject_t& oid)
 {
   Collection *c = static_cast<Collection *>(c_.get());
@@ -6539,18 +6531,6 @@ bool BlueStore::exists(CollectionHandle &c_, const ghobject_t& oid)
   }
 
   return r;
-}
-
-int BlueStore::stat(
-    const coll_t& cid,
-    const ghobject_t& oid,
-    struct stat *st,
-    bool allow_eio)
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return stat(c, oid, st, allow_eio);
 }
 
 int BlueStore::stat(
@@ -6583,33 +6563,16 @@ int BlueStore::stat(
   return r;
 }
 int BlueStore::set_collection_opts(
-  const coll_t& cid,
+  CollectionHandle& ch,
   const pool_opts_t& opts)
 {
-  CollectionHandle ch = _get_collection(cid);
-  if (!ch)
-    return -ENOENT;
   Collection *c = static_cast<Collection *>(ch.get());
-  dout(15) << __func__ << " " << cid << " options " << opts << dendl;
+  dout(15) << __func__ << " " << ch->cid << " options " << opts << dendl;
   if (!c->exists)
     return -ENOENT;
   RWLock::WLocker l(c->lock);
   c->pool_opts = opts;
   return 0;
-}
-
-int BlueStore::read(
-  const coll_t& cid,
-  const ghobject_t& oid,
-  uint64_t offset,
-  size_t length,
-  bufferlist& bl,
-  uint32_t op_flags)
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return read(c, oid, offset, length, bl, op_flags);
 }
 
 int BlueStore::read(
@@ -7119,19 +7082,6 @@ int BlueStore::_fiemap(
 }
 
 int BlueStore::fiemap(
-  const coll_t& cid,
-  const ghobject_t& oid,
-  uint64_t offset,
-  size_t len,
-  bufferlist& bl)
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return fiemap(c, oid, offset, len, bl);
-}
-
-int BlueStore::fiemap(
   CollectionHandle &c_,
   const ghobject_t& oid,
   uint64_t offset,
@@ -7147,19 +7097,6 @@ int BlueStore::fiemap(
 }
 
 int BlueStore::fiemap(
-  const coll_t& cid,
-  const ghobject_t& oid,
-  uint64_t offset,
-  size_t len,
-  map<uint64_t, uint64_t>& destmap)
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return fiemap(c, oid, offset, len, destmap);
-}
-
-int BlueStore::fiemap(
   CollectionHandle &c_,
   const ghobject_t& oid,
   uint64_t offset,
@@ -7172,18 +7109,6 @@ int BlueStore::fiemap(
     m.move_into(destmap);
   }
   return r;
-}
-
-int BlueStore::getattr(
-  const coll_t& cid,
-  const ghobject_t& oid,
-  const char *name,
-  bufferptr& value)
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return getattr(c, oid, name, value);
 }
 
 int BlueStore::getattr(
@@ -7223,18 +7148,6 @@ int BlueStore::getattr(
   dout(10) << __func__ << " " << c->cid << " " << oid << " " << name
 	   << " = " << r << dendl;
   return r;
-}
-
-
-int BlueStore::getattrs(
-  const coll_t& cid,
-  const ghobject_t& oid,
-  map<string,bufferptr>& aset)
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return getattrs(c, oid, aset);
 }
 
 int BlueStore::getattrs(
@@ -7288,12 +7201,12 @@ bool BlueStore::collection_exists(const coll_t& c)
   return coll_map.count(c);
 }
 
-int BlueStore::collection_empty(const coll_t& cid, bool *empty)
+int BlueStore::collection_empty(CollectionHandle& ch, bool *empty)
 {
-  dout(15) << __func__ << " " << cid << dendl;
+  dout(15) << __func__ << " " << ch->cid << dendl;
   vector<ghobject_t> ls;
   ghobject_t next;
-  int r = collection_list(cid, ghobject_t(), ghobject_t::get_max(), 1,
+  int r = collection_list(ch, ghobject_t(), ghobject_t::get_max(), 1,
 			  &ls, &next);
   if (r < 0) {
     derr << __func__ << " collection_list returned: " << cpp_strerror(r)
@@ -7301,29 +7214,17 @@ int BlueStore::collection_empty(const coll_t& cid, bool *empty)
     return r;
   }
   *empty = ls.empty();
-  dout(10) << __func__ << " " << cid << " = " << (int)(*empty) << dendl;
+  dout(10) << __func__ << " " << ch->cid << " = " << (int)(*empty) << dendl;
   return 0;
 }
 
-int BlueStore::collection_bits(const coll_t& cid)
+int BlueStore::collection_bits(CollectionHandle& ch)
 {
-  dout(15) << __func__ << " " << cid << dendl;
-  CollectionRef c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
+  dout(15) << __func__ << " " << ch->cid << dendl;
+  Collection *c = static_cast<Collection*>(ch.get());
   RWLock::RLocker l(c->lock);
-  dout(10) << __func__ << " " << cid << " = " << c->cnode.bits << dendl;
+  dout(10) << __func__ << " " << ch->cid << " = " << c->cnode.bits << dendl;
   return c->cnode.bits;
-}
-
-int BlueStore::collection_list(
-  const coll_t& cid, const ghobject_t& start, const ghobject_t& end, int max,
-  vector<ghobject_t> *ls, ghobject_t *pnext)
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return collection_list(c, start, end, max, ls, pnext);
 }
 
 int BlueStore::collection_list(
@@ -7458,19 +7359,6 @@ out:
 }
 
 int BlueStore::omap_get(
-  const coll_t& cid,                ///< [in] Collection containing oid
-  const ghobject_t &oid,   ///< [in] Object containing omap
-  bufferlist *header,      ///< [out] omap header
-  map<string, bufferlist> *out /// < [out] Key to value map
-  )
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return omap_get(c, oid, header, out);
-}
-
-int BlueStore::omap_get(
   CollectionHandle &c_,    ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
   bufferlist *header,      ///< [out] omap header
@@ -7523,19 +7411,6 @@ int BlueStore::omap_get(
 }
 
 int BlueStore::omap_get_header(
-  const coll_t& cid,                ///< [in] Collection containing oid
-  const ghobject_t &oid,   ///< [in] Object containing omap
-  bufferlist *header,      ///< [out] omap header
-  bool allow_eio ///< [in] don't assert on eio
-  )
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return omap_get_header(c, oid, header, allow_eio);
-}
-
-int BlueStore::omap_get_header(
   CollectionHandle &c_,                ///< [in] Collection containing oid
   const ghobject_t &oid,   ///< [in] Object containing omap
   bufferlist *header,      ///< [out] omap header
@@ -7570,18 +7445,6 @@ int BlueStore::omap_get_header(
   dout(10) << __func__ << " " << c->get_cid() << " oid " << oid << " = " << r
 	   << dendl;
   return r;
-}
-
-int BlueStore::omap_get_keys(
-  const coll_t& cid,              ///< [in] Collection containing oid
-  const ghobject_t &oid, ///< [in] Object containing omap
-  set<string> *keys      ///< [out] Keys defined on oid
-  )
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return omap_get_keys(c, oid, keys);
 }
 
 int BlueStore::omap_get_keys(
@@ -7632,19 +7495,6 @@ int BlueStore::omap_get_keys(
 }
 
 int BlueStore::omap_get_values(
-  const coll_t& cid,                    ///< [in] Collection containing oid
-  const ghobject_t &oid,       ///< [in] Object containing omap
-  const set<string> &keys,     ///< [in] Keys to get
-  map<string, bufferlist> *out ///< [out] Returned keys and values
-  )
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return omap_get_values(c, oid, keys, out);
-}
-
-int BlueStore::omap_get_values(
   CollectionHandle &c_,        ///< [in] Collection containing oid
   const ghobject_t &oid,       ///< [in] Object containing omap
   const set<string> &keys,     ///< [in] Keys to get
@@ -7686,19 +7536,6 @@ int BlueStore::omap_get_values(
   dout(10) << __func__ << " " << c->get_cid() << " oid " << oid << " = " << r
 	   << dendl;
   return r;
-}
-
-int BlueStore::omap_check_keys(
-  const coll_t& cid,                ///< [in] Collection containing oid
-  const ghobject_t &oid,   ///< [in] Object containing omap
-  const set<string> &keys, ///< [in] Keys to check
-  set<string> *out         ///< [out] Subset of keys defined on oid
-  )
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c)
-    return -ENOENT;
-  return omap_check_keys(c, oid, keys, out);
 }
 
 int BlueStore::omap_check_keys(
@@ -7746,19 +7583,6 @@ int BlueStore::omap_check_keys(
   dout(10) << __func__ << " " << c->get_cid() << " oid " << oid << " = " << r
 	   << dendl;
   return r;
-}
-
-ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(
-  const coll_t& cid,              ///< [in] collection
-  const ghobject_t &oid  ///< [in] object
-  )
-{
-  CollectionHandle c = _get_collection(cid);
-  if (!c) {
-    dout(10) << __func__ << " " << cid << "doesn't exist" <<dendl;
-    return ObjectMap::ObjectMapIterator();
-  }
-  return get_omap_iterator(c, oid);
 }
 
 ObjectMap::ObjectMapIterator BlueStore::get_omap_iterator(

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3216,13 +3216,25 @@ void BlueStore::DeferredBatch::_audit(CephContext *cct)
 #define dout_prefix *_dout << "bluestore(" << store->path << ").collection(" << cid << " " << this << ") "
 
 BlueStore::Collection::Collection(BlueStore *ns, Cache *c, coll_t cid)
-  : store(ns),
+  : CollectionImpl(cid),
+    store(ns),
+    osr(new OpSequencer(store)),
     cache(c),
-    cid(cid),
     lock("BlueStore::Collection::lock", true, false),
     exists(true),
     onode_map(c)
 {
+  osr->shard = cid.hash_to_shard(ns->m_finisher_num);
+}
+
+bool BlueStore::Collection::flush_commit(Context *c)
+{
+  return osr->flush_commit(c);
+}
+
+void BlueStore::Collection::flush()
+{
+  osr->flush();
 }
 
 void BlueStore::Collection::open_shared_blob(uint64_t sbid, BlobRef b)
@@ -5631,7 +5643,6 @@ int BlueStore::umount()
   dout(1) << __func__ << dendl;
 
   _osr_drain_all();
-  _osr_unregister_all();
 
   mounted = false;
   if (!_kv_only) {
@@ -6489,6 +6500,18 @@ void BlueStore::_update_cache_logger()
 ObjectStore::CollectionHandle BlueStore::open_collection(const coll_t& cid)
 {
   return _get_collection(cid);
+}
+
+ObjectStore::CollectionHandle BlueStore::create_new_collection(
+  const coll_t& cid)
+{
+  RWLock::WLocker l(coll_lock);
+  Collection *c = new Collection(
+    this,
+    cache_shards[cid.hash_to_shard(cache_shards.size())],
+    cid);
+  new_coll_map[cid] = c;
+  return c;
 }
 
 bool BlueStore::exists(const coll_t& cid, const ghobject_t& oid)
@@ -7994,9 +8017,10 @@ void BlueStore::get_db_statistics(Formatter *f)
   db->get_statistics(f);
 }
 
-BlueStore::TransContext *BlueStore::_txc_create(OpSequencer *osr)
+BlueStore::TransContext *BlueStore::_txc_create(
+  Collection *c, OpSequencer *osr)
 {
-  TransContext *txc = new TransContext(cct, osr);
+  TransContext *txc = new TransContext(cct, c, osr);
   txc->t = db->get_transaction();
   osr->queue_new(txc);
   dout(20) << __func__ << " osr " << osr << " = " << txc
@@ -8416,8 +8440,14 @@ void BlueStore::_txc_finish(TransContext *txc)
   }
 
   if (empty && osr->zombie) {
-    dout(10) << __func__ << " reaping empty zombie osr " << osr << dendl;
-    osr->_unregister();
+    std::lock_guard<std::mutex> l(zombie_osr_lock);
+    auto p = zombie_osr_set.find(osr);
+    if (p != zombie_osr_set.end()) {
+      dout(10) << __func__ << " reaping empty zombie osr " << osr << dendl;
+      zombie_osr_set.erase(p);
+    } else {
+      dout(10) << __func__ << " empty zombie osr " << osr << " already reaped" << dendl;
+    }
   }
 }
 
@@ -8430,6 +8460,14 @@ void BlueStore::_txc_release_alloc(TransContext *txc)
   }
   txc->allocated.clear();
   txc->released.clear();
+}
+
+void BlueStore::_osr_register_zombie(OpSequencer *osr)
+{
+  std::lock_guard<std::mutex> l(zombie_osr_lock);
+  dout(10) << __func__ << " " << osr << dendl;
+  osr->zombie = true;
+  zombie_osr_set.insert(osr);
 }
 
 void BlueStore::_osr_drain_preceding(TransContext *txc)
@@ -8461,9 +8499,19 @@ void BlueStore::_osr_drain_all()
   dout(10) << __func__ << dendl;
 
   set<OpSequencerRef> s;
+  set<OpSequencerRef> zombies;
   {
-    std::lock_guard<std::mutex> l(osr_lock);
-    s = osr_set;
+    RWLock::RLocker l(coll_lock);
+    for (auto& i : coll_map) {
+      s.insert(i.second->osr);
+    }
+  }
+  {
+    std::lock_guard<std::mutex> l(zombie_osr_lock);
+    for (auto& i : zombie_osr_set) {
+      s.insert(i);
+      zombies.insert(i);
+    }
   }
   dout(20) << __func__ << " osr_set " << s << dendl;
 
@@ -8487,34 +8535,23 @@ void BlueStore::_osr_drain_all()
   }
   --deferred_aggressive;
 
+  {
+    std::lock_guard<std::mutex> l(zombie_osr_lock);
+    for (auto& osr : zombies) {
+      auto p = zombie_osr_set.find(osr);
+      if (p != zombie_osr_set.end()) {
+	dout(10) << __func__ << " reaping empty zombie osr " << osr << dendl;
+	zombie_osr_set.erase(p);
+      } else {
+	dout(10) << __func__ << " empty zombie osr " << osr << " already reaped" << dendl;
+      }
+      assert(osr->q.empty());
+    }
+  }
+
   dout(10) << __func__ << " done" << dendl;
 }
 
-void BlueStore::_osr_unregister_all()
-{
-  set<OpSequencerRef> s;
-  {
-    std::lock_guard<std::mutex> l(osr_lock);
-    s = osr_set;
-  }
-  dout(10) << __func__ << " " << s << dendl;
-  for (auto osr : s) {
-    osr->_unregister();
-
-    if (!osr->zombie) {
-      // break link from Sequencer to us so that this OpSequencer
-      // instance can die with this mount/umount cycle.  note that
-      // we assume umount() will not race against ~Sequencer.
-      assert(osr->parent);
-      osr->parent->p.reset();
-    }
-  }
-  // nobody should be creating sequencers during umount either.
-  {
-    std::lock_guard<std::mutex> l(osr_lock);
-    assert(osr_set.empty());
-  }
-}
 
 void BlueStore::_kv_start()
 {
@@ -9071,9 +9108,16 @@ void BlueStore::_deferred_aio_finish(OpSequencer *osr)
 int BlueStore::_deferred_replay()
 {
   dout(10) << __func__ << " start" << dendl;
-  OpSequencerRef osr = new OpSequencer(cct, this);
   int count = 0;
   int r = 0;
+  CollectionRef ch = _get_collection(coll_t::meta());
+  bool fake_ch = false;
+  if (!ch) {
+    // hmm, replaying initial mkfs?
+    ch = static_cast<Collection*>(create_new_collection(coll_t::meta()).get());
+    fake_ch = true;
+  }
+  OpSequencer *osr = static_cast<OpSequencer*>(ch->osr.get());
   KeyValueDB::Iterator it = db->get_iterator(PREFIX_DEFERRED);
   for (it->lower_bound(string()); it->valid(); it->next(), ++count) {
     dout(20) << __func__ << " replay " << pretty_binary_string(it->key())
@@ -9091,15 +9135,18 @@ int BlueStore::_deferred_replay()
       r = -EIO;
       goto out;
     }
-    TransContext *txc = _txc_create(osr.get());
+    TransContext *txc = _txc_create(ch.get(), osr);
     txc->deferred_txn = deferred_txn;
     txc->state = TransContext::STATE_KV_DONE;
     _txc_state_proc(txc);
   }
  out:
   dout(20) << __func__ << " draining osr" << dendl;
+  _osr_register_zombie(osr);
   _osr_drain_all();
-  osr->discard();
+  if (fake_ch) {
+    new_coll_map.clear();
+  }
   dout(10) << __func__ << " completed " << count << " events" << dendl;
   return r;
 }
@@ -9108,10 +9155,10 @@ int BlueStore::_deferred_replay()
 // transactions
 
 int BlueStore::queue_transactions(
-    Sequencer *posr,
-    vector<Transaction>& tls,
-    TrackedOpRef op,
-    ThreadPool::TPHandle *handle)
+  CollectionHandle& ch,
+  vector<Transaction>& tls,
+  TrackedOpRef op,
+  ThreadPool::TPHandle *handle)
 {
   FUNCTRACE(cct);
   list<Context *> on_applied, on_commit, on_applied_sync;
@@ -9129,22 +9176,13 @@ int BlueStore::queue_transactions(
     return 0;
   }
   utime_t start = ceph_clock_now();
-  // set up the sequencer
-  OpSequencer *osr;
-  assert(posr);
-  if (posr->p) {
-    osr = static_cast<OpSequencer *>(posr->p.get());
-    dout(10) << __func__ << " existing " << osr << " " << *osr << dendl;
-  } else {
-    osr = new OpSequencer(cct, this);
-    osr->parent = posr;
-    osr->shard = posr->shard_hint.hash_to_shard(m_finisher_num);
-    posr->p = osr;
-    dout(10) << __func__ << " new " << osr << " " << *osr << dendl;
-  }
+
+  Collection *c = static_cast<Collection*>(ch.get());
+  OpSequencer *osr = c->osr.get();
+  dout(10) << __func__ << " ch " << c << " " << c->cid << dendl;
 
   // prepare
-  TransContext *txc = _txc_create(osr);
+  TransContext *txc = _txc_create(static_cast<Collection*>(ch.get()), osr);
   txc->oncommits.swap(on_commit);
 
   for (vector<Transaction>::iterator p = tls.begin(); p != tls.end(); ++p) {
@@ -11463,13 +11501,12 @@ int BlueStore::_create_collection(
       r = -EEXIST;
       goto out;
     }
-    c->reset(
-      new Collection(
-	this,
-	cache_shards[cid.hash_to_shard(cache_shards.size())],
-	cid));
+    auto p = new_coll_map.find(cid);
+    assert(p != new_coll_map.end());
+    *c = p->second;
     (*c)->cnode.bits = bits;
     coll_map[cid] = *c;
+    new_coll_map.erase(p);
   }
   encode((*c)->cnode, bl);
   txc->t->set(PREFIX_COLL, stringify(cid), bl);
@@ -11531,6 +11568,7 @@ int BlueStore::_remove_collection(TransContext *txc, const coll_t &cid,
         coll_map.erase(cid);
         txc->removed_collections.push_back(*c);
         (*c)->exists = false;
+	_osr_register_zombie((*c)->osr.get());
         c->reset();
         txc->t->rmkey(PREFIX_COLL, stringify(cid));
         r = 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7232,6 +7232,7 @@ int BlueStore::collection_list(
   vector<ghobject_t> *ls, ghobject_t *pnext)
 {
   Collection *c = static_cast<Collection *>(c_.get());
+  c->flush();
   dout(15) << __func__ << " " << c->cid
            << " start " << start << " end " << end << " max " << max << dendl;
   int r;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1337,10 +1337,13 @@ public:
     bool map_any(std::function<bool(OnodeRef)> f);
   };
 
+  class OpSequencer;
+  typedef boost::intrusive_ptr<OpSequencer> OpSequencerRef;
+
   struct Collection : public CollectionImpl {
     BlueStore *store;
+    OpSequencerRef osr;
     Cache *cache;       ///< our cache shard
-    coll_t cid;
     bluestore_cnode_t cnode;
     RWLock lock;
 
@@ -1379,10 +1382,6 @@ public:
       return b;
     }
 
-    const coll_t &get_cid() override {
-      return cid;
-    }
-
     bool contains(const ghobject_t& oid) {
       if (cid.is_meta())
 	return oid.hobj.pool == -1;
@@ -1395,6 +1394,9 @@ public:
     }
 
     void split_cache(Collection *dest);
+
+    bool flush_commit(Context *c) override;
+    void flush() override;
 
     Collection(BlueStore *ns, Cache *ca, coll_t c);
   };
@@ -1417,9 +1419,6 @@ public:
       return 0;
     }
   };
-
-  class OpSequencer;
-  typedef boost::intrusive_ptr<OpSequencer> OpSequencerRef;
 
   struct volatile_statfs{
     enum {
@@ -1547,7 +1546,8 @@ public:
       last_stamp = now;
     }
 
-    OpSequencerRef osr;
+    CollectionRef ch;
+    OpSequencerRef osr;  // this should be ch->osr
     boost::intrusive::list_member_hook<> sequencer_item;
 
     uint64_t bytes = 0, cost = 0;
@@ -1577,8 +1577,9 @@ public:
     uint64_t last_nid = 0;     ///< if non-zero, highest new nid we allocated
     uint64_t last_blobid = 0;  ///< if non-zero, highest new blobid we allocated
 
-    explicit TransContext(CephContext* cct, OpSequencer *o)
-      : osr(o),
+    explicit TransContext(CephContext* cct, Collection *c, OpSequencer *o)
+      : ch(c),
+	osr(o),
 	ioc(cct, this),
 	start(ceph_clock_now()) {
       last_stamp = start;
@@ -1647,7 +1648,7 @@ public:
     }
   };
 
-  class OpSequencer : public Sequencer_impl {
+  class OpSequencer : public RefCountedObject {
   public:
     std::mutex qlock;
     std::condition_variable qcond;
@@ -1664,7 +1665,6 @@ public:
     DeferredBatch *deferred_running = nullptr;
     DeferredBatch *deferred_pending = nullptr;
 
-    Sequencer *parent;
     BlueStore *store;
 
     size_t shard;
@@ -1677,41 +1677,13 @@ public:
 
     std::atomic_int kv_submitted_waiters = {0};
 
-    std::atomic_bool registered = {true}; ///< registered in BlueStore's osr_set
-    std::atomic_bool zombie = {false};    ///< owning Sequencer has gone away
+    std::atomic_bool zombie = {false};    ///< in zombie_osr set (collection going away)
 
-    OpSequencer(CephContext* cct, BlueStore *store)
-      : Sequencer_impl(cct),
-	parent(NULL), store(store) {
-      store->register_osr(this);
+    OpSequencer(BlueStore *store)
+      : store(store) {
     }
-    ~OpSequencer() override {
+    ~OpSequencer() {
       assert(q.empty());
-      _unregister();
-    }
-
-    void discard() override {
-      // Note that we may have txc's in flight when the parent Sequencer
-      // goes away.  Reflect this with zombie==registered==true and let
-      // _osr_drain_all clean up later.
-      assert(!zombie);
-      zombie = true;
-      parent = nullptr;
-      bool empty;
-      {
-	std::lock_guard<std::mutex> l(qlock);
-	empty = q.empty();
-      }
-      if (empty) {
-	_unregister();
-      }
-    }
-
-    void _unregister() {
-      if (registered) {
-	store->unregister_osr(this);
-	registered = false;
-      }
     }
 
     void queue_new(TransContext *txc) {
@@ -1742,7 +1714,7 @@ public:
       return false;
     }
 
-    void flush() override {
+    void flush() {
       std::unique_lock<std::mutex> l(qlock);
       while (true) {
 	// set flag before the check because the condition
@@ -1758,7 +1730,7 @@ public:
       }
     }
 
-    bool flush_commit(Context *c) override {
+    bool flush_commit(Context *c) {
       std::lock_guard<std::mutex> l(qlock);
       if (q.empty()) {
 	return true;
@@ -1839,11 +1811,12 @@ private:
 
   RWLock coll_lock = {"BlueStore::coll_lock"};  ///< rwlock to protect coll_map
   mempool::bluestore_cache_other::unordered_map<coll_t, CollectionRef> coll_map;
+  map<coll_t,CollectionRef> new_coll_map;
 
   vector<Cache*> cache_shards;
 
-  std::mutex osr_lock;              ///< protect osd_set
-  std::set<OpSequencerRef> osr_set; ///< set of all OpSequencers
+  std::mutex zombie_osr_lock;              ///< protect zombie_osr_set
+  std::set<OpSequencerRef> zombie_osr_set; ///< set of OpSequencers for deleted collections
 
   std::atomic<uint64_t> nid_last = {0};
   std::atomic<uint64_t> nid_max = {0};
@@ -2026,7 +1999,7 @@ private:
   void _dump_extent_map(ExtentMap& em, int log_level=30);
   void _dump_transaction(Transaction *t, int log_level = 30);
 
-  TransContext *_txc_create(OpSequencer *osr);
+  TransContext *_txc_create(Collection *c, OpSequencer *osr);
   void _txc_update_store_statfs(TransContext *txc);
   void _txc_add_transaction(TransContext *txc, Transaction *t);
   void _txc_calc_cost(TransContext *txc);
@@ -2045,9 +2018,9 @@ private:
   void _txc_finish(TransContext *txc);
   void _txc_release_alloc(TransContext *txc);
 
+  void _osr_register_zombie(OpSequencer *osr);
   void _osr_drain_preceding(TransContext *txc);
   void _osr_drain_all();
-  void _osr_unregister_all();
 
   void _kv_start();
   void _kv_stop();
@@ -2205,15 +2178,6 @@ public:
     f->close_section();
   }
 
-  void register_osr(OpSequencer *osr) {
-    std::lock_guard<std::mutex> l(osr_lock);
-    osr_set.insert(osr);
-  }
-  void unregister_osr(OpSequencer *osr) {
-    std::lock_guard<std::mutex> l(osr_lock);
-    osr_set.erase(osr);
-  }
-
 public:
   int statfs(struct store_statfs_t *buf) override;
 
@@ -2283,6 +2247,7 @@ public:
   int list_collections(vector<coll_t>& ls) override;
 
   CollectionHandle open_collection(const coll_t &c) override;
+  CollectionHandle create_new_collection(const coll_t& cid) override;
 
   bool collection_exists(const coll_t& c) override;
   int collection_empty(const coll_t& c, bool *empty) override;
@@ -2409,7 +2374,7 @@ public:
   }
 
   int queue_transactions(
-    Sequencer *osr,
+    CollectionHandle& ch,
     vector<Transaction>& tls,
     TrackedOpRef op = TrackedOpRef(),
     ThreadPool::TPHandle *handle = NULL) override;
@@ -2711,10 +2676,6 @@ private:
 			CollectionRef& d,
 			unsigned bits, int rem);
 };
-
-inline ostream& operator<<(ostream& out, const BlueStore::OpSequencer& s) {
-  return out << *s.parent;
-}
 
 static inline void intrusive_ptr_add_ref(BlueStore::Onode *o) {
   o->get();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2183,28 +2183,15 @@ public:
 
   void collect_metadata(map<string,string> *pm) override;
 
-  bool exists(const coll_t& cid, const ghobject_t& oid) override;
   bool exists(CollectionHandle &c, const ghobject_t& oid) override;
   int set_collection_opts(
-    const coll_t& cid,
+    CollectionHandle& c,
     const pool_opts_t& opts) override;
-  int stat(
-    const coll_t& cid,
-    const ghobject_t& oid,
-    struct stat *st,
-    bool allow_eio = false) override;
   int stat(
     CollectionHandle &c,
     const ghobject_t& oid,
     struct stat *st,
     bool allow_eio = false) override;
-  int read(
-    const coll_t& cid,
-    const ghobject_t& oid,
-    uint64_t offset,
-    size_t len,
-    bufferlist& bl,
-    uint32_t op_flags = 0) override;
   int read(
     CollectionHandle &c,
     const ghobject_t& oid,
@@ -2224,23 +2211,15 @@ private:
   int _fiemap(CollectionHandle &c_, const ghobject_t& oid,
  	     uint64_t offset, size_t len, interval_set<uint64_t>& destset);
 public:
-  int fiemap(const coll_t& cid, const ghobject_t& oid,
-	     uint64_t offset, size_t len, bufferlist& bl) override;
   int fiemap(CollectionHandle &c, const ghobject_t& oid,
 	     uint64_t offset, size_t len, bufferlist& bl) override;
-  int fiemap(const coll_t& cid, const ghobject_t& oid,
-	     uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) override;
   int fiemap(CollectionHandle &c, const ghobject_t& oid,
 	     uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) override;
 
 
-  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name,
-	      bufferptr& value) override;
   int getattr(CollectionHandle &c, const ghobject_t& oid, const char *name,
 	      bufferptr& value) override;
 
-  int getattrs(const coll_t& cid, const ghobject_t& oid,
-	       map<string,bufferptr>& aset) override;
   int getattrs(CollectionHandle &c, const ghobject_t& oid,
 	       map<string,bufferptr>& aset) override;
 
@@ -2250,26 +2229,15 @@ public:
   CollectionHandle create_new_collection(const coll_t& cid) override;
 
   bool collection_exists(const coll_t& c) override;
-  int collection_empty(const coll_t& c, bool *empty) override;
-  int collection_bits(const coll_t& c) override;
+  int collection_empty(CollectionHandle& c, bool *empty) override;
+  int collection_bits(CollectionHandle& c) override;
 
-  int collection_list(const coll_t& cid,
-		      const ghobject_t& start,
-		      const ghobject_t& end,
-		      int max,
-		      vector<ghobject_t> *ls, ghobject_t *next) override;
   int collection_list(CollectionHandle &c,
 		      const ghobject_t& start,
 		      const ghobject_t& end,
 		      int max,
 		      vector<ghobject_t> *ls, ghobject_t *next) override;
 
-  int omap_get(
-    const coll_t& cid,                ///< [in] Collection containing oid
-    const ghobject_t &oid,   ///< [in] Object containing omap
-    bufferlist *header,      ///< [out] omap header
-    map<string, bufferlist> *out /// < [out] Key to value map
-    ) override;
   int omap_get(
     CollectionHandle &c,     ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
@@ -2279,12 +2247,6 @@ public:
 
   /// Get omap header
   int omap_get_header(
-    const coll_t& cid,                ///< [in] Collection containing oid
-    const ghobject_t &oid,   ///< [in] Object containing omap
-    bufferlist *header,      ///< [out] omap header
-    bool allow_eio = false ///< [in] don't assert on eio
-    ) override;
-  int omap_get_header(
     CollectionHandle &c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
@@ -2293,23 +2255,12 @@ public:
 
   /// Get keys defined on oid
   int omap_get_keys(
-    const coll_t& cid,              ///< [in] Collection containing oid
-    const ghobject_t &oid, ///< [in] Object containing omap
-    set<string> *keys      ///< [out] Keys defined on oid
-    ) override;
-  int omap_get_keys(
     CollectionHandle &c,              ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
     set<string> *keys      ///< [out] Keys defined on oid
     ) override;
 
   /// Get key values
-  int omap_get_values(
-    const coll_t& cid,                    ///< [in] Collection containing oid
-    const ghobject_t &oid,       ///< [in] Object containing omap
-    const set<string> &keys,     ///< [in] Keys to get
-    map<string, bufferlist> *out ///< [out] Returned keys and values
-    ) override;
   int omap_get_values(
     CollectionHandle &c,         ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
@@ -2319,22 +2270,12 @@ public:
 
   /// Filters keys into out which are defined on oid
   int omap_check_keys(
-    const coll_t& cid,                ///< [in] Collection containing oid
-    const ghobject_t &oid,   ///< [in] Object containing omap
-    const set<string> &keys, ///< [in] Keys to check
-    set<string> *out         ///< [out] Subset of keys defined on oid
-    ) override;
-  int omap_check_keys(
     CollectionHandle &c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     const set<string> &keys, ///< [in] Keys to check
     set<string> *out         ///< [out] Subset of keys defined on oid
     ) override;
 
-  ObjectMap::ObjectMapIterator get_omap_iterator(
-    const coll_t& cid,              ///< [in] collection
-    const ghobject_t &oid  ///< [in] object
-    ) override;
   ObjectMap::ObjectMapIterator get_omap_iterator(
     CollectionHandle &c,   ///< [in] collection
     const ghobject_t &oid  ///< [in] object

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -156,7 +156,7 @@ void FileStore::FSPerfTracker::update_from_perfcounters(
 
 ostream& operator<<(ostream& out, const FileStore::OpSequencer& s)
 {
-  return out << *s.parent;
+  return out << "osr(" << s.cid << ")";
 }
 
 int FileStore::get_cdir(const coll_t& cid, char *s, int len)
@@ -535,6 +535,7 @@ FileStore::FileStore(CephContext* cct, const std::string &base,
   sync_entry_timeo_lock("FileStore::sync_entry_timeo_lock"),
   timer(cct, sync_entry_timeo_lock),
   stop(false), sync_thread(this),
+  coll_lock("FileStore::coll_lock"),
   fdcache(cct),
   wbthrottle(cct),
   next_osr_id(0),
@@ -1929,6 +1930,7 @@ void FileStore::init_temp_collections()
   for (vector<coll_t>::iterator p = ls.begin(); p != ls.end(); ++p) {
     if (p->is_temp())
       continue;
+    coll_map[*p] = new OpSequencer(cct, ++next_osr_id, *p);
     if (p->is_meta())
       continue;
     coll_t temp = p->get_temp();
@@ -2011,6 +2013,25 @@ int FileStore::umount()
 }
 
 
+/// -----------------------------
+
+ObjectStore::CollectionHandle FileStore::open_collection(const coll_t& c)
+{
+  Mutex::Locker l(coll_lock);
+  auto p = coll_map.find(c);
+  if (p == coll_map.end()) {
+    return CollectionHandle();
+  }
+  return p->second;
+}
+
+ObjectStore::CollectionHandle FileStore::create_new_collection(const coll_t& c)
+{
+  Mutex::Locker l(coll_lock);
+  auto *r = new OpSequencer(cct, ++next_osr_id, c);
+  coll_map[c] = r;
+  return r;
+}
 
 
 /// -----------------------------
@@ -2096,7 +2117,7 @@ void FileStore::_do_op(OpSequencer *osr, ThreadPool::TPHandle &handle)
   Op *o = osr->peek_queue();
   o->trace.event("op_apply_start");
   apply_manager.op_apply_start(o->op);
-  dout(5) << __FUNC__ << ": " << o << " seq " << o->op << " " << *osr << "/" << osr->parent << " start" << dendl;
+  dout(5) << __FUNC__ << ": " << o << " seq " << o->op << " " << *osr << " start" << dendl;
   o->trace.event("_do_transactions start");
   int r = _do_transactions(o->tls, o->op, &handle);
   o->trace.event("op_apply_finish");
@@ -2116,7 +2137,7 @@ void FileStore::_finish_op(OpSequencer *osr)
   utime_t lat = ceph_clock_now();
   lat -= o->start;
 
-  dout(10) << __FUNC__ << ": " << o << " seq " << o->op << " " << *osr << "/" << osr->parent << " lat " << lat << dendl;
+  dout(10) << __FUNC__ << ": " << o << " seq " << o->op << " " << *osr << " lat " << lat << dendl;
   osr->apply_lock.Unlock();  // locked in _do_op
   o->trace.event("_finish_op");
 
@@ -2152,7 +2173,7 @@ struct C_JournaledAhead : public Context {
   }
 };
 
-int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
+int FileStore::queue_transactions(CollectionHandle& ch, vector<Transaction>& tls,
 				  TrackedOpRef osd_op,
 				  ThreadPool::TPHandle *handle)
 {
@@ -2175,19 +2196,9 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
   }
 
   utime_t start = ceph_clock_now();
-  // set up the sequencer
-  OpSequencer *osr;
-  assert(posr);
-  if (posr->p) {
-    osr = static_cast<OpSequencer *>(posr->p.get());
-    dout(5) << __FUNC__ << ": existing " << osr << " " << *osr << dendl;
-  } else {
-    osr = new OpSequencer(cct, ++next_osr_id);
-    osr->set_cct(cct);
-    osr->parent = posr;
-    posr->p = osr;
-    dout(5) << __FUNC__ << ": new " << osr << " " << *osr << dendl;
-  }
+
+  OpSequencer *osr = static_cast<OpSequencer*>(ch.get());
+  dout(5) << __FUNC__ << ": osr " << osr << " " << *osr << dendl;
 
   // used to include osr information in tracepoints during transaction apply
   for (vector<Transaction>::iterator i = tls.begin(); i != tls.end(); ++i) {
@@ -2645,7 +2656,8 @@ void FileStore::_do_transaction(
   dout(10) << __FUNC__ << ": on " << &t << dendl;
 
 #ifdef WITH_LTTNG
-  const char *osr_name = t.get_osr() ? static_cast<OpSequencer*>(t.get_osr())->get_name().c_str() : "<NULL>";
+  string osr_name_str = stringify(static_cast<OpSequencer*>(t.get_osr())->cid);
+  const char *osr_name = osr_name_str.c_str();
 #endif
 
   Transaction::iterator i = t.begin();
@@ -5306,6 +5318,11 @@ int FileStore::_destroy_collection(const coll_t& c)
     goto out;
   }
 
+  {
+    Mutex::Locker l(coll_lock);
+    coll_map.erase(c);
+  }
+
  out:
   // destroy parallel temp collection, too
   if (!c.is_meta() && !c.is_temp()) {
@@ -5902,7 +5919,7 @@ void FileStore::dump_transactions(vector<ObjectStore::Transaction>& ls, uint64_t
   unsigned trans_num = 0;
   for (vector<ObjectStore::Transaction>::iterator i = ls.begin(); i != ls.end(); ++i, ++trans_num) {
     m_filestore_dump_fmt.open_object_section("transaction");
-    m_filestore_dump_fmt.dump_string("osr", osr->get_name());
+    m_filestore_dump_fmt.dump_stream("osr") << osr->cid;
     m_filestore_dump_fmt.dump_unsigned("seq", seq);
     m_filestore_dump_fmt.dump_unsigned("trans_num", trans_num);
     (*i).dump(&m_filestore_dump_fmt);

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3206,28 +3206,27 @@ void FileStore::_do_transaction(
 // --------------------
 // objects
 
-bool FileStore::exists(const coll_t& _cid, const ghobject_t& oid)
+bool FileStore::exists(CollectionHandle& ch, const ghobject_t& oid)
 {
-  tracepoint(objectstore, exists_enter, _cid.c_str());
-  const coll_t& cid = !_need_temp_object_collection(_cid, oid) ? _cid : _cid.get_temp();
+  tracepoint(objectstore, exists_enter, ch->cid.c_str());
   struct stat st;
-  bool retval = stat(cid, oid, &st) == 0;
+  bool retval = stat(ch, oid, &st) == 0;
   tracepoint(objectstore, exists_exit, retval);
   return retval;
 }
 
 int FileStore::stat(
-  const coll_t& _cid, const ghobject_t& oid, struct stat *st, bool allow_eio)
+  CollectionHandle& ch, const ghobject_t& oid, struct stat *st, bool allow_eio)
 {
-  tracepoint(objectstore, stat_enter, _cid.c_str());
-  const coll_t& cid = !_need_temp_object_collection(_cid, oid) ? _cid : _cid.get_temp();
+  tracepoint(objectstore, stat_enter, ch->cid.c_str());
+  const coll_t& cid = !_need_temp_object_collection(ch->cid, oid) ? ch->cid : ch->cid.get_temp();
   int r = lfn_stat(cid, oid, st);
   assert(allow_eio || !m_filestore_fail_eio || r != -EIO);
   if (r < 0) {
-    dout(10) << __FUNC__ << ": " << cid << "/" << oid
+    dout(10) << __FUNC__ << ": " << ch->cid << "/" << oid
 	     << " = " << r << dendl;
   } else {
-    dout(10) << __FUNC__ << ": " << cid << "/" << oid
+    dout(10) << __FUNC__ << ": " << ch->cid << "/" << oid
 	     << " = " << r
 	     << " (size " << st->st_size << ")" << dendl;
   }
@@ -3241,14 +3240,14 @@ int FileStore::stat(
 }
 
 int FileStore::set_collection_opts(
-  const coll_t& cid,
+  CollectionHandle& ch,
   const pool_opts_t& opts)
 {
   return -EOPNOTSUPP;
 }
 
 int FileStore::read(
-  const coll_t& _cid,
+  CollectionHandle& ch,
   const ghobject_t& oid,
   uint64_t offset,
   size_t len,
@@ -3256,8 +3255,8 @@ int FileStore::read(
   uint32_t op_flags)
 {
   int got;
-  tracepoint(objectstore, read_enter, _cid.c_str(), offset, len);
-  const coll_t& cid = !_need_temp_object_collection(_cid, oid) ? _cid : _cid.get_temp();
+  tracepoint(objectstore, read_enter, ch->cid.c_str(), offset, len);
+  const coll_t& cid = !_need_temp_object_collection(ch->cid, oid) ? ch->cid : ch->cid.get_temp();
 
   dout(15) << __FUNC__ << ": " << cid << "/" << oid << " " << offset << "~" << len << dendl;
 
@@ -3442,24 +3441,24 @@ int FileStore::_do_seek_hole_data(int fd, uint64_t offset, size_t len,
 #endif
 }
 
-int FileStore::fiemap(const coll_t& _cid, const ghobject_t& oid,
+int FileStore::fiemap(CollectionHandle& ch, const ghobject_t& oid,
                     uint64_t offset, size_t len,
                     bufferlist& bl)
 {
   map<uint64_t, uint64_t> exomap;
-  int r = fiemap(_cid, oid, offset, len, exomap);
+  int r = fiemap(ch, oid, offset, len, exomap);
   if (r >= 0) {
     encode(exomap, bl);
   }
   return r;
 }
 
-int FileStore::fiemap(const coll_t& _cid, const ghobject_t& oid,
+int FileStore::fiemap(CollectionHandle& ch, const ghobject_t& oid,
                     uint64_t offset, size_t len,
                     map<uint64_t, uint64_t>& destmap)
 {
-  tracepoint(objectstore, fiemap_enter, _cid.c_str(), offset, len);
-  const coll_t& cid = !_need_temp_object_collection(_cid, oid) ? _cid : _cid.get_temp();
+  tracepoint(objectstore, fiemap_enter, ch->cid.c_str(), offset, len);
+  const coll_t& cid = !_need_temp_object_collection(ch->cid, oid) ? ch->cid : ch->cid.get_temp();
   destmap.clear();
 
   if ((!backend->has_seek_data_hole() && !backend->has_fiemap()) ||
@@ -4429,10 +4428,10 @@ bool FileStore::debug_mdata_eio(const ghobject_t &oid) {
 
 // objects
 
-int FileStore::getattr(const coll_t& _cid, const ghobject_t& oid, const char *name, bufferptr &bp)
+int FileStore::getattr(CollectionHandle& ch, const ghobject_t& oid, const char *name, bufferptr &bp)
 {
-  tracepoint(objectstore, getattr_enter, _cid.c_str());
-  const coll_t& cid = !_need_temp_object_collection(_cid, oid) ? _cid : _cid.get_temp();
+  tracepoint(objectstore, getattr_enter, ch->cid.c_str());
+  const coll_t& cid = !_need_temp_object_collection(ch->cid, oid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << cid << "/" << oid << " '" << name << "'" << dendl;
   FDRef fd;
   int r = lfn_open(cid, oid, false, &fd);
@@ -4478,10 +4477,10 @@ int FileStore::getattr(const coll_t& _cid, const ghobject_t& oid, const char *na
   }
 }
 
-int FileStore::getattrs(const coll_t& _cid, const ghobject_t& oid, map<string,bufferptr>& aset)
+int FileStore::getattrs(CollectionHandle& ch, const ghobject_t& oid, map<string,bufferptr>& aset)
 {
-  tracepoint(objectstore, getattrs_enter, _cid.c_str());
-  const coll_t& cid = !_need_temp_object_collection(_cid, oid) ? _cid : _cid.get_temp();
+  tracepoint(objectstore, getattrs_enter, ch->cid.c_str());
+  const coll_t& cid = !_need_temp_object_collection(ch->cid, oid) ? ch->cid : ch->cid.get_temp();
   set<string> omap_attrs;
   map<string, bufferlist> omap_aset;
   Index index;
@@ -4898,12 +4897,12 @@ bool FileStore::collection_exists(const coll_t& c)
   return ret;
 }
 
-int FileStore::collection_empty(const coll_t& c, bool *empty)
+int FileStore::collection_empty(const coll_t& cid, bool *empty)
 {
-  tracepoint(objectstore, collection_empty_enter, c.c_str());
-  dout(15) << __FUNC__ << ": " << c << dendl;
+  tracepoint(objectstore, collection_empty_enter, cid.c_str());
+  dout(15) << __FUNC__ << ": " << cid << dendl;
   Index index;
-  int r = get_index(c, &index);
+  int r = get_index(cid, &index);
   if (r < 0) {
     derr << __FUNC__ << ": get_index returned: " << cpp_strerror(r)
          << dendl;
@@ -4948,10 +4947,10 @@ int FileStore::_collection_set_bits(const coll_t& c, int bits)
   return r;
 }
 
-int FileStore::collection_bits(const coll_t& c)
+int FileStore::collection_bits(CollectionHandle& ch)
 {
   char fn[PATH_MAX];
-  get_cdir(c, fn, sizeof(fn));
+  get_cdir(ch->cid, fn, sizeof(fn));
   dout(15) << __FUNC__ << ": " << fn << dendl;
   int r;
   char n[PATH_MAX];
@@ -5056,12 +5055,12 @@ int FileStore::collection_list(const coll_t& c,
   return 0;
 }
 
-int FileStore::omap_get(const coll_t& _c, const ghobject_t &hoid,
+int FileStore::omap_get(CollectionHandle& ch, const ghobject_t &hoid,
 			bufferlist *header,
 			map<string, bufferlist> *out)
 {
-  tracepoint(objectstore, omap_get_enter, _c.c_str());
-  const coll_t& c = !_need_temp_object_collection(_c, hoid) ? _c : _c.get_temp();
+  tracepoint(objectstore, omap_get_enter, ch->cid.c_str());
+  const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
   Index index;
   int r = get_index(c, &index);
@@ -5084,13 +5083,13 @@ int FileStore::omap_get(const coll_t& _c, const ghobject_t &hoid,
 }
 
 int FileStore::omap_get_header(
-  const coll_t& _c,
+  CollectionHandle& ch,
   const ghobject_t &hoid,
   bufferlist *bl,
   bool allow_eio)
 {
-  tracepoint(objectstore, omap_get_header_enter, _c.c_str());
-  const coll_t& c = !_need_temp_object_collection(_c, hoid) ? _c : _c.get_temp();
+  tracepoint(objectstore, omap_get_header_enter, ch->cid.c_str());
+  const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
   Index index;
   int r = get_index(c, &index);
@@ -5112,10 +5111,10 @@ int FileStore::omap_get_header(
   return 0;
 }
 
-int FileStore::omap_get_keys(const coll_t& _c, const ghobject_t &hoid, set<string> *keys)
+int FileStore::omap_get_keys(CollectionHandle& ch, const ghobject_t &hoid, set<string> *keys)
 {
-  tracepoint(objectstore, omap_get_keys_enter, _c.c_str());
-  const coll_t& c = !_need_temp_object_collection(_c, hoid) ? _c : _c.get_temp();
+  tracepoint(objectstore, omap_get_keys_enter, ch->cid.c_str());
+  const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
   Index index;
   int r = get_index(c, &index);
@@ -5137,12 +5136,12 @@ int FileStore::omap_get_keys(const coll_t& _c, const ghobject_t &hoid, set<strin
   return 0;
 }
 
-int FileStore::omap_get_values(const coll_t& _c, const ghobject_t &hoid,
+int FileStore::omap_get_values(CollectionHandle& ch, const ghobject_t &hoid,
 			       const set<string> &keys,
 			       map<string, bufferlist> *out)
 {
-  tracepoint(objectstore, omap_get_values_enter, _c.c_str());
-  const coll_t& c = !_need_temp_object_collection(_c, hoid) ? _c : _c.get_temp();
+  tracepoint(objectstore, omap_get_values_enter, ch->cid.c_str());
+  const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
   Index index;
   const char *where = "()";
@@ -5174,12 +5173,12 @@ int FileStore::omap_get_values(const coll_t& _c, const ghobject_t &hoid,
   return r;
 }
 
-int FileStore::omap_check_keys(const coll_t& _c, const ghobject_t &hoid,
+int FileStore::omap_check_keys(CollectionHandle& ch, const ghobject_t &hoid,
 			       const set<string> &keys,
 			       set<string> *out)
 {
-  tracepoint(objectstore, omap_check_keys_enter, _c.c_str());
-  const coll_t& c = !_need_temp_object_collection(_c, hoid) ? _c : _c.get_temp();
+  tracepoint(objectstore, omap_check_keys_enter, ch->cid.c_str());
+  const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
 
   Index index;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2124,15 +2124,14 @@ void FileStore::_do_op(OpSequencer *osr, ThreadPool::TPHandle &handle)
   apply_manager.op_apply_finish(o->op);
   dout(10) << __FUNC__ << ": " << o << " seq " << o->op << " r = " << r
 	   << ", finisher " << o->onreadable << " " << o->onreadable_sync << dendl;
-
-  o->tls.clear();
-
 }
 
 void FileStore::_finish_op(OpSequencer *osr)
 {
   list<Context*> to_queue;
   Op *o = osr->dequeue(&to_queue);
+
+  o->tls.clear();
 
   utime_t lat = ceph_clock_now();
   lat -= o->start;
@@ -2158,7 +2157,6 @@ void FileStore::_finish_op(OpSequencer *osr)
   delete o;
   o = nullptr;
 }
-
 
 struct C_JournaledAhead : public Context {
   FileStore *fs;
@@ -3209,6 +3207,8 @@ void FileStore::_do_transaction(
 bool FileStore::exists(CollectionHandle& ch, const ghobject_t& oid)
 {
   tracepoint(objectstore, exists_enter, ch->cid.c_str());
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(oid);
   struct stat st;
   bool retval = stat(ch, oid, &st) == 0;
   tracepoint(objectstore, exists_exit, retval);
@@ -3219,6 +3219,8 @@ int FileStore::stat(
   CollectionHandle& ch, const ghobject_t& oid, struct stat *st, bool allow_eio)
 {
   tracepoint(objectstore, stat_enter, ch->cid.c_str());
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(oid);
   const coll_t& cid = !_need_temp_object_collection(ch->cid, oid) ? ch->cid : ch->cid.get_temp();
   int r = lfn_stat(cid, oid, st);
   assert(allow_eio || !m_filestore_fail_eio || r != -EIO);
@@ -3259,6 +3261,9 @@ int FileStore::read(
   const coll_t& cid = !_need_temp_object_collection(ch->cid, oid) ? ch->cid : ch->cid.get_temp();
 
   dout(15) << __FUNC__ << ": " << cid << "/" << oid << " " << offset << "~" << len << dendl;
+
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(oid);
 
   FDRef fd;
   int r = lfn_open(cid, oid, false, &fd);
@@ -3468,6 +3473,9 @@ int FileStore::fiemap(CollectionHandle& ch, const ghobject_t& oid,
   }
 
   dout(15) << __FUNC__ << ": " << cid << "/" << oid << " " << offset << "~" << len << dendl;
+
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(oid);
 
   FDRef fd;
 
@@ -4433,6 +4441,10 @@ int FileStore::getattr(CollectionHandle& ch, const ghobject_t& oid, const char *
   tracepoint(objectstore, getattr_enter, ch->cid.c_str());
   const coll_t& cid = !_need_temp_object_collection(ch->cid, oid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << cid << "/" << oid << " '" << name << "'" << dendl;
+
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(oid);
+
   FDRef fd;
   int r = lfn_open(cid, oid, false, &fd);
   if (r < 0) {
@@ -4485,6 +4497,10 @@ int FileStore::getattrs(CollectionHandle& ch, const ghobject_t& oid, map<string,
   map<string, bufferlist> omap_aset;
   Index index;
   dout(15) << __FUNC__ << ": " << cid << "/" << oid << dendl;
+
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(oid);
+
   FDRef fd;
   bool spill_out = true;
   char buf[2];
@@ -5062,6 +5078,10 @@ int FileStore::omap_get(CollectionHandle& ch, const ghobject_t &hoid,
   tracepoint(objectstore, omap_get_enter, ch->cid.c_str());
   const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
+
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(hoid);
+
   Index index;
   int r = get_index(c, &index);
   if (r < 0)
@@ -5091,6 +5111,10 @@ int FileStore::omap_get_header(
   tracepoint(objectstore, omap_get_header_enter, ch->cid.c_str());
   const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
+
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(hoid);
+
   Index index;
   int r = get_index(c, &index);
   if (r < 0)
@@ -5116,6 +5140,10 @@ int FileStore::omap_get_keys(CollectionHandle& ch, const ghobject_t &hoid, set<s
   tracepoint(objectstore, omap_get_keys_enter, ch->cid.c_str());
   const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
+
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(hoid);
+
   Index index;
   int r = get_index(c, &index);
   if (r < 0)
@@ -5143,6 +5171,10 @@ int FileStore::omap_get_values(CollectionHandle& ch, const ghobject_t &hoid,
   tracepoint(objectstore, omap_get_values_enter, ch->cid.c_str());
   const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
+
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(hoid);
+
   Index index;
   const char *where = "()";
   int r = get_index(c, &index);
@@ -5180,6 +5212,9 @@ int FileStore::omap_check_keys(CollectionHandle& ch, const ghobject_t &hoid,
   tracepoint(objectstore, omap_check_keys_enter, ch->cid.c_str());
   const coll_t& c = !_need_temp_object_collection(ch->cid, hoid) ? ch->cid : ch->cid.get_temp();
   dout(15) << __FUNC__ << ": " << c << "/" << hoid << dendl;
+
+  auto osr = static_cast<OpSequencer*>(ch.get());
+  osr->wait_for_apply(hoid);
 
   Index index;
   int r = get_index(c, &index);
@@ -6050,4 +6085,50 @@ void FSSuperblock::generate_test_instances(list<FSSuperblock*>& o)
   o.push_back(new FSSuperblock(z));
   z.omap_backend = "rocksdb";
   o.push_back(new FSSuperblock(z));
+}
+
+#undef dout_prefix
+#define dout_prefix *_dout << "filestore.osr(" << this << ") "
+
+void FileStore::OpSequencer::_register_apply(Op *o)
+{
+  if (o->registered_apply) {
+    dout(20) << __func__ << " " << o << " already registered" << dendl;
+    return;
+  }
+  o->registered_apply = true;
+  for (auto& t : o->tls) {
+    for (auto& i : t.get_object_index()) {
+      ++applying[i.first];
+      dout(20) << __func__ << " " << o << " " << i.first << " now " << applying[i.first]
+	       << dendl;      
+    }
+  }
+}
+
+void FileStore::OpSequencer::_unregister_apply(Op *o)
+{
+  assert(o->registered_apply);
+  for (auto& t : o->tls) {
+    for (auto& i : t.get_object_index()) {
+      auto p = applying.find(i.first);
+      assert(p != applying.end());
+      if (--p->second == 0) {
+	dout(20) << __func__ << " " << o << " " << i.first << " now 0, removing" << dendl;
+	applying.erase(p);
+      } else {
+	dout(20) << __func__ << " " << o << " " << i.first << " now " << p->second << dendl;
+      }
+    }
+  }
+}
+
+void FileStore::OpSequencer::wait_for_apply(const ghobject_t& oid)
+{
+  Mutex::Locker l(qlock);
+  while (applying.count(oid)) {
+    dout(20) << __func__ << " " << oid << " waiting" << dendl;
+    cond.Wait(qlock);
+  }
+  dout(20) << __func__ << " " << oid << " done" << dendl;
 }

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2247,7 +2247,7 @@ int FileStore::queue_transactions(CollectionHandle& ch, vector<Transaction>& tls
     } else if (m_filestore_journal_writeahead) {
       dout(5) << __FUNC__ << ": (writeahead) " << o->op << " " << o->tls << dendl;
 
-      osr->queue_journal(o->op);
+      osr->queue_journal(o);
 
       trace.keyval("journal mode", "writeahead");
       trace.event("journal started");

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -577,20 +577,20 @@ public:
     return 0;
   }
   using ObjectStore::exists;
-  bool exists(const coll_t& cid, const ghobject_t& oid) override;
+  bool exists(CollectionHandle& c, const ghobject_t& oid) override;
   using ObjectStore::stat;
   int stat(
-    const coll_t& cid,
+    CollectionHandle& c,
     const ghobject_t& oid,
     struct stat *st,
     bool allow_eio = false) override;
   using ObjectStore::set_collection_opts;
   int set_collection_opts(
-    const coll_t& cid,
+    CollectionHandle& c,
     const pool_opts_t& opts) override;
   using ObjectStore::read;
   int read(
-    const coll_t& cid,
+    CollectionHandle& c,
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
@@ -601,8 +601,8 @@ public:
   int _do_seek_hole_data(int fd, uint64_t offset, size_t len,
                          map<uint64_t, uint64_t> *m);
   using ObjectStore::fiemap;
-  int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl) override;
-  int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) override;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl) override;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) override;
 
   int _touch(const coll_t& cid, const ghobject_t& oid);
   int _write(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len,
@@ -665,8 +665,8 @@ public:
   // attrs
   using ObjectStore::getattr;
   using ObjectStore::getattrs;
-  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name, bufferptr &bp) override;
-  int getattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset) override;
+  int getattr(CollectionHandle& c, const ghobject_t& oid, const char *name, bufferptr &bp) override;
+  int getattrs(CollectionHandle& c, const ghobject_t& oid, map<string,bufferptr>& aset) override;
 
   int _setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset,
 		const SequencerPosition &spos);
@@ -682,36 +682,47 @@ public:
 
   // collections
   using ObjectStore::collection_list;
-  int collection_bits(const coll_t& c) override;
-  int collection_list(const coll_t& c,
+  int collection_bits(CollectionHandle& c) override;
+  int collection_list(CollectionHandle& c,
 		      const ghobject_t& start, const ghobject_t& end, int max,
-		      vector<ghobject_t> *ls, ghobject_t *next) override;
+		      vector<ghobject_t> *ls, ghobject_t *next) override {
+    return collection_list(c->cid, start, end, max, ls, next);
+  }
+  int collection_list(const coll_t& cid,
+		      const ghobject_t& start, const ghobject_t& end, int max,
+		      vector<ghobject_t> *ls, ghobject_t *next);
   int list_collections(vector<coll_t>& ls) override;
   int list_collections(vector<coll_t>& ls, bool include_temp);
   int collection_stat(const coll_t& c, struct stat *st);
   bool collection_exists(const coll_t& c) override;
-  int collection_empty(const coll_t& c, bool *empty) override;
+  int collection_empty(CollectionHandle& c, bool *empty) override {
+    return collection_empty(c->cid, empty);
+  }
+  int collection_empty(const coll_t& cid, bool *empty);
 
   // omap (see ObjectStore.h for documentation)
   using ObjectStore::omap_get;
-  int omap_get(const coll_t& c, const ghobject_t &oid, bufferlist *header,
+  int omap_get(CollectionHandle& c, const ghobject_t &oid, bufferlist *header,
 	       map<string, bufferlist> *out) override;
   using ObjectStore::omap_get_header;
   int omap_get_header(
-    const coll_t& c,
+    CollectionHandle& c,
     const ghobject_t &oid,
     bufferlist *out,
     bool allow_eio = false) override;
   using ObjectStore::omap_get_keys;
-  int omap_get_keys(const coll_t& c, const ghobject_t &oid, set<string> *keys) override;
+  int omap_get_keys(CollectionHandle& c, const ghobject_t &oid, set<string> *keys) override;
   using ObjectStore::omap_get_values;
-  int omap_get_values(const coll_t& c, const ghobject_t &oid, const set<string> &keys,
+  int omap_get_values(CollectionHandle& c, const ghobject_t &oid, const set<string> &keys,
 		      map<string, bufferlist> *out) override;
   using ObjectStore::omap_check_keys;
-  int omap_check_keys(const coll_t& c, const ghobject_t &oid, const set<string> &keys,
+  int omap_check_keys(CollectionHandle& c, const ghobject_t &oid, const set<string> &keys,
 		      set<string> *out) override;
   using ObjectStore::get_omap_iterator;
-  ObjectMap::ObjectMapIterator get_omap_iterator(const coll_t& c, const ghobject_t &oid) override;
+  ObjectMap::ObjectMapIterator get_omap_iterator(CollectionHandle& c, const ghobject_t &oid) override {
+    return get_omap_iterator(c->cid, oid);
+  }
+  ObjectMap::ObjectMapIterator get_omap_iterator(const coll_t& cid, const ghobject_t &oid);
 
   int _create_collection(const coll_t& c, int bits,
 			 const SequencerPosition &spos);

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -301,34 +301,9 @@ private:
       _register_apply(o);
       o->trace.keyval("queue depth", q.size());
     }
-    void _register_apply(Op *o) {
-      if (o->registered_apply)
-	return;
-      o->registered_apply = true;
-      for (auto& t : o->tls) {
-	for (auto& i : t.get_object_index()) {
-	  ++applying[i.first];
-	}
-      }
-    }
-    void _unregister_apply(Op *o) {
-      assert(o->registered_apply);
-      for (auto& t : o->tls) {
-	for (auto& i : t.get_object_index()) {
-	  auto p = applying.find(i.first);
-	  assert(p != applying.end());
-	  if (--p->second == 0) {
-	    applying.erase(p);
-	  }
-	}
-      }
-    }
-    void wait_for_apply(const ghobject_t& oid) {
-      Mutex::Locker l(qlock);
-      while (applying.count(oid)) {
-	cond.Wait(qlock);
-      }
-    }
+    void _register_apply(Op *o);
+    void _unregister_apply(Op *o);
+    void wait_for_apply(const ghobject_t& oid);
     Op *peek_queue() {
       Mutex::Locker l(qlock);
       assert(apply_lock.is_locked());

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -221,6 +221,7 @@ private:
     uint64_t ops, bytes;
     TrackedOpRef osd_op;
     ZTracer::Trace trace;
+    bool registered_apply = false;
   };
   class OpSequencer : public CollectionImpl {
     CephContext *cct;
@@ -229,6 +230,7 @@ private:
     list<uint64_t> jq;
     list<pair<uint64_t, Context*> > flush_commit_waiters;
     Cond cond;
+    map<ghobject_t,int> applying;
   public:
     Mutex apply_lock;  // for apply mutual exclusion
     int id;
@@ -282,9 +284,10 @@ private:
       }
     }
 
-    void queue_journal(uint64_t s) {
+    void queue_journal(Op *o) {
       Mutex::Locker l(qlock);
-      jq.push_back(s);
+      jq.push_back(o->op);
+      _register_apply(o);
     }
     void dequeue_journal(list<Context*> *to_queue) {
       Mutex::Locker l(qlock);
@@ -295,7 +298,36 @@ private:
     void queue(Op *o) {
       Mutex::Locker l(qlock);
       q.push_back(o);
+      _register_apply(o);
       o->trace.keyval("queue depth", q.size());
+    }
+    void _register_apply(Op *o) {
+      if (o->registered_apply)
+	return;
+      o->registered_apply = true;
+      for (auto& t : o->tls) {
+	for (auto& i : t.get_object_index()) {
+	  ++applying[i.first];
+	}
+      }
+    }
+    void _unregister_apply(Op *o) {
+      assert(o->registered_apply);
+      for (auto& t : o->tls) {
+	for (auto& i : t.get_object_index()) {
+	  auto p = applying.find(i.first);
+	  assert(p != applying.end());
+	  if (--p->second == 0) {
+	    applying.erase(p);
+	  }
+	}
+      }
+    }
+    void wait_for_apply(const ghobject_t& oid) {
+      Mutex::Locker l(qlock);
+      while (applying.count(oid)) {
+	cond.Wait(qlock);
+      }
     }
     Op *peek_queue() {
       Mutex::Locker l(qlock);
@@ -310,7 +342,7 @@ private:
       Op *o = q.front();
       q.pop_front();
       cond.Signal();
-
+      _unregister_apply(o);
       _wake_flush_waiters(to_queue);
       return o;
     }

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -693,6 +693,7 @@ public:
   int collection_list(CollectionHandle& c,
 		      const ghobject_t& start, const ghobject_t& end, int max,
 		      vector<ghobject_t> *ls, ghobject_t *next) override {
+    c->flush();
     return collection_list(c->cid, start, end, max, ls, next);
   }
   int collection_list(const coll_t& cid,
@@ -703,6 +704,7 @@ public:
   int collection_stat(const coll_t& c, struct stat *st);
   bool collection_exists(const coll_t& c) override;
   int collection_empty(CollectionHandle& c, bool *empty) override {
+    c->flush();
     return collection_empty(c->cid, empty);
   }
   int collection_empty(const coll_t& cid, bool *empty);

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -217,7 +217,7 @@ private:
     utime_t start;
     uint64_t op;
     vector<Transaction> tls;
-    Context *onreadable, *onreadable_sync;
+    Context *onreadable;
     uint64_t ops, bytes;
     TrackedOpRef osd_op;
     ZTracer::Trace trace;
@@ -420,7 +420,7 @@ private:
   void _do_op(OpSequencer *o, ThreadPool::TPHandle &handle);
   void _finish_op(OpSequencer *o);
   Op *build_op(vector<Transaction>& tls,
-	       Context *onreadable, Context *onreadable_sync,
+	       Context *onreadable,
 	       TrackedOpRef osd_op);
   void queue_op(OpSequencer *osr, Op *o);
   void op_queue_reserve_throttle(Op *o);

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1443,6 +1443,7 @@ int KStore::collection_list(
 
 {
   Collection *c = static_cast<Collection*>(c_.get());
+  c->flush();
   dout(15) << __func__ << " " << c->cid
            << " start " << start << " end " << end << " max " << max << dendl;
   int r;

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -442,19 +442,19 @@ public:
   CollectionHandle create_new_collection(const coll_t& c) override;
 
   using ObjectStore::exists;
-  bool exists(const coll_t& cid, const ghobject_t& oid) override;
+  bool exists(CollectionHandle& c, const ghobject_t& oid) override;
   using ObjectStore::stat;
   int stat(
-    const coll_t& cid,
+    CollectionHandle& c,
     const ghobject_t& oid,
     struct stat *st,
     bool allow_eio = false) override; // struct stat?
   int set_collection_opts(
-    const coll_t& cid,
+    CollectionHandle& c,
     const pool_opts_t& opts) override;
   using ObjectStore::read;
   int read(
-    const coll_t& cid,
+    CollectionHandle& c,
     const ghobject_t& oid,
     uint64_t offset,
     size_t len,
@@ -468,21 +468,17 @@ public:
     uint32_t op_flags = 0);
 
   using ObjectStore::fiemap;
-  int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& bl) override;
-  int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) override;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap) override;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset, size_t len, bufferlist& outbl) override;
   using ObjectStore::getattr;
-  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name, bufferptr& value) override;
+  int getattr(CollectionHandle& c, const ghobject_t& oid, const char *name, bufferptr& value) override;
   using ObjectStore::getattrs;
-  int getattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset) override;
+  int getattrs(CollectionHandle& c, const ghobject_t& oid, map<string,bufferptr>& aset) override;
 
   int list_collections(vector<coll_t>& ls) override;
   bool collection_exists(const coll_t& c) override;
-  int collection_empty(const coll_t& c, bool *empty) override;
-  int collection_bits(const coll_t& c) override;
-  int collection_list(
-    const coll_t& cid, const ghobject_t& start, const ghobject_t& end,
-    int max,
-    vector<ghobject_t> *ls, ghobject_t *next) override;
+  int collection_empty(CollectionHandle& c, bool *empty) override;
+  int collection_bits(CollectionHandle& c) override;
   int collection_list(
     CollectionHandle &c, const ghobject_t& start, const ghobject_t& end,
     int max,
@@ -490,7 +486,7 @@ public:
 
   using ObjectStore::omap_get;
   int omap_get(
-    const coll_t& cid,                ///< [in] Collection containing oid
+    CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     map<string, bufferlist> *out /// < [out] Key to value map
@@ -499,7 +495,7 @@ public:
   using ObjectStore::omap_get_header;
   /// Get omap header
   int omap_get_header(
-    const coll_t& cid,                ///< [in] Collection containing oid
+    CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     bool allow_eio = false ///< [in] don't assert on eio
@@ -508,7 +504,7 @@ public:
   using ObjectStore::omap_get_keys;
   /// Get keys defined on oid
   int omap_get_keys(
-    const coll_t& cid,              ///< [in] Collection containing oid
+    CollectionHandle& c,              ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
     set<string> *keys      ///< [out] Keys defined on oid
     ) override;
@@ -516,7 +512,7 @@ public:
   using ObjectStore::omap_get_values;
   /// Get key values
   int omap_get_values(
-    const coll_t& cid,                    ///< [in] Collection containing oid
+    CollectionHandle& c,                    ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
     map<string, bufferlist> *out ///< [out] Returned keys and values
@@ -525,7 +521,7 @@ public:
   using ObjectStore::omap_check_keys;
   /// Filters keys into out which are defined on oid
   int omap_check_keys(
-    const coll_t& cid,                ///< [in] Collection containing oid
+    CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     const set<string> &keys, ///< [in] Keys to check
     set<string> *out         ///< [out] Subset of keys defined on oid
@@ -533,7 +529,7 @@ public:
 
   using ObjectStore::get_omap_iterator;
   ObjectMap::ObjectMapIterator get_omap_iterator(
-    const coll_t& cid,              ///< [in] collection
+    CollectionHandle& c,              ///< [in] collection
     const ghobject_t &oid  ///< [in] object
     ) override;
 

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -228,7 +228,6 @@ public:
     KeyValueDB::Transaction t; ///< then we will commit this
     Context *oncommit;         ///< signal on commit
     Context *onreadable;         ///< signal on readable
-    Context *onreadable_sync;         ///< signal on readable
     list<Context*> oncommits;  ///< more commit completions
     list<CollectionRef> removed_collections; ///< colls we removed
 
@@ -241,7 +240,6 @@ public:
 	bytes(0),
 	oncommit(NULL),
 	onreadable(NULL),
-	onreadable_sync(NULL),
         start(ceph_clock_now()){
       //cout << "txc new " << this << std::endl;
     }

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -639,11 +639,8 @@ int MemStore::queue_transactions(
     _do_transaction(*p);
   }
 
-  Context *on_apply = NULL, *on_apply_sync = NULL, *on_commit = NULL;
-  ObjectStore::Transaction::collect_contexts(tls, &on_apply, &on_commit,
-					     &on_apply_sync);
-  if (on_apply_sync)
-    on_apply_sync->complete(0);
+  Context *on_apply = NULL, *on_commit = NULL;
+  ObjectStore::Transaction::collect_contexts(tls, &on_apply, &on_commit);
   if (on_apply)
     finisher.queue(on_apply);
   if (on_commit)

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -292,22 +292,12 @@ public:
 
   int statfs(struct store_statfs_t *buf) override;
 
-  bool exists(const coll_t& cid, const ghobject_t& oid) override;
   bool exists(CollectionHandle &c, const ghobject_t& oid) override;
-  int stat(const coll_t& cid, const ghobject_t& oid,
-	   struct stat *st, bool allow_eio = false) override;
   int stat(CollectionHandle &c, const ghobject_t& oid,
 	   struct stat *st, bool allow_eio = false) override;
   int set_collection_opts(
-    const coll_t& cid,
+    CollectionHandle& c,
     const pool_opts_t& opts) override;
-  int read(
-    const coll_t& cid,
-    const ghobject_t& oid,
-    uint64_t offset,
-    size_t len,
-    bufferlist& bl,
-    uint32_t op_flags = 0) override;
   int read(
     CollectionHandle &c,
     const ghobject_t& oid,
@@ -316,16 +306,12 @@ public:
     bufferlist& bl,
     uint32_t op_flags = 0) override;
   using ObjectStore::fiemap;
-  int fiemap(const coll_t& cid, const ghobject_t& oid,
+  int fiemap(CollectionHandle& c, const ghobject_t& oid,
 	     uint64_t offset, size_t len, bufferlist& bl) override;
-  int fiemap(const coll_t& cid, const ghobject_t& oid, uint64_t offset,
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset,
 	     size_t len, map<uint64_t, uint64_t>& destmap) override;
-  int getattr(const coll_t& cid, const ghobject_t& oid, const char *name,
-	      bufferptr& value) override;
   int getattr(CollectionHandle &c, const ghobject_t& oid, const char *name,
 	      bufferptr& value) override;
-  int getattrs(const coll_t& cid, const ghobject_t& oid,
-	       map<string,bufferptr>& aset) override;
   int getattrs(CollectionHandle &c, const ghobject_t& oid,
 	       map<string,bufferptr>& aset) override;
 
@@ -336,16 +322,15 @@ public:
   }
   CollectionHandle create_new_collection(const coll_t& c) override;
   bool collection_exists(const coll_t& c) override;
-  int collection_empty(const coll_t& c, bool *empty) override;
-  int collection_bits(const coll_t& c) override;
-  using ObjectStore::collection_list;
-  int collection_list(const coll_t& cid,
+  int collection_empty(CollectionHandle& c, bool *empty) override;
+  int collection_bits(CollectionHandle& c) override;
+  int collection_list(CollectionHandle& cid,
 		      const ghobject_t& start, const ghobject_t& end, int max,
 		      vector<ghobject_t> *ls, ghobject_t *next) override;
 
   using ObjectStore::omap_get;
   int omap_get(
-    const coll_t& cid,                ///< [in] Collection containing oid
+    CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     map<string, bufferlist> *out /// < [out] Key to value map
@@ -354,7 +339,7 @@ public:
   using ObjectStore::omap_get_header;
   /// Get omap header
   int omap_get_header(
-    const coll_t& cid,                ///< [in] Collection containing oid
+    CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     bufferlist *header,      ///< [out] omap header
     bool allow_eio = false ///< [in] don't assert on eio
@@ -363,7 +348,7 @@ public:
   using ObjectStore::omap_get_keys;
   /// Get keys defined on oid
   int omap_get_keys(
-    const coll_t& cid,              ///< [in] Collection containing oid
+    CollectionHandle& c,              ///< [in] Collection containing oid
     const ghobject_t &oid, ///< [in] Object containing omap
     set<string> *keys      ///< [out] Keys defined on oid
     ) override;
@@ -371,7 +356,7 @@ public:
   using ObjectStore::omap_get_values;
   /// Get key values
   int omap_get_values(
-    const coll_t& cid,                    ///< [in] Collection containing oid
+    CollectionHandle& c,                    ///< [in] Collection containing oid
     const ghobject_t &oid,       ///< [in] Object containing omap
     const set<string> &keys,     ///< [in] Keys to get
     map<string, bufferlist> *out ///< [out] Returned keys and values
@@ -380,7 +365,7 @@ public:
   using ObjectStore::omap_check_keys;
   /// Filters keys into out which are defined on oid
   int omap_check_keys(
-    const coll_t& cid,                ///< [in] Collection containing oid
+    CollectionHandle& c,                ///< [in] Collection containing oid
     const ghobject_t &oid,   ///< [in] Object containing omap
     const set<string> &keys, ///< [in] Keys to check
     set<string> *out         ///< [out] Subset of keys defined on oid
@@ -388,7 +373,7 @@ public:
 
   using ObjectStore::get_omap_iterator;
   ObjectMap::ObjectMapIterator get_omap_iterator(
-    const coll_t& cid,              ///< [in] collection
+    CollectionHandle& c,              ///< [in] collection
     const ghobject_t &oid  ///< [in] object
     ) override;
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -923,8 +923,7 @@ void ECBackend::handle_sub_write(
   pg_shard_t from,
   OpRequestRef msg,
   ECSubWrite &op,
-  const ZTracer::Trace &trace,
-  Context *on_local_applied_sync)
+  const ZTracer::Trace &trace)
 {
   if (msg)
     msg->mark_started();
@@ -964,10 +963,6 @@ void ECBackend::handle_sub_write(
       ec_impl->get_data_chunk_count())
     op.t.set_fadvise_flag(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
 
-  if (on_local_applied_sync) {
-    dout(10) << "Queueing onreadable_sync: " << on_local_applied_sync << dendl;
-    localt.register_on_applied_sync(on_local_applied_sync);
-  }
   localt.register_on_commit(
     get_parent()->bless_context(
       new SubWriteCommitted(
@@ -1466,7 +1461,6 @@ void ECBackend::submit_transaction(
   const eversion_t &roll_forward_to,
   const vector<pg_log_entry_t> &log_entries,
   boost::optional<pg_hit_set_history_t> &hset_history,
-  Context *on_local_applied_sync,
   Context *on_all_applied,
   Context *on_all_commit,
   ceph_tid_t tid,
@@ -1483,7 +1477,6 @@ void ECBackend::submit_transaction(
   op->roll_forward_to = std::max(roll_forward_to, committed_to);
   op->log_entries = log_entries;
   std::swap(op->updated_hit_set_history, hset_history);
-  op->on_local_applied_sync = on_local_applied_sync;
   op->on_all_applied = on_all_applied;
   op->on_all_commit = on_all_commit;
   op->tid = tid;
@@ -1494,7 +1487,6 @@ void ECBackend::submit_transaction(
   
   dout(10) << __func__ << ": op " << *op << " starting" << dendl;
   start_rmw(op, std::move(t));
-  dout(10) << "onreadable_sync: " << op->on_local_applied_sync << dendl;
 }
 
 void ECBackend::call_write_ordered(std::function<void(void)> &&cb)
@@ -1984,7 +1976,6 @@ bool ECBackend::try_reads_to_commit()
   op->remote_read.clear();
   op->remote_read_result.clear();
 
-  dout(10) << "onreadable_sync: " << op->on_local_applied_sync << dendl;
   ObjectStore::Transaction empty;
   bool should_write_local = false;
   ECSubWrite local_write_op;
@@ -2044,9 +2035,7 @@ bool ECBackend::try_reads_to_commit()
       get_parent()->whoami_shard(),
       op->client_op,
       local_write_op,
-      op->trace,
-      op->on_local_applied_sync);
-    op->on_local_applied_sync = 0;
+      op->trace);
   }
   return true;
 }

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -57,10 +57,6 @@ public:
     ) override;
   friend struct SubWriteApplied;
   friend struct SubWriteCommitted;
-  void sub_write_applied(
-    ceph_tid_t tid,
-    eversion_t version,
-    const ZTracer::Trace &trace);
   void sub_write_committed(
     ceph_tid_t tid,
     eversion_t version,

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -70,8 +70,7 @@ public:
     pg_shard_t from,
     OpRequestRef msg,
     ECSubWrite &op,
-    const ZTracer::Trace &trace,
-    Context *on_local_applied_sync = 0
+    const ZTracer::Trace &trace
     );
   void handle_sub_read(
     pg_shard_t from,
@@ -110,7 +109,6 @@ public:
     const eversion_t &roll_forward_to,
     const vector<pg_log_entry_t> &log_entries,
     boost::optional<pg_hit_set_history_t> &hset_history,
-    Context *on_local_applied_sync,
     Context *on_all_applied,
     Context *on_all_commit,
     ceph_tid_t tid,
@@ -504,7 +502,6 @@ public:
     ExtentCache::write_pin pin;
 
     /// Callbacks
-    Context *on_local_applied_sync = nullptr;
     Context *on_all_applied = nullptr;
     Context *on_all_commit = nullptr;
 
@@ -512,7 +509,6 @@ public:
     Op(ceph_tid_t t, std::function<void(void)>&& cb)
       : tid(t), on_write(cb) { }
     ~Op() {
-      delete on_local_applied_sync;
       delete on_all_applied;
       delete on_all_commit;
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1884,15 +1884,11 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, const string &dev,
     ObjectStore::Transaction t;
     t.create_collection(coll_t::meta(), 0);
     t.write(coll_t::meta(), OSD_SUPERBLOCK_GOBJECT, 0, bl.length(), bl);
-    ret = store->apply_transaction(ch, std::move(t));
+    ret = store->queue_transaction(ch, std::move(t));
     if (ret) {
       derr << "OSD::mkfs: error while writing OSD_SUPERBLOCK_GOBJECT: "
-	   << "apply_transaction returned " << cpp_strerror(ret) << dendl;
+	   << "queue_transaction returned " << cpp_strerror(ret) << dendl;
       goto umount_store;
-    }
-    C_SaferCond waiter;
-    if (!ch->flush_commit(&waiter)) {
-      waiter.wait();
     }
   }
 
@@ -2651,7 +2647,7 @@ int OSD::init()
     dout(5) << "Upgrading superblock adding: " << diff << dendl;
     ObjectStore::Transaction t;
     write_superblock(t);
-    r = store->apply_transaction(service.meta_ch, std::move(t));
+    r = store->queue_transaction(service.meta_ch, std::move(t));
     if (r < 0)
       goto out;
   }
@@ -2661,7 +2657,7 @@ int OSD::init()
     dout(10) << "init creating/touching snapmapper object" << dendl;
     ObjectStore::Transaction t;
     t.touch(coll_t::meta(), OSD::make_snapmapper_oid());
-    r = store->apply_transaction(service.meta_ch, std::move(t));
+    r = store->queue_transaction(service.meta_ch, std::move(t));
     if (r < 0)
       goto out;
   }
@@ -3487,7 +3483,7 @@ int OSD::shutdown()
   superblock.clean_thru = osdmap->get_epoch();
   ObjectStore::Transaction t;
   write_superblock(t);
-  int r = store->apply_transaction(service.meta_ch, std::move(t));
+  int r = store->queue_transaction(service.meta_ch, std::move(t));
   if (r) {
     derr << "OSD::shutdown: error writing superblock: "
 	 << cpp_strerror(r) << dendl;
@@ -3749,13 +3745,13 @@ void OSD::clear_temp_objects()
 	dout(20) << "  removing " << *p << " object " << *q << dendl;
 	t.remove(*p, *q);
         if (++removed > cct->_conf->osd_target_transaction_size) {
-          store->apply_transaction(service.meta_ch, std::move(t));
+          store->queue_transaction(service.meta_ch, std::move(t));
           t = ObjectStore::Transaction();
           removed = 0;
         }
       }
       if (removed) {
-        store->apply_transaction(service.meta_ch, std::move(t));
+        store->queue_transaction(service.meta_ch, std::move(t));
       }
     }
   }
@@ -3788,14 +3784,14 @@ void OSD::recursive_remove_collection(CephContext* cct,
       ceph_abort();
     t.remove(tmp, *p);
     if (removed > cct->_conf->osd_target_transaction_size) {
-      int r = store->apply_transaction(ch, std::move(t));
+      int r = store->queue_transaction(ch, std::move(t));
       assert(r == 0);
       t = ObjectStore::Transaction();
       removed = 0;
     }
   }
   t.remove_collection(tmp);
-  int r = store->apply_transaction(ch, std::move(t));
+  int r = store->queue_transaction(ch, std::move(t));
   assert(r == 0);
 
   C_SaferCond waiter;
@@ -5098,7 +5094,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       val.append(valstr);
       newattrs[key] = val;
       t.omap_setkeys(coll_t(pgid), ghobject_t(obj), newattrs);
-      r = store->apply_transaction(service->meta_ch, std::move(t));
+      r = store->queue_transaction(service->meta_ch, std::move(t));
       if (r < 0)
         ss << "error=" << r;
       else
@@ -5110,7 +5106,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
 
       keys.insert(key);
       t.omap_rmkeys(coll_t(pgid), ghobject_t(obj), keys);
-      r = store->apply_transaction(service->meta_ch, std::move(t));
+      r = store->queue_transaction(service->meta_ch, std::move(t));
       if (r < 0)
         ss << "error=" << r;
       else
@@ -5122,7 +5118,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       cmd_getval(service->cct, cmdmap, "header", headerstr);
       newheader.append(headerstr);
       t.omap_setheader(coll_t(pgid), ghobject_t(obj), newheader);
-      r = store->apply_transaction(service->meta_ch, std::move(t));
+      r = store->queue_transaction(service->meta_ch, std::move(t));
       if (r < 0)
         ss << "error=" << r;
       else
@@ -5151,7 +5147,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       int64_t trunclen;
       cmd_getval(service->cct, cmdmap, "len", trunclen);
       t.truncate(coll_t(pgid), ghobject_t(obj), trunclen);
-      r = store->apply_transaction(service->meta_ch, std::move(t));
+      r = store->queue_transaction(service->meta_ch, std::move(t));
       if (r < 0)
 	ss << "error=" << r;
       else

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -204,7 +204,6 @@ CompatSet OSD::get_osd_compat_set() {
 OSDService::OSDService(OSD *osd) :
   osd(osd),
   cct(osd->cct),
-  meta_osr(new ObjectStore::Sequencer("meta")),
   whoami(osd->whoami), store(osd->store),
   log_client(osd->log_client), clog(osd->clog),
   pg_recovery_stats(osd->pg_recovery_stats),
@@ -1823,11 +1822,8 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, const string &dev,
 {
   int ret;
 
-  ceph::shared_ptr<ObjectStore::Sequencer> osr(
-    new ObjectStore::Sequencer("mkfs"));
   OSDSuperblock sb;
   bufferlist sbbl;
-  C_SaferCond waiter;
 
   // if we are fed a uuid for this osd, use it.
   store->set_fsid(cct->_conf->osd_uuid);
@@ -1877,19 +1873,21 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, const string &dev,
     bufferlist bl;
     encode(sb, bl);
 
+    ObjectStore::CollectionHandle ch = store->create_new_collection(
+      coll_t::meta());
     ObjectStore::Transaction t;
     t.create_collection(coll_t::meta(), 0);
     t.write(coll_t::meta(), OSD_SUPERBLOCK_GOBJECT, 0, bl.length(), bl);
-    ret = store->apply_transaction(osr.get(), std::move(t));
+    ret = store->apply_transaction(ch, std::move(t));
     if (ret) {
       derr << "OSD::mkfs: error while writing OSD_SUPERBLOCK_GOBJECT: "
 	   << "apply_transaction returned " << cpp_strerror(ret) << dendl;
       goto umount_store;
     }
-  }
-
-  if (!osr->flush_commit(&waiter)) {
-    waiter.wait();
+    C_SaferCond waiter;
+    if (!ch->flush_commit(&waiter)) {
+      waiter.wait();
+    }
   }
 
   ret = write_meta(cct, store, sb.cluster_fsid, sb.osd_fsid, whoami);
@@ -2536,6 +2534,8 @@ int OSD::init()
 
   dout(2) << "boot" << dendl;
 
+  service.meta_ch = store->open_collection(coll_t::meta());
+
   // initialize the daily loadavg with current 15min loadavg
   double loadavgs[3];
   if (getloadavg(loadavgs, 3) == 3) {
@@ -2645,7 +2645,7 @@ int OSD::init()
     dout(5) << "Upgrading superblock adding: " << diff << dendl;
     ObjectStore::Transaction t;
     write_superblock(t);
-    r = store->apply_transaction(service.meta_osr.get(), std::move(t));
+    r = store->apply_transaction(service.meta_ch, std::move(t));
     if (r < 0)
       goto out;
   }
@@ -2655,7 +2655,7 @@ int OSD::init()
     dout(10) << "init creating/touching snapmapper object" << dendl;
     ObjectStore::Transaction t;
     t.touch(coll_t::meta(), OSD::make_snapmapper_oid());
-    r = store->apply_transaction(service.meta_osr.get(), std::move(t));
+    r = store->apply_transaction(service.meta_ch, std::move(t));
     if (r < 0)
       goto out;
   }
@@ -3481,7 +3481,7 @@ int OSD::shutdown()
   superblock.clean_thru = osdmap->get_epoch();
   ObjectStore::Transaction t;
   write_superblock(t);
-  int r = store->apply_transaction(service.meta_osr.get(), std::move(t));
+  int r = store->apply_transaction(service.meta_ch, std::move(t));
   if (r) {
     derr << "OSD::shutdown: error writing superblock: "
 	 << cpp_strerror(r) << dendl;
@@ -3514,6 +3514,7 @@ int OSD::shutdown()
 	  ceph_abort();
 	}
       }
+      p->second->ch.reset();
       p->second->unlock();
       p->second->put("PGMap");
     }
@@ -3523,6 +3524,8 @@ int OSD::shutdown()
   service.dump_live_pgids();
 #endif
   cct->_conf->remove_observer(this);
+
+  service.meta_ch.reset();
 
   dout(10) << "syncing store" << dendl;
   enable_disable_fuse(true);
@@ -3738,13 +3741,13 @@ void OSD::clear_temp_objects()
 	dout(20) << "  removing " << *p << " object " << *q << dendl;
 	t.remove(*p, *q);
         if (++removed > cct->_conf->osd_target_transaction_size) {
-          store->apply_transaction(service.meta_osr.get(), std::move(t));
+          store->apply_transaction(service.meta_ch, std::move(t));
           t = ObjectStore::Transaction();
           removed = 0;
         }
       }
       if (removed) {
-        store->apply_transaction(service.meta_osr.get(), std::move(t));
+        store->apply_transaction(service.meta_ch, std::move(t));
       }
     }
   }
@@ -3759,8 +3762,7 @@ void OSD::recursive_remove_collection(CephContext* cct,
     coll_t(),
     make_snapmapper_oid());
 
-  ceph::shared_ptr<ObjectStore::Sequencer> osr (std::make_shared<
-                                      ObjectStore::Sequencer>("rm"));
+  ObjectStore::CollectionHandle ch = store->open_collection(tmp);
   ObjectStore::Transaction t;
   SnapMapper mapper(cct, &driver, 0, 0, 0, pgid.shard);
 
@@ -3779,18 +3781,18 @@ void OSD::recursive_remove_collection(CephContext* cct,
       ceph_abort();
     t.remove(tmp, *p);
     if (removed > cct->_conf->osd_target_transaction_size) {
-      int r = store->apply_transaction(osr.get(), std::move(t));
+      int r = store->apply_transaction(ch, std::move(t));
       assert(r == 0);
       t = ObjectStore::Transaction();
       removed = 0;
     }
   }
   t.remove_collection(tmp);
-  int r = store->apply_transaction(osr.get(), std::move(t));
+  int r = store->apply_transaction(ch, std::move(t));
   assert(r == 0);
 
   C_SaferCond waiter;
-  if (!osr->flush_commit(&waiter)) {
+  if (!ch->flush_commit(&waiter)) {
     waiter.wait();
   }
 }
@@ -3888,7 +3890,6 @@ PG *OSD::_create_lock_pg(
   PG *pg = _open_lock_pg(createmap, pgid, true);
 
   service.init_splits_between(pgid, pg->get_osdmap(), service.get_osdmap());
-
   pg->init(
     role,
     up,
@@ -3899,6 +3900,8 @@ PG *OSD::_create_lock_pg(
     pi,
     backfill,
     &t);
+
+  pg->ch = store->create_new_collection(pg->coll);
 
   dout(7) << "_create_lock_pg " << *pg << dendl;
   return pg;
@@ -5088,7 +5091,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       val.append(valstr);
       newattrs[key] = val;
       t.omap_setkeys(coll_t(pgid), ghobject_t(obj), newattrs);
-      r = store->apply_transaction(service->meta_osr.get(), std::move(t));
+      r = store->apply_transaction(service->meta_ch, std::move(t));
       if (r < 0)
         ss << "error=" << r;
       else
@@ -5100,7 +5103,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
 
       keys.insert(key);
       t.omap_rmkeys(coll_t(pgid), ghobject_t(obj), keys);
-      r = store->apply_transaction(service->meta_osr.get(), std::move(t));
+      r = store->apply_transaction(service->meta_ch, std::move(t));
       if (r < 0)
         ss << "error=" << r;
       else
@@ -5112,7 +5115,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       cmd_getval(service->cct, cmdmap, "header", headerstr);
       newheader.append(headerstr);
       t.omap_setheader(coll_t(pgid), ghobject_t(obj), newheader);
-      r = store->apply_transaction(service->meta_osr.get(), std::move(t));
+      r = store->apply_transaction(service->meta_ch, std::move(t));
       if (r < 0)
         ss << "error=" << r;
       else
@@ -5135,7 +5138,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       int64_t trunclen;
       cmd_getval(service->cct, cmdmap, "len", trunclen);
       t.truncate(coll_t(pgid), ghobject_t(obj), trunclen);
-      r = store->apply_transaction(service->meta_osr.get(), std::move(t));
+      r = store->apply_transaction(service->meta_ch, std::move(t));
       if (r < 0)
 	ss << "error=" << r;
       else
@@ -6044,9 +6047,6 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
     cmd_getval(cct, cmdmap, "object_size", osize, (int64_t)0);
     cmd_getval(cct, cmdmap, "object_num", onum, (int64_t)0);
 
-    ceph::shared_ptr<ObjectStore::Sequencer> osr (std::make_shared<
-                                        ObjectStore::Sequencer>("bench"));
-
     uint32_t duration = cct->_conf->osd_bench_duration;
 
     if (bsize > (int64_t) cct->_conf->osd_bench_max_block_size) {
@@ -6122,7 +6122,7 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
 	hobject_t soid(sobject_t(oid, 0));
 	ObjectStore::Transaction t;
 	t.write(coll_t(), ghobject_t(soid), 0, osize, bl);
-	store->queue_transaction(osr.get(), std::move(t), NULL);
+	store->queue_transaction(service.meta_ch, std::move(t), NULL);
 	cleanupt.remove(coll_t(), ghobject_t(soid));
       }
     }
@@ -6135,7 +6135,7 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
 
     {
       C_SaferCond waiter;
-      if (!osr->flush_commit(&waiter)) {
+      if (!service.meta_ch->flush_commit(&waiter)) {
 	waiter.wait();
       }
     }
@@ -6154,24 +6154,24 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       hobject_t soid(sobject_t(oid, 0));
       ObjectStore::Transaction t;
       t.write(coll_t::meta(), ghobject_t(soid), offset, bsize, bl);
-      store->queue_transaction(osr.get(), std::move(t), NULL);
+      store->queue_transaction(service.meta_ch, std::move(t), NULL);
       if (!onum || !osize)
 	cleanupt.remove(coll_t::meta(), ghobject_t(soid));
     }
 
     {
       C_SaferCond waiter;
-      if (!osr->flush_commit(&waiter)) {
+      if (!service.meta_ch->flush_commit(&waiter)) {
 	waiter.wait();
       }
     }
     utime_t end = ceph_clock_now();
 
     // clean up
-    store->queue_transaction(osr.get(), std::move(cleanupt), NULL);
+    store->queue_transaction(service.meta_ch, std::move(cleanupt), NULL);
     {
       C_SaferCond waiter;
-      if (!osr->flush_commit(&waiter)) {
+      if (!service.meta_ch->flush_commit(&waiter)) {
 	waiter.wait();
       }
     }
@@ -7114,7 +7114,7 @@ void OSD::trim_maps(epoch_t oldest, int nreceived, bool skip_maps)
     if (num >= cct->_conf->osd_target_transaction_size && num >= nreceived) {
       service.publish_superblock(superblock);
       write_superblock(t);
-      int tr = store->queue_transaction(service.meta_osr.get(), std::move(t), nullptr);
+      int tr = store->queue_transaction(service.meta_ch, std::move(t), nullptr);
       assert(tr == 0);
       num = 0;
       if (!skip_maps) {
@@ -7130,7 +7130,7 @@ void OSD::trim_maps(epoch_t oldest, int nreceived, bool skip_maps)
   if (num > 0) {
     service.publish_superblock(superblock);
     write_superblock(t);
-    int tr = store->queue_transaction(service.meta_osr.get(), std::move(t), nullptr);
+    int tr = store->queue_transaction(service.meta_ch, std::move(t), nullptr);
     assert(tr == 0);
   }
   // we should not remove the cached maps
@@ -7387,7 +7387,7 @@ void OSD::handle_osd_map(MOSDMap *m)
   // superblock and commit
   write_superblock(t);
   store->queue_transaction(
-    service.meta_osr.get(),
+    service.meta_ch,
     std::move(t),
     new C_OnMapApply(&service, std::move(pinned_maps), last),
     new C_OnMapCommit(this, start, last, m), 0);
@@ -7719,7 +7719,7 @@ void OSD::check_osdmap_features()
       superblock.compat_features.incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_SHARDS);
       ObjectStore::Transaction t;
       write_superblock(t);
-      int err = store->queue_transaction(service.meta_osr.get(), std::move(t), NULL);
+      int err = store->queue_transaction(service.meta_ch, std::move(t), NULL);
       assert(err == 0);
     }
   }
@@ -8091,6 +8091,7 @@ void OSD::split_pgs(
       child,
       split_bits);
 
+    child->ch = store->create_new_collection(child->coll);
     child->finish_split_stats(*stat_iter, rctx->transaction);
     child->unlock();
   }
@@ -8221,7 +8222,7 @@ void OSD::dispatch_context_transaction(PG::RecoveryCtx &ctx, PG *pg,
 {
   if (!ctx.transaction->empty()) {
     int tr = store->queue_transaction(
-      pg->osr.get(),
+      pg->ch,
       std::move(*ctx.transaction), ctx.on_applied, ctx.on_safe, NULL,
       TrackedOpRef(), handle);
     assert(tr == 0);
@@ -8259,7 +8260,7 @@ void OSD::dispatch_context(PG::RecoveryCtx &ctx, PG *pg, OSDMapRef curmap,
     assert(ctx.created_pgs.empty());
   } else {
     int tr = store->queue_transaction(
-      pg->osr.get(),
+      pg->ch,
       std::move(*ctx.transaction), ctx.on_applied, ctx.on_safe, NULL, TrackedOpRef(),
       handle);
     for (auto pg : ctx.created_pgs) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8216,37 +8216,21 @@ PG::RecoveryCtx OSD::create_context()
   return rctx;
 }
 
-struct C_OpenPGs : public Context {
-  set<PGRef> pgs;
-  ObjectStore *store;
-  OSD *osd;
-  C_OpenPGs(set<PGRef>& p, ObjectStore *s, OSD* o) : store(s), osd(o) {
-    pgs.swap(p);
-  }
-  void finish(int r) override {
-    RWLock::RLocker l(osd->pg_map_lock);
-    for (auto p : pgs) {
-      if (osd->pg_map.count(p->get_pgid())) {
-        p->ch = store->open_collection(p->coll);
-        assert(p->ch);
-      }
-    }
-  }
-};
-
 void OSD::dispatch_context_transaction(PG::RecoveryCtx &ctx, PG *pg,
                                        ThreadPool::TPHandle *handle)
 {
   if (!ctx.transaction->empty()) {
-    if (!ctx.created_pgs.empty()) {
-      ctx.on_applied->add(new C_OpenPGs(ctx.created_pgs, store, this));
-    }
     int tr = store->queue_transaction(
       pg->osr.get(),
       std::move(*ctx.transaction), ctx.on_applied, ctx.on_safe, NULL,
       TrackedOpRef(), handle);
-    delete (ctx.transaction);
     assert(tr == 0);
+    delete (ctx.transaction);
+    for (auto pg : ctx.created_pgs) {
+      pg->ch = store->open_collection(pg->coll);
+      assert(pg->ch);
+    }
+    ctx.created_pgs.clear();
     ctx.transaction = new ObjectStore::Transaction;
     ctx.on_applied = new C_Contexts(cct);
     ctx.on_safe = new C_Contexts(cct);
@@ -8274,13 +8258,15 @@ void OSD::dispatch_context(PG::RecoveryCtx &ctx, PG *pg, OSDMapRef curmap,
     delete ctx.on_safe;
     assert(ctx.created_pgs.empty());
   } else {
-    if (!ctx.created_pgs.empty()) {
-      ctx.on_applied->add(new C_OpenPGs(ctx.created_pgs, store, this));
-    }
     int tr = store->queue_transaction(
       pg->osr.get(),
       std::move(*ctx.transaction), ctx.on_applied, ctx.on_safe, NULL, TrackedOpRef(),
       handle);
+    for (auto pg : ctx.created_pgs) {
+      pg->ch = store->open_collection(pg->coll);
+      assert(pg->ch);
+    }
+    ctx.created_pgs.clear();
     delete (ctx.transaction);
     assert(tr == 0);
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1459,7 +1459,7 @@ bool OSDService::_get_map_bl(epoch_t e, bufferlist& bl)
   }
   if (logger)
     logger->inc(l_osd_map_bl_cache_miss);
-  found = store->read(coll_t::meta(),
+  found = store->read(meta_ch,
 		      OSD::get_osdmap_pobject_name(e), 0, 0, bl,
 		      CEPH_OSD_OP_FLAG_FADVISE_WILLNEED) >= 0;
   if (found) {
@@ -1479,7 +1479,7 @@ bool OSDService::get_inc_map_bl(epoch_t e, bufferlist& bl)
   }
   if (logger)
     logger->inc(l_osd_map_bl_cache_miss);
-  found = store->read(coll_t::meta(),
+  found = store->read(meta_ch,
 		      OSD::get_inc_osdmap_pobject_name(e), 0, 0, bl,
 		      CEPH_OSD_OP_FLAG_FADVISE_WILLNEED) >= 0;
   if (found) {
@@ -1581,7 +1581,7 @@ int OSDService::get_deleted_pool_pg_num(int64_t pool)
   dout(20) << __func__ << " " << pool << " loading" << dendl;
   ghobject_t oid = OSD::make_final_pool_info_oid(pool);
   bufferlist bl;
-  int r = store->read(coll_t::meta(), oid, 0, 0, bl);
+  int r = store->read(meta_ch, oid, 0, 0, bl);
   ceph_assert(r >= 0);
   auto blp = bl.begin();
   pg_pool_t pi;
@@ -1824,6 +1824,7 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, const string &dev,
 
   OSDSuperblock sb;
   bufferlist sbbl;
+  ObjectStore::CollectionHandle ch;
 
   // if we are fed a uuid for this osd, use it.
   store->set_fsid(cct->_conf->osd_uuid);
@@ -1844,8 +1845,13 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, const string &dev,
     goto free_store;
   }
 
-  ret = store->read(coll_t::meta(), OSD_SUPERBLOCK_GOBJECT, 0, 0, sbbl);
-  if (ret >= 0) {
+  ch = store->open_collection(coll_t::meta());
+  if (ch) {
+    ret = store->read(ch, OSD_SUPERBLOCK_GOBJECT, 0, 0, sbbl);
+    if (ret < 0) {
+      derr << "OSD::mkfs: have meta collection but no superblock" << dendl;
+      goto free_store;
+    }
     /* if we already have superblock, check content of superblock */
     dout(0) << " have superblock" << dendl;
     bufferlist::iterator p;
@@ -2626,7 +2632,7 @@ int OSD::init()
       if (c.is_pg(&pgid) &&
 	  !osdmap->have_pg_pool(pgid.pool())) {
 	ghobject_t oid = make_final_pool_info_oid(pgid.pool());
-	if (!store->exists(coll_t::meta(), oid)) {
+	if (!store->exists(service.meta_ch, oid)) {
 	  derr << __func__ << " missing pg_pool_t for deleted pool "
 	       << pgid.pool() << " for pg " << pgid
 	       << "; please downgrade to luminous and allow "
@@ -2651,7 +2657,7 @@ int OSD::init()
   }
 
   // make sure snap mapper object exists
-  if (!store->exists(coll_t::meta(), OSD::make_snapmapper_oid())) {
+  if (!store->exists(service.meta_ch, OSD::make_snapmapper_oid())) {
     dout(10) << "init creating/touching snapmapper object" << dendl;
     ObjectStore::Transaction t;
     t.touch(coll_t::meta(), OSD::make_snapmapper_oid());
@@ -3686,7 +3692,7 @@ void OSD::write_superblock(ObjectStore::Transaction& t)
 int OSD::read_superblock()
 {
   bufferlist bl;
-  int r = store->read(coll_t::meta(), OSD_SUPERBLOCK_GOBJECT, 0, 0, bl);
+  int r = store->read(service.meta_ch, OSD_SUPERBLOCK_GOBJECT, 0, 0, bl);
   if (r < 0)
     return r;
 
@@ -3715,7 +3721,9 @@ void OSD::clear_temp_objects()
     ghobject_t next;
     while (1) {
       vector<ghobject_t> objects;
-      store->collection_list(*p, next, ghobject_t::get_max(),
+      auto ch = store->open_collection(*p);
+      assert(ch);
+      store->collection_list(ch, next, ghobject_t::get_max(),
 			     store->get_ideal_list_max(),
 			     &objects, &next);
       if (objects.empty())
@@ -3759,7 +3767,6 @@ void OSD::recursive_remove_collection(CephContext* cct,
 {
   OSDriver driver(
     store,
-    coll_t(),
     make_snapmapper_oid());
 
   ObjectStore::CollectionHandle ch = store->open_collection(tmp);
@@ -3767,7 +3774,7 @@ void OSD::recursive_remove_collection(CephContext* cct,
   SnapMapper mapper(cct, &driver, 0, 0, 0, pgid.shard);
 
   vector<ghobject_t> objects;
-  store->collection_list(tmp, ghobject_t(), ghobject_t::get_max(),
+  store->collection_list(ch, ghobject_t(), ghobject_t::get_max(),
 			 INT_MAX, &objects, 0);
   generic_dout(10) << __func__ << " " << objects << dendl;
   // delete them.
@@ -3832,7 +3839,7 @@ PG* OSD::_make_pg(
     // pool was deleted; grab final pg_pool_t off disk.
     ghobject_t oid = make_final_pool_info_oid(pgid.pool());
     bufferlist bl;
-    int r = store->read(coll_t::meta(), oid, 0, 0, bl);
+    int r = store->read(service.meta_ch, oid, 0, 0, bl);
     ceph_assert(r >= 0);
     auto p = bl.begin();
     decode(pi, p);
@@ -5124,15 +5131,21 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       //Debug: Output entire omap
       bufferlist hdrbl;
       map<string, bufferlist> keyvals;
-      r = store->omap_get(coll_t(pgid), ghobject_t(obj), &hdrbl, &keyvals);
-      if (r >= 0) {
+      auto ch = store->open_collection(coll_t(pgid));
+      if (!ch) {
+	ss << "unable to open collection for " << pgid;
+	r = -ENOENT;
+      } else {
+	r = store->omap_get(ch, ghobject_t(obj), &hdrbl, &keyvals);
+	if (r >= 0) {
           ss << "header=" << string(hdrbl.c_str(), hdrbl.length());
           for (map<string, bufferlist>::iterator it = keyvals.begin();
-              it != keyvals.end(); ++it)
+	       it != keyvals.end(); ++it)
             ss << " key=" << (*it).first << " val="
                << string((*it).second.c_str(), (*it).second.length());
-      } else {
+	} else {
           ss << "error=" << r;
+	}
       }
     } else if (command == "truncobj") {
       int64_t trunclen;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -236,7 +236,6 @@ struct C_CompleteSplits;
 struct C_OpenPGs;
 class LogChannel;
 class CephContext;
-typedef ceph::shared_ptr<ObjectStore::Sequencer> SequencerRef;
 class MOSDOp;
 
 class OSD;
@@ -245,8 +244,7 @@ class OSDService {
 public:
   OSD *osd;
   CephContext *cct;
-  SharedPtrRegistry<spg_t, ObjectStore::Sequencer> osr_registry;
-  ceph::shared_ptr<ObjectStore::Sequencer> meta_osr;
+  ObjectStore::CollectionHandle meta_ch;
   const int whoami;
   ObjectStore *&store;
   LogClient &log_client;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -859,12 +859,6 @@ public:
   SimpleLRU<epoch_t, bufferlist> map_bl_cache;
   SimpleLRU<epoch_t, bufferlist> map_bl_inc_cache;
 
-  /// newest map fully consumed by handle_osd_map (i.e., written to disk)
-  epoch_t map_cache_pinned_epoch = 0;
-
-  /// true if pg consumption affected our unpinning
-  std::atomic<bool> map_cache_pinned_low = {false};
-
   /// final pg_num values for recently deleted pools
   map<int64_t,int> deleted_pool_pg_nums;
 
@@ -884,7 +878,6 @@ public:
     Mutex::Locker l(map_cache_lock);
     return _add_map_bl(e, bl);
   }
-  void pin_map_bl(epoch_t e, bufferlist &bl);
   void _add_map_bl(epoch_t e, bufferlist& bl);
   bool get_map_bl(epoch_t e, bufferlist& bl) {
     Mutex::Locker l(map_cache_lock);
@@ -896,12 +889,8 @@ public:
     Mutex::Locker l(map_cache_lock);
     return _add_map_inc_bl(e, bl);
   }
-  void pin_map_inc_bl(epoch_t e, bufferlist &bl);
   void _add_map_inc_bl(epoch_t e, bufferlist& bl);
   bool get_inc_map_bl(epoch_t e, bufferlist& bl);
-
-  void clear_map_bl_cache_pins(epoch_t e);
-  void check_map_bl_cache_pins();
 
   /// get last pg_num before a pool was deleted (if any)
   int get_deleted_pool_pg_num(int64_t pool);
@@ -1826,17 +1815,11 @@ private:
   void add_map_bl(epoch_t e, bufferlist& bl) {
     return service.add_map_bl(e, bl);
   }
-  void pin_map_bl(epoch_t e, bufferlist &bl) {
-    return service.pin_map_bl(e, bl);
-  }
   bool get_map_bl(epoch_t e, bufferlist& bl) {
     return service.get_map_bl(e, bl);
   }
   void add_map_inc_bl(epoch_t e, bufferlist& bl) {
     return service.add_map_inc_bl(e, bl);
-  }
-  void pin_map_inc_bl(epoch_t e, bufferlist &bl) {
-    return service.pin_map_inc_bl(e, bl);
   }
 
 protected:

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -309,7 +309,6 @@ PG::PG(OSDService *o, OSDMapRef curmap,
        const PGPool &_pool, spg_t p) :
   pg_id(p),
   coll(p),
-  osr(o->osr_registry.lookup_or_create(p, (stringify(p)))),
   osd(o),
   cct(o->cct),
   osdmap_ref(curmap),
@@ -366,7 +365,6 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   ss << "PG " << info.pgid;
   trace_endpoint.copy_name(ss.str());
 #endif
-  osr->shard_hint = p;
 }
 
 PG::~PG()
@@ -3052,9 +3050,8 @@ void PG::upgrade(ObjectStore *store)
   dirty_big_info = true;
   write_if_dirty(t);
 
-  ceph::shared_ptr<ObjectStore::Sequencer> osr (std::make_shared<
-                                      ObjectStore::Sequencer>("upgrade"));
-  int r = store->apply_transaction(osr.get(), std::move(t));
+  ObjectStore::CollectionHandle ch = store->open_collection(coll);
+  int r = store->apply_transaction(ch, std::move(t));
   if (r != 0) {
     derr << __func__ << ": apply_transaction returned "
 	 << cpp_strerror(r) << dendl;
@@ -3063,7 +3060,7 @@ void PG::upgrade(ObjectStore *store)
   assert(r == 0);
 
   C_SaferCond waiter;
-  if (!osr->flush_commit(&waiter)) {
+  if (!ch->flush_commit(&waiter)) {
     waiter.wait();
   }
 }
@@ -3307,7 +3304,7 @@ void PG::handle_pg_trim(epoch_t epoch, int from, shard_id_t shard, eversion_t tr
     pg_log.trim(trim_to, info);
     dirty_info = true;
     write_if_dirty(t);
-    int tr = osd->store->queue_transaction(osr.get(), std::move(t), NULL);
+    int tr = osd->store->queue_transaction(ch, std::move(t), NULL);
     assert(tr == 0);
   }
 }
@@ -3517,7 +3514,7 @@ void PG::read_state(ObjectStore *store)
   PG::RecoveryCtx rctx(0, 0, 0, 0, 0, new ObjectStore::Transaction);
   handle_loaded(&rctx);
   write_if_dirty(*rctx.transaction);
-  store->apply_transaction(osr.get(), std::move(*rctx.transaction));
+  store->apply_transaction(ch, std::move(*rctx.transaction));
   delete rctx.transaction;
 }
 
@@ -4102,7 +4099,7 @@ void PG::_scan_rollback_obs(
   if (!t.empty()) {
     derr << __func__ << ": queueing trans to clean up obsolete rollback objs"
 	 << dendl;
-    osd->store->queue_transaction(osr.get(), std::move(t), NULL);
+    osd->store->queue_transaction(ch, std::move(t), NULL);
   }
 }
 
@@ -4182,7 +4179,7 @@ void PG::_scan_snaps(ScrubMap &smap)
 			    << "...repaired";
 	}
 	snap_mapper.add_oid(hoid, obj_snaps, &_t);
-	r = osd->store->apply_transaction(osr.get(), std::move(t));
+	r = osd->store->apply_transaction(ch, std::move(t));
 	if (r != 0) {
 	  derr << __func__ << ": apply_transaction got " << cpp_strerror(r)
 	       << dendl;
@@ -4229,7 +4226,7 @@ void PG::_repair_oinfo_oid(ScrubMap &smap)
       o.attrs[OI_ATTR] = bp;
 
       t.setattr(coll, ghobject_t(hoid), OI_ATTR, bl);
-      int r = osd->store->apply_transaction(osr.get(), std::move(t));
+      int r = osd->store->apply_transaction(ch, std::move(t));
       if (r != 0) {
 	derr << __func__ << ": apply_transaction got " << cpp_strerror(r)
 	     << dendl;
@@ -4601,7 +4598,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  scrubber.cleanup_store(&t);
 	  scrubber.store.reset(Scrub::Store::create(osd->store, &t,
 						    info.pgid, coll));
-	  osd->store->queue_transaction(osr.get(), std::move(t), nullptr);
+	  osd->store->queue_transaction(ch, std::move(t), nullptr);
 	}
 
         // Don't include temporary objects when scrubbing
@@ -4660,7 +4657,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           hobject_t start = scrubber.start;
 	  hobject_t candidate_end;
 	  vector<hobject_t> objects;
-	  osr->flush();
+	  ch->flush();
 	  ret = get_pgbackend()->objects_list_partial(
 	    start,
 	    min,
@@ -5079,7 +5076,7 @@ void PG::scrub_compare_maps()
       dout(10) << __func__ << ": updating scrub object" << dendl;
       ObjectStore::Transaction t;
       scrubber.store->flush(&t);
-      osd->store->queue_transaction(osr.get(), std::move(t), nullptr);
+      osd->store->queue_transaction(ch, std::move(t), nullptr);
     }
   }
 }
@@ -5219,7 +5216,7 @@ void PG::scrub_finish()
     ObjectStore::Transaction t;
     dirty_info = true;
     write_if_dirty(t);
-    int tr = osd->store->queue_transaction(osr.get(), std::move(t), NULL);
+    int tr = osd->store->queue_transaction(ch, std::move(t), NULL);
     assert(tr == 0);
   }
 
@@ -5519,7 +5516,7 @@ void PG::reset_interval_flush()
   
   Context *c = new QueuePeeringEvt<IntervalFlush>(
     this, get_osdmap()->get_epoch(), IntervalFlush());
-  if (!osr->flush_commit(c)) {
+  if (!ch->flush_commit(c)) {
     dout(10) << "Beginning to block outgoing recovery messages" << dendl;
     recovery_state.begin_block_outgoing();
   } else {
@@ -6203,7 +6200,7 @@ void PG::update_store_on_load()
       lderr(cct) << __func__ << " setting bit width to " << bits << dendl;
       ObjectStore::Transaction t;
       t.collection_set_bits(coll, bits);
-      osd->store->apply_transaction(osr.get(), std::move(t));
+      osd->store->apply_transaction(ch, std::move(t));
     }
   }
 }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4256,7 +4256,6 @@ int PG::build_scrub_map_chunk(
   while (pos.empty()) {
     pos.deep = deep;
     map.valid_through = info.last_update;
-    ch->flush();
 
     // objects
     vector<ghobject_t> rollback_obs;
@@ -4663,7 +4662,6 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           hobject_t start = scrubber.start;
 	  hobject_t candidate_end;
 	  vector<hobject_t> objects;
-	  ch->flush();
 	  ret = get_pgbackend()->objects_list_partial(
 	    start,
 	    min,

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6208,18 +6208,12 @@ void PG::update_store_on_load()
 struct C_DeleteMore : public Context {
   PGRef pg;
   epoch_t epoch;
-  int count = 2;
   C_DeleteMore(PG *p, epoch_t e) : pg(p), epoch(e) {}
   void finish(int r) override {
     ceph_abort();
   }
   void complete(int r) override {
     assert(r == 0);
-    // complete will be called exactly count times; only the last time will actualy
-    // complete.
-    if (--count) {
-      return;
-    }
     pg->lock();
     if (!pg->pg_has_reset_since(epoch)) {
       pg->osd->queue_for_pg_delete(pg->get_pgid(), epoch);
@@ -6268,7 +6262,6 @@ void PG::_delete_some()
   if (num) {
     dout(20) << __func__ << " deleting " << num << " objects" << dendl;
     Context *fin = new C_DeleteMore(this, e);
-    t.register_on_applied(fin);
     t.register_on_commit(fin);
     osd->store->queue_transaction(
       ch,
@@ -8193,7 +8186,6 @@ PG::RecoveryState::Deleting::Deleting(my_context ctx)
   pg->on_removal(t);
   RecoveryCtx *rctx = context<RecoveryMachine>().get_recovery_ctx();
   Context *fin = new C_DeleteMore(pg, pg->get_osdmap()->get_epoch());
-  rctx->on_applied->contexts.push_back(fin);
   rctx->on_safe->contexts.push_back(fin);
 }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3051,9 +3051,9 @@ void PG::upgrade(ObjectStore *store)
   write_if_dirty(t);
 
   ObjectStore::CollectionHandle ch = store->open_collection(coll);
-  int r = store->apply_transaction(ch, std::move(t));
+  int r = store->queue_transaction(ch, std::move(t));
   if (r != 0) {
-    derr << __func__ << ": apply_transaction returned "
+    derr << __func__ << ": queue_transaction returned "
 	 << cpp_strerror(r) << dendl;
     ceph_abort();
   }
@@ -3520,7 +3520,7 @@ void PG::read_state(ObjectStore *store)
   PG::RecoveryCtx rctx(0, 0, 0, 0, 0, new ObjectStore::Transaction);
   handle_loaded(&rctx);
   write_if_dirty(*rctx.transaction);
-  store->apply_transaction(ch, std::move(*rctx.transaction));
+  store->queue_transaction(ch, std::move(*rctx.transaction));
   delete rctx.transaction;
 }
 
@@ -4185,9 +4185,9 @@ void PG::_scan_snaps(ScrubMap &smap)
 			    << "...repaired";
 	}
 	snap_mapper.add_oid(hoid, obj_snaps, &_t);
-	r = osd->store->apply_transaction(ch, std::move(t));
+	r = osd->store->queue_transaction(ch, std::move(t));
 	if (r != 0) {
-	  derr << __func__ << ": apply_transaction got " << cpp_strerror(r)
+	  derr << __func__ << ": queue_transaction got " << cpp_strerror(r)
 	       << dendl;
 	}
       }
@@ -4232,9 +4232,9 @@ void PG::_repair_oinfo_oid(ScrubMap &smap)
       o.attrs[OI_ATTR] = bp;
 
       t.setattr(coll, ghobject_t(hoid), OI_ATTR, bl);
-      int r = osd->store->apply_transaction(ch, std::move(t));
+      int r = osd->store->queue_transaction(ch, std::move(t));
       if (r != 0) {
-	derr << __func__ << ": apply_transaction got " << cpp_strerror(r)
+	derr << __func__ << ": queue_transaction got " << cpp_strerror(r)
 	     << dendl;
       }
     }
@@ -6204,7 +6204,7 @@ void PG::update_store_on_load()
       lderr(cct) << __func__ << " setting bit width to " << bits << dendl;
       ObjectStore::Transaction t;
       t.collection_set_bits(coll, bits);
-      osd->store->apply_transaction(ch, std::move(t));
+      osd->store->queue_transaction(ch, std::move(t));
     }
   }
 }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3389,11 +3389,7 @@ void PG::append_log(
     pg_log.roll_forward_to(
       roll_forward_to,
       &handler);
-    t.register_on_applied(
-      new C_UpdateLastRollbackInfoTrimmedToApplied(
-	this,
-	get_osdmap()->get_epoch(),
-	roll_forward_to));
+    last_rollback_info_trimmed_to_applied = roll_forward_to;
   }
 
   pg_log.trim(trim_to, info);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6278,7 +6278,6 @@ void PG::_delete_some()
     PGRef pgref(this);
     // keep pg ref around until txn completes to avoid any issues
     // with Sequencer lifecycle (seen w/ filestore).
-    t.register_on_applied(new ContainerContext<PGRef>(pgref));
     t.register_on_commit(new ContainerContext<PGRef>(pgref));
     int r = osd->store->queue_transaction(
       osd->meta_ch, std::move(t));

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -313,7 +313,7 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   cct(o->cct),
   osdmap_ref(curmap),
   pool(_pool),
-  osdriver(osd->store, coll_t(), OSD::make_snapmapper_oid()),
+  osdriver(osd->store, OSD::make_snapmapper_oid()),
   snap_mapper(
     cct,
     &osdriver,
@@ -3198,7 +3198,9 @@ bool PG::_has_removal_flag(ObjectStore *store,
   set<string> keys;
   keys.insert("_remove");
   map<string,bufferlist> values;
-  if (store->omap_get_values(coll, pgmeta_oid, keys, &values) == 0 &&
+  auto ch = store->open_collection(coll);
+  assert(ch);
+  if (store->omap_get_values(ch, pgmeta_oid, keys, &values) == 0 &&
       values.size() == 1)
     return true;
 
@@ -3222,7 +3224,9 @@ int PG::peek_map_epoch(ObjectStore *store,
   keys.insert(infover_key);
   keys.insert(epoch_key);
   map<string,bufferlist> values;
-  int r = store->omap_get_values(coll, pgmeta_oid, keys, &values);
+  auto ch = store->open_collection(coll);
+  assert(ch);
+  int r = store->omap_get_values(ch, pgmeta_oid, keys, &values);
   if (r == 0) {
     assert(values.size() == 2);
 
@@ -3435,7 +3439,9 @@ int PG::read_info(
   keys.insert(fastinfo_key);
   ghobject_t pgmeta_oid(pgid.make_pgmeta_oid());
   map<string,bufferlist> values;
-  int r = store->omap_get_values(coll, pgmeta_oid, keys, &values);
+  auto ch = store->open_collection(coll);
+  assert(ch);
+  int r = store->omap_get_values(ch, pgmeta_oid, keys, &values);
   assert(r == 0);
   assert(values.size() == 3 ||
 	 values.size() == 4);
@@ -3477,7 +3483,7 @@ void PG::read_state(ObjectStore *store)
   ostringstream oss;
   pg_log.read_log_and_missing(
     store,
-    coll,
+    ch,
     pgmeta_oid,
     info,
     oss,
@@ -4250,7 +4256,7 @@ int PG::build_scrub_map_chunk(
   while (pos.empty()) {
     pos.deep = deep;
     map.valid_through = info.last_update;
-    osr->flush();
+    ch->flush();
 
     // objects
     vector<ghobject_t> rollback_obs;
@@ -6183,7 +6189,7 @@ void PG::handle_query_state(Formatter *f)
 
 void PG::update_store_with_options()
 {
-  auto r = osd->store->set_collection_opts(coll, pool.info.opts);
+  auto r = osd->store->set_collection_opts(ch, pool.info.opts);
   if(r < 0 && r != -EOPNOTSUPP) {
     derr << __func__ << " set_collection_opts returns error:" << r << dendl;
   }
@@ -6193,7 +6199,7 @@ void PG::update_store_on_load()
 {
   if (osd->store->get_type() == "filestore") {
     // legacy filestore didn't store collection bit width; fix.
-    int bits = osd->store->collection_bits(coll);
+    int bits = osd->store->collection_bits(ch);
     if (bits < 0) {
       assert(!coll.is_meta()); // otherwise OSD::load_pgs() did a bad thing
       bits = info.pgid.get_split_bits(pool.info.get_pg_num());
@@ -6243,7 +6249,7 @@ void PG::_delete_some()
 		     (int)cct->_conf->osd_target_transaction_size);
   ghobject_t next;
   osd->store->collection_list(
-    coll,
+    ch,
     next,
     ghobject_t::get_max(),
     max,
@@ -6269,7 +6275,7 @@ void PG::_delete_some()
     dout(20) << __func__ << " deleting " << num << " objects" << dendl;
     Context *fin = new C_DeleteMore(this, e);
     osd->store->queue_transaction(
-      osr.get(),
+      ch,
       std::move(t),
       fin,
       fin);
@@ -6284,7 +6290,7 @@ void PG::_delete_some()
     t.remove_collection(coll);
     PGRef pgref(this);
     int r = osd->store->queue_transaction(
-      osd->meta_osr.get(), std::move(t),
+      osd->meta_ch, std::move(t),
       // keep pg ref around until txn completes to avoid any issues
       // with Sequencer lifecycle (seen w/ filestore).
       new ContainerContext<PGRef>(pgref),

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -829,27 +829,7 @@ protected:
   eversion_t  last_complete_ondisk;  // last_complete that has committed.
   eversion_t  last_update_applied;
 
-
-  struct C_UpdateLastRollbackInfoTrimmedToApplied : Context {
-    PGRef pg;
-    epoch_t e;
-    eversion_t v;
-    C_UpdateLastRollbackInfoTrimmedToApplied(PG *pg, epoch_t e, eversion_t v)
-      : pg(pg), e(e), v(v) {}
-    bool sync_finish(int r) override {
-      pg->last_rollback_info_trimmed_to_applied = v;
-      return true;
-    }
-    void finish(int) override {
-      pg->lock();
-      if (!pg->pg_has_reset_since(e)) {
-	pg->last_rollback_info_trimmed_to_applied = v;
-      }
-      pg->unlock();
-    }
-  };
-  // entries <= last_rollback_info_trimmed_to_applied have been trimmed,
-  // and the transaction has applied
+  // entries <= last_rollback_info_trimmed_to_applied have been trimmed
   eversion_t  last_rollback_info_trimmed_to_applied;
 
   // primary state

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -251,9 +251,6 @@ public:
   const spg_t pg_id;
   const coll_t coll;
 
-  // for ordering writes
-  ceph::shared_ptr<ObjectStore::Sequencer> osr;
-
   ObjectStore::CollectionHandle ch;
 
   class RecoveryCtx;

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -438,7 +438,6 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      const vector<pg_log_entry_t> &log_entries, ///< [in] log entries for t
      /// [in] hitset history (if updated with this transaction)
      boost::optional<pg_hit_set_history_t> &hset_history,
-     Context *on_local_applied_sync,      ///< [in] called when applied locally
      Context *on_all_applied,             ///< [in] called when all acked
      Context *on_all_commit,              ///< [in] called when all commit
      ceph_tid_t tid,                      ///< [in] tid

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -915,9 +915,10 @@ void PGLog::_write_log_and_missing(
     t.omap_rmkeys(coll, log_oid, to_remove);
 }
 
-void PGLog::rebuild_missing_set_with_deletes(ObjectStore *store,
-					     coll_t pg_coll,
-					     const pg_info_t &info)
+void PGLog::rebuild_missing_set_with_deletes(
+  ObjectStore *store,
+  ObjectStore::CollectionHandle& ch,
+  const pg_info_t &info)
 {
   // save entries not generated from the current log (e.g. added due
   // to repair, EIO handling, or divergent_priors).
@@ -949,7 +950,7 @@ void PGLog::rebuild_missing_set_with_deletes(ObjectStore *store,
 
     bufferlist bv;
     int r = store->getattr(
-	pg_coll,
+      ch,
 	ghobject_t(i->soid, ghobject_t::NO_GEN, info.pgid.shard),
 	OI_ATTR,
 	bv);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1208,7 +1208,7 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	}
 
 	hobject_t current = lower_bound;
-	osr->flush();
+	ch->flush();
 	int r = pgbackend->objects_list_partial(
 	  current,
 	  list_size,
@@ -1365,7 +1365,7 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 
 	hobject_t next;
 	hobject_t current = response.handle;
-	osr->flush();
+	ch->flush();
 	int r = pgbackend->objects_list_partial(
 	  current,
 	  list_size,
@@ -4097,7 +4097,7 @@ void PrimaryLogPG::do_backfill(OpRequestRef op)
       ObjectStore::Transaction t;
       dirty_info = true;
       write_if_dirty(t);
-      int tr = osd->store->queue_transaction(osr.get(), std::move(t), NULL);
+      int tr = osd->store->queue_transaction(ch, std::move(t), NULL);
       assert(tr == 0);
     }
     break;
@@ -4125,7 +4125,7 @@ void PrimaryLogPG::do_backfill_remove(OpRequestRef op)
   for (auto& p : m->ls) {
     remove_snap_mapped_object(t, p.first);
   }
-  int r = osd->store->queue_transaction(osr.get(), std::move(t), NULL);
+  int r = osd->store->queue_transaction(ch, std::move(t), NULL);
   assert(r == 0);
 }
 
@@ -10377,7 +10377,7 @@ void PrimaryLogPG::submit_log_entries(
 	new OnComplete{this, rep_tid, get_osdmap()->get_epoch()});
       t.register_on_applied(
 	new C_OSD_OnApplied{this, get_osdmap()->get_epoch(), info.last_update});
-      int r = osd->store->queue_transaction(osr.get(), std::move(t), NULL);
+      int r = osd->store->queue_transaction(ch, std::move(t), NULL);
       assert(r == 0);
     });
 }
@@ -11136,7 +11136,7 @@ void PrimaryLogPG::remove_missing_object(const hobject_t &soid,
 	 ObjectStore::Transaction t2;
 	 on_local_recover(soid, recovery_info, ObjectContextRef(), true, &t2);
 	 t2.register_on_complete(on_complete);
-	 int r = osd->store->queue_transaction(osr.get(), std::move(t2), nullptr);
+	 int r = osd->store->queue_transaction(ch, std::move(t2), nullptr);
 	 assert(r == 0);
 	 unlock();
        } else {
@@ -11144,7 +11144,7 @@ void PrimaryLogPG::remove_missing_object(const hobject_t &soid,
 	 on_complete->complete(-EAGAIN);
        }
      }));
-  int r = osd->store->queue_transaction(osr.get(), std::move(t), nullptr);
+  int r = osd->store->queue_transaction(ch, std::move(t), nullptr);
   assert(r == 0);
 }
 
@@ -11356,7 +11356,7 @@ void PrimaryLogPG::do_update_log_missing(OpRequestRef &op)
   t.register_on_applied(
     new C_OSD_OnApplied{this, get_osdmap()->get_epoch(), info.last_update});
   int tr = osd->store->queue_transaction(
-    osr.get(),
+    ch,
     std::move(t),
     nullptr);
   assert(tr == 0);
@@ -11654,7 +11654,7 @@ void PrimaryLogPG::shutdown()
   lock();
   on_shutdown();
   unlock();
-  osr->flush();
+  ch->flush();
 }
 
 void PrimaryLogPG::on_shutdown()
@@ -12268,7 +12268,7 @@ uint64_t PrimaryLogPG::recover_primary(uint64_t max, ThreadPool::TPHandle &handl
 
 	      ++active_pushes;
 
-	      osd->store->queue_transaction(osr.get(), std::move(t),
+	      osd->store->queue_transaction(ch, std::move(t),
 					    new C_OSD_AppliedRecoveredObject(this, obc),
 					    new C_OSD_CommittedPushedObject(
 					      this,
@@ -13001,7 +13001,7 @@ void PrimaryLogPG::update_range(
   if (bi->version < info.log_tail) {
     dout(10) << __func__<< ": bi is old, rescanning local backfill_info"
 	     << dendl;
-    osr->flush();
+    ch->flush();
     if (last_update_applied >= info.log_tail) {
       bi->version = last_update_applied;
     } else {
@@ -14967,7 +14967,7 @@ boost::statechart::result PrimaryLogPG::AwaitAsyncWork::react(const DoSnapWork&)
     ObjectStore::Transaction t;
     pg->dirty_big_info = true;
     pg->write_if_dirty(t);
-    int tr = pg->osd->store->queue_transaction(pg->osr.get(), std::move(t), NULL);
+    int tr = pg->osd->store->queue_transaction(pg->ch, std::move(t), NULL);
     assert(tr == 0);
 
     pg->share_pg_info();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6975,7 +6975,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	bool truncated = false;
 	if (oi.is_omap()) {
 	  ObjectMap::ObjectMapIterator iter = osd->store->get_omap_iterator(
-	    coll, ghobject_t(soid)
+	    ch, ghobject_t(soid)
 	    );
 	  assert(iter);
 	  iter->upper_bound(start_after);
@@ -7022,7 +7022,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	bufferlist bl;
 	if (oi.is_omap()) {
 	  ObjectMap::ObjectMapIterator iter = osd->store->get_omap_iterator(
-	    coll, ghobject_t(soid)
+	    ch, ghobject_t(soid)
 	    );
           if (!iter) {
             result = -ENOENT;
@@ -8422,7 +8422,7 @@ int PrimaryLogPG::do_copy_get(OpContext *ctx, bufferlist::iterator& bp,
       }
       bufferlist omap_data;
       ObjectMap::ObjectMapIterator iter =
-	osd->store->get_omap_iterator(coll, ghobject_t(oi.soid));
+	osd->store->get_omap_iterator(ch, ghobject_t(oi.soid));
       assert(iter);
       iter->upper_bound(cursor.omap_offset);
       for (; iter->valid(); iter->next(false)) {
@@ -11753,7 +11753,7 @@ void PrimaryLogPG::_on_new_interval()
   dout(20) << __func__ << " checking missing set deletes flag. missing = " << pg_log.get_missing() << dendl;
   if (!pg_log.get_missing().may_include_deletes &&
       get_osdmap()->test_flag(CEPH_OSDMAP_RECOVERY_DELETES)) {
-    pg_log.rebuild_missing_set_with_deletes(osd->store, coll, info);
+    pg_log.rebuild_missing_set_with_deletes(osd->store, ch, info);
   }
   assert(pg_log.get_missing().may_include_deletes == get_osdmap()->test_flag(CEPH_OSDMAP_RECOVERY_DELETES));
 }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -196,22 +196,6 @@ class PrimaryLogPG::C_PG_ObjectContext : public Context {
   }
 };
 
-class PrimaryLogPG::C_OSD_OndiskWriteUnlock : public Context {
-  ObjectContextRef obc, obc2, obc3;
-  public:
-  C_OSD_OndiskWriteUnlock(
-    ObjectContextRef o,
-    ObjectContextRef o2 = ObjectContextRef(),
-    ObjectContextRef o3 = ObjectContextRef()) : obc(o), obc2(o2), obc3(o3) {}
-  void finish(int r) override {
-    obc->ondisk_write_unlock();
-    if (obc2)
-      obc2->ondisk_write_unlock();
-    if (obc3)
-      obc3->ondisk_write_unlock();
-  }
-};
-
 struct OnReadComplete : public Context {
   PrimaryLogPG *pg;
   PrimaryLogPG::OpContext *opcontext;
@@ -419,7 +403,6 @@ void PrimaryLogPG::on_local_recover(
   if (is_primary()) {
     if (!is_delete) {
       obc->obs.exists = true;
-      obc->ondisk_write_lock();
 
       bool got = obc->get_recovery_read();
       assert(got);
@@ -427,7 +410,6 @@ void PrimaryLogPG::on_local_recover(
       assert(recovering.count(obc->obs.oi.soid));
       recovering[obc->obs.oi.soid] = obc;
       obc->obs.oi = recovery_info.oi;  // may have been updated above
-      t->register_on_applied_sync(new C_OSD_OndiskWriteUnlock(obc));
     }
 
     t->register_on_applied(new C_OSD_AppliedRecoveredObject(this, obc));
@@ -3736,11 +3718,6 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
     ctx->user_at_version = obc->obs.oi.user_version;
   dout(30) << __func__ << " user_at_version " << ctx->user_at_version << dendl;
 
-  if (op->may_read()) {
-    dout(10) << " taking ondisk_read_lock" << dendl;
-    obc->ondisk_read_lock();
-  }
-
   {
 #ifdef WITH_LTTNG
     osd_reqid_t reqid = ctx->op->get_reqid();
@@ -3757,11 +3734,6 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
 #endif
     tracepoint(osd, prepare_tx_exit, reqid.name._type,
         reqid.name._num, reqid.tid, reqid.inc);
-  }
-
-  if (op->may_read()) {
-    dout(10) << " dropping ondisk_read_lock" << dendl;
-    obc->ondisk_read_unlock();
   }
 
   bool pending_async_reads = !ctx->pending_async_reads.empty();
@@ -10140,24 +10112,16 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     }
   }
 
-  ctx->obc->ondisk_write_lock();
-
   ctx->op_t->add_obc(ctx->obc);
   if (ctx->clone_obc) {
-    ctx->clone_obc->ondisk_write_lock();
     ctx->op_t->add_obc(ctx->clone_obc);
   }
   if (ctx->head_obc) {
-    ctx->head_obc->ondisk_write_lock();
     ctx->op_t->add_obc(ctx->head_obc);
   }
 
   Context *on_all_commit = new C_OSD_RepopCommit(this, repop);
   Context *on_all_applied = new C_OSD_RepopApplied(this, repop);
-  Context *onapplied_sync = new C_OSD_OndiskWriteUnlock(
-    ctx->obc,
-    ctx->clone_obc,
-    ctx->head_obc);
   if (!(ctx->log.empty())) {
     assert(ctx->at_version >= projected_last_update);
     projected_last_update = ctx->at_version;
@@ -10174,7 +10138,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     min_last_complete_ondisk,
     ctx->log,
     ctx->updated_hset_history,
-    onapplied_sync,
+    nullptr,
     on_all_applied,
     on_all_commit,
     repop->rep_tid,
@@ -12249,7 +12213,6 @@ uint64_t PrimaryLogPG::recover_primary(uint64_t max, ThreadPool::TPHandle &handl
 	      dout(10) << " already reverting " << soid << dendl;
 	    } else {
 	      dout(10) << " reverting " << soid << " to " << latest->prior_version << dendl;
-	      obc->ondisk_write_lock();
 	      obc->obs.oi.version = latest->version;
 
 	      ObjectStore::Transaction t;
@@ -12265,7 +12228,6 @@ uint64_t PrimaryLogPG::recover_primary(uint64_t max, ThreadPool::TPHandle &handl
 
 	      ++active_pushes;
 
-	      t.register_on_applied_sync(new C_OSD_OndiskWriteUnlock(obc));
 	      t.register_on_applied(new C_OSD_AppliedRecoveredObject(this, obc));
 	      t.register_on_commit(new C_OSD_CommittedPushedObject(
 				     this,
@@ -12412,14 +12374,12 @@ int PrimaryLogPG::prep_object_replica_pushes(
    * a client write would be blocked since the object is degraded.
    * In almost all cases, therefore, this lock should be uncontended.
    */
-  obc->ondisk_read_lock();
   int r = pgbackend->recover_object(
     soid,
     v,
     ObjectContextRef(),
     obc, // has snapset context
     h);
-  obc->ondisk_read_unlock();
   if (r < 0) {
     dout(0) << __func__ << " Error " << r << " on oid " << soid << dendl;
     primary_failed(soid);
@@ -12970,14 +12930,12 @@ int PrimaryLogPG::prep_backfill_object_push(
   recovering.insert(make_pair(oid, obc));
 
   // We need to take the read_lock here in order to flush in-progress writes
-  obc->ondisk_read_lock();
   int r = pgbackend->recover_object(
     oid,
     v,
     ObjectContextRef(),
     obc,
     h);
-  obc->ondisk_read_unlock();
   if (r < 0) {
     dout(0) << __func__ << " Error " << r << " on oid " << oid << dendl;
     primary_failed(oid);
@@ -13738,10 +13696,8 @@ void PrimaryLogPG::agent_load_hit_sets()
 
 	bufferlist bl;
 	{
-	  obc->ondisk_read_lock();
 	  int r = osd->store->read(ch, ghobject_t(oid), 0, 0, bl);
 	  assert(r >= 0);
-	  obc->ondisk_read_unlock();
 	}
 	HitSetRef hs(new HitSet);
 	bufferlist::iterator pbl = bl.begin();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10138,7 +10138,6 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     min_last_complete_ondisk,
     ctx->log,
     ctx->updated_hset_history,
-    nullptr,
     on_all_applied,
     on_all_commit,
     repop->rep_tid,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1208,7 +1208,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	}
 
 	hobject_t current = lower_bound;
-	ch->flush();
 	int r = pgbackend->objects_list_partial(
 	  current,
 	  list_size,
@@ -1365,7 +1364,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 
 	hobject_t next;
 	hobject_t current = response.handle;
-	ch->flush();
 	int r = pgbackend->objects_list_partial(
 	  current,
 	  list_size,
@@ -13001,7 +12999,6 @@ void PrimaryLogPG::update_range(
   if (bi->version < info.log_tail) {
     dout(10) << __func__<< ": bi is old, rescanning local backfill_info"
 	     << dendl;
-    ch->flush();
     if (last_update_applied >= info.log_tail) {
       bi->version = last_update_applied;
     } else {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -12265,13 +12265,13 @@ uint64_t PrimaryLogPG::recover_primary(uint64_t max, ThreadPool::TPHandle &handl
 
 	      ++active_pushes;
 
-	      osd->store->queue_transaction(ch, std::move(t),
-					    new C_OSD_AppliedRecoveredObject(this, obc),
-					    new C_OSD_CommittedPushedObject(
-					      this,
-					      get_osdmap()->get_epoch(),
-					      info.last_complete),
-					    new C_OSD_OndiskWriteUnlock(obc));
+	      t.register_on_applied_sync(new C_OSD_OndiskWriteUnlock(obc));
+	      t.register_on_applied(new C_OSD_AppliedRecoveredObject(this, obc));
+	      t.register_on_commit(new C_OSD_CommittedPushedObject(
+				     this,
+				     get_osdmap()->get_epoch(),
+				     info.last_complete));
+	      osd->store->queue_transaction(ch, std::move(t));
 	      continue;
 	    }
 	  } else {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11652,7 +11652,6 @@ void PrimaryLogPG::shutdown()
   lock();
   on_shutdown();
   unlock();
-  ch->flush();
 }
 
 void PrimaryLogPG::on_shutdown()

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -84,27 +84,6 @@ PGLSFilter::~PGLSFilter()
 {
 }
 
-struct PrimaryLogPG::C_OSD_OnApplied : Context {
-  PrimaryLogPGRef pg;
-  epoch_t epoch;
-  eversion_t v;
-  C_OSD_OnApplied(
-    PrimaryLogPGRef pg,
-    epoch_t epoch,
-    eversion_t v)
-    : pg(pg), epoch(epoch), v(v) {}
-  bool sync_finish(int r) override {
-    pg->op_applied(v);
-    return true;
-  }
-  void finish(int) override {
-    pg->lock();
-    if (!pg->pg_has_reset_since(epoch))
-      pg->op_applied(v);
-    pg->unlock();
-  }
-};
-
 /**
  * The CopyCallback class defines an interface for completions to the
  * copy_start code. Users of the copy infrastructure must implement
@@ -9967,10 +9946,7 @@ void PrimaryLogPG::repop_all_committed(RepGather *repop)
 void PrimaryLogPG::op_applied(const eversion_t &applied_version)
 {
   dout(10) << "op_applied version " << applied_version << dendl;
-  if (applied_version == eversion_t())
-    return;
-  assert(applied_version > last_update_applied);
-  assert(applied_version <= info.last_update);
+  assert(applied_version == info.last_update);
   last_update_applied = applied_version;
   if (is_primary()) {
     if (scrubber.active) {
@@ -10336,10 +10312,9 @@ void PrimaryLogPG::submit_log_entries(
       };
       t.register_on_commit(
 	new OnComplete{this, rep_tid, get_osdmap()->get_epoch()});
-      t.register_on_applied(
-	new C_OSD_OnApplied{this, get_osdmap()->get_epoch(), info.last_update});
       int r = osd->store->queue_transaction(ch, std::move(t), NULL);
       assert(r == 0);
+      op_applied(info.last_update);
     });
 }
 
@@ -11314,13 +11289,12 @@ void PrimaryLogPG::do_update_log_missing(OpRequestRef &op)
       t.register_on_commit(complete);
     }
   }
-  t.register_on_applied(
-    new C_OSD_OnApplied{this, get_osdmap()->get_epoch(), info.last_update});
   int tr = osd->store->queue_transaction(
     ch,
     std::move(t),
     nullptr);
   assert(tr == 0);
+  op_applied(info.last_update);
 }
 
 void PrimaryLogPG::do_update_log_missing_reply(OpRequestRef &op)

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -310,11 +310,11 @@ public:
   }
   void queue_transaction(ObjectStore::Transaction&& t,
 			 OpRequestRef op) override {
-    osd->store->queue_transaction(ch, std::move(t), 0, 0, 0, op);
+    osd->store->queue_transaction(ch, std::move(t), op);
   }
   void queue_transactions(vector<ObjectStore::Transaction>& tls,
 			  OpRequestRef op) override {
-    osd->store->queue_transactions(ch, tls, 0, 0, 0, op, NULL);
+    osd->store->queue_transactions(ch, tls, op, NULL);
   }
   epoch_t get_epoch() const override {
     return get_osdmap()->get_epoch();

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1270,7 +1270,6 @@ protected:
   void send_remove_op(const hobject_t& oid, eversion_t v, pg_shard_t peer);
 
 
-  class C_OSD_OndiskWriteUnlock;
   class C_OSD_AppliedRecoveredObject;
   class C_OSD_CommittedPushedObject;
   class C_OSD_AppliedRecoveredObjectReplica;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -310,11 +310,11 @@ public:
   }
   void queue_transaction(ObjectStore::Transaction&& t,
 			 OpRequestRef op) override {
-    osd->store->queue_transaction(osr.get(), std::move(t), 0, 0, 0, op);
+    osd->store->queue_transaction(ch, std::move(t), 0, 0, 0, op);
   }
   void queue_transactions(vector<ObjectStore::Transaction>& tls,
 			  OpRequestRef op) override {
-    osd->store->queue_transactions(osr.get(), tls, 0, 0, 0, op, NULL);
+    osd->store->queue_transactions(ch, tls, 0, 0, 0, op, NULL);
   }
   epoch_t get_epoch() const override {
     return get_osdmap()->get_epoch();

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -717,7 +717,7 @@ int ReplicatedBackend::be_deep_scrub(
 
     bufferlist hdrbl;
     r = store->omap_get_header(
-      coll,
+      ch,
       ghobject_t(
 	poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
       &hdrbl, true);
@@ -736,7 +736,7 @@ int ReplicatedBackend::be_deep_scrub(
 
   // omap
   ObjectMap::ObjectMapIterator iter = store->get_omap_iterator(
-    coll,
+    ch,
     ghobject_t(
       poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard));
   assert(iter);
@@ -1919,7 +1919,7 @@ int ReplicatedBackend::build_push_op(const ObjectRecoveryInfo &recovery_info,
 
   eversion_t v  = recovery_info.version;
   if (progress.first) {
-    int r = store->omap_get_header(coll, ghobject_t(recovery_info.soid), &out_op->omap_header);
+    int r = store->omap_get_header(ch, ghobject_t(recovery_info.soid), &out_op->omap_header);
     if(r < 0) {
       dout(1) << __func__ << " get omap header failed: " << cpp_strerror(-r) << dendl; 
       return r;
@@ -1962,7 +1962,7 @@ int ReplicatedBackend::build_push_op(const ObjectRecoveryInfo &recovery_info,
   uint64_t available = cct->_conf->osd_recovery_max_chunk;
   if (!progress.omap_complete) {
     ObjectMap::ObjectMapIterator iter =
-      store->get_omap_iterator(coll,
+      store->get_omap_iterator(ch,
 			       ghobject_t(recovery_info.soid));
     assert(iter);
     for (iter->lower_bound(progress.omap_recovered_to);

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -449,7 +449,6 @@ void ReplicatedBackend::submit_transaction(
   const eversion_t &roll_forward_to,
   const vector<pg_log_entry_t> &_log_entries,
   boost::optional<pg_hit_set_history_t> &hset_history,
-  Context *on_local_applied_sync,
   Context *on_all_acked,
   Context *on_all_commit,
   ceph_tid_t tid,
@@ -517,7 +516,6 @@ void ReplicatedBackend::submit_transaction(
     true,
     op_t);
   
-  op_t.register_on_applied_sync(on_local_applied_sync);
   op_t.register_on_applied(
     parent->bless_context(
       new C_OSD_OnOpApplied(this, &op)));

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -365,7 +365,6 @@ public:
     const eversion_t &roll_forward_to,
     const vector<pg_log_entry_t> &log_entries,
     boost::optional<pg_hit_set_history_t> &hset_history,
-    Context *on_local_applied_sync,
     Context *on_all_applied,
     Context *on_all_commit,
     ceph_tid_t tid,

--- a/src/osd/ScrubStore.cc
+++ b/src/osd/ScrubStore.cc
@@ -109,7 +109,7 @@ Store::create(ObjectStore* store,
 Store::Store(const coll_t& coll, const ghobject_t& oid, ObjectStore* store)
   : coll(coll),
     hoid(oid),
-    driver(store, coll, hoid),
+    driver(store, hoid),
     backend(&driver)
 {}
 

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -28,7 +28,7 @@ int OSDriver::get_keys(
   const std::set<std::string> &keys,
   std::map<std::string, bufferlist> *out)
 {
-  return os->omap_get_values(cid, hoid, keys, out);
+  return os->omap_get_values(ch, hoid, keys, out);
 }
 
 int OSDriver::get_next(
@@ -36,7 +36,7 @@ int OSDriver::get_next(
   pair<std::string, bufferlist> *next)
 {
   ObjectMap::ObjectMapIterator iter =
-    os->get_omap_iterator(cid, hoid);
+    os->get_omap_iterator(ch, hoid);
   if (!iter) {
     ceph_abort();
     return -EINVAL;

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -29,7 +29,7 @@
 
 class OSDriver : public MapCacher::StoreDriver<std::string, bufferlist> {
   ObjectStore *os;
-  coll_t cid;
+  ObjectStore::CollectionHandle ch;
   ghobject_t hoid;
 
 public:
@@ -60,11 +60,14 @@ public:
 
   OSTransaction get_transaction(
     ObjectStore::Transaction *t) {
-    return OSTransaction(cid, hoid, t);
+    return OSTransaction(ch->cid, hoid, t);
   }
 
-  OSDriver(ObjectStore *os, coll_t cid, const ghobject_t &hoid) :
-    os(os), cid(cid), hoid(hoid) {}
+  OSDriver(ObjectStore *os, const ghobject_t &hoid) :
+    os(os),
+    hoid(hoid) {
+    ch = os->open_collection(coll_t::meta());
+  }
   int get_keys(
     const std::set<std::string> &keys,
     std::map<std::string, bufferlist> *out) override;

--- a/src/test/bench/small_io_bench_fs.cc
+++ b/src/test/bench/small_io_bench_fs.cc
@@ -173,12 +173,12 @@ int main(int argc, char **argv)
     std::cout << "collection " << pgid << std::endl;
     ObjectStore::Transaction t;
     t.create_collection(coll_t(pgid), 0);
-    fs.apply_transaction(&osr, std::move(t));
+    fs.queue_transaction(&osr, std::move(t));
   }
   {
     ObjectStore::Transaction t;
     t.create_collection(coll_t(), 0);
-    fs.apply_transaction(&osr, std::move(t));
+    fs.queue_transaction(&osr, std::move(t));
   }
 
   vector<ceph::shared_ptr<Bencher> > benchers(

--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -183,7 +183,7 @@ int init_collections(std::unique_ptr<ObjectStore>& os,
     }
   }
   ObjectStore::Sequencer sequencer("Engine init");
-  int r = os->apply_transaction(&sequencer, std::move(t));
+  int r = os->queue_transaction(&sequencer, std::move(t));
   if (r)
     derr << "Engine init failed with " << cpp_strerror(-r) << dendl;
   return r;
@@ -201,7 +201,7 @@ int destroy_collections(
     t.remove_collection(coll.cid);
   }
   ObjectStore::Sequencer sequencer("Engine cleanup");
-  int r = os->apply_transaction(&sequencer, std::move(t));
+  int r = os->queue_transaction(&sequencer, std::move(t));
   if (r)
     derr << "Engine cleanup failed with " << cpp_strerror(-r) << dendl;
   return r;
@@ -408,7 +408,7 @@ Job::Job(Engine* engine, const thread_data* td)
 
   // apply the entire transaction synchronously
   ObjectStore::Sequencer sequencer("job init");
-  int r = engine->os->apply_transaction(&sequencer, std::move(t));
+  int r = engine->os->queue_transaction(&sequencer, std::move(t));
   if (r) {
     engine->deref();
     throw std::system_error(r, std::system_category(), "job init");
@@ -425,7 +425,7 @@ Job::~Job()
       t.remove(obj.coll.cid, obj.oid);
     }
     ObjectStore::Sequencer sequencer("job cleanup");
-    int r = engine->os->apply_transaction(&sequencer, std::move(t));
+    int r = engine->os->queue_transaction(&sequencer, std::move(t));
     if (r)
       derr << "job cleanup failed with " << cpp_strerror(-r) << dendl;
   }

--- a/src/test/objectstore/DeterministicOpSequence.cc
+++ b/src/test/objectstore/DeterministicOpSequence.cc
@@ -454,7 +454,7 @@ void DeterministicOpSequence::_do_coll_create(coll_t cid, uint32_t pg_num, uint6
   dout(0) << "Give collection: " << cid << " a hint, pg_num is: " << pg_num << ", num_objs is: "
     << num_objs << dendl;
 
-  m_store->apply_transaction(&m_osr, std::move(t));
+  m_store->queue_transaction(&m_osr, std::move(t));
 }
 
 void DeterministicOpSequence::_do_touch(coll_t coll, hobject_t& obj)
@@ -462,7 +462,7 @@ void DeterministicOpSequence::_do_touch(coll_t coll, hobject_t& obj)
   ObjectStore::Transaction t;
   note_txn(&t);
   t.touch(coll, ghobject_t(obj));
-  m_store->apply_transaction(&m_osr, std::move(t));
+  m_store->queue_transaction(&m_osr, std::move(t));
 }
 
 void DeterministicOpSequence::_do_remove(coll_t coll, hobject_t& obj)
@@ -470,7 +470,7 @@ void DeterministicOpSequence::_do_remove(coll_t coll, hobject_t& obj)
   ObjectStore::Transaction t;
   note_txn(&t);
   t.remove(coll, ghobject_t(obj));
-  m_store->apply_transaction(&m_osr, std::move(t));
+  m_store->queue_transaction(&m_osr, std::move(t));
 }
 
 void DeterministicOpSequence::_do_set_attrs(coll_t coll,
@@ -480,7 +480,7 @@ void DeterministicOpSequence::_do_set_attrs(coll_t coll,
   ObjectStore::Transaction t;
   note_txn(&t);
   t.omap_setkeys(coll, ghobject_t(obj), attrs);
-  m_store->apply_transaction(&m_osr, std::move(t));
+  m_store->queue_transaction(&m_osr, std::move(t));
 }
 
 void DeterministicOpSequence::_do_write(coll_t coll, hobject_t& obj,
@@ -489,7 +489,7 @@ void DeterministicOpSequence::_do_write(coll_t coll, hobject_t& obj,
   ObjectStore::Transaction t;
   note_txn(&t);
   t.write(coll, ghobject_t(obj), off, len, data);
-  m_store->apply_transaction(&m_osr, std::move(t));
+  m_store->queue_transaction(&m_osr, std::move(t));
 }
 
 void DeterministicOpSequence::_do_clone(coll_t coll, hobject_t& orig_obj,
@@ -498,7 +498,7 @@ void DeterministicOpSequence::_do_clone(coll_t coll, hobject_t& orig_obj,
   ObjectStore::Transaction t;
   note_txn(&t);
   t.clone(coll, ghobject_t(orig_obj), ghobject_t(new_obj));
-  m_store->apply_transaction(&m_osr, std::move(t));
+  m_store->queue_transaction(&m_osr, std::move(t));
 }
 
 void DeterministicOpSequence::_do_clone_range(coll_t coll,
@@ -509,7 +509,7 @@ void DeterministicOpSequence::_do_clone_range(coll_t coll,
   note_txn(&t);
   t.clone_range(coll, ghobject_t(orig_obj), ghobject_t(new_obj),
 		srcoff, srclen, dstoff);
-  m_store->apply_transaction(&m_osr, std::move(t));
+  m_store->queue_transaction(&m_osr, std::move(t));
 }
 
 void DeterministicOpSequence::_do_write_and_clone_range(coll_t coll,
@@ -525,7 +525,7 @@ void DeterministicOpSequence::_do_write_and_clone_range(coll_t coll,
   t.write(coll, ghobject_t(orig_obj), srcoff, bl.length(), bl);
   t.clone_range(coll, ghobject_t(orig_obj), ghobject_t(new_obj),
 		srcoff, srclen, dstoff);
-  m_store->apply_transaction(&m_osr, std::move(t));
+  m_store->queue_transaction(&m_osr, std::move(t));
 }
 
 void DeterministicOpSequence::_do_coll_move(coll_t orig_coll, coll_t new_coll,
@@ -535,6 +535,6 @@ void DeterministicOpSequence::_do_coll_move(coll_t orig_coll, coll_t new_coll,
   note_txn(&t);
   t.remove(new_coll, ghobject_t(obj));
   t.collection_move_rename(orig_coll, ghobject_t(obj), new_coll, ghobject_t(obj));
-  m_store->apply_transaction(&m_osr, std::move(t));
+  m_store->queue_transaction(&m_osr, std::move(t));
 }
 

--- a/src/test/objectstore/TestObjectStoreState.cc
+++ b/src/test/objectstore/TestObjectStoreState.cc
@@ -38,7 +38,7 @@ void TestObjectStoreState::init(int colls, int objs)
   ObjectStore::Transaction t;
 
   t.create_collection(coll_t::meta(), 0);
-  m_store->apply_transaction(&osr, std::move(t));
+  m_store->queue_transaction(&osr, std::move(t));
 
   wait_for_ready();
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2421,7 +2421,6 @@ TEST_P(StoreTest, SimpleAttrTest) {
     r = apply_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  ch->flush();
   {
     bool empty;
     int r = store->collection_empty(ch, &empty);
@@ -2441,7 +2440,6 @@ TEST_P(StoreTest, SimpleAttrTest) {
     r = apply_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  ch->flush();
   {
     bool empty;
     int r = store->collection_empty(ch, &empty);
@@ -2500,7 +2498,6 @@ TEST_P(StoreTest, SimpleListTest) {
     r = apply_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  ch->flush();
   {
     set<ghobject_t> saw;
     vector<ghobject_t> objects;
@@ -2565,7 +2562,6 @@ TEST_P(StoreTest, ListEndTest) {
     r = apply_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  ch->flush();
   {
     ghobject_t end(hobject_t(sobject_t("object_100", CEPH_NOSNAP)),
 		   ghobject_t::NO_GEN, shard_id_t(1));
@@ -2648,7 +2644,6 @@ TEST_P(StoreTest, MultipoolListTest) {
     r = apply_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  ch->flush();
   {
     vector<ghobject_t> objects;
     ghobject_t next, current;
@@ -3318,8 +3313,6 @@ TEST_P(StoreTest, ManyObjectTest) {
     ASSERT_TRUE(!store->stat(ch, *i, &buf));
   }
 
-  ch->flush();
-
   set<ghobject_t> listed, listed2;
   vector<ghobject_t> objects;
   r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(), INT_MAX, &objects, 0);
@@ -3578,7 +3571,6 @@ public:
   }
   void shutdown() {
     while (1) {
-      ch->flush();
       vector<ghobject_t> objects;
       int r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(),
 				     10, &objects, 0);
@@ -3617,7 +3609,6 @@ public:
   }
 
   void wait_for_done() {
-    ch->flush();
     Mutex::Locker locker(lock);
     while (in_flight)
       cond.Wait(lock);
@@ -4188,7 +4179,6 @@ public:
     EnterExit ee("scan");
     while (in_flight)
       cond.Wait(lock);
-    ch->flush();
     vector<ghobject_t> objects;
     set<ghobject_t> objects_set, objects_set2;
     ghobject_t next, current;
@@ -4610,7 +4600,6 @@ TEST_P(StoreTest, HashCollisionTest) {
   }
   }
   vector<ghobject_t> objects;
-  ch->flush();
   r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(), INT_MAX, &objects, 0);
   ASSERT_EQ(r, 0);
   set<ghobject_t> listed(objects.begin(), objects.end());
@@ -4708,7 +4697,6 @@ TEST_P(StoreTest, ScrubTest) {
     ASSERT_EQ(r, 0);
   }
 
-  ch->flush();
   vector<ghobject_t> objects;
   r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(),
 			     INT_MAX, &objects, 0);
@@ -5184,7 +5172,6 @@ void colsplittest(
     ASSERT_EQ(r, 0);
   }
 
-  ch->flush();
   ObjectStore::Transaction t;
   vector<ghobject_t> objects;
   r = store->collection_list(ch, ghobject_t(), ghobject_t::get_max(),
@@ -5205,7 +5192,6 @@ void colsplittest(
     }
   }
 
-  ch->flush();
   objects.clear();
   r = store->collection_list(tch, ghobject_t(), ghobject_t::get_max(),
 			     INT_MAX, &objects, 0);
@@ -5483,8 +5469,6 @@ TEST_P(StoreTest, BigRGWObjectName) {
     r = apply_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
-
-  ch->flush();
 
   {
     vector<ghobject_t> objects;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -86,16 +86,16 @@ static bool bl_eq(bufferlist& expected, bufferlist& actual)
 
 
 template <typename T>
-int apply_transaction(
+int queue_transaction(
   T &store,
   ObjectStore::CollectionHandle ch,
   ObjectStore::Transaction &&t) {
   if (rand() % 2) {
     ObjectStore::Transaction t2;
     t2.append(t);
-    return store->apply_transaction(ch, std::move(t2));
+    return store->queue_transaction(ch, std::move(t2));
   } else {
-    return store->apply_transaction(ch, std::move(t));
+    return store->queue_transaction(ch, std::move(t));
   }
 }
 
@@ -292,7 +292,7 @@ TEST_P(StoreTest, SimpleRemount) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     t.write(cid, hoid, 0, bl.length(), bl);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ch.reset();
@@ -304,7 +304,7 @@ TEST_P(StoreTest, SimpleRemount) {
   {
     ObjectStore::Transaction t;
     t.write(cid, hoid2, 0, bl.length(), bl);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -313,7 +313,7 @@ TEST_P(StoreTest, SimpleRemount) {
     t.remove(cid, hoid2);
     t.remove_collection(cid);
     cerr << "remove collection" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ch.reset();
@@ -325,7 +325,7 @@ TEST_P(StoreTest, SimpleRemount) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
     bool exists = store->exists(ch, hoid);
     ASSERT_TRUE(!exists);
@@ -334,7 +334,7 @@ TEST_P(StoreTest, SimpleRemount) {
     ObjectStore::Transaction t;
     t.remove_collection(cid);
     cerr << "remove collection" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -353,7 +353,7 @@ TEST_P(StoreTest, IORemount) {
       ghobject_t hoid(hobject_t(sobject_t("Object " + stringify(n), CEPH_NOSNAP)));
       t.write(cid, hoid, 0, bl.length(), bl);
     }
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   // overwrites
@@ -363,7 +363,7 @@ TEST_P(StoreTest, IORemount) {
       ObjectStore::Transaction t;
       ghobject_t hoid(hobject_t(sobject_t("Object " + stringify(n), CEPH_NOSNAP)));
       t.write(cid, hoid, 1, bl.length(), bl);
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
   }
@@ -380,7 +380,7 @@ TEST_P(StoreTest, IORemount) {
     }
     t.remove_collection(cid);
     auto ch = store->open_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -399,7 +399,7 @@ TEST_P(StoreTest, UnprintableCharsName) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     t.touch(cid, oid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ch.reset();
@@ -413,7 +413,7 @@ TEST_P(StoreTest, UnprintableCharsName) {
     t.remove(cid, oid);
     t.remove_collection(cid);
     auto ch = store->open_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -428,7 +428,7 @@ TEST_P(StoreTest, FiemapEmpty) {
     t.create_collection(cid, 0);
     t.touch(cid, oid);
     t.truncate(cid, oid, 100000);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -446,7 +446,7 @@ TEST_P(StoreTest, FiemapEmpty) {
     t.remove(cid, oid);
     t.remove_collection(cid);
     cerr << "remove collection" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -466,7 +466,7 @@ TEST_P(StoreTest, FiemapHoles) {
     t.touch(cid, oid);
     for (uint64_t i = 0; i < MAX_EXTENTS; i++)
       t.write(cid, oid, SKIP_STEP * i, 3, bl);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -518,7 +518,7 @@ TEST_P(StoreTest, FiemapHoles) {
     t.remove(cid, oid);
     t.remove_collection(cid);
     cerr << "remove collection" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -531,7 +531,7 @@ TEST_P(StoreTest, SimpleMetaColTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "create collection" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -539,7 +539,7 @@ TEST_P(StoreTest, SimpleMetaColTest) {
     t.remove_collection(cid);
     cerr << "remove collection" << std::endl;
     auto ch = store->open_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -547,7 +547,7 @@ TEST_P(StoreTest, SimpleMetaColTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "add collection" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -555,7 +555,7 @@ TEST_P(StoreTest, SimpleMetaColTest) {
     t.remove_collection(cid);
     cerr << "remove collection" << std::endl;
     auto ch = store->open_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -568,7 +568,7 @@ TEST_P(StoreTest, SimplePGColTest) {
     auto ch = store->create_new_collection(cid);
     t.create_collection(cid, 4);
     cerr << "create collection" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -576,7 +576,7 @@ TEST_P(StoreTest, SimplePGColTest) {
     t.remove_collection(cid);
     cerr << "remove collection" << std::endl;
     auto ch = store->open_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -584,7 +584,7 @@ TEST_P(StoreTest, SimplePGColTest) {
     t.create_collection(cid, 4);
     cerr << "add collection" << std::endl;
     auto ch = store->create_new_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -592,7 +592,7 @@ TEST_P(StoreTest, SimplePGColTest) {
     t.remove_collection(cid);
     cerr << "remove collection" << std::endl;
     auto ch = store->open_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -630,7 +630,7 @@ TEST_P(StoreTest, SimpleColPreHashTest) {
     encode(expected_num_objs, hint);
     t.collection_hint(cid, ObjectStore::Transaction::COLL_HINT_EXPECTED_NUM_OBJECTS, hint);
     cerr << "collection hint" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -638,7 +638,7 @@ TEST_P(StoreTest, SimpleColPreHashTest) {
     ObjectStore::Transaction t;
     t.remove_collection(cid);
     cerr << "remove collection" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   // Revert the config change so that it does not affect the split/merge tests
@@ -658,7 +658,7 @@ TEST_P(StoreTest, SmallBlockWrites) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist a;
@@ -680,7 +680,7 @@ TEST_P(StoreTest, SmallBlockWrites) {
   {
     ObjectStore::Transaction t;
     t.write(cid, hoid, 0, 0x1000, a);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist in, exp;
@@ -692,7 +692,7 @@ TEST_P(StoreTest, SmallBlockWrites) {
   {
     ObjectStore::Transaction t;
     t.write(cid, hoid, 0x1000, 0x1000, b);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist in, exp;
@@ -705,7 +705,7 @@ TEST_P(StoreTest, SmallBlockWrites) {
   {
     ObjectStore::Transaction t;
     t.write(cid, hoid, 0x3000, 0x1000, c);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist in, exp;
@@ -720,7 +720,7 @@ TEST_P(StoreTest, SmallBlockWrites) {
   {
     ObjectStore::Transaction t;
     t.write(cid, hoid, 0x2000, 0x1000, a);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist in, exp;
@@ -735,7 +735,7 @@ TEST_P(StoreTest, SmallBlockWrites) {
   {
     ObjectStore::Transaction t;
     t.write(cid, hoid, 0, 0x1000, c);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -753,7 +753,7 @@ TEST_P(StoreTest, SmallBlockWrites) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -771,7 +771,7 @@ TEST_P(StoreTest, BufferCacheReadTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -781,7 +781,7 @@ TEST_P(StoreTest, BufferCacheReadTest) {
     ObjectStore::Transaction t;
     t.touch(cid, hoid);
     cerr << "Creating object " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     exists = store->exists(ch, hoid);
@@ -794,7 +794,7 @@ TEST_P(StoreTest, BufferCacheReadTest) {
     t.write(cid, hoid, 0, 5, bl);
     t.write(cid, hoid, 10, 5, bl);
     cerr << "TwinWrite" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     r = store->read(ch, hoid, 0, 15, newdata);
@@ -815,7 +815,7 @@ TEST_P(StoreTest, BufferCacheReadTest) {
     t.write(cid, hoid, 0, 5, bl);
     t.write(cid, hoid, 10, 5, bl);
     cerr << "TwinWrite" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     r = store->read(ch, hoid, 0, 15, newdata);
@@ -836,7 +836,7 @@ TEST_P(StoreTest, BufferCacheReadTest) {
 
     t.write(cid, hoid, 20, bl2.length(), bl2);
     cerr << "Append" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     r = store->read(ch, hoid, 0, 30, newdata);
@@ -864,7 +864,7 @@ TEST_P(StoreTest, BufferCacheReadTest) {
     t.write(cid, hoid, 1, bl.length(), bl);
     t.write(cid, hoid, 13, bl3.length(), bl3);
     cerr << "TripleWrite" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     r = store->read(ch, hoid, 0, 40, newdata);
@@ -897,7 +897,7 @@ void doCompressionTest( boost::scoped_ptr<ObjectStore>& store)
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -907,7 +907,7 @@ void doCompressionTest( boost::scoped_ptr<ObjectStore>& store)
     ObjectStore::Transaction t;
     t.touch(cid, hoid);
     cerr << "Creating object " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     exists = store->exists(ch, hoid);
@@ -923,7 +923,7 @@ void doCompressionTest( boost::scoped_ptr<ObjectStore>& store)
     bl.append(data);
     t.write(cid, hoid, 0, bl.length(), bl);
     cerr << "CompressibleData (4xAU) Write" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     r = store->read(ch, hoid, 0, data.size() , newdata);
@@ -970,7 +970,7 @@ void doCompressionTest( boost::scoped_ptr<ObjectStore>& store)
     bl.append(data2);
     t.write(cid, hoid, 0x8000, bl.length(), bl);
     cerr << "CompressibleData partial overwrite" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     r = store->read(ch, hoid, 0, 0x10000, newdata);
@@ -1009,7 +1009,7 @@ void doCompressionTest( boost::scoped_ptr<ObjectStore>& store)
     bl.append(data2);
     t.write(cid, hoid, 0, bl.length(), bl);
     cerr << "CompressibleData partial overwrite, two extents overlapped, single one to be removed" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     r = store->read(ch, hoid, 0, 0x3e000 - 1, newdata);
@@ -1047,7 +1047,7 @@ void doCompressionTest( boost::scoped_ptr<ObjectStore>& store)
     bl.append(data);
     t.write(cid, hoid, 0x3f000-1, bl.length(), bl);
     cerr << "Small chunk partial overwrite, two extents overlapped, single one to be removed" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     r = store->read(ch, hoid, 0x3e000, 0x2000, newdata);
@@ -1063,7 +1063,7 @@ void doCompressionTest( boost::scoped_ptr<ObjectStore>& store)
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
     cerr << "Cleaning object" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   //force fsck
@@ -1084,7 +1084,7 @@ void doCompressionTest( boost::scoped_ptr<ObjectStore>& store)
     bl.append(data);
     t.write(cid, hoid, 0, bl.length(), bl);
     cerr << "CompressibleData large blob" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   //force fsck
@@ -1097,7 +1097,7 @@ void doCompressionTest( boost::scoped_ptr<ObjectStore>& store)
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   g_conf->set_val("bluestore_compression_min_blob_size", stringify(orig_min_blob_size));
@@ -1139,7 +1139,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -1149,7 +1149,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
     ObjectStore::Transaction t;
     t.touch(cid, hoid);
     cerr << "Creating object " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     exists = store->exists(ch, hoid);
@@ -1160,7 +1160,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
     t.remove(cid, hoid);
     t.touch(cid, hoid);
     cerr << "Remove then create" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -1171,7 +1171,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
     t.remove(cid, hoid);
     t.write(cid, hoid, 0, 5, bl);
     cerr << "Remove then create" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist in;
@@ -1187,7 +1187,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
     exp.append(bl);
     t.write(cid, hoid, 5, 5, bl);
     cerr << "Append" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist in;
@@ -1202,7 +1202,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
     exp = bl;
     t.write(cid, hoid, 0, 10, bl);
     cerr << "Full overwrite" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist in;
@@ -1216,7 +1216,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
     bl.append("abcde");
     t.write(cid, hoid, 3, 5, bl);
     cerr << "Partial overwrite" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist in, exp;
@@ -1234,7 +1234,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
       t.truncate(cid, hoid, 0);
       t.write(cid, hoid, 5, 5, bl);
       cerr << "Truncate + hole" << std::endl;
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
     {
@@ -1243,7 +1243,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
       bl.append("abcde");
       t.write(cid, hoid, 0, 5, bl);
       cerr << "Reverse fill-in" << std::endl;
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
 
@@ -1260,7 +1260,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
     bl.append("abcde01234012340123401234abcde01234012340123401234abcde01234012340123401234abcde01234012340123401234");
     t.write(cid, hoid, 0, bl.length(), bl);
     cerr << "larger overwrite" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist in;
@@ -1291,7 +1291,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
       t.truncate(cid, hoid, 0);
       t.write(cid, hoid, 0x1000-1, bl.length(), bl);
       cerr << "Write unaligned csum, stage 1" << std::endl;
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
 
@@ -1313,7 +1313,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
       bl.append(s3);
       t.write(cid, hoid, 1, bl.length(), bl);
       cerr << "Write unaligned csum, stage 2" << std::endl;
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
     in.clear();
@@ -1336,7 +1336,7 @@ TEST_P(StoreTest, SimpleObjectTest) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -1366,7 +1366,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -1376,7 +1376,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     ObjectStore::Transaction t;
     t.touch(cid, hoid);
     cerr << "Creating object " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     exists = store->exists(ch, hoid);
@@ -1402,7 +1402,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     bl.append("abcde");
     t.write(cid, hoid, 0, 5, bl);
     cerr << "Append 5 bytes" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1426,7 +1426,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     bl.append(s);
     t.write(cid, hoid, 0x10000, bl.length(), bl);
     cerr << "Append 0x30000 compressible bytes" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1448,7 +1448,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     t.zero(cid, hoid, 1, 3);
     t.zero(cid, hoid, 0x20000, 9);
     cerr << "Punch hole at 1~3, 0x20000~9" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1473,7 +1473,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     t.write(cid, hoid, 1, bl.length(), bl);
     t.write(cid, hoid, 0x10001, bl.length(), bl);
     cerr << "Overwrite first and second(compressible) extents" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1499,7 +1499,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     t.write(cid, hoid, 0x20000, bl.length(), bl);
     t.write(cid, hoid, 0x30000, bl.length(), bl);
     cerr << "Overwrite compressed extent with 3 uncompressible ones" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1520,7 +1520,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     ObjectStore::Transaction t;
     t.zero(cid, hoid, 0, 0x40000);
     cerr << "Zero object" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
     struct store_statfs_t statfs;
     int r = store->statfs(&statfs);
@@ -1546,7 +1546,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     bl.append(s.substr(0, 0x10000-2));
     t.write(cid, hoid, 0, bl.length(), bl);
     cerr << "Yet another compressible write" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
     struct store_statfs_t statfs;
     r = store->statfs(&statfs);
@@ -1570,7 +1570,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     ObjectStore::Transaction t;
     t.clone(cid, hoid, hoid2);
     cerr << "Clone compressed objecte" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
     struct store_statfs_t statfs2;
     r = store->statfs(&statfs2);
@@ -1588,7 +1588,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
     t.remove(cid, hoid2);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1618,7 +1618,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreFragmentedBlobTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -1628,7 +1628,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreFragmentedBlobTest) {
     ObjectStore::Transaction t;
     t.touch(cid, hoid);
     cerr << "Creating object " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     exists = store->exists(ch, hoid);
@@ -1654,7 +1654,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreFragmentedBlobTest) {
     t.write(cid, hoid, 0, bl.length(), bl);
     t.zero(cid, hoid, 0x10000, 0x10000);
     cerr << "Append 3*0x10000 bytes and punch a hole 0x10000~10000" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1698,7 +1698,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreFragmentedBlobTest) {
     bl.append(data2);
     t.write(cid, hoid, 0x20000, bl.length(), bl);
     cerr << "Write 3 bytes after the hole" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1731,7 +1731,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreFragmentedBlobTest) {
     bl.append(data2);
     t.write(cid, hoid, 0x10000+1, bl.length(), bl);
     cerr << "Write 3 bytes to the hole" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1762,7 +1762,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreFragmentedBlobTest) {
     t.zero(cid, hoid, 0, 0x10000);
     t.zero(cid, hoid, 0x20000, 0x10000);
     cerr << "Rewrite an object and create two holes at the begining and the end" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1794,7 +1794,7 @@ TEST_P(StoreTestSpecificAUSize, BluestoreFragmentedBlobTest) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;
@@ -1819,7 +1819,7 @@ TEST_P(StoreTest, ManySmallWrite) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist bl;
@@ -1829,13 +1829,13 @@ TEST_P(StoreTest, ManySmallWrite) {
   for (int i=0; i<100; ++i) {
     ObjectStore::Transaction t;
     t.write(cid, a, i*4096, 4096, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   for (int i=0; i<100; ++i) {
     ObjectStore::Transaction t;
     t.write(cid, b, (rand() % 1024)*4096, 4096, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -1844,7 +1844,7 @@ TEST_P(StoreTest, ManySmallWrite) {
     t.remove(cid, b);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -1858,7 +1858,7 @@ TEST_P(StoreTest, MultiSmallWriteSameBlock) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist bl;
@@ -1899,7 +1899,7 @@ TEST_P(StoreTest, MultiSmallWriteSameBlock) {
     t.remove(cid, a);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -1913,14 +1913,14 @@ TEST_P(StoreTest, SmallSkipFront) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.touch(cid, a);
     t.truncate(cid, a, 3000);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -1930,7 +1930,7 @@ TEST_P(StoreTest, SmallSkipFront) {
     bl.append(bp);
     ObjectStore::Transaction t;
     t.write(cid, a, 4096, 4096, bl);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -1946,7 +1946,7 @@ TEST_P(StoreTest, SmallSkipFront) {
     t.remove(cid, a);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -1960,7 +1960,7 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   unsigned min_alloc = g_conf->bluestore_min_alloc_size;
@@ -1974,7 +1974,7 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
   {
     ObjectStore::Transaction t;
     t.write(cid, a, 0, bla.length(), bla, 0);
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -1995,7 +1995,7 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
   {
     ObjectStore::Transaction t;
     t.write(cid, a, bla.length(), blb.length(), blb, 0);
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferptr bpc(size);
@@ -2005,7 +2005,7 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
   {
     ObjectStore::Transaction t;
     t.write(cid, a, bla.length() + blb.length(), blc.length(), blc, 0);
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist final;
@@ -2023,7 +2023,7 @@ TEST_P(StoreTest, AppendDeferredVsTailCache) {
     t.remove(cid, a);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   g_conf->set_val("bluestore_inject_deferred_apply_delay", "0");
@@ -2041,7 +2041,7 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   unsigned min_alloc = g_conf->bluestore_min_alloc_size;
@@ -2057,13 +2057,13 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
     bt.append("BADBADBADBAD");
     ObjectStore::Transaction t;
     t.write(cid, a, 0, bt.length(), bt, 0);
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.truncate(cid, a, size);
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -2071,7 +2071,7 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
   {
     ObjectStore::Transaction t;
     t.clone(cid, a, b);
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -2083,7 +2083,7 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
   {
     ObjectStore::Transaction t;
     t.write(cid, a, min_alloc * 3, blb.length(), blb, 0);
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist final;
@@ -2106,7 +2106,7 @@ TEST_P(StoreTest, AppendZeroTrailingSharedBlock) {
     t.remove(cid, b);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -2120,7 +2120,7 @@ TEST_P(StoreTest, SmallSequentialUnaligned) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist bl;
@@ -2131,7 +2131,7 @@ TEST_P(StoreTest, SmallSequentialUnaligned) {
   for (int i=0; i<1000; ++i) {
     ObjectStore::Transaction t;
     t.write(cid, a, i*len, len, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -2139,7 +2139,7 @@ TEST_P(StoreTest, SmallSequentialUnaligned) {
     t.remove(cid, a);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -2154,7 +2154,7 @@ TEST_P(StoreTest, ManyBigWrite) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist bl;
@@ -2164,28 +2164,28 @@ TEST_P(StoreTest, ManyBigWrite) {
   for (int i=0; i<10; ++i) {
     ObjectStore::Transaction t;
     t.write(cid, a, i*4*1048586, 4*1048576, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   // aligned
   for (int i=0; i<10; ++i) {
     ObjectStore::Transaction t;
     t.write(cid, b, (rand() % 256)*4*1048576, 4*1048576, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   // unaligned
   for (int i=0; i<10; ++i) {
     ObjectStore::Transaction t;
     t.write(cid, b, (rand() % (256*4096))*1024, 4*1048576, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   // do some zeros
   for (int i=0; i<10; ++i) {
     ObjectStore::Transaction t;
     t.zero(cid, b, (rand() % (256*4096))*1024, 16*1048576);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -2194,7 +2194,7 @@ TEST_P(StoreTest, ManyBigWrite) {
     t.remove(cid, b);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -2207,7 +2207,7 @@ TEST_P(StoreTest, BigWriteBigZero) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist bl;
@@ -2221,26 +2221,26 @@ TEST_P(StoreTest, BigWriteBigZero) {
   {
     ObjectStore::Transaction t;
     t.write(cid, a, 0, bl.length(), bl);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.zero(cid, a, bl.length() / 4, bl.length() / 2);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.write(cid, a, bl.length() / 2, s.length(), s);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.remove(cid, a);
     t.remove_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -2254,7 +2254,7 @@ TEST_P(StoreTest, MiscFragmentTests) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist bl;
@@ -2264,13 +2264,13 @@ TEST_P(StoreTest, MiscFragmentTests) {
   {
     ObjectStore::Transaction t;
     t.write(cid, a, 0, 524288, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.write(cid, a, 1048576, 524288, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -2283,7 +2283,7 @@ TEST_P(StoreTest, MiscFragmentTests) {
   {
     ObjectStore::Transaction t;
     t.write(cid, a, 1048576 - 4096, 524288, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -2291,7 +2291,7 @@ TEST_P(StoreTest, MiscFragmentTests) {
     t.remove(cid, a);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -2307,7 +2307,7 @@ TEST_P(StoreTest, ZeroVsObjectSize) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist a;
@@ -2315,7 +2315,7 @@ TEST_P(StoreTest, ZeroVsObjectSize) {
   {
     ObjectStore::Transaction t;
     t.write(cid, hoid, 0, 5, a);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_EQ(0, store->stat(ch, hoid, &stat));
@@ -2323,7 +2323,7 @@ TEST_P(StoreTest, ZeroVsObjectSize) {
   {
     ObjectStore::Transaction t;
     t.zero(cid, hoid, 1, 2);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_EQ(0, store->stat(ch, hoid, &stat));
@@ -2331,7 +2331,7 @@ TEST_P(StoreTest, ZeroVsObjectSize) {
   {
     ObjectStore::Transaction t;
     t.zero(cid, hoid, 3, 200);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_EQ(0, store->stat(ch, hoid, &stat));
@@ -2339,7 +2339,7 @@ TEST_P(StoreTest, ZeroVsObjectSize) {
   {
     ObjectStore::Transaction t;
     t.zero(cid, hoid, 100000, 200);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_EQ(0, store->stat(ch, hoid, &stat));
@@ -2355,14 +2355,14 @@ TEST_P(StoreTest, ZeroLengthWrite) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     t.touch(cid, hoid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     bufferlist empty;
     t.write(cid, hoid, 1048576, 0, empty);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   struct stat stat;
@@ -2384,13 +2384,13 @@ TEST_P(StoreTest, ZeroLengthZero) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     t.touch(cid, hoid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(0, r);
   }
   {
     ObjectStore::Transaction t;
     t.zero(cid, hoid, 1048576, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(0, r);
   }
   struct stat stat;
@@ -2418,7 +2418,7 @@ TEST_P(StoreTest, SimpleAttrTest) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -2437,7 +2437,7 @@ TEST_P(StoreTest, SimpleAttrTest) {
     t.touch(cid, hoid);
     t.setattr(cid, hoid, "foo", val);
     t.setattr(cid, hoid, "bar", val2);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -2466,7 +2466,7 @@ TEST_P(StoreTest, SimpleAttrTest) {
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
     t.remove_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -2479,7 +2479,7 @@ TEST_P(StoreTest, SimpleListTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   set<ghobject_t> all;
@@ -2495,7 +2495,7 @@ TEST_P(StoreTest, SimpleListTest) {
       t.touch(cid, hoid);
       cerr << "Creating object " << hoid << std::endl;
     }
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -2530,7 +2530,7 @@ TEST_P(StoreTest, SimpleListTest) {
       t.remove(cid, *p);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -2543,7 +2543,7 @@ TEST_P(StoreTest, ListEndTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   set<ghobject_t> all;
@@ -2559,7 +2559,7 @@ TEST_P(StoreTest, ListEndTest) {
       t.touch(cid, hoid);
       cerr << "Creating object " << hoid << std::endl;
     }
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -2581,7 +2581,7 @@ TEST_P(StoreTest, ListEndTest) {
       t.remove(cid, *p);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -2623,7 +2623,7 @@ TEST_P(StoreTest, MultipoolListTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   set<ghobject_t> all, saw;
@@ -2641,7 +2641,7 @@ TEST_P(StoreTest, MultipoolListTest) {
       t.touch(cid, hoid);
       cerr << "Creating object " << hoid << std::endl;
     }
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -2667,7 +2667,7 @@ TEST_P(StoreTest, MultipoolListTest) {
       t.remove(cid, *p);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -2680,7 +2680,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP),
@@ -2698,7 +2698,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     t.write(cid, hoid, 0, small.length(), small);
     t.write(cid, hoid, 10, small.length(), small);
     cerr << "Creating object and set attr " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -2714,7 +2714,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     t.setattr(cid, hoid, "attr1", large);
     t.setattr(cid, hoid, "attr2", small);
     cerr << "Clone object and rm attr" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     r = store->read(ch, hoid, 10, 5, newdata);
@@ -2749,7 +2749,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
     t.remove(cid, hoid2);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
   }
   {
     bufferlist final;
@@ -2767,7 +2767,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     al.append(a);
     final.append(a);
     t.write(cid, hoid, pl.length(), a.length(), al);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
     bufferlist rl;
     ASSERT_EQ((int)final.length(),
@@ -2778,7 +2778,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
     t.remove(cid, hoid2);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
   }
   {
     bufferlist final;
@@ -2799,7 +2799,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     al.append(a);
     final.append(a);
     t.write(cid, hoid, pl.length() + z.length(), a.length(), al);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
     bufferlist rl;
     ASSERT_EQ((int)final.length(),
@@ -2810,7 +2810,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
     t.remove(cid, hoid2);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
   }
   {
     bufferlist final;
@@ -2831,7 +2831,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     al.append(a);
     final.append(a);
     t.write(cid, hoid, 17000, a.length(), al);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
     bufferlist rl;
     ASSERT_EQ((int)final.length(),
 	      store->read(ch, hoid, 0, final.length(), rl));
@@ -2845,7 +2845,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
     t.remove(cid, hoid2);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
   }
   {
     bufferptr p(1048576);
@@ -2860,7 +2860,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     bufferlist al;
     al.append(a);
     t.write(cid, hoid, a.length(), a.length(), al);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
     bufferlist rl;
     bufferlist final;
     final.substr_of(pl, 0, al.length());
@@ -2880,7 +2880,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
     t.remove(cid, hoid2);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
   }
   {
     bufferptr p(65536);
@@ -2895,7 +2895,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     bufferlist al;
     al.append(a);
     t.write(cid, hoid, 32768, a.length(), al);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
     bufferlist rl;
     bufferlist final;
     final.substr_of(pl, 0, 32768);
@@ -2915,7 +2915,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
     t.remove(cid, hoid2);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
   }
   {
     bufferptr p(65536);
@@ -2930,7 +2930,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     bufferlist al;
     al.append(a);
     t.write(cid, hoid, 33768, a.length(), al);
-    ASSERT_EQ(0, apply_transaction(store, ch, std::move(t)));
+    ASSERT_EQ(0, queue_transaction(store, ch, std::move(t)));
     bufferlist rl;
     bufferlist final;
     final.substr_of(pl, 0, 33768);
@@ -2966,12 +2966,12 @@ TEST_P(StoreTest, SimpleCloneTest) {
     t.remove_collection(cid);
     cerr << "Invalid rm coll" << std::endl;
     PrCtl unset_dumpable;
-    EXPECT_DEATH(apply_transaction(store, ch, std::move(t)), "");
+    EXPECT_DEATH(queue_transaction(store, ch, std::move(t)), "");
   }
   {
     ObjectStore::Transaction t;
     t.touch(cid, hoid3); //new record in db
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   //See comment above for "filestore" check explanation.
@@ -2990,7 +2990,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     t.remove(cid, hoid2);
     t.remove_collection(cid);
     PrCtl unset_dumpable;
-    EXPECT_DEATH(apply_transaction(store, ch, std::move(t)), "");
+    EXPECT_DEATH(queue_transaction(store, ch, std::move(t)), "");
   }
   {
     ObjectStore::Transaction t;
@@ -2999,7 +2999,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     t.remove(cid, hoid3);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -3012,7 +3012,7 @@ TEST_P(StoreTest, OmapSimple) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ghobject_t hoid(hobject_t(sobject_t("omap_obj", CEPH_NOSNAP),
@@ -3030,7 +3030,7 @@ TEST_P(StoreTest, OmapSimple) {
     t.omap_setkeys(cid, hoid, km);
     t.omap_setheader(cid, hoid, header);
     cerr << "Creating object and set omap " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   // get header, keys
@@ -3067,7 +3067,7 @@ TEST_P(StoreTest, OmapSimple) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -3080,7 +3080,7 @@ TEST_P(StoreTest, OmapCloneTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP),
@@ -3098,7 +3098,7 @@ TEST_P(StoreTest, OmapCloneTest) {
     t.omap_setkeys(cid, hoid, km);
     t.omap_setheader(cid, hoid, header);
     cerr << "Creating object and set omap " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ghobject_t hoid2(hobject_t(sobject_t("Object 2", CEPH_NOSNAP),
@@ -3107,7 +3107,7 @@ TEST_P(StoreTest, OmapCloneTest) {
     ObjectStore::Transaction t;
     t.clone(cid, hoid, hoid2);
     cerr << "Clone object" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -3123,7 +3123,7 @@ TEST_P(StoreTest, OmapCloneTest) {
     t.remove(cid, hoid2);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -3136,7 +3136,7 @@ TEST_P(StoreTest, SimpleCloneRangeTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
@@ -3147,7 +3147,7 @@ TEST_P(StoreTest, SimpleCloneRangeTest) {
     ObjectStore::Transaction t;
     t.write(cid, hoid, 10, 5, small);
     cerr << "Creating object and write bl " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ghobject_t hoid2(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
@@ -3156,7 +3156,7 @@ TEST_P(StoreTest, SimpleCloneRangeTest) {
     ObjectStore::Transaction t;
     t.clone_range(cid, hoid, hoid2, 10, 5, 10);
     cerr << "Clone range object" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
     r = store->read(ch, hoid2, 10, 5, newdata);
     ASSERT_EQ(r, 5);
@@ -3167,7 +3167,7 @@ TEST_P(StoreTest, SimpleCloneRangeTest) {
     t.truncate(cid, hoid, 1024*1024);
     t.clone_range(cid, hoid, hoid2, 0, 1024*1024, 0);
     cerr << "Clone range object" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
     struct stat stat, stat2;
     r = store->stat(ch, hoid, &stat);
@@ -3181,7 +3181,7 @@ TEST_P(StoreTest, SimpleCloneRangeTest) {
     t.remove(cid, hoid2);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -3195,7 +3195,7 @@ TEST_P(StoreTest, SimpleObjectLongnameTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ghobject_t hoid(hobject_t(sobject_t("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaObjectaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 1", CEPH_NOSNAP)));
@@ -3203,7 +3203,7 @@ TEST_P(StoreTest, SimpleObjectLongnameTest) {
     ObjectStore::Transaction t;
     t.touch(cid, hoid);
     cerr << "Creating object " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -3211,7 +3211,7 @@ TEST_P(StoreTest, SimpleObjectLongnameTest) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -3234,7 +3234,7 @@ TEST_P(StoreTest, LongnameSplitTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(0, r);
   }
   for (unsigned i = 0; i < 320; ++i) {
@@ -3242,7 +3242,7 @@ TEST_P(StoreTest, LongnameSplitTest) {
     ghobject_t hoid = generate_long_name(i);
     t.touch(cid, hoid);
     cerr << "Creating object " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(0, r);
   }
 
@@ -3255,7 +3255,7 @@ TEST_P(StoreTest, LongnameSplitTest) {
     t.collection_move_rename(
       cid, test_obj,
       cid, test_obj_2);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(0, r);
   }
 
@@ -3264,7 +3264,7 @@ TEST_P(StoreTest, LongnameSplitTest) {
     ghobject_t hoid = generate_long_name(i);
     t.remove(cid, hoid);
     cerr << "Removing object " << hoid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(0, r);
   }
   {
@@ -3272,7 +3272,7 @@ TEST_P(StoreTest, LongnameSplitTest) {
     t.remove(cid, test_obj_2);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(0, r);
   }
 
@@ -3289,7 +3289,7 @@ TEST_P(StoreTest, ManyObjectTest) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   for (int i = 0; i < NUM_OBJS; ++i) {
@@ -3302,7 +3302,7 @@ TEST_P(StoreTest, ManyObjectTest) {
     ghobject_t hoid(hobject_t(sobject_t(string(buf) + base, CEPH_NOSNAP)));
     t.touch(cid, hoid);
     created.insert(hoid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -3375,14 +3375,14 @@ TEST_P(StoreTest, ManyObjectTest) {
        ++i) {
     ObjectStore::Transaction t;
     t.remove(cid, *i);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   cerr << "cleaning up" << std::endl;
   {
     ObjectStore::Transaction t;
     t.remove_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -3567,7 +3567,7 @@ public:
     ObjectStore::Transaction t;
     ch = store->create_new_collection(cid);
     t.create_collection(cid, 0);
-    return apply_transaction(store, ch, std::move(t));
+    return queue_transaction(store, ch, std::move(t));
   }
   void shutdown() {
     while (1) {
@@ -3582,11 +3582,11 @@ public:
 	   p != objects.end(); ++p) {
 	t.remove(cid, *p);
       }
-      apply_transaction(store, ch, std::move(t));
+      queue_transaction(store, ch, std::move(t));
     }
     ObjectStore::Transaction t;
     t.remove_collection(cid);
-    apply_transaction(store, ch, std::move(t));
+    queue_transaction(store, ch, std::move(t));
   }
   void statfs(store_statfs_t& stat) {
     store->statfs(&stat);
@@ -4388,7 +4388,7 @@ TEST_P(StoreTestSpecificAUSize, ZipperPatternSharded) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist bl;
@@ -4399,13 +4399,13 @@ TEST_P(StoreTestSpecificAUSize, ZipperPatternSharded) {
   for (int i=0; i<1000; ++i) {
     ObjectStore::Transaction t;
     t.write(cid, a, i*2*len, len, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   for (int i=0; i<1000; ++i) {
     ObjectStore::Transaction t;
     t.write(cid, a, i*2*len + 1, len, bl, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -4413,7 +4413,7 @@ TEST_P(StoreTestSpecificAUSize, ZipperPatternSharded) {
     t.remove(cid, a);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -4574,7 +4574,7 @@ TEST_P(StoreTest, HashCollisionTest) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   string base = "";
@@ -4593,7 +4593,7 @@ TEST_P(StoreTest, HashCollisionTest) {
     {
       ObjectStore::Transaction t;
       t.touch(cid, hoid);
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
     created.insert(hoid);
@@ -4640,12 +4640,12 @@ TEST_P(StoreTest, HashCollisionTest) {
        ++i) {
     ObjectStore::Transaction t;
     t.remove(cid, *i);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ObjectStore::Transaction t;
   t.remove_collection(cid);
-  r = apply_transaction(store, ch, std::move(t));
+  r = queue_transaction(store, ch, std::move(t));
   ASSERT_EQ(r, 0);
 }
 
@@ -4657,7 +4657,7 @@ TEST_P(StoreTest, ScrubTest) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   string base = "aaaaa";
@@ -4674,7 +4674,7 @@ TEST_P(StoreTest, ScrubTest) {
     {
       ObjectStore::Transaction t;
       t.touch(cid, hoid);
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
     created.insert(hoid);
@@ -4690,7 +4690,7 @@ TEST_P(StoreTest, ScrubTest) {
     t.touch(cid, hoid1);
     t.touch(cid, hoid2);
     t.touch(cid, hoid3);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     created.insert(hoid1);
     created.insert(hoid2);
     created.insert(hoid3);
@@ -4738,12 +4738,12 @@ TEST_P(StoreTest, ScrubTest) {
        ++i) {
     ObjectStore::Transaction t;
     t.remove(cid, *i);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ObjectStore::Transaction t;
   t.remove_collection(cid);
-  r = apply_transaction(store, ch, std::move(t));
+  r = queue_transaction(store, ch, std::move(t));
   ASSERT_EQ(r, 0);
 }
 
@@ -4756,7 +4756,7 @@ TEST_P(StoreTest, OMapTest) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -4767,7 +4767,7 @@ TEST_P(StoreTest, OMapTest) {
     t.omap_clear(cid, hoid);
     map<string, bufferlist> start_set;
     t.omap_setkeys(cid, hoid, start_set);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -4803,7 +4803,7 @@ TEST_P(StoreTest, OMapTest) {
     to_add.insert(pair<string, bufferlist>("key-" + string(buf), bl));
     attrs.insert(pair<string, bufferlist>("key-" + string(buf), bl));
     t.omap_setkeys(cid, hoid, to_add);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -4834,7 +4834,7 @@ TEST_P(StoreTest, OMapTest) {
     set<string> keys_to_remove;
     keys_to_remove.insert(to_remove);
     t.omap_rmkeys(cid, hoid, keys_to_remove);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     attrs.erase(to_remove);
@@ -4847,7 +4847,7 @@ TEST_P(StoreTest, OMapTest) {
     bl1.append("omap_header");
     ObjectStore::Transaction t;
     t.omap_setheader(cid, hoid, bl1);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
     t = ObjectStore::Transaction();
  
@@ -4856,7 +4856,7 @@ TEST_P(StoreTest, OMapTest) {
     map<string, bufferlist> to_add;
     to_add.insert(pair<string, bufferlist>("key", bl2));
     t.omap_setkeys(cid, hoid, to_add);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bufferlist bl3;
@@ -4886,13 +4886,13 @@ TEST_P(StoreTest, OMapTest) {
       t.touch(cid, hoid);
       t.omap_setheader(cid, hoid, h);
       t.omap_setkeys(cid, hoid, to_set);
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
     {
       ObjectStore::Transaction t;
       t.omap_rmkeyrange(cid, hoid, "3", "7");
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
     {
@@ -4911,7 +4911,7 @@ TEST_P(StoreTest, OMapTest) {
     {
       ObjectStore::Transaction t;
       t.omap_clear(cid, hoid);
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
     {
@@ -4926,7 +4926,7 @@ TEST_P(StoreTest, OMapTest) {
   ObjectStore::Transaction t;
   t.remove(cid, hoid);
   t.remove_collection(cid);
-  r = apply_transaction(store, ch, std::move(t));
+  r = queue_transaction(store, ch, std::move(t));
   ASSERT_EQ(r, 0);
 }
 
@@ -4939,7 +4939,7 @@ TEST_P(StoreTest, OMapIterator) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -4950,7 +4950,7 @@ TEST_P(StoreTest, OMapIterator) {
     t.omap_clear(cid, hoid);
     map<string, bufferlist> start_set;
     t.omap_setkeys(cid, hoid, start_set);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ObjectMap::ObjectMapIterator iter;
@@ -4981,7 +4981,7 @@ TEST_P(StoreTest, OMapIterator) {
     }
     ASSERT_EQ((int)attrs.size(), count);
 
-    // FileStore may deadlock an active iterator vs apply_transaction
+    // FileStore may deadlock an active iterator vs queue_transaction
     iter = ObjectMap::ObjectMapIterator();
 
     char buf[100];
@@ -4994,7 +4994,7 @@ TEST_P(StoreTest, OMapIterator) {
     attrs.insert(pair<string, bufferlist>("key-" + string(buf), bl));
     ObjectStore::Transaction t;
     t.omap_setkeys(cid, hoid, to_add);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -5015,13 +5015,13 @@ TEST_P(StoreTest, OMapIterator) {
   }
   ASSERT_EQ(correct, true);
 
-  // FileStore may deadlock an active iterator vs apply_transaction
+  // FileStore may deadlock an active iterator vs queue_transaction
   iter = ObjectMap::ObjectMapIterator();
   {
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
     t.remove_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -5043,7 +5043,7 @@ TEST_P(StoreTest, XattrTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     t.touch(cid, hoid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -5062,7 +5062,7 @@ TEST_P(StoreTest, XattrTest) {
     attrs["attr4"] = big;
     t.setattr(cid, hoid, "attr3", big);
     attrs["attr3"] = big;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -5081,7 +5081,7 @@ TEST_P(StoreTest, XattrTest) {
     ObjectStore::Transaction t;
     t.rmattr(cid, hoid, "attr2");
     attrs.erase("attr2");
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -5109,7 +5109,7 @@ TEST_P(StoreTest, XattrTest) {
   ObjectStore::Transaction t;
   t.remove(cid, hoid);
   t.remove_collection(cid);
-  r = apply_transaction(store, ch, std::move(t));
+  r = queue_transaction(store, ch, std::move(t));
   ASSERT_EQ(r, 0);
 }
 
@@ -5127,7 +5127,7 @@ void colsplittest(
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, common_suffix_size);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   bufferlist small;
@@ -5156,19 +5156,19 @@ void colsplittest(
 	t.clone(cid, a, b);
       }
       if (i % 100) {
-	r = apply_transaction(store, ch, std::move(t));
+	r = queue_transaction(store, ch, std::move(t));
 	ASSERT_EQ(r, 0);
 	t = ObjectStore::Transaction();
       }
     }
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.create_collection(tid, common_suffix_size + 1);
     t.split_collection(cid, common_suffix_size+1, 1<<common_suffix_size, tid);
-    r = apply_transaction(store, tch, std::move(t));
+    r = queue_transaction(store, tch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -5186,7 +5186,7 @@ void colsplittest(
     t.remove(cid, *i);
     if (++size > 100) {
       size = 0;
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
       t = ObjectStore::Transaction();
     }
@@ -5204,7 +5204,7 @@ void colsplittest(
     t.remove(tid, *i);
     if (++size > 100) {
       size = 0;
-      r = apply_transaction(store, tch, std::move(t));
+      r = queue_transaction(store, tch, std::move(t));
       ASSERT_EQ(r, 0);
       t = ObjectStore::Transaction();
     }
@@ -5212,7 +5212,7 @@ void colsplittest(
 
   t.remove_collection(cid);
   t.remove_collection(tid);
-  r = apply_transaction(store, tch, std::move(t));
+  r = queue_transaction(store, tch, std::move(t));
   ASSERT_EQ(r, 0);
 }
 
@@ -5249,7 +5249,7 @@ TEST_P(StoreTest, TwoHash) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   std::cout << "Making objects" << std::endl;
@@ -5263,7 +5263,7 @@ TEST_P(StoreTest, TwoHash) {
     }
     o.hobj.set_hash((i << 16) | 0xB1);
     t.touch(cid, o);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   std::cout << "Removing half" << std::endl;
@@ -5273,7 +5273,7 @@ TEST_P(StoreTest, TwoHash) {
     o.hobj.pool = -1;
     o.hobj.set_hash((i << 16) | 0xA1);
     t.remove(cid, o);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   std::cout << "Checking" << std::endl;
@@ -5301,12 +5301,12 @@ TEST_P(StoreTest, TwoHash) {
     t.remove(cid, o);
     o.hobj.set_hash((i << 16) | 0xB1);
     t.remove(cid, o);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ObjectStore::Transaction t;
   t.remove_collection(cid);
-  r = apply_transaction(store, ch, std::move(t));
+  r = queue_transaction(store, ch, std::move(t));
   ASSERT_EQ(r, 0);
 }
 
@@ -5323,7 +5323,7 @@ TEST_P(StoreTest, Rename) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     t.write(cid, srcoid, 0, a.length(), a);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_TRUE(store->exists(ch, srcoid));
@@ -5332,7 +5332,7 @@ TEST_P(StoreTest, Rename) {
     t.collection_move_rename(cid, srcoid, cid, dstoid);
     t.write(cid, srcoid, 0, b.length(), b);
     t.setattr(cid, srcoid, "attr", b);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_TRUE(store->exists(ch, srcoid));
@@ -5348,7 +5348,7 @@ TEST_P(StoreTest, Rename) {
     ObjectStore::Transaction t;
     t.remove(cid, dstoid);
     t.collection_move_rename(cid, srcoid, cid, dstoid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_TRUE(store->exists(ch, dstoid));
@@ -5362,7 +5362,7 @@ TEST_P(StoreTest, Rename) {
     ObjectStore::Transaction t;
     t.remove(cid, dstoid);
     t.remove_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -5377,7 +5377,7 @@ TEST_P(StoreTest, MoveRename) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     t.touch(cid, oid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_TRUE(store->exists(ch, oid));
@@ -5392,7 +5392,7 @@ TEST_P(StoreTest, MoveRename) {
     t.write(cid, temp_oid, 0, data.length(), data);
     t.setattr(cid, temp_oid, "attr", attr);
     t.omap_setkeys(cid, temp_oid, omap);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_TRUE(store->exists(ch, temp_oid));
@@ -5400,7 +5400,7 @@ TEST_P(StoreTest, MoveRename) {
     ObjectStore::Transaction t;
     t.remove(cid, oid);
     t.collection_move_rename(cid, temp_oid, cid, oid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   ASSERT_TRUE(store->exists(ch, oid));
@@ -5427,7 +5427,7 @@ TEST_P(StoreTest, MoveRename) {
     ObjectStore::Transaction t;
     t.remove(cid, oid);
     t.remove_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -5459,14 +5459,14 @@ TEST_P(StoreTest, BigRGWObjectName) {
     t.collection_move_rename(cid, oidhead, cid, oid);
     t.touch(cid, oidhead);
     t.collection_move_rename(cid, oidhead, cid, oid2);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
   {
     ObjectStore::Transaction t;
     t.remove(cid, oid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -5485,7 +5485,7 @@ TEST_P(StoreTest, BigRGWObjectName) {
     ObjectStore::Transaction t;
     t.remove(cid, oid2);
     t.remove_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
   }
@@ -5500,31 +5500,31 @@ TEST_P(StoreTest, SetAllocHint) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     t.touch(cid, hoid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.set_alloc_hint(cid, hoid, 4*1024*1024, 1024*4, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.remove(cid, hoid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.set_alloc_hint(cid, hoid, 4*1024*1024, 1024*4, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.remove_collection(cid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -5538,25 +5538,25 @@ TEST_P(StoreTest, TryMoveRename) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.try_rename(cid, hoid, hoid2);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.touch(cid, hoid);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
     ObjectStore::Transaction t;
     t.try_rename(cid, hoid, hoid2);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   struct stat st;
@@ -5583,7 +5583,7 @@ TEST_P(StoreTest, BluestoreOnOffCSumTest) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -5597,7 +5597,7 @@ TEST_P(StoreTest, BluestoreOnOffCSumTest) {
     t.set_alloc_hint(cid, hoid, 4*1024*1024, 1024*8, 0);
     t.write(cid, hoid, 0, bl.length(), bl);
     cerr << "Remove then create" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     g_conf->set_val("bluestore_csum_type", "none");
@@ -5621,7 +5621,7 @@ TEST_P(StoreTest, BluestoreOnOffCSumTest) {
     t.set_alloc_hint(cid, hoid, 4*1024*1024, 1024*8, 0);
     t.write(cid, hoid, 0, bl.length(), bl);
     cerr << "Remove then create" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     g_conf->set_val("bluestore_csum_type", "crc32c");
@@ -5643,7 +5643,7 @@ TEST_P(StoreTest, BluestoreOnOffCSumTest) {
     t.remove(cid, hoid);
     t.write(cid, hoid, 0, bl.length(), bl);
     cerr << "Remove then create" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     g_conf->set_val("bluestore_csum_type", "none");
@@ -5652,7 +5652,7 @@ TEST_P(StoreTest, BluestoreOnOffCSumTest) {
     ObjectStore::Transaction t2;
     t2.write(cid, hoid, block_size*2, bl.length(), bl);
     cerr << "Append 'unprotected'" << std::endl;
-    r = apply_transaction(store, ch, std::move(t2));
+    r = queue_transaction(store, ch, std::move(t2));
     ASSERT_EQ(r, 0);
 
     bufferlist in;
@@ -5688,7 +5688,7 @@ TEST_P(StoreTest, BluestoreOnOffCSumTest) {
     t.set_alloc_hint(cid, hoid, 4*1024*1024, 1024*8, 0);
     t.write(cid, hoid, 0, bl.length(), bl);
     cerr << "Remove then create" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     g_conf->set_val("bluestore_csum_type", "none");
@@ -5700,7 +5700,7 @@ TEST_P(StoreTest, BluestoreOnOffCSumTest) {
     t2.write(cid, hoid, 0, bl.length(), bl);
     t2.write(cid, hoid, block_size0, bl.length(), bl);
     cerr << "Overwrite with unprotected data" << std::endl;
-    r = apply_transaction(store, ch, std::move(t2));
+    r = queue_transaction(store, ch, std::move(t2));
     ASSERT_EQ(r, 0);
 
     orig = bl;
@@ -5724,7 +5724,7 @@ TEST_P(StoreTest, BluestoreOnOffCSumTest) {
     bl.append(std::string(block_size2, 'c'));
     t3.write(cid, hoid, block_size0, bl.length(), bl);
     cerr << "Overwrite with protected data" << std::endl;
-    r = apply_transaction(store, ch, std::move(t3));
+    r = queue_transaction(store, ch, std::move(t3));
     ASSERT_EQ(r, 0);
 
     in.clear();
@@ -5740,7 +5740,7 @@ TEST_P(StoreTest, BluestoreOnOffCSumTest) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 }
@@ -5902,7 +5902,7 @@ TEST_P(StoreTestSpecificAUSize, OnodeSizeTracking) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -5911,7 +5911,7 @@ TEST_P(StoreTestSpecificAUSize, OnodeSizeTracking) {
     
     bl.append(std::string(obj_size, 'a'));
     t.write(cid, hoid, 0, bl.length(), bl);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   get_mempool_stats(&total_bytes, &total_onodes);
@@ -5921,7 +5921,7 @@ TEST_P(StoreTestSpecificAUSize, OnodeSizeTracking) {
   {
     ObjectStore::Transaction t;
     t.truncate(cid, hoid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
  
@@ -5931,7 +5931,7 @@ TEST_P(StoreTestSpecificAUSize, OnodeSizeTracking) {
     for( size_t j = 0; j < obj_size; j+= bl.length()) {
       ObjectStore::Transaction t;
       t.write(cid, hoid, j, bl.length(), bl);
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
     get_mempool_stats(&total_bytes2, &total_onodes);
@@ -5971,7 +5971,7 @@ TEST_P(StoreTestSpecificAUSize, OnodeSizeTracking) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   g_ceph_context->_conf->set_val("bluestore_cache_size_hdd", "4000000");
@@ -6001,7 +6001,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6010,7 +6010,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
 
     bl.append(std::string(block_size * 2, 'a'));
     t.write(cid, hoid, 0, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6020,7 +6020,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
 
     bl.append(std::string(block_size, 'b'));
     t.write(cid, hoid, 0, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6030,7 +6030,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
 
     bl.append(std::string(block_size * 2, 'c'));
     t.write(cid, hoid, block_size * 2, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6040,7 +6040,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
 
     bl.append(std::string(block_size * 2, 'd'));
     t.write(cid, hoid, block_size * 5, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6065,7 +6065,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
 
     // Currently we are unable to reuse blob when overwriting in a single step
     t.write(cid, hoid, block_size * 6, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6089,7 +6089,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
     bl.append(std::string(block_size, 'f'));
 
     t.write(cid, hoid, block_size * 4, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6149,7 +6149,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   g_conf->set_val("bluestore_max_blob_size", "0");
@@ -6177,7 +6177,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6187,7 +6187,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
     bl.append(std::string(block_size * 2, 'a'));
     t.write(cid, hoid, block_size * 10, bl.length(), bl, 
             CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6198,7 +6198,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
     bl.append(std::string(block_size, 'b'));
     t.write(cid, hoid, block_size * 9, bl.length(), bl,
             CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6225,7 +6225,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
     bl.append(std::string(block_size, 'c'));
     t.write(cid, hoid, block_size * 7, bl.length(), bl,
             CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6252,7 +6252,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
     bl.append(std::string(block_size, 'd'));
     t.write(cid, hoid, block_size * 13, bl.length(), bl,
             CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6281,7 +6281,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
             CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
     t.write(cid, hoid, block_size * 19, bl.length(), bl,
             CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6309,7 +6309,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
             CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
     t.write(cid, hoid, block_size * 18, bl.length(), bl,
             CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6333,7 +6333,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   g_conf->set_val("bluestore_max_blob_size", "0");
@@ -6359,7 +6359,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnSmallOverwrite) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6370,7 +6370,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnSmallOverwrite) {
     t.write(cid, hoid, 0, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
     t.write(cid, hoid, block_size * 2, bl.length(), bl,
       CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6381,7 +6381,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnSmallOverwrite) {
     bl.append(std::string(3, 'b'));
     t.write(cid, hoid, block_size + 1, bl.length(), bl,
       CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6407,7 +6407,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnSmallOverwrite) {
     t.remove(cid, hoid);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   g_conf->set_val("bluestore_max_blob_size", "0");
@@ -6439,7 +6439,7 @@ TEST_P(StoreTestSpecificAUSize, SmallWriteOnShardedExtents) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   {
@@ -6450,13 +6450,13 @@ TEST_P(StoreTestSpecificAUSize, SmallWriteOnShardedExtents) {
     bl.append(std::string(0x80000, 'a'));
     t.write(cid, hoid1, 0, bl.length(), bl, 0);
     t.zero(cid, hoid1, 0x719e0, 0x75b0 );
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
     bl2.append(std::string(0x70000, 'b'));
     t.write(cid, hoid1, 0, bl2.length(), bl2, 0);
     t.zero(cid, hoid1, 0, 0x50000);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
 
   }
@@ -6473,7 +6473,7 @@ TEST_P(StoreTestSpecificAUSize, SmallWriteOnShardedExtents) {
     bl.append(std::string(0x6520, 'c'));
     t.write(cid, hoid1, 0x71c00, bl.length(), bl, 0);
 
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -6498,7 +6498,7 @@ TEST_P(StoreTestSpecificAUSize, SmallWriteOnShardedExtents) {
     t.remove(cid, hoid1);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   g_conf->set_val("bluestore_max_target_blob", "524288");
@@ -6523,7 +6523,7 @@ TEST_P(StoreTest, KVDBHistogramTest) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   for (int i = 0; i < NUM_OBJS; ++i) {
@@ -6532,7 +6532,7 @@ TEST_P(StoreTest, KVDBHistogramTest) {
     snprintf(buf, sizeof(buf), "%d", i);
     ghobject_t hoid(hobject_t(sobject_t(base + string(buf), CEPH_NOSNAP)));
     t.write(cid, hoid, 0, 0x1000, a);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -6567,7 +6567,7 @@ TEST_P(StoreTest, KVDBStatsTest) {
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
   for (int i = 0; i < NUM_OBJS; ++i) {
@@ -6576,7 +6576,7 @@ TEST_P(StoreTest, KVDBStatsTest) {
     snprintf(buf, sizeof(buf), "%d", i);
     ghobject_t hoid(hobject_t(sobject_t(base + string(buf), CEPH_NOSNAP)));
     t.write(cid, hoid, 0, 0x1000, a);
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -6610,7 +6610,7 @@ TEST_P(StoreTestSpecificAUSize, garbageCollection) {
       } else {\
         t.write(cid, hoid, offset, bl.length(), bl);\
       }\
-      r = apply_transaction(store, ch, std::move(t));\
+      r = queue_transaction(store, ch, std::move(t));\
       ASSERT_EQ(r, 0);\
   }
 
@@ -6633,7 +6633,7 @@ TEST_P(StoreTestSpecificAUSize, garbageCollection) {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
     cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, ch, std::move(t));
+    r = queue_transaction(store, ch, std::move(t));
     ASSERT_EQ(r, 0);
   }
 
@@ -6648,7 +6648,7 @@ TEST_P(StoreTestSpecificAUSize, garbageCollection) {
       ObjectStore::Transaction t;
       t.touch(cid, hoid);
       cerr << "Creating object " << hoid << std::endl;
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
 
       exists = store->exists(ch, hoid);
@@ -6747,7 +6747,7 @@ TEST_P(StoreTestSpecificAUSize, garbageCollection) {
       ObjectStore::Transaction t;
       t.remove(cid, hoid);
       cerr << "Cleaning" << std::endl;
-      r = apply_transaction(store, ch, std::move(t));
+      r = queue_transaction(store, ch, std::move(t));
       ASSERT_EQ(r, 0);
     }
   }

--- a/src/test/objectstore/store_test_fixture.h
+++ b/src/test/objectstore/store_test_fixture.h
@@ -10,6 +10,7 @@ class StoreTestFixture : virtual public ::testing::Test {
 
 public:
   boost::scoped_ptr<ObjectStore> store;
+  ObjectStore::CollectionHandle ch;
 
   StoreTestFixture(const std::string& type)
     : type(type), data_dir(type + ".test_temp_dir")

--- a/src/test/objectstore/test_idempotent.cc
+++ b/src/test/objectstore/test_idempotent.cc
@@ -78,7 +78,7 @@ int main(int argc, char **argv) {
     ObjectStore::Transaction t;
     assert(!store->mount());
     t.create_collection(coll, 0);
-    store->apply_transaction(&osr, std::move(t));
+    store->queue_transaction(&osr, std::move(t));
   } else {
     assert(!store->mount());
   }

--- a/src/test/objectstore/test_memstore_clone.cc
+++ b/src/test/objectstore/test_memstore_clone.cc
@@ -44,12 +44,16 @@ public:
       return;
     }
     ObjectStore::Transaction t;
+    ch = store->create_new_collection(cid);
     t.create_collection(cid, 4);
-    unsigned r = store->apply_transaction(nullptr, std::move(t));
+    unsigned r = store->apply_transaction(ch, std::move(t));
     if (r != 0) {
       derr << "failed to create collection with " << cpp_strerror(r) << dendl;
     }
     ASSERT_EQ(0U, r);
+  }
+  void TearDown() override {
+    ch.reset();
   }
 };
 
@@ -72,7 +76,7 @@ TEST_F(MemStoreClone, CloneRangeAllocated)
   t.write(cid, src, 0, 12, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(nullptr, std::move(t)));
+  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
@@ -96,7 +100,7 @@ TEST_F(MemStoreClone, CloneRangeHole)
   t.write(cid, src, 12, 4, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(nullptr, std::move(t)));
+  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
@@ -120,7 +124,7 @@ TEST_F(MemStoreClone, CloneRangeHoleStart)
   t.write(cid, src, 8, 4, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(nullptr, std::move(t)));
+  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
@@ -145,7 +149,7 @@ TEST_F(MemStoreClone, CloneRangeHoleMiddle)
   t.write(cid, src, 8, 4, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(nullptr, std::move(t)));
+  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
@@ -170,7 +174,7 @@ TEST_F(MemStoreClone, CloneRangeHoleEnd)
   t.write(cid, src, 12, 4, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(nullptr, std::move(t)));
+  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }

--- a/src/test/objectstore/test_memstore_clone.cc
+++ b/src/test/objectstore/test_memstore_clone.cc
@@ -46,7 +46,7 @@ public:
     ObjectStore::Transaction t;
     ch = store->create_new_collection(cid);
     t.create_collection(cid, 4);
-    unsigned r = store->apply_transaction(ch, std::move(t));
+    unsigned r = store->queue_transaction(ch, std::move(t));
     if (r != 0) {
       derr << "failed to create collection with " << cpp_strerror(r) << dendl;
     }
@@ -76,7 +76,7 @@ TEST_F(MemStoreClone, CloneRangeAllocated)
   t.write(cid, src, 0, 12, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
+  ASSERT_EQ(0u, store->queue_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
@@ -100,7 +100,7 @@ TEST_F(MemStoreClone, CloneRangeHole)
   t.write(cid, src, 12, 4, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
+  ASSERT_EQ(0u, store->queue_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
@@ -124,7 +124,7 @@ TEST_F(MemStoreClone, CloneRangeHoleStart)
   t.write(cid, src, 8, 4, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
+  ASSERT_EQ(0u, store->queue_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
@@ -149,7 +149,7 @@ TEST_F(MemStoreClone, CloneRangeHoleMiddle)
   t.write(cid, src, 8, 4, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
+  ASSERT_EQ(0u, store->queue_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
@@ -174,7 +174,7 @@ TEST_F(MemStoreClone, CloneRangeHoleEnd)
   t.write(cid, src, 12, 4, srcbl);
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
-  ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
+  ASSERT_EQ(0u, store->queue_transaction(ch, std::move(t)));
   ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }

--- a/src/test/objectstore/test_memstore_clone.cc
+++ b/src/test/objectstore/test_memstore_clone.cc
@@ -77,7 +77,7 @@ TEST_F(MemStoreClone, CloneRangeAllocated)
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
   ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
-  ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
+  ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
 
@@ -101,7 +101,7 @@ TEST_F(MemStoreClone, CloneRangeHole)
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
   ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
-  ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
+  ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
 
@@ -125,7 +125,7 @@ TEST_F(MemStoreClone, CloneRangeHoleStart)
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
   ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
-  ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
+  ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
 
@@ -150,7 +150,7 @@ TEST_F(MemStoreClone, CloneRangeHoleMiddle)
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
   ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
-  ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
+  ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
 
@@ -175,7 +175,7 @@ TEST_F(MemStoreClone, CloneRangeHoleEnd)
   t.write(cid, dst, 0, 12, dstbl);
   t.clone_range(cid, src, dst, 2, 8, 2);
   ASSERT_EQ(0u, store->apply_transaction(ch, std::move(t)));
-  ASSERT_EQ(12, store->read(cid, dst, 0, 12, result));
+  ASSERT_EQ(12, store->read(ch, dst, 0, 12, result));
   ASSERT_EQ(expected, result);
 }
 

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -353,7 +353,6 @@ void WorkloadGenerator::do_destroy_collection(ObjectStore::Transaction *t,
 					      C_StatState *stat)
 {  
   m_nr_runs = 0;
-  entry->m_osr.flush();
   vector<ghobject_t> ls;
   m_store->collection_list(entry->m_coll, ghobject_t(), ghobject_t::get_max(),
 			   INT_MAX, &ls, NULL);

--- a/src/test/objectstore_bench.cc
+++ b/src/test/objectstore_bench.cc
@@ -261,7 +261,7 @@ int main(int argc, const char *argv[])
     ObjectStore::Sequencer osr(__func__);
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
-    os->apply_transaction(&osr, std::move(t));
+    os->queue_transaction(&osr, std::move(t));
   }
 
   // create the objects
@@ -276,7 +276,7 @@ int main(int argc, const char *argv[])
       ObjectStore::Sequencer osr(__func__);
       ObjectStore::Transaction t;
       t.touch(cid, oids[i]);
-      int r = os->apply_transaction(&osr, std::move(t));
+      int r = os->queue_transaction(&osr, std::move(t));
       assert(r == 0);
     }
   } else {
@@ -285,7 +285,7 @@ int main(int argc, const char *argv[])
     ObjectStore::Sequencer osr(__func__);
     ObjectStore::Transaction t;
     t.touch(cid, oids.back());
-    int r = os->apply_transaction(&osr, std::move(t));
+    int r = os->queue_transaction(&osr, std::move(t));
     assert(r == 0);
   }
 
@@ -318,7 +318,7 @@ int main(int argc, const char *argv[])
   ObjectStore::Transaction t;
   for (const auto &oid : oids)
     t.remove(cid, oid);
-  os->apply_transaction(&osr,std::move(t));
+  os->queue_transaction(&osr,std::move(t));
 
   os->umount();
   return 0;

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2317,11 +2317,11 @@ public:
   PGLogTestRebuildMissing() : PGLogTest(), StoreTestFixture("memstore") {}
   void SetUp() override {
     StoreTestFixture::SetUp();
-    ObjectStore::Sequencer osr(__func__);
     ObjectStore::Transaction t;
     test_coll = coll_t(spg_t(pg_t(1, 1)));
+    auto ch = store->create_new_collection(test_coll);
     t.create_collection(test_coll, 0);
-    store->queue_transaction(&osr, std::move(t));
+    store->queue_transaction(ch, std::move(t));
     existing_oid = mk_obj(0);
     nonexistent_oid = mk_obj(1);
     ghobject_t existing_ghobj(existing_oid);
@@ -2332,7 +2332,7 @@ public:
     ObjectStore::Transaction t2;
     t2.touch(test_coll, ghobject_t(existing_oid));
     t2.setattr(test_coll, ghobject_t(existing_oid), OI_ATTR, enc_oi);
-    ASSERT_EQ(0u, store->queue_transaction(&osr, std::move(t2)));
+    ASSERT_EQ(0u, store->queue_transaction(ch, std::move(t2)));
     info.last_backfill = hobject_t::get_max();
     info.last_complete = eversion_t();
   }
@@ -2348,7 +2348,7 @@ public:
   hobject_t existing_oid, nonexistent_oid;
 
   void run_rebuild_missing_test(const map<hobject_t, pg_missing_item> &expected_missing_items) {
-    rebuild_missing_set_with_deletes(store.get(), test_coll, info);
+    rebuild_missing_set_with_deletes(store.get(), ch, info);
     ASSERT_EQ(expected_missing_items, missing.get_items());
   }
 };
@@ -2400,11 +2400,11 @@ public:
 
   void SetUp() override {
     StoreTestFixture::SetUp();
-    ObjectStore::Sequencer osr(__func__);
     ObjectStore::Transaction t;
     test_coll = coll_t(spg_t(pg_t(1, 1)));
+    auto ch = store->create_new_collection(test_coll);
     t.create_collection(test_coll, 0);
-    store->queue_transaction(&osr, std::move(t));
+    store->queue_transaction(ch, std::move(t));
   }
 
   void TearDown() override {
@@ -2479,7 +2479,6 @@ public:
   }
 
   void test_disk_roundtrip() {
-    ObjectStore::Sequencer osr(__func__);
     ObjectStore::Transaction t;
     hobject_t hoid;
     hoid.pool = 1;
@@ -2490,12 +2489,13 @@ public:
     if (!km.empty()) {
       t.omap_setkeys(test_coll, log_oid, km);
     }
-    ASSERT_EQ(0u, store->queue_transaction(&osr, std::move(t)));
+    auto ch = store->open_collection(test_coll);
+    ASSERT_EQ(0u, store->queue_transaction(ch, std::move(t)));
 
     auto orig_dups = log.dups;
     clear();
     ostringstream err;
-    read_log_and_missing(store.get(), test_coll, log_oid,
+    read_log_and_missing(store.get(), ch, log_oid,
 			 pg_info_t(), err, false);
     ASSERT_EQ(orig_dups.size(), log.dups.size());
     ASSERT_EQ(orig_dups, log.dups);

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2321,7 +2321,7 @@ public:
     ObjectStore::Transaction t;
     test_coll = coll_t(spg_t(pg_t(1, 1)));
     t.create_collection(test_coll, 0);
-    store->apply_transaction(&osr, std::move(t));
+    store->queue_transaction(&osr, std::move(t));
     existing_oid = mk_obj(0);
     nonexistent_oid = mk_obj(1);
     ghobject_t existing_ghobj(existing_oid);
@@ -2332,7 +2332,7 @@ public:
     ObjectStore::Transaction t2;
     t2.touch(test_coll, ghobject_t(existing_oid));
     t2.setattr(test_coll, ghobject_t(existing_oid), OI_ATTR, enc_oi);
-    ASSERT_EQ(0u, store->apply_transaction(&osr, std::move(t2)));
+    ASSERT_EQ(0u, store->queue_transaction(&osr, std::move(t2)));
     info.last_backfill = hobject_t::get_max();
     info.last_complete = eversion_t();
   }
@@ -2404,7 +2404,7 @@ public:
     ObjectStore::Transaction t;
     test_coll = coll_t(spg_t(pg_t(1, 1)));
     t.create_collection(test_coll, 0);
-    store->apply_transaction(&osr, std::move(t));
+    store->queue_transaction(&osr, std::move(t));
   }
 
   void TearDown() override {
@@ -2490,7 +2490,7 @@ public:
     if (!km.empty()) {
       t.omap_setkeys(test_coll, log_oid, km);
     }
-    ASSERT_EQ(0u, store->apply_transaction(&osr, std::move(t)));
+    ASSERT_EQ(0u, store->queue_transaction(&osr, std::move(t)));
 
     auto orig_dups = log.dups;
     clear();

--- a/src/test/test_trans.cc
+++ b/src/test/test_trans.cc
@@ -74,7 +74,7 @@ int main(int argc, const char **argv)
   dout(0) << "starting thread" << dendl;
   foo.create("foo");
   dout(0) << "starting op" << dendl;
-  fs->apply_transaction(&osr, std::move(t));
+  fs->queue_transaction(&osr, std::move(t));
 
 }
 

--- a/src/test/xattr_bench.cc
+++ b/src/test/xattr_bench.cc
@@ -106,7 +106,7 @@ uint64_t do_run(ObjectStore *store, int attrsize, int numattrs,
     }
     collections[coll] = make_pair(objects, new ObjectStore::Sequencer(coll.to_str()));
   }
-  store->apply_transaction(&osr, std::move(t));
+  store->queue_transaction(&osr, std::move(t));
 
   bufferlist bl;
   for (int i = 0; i < attrsize; ++i) {

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -412,8 +412,7 @@ int mark_pg_for_removal(ObjectStore *fs, spg_t pgid, ObjectStore::Transaction *t
 #pragma GCC diagnostic pop
 #pragma GCC diagnostic warning "-Wpragmas"
 
-int initiate_new_remove_pg(ObjectStore *store, spg_t r_pgid,
-			   ObjectStore::Sequencer &osr)
+int initiate_new_remove_pg(ObjectStore *store, spg_t r_pgid)
 {
   if (!dry_run)
     finish_remove_pgs(store);
@@ -428,7 +427,8 @@ int initiate_new_remove_pg(ObjectStore *store, spg_t r_pgid,
   if (r < 0) {
     return r;
   }
-  store->apply_transaction(&osr, std::move(rmt));
+  ObjectStore::CollectionHandle ch = store->open_collection(coll_t(r_pgid));
+  store->apply_transaction(ch, std::move(rmt));
   finish_remove_pgs(store);
   return r;
 }
@@ -635,8 +635,7 @@ int ObjectStoreTool::export_files(ObjectStore *store, coll_t coll)
   return 0;
 }
 
-int set_inc_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force,
-		   ObjectStore::Sequencer &osr) {
+int set_inc_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
   OSDMap::Incremental inc;
   bufferlist::iterator it = bl.begin();
   inc.decode(it);
@@ -661,10 +660,11 @@ int set_inc_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force,
   }
   if (dry_run)
     return 0;
+  ObjectStore::CollectionHandle ch = store->open_collection(coll_t::meta());
   ObjectStore::Transaction t;
   t.write(coll_t::meta(), inc_oid, 0, bl.length(), bl);
   t.truncate(coll_t::meta(), inc_oid, bl.length());
-  int ret = store->apply_transaction(&osr, std::move(t));
+  int ret = store->apply_transaction(ch, std::move(t));
   if (ret) {
     cerr << "Failed to set inc-osdmap (" << inc_oid << "): " << ret << std::endl;
   } else {
@@ -683,8 +683,7 @@ int get_inc_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl)
   return 0;
 }
 
-int set_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force,
-	       ObjectStore::Sequencer &osr) {
+int set_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
   OSDMap osdmap;
   osdmap.decode(bl);
   if (e == 0) {
@@ -709,9 +708,10 @@ int set_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force,
   if (dry_run)
     return 0;
   ObjectStore::Transaction t;
+  ObjectStore::CollectionHandle ch = store->open_collection(coll_t::meta());
   t.write(coll_t::meta(), full_oid, 0, bl.length(), bl);
   t.truncate(coll_t::meta(), full_oid, bl.length());
-  int ret = store->apply_transaction(&osr, std::move(t));
+  int ret = store->apply_transaction(ch, std::move(t));
   if (ret) {
     cerr << "Failed to set osdmap (" << full_oid << "): " << ret << std::endl;
   } else {
@@ -1064,10 +1064,10 @@ int ObjectStoreTool::dump_object(Formatter *formatter,
   return 0;
 }
 
-int ObjectStoreTool::get_object(ObjectStore *store, coll_t coll,
+int ObjectStoreTool::get_object(ObjectStore *store,
+				coll_t coll,
 				bufferlist &bl, OSDMap &curmap,
-				bool *skipped_objects,
-				ObjectStore::Sequencer &osr)
+				bool *skipped_objects)
 {
   ObjectStore::Transaction tran;
   ObjectStore::Transaction *t = &tran;
@@ -1087,6 +1087,8 @@ int ObjectStoreTool::get_object(ObjectStore *store, coll_t coll,
     return -EFAULT;
   }
   assert(g_ceph_context);
+
+  auto ch = store->open_collection(coll);
   if (ob.hoid.hobj.nspace != g_ceph_context->_conf->osd_hit_set_namespace) {
     object_t oid = ob.hoid.hobj.oid;
     object_locator_t loc(ob.hoid.hobj);
@@ -1161,7 +1163,7 @@ int ObjectStoreTool::get_object(ObjectStore *store, coll_t coll,
     }
   }
   if (!dry_run)
-    store->apply_transaction(&osr, std::move(*t));
+    store->apply_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -1571,8 +1573,7 @@ int ObjectStoreTool::dump_import(Formatter *formatter)
 }
 
 int ObjectStoreTool::do_import(ObjectStore *store, OSDSuperblock& sb,
-			       bool force, std::string pgidstr,
-			       ObjectStore::Sequencer &osr)
+			       bool force, std::string pgidstr)
 {
   bufferlist ebl;
   pg_info_t info;
@@ -1691,6 +1692,7 @@ int ObjectStoreTool::do_import(ObjectStore *store, OSDSuperblock& sb,
   }
 
   if (!dry_run) {
+    ObjectStore::CollectionHandle ch = store->open_collection(coll);
     ObjectStore::Transaction t;
     PG::_create(t, pgid,
 		pgid.get_split_bits(curmap.get_pg_pool(pgid.pool())->get_pg_num()));
@@ -1701,7 +1703,7 @@ int ObjectStoreTool::do_import(ObjectStore *store, OSDSuperblock& sb,
     encode((char)1, values["_remove"]);
     t.omap_setkeys(coll, pgid.make_pgmeta_oid(), values);
 
-    store->apply_transaction(&osr, std::move(t));
+    store->apply_transaction(ch, std::move(t));
   }
 
   cout << "Importing pgid " << pgid;
@@ -1727,7 +1729,7 @@ int ObjectStoreTool::do_import(ObjectStore *store, OSDSuperblock& sb,
     }
     switch(type) {
     case TYPE_OBJECT_BEGIN:
-      ret = get_object(store, coll, ebl, curmap, &skipped_objects, osr);
+      ret = get_object(store, coll, ebl, curmap, &skipped_objects);
       if (ret) return ret;
       break;
     case TYPE_PG_METADATA:
@@ -1816,10 +1818,11 @@ int ObjectStoreTool::do_import(ObjectStore *store, OSDSuperblock& sb,
     cerr << "done, clearing removal flag" << std::endl;
 
   if (!dry_run) {
+    auto ch = store->open_collection(coll);
     set<string> remove;
     remove.insert("_remove");
     t.omap_rmkeys(coll, pgid.make_pgmeta_oid(), remove);
-    store->apply_transaction(&osr, std::move(t));
+    store->apply_transaction(ch, std::move(t));
   }
 
   return 0;
@@ -1873,8 +1876,7 @@ int remove_object(coll_t coll, ghobject_t &ghobj,
 int get_snapset(ObjectStore *store, coll_t coll, ghobject_t &ghobj, SnapSet &ss, bool silent);
 
 int do_remove_object(ObjectStore *store, coll_t coll,
-		     ghobject_t &ghobj, bool all, bool force,
-		     ObjectStore::Sequencer &osr)
+		     ghobject_t &ghobj, bool all, bool force)
 {
   spg_t pg;
   coll.is_pg_prefix(&pg);
@@ -1916,6 +1918,7 @@ int do_remove_object(ObjectStore *store, coll_t coll,
 
   cout << "remove " << ghobj << std::endl;
 
+  auto ch = store->open_collection(coll);
   if (!dry_run) {
     r = remove_object(coll, ghobj, mapper, &_t, &t);
     if (r < 0)
@@ -1935,7 +1938,7 @@ int do_remove_object(ObjectStore *store, coll_t coll,
   }
 
   if (!dry_run)
-    store->apply_transaction(&osr, std::move(t));
+    store->apply_transaction(ch, std::move(t));
 
   return 0;
 }
@@ -2026,8 +2029,7 @@ int do_get_bytes(ObjectStore *store, coll_t coll, ghobject_t &ghobj, int fd)
 }
 
 int do_set_bytes(ObjectStore *store, coll_t coll,
-		 ghobject_t &ghobj, int fd,
-		 ObjectStore::Sequencer &osr)
+		 ghobject_t &ghobj, int fd)
 {
   ObjectStore::Transaction tran;
   ObjectStore::Transaction *t = &tran;
@@ -2062,8 +2064,9 @@ int do_set_bytes(ObjectStore *store, coll_t coll,
     // XXX: Should we apply_transaction() every once in a while for very large files
   } while(true);
 
+  auto ch = store->open_collection(coll);
   if (!dry_run)
-    store->apply_transaction(&osr, std::move(*t));
+    store->apply_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -2088,8 +2091,7 @@ int do_get_attr(ObjectStore *store, coll_t coll, ghobject_t &ghobj, string key)
 }
 
 int do_set_attr(ObjectStore *store, coll_t coll,
-		ghobject_t &ghobj, string key, int fd,
-		ObjectStore::Sequencer &osr)
+		ghobject_t &ghobj, string key, int fd)
 {
   ObjectStore::Transaction tran;
   ObjectStore::Transaction *t = &tran;
@@ -2109,13 +2111,13 @@ int do_set_attr(ObjectStore *store, coll_t coll,
 
   t->setattr(coll, ghobj, key,  bl);
 
-  store->apply_transaction(&osr, std::move(*t));
+  auto ch = store->open_collection(coll);
+  store->apply_transaction(ch, std::move(*t));
   return 0;
 }
 
 int do_rm_attr(ObjectStore *store, coll_t coll,
-	       ghobject_t &ghobj, string key,
-	       ObjectStore::Sequencer &osr)
+	       ghobject_t &ghobj, string key)
 {
   ObjectStore::Transaction tran;
   ObjectStore::Transaction *t = &tran;
@@ -2128,7 +2130,8 @@ int do_rm_attr(ObjectStore *store, coll_t coll,
 
   t->rmattr(coll, ghobj, key);
 
-  store->apply_transaction(&osr, std::move(*t));
+  auto ch = store->open_collection(coll);
+  store->apply_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -2164,8 +2167,7 @@ int do_get_omap(ObjectStore *store, coll_t coll, ghobject_t &ghobj, string key)
 }
 
 int do_set_omap(ObjectStore *store, coll_t coll,
-		ghobject_t &ghobj, string key, int fd,
-		ObjectStore::Sequencer &osr)
+		ghobject_t &ghobj, string key, int fd)
 {
   ObjectStore::Transaction tran;
   ObjectStore::Transaction *t = &tran;
@@ -2188,13 +2190,13 @@ int do_set_omap(ObjectStore *store, coll_t coll,
 
   t->omap_setkeys(coll, ghobj, attrset);
 
-  store->apply_transaction(&osr, std::move(*t));
+  auto ch = store->open_collection(coll);
+  store->apply_transaction(ch, std::move(*t));
   return 0;
 }
 
 int do_rm_omap(ObjectStore *store, coll_t coll,
-	       ghobject_t &ghobj, string key,
-	       ObjectStore::Sequencer &osr)
+	       ghobject_t &ghobj, string key)
 {
   ObjectStore::Transaction tran;
   ObjectStore::Transaction *t = &tran;
@@ -2210,7 +2212,8 @@ int do_rm_omap(ObjectStore *store, coll_t coll,
 
   t->omap_rmkeys(coll, ghobj, keys);
 
-  store->apply_transaction(&osr, std::move(*t));
+  auto ch = store->open_collection(coll);
+  store->apply_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -2235,8 +2238,7 @@ int do_get_omaphdr(ObjectStore *store, coll_t coll, ghobject_t &ghobj)
 }
 
 int do_set_omaphdr(ObjectStore *store, coll_t coll,
-		   ghobject_t &ghobj, int fd,
-		   ObjectStore::Sequencer &osr)
+		   ghobject_t &ghobj, int fd)
 {
   ObjectStore::Transaction tran;
   ObjectStore::Transaction *t = &tran;
@@ -2256,15 +2258,12 @@ int do_set_omaphdr(ObjectStore *store, coll_t coll,
 
   t->omap_setheader(coll, ghobj, hdrbl);
 
-  store->apply_transaction(&osr, std::move(*t));
+  auto ch = store->open_collection(coll);
+  store->apply_transaction(ch, std::move(*t));
   return 0;
 }
 
 struct do_fix_lost : public action_on_object_t {
-  ObjectStore::Sequencer *osr;
-
-  explicit do_fix_lost(ObjectStore::Sequencer *_osr) : osr(_osr) {}
-
   int call(ObjectStore *store, coll_t coll,
 		   ghobject_t &ghobj, object_info_t &oi) override {
     if (oi.is_lost()) {
@@ -2279,7 +2278,8 @@ struct do_fix_lost : public action_on_object_t {
       encode(oi, bl, -1);  /* fixme: using full features */
       ObjectStore::Transaction t;
       t.setattr(coll, ghobj, OI_ATTR, bl);
-      int r = store->apply_transaction(osr, std::move(t));
+      auto ch = store->open_collection(coll);
+      int r = store->apply_transaction(ch, std::move(t));
       if (r < 0) {
 	cerr << "Error getting fixing attr on : " << make_pair(coll, ghobj)
 	     << ", "
@@ -2373,8 +2373,9 @@ int print_obj_info(ObjectStore *store, coll_t coll, ghobject_t &ghobj, Formatter
   return r;
 }
 
-int set_size(ObjectStore *store, coll_t coll, ghobject_t &ghobj, uint64_t setsize, Formatter* formatter,
-	     ObjectStore::Sequencer &osr, bool corrupt)
+int set_size(
+  ObjectStore *store, coll_t coll, ghobject_t &ghobj, uint64_t setsize, Formatter* formatter,
+  bool corrupt)
 {
   if (ghobj.hobj.is_snapdir()) {
     cerr << "Can't set the size of a snapdir" << std::endl;
@@ -2463,7 +2464,8 @@ int set_size(ObjectStore *store, coll_t coll, ghobject_t &ghobj, uint64_t setsiz
       encode(ss, snapattr);
       t.setattr(coll, head, SS_ATTR, snapattr);
     }
-    r = store->apply_transaction(&osr, std::move(t));
+    auto ch = store->open_collection(coll);
+    r = store->apply_transaction(ch, std::move(t));
     if (r < 0) {
       cerr << "Error writing object info: " << make_pair(coll, ghobj) << ", "
          << cpp_strerror(r) << std::endl;
@@ -2474,7 +2476,7 @@ int set_size(ObjectStore *store, coll_t coll, ghobject_t &ghobj, uint64_t setsiz
 }
 
 int clear_snapset(ObjectStore *store, coll_t coll, ghobject_t &ghobj,
-                  string arg, ObjectStore::Sequencer &osr)
+                  string arg)
 {
   SnapSet ss;
   int ret = get_snapset(store, coll, ghobj, ss);
@@ -2509,7 +2511,8 @@ int clear_snapset(ObjectStore *store, coll_t coll, ghobject_t &ghobj,
     encode(ss, bl);
     ObjectStore::Transaction t;
     t.setattr(coll, ghobj, SS_ATTR, bl);
-    int r = store->apply_transaction(&osr, std::move(t));
+    auto ch = store->open_collection(coll);
+    int r = store->apply_transaction(ch, std::move(t));
     if (r < 0) {
       cerr << "Error setting snapset on : " << make_pair(coll, ghobj) << ", "
 	   << cpp_strerror(r) << std::endl;
@@ -2554,8 +2557,8 @@ int remove_from(T &mv, string name, snapid_t cloneid, bool force)
   return 0;
 }
 
-int remove_clone(ObjectStore *store, coll_t coll, ghobject_t &ghobj, snapid_t cloneid, bool force,
-		     ObjectStore::Sequencer &osr)
+int remove_clone(
+  ObjectStore *store, coll_t coll, ghobject_t &ghobj, snapid_t cloneid, bool force)
 {
   // XXX: Don't allow this if in a cache tier or former cache tier
   // bool allow_incomplete_clones() const {
@@ -2607,7 +2610,8 @@ int remove_clone(ObjectStore *store, coll_t coll, ghobject_t &ghobj, snapid_t cl
   encode(snapset, bl);
   ObjectStore::Transaction t;
   t.setattr(coll, ghobj, SS_ATTR, bl);
-  int r = store->apply_transaction(&osr, std::move(t));
+  auto ch = store->open_collection(coll);
+  int r = store->apply_transaction(ch, std::move(t));
   if (r < 0) {
     cerr << "Error setting snapset on : " << make_pair(coll, ghobj) << ", "
 	 << cpp_strerror(r) << std::endl;
@@ -2623,7 +2627,6 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
   cout << "dup from " << src->get_type() << ": " << srcpath << "\n"
        << "      to " << dst->get_type() << ": " << dstpath
        << std::endl;
-  ObjectStore::Sequencer osr("dup");
   int num, i;
   vector<coll_t> collections;
   int r;
@@ -2668,6 +2671,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
   i = 1;
   for (auto cid : collections) {
     cout << i++ << "/" << num << " " << cid << std::endl;
+    auto ch = dst->create_new_collection(cid);
     {
       ObjectStore::Transaction t;
       int bits = src->collection_bits(cid);
@@ -2681,7 +2685,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
         }
       }
       t.create_collection(cid, bits);
-      dst->apply_transaction(&osr, std::move(t));
+      dst->apply_transaction(ch, std::move(t));
     }
 
     ghobject_t pos;
@@ -2737,7 +2741,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
 	  t.omap_setkeys(cid, oid, omap);
 	}
 
-	dst->apply_transaction(&osr, std::move(t));
+	dst->apply_transaction(ch, std::move(t));
       }
     }
     cout << "  " << std::setw(16) << n << " objects, "
@@ -3260,7 +3264,6 @@ int main(int argc, char **argv)
     return 0;
   }
 
-  ObjectStore::Sequencer *osr = new ObjectStore::Sequencer(__func__);
   int ret = fs->mount();
   if (ret < 0) {
     if (ret == -EBUSY) {
@@ -3444,7 +3447,7 @@ int main(int argc, char **argv)
   if (op == "import") {
 
     try {
-      ret = tool.do_import(fs, superblock, force, pgidstr, *osr);
+      ret = tool.do_import(fs, superblock, force, pgidstr);
     }
     catch (const buffer::error &e) {
       cerr << "do_import threw exception error " << e.what() << std::endl;
@@ -3494,7 +3497,7 @@ int main(int argc, char **argv)
     if (ret < 0) {
       cerr << "Failed to read osdmap " << cpp_strerror(ret) << std::endl;
     } else {
-      ret = set_osdmap(fs, epoch, bl, force, *osr);
+      ret = set_osdmap(fs, epoch, bl, force);
     }
     goto out;
   } else if (op == "get-inc-osdmap") {
@@ -3522,7 +3525,7 @@ int main(int argc, char **argv)
       cerr << "Failed to read incremental osdmap  " << cpp_strerror(ret) << std::endl;
       goto out;
     } else {
-      ret = set_inc_osdmap(fs, epoch, bl, force, *osr);
+      ret = set_inc_osdmap(fs, epoch, bl, force);
     }
     goto out;
   } else if (op == "update-mon-db") {
@@ -3541,7 +3544,7 @@ int main(int argc, char **argv)
       ret = -EINVAL;
       goto out;
     }
-    ret = initiate_new_remove_pg(fs, pgid, *osr);
+    ret = initiate_new_remove_pg(fs, pgid);
     if (ret < 0) {
       cerr << "PG '" << pgid << "' not found" << std::endl;
       goto out;
@@ -3552,7 +3555,7 @@ int main(int argc, char **argv)
 
   if (op == "fix-lost") {
     boost::scoped_ptr<action_on_object_t> action;
-    action.reset(new do_fix_lost(osr));
+    action.reset(new do_fix_lost());
     if (pgidstr.length())
       ret = action_on_all_objects_in_exact_pg(fs, coll_t(pgid), *action, debug);
     else
@@ -3651,7 +3654,7 @@ int main(int argc, char **argv)
       ret = 0;
       if (objcmd == "remove" || objcmd == "removeall") {
         bool all = (objcmd == "removeall");
-        ret = do_remove_object(fs, coll, ghobj, all, force, *osr);
+        ret = do_remove_object(fs, coll, ghobj, all, force);
         goto out;
       } else if (objcmd == "list-attrs") {
         ret = do_list_attrs(fs, coll, ghobj);
@@ -3693,7 +3696,7 @@ int main(int argc, char **argv)
               goto out;
             }
           }
-          ret = do_set_bytes(fs, coll, ghobj, fd, *osr);
+          ret = do_set_bytes(fs, coll, ghobj, fd);
           if (fd != STDIN_FILENO)
             close(fd);
         }
@@ -3729,7 +3732,7 @@ int main(int argc, char **argv)
 	    goto out;
 	  }
 	}
-	ret = do_set_attr(fs, coll, ghobj, arg1, fd, *osr);
+	ret = do_set_attr(fs, coll, ghobj, arg1, fd);
 	if (fd != STDIN_FILENO)
 	  close(fd);
         goto out;
@@ -3739,7 +3742,7 @@ int main(int argc, char **argv)
           ret = 1;
           goto out;
         }
-	ret = do_rm_attr(fs, coll, ghobj, arg1, *osr);
+	ret = do_rm_attr(fs, coll, ghobj, arg1);
         goto out;
       } else if (objcmd == "get-omap") {
 	if (vm.count("arg1") == 0) {
@@ -3772,7 +3775,7 @@ int main(int argc, char **argv)
 	    goto out;
 	  }
 	}
-	ret = do_set_omap(fs, coll, ghobj, arg1, fd, *osr);
+	ret = do_set_omap(fs, coll, ghobj, arg1, fd);
 	if (fd != STDIN_FILENO)
 	  close(fd);
         goto out;
@@ -3782,7 +3785,7 @@ int main(int argc, char **argv)
           ret = 1;
           goto out;
         }
-	ret = do_rm_omap(fs, coll, ghobj, arg1, *osr);
+	ret = do_rm_omap(fs, coll, ghobj, arg1);
         goto out;
       } else if (objcmd == "get-omaphdr") {
 	if (vm.count("arg1")) {
@@ -3816,7 +3819,7 @@ int main(int argc, char **argv)
 	    goto out;
 	  }
 	}
-	ret = do_set_omaphdr(fs, coll, ghobj, fd, *osr);
+	ret = do_set_omaphdr(fs, coll, ghobj, fd);
 	if (fd != STDIN_FILENO)
 	  close(fd);
         goto out;
@@ -3844,7 +3847,7 @@ int main(int argc, char **argv)
 	  goto out;
 	}
 	uint64_t size = atoll(arg1.c_str());
-	ret = set_size(fs, coll, ghobj, size, formatter, *osr, corrupt);
+	ret = set_size(fs, coll, ghobj, size, formatter, corrupt);
 	goto out;
       } else if (objcmd == "clear-snapset") {
         // UNDOCUMENTED: For testing zap SnapSet
@@ -3854,7 +3857,7 @@ int main(int argc, char **argv)
 	  ret = 1;
 	  goto out;
 	}
-        ret = clear_snapset(fs, coll, ghobj, arg1, *osr);
+        ret = clear_snapset(fs, coll, ghobj, arg1);
         goto out;
       } else if (objcmd == "remove-clone-metadata") {
         // Extra arg
@@ -3874,7 +3877,7 @@ int main(int argc, char **argv)
 	  goto out;
 	}
         snapid_t cloneid = atoi(arg1.c_str());
-	ret = remove_clone(fs, coll, ghobj, cloneid, force, *osr);
+	ret = remove_clone(fs, coll, ghobj, cloneid, force);
 	goto out;
       }
       cerr << "Unknown object command '" << objcmd << "'" << std::endl;
@@ -3911,7 +3914,7 @@ int main(int argc, char **argv)
       if (ret == 0) {
         cerr << "Export successful" << std::endl;
         if (op == "export-remove") {
-          ret = initiate_new_remove_pg(fs, pgid, *osr);
+          ret = initiate_new_remove_pg(fs, pgid);
           // Export succeeded, so pgid is there
           assert(ret == 0);
           cerr << "Remove successful" << std::endl;
@@ -3956,7 +3959,8 @@ int main(int argc, char **argv)
 	ret = write_info(*t, map_epoch, info, past_intervals);
 	if (ret != 0)
 	  goto out;
-	fs->apply_transaction(osr, std::move(*t));
+	auto ch = fs->open_collection(coll_t(pgid));
+	fs->apply_transaction(ch, std::move(*t));
       }
       cout << "Marking complete succeeded" << std::endl;
     } else {
@@ -3969,7 +3973,6 @@ int main(int argc, char **argv)
 
 out:
   int r = fs->umount();
-  delete osr;
   if (r < 0) {
     cerr << "umount failed: " << cpp_strerror(r) << std::endl;
     // If no previous error, then use umount() error

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -81,12 +81,12 @@ struct action_on_object_t {
 
 int _action_on_all_objects_in_pg(ObjectStore *store, coll_t coll, action_on_object_t &action, bool debug)
 {
+  auto ch = store->open_collection(coll);
   unsigned LIST_AT_A_TIME = 100;
   ghobject_t next;
   while (!next.is_max()) {
     vector<ghobject_t> list;
-    int r = store->collection_list(
-				   coll,
+    int r = store->collection_list(ch,
 				   next,
 				   ghobject_t::get_max(),
 				   LIST_AT_A_TIME,
@@ -105,7 +105,7 @@ int _action_on_all_objects_in_pg(ObjectStore *store, coll_t coll, action_on_obje
       object_info_t oi;
       if (coll != coll_t::meta()) {
         bufferlist attr;
-        r = store->getattr(coll, *obj, OI_ATTR, attr);
+        r = store->getattr(ch, *obj, OI_ATTR, attr);
         if (r < 0) {
 	  cerr << "Error getting attr on : " << make_pair(coll, *obj) << ", "
 	       << cpp_strerror(r) << std::endl;
@@ -314,14 +314,14 @@ static int get_fd_data(int fd, bufferlist &bl)
 }
 
 int get_log(ObjectStore *fs, __u8 struct_ver,
-	    coll_t coll, spg_t pgid, const pg_info_t &info,
+	    ObjectStore::CollectionHandle &ch, spg_t pgid, const pg_info_t &info,
 	    PGLog::IndexedLog &log, pg_missing_t &missing)
 {
   try {
     ostringstream oss;
     assert(struct_ver > 0);
     PGLog::read_log_and_missing(
-      fs, coll,
+      fs, ch,
       pgid.make_pgmeta_oid(),
       info, log, missing,
       oss,
@@ -497,7 +497,8 @@ int ObjectStoreTool::export_file(ObjectStore *store, coll_t cid, ghobject_t &obj
   mysize_t total;
   footer ft;
 
-  int ret = store->stat(cid, obj, &st);
+  auto ch = store->open_collection(cid);
+  int ret = store->stat(ch, obj, &st);
   if (ret < 0)
     return ret;
 
@@ -512,7 +513,7 @@ int ObjectStoreTool::export_file(ObjectStore *store, coll_t cid, ghobject_t &obj
   {
     bufferptr bp;
     bufferlist bl;
-    ret = store->getattr(cid, obj, OI_ATTR, bp);
+    ret = store->getattr(ch, obj, OI_ATTR, bp);
     if (ret < 0) {
       cerr << "getattr failure object_info " << ret << std::endl;
       return ret;
@@ -537,7 +538,7 @@ int ObjectStoreTool::export_file(ObjectStore *store, coll_t cid, ghobject_t &obj
     if (len > total)
       len = total;
 
-    ret = store->read(cid, obj, offset, len, rawdatabl);
+    ret = store->read(ch, obj, offset, len, rawdatabl);
     if (ret < 0)
       return ret;
     if (ret == 0)
@@ -556,7 +557,7 @@ int ObjectStoreTool::export_file(ObjectStore *store, coll_t cid, ghobject_t &obj
 
   //Handle attrs for this object
   map<string,bufferptr> aset;
-  ret = store->getattrs(cid, obj, aset);
+  ret = store->getattrs(ch, obj, aset);
   if (ret) return ret;
   attr_section as(aset);
   ret = write_section(TYPE_ATTRS, as, file_fd);
@@ -569,7 +570,7 @@ int ObjectStoreTool::export_file(ObjectStore *store, coll_t cid, ghobject_t &obj
 
   //Handle omap information
   bufferlist hdrbuf;
-  ret = store->omap_get_header(cid, obj, &hdrbuf, true);
+  ret = store->omap_get_header(ch, obj, &hdrbuf, true);
   if (ret < 0) {
     cerr << "omap_get_header: " << cpp_strerror(ret) << std::endl;
     return ret;
@@ -580,7 +581,7 @@ int ObjectStoreTool::export_file(ObjectStore *store, coll_t cid, ghobject_t &obj
   if (ret)
     return ret;
 
-  ObjectMap::ObjectMapIterator iter = store->get_omap_iterator(cid, obj);
+  ObjectMap::ObjectMapIterator iter = store->get_omap_iterator(ch, obj);
   if (!iter) {
     ret = -ENOENT;
     cerr << "omap_get_iterator: " << cpp_strerror(ret) << std::endl;
@@ -613,10 +614,10 @@ int ObjectStoreTool::export_file(ObjectStore *store, coll_t cid, ghobject_t &obj
 int ObjectStoreTool::export_files(ObjectStore *store, coll_t coll)
 {
   ghobject_t next;
-
+  auto ch = store->open_collection(coll);
   while (!next.is_max()) {
     vector<ghobject_t> objects;
-    int r = store->collection_list(coll, next, ghobject_t::get_max(), 300,
+    int r = store->collection_list(ch, next, ghobject_t::get_max(), 300,
       &objects, &next);
     if (r < 0)
       return r;
@@ -650,8 +651,9 @@ int set_inc_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
       return -EINVAL;
     }
   }
+  auto ch = store->open_collection(coll_t::meta());
   const ghobject_t inc_oid = OSD::get_inc_osdmap_pobject_name(e);
-  if (!store->exists(coll_t::meta(), inc_oid)) {
+  if (!store->exists(ch, inc_oid)) {
     cerr << "inc-osdmap (" << inc_oid << ") does not exist." << std::endl;
     if (!force) {
       return -ENOENT;
@@ -660,7 +662,6 @@ int set_inc_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
   }
   if (dry_run)
     return 0;
-  ObjectStore::CollectionHandle ch = store->open_collection(coll_t::meta());
   ObjectStore::Transaction t;
   t.write(coll_t::meta(), inc_oid, 0, bl.length(), bl);
   t.truncate(coll_t::meta(), inc_oid, bl.length());
@@ -675,7 +676,8 @@ int set_inc_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
 
 int get_inc_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl)
 {
-  if (store->read(coll_t::meta(),
+  auto ch = store->open_collection(coll_t::meta());
+  if (store->read(ch,
 		  OSD::get_inc_osdmap_pobject_name(e),
 		  0, 0, bl) < 0) {
     return -ENOENT;
@@ -697,8 +699,9 @@ int set_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
       return -EINVAL;
     }
   }
+  auto ch = store->open_collection(coll_t::meta());
   const ghobject_t full_oid = OSD::get_osdmap_pobject_name(e);
-  if (!store->exists(coll_t::meta(), full_oid)) {
+  if (!store->exists(ch, full_oid)) {
     cerr << "osdmap (" << full_oid << ") does not exist." << std::endl;
     if (!force) {
       return -ENOENT;
@@ -708,7 +711,6 @@ int set_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
   if (dry_run)
     return 0;
   ObjectStore::Transaction t;
-  ObjectStore::CollectionHandle ch = store->open_collection(coll_t::meta());
   t.write(coll_t::meta(), full_oid, 0, bl.length(), bl);
   t.truncate(coll_t::meta(), full_oid, bl.length());
   int ret = store->apply_transaction(ch, std::move(t));
@@ -722,8 +724,9 @@ int set_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
 
 int get_osdmap(ObjectStore *store, epoch_t e, OSDMap &osdmap, bufferlist& bl)
 {
+  ObjectStore::CollectionHandle ch = store->open_collection(coll_t::meta());
   bool found = store->read(
-      coll_t::meta(), OSD::get_osdmap_pobject_name(e), 0, 0, bl) >= 0;
+    ch, OSD::get_osdmap_pobject_name(e), 0, 0, bl) >= 0;
   if (!found) {
     cerr << "Can't find OSDMap for pg epoch " << e << std::endl;
     return -ENOENT;
@@ -749,7 +752,8 @@ int ObjectStoreTool::do_export(ObjectStore *fs, coll_t coll, spg_t pgid,
 
   cerr << "Exporting " << pgid << " info " << info << std::endl;
 
-  int ret = get_log(fs, struct_ver, coll, pgid, info, log, missing);
+  auto ch = fs->open_collection(coll);
+  int ret = get_log(fs, struct_ver, ch, pgid, info, log, missing);
   if (ret > 0)
       return ret;
 
@@ -893,6 +897,7 @@ int get_attrs(
   attr_section as;
   as.decode(ebliter);
 
+  auto ch = store->open_collection(coll);
   if (debug)
     cerr << "\tattrs: len " << as.data.size() << std::endl;
   t->setattrs(coll, hoid, as.data);
@@ -911,7 +916,7 @@ int get_attrs(
 	ghobject_t clone = hoid;
 	clone.hobj.snap = p.first;
 	set<snapid_t> snaps(p.second.begin(), p.second.end());
-	if (!store->exists(coll, clone)) {
+	if (!store->exists(ch, clone)) {
 	  // no clone, skip.  this is probably a cache pool.  this works
 	  // because we use a separate transaction per object and clones
 	  // come before head in the archive.
@@ -1076,7 +1081,6 @@ int ObjectStoreTool::get_object(ObjectStore *store,
   ob.decode(ebliter);
   OSDriver driver(
     store,
-    coll_t(),
     OSD::make_snapmapper_oid());
   spg_t pg;
   coll.is_pg_prefix(&pg);
@@ -1878,16 +1882,16 @@ int get_snapset(ObjectStore *store, coll_t coll, ghobject_t &ghobj, SnapSet &ss,
 int do_remove_object(ObjectStore *store, coll_t coll,
 		     ghobject_t &ghobj, bool all, bool force)
 {
+  auto ch = store->open_collection(coll);
   spg_t pg;
   coll.is_pg_prefix(&pg);
   OSDriver driver(
     store,
-    coll_t(),
     OSD::make_snapmapper_oid());
   SnapMapper mapper(g_ceph_context, &driver, 0, 0, 0, pg.shard);
   struct stat st;
 
-  int r = store->stat(coll, ghobj, &st);
+  int r = store->stat(ch, ghobj, &st);
   if (r < 0) {
     cerr << "remove: " << cpp_strerror(r) << std::endl;
     return r;
@@ -1918,7 +1922,6 @@ int do_remove_object(ObjectStore *store, coll_t coll,
 
   cout << "remove " << ghobj << std::endl;
 
-  auto ch = store->open_collection(coll);
   if (!dry_run) {
     r = remove_object(coll, ghobj, mapper, &_t, &t);
     if (r < 0)
@@ -1945,8 +1948,9 @@ int do_remove_object(ObjectStore *store, coll_t coll,
 
 int do_list_attrs(ObjectStore *store, coll_t coll, ghobject_t &ghobj)
 {
+  auto ch = store->open_collection(coll);
   map<string,bufferptr> aset;
-  int r = store->getattrs(coll, ghobj, aset);
+  int r = store->getattrs(ch, ghobj, aset);
   if (r < 0) {
     cerr << "getattrs: " << cpp_strerror(r) << std::endl;
     return r;
@@ -1963,7 +1967,8 @@ int do_list_attrs(ObjectStore *store, coll_t coll, ghobject_t &ghobj)
 
 int do_list_omap(ObjectStore *store, coll_t coll, ghobject_t &ghobj)
 {
-  ObjectMap::ObjectMapIterator iter = store->get_omap_iterator(coll, ghobj);
+  auto ch = store->open_collection(coll);
+  ObjectMap::ObjectMapIterator iter = store->get_omap_iterator(ch, ghobj);
   if (!iter) {
     cerr << "omap_get_iterator: " << cpp_strerror(ENOENT) << std::endl;
     return -ENOENT;
@@ -1985,10 +1990,11 @@ int do_list_omap(ObjectStore *store, coll_t coll, ghobject_t &ghobj)
 
 int do_get_bytes(ObjectStore *store, coll_t coll, ghobject_t &ghobj, int fd)
 {
+  auto ch = store->open_collection(coll);
   struct stat st;
   mysize_t total;
 
-  int ret = store->stat(coll, ghobj, &st);
+  int ret = store->stat(ch, ghobj, &st);
   if (ret < 0) {
     cerr << "get-bytes: " << cpp_strerror(ret) << std::endl;
     return ret;
@@ -2006,7 +2012,7 @@ int do_get_bytes(ObjectStore *store, coll_t coll, ghobject_t &ghobj, int fd)
     if (len > total)
       len = total;
 
-    ret = store->read(coll, ghobj, offset, len, rawdatabl);
+    ret = store->read(ch, ghobj, offset, len, rawdatabl);
     if (ret < 0)
       return ret;
     if (ret == 0)
@@ -2072,9 +2078,10 @@ int do_set_bytes(ObjectStore *store, coll_t coll,
 
 int do_get_attr(ObjectStore *store, coll_t coll, ghobject_t &ghobj, string key)
 {
+  auto ch = store->open_collection(coll);
   bufferptr bp;
 
-  int r = store->getattr(coll, ghobj, key.c_str(), bp);
+  int r = store->getattr(ch, ghobj, key.c_str(), bp);
   if (r < 0) {
     cerr << "getattr: " << cpp_strerror(r) << std::endl;
     return r;
@@ -2137,12 +2144,13 @@ int do_rm_attr(ObjectStore *store, coll_t coll,
 
 int do_get_omap(ObjectStore *store, coll_t coll, ghobject_t &ghobj, string key)
 {
+  auto ch = store->open_collection(coll);
   set<string> keys;
   map<string, bufferlist> out;
 
   keys.insert(key);
 
-  int r = store->omap_get_values(coll, ghobj, keys, &out);
+  int r = store->omap_get_values(ch, ghobj, keys, &out);
   if (r < 0) {
     cerr << "omap_get_values: " << cpp_strerror(r) << std::endl;
     return r;
@@ -2219,9 +2227,10 @@ int do_rm_omap(ObjectStore *store, coll_t coll,
 
 int do_get_omaphdr(ObjectStore *store, coll_t coll, ghobject_t &ghobj)
 {
+  auto ch = store->open_collection(coll);
   bufferlist hdrbl;
 
-  int r = store->omap_get_header(coll, ghobj, &hdrbl, true);
+  int r = store->omap_get_header(ch, ghobj, &hdrbl, true);
   if (r < 0) {
     cerr << "omap_get_header: " << cpp_strerror(r) << std::endl;
     return r;
@@ -2293,8 +2302,9 @@ struct do_fix_lost : public action_on_object_t {
 
 int get_snapset(ObjectStore *store, coll_t coll, ghobject_t &ghobj, SnapSet &ss, bool silent = false)
 {
+  auto ch = store->open_collection(coll);
   bufferlist attr;
-  int r = store->getattr(coll, ghobj, SS_ATTR, attr);
+  int r = store->getattr(ch, ghobj, SS_ATTR, attr);
   if (r < 0) {
     if (!silent)
       cerr << "Error getting snapset on : " << make_pair(coll, ghobj) << ", "
@@ -2315,6 +2325,7 @@ int get_snapset(ObjectStore *store, coll_t coll, ghobject_t &ghobj, SnapSet &ss,
 
 int print_obj_info(ObjectStore *store, coll_t coll, ghobject_t &ghobj, Formatter* formatter)
 {
+  auto ch = store->open_collection(coll);
   int r = 0;
   formatter->open_object_section("obj");
   formatter->open_object_section("id");
@@ -2322,7 +2333,7 @@ int print_obj_info(ObjectStore *store, coll_t coll, ghobject_t &ghobj, Formatter
   formatter->close_section();
 
   bufferlist attr;
-  int gr = store->getattr(coll, ghobj, OI_ATTR, attr);
+  int gr = store->getattr(ch, ghobj, OI_ATTR, attr);
   if (gr < 0) {
     r = gr;
     cerr << "Error getting attr on : " << make_pair(coll, ghobj) << ", "
@@ -2342,7 +2353,7 @@ int print_obj_info(ObjectStore *store, coll_t coll, ghobject_t &ghobj, Formatter
     }
   }
   struct stat st;
-  int sr =  store->stat(coll, ghobj, &st, true);
+  int sr =  store->stat(ch, ghobj, &st, true);
   if (sr < 0) {
     r = sr;
     cerr << "Error stat on : " << make_pair(coll, ghobj) << ", "
@@ -2377,12 +2388,13 @@ int set_size(
   ObjectStore *store, coll_t coll, ghobject_t &ghobj, uint64_t setsize, Formatter* formatter,
   bool corrupt)
 {
+  auto ch = store->open_collection(coll);
   if (ghobj.hobj.is_snapdir()) {
     cerr << "Can't set the size of a snapdir" << std::endl;
     return -EINVAL;
   }
   bufferlist attr;
-  int r = store->getattr(coll, ghobj, OI_ATTR, attr);
+  int r = store->getattr(ch, ghobj, OI_ATTR, attr);
   if (r < 0) {
     cerr << "Error getting attr on : " << make_pair(coll, ghobj) << ", "
        << cpp_strerror(r) << std::endl;
@@ -2399,7 +2411,7 @@ int set_size(
     return r;
   }
   struct stat st;
-  r =  store->stat(coll, ghobj, &st, true);
+  r =  store->stat(ch, ghobj, &st, true);
   if (r < 0) {
     cerr << "Error stat on : " << make_pair(coll, ghobj) << ", "
          << cpp_strerror(r) << std::endl;
@@ -2671,10 +2683,11 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
   i = 1;
   for (auto cid : collections) {
     cout << i++ << "/" << num << " " << cid << std::endl;
-    auto ch = dst->create_new_collection(cid);
+    auto ch = src->open_collection(cid);
+    auto dch = dst->create_new_collection(cid);
     {
       ObjectStore::Transaction t;
-      int bits = src->collection_bits(cid);
+      int bits = src->collection_bits(ch);
       if (bits < 0) {
         if (src->get_type() == "filestore" && cid.is_meta()) {
           bits = 0;
@@ -2685,7 +2698,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
         }
       }
       t.create_collection(cid, bits);
-      dst->apply_transaction(ch, std::move(t));
+      dst->apply_transaction(dch, std::move(t));
     }
 
     ghobject_t pos;
@@ -2693,7 +2706,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
     uint64_t bytes = 0, keys = 0;
     while (true) {
       vector<ghobject_t> ls;
-      r = src->collection_list(cid, pos, ghobject_t::get_max(), 1000, &ls, &pos);
+      r = src->collection_list(ch, pos, ghobject_t::get_max(), 1000, &ls, &pos);
       if (r < 0) {
 	cerr << "collection_list on " << cid << " from " << pos << " got: "
 	     << cpp_strerror(r) << std::endl;
@@ -2717,13 +2730,13 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
 	t.touch(cid, oid);
 
 	map<string,bufferptr> attrs;
-	src->getattrs(cid, oid, attrs);
+	src->getattrs(ch, oid, attrs);
 	if (!attrs.empty()) {
 	  t.setattrs(cid, oid, attrs);
 	}
 
 	bufferlist bl;
-	src->read(cid, oid, 0, 0, bl);
+	src->read(ch, oid, 0, 0, bl);
 	if (bl.length()) {
 	  t.write(cid, oid, 0, bl.length(), bl);
 	  bytes += bl.length();
@@ -2731,7 +2744,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
 
 	bufferlist header;
 	map<string,bufferlist> omap;
-	src->omap_get(cid, oid, &header, &omap);
+	src->omap_get(ch, oid, &header, &omap);
 	if (header.length()) {
 	  t.omap_setheader(cid, oid, header);
 	  ++keys;
@@ -2741,7 +2754,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
 	  t.omap_setkeys(cid, oid, omap);
 	}
 
-	dst->apply_transaction(ch, std::move(t));
+	dst->apply_transaction(dch, std::move(t));
       }
     }
     cout << "  " << std::setw(16) << n << " objects, "
@@ -3301,8 +3314,9 @@ int main(int argc, char **argv)
 
   bufferlist bl;
   OSDSuperblock superblock;
+  auto ch = fs->open_collection(coll_t::meta());
   bufferlist::iterator p;
-  ret = fs->read(coll_t::meta(), OSD_SUPERBLOCK_GOBJECT, 0, 0, bl);
+  ret = fs->read(ch, OSD_SUPERBLOCK_GOBJECT, 0, 0, bl);
   if (ret < 0) {
     cerr << "Failure to read OSD superblock: " << cpp_strerror(ret) << std::endl;
     goto out;
@@ -3929,7 +3943,7 @@ int main(int argc, char **argv)
     } else if (op == "log") {
       PGLog::IndexedLog log;
       pg_missing_t missing;
-      ret = get_log(fs, struct_ver, coll, pgid, info, log, missing);
+      ret = get_log(fs, struct_ver, ch, pgid, info, log, missing);
       if (ret < 0)
           goto out;
 

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -428,7 +428,7 @@ int initiate_new_remove_pg(ObjectStore *store, spg_t r_pgid)
     return r;
   }
   ObjectStore::CollectionHandle ch = store->open_collection(coll_t(r_pgid));
-  store->apply_transaction(ch, std::move(rmt));
+  store->queue_transaction(ch, std::move(rmt));
   finish_remove_pgs(store);
   return r;
 }
@@ -665,7 +665,7 @@ int set_inc_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
   ObjectStore::Transaction t;
   t.write(coll_t::meta(), inc_oid, 0, bl.length(), bl);
   t.truncate(coll_t::meta(), inc_oid, bl.length());
-  int ret = store->apply_transaction(ch, std::move(t));
+  int ret = store->queue_transaction(ch, std::move(t));
   if (ret) {
     cerr << "Failed to set inc-osdmap (" << inc_oid << "): " << ret << std::endl;
   } else {
@@ -713,7 +713,7 @@ int set_osdmap(ObjectStore *store, epoch_t e, bufferlist& bl, bool force) {
   ObjectStore::Transaction t;
   t.write(coll_t::meta(), full_oid, 0, bl.length(), bl);
   t.truncate(coll_t::meta(), full_oid, bl.length());
-  int ret = store->apply_transaction(ch, std::move(t));
+  int ret = store->queue_transaction(ch, std::move(t));
   if (ret) {
     cerr << "Failed to set osdmap (" << full_oid << "): " << ret << std::endl;
   } else {
@@ -1167,7 +1167,7 @@ int ObjectStoreTool::get_object(ObjectStore *store,
     }
   }
   if (!dry_run)
-    store->apply_transaction(ch, std::move(*t));
+    store->queue_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -1707,7 +1707,7 @@ int ObjectStoreTool::do_import(ObjectStore *store, OSDSuperblock& sb,
     encode((char)1, values["_remove"]);
     t.omap_setkeys(coll, pgid.make_pgmeta_oid(), values);
 
-    store->apply_transaction(ch, std::move(t));
+    store->queue_transaction(ch, std::move(t));
   }
 
   cout << "Importing pgid " << pgid;
@@ -1826,7 +1826,7 @@ int ObjectStoreTool::do_import(ObjectStore *store, OSDSuperblock& sb,
     set<string> remove;
     remove.insert("_remove");
     t.omap_rmkeys(coll, pgid.make_pgmeta_oid(), remove);
-    store->apply_transaction(ch, std::move(t));
+    store->queue_transaction(ch, std::move(t));
   }
 
   return 0;
@@ -1941,7 +1941,7 @@ int do_remove_object(ObjectStore *store, coll_t coll,
   }
 
   if (!dry_run)
-    store->apply_transaction(ch, std::move(t));
+    store->queue_transaction(ch, std::move(t));
 
   return 0;
 }
@@ -2067,12 +2067,12 @@ int do_set_bytes(ObjectStore *store, coll_t coll,
       t->write(coll, ghobj, offset, bytes,  rawdatabl);
 
     offset += bytes;
-    // XXX: Should we apply_transaction() every once in a while for very large files
+    // XXX: Should we queue_transaction() every once in a while for very large files
   } while(true);
 
   auto ch = store->open_collection(coll);
   if (!dry_run)
-    store->apply_transaction(ch, std::move(*t));
+    store->queue_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -2119,7 +2119,7 @@ int do_set_attr(ObjectStore *store, coll_t coll,
   t->setattr(coll, ghobj, key,  bl);
 
   auto ch = store->open_collection(coll);
-  store->apply_transaction(ch, std::move(*t));
+  store->queue_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -2138,7 +2138,7 @@ int do_rm_attr(ObjectStore *store, coll_t coll,
   t->rmattr(coll, ghobj, key);
 
   auto ch = store->open_collection(coll);
-  store->apply_transaction(ch, std::move(*t));
+  store->queue_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -2199,7 +2199,7 @@ int do_set_omap(ObjectStore *store, coll_t coll,
   t->omap_setkeys(coll, ghobj, attrset);
 
   auto ch = store->open_collection(coll);
-  store->apply_transaction(ch, std::move(*t));
+  store->queue_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -2221,7 +2221,7 @@ int do_rm_omap(ObjectStore *store, coll_t coll,
   t->omap_rmkeys(coll, ghobj, keys);
 
   auto ch = store->open_collection(coll);
-  store->apply_transaction(ch, std::move(*t));
+  store->queue_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -2268,7 +2268,7 @@ int do_set_omaphdr(ObjectStore *store, coll_t coll,
   t->omap_setheader(coll, ghobj, hdrbl);
 
   auto ch = store->open_collection(coll);
-  store->apply_transaction(ch, std::move(*t));
+  store->queue_transaction(ch, std::move(*t));
   return 0;
 }
 
@@ -2288,7 +2288,7 @@ struct do_fix_lost : public action_on_object_t {
       ObjectStore::Transaction t;
       t.setattr(coll, ghobj, OI_ATTR, bl);
       auto ch = store->open_collection(coll);
-      int r = store->apply_transaction(ch, std::move(t));
+      int r = store->queue_transaction(ch, std::move(t));
       if (r < 0) {
 	cerr << "Error getting fixing attr on : " << make_pair(coll, ghobj)
 	     << ", "
@@ -2477,7 +2477,7 @@ int set_size(
       t.setattr(coll, head, SS_ATTR, snapattr);
     }
     auto ch = store->open_collection(coll);
-    r = store->apply_transaction(ch, std::move(t));
+    r = store->queue_transaction(ch, std::move(t));
     if (r < 0) {
       cerr << "Error writing object info: " << make_pair(coll, ghobj) << ", "
          << cpp_strerror(r) << std::endl;
@@ -2524,7 +2524,7 @@ int clear_snapset(ObjectStore *store, coll_t coll, ghobject_t &ghobj,
     ObjectStore::Transaction t;
     t.setattr(coll, ghobj, SS_ATTR, bl);
     auto ch = store->open_collection(coll);
-    int r = store->apply_transaction(ch, std::move(t));
+    int r = store->queue_transaction(ch, std::move(t));
     if (r < 0) {
       cerr << "Error setting snapset on : " << make_pair(coll, ghobj) << ", "
 	   << cpp_strerror(r) << std::endl;
@@ -2623,7 +2623,7 @@ int remove_clone(
   ObjectStore::Transaction t;
   t.setattr(coll, ghobj, SS_ATTR, bl);
   auto ch = store->open_collection(coll);
-  int r = store->apply_transaction(ch, std::move(t));
+  int r = store->queue_transaction(ch, std::move(t));
   if (r < 0) {
     cerr << "Error setting snapset on : " << make_pair(coll, ghobj) << ", "
 	 << cpp_strerror(r) << std::endl;
@@ -2698,7 +2698,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
         }
       }
       t.create_collection(cid, bits);
-      dst->apply_transaction(dch, std::move(t));
+      dst->queue_transaction(dch, std::move(t));
     }
 
     ghobject_t pos;
@@ -2754,7 +2754,7 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
 	  t.omap_setkeys(cid, oid, omap);
 	}
 
-	dst->apply_transaction(dch, std::move(t));
+	dst->queue_transaction(dch, std::move(t));
       }
     }
     cout << "  " << std::setw(16) << n << " objects, "
@@ -3974,7 +3974,7 @@ int main(int argc, char **argv)
 	if (ret != 0)
 	  goto out;
 	auto ch = fs->open_collection(coll_t(pgid));
-	fs->apply_transaction(ch, std::move(*t));
+	fs->queue_transaction(ch, std::move(*t));
       }
       cout << "Marking complete succeeded" << std::endl;
     } else {

--- a/src/tools/ceph_objectstore_tool.h
+++ b/src/tools/ceph_objectstore_tool.h
@@ -26,8 +26,7 @@ class ObjectStoreTool : public RadosDump
 
     int dump_import(Formatter *formatter);
     int do_import(ObjectStore *store, OSDSuperblock& sb, bool force,
-		  std::string pgidstr,
-		  ObjectStore::Sequencer &osr);
+		  std::string pgidstr);
     int do_export(ObjectStore *fs, coll_t coll, spg_t pgid,
           pg_info_t &info, epoch_t map_epoch, __u8 struct_ver,
           const OSDSuperblock& superblock,
@@ -36,8 +35,7 @@ class ObjectStoreTool : public RadosDump
 				bufferlist &bl);
     int get_object(
       ObjectStore *store, coll_t coll,
-      bufferlist &bl, OSDMap &curmap, bool *skipped_objects,
-      ObjectStore::Sequencer &osr);
+      bufferlist &bl, OSDMap &curmap, bool *skipped_objects);
     int export_file(
         ObjectStore *store, coll_t cid, ghobject_t &obj);
     int export_files(ObjectStore *store, coll_t coll);

--- a/src/tools/rebuild_mondb.cc
+++ b/src/tools/rebuild_mondb.cc
@@ -240,6 +240,7 @@ int update_osdmap(ObjectStore& fs, OSDSuperblock& sb, MonitorDBStore& ms)
 
   unsigned nadded = 0;
 
+  auto ch = fs.open_collection(coll_t::meta());
   OSDMap osdmap;
   for (auto e = std::max(last_committed+1, sb.oldest_map);
        e <= sb.newest_map; e++) {
@@ -250,7 +251,7 @@ int update_osdmap(ObjectStore& fs, OSDSuperblock& sb, MonitorDBStore& ms)
     {
       const auto oid = OSD::get_inc_osdmap_pobject_name(e);
       bufferlist bl;
-      int nread = fs.read(coll_t::meta(), oid, 0, 0, bl);
+      int nread = fs.read(ch, oid, 0, 0, bl);
       if (nread <= 0) {
         cerr << "missing " << oid << std::endl;
         return -EINVAL;
@@ -285,7 +286,7 @@ int update_osdmap(ObjectStore& fs, OSDSuperblock& sb, MonitorDBStore& ms)
     {
       const auto oid = OSD::get_osdmap_pobject_name(e);
       bufferlist bl;
-      int nread = fs.read(coll_t::meta(), oid, 0, 0, bl);
+      int nread = fs.read(ch, oid, 0, 0, bl);
       if (nread <= 0) {
         cerr << "missing " << oid << std::endl;
         return -EINVAL;


### PR DESCRIPTION
In practice each PG has a sequencer; just link it directly to the CollectionHandle and simplify the ObjectStore interface.

The upshot of this is that a read operation that takes a collection handle will be able to flush the sequencer on filestore.

- [x] combine Sequencer and CollectionHandle
- [x] add blocking to filestore read ops to wait for apply
- [x] remove io path on_applied/onreadable users in OSD
- [ ] verify filestore performance penalty for additional tracking is minimal (or offset by callbacks we've eliminated)
- [ ] remove remaining on_applied/onreadable users in OSD
- [ ] remove on_applied from ObjectStore interface entirely
- [ ] clean out artifacts of on_applied from OSD (lots of *_applied) variables and now unneeded complexity 