### PR TITLE
rbd: add '--expire/-e' option for 'lock rm' op

### DIFF
--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -514,6 +514,7 @@ public:
   int update_unwatch(uint64_t handle);
 
   int list_watchers(std::list<image_watcher_t> &watchers);
+  void set_blacklist_expire_seconds(uint32_t expire);
 
 private:
   friend class RBD;

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2134,6 +2134,10 @@ namespace librbd {
     return r;
   }
 
+  void Image::set_blacklist_expire_seconds(uint32_t expire) {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    ictx->blacklist_expire_seconds = expire;
+  }
 } // namespace librbd
 
 extern "C" void rbd_version(int *major, int *minor, int *extra)

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -990,20 +990,21 @@ Skip test on FreeBSD as it generates different output there.
     --pretty-format      pretty formatting (json and xml)
   
   rbd help lock remove
-  usage: rbd lock remove [--pool <pool>] [--image <image>] 
+  usage: rbd lock remove [--pool <pool>] [--image <image>] [--expire <expire>] 
                          <image-spec> <lock-id> <locker> 
   
   Release a lock on an image.
   
   Positional arguments
-    <image-spec>         image specification
-                         (example: [<pool-name>/]<image-name>)
-    <lock-id>            unique lock id
-    <locker>             locker client
+    <image-spec>             image specification
+                             (example: [<pool-name>/]<image-name>)
+    <lock-id>                unique lock id
+    <locker>                 locker client
   
   Optional arguments
-    -p [ --pool ] arg    pool name
-    --image arg          image name
+    -p [ --pool ] arg        pool name
+    --image arg              image name
+    -e [ --expire ] arg (=0) blacklist's expire time
   
   rbd help map
   usage: rbd map [--pool <pool>] [--image <image>] [--snap <snap>] 

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -297,6 +297,12 @@ void add_create_image_options(po::options_description *opt,
   add_create_journal_options(opt);
 }
 
+void add_expire_option(boost::program_options::options_description *opt) {
+  opt->add_options()
+    ((EXPIRE + ",e").c_str(), po::value<uint32_t>()->default_value(0),
+      "blacklist's expire time");
+}
+
 void add_create_journal_options(po::options_description *opt) {
   opt->add_options()
     (JOURNAL_SPLAY_WIDTH.c_str(), po::value<uint64_t>(),

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -82,6 +82,7 @@ static const std::string VERBOSE("verbose");
 static const std::string NO_ERROR("no-error");
 
 static const std::string LIMIT("limit");
+static const std::string EXPIRE("expire");
 
 static const std::set<std::string> SWITCH_ARGUMENTS = {
   WHOLE_OBJECT, NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERROR};
@@ -177,6 +178,7 @@ void add_journal_spec_options(
   boost::program_options::options_description *opt,
   ArgumentModifier modifier);
 
+void add_expire_option(boost::program_options::options_description *opt);
 void add_create_image_options(boost::program_options::options_description *opt,
                               bool include_format);
 


### PR DESCRIPTION
Remove rbd image lock will automatically add the previous
lock owner into blacklist. With this option, user can specify
this blacklist item's expire time.

Signed-off-by: Yang Honggang <joseph.yang@xtaotech.com>