### PR TITLE
luminous: rgw: log the right http status code in civetweb frontend's access log

### DIFF
--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -31,15 +31,20 @@ int RGWCivetWebFrontend::process(struct mg_connection*  const conn)
   RGWRestfulIO client_io(dout_context, &real_client_io);
 
   RGWRequest req(env.store->get_new_req_id());
+  int http_ret = 0;
   int ret = process_request(env.store, env.rest, &req, env.uri_prefix,
-                            *env.auth_registry, &client_io, env.olog);
+                            *env.auth_registry, &client_io, env.olog, &http_ret);
   if (ret < 0) {
     /* We don't really care about return code. */
     dout(20) << "process_request() returned " << ret << dendl;
   }
 
-  /* Mark as processed. */
-  return 1;
+  if (http_ret <= 0) {
+    /* Mark as processed. */
+    return 1;
+  }
+
+  return http_ret;
 }
 
 int RGWCivetWebFrontend::run()

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -115,7 +115,8 @@ int process_request(RGWRados* const store,
                     const std::string& frontend_prefix,
                     const rgw_auth_registry_t& auth_registry,
                     RGWRestfulIO* const client_io,
-                    OpsLogSocket* const olog)
+                    OpsLogSocket* const olog,
+                    int* http_ret)
 {
   int ret = 0;
 
@@ -216,14 +217,16 @@ done:
     rgw_log_op(store, rest, s, (op ? op->name() : "unknown"), olog);
   }
 
-  int http_ret = s->err.http_ret;
+  if (http_ret != nullptr) {
+    *http_ret = s->err.http_ret;
+  }
   int op_ret = 0;
   if (op) {
     op_ret = op->get_ret();
   }
 
   req->log_format(s, "op status=%d", op_ret);
-  req->log_format(s, "http status=%d", http_ret);
+  req->log_format(s, "http status=%d", s->err.http_ret);
 
   if (handler)
     handler->put_op(op);
@@ -231,7 +234,7 @@ done:
 
   dout(1) << "====== req done req=" << hex << req << dec
 	  << " op status=" << op_ret
-	  << " http_status=" << http_ret
+	  << " http_status=" << s->err.http_ret
 	  << " ======"
 	  << dendl;
 

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -196,7 +196,8 @@ extern int process_request(RGWRados* store,
                            const std::string& frontend_prefix,
                            const rgw_auth_registry_t& auth_registry,
                            RGWRestfulIO* client_io,
-                           OpsLogSocket* olog);
+                           OpsLogSocket* olog,
+                           int* http_ret = nullptr);
 
 extern int rgw_process_authenticated(RGWHandler_REST* handler,
                                      RGWOp*& op,


### PR DESCRIPTION
http://tracker.ceph.com/issues/22812