### PR TITLE
pybind/mgr/balancer: remove optimization plan properly

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -334,7 +334,7 @@ class Module(MgrModule):
             if not plan:
                 return (-errno.ENOENT, '', 'plan %s not found' % command['plan'])
             self.execute(plan)
-            self.plan_rm(plan)
+            self.plan_rm(command['plan'])
             return (0, '', '')
         else:
             return (-errno.EINVAL, '',


### PR DESCRIPTION
Should pass in plan name instead of the plan itself.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>