### PR TITLE
mgr/mon: Duplicate "config set" command is displayed

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -202,10 +202,6 @@ COMMAND_WITH_FLAG("injectargs " \
 	     "name=injected_args,type=CephString,n=N",			\
 	     "inject config arguments into monitor", "mon", "rw", "cli,rest",
 	     FLAG(NOFORWARD))
-COMMAND("config set " \
-	"name=key,type=CephString name=value,type=CephString",
-	"Set a configuration option at runtime (not persistent)",
-	"mon", "rw", "cli,rest")
 COMMAND("status", "show cluster status", "mon", "r", "cli,rest")
 COMMAND("health name=detail,type=CephChoices,strings=detail,req=false", \
 	"show cluster health", "mon", "r", "cli,rest")


### PR DESCRIPTION
mgr/mon: Duplicate "config set" command is displayed

If you use "ceph config -h" command, you can see the following duplicate message:
......
Monitor commands:
config set <key> <value>       Set a configuration option at runtime (not persistent)
config set <key> <value>       Set a configuration option at runtime (not persistent)
config-key del <key>           delete <key>
......

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>