### PR TITLE
mgr: balancer: fixed mistype "AttributeError: 'Logger' object has no ...

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -671,7 +671,7 @@ class Module(MgrModule):
                     overlap[osd] = 1
                 visited[osd] = 1
         if len(overlap) > 0:
-            self.log.err('error: some osds belong to multiple subtrees: %s' %
+            self.log.error('error: some osds belong to multiple subtrees: %s' %
                          overlap)
             return False
 


### PR DESCRIPTION
…attribute 'err'"

Signed-off-by: Konstantin Shalygin <k0ste@k0ste.ru>
(cherry picked from commit 2062e84c7a33fc5170740f2d60d07ddf62085457)