### PR TITLE
ceph-volume consume mount/format options from ceph.conf

### DIFF
--- a/src/ceph-volume/ceph_volume/configuration.py
+++ b/src/ceph-volume/ceph_volume/configuration.py
@@ -65,6 +65,11 @@ class Conf(configparser.SafeConfigParser):
         except (configparser.NoSectionError, configparser.NoOptionError):
             raise exceptions.ConfigurationKeyError('global', 'fsid')
 
+    def optionxform(self, s):
+        s = s.replace('_', ' ')
+        s = '_'.join(s.split())
+        return s
+
     def get_safe(self, section, key, default=None):
         """
         Attempt to get a configuration value from a certain section

--- a/src/ceph-volume/ceph_volume/util/constants.py
+++ b/src/ceph-volume/ceph_volume/util/constants.py
@@ -1,7 +1,7 @@
 
 # mount flags
 mount = dict(
-    xfs='noatime,inode64',
+    xfs=['rw', 'noatime' , 'inode64']
 )
 
 

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -153,7 +153,7 @@ def mount_osd(device, osd_id):
         default=constants.mount.get('xfs'),
         split=' ',
     )
-    command.append(flags)
+    command.extend(flags)
     command.append(device)
     command.append(destination)
     process.run(command)


### PR DESCRIPTION
Format and mount options were not being consumed correctly from ceph.conf

If defined for formatting, the command would crash, and it was ignored when mounting. 

Fixes: 
* https://tracker.ceph.com/issues/22785
* https://tracker.ceph.com/issues/22879