### PR TITLE
osd/ReplicatedBackend: 'osd_deep_scrub_keys' doesn't work

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -749,7 +749,7 @@ int ReplicatedBackend::be_deep_scrub(
   while (iter->status() == 0 && iter->valid()) {
     pos.omap_bytes += iter->value().length();
     ++pos.omap_keys;
-
+    --max;
     // fixme: we can do this more efficiently.
     bufferlist bl;
     encode(iter->key(), bl);


### PR DESCRIPTION
Maybe there is an omission in #18971, @liewegas 