### PR TITLE
tests: ceph-disk: Remove sitepackages=True

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -17,7 +17,7 @@ deps =
   ../ceph-detect-init
 
 [testenv:py27]
-sitepackages=True
+whitelist_externals = prettyprint
 passenv = CEPH_ROOT CEPH_BIN CEPH_LIB CEPH_BUILD_VIRTUALENV
 changedir = {env:CEPH_BUILD_DIR}
 commands = coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_main.py


### PR DESCRIPTION
"sitepackages=True" causes issues on systems that may have packages like
"coverage" or "pytest" installed at the system level. We can try just
white listing "prettyprint" which was the driver for the "sitepackages"
blanket change in the first place.

Fixes: http://tracker.ceph.com/issues/22823

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>