### PR TITLE
cmake: fix the include dir for building boost::python

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -91,11 +91,13 @@ function(do_build_boost version)
     " : ${CMAKE_CXX_COMPILER}"
     " ;\n")
   if(with_python GREATER -1)
+    set(python_ver ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
+    string(REPLACE ";" " " python_includes "${PYTHON_INCLUDE_DIRS}")
     file(APPEND ${user_config}
       "using python"
       " : ${python_ver}"
       " : ${PYTHON_EXECUTABLE}"
-      " : ${PYTHON_INCLUDE_DIRS}"
+      " : ${python_includes}"
       " : ${PYTHON_LIBRARIES}"
       " ;\n")
   endif()
@@ -107,7 +109,6 @@ function(do_build_boost version)
       message(FATAL_ERROR "Please call find_package(PythonLibs) first for building "
         "Boost.Python")
     endif()
-    set(python_ver ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR})
     list(APPEND b2 python=${python_ver})
   endif()
 


### PR DESCRIPTION
the "includes" directories are separated by spaces not semicolons.

Signed-off-by: Kefu Chai <kchai@redhat.com>