### PR TITLE
 log: clear thread-local stream's ios flags on reuse

### DIFF
--- a/src/common/CachedPrebufferedStreambuf.cc
+++ b/src/common/CachedPrebufferedStreambuf.cc
@@ -47,6 +47,8 @@ CachedPrebufferedStreambuf::create(prebuffered_data* data)
     streambuf = new CachedPrebufferedStreambuf();
   } else {
     streambuf = t_os.streambuf;
+    // reset ios flags (failbit, badbit) from previous use
+    streambuf->get_ostream().clear();
   }
   streambuf->data = data;
   streambuf->setp(data->m_buf, data->m_buf + data->m_buf_len);


### PR DESCRIPTION
when reusing a thread-local std::ostream for a new log entry, clear any
ios flags (ie eofbit/failbit/badbit) that may have been set during its
previous use

without this, any stream errors (for example, passing a nullptr to
operator<< sets the badbit) will cause all log output on that thread
to be blank for the remainder of the process