### PR TITLE
common: Replace singleton class with std::any

### DIFF
--- a/src/common/TracepointProvider.h
+++ b/src/common/TracepointProvider.h
@@ -10,7 +10,7 @@
 
 struct md_config_t;
 
-class TracepointProvider : public md_config_obs_t, boost::noncopyable {
+class TracepointProvider : public md_config_obs_t {
 public:
   struct Traits {
     const char *library;
@@ -49,11 +49,15 @@ public:
                      const char *config_key);
   ~TracepointProvider() override;
 
+  TracepointProvider(const TracepointProvider&) = delete;
+  TracepointProvider operator =(const TracepointProvider&) = delete;
+  TracepointProvider(TracepointProvider&&) = delete;
+  TracepointProvider operator =(TracepointProvider&&) = delete;
+
   template <const Traits &traits>
   static void initialize(CephContext *cct) {
 #ifdef WITH_LTTNG
-    TypedSingleton<traits> *singleton;
-    cct->lookup_or_create_singleton_object(singleton, traits.library);
+     cct->lookup_or_create_singleton_object<TypedSingleton<traits>>(traits.library);
 #endif
   }
 

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -639,17 +639,12 @@ CephContext::CephContext(uint32_t module_type_,
   _crypto_aes = CryptoHandler::create(CEPH_CRYPTO_AES);
   _crypto_random.reset(new CryptoRandom());
 
-  MempoolObs *mempool_obs = 0;
-  lookup_or_create_singleton_object(mempool_obs, "mempool_obs");
+  lookup_or_create_singleton_object<MempoolObs>("mempool_obs");
 }
 
 CephContext::~CephContext()
 {
   join_service_thread();
-
-  for (map<string, SingletonWrapper*>::iterator it = _associated_objs.begin();
-       it != _associated_objs.end(); ++it)
-    delete it->second;
 
   if (_cct_perf) {
     _perf_counters_collection->remove(_cct_perf);

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1163,18 +1163,18 @@ struct C_InvalidateCache : public Context {
   void ImageCtx::get_thread_pool_instance(CephContext *cct,
                                           ThreadPool **thread_pool,
                                           ContextWQ **op_work_queue) {
-    ThreadPoolSingleton *thread_pool_singleton;
-    cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
-      thread_pool_singleton, "librbd::thread_pool");
+    auto thread_pool_singleton =
+      &cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
+	"librbd::thread_pool");
     *thread_pool = thread_pool_singleton;
     *op_work_queue = thread_pool_singleton->op_work_queue;
   }
 
   void ImageCtx::get_timer_instance(CephContext *cct, SafeTimer **timer,
                                     Mutex **timer_lock) {
-    SafeTimerSingleton *safe_timer_singleton;
-    cct->lookup_or_create_singleton_object<SafeTimerSingleton>(
-      safe_timer_singleton, "librbd::journal::safe_timer");
+    auto safe_timer_singleton =
+      &cct->lookup_or_create_singleton_object<SafeTimerSingleton>(
+	"librbd::journal::safe_timer");
     *timer = safe_timer_singleton;
     *timer_lock = &safe_timer_singleton->lock;
   }

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -212,12 +212,11 @@ private:
     if (m_work_queue != nullptr) {
       return;
     }
-    ThreadPoolSingleton *thread_pool_singleton;
-    m_cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
-      thread_pool_singleton, "librbd::ImageUpdateWatchers::thread_pool");
+    auto& thread_pool = m_cct->lookup_or_create_singleton_object<
+      ThreadPoolSingleton>("librbd::ImageUpdateWatchers::thread_pool");
     m_work_queue = new ContextWQ("librbd::ImageUpdateWatchers::op_work_queue",
 				 m_cct->_conf->get_val<int64_t>("rbd_op_thread_timeout"),
-				 thread_pool_singleton);
+				 &thread_pool);
   }
 
   void destroy_work_queue() {

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -334,12 +334,12 @@ Journal<I>::Journal(I &image_ctx)
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 5) << this << ": ictx=" << &m_image_ctx << dendl;
 
-  ThreadPoolSingleton *thread_pool_singleton;
-  cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
-    thread_pool_singleton, "librbd::journal::thread_pool");
+  auto thread_pool_singleton =
+    &cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
+      "librbd::journal::thread_pool");
   m_work_queue = new ContextWQ("librbd::journal::work_queue",
-                               cct->_conf->get_val<int64_t>("rbd_op_thread_timeout"),
-                               thread_pool_singleton);
+			       cct->_conf->get_val<int64_t>("rbd_op_thread_timeout"),
+			       thread_pool_singleton);
   ImageCtx::get_timer_instance(cct, &m_timer, &m_timer_lock);
 }
 

--- a/src/librbd/TaskFinisher.h
+++ b/src/librbd/TaskFinisher.h
@@ -4,6 +4,7 @@
 #define LIBRBD_TASK_FINISHER_H
 
 #include "include/Context.h"
+#include "common/ceph_context.h"
 #include "common/Finisher.h"
 #include "common/Mutex.h"
 #include "common/Timer.h"
@@ -43,12 +44,12 @@ template <typename Task>
 class TaskFinisher {
 public:
   TaskFinisher(CephContext &cct) : m_cct(cct) {
-    TaskFinisherSingleton *singleton;
-    cct.lookup_or_create_singleton_object<TaskFinisherSingleton>(
-      singleton, "librbd::TaskFinisher::m_safe_timer");
-    m_lock = &singleton->m_lock;
-    m_safe_timer = singleton->m_safe_timer;
-    m_finisher = singleton->m_finisher;
+    auto& singleton =
+      cct.lookup_or_create_singleton_object<TaskFinisherSingleton>(
+      "librbd::TaskFinisher::m_safe_timer");
+    m_lock = &singleton.m_lock;
+    m_safe_timer = singleton.m_safe_timer;
+    m_finisher = singleton.m_finisher;
   }
 
   void cancel(const Task& task) {

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -259,8 +259,8 @@ AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
   else if (type.find("dpdk") != std::string::npos)
     transport_type = "dpdk";
 
-  StackSingleton *single;
-  cct->lookup_or_create_singleton_object<StackSingleton>(single, "AsyncMessenger::NetworkStack::"+transport_type);
+  auto single = &cct->lookup_or_create_singleton_object<StackSingleton>(
+    "AsyncMessenger::NetworkStack::" + transport_type);
   single->ready(transport_type);
   stack = single->stack.get();
   stack->start();

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -189,8 +189,9 @@ void EventCenter::set_owner()
   owner = pthread_self();
   ldout(cct, 2) << __func__ << " idx=" << idx << " owner=" << owner << dendl;
   if (!global_centers) {
-    cct->lookup_or_create_singleton_object<EventCenter::AssociatedCenters>(
-        global_centers, "AsyncMessenger::EventCenter::global_center::"+type);
+    global_centers = &cct->lookup_or_create_singleton_object<
+      EventCenter::AssociatedCenters>(
+	"AsyncMessenger::EventCenter::global_center::" + type);
     assert(global_centers);
     global_centers->centers[idx] = this;
     if (driver->need_wakeup()) {

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -204,8 +204,9 @@ Mirror::Mirror(CephContext *cct, const std::vector<const char*> &args) :
   m_local(new librados::Rados()),
   m_asok_hook(new MirrorAdminSocketHook(cct, this))
 {
-  cct->lookup_or_create_singleton_object<Threads<librbd::ImageCtx> >(
-    m_threads, "rbd_mirror::threads");
+  m_threads =
+    &(cct->lookup_or_create_singleton_object<Threads<librbd::ImageCtx>>(
+	"rbd_mirror::threads"));
   m_service_daemon.reset(new ServiceDaemon<>(m_cct, m_local, m_threads));
 }
 


### PR DESCRIPTION
This cleans up the interface a bit. Also make things slightly more
robust by indexing on name and type both.