### PR TITLE
mgr/influx: Various fixes and improvements

### DIFF
--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -79,12 +79,17 @@ class Module(MgrModule):
 
         df_types = [
             'bytes_used',
+            'kb_used',
             'dirty',
+            'rd',
             'rd_bytes',
             'raw_bytes_used',
+            'wr',
             'wr_bytes',
             'objects',
-            'max_avail'
+            'max_avail',
+            'quota_objects',
+            'quota_bytes'
         ]
 
         for df_type in df_types:


### PR DESCRIPTION
The InfluxDBClient can also re-raise a ConnectionError from the
python requests module if that was caught.

The Exception might be:

<pre>ConnectionError: ('Connection aborted.', error(104, 'Connection reset by peer'))</pre>

Catch and log this error instead of having it raised which might
cause problems further down.

Signed-off-by: Wido den Hollander <wido@42on.com>