### PR TITLE
Wip jewel rgw swift acl

### DIFF
--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -44,15 +44,40 @@ void RGWAccessControlList::add_grant(ACLGrant *grant)
   _add_grant(grant);
 }
 
-int RGWAccessControlList::get_perm(rgw_user& id, int perm_mask) {
-  ldout(cct, 5) << "Searching permissions for uid=" << id << " mask=" << perm_mask << dendl;
-  map<string, int>::iterator iter = acl_user_map.find(id.to_str());
+int RGWAccessControlList::get_perm(req_state *s, int perm_mask) {
+  int r = 0;
+  map<string, int>::iterator iter;
+  ldout(cct, 5) << "Searching permissions for uid=" << s->user->user_id << " mask=" << perm_mask << dendl;
+  ldout(cct, 5) << " keystone: project=" << s->keystone_project_name <<
+	"/" << s->keystone_project_id << " user=" << s->keystone_user_name
+	<< "/" << s->keystone_user_id << dendl;
+  for (iter = acl_user_map.begin(); iter != acl_user_map.end(); ++iter) {
+    int pos = iter->first.find(":");
+    if (pos == string::npos) continue;
+    if (iter->first.compare(0, pos, "*") != 0
+	&& iter->first.compare(0, pos, s->keystone_project_id) != 0
+	&& (!s->keystone_name_matching_ok
+	    || iter->first.compare(0, pos, s->keystone_project_name) != 0)) {
+      continue;
+    }
+    if (iter->first.compare(pos+1, string::npos, "*") != 0
+	&& iter->first.compare(pos+1, string::npos, s->keystone_user_id) != 0
+	&& (!s->keystone_name_matching_ok
+	    || iter->first.compare(pos+1, string::npos, s->keystone_user_name) != 0)) {
+      continue;
+    }
+    ldout(cct, 5) << "Found keystone acl match: pat=" << iter->first
+	<< ", perms=" << iter->second << dendl;
+    r |= iter->second;
+  }
+  iter = acl_user_map.find(s->user->user_id.to_str());
   if (iter != acl_user_map.end()) {
     ldout(cct, 5) << "Found permission: " << iter->second << dendl;
-    return iter->second & perm_mask;
+    r |= iter->second;
+  } else {
+    ldout(cct, 5) << "Permissions for user not found" << dendl;
   }
-  ldout(cct, 5) << "Permissions for user not found" << dendl;
-  return 0;
+  return r & perm_mask;
 }
 
 int RGWAccessControlList::get_group_perm(ACLGroupTypeEnum group, int perm_mask) {
@@ -66,10 +91,10 @@ int RGWAccessControlList::get_group_perm(ACLGroupTypeEnum group, int perm_mask) 
   return 0;
 }
 
-int RGWAccessControlPolicy::get_perm(rgw_user& id, int perm_mask) {
-  int perm = acl.get_perm(id, perm_mask);
+int RGWAccessControlPolicy::get_perm(req_state *s, int perm_mask) {
+  int perm = acl.get_perm(s, perm_mask);
 
-  if (id.compare(owner.get_id()) == 0) {
+  if (s->user->user_id.compare(owner.get_id()) == 0) {
     perm |= perm_mask & (RGW_PERM_READ_ACP | RGW_PERM_WRITE_ACP);
   }
 
@@ -80,22 +105,22 @@ int RGWAccessControlPolicy::get_perm(rgw_user& id, int perm_mask) {
   if ((perm & perm_mask) != perm_mask) {
     perm |= acl.get_group_perm(ACL_GROUP_ALL_USERS, perm_mask);
 
-    if (id.compare(RGW_USER_ANON_ID)) {
+    if (s->user->user_id.compare(RGW_USER_ANON_ID)) {
       /* this is not the anonymous user */
       perm |= acl.get_group_perm(ACL_GROUP_AUTHENTICATED_USERS, perm_mask);
     }
   }
 
-  ldout(cct, 5) << "Getting permissions id=" << id << " owner=" << owner.get_id() << " perm=" << perm << dendl;
+  ldout(cct, 5) << "Getting permissions id=" << s->user->user_id << " owner=" << owner.get_id() << " perm=" << perm << dendl;
 
   return perm;
 }
 
-bool RGWAccessControlPolicy::verify_permission(rgw_user& uid, int user_perm_mask, int perm)
+bool RGWAccessControlPolicy::verify_permission(req_state *s, int user_perm_mask, int perm)
 {
   int test_perm = perm | RGW_PERM_READ_OBJS | RGW_PERM_WRITE_OBJS;
 
-  int policy_perm = get_perm(uid, test_perm);
+  int policy_perm = get_perm(s, test_perm);
 
   /* the swift WRITE_OBJS perm is equivalent to the WRITE obj, just
      convert those bits. Note that these bits will only be set on
@@ -110,7 +135,7 @@ bool RGWAccessControlPolicy::verify_permission(rgw_user& uid, int user_perm_mask
    
   int acl_perm = policy_perm & perm & user_perm_mask;
 
-  ldout(cct, 10) << " uid=" << uid << " requested perm (type)=" << perm << ", policy perm=" << policy_perm << ", user_perm_mask=" << user_perm_mask << ", acl perm=" << acl_perm << dendl;
+  ldout(cct, 10) << " uid=" << s->user->user_id << " requested perm (type)=" << perm << ", policy perm=" << policy_perm << ", user_perm_mask=" << user_perm_mask << ", acl perm=" << acl_perm << dendl;
 
   return (perm == acl_perm);
 }

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -26,6 +26,8 @@ using namespace std;
 #define RGW_PERM_ALL_S3          RGW_PERM_FULL_CONTROL
 #define RGW_PERM_INVALID         0xFF00
 
+struct req_state;
+
 enum ACLGranteeTypeEnum {
 /* numbers are encoded, should not change */
   ACL_TYPE_CANON_USER = 0,
@@ -204,7 +206,7 @@ public:
 
   virtual ~RGWAccessControlList() {}
 
-  int get_perm(rgw_user& id, int perm_mask);
+  int get_perm(req_state* s, int perm_mask);
   int get_group_perm(ACLGroupTypeEnum group, int perm_mask);
   void encode(bufferlist& bl) const {
     ENCODE_START(3, 3, bl);
@@ -302,9 +304,9 @@ public:
     acl.set_ctx(ctx);
   }
 
-  int get_perm(rgw_user& id, int perm_mask);
+  int get_perm(req_state *s, int perm_mask);
   int get_group_perm(ACLGroupTypeEnum group, int perm_mask);
-  bool verify_permission(rgw_user& uid, int user_perm_mask, int perm);
+  bool verify_permission(req_state *s, int user_perm_mask, int perm);
 
   void encode(bufferlist& bl) const {
     ENCODE_START(2, 2, bl);

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -83,6 +83,7 @@ int RGWAccessControlPolicy_SWIFT::add_grants(RGWRados *store, list<string>& uids
 	/* might be a HTTP referrer-based acl.  Not now (ever?) */
         ldout(cct, 10) << "Unknown designator: " << uid << dendl;
 	if (!result) result = -EUNKNOWN_DESIGNATOR;
+	// Todo: return smarter error to user.
       }
       acl.add_grant(&grant);
     } else {
@@ -92,12 +93,16 @@ int RGWAccessControlPolicy_SWIFT::add_grants(RGWRados *store, list<string>& uids
         ldout(cct, 10) << "grant user does not exist:" << uid << dendl;
         /* skipping not so silently */
 	if (!result) result = -ENO_SUCH_USER;
+	// Todo: return smarter error to user.
       } else {
         grant.set_canon(user, grant_user.display_name, perm);
         acl.add_grant(&grant);
       }
     }
   }
+  // Someday! should build composite informative error message.
+  //	"Bad acl: unknown designator X, no such user Y."
+  // for now; just the common error return here.
   return result;
 }
 

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -59,9 +59,14 @@ static bool uid_is_public(string& uid)
          sub.compare(".referrer") == 0;
 }
 
+#define EUNKNOWN_DESIGNATOR EINVAL
+#define EBADREFERRER	EINVAL
+#define ENO_SUCH_USER	EINVAL
+
 int RGWAccessControlPolicy_SWIFT::add_grants(RGWRados *store, list<string>& uids, int perm)
 {
   list<string>::iterator iter;
+  int result = 0;
   for (iter = uids.begin(); iter != uids.end(); ++iter ) {
     ACLGrant grant;
     RGWUserInfo grant_user;
@@ -69,19 +74,31 @@ int RGWAccessControlPolicy_SWIFT::add_grants(RGWRados *store, list<string>& uids
     if (uid_is_public(uid)) {
       grant.set_group(ACL_GROUP_ALL_USERS, perm);
       acl.add_grant(&grant);
-    } else  {
+    } else if ((uid.find(':')) != std::string::npos) {
+      if (uid[0] != '.') {
+	rgw_user user(uid);
+        std::string empty_string;
+	grant.set_canon(user, empty_string, perm);
+      } else {
+	/* might be a HTTP referrer-based acl.  Not now (ever?) */
+        ldout(cct, 10) << "Unknown designator: " << uid << dendl;
+	if (!result) result = -EUNKNOWN_DESIGNATOR;
+      }
+      acl.add_grant(&grant);
+    } else {
       rgw_user user(uid);
       if (rgw_get_user_info_by_uid(store, user, grant_user) < 0) {
+	// also catches ".rlistings" case - no separate mech for this in ceph
         ldout(cct, 10) << "grant user does not exist:" << uid << dendl;
         /* skipping not so silently */
-        return ESRCH;
+	if (!result) result = -ENO_SUCH_USER;
       } else {
         grant.set_canon(user, grant_user.display_name, perm);
         acl.add_grant(&grant);
       }
     }
   }
-  return 0;
+  return result;
 }
 
 int RGWAccessControlPolicy_SWIFT::create(RGWRados *store, rgw_user& id, string& name, const char* read_list, const char* write_list, uint32_t& rw_mask)

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -18,9 +18,9 @@ using namespace std;
 
 #define SWIFT_GROUP_ALL_USERS ".r:*"
 
-static int parse_list(string& uid_list, list<string>& uids)
+static int parse_list(const char* uid_list, list<string>& uids)
 {
-  char *s = strdup(uid_list.c_str());
+  char *s = strdup(uid_list);
   if (!s) {
     return -ENOMEM;
   }
@@ -82,14 +82,14 @@ void RGWAccessControlPolicy_SWIFT::add_grants(RGWRados *store, list<string>& uid
   }
 }
 
-bool RGWAccessControlPolicy_SWIFT::create(RGWRados *store, rgw_user& id, string& name, string& read_list, string& write_list, uint32_t& rw_mask)
+bool RGWAccessControlPolicy_SWIFT::create(RGWRados *store, rgw_user& id, string& name, const char* read_list, const char* write_list, uint32_t& rw_mask)
 {
   acl.create_default(id, name);
   owner.set_id(id);
   owner.set_name(name);
   rw_mask = 0;
 
-  if (read_list.size()) {
+  if (read_list) {
     list<string> uids;
     int r = parse_list(read_list, uids);
     if (r < 0) {
@@ -100,7 +100,7 @@ bool RGWAccessControlPolicy_SWIFT::create(RGWRados *store, rgw_user& id, string&
     add_grants(store, uids, SWIFT_PERM_READ);
     rw_mask |= SWIFT_PERM_READ;
   }
-  if (write_list.size()) {
+  if (write_list) {
     list<string> uids;
     int r = parse_list(write_list, uids);
     if (r < 0) {

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -19,8 +19,8 @@ public:
   explicit RGWAccessControlPolicy_SWIFT(CephContext *_cct) : RGWAccessControlPolicy(_cct) {}
   ~RGWAccessControlPolicy_SWIFT() {}
 
-  void add_grants(RGWRados *store, list<string>& uids, int perm);
-  bool create(RGWRados *store, rgw_user& id, string& name, const char* read_list, const char* write_list, uint32_t& rw_mask);
+  int add_grants(RGWRados *store, list<string>& uids, int perm);
+  int create(RGWRados *store, rgw_user& id, string& name, const char* read_list, const char* write_list, uint32_t& rw_mask);
   void filter_merge(uint32_t mask, RGWAccessControlPolicy_SWIFT *policy);
   void to_str(string& read, string& write);
 };

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -20,7 +20,8 @@ public:
   ~RGWAccessControlPolicy_SWIFT() {}
 
   void add_grants(RGWRados *store, list<string>& uids, int perm);
-  bool create(RGWRados *store, rgw_user& id, string& name, string& read_list, string& write_list);
+  bool create(RGWRados *store, rgw_user& id, string& name, string& read_list, string& write_list, uint32_t& rw_mask);
+  void filter_merge(uint32_t mask, RGWAccessControlPolicy_SWIFT *policy);
   void to_str(string& read, string& write);
 };
 

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -20,7 +20,7 @@ public:
   ~RGWAccessControlPolicy_SWIFT() {}
 
   void add_grants(RGWRados *store, list<string>& uids, int perm);
-  bool create(RGWRados *store, rgw_user& id, string& name, string& read_list, string& write_list, uint32_t& rw_mask);
+  bool create(RGWRados *store, rgw_user& id, string& name, const char* read_list, const char* write_list, uint32_t& rw_mask);
   void filter_merge(uint32_t mask, RGWAccessControlPolicy_SWIFT *policy);
   void to_str(string& read, string& write);
 };

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -895,7 +895,7 @@ bool verify_bucket_permission(struct req_state * const s,
   if (!verify_requester_payer_permission(s))
     return false;
 
-  return bucket_acl->verify_permission(s->user->user_id, perm, perm);
+  return bucket_acl->verify_permission(s, perm, perm);
 }
 
 bool verify_bucket_permission(struct req_state * const s, const int perm)
@@ -928,7 +928,7 @@ bool verify_object_permission(struct req_state * const s,
   if (!object_acl)
     return false;
 
-  bool ret = object_acl->verify_permission(s->user->user_id, s->perm_mask,
+  bool ret = object_acl->verify_permission(s, s->perm_mask,
 					  perm);
   if (ret)
     return true;
@@ -949,7 +949,7 @@ bool verify_object_permission(struct req_state * const s,
     return false;
   /* we already verified the user mask above, so we pass swift_perm as the mask here,
      otherwise the mask might not cover the swift permissions bits */
-  return bucket_acl->verify_permission(s->user->user_id, swift_perm,
+  return bucket_acl->verify_permission(s, swift_perm,
 				      swift_perm);
 }
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1299,6 +1299,9 @@ struct req_state {
   const char *os_auth_token;
   string swift_user;
   string swift_groups;
+  string keystone_project_id, keystone_project_name;
+  string keystone_user_id, keystone_user_name;
+  bool keystone_name_matching_ok;
   /* Content-Disposition override for TempURL of Swift API. */
   struct {
     string override;

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -179,16 +179,19 @@ int KeystoneToken::parse(CephContext * const cct,
          * must be in v3. Otherwise we can assume it's wrongly formatted. */
         JSONDecoder::decode_json("token", *this, &parser, true);
         token.id = token_str;
+	this->version = KeystoneApiVersion::VER_2;
       }
     } else if (version == KeystoneApiVersion::VER_3) {
       if (!JSONDecoder::decode_json("token", *this, &parser)) {
         /* If the token cannot be parsed according to V3, try V2. */
         JSONDecoder::decode_json("access", *this, &parser, true);
+	this->version = KeystoneApiVersion::VER_2;
       } else {
         /* v3 suceeded. We have to fill token.id from external input as it
          * isn't a part of the JSON response anymore. It has been moved
          * to X-Subject-Token HTTP header instead. */
         token.id = token_str;
+	this->version = KeystoneApiVersion::VER_3;
       }
     } else {
       return -ENOTSUP;

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -71,6 +71,7 @@ public:
   Project project;
   User user;
   list<Role> roles;
+  KeystoneApiVersion version;
 
 public:
   // FIXME: default ctor needs to be eradicated here

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3163,6 +3163,12 @@ void RGWPutMetadataBucket::execute()
        * the hood. This method will add the new items only if the map doesn't
        * contain such keys yet. */
       if (has_policy) {
+	if (s->dialect.compare("swift") == 0) {
+	    auto old_policy = static_cast<RGWAccessControlPolicy_SWIFT*>(s->bucket_acl);
+	    auto new_policy = static_cast<RGWAccessControlPolicy_SWIFT*>(&policy);
+	    new_policy->filter_merge(policy_rw_mask, old_policy);
+	    policy = *new_policy;
+	}
 	buffer::list bl;
 	policy.encode(bl);
 	emplace_attr(RGW_ATTR_ACL, std::move(bl));

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -298,7 +298,7 @@ static int read_policy(RGWRados *store, struct req_state *s,
       return ret;
     rgw_user& owner = bucket_policy.get_owner().get_id();
     if (!s->system_request && owner.compare(s->user->user_id) != 0 &&
-        !bucket_policy.verify_permission(s->user->user_id, s->perm_mask,
+        !bucket_policy.verify_permission(s, s->perm_mask,
 					RGW_PERM_READ))
       ret = -EACCES;
     else
@@ -2338,7 +2338,7 @@ int RGWPutObj::verify_permission()
 
     /* system request overrides permission checks */
     if (!s->system_request &&
-        !cs_policy.verify_permission(s->user->user_id, s->perm_mask,
+        !cs_policy.verify_permission(s, s->perm_mask,
 				     RGW_PERM_READ)) {
       return -EACCES;
     }
@@ -3501,7 +3501,7 @@ int RGWCopyObj::verify_permission()
       return op_ret;
 
     if (!s->system_request && /* system request overrides permission checks */
-        !src_policy.verify_permission(s->user->user_id, s->perm_mask,
+        !src_policy.verify_permission(s, s->perm_mask,
 				      RGW_PERM_READ))
       return -EACCES;
   }
@@ -3538,7 +3538,7 @@ int RGWCopyObj::verify_permission()
     return op_ret;
 
   if (!s->system_request && /* system request overrides permission checks */
-      !dest_bucket_policy.verify_permission(s->user->user_id, s->perm_mask,
+      !dest_bucket_policy.verify_permission(s, s->perm_mask,
 					    RGW_PERM_WRITE))
     return -EACCES;
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -803,6 +803,7 @@ protected:
   map<string, buffer::list> attrs;
   set<string> rmattr_names;
   bool has_policy, has_cors;
+  uint32_t policy_rw_mask;
   RGWAccessControlPolicy policy;
   RGWCORSConfiguration cors_config;
   string placement_rule;
@@ -810,7 +811,7 @@ protected:
 
 public:
   RGWPutMetadataBucket()
-    : has_policy(false), has_cors(false)
+    : has_policy(false), has_cors(false), policy_rw_mask(0)
   {}
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -289,6 +289,7 @@ protected:
   uint64_t buckets_size_rounded;
   map<string, bufferlist> attrs;
   bool is_truncated;
+  bool doing_swift_cross_tenant;
 
   virtual uint64_t get_default_max() const {
     return 1000;

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -55,6 +55,7 @@ int RGWListBuckets_ObjStore_SWIFT::get_params()
       need_stats = stats;
     }
   }
+  doing_swift_cross_tenant = s->bucket_tenant != s->user->user_id.tenant;
 
   return 0;
 }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -438,20 +438,12 @@ void RGWStatBucket_ObjStore_SWIFT::send_response()
 static int get_swift_container_settings(req_state *s, RGWRados *store, RGWAccessControlPolicy *policy, bool *has_policy, uint32_t * rw_mask,
                                         RGWCORSConfiguration *cors_config, bool *has_cors)
 {
-  string read_list, write_list;
-
-  const char *read_attr = s->info.env->get("HTTP_X_CONTAINER_READ");
-  if (read_attr) {
-    read_list = read_attr;
-  }
-  const char *write_attr = s->info.env->get("HTTP_X_CONTAINER_WRITE");
-  if (write_attr) {
-    write_list = write_attr;
-  }
+  const char *read_list = s->info.env->get("HTTP_X_CONTAINER_READ");
+  const char *write_list = s->info.env->get("HTTP_X_CONTAINER_WRITE");
 
   *has_policy = false;
 
-  if (read_attr || write_attr) {
+  if (read_list || write_list) {
     RGWAccessControlPolicy_SWIFT swift_policy(s->cct);
     int r = swift_policy.create(store, s->user->user_id, s->user->display_name, read_list, write_list, *rw_mask);
     if (r < 0)

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -435,7 +435,7 @@ void RGWStatBucket_ObjStore_SWIFT::send_response()
   dump_start(s);
 }
 
-static int get_swift_container_settings(req_state *s, RGWRados *store, RGWAccessControlPolicy *policy, bool *has_policy,
+static int get_swift_container_settings(req_state *s, RGWRados *store, RGWAccessControlPolicy *policy, bool *has_policy, uint32_t * rw_mask,
                                         RGWCORSConfiguration *cors_config, bool *has_cors)
 {
   string read_list, write_list;
@@ -453,7 +453,7 @@ static int get_swift_container_settings(req_state *s, RGWRados *store, RGWAccess
 
   if (read_attr || write_attr) {
     RGWAccessControlPolicy_SWIFT swift_policy(s->cct);
-    int r = swift_policy.create(store, s->user->user_id, s->user->display_name, read_list, write_list);
+    int r = swift_policy.create(store, s->user->user_id, s->user->display_name, read_list, write_list, *rw_mask);
     if (r < 0)
       return r;
 
@@ -550,8 +550,10 @@ static int get_swift_versioning_settings(
 int RGWCreateBucket_ObjStore_SWIFT::get_params()
 {
   bool has_policy;
+  uint32_t policy_rw_mask = 0;
 
-  int r = get_swift_container_settings(s, store, &policy, &has_policy, &cors_config, &has_cors);
+  int r = get_swift_container_settings(s, store, &policy, &has_policy,
+				&policy_rw_mask, &cors_config, &has_cors);
   if (r < 0) {
     return r;
   }
@@ -781,7 +783,7 @@ int RGWPutMetadataBucket_ObjStore_SWIFT::get_params()
   }
 
   int r = get_swift_container_settings(s, store, &policy, &has_policy,
-				       &cors_config, &has_cors);
+				       &policy_rw_mask, &cors_config, &has_cors);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1593,6 +1593,10 @@ int RGWHandler_REST_SWIFT::authorize()
 
       *(s->user) = einfo;
     }
+  } else {
+    if (! s->account_name.empty()) {
+      s->bucket_tenant = s->account_name;
+    }
   }
 
   return 0;

--- a/src/rgw/rgw_swift.cc
+++ b/src/rgw/rgw_swift.cc
@@ -410,9 +410,28 @@ int RGWSwift::parse_keystone_token_response(const string& token,
   return 0;
 }
 
+void RGWSwift::keep_token_attributes_for_acls(KeystoneToken& t, req_state* s)
+{
+  /* swift acls need all this extra stuff */
+  s->keystone_user_id = t.get_user_id();
+  s->keystone_user_name = t.get_user_name();
+  s->keystone_project_id = t.get_project_id();
+  s->keystone_project_name = t.get_project_name();
+
+  switch(t.version) {
+  case KeystoneApiVersion::VER_2:
+    s->keystone_name_matching_ok = true;
+    break;
+  case KeystoneApiVersion::VER_3:
+    s->keystone_name_matching_ok = t.user.domain.id == t.project.domain.id;
+    break;
+  }
+}
+
 int RGWSwift::update_user_info(RGWRados *store, struct rgw_swift_auth_info *info, RGWUserInfo& user_info)
 {
   ldout(cct, 20) << "updating user=" << info->user << dendl; // P3 XXX
+
   /*
    * Normally once someone parsed the token, the tenant and user are set
    * in rgw_swift_auth_info. If .tenant is empty in it, the client has
@@ -460,14 +479,13 @@ int RGWSwift::update_user_info(RGWRados *store, struct rgw_swift_auth_info *info
   return 0;
 }
 
-int RGWSwift::validate_keystone_token(RGWRados *store, const string& token,
-				      RGWUserInfo& rgw_user)
+int RGWSwift::validate_keystone_token(RGWRados *store, req_state *s)
 {
   KeystoneToken t;
   struct rgw_swift_auth_info info;
 
   string token_id;
-  rgw_get_token_id(token, token_id);
+  rgw_get_token_id(s->os_auth_token, token_id);
 
   ldout(cct, 20) << "token_id=" << token_id << dendl;
 
@@ -477,7 +495,8 @@ int RGWSwift::validate_keystone_token(RGWRados *store, const string& token,
 
     ldout(cct, 20) << "cached token.project.id=" << t.get_project_id() << dendl;
 
-    int ret = update_user_info(store, &info, rgw_user);
+    keep_token_attributes_for_acls(t, s);
+    int ret = update_user_info(store, &info, *s->user);
     if (ret < 0)
       return ret;
 
@@ -487,7 +506,7 @@ int RGWSwift::validate_keystone_token(RGWRados *store, const string& token,
   bufferlist bl;
 
   /* check if that's a self signed token that we can decode */
-  if (!rgw_decode_pki_token(cct, token, bl)) {
+  if (!rgw_decode_pki_token(cct, s->os_auth_token, bl)) {
 
     /* can't decode, just go to the keystone server for validation */
 
@@ -511,11 +530,11 @@ int RGWSwift::validate_keystone_token(RGWRados *store, const string& token,
     const auto keystone_version = KeystoneService::get_api_version();
     if (keystone_version == KeystoneApiVersion::VER_2) {
       url.append("v2.0/tokens/");
-      url.append(token);
+      url.append(s->os_auth_token);
     }
     if (keystone_version == KeystoneApiVersion::VER_3) {
       url.append("v3/auth/tokens");
-      validate.append_header("X-Subject-Token", token);
+      validate.append_header("X-Subject-Token", s->os_auth_token);
     }
 
     validate.set_send_length(0);
@@ -529,7 +548,7 @@ int RGWSwift::validate_keystone_token(RGWRados *store, const string& token,
 
   ldout(cct, 20) << "received response: " << bl.c_str() << dendl;
 
-  int ret = parse_keystone_token_response(token, bl, &info, t);
+  int ret = parse_keystone_token_response(s->os_auth_token, bl, &info, t);
   if (ret < 0)
     return ret;
 
@@ -542,7 +561,8 @@ int RGWSwift::validate_keystone_token(RGWRados *store, const string& token,
 
   keystone_token_cache->add(token_id, t);
 
-  ret = update_user_info(store, &info, rgw_user);
+  keep_token_attributes_for_acls(t, s);
+  ret = update_user_info(store, &info, *s->user);
   if (ret < 0)
     return ret;
 
@@ -782,7 +802,7 @@ bool RGWSwift::do_verify_swift_token(RGWRados *store, req_state *s)
   }
 
   if (supports_keystone()) {
-    int ret = validate_keystone_token(store, s->os_auth_token, *(s->user));
+    int ret = validate_keystone_token(store, s);
     return (ret >= 0);
   }
 

--- a/src/rgw/rgw_swift.h
+++ b/src/rgw/rgw_swift.h
@@ -27,13 +27,13 @@ class RGWSwift {
   atomic_t down_flag;
 
   int validate_token(const char *token, struct rgw_swift_auth_info *info);
-  int validate_keystone_token(RGWRados *store, const string& token,
-			      RGWUserInfo& rgw_user);
+  int validate_keystone_token(RGWRados *store, req_state *s);
 
   int parse_keystone_token_response(const string& token,
                                     bufferlist& bl,
                                     struct rgw_swift_auth_info *info,
 		                    KeystoneToken& t);
+  void keep_token_attributes_for_acls(KeystoneToken& t, req_state *s);
   int update_user_info(RGWRados *store, struct rgw_swift_auth_info *info, RGWUserInfo& user_info);
   int get_keystone_url(std::string& url);
   int get_keystone_admin_token(std::string& token);


### PR DESCRIPTION
Backport trackers:
* https://tracker.ceph.com/issues/20587
* https://tracker.ceph.com/issues/24303

--- 

The existing jewel/keystone acl logic was deficient.  It's confused many folks over the years.  I've pulled out some patches from master, created some new ones (that should go to master), and more (that duplicate functionality that in master gets done with much more spiffy but complicated logic.)

Right now, this should be in a good reviewable state, but there are a few pending issues I note at the end.

fc655cd35e radosgw: fix swift anonymous access.
        this has an existing PR #19194 - but I needed that logic for these
        other changes.
2aa2d66be2 rgw: swift: ability to update swift read and write acls separately.
        this is a backport from master; I needed it to make things
        behave right in jewel too.
ae4782cfa1 Allow swift acls to be deleted.
        This is a new thing, something very like this needs to go into master.
        (and this needs a tracker ID, sorry)
7933badddf Reject invalid swift acls.
        This is a new thing; but it matches the behavior of upstream  
        swift, which most definitely rejects swift acls that it does
        not understand.  The old jewel behavior, silently eating
        acls that it didn't understand, was really not a nice thing
        to inflict on users.
63665df25d Store swift acls with keystone elements.
        this takes care to store things the same way master does.
        this commit just handles storing the acls, no evaluation logic here.
213eecff25 Execute swift acls with keystone elements.
        this commit handles the actual evaluation logic.
4fb163cbb2 Enable 3rd party access to swift for most operations.
        to make tenant keystone acls useful, it's necessary to
        actually eanble 3rd party access (cross-tenant).
        The existing logic correctly parsed out cross-tenant access,
        then pretended it never saw it.  This patch should cover
        all but listing buckets.
b1cd670cd0 (HEAD -> wip-jewel-rgw-swift-acl-5, m-l/wip-jewel-rgw-swift-acl-5, m-l-1/wip-je
wel-rgw-swift-acl) Enable 3rd party access for bucket listings (swift).
        this handles 3rd party access for cross-bucket.

pending issues:
1. .rlistings.  This treats this as "invalid" - possibly it should silently accept and ignore this.
2. keystone_auth_version - the issue here is that with keystonev3, "name" matching is deprecated and "id" matching is recommended instead.  "name" matching should only be done within a realm - and so the check should be "v2 or realms match".  But I don't have that code yet.
2. The last commit turns off metadata for cross-tenant access.  That may not be right.