### PR TITLE
osd/OSDMap: misleading message in print_oneline_summary()

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3410,9 +3410,9 @@ void OSDMap::print_oneline_summary(ostream& out) const
       << get_num_up_osds() << " up, "
       << get_num_in_osds() << " in";
   if (test_flag(CEPH_OSDMAP_FULL))
-    out << " full";
+    out << "; full flag set";
   else if (test_flag(CEPH_OSDMAP_NEARFULL))
-    out << " nearfull";
+    out << "; nearfull flag set";
 }
 
 bool OSDMap::crush_rule_in_use(int rule_id) const


### PR DESCRIPTION
The output scared people as showing so many osds were full/nearfull

Improve the output to make the message clearer

Fixes: http://tracker.ceph.com/issues/22350
Signed-off-by: Gu Zhongyan <guzhongyan@360.cn>