### PR TITLE
crush, mon: bump up map version only if we truly created a weight-set

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1391,9 +1391,9 @@ public:
     free(arg_map.args);
   }
 
-  void create_choose_args(int64_t id, int positions) {
+  bool create_choose_args(int64_t id, int positions) {
     if (choose_args.count(id))
-      return;
+      return false;
     assert(positions);
     auto &cmap = choose_args[id];
     cmap.args = (crush_choose_arg*)calloc(sizeof(crush_choose_arg),
@@ -1422,6 +1422,7 @@ public:
 	carg.weight_set_size = 0;
       }
     }
+    return true;
   }
 
   void rm_choose_args(int64_t id) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7699,7 +7699,15 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       pool = CrushWrapper::DEFAULT_CHOOSE_ARGS;
       positions = 1;
     }
-    newcrush.create_choose_args(pool, positions);
+    if (!newcrush.create_choose_args(pool, positions)) {
+      if (pool == CrushWrapper::DEFAULT_CHOOSE_ARGS) {
+        ss << "compat weight-set already created";
+      } else {
+        ss << "weight-set for pool '" << osdmap.get_pool_name(pool)
+           << "' already created";
+      }
+      goto reply;
+    }
     pending_inc.crush.clear();
     newcrush.encode(pending_inc.crush, mon->get_quorum_con_features());
     goto update;


### PR DESCRIPTION
In crush-compat mode mgr/balancer will do 'ceph osd crush weight-set create-compat'
on each call to 'ceph balancer optimize <plan>', which turns out to be
bumping up osdmap version without modifying anything (we haven't executed the
plan yet).

E.g.:
**./bin/ceph balancer reset && ./bin/ceph balancer optimize crush test && ./bin/ceph balancer show crush**
```
starting osdmap epoch 993
starting crush version 962
mode crush-compat
```

**./bin/ceph balancer reset && ./bin/ceph balancer optimize crush test && ./bin/ceph balancer show crush**
```
starting osdmap epoch 994
starting crush version 963
mode crush-compat
```

Fix the above problem by checking whether a new weight-set is truly created or not
on the OSDMonitor-side.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>