### PR TITLE
[WIP] os/bluestore: eradicate some unnecessary divisions with p2_t

### DIFF
--- a/src/common/align.h
+++ b/src/common/align.h
@@ -17,14 +17,26 @@
 #ifndef CEPH_COMMON_ALIGN_H
 #define CEPH_COMMON_ALIGN_H
 
+#include "include/intarith.h"
+
 template <typename T>
 inline constexpr T align_up(T v, T align) {
   return (v + align - 1) & ~(align - 1);
 }
 
 template <typename T>
+inline constexpr T align_up(T v, const ceph::math::p2_t<T>& align) {
+  return (v + align - 1) & ~(align - 1);
+}
+
+template <typename T>
 inline constexpr T align_down(T v, T align) {
-  return v & ~(align - 1);
+  return v & ~(static_cast<T>(align) - 1);
+}
+
+template <typename T>
+inline constexpr T align_down(T v, const ceph::math::p2_t<T>& align) {
+  return v & ~(static_cast<T>(align) - 1);
 }
 
 #endif /* CEPH_COMMON_ALIGN_H */

--- a/src/include/intarith.h
+++ b/src/include/intarith.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_INTARITH_H
 #define CEPH_INTARITH_H
 
+#include <limits>
 #include <type_traits>
 
 #ifndef MIN
@@ -219,5 +220,63 @@ template<class T>
     return 0;
   return (sizeof(v) * 8) - __builtin_clzll(v);
 }
+
+namespace ceph {
+namespace math {
+
+template<class UnsignedValueT>
+class p2_t {
+  typedef uint8_t exponent_type;
+  typedef UnsignedValueT value_type;
+
+  static_assert(std::is_unsigned_v<value_type>);
+  static_assert(std::numeric_limits<exponent_type>::max() >
+		std::numeric_limits<value_type>::digits);
+
+  value_type value;
+
+  struct _check_skipper_t {};
+  p2_t(const value_type value, _check_skipper_t)
+    : value(value) {
+  }
+
+public:
+  p2_t(const value_type value)
+    : value(value) {
+    // 0 isn't a power of two. Additional validation is necessary as
+    // the isp2 routine doesn't sanitize that case.
+    //assert(value != 0);
+    assert(isp2(value));
+  }
+
+  static p2_t<value_type> from_p2(const exponent_type exponent) {
+    return p2_t(1 << exponent, _check_skipper_t());
+  }
+
+  exponent_type get_exponent() const {
+    return ctz(value);
+  }
+
+  value_type get_value() const {
+    return value;
+  }
+
+  operator value_type() const {
+    return value;
+  }
+
+  friend value_type operator/(const value_type& l,
+                                  const p2_t<value_type>& r) {
+    return l >> (cbits(r.value) - 1);
+  }
+
+  friend value_type operator%(const value_type& l,
+                                  const p2_t<value_type>& r) {
+    return l & (r.value - 1);
+  }
+};
+
+} // math
+} // ceph
 
 #endif

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -32,6 +32,7 @@
 #endif
 #include "include/assert.h"
 #include "include/buffer.h"
+#include "include/intarith.h"
 
 #define SPDK_PREFIX "spdk:"
 
@@ -113,7 +114,7 @@ private:
 
 protected:
   uint64_t size;
-  uint64_t block_size;
+  ceph::math::p2_t<uint64_t> block_size;
   bool rotational = true;
 
 public:
@@ -135,8 +136,12 @@ public:
 
   virtual void aio_submit(IOContext *ioc) = 0;
 
-  uint64_t get_size() const { return size; }
-  uint64_t get_block_size() const { return block_size; }
+  uint64_t get_size() const {
+    return size;
+  }
+  ceph::math::p2_t<uint64_t> get_block_size() const {
+    return block_size;
+  }
 
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const = 0;
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4297,7 +4297,6 @@ int BlueStore::_open_bdev(bool create)
 
   // initialize global block parameters
   block_size = bdev->get_block_size();
-  block_mask = ~(block_size - 1);
   // TODO(rzarzynski): introduce a subtype with cached exponent to eradicate
   // *_order members.
   block_size_order = block_size.get_exponent();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1896,7 +1896,8 @@ private:
 
   std::atomic<int> csum_type = {Checksummer::CSUM_CRC32C};
 
-  uint64_t block_size = 0;     ///< block size of block device (power of 2)
+  ///< block size of block device (power of 2)
+  ceph::math::p2_t<uint64_t> block_size = 0;
   uint64_t block_mask = 0;     ///< mask to get just the block offset
   size_t block_size_order = 0; ///< bits to shift to get block size
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1898,7 +1898,6 @@ private:
 
   ///< block size of block device (power of 2)
   ceph::math::p2_t<uint64_t> block_size = 0;
-  uint64_t block_mask = 0;     ///< mask to get just the block offset
   size_t block_size_order = 0; ///< bits to shift to get block size
 
   uint64_t min_alloc_size = 0; ///< minimum allocation unit (power of 2)

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -20,6 +20,7 @@
 #include "include/types.h"
 #include "include/interval_set.h"
 #include "include/utime.h"
+#include "include/intarith.h"
 #include "common/hobject.h"
 #include "compressor/Compressor.h"
 #include "common/Checksummer.h"
@@ -615,12 +616,14 @@ public:
   }
 
   /// return chunk (i.e. min readable block) size for the blob
-  uint64_t get_chunk_size(uint64_t dev_block_size) const {
+  ceph::math::p2_t<uint64_t>
+  get_chunk_size(ceph::math::p2_t<uint64_t> dev_block_size) const {
     return has_csum() ?
-      std::max<uint64_t>(dev_block_size, get_csum_chunk_size()) : dev_block_size;
+      std::max(dev_block_size, get_csum_chunk_size<uint64_t>()) : dev_block_size;
   }
-  uint32_t get_csum_chunk_size() const {
-    return 1 << csum_chunk_order;
+  template<class UnsignedT = uint32_t>
+  ceph::math::p2_t<UnsignedT> get_csum_chunk_size() const {
+    return ceph::math::p2_t<UnsignedT>::from_p2(csum_chunk_order);
   }
   uint32_t get_compressed_payload_length() const {
     return is_compressed() ? compressed_length : 0;
@@ -825,7 +828,8 @@ public:
     flags |= FLAG_CSUM;
     csum_type = type;
     csum_chunk_order = order;
-    csum_data = buffer::create(get_csum_value_size() * len / get_csum_chunk_size());
+    csum_data = buffer::create(
+     get_csum_value_size() * len / get_csum_chunk_size<size_t>());
     csum_data.zero();
     csum_data.reassign_to_mempool(mempool::mempool_bluestore_cache_other);
   }
@@ -870,7 +874,7 @@ public:
       bufferptr t;
       t.swap(csum_data);
       csum_data = buffer::create(
-	get_csum_value_size() * logical_length / get_csum_chunk_size());
+	get_csum_value_size() * logical_length / get_csum_chunk_size<size_t>());
       csum_data.copy_in(0, t.length(), t.c_str());
       csum_data.zero(t.length(), csum_data.length() - t.length());
     }


### PR DESCRIPTION
`BlockDevice::is_valid_io`:

```
       │       bool is_valid_io(uint64_t off, uint64_t len) const {
       │         return (off % block_size == 0 &&
  4,24 │       xor    %edx,%edx
       │       mov    %r12,%rax
       │       mov    0x58(%rbx),%rsi
  7,07 │       div    %rcx
       │                 len % block_size == 0 &&
       │                 len > 0 &&
       │                 off < size &&
 53,00 │       test   %rdx,%rdx
       │     ↓ jne    8b8be0 <KernelDevice::read(unsigned long, unsigned long, 470
```