### PR TITLE
osd/OSDMap: add osdmap epoch info when printing info summary

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3621,7 +3621,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
 
   if (prefix == "osd stat") {
-    osdmap.print_summary(f.get(), ds, "");
+    osdmap.print_summary(f.get(), ds, "", true);
     if (f)
       f->flush(rdata);
     else

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3373,7 +3373,7 @@ void OSDMap::print_tree(Formatter *f, ostream *out, unsigned filter, string buck
 }
 
 void OSDMap::print_summary(Formatter *f, ostream& out,
-			   const string& prefix) const
+			   const string& prefix, bool extra) const
 {
   if (f) {
     f->open_object_section("osdmap");
@@ -3389,6 +3389,8 @@ void OSDMap::print_summary(Formatter *f, ostream& out,
     out << get_num_osds() << " osds: "
 	<< get_num_up_osds() << " up, "
 	<< get_num_in_osds() << " in";
+    if (extra)
+      out << "; epoch: e" << get_epoch();
     if (get_num_pg_temp())
       out << "; " << get_num_pg_temp() << " remapped pgs";
     out << "\n";

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1373,7 +1373,7 @@ private:
 public:
   void print(ostream& out) const;
   void print_pools(ostream& out) const;
-  void print_summary(Formatter *f, ostream& out, const string& prefix) const;
+  void print_summary(Formatter *f, ostream& out, const string& prefix, bool extra=false) const;
   void print_oneline_summary(ostream& out) const;
 
   enum {


### PR DESCRIPTION
  add osdmap epoch info when printing info summary

Signed-off-by: shun-s <song.shun3@zte.com.cn>