### PR TITLE
qa/tests: use norequire_active_mds options only for test kernel mounts

### DIFF
--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -18,7 +18,7 @@ UMOUNT_TIMEOUT = 300
 
 class KernelMount(CephFSMount):
     def __init__(self, mons, test_dir, client_id, client_remote,
-                 ipmi_user, ipmi_password, ipmi_domain):
+                 ipmi_user, ipmi_password, ipmi_domain, is_distro_kernel=False):
         super(KernelMount, self).__init__(test_dir, client_id, client_remote)
         self.mons = mons
 
@@ -26,6 +26,7 @@ class KernelMount(CephFSMount):
         self.ipmi_user = ipmi_user
         self.ipmi_password = ipmi_password
         self.ipmi_domain = ipmi_domain
+        self.is_distro_kernel = is_distro_kernel
 
     def write_secret_file(self, remote, role, keyring, filename):
         """
@@ -65,8 +66,13 @@ class KernelMount(CephFSMount):
         if mount_path is None:
             mount_path = "/"
 
-        opts = 'name={id},secretfile={secret},norequire_active_mds'.format(id=self.client_id,
-                                                      secret=secret)
+        # norequire_active_mds kernel option is available in test kernels
+        if self.is_distro_kernel:
+            opts = 'name={id},secretfile={secret}'.format(id=self.client_id,
+                                                          secret=secret)
+        else:
+            opts = 'name={id},secretfile={secret},norequire_active_mds'.format(id=self.client_id,
+                                                                               secret=secret)
 
         if mount_fs_name is not None:
             opts += ",mds_namespace={0}".format(mount_fs_name)

--- a/qa/tasks/kclient.py
+++ b/qa/tasks/kclient.py
@@ -88,6 +88,13 @@ def task(ctx, config):
         if config.get("disabled", False) or not client_config.get('mounted', True):
             continue
 
+        # check if we are using distro or test kernel and pass options to mount
+        kernel_sha = ctx.config.get('kernel')['sha1']
+        if kernel_sha == 'distro':
+            is_distro_kernel = True
+        else:
+            is_distro_kernel = False
+
         kernel_mount = KernelMount(
             mons,
             test_dir,
@@ -95,7 +102,8 @@ def task(ctx, config):
             remote,
             ctx.teuthology_config.get('ipmi_user', None),
             ctx.teuthology_config.get('ipmi_password', None),
-            ctx.teuthology_config.get('ipmi_domain', None)
+            ctx.teuthology_config.get('ipmi_domain', None),
+            is_distro_kernel,
         )
 
         mounts[id_] = kernel_mount


### PR DESCRIPTION
we run tests on distro kernels and the option still doesn't exist, can be removed when it exits in downstream.

will schedule some tests

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>