### PR TITLE
ceph_volume: recognize a loop device as a disk

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -203,13 +203,10 @@ def is_device(dev):
     # use lsblk first, fall back to using stat
     TYPE = lsblk(dev).get('TYPE')
     if TYPE:
-        return TYPE == 'disk'
+        return TYPE == 'disk' or TYPE == 'loop'
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)
-    if stat.S_ISBLK(os.lstat(dev)):
-        return True
-    return False
 
 
 def is_partition(dev):


### PR DESCRIPTION
ceph-volume is unable to prepare a loop device, where ceph-disk was once able to because a loop device is not recognized as a block device. This is due to lsblk returning TYPE 'loop' instead of 'disk'.

Here's a quick test script to show the differences in disk detection:
> import os
from ceph_volume.util.disk import lsblk, _stat_is_device
> 
> loop_device = '/dev/loop0'
> 
> print 'TYPE: {}'.format(lsblk(loop_device).get('TYPE'))
stat_mode = os.lstat(loop_device).st_mode
print '_stat_is_device: {}'.format(_stat_is_device(stat_mode))
> 
> from ceph_disk.main import ldev_is_diskdevice
print 'deprecated is_diskdevice: {}'.format(ldev_is_diskdevice(loop_device))

Signed-off-by: Justin C Moy <justin.moy@sendgrid.com>