### PR TITLE
 common/config: limit calls to normalize_key_name

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -905,8 +905,7 @@ Option::value_t md_config_t::_get_val_generic(const std::string &key) const
 int md_config_t::_get_val(const std::string &key, std::string *value) const {
   assert(lock.is_locked());
 
-  std::string normalized_key(ConfFile::normalize_key_name(key));
-  Option::value_t config_value = _get_val_generic(normalized_key.c_str());
+  auto config_value = _get_val_generic(key);
   if (!boost::get<boost::blank>(&config_value)) {
     ostringstream oss;
     if (bool *flag = boost::get<bool>(&config_value)) {


### PR DESCRIPTION
It's not the most expensive thing in that module, but it's redundant in _get_val, as it's later done also in _get_val_generic. And it's still expensive.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>