### PR TITLE
cmake: fix libcephfs-test.jar build failure

### DIFF
--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -36,7 +36,7 @@ add_custom_target(
 add_dependencies(jni-header libcephfs)
 
 find_jar(JUNIT_JAR
-  NAMES junit junit4
+  NAMES junit4 junit
   PATHS "/usr/share/java")
 if(JUNIT_JAR)
   set(CMAKE_JAVA_INCLUDE_PATH ${JUNIT_JAR} ${libcephfs_jar})


### PR DESCRIPTION
When building Ceph Debian installation package, libcephfs-test.jar
build would fail if multi junit versions are installed on the host.

In src/java/CMakeLists.txt, the "junit" search order is "junit"
and then "junit4". In case multi junit versions are installed,
the lower version (like 3.8) is found firstly, but junit4 is
required only. The search result will cause the failure.

Fix the issue by change search order to firstly search junit4
by default.

Fixes: http://tracker.ceph.com/issues/22828

Signed-off-by: Tone Zhang <tone.zhang@arm.com>