### PR TITLE
test/pybind/rbd: skip test_deep_copy_clone if layering not enabled

### DIFF
--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -518,6 +518,7 @@ class TestImage(object):
             copy.remove_snap('snap1')
         self.rbd.remove(ioctx, dst_name)
 
+    @require_features([RBD_FEATURE_LAYERING])
     def test_deep_copy_clone(self):
         global ioctx
         global features


### PR DESCRIPTION
(otherwise it will fail on protect snap)

Signed-off-by: Mykola Golub <mgolub@suse.com>