### PR TITLE
qa/tests - Added openstack.yaml fragment

### DIFF
--- a/qa/suites/ceph-deploy/ceph-volume/cluster/openstack.yaml
+++ b/qa/suites/ceph-deploy/ceph-volume/cluster/openstack.yaml
@@ -1,0 +1,8 @@
+openstack:
+  - machine:
+      disk: 10 # GB
+      ram: 2000 # MB
+      cpus: 1
+    volumes: # attached to each instance
+      count: 2
+      size: 15 # GB


### PR DESCRIPTION
This is to enable runs on ovh machines

Note: needs backport to luminous and maybe jewel

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>