### PR TITLE
qa/rgw: remove some civetweb overrides for beast testing

### DIFF
--- a/qa/suites/rgw/singleton/overrides.yaml
+++ b/qa/suites/rgw/singleton/overrides.yaml
@@ -4,5 +4,3 @@ overrides:
     conf:
       client:
         debug rgw: 20
-  rgw:
-    frontend: civetweb

--- a/qa/suites/rgw/verify/overrides.yaml
+++ b/qa/suites/rgw/verify/overrides.yaml
@@ -6,5 +6,4 @@ overrides:
         rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl: false
   rgw:
-    frontend: civetweb
     compression type: random


### PR DESCRIPTION
these overrides were preventing frontend/beast.yaml from selecting the beast frontend

Fixes: http://tracker.ceph.com/issues/23002