### PR TITLE
mgr: shutdown() before performing respawn

### DIFF
--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -255,6 +255,8 @@ void MgrStandby::shutdown()
 
 void MgrStandby::respawn()
 {
+  shutdown();
+
   char *new_argv[orig_argc+1];
   dout(1) << " e: '" << orig_argv[0] << "'" << dendl;
   for (int i=0; i<orig_argc; i++) {


### PR DESCRIPTION
so the shutdown() methods of mgr modules can be called when we enable/disable modules.

Signed-off-by: Kefu Chai <kchai@redhat.com>