### PR TITLE
build/ops: change WITH_SYSTEMD default to ON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -633,7 +633,7 @@ if(WITH_MANPAGE)
   add_subdirectory(man)
 endif(WITH_MANPAGE)
 
-option(WITH_SYSTEMD "install systemd target and service files" OFF)
+option(WITH_SYSTEMD "install systemd target and service files" ON)
 if(WITH_SYSTEMD)
   add_subdirectory(systemd)
 endif()

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -894,7 +894,6 @@ cmake .. \
     -DWITH_PYTHON2=OFF \
     -DMGR_PYTHON_VERSION=3 \
 %endif
-    -DWITH_SYSTEMD=ON \
 %if 0%{?rhel} && ! 0%{?centos}
     -DWITH_SUBMAN=ON \
 %endif

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ export DESTDIR=$(CURDIR)/debian/tmp
 export DEB_HOST_ARCH      ?= $(shell dpkg-architecture -qDEB_HOST_ARCH)
 
 extraopts += -DUSE_CRYPTOPP=OFF -DWITH_OCF=ON -DWITH_LTTNG=ON -DWITH_PYTHON3=ON -DWITH_EMBEDDED=OFF
-extraopts += -DWITH_CEPHFS_JAVA=ON
+extraopts += -DWITH_CEPHFS_JAVA=ON -DWITH_SYSTEMD=OFF
 # assumes that ceph is exmpt from multiarch support, so we override the libdir.
 extraopts += -DCMAKE_INSTALL_LIBDIR=/usr/lib
 extraopts += -DCMAKE_INSTALL_LIBEXECDIR=/usr/lib


### PR DESCRIPTION
In a systemd world, it makes more sense to default to "ON" and be explicit when we want to turn it OFF.