### PR TITLE
test/admin_socket_output: add --vstart=path/to/asok option

### DIFF
--- a/src/test/admin_socket_output.cc
+++ b/src/test/admin_socket_output.cc
@@ -76,7 +76,7 @@ bool AdminSocketOutput::init_sockets() {
   std::cout << "Initialising sockets" << std::endl;
   for (const auto &x : fs::directory_iterator(socketdir)) {
     std::cout << x.path() << std::endl;
-    if (fs::path(x.path()).extension() == ".asok") {
+    if (x.path().extension() == ".asok") {
       for (auto &target : targets) {
         if (std::regex_search(x.path().filename().string(),
             std::regex(prefix + target + R"(\..*\.asok)"))) {

--- a/src/test/admin_socket_output.h
+++ b/src/test/admin_socket_output.h
@@ -41,8 +41,8 @@ public:
 
   void exec();
 
-  void mod_for_vstart() {
-    socketdir = "./out";
+  void mod_for_vstart(const std::string& dir) {
+    socketdir = dir;
     prefix = "";
   }
 

--- a/src/test/test_admin_socket_output.cc
+++ b/src/test/test_admin_socket_output.cc
@@ -58,7 +58,8 @@ int main(int argc, char** argv) {
     ("mgr", "Test mgr admin socket output")
     ("mds", "Test mds admin socket output")
     ("client", "Test client (includes rgw) admin socket output")
-    ("vstart", "Modify to run in vstart environment")
+    ("vstart", po::value<std::string>()->implicit_value("./out"),
+     "Modify to run in vstart environment")
     ;
   auto parsed =
     po::command_line_parser(argc, argv).options(desc).allow_unregistered().run();
@@ -80,7 +81,7 @@ int main(int argc, char** argv) {
   std::unique_ptr<AdminSocketOutput> asockout(new AdminSocketOutput);
 
   if (vm.count("vstart")) {
-    asockout->mod_for_vstart();
+    asockout->mod_for_vstart(vm["vstart"].as<std::string>());
   }
 
   if(vm.count("all")) {


### PR DESCRIPTION
so we can test it using a vstart cluster