### PR TITLE
ceph-volume: lvm zap will unmount osd paths used by zapped devices

### DIFF
--- a/doc/ceph-volume/lvm/zap.rst
+++ b/doc/ceph-volume/lvm/zap.rst
@@ -10,6 +10,9 @@ on the given lv or partition will be removed and all data will be purged.
 
 .. note:: The lv or partition will be kept intact.
 
+.. note:: If the logicial volume, raw device or partition is being used for any ceph related
+          mountpoints they will be unmounted.
+
 Zapping a logical volume::
 
       ceph-volume lvm zap {vg name/lv name}

--- a/doc/ceph-volume/lvm/zap.rst
+++ b/doc/ceph-volume/lvm/zap.rst
@@ -10,8 +10,8 @@ on the given lv or partition will be removed and all data will be purged.
 
 .. note:: The lv or partition will be kept intact.
 
-.. note:: If the logicial volume, raw device or partition is being used for any ceph related
-          mountpoints they will be unmounted.
+.. note:: If the logical volume, raw device or partition is being used for any ceph related
+          mount points they will be unmounted.
 
 Zapping a logical volume::
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -8,6 +8,7 @@ from ceph_volume.api import lvm as api
 from ceph_volume.util import system
 
 logger = logging.getLogger(__name__)
+mlogger = terminal.MultiLogger(__name__)
 
 
 def wipefs(path):
@@ -57,8 +58,7 @@ class Zap(object):
             #TODO: ensure device is a partition
             path = device
 
-        logger.info("Zapping: %s", path)
-        terminal.write("Zapping: %s" % path)
+        mlogger.info("Zapping: %s", path)
 
         # check if there was a pv created with the
         # name of device
@@ -70,22 +70,18 @@ class Zap(object):
         if lv:
             osd_path = "/var/lib/ceph/osd/{}-{}".format(lv.tags['ceph.cluster_name'], lv.tags['ceph.osd_id'])
             if system.path_is_mounted(osd_path):
-                logger.info("Unmounting %s", osd_path)
-                terminal.write("Unmounting %s" % osd_path)
+                mlogger.info("Unmounting %s", osd_path)
                 system.unmount(osd_path)
 
         if args.destroy and pv:
             logger.info("Found a physical volume created from %s, will destroy all it's vgs and lvs", device)
             vg_name = pv.vg_name
-            logger.info("Destroying volume group %s because --destroy was given", vg_name)
-            terminal.write("Destroying volume group %s because --destroy was given" % vg_name)
+            mlogger.info("Destroying volume group %s because --destroy was given", vg_name)
             api.remove_vg(vg_name)
-            logger.info("Destroying physical volume %s because --destroy was given", device)
-            terminal.write("Destroying physical volume %s because --destroy was given" % device)
+            mlogger.info("Destroying physical volume %s because --destroy was given", device)
             api.remove_pv(device)
         elif args.destroy and not pv:
-            logger.info("Skipping --destroy because no associated physical volumes are found for %s", device)
-            terminal.write("Skipping --destroy because no associated physical volumes are found for %s" % device)
+            mlogger.info("Skipping --destroy because no associated physical volumes are found for %s", device)
 
         wipefs(path)
         zap_data(path)

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -62,10 +62,10 @@ class Zap(object):
 
         # check if there was a pv created with the
         # name of device
-        pv = api.PVolumes().get(pv_name=device)
+        pv = api.get_pv(pv_name=device)
         if pv:
             vg_name = pv.vg_name
-            lv = api.Volumes().get(vg_name=vg_name)
+            lv = api.get_lv(vg_name=vg_name)
 
         if lv:
             osd_path = "/var/lib/ceph/osd/{}-{}".format(lv.tags['ceph.cluster_name'], lv.tags['ceph.osd_id'])

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -103,8 +103,8 @@ class Zap(object):
         filesystems present on the given device, vg/lv, or partition will be removed and
         all data will be purged.
 
-        If the logicial volume, raw device or partition is being used for any ceph related
-        mountpoints they will be unmounted.
+        If the logical volume, raw device or partition is being used for any ceph related
+        mount points they will be unmounted.
 
         However, the lv or partition will be kept intact.
 

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -121,6 +121,17 @@ class tmp_mount(object):
             encryption.dmcrypt_close(self.device)
 
 
+def unmount(path):
+    """
+    Removes mounts at the given path
+    """
+    process.run([
+        'umount',
+        '-v',
+        path,
+    ])
+
+
 def path_is_mounted(path, destination=None):
     """
     Check if the given path is mounted


### PR DESCRIPTION
If ``ceph-volume lvm zap`` finds that a device, lv, or partition was mounted for use by ceph it will unmount that path so zapping can continue.

fixes: http://tracker.ceph.com/issues/22876