### PR TITLE
common/ConfUtils: check key before actually normalizing

### DIFF
--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -252,6 +252,10 @@ trim_whitespace(std::string &str, bool strip_internal)
 std::string ConfFile::
 normalize_key_name(const std::string &key)
 {
+  if (key.find_first_of(" \t\r\n\f\v\xa0") == string::npos) {
+    return key;
+  }
+
   string k(key);
   ConfFile::trim_whitespace(k, true);
   std::replace(k.begin(), k.end(), ' ', '_');


### PR DESCRIPTION
Key normalization involves some copying and strlens, and these are expensive. Check if key contain whitespaces, normalize it only when it does.
In my testing, normalize_key eats better part of the entire cpu time consumed by get_val<T>() so this improves things in cases of calls with proper (already normalized) variable names, which I believe is majority.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>