### PR TITLE
osd: avoid the config's get_val() overhead on the read path.

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -812,6 +812,8 @@ OPTION(osd_fast_info, OPT_BOOL) // use fast info attr, if we can
 // determines whether PGLog::check() compares written out log to stored log
 OPTION(osd_debug_pg_log_writeout, OPT_BOOL)
 OPTION(osd_loop_before_reset_tphandle, OPT_U32) // Max number of loop before we reset thread-pool's handle
+OPTION(osd_max_snap_prune_intervals_per_epoch, OPT_U64) // Max number of snap intervals to report to mgr in pg_stat_t
+
 // default timeout while caling WaitInterval on an empty queue
 OPTION(threadpool_default_timeout, OPT_INT)
 // default wait time for an empty queue before pinging the hb timeout

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2912,7 +2912,7 @@ void PG::publish_stats_to_osd()
   if (get_osdmap()->require_osd_release >= CEPH_RELEASE_MIMIC) {
     // share (some of) our purged_snaps via the pg_stats. limit # of intervals
     // because we don't want to make the pg_stat_t structures too expensive.
-    unsigned max = cct->_conf->get_val<uint64_t>("osd_max_snap_prune_intervals_per_epoch");
+    unsigned max = cct->_conf->osd_max_snap_prune_intervals_per_epoch;
     unsigned num = 0;
     auto i = info.purged_snaps.begin();
     while (num < max && i != info.purged_snaps.end()) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5494,9 +5494,8 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   object_info_t& oi = obs.oi;
   const hobject_t& soid = oi.soid;
   bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->get_val<bool>("osd_skip_data_digest");
-  auto osd_max_object_size = cct->_conf->get_val<uint64_t>(
-    "osd_max_object_size");
+    cct->_conf->osd_skip_data_digest;
+  const uint64_t osd_max_object_size = cct->_conf->osd_max_object_size;
 
   PGTransaction* t = ctx->op_t.get();
 


### PR DESCRIPTION
Profiling shows the overhead of the `md_config_t::get_val<T>` can be significant. Unfortunately, it is being used in two critical places across the read path.

The patch resorts to the legacy config infrastructure to mitigate the performance penalty. It is expected it will be superseded with a solution that allows to use the new, intended routines without hurting performance.

Before:
```
Samples: 924K of event 'cycles:p', Event count (approx.): 225233537585
  Children      Self  Command          Shared Object        Symbol                                                                                                                                           ◆
-   56,06%     0,13%  tp_osd_tp        ceph-osd             [.] ShardedThreadPool::shardedthreadpool_worker                                                                                                  ▒
   - 55,93% ShardedThreadPool::shardedthreadpool_worker                                                                                                                                                      ▒
      - 55,70% OSD::ShardedOpWQ::_process                                                                                                                                                                    ▒
         - 24,53% PGOpItem::run                                                                                                                                                                              ▒
            - 23,53% OSD::dequeue_op                                                                                                                                                                         ▒
               - 21,74% PrimaryLogPG::do_request                                                                                                                                                             ▒
                  - 20,37% PrimaryLogPG::do_op                                                                                                                                                               ▒
                     - 9,59% PrimaryLogPG::execute_ctx                                                                                                                                                       ▒
                        - 5,30% PrimaryLogPG::prepare_transaction                                                                                                                                            ▒
                           - 5,21% PrimaryLogPG::do_osd_ops                                                                                                                                                  ▒
                              + 3,56% PrimaryLogPG::do_read                                                                                                                                                  ▒
                              - 1,25% md_config_t::get_val<bool>                                                                                                                                             ▒
                                 - 1,22% md_config_t::get_val_generic                                                                                                                                        ▒
                                      1,04% md_config_t::_get_val_generic                                                                                                                                    ▒
                        + 2,04% PrimaryLogPG::OpContext::start_async_reads                                                                                                                                   ▒
                     + 1,76% PrimaryLogPG::maybe_await_blocked_head                                                                                                                                          ▒
                       1,28% MOSDOp::finish_decode                                                                                                                                                           ▒
                     + 1,05% std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >::basic_ostringstream                                                                     ▒
                     + 0,85% PrimaryLogPG::find_object_context                                                                                                                                               ▒
                       0,84% PG::op_has_sufficient_caps                                                                                                                                                      ▒
                     + 0,76% OpRequest::mark_flag_point                                                                                                                                                      ▒
                       0,68% Connection::get_priv                                                                                                                                                            ▒
                       0,59% PrimaryLogPG::OpContext::OpContext                                                                                                                                              ▒
                    0,56% Connection::get_priv                                                                                                                                                               ▒
                 0,69% Connection::get_priv                                                                                                                                                                  ▒
               + 0,67% OpRequest::mark_flag_point                                                                                                                                                            ▒
            + 0,92% Mutex::Unlock                                                                                                                                                                            ▒
         - 18,66% PGRecoveryContext::run                                                                                                                                                                     ▒
            - 18,29% PrimaryLogPG::execute_ctx                                                                                                                                                               ▒
               + 5,84% OpTracker::unregister_inflight_op                                                                                                                                                     ▒
               - 4,90% PrimaryLogPG::complete_read_ctx                                                                                                                                                       ▒
                  - 2,58% PG::publish_stats_to_osd                                                                                                                                                           ▒
                     - 1,17% md_config_t::get_val<unsigned long>                                                                                                                                             ▒
                        - 1,14% md_config_t::get_val_generic                                                                                                                                                 ▒
                             0,98% md_config_t::_get_val_generic                                                                                                                                             ▒
                  + 1,65% AsyncConnection::send_message                                                                                                                                                      ▒
               - 1,72% PrimaryLogPG::prepare_transaction                                                                                                                                                     ▒
                  - 1,57% PrimaryLogPG::do_osd_ops                                                                                                                                                           ▒
                     - 1,17% md_config_t::get_val<bool>                                                                                                                                                      ▒
                        - 1,14% md_config_t::get_val_generic                                                                                                                                                 ▒
0,97% md_config_t::_get_val_generic 
```

After:
```
Samples: 686K of event 'cycles:p', Event count (approx.): 153042142576
  Children      Self  Command          Shared Object        Symbol                                                                                                                                           ◆
-   50,64%     0,13%  tp_osd_tp        ceph-osd             [.] ShardedThreadPool::shardedthreadpool_worker                                                                                                  ▒
   - 50,51% ShardedThreadPool::shardedthreadpool_worker                                                                                                                                                      ▒
      - 50,22% OSD::ShardedOpWQ::_process                                                                                                                                                                    ▒
         - 22,16% PGOpItem::run                                                                                                                                                                              ▒
            - 21,38% OSD::dequeue_op                                                                                                                                                                         ▒
               - 19,92% PrimaryLogPG::do_request                                                                                                                                                             ▒
                  - 18,58% PrimaryLogPG::do_op                                                                                                                                                               ▒
                     - 8,15% PrimaryLogPG::execute_ctx                                                                                                                                                       ▒
                        - 4,02% PrimaryLogPG::prepare_transaction                                                                                                                                            ▒
                           - 3,93% PrimaryLogPG::do_osd_ops                                                                                                                                                  ▒
                              - 3,68% PrimaryLogPG::do_read                                                                                                                                                  ▒
                                 + 3,37% PrimaryLogPG::OpContext::read_maybe_async                                                                                                                           ▒
                        + 2,24% PrimaryLogPG::OpContext::start_async_reads                                                                                                                                   ▒
                     + 1,63% PrimaryLogPG::maybe_await_blocked_head                                                                                                                                          ▒
                       1,39% MOSDOp::finish_decode                                                                                                                                                           ▒
                     + 1,13% std::__cxx11::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >::basic_ostringstream                                                                     ▒
                       0,74% PG::op_has_sufficient_caps                                                                                                                                                      ▒
                     + 0,71% PrimaryLogPG::find_object_context                                                                                                                                               ▒
                       0,63% PrimaryLogPG::OpContext::OpContext                                                                                                                                              ▒
                     + 0,59% OpRequest::mark_flag_point                                                                                                                                                      ▒
                       0,51% Connection::get_priv                                                                                                                                                            ▒
                 0,56% OpRequest::mark_flag_point                                                                                                                                                            ▒
              0,69% Mutex::Unlock                                                                                                                                                                            ▒
         - 15,62% PGRecoveryContext::run                                                                                                                                                                     ▒
            - 15,26% PrimaryLogPG::execute_ctx                                                                                                                                                               ▒
               + 5,39% OpTracker::unregister_inflight_op                                                                                                                                                     ▒
               - 3,89% PrimaryLogPG::complete_read_ctx                                                                                                                                                       ▒
                  + 2,00% AsyncConnection::send_message                                                                                                                                                      ▒
                    1,17% PG::publish_stats_to_osd                                                                                                                                                           ▒
               + 1,44% PrimaryLogPG::close_op_ctx                                                                                                                                                            ▒
                 0,68% PrimaryLogPG::do_osd_op_effects                                                                                                                                                       ▒
               + 0,65% TrackedOp::put
```

Tested on the top of PR #19380 which means old `master`. However, the benefit could be higher now because of the recently introduced third call: `cct->_conf->get_val<uint64_t>("osd_max_object_size")`.

See also:
* https://gist.github.com/rzarzynski/baba188854f585afad7071c903e93d8d
* https://github.com/ceph/ceph/pull/19380/commits/f6048bfc157533771fb43e06f94f844a8adf3e80

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>