### PR TITLE
luminous: pybind/mgr/dashboard: fix duplicated slash in html href

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -69,10 +69,11 @@ def get_prefixed_url(url):
 
 
 def prepare_url_prefix(url_prefix):
+    """
+    return '' if no prefix, or '/prefix' without slash in the end.
+    """
     url_prefix = urlparse.urljoin('/', url_prefix)
-    if url_prefix[-1] != '/':
-        url_prefix = url_prefix + '/'
-    return url_prefix
+    return url_prefix.rstrip('/')
 
 class StandbyModule(MgrStandbyModule):
     def serve(self):
@@ -916,7 +917,7 @@ class Module(MgrModule):
 
         # Publish the URI that others may use to access the service we're
         # about to start serving
-        self.set_uri("http://{0}:{1}{2}".format(
+        self.set_uri("http://{0}:{1}{2}/".format(
             socket.getfqdn() if server_addr == "::" else server_addr,
             server_port,
             url_prefix


### PR DESCRIPTION
The url_prefix val in html templates is expected not containing '/'
in the end. Otherwise the href will be rendered as '//static/', which
causes browser treating it as http://static/.

Fixes: http://tracker.ceph.com/issues/22851
Signed-off-by: Shengjing Zhu <zhsj@umcloud.com>
(cherry picked from commit 24fe1cae636bf00e3d5923c7e826992d42d92946)