### PR TITLE
rgw: can't download object with range when compression enabled

### DIFF
--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -121,15 +121,17 @@ int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len
   }
 
   cur_ofs += bl_len;
-
   off_t ch_len = std::min<off_t>(out_bl.length() - q_ofs, q_len);
-  r = next->handle_data(out_bl, q_ofs, ch_len);
-  if (r < 0) {
-    lderr(cct) << "handle_data failed with exit code " << r << dendl;
-    return r;
+  if (ch_len > 0) {
+    r = next->handle_data(out_bl, q_ofs, ch_len);
+    if (r < 0) {
+      lderr(cct) << "handle_data failed with exit code " << r << dendl;
+      return r;
+    }
+    out_bl.splice(0, q_ofs + ch_len);
+    q_len -= ch_len;
+    q_ofs = 0;
   }
-  q_len -= ch_len;
-  q_ofs = 0;
   return r;
 }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22852

Signed-off-by: fang yuxiang <fang.yuxiang@eisoo.com>