### PR TITLE
rados: clean up rados_getxattrs() and rados_striper_getxattrs()

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -4269,8 +4269,6 @@ extern "C" int rados_getxattrs(rados_ioctx_t io, const char *oid,
   }
   it->i = it->attrset.begin();
 
-  librados::RadosXattrsIter **iret = (librados::RadosXattrsIter**)iter;
-  *iret = it;
   *iter = it;
   tracepoint(librados, rados_getxattrs_exit, 0, *iter);
   return 0;

--- a/src/libradosstriper/libradosstriper.cc
+++ b/src/libradosstriper/libradosstriper.cc
@@ -506,8 +506,6 @@ extern "C" int rados_striper_getxattrs(rados_striper_t striper,
     return ret;
   }
   it->i = it->attrset.begin();
-  librados::RadosXattrsIter **iret = (librados::RadosXattrsIter**)iter;
-  *iret = it;
   *iter = it;
   return 0;
 }


### PR DESCRIPTION
Signed-off-by: Gu Zhongyan <guzhongyan@360.cn>