### PR TITLE
tests: client-upgrade-kraken: upgrade ceph-test along with other ceph packages

### DIFF
--- a/qa/suites/upgrade/client-upgrade-kraken/kraken-client-x/basic/1-install/kraken-client-x.yaml
+++ b/qa/suites/upgrade/client-upgrade-kraken/kraken-client-x/basic/1-install/kraken-client-x.yaml
@@ -6,6 +6,6 @@ tasks:
 upgrade_workload:
   sequential:
   - install.upgrade:
-      exclude_packages: ['ceph-test', 'ceph-test-dbg','libcephfs1']
+      exclude_packages: ['libcephfs1']
       client.0:
   - print: "**** done install.upgrade to -x on client.0"

--- a/qa/suites/upgrade/client-upgrade-kraken/kraken-client-x/basic/2-workload/rbd_api_tests.yaml
+++ b/qa/suites/upgrade/client-upgrade-kraken/kraken-client-x/basic/2-workload/rbd_api_tests.yaml
@@ -10,7 +10,7 @@ tasks:
     client.0:
     - "cp --force $TESTDIR/ceph_test_librbd_api $(which ceph_test_librbd_api)"
     - "rm -rf $TESTDIR/ceph_test_librbd_api"
-- print: "**** done reverting to jewel ceph_test_librbd_api"
+- print: "**** done reverting to kraken ceph_test_librbd_api"
 - workunit:
     branch: kraken
     clients:

--- a/qa/suites/upgrade/client-upgrade-kraken/kraken-client-x/rbd/1-install/kraken-client-x.yaml
+++ b/qa/suites/upgrade/client-upgrade-kraken/kraken-client-x/rbd/1-install/kraken-client-x.yaml
@@ -4,7 +4,7 @@ tasks:
     exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev']
 - print: "**** done install jewel"
 - install.upgrade:
-   exclude_packages: ['ceph-test', 'ceph-test-dbg','libcephfs1']
+   exclude_packages: ['libcephfs1']
    client.1:
 - print: "**** done install.upgrade to -x on client.0"
 - ceph:

--- a/qa/suites/upgrade/client-upgrade-kraken/kraken-client-x/rbd/1-install/kraken-client-x.yaml
+++ b/qa/suites/upgrade/client-upgrade-kraken/kraken-client-x/rbd/1-install/kraken-client-x.yaml
@@ -2,10 +2,10 @@ tasks:
 - install:
     branch: kraken
     exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev']
-- print: "**** done install jewel"
+- print: "**** done install kraken"
 - install.upgrade:
    exclude_packages: ['libcephfs1']
    client.1:
-- print: "**** done install.upgrade to -x on client.0"
+- print: "**** done install.upgrade to -x on client.1"
 - ceph:
 - print: "**** done ceph task"


### PR DESCRIPTION
Upgrade test was failing because, in luminous and above, three files were moved
from ceph-test to ceph-{base,mon,osd}. When the latter packages are upgraded,
they conflict with ceph-test, which was not being upgraded.

Since it is no longer necessary to avoid upgrading ceph-test, and since
b07aa210aa0ede54ffc3dbe49e334bd51a8f6342 tied ceph-test to the ceph-common of
the exact same version, this bug could be fixed by removing ceph-test from
the list of packages to be excluded from the upgrade.

Fixes: https://tracker.ceph.com/issues/22558