### PR TITLE
filestore: include <linux/falloc.h>

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -28,6 +28,7 @@
 
 #if defined(__linux__)
 #include <linux/fs.h>
+#include <linux/falloc.h>
 #endif
 
 #include <iostream>

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -48,12 +48,6 @@
 
 #include "include/uuid.h"
 
-
-// from include/linux/falloc.h:
-#ifndef FALLOC_FL_PUNCH_HOLE
-# define FALLOC_FL_PUNCH_HOLE 0x2
-#endif
-
 #if defined(__linux__)
 # ifndef BTRFS_SUPER_MAGIC
 #define BTRFS_SUPER_MAGIC 0x9123683EL

--- a/src/os/fs/FS.cc
+++ b/src/os/fs/FS.cc
@@ -17,9 +17,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-// from include/linux/falloc.h:
-#ifndef FALLOC_FL_PUNCH_HOLE
-# define FALLOC_FL_PUNCH_HOLE 0x2
+#ifdef __linux__
+#include <linux/falloc.h>
 #endif
 
 #include "FS.h"


### PR DESCRIPTION
see https://github.com/ceph/ceph/pull/7768
because we neither define FALLOC_FL_KEEP_SIZE nor include linux/falloc.h，this pull actually disable punching hole.

Signed-off-by: wumingqiao <wumingqiao@inspur.com>