### PR TITLE
config: Change bluestore_cache_kv_max to type INT64

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1029,7 +1029,7 @@ OPTION(bluestore_cache_size_hdd, OPT_U64)
 OPTION(bluestore_cache_size_ssd, OPT_U64)
 OPTION(bluestore_cache_meta_ratio, OPT_DOUBLE)
 OPTION(bluestore_cache_kv_ratio, OPT_DOUBLE)
-OPTION(bluestore_cache_kv_max, OPT_U64) // limit the maximum amount of cache for the kv store
+OPTION(bluestore_cache_kv_max, OPT_INT) // limit the maximum amount of cache for the kv store
 OPTION(bluestore_kvbackend, OPT_STR)
 OPTION(bluestore_allocator, OPT_STR)     // stupid | bitmap
 OPTION(bluestore_freelist_blocks_per_key, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3733,9 +3733,12 @@ std::vector<Option> get_global_options() {
     .set_default(.99)
     .set_description("Ratio of bluestore cache to devote to kv database (rocksdb)"),
 
-    Option("bluestore_cache_kv_max", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    Option("bluestore_cache_kv_max", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(512_M)
-    .set_description("Max memory (bytes) to devote to kv database (rocksdb)"),
+    .set_description("Max memory (bytes) to devote to kv database (rocksdb)")
+    .set_long_description("A negative value means using bluestore_cache_meta_ratio "
+      "and bluestore_cache_kv_ratio instead of calculating these ratios using "
+      "bluestore_cache_size_* and bluestore_cache_kv_max."),
 
     Option("bluestore_kvbackend", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("rocksdb")


### PR DESCRIPTION
If bluestore_cache_kv_max is negative, bluestore won't calculate meta ratio and kv ratio automatically. So change the type from UINT to INT to make this bluestore logic work.


<pre>
double cache_kv_max = cct->_conf->bluestore_cache_kv_max;
double cache_kv_max_ratio = 0;

  // if cache_kv_max is negative, disable it
  if (cache_size > 0 && cache_kv_max >= 0) {
    cache_kv_max_ratio = (double) cache_kv_max / (double) cache_size;
    if (cache_kv_max_ratio < 1.0 && cache_kv_max_ratio < cache_kv_ratio) {
      dout(1) << __func__ << " max " << cache_kv_max_ratio
            << " < ratio " << cache_kv_ratio
            << dendl;
      cache_meta_ratio = cache_meta_ratio + cache_kv_ratio - cache_kv_max_ratio;
      cache_kv_ratio = cache_kv_max_ratio;
    }
  }  
</pre>

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>