### PR TITLE
PG: primary should not be in the peer_info, skip if it is

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2740,6 +2740,8 @@ void PG::_update_calc_stats()
       if (!actingbackfill.count(peer.first)) {
 	continue;
       }
+      // Primary should not be in the peer_info, skip if it is.
+      if (peer.first == pg_whoami) continue;
       missing = 0;
       // Backfill targets always track num_objects accurately
       // all other peers track missing accurately.


### PR DESCRIPTION
Skip the primary when iterating over peer_info to avoid adding the primary twice.

Signed-off-by: Neha Ojha <nojha@redhat.com>