### PR TITLE
rpm: adjust ceph-{osdomap,kvstore,monstore}-tool feature move

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -282,6 +282,7 @@ Requires:      python%{_python_buildid}-setuptools
 Requires:      util-linux
 Requires:      xfsprogs
 Requires:      which
+Conflicts:     ceph-test <= 12.2.2-9
 %if 0%{?suse_version}
 Recommends:    ntp-daemon
 %endif
@@ -340,6 +341,7 @@ Requires:      python%{_python_buildid}-flask
 %if 0%{?suse_version}
 Requires:      python%{_python_buildid}-Flask
 %endif
+Conflicts:     ceph-test <= 12.2.2-9
 %description mon
 ceph-mon is the cluster monitor daemon for the Ceph distributed file
 system. One or more instances of ceph-mon form a Paxos part-time
@@ -462,6 +464,7 @@ Requires:	gptfdisk
 %endif
 Requires:	parted
 Requires:	lvm2
+Conflicts:	ceph-test <= 12.2.2-9
 %description osd
 ceph-osd is the object storage daemon for the Ceph distributed file
 system.  It is responsible for storing objects on a local file system


### PR DESCRIPTION
in pre luminous era, ceph-test "Requires" ceph-common without specifying
any version requirement. this allows a luminous ceph-common package to
co-exist with a kraken ceph-test, so, even if we let luminous ceph-osd
to "Require" the ceph-base of the same version, we are not able to
address following error:

Transaction check error:
  file /usr/bin/ceph-kvstore-tool from install of ceph-base-2:12.2.2-773.g3d84e35.el7.x86_64 conflicts with file from package ceph-test-1:11.2.1-12.gad30823.el7.x86_64

so, per [1], we can use Conflict in this case, as ceph-{base,osd,mon} do
not depend on ceph-test. they are installable independently of whether
ceph-test is installed.

[1] https://fedoraproject.org/wiki/Packaging:Conflicts#Splitting_Packages

Fixes: http://tracker.ceph.com/issues/22558
Signed-off-by: Kefu Chai <kchai@redhat.com>