### PR TITLE
install-deps.sh: set python2 %bcond by environment

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -24,6 +24,11 @@ export LC_ALL=C # the following is vulnerable to i18n
 function munge_ceph_spec_in {
     local OUTFILE=$1
     sed -e 's/@//g' -e 's/%bcond_with make_check/%bcond_without make_check/g' < ceph.spec.in > $OUTFILE
+    if type python2 > /dev/null 2>&1 ; then
+        sed -i -e 's/%bcond_with python2/%bcond_without python2/g' $OUTFILE
+    else
+        sed -i -e 's/%bcond_without python2/%bcond_with python2/g' $OUTFILE
+    fi
 }
 
 function ensure_decent_gcc_on_deb {


### PR DESCRIPTION
If there is no /usr/bin/python2 we need to set %bcond_with python2.

Fixes: http://tracker.ceph.com/issues/22999
Signed-off-by: Nathan Cutler <ncutler@suse.com>