### PR TITLE
mds: dump tree by traversing the tree directly

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -140,8 +140,18 @@ public:
   static const uint64_t WAIT_ATFREEZEROOT = (WAIT_UNFREEZE);
   static const uint64_t WAIT_ATSUBTREEROOT = (WAIT_SINGLEAUTH);
 
-
-
+  // -- dump flags --
+  static const int DUMP_PATH             = (1 << 0);
+  static const int DUMP_DIRFRAG          = (1 << 1);
+  static const int DUMP_SNAPID_FIRST     = (1 << 2);
+  static const int DUMP_VERSIONS         = (1 << 3);
+  static const int DUMP_REP              = (1 << 4);
+  static const int DUMP_DIR_AUTH         = (1 << 5);
+  static const int DUMP_STATES           = (1 << 6);
+  static const int DUMP_MDS_CACHE_OBJECT = (1 << 7);
+  static const int DUMP_ITEMS            = (1 << 8);
+  static const int DUMP_ALL              = (-1);
+  static const int DUMP_DEFAULT          = DUMP_ALL & (~DUMP_ITEMS); 
 
  public:
   // context
@@ -746,7 +756,7 @@ public:
 
   ostream& print_db_line_prefix(ostream& out) override;
   void print(ostream& out) override;
-  void dump(Formatter *f) const;
+  void dump(Formatter *f, int flags = DUMP_DEFAULT) const;
   void dump_load(Formatter *f, utime_t now, const DecayRate& rate);
 };
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -601,7 +601,7 @@ CDir *CInode::get_approx_dirfrag(frag_t fg)
   return NULL;
 }	
 
-void CInode::get_dirfrags(std::list<CDir*>& ls) 
+void CInode::get_dirfrags(std::list<CDir*>& ls) const
 {
   // all dirfrags
   for (const auto &p : dirfrags) {
@@ -4355,6 +4355,19 @@ void CInode::dump(Formatter *f, int flags) const
       f->open_object_section("mds_cap_wanted");
       f->dump_int("rank", p.first);
       f->dump_string("cap", ccap_string(p.second));
+      f->close_section();
+    }
+    f->close_section();
+  }
+
+  if (flags & DUMP_DIRFRAGS) {
+    f->open_array_section("dirfrags");
+    list<CDir*> dfs;
+    get_dirfrags(dfs);
+    for(const auto &dir: dfs) {
+      f->open_object_section("dir");
+      dir->dump(f, CDir::DUMP_DEFAULT | CDir::DUMP_ITEMS);
+      dir->check_rstats();
       f->close_section();
     }
     f->close_section();

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -210,8 +210,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int DUMP_STATE =            (1 << 3);
   static const int DUMP_CAPS =             (1 << 4);
   static const int DUMP_PATH =             (1 << 5);
+  static const int DUMP_DIRFRAGS =         (1 << 6);
   static const int DUMP_ALL =              (-1);
-  static const int DUMP_DEFAULT = DUMP_ALL & (~DUMP_PATH);
+  static const int DUMP_DEFAULT = DUMP_ALL & (~DUMP_PATH) & (~DUMP_DIRFRAGS);
 
   // -- state --
   static const int STATE_EXPORTING =   (1<<2);   // on nonauth bystander.
@@ -533,7 +534,7 @@ public:
   }
   bool get_dirfrags_under(frag_t fg, std::list<CDir*>& ls);
   CDir* get_approx_dirfrag(frag_t fg);
-  void get_dirfrags(std::list<CDir*>& ls);
+  void get_dirfrags(std::list<CDir*>& ls) const;
   void get_nested_dirfrags(std::list<CDir*>& ls);
   void get_subtree_dirfrags(std::list<CDir*>& ls);
   CDir *get_or_open_dirfrag(MDCache *mdcache, frag_t fg);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1172,14 +1172,12 @@ public:
   void discard_delayed_expire(CDir *dir);
 
 protected:
-  int dump_cache(std::string_view fn, Formatter *f,
-		  std::string_view dump_root = "",
-		  int depth = -1);
+  int dump_cache(const char *fn, Formatter *f);
 public:
   int dump_cache() { return dump_cache(NULL, NULL); }
   int dump_cache(std::string_view filename);
   int dump_cache(Formatter *f);
-  int dump_cache(std::string_view dump_root, int depth, Formatter *f);
+  void dump_tree(CInode *in, const int cur_depth, const int max_depth, Formatter *f);
 
   int cache_status(Formatter *f);
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1172,7 +1172,7 @@ public:
   void discard_delayed_expire(CDir *dir);
 
 protected:
-  int dump_cache(const char *fn, Formatter *f);
+  int dump_cache(std::string_view fn, Formatter *f);
 public:
   int dump_cache() { return dump_cache(NULL, NULL); }
   int dump_cache(std::string_view filename);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -441,6 +441,7 @@ class MDSRank {
         const cmdmap_t &cmdmap,
         std::ostream &ss);
     void command_openfiles_ls(Formatter *f);
+    void command_dump_tree(const cmdmap_t &cmdmap, std::ostream &ss, Formatter *f);
 
   protected:
     Messenger    *messenger;


### PR DESCRIPTION
1 dump the tree in efficient way
2 add DUMP flags to CDir::dump and make dump_cache more clean!