### PR TITLE
rgw: civetweb: don't set null env values

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -79,6 +79,12 @@ void RGWCivetWeb::init_env(CephContext *cct)
   for (int i = 0; i < info->num_headers; i++) {
     const struct mg_request_info::mg_header* header = &info->http_headers[i];
     const boost::string_ref name(header->name);
+
+    if (!header->value) {
+      lderr(cct) << "client supplied invalid headers key:" << name << dendl;
+      continue;
+    }
+
     const auto& value = header->value;
 
     if (boost::algorithm::iequals(name, "content-length")) {


### PR DESCRIPTION
civetweb can potentially return null from `parse_http_headers` when a HTTP
header without a ":" is supplied at which point headers.value is null which can
lead to undefined behaviour later in RGW.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>