### PR TITLE
rgw: drop repeated namespace statement for member func in XMLObj

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2751,7 +2751,6 @@ int main(int argc, const char **argv)
   std::string val;
   std::ostringstream errs;
   string err;
-  long long tmp = 0;
 
   string source_zone_name;
   string source_zone; /* zone id */


### PR DESCRIPTION
Signed-off-by: luomuyao <luo.muyao@zte.com.cn>