### PR TITLE
test/admin_socket_output: switch to std::experimental::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,8 +560,7 @@ option(WITH_SYSTEM_BOOST "require and build with system Boost" OFF)
 
 # Boost::thread depends on Boost::atomic, so list it explicitly.
 set(BOOST_COMPONENTS
-  atomic thread system regex random program_options date_time iostreams
-  filesystem)
+  atomic thread system regex random program_options date_time iostreams)
 set(BOOST_HEADER_COMPONENTS container)
 
 if(WITH_MGR)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -525,9 +525,14 @@ add_executable(ceph_test_admin_socket_output
   admin_socket_output_tests.cc
   )
 target_link_libraries(ceph_test_admin_socket_output
-  ceph-common
-  ${Boost_FILESYSTEM_LIBRARY}
-  )
+  ceph-common)
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+  target_link_libraries(ceph_test_admin_socket_output
+    -lstdc++fs)
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+  target_link_libraries(ceph_test_admin_socket_output
+    -lc++experimental)
+endif()
 install(TARGETS
   ceph_test_admin_socket_output
   DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/admin_socket_output.cc
+++ b/src/test/admin_socket_output.cc
@@ -14,7 +14,7 @@
 
 #include <iostream>
 #include <regex>                 // For regex, regex_search
-#include <boost/filesystem/convenience.hpp> // For extension
+#include <experimental/filesystem> // For extension
 
 #include "common/admin_socket_client.h"     // For AdminSocketClient
 #include "common/ceph_json.h"               // For JSONParser, JSONObjIter
@@ -74,9 +74,9 @@ void AdminSocketOutput::postpone(const std::string &target,
 
 bool AdminSocketOutput::init_sockets() {
   std::cout << "Initialising sockets" << std::endl;
-  for (const auto &x : bfs::directory_iterator(socketdir)) {
+  for (const auto &x : fs::directory_iterator(socketdir)) {
     std::cout << x.path() << std::endl;
-    if (bfs::extension(x.path()) == ".asok") {
+    if (fs::path(x.path()).extension() == ".asok") {
       for (auto &target : targets) {
         if (std::regex_search(x.path().filename().string(),
             std::regex(prefix + target + R"(\..*\.asok)"))) {

--- a/src/test/admin_socket_output.h
+++ b/src/test/admin_socket_output.h
@@ -19,11 +19,9 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <experimental/filesystem>       // For path
 
-#include <boost/filesystem/path.hpp>       // For path
-#include <boost/filesystem/operations.hpp> // For exists, is_directory
-
-namespace bfs = boost::filesystem;
+namespace fs = std::experimental::filesystem;
 
 using socket_results = std::map<std::string, std::string>;
 using test_functions =
@@ -72,7 +70,7 @@ private:
   std::map<std::string, test_functions> tests;
 
   std::string prefix = "ceph-";
-  bfs::path socketdir = "/var/run/ceph";
+  fs::path socketdir = "/var/run/ceph";
 };
 
 #endif // CEPH_ADMIN_SOCKET_OUTPUT_H


### PR DESCRIPTION
so we don't need to compile boost::filesystem anymore.

Signed-off-by: Kefu Chai <kchai@redhat.com>