### PR TITLE
osd: don't process ostream strings when not debugging.

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -285,9 +285,8 @@ void ECBackend::handle_recovery_push(
   const PushOp &op,
   RecoveryMessages *m)
 {
-  ostringstream ss;
-  if (get_parent()->check_failsafe_full(ss)) {
-    dout(10) << __func__ << " Out of space (failsafe) processing push request: " << ss.str() << dendl;
+  if (get_parent()->check_failsafe_full()) {
+    dout(10) << __func__ << " Out of space (failsafe) processing push request." << dendl;
     ceph_abort();
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -874,7 +874,8 @@ bool OSDService::_check_full(DoutPrefixProvider *dpp, s_names type) const
              << dendl;
     return true;
   }
-  ldpp_dout(dpp, 10) << __func__ << " current usage is " << cur_ratio << dendl;
+  if (cur_state >= type)
+    ldpp_dout(dpp, 10) << __func__ << " current usage is " << cur_ratio << dendl;
 
   return cur_state >= type;
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -860,7 +860,7 @@ bool OSDService::need_fullness_update()
   return want != cur;
 }
 
-bool OSDService::_check_full(s_names type, ostream &ss) const
+bool OSDService::_check_full(DoutPrefixProvider *dpp, s_names type) const
 {
   Mutex::Locker l(full_status_lock);
 
@@ -869,33 +869,34 @@ bool OSDService::_check_full(s_names type, ostream &ss) const
     // or if -1 then always return full
     if (injectfull > 0)
       --injectfull;
-    ss << "Injected " << get_full_state_name(type) << " OSD ("
-       << (injectfull < 0 ? "set" : std::to_string(injectfull)) << ")";
+    ldpp_dout(dpp, 10) << __func__ << " Injected " << get_full_state_name(type) << " OSD ("
+             << (injectfull < 0 ? "set" : std::to_string(injectfull)) << ")"
+             << dendl;
     return true;
   }
+  ldpp_dout(dpp, 10) << __func__ << " current usage is " << cur_ratio << dendl;
 
-  ss << "current usage is " << cur_ratio;
   return cur_state >= type;
 }
 
-bool OSDService::check_failsafe_full(ostream &ss) const
+bool OSDService::check_failsafe_full(DoutPrefixProvider *dpp) const
 {
-  return _check_full(FAILSAFE, ss);
+  return _check_full(dpp, FAILSAFE);
 }
 
-bool OSDService::check_full(ostream &ss) const
+bool OSDService::check_full(DoutPrefixProvider *dpp) const
 {
-  return _check_full(FULL, ss);
+  return _check_full(dpp, FULL);
 }
 
-bool OSDService::check_backfill_full(ostream &ss) const
+bool OSDService::check_backfill_full(DoutPrefixProvider *dpp) const
 {
-  return _check_full(BACKFILLFULL, ss);
+  return _check_full(dpp, BACKFILLFULL);
 }
 
-bool OSDService::check_nearfull(ostream &ss) const
+bool OSDService::check_nearfull(DoutPrefixProvider *dpp) const
 {
-  return _check_full(NEARFULL, ss);
+  return _check_full(dpp, NEARFULL);
 }
 
 bool OSDService::is_failsafe_full() const

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1015,12 +1015,12 @@ private:
   s_names injectfull_state = NONE;
   float get_failsafe_full_ratio();
   void check_full_status(float ratio);
-  bool _check_full(s_names type, ostream &ss) const;
+  bool _check_full(DoutPrefixProvider *dpp, s_names type) const;
 public:
-  bool check_failsafe_full(ostream &ss) const;
-  bool check_full(ostream &ss) const;
-  bool check_backfill_full(ostream &ss) const;
-  bool check_nearfull(ostream &ss) const;
+  bool check_failsafe_full(DoutPrefixProvider *dpp) const;
+  bool check_full(DoutPrefixProvider *dpp) const;
+  bool check_backfill_full(DoutPrefixProvider *dpp) const;
+  bool check_nearfull(DoutPrefixProvider *dpp) const;
   bool is_failsafe_full() const;
   bool is_full() const;
   bool is_backfillfull() const;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7040,17 +7040,15 @@ boost::statechart::result
 PG::RecoveryState::RepNotRecovering::react(const RequestBackfillPrio &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
-  ostringstream ss;
-
   if (pg->cct->_conf->osd_debug_reject_backfill_probability > 0 &&
       (rand()%1000 < (pg->cct->_conf->osd_debug_reject_backfill_probability*1000.0))) {
     ldout(pg->cct, 10) << "backfill reservation rejected: failure injection"
 		       << dendl;
     post_event(RejectRemoteReservation());
   } else if (!pg->cct->_conf->osd_debug_skip_full_check_in_backfill_reservation &&
-      pg->osd->check_backfill_full(ss)) {
-    ldout(pg->cct, 10) << "backfill reservation rejected: "
-		       << ss.str() << dendl;
+      pg->osd->check_backfill_full(pg)) {
+    ldout(pg->cct, 10) << "backfill reservation rejected: backfill full"
+		       << dendl;
     post_event(RejectRemoteReservation());
   } else {
     Context *preempt = nullptr;
@@ -7111,7 +7109,6 @@ PG::RecoveryState::RepWaitBackfillReserved::react(const RemoteBackfillReserved &
 {
   PG *pg = context< RecoveryMachine >().pg;
 
-  ostringstream ss;
   if (pg->cct->_conf->osd_debug_reject_backfill_probability > 0 &&
       (rand()%1000 < (pg->cct->_conf->osd_debug_reject_backfill_probability*1000.0))) {
     ldout(pg->cct, 10) << "backfill reservation rejected after reservation: "
@@ -7119,9 +7116,9 @@ PG::RecoveryState::RepWaitBackfillReserved::react(const RemoteBackfillReserved &
     post_event(RejectRemoteReservation());
     return discard_event();
   } else if (!pg->cct->_conf->osd_debug_skip_full_check_in_backfill_reservation &&
-	     pg->osd->check_backfill_full(ss)) {
-    ldout(pg->cct, 10) << "backfill reservation rejected after reservation: "
-		       << ss.str() << dendl;
+	     pg->osd->check_backfill_full(pg)) {
+    ldout(pg->cct, 10) << "backfill reservation rejected after reservation: backfill full"
+		       << dendl;
     post_event(RejectRemoteReservation());
     return discard_event();
   } else {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -490,7 +490,6 @@ public:
     return ref;
   }
 
-
   // ctor
   PG(OSDService *o, OSDMapRef curmap,
      const PGPool &pool, spg_t p);

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -287,7 +287,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      virtual LogClientTemp clog_error() = 0;
      virtual LogClientTemp clog_warn() = 0;
 
-     virtual bool check_failsafe_full(ostream &ss) = 0;
+     virtual bool check_failsafe_full() = 0;
 
      virtual bool check_osdmap_full(const set<pg_shard_t> &missing_on) = 0;
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1987,11 +1987,9 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   // mds should have stopped writing before this point.
   // We can't allow OSD to become non-startable even if mds
   // could be writing as part of file removals.
-  ostringstream ss;
-  if (write_ordered && osd->check_failsafe_full(ss) && !m->has_flag(CEPH_OSD_FLAG_FULL_TRY)) {
-    dout(10) << __func__ << " fail-safe full check failed, dropping request"
-             << ss.str()
-	     << dendl;
+  if (write_ordered && osd->check_failsafe_full(get_dpp()) && 
+      !m->has_flag(CEPH_OSD_FLAG_FULL_TRY)) {
+    dout(10) << __func__ << " fail-safe full check failed, dropping request." << dendl;
     return;
   }
   int64_t poolid = get_pgid().pool();
@@ -3997,9 +3995,9 @@ void PrimaryLogPG::do_scan(
   switch (m->op) {
   case MOSDPGScan::OP_SCAN_GET_DIGEST:
     {
-      ostringstream ss;
-      if (osd->check_backfill_full(ss)) {
-	dout(1) << __func__ << ": Canceling backfill, " << ss.str() << dendl;
+      auto dpp = get_dpp();
+      if (osd->check_backfill_full(dpp)) {
+	dout(1) << __func__ << ": Canceling backfill: Full." << dendl;
 	queue_peering_event(
 	  PGPeeringEventRef(
 	    std::make_shared<PGPeeringEvent>(
@@ -15087,8 +15085,8 @@ int PrimaryLogPG::getattrs_maybe_cache(
   return r;
 }
 
-bool PrimaryLogPG::check_failsafe_full(ostream &ss) {
-    return osd->check_failsafe_full(ss);
+bool PrimaryLogPG::check_failsafe_full() {
+    return osd->check_failsafe_full(get_dpp());
 }
 
 void intrusive_ptr_add_ref(PrimaryLogPG *pg) { pg->get("intptr"); }

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1840,7 +1840,7 @@ public:
   void on_removal(ObjectStore::Transaction *t) override;
   void shutdown() override;
   void on_shutdown();
-  bool check_failsafe_full(ostream &ss) override;
+  bool check_failsafe_full() override;
   bool check_osdmap_full(const set<pg_shard_t> &missing_on) override;
   bool maybe_preempt_replica_scrub(const hobject_t& oid) override {
     return write_blocked_by_scrub(oid);

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -802,9 +802,8 @@ void ReplicatedBackend::_do_push(OpRequestRef op)
 
   vector<PushReplyOp> replies;
   ObjectStore::Transaction t;
-  ostringstream ss;
-  if (get_parent()->check_failsafe_full(ss)) {
-    dout(10) << __func__ << " Out of space (failsafe) processing push request: " << ss.str() << dendl;
+  if (get_parent()->check_failsafe_full()) {
+    dout(10) << __func__ << " Out of space (failsafe) processing push request." << dendl;
     ceph_abort();
   }
   for (vector<PushOp>::const_iterator i = m->pushes.begin();
@@ -868,10 +867,8 @@ void ReplicatedBackend::_do_pull_response(OpRequestRef op)
   op->mark_started();
 
   vector<PullOp> replies(1);
-
-  ostringstream ss;
-  if (get_parent()->check_failsafe_full(ss)) {
-    dout(10) << __func__ << " Out of space (failsafe) processing pull response (push): " << ss.str() << dendl;
+  if (get_parent()->check_failsafe_full()) {
+    dout(10) << __func__ << " Out of space (failsafe) processing pull response (push)." << dendl;
     ceph_abort();
   }
 


### PR DESCRIPTION
When testing a fast in-memory object store, check_failsafe_full was shown to be spending significant time (and holding a lock!) in the tp_osd_tp threads to process debugging output even when dout(10) isn't specified.  This PR ditches the ostream and just outputs a distinct dout(10) inside OSDSerivce::_check_full.

Before change:

        | |   | | | + 6.40% OSDService::check_failsafe_full
        | |   | | | + 4.10% OSDService::check_failsafe_full
        | |   | | | + 5.00% OSDService::check_failsafe_full
        | |   | | | + 6.80% OSDService::check_failsafe_full
        | |   | | | + 6.20% OSDService::check_failsafe_full

After Change:

          |   | | | + 0.10% OSDService::check_failsafe_full
        | |     | | + 0.20% OSDService::check_failsafe_full
        | |     | | + 0.10% OSDService::check_failsafe_full
        | |   | | | + 0.20% OSDService::check_failsafe_full

Signed-off-by: Mark Nelson <mnelson@redhat.com>