### PR TITLE
jewel: [cli] rename of non-existent image results in seg fault

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1666,8 +1666,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
     ImageCtx *ictx = new ImageCtx(srcname, "", "", io_ctx, false);
     int r = ictx->state->open(false);
     if (r < 0) {
-      lderr(ictx->cct) << "error opening source image: " << cpp_strerror(r)
-		       << dendl;
+      lderr(cct) << "error opening source image: " << cpp_strerror(r) << dendl;
       delete ictx;
       return r;
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/21266