### PR TITLE
doc: Fix path in ceph-fuse.rst

### DIFF
--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -64,4 +64,4 @@ See also
 fusermount(8),
 :doc:`ceph <ceph>`\(8)
 
-.. _Mount Ceph FS using FUSE: ../../cephfs/fuse/
+.. _Mount Ceph FS using FUSE: ../../../cephfs/fuse/


### PR DESCRIPTION
This mistake was introduced in https://github.com/ceph/ceph/commit/9b6f9da3ce935ba1dcc28dfd6723ca46883ccb5e. Sorry.

Signed-off-by: Jos Collin <jcollin@redhat.com>