### PR TITLE
Allow multipath volumes in ceph-volume.

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -151,7 +151,7 @@ def is_device(dev):
     # use lsblk first, fall back to using stat
     TYPE = lsblk(dev).get('TYPE')
     if TYPE:
-        return TYPE == 'disk'
+        return TYPE in ('disk', 'mpath')
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)


### PR DESCRIPTION
This allows setups that use mulitpath volumes to create new ceph volumes on
them. The `TYPE` returned by `lsblk` for those is `mpath` so they can easily
identified.

We have used this modification on luminous for 3 months in combination with a
SAS multipath setup.