### PR TITLE
mon, osd: add create-time for pool

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5823,6 +5823,7 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
   int64_t pool = ++pending_inc.new_pool_max;
   pg_pool_t empty;
   pg_pool_t *pi = pending_inc.get_new_pool(pool, &empty);
+  pi->create_time = ceph_clock_now();
   pi->type = pool_type;
   pi->fast_read = fread; 
   pi->flags = g_conf->osd_pool_default_flags;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1303,6 +1303,7 @@ struct pg_pool_t {
     }
   }
 
+  utime_t create_time;
   uint64_t flags;           ///< FLAG_*
   __u8 type;                ///< TYPE_*
   __u8 size, min_size;      ///< number of osds in each pg
@@ -1464,6 +1465,7 @@ public:
 
   void dump(Formatter *f) const;
 
+  const utime_t &get_create_time() const { return create_time; }
   uint64_t get_flags() const { return flags; }
   bool has_flag(uint64_t f) const { return flags & f; }
   void set_flag(uint64_t f) { flags |= f; }


### PR DESCRIPTION
We want to know how old the pools currently are, on which mgr/balancer
can make some time-related smart decisions based.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>