### PR TITLE
Revert " luminous: msg/async: unregister connection failed when racing happened"

### DIFF
--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -356,6 +356,9 @@ public:
       Mutex::Locker l(deleted_lock);
       if (deleted_conns.erase(existing)) {
         existing->get_perf_counter()->dec(l_msgr_active_connections);
+        conns.erase(it);
+      } else if (conn != existing) {
+        return -1;
       }
     }
     conns[conn->peer_addr] = conn;


### PR DESCRIPTION
Reverts ceph/ceph#19552

See master revert 01dd3dd79c8e9b5ae0a6740eb7941f6d91392689 and bug
http://tracker.ceph.com/issues/22231

Signed-off-by: Sage Weil <sage@redhat.com>