### PR TITLE
osd: avoid encoding the same log entries repeatedly for different peers

### DIFF
--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -383,7 +383,7 @@ private:
     eversion_t pg_roll_forward_to,
     hobject_t new_temp_oid,
     hobject_t discard_temp_oid,
-    const vector<pg_log_entry_t> &log_entries,
+    const bufferlist &log_entries,
     boost::optional<pg_hit_set_history_t> &hset_history,
     ObjectStore::Transaction &op_t,
     pg_shard_t peer,


### PR DESCRIPTION
For replicated pool, the replica size normal is three. Using this PR can reduce once encode(log_entries).