### PR TITLE
osd: pass ops_blocked_by_scrub() to requeue_scrub()

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3908,11 +3908,7 @@ void PG::do_replica_scrub_map(OpRequestRef op)
     scrub_preempted = true;
   }
   if (scrubber.waiting_on_whom.empty()) {
-    if (ops_blocked_by_scrub()) {
-      requeue_scrub(true);
-    } else {
-      requeue_scrub(false);
-    }
+    requeue_scrub(ops_blocked_by_scrub());
   }
 }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10004,12 +10004,7 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
   if (is_primary()) {
     if (scrubber.active) {
       if (last_update_applied >= scrubber.subset_last_update) {
-        if (ops_blocked_by_scrub()) {
-          requeue_scrub(true);
-        } else {
-          requeue_scrub(false);
-        }
-
+	requeue_scrub(ops_blocked_by_scrub());
       }
     } else {
       assert(scrubber.start == scrubber.end);
@@ -11210,11 +11205,7 @@ void PrimaryLogPG::_applied_recovered_object(ObjectContextRef obc)
   // requeue an active chunky scrub waiting on recovery ops
   if (!deleting && active_pushes == 0
       && scrubber.is_chunky_scrub_active()) {
-    if (ops_blocked_by_scrub()) {
-      requeue_scrub(true);
-    } else {
-      requeue_scrub(false);
-    }
+    requeue_scrub(ops_blocked_by_scrub());
   }
 }
 


### PR DESCRIPTION
less nesting levels, and less repeatings.

Signed-off-by: Kefu Chai <kchai@redhat.com>