### PR TITLE
luminous: doc/ceph-volume OSD use the fsid file, not the osd_fsid

### DIFF
--- a/doc/ceph-volume/lvm/activate.rst
+++ b/doc/ceph-volume/lvm/activate.rst
@@ -19,7 +19,7 @@ need to be supplied. For example::
 
     ceph-volume lvm activate --bluestore 0 0263644D-0BF1-4D6D-BC34-28BD98AE3BC8
 
-.. note:: The UUID is stored in the ``osd_fsid`` file in the OSD path, which is
+.. note:: The UUID is stored in the ``fsid`` file in the OSD path, which is
           generated when :ref:`ceph-volume-lvm-prepare` is used.
 
 requiring uuids


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>
(cherry picked from commit a5f26c622b0f11b7d8179da22d18f719b9febe0a)

backport of #20059