### PR TITLE
client: wire up ceph_ll_readv and ceph_ll_writev

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -835,6 +835,7 @@ private:
   int64_t _read(Fh *fh, int64_t offset, uint64_t size, bufferlist *bl);
   int64_t _write(Fh *fh, int64_t offset, uint64_t size, const char *buf,
           const struct iovec *iov, int iovcnt);
+  int64_t _preadv_pwritev_locked(Fh *f, const struct iovec *iov, unsigned iovcnt, int64_t offset, bool write);
   int _preadv_pwritev(int fd, const struct iovec *iov, unsigned iovcnt, int64_t offset, bool write);
   int _flush(Fh *fh);
   int _fsync(Fh *fh, bool syncdataonly);
@@ -1214,6 +1215,8 @@ public:
 
   int ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl);
   int ll_write(Fh *fh, loff_t off, loff_t len, const char *data);
+  int64_t ll_readv(struct Fh *fh, const struct iovec *iov, int iovcnt, int64_t off);
+  int64_t ll_writev(struct Fh *fh, const struct iovec *iov, int iovcnt, int64_t off);
   loff_t ll_lseek(Fh *fh, loff_t offset, int whence);
   int ll_flush(Fh *fh);
   int ll_fsync(Fh *fh, bool syncdataonly);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -832,8 +832,8 @@ private:
 	      const char *data_pool, bool *created, const UserPerm &perms);
 
   loff_t _lseek(Fh *fh, loff_t offset, int whence);
-  int _read(Fh *fh, int64_t offset, uint64_t size, bufferlist *bl);
-  int _write(Fh *fh, int64_t offset, uint64_t size, const char *buf,
+  int64_t _read(Fh *fh, int64_t offset, uint64_t size, bufferlist *bl);
+  int64_t _write(Fh *fh, int64_t offset, uint64_t size, const char *buf,
           const struct iovec *iov, int iovcnt);
   int _preadv_pwritev(int fd, const struct iovec *iov, unsigned iovcnt, int64_t offset, bool write);
   int _flush(Fh *fh);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -835,7 +835,8 @@ private:
   int64_t _read(Fh *fh, int64_t offset, uint64_t size, bufferlist *bl);
   int64_t _write(Fh *fh, int64_t offset, uint64_t size, const char *buf,
           const struct iovec *iov, int iovcnt);
-  int64_t _preadv_pwritev_locked(Fh *f, const struct iovec *iov, unsigned iovcnt, int64_t offset, bool write);
+  int64_t _preadv_pwritev_locked(Fh *f, const struct iovec *iov,
+	      unsigned iovcnt, int64_t offset, bool write, bool clamp_to_int);
   int _preadv_pwritev(int fd, const struct iovec *iov, unsigned iovcnt, int64_t offset, bool write);
   int _flush(Fh *fh);
   int _fsync(Fh *fh, bool syncdataonly);

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -1559,14 +1559,14 @@ extern "C" int64_t ceph_ll_readv(class ceph_mount_info *cmount,
 				 struct Fh *fh, const struct iovec *iov,
 				 int iovcnt, int64_t off)
 {
-  return -1; // TODO:  implement
+  return (cmount->get_client()->ll_readv(fh, iov, iovcnt, off));
 }
 
 extern "C" int64_t ceph_ll_writev(class ceph_mount_info *cmount,
 				  struct Fh *fh, const struct iovec *iov,
 				  int iovcnt, int64_t off)
 {
-  return -1; // TODO:  implement
+  return (cmount->get_client()->ll_writev(fh, iov, iovcnt, off));
 }
 
 extern "C" int ceph_ll_close(class ceph_mount_info *cmount, Fh* fh)


### PR DESCRIPTION
Ganesha is adding vectorized I/O operations, and samba could probably use them too. This wires them in properly.

First a cleanup: some of the underlying infrastructure was carelessly casting uint64_t values to int32_t when returning read/write lengths. That's potentially problematic if someone issues a large I/O (possibly spread over a large iovec array) as the result could end up looking negative after success. This cleans that code up and pushes the casts up into the callers.

This was necessary as ceph_ll_readv/writev return int64_t, unlike preadv/pwritev which return int. We may want to follow up here with saner handling for really large I/Os when we can't actually return a size that large. (Maybe clamp the I/O sizes in those functions to INT_MAX?)

ceph_ll_readv/writev are defined in the header, but the code always just returns -1. Wire it into the preadv/pwritev code, and simply avoid doing the fd -> Fh conversion in those codepaths.

Finally, add a testcase for ceph_ll_readv and ceph_ll_writev. This is just a clone of the ceph_preadv/ceph_pwritev test, but done with ceph_ll_readv/ceph_ll_writev.