### PR TITLE
rgw: switch beast frontend back to stackful coroutine

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -142,11 +142,7 @@ add_library(rgw_a STATIC ${rgw_a_srcs})
 
 add_dependencies(rgw_a civetweb_h)
 
-target_include_directories(rgw_a SYSTEM PUBLIC
-  ${FCGI_INCLUDE_DIR}
-  "../rapidjson/include"
-  )
-target_compile_definitions(rgw_a PUBLIC BOOST_COROUTINES_NO_DEPRECATION_WARNING)
+target_include_directories(rgw_a SYSTEM PUBLIC "../rapidjson/include")
 
 target_link_libraries(rgw_a librados cls_lock_client cls_rgw_client cls_refcount_client
   cls_log_client cls_statelog_client cls_timeindex_client cls_version_client
@@ -154,6 +150,11 @@ target_link_libraries(rgw_a librados cls_lock_client cls_rgw_client cls_refcount
   ${CURL_LIBRARIES}
   ${EXPAT_LIBRARIES}
   ${OPENLDAP_LIBRARIES} ${CRYPTO_LIBS})
+
+if (WITH_RADOSGW_BEAST_FRONTEND)
+  target_compile_definitions(rgw_a PUBLIC BOOST_COROUTINES_NO_DEPRECATION_WARNING)
+  target_link_libraries(rgw_a Boost::coroutine Boost::context)
+endif()
 
 set(radosgw_srcs
   rgw_loadgen_process.cc


### PR DESCRIPTION
https://github.com/ceph/ceph/pull/17923 removed the use of stackful coroutines and their extra dependency on boost::context, which isn't available on all platforms (see http://tracker.ceph.com/issues/20048). but future plans for async request processing depend on these stackful coroutines, and i'd like to get this refactoring reviewed/merged so that other work (like ssl support) can build on it