### PR TITLE
ceph_test_filestore_idempotent_sequence: many fixes

### DIFF
--- a/qa/tasks/filestore_idempotent.py
+++ b/qa/tasks/filestore_idempotent.py
@@ -38,7 +38,9 @@ def task(ctx, config):
 
     dir = '%s/ceph.data/test.%s' % (testdir, client)
 
-    seed = str(int(random.uniform(1,100)))
+    seed = int(random.uniform(1,100))
+    start = 800 + random.randint(800,1200)
+    end = start + 150
 
     try:
         log.info('creating a working dir')
@@ -61,7 +63,7 @@ def task(ctx, config):
             args=[
                 'cd', dir,
                 run.Raw('&&'),
-                './run_seed_to_range.sh', seed, '50', '300',
+                './run_seed_to_range.sh', str(seed), str(start), str(end),
                 ],
             wait=False,
             check_status=False)

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2999,7 +2999,8 @@ void FileStore::_do_transaction(
         const coll_t &cid = !_need_temp_object_collection(_cid, oid) ?
           _cid : _cid.get_temp();
         tracepoint(objectstore, omap_clear_enter, osr_name);
-        r = _omap_clear(cid, oid, spos);
+        if (_check_replay_guard(cid, oid, spos) > 0)
+	  r = _omap_clear(cid, oid, spos);
         tracepoint(objectstore, omap_clear_exit, r);
       }
       break;
@@ -3012,7 +3013,8 @@ void FileStore::_do_transaction(
         map<string, bufferlist> aset;
         i.decode_attrset(aset);
         tracepoint(objectstore, omap_setkeys_enter, osr_name);
-        r = _omap_setkeys(cid, oid, aset, spos);
+        if (_check_replay_guard(cid, oid, spos) > 0)
+	  r = _omap_setkeys(cid, oid, aset, spos);
         tracepoint(objectstore, omap_setkeys_exit, r);
       }
       break;
@@ -3025,7 +3027,8 @@ void FileStore::_do_transaction(
         set<string> keys;
         i.decode_keyset(keys);
         tracepoint(objectstore, omap_rmkeys_enter, osr_name);
-        r = _omap_rmkeys(cid, oid, keys, spos);
+        if (_check_replay_guard(cid, oid, spos) > 0)
+	  r = _omap_rmkeys(cid, oid, keys, spos);
         tracepoint(objectstore, omap_rmkeys_exit, r);
       }
       break;
@@ -3039,7 +3042,8 @@ void FileStore::_do_transaction(
         first = i.decode_string();
         last = i.decode_string();
         tracepoint(objectstore, omap_rmkeyrange_enter, osr_name);
-        r = _omap_rmkeyrange(cid, oid, first, last, spos);
+        if (_check_replay_guard(cid, oid, spos) > 0)
+	  r = _omap_rmkeyrange(cid, oid, first, last, spos);
         tracepoint(objectstore, omap_rmkeyrange_exit, r);
       }
       break;
@@ -3052,7 +3056,8 @@ void FileStore::_do_transaction(
         bufferlist bl;
         i.decode_bl(bl);
         tracepoint(objectstore, omap_setheader_enter, osr_name);
-        r = _omap_setheader(cid, oid, bl, spos);
+        if (_check_replay_guard(cid, oid, spos) > 0)
+	  r = _omap_setheader(cid, oid, bl, spos);
         tracepoint(objectstore, omap_setheader_exit, r);
       }
       break;

--- a/src/test/objectstore/DeterministicOpSequence.cc
+++ b/src/test/objectstore/DeterministicOpSequence.cc
@@ -167,7 +167,7 @@ bool DeterministicOpSequence::do_touch(rngen_t& gen)
 
   dout(0) << "do_touch " << entry->m_coll << "/" << obj << dendl;
 
-  _do_touch(entry->m_coll, *obj);
+  _do_touch(entry, *obj);
   return true;
 }
 
@@ -188,7 +188,7 @@ bool DeterministicOpSequence::do_remove(rngen_t& gen)
 
   dout(0) << "do_remove " << entry->m_coll << "/" << obj << dendl;
 
-  _do_remove(entry->m_coll, *obj);
+  _do_remove(entry, *obj);
   hobject_t *rmobj = entry->remove_obj(obj_id);
   ceph_assert(rmobj);
   delete rmobj;
@@ -246,7 +246,7 @@ bool DeterministicOpSequence::do_set_attrs(rngen_t& gen)
   gen_attrs(gen, &out);
 
   dout(0) << "do_set_attrs " << out.size() << " entries" << dendl;
-  _do_set_attrs(entry->m_coll, *obj, out);
+  _do_set_attrs(entry, *obj, out);
   return true;
 }
 
@@ -273,7 +273,7 @@ bool DeterministicOpSequence::do_write(rngen_t& gen)
   dout(0) << "do_write " << entry->m_coll << "/" << obj
 	  << " 0~" << size << dendl;
 
-  _do_write(entry->m_coll, *obj, 0, bl.length(), bl);
+  _do_write(entry, *obj, 0, bl.length(), bl);
   return true;
 }
 
@@ -324,7 +324,7 @@ bool DeterministicOpSequence::do_clone(rngen_t& gen)
   dout(0) << "do_clone " << entry->m_coll << "/" << orig_obj
       << " => " << entry->m_coll << "/" << new_obj << dendl;
 
-  _do_clone(entry->m_coll, orig_obj, new_obj);
+  _do_clone(entry, orig_obj, new_obj);
   return true;
 }
 
@@ -356,7 +356,7 @@ bool DeterministicOpSequence::do_clone_range(rngen_t& gen)
       << " (0~" << size << ")"
       << " => " << entry->m_coll << "/" << new_obj
       << " (0)" << dendl;
-  _do_write_and_clone_range(entry->m_coll, orig_obj, new_obj, 0, size, 0, bl);
+  _do_write_and_clone_range(entry, orig_obj, new_obj, 0, size, 0, bl);
   return true;
 }
 
@@ -373,7 +373,7 @@ bool DeterministicOpSequence::do_coll_move(rngen_t& gen)
         << " => " << entry->m_coll << "/" << new_obj << dendl;
   entry->remove_obj(orig_id);
 
-  _do_coll_move(entry->m_coll, orig_obj, new_obj);
+  _do_coll_move(entry, orig_obj, new_obj);
 
   return true;
 }
@@ -385,82 +385,83 @@ bool DeterministicOpSequence::do_coll_create(rngen_t& gen)
   m_collections.insert(make_pair(i, entry));
   m_collections_ids.push_back(i);
 
-  _do_coll_create(entry->m_coll, 10, 10);
+  _do_coll_create(entry, 10, 10);
   
   return true;
 }
 
-void DeterministicOpSequence::_do_coll_create(coll_t cid, uint32_t pg_num, uint64_t num_objs)
+void DeterministicOpSequence::_do_coll_create(coll_entry_t *entry, uint32_t pg_num, uint64_t num_objs)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.create_collection(cid, 32);
+  t.create_collection(entry->m_coll, 32);
   bufferlist hint;
   encode(pg_num, hint);
   encode(num_objs, hint);
-  t.collection_hint(cid, ObjectStore::Transaction::COLL_HINT_EXPECTED_NUM_OBJECTS, hint);
-  dout(0) << "Give collection: " << cid << " a hint, pg_num is: " << pg_num << ", num_objs is: "
-    << num_objs << dendl;
+  t.collection_hint(entry->m_coll, ObjectStore::Transaction::COLL_HINT_EXPECTED_NUM_OBJECTS, hint);
+  dout(0) << "Give collection: " << entry->m_coll
+	  << " a hint, pg_num is: " << pg_num << ", num_objs is: "
+	  << num_objs << dendl;
 
   m_store->apply_transaction(&m_osr, std::move(t));
 }
 
-void DeterministicOpSequence::_do_touch(coll_t coll, hobject_t& obj)
+void DeterministicOpSequence::_do_touch(coll_entry_t *entry, hobject_t& obj)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.touch(coll, ghobject_t(obj));
+  t.touch(entry->m_coll, ghobject_t(obj));
   m_store->apply_transaction(&m_osr, std::move(t));
 }
 
-void DeterministicOpSequence::_do_remove(coll_t coll, hobject_t& obj)
+void DeterministicOpSequence::_do_remove(coll_entry_t *entry, hobject_t& obj)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.remove(coll, ghobject_t(obj));
+  t.remove(entry->m_coll, ghobject_t(obj));
   m_store->apply_transaction(&m_osr, std::move(t));
 }
 
-void DeterministicOpSequence::_do_set_attrs(coll_t coll,
+void DeterministicOpSequence::_do_set_attrs(coll_entry_t *entry,
 					    hobject_t &obj,
 					    const map<string, bufferlist> &attrs)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.omap_setkeys(coll, ghobject_t(obj), attrs);
+  t.omap_setkeys(entry->m_coll, ghobject_t(obj), attrs);
   m_store->apply_transaction(&m_osr, std::move(t));
 }
 
-void DeterministicOpSequence::_do_write(coll_t coll, hobject_t& obj,
+void DeterministicOpSequence::_do_write(coll_entry_t *entry, hobject_t& obj,
 					uint64_t off, uint64_t len, const bufferlist& data)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.write(coll, ghobject_t(obj), off, len, data);
+  t.write(entry->m_coll, ghobject_t(obj), off, len, data);
   m_store->apply_transaction(&m_osr, std::move(t));
 }
 
-void DeterministicOpSequence::_do_clone(coll_t coll, hobject_t& orig_obj,
+void DeterministicOpSequence::_do_clone(coll_entry_t *entry, hobject_t& orig_obj,
 					hobject_t& new_obj)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.clone(coll, ghobject_t(orig_obj), ghobject_t(new_obj));
+  t.clone(entry->m_coll, ghobject_t(orig_obj), ghobject_t(new_obj));
   m_store->apply_transaction(&m_osr, std::move(t));
 }
 
-void DeterministicOpSequence::_do_clone_range(coll_t coll,
+void DeterministicOpSequence::_do_clone_range(coll_entry_t *entry,
 					      hobject_t& orig_obj, hobject_t& new_obj, uint64_t srcoff,
 					      uint64_t srclen, uint64_t dstoff)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.clone_range(coll, ghobject_t(orig_obj), ghobject_t(new_obj),
+  t.clone_range(entry->m_coll, ghobject_t(orig_obj), ghobject_t(new_obj),
 		srcoff, srclen, dstoff);
   m_store->apply_transaction(&m_osr, std::move(t));
 }
 
-void DeterministicOpSequence::_do_write_and_clone_range(coll_t coll,
+void DeterministicOpSequence::_do_write_and_clone_range(coll_entry_t *entry,
                                                         hobject_t& orig_obj,
                                                         hobject_t& new_obj,
                                                         uint64_t srcoff,
@@ -470,21 +471,21 @@ void DeterministicOpSequence::_do_write_and_clone_range(coll_t coll,
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.write(coll, ghobject_t(orig_obj), srcoff, bl.length(), bl);
-  t.clone_range(coll, ghobject_t(orig_obj), ghobject_t(new_obj),
+  t.write(entry->m_coll, ghobject_t(orig_obj), srcoff, bl.length(), bl);
+  t.clone_range(entry->m_coll, ghobject_t(orig_obj), ghobject_t(new_obj),
 		srcoff, srclen, dstoff);
   m_store->apply_transaction(&m_osr, std::move(t));
 }
 
-void DeterministicOpSequence::_do_coll_move(coll_t coll,
+void DeterministicOpSequence::_do_coll_move(coll_entry_t *entry,
 					    hobject_t& orig_obj,
 					    hobject_t& new_obj)
 {
   ObjectStore::Transaction t;
   note_txn(&t);
-  t.remove(coll, ghobject_t(new_obj));
-  t.collection_move_rename(coll, ghobject_t(orig_obj),
-			   coll, ghobject_t(new_obj));
+  t.remove(entry->m_coll, ghobject_t(new_obj));
+  t.collection_move_rename(entry->m_coll, ghobject_t(orig_obj),
+			   entry->m_coll, ghobject_t(new_obj));
   m_store->apply_transaction(&m_osr, std::move(t));
 }
 

--- a/src/test/objectstore/DeterministicOpSequence.cc
+++ b/src/test/objectstore/DeterministicOpSequence.cc
@@ -420,26 +420,13 @@ bool DeterministicOpSequence::do_coll_move(rngen_t& gen)
 
 bool DeterministicOpSequence::do_coll_create(rngen_t& gen)
 {
-  boost::uniform_int<> pg_num_range(0, 512);
-  int pg_num = pg_num_range(gen);
+  int i = m_collections.size();
+  coll_entry_t *entry = coll_create(i);
+  m_collections.insert(make_pair(i, entry));
+  m_collections_ids.push_back(i);
 
-  // Assume there is 7 OSDs in total, the PGs are evenly distributed across those OSDs
-  int pgs = pg_num / 7;
-
-  boost::uniform_int<> num_objs_range(1, 1024);
-  int num_objs = num_objs_range(gen);
-
-  int pool_id = get_next_pool_id();
-  std::set<int> pg_created;
-  for (int i = 0; i < pgs; i++) {
-    boost::uniform_int<> pg_range(0, pg_num - 1);
-    int pg_id = pg_range(gen);
-    if (pg_created.count(pg_id) > 0)
-      continue;
-    _do_coll_create(coll_t(spg_t(pg_t(pg_id,pool_id),shard_id_t::NO_SHARD)),
-		    (uint32_t) pg_num, (uint64_t) num_objs);
-    pg_created.insert(pg_id);
-  }
+  _do_coll_create(entry->m_coll, 10, 10);
+  
   return true;
 }
 

--- a/src/test/objectstore/DeterministicOpSequence.cc
+++ b/src/test/objectstore/DeterministicOpSequence.cc
@@ -285,7 +285,7 @@ bool DeterministicOpSequence::_prepare_clone(rngen_t& gen,
   coll_entry_t *entry = get_coll_at(coll_id);
   ceph_assert(entry != NULL);
 
-  if (entry->m_objects.size() >= 2) {
+  if (entry->m_objects.size() < 2) {
     dout(0) << "_prepare_clone coll " << entry->m_coll.to_str()
 	    << " doesn't have 2 or more objects" << dendl;
     return false;

--- a/src/test/objectstore/DeterministicOpSequence.cc
+++ b/src/test/objectstore/DeterministicOpSequence.cc
@@ -81,6 +81,7 @@ bool DeterministicOpSequence::run_one_op(int op, rngen_t& gen)
     break;
 
   default:
+    cout << "bad op " << op << std::endl;
     assert(0 == "bad op");
   }
   return ok;

--- a/src/test/objectstore/DeterministicOpSequence.h
+++ b/src/test/objectstore/DeterministicOpSequence.h
@@ -67,21 +67,21 @@ class DeterministicOpSequence : public TestObjectStoreState {
   bool do_set_attrs(rngen_t& gen);
   bool do_coll_create(rngen_t& gen);
 
-  virtual void _do_touch(coll_t coll, hobject_t& obj);
-  virtual void _do_remove(coll_t coll, hobject_t& obj);
-  virtual void _do_write(coll_t coll, hobject_t& obj, uint64_t off,
+  virtual void _do_touch(coll_entry_t *entry, hobject_t& obj);
+  virtual void _do_remove(coll_entry_t *entry, hobject_t& obj);
+  virtual void _do_write(coll_entry_t *entry, hobject_t& obj, uint64_t off,
       uint64_t len, const bufferlist& data);
-  virtual void _do_set_attrs(coll_t coll,
+  virtual void _do_set_attrs(coll_entry_t *entry,
 			     hobject_t &obj,
 			     const map<string, bufferlist> &attrs);
-  virtual void _do_clone(coll_t coll, hobject_t& orig_obj, hobject_t& new_obj);
-  virtual void _do_clone_range(coll_t coll, hobject_t& orig_obj,
+  virtual void _do_clone(coll_entry_t *entry, hobject_t& orig_obj, hobject_t& new_obj);
+  virtual void _do_clone_range(coll_entry_t *entry, hobject_t& orig_obj,
       hobject_t& new_obj, uint64_t srcoff, uint64_t srclen, uint64_t dstoff);
-  virtual void _do_write_and_clone_range(coll_t coll, hobject_t& orig_obj,
+  virtual void _do_write_and_clone_range(coll_entry_t *entry, hobject_t& orig_obj,
       hobject_t& new_obj, uint64_t srcoff, uint64_t srclen,
       uint64_t dstoff, bufferlist& bl);
-  virtual void _do_coll_move(coll_t cid, hobject_t& orig_obj, hobject_t& new_obj);
-  virtual void _do_coll_create(coll_t cid, uint32_t pg_num, uint64_t num_objs);
+  virtual void _do_coll_move(coll_entry_t *entry, hobject_t& orig_obj, hobject_t& new_obj);
+  virtual void _do_coll_create(coll_entry_t *entry, uint32_t pg_num, uint64_t num_objs);
 
   int _gen_coll_id(rngen_t& gen);
   int _gen_obj_id(rngen_t& gen);

--- a/src/test/objectstore/DeterministicOpSequence.h
+++ b/src/test/objectstore/DeterministicOpSequence.h
@@ -80,7 +80,7 @@ class DeterministicOpSequence : public TestObjectStoreState {
   virtual void _do_write_and_clone_range(coll_t coll, hobject_t& orig_obj,
       hobject_t& new_obj, uint64_t srcoff, uint64_t srclen,
       uint64_t dstoff, bufferlist& bl);
-  virtual void _do_coll_move(coll_t orig_coll, coll_t new_coll, hobject_t& obj);
+  virtual void _do_coll_move(coll_t cid, hobject_t& orig_obj, hobject_t& new_obj);
   virtual void _do_coll_create(coll_t cid, uint32_t pg_num, uint64_t num_objs);
 
   int _gen_coll_id(rngen_t& gen);
@@ -88,10 +88,13 @@ class DeterministicOpSequence : public TestObjectStoreState {
   void _print_status(int seq, int op);
 
  private:
-  bool _prepare_clone(rngen_t& gen, coll_t& coll_ret,
-      hobject_t& orig_obj_ret, hobject_t& new_obj_ret);
-  bool _prepare_colls(rngen_t& gen,
-      coll_entry_t* &orig_coll, coll_entry_t* &new_coll);
+  bool _prepare_clone(
+    rngen_t& gen,
+    coll_entry_t **entry_ret,
+    int *orig_obj_id,
+    hobject_t *orig_obj_ret,
+    int *new_obj_id,
+    hobject_t *new_obj_ret);
 };
 
 

--- a/src/test/objectstore/DeterministicOpSequence.h
+++ b/src/test/objectstore/DeterministicOpSequence.h
@@ -39,9 +39,9 @@ class DeterministicOpSequence : public TestObjectStoreState {
     DSOP_CLONE = 2,
     DSOP_CLONE_RANGE = 3,
     DSOP_OBJ_REMOVE = 4,
-    DSOP_COLL_MOVE = 6,
-    DSOP_SET_ATTRS = 7,
-    DSOP_COLL_CREATE = 8,
+    DSOP_COLL_MOVE = 5,
+    DSOP_SET_ATTRS = 6,
+    DSOP_COLL_CREATE = 7,
 
     DSOP_FIRST = DSOP_TOUCH,
     DSOP_LAST = DSOP_COLL_CREATE,

--- a/src/test/objectstore/FileStoreDiff.cc
+++ b/src/test/objectstore/FileStoreDiff.cc
@@ -51,14 +51,14 @@ bool FileStoreDiff::diff_attrs(std::map<std::string,bufferptr>& b,
   std::map<std::string, bufferptr>::iterator a_it = a.begin();
   for (; b_it != b.end(); ++b_it, ++a_it) {
     if (b_it->first != a_it->first) {
-      dout(0) << "diff_attrs name mismatch (verify: " << b_it->first
-          << ", store: " << a_it->first << ")" << dendl;
+      cout << "diff_attrs name mismatch (verify: " << b_it->first
+          << ", store: " << a_it->first << ")" << std::endl;
       ret = true;
       continue;
     }
 
     if (!b_it->second.cmp(a_it->second)) {
-      dout(0) << "diff_attrs contents mismatch on attr " << b_it->first << dendl;
+      cout << "diff_attrs contents mismatch on attr " << b_it->first << std::endl;
       ret = true;
       continue;
     }
@@ -73,15 +73,21 @@ static bool diff_omap(std::map<std::string,bufferlist>& b,
   std::map<std::string, bufferlist>::iterator b_it = b.begin();
   std::map<std::string, bufferlist>::iterator a_it = a.begin();
   for (; b_it != b.end(); ++b_it, ++a_it) {
+    if (a_it == a.end()) {
+      cout << __func__ << " a reached end before b, a missing " << b_it->first
+	   << std::endl;
+      ret = true;
+      break;
+    }
     if (b_it->first != a_it->first) {
-      dout(0) << "diff_attrs name mismatch (verify: " << b_it->first
-          << ", store: " << a_it->first << ")" << dendl;
+      cout << "diff_attrs name mismatch (verify: " << b_it->first
+          << ", store: " << a_it->first << ")" << std::endl;
       ret = true;
       continue;
     }
 
     if (!(b_it->second == a_it->second)) {
-      dout(0) << "diff_attrs contents mismatch on attr " << b_it->first << dendl;
+      cout << "diff_attrs contents mismatch on attr " << b_it->first << std::endl;
       ret = true;
       continue;
     }
@@ -94,32 +100,32 @@ bool FileStoreDiff::diff_objects_stat(struct stat& a, struct stat& b)
   bool ret = false;
 
   if (a.st_uid != b.st_uid) {
-    dout(0) << "diff_objects_stat uid mismatch (A: "
-        << a.st_uid << " != B: " << b.st_uid << ")" << dendl;
+    cout << "diff_objects_stat uid mismatch (A: "
+        << a.st_uid << " != B: " << b.st_uid << ")" << std::endl;
     ret = true;
   }
 
   if (a.st_gid != b.st_gid) {
-    dout(0) << "diff_objects_stat gid mismatch (A: "
-        << a.st_gid << " != B: " << b.st_gid << ")" << dendl;
+    cout << "diff_objects_stat gid mismatch (A: "
+        << a.st_gid << " != B: " << b.st_gid << ")" << std::endl;
     ret = true;
   }
 
   if (a.st_mode != b.st_mode) {
-    dout(0) << "diff_objects_stat mode mismatch (A: "
-        << a.st_mode << " != B: " << b.st_mode << ")" << dendl;
+    cout << "diff_objects_stat mode mismatch (A: "
+        << a.st_mode << " != B: " << b.st_mode << ")" << std::endl;
     ret = true;
   }
 
   if (a.st_nlink != b.st_nlink) {
-    dout(0) << "diff_objects_stat nlink mismatch (A: "
-        << a.st_nlink << " != B: " << b.st_nlink << ")" << dendl;
+    cout << "diff_objects_stat nlink mismatch (A: "
+        << a.st_nlink << " != B: " << b.st_nlink << ")" << std::endl;
     ret = true;
   }
 
   if (a.st_size != b.st_size) {
-    dout(0) << "diff_objects_stat size mismatch (A: "
-        << a.st_size << " != B: " << b.st_size << ")" << dendl;
+    cout << "diff_objects_stat size mismatch (A: "
+        << a.st_size << " != B: " << b.st_size << ")" << std::endl;
     ret = true;
   }
   return ret;
@@ -127,8 +133,6 @@ bool FileStoreDiff::diff_objects_stat(struct stat& a, struct stat& b)
 
 bool FileStoreDiff::diff_objects(FileStore *a_store, FileStore *b_store, coll_t coll)
 {
-  dout(2) << __func__ << " coll "  << coll << dendl;
-
   bool ret = false;
 
   int err;
@@ -136,21 +140,21 @@ bool FileStoreDiff::diff_objects(FileStore *a_store, FileStore *b_store, coll_t 
   err = b_store->collection_list(coll, ghobject_t(), ghobject_t::get_max(),
 				 INT_MAX, &b_objects, NULL);
   if (err < 0) {
-    dout(0) << "diff_objects list on verify coll " << coll.to_str()
-	    << " returns " << err << dendl;
+    cout << "diff_objects list on verify coll " << coll.to_str()
+	    << " returns " << err << std::endl;
     return true;
   }
   err = a_store->collection_list(coll, ghobject_t(), ghobject_t::get_max(),
 				 INT_MAX, &a_objects, NULL);
   if (err < 0) {
-    dout(0) << "diff_objects list on store coll " << coll.to_str()
-              << " returns " << err << dendl;
+    cout << "diff_objects list on store coll " << coll.to_str()
+              << " returns " << err << std::endl;
     return true;
   }
 
   if (b_objects.size() != a_objects.size()) {
-    dout(0) << "diff_objects num objs mismatch (A: " << a_objects.size()
-        << ", B: " << b_objects.size() << ")" << dendl;
+    cout << "diff_objects num objs mismatch (A: " << a_objects.size()
+        << ", B: " << b_objects.size() << ")" << std::endl;
     ret = true;
   }
 
@@ -159,9 +163,9 @@ bool FileStoreDiff::diff_objects(FileStore *a_store, FileStore *b_store, coll_t 
   for (; b_it != b_objects.end(); ++b_it, ++a_it) {
     ghobject_t b_obj = *b_it, a_obj = *a_it;
     if (b_obj.hobj.oid.name != a_obj.hobj.oid.name) {
-      dout(0) << "diff_objects name mismatch on A object "
+      cout << "diff_objects name mismatch on A object "
           << coll << "/" << a_obj << " and B object "
-          << coll << "/" << b_obj << dendl;
+          << coll << "/" << b_obj << std::endl;
       ret = true;
       continue;
     }
@@ -169,20 +173,20 @@ bool FileStoreDiff::diff_objects(FileStore *a_store, FileStore *b_store, coll_t 
     struct stat b_stat, a_stat;
     err = b_store->stat(coll, b_obj, &b_stat);
     if (err < 0) {
-      dout(0) << "diff_objects error stating B object "
-	      << coll.to_str() << "/" << b_obj.hobj.oid.name << dendl;
+      cout << "diff_objects error stating B object "
+	      << coll.to_str() << "/" << b_obj.hobj.oid.name << std::endl;
       ret = true;
     }
     err = a_store->stat(coll, a_obj, &a_stat);
     if (err < 0) {
-      dout(0) << "diff_objects error stating A object "
-          << coll << "/" << a_obj << dendl;
+      cout << "diff_objects error stating A object "
+          << coll << "/" << a_obj << std::endl;
       ret = true;
     }
 
     if (diff_objects_stat(a_stat, b_stat)) {
-      dout(0) << "diff_objects stat mismatch on "
-          << coll << "/" << b_obj << dendl;
+      cout << "diff_objects stat mismatch on "
+          << coll << "/" << b_obj << std::endl;
       ret = true;
     }
 
@@ -191,29 +195,29 @@ bool FileStoreDiff::diff_objects(FileStore *a_store, FileStore *b_store, coll_t 
     a_store->read(coll, a_obj, 0, a_stat.st_size, a_obj_bl);
 
     if (!a_obj_bl.contents_equal(b_obj_bl)) {
-      dout(0) << "diff_objects content mismatch on "
-          << coll << "/" << b_obj << dendl;
+      cout << "diff_objects content mismatch on "
+          << coll << "/" << b_obj << std::endl;
       ret = true;
     }
 
     std::map<std::string, bufferptr> a_obj_attrs_map, b_obj_attrs_map;
     err = a_store->getattrs(coll, a_obj, a_obj_attrs_map);
     if (err < 0) {
-      dout(0) << "diff_objects getattrs on A object " << coll << "/" << a_obj
-              << " returns " << err << dendl;
+      cout << "diff_objects getattrs on A object " << coll << "/" << a_obj
+              << " returns " << err << std::endl;
       ret = true;
     }
     err = b_store->getattrs(coll, b_obj, b_obj_attrs_map);
     if (err < 0) {
-      dout(0) << "diff_objects getattrs on B object " << coll << "/" << b_obj
-              << "returns " << err << dendl;
+      cout << "diff_objects getattrs on B object " << coll << "/" << b_obj
+              << "returns " << err << std::endl;
       ret = true;
     }
 
     if (diff_attrs(b_obj_attrs_map, a_obj_attrs_map)) {
-      dout(0) << "diff_objects attrs mismatch on A object "
+      cout << "diff_objects attrs mismatch on A object "
           << coll << "/" << a_obj << " and B object "
-          << coll << "/" << b_obj << dendl;
+          << coll << "/" << b_obj << std::endl;
       ret = true;
     }
 
@@ -221,32 +225,34 @@ bool FileStoreDiff::diff_objects(FileStore *a_store, FileStore *b_store, coll_t 
     std::set<std::string> a_omap_keys, b_omap_keys;
     err = a_store->omap_get_keys(coll, a_obj, &a_omap_keys);
     if (err < 0) {
-      dout(0) << "diff_objects getomap on A object " << coll << "/" << a_obj
-              << " returns " << err << dendl;
+      cout << "diff_objects getomap on A object " << coll << "/" << a_obj
+              << " returns " << err << std::endl;
       ret = true;
     }
     err = a_store->omap_get_values(coll, a_obj, a_omap_keys, &a_obj_omap);
     if (err < 0) {
-      dout(0) << "diff_objects getomap on A object " << coll << "/" << a_obj
-              << " returns " << err << dendl;
+      cout << "diff_objects getomap on A object " << coll << "/" << a_obj
+              << " returns " << err << std::endl;
       ret = true;
     }
     err = b_store->omap_get_keys(coll, b_obj, &b_omap_keys);
     if (err < 0) {
-      dout(0) << "diff_objects getomap on A object " << coll << "/" << b_obj
-              << " returns " << err << dendl;
+      cout << "diff_objects getomap on A object " << coll << "/" << b_obj
+              << " returns " << err << std::endl;
       ret = true;
     }
     err = b_store->omap_get_values(coll, b_obj, b_omap_keys, &b_obj_omap);
     if (err < 0) {
-      dout(0) << "diff_objects getomap on A object " << coll << "/" << b_obj
-              << " returns " << err << dendl;
+      cout << "diff_objects getomap on A object " << coll << "/" << b_obj
+              << " returns " << err << std::endl;
       ret = true;
     }
     if (diff_omap(a_obj_omap, b_obj_omap)) {
-      dout(0) << "diff_objects omap mismatch on A object "
+      cout << "diff_objects omap mismatch on A object "
 	      << coll << "/" << a_obj << " and B object "
-	      << coll << "/" << b_obj << dendl;
+	      << coll << "/" << b_obj << std::endl;
+      cout << "a: " << a_obj_omap << std::endl;
+      cout << "b: " << b_obj_omap << std::endl;
       ret = true;
     }
   }
@@ -266,7 +272,7 @@ bool FileStoreDiff::diff()
   for (; it != b_coll_list.end(); ++it) {
     coll_t b_coll = *it;
     if (!a_store->collection_exists(b_coll)) {
-      dout(0) << "diff B coll " << b_coll.to_str() << " DNE on A" << dendl;
+      cout << "diff B coll " << b_coll.to_str() << " DNE on A" << std::endl;
       ret = true;
       continue;
     }
@@ -283,7 +289,7 @@ bool FileStoreDiff::diff()
   }
   for (std::vector<coll_t>::iterator it = a_coll_list.begin();
        it != a_coll_list.end(); ++it) {
-    dout(0) << "diff A coll " << *it << " DNE on B" << dendl;
+    cout << "diff A coll " << *it << " DNE on B" << std::endl;
     ret = true;
   }
 

--- a/src/test/objectstore/TestObjectStoreState.h
+++ b/src/test/objectstore/TestObjectStoreState.h
@@ -100,7 +100,7 @@ public:
  public:
   explicit TestObjectStoreState(ObjectStore *store) :
     m_next_coll_nr(0), m_num_objs_per_coll(10), m_num_objects(0),
-    m_max_in_flight(0), m_finished_lock("Finished Lock"), m_next_pool(1) {
+    m_max_in_flight(0), m_finished_lock("Finished Lock"), m_next_pool(2) {
     m_store.reset(store);
   }
   ~TestObjectStoreState() { 

--- a/src/test/objectstore/run_seed_to.sh
+++ b/src/test/objectstore/run_seed_to.sh
@@ -52,6 +52,8 @@ usage() {
   echo
 }
 
+echo $0 $*
+
 die_on_missing_arg() {
   if [[ "$2" == "" ]]; then
     echo "$1: missing required parameter"
@@ -248,12 +250,12 @@ do
     $tmp_name_a $tmp_name_a/journal \
     --test-seed $seed --osd-journal-size 100 \
     --filestore-kill-at $killat $tmp_opts_a \
-    --log-file $tmp_name_a.fail --debug-filestore 20 || true
+    --log-file $tmp_name_a.fail --debug-filestore 20 --no-log-to-stderr || true
 
   stop_at=`ceph_test_filestore_idempotent_sequence get-last-op \
     $tmp_name_a $tmp_name_a/journal \
     --log-file $tmp_name_a.recover \
-    --debug-filestore 20 --debug-journal 20`
+    --debug-filestore 20 --debug-journal 20 --no-log-to-stderr`
 
   if [[ "`expr $stop_at - $stop_at 2>/dev/null`" != "0" ]]; then
     echo "error: get-last-op returned '$stop_at'"
@@ -266,10 +268,11 @@ do
   $v ceph_test_filestore_idempotent_sequence run-sequence-to \
     $stop_at $tmp_name_b $tmp_name_b/journal \
     --test-seed $seed --osd-journal-size 100 \
-    --log-file $tmp_name_b.clean --debug-filestore 20 $tmp_opts_b
+    --log-file $tmp_name_b.clean --debug-filestore 20 --no-log-to-stderr \
+    $tmp_opts_b
 
   if $v ceph_test_filestore_idempotent_sequence diff \
-    $tmp_name_a $tmp_name_a/journal $tmp_name_b $tmp_name_b/journal ; then
+    $tmp_name_a $tmp_name_a/journal $tmp_name_b $tmp_name_b/journal --no-log-to-stderr --log-file $tmp_name_a.diff.log --debug-filestore 20 ; then
       echo OK
   else
     echo "FAIL"

--- a/src/test/objectstore/run_seed_to_range.sh
+++ b/src/test/objectstore/run_seed_to_range.sh
@@ -12,7 +12,7 @@ mydir=`dirname $0`
 
 for f in `seq $from $to`
 do
-    if ! $mydir/run_seed_to.sh -o 10 $seed $f; then
+    if ! $mydir/run_seed_to.sh -o 10 -e $seed $f; then
 	if [ -d "$dir" ]; then
 	    echo copying evidence to $dir
 	    cp -a . $dir

--- a/src/test/objectstore/run_seed_to_range.sh
+++ b/src/test/objectstore/run_seed_to_range.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+set -x
 set -e
 
 seed=$1
@@ -11,7 +12,7 @@ mydir=`dirname $0`
 
 for f in `seq $from $to`
 do
-    if ! $mydir/run_seed_to.sh $seed $f; then
+    if ! $mydir/run_seed_to.sh -o 10 $seed $f; then
 	if [ -d "$dir" ]; then
 	    echo copying evidence to $dir
 	    cp -a . $dir


### PR DESCRIPTION
This tool was pretty broken and the tests weren't testing anything. 

- bunch of cleanups to the bash scripts and output so that you could tell wtf was going on
- restructured the code in terms of the coll_entry_t* instead of coll_t
- redid the collection_move_rename op so that it stayed without a collection, like a modern osd
- fixed up the teuthology test to check random ranges of the sequence (as well as random seeds)

*Most importantly*, this includes a fix for a bug exposed in FileStore where omap ops aren't guarded during replay: http://tracker.ceph.com/issues/22920
