### PR TITLE
common/str_list: s/boost::string_view/std::string_view

### DIFF
--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -41,7 +41,7 @@ std::string cmddesc_get_prefix(const std::string &cmddesc)
   return result.str();
 }
 
-using arg_desc_t = std::map<boost::string_view, boost::string_view>;
+using arg_desc_t = std::map<std::string_view, std::string_view>;
 
 // Snarf up all the key=val,key=val pairs, put 'em in a dict.
 template<class String>
@@ -396,7 +396,7 @@ int parse_osd_id(const char *s, std::ostream *pss)
 
 namespace {
 template <typename Func>
-bool find_first_in(boost::string_view s, const char *delims, Func&& f)
+bool find_first_in(std::string_view s, const char *delims, Func&& f)
 {
   auto pos = s.find_first_not_of(delims);
   while (pos != s.npos) {
@@ -443,8 +443,8 @@ bool arg_in_range(T value, const arg_desc_t& desc, std::ostream& os) {
   return true;
 }
 
-bool validate_str_arg(boost::string_view value,
-		      boost::string_view type,
+bool validate_str_arg(std::string_view value,
+		      std::string_view type,
 		      const arg_desc_t& desc,
 		      std::ostream& os)
 {
@@ -482,8 +482,8 @@ template<bool is_vector,
 bool validate_arg(CephContext* cct,
 		  const cmdmap_t& cmdmap,
 		  const arg_desc_t& desc,
-		  const boost::string_view name,
-		  const boost::string_view type,
+		  const std::string_view name,
+		  const std::string_view type,
 		  std::ostream& os)
 {
   Value v;

--- a/src/common/str_list.cc
+++ b/src/common/str_list.cc
@@ -23,7 +23,7 @@ using ceph::for_each_substr;
 void get_str_list(const string& str, const char *delims, list<string>& str_list)
 {
   str_list.clear();
-  for_each_substr(str, delims, [&str_list] (boost::string_view token) {
+  for_each_substr(str, delims, [&str_list] (auto token) {
       str_list.emplace_back(token.begin(), token.end());
     });
 }
@@ -44,7 +44,7 @@ list<string> get_str_list(const string& str, const char *delims)
 void get_str_vec(const string& str, const char *delims, vector<string>& str_vec)
 {
   str_vec.clear();
-  for_each_substr(str, delims, [&str_vec] (boost::string_view token) {
+  for_each_substr(str, delims, [&str_vec] (auto token) {
       str_vec.emplace_back(token.begin(), token.end());
     });
 }
@@ -65,7 +65,7 @@ vector<string> get_str_vec(const string& str, const char *delims)
 void get_str_set(const string& str, const char *delims, set<string>& str_set)
 {
   str_set.clear();
-  for_each_substr(str, delims, [&str_set] (boost::string_view token) {
+  for_each_substr(str, delims, [&str_set] (auto token) {
       str_set.emplace(token.begin(), token.end());
     });
 }

--- a/src/include/str_list.h
+++ b/src/include/str_list.h
@@ -11,9 +11,9 @@
 namespace ceph {
 
 /// Split a string using the given delimiters, passing each piece as a
-/// (non-null-terminated) boost::string_view to the callback.
-template <typename Func> // where Func(boost::string_view) is a valid call
-void for_each_substr(boost::string_view s, const char *delims, Func&& f)
+/// (non-null-terminated) std::string_view to the callback.
+template <typename Func> // where Func(std::string_view) is a valid call
+void for_each_substr(std::string_view s, const char *delims, Func&& f)
 {
   auto pos = s.find_first_not_of(delims);
   while (pos != s.npos) {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -350,7 +350,7 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
       "rocksdb_db_paths", [&opt, this](const std::string& paths) {
 	ceph::for_each_substr(
 	  paths, "; \t",
-	  [&paths, &opt, this](boost::string_view s) {
+	  [&paths, &opt, this](auto s) {
 	    size_t pos = s.find(',');
 	    if (pos == std::string::npos) {
 	      derr << __func__ << " invalid db path item " << s << " in "


### PR DESCRIPTION
since string_view is include by standard library, we can now switch from
boost::string_view to std::string_view.

Signed-off-by: Kefu Chai <kchai@redhat.com>