### PR TITLE
msg/DispatchQueue: clear queue after wait()

### DIFF
--- a/src/msg/DispatchQueue.cc
+++ b/src/msg/DispatchQueue.cc
@@ -81,6 +81,10 @@ void DispatchQueue::enqueue(Message *m, int priority, uint64_t id)
 {
 
   Mutex::Locker l(lock);
+  if (stop) {
+    m->put();
+    return;
+  }
   ldout(cct,20) << "queue " << m << " prio " << priority << dendl;
   add_arrival(m);
   if (priority >= CEPH_MSG_PRIO_LOW) {


### PR DESCRIPTION
Throw out new items after worker thread is stopped.  All over enqueue_* methods were checking for stop except for this one.

Fixes: http://tracker.ceph.com/issues/18351
Signed-off-by: Sage Weil <sage@redhat.com>