### PR TITLE
common: Make code to invoke assert() smaller.

### DIFF
--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -66,6 +66,11 @@ namespace ceph {
     abort();
   }
 
+  void __ceph_assert_fail(const assert_data &ctx)
+  {
+    __ceph_assert_fail(ctx.assertion, ctx.file, ctx.line, ctx.function);
+  }
+
   void __ceph_assertf_fail(const char *assertion, const char *file, int line,
 			   const char *func, const char* msg, ...)
   {

--- a/src/include/assert.h
+++ b/src/include/assert.h
@@ -66,8 +66,18 @@ struct BackTrace;
 extern void register_assert_context(CephContext *cct);
 #endif
 
+struct assert_data {
+  const char *assertion;
+  const char *file;
+  const int line;
+  const char *function;
+};
+
 extern void __ceph_assert_fail(const char *assertion, const char *file, int line, const char *function)
   __attribute__ ((__noreturn__));
+extern void __ceph_assert_fail(const assert_data &ctx)
+  __attribute__ ((__noreturn__));
+
 extern void __ceph_assertf_fail(const char *assertion, const char *file, int line, const char *function, const char* msg, ...)
   __attribute__ ((__noreturn__));
 extern void __ceph_assert_warn(const char *assertion, const char *file, int line, const char *function);
@@ -121,21 +131,28 @@ using namespace ceph;
 #undef __ASSERT_FUNCTION
 #define __ASSERT_FUNCTION
 
-#define assert(expr)							\
-  ((expr)								\
-   ? _CEPH_ASSERT_VOID_CAST (0)					\
-   : __ceph_assert_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION))
+#define assert(expr) \
+  do { static const ceph::assert_data assert_data_ctx = \
+   {__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION}; \
+   ((expr) \
+   ? _CEPH_ASSERT_VOID_CAST (0)	\
+   : __ceph_assert_fail(assert_data_ctx)); } while(false)
+
 #define ceph_assert(expr)							\
-  ((expr)								\
-   ? _CEPH_ASSERT_VOID_CAST (0)					\
-   : __ceph_assert_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION))
+  do { static const ceph::assert_data assert_data_ctx = \
+   {__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION}; \
+   ((expr) \
+   ? _CEPH_ASSERT_VOID_CAST (0) \
+   : __ceph_assert_fail(assert_data_ctx)); } while(false)
 
 // this variant will *never* get compiled out to NDEBUG in the future.
 // (ceph_assert currently doesn't either, but in the future it might.)
 #define ceph_assert_always(expr)							\
-  ((expr)								\
-   ? _CEPH_ASSERT_VOID_CAST (0)					\
-   : __ceph_assert_fail (__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION))
+  do { static const ceph::assert_data assert_data_ctx = \
+   {__STRING(expr), __FILE__, __LINE__, __CEPH_ASSERT_FUNCTION}; \
+   ((expr) \
+   ? _CEPH_ASSERT_VOID_CAST (0) \
+   : __ceph_assert_fail(assert_data_ctx)); } while(false)
 
 // Named by analogy with printf.  Along with an expression, takes a format
 // string and parameters which are printed if the assertion fails.


### PR DESCRIPTION
Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>

Before:
```
     6ab:	48 8d 0d 00 00 00 00 	lea    0x0(%rip),%rcx        # 6b2 <_ZN4ceph6buffer3ptrC1ERKS1_jj+0x32>
			6ae: R_X86_64_PC32	.rodata+0xbfc
     6b2:	48 8d 35 00 00 00 00 	lea    0x0(%rip),%rsi        # 6b9 <_ZN4ceph6buffer3ptrC1ERKS1_jj+0x39>
			6b5: R_X86_64_PC32	.LC3-0x4
     6b9:	48 8d 3d 00 00 00 00 	lea    0x0(%rip),%rdi        # 6c0 <_ZN4ceph6buffer3ptrC1ERKS1_jj+0x40>
			6bc: R_X86_64_PC32	.LC11-0x4
     6c0:	ba 69 03 00 00       	mov    $0x369,%edx
     6c5:	e8 00 00 00 00       	callq  6ca <_ZN4ceph6buffer3ptrC1ERKS1_jj+0x4a>
			6c6: R_X86_64_PLT32	_ZN4ceph18__ceph_assert_failEPKcS1_iS1_-0x4
```
After:
```
     6ab:	48 8d 3d 00 00 00 00 	lea    0x0(%rip),%rdi        # 6b2 <_ZN4ceph6buffer3ptrC1ERKS1_jj+0x32>
			6ae: R_X86_64_PC32	.data.rel.ro.local+0x37c
     6b2:	e8 00 00 00 00       	callq  6b7 <_ZN4ceph6buffer3ptrC1ERKS1_jj+0x37>
			6b3: R_X86_64_PLT32	_ZN4ceph18__ceph_assert_failEPKNS_18__ceph_assert_dataE-0x4
```
