### PR TITLE
Fully deprecate client_mount_uid and client_mount_gid

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -251,7 +251,7 @@ int main(int argc, const char **argv, const char *envp[]) {
     }
     
     client->update_metadata("mount_point", cfuse->get_mount_point());
-    perms = client->pick_my_perms();
+    perms = client->default_perms();
     {
       // start up fuse
       // use my argc, argv (make sure you pass a mount point!)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -265,9 +265,6 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
   _dir_vxattrs_name_size = _vxattrs_calcu_name_size(_dir_vxattrs);
   _file_vxattrs_name_size = _vxattrs_calcu_name_size(_file_vxattrs);
 
-  user_id = cct->_conf->client_mount_uid;
-  group_id = cct->_conf->client_mount_gid;
-
   acl_type = NO_ACL;
   if (cct->_conf->client_acl_type == "posix_acl")
     acl_type = POSIX_ACL;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -290,16 +290,8 @@ class Client : public Dispatcher, public md_config_obs_t {
 public:
   void tick();
 
-  UserPerm pick_my_perms() {
-    uid_t uid = user_id >= 0 ? user_id : -1;
-    gid_t gid = group_id >= 0 ? group_id : -1;
-    return UserPerm(uid, gid);
-  }
-
-  static UserPerm pick_my_perms(CephContext *c) {
-    uid_t uid = c->_conf->client_mount_uid >= 0 ? c->_conf->client_mount_uid : -1;
-    gid_t gid = c->_conf->client_mount_gid >= 0 ? c->_conf->client_mount_gid : -1;
-    return UserPerm(uid, gid);
+  static UserPerm default_perms() {
+    return UserPerm(-1, -1);
   }
 protected:
   Messenger *messenger;  
@@ -308,7 +300,6 @@ protected:
 
   client_t whoami;
 
-  int user_id, group_id;
   int acl_type;
 
   void set_cap_epoch_barrier(epoch_t e);

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -93,10 +93,14 @@ struct CapSnap {
   bool writing, dirty_data;
   uint64_t flush_tid;
 
+  int64_t cap_dirtier_uid;
+  int64_t cap_dirtier_gid;
+
   explicit CapSnap(Inode *i)
     : in(i), issued(0), dirty(0), size(0), time_warp_seq(0), change_attr(0),
       mode(0), uid(0), gid(0), xattr_version(0), inline_version(0),
-      writing(false), dirty_data(false), flush_tid(0)
+      writing(false), dirty_data(false), flush_tid(0), cap_dirtier_uid(-1),
+      cap_dirtier_gid(-1)
   {}
 
   void dump(Formatter *f) const;

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -312,7 +312,7 @@ string SyntheticClient::get_sarg(int seq)
 
 int SyntheticClient::run()
 {
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   dout(15) << "initing" << dendl;
   int err = client->init();
   if (err < 0) {
@@ -1005,7 +1005,7 @@ void SyntheticClient::up()
 int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
 {
   dout(4) << "play trace prefix '" << prefix << "'" << dendl;
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   t.start();
 
   string buf;
@@ -1074,7 +1074,7 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
     }
 
     // high level ops ---------------------
-    UserPerm perms = client->pick_my_perms();
+    UserPerm perms = client->default_perms();
     if (strcmp(op, "link") == 0) {
       const char *a = t.get_string(buf, p);
       const char *b = t.get_string(buf2, p);
@@ -1551,7 +1551,7 @@ int SyntheticClient::clean_dir(string& basedir)
 {
   // read dir
   list<string> contents;
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   int r = client->getdir(basedir.c_str(), contents, perms);
   if (r < 0) {
     dout(1) << "getdir on " << basedir << " returns " << r << dendl;
@@ -1601,7 +1601,7 @@ int SyntheticClient::full_walk(string& basedir)
   ceph::unordered_map<inodeno_t, int> nlink;
   ceph::unordered_map<inodeno_t, int> nlink_seen;
 
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   while (!dirq.empty()) {
     string dir = dirq.front();
     frag_info_t expect = statq.front();
@@ -1690,7 +1690,7 @@ int SyntheticClient::full_walk(string& basedir)
 
 int SyntheticClient::dump_placement(string& fn) {
   
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
 
   // open file
   int fd = client->open(fn.c_str(), O_RDONLY, perms);
@@ -1738,7 +1738,7 @@ int SyntheticClient::make_dirs(const char *basedir, int dirs, int files, int dep
 {
   if (time_to_stop()) return 0;
 
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   // make sure base dir exists
   int r = client->mkdir(basedir, 0755, perms);
   if (r != 0) {
@@ -1768,7 +1768,7 @@ int SyntheticClient::stat_dirs(const char *basedir, int dirs, int files, int dep
 {
   if (time_to_stop()) return 0;
 
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
 
   // make sure base dir exists
   struct stat st;
@@ -1806,7 +1806,7 @@ int SyntheticClient::read_dirs(const char *basedir, int dirs, int files, int dep
   dout(3) << "read_dirs " << basedir << " dirs " << dirs << " files " << files << " depth " << depth << dendl;
 
   list<string> contents;
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   utime_t s = ceph_clock_now();
   int r = client->getdir(basedir, contents, perms);
   utime_t e = ceph_clock_now();
@@ -1841,7 +1841,7 @@ int SyntheticClient::make_files(int num, int count, int priv, bool more)
 {
   int whoami = client->get_nodeid().v;
   char d[255];
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
 
   if (priv) {
     for (int c=0; c<count; c++) {
@@ -1891,7 +1891,7 @@ int SyntheticClient::link_test()
   char d[255];
   char e[255];
 
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
 
  // create files
   int num = 200;
@@ -1927,7 +1927,7 @@ int SyntheticClient::link_test()
 int SyntheticClient::create_shared(int num)
 {
   // files
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   char d[255];
   client->mkdir("test", 0755, perms);
   for (int n=0; n<num; n++) {
@@ -1942,7 +1942,7 @@ int SyntheticClient::open_shared(int num, int count)
 {
   // files
   char d[255];
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   for (int c=0; c<count; c++) {
     // open
     list<int> fds;
@@ -1971,7 +1971,7 @@ int SyntheticClient::open_shared(int num, int count)
 
 // Hits OSD 0 with writes to various files with OSD 0 as the primary.
 int SyntheticClient::overload_osd_0(int n, int size, int wrsize) {
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   // collect a bunch of files starting on OSD 0
   int left = n;
   int tried = 0;
@@ -2018,7 +2018,7 @@ int SyntheticClient::check_first_primary(int fh)
 
 int SyntheticClient::rm_file(string& fn)
 {
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   return client->unlink(fn.c_str(), perms);
 }
 
@@ -2028,7 +2028,7 @@ int SyntheticClient::write_file(string& fn, int size, loff_t wrsize)   // size i
   char *buf = new char[wrsize+100];   // 1 MB
   memset(buf, 7, wrsize);
   int64_t chunks = (uint64_t)size * (uint64_t)(1024*1024) / (uint64_t)wrsize;
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
 
   int fd = client->open(fn.c_str(), O_RDWR|O_CREAT, perms);
   dout(5) << "writing to " << fn << " fd " << fd << dendl;
@@ -2145,7 +2145,7 @@ int SyntheticClient::read_file(const std::string& fn, int size,
   char *buf = new char[rdsize]; 
   memset(buf, 1, rdsize);
   uint64_t chunks = (uint64_t)size * (uint64_t)(1024*1024) / (uint64_t)rdsize;
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
 
   int fd = client->open(fn.c_str(), O_RDONLY, perms);
   dout(5) << "reading from " << fn << " fd " << fd << dendl;
@@ -2411,7 +2411,7 @@ int SyntheticClient::object_rw(int nobj, int osize, int wrpc,
 
 int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is in MB, wrsize in bytes
 {
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   uint64_t chunks = (uint64_t)size * (uint64_t)(1024*1024) / (uint64_t)rdsize;
   int fd = client->open(fn.c_str(), O_RDWR, perms);
   dout(5) << "reading from " << fn << " fd " << fd << dendl;
@@ -2541,7 +2541,7 @@ int normdist(int min, int max, int stdev) /* specifies input values */
 int SyntheticClient::read_random_ex(string& fn, int size, int rdsize)   // size is in MB, wrsize in bytes
 {
   uint64_t chunks = (uint64_t)size * (uint64_t)(1024*1024) / (uint64_t)rdsize;
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   int fd = client->open(fn.c_str(), O_RDWR, perms);
   dout(5) << "reading from " << fn << " fd " << fd << dendl;
   
@@ -2645,7 +2645,7 @@ int SyntheticClient::random_walk(int num_req)
 
   init_op_dist();  // set up metadata op distribution
  
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   while (left > 0) {
     left--;
 
@@ -2832,7 +2832,7 @@ int SyntheticClient::random_walk(int num_req)
 
 void SyntheticClient::make_dir_mess(const char *basedir, int n)
 {
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   vector<string> dirs;
   
   dirs.push_back(basedir);
@@ -2871,7 +2871,7 @@ void SyntheticClient::make_dir_mess(const char *basedir, int n)
 
 void SyntheticClient::foo()
 {
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
 
   if (1) {
     // make 2 parallel dirs, link/unlink between them.
@@ -3068,7 +3068,7 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
 
   if (time_to_stop()) return 0;
 
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
 
   srand(0);
   if (1) {
@@ -3203,7 +3203,7 @@ void SyntheticClient::import_find(const char *base, const char *find, bool data)
    *
    */
 
-  UserPerm process_perms = client->pick_my_perms();
+  UserPerm process_perms = client->default_perms();
 
   if (base[0] != '-') 
     client->mkdir(base, 0755, process_perms);
@@ -3343,7 +3343,7 @@ int SyntheticClient::lookup_ino(inodeno_t ino, const UserPerm& perms)
 
 int SyntheticClient::chunk_file(string &filename)
 {
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   int fd = client->open(filename.c_str(), O_RDONLY, perms);
   if (fd < 0)
     return fd;
@@ -3417,7 +3417,7 @@ void SyntheticClient::rmsnap(const char *base, const char *name, const UserPerm&
 
 void SyntheticClient::mksnapfile(const char *dir)
 {
-  UserPerm perms = client->pick_my_perms();
+  UserPerm perms = client->default_perms();
   client->mkdir(dir, 0755, perms);
 
   string f = dir;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -351,8 +351,6 @@ OPTION(client_readahead_max_bytes, OPT_LONGLONG)  // default unlimited
 OPTION(client_readahead_max_periods, OPT_LONGLONG)  // as multiple of file layout period (object size * num stripes)
 OPTION(client_reconnect_stale, OPT_BOOL)  // automatically reconnect stale session
 OPTION(client_snapdir, OPT_STR)
-OPTION(client_mount_uid, OPT_INT)
-OPTION(client_mount_gid, OPT_INT)
 OPTION(client_notify_timeout, OPT_INT) // in seconds
 OPTION(osd_client_watch_timeout, OPT_INT) // in seconds
 OPTION(client_caps_release_delay, OPT_INT) // in seconds

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6617,14 +6617,6 @@ std::vector<Option> get_mds_client_options() {
     .set_default("/")
     .set_description(""),
 
-    Option("client_mount_uid", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(-1)
-    .set_description(""),
-
-    Option("client_mount_gid", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(-1)
-    .set_description(""),
-
     Option("client_notify_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(10)
     .set_description(""),

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -165,6 +165,19 @@ void ceph_userperm_destroy(UserPerm *perm);
 struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount);
 
 /**
+ * Set cmount's default permissions
+ *
+ * @param cmount the mount info handle
+ * @param perm permissions to set to default for mount
+ *
+ * Every cmount has a default set of credentials. This sets copies the given
+ * permissions to the ones in the cmount. Must be done after ceph_init
+ *
+ * Returns 0 on success, and -EISCONN if the cmount is already mounted.
+ */
+int ceph_mount_perms_set(struct ceph_mount_info *cmount, UserPerm *perm);
+
+/**
  * @defgroup libcephfs_h_init Setup and Teardown
  * These are the first and last functions that should be called
  * when using libcephfs.

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -462,6 +462,15 @@ extern "C" struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount)
   return &cmount->default_perms;
 }
 
+extern "C" int ceph_mount_perms_set(struct ceph_mount_info *cmount,
+				    struct UserPerm *perms)
+{
+  if (cmount->is_mounted())
+    return -EISCONN;
+  cmount->default_perms = *perms;
+  return 0;
+}
+
 extern "C" int ceph_statfs(struct ceph_mount_info *cmount, const char *path,
 			   struct statvfs *stbuf)
 {

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -100,7 +100,7 @@ public:
     if (ret)
       goto fail;
 
-    default_perms = Client::pick_my_perms(cct);
+    default_perms = Client::default_perms();
     inited = true;
     return 0;
 

--- a/src/test/libcephfs/access.cc
+++ b/src/test/libcephfs/access.cc
@@ -265,8 +265,13 @@ TEST(AccessTest, User) {
   ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
   ASSERT_EQ(0, ceph_conf_set(cmount, "key", key.c_str()));
   ASSERT_EQ(-EACCES, ceph_mount(cmount, "/"));
-  ASSERT_EQ(0, ceph_conf_set(cmount, "client_mount_uid", "123"));
-  ASSERT_EQ(0, ceph_conf_set(cmount, "client_mount_gid", "456"));
+  ASSERT_EQ(0, ceph_init(cmount));
+
+  UserPerm *perms = ceph_userperm_new(123, 456, 0, NULL);
+  ASSERT_NE(nullptr, perms);
+  ASSERT_EQ(0, ceph_mount_perms_set(cmount, perms));
+  ceph_userperm_destroy(perms);
+
   ASSERT_EQ(0, ceph_conf_set(cmount, "client_permissions", "0"));
   ASSERT_EQ(0, ceph_mount(cmount, "/"));
 


### PR DESCRIPTION
This set should take care of these two tracker bugs:

http://tracker.ceph.com/issues/22801
http://tracker.ceph.com/issues/22802

The first patch in the series cleans up some permission handling in CapSnap. This is the basic approach that @ukernel suggested, but I'm not 100% sure I got the rules right for setting the caller_uid/gid correctly.

For the last two patches, we're just converting to a new way of setting default permissions on a mount and deprecating the old config file options. It's a fairly straightforward change, my only real question at this point is whether this is the right thing to do.

Does this materially improve the code, given that we're just replacing one way of setting default permissions with another?