### PR TITLE
mon: dump percent_used PGMap field as float

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -877,7 +877,7 @@ void PGMapDigest::dump_object_stat_sum(
   if (f) {
     f->dump_int("kb_used", shift_round_up(sum.num_bytes, 10));
     f->dump_int("bytes_used", sum.num_bytes);
-    f->dump_format_unquoted("percent_used", "%.2f", (used*100));
+    f->dump_float("percent_used", used);
     f->dump_unsigned("max_avail", avail / raw_used_rate);
     f->dump_int("objects", sum.num_objects);
     if (verbose) {


### PR DESCRIPTION
Inspired by discussion on https://github.com/ceph/ceph/pull/20187, which was getting tripped up by this string field.

---

Formatting this as a string was awkward for anyone
consuming it from other code.

Signed-off-by: John Spray <john.spray@redhat.com>