### PR TITLE
qa/rgw: verify suite tests civetweb with ssl

### DIFF
--- a/qa/suites/rgw/verify/frontend
+++ b/qa/suites/rgw/verify/frontend
@@ -1,1 +1,0 @@
-../../../rgw_frontend

--- a/qa/suites/rgw/verify/frontend/beast.yaml
+++ b/qa/suites/rgw/verify/frontend/beast.yaml
@@ -1,0 +1,1 @@
+../../../../rgw_frontend/beast.yaml

--- a/qa/suites/rgw/verify/frontend/civetweb.yaml
+++ b/qa/suites/rgw/verify/frontend/civetweb.yaml
@@ -1,0 +1,1 @@
+../../../../rgw_frontend/civetweb.yaml

--- a/qa/suites/rgw/verify/frontend/civetweb_ssl.yaml
+++ b/qa/suites/rgw/verify/frontend/civetweb_ssl.yaml
@@ -1,0 +1,21 @@
+overrides:
+  ssl:
+    root:
+      client: client.0
+      key-type: rsa:4096
+      cn: teuthology
+      install: [client.0, client.1]
+    rgw.client.0:
+      client: client.0
+      ca: root
+      embed-key: true
+    rgw.client.1:
+      client: client.1
+      ca: root
+      embed-key: true
+  rgw:
+    frontend: civetweb
+    client.0:
+      ssl certificate: rgw.client.0
+    client.1:
+      ssl certificate: rgw.client.1

--- a/qa/suites/rgw/verify/tasks/rgw_tests.yaml
+++ b/qa/suites/rgw/verify/tasks/rgw_tests.yaml
@@ -5,6 +5,7 @@ tasks:
 - install:
     flavor: notcmalloc
 - ceph:
+- ssl:
 - rgw:
     client.0:
       valgrind: [--tool=memcheck]

--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -279,7 +279,7 @@ def task(ctx, config):
 
     # once the client is chosen, pull the host name and  assigned port out of
     # the role_endpoints that were assigned by the rgw task
-    (remote_host, remote_port) = ctx.rgw.role_endpoints[client]
+    endpoint = ctx.rgw.role_endpoints[client]
 
     ##
     user1='foo'
@@ -305,16 +305,16 @@ def task(ctx, config):
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
         is_secure=False,
-        port=remote_port,
-        host=remote_host,
+        port=endpoint.port,
+        host=endpoint.hostname,
         calling_format=boto.s3.connection.OrdinaryCallingFormat(),
         )
     connection2 = boto.s3.connection.S3Connection(
         aws_access_key_id=access_key2,
         aws_secret_access_key=secret_key2,
         is_secure=False,
-        port=remote_port,
-        host=remote_host,
+        port=endpoint.port,
+        host=endpoint.hostname,
         calling_format=boto.s3.connection.OrdinaryCallingFormat(),
         )
 

--- a/qa/tasks/ragweed.py
+++ b/qa/tasks/ragweed.py
@@ -308,6 +308,7 @@ def task(ctx, config):
             client.1:
               extra_args: ['--exclude', 'test_100_continue']
     """
+    assert hasattr(ctx, 'rgw'), 'ragweed must run after the rgw task'
     assert config is None or isinstance(config, list) \
         or isinstance(config, dict), \
         "task ragweed only supports a list or dictionary for configuration"
@@ -330,12 +331,15 @@ def task(ctx, config):
 
     ragweed_conf = {}
     for client in clients:
+        endpoint = ctx.rgw.role_endpoints.get(client)
+        assert endpoint, 'ragweed: no rgw endpoint for {}'.format(client)
+
         ragweed_conf[client] = ConfigObj(
             indent_type='',
             infile={
                 'rgw':
                     {
-                    'port'      : 7280,
+                    'port'      : endpoint.port,
                     'is_secure' : 'no',
                     },
                 'fixtures' : {},

--- a/qa/tasks/ragweed.py
+++ b/qa/tasks/ragweed.py
@@ -340,7 +340,7 @@ def task(ctx, config):
                 'rgw':
                     {
                     'port'      : endpoint.port,
-                    'is_secure' : 'no',
+                    'is_secure' : 'yes' if endpoint.cert else 'no',
                     },
                 'fixtures' : {},
                 'user system'  : {},

--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -136,7 +136,7 @@ def start_rgw(ctx, config, clients):
             )
 
     # XXX: add_daemon() doesn't let us wait until radosgw finishes startup
-    for client in config.keys():
+    for client in clients:
         endpoint = ctx.rgw.role_endpoints[client]
         url = endpoint.url()
         log.info('Polling {client} until it starts accepting connections on {url}'.format(client=client, url=url))
@@ -145,7 +145,7 @@ def start_rgw(ctx, config, clients):
     try:
         yield
     finally:
-        for client in config.iterkeys():
+        for client in clients:
             cluster_name, daemon_type, client_id = teuthology.split_role(client)
             client_with_id = daemon_type + '.' + client_id
             client_with_cluster = cluster_name + '.' + client_with_id

--- a/qa/tasks/rgw_multisite.py
+++ b/qa/tasks/rgw_multisite.py
@@ -236,7 +236,7 @@ def extract_clusters_and_gateways(ctx, role_endpoints):
     """ create cluster and gateway instances for all of the radosgw roles """
     clusters = {}
     gateways = {}
-    for role, (host, port) in role_endpoints.iteritems():
+    for role, endpoint in role_endpoints.iteritems():
         cluster_name, daemon_type, client_id = misc.split_role(role)
         # find or create the cluster by name
         cluster = clusters.get(cluster_name)
@@ -249,7 +249,8 @@ def extract_clusters_and_gateways(ctx, role_endpoints):
             raise ConfigError('no daemon for role=%s cluster=%s type=rgw id=%s' % \
                               (role, cluster_name, client_id))
         (remote,) = ctx.cluster.only(role).remotes.keys()
-        gateways[role] = Gateway(role, remote, daemon, host, port, cluster)
+        gateways[role] = Gateway(role, remote, daemon, endpoint.hostname,
+                endpoint.port, cluster)
     return clusters, gateways
 
 def create_realm(cluster, config):

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -335,6 +335,7 @@ def task(ctx, config):
             client.1:
               extra_args: ['--exclude', 'test_100_continue']
     """
+    assert hasattr(ctx, 'rgw'), 's3tests must run after the rgw task'
     assert config is None or isinstance(config, list) \
         or isinstance(config, dict), \
         "task s3tests only supports a list or dictionary for configuration"
@@ -357,12 +358,15 @@ def task(ctx, config):
 
     s3tests_conf = {}
     for client in clients:
+        endpoint = ctx.rgw.role_endpoints.get(client)
+        assert endpoint, 's3tests: no rgw endpoint for {}'.format(client)
+
         s3tests_conf[client] = ConfigObj(
             indent_type='',
             infile={
                 'DEFAULT':
                     {
-                    'port'      : 7280,
+                    'port'      : endpoint.port,
                     'is_secure' : 'no',
                     },
                 'fixtures' : {},

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -233,9 +233,19 @@ def run_tests(ctx, config):
     if ctx.rgw.frontend == 'beast':
         attrs.append("!fails_strict_rfc2616")
     for client, client_config in config.iteritems():
+        (remote,) = ctx.cluster.only(client).remotes.keys()
         args = [
             'S3TEST_CONF={tdir}/archive/s3-tests.{client}.conf'.format(tdir=testdir, client=client),
-            'BOTO_CONFIG={tdir}/boto.cfg'.format(tdir=testdir),
+            'BOTO_CONFIG={tdir}/boto.cfg'.format(tdir=testdir)
+            ]
+        # the 'requests' library comes with its own ca bundle to verify ssl
+        # certificates - override that to use the system's ca bundle, which
+        # is where the ssl task installed this certificate
+        if remote.os.package_type == 'deb':
+            args += ['REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt']
+        else:
+            args += ['REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt']
+        args += [
             '{tdir}/s3-tests/virtualenv/bin/nosetests'.format(tdir=testdir),
             '-w',
             '{tdir}/s3-tests'.format(tdir=testdir),
@@ -245,7 +255,7 @@ def run_tests(ctx, config):
         if client_config is not None and 'extra_args' in client_config:
             args.extend(client_config['extra_args'])
 
-        ctx.cluster.only(client).run(
+        remote.run(
             args=args,
             label="s3 tests against rgw"
             )

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -367,7 +367,7 @@ def task(ctx, config):
                 'DEFAULT':
                     {
                     'port'      : endpoint.port,
-                    'is_secure' : 'no',
+                    'is_secure' : 'yes' if endpoint.cert else 'no',
                     },
                 'fixtures' : {},
                 's3 main'  : {},

--- a/qa/tasks/ssl.py
+++ b/qa/tasks/ssl.py
@@ -1,0 +1,225 @@
+"""
+Generates and installs a signed SSL certificate.
+"""
+import argparse
+import logging
+import os
+
+from teuthology import misc
+from teuthology.exceptions import ConfigError
+from teuthology.orchestra import run
+from teuthology.task import Task
+
+log = logging.getLogger(__name__)
+
+class SSL(Task):
+    """
+    Generates and installs a signed SSL certificate.
+
+    To create a self-signed certificate:
+
+        - ssl:
+            # certificate name
+            root: # results in root.key and root.crt
+
+              # [required] make the private key and certificate available in this client's test directory
+              client: client.0
+
+              # common name, defaults to `hostname`. chained certificates must not share a common name
+              cn: teuthology
+
+              # private key type for -newkey, defaults to rsa:2048
+              key-type: rsa:4096
+
+              # install the certificate as trusted on these clients:
+              install: [client.0, client.1]
+
+
+    To create a certificate signed by a ca certificate:
+
+        - ssl:
+            root: (self-signed certificate as above)
+              ...
+
+            cert-for-client1:
+              client: client.1
+
+              # use another ssl certificate (by 'name') as the certificate authority
+              ca: root  # --CAkey=root.key -CA=root.crt
+
+              # embed the private key in the certificate file
+              embed-key: true
+    """
+
+    def __init__(self, ctx, config):
+        super(SSL, self).__init__(ctx, config)
+        self.certs = []
+        self.installed = []
+
+    def setup(self):
+        # global dictionary allows other tasks to look up certificate paths
+        if not hasattr(self.ctx, 'ssl_certificates'):
+            self.ctx.ssl_certificates = {}
+
+        # use testdir/ca as a working directory
+        self.cadir = '/'.join((misc.get_testdir(self.ctx), 'ca'))
+
+        for name, config in self.config.items():
+            # names must be unique to avoid clobbering each others files
+            if name in self.ctx.ssl_certificates:
+                raise ConfigError('ssl: duplicate certificate name {}'.format(name))
+
+            # create the key and certificate
+            cert = self.create_cert(name, config)
+
+            self.ctx.ssl_certificates[name] = cert
+            self.certs.append(cert)
+
+            # install as trusted on the requested clients
+            for client in config.get('install', []):
+                installed = self.install_cert(cert, client)
+                self.installed.append(installed)
+
+    def teardown(self):
+        """
+        Clean up any created/installed certificate files.
+        """
+        for cert in self.certs:
+            self.remove_cert(cert)
+
+        for installed in self.installed:
+            self.uninstall_cert(installed)
+
+    def create_cert(self, name, config):
+        """
+        Create a certificate with the given configuration.
+        """
+        cert = argparse.Namespace()
+        cert.name = name
+        cert.key_type = config.get('key-type', 'rsa:2048')
+
+        cert.client = config.get('client', None)
+        if not cert.client:
+            raise ConfigError('ssl: missing required field "client"')
+
+        (cert.remote,) = self.ctx.cluster.only(cert.client).remotes.keys()
+
+        cert.remote.run(args=['mkdir', '-p', self.cadir])
+
+        cert.key = '{}/{}.key'.format(self.cadir, cert.name)
+        cert.certificate = '{}/{}.crt'.format(self.cadir, cert.name)
+
+        # provide the common name in -subj to avoid the openssl command prompts
+        subject = '/CN={}'.format(config.get('cn', cert.remote.hostname))
+
+        # if a ca certificate is provided, use it to sign the new certificate
+        ca = config.get('ca', None)
+        if ca:
+            # the ca certificate must have been created by a prior ssl task
+            ca_cert = self.ctx.ssl_certificates.get(ca, None)
+            if not ca_cert:
+                raise ConfigError('ssl: ca {} not found for certificate {}'
+                        .format(ca, cert.name))
+
+            # these commands are run on the ca certificate's client because
+            # they need access to its private key and cert
+
+            # generate a private key and signing request
+            csr = '{}/{}.csr'.format(self.cadir, cert.name)
+            ca_cert.remote.run(args=['openssl', 'req', '-nodes',
+                '-newkey', cert.key_type, '-keyout', cert.key,
+                '-out', csr, '-subj', subject])
+
+            # create the signed certificate
+            ca_cert.remote.run(args=['openssl', 'x509', '-req', '-in', csr,
+                '-CA', ca_cert.certificate, '-CAkey', ca_cert.key, '-CAcreateserial',
+                '-out', cert.certificate, '-days', '365', '-sha256'])
+
+            srl = '{}/{}.srl'.format(self.cadir, ca_cert.name)
+            ca_cert.remote.run(args=['rm', csr, srl]) # clean up the signing request and serial
+
+            # verify the new certificate against its ca cert
+            ca_cert.remote.run(args=['openssl', 'verify',
+                '-CAfile', ca_cert.certificate, cert.certificate])
+
+            if cert.remote != ca_cert.remote:
+                # copy to remote client
+                self.remote_copy_file(ca_cert.remote, cert.certificate, cert.remote, cert.certificate)
+                self.remote_copy_file(ca_cert.remote, cert.key, cert.remote, cert.key)
+                # clean up the local copies
+                ca_cert.remote.run(args=['rm', cert.certificate, cert.key])
+                # verify the remote certificate (requires ca to be in its trusted ca certificate store)
+                cert.remote.run(args=['openssl', 'verify', cert.certificate])
+        else:
+            # otherwise, generate a private key and use it to self-sign a new certificate
+            cert.remote.run(args=['openssl', 'req', '-x509', '-nodes',
+                '-newkey', cert.key_type, '-keyout', cert.key,
+                '-days', '365', '-out', cert.certificate, '-subj', subject])
+
+        if config.get('embed-key', False):
+            # append the private key to the certificate file
+            cert.remote.run(args=['cat', cert.key, run.Raw('>>'), cert.certificate])
+
+        return cert
+
+    def remove_cert(self, cert):
+        """
+        Delete all of the files associated with the given certificate.
+        """
+        # remove the private key and certificate
+        cert.remote.run(args=['rm', '-f', cert.certificate, cert.key])
+
+        # remove ca subdirectory if it's empty
+        cert.remote.run(args=['rmdir', '--ignore-fail-on-non-empty', self.cadir])
+
+    def install_cert(self, cert, client):
+        """
+        Install as a trusted ca certificate on the given client.
+        """
+        (remote,) = self.ctx.cluster.only(client).remotes.keys()
+
+        installed = argparse.Namespace()
+        installed.remote = remote
+
+        if remote.os.package_type == 'deb':
+            installed.path = '/usr/local/share/ca-certificates/{}.crt'.format(cert.name)
+            installed.command = ['sudo', 'update-ca-certificates']
+        else:
+            installed.path = '/usr/share/pki/ca-trust-source/anchors/{}.crt'.format(cert.name)
+            installed.command = ['sudo', 'update-ca-trust']
+
+        cp_or_mv = 'cp'
+        if remote != cert.remote:
+            # copy into remote cadir (with mkdir if necessary)
+            remote.run(args=['mkdir', '-p', self.cadir])
+            self.remote_copy_file(cert.remote, cert.certificate, remote, cert.certificate)
+            cp_or_mv = 'mv' # move this remote copy into the certificate store
+
+        # install into certificate store as root
+        remote.run(args=['sudo', cp_or_mv, cert.certificate, installed.path])
+        remote.run(args=installed.command)
+
+        return installed
+
+    def uninstall_cert(self, installed):
+        """
+        Uninstall a certificate from the trusted certificate store.
+        """
+        installed.remote.run(args=['sudo', 'rm', installed.path])
+        installed.remote.run(args=installed.command)
+
+    def remote_copy_file(self, from_remote, from_path, to_remote, to_path):
+        """
+        Copies a file from one remote to another.
+
+        The remotes don't have public-key auth for 'scp' or misc.copy_file(),
+        so this copies through an intermediate local tmp file.
+        """
+        log.info('copying from {}:{} to {}:{}...'.format(from_remote, from_path, to_remote, to_path))
+        local_path = from_remote.get_file(from_path)
+        try:
+            to_remote.put_file(local_path, to_path)
+        finally:
+            os.remove(local_path)
+
+task = SSL

--- a/qa/tasks/swift.py
+++ b/qa/tasks/swift.py
@@ -245,7 +245,7 @@ def task(ctx, config):
                     'func_test':
                         {
                         'auth_port'      : endpoint.port,
-                        'auth_ssl' : 'no',
+                        'auth_ssl' : 'yes' if endpoint.cert else 'no',
                         'auth_prefix' : '/auth/',
                         },
                     }

--- a/qa/tasks/swift.py
+++ b/qa/tasks/swift.py
@@ -220,6 +220,7 @@ def task(ctx, config):
             client.1:
               extra_args: ['--exclude', 'TestFile']
     """
+    assert hasattr(ctx, 'rgw'), 'swift must run after the rgw task'
     assert config is None or isinstance(config, list) \
         or isinstance(config, dict), \
         "task testswift only supports a list or dictionary for configuration"
@@ -235,12 +236,15 @@ def task(ctx, config):
 
     testswift_conf = {}
     for client in clients:
+        endpoint = ctx.rgw.role_endpoints.get(client)
+        assert endpoint, 'swift: no rgw endpoint for {}'.format(client)
+
         testswift_conf[client] = ConfigObj(
                 indent_type='',
                 infile={
                     'func_test':
                         {
-                        'auth_port'      : 7280,
+                        'auth_port'      : endpoint.port,
                         'auth_ssl' : 'no',
                         'auth_prefix' : '/auth/',
                         },


### PR DESCRIPTION
adds an 'ssl' task to generate certificates with openssl and install them as trusted. if the rgw task specifies a certificate, it's added to the rgw_frontends configuration, and the s3test/swift tasks will configure ssl as well