### PR TITLE
mon/OSDMonitor: wrong calculations on weight in parse_reweights()

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7099,7 +7099,7 @@ static int parse_reweights(CephContext *cct,
       if (osd_weight.second.type() != json_spirit::str_type) {
 	return -EINVAL;
       }
-      auto weight = std::stoul(osd_weight.second.get_str());
+      auto weight = CEPH_OSD_IN*std::stod(osd_weight.second.get_str());
       weights->insert({osd_id, weight});
     }
   } catch (const std::logic_error& e) {


### PR DESCRIPTION
weight values in cmd 'ceph osd reweightn' changed to an unexpected value.
Seems the weight calculation is wrong.

Correct the weight value calculations on weight in parse_reweights()
'ceph osd reweightn' will be consistent with 'ceph osd reweight'

Fixes:http://tracker.ceph.com/issues/22300
Signed-off-by: Gu Zhongyan <guzhongyan@360.cn>