### PR TITLE
build/ops: rpm: fix _defined_if_python2_absent conditional

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -48,9 +48,11 @@
 %endif
 %if 0%{?suse_version} >= 1500
 %bcond_with python2
-%global _defined_if_python2_absent 1
 %else
 %bcond_without python2
+%endif
+%if 0%{without python2}
+%global _defined_if_python2_absent 1
 %endif
 
 %if %{with selinux}


### PR DESCRIPTION
The expectation is that _defined_if_python2_absent will be defined
if (and only if) the python2 bcond is not set. Before this patch, if
somebody were to build the package on suse_version 1500 with
--with-python2, the _defined_if_python2_absent would be defined,
which is a bug.

Signed-off-by: Nathan Cutler <ncutler@suse.com>