### PR TITLE
doc: print pg peering in SVG instead of PNG

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -111,6 +111,7 @@ for target in $sphinx_targets; do
     case $target in
         html)
             builder=dirhtml
+            extra_opt="-D graphviz_output_format=svg"
             ;;
         man)
             extra_opt="-t man"


### PR DESCRIPTION
1. Png images included into docs are useless because of small resolution.
      http://docs.ceph.com/docs/master/dev/peering/#state-model
    While SVG is vector and supported by Sphinx.

2. Add troubleshooting of incomplete PG blocked by history les bound.