### PR TITLE
rgw: Allow swift acls to be deleted.

### DIFF
--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -23,10 +23,10 @@
 
 #define SWIFT_GROUP_ALL_USERS ".r:*"
 
-static int parse_list(const std::string& uid_list,
+static int parse_list(const char* uid_list,
                       std::vector<std::string>& uids)           /* out */
 {
-  char *s = strdup(uid_list.c_str());
+  char *s = strdup(uid_list);
   if (!s) {
     return -ENOMEM;
   }
@@ -176,8 +176,8 @@ int RGWAccessControlPolicy_SWIFT::add_grants(RGWRados* const store,
 int RGWAccessControlPolicy_SWIFT::create(RGWRados* const store,
                                          const rgw_user& id,
                                          const std::string& name,
-                                         const std::string& read_list,
-                                         const std::string& write_list,
+                                         const char* read_list,
+                                         const char* write_list,
                                          uint32_t& rw_mask)
 {
   acl.create_default(id, name);
@@ -185,7 +185,7 @@ int RGWAccessControlPolicy_SWIFT::create(RGWRados* const store,
   owner.set_name(name);
   rw_mask = 0;
 
-  if (read_list.size()) {
+  if (read_list) {
     std::vector<std::string> uids;
     int r = parse_list(read_list, uids);
     if (r < 0) {
@@ -202,7 +202,7 @@ int RGWAccessControlPolicy_SWIFT::create(RGWRados* const store,
     }
     rw_mask |= SWIFT_PERM_READ;
   }
-  if (write_list.size()) {
+  if (write_list) {
     std::vector<std::string> uids;
     int r = parse_list(write_list, uids);
     if (r < 0) {

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -28,8 +28,8 @@ public:
   int create(RGWRados *store,
              const rgw_user& id,
              const std::string& name,
-             const std::string& read_list,
-             const std::string& write_list,
+             const char* read_list,
+             const char* write_list,
              uint32_t& rw_mask);
   void filter_merge(uint32_t mask, RGWAccessControlPolicy_SWIFT *policy);
   void to_str(std::string& read, std::string& write);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -572,20 +572,12 @@ static int get_swift_container_settings(req_state * const s,
                                         RGWCORSConfiguration * const cors_config,
                                         bool * const has_cors)
 {
-  string read_list, write_list;
-
-  const char * const read_attr = s->info.env->get("HTTP_X_CONTAINER_READ");
-  if (read_attr) {
-    read_list = read_attr;
-  }
-  const char * const write_attr = s->info.env->get("HTTP_X_CONTAINER_WRITE");
-  if (write_attr) {
-    write_list = write_attr;
-  }
+  const char * const read_list = s->info.env->get("HTTP_X_CONTAINER_READ");
+  const char * const write_list = s->info.env->get("HTTP_X_CONTAINER_WRITE");
 
   *has_policy = false;
 
-  if (read_attr || write_attr) {
+  if (read_list || write_list) {
     RGWAccessControlPolicy_SWIFT swift_policy(s->cct);
     const auto r = swift_policy.create(store,
                                        s->user->user_id,


### PR DESCRIPTION
The openstack "swift" command deletes acls by submitting an
acl with an empty string.  The existing logic uses c++ strings,
which can't distinguish between an empty string and a non-existant
string.  Additional, the strings are coming from RGWEnv which
supplies C strings not c++.  Using C strings instead makes it
trivial to pass "non-existance" (as a null string).  It also avoids
some type conversion with string copying.

Fixes: http://tracker.ceph.com/issues/22897

Signed-off-by: Marcus Watts <mwatts@redhat.com>