### PR TITLE
build/ops: rpm: use distro conditional to control MGR Python version

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -46,11 +46,7 @@
 %endif
 %endif
 %endif
-%if 0%{?suse_version} >= 1500
-%bcond_with python2
-%else
 %bcond_without python2
-%endif
 %if 0%{without python2}
 %global _defined_if_python2_absent 1
 %endif
@@ -887,6 +883,7 @@ cmake .. \
     -DCMAKE_INSTALL_INCLUDEDIR=%{_includedir} \
     -DWITH_EMBEDDED=OFF \
     -DWITH_MANPAGE=ON \
+    -DWITH_SYSTEMD=ON \
     -DWITH_PYTHON3=ON \
 %if %{with python2}
     -DWITH_PYTHON2=ON \
@@ -894,7 +891,6 @@ cmake .. \
     -DWITH_PYTHON2=OFF \
     -DMGR_PYTHON_VERSION=3 \
 %endif
-    -DWITH_SYSTEMD=ON \
 %if 0%{?rhel} && ! 0%{?centos}
     -DWITH_SUBMAN=ON \
 %endif

--- a/src/crypto/isa-l/CMakeLists.txt
+++ b/src/crypto/isa-l/CMakeLists.txt
@@ -34,5 +34,8 @@ endif(HAVE_GOOD_YASM_ELF64)
 add_library(ceph_crypto_isal SHARED ${isal_crypto_plugin_srcs})
 target_include_directories(ceph_crypto_isal PRIVATE ${isal_dir}/include)
 add_dependencies(ceph_crypto_isal ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-set_target_properties(ceph_crypto_isal PROPERTIES VERSION 1.0.0 SOVERSION 1)
+set_target_properties(ceph_crypto_isal PROPERTIES
+  VERSION 1.0.0
+  SOVERSION 1
+  INSTALL_RPATH "")
 install(TARGETS ceph_crypto_isal DESTINATION ${isal_crypto_plugin_dir})


### PR DESCRIPTION
SUSE needs to build with and without Python 2, and will control this
by sending (or not sending) --without-python2. So we need to drop the
distro conditional around %bcond_without python2.

However, on recent SUSEs we always want MGR to use Python 3, so add
the conditional there.

Signed-off-by: Nathan Cutler <ncutler@suse.com>