### PR TITLE
os/bluestore: cleanup around ExtentList, AllocExtent and bluestore_extent_t classes

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -34,10 +34,10 @@ public:
    */
   virtual int64_t allocate(uint64_t want_size, uint64_t alloc_unit,
 			   uint64_t max_alloc_size, int64_t hint,
-			   AllocExtentVector *extents) = 0;
+			   PExtentVector *extents) = 0;
 
   int64_t allocate(uint64_t want_size, uint64_t alloc_unit,
-		   int64_t hint, AllocExtentVector *extents) {
+		   int64_t hint, PExtentVector *extents) {
     return allocate(want_size, alloc_unit, want_size, hint, extents);
   }
 

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -111,7 +111,7 @@ void BitMapAllocator::unreserve(uint64_t unused)
 
 int64_t BitMapAllocator::allocate(
   uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents)
+  int64_t hint, PExtentVector *extents)
 {
 
   assert(!(alloc_unit % m_block_size));
@@ -131,7 +131,7 @@ int64_t BitMapAllocator::allocate(
 
 int64_t BitMapAllocator::allocate_dis(
   uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents)
+  int64_t hint, PExtentVector *extents)
 {
   ExtentList block_list = ExtentList(extents, m_block_size, max_alloc_size);
   int64_t nblks = (want_size + m_block_size - 1) / m_block_size;

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -133,7 +133,7 @@ int64_t BitMapAllocator::allocate_dis(
   uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
   int64_t hint, PExtentVector *extents)
 {
-  ExtentList block_list = ExtentList(extents, m_block_size, max_alloc_size);
+  AllocatorExtentList block_list(extents, m_block_size, max_alloc_size);
   int64_t nblks = (want_size + m_block_size - 1) / m_block_size;
   int64_t num = 0;
 

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -21,7 +21,7 @@ class BitMapAllocator : public Allocator {
 
   int64_t allocate_dis(
     uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents);
+    int64_t hint, PExtentVector *extents);
 
 public:
   BitMapAllocator(CephContext* cct, int64_t device_size, int64_t block_size);
@@ -32,7 +32,7 @@ public:
 
   int64_t allocate(
     uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents) override;
+    int64_t hint, PExtentVector *extents) override;
 
   void release(
     const interval_set<uint64_t>& release_set) override;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -184,7 +184,7 @@ void BlueFS::add_block_extent(unsigned id, uint64_t offset, uint64_t length)
 }
 
 int BlueFS::reclaim_blocks(unsigned id, uint64_t want,
-			   AllocExtentVector *extents)
+			   PExtentVector *extents)
 {
   std::unique_lock<std::mutex> l(lock);
   dout(1) << __func__ << " bdev " << id
@@ -1935,7 +1935,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   uint64_t left = round_up_to(len, min_alloc_size);
   int r = -ENOSPC;
   int64_t alloc_len = 0;
-  AllocExtentVector extents;
+  PExtentVector extents;
   
   if (alloc[id]) {
     r = alloc[id]->reserve(left);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -403,7 +403,7 @@ public:
 
   /// reclaim block space
   int reclaim_blocks(unsigned bdev, uint64_t want,
-		     AllocExtentVector *extents);
+		     PExtentVector *extents);
 
   void flush(FileWriter *h) {
     std::lock_guard<std::mutex> l(lock);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -937,7 +937,7 @@ public:
       uint64_t min_alloc_size);
 
     /// return a collection of extents to perform GC on
-    const vector<AllocExtent>& get_extents_to_collect() const {
+    const vector<bluestore_pextent_t>& get_extents_to_collect() const {
       return extents_to_collect;
     }
     GarbageCollector(CephContext* _cct) : cct(_cct) {}
@@ -967,8 +967,8 @@ public:
                                          ///< copies that are affected by the
                                          ///< specific write
 
-    vector<AllocExtent> extents_to_collect; ///< protrusive extents that should
-                                            ///< be collected if GC takes place
+    ///< protrusive extents that should be collected if GC takes place
+    vector<bluestore_pextent_t> extents_to_collect;
 
     boost::optional<uint64_t > used_alloc_unit; ///< last processed allocation
                                                 ///<  unit when traversing 

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -219,8 +219,6 @@ int64_t StupidAllocator::allocate(
     max_alloc_size = want_size;
   }
 
-  ExtentList block_list = ExtentList(extents, 1, max_alloc_size);
-
   while (allocated_size < want_size) {
     res = allocate_int(std::min(max_alloc_size, (want_size - allocated_size)),
        alloc_unit, hint, &offset, &length);
@@ -230,7 +228,19 @@ int64_t StupidAllocator::allocate(
        */
       break;
     }
-    block_list.add_extents(offset, length);
+    bool can_append = true;
+    if (!extents->empty()) {
+      bluestore_pextent_t &last_extent  = extents->back();
+      if ((last_extent.end() == offset) &&
+	  ((last_extent.length + length) <= max_alloc_size)) {
+	can_append = false;
+	last_extent.length += length;
+      }
+    }
+    if (can_append) {
+      extents->emplace_back(bluestore_pextent_t(offset, length));
+    }
+
     allocated_size += length;
     hint = offset + length;
   }

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -208,7 +208,7 @@ int64_t StupidAllocator::allocate(
   uint64_t alloc_unit,
   uint64_t max_alloc_size,
   int64_t hint,
-  mempool::bluestore_alloc::vector<AllocExtent> *extents)
+  PExtentVector *extents)
 {
   uint64_t allocated_size = 0;
   uint64_t offset = 0;

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -43,7 +43,7 @@ public:
 
   int64_t allocate(
     uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents) override;
+    int64_t hint, PExtentVector *extents) override;
 
   int64_t allocate_int(
     uint64_t want_size, uint64_t alloc_unit, int64_t hint,

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -8,13 +8,16 @@
 #include "include/encoding.h"
 #include "include/denc.h"
 
-class bluefs_extent_t : public AllocExtent{
+class bluefs_extent_t {
 public:
   uint8_t bdev;
+  uint64_t offset = 0;
+  uint32_t length = 0;
 
   bluefs_extent_t(uint8_t b = 0, uint64_t o = 0, uint32_t l = 0)
-    : AllocExtent(o, l), bdev(b) {}
+    : bdev(b), offset(o), length(l) {}
 
+  uint64_t end() const { return  offset + length; }
   DENC(bluefs_extent_t, v, p) {
     DENC_START(1, 1, p);
     denc_lba(v.offset, p);

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -18,7 +18,7 @@
 #include "include/stringify.h"
 
 void ExtentList::add_extents(int64_t start, int64_t count) {
-  AllocExtent *last_extent = NULL;
+  bluestore_pextent_t *last_extent = NULL;
   bool can_merge = false;
 
   if (!m_extents->empty()) {
@@ -34,7 +34,7 @@ void ExtentList::add_extents(int64_t start, int64_t count) {
   if (can_merge) {
     last_extent->length += (count * m_block_size);
   } else {
-    m_extents->emplace_back(AllocExtent(start * m_block_size,
+    m_extents->emplace_back(bluestore_pextent_t(start * m_block_size,
 					count * m_block_size));
   }
 }
@@ -762,7 +762,7 @@ int bluestore_blob_t::verify_csum(uint64_t b_off, const bufferlist& bl,
     return 0;
 }
 
-void bluestore_blob_t::allocated(uint32_t b_off, uint32_t length, const AllocExtentVector& allocs)
+void bluestore_blob_t::allocated(uint32_t b_off, uint32_t length, const PExtentVector& allocs)
 {
   if (extents.size() == 0) {
     // if blob is compressed then logical length to be already configured
@@ -774,6 +774,7 @@ void bluestore_blob_t::allocated(uint32_t b_off, uint32_t length, const AllocExt
     if (b_off) {
       extents.emplace_back(
         bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, b_off));
+
     }
     uint32_t new_len = b_off;
     for (auto& a : allocs) {
@@ -854,7 +855,8 @@ struct vecbuilder {
   void flush() {
     if (invalid) {
       v.emplace_back(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET,
-	invalid));
+        invalid));
+
       invalid = 0;
     }
   }
@@ -864,7 +866,7 @@ struct vecbuilder {
     }
     else {
       flush();
-      v.emplace_back(bluestore_pextent_t(offset, length));
+      v.emplace_back(offset, length);
     }
   }
 };

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -17,28 +17,6 @@
 #include "common/Checksummer.h"
 #include "include/stringify.h"
 
-void ExtentList::add_extents(int64_t start, int64_t count) {
-  bluestore_pextent_t *last_extent = NULL;
-  bool can_merge = false;
-
-  if (!m_extents->empty()) {
-    last_extent = &(m_extents->back());
-    uint64_t last_offset = last_extent->end() / m_block_size;
-    uint32_t last_length = last_extent->length / m_block_size;
-    if ((last_offset == (uint64_t) start) &&
-        (!m_max_blocks || (last_length + count) <= m_max_blocks)) {
-      can_merge = true;
-    }
-  }
-
-  if (can_merge) {
-    last_extent->length += (count * m_block_size);
-  } else {
-    m_extents->emplace_back(bluestore_pextent_t(start * m_block_size,
-					count * m_block_size));
-  }
-}
-
 // bluestore_bdev_label_t
 
 void bluestore_bdev_label_t::encode(bufferlist& bl) const

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -134,51 +134,6 @@ struct denc_traits<PExtentVector> {
   }
 };
 
-
-class ExtentList {
-  PExtentVector *m_extents;
-  int64_t m_block_size;
-  int64_t m_max_blocks;
-
-public:
-  void init(PExtentVector *extents, int64_t block_size,
-	    uint64_t max_alloc_size) {
-    m_extents = extents;
-    m_block_size = block_size;
-    m_max_blocks = max_alloc_size / block_size;
-    assert(m_extents->empty());
-  }
-
-  ExtentList(PExtentVector *extents, int64_t block_size) {
-    init(extents, block_size, 0);
-  }
-
-  ExtentList(PExtentVector *extents, int64_t block_size,
-	     uint64_t max_alloc_size) {
-    init(extents, block_size, max_alloc_size);
-  }
-
-  void reset() {
-    m_extents->clear();
-  }
-
-  void add_extents(int64_t start, int64_t count);
-
-  PExtentVector *get_extents() {
-    return m_extents;
-  }
-
-  std::pair<int64_t, int64_t> get_nth_extent(int index) {
-      return std::make_pair
-            ((*m_extents)[index].offset / m_block_size,
-             (*m_extents)[index].length / m_block_size);
-  }
-
-  int64_t get_extent_count() {
-    return m_extents->size();
-  }
-};
-
 /// extent_map: a map of reference counted extents
 struct bluestore_extent_ref_map_t {
   struct record_t {

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -64,92 +64,27 @@ struct bluestore_cnode_t {
 };
 WRITE_CLASS_DENC(bluestore_cnode_t)
 
-class AllocExtent;
-typedef mempool::bluestore_alloc::vector<AllocExtent> AllocExtentVector;
-class AllocExtent {
-public:
-  uint64_t offset;
-  uint32_t length;
-
-  AllocExtent() { 
-    offset = 0;
-    length = 0;
-  }
-
-  AllocExtent(int64_t off, int32_t len) : offset(off), length(len) { }
-  uint64_t end() const {
-    return offset + length;
-  }
-  bool operator==(const AllocExtent& other) const {
-    return offset == other.offset && length == other.length;
-  }
-};
-
-inline static ostream& operator<<(ostream& out, const AllocExtent& e) {
-  return out << "0x" << std::hex << e.offset << "~" << e.length << std::dec;
-}
-
-class ExtentList {
-  AllocExtentVector *m_extents;
-  int64_t m_block_size;
-  int64_t m_max_blocks;
-
-public:
-  void init(AllocExtentVector *extents, int64_t block_size,
-	    uint64_t max_alloc_size) {
-    m_extents = extents;
-    m_block_size = block_size;
-    m_max_blocks = max_alloc_size / block_size;
-    assert(m_extents->empty());
-  }
-
-  ExtentList(AllocExtentVector *extents, int64_t block_size) {
-    init(extents, block_size, 0);
-  }
-
-  ExtentList(AllocExtentVector *extents, int64_t block_size,
-	     uint64_t max_alloc_size) {
-    init(extents, block_size, max_alloc_size);
-  }
-
-  void reset() {
-    m_extents->clear();
-  }
-
-  void add_extents(int64_t start, int64_t count);
-
-  AllocExtentVector *get_extents() {
-    return m_extents;
-  }
-
-  std::pair<int64_t, int64_t> get_nth_extent(int index) {
-      return std::make_pair
-            ((*m_extents)[index].offset / m_block_size,
-             (*m_extents)[index].length / m_block_size);
-  }
-
-  int64_t get_extent_count() {
-    return m_extents->size();
-  }
-};
-
-
 /// pextent: physical extent
-struct bluestore_pextent_t : public AllocExtent {
-  const static uint64_t INVALID_OFFSET = ~0ull;
+struct bluestore_pextent_t {
+  static const uint64_t INVALID_OFFSET = ~0ull;
 
-  bluestore_pextent_t() : AllocExtent() {}
-  bluestore_pextent_t(uint64_t o, uint64_t l) : AllocExtent(o, l) {}
-  bluestore_pextent_t(const AllocExtent &ext) :
-    AllocExtent(ext.offset, ext.length) { }
+  uint64_t offset = 0;
+  uint32_t length = 0;
 
-  bluestore_pextent_t& operator=(const AllocExtent &ext) {
-    offset = ext.offset;
-    length = ext.length;
-    return *this;
-  }
+  bluestore_pextent_t() {}
+  bluestore_pextent_t(uint64_t o, uint64_t l) : offset(o), length(l) {}
+  bluestore_pextent_t(const bluestore_pextent_t &ext) :
+    offset(ext.offset), length(ext.length) {}
+
   bool is_valid() const {
     return offset != INVALID_OFFSET;
+  }
+  uint64_t end() const {
+    return offset != INVALID_OFFSET ? offset + length : INVALID_OFFSET;
+  }
+
+  bool operator==(const bluestore_pextent_t& other) const {
+    return offset == other.offset && length == other.length;
   }
 
   DENC(bluestore_pextent_t, v, p) {
@@ -199,6 +134,50 @@ struct denc_traits<PExtentVector> {
   }
 };
 
+
+class ExtentList {
+  PExtentVector *m_extents;
+  int64_t m_block_size;
+  int64_t m_max_blocks;
+
+public:
+  void init(PExtentVector *extents, int64_t block_size,
+	    uint64_t max_alloc_size) {
+    m_extents = extents;
+    m_block_size = block_size;
+    m_max_blocks = max_alloc_size / block_size;
+    assert(m_extents->empty());
+  }
+
+  ExtentList(PExtentVector *extents, int64_t block_size) {
+    init(extents, block_size, 0);
+  }
+
+  ExtentList(PExtentVector *extents, int64_t block_size,
+	     uint64_t max_alloc_size) {
+    init(extents, block_size, max_alloc_size);
+  }
+
+  void reset() {
+    m_extents->clear();
+  }
+
+  void add_extents(int64_t start, int64_t count);
+
+  PExtentVector *get_extents() {
+    return m_extents;
+  }
+
+  std::pair<int64_t, int64_t> get_nth_extent(int index) {
+      return std::make_pair
+            ((*m_extents)[index].offset / m_block_size,
+             (*m_extents)[index].length / m_block_size);
+  }
+
+  int64_t get_extent_count() {
+    return m_extents->size();
+  }
+};
 
 /// extent_map: a map of reference counted extents
 struct bluestore_extent_ref_map_t {
@@ -893,7 +872,7 @@ public:
   }
 
   void split(uint32_t blob_offset, bluestore_blob_t& rb);
-  void allocated(uint32_t b_off, uint32_t length, const AllocExtentVector& allocs);
+  void allocated(uint32_t b_off, uint32_t length, const PExtentVector& allocs);
   void allocated_test(const bluestore_pextent_t& alloc); // intended for UT only
 
   /// updates blob's pextents container and return unused pextents eligible

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -58,7 +58,7 @@ TEST_P(AllocTest, test_alloc_min_alloc)
     init_alloc(blocks, block_size);
     alloc->init_add_free(block_size, block_size);
     EXPECT_EQ(alloc->reserve(block_size), 0);
-    AllocExtentVector extents;
+    PExtentVector extents;
     EXPECT_EQ(block_size, alloc->allocate(block_size, block_size,
 					  0, (int64_t) 0, &extents));
   }
@@ -69,7 +69,7 @@ TEST_P(AllocTest, test_alloc_min_alloc)
   {
     alloc->init_add_free(0, block_size * 4);
     EXPECT_EQ(alloc->reserve(block_size * 4), 0);
-    AllocExtentVector extents;
+    PExtentVector extents;
     EXPECT_EQ(4*block_size,
 	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
 			      0, (int64_t) 0, &extents));
@@ -84,7 +84,7 @@ TEST_P(AllocTest, test_alloc_min_alloc)
     alloc->init_add_free(0, block_size * 2);
     alloc->init_add_free(3 * block_size, block_size * 2);
     EXPECT_EQ(alloc->reserve(block_size * 4), 0);
-    AllocExtentVector extents;
+    PExtentVector extents;
   
     EXPECT_EQ(4*block_size,
 	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
@@ -110,7 +110,7 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
   {
     alloc->init_add_free(0, block_size * 4);
     EXPECT_EQ(alloc->reserve(block_size * 4), 0);
-    AllocExtentVector extents;
+    PExtentVector extents;
     EXPECT_EQ(4*block_size,
 	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
 			      block_size, (int64_t) 0, &extents));
@@ -128,7 +128,7 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
   {
     alloc->init_add_free(0, block_size * 4);
     EXPECT_EQ(alloc->reserve(block_size * 4), 0);
-    AllocExtentVector extents;
+    PExtentVector extents;
     EXPECT_EQ(4*block_size,
 	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
 			      2 * block_size, (int64_t) 0, &extents));
@@ -144,7 +144,7 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
   {
     alloc->init_add_free(0, block_size * 1024);
     EXPECT_EQ(alloc->reserve(block_size * 1024), 0);
-    AllocExtentVector extents;
+    PExtentVector extents;
     EXPECT_EQ(1024 * block_size,
 	      alloc->allocate(1024 * (uint64_t)block_size,
 			      (uint64_t) block_size * 4,
@@ -161,7 +161,7 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
   {
     alloc->init_add_free(0, block_size * 16);
     EXPECT_EQ(alloc->reserve(block_size * 16), 0);
-    AllocExtentVector extents;
+    PExtentVector extents;
     EXPECT_EQ(16 * block_size,
 	      alloc->allocate(16 * (uint64_t)block_size, (uint64_t) block_size,
 			      2 * block_size, (int64_t) 0, &extents));
@@ -184,7 +184,7 @@ TEST_P(AllocTest, test_alloc_failure)
     alloc->init_add_free(block_size * 512, block_size * 256);
 
     EXPECT_EQ(alloc->reserve(block_size * 512), 0);
-    AllocExtentVector extents;
+    PExtentVector extents;
     EXPECT_EQ(512 * block_size,
 	      alloc->allocate(512 * (uint64_t)block_size,
 			      (uint64_t) block_size * 256,
@@ -210,7 +210,7 @@ TEST_P(AllocTest, test_alloc_big)
   for (int64_t big = mas; big < 1048576*128; big*=2) {
     cout << big << std::endl;
     EXPECT_EQ(alloc->reserve(big), 0);
-    AllocExtentVector extents;
+    PExtentVector extents;
     EXPECT_EQ(big,
 	      alloc->allocate(big, mas, 0, &extents));
   }
@@ -230,7 +230,7 @@ TEST_P(AllocTest, test_alloc_hint_bmap)
   init_alloc(blocks, 1);
   alloc->init_add_free(0, blocks);
 
-  AllocExtentVector extents;
+  PExtentVector extents;
   alloc->reserve(blocks);
 
   allocated = alloc->allocate(1, 1, 1, zone_size, &extents);
@@ -286,7 +286,7 @@ TEST_P(AllocTest, test_alloc_non_aligned_len)
   alloc->init_add_free(3670016, 2097152);
 
   EXPECT_EQ(0, alloc->reserve(want_size));
-  AllocExtentVector extents;
+  PExtentVector extents;
   EXPECT_EQ(want_size, alloc->allocate(want_size, alloc_unit, 0, &extents));
 }
 

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -283,7 +283,7 @@ TEST(BitAllocator, test_zone_alloc)
   bmap_test_assert(lock);
 
   int64_t blk_size = 1024;
-  AllocExtentVector extents;
+  PExtentVector extents;
   std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, blk_size);
   allocated = zone->alloc_blocks_dis(zone->size() / 2, 1, 0, 0, block_list.get());
   bmap_test_assert(allocated == zone->size() / 2);
@@ -291,7 +291,7 @@ TEST(BitAllocator, test_zone_alloc)
 
   {
     int64_t blk_size = 1024;
-    AllocExtentVector extents;
+    PExtentVector extents;
     std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, blk_size);
 
     zone = std::make_unique<BitMapZone>(g_ceph_context, total_blocks, 0);
@@ -314,7 +314,7 @@ TEST(BitAllocator, test_zone_alloc)
    */
   {
     int64_t blk_size = 1;
-    AllocExtentVector extents;
+    PExtentVector extents;
 
     for (int i = 1; i <= total_blocks - BmapEntry::size(); i = i << 1) {
       for (int64_t j = 0; j <= BmapEntry::size(); j = 1 << j) {
@@ -425,7 +425,7 @@ TEST(BitAllocator, test_bmap_alloc)
     for (int64_t iter = 0; iter < max_iter; iter++) {
       for (int64_t j = 0; alloc_size <= total_blocks; j++) {
         int64_t blk_size = 1024;
-        AllocExtentVector extents;
+        PExtentVector extents;
         std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, blk_size, alloc_size);
         for (int64_t i = 0; i < total_blocks; i += alloc_size) {
           bmap_test_assert(alloc->reserve_blocks(alloc_size) == true);
@@ -447,7 +447,7 @@ TEST(BitAllocator, test_bmap_alloc)
     }
 
     int64_t blk_size = 1024;
-    AllocExtentVector extents;
+    PExtentVector extents;
 
     ExtentList *block_list = new ExtentList(&extents, blk_size);
   
@@ -488,7 +488,7 @@ bool alloc_extents_max_block(BitAllocator *alloc,
   int64_t allocated = 0;
   int64_t verified = 0;
   int64_t count = 0;
-  AllocExtentVector extents;
+  PExtentVector extents;
 
   std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, blk_size, max_alloc);
 
@@ -533,7 +533,7 @@ do_work_dis(BitAllocator *alloc)
   int64_t alloced = 0;
   int64_t num_blocks = alloc->size() / NUM_THREADS;
 
-  AllocExtentVector extents;
+  PExtentVector extents;
   std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, 4096);
 
   while (num_iters--) {

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -284,22 +284,22 @@ TEST(BitAllocator, test_zone_alloc)
 
   int64_t blk_size = 1024;
   PExtentVector extents;
-  std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, blk_size);
-  allocated = zone->alloc_blocks_dis(zone->size() / 2, 1, 0, 0, block_list.get());
+  AllocatorExtentList block_list(&extents, blk_size);
+  allocated = zone->alloc_blocks_dis(zone->size() / 2, 1, 0, 0, &block_list);
   bmap_test_assert(allocated == zone->size() / 2);
 
 
   {
     int64_t blk_size = 1024;
     PExtentVector extents;
-    std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, blk_size);
+    AllocatorExtentList block_list(&extents, blk_size);
 
     zone = std::make_unique<BitMapZone>(g_ceph_context, total_blocks, 0);
     lock = zone->lock_excl_try();
     bmap_test_assert(lock);
     for (int i = 0; i < zone->size(); i += 4) {
-      block_list->reset();
-      allocated = zone->alloc_blocks_dis(1, 1, i, 0, block_list.get());
+      block_list.reset();
+      allocated = zone->alloc_blocks_dis(1, 1, i, 0, &block_list);
       bmap_test_assert(allocated == 1);
       EXPECT_EQ(extents[0].offset, (uint64_t) i * blk_size);
     }
@@ -319,24 +319,23 @@ TEST(BitAllocator, test_zone_alloc)
     for (int i = 1; i <= total_blocks - BmapEntry::size(); i = i << 1) {
       for (int64_t j = 0; j <= BmapEntry::size(); j = 1 << j) {
 	extents.clear();
-        ExtentList *block_list = new ExtentList(&extents, blk_size);
+        AllocatorExtentList block_list(&extents, blk_size);
 	zone = std::make_unique<BitMapZone>(g_ceph_context, total_blocks, 0);
         lock = zone->lock_excl_try();
         bmap_test_assert(lock);
 
-        block_list->reset();
+        block_list.reset();
         int64_t need_blks = (((total_blocks - j) / i) * i);
-        allocated = zone->alloc_blocks_dis(need_blks, i, j, 0, block_list);
+        allocated = zone->alloc_blocks_dis(need_blks, i, j, 0, &block_list);
         bmap_test_assert(allocated == need_blks);
         bmap_test_assert(extents[0].offset ==  (uint64_t) j);
-        delete block_list;
       }
     }
 
     //allocation in loop
     {
       extents.clear();
-      ExtentList *block_list = new ExtentList(&extents, blk_size);
+      AllocatorExtentList block_list(&extents, blk_size);
       zone = std::make_unique<BitMapZone>(g_ceph_context, total_blocks, 0);
       lock = zone->lock_excl_try();
 
@@ -344,17 +343,17 @@ TEST(BitAllocator, test_zone_alloc)
         for (int i = 1; i <= total_blocks; i = i << 1) {
           for (int j = 0; j < total_blocks; j +=i) {
             bmap_test_assert(lock);
-            block_list->reset();
+            block_list.reset();
             int64_t need_blks = i;
-            allocated = zone->alloc_blocks_dis(need_blks, i, 0, 0, block_list);
+            allocated = zone->alloc_blocks_dis(need_blks, i, 0, 0, &block_list);
             bmap_test_assert(allocated == need_blks);
             bmap_test_assert(extents[0].offset ==  (uint64_t) j);
-            block_list->reset();
+            block_list.reset();
           }
           {
-            allocated = zone->alloc_blocks_dis(1, 1, 0, 0, block_list);
+            allocated = zone->alloc_blocks_dis(1, 1, 0, 0, &block_list);
             bmap_test_assert(allocated == 0);
-            block_list->reset();
+            block_list.reset();
           }
          
           for (int j = 0; j < total_blocks; j +=i) {
@@ -362,34 +361,33 @@ TEST(BitAllocator, test_zone_alloc)
           }
         }
       }
-      delete block_list;
     }
 
     {
       extents.clear();
-      std::unique_ptr<ExtentList> block_list(new ExtentList(&extents, blk_size));
+      AllocatorExtentList block_list(&extents, blk_size);
       zone = std::make_unique<BitMapZone>(g_ceph_context, total_blocks, 0);
       lock = zone->lock_excl_try();
       bmap_test_assert(lock);
 
-      block_list->reset();
-      allocated = zone->alloc_blocks_dis(total_blocks + 1, total_blocks + 1, 0, 1024, block_list.get());
+      block_list.reset();
+      allocated = zone->alloc_blocks_dis(total_blocks + 1, total_blocks + 1, 0, 1024, &block_list);
       bmap_test_assert(allocated == 0);
 
-      block_list->reset();
-      allocated = zone->alloc_blocks_dis(total_blocks, total_blocks, 1, 1024, block_list.get());
+      block_list.reset();
+      allocated = zone->alloc_blocks_dis(total_blocks, total_blocks, 1, 1024, &block_list);
       bmap_test_assert(allocated == 0);
 
-      block_list->reset();
-      allocated = zone->alloc_blocks_dis(total_blocks, total_blocks, 0, 0, block_list.get());
+      block_list.reset();
+      allocated = zone->alloc_blocks_dis(total_blocks, total_blocks, 0, 0, &block_list);
       bmap_test_assert(allocated == total_blocks);
       bmap_test_assert(extents[0].offset == 0);
 
       zone->free_blocks(extents[0].offset, allocated);
         
       extents.clear();
-      block_list = std::make_unique<ExtentList>(&extents, blk_size, total_blocks / 4 * blk_size);
-      allocated = zone->alloc_blocks_dis(total_blocks, total_blocks / 4, 0, 0, block_list.get());
+      block_list = AllocatorExtentList(&extents, blk_size, total_blocks / 4 * blk_size);
+      allocated = zone->alloc_blocks_dis(total_blocks, total_blocks / 4, 0, 0, &block_list);
       bmap_test_assert(allocated == total_blocks);
       for (int i = 0; i < 4; i++) {
 	bmap_test_assert(extents[i].offset == (uint64_t) i * (total_blocks / 4));
@@ -426,18 +424,18 @@ TEST(BitAllocator, test_bmap_alloc)
       for (int64_t j = 0; alloc_size <= total_blocks; j++) {
         int64_t blk_size = 1024;
         PExtentVector extents;
-        std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, blk_size, alloc_size);
+        AllocatorExtentList block_list(&extents, blk_size, alloc_size);
         for (int64_t i = 0; i < total_blocks; i += alloc_size) {
           bmap_test_assert(alloc->reserve_blocks(alloc_size) == true);
           allocated = alloc->alloc_blocks_dis_res(alloc_size, std::min(alloc_size, zone_size),
-                                                  0, block_list.get());
+                                                  0, &block_list);
           bmap_test_assert(alloc_size == allocated);
-          bmap_test_assert(block_list->get_extent_count() == 
+          bmap_test_assert(block_list.get_extent_count() == 
                            (alloc_size > zone_size? alloc_size / zone_size: 1));
           bmap_test_assert(extents[0].offset == (uint64_t) i * blk_size);
           bmap_test_assert((int64_t) extents[0].length == 
                            ((alloc_size > zone_size? zone_size: alloc_size) * blk_size));
-          block_list->reset();
+          block_list.reset();
         }
         for (int64_t i = 0; i < total_blocks; i += alloc_size) {
           alloc->free_blocks(i, alloc_size);
@@ -449,27 +447,26 @@ TEST(BitAllocator, test_bmap_alloc)
     int64_t blk_size = 1024;
     PExtentVector extents;
 
-    ExtentList *block_list = new ExtentList(&extents, blk_size);
+    AllocatorExtentList block_list(&extents, blk_size);
   
     ASSERT_EQ(alloc->reserve_blocks(alloc->size() / 2), true);
-    allocated = alloc->alloc_blocks_dis_res(alloc->size()/2, 1, 0, block_list);
+    allocated = alloc->alloc_blocks_dis_res(alloc->size()/2, 1, 0, &block_list);
     ASSERT_EQ(alloc->size()/2, allocated);
 
-    block_list->reset();
+    block_list.reset();
     ASSERT_EQ(alloc->reserve_blocks(1), true);
-    allocated = alloc->alloc_blocks_dis_res(1, 1, 0, block_list);
+    allocated = alloc->alloc_blocks_dis_res(1, 1, 0, &block_list);
     bmap_test_assert(allocated == 1);
 
     alloc->free_blocks(alloc->size()/2, 1);
 
-    block_list->reset();
+    block_list.reset();
     ASSERT_EQ(alloc->reserve_blocks(1), true);
-    allocated = alloc->alloc_blocks_dis_res(1, 1, 0, block_list);
+    allocated = alloc->alloc_blocks_dis_res(1, 1, 0, &block_list);
     bmap_test_assert(allocated == 1);
 
     bmap_test_assert((int64_t) extents[0].offset == alloc->size()/2 * blk_size);
 
-    delete block_list;
     delete alloc;
 
   }
@@ -490,10 +487,10 @@ bool alloc_extents_max_block(BitAllocator *alloc,
   int64_t count = 0;
   PExtentVector extents;
 
-  std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, blk_size, max_alloc);
+  AllocatorExtentList block_list(&extents, blk_size, max_alloc);
 
   EXPECT_EQ(alloc->reserve_blocks(total_alloc), true);
-  allocated = alloc->alloc_blocks_dis_res(total_alloc, blk_size, 0, block_list.get());
+  allocated = alloc->alloc_blocks_dis_res(total_alloc, blk_size, 0, &block_list);
   EXPECT_EQ(allocated, total_alloc);
 
   max_alloc = total_alloc > max_alloc? max_alloc: total_alloc;
@@ -534,16 +531,16 @@ do_work_dis(BitAllocator *alloc)
   int64_t num_blocks = alloc->size() / NUM_THREADS;
 
   PExtentVector extents;
-  std::unique_ptr<ExtentList> block_list = std::make_unique<ExtentList>(&extents, 4096);
+  AllocatorExtentList block_list(&extents, 4096);
 
   while (num_iters--) {
     alloc_assert(alloc->reserve_blocks(num_blocks));
-    alloced = alloc->alloc_blocks_dis_res(num_blocks, 1, 0, block_list.get());
+    alloced = alloc->alloc_blocks_dis_res(num_blocks, 1, 0, &block_list);
     alloc_assert(alloced == num_blocks);
 
-    alloc_assert(alloc->is_allocated_dis(block_list.get(), num_blocks));
-    alloc->free_blocks_dis(num_blocks, block_list.get());
-    block_list.get()->reset();
+    alloc_assert(alloc->is_allocated_dis(&block_list, num_blocks));
+    alloc->free_blocks_dis(num_blocks, &block_list);
+    block_list.reset();
   }
 }
 

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1242,7 +1242,7 @@ TEST(GarbageCollector, BasicTest)
     ASSERT_EQ(saving, 1);
     auto& to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.size(), 1u);
-    ASSERT_EQ(to_collect[0], AllocExtent(100,10) );
+    ASSERT_EQ(to_collect[0], bluestore_pextent_t(100,10) );
 
     em.clear();
     old_extents.clear();
@@ -1312,10 +1312,10 @@ TEST(GarbageCollector, BasicTest)
     ASSERT_EQ(saving, 2);
     auto& to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.size(), 2u);
-    ASSERT_TRUE(to_collect[0] == AllocExtent(0x0,0x8000) ||
-		  to_collect[1] == AllocExtent(0x0,0x8000));
-    ASSERT_TRUE(to_collect[0] == AllocExtent(0x3f000,0x1000) ||
-		  to_collect[1] == AllocExtent(0x3f000,0x1000));
+    ASSERT_TRUE(to_collect[0] == bluestore_pextent_t(0x0,0x8000) ||
+		  to_collect[1] == bluestore_pextent_t(0x0,0x8000));
+    ASSERT_TRUE(to_collect[0] == bluestore_pextent_t(0x3f000,0x1000) ||
+		  to_collect[1] == bluestore_pextent_t(0x3f000,0x1000));
 
     em.clear();
     old_extents.clear();
@@ -1433,10 +1433,10 @@ TEST(GarbageCollector, BasicTest)
     ASSERT_EQ(saving, 2);
     auto& to_collect = gc.get_extents_to_collect();
     ASSERT_EQ(to_collect.size(), 2u);
-    ASSERT_TRUE(to_collect[0] == AllocExtent(0x0,0x8000) ||
-		  to_collect[1] == AllocExtent(0x0,0x8000));
-    ASSERT_TRUE(to_collect[0] == AllocExtent(0x3f000,0x1000) ||
-		  to_collect[1] == AllocExtent(0x3f000,0x1000));
+    ASSERT_TRUE(to_collect[0] == bluestore_pextent_t(0x0,0x8000) ||
+		  to_collect[1] == bluestore_pextent_t(0x0,0x8000));
+    ASSERT_TRUE(to_collect[0] == bluestore_pextent_t(0x3f000,0x1000) ||
+		  to_collect[1] == bluestore_pextent_t(0x3f000,0x1000));
 
     em.clear();
     old_extents.clear();


### PR DESCRIPTION
There is no much need in having both AllocExtent and bluestore_extent_t classes. The same for corresponding vectors. Hence merging that stuff.
Also moving and renaming ExtentList helper as it's used within allocator's subsystem only.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>