### PR TITLE
librbd: fix wrongly return EROFS

### DIFF
--- a/src/librbd/ManagedLock.cc
+++ b/src/librbd/ManagedLock.cc
@@ -508,12 +508,12 @@ void ManagedLock<I>::handle_acquire_lock(int r) {
 
   m_work_queue->queue(new FunctionContext([this, r](int ret) {
     post_acquire_lock_handler(r, create_context_callback<
-        ManagedLock<I>, &ManagedLock<I>::handle_post_acquire_lock>(this));
+        ManagedLock<I>, &ManagedLock<I>::handle_post_acquired_lock>(this));
   }));
 }
 
 template <typename I>
-void ManagedLock<I>::handle_post_acquire_lock(int r) {
+void ManagedLock<I>::handle_post_acquired_lock(int r) {
   ldout(m_cct, 10) << "r=" << r << dendl;
 
   Mutex::Locker locker(m_lock);

--- a/src/librbd/ManagedLock.h
+++ b/src/librbd/ManagedLock.h
@@ -240,7 +240,7 @@ private:
   void send_acquire_lock();
   void handle_pre_acquire_lock(int r);
   void handle_acquire_lock(int r);
-  void handle_post_acquire_lock(int r);
+  void handle_post_acquired_lock(int r);
   void revert_to_unlock_state(int r);
 
   void send_reacquire_lock();


### PR DESCRIPTION
  when configing rbd_auto_exclusive_lock_until_manual_request=false,
  IO is expected to  excute when caller is the lock owner.
  but it actually return EROFS no matter exclusive lock is locked or not.
  add lock owner check before returning EROFS.

Signed-off-by: shun-s <song.shun3@zte.com.cn>