### PR TITLE
common/admin_socket: various cleanups

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -137,8 +137,9 @@ Client::CommandHook::CommandHook(Client *client) :
 {
 }
 
-bool Client::CommandHook::call(std::string command, cmdmap_t& cmdmap,
-			       std::string format, bufferlist& out)
+bool Client::CommandHook::call(std::string_view command,
+			       const cmdmap_t& cmdmap,
+			       std::string_view format, bufferlist& out)
 {
   std::unique_ptr<Formatter> f(Formatter::create(format));
   f->open_object_section("result");

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -257,8 +257,8 @@ class Client : public Dispatcher, public md_config_obs_t {
     Client *m_client;
   public:
     explicit CommandHook(Client *client);
-    bool call(std::string command, cmdmap_t &cmdmap, std::string format,
-	      bufferlist& out) override;
+    bool call(std::string_view command, const cmdmap_t& cmdmap,
+              std::string_view format, bufferlist& out) override;
   };
   CommandHook m_command_hook;
 

--- a/src/common/Thread.cc
+++ b/src/common/Thread.cc
@@ -12,7 +12,8 @@
  *
  */
 
-#include "include/compat.h"
+#include <signal.h>
+
 #include "common/Thread.h"
 #include "common/code_environment.h"
 #include "common/debug.h"
@@ -197,4 +198,33 @@ int Thread::set_affinity(int id)
   if (pid && ceph_gettid() == pid)
     r = _set_affinity(id);
   return r;
+}
+
+// Functions for std::thread
+// =========================
+
+void set_thread_name(std::thread& t, const std::string& s) {
+  int r = ceph_pthread_setname(t.native_handle(), s.c_str());
+  if (r != 0) {
+    throw std::system_error(r, std::generic_category());
+  }
+}
+std::string get_thread_name(const std::thread& t) {
+  std::string s(256, '\0');
+
+  int r = ceph_pthread_getname(const_cast<std::thread&>(t).native_handle(),
+			       s.data(), s.length());
+  if (r != 0) {
+    throw std::system_error(r, std::generic_category());
+  }
+  s.resize(std::strlen(s.data()));
+  return s;
+}
+
+void kill(std::thread& t, int signal)
+{
+  auto r = pthread_kill(t.native_handle(), signal);
+  if (r != 0) {
+    throw std::system_error(r, std::generic_category());
+  }
 }

--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -1,4 +1,4 @@
- // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -16,8 +16,13 @@
 #ifndef CEPH_THREAD_H
 #define CEPH_THREAD_H
 
+#include <system_error>
+#include <thread>
+
 #include <pthread.h>
 #include <sys/types.h>
+
+#include "include/compat.h"
 
 class Thread {
  private:
@@ -55,5 +60,21 @@ class Thread {
   int set_ioprio(int cls, int prio);
   int set_affinity(int cpuid);
 };
+
+// Functions for with std::thread
+
+void set_thread_name(std::thread& t, const std::string& s);
+std::string get_thread_name(const std::thread& t);
+void kill(std::thread& t, int signal);
+
+template<typename Fun, typename... Args>
+std::thread make_named_thread(const std::string& s,
+			      Fun&& fun,
+			      Args&& ...args) {
+  auto t = std::thread(std::forward<Fun>(fun),
+		       std::forward<Args>(args)...);
+  set_thread_name(t, s);
+  return t;
+}
 
 #endif

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -108,9 +108,6 @@ AdminSocket::~AdminSocket()
  * AdminSocketConfigObs class to join() it.
  */
 
-#define PFL_SUCCESS ((void*)(intptr_t)0)
-#define PFL_FAIL ((void*)(intptr_t)1)
-
 std::string AdminSocket::create_shutdown_pipe(int *pipe_rd, int *pipe_wr)
 {
   int pipefd[2];

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -38,7 +38,7 @@ public:
   virtual ~AdminSocketHook() {}
 };
 
-class AdminSocket 
+class AdminSocket
 {
 public:
   AdminSocket(CephContext *cct);
@@ -113,13 +113,21 @@ private:
 
   bool in_hook = false;
   std::condition_variable in_hook_cond;
-  std::mutex lock;    // protects m_hooks, m_descs, m_help
+  std::mutex lock;  // protects `hooks`
   AdminSocketHook *m_version_hook = nullptr, *m_help_hook = nullptr,
     *m_getdescs_hook = nullptr;
 
-  std::map<std::string,AdminSocketHook*, std::less<>> m_hooks;
-  std::map<std::string,std::string, std::less<>> m_descs;
-  std::map<std::string,std::string, std::less<>> m_help;
+  struct hook_info {
+    AdminSocketHook* hook;
+    std::string desc;
+    std::string help;
+
+    hook_info(AdminSocketHook* hook, std::string_view desc,
+	      std::string_view help)
+      : hook(hook), desc(desc), help(help) {}
+  };
+
+  std::map<std::string, hook_info, std::less<>> hooks;
 
   friend class AdminSocketTest;
   friend class HelpHook;

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,9 +7,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #ifndef CEPH_COMMON_ADMIN_SOCKET_H
@@ -114,8 +114,9 @@ private:
   bool in_hook = false;
   std::condition_variable in_hook_cond;
   std::mutex lock;  // protects `hooks`
-  AdminSocketHook *m_version_hook = nullptr, *m_help_hook = nullptr,
-    *m_getdescs_hook = nullptr;
+  std::unique_ptr<AdminSocketHook> version_hook;
+  std::unique_ptr<AdminSocketHook> help_hook;
+  std::unique_ptr<AdminSocketHook> getdescs_hook;
 
   struct hook_info {
     AdminSocketHook* hook;

--- a/src/common/admin_socket_client.cc
+++ b/src/common/admin_socket_client.cc
@@ -12,12 +12,14 @@
  *
  */
 
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+
 #include "common/admin_socket.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
 #include "common/admin_socket_client.h"
-
-#include <sys/un.h>
 
 using std::ostringstream;
 

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -105,8 +105,8 @@ public:
   }
 
   // AdminSocketHook
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override {
     if (command == "dump_mempools") {
       std::unique_ptr<Formatter> f(Formatter::create(format));
       f->open_object_section("mempools");
@@ -367,19 +367,19 @@ class CephContextHook : public AdminSocketHook {
 public:
   explicit CephContextHook(CephContext *cct) : m_cct(cct) {}
 
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override {
     m_cct->do_command(command, cmdmap, format, &out);
     return true;
   }
 };
 
-void CephContext::do_command(std::string command, cmdmap_t& cmdmap,
-			     std::string format, bufferlist *out)
+void CephContext::do_command(std::string_view command, const cmdmap_t& cmdmap,
+			     std::string_view format, bufferlist *out)
 {
   Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
   stringstream ss;
-  for (cmdmap_t::iterator it = cmdmap.begin(); it != cmdmap.end(); ++it) {
+  for (auto it = cmdmap.begin(); it != cmdmap.end(); ++it) {
     if (it->first != "prefix") {
       ss << it->first  << ":" << cmd_vartype_stringify(it->second) << " ";
     }
@@ -411,7 +411,7 @@ void CephContext::do_command(std::string command, cmdmap_t& cmdmap,
   }
   else if (command == "perf reset") {
     std::string var;
-    string section = command;
+    std::string section(command);
     f->open_object_section(section.c_str());
     if (!cmd_getval(this, cmdmap, "var", var)) {
       f->dump_string("error", "syntax error: 'perf reset <var>'");
@@ -419,12 +419,12 @@ void CephContext::do_command(std::string command, cmdmap_t& cmdmap,
      if(!_perf_counters_collection->reset(var))
         f->dump_stream("error") << "Not find: " << var;
      else
-       f->dump_string("success", command + ' ' + var);
+       f->dump_string("success", std::string(command) + ' ' + var);
     }
     f->close_section();
   }
   else {
-    string section = command;
+    std::string section(command);
     boost::replace_all(section, " ", "_");
     f->open_object_section(section.c_str());
     if (command == "config show") {

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -24,10 +24,15 @@
 #include "common/admin_socket.h"
 #include "common/perf_counters.h"
 #include "common/code_environment.h"
+#include "common/Cond.h"
+#include "common/config.h"
 #include "common/ceph_crypto.h"
 #include "common/HeartbeatMap.h"
 #include "common/errno.h"
 #include "common/Graylog.h"
+
+#include "log/Log.h"
+
 #include "auth/Crypto.h"
 #include "include/str_list.h"
 #include "common/PluginRegistry.h"

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -126,8 +126,8 @@ public:
   /**
    * process an admin socket command
    */
-  void do_command(std::string command, cmdmap_t& cmdmap, std::string format,
-		  ceph::bufferlist *out);
+  void do_command(std::string_view command, const cmdmap_t& cmdmap,
+		  std::string_view format, ceph::bufferlist *out);
 
   template<typename T>
   void lookup_or_create_singleton_object(T*& p, const std::string &name) {

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -211,7 +211,7 @@ void cmdmap_dump(const cmdmap_t &cmdmap, Formatter *f)
  * false, ss is valid */
 
 bool
-cmdmap_from_json(vector<string> cmd, map<string, cmd_vartype> *mapp, stringstream &ss)
+cmdmap_from_json(vector<string> cmd, cmdmap_t *mapp, stringstream &ss)
 {
   json_spirit::mValue v;
 

--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -23,7 +23,7 @@ typedef boost::variant<std::string,
 		       std::vector<std::string>,
 		       std::vector<int64_t>,
 		       std::vector<double>>  cmd_vartype;
-typedef std::map<std::string, cmd_vartype> cmdmap_t;
+typedef std::map<std::string, cmd_vartype, std::less<>> cmdmap_t;
 
 std::string cmddesc_get_prefix(const std::string &cmddesc);
 void dump_cmd_to_json(ceph::Formatter *f, const std::string& cmd);

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -14,7 +14,10 @@
 
 #include "common/admin_socket.h"
 #include "common/ceph_argparse.h"
+#include "common/ceph_context.h"
 #include "common/common_init.h"
+#include "common/config.h"
+#include "common/dout.h"
 #include "common/valgrind.h"
 #include "common/zipkin_trace.h"
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -43,6 +43,10 @@
 #include <list>
 #include <vector>
 #include <string>
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif // __cplusplus >= 201703L
+
 #include <exception>
 #include <type_traits>
 
@@ -334,6 +338,11 @@ namespace buffer CEPH_BUFFER_API {
 
     unsigned append(char c);
     unsigned append(const char *p, unsigned l);
+#if __cplusplus >= 201703L
+    inline unsigned append(std::string_view s) {
+      return append(s.data(), s.length());
+    }
+#endif // __cplusplus >= 201703L
     void copy_in(unsigned o, unsigned l, const char *src);
     void copy_in(unsigned o, unsigned l, const char *src, bool crc_reset);
     void zero();
@@ -844,9 +853,23 @@ namespace buffer CEPH_BUFFER_API {
 
     void append(char c);
     void append(const char *data, unsigned len);
-    void append(const std::string& s) {
+    void append(std::string s) {
       append(s.data(), s.length());
     }
+#if __cplusplus >= 201703L
+    // To forcibly disambiguate between string and string_view in the
+    // case of arrays
+    template<std::size_t N>
+    void append(const char (&s)[N]) {
+      append(s, N);
+    }
+    void append(const char* s) {
+      append(s, strlen(s));
+    }
+    void append(std::string_view s) {
+      append(s.data(), s.length());
+    }
+#endif // __cplusplus >= 201703L
     void append(const ptr& bp);
     void append(ptr&& bp);
     void append(const ptr& bp, unsigned off, unsigned len);

--- a/src/librbd/LibrbdAdminSocketHook.cc
+++ b/src/librbd/LibrbdAdminSocketHook.cc
@@ -88,8 +88,10 @@ LibrbdAdminSocketHook::~LibrbdAdminSocketHook() {
   }
 }
 
-bool LibrbdAdminSocketHook::call(std::string command, cmdmap_t& cmdmap,
-				 std::string format, bufferlist& out) {
+bool LibrbdAdminSocketHook::call(std::string_view command,
+				 const cmdmap_t& cmdmap,
+				 std::string_view format,
+				 bufferlist& out) {
   Commands::const_iterator i = commands.find(command);
   assert(i != commands.end());
   stringstream ss;

--- a/src/librbd/LibrbdAdminSocketHook.h
+++ b/src/librbd/LibrbdAdminSocketHook.h
@@ -17,11 +17,12 @@ namespace librbd {
     LibrbdAdminSocketHook(ImageCtx *ictx);
     ~LibrbdAdminSocketHook() override;
 
-    bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	      bufferlist& out) override;
+    bool call(std::string_view command, const cmdmap_t& cmdmap,
+	      std::string_view format, bufferlist& out) override;
 
   private:
-    typedef std::map<std::string,LibrbdAdminSocketCommand*> Commands;
+    typedef std::map<std::string,LibrbdAdminSocketCommand*,
+		     std::less<>> Commands;
 
     AdminSocket *admin_socket;
     Commands commands;

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -117,8 +117,8 @@ class MDSSocketHook : public AdminSocketHook {
   MDSDaemon *mds;
 public:
   explicit MDSSocketHook(MDSDaemon *m) : mds(m) {}
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override {
     stringstream ss;
     bool r = mds->asok_command(command, cmdmap, format, ss);
     out.append(ss);
@@ -126,8 +126,8 @@ public:
   }
 };
 
-bool MDSDaemon::asok_command(string command, cmdmap_t& cmdmap, string format,
-		    ostream& ss)
+bool MDSDaemon::asok_command(std::string_view command, const cmdmap_t& cmdmap,
+			     std::string_view format, std::ostream& ss)
 {
   dout(1) << "asok_command: " << command << " (starting...)" << dendl;
 

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -113,8 +113,8 @@ class MDSDaemon : public Dispatcher, public md_config_obs_t {
   void set_up_admin_socket();
   void clean_up_admin_socket();
   void check_ops_in_flight(); // send off any slow ops to monitor
-  bool asok_command(string command, cmdmap_t& cmdmap, string format,
-		    ostream& ss);
+  bool asok_command(std::string_view command, const cmdmap_t& cmdmap,
+		    std::string_view format, ostream& ss);
 
   void dump_status(Formatter *f);
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1851,9 +1851,10 @@ void MDSRank::handle_mds_failure(mds_rank_t who)
   snapclient->handle_mds_failure(who);
 }
 
-bool MDSRankDispatcher::handle_asok_command(
-    std::string command, cmdmap_t& cmdmap, Formatter *f,
-		    std::ostream& ss)
+bool MDSRankDispatcher::handle_asok_command(std::string_view command,
+					    const cmdmap_t& cmdmap,
+					    Formatter *f,
+					    std::ostream& ss)
 {
   if (command == "dump_ops_in_flight" ||
              command == "ops") {

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -541,7 +541,7 @@ public:
   void init();
   void tick();
   void shutdown();
-  bool handle_asok_command(std::string command, cmdmap_t& cmdmap,
+  bool handle_asok_command(std::string_view command, const cmdmap_t& cmdmap,
                            Formatter *f, std::ostream& ss);
   void handle_mds_map(MMDSMap *m, MDSMap *oldmap);
   void handle_osd_map();

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -522,10 +522,10 @@ bool DaemonServer::handle_report(MMgrReport *m)
 
 
 void DaemonServer::_generate_command_map(
-  map<string,cmd_vartype>& cmdmap,
+  cmdmap_t& cmdmap,
   map<string,string> &param_str_map)
 {
-  for (map<string,cmd_vartype>::const_iterator p = cmdmap.begin();
+  for (auto p = cmdmap.begin();
        p != cmdmap.end(); ++p) {
     if (p->first == "prefix")
       continue;
@@ -562,7 +562,7 @@ bool DaemonServer::_allowed_command(
   MgrSession *s,
   const string &module,
   const string &prefix,
-  const map<string,cmd_vartype>& cmdmap,
+  const cmdmap_t& cmdmap,
   const map<string,string>& param_str_map,
   const MonCommand *this_cmd) {
 

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -80,13 +80,13 @@ protected:
 
   Mutex lock;
 
-  static void _generate_command_map(map<string,cmd_vartype>& cmdmap,
+  static void _generate_command_map(cmdmap_t& cmdmap,
                                     map<string,string> &param_str_map);
   static const MonCommand *_get_mgrcommand(const string &cmd_prefix,
                                            const std::vector<MonCommand> &commands);
   bool _allowed_command(
     MgrSession *s, const string &module, const string &prefix,
-    const map<string,cmd_vartype>& cmdmap,
+    const cmdmap_t& cmdmap,
     const map<string,string>& param_str_map,
     const MonCommand *this_cmd);
 

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -524,7 +524,7 @@ bool AuthMonitor::preprocess_command(MonOpRequestRef op)
   bufferlist rdata;
   stringstream ss, ds;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     // ss has reason for failure
     string rs = ss.str();
@@ -1011,7 +1011,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
   string rs;
   int err = -EINVAL;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     // ss has reason for failure
     string rs = ss.str();

--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -165,7 +165,7 @@ bool ConfigKeyService::service_dispatch(MonOpRequestRef op)
   bufferlist rdata;
 
   string prefix;
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
 
   if (!cmdmap_from_json(cmd->cmd, &cmdmap, ss)) {
     return false;

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -40,7 +40,7 @@ class FlagSetHandler : public FileSystemCommandHandler
       Monitor *mon,
       FSMap &fsmap,
       MonOpRequestRef op,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
     string flag_name;
@@ -93,7 +93,7 @@ class FsNewHandler : public FileSystemCommandHandler
       Monitor *mon,
       FSMap &fsmap,
       MonOpRequestRef op,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
     assert(m_paxos->is_plugged());
@@ -224,7 +224,7 @@ public:
       Monitor *mon,
       FSMap &fsmap,
       MonOpRequestRef op,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
     std::string fs_name;
@@ -507,7 +507,7 @@ class AddDataPoolHandler : public FileSystemCommandHandler
       Monitor *mon,
       FSMap &fsmap,
       MonOpRequestRef op,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
     assert(m_paxos->is_plugged());
@@ -586,7 +586,7 @@ class SetDefaultHandler : public FileSystemCommandHandler
       Monitor *mon,
       FSMap &fsmap,
       MonOpRequestRef op,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
     std::string fs_name;
@@ -613,7 +613,7 @@ class RemoveFilesystemHandler : public FileSystemCommandHandler
       Monitor *mon,
       FSMap &fsmap,
       MonOpRequestRef op,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
     // Check caller has correctly named the FS to delete
@@ -677,7 +677,7 @@ class ResetFilesystemHandler : public FileSystemCommandHandler
       Monitor *mon,
       FSMap &fsmap,
       MonOpRequestRef op,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
     string fs_name;
@@ -722,7 +722,7 @@ class RemoveDataPoolHandler : public FileSystemCommandHandler
       Monitor *mon,
       FSMap &fsmap,
       MonOpRequestRef op,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
     string poolname;
@@ -803,7 +803,7 @@ class AliasHandler : public T
       Monitor *mon,
       FSMap &fsmap,
       MonOpRequestRef op,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss) override
   {
     return T::handle(mon, fsmap, op, cmdmap, ss);

--- a/src/mon/FSCommands.h
+++ b/src/mon/FSCommands.h
@@ -80,7 +80,7 @@ public:
     Monitor *mon,
     FSMap &fsmap,
     MonOpRequestRef op,
-    map<string, cmd_vartype> &cmdmap,
+    const cmdmap_t& cmdmap,
     std::stringstream &ss) = 0;
 };
 

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -382,7 +382,7 @@ bool LogMonitor::preprocess_command(MonOpRequestRef op)
   bufferlist rdata;
   stringstream ss;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     string rs = ss.str();
     mon->reply_command(op, -EINVAL, rs, get_last_committed());
@@ -479,7 +479,7 @@ bool LogMonitor::prepare_command(MonOpRequestRef op)
   string rs;
   int err = -EINVAL;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     // ss has reason for failure
     string rs = ss.str();

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -839,7 +839,7 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
   bufferlist rdata;
   stringstream ss, ds;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     // ss has reason for failure
     string rs = ss.str();
@@ -1167,7 +1167,7 @@ bool MDSMonitor::prepare_command(MonOpRequestRef op)
   stringstream ss;
   bufferlist rdata;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     string rs = ss.str();
     mon->reply_command(op, -EINVAL, rs, rdata, get_last_committed());
@@ -1283,7 +1283,7 @@ int MDSMonitor::parse_role(
 int MDSMonitor::filesystem_command(
     MonOpRequestRef op,
     std::string const &prefix,
-    map<string, cmd_vartype> &cmdmap,
+    const cmdmap_t& cmdmap,
     std::stringstream &ss)
 {
   dout(4) << __func__ << " prefix='" << prefix << "'" << dendl;
@@ -1331,13 +1331,13 @@ int MDSMonitor::filesystem_command(
     mds_gid_t gid;
     if (!cmd_getval(g_ceph_context, cmdmap, "gid", gid)) {
       ss << "error parsing 'gid' value '"
-         << cmd_vartype_stringify(cmdmap["gid"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("gid")) << "'";
       return -EINVAL;
     }
     MDSMap::DaemonState state;
     if (!cmd_getval(g_ceph_context, cmdmap, "state", state)) {
       ss << "error parsing 'state' string value '"
-         << cmd_vartype_stringify(cmdmap["state"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("state")) << "'";
       return -EINVAL;
     }
     if (pending_fsmap.gid_exists(gid)) {
@@ -1368,7 +1368,7 @@ int MDSMonitor::filesystem_command(
     mds_gid_t gid;
     if (!cmd_getval(g_ceph_context, cmdmap, "gid", gid)) {
       ss << "error parsing 'gid' value '"
-         << cmd_vartype_stringify(cmdmap["gid"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("gid")) << "'";
       return -EINVAL;
     }
     if (!pending_fsmap.gid_exists(gid)) {
@@ -1417,7 +1417,7 @@ int MDSMonitor::filesystem_command(
     int64_t f;
     if (!cmd_getval(g_ceph_context, cmdmap, "feature", f)) {
       ss << "error parsing feature value '"
-         << cmd_vartype_stringify(cmdmap["feature"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("feature")) << "'";
       return -EINVAL;
     }
     if (pending_fsmap.compat.compat.contains(f)) {
@@ -1433,7 +1433,7 @@ int MDSMonitor::filesystem_command(
     int64_t f;
     if (!cmd_getval(g_ceph_context, cmdmap, "feature", f)) {
       ss << "error parsing feature value '"
-         << cmd_vartype_stringify(cmdmap["feature"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("feature")) << "'";
       return -EINVAL;
     }
     if (pending_fsmap.compat.incompat.contains(f)) {

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -98,7 +98,7 @@ class MDSMonitor : public PaxosService {
   int filesystem_command(
       MonOpRequestRef op,
       std::string const &prefix,
-      map<string, cmd_vartype> &cmdmap,
+      const cmdmap_t& cmdmap,
       std::stringstream &ss);
 
   // beacons

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -666,7 +666,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
   std::stringstream ss;
   bufferlist rdata;
 
-  std::map<std::string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     string rs = ss.str();
     mon->reply_command(op, -EINVAL, rs, rdata, get_last_committed());
@@ -806,7 +806,7 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
   std::stringstream ss;
   bufferlist rdata;
 
-  std::map<std::string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     string rs = ss.str();
     mon->reply_command(op, -EINVAL, rs, rdata, get_last_committed());

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -665,18 +665,20 @@ public:
   void handle_subscribe(MonOpRequestRef op);
   void handle_mon_get_map(MonOpRequestRef op);
 
-  static void _generate_command_map(map<string,cmd_vartype>& cmdmap,
+  static void _generate_command_map(cmdmap_t& cmdmap,
                                     map<string,string> &param_str_map);
   static const MonCommand *_get_moncommand(
     const string &cmd_prefix,
     const vector<MonCommand>& cmds);
-  bool _allowed_command(MonSession *s, string &module, string &prefix,
-                        const map<string,cmd_vartype>& cmdmap,
+  bool _allowed_command(MonSession *s, const string& module,
+			const string& prefix,
+                        const cmdmap_t& cmdmap,
                         const map<string,string>& param_str_map,
                         const MonCommand *this_cmd);
   void get_mon_status(Formatter *f, ostream& ss);
   void _quorum_status(Formatter *f, ostream& ss);
-  bool _add_bootstrap_peer_hint(string cmd, cmdmap_t& cmdmap, ostream& ss);
+  bool _add_bootstrap_peer_hint(std::string_view cmd, const cmdmap_t& cmdmap,
+				std::ostream& ss);
   void handle_command(MonOpRequestRef op);
   void handle_route(MonOpRequestRef op);
 
@@ -944,8 +946,8 @@ public:
   int write_fsid();
   int write_fsid(MonitorDBStore::TransactionRef t);
 
-  void do_admin_command(std::string command, cmdmap_t& cmdmap,
-			std::string format, ostream& ss);
+  void do_admin_command(std::string_view command, const cmdmap_t& cmdmap,
+			std::string_view format, std::ostream& ss);
 
 private:
   // don't allow copying

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -230,7 +230,7 @@ bool MonmapMonitor::preprocess_command(MonOpRequestRef op)
   bufferlist rdata;
   stringstream ss;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     string rs = ss.str();
     mon->reply_command(op, -EINVAL, rs, rdata, get_last_committed());
@@ -422,7 +422,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
   string rs;
   int err = -EINVAL;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     string rs = ss.str();
     mon->reply_command(op, -EINVAL, rs, get_last_committed());

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3603,7 +3603,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   bufferlist rdata;
   stringstream ss, ds;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     string rs = ss.str();
     mon->reply_command(op, -EINVAL, rs, get_last_committed());
@@ -5895,7 +5895,7 @@ bool OSDMonitor::prepare_unset_flag(MonOpRequestRef op, int flag)
   return true;
 }
 
-int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
+int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
                                          stringstream& ss)
 {
   string poolstr;
@@ -6382,7 +6382,7 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
 }
 
 int OSDMonitor::prepare_command_pool_application(const string &prefix,
-                                                 map<string,cmd_vartype> &cmdmap,
+                                                 const cmdmap_t& cmdmap,
                                                  stringstream& ss)
 {
   string pool_name;
@@ -6809,7 +6809,7 @@ int OSDMonitor::prepare_command_osd_create(
 
 int OSDMonitor::prepare_command_osd_new(
     MonOpRequestRef op,
-    const map<string,cmd_vartype>& cmdmap,
+    const cmdmap_t& cmdmap,
     const map<string,string>& params,
     stringstream &ss,
     Formatter *f)
@@ -7074,7 +7074,7 @@ bool OSDMonitor::prepare_command(MonOpRequestRef op)
   op->mark_osdmon_event(__func__);
   MMonCommand *m = static_cast<MMonCommand*>(op->get_req());
   stringstream ss;
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
     string rs = ss.str();
     mon->reply_command(op, -EINVAL, rs, get_last_committed());
@@ -7091,7 +7091,7 @@ bool OSDMonitor::prepare_command(MonOpRequestRef op)
 }
 
 static int parse_reweights(CephContext *cct,
-			   const map<string,cmd_vartype> &cmdmap,
+			   const cmdmap_t& cmdmap,
 			   const OSDMap& osdmap,
 			   map<int32_t, uint32_t>* weights)
 {
@@ -7268,7 +7268,7 @@ int OSDMonitor::prepare_command_osd_purge(
 }
 
 bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
-				      map<string,cmd_vartype> &cmdmap)
+				      const cmdmap_t& cmdmap)
 {
   op->mark_osdmon_event(__func__);
   MMonCommand *m = static_cast<MMonCommand*>(op->get_req());
@@ -7846,7 +7846,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     double weight;
     if (!cmd_getval(cct, cmdmap, "weight", weight)) {
       ss << "unable to parse weight value '"
-         << cmd_vartype_stringify(cmdmap["weight"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("weight")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -7915,7 +7915,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       double weight;
       if (!cmd_getval(cct, cmdmap, "weight", weight)) {
         ss << "unable to parse weight value '"
-           << cmd_vartype_stringify(cmdmap["weight"]) << "'";
+           << cmd_vartype_stringify(cmdmap.at("weight")) << "'";
         err = -EINVAL;
         goto reply;
       }
@@ -8191,7 +8191,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     double w;
     if (!cmd_getval(cct, cmdmap, "weight", w)) {
       ss << "unable to parse weight value '"
-	 << cmd_vartype_stringify(cmdmap["weight"]) << "'";
+	 << cmd_vartype_stringify(cmdmap.at("weight")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -8229,7 +8229,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     double w;
     if (!cmd_getval(cct, cmdmap, "weight", w)) {
       ss << "unable to parse weight value '"
-	 << cmd_vartype_stringify(cmdmap["weight"]) << "'";
+	 << cmd_vartype_stringify(cmdmap.at("weight")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -8295,7 +8295,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     int64_t value = -1;
     if (!cmd_getval(cct, cmdmap, "value", value)) {
       err = -EINVAL;
-      ss << "failed to parse integer value " << cmd_vartype_stringify(cmdmap["value"]);
+      ss << "failed to parse integer value "
+	 << cmd_vartype_stringify(cmdmap.at("value"));
       goto reply;
     }
 
@@ -8648,7 +8649,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     int64_t newmax;
     if (!cmd_getval(cct, cmdmap, "newmax", newmax)) {
       ss << "unable to parse 'newmax' value '"
-         << cmd_vartype_stringify(cmdmap["newmax"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("newmax")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -8690,7 +8691,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     double n;
     if (!cmd_getval(cct, cmdmap, "ratio", n)) {
       ss << "unable to parse 'ratio' value '"
-         << cmd_vartype_stringify(cmdmap["ratio"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("ratio")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -9393,7 +9394,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     string pgidstr;
     if (!cmd_getval(cct, cmdmap, "pgid", pgidstr)) {
       ss << "unable to parse 'pgid' value '"
-         << cmd_vartype_stringify(cmdmap["pgid"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("pgid")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -9455,7 +9456,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     string pgidstr;
     if (!cmd_getval(cct, cmdmap, "pgid", pgidstr)) {
       ss << "unable to parse 'pgid' value '"
-         << cmd_vartype_stringify(cmdmap["pgid"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("pgid")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -9474,7 +9475,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     int64_t osd;
     if (!cmd_getval(cct, cmdmap, "id", osd)) {
       ss << "unable to parse 'id' value '"
-         << cmd_vartype_stringify(cmdmap["id"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("id")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -9517,7 +9518,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     string pgidstr;
     if (!cmd_getval(cct, cmdmap, "pgid", pgidstr)) {
       ss << "unable to parse 'pgid' value '"
-         << cmd_vartype_stringify(cmdmap["pgid"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("pgid")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -9584,7 +9585,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
         vector<int64_t> id_vec;
         if (!cmd_getval(cct, cmdmap, "id", id_vec)) {
           ss << "unable to parse 'id' value(s) '"
-             << cmd_vartype_stringify(cmdmap["id"]) << "'";
+             << cmd_vartype_stringify(cmdmap.at("id")) << "'";
           err = -EINVAL;
           goto reply;
         }
@@ -9644,7 +9645,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
         vector<int64_t> id_vec;
         if (!cmd_getval(cct, cmdmap, "id", id_vec)) {
           ss << "unable to parse 'id' value(s) '"
-             << cmd_vartype_stringify(cmdmap["id"]) << "'";
+             << cmd_vartype_stringify(cmdmap.at("id")) << "'";
           err = -EINVAL;
           goto reply;
         }
@@ -9726,14 +9727,14 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     int64_t id;
     if (!cmd_getval(cct, cmdmap, "id", id)) {
       ss << "invalid osd id value '"
-         << cmd_vartype_stringify(cmdmap["id"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("id")) << "'";
       err = -EINVAL;
       goto reply;
     }
     double w;
     if (!cmd_getval(cct, cmdmap, "weight", w)) {
       ss << "unable to parse 'weight' value '"
-           << cmd_vartype_stringify(cmdmap["weight"]) << "'";
+	 << cmd_vartype_stringify(cmdmap.at("weight")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -9767,14 +9768,14 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     int64_t id;
     if (!cmd_getval(cct, cmdmap, "id", id)) {
       ss << "unable to parse osd id value '"
-         << cmd_vartype_stringify(cmdmap["id"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("id")) << "'";
       err = -EINVAL;
       goto reply;
     }
     double w;
     if (!cmd_getval(cct, cmdmap, "weight", w)) {
       ss << "unable to parse weight value '"
-         << cmd_vartype_stringify(cmdmap["weight"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("weight")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -9801,7 +9802,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     err = parse_reweights(cct, cmdmap, osdmap, &weights);
     if (err) {
       ss << "unable to parse 'weights' value '"
-         << cmd_vartype_stringify(cmdmap["weights"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("weights")) << "'";
       goto reply;
     }
     pending_inc.new_weight.insert(weights.begin(), weights.end());
@@ -9813,7 +9814,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     int64_t id;
     if (!cmd_getval(cct, cmdmap, "id", id)) {
       ss << "unable to parse osd id value '"
-         << cmd_vartype_stringify(cmdmap["id"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("id")) << "'";
       err = -EINVAL;
       goto reply;
     }
@@ -9865,7 +9866,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     int64_t id;
     if (!cmd_getval(cct, cmdmap, "id", id)) {
       ss << "unable to parse osd id value '"
-         << cmd_vartype_stringify(cmdmap["id"]) << "";
+         << cmd_vartype_stringify(cmdmap.at("id")) << "";
       err = -EINVAL;
       goto reply;
     }
@@ -10842,7 +10843,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     int64_t size = 0;
     if (!cmd_getval(cct, cmdmap, "size", size)) {
       ss << "unable to parse 'size' value '"
-         << cmd_vartype_stringify(cmdmap["size"]) << "'";
+         << cmd_vartype_stringify(cmdmap.at("size")) << "'";
       err = -EINVAL;
       goto reply;
     }

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -484,7 +484,7 @@ public:
 
   bool preprocess_command(MonOpRequestRef op);
   bool prepare_command(MonOpRequestRef op);
-  bool prepare_command_impl(MonOpRequestRef op, map<string,cmd_vartype>& cmdmap);
+  bool prepare_command_impl(MonOpRequestRef op, const cmdmap_t& cmdmap);
 
   int validate_osd_create(
       const int32_t id,
@@ -518,15 +518,15 @@ public:
   int prepare_command_osd_remove(int32_t id);
   int prepare_command_osd_new(
       MonOpRequestRef op,
-      const map<string,cmd_vartype>& cmdmap,
+      const cmdmap_t& cmdmap,
       const map<string,string>& secrets,
       stringstream &ss,
       Formatter *f);
 
-  int prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
+  int prepare_command_pool_set(const cmdmap_t& cmdmap,
                                stringstream& ss);
   int prepare_command_pool_application(const string &prefix,
-                                       map<string,cmd_vartype> &cmdmap,
+                                       const cmdmap_t& cmdmap,
                                        stringstream& ss);
 
   bool handle_osd_timeouts(const utime_t &now,

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2925,7 +2925,7 @@ void PGMap::get_health_checks(
 
 int process_pg_map_command(
   const string& orig_prefix,
-  const map<string,cmd_vartype>& orig_cmdmap,
+  const cmdmap_t& orig_cmdmap,
   const PGMap& pg_map,
   const OSDMap& osdmap,
   Formatter *f,
@@ -2933,7 +2933,7 @@ int process_pg_map_command(
   bufferlist *odata)
 {
   string prefix = orig_prefix;
-  map<string,cmd_vartype> cmdmap = orig_cmdmap;
+  auto cmdmap = orig_cmdmap;
 
   // perhaps these would be better in the parsing, but it's weird
   bool primary = false;

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -453,7 +453,7 @@ inline ostream& operator<<(ostream& out, const PGMapDigest& m) {
 
 int process_pg_map_command(
   const string& prefix,
-  const map<string,cmd_vartype>& cmdmap,
+  const cmdmap_t& cmdmap,
   const PGMap& pg_map,
   const OSDMap& osdmap,
   Formatter *f,

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1815,7 +1815,7 @@ void OSDService::_queue_for_recovery(
 namespace ceph { 
 namespace osd_cmds { 
 
-int heap(CephContext& cct, cmdmap_t& cmdmap, Formatter& f, std::ostream& os);
+int heap(CephContext& cct, const cmdmap_t& cmdmap, Formatter& f, std::ostream& os);
  
 }} // namespace ceph::osd_cmds
 
@@ -2149,8 +2149,8 @@ class OSDSocketHook : public AdminSocketHook {
   OSD *osd;
 public:
   explicit OSDSocketHook(OSD *o) : osd(o) {}
-  bool call(std::string admin_command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override {
+  bool call(std::string_view admin_command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override {
     stringstream ss;
     bool r = osd->asok_command(admin_command, cmdmap, format, ss);
     out.append(ss);
@@ -2166,8 +2166,8 @@ std::set<int> OSD::get_mapped_pools() {
     return pools;
 }
 
-bool OSD::asok_command(string admin_command, cmdmap_t& cmdmap, string format,
-		       ostream& ss)
+bool OSD::asok_command(std::string_view admin_command, const cmdmap_t& cmdmap,
+		       std::string_view format, ostream& ss)
 {
   Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
   if (admin_command == "status") {
@@ -2404,15 +2404,15 @@ class TestOpsSocketHook : public AdminSocketHook {
   ObjectStore *store;
 public:
   TestOpsSocketHook(OSDService *s, ObjectStore *st) : service(s), store(st) {}
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override {
     stringstream ss;
     test_ops(service, store, command, cmdmap, ss);
     out.append(ss);
     return true;
   }
   void test_ops(OSDService *service, ObjectStore *store,
-		const std::string &command, cmdmap_t& cmdmap, ostream &ss);
+		std::string_view command, const cmdmap_t& cmdmap, ostream &ss);
 
 };
 
@@ -5035,7 +5035,8 @@ void OSD::tick_without_osd_lock()
 //
 //   set_recovery_delay [utime]
 void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
-     const std::string &command, cmdmap_t& cmdmap, ostream &ss)
+				 std::string_view command,
+				 const cmdmap_t& cmdmap, ostream &ss)
 {
   //Test support
   //Support changing the omap on a single osd by using the Admin Socket to
@@ -5900,7 +5901,7 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
 
   dout(20) << "do_command tid " << tid << " " << cmd << dendl;
 
-  map<string, cmd_vartype> cmdmap;
+  cmdmap_t cmdmap;
   string prefix;
   string format;
   string pgidstr;
@@ -9929,7 +9930,8 @@ void OSD::ShardedOpWQ::_enqueue_front(OpQueueItem&& item)
 namespace ceph { 
 namespace osd_cmds { 
 
-int heap(CephContext& cct, cmdmap_t& cmdmap, Formatter& f, std::ostream& os)
+int heap(CephContext& cct, const cmdmap_t& cmdmap, Formatter& f,
+	 std::ostream& os)
 {
   if (!ceph_using_tcmalloc()) {
         os << "could not issue heap profiler command -- not using tcmalloc!";

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1162,7 +1162,8 @@ protected:
   // asok
   friend class OSDSocketHook;
   class OSDSocketHook *asok_hook;
-  bool asok_command(string admin_command, cmdmap_t& cmdmap, string format, ostream& ss);
+  bool asok_command(std::string_view admin_command, const cmdmap_t& cmdmap,
+		    std::string_view format, std::ostream& ss);
 
 public:
   ClassHandler  *class_handler = nullptr;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -159,8 +159,8 @@ class Objecter::RequestStateHook : public AdminSocketHook {
   Objecter *m_objecter;
 public:
   explicit RequestStateHook(Objecter *objecter);
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-            bufferlist& out) override;
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override;
 };
 
 /**
@@ -4717,8 +4717,10 @@ Objecter::RequestStateHook::RequestStateHook(Objecter *objecter) :
 {
 }
 
-bool Objecter::RequestStateHook::call(std::string command, cmdmap_t& cmdmap,
-				      std::string format, bufferlist& out)
+bool Objecter::RequestStateHook::call(std::string_view command,
+				      const cmdmap_t& cmdmap,
+				      std::string_view format,
+				      bufferlist& out)
 {
   Formatter *f = Formatter::create(format, "json-pretty", "json-pretty");
   shared_lock rl(m_objecter->rwlock);

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -711,8 +711,10 @@ int RGWCoroutinesManagerRegistry::hook_to_admin_command(const string& command)
   return 0;
 }
 
-bool RGWCoroutinesManagerRegistry::call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) {
+bool RGWCoroutinesManagerRegistry::call(std::string_view command,
+                                        const cmdmap_t& cmdmap,
+                                        std::string_view format,
+                                        bufferlist& out) {
   RWLock::RLocker rl(lock);
   stringstream ss;
   JSONFormatter f;

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_RGW_COROUTINE_H
 #define CEPH_RGW_COROUTINE_H
 
@@ -500,9 +503,9 @@ public:
   void remove(RGWCoroutinesManager *mgr);
 
   int hook_to_admin_command(const string& command);
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override;
-    
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+            std::string_view format, bufferlist& out) override;
+
   void dump(Formatter *f) const;
 };
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -14046,8 +14046,8 @@ int rgw_compression_info_from_attrset(map<string, bufferlist>& attrs, bool& need
   }
 }
 
-bool RGWRados::call(std::string command, cmdmap_t& cmdmap, std::string format,
-                    bufferlist& out)
+bool RGWRados::call(std::string_view command, const cmdmap_t& cmdmap,
+		    std::string_view format, bufferlist& out)
 {
   if (command == "cache list"sv) {
     std::optional<std::string> filter;
@@ -14068,7 +14068,7 @@ bool RGWRados::call(std::string command, cmdmap_t& cmdmap, std::string format,
   } else if (command == "cache inspect"sv) {
     std::unique_ptr<Formatter> f(ceph::Formatter::create(format, "json-pretty"));
     if (f) {
-      const auto& target = boost::get<std::string>(cmdmap["target"]);
+      const auto& target = boost::get<std::string>(cmdmap.at("target"));
       if (call_inspect(target, f.get())) {
         f->flush(out);
         return true;
@@ -14081,7 +14081,7 @@ bool RGWRados::call(std::string command, cmdmap_t& cmdmap, std::string format,
       return false;
     }
   } else if (command == "cache erase"sv) {
-    const auto& target = boost::get<std::string>(cmdmap["target"]);
+    const auto& target = boost::get<std::string>(cmdmap.at("target"));
     if (call_erase(target)) {
       return true;
     } else {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3449,7 +3449,8 @@ private:
 		       boost::optional<obj_version> refresh_version);
 public:
 
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format,
 	    bufferlist& out) override final;
 
 protected:

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -193,8 +193,8 @@ string RGWSyncTraceManager::get_active_names()
   return ss.str();
 }
 
-bool RGWSyncTraceManager::call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) {
+bool RGWSyncTraceManager::call(std::string_view command, const cmdmap_t& cmdmap,
+                               std::string_view format, bufferlist& out) {
 
   bool show_history = (command == "sync trace history");
   bool show_short = (command == "sync trace active_short");

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 #ifndef CEPH_RGW_SYNC_LOG_H
 #define CEPH_RGW_SYNC_LOG_H
 
@@ -129,7 +131,8 @@ public:
   void finish_node(RGWSyncTraceNode *node);
 
   int hook_to_admin_command();
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format, bufferlist& out);
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+            std::string_view format, bufferlist& out) override;
   string get_active_names();
 };
 

--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -115,7 +115,8 @@ TEST(AdminSocket, SendTooLongRequest) {
 }
 
 class MyTest : public AdminSocketHook {
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format, bufferlist& result) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& result) override {
     std::vector<std::string> args;
     cmd_getval(g_ceph_context, cmdmap, "args", args);
     result.append(command);
@@ -147,7 +148,8 @@ TEST(AdminSocket, RegisterCommand) {
 }
 
 class MyTest2 : public AdminSocketHook {
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format, bufferlist& result) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& result) override {
     std::vector<std::string> args;
     cmd_getval(g_ceph_context, cmdmap, "args", args);
     result.append(command);
@@ -200,7 +202,8 @@ public:
 
   BlockingHook() : _lock("BlockingHook::_lock") {}
 
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format, bufferlist& result) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& result) override {
     Mutex::Locker l(_lock);
     _cond.Wait(_lock);
     return true;

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -366,7 +366,7 @@ TEST(ZlibCompressor, zlib_isal_compatibility)
   res = zlib->decompress(out, after);
   EXPECT_EQ(res, 0);
   bufferlist exp;
-  exp.append(test);
+  exp.append(static_cast<char*>(test));
   EXPECT_TRUE(exp.contents_equal(after));
   after.clear();
   out.clear();
@@ -376,7 +376,7 @@ TEST(ZlibCompressor, zlib_isal_compatibility)
   EXPECT_EQ(res, 0);
   res = isal->decompress(out, after);
   EXPECT_EQ(res, 0);
-  exp.append(test);
+  exp.append(static_cast<char*>(test));
   EXPECT_TRUE(exp.contents_equal(after));
 }
 #endif

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -103,8 +103,8 @@ public:
     }
   }
 
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override {
     Commands::const_iterator i = commands.find(command);
     assert(i != commands.end());
     Formatter *f = Formatter::create(format);
@@ -116,7 +116,8 @@ public:
   }
 
 private:
-  typedef std::map<std::string, ImageDeleterAdminSocketCommand*> Commands;
+  typedef std::map<std::string, ImageDeleterAdminSocketCommand*,
+		   std::less<>> Commands;
   AdminSocket *admin_socket;
   Commands commands;
 };

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -200,8 +200,8 @@ public:
     commands.clear();
   }
 
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override {
     auto i = commands.find(command);
     assert(i != commands.end());
     Formatter *f = Formatter::create(format);
@@ -213,7 +213,8 @@ public:
   }
 
 private:
-  typedef std::map<std::string, ImageReplayerAdminSocketCommand<I> *> Commands;
+  typedef std::map<std::string, ImageReplayerAdminSocketCommand<I>*,
+		   std::less<>> Commands;
 
   AdminSocket *admin_socket;
   Commands commands;

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -178,8 +178,8 @@ public:
     }
   }
 
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override {
     Commands::const_iterator i = commands.find(command);
     assert(i != commands.end());
     Formatter *f = Formatter::create(format);
@@ -191,7 +191,7 @@ public:
   }
 
 private:
-  typedef std::map<std::string, MirrorAdminSocketCommand*> Commands;
+  typedef std::map<std::string, MirrorAdminSocketCommand*, std::less<>> Commands;
 
   AdminSocket *admin_socket;
   Commands commands;

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -192,8 +192,8 @@ public:
     }
   }
 
-  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	    bufferlist& out) override {
+  bool call(std::string_view command, const cmdmap_t& cmdmap,
+	    std::string_view format, bufferlist& out) override {
     Commands::const_iterator i = commands.find(command);
     assert(i != commands.end());
     Formatter *f = Formatter::create(format);
@@ -205,7 +205,8 @@ public:
   }
 
 private:
-  typedef std::map<std::string, PoolReplayerAdminSocketCommand*> Commands;
+  typedef std::map<std::string, PoolReplayerAdminSocketCommand*,
+		   std::less<>> Commands;
 
   AdminSocket *admin_socket;
   Commands commands;


### PR DESCRIPTION
Generally clean up the admin socket.

Most importantly, stop passing strings by value all over the place.

Cut resource use.

Also fix a few hidden bugs.