### PR TITLE
luminous: common/pick_address: wrong prefix_len in pick_iface()

### DIFF
--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -205,7 +205,7 @@ std::string pick_iface(CephContext *cct, const struct sockaddr_storage &network)
     return {};
   }
 
-  unsigned int prefix_len = 0;
+  const unsigned int prefix_len = max(sizeof(in_addr::s_addr), sizeof(in6_addr::s6_addr)) * CHAR_BIT;
   const struct ifaddrs *found = find_ip_in_subnet(ifa,
                                   (const struct sockaddr *) &network, prefix_len);
 


### PR DESCRIPTION
With prefix_len initialized as zero, mask in netmask_ipv4/6()
will always be zero, so find_ip_in_subnet() always return the
first interface.
Set prefix_len to the right value to fetch the right interface.

Signed-off-by: Gu Zhongyan guzhongyan@360.cn
Signed-off-by: yupeng chen chenyupeng-it@360.cn
(cherry picked from commit b0d8043a72af22648c058382c46a132264736aaa)