### PR TITLE
os/bluestore: mark derivatives of AioContext as final.

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1480,7 +1480,7 @@ public:
     }
   };
 
-  struct TransContext : public AioContext {
+  struct TransContext final : public AioContext {
     MEMPOOL_CLASS_HELPERS();
 
     typedef enum {
@@ -1619,7 +1619,7 @@ public:
       boost::intrusive::list_member_hook<>,
       &TransContext::deferred_queue_item> > deferred_queue_t;
 
-  struct DeferredBatch : public AioContext {
+  struct DeferredBatch final : public AioContext {
     OpSequencer *osr;
     struct deferred_io {
       bufferlist bl;    ///< data


### PR DESCRIPTION
Profiling `AioReadBatch`, a freshly introduced (at the moment in a wip branch; see PR #19380) descendant of `AioContext` showed that CPU cycles are burnt unnecessarily because of the dynamically polymorphic destructor call that can't be inlined:

It's quite probable the same affects `TransContext` and `DeferredBatch`. Marking the classes as final allows compiler to inline the dtors calls in `::aio_finish` and, hopefully, optimize some of the extra overhead.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>