### PR TITLE
pybind/mgr/dashboard: fix duplicated slash in html href

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -71,10 +71,11 @@ def to_sorted_array(data):
     return sorted(data.iteritems())
 
 def prepare_url_prefix(url_prefix):
+    """
+    return '' if no prefix, or '/prefix' without slash in the end.
+    """
     url_prefix = urlparse.urljoin('/', url_prefix)
-    if url_prefix[-1] != '/':
-        url_prefix = url_prefix + '/'
-    return url_prefix
+    return url_prefix.rstrip('/')
 
 class StandbyModule(MgrStandbyModule):
     def serve(self):
@@ -1012,7 +1013,7 @@ class Module(MgrModule):
 
         # Publish the URI that others may use to access the service we're
         # about to start serving
-        self.set_uri("http://{0}:{1}{2}".format(
+        self.set_uri("http://{0}:{1}{2}/".format(
             socket.getfqdn() if server_addr == "::" else server_addr,
             server_port,
             url_prefix


### PR DESCRIPTION
The url_prefix val in html templates is expected not containing '/'
in the end. Otherwise the href will be rendered as '//static/', which
causes browser treating it as http://static/.
    
Fixes: http://tracker.ceph.com/issues/22851