### PR TITLE
mon: Do not allow removal of pools which still contain objects

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -57,6 +57,10 @@
 * The -f option of the rados tool now means "--format" instead of "--force",
   for consistency with the ceph tool.
 
+* The 'mon_allow_pool_delete_non_empty' option controls if the Monitors allow
+  removing a non-empty (containing objects) pool. The default is set to false
+  meaning that no pool containing data can be removed.
+
 >= 12.2.2
 ---------
 

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -199,6 +199,10 @@ To delete a pool, execute::
 To remove a pool the mon_allow_pool_delete flag must be set to true in the Monitor's
 configuration. Otherwise they will refuse to remove a pool.
 
+In addition Monitors will not allow pools to be removed which still contain objects.
+To remove a pool which still contains objects set the mon_allow_pool_delete_non_empty
+option to true.
+
 See `Monitor Configuration`_ for more information.
 
 .. _Monitor Configuration: ../../configuration/mon-config-ref

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1127,6 +1127,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("mon_allow_pool_delete_non_empty", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("allow removal of a pool which still contains objects"),
+
     Option("mon_fake_pool_delete", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description(""),

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -445,6 +445,7 @@ const char** Monitor::get_tracked_conf_keys() const
     // scrub interval
     "mon_scrub_interval",
     "mon_allow_pool_delete",
+    "mon_allow_pool_delete_non_empty",
     NULL
   };
   return KEYS;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -11309,6 +11309,12 @@ int OSDMonitor::_check_remove_pool(int64_t pool_id, const pg_pool_t& pool,
     return -EPERM;
   }
 
+  const pool_stat_t& st = get_pg_pool_sum_stat(pool_id);
+  if (st.sum.num_objects > 0 && !g_conf->mon_allow_pool_delete_non_empty) {
+    *ss << "pool is not empty; please delete all objects before removing it";
+    return -ENOTEMPTY;
+  }
+
   *ss << "pool '" << poolstr << "' removed";
   return 0;
 }


### PR DESCRIPTION
The option 'mon_allow_pool_delete_non_empty' controls if removing
a non-empty pool is allowed to be removed. The default value is
false.

Signed-off-by: Wido den Hollander <wido@42on.com>