### PR TITLE
osd,dmclock: fix dmclock test simulator change

### DIFF
--- a/src/dmclock/sim/src/ssched/ssched_server.h
+++ b/src/dmclock/sim/src/ssched/ssched_server.h
@@ -104,10 +104,11 @@ namespace crimson {
       void add_request(R&& request,
 		       const C& client_id,
 		       const ReqParams& req_params) {
-	add_request(std::move(request), client_id, req_params);
+	add_request(RequestRef(new R(std::move(request))),
+		    client_id, req_params);
       }
 
-      void add_request(R&& request,
+      void add_request(RequestRef&& request,
 		       const C& client_id,
 		       const ReqParams& req_params) {
 	DataGuard g(queue_mtx);


### PR DESCRIPTION
Revert change from commit 8c5fea68cb9e0c2e6cc2352e64c4f3f46e29c58f
that introduced a compilation error that was not noticed since the
dmclock support/testing simulators are not built by ceph.

Also, changes below the src/dmclock tree should be made in the dmclock
library and then pulled into ceph.