### PR TITLE
osbench: fix core dump when sequencer leaves its scope

### DIFF
--- a/src/test/objectstore_bench.cc
+++ b/src/test/objectstore_bench.cc
@@ -135,7 +135,7 @@ void osbench_worker(ObjectStore *os, const Config &cfg,
     std::condition_variable cond;
     bool done = false;
 
-    os->queue_transactions(&sequencer, tls, nullptr,
+    os->queue_transactions(&sequencer, tls,
                            new C_NotifyCond(&mutex, &cond, &done));
 
     std::unique_lock<std::mutex> lock(mutex);


### PR DESCRIPTION
In filestore, ondisk is called after journal is written,
and sequencer leaves its scope and destruct, but in
FileStore::_do_op, sequencer is still used. So we need to
wait onreadable callback.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>