### PR TITLE
librbd: disallow creation of v1 image format

### DIFF
--- a/qa/tasks/rbd.py
+++ b/qa/tasks/rbd.py
@@ -16,6 +16,9 @@ from teuthology.task.common_fs_utils import generic_mkfs
 from teuthology.task.common_fs_utils import generic_mount
 from teuthology.task.common_fs_utils import default_image_name
 
+#V1 image unsupported but required for testing purposes
+os.environ["RBD_FORCE_ALLOW_V1"] = "1"
+
 log = logging.getLogger(__name__)
 
 @contextlib.contextmanager

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -ex
 
+export RBD_FORCE_ALLOW_V1=1
+
 # make sure rbd pool is EMPTY.. this is a test script!!
 rbd ls | wc -l | grep -v '^0$' && echo "nonempty rbd pool, aborting!  run this script on an empty test cluster only." && exit 1
 

--- a/qa/workunits/rbd/image_read.sh
+++ b/qa/workunits/rbd/image_read.sh
@@ -54,6 +54,8 @@ DEFAULT_OBJECT_ORDER=22
 MIN_OBJECT_ORDER=12	# technically 9, but the rbd CLI enforces 12
 MAX_OBJECT_ORDER=32
 
+RBD_FORCE_ALLOW_V1=1
+
 PROGNAME=$(basename $0)
 
 ORIGINAL=original-$$

--- a/qa/workunits/rbd/import_export.sh
+++ b/qa/workunits/rbd/import_export.sh
@@ -1,5 +1,8 @@
 #!/bin/sh -ex
 
+# V1 image unsupported but required for testing purposes
+export RBD_FORCE_ALLOW_V1=1
+
 # returns data pool for a given image
 get_image_data_pool () {
     image=$1

--- a/qa/workunits/rbd/krbd_data_pool.sh
+++ b/qa/workunits/rbd/krbd_data_pool.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+export RBD_FORCE_ALLOW_V1=1
+
 function fill_image() {
     local spec=$1
 

--- a/qa/workunits/rbd/merge_diff.sh
+++ b/qa/workunits/rbd/merge_diff.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -ex
 
+export RBD_FORCE_ALLOW_V1=1
+
 pool=rbd
 gen=$pool/gen
 out=$pool/out

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -869,6 +869,11 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
     }
 
     if (old_format) {
+      if ( !getenv("RBD_FORCE_ALLOW_V1") ) {
+        lderr(cct) << "Format 1 image creation unsupported. " << dendl;
+        return -EINVAL;
+      }
+      lderr(cct) << "Forced V1 image creation. " << dendl;
       r = create_v1(io_ctx, image_name.c_str(), size, order);
     } else {
       ThreadPool *thread_pool;

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -12,11 +12,11 @@ ls on empty pool never containing images
 
 create
 =======
-  $ rbd create -s 1024 --image-format 1 foo
+  $ RBD_FORCE_ALLOW_V1=1 rbd create -s 1024 --image-format 1 foo
   rbd: image format 1 is deprecated
   $ rbd create -s 512 --image-format 2 bar
   $ rbd create -s 2048 --image-format 2 --image-feature layering baz
-  $ rbd create -s 1 --image-format 1 quux
+  $ RBD_FORCE_ALLOW_V1=1 rbd create -s 1 --image-format 1 quux
   rbd: image format 1 is deprecated
   $ rbd create -s 1G --image-format 2 quuy
 

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -24,6 +24,8 @@ extern void register_test_operations();
 
 int main(int argc, char **argv)
 {
+  setenv("RBD_FORCE_ALLOW_V1","1",1);
+
   register_test_librbd();
 #ifdef TEST_LIBRBD_INTERNALS
   register_test_deep_copy();

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -37,6 +37,8 @@ pool_name = None
 IMG_SIZE = 8 << 20 # 8 MiB
 IMG_ORDER = 22 # 4 MiB objects
 
+os.environ["RBD_FORCE_ALLOW_V1"] = "1"
+
 def setup_module():
     global rados
     rados = Rados(conffile='')


### PR DESCRIPTION
V1 image format has been deprecated since the jewel release, so
forbit it. However some internal test cases still need v1 images
so allow their creation if the RBD_FORCE_ALLOW_V1 env var is set.

Signed-off-by: Julien Collet <julien.collet@cern.ch>