### PR TITLE
test/log: fix for crash with libc++

### DIFF
--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -59,7 +59,7 @@ TEST(Log, ReuseBad)
   {
     auto e = log.create_entry(l, 1);
     auto& out = e->get_ostream();
-    out << (const char*)nullptr;
+    out << (std::streambuf*)nullptr;
     EXPECT_TRUE(out.bad()); // writing nullptr to a stream sets its badbit
     log.submit_entry(e);
   }


### PR DESCRIPTION
the original issue reproduced with operator<<(const char*) in libstdc++, but this actually crashes with libc++. test the std::basic_streambuf* overload instead, which is called out explicitly in http://en.cppreference.com/w/cpp/io/ios_base/iostate:

> The badbit is set by the following standard library functions:
> * basic_ostream::operator<<(basic_streambuf*) when a null pointer is passed as the argument.