### PR TITLE
qa/tests: Applied PR 20053 to stress-split tests

### DIFF
--- a/qa/suites/upgrade/kraken-x/stress-split/4-workload/rbd-cls.yaml
+++ b/qa/suites/upgrade/kraken-x/stress-split/4-workload/rbd-cls.yaml
@@ -7,4 +7,6 @@ stress-tasks:
     clients:
       client.0:
         - cls/test_cls_rbd.sh
+    env:
+      CLS_RBD_GTEST_FILTER: '*:-TestClsRbd.snapshots_namespaces'
 - print: "**** done cls/test_cls_rbd.sh 5-workload"


### PR DESCRIPTION
Per suggestion to apply  PR 20053 to failed tests
(see 12.2.3 release validation notes http://tracker.ceph.com/issues/22665#note-4)

@dillaman Does this look kosher?

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>