### PR TITLE
test/librados: s/invoke_result_t/result_of_t/

### DIFF
--- a/src/test/librados/lock.cc
+++ b/src/test/librados/lock.cc
@@ -21,7 +21,7 @@ typedef RadosTestECPP LibRadosLockECPP;
 
 
 template<class Rep, class Period, typename Func, typename... Args,
-         typename Return = std::invoke_result_t<Func, Args...>>
+         typename Return = std::result_of_t<Func&&(Args&&...)>>
 Return wait_until(const std::chrono::duration<Rep, Period>& rel_time,
                 const std::chrono::duration<Rep, Period>& step,
                 const Return& expected,


### PR DESCRIPTION
to workaround buggy libc++ implementation. see
https://cplusplus.github.io/LWG/issue2807 . we should switch to
invoke_result_t once issue2807 is fixed in the latest release of
libc++.

Signed-off-by: Kefu Chai <kchai@redhat.com>