### PR TITLE
mgr: initialize PyModuleRegistry sooner

### DIFF
--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -144,6 +144,8 @@ int MgrStandby::init()
   client.init();
   timer.init();
 
+  py_module_registry.init();
+
   tick();
 
   dout(4) << "Complete." << dendl;
@@ -330,16 +332,11 @@ void MgrStandby::handle_mgr_map(MMgrMap* mmap)
   dout(4) << "active in map: " << active_in_map
           << " active is " << map.active_gid << dendl;
 
-  if (!py_module_registry.is_initialized()) {
-    int r = py_module_registry.init(map);
-
-    // FIXME: error handling
-    assert(r == 0);
-  } else {
-    bool need_respawn = py_module_registry.handle_mgr_map(map);
-    if (need_respawn) {
-      respawn();
-    }
+  // PyModuleRegistry may ask us to respawn if it sees that
+  // this MgrMap is changing its set of enabled modules
+  bool need_respawn = py_module_registry.handle_mgr_map(map);
+  if (need_respawn) {
+    respawn();
   }
 
   if (active_in_map) {

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -69,8 +69,8 @@ public:
   PyObject *pClass = nullptr;
   PyObject *pStandbyClass = nullptr;
 
-  PyModule(const std::string &module_name_, bool const enabled_)
-    : module_name(module_name_), enabled(enabled_)
+  PyModule(const std::string &module_name_)
+    : module_name(module_name_)
   {
   }
 
@@ -84,6 +84,11 @@ public:
   static void init_ceph_logger();
   static void init_ceph_module();
 #endif
+
+  void set_enabled(const bool enabled_)
+  {
+    enabled = enabled_;
+  }
 
   /**
    * Extend `out` with the contents of `this->commands`

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -37,7 +37,7 @@ std::string PyModuleRegistry::config_prefix;
 
 
 
-int PyModuleRegistry::init()
+void PyModuleRegistry::init()
 {
   Mutex::Locker locker(lock);
 
@@ -98,8 +98,6 @@ int PyModuleRegistry::init()
     clog->error() << "Failed to load ceph-mgr modules: " << joinify(
         failed_modules.begin(), failed_modules.end(), std::string(", "));
   }
-
-  return 0;
 }
 
 bool PyModuleRegistry::handle_mgr_map(const MgrMap &mgr_map_)

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -81,26 +81,12 @@ public:
     : clog(clog_)
   {}
 
-  bool handle_mgr_map(const MgrMap &mgr_map_)
-  {
-    Mutex::Locker l(lock);
+  /**
+   * @return true if the mgrmap has changed such that the service needs restart
+   */
+  bool handle_mgr_map(const MgrMap &mgr_map_);
 
-    bool modules_changed = mgr_map_.modules != mgr_map.modules;
-    mgr_map = mgr_map_;
-
-    if (standby_modules != nullptr) {
-      standby_modules->handle_mgr_map(mgr_map_);
-    }
-
-    return modules_changed;
-  }
-
-  bool is_initialized() const
-  {
-    return mgr_map.epoch > 0;
-  }
-
-  int init(const MgrMap &map);
+  int init();
 
   void active_start(
                 PyModuleConfig &config_,

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -86,7 +86,7 @@ public:
    */
   bool handle_mgr_map(const MgrMap &mgr_map_);
 
-  int init();
+  void init();
 
   void active_start(
                 PyModuleConfig &config_,


### PR DESCRIPTION
This was waiting on MgrMap to init, so that it would know whether
modules should be enabled.  However, you don't really need to know
that until someone calls standby_start or active_start, so we
can initialize during MgrStandby::init, and fill out the enabled
flags later.

This prevents the mgr from prematurely emitting a MMgrBeacon
that claims no modules are found.

http://tracker.ceph.com/issues/22918
Signed-off-by: John Spray <john.spray@redhat.com>