### PR TITLE
rgw: return valid Location element, PostObj

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2008,14 +2008,23 @@ done:
     for (auto &it : crypt_http_responses)
       dump_header(s, it.first, it.second);
     s->formatter->open_object_section("PostResponse");
-    if (g_conf()->rgw_dns_name.length())
-      s->formatter->dump_format("Location", "%s/%s",
-				s->info.script_uri.c_str(),
-				s->object.name.c_str());
-    if (!s->bucket_tenant.empty())
+    std::string base_uri = compute_domain_uri(s);
+    if (!s->bucket_tenant.empty()){
+      s->formatter->dump_format("Location", "%s/%s:%s/%s",
+                                base_uri.c_str(),
+                                url_encode(s->bucket_tenant).c_str(),
+                                url_encode(s->bucket_name).c_str(),
+                                url_encode(s->object.name).c_str());
       s->formatter->dump_string("Tenant", s->bucket_tenant);
+    } else {
+      s->formatter->dump_format("Location", "%s/%s/%s",
+                                base_uri.c_str(),
+                                url_encode(s->bucket_name).c_str(),
+                                url_encode(s->object.name).c_str());
+    }
     s->formatter->dump_string("Bucket", s->bucket_name);
     s->formatter->dump_string("Key", s->object.name);
+    s->formatter->dump_string("ETag", etag);
     s->formatter->close_section();
   }
   s->err.message = err_msg;


### PR DESCRIPTION
according to https://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPOST.html 

response should contain ETag and fix the Location Element

in amazon s3
```
<PostResponse><Location>http://s3.amazonaws.com/happybucket2/prefix%2F111222</Location><Bucket>happybucket2</Bucket><Key>prefix/111222</Key><ETag>"22cf483cd7c9ca14793b86144ad31fba"</ETag></PostResponse>
```

in rgw 
```
<PostResponse><Location>/test2/prefix/keyv7</Location><Bucket>test2</Bucket><Key>prefix/keyv7</Key></PostResponse>
```

the objectname bucketname should urlencode and we should have domain url in Location

Fixes: http://tracker.ceph.com/issues/22927

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>