### PR TITLE
ceph-volume: adds custom cluster name support to simple

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/activate.py
@@ -5,7 +5,7 @@ import json
 import logging
 import os
 from textwrap import dedent
-from ceph_volume import process, decorators, terminal
+from ceph_volume import process, decorators, terminal, conf
 from ceph_volume.util import system, disk
 from ceph_volume.util import encryption as encryption_utils
 from ceph_volume.systemd import systemctl
@@ -94,6 +94,7 @@ class Activate(object):
         osd_id = osd_metadata.get('whoami', args.osd_id)
         osd_fsid = osd_metadata.get('fsid', args.osd_fsid)
         data_uuid = osd_metadata.get('data', {}).get('uuid')
+        conf.cluster = osd_metadata.get('cluster_name', 'ceph')
         if not data_uuid:
             raise RuntimeError(
                 'Unable to activate OSD %s - no "uuid" key found for data' % args.osd_id

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/activate/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/activate/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-luks/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-luks/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-plain/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-plain/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/activate/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/activate/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/dmcrypt-luks/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/dmcrypt-luks/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/dmcrypt-plain/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/dmcrypt-plain/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/activate/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/activate/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/dmcrypt-luks/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/dmcrypt-luks/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/dmcrypt-plain/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/dmcrypt-plain/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/activate/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/activate/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/dmcrypt-luks/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/dmcrypt-luks/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/dmcrypt-plain/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/dmcrypt-plain/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.1.0/24"
 cluster_network: "192.168.2.0/24"
 monitor_interface: eth1


### PR DESCRIPTION
We need this so that ``ceph-volume simple activate`` can activate ``ceph-disk`` OSDs that were created in a cluster using a custom name.