### PR TITLE
luminous: ceph-volume: do not use --key during mkfs

### DIFF
--- a/src/ceph-volume/ceph_volume/process.py
+++ b/src/ceph-volume/ceph_volume/process.py
@@ -100,7 +100,6 @@ def run(command, **kw):
     """
     stop_on_error = kw.pop('stop_on_error', True)
     command_msg = obfuscate(command, kw.pop('obfuscate', None))
-    stdin = kw.pop('stdin', None)
     fail_msg = kw.pop('fail_msg', None)
     logger.info(command_msg)
     terminal.write(command_msg)
@@ -108,15 +107,12 @@ def run(command, **kw):
 
     process = subprocess.Popen(
         command,
-        stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         close_fds=True,
         **kw
     )
 
-    if stdin:
-        process.communicate(stdin)
     while True:
         reads, _, _ = select(
             [process.stdout.fileno(), process.stderr.fileno()],

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -202,7 +202,7 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
     ]
 
     if keyring is not None:
-        base_command.extend(['--key', keyring])
+        base_command.extend(['--keyfile', '-'])
 
     if wal:
         base_command.extend(
@@ -218,7 +218,7 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
 
     command = base_command + supplementary_command
 
-    process.run(command, obfuscate='--key')
+    process.call(command, stdin=keyring)
 
 
 def osd_mkfs_filestore(osd_id, fsid):


### PR DESCRIPTION
backport of #19276