### PR TITLE
luminous: rgw: If use 'copy part' without 'x-amz-copy-source-range',

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3272,8 +3272,10 @@ int RGWHandler_REST_S3::init(RGWRados *store, struct req_state *s,
   s->has_acl_header = s->info.env->exists_prefix("HTTP_X_AMZ_GRANT");
 
   const char *copy_source = s->info.env->get("HTTP_X_AMZ_COPY_SOURCE");
+  if (copy_source &&
+      (! s->info.env->get("HTTP_X_AMZ_COPY_SOURCE_RANGE")) &&
+      (! s->info.args.exists("uploadId"))) {
 
-  if (copy_source && !s->info.env->get("HTTP_X_AMZ_COPY_SOURCE_RANGE")) {
     ret = RGWCopyObj::parse_copy_location(copy_source,
                                           s->init_state.src_bucket,
                                           s->src_object);


### PR DESCRIPTION
Backport tracker: http://tracker.ceph.com/issues/22903

it will copy an entire source object

Fixes: http://tracker.ceph.com/issues/22729

Signed-off-by: Malcolm Lee <fengxueyu35@126.com>
(cherry picked from commit 753b3a7cbfa791468a0d94ea1a29beb6ebc3feb2)
Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>