### PR TITLE
mgr/zabbix: Implement health checks

### DIFF
--- a/qa/suites/rados/mgr/tasks/module_selftest.yaml
+++ b/qa/suites/rados/mgr/tasks/module_selftest.yaml
@@ -16,6 +16,7 @@ tasks:
         - objects misplaced
         - Synthetic exception in serve
         - influxdb python module not found
+        - \(MGR_ZABBIX_
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_module_selftest


### PR DESCRIPTION
This PR adds health checks for the Zabbix Mgr module to notify the admin if something goes wrong with sending data to Zabbix.