### PR TITLE
rgw: beast frontend can listen on multiple endpoints

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -43,7 +43,8 @@ Options
 :Description: Sets the listening port number. For SSL-enabled ports, add an
               ``s`` suffix like ``443s``. To bind a specific IPv4 or IPv6
               address, use the form ``address:port``. Multiple endpoints
-              can be separated by ``+`` as in ``127.0.0.1:8000+443s``.
+              can either be separated by ``+`` as in ``127.0.0.1:8000+443s``,
+              or by providing multiple options as in ``port=8000 port=443s``.
 
 :Type: String
 :Default: ``7480``

--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -20,10 +20,23 @@ Options
 
 ``port``
 
-:Description: Sets the listening port number.
+:Description: Sets the listening port number. Can be specified multiple
+              times as in ``port=80 port=8000``.
 
 :Type: Integer
 :Default: ``80``
+
+
+``endpoint``
+
+:Description: Sets the listening address in the form ``address[:port]``,
+              where the address is an IPv4 address string in dotted decimal
+              form, or an IPv6 address in hexadecimal notation. The
+              optional port defaults to 80. Can be specified multiple times
+              as in ``endpoint=::1 endpoint=192.168.0.100:8000``.
+
+:Type: Integer
+:Default: None
 
 
 Civetweb

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -61,13 +61,13 @@ int RGWCivetWebFrontend::run()
   set_conf_default(conf_map, "enable_auth_domain_check", "no");
   conf->get_val("port", "80", &port_str);
   std::replace(port_str.begin(), port_str.end(), '+', ',');
-  conf_map["listening_ports"] = port_str;
+  conf_map.emplace("listening_ports", std::move(port_str));
 
   /* Set run_as_user. This will cause civetweb to invoke setuid() and setgid()
    * based on pw_uid and pw_gid obtained from pw_name. */
   std::string uid_string = g_ceph_context->get_set_uid_string();
   if (! uid_string.empty()) {
-    conf_map["run_as_user"] = std::move(uid_string);
+    conf_map.emplace("run_as_user", std::move(uid_string));
   }
 
   /* Prepare options for CivetWeb. */

--- a/src/rgw/rgw_frontend.cc
+++ b/src/rgw/rgw_frontend.cc
@@ -13,14 +13,9 @@
 #define dout_subsys ceph_subsys_rgw
 
 int RGWFrontendConfig::parse_config(const string& config,
-				    map<string, string>& config_map)
+				    std::multimap<string, string>& config_map)
 {
-  list<string> config_list;
-  get_str_list(config, " ", config_list);
-
-  list<string>::iterator iter;
-  for (iter = config_list.begin(); iter != config_list.end(); ++iter) {
-    string& entry = *iter;
+  for (auto& entry : get_str_vec(config, " ")) {
     string key;
     string val;
 
@@ -33,7 +28,7 @@ int RGWFrontendConfig::parse_config(const string& config,
     ssize_t pos = entry.find('=');
     if (pos < 0) {
       dout(0) << "framework conf key: " << entry << dendl;
-      config_map[entry] = "";
+      config_map.emplace(std::move(entry), "");
       continue;
     }
 
@@ -44,7 +39,7 @@ int RGWFrontendConfig::parse_config(const string& config,
     }
 
     dout(0) << "framework conf key: " << key << ", val: " << val << dendl;
-    config_map[key] = val;
+    config_map.emplace(std::move(key), std::move(val));
   }
 
   return 0;
@@ -53,7 +48,7 @@ int RGWFrontendConfig::parse_config(const string& config,
 bool RGWFrontendConfig::get_val(const string& key, const string& def_val,
 				string *out)
 {
- map<string, string>::iterator iter = config_map.find(key);
+ auto iter = config_map.find(key);
  if (iter == config_map.end()) {
    *out = def_val;
    return false;

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -22,11 +22,11 @@
 
 class RGWFrontendConfig {
   std::string config;
-  std::map<std::string, std::string> config_map;
+  std::multimap<std::string, std::string> config_map;
   std::string framework;
 
   int parse_config(const std::string& config,
-                   std::map<std::string, std::string>& config_map);
+                   std::multimap<std::string, std::string>& config_map);
 
 public:
   RGWFrontendConfig(const std::string& config)
@@ -54,7 +54,7 @@ public:
     return config;
   }
 
-  std::map<std::string, std::string>& get_config_map() {
+  std::multimap<std::string, std::string>& get_config_map() {
     return config_map;
   }
 
@@ -97,11 +97,11 @@ class RGWCivetWebFrontend : public RGWFrontend {
   struct mg_context* ctx;
   RGWMongooseEnv env;
 
-  void set_conf_default(std::map<std::string, std::string>& m,
+  void set_conf_default(std::multimap<std::string, std::string>& m,
                         const std::string& key,
 			const std::string& def_val) {
     if (m.find(key) == std::end(m)) {
-      m[key] = def_val;
+      m.emplace(key, def_val);
     }
   }
 


### PR DESCRIPTION
extends the frontend configuration to store options in a multimap, so that `port` and `endpoint` can be specified multiple times. the beast frontend creates a separate `Listener` for each port/endpoint given, and this `Listener` instance is passed as an extra argument when `accept()`ing new connections. the civetweb frontend also supports multiple `port` options

Fixes: http://tracker.ceph.com/issues/22779