### PR TITLE
doc: log-and-debug: fix default value of "log max recent"

### DIFF
--- a/doc/rados/troubleshooting/log-and-debug.rst
+++ b/doc/rados/troubleshooting/log-and-debug.rst
@@ -327,7 +327,7 @@ settings:
 :Description: The maximum number of recent events to include in a log file.
 :Type: Integer
 :Required:  No
-:Default: ``1000000``
+:Default: ``10000``
 
 
 ``log to stderr``


### PR DESCRIPTION
Doc says 1000000, but the real figure is two orders of magnitude less:

    Option("log_max_recent", Option::TYPE_INT, Option::LEVEL_ADVANCED)
      .set_default(500)
      .set_daemon_default(10000)

Signed-off-by: Nathan Cutler <ncutler@suse.com>