### PR TITLE
[WIP] support configurable worker threads ("rbd op threads")

### DIFF
--- a/src/librbd/DeepCopyRequest.cc
+++ b/src/librbd/DeepCopyRequest.cc
@@ -211,13 +211,19 @@ void DeepCopyRequest<I>::send_copy_object_map() {
 
   // rollback the object map (copy snapshot object map to HEAD)
   RWLock::WLocker object_map_locker(m_dst_image_ctx->object_map_lock);
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
-      handle_copy_object_map(r);
-      finish_op_ctx->complete(0);
-    });
+
   assert(m_snap_seqs->count(m_snap_id_end) > 0);
   librados::snap_t copy_snap_id = (*m_snap_seqs)[m_snap_id_end];
+
+  using klass = DeepCopyRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_copy_object_map>(this, m_dst_image_ctx->object_map);
+  ctx = new FunctionContext([this, ctx, finish_op_ctx](int r) {
+      ctx->complete(r);
+      finish_op_ctx->complete(0);
+    });
   m_dst_image_ctx->object_map->rollback(copy_snap_id, ctx);
+
   m_dst_image_ctx->snap_lock.put_read();
   m_dst_image_ctx->owner_lock.put_read();
 }
@@ -247,11 +253,15 @@ void DeepCopyRequest<I>::send_refresh_object_map() {
 
   ldout(m_cct, 20) << dendl;
 
-  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
-      handle_refresh_object_map(r);
+  m_object_map = m_dst_image_ctx->create_object_map(CEPH_NOSNAP);
+
+  using klass = DeepCopyRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_refresh_object_map>(this, m_object_map);
+  ctx = new FunctionContext([this, ctx, finish_op_ctx](int r) {
+      ctx->complete(r);
       finish_op_ctx->complete(0);
     });
-  m_object_map = m_dst_image_ctx->create_object_map(CEPH_NOSNAP);
   m_object_map->open(ctx);
 }
 
@@ -264,7 +274,7 @@ void DeepCopyRequest<I>::handle_refresh_object_map(int r) {
     RWLock::WLocker snap_locker(m_dst_image_ctx->snap_lock);
     std::swap(m_dst_image_ctx->object_map, m_object_map);
   }
-  delete m_object_map;
+  m_object_map->put();
 
   send_copy_metadata();
 }

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -27,7 +27,8 @@ using ML = ManagedLock<I>;
 
 template <typename I>
 ExclusiveLock<I>::ExclusiveLock(I &image_ctx)
-  : ML<I>(image_ctx.md_ctx, image_ctx.op_work_queue, image_ctx.header_oid,
+  : RefCountedObject(image_ctx.cct),
+    ML<I>(image_ctx.md_ctx, image_ctx.op_work_queue, image_ctx.header_oid,
           image_ctx.image_watcher, managed_lock::EXCLUSIVE,
           image_ctx.blacklist_on_break_lock,
           image_ctx.blacklist_expire_seconds),

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -6,11 +6,13 @@
 
 #include "librbd/ManagedLock.h"
 #include "common/AsyncOpTracker.h"
+#include "common/RefCountedObj.h"
 
 namespace librbd {
 
 template <typename ImageCtxT = ImageCtx>
-class ExclusiveLock : public ManagedLock<ImageCtxT> {
+class ExclusiveLock : public RefCountedObject,
+                      public ManagedLock<ImageCtxT> {
 public:
   static ExclusiveLock *create(ImageCtxT &image_ctx) {
     return new ExclusiveLock<ImageCtxT>(image_ctx);

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -59,8 +59,8 @@ public:
   ContextWQ *op_work_queue;
 
   explicit ThreadPoolSingleton(CephContext *cct)
-    : ThreadPool(cct, "librbd::thread_pool", "tp_librbd", 1,
-                 "rbd_op_threads"),
+    : ThreadPool(cct, "librbd::thread_pool", "tp_librbd",
+                 cct->_conf->get_val<int64_t>("rbd_op_threads"), "rbd_op_threads"),
       op_work_queue(new ContextWQ("librbd::op_work_queue",
                                   cct->_conf->get_val<int64_t>("rbd_op_thread_timeout"),
                                   this)) {

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -12,7 +12,6 @@
 #include "journal/ReplayEntry.h"
 #include "journal/Settings.h"
 #include "journal/Utils.h"
-#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/io/ImageRequestWQ.h"
 #include "librbd/io/ObjectDispatchSpec.h"

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -351,6 +351,7 @@ Journal<I>::~Journal() {
     delete m_work_queue;
   }
 
+  Mutex::Locker locker(m_lock);
   assert(m_state == STATE_UNINITIALIZED || m_state == STATE_CLOSED);
   assert(m_journaler == NULL);
   assert(m_journal_replay == NULL);
@@ -1218,6 +1219,8 @@ void Journal<I>::handle_replay_ready() {
     m_processing_entry = true;
   }
 
+  m_async_journal_op_tracker.start_op();
+
   bufferlist data = replay_entry.get_data();
   auto it = data.cbegin();
 
@@ -1279,11 +1282,15 @@ void Journal<I>::handle_replay_complete(int r) {
       // ensure the commit position is flushed to disk
       m_journaler->flush_commit_position(ctx);
     });
+  ctx = new FunctionContext([this, ctx](int r) {
+      m_async_journal_op_tracker.wait(m_image_ctx, ctx);
+    });
   ctx = new FunctionContext([this, cct, cancel_ops, ctx](int r) {
       ldout(cct, 20) << this << " handle_replay_complete: "
                      << "shut down replay" << dendl;
       m_journal_replay->shut_down(cancel_ops, ctx);
     });
+
   m_journaler->stop_replay(ctx);
 }
 
@@ -1342,11 +1349,13 @@ void Journal<I>::handle_replay_process_safe(ReplayEntry replay_entry, int r) {
           m_journal_replay->shut_down(true, ctx);
         });
       m_journaler->stop_replay(ctx);
+      m_async_journal_op_tracker.finish_op();
       return;
     } else if (m_state == STATE_FLUSHING_REPLAY) {
       // end-of-replay flush in-progress -- we need to restart replay
       transition_state(STATE_FLUSHING_RESTART, r);
       m_lock.Unlock();
+      m_async_journal_op_tracker.finish_op();
       return;
     }
   } else {
@@ -1354,6 +1363,7 @@ void Journal<I>::handle_replay_process_safe(ReplayEntry replay_entry, int r) {
     m_journaler->committed(replay_entry);
   }
   m_lock.Unlock();
+  m_async_journal_op_tracker.finish_op();
 }
 
 template <typename I>

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -325,7 +325,8 @@ std::ostream &operator<<(std::ostream &os,
 
 template <typename I>
 Journal<I>::Journal(I &image_ctx)
-  : m_image_ctx(image_ctx), m_journaler(NULL),
+  : RefCountedObject(image_ctx.cct),
+    m_image_ctx(image_ctx), m_journaler(NULL),
     m_lock("Journal<I>::m_lock"), m_state(STATE_UNINITIALIZED),
     m_error_result(0), m_replay_handler(this), m_close_pending(false),
     m_event_lock("Journal<I>::m_event_lock"), m_event_tid(0),

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -9,7 +9,6 @@
 #include "include/interval_set.h"
 #include "common/Cond.h"
 #include "common/Mutex.h"
-#include "common/Cond.h"
 #include "common/WorkQueue.h"
 #include "journal/Future.h"
 #include "journal/JournalMetadataListener.h"

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -8,6 +8,7 @@
 #include "include/Context.h"
 #include "include/interval_set.h"
 #include "common/Cond.h"
+#include "common/RefCountedObj.h"
 #include "common/Mutex.h"
 #include "common/WorkQueue.h"
 #include "journal/Future.h"
@@ -39,7 +40,7 @@ class ImageCtx;
 namespace journal { template <typename> class Replay; }
 
 template <typename ImageCtxT = ImageCtx>
-class Journal {
+class Journal : public RefCountedObject {
 public:
   /**
    * @verbatim

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -16,7 +16,6 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/internal.h"
 #include "librbd/LibrbdWriteback.h"
-#include "librbd/ObjectMap.h"
 #include "librbd/Journal.h"
 #include "librbd/Utils.h"
 #include "librbd/io/AioCompletion.h"

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -34,7 +34,8 @@ namespace librbd {
 
 template <typename I>
 ObjectMap<I>::ObjectMap(I &image_ctx, uint64_t snap_id)
-  : m_image_ctx(image_ctx), m_snap_id(snap_id),
+  : RefCountedObject(image_ctx.cct),
+    m_image_ctx(image_ctx), m_snap_id(snap_id),
     m_update_guard(new UpdateGuard(m_image_ctx.cct)) {
 }
 

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -8,6 +8,7 @@
 #include "include/fs_types.h"
 #include "include/rbd/object_map_types.h"
 #include "common/bit_vector.hpp"
+#include "common/RefCountedObj.h"
 #include "librbd/Utils.h"
 #include <boost/optional.hpp>
 
@@ -23,7 +24,7 @@ struct BlockGuardCell;
 class ImageCtx;
 
 template <typename ImageCtxT = ImageCtx>
-class ObjectMap {
+class ObjectMap : public RefCountedObject {
 public:
   static ObjectMap *create(ImageCtxT &image_ctx, uint64_t snap_id) {
     return new ObjectMap(image_ctx, snap_id);
@@ -68,6 +69,8 @@ public:
                   const boost::optional<uint8_t> &current_state,
                   const ZTracer::Trace &parent_trace, T *callback_object) {
     assert(start_object_no < end_object_no);
+
+    Context *ctx = util::create_context_callback<T, MF>(callback_object, this);
     if (snap_id == CEPH_NOSNAP) {
       end_object_no = std::min(end_object_no, m_object_map.size());
       if (start_object_no >= end_object_no) {
@@ -87,14 +90,11 @@ public:
       }
 
       UpdateOperation update_operation(start_object_no, end_object_no,
-                                       new_state, current_state, parent_trace,
-                                       util::create_context_callback<T, MF>(
-                                         callback_object));
+                                       new_state, current_state, parent_trace, ctx);
       detained_aio_update(std::move(update_operation));
     } else {
       aio_update(snap_id, start_object_no, end_object_no, new_state,
-                 current_state, parent_trace,
-                 util::create_context_callback<T, MF>(callback_object));
+                 current_state, parent_trace, ctx);
     }
     return true;
   }

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -207,8 +207,9 @@ struct C_InvokeAsyncRequest : public Context {
 
     Context *ctx = util::create_async_context_callback(
       image_ctx, util::create_context_callback<
-        C_InvokeAsyncRequest<I>,
-        &C_InvokeAsyncRequest<I>::handle_acquire_exclusive_lock>(this));
+      C_InvokeAsyncRequest<I>,
+      &C_InvokeAsyncRequest<I>::handle_acquire_exclusive_lock>(
+        this, image_ctx.exclusive_lock));
 
     if (request_lock) {
       // current lock owner doesn't support op -- try to perform

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -6,7 +6,6 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "cls/rbd/cls_rbd_client.h"
-#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/Journal.h"

--- a/src/librbd/exclusive_lock/PreReleaseRequest.cc
+++ b/src/librbd/exclusive_lock/PreReleaseRequest.cc
@@ -225,8 +225,8 @@ void PreReleaseRequest<I>::send_close_journal() {
   ldout(cct, 10) << dendl;
 
   using klass = PreReleaseRequest<I>;
-  Context *ctx = create_context_callback<klass, &klass::handle_close_journal>(
-    this);
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_close_journal>(this, m_journal);
   m_journal->close(ctx);
 }
 
@@ -240,7 +240,8 @@ void PreReleaseRequest<I>::handle_close_journal(int r) {
     lderr(cct) << "failed to close journal: " << cpp_strerror(r) << dendl;
   }
 
-  delete m_journal;
+  m_journal->put();
+  m_journal = nullptr;
 
   send_close_object_map();
 }
@@ -262,7 +263,7 @@ void PreReleaseRequest<I>::send_close_object_map() {
 
   using klass = PreReleaseRequest<I>;
   Context *ctx = create_context_callback<
-    klass, &klass::handle_close_object_map>(this);
+    klass, &klass::handle_close_object_map>(this, m_object_map);
   m_object_map->close(ctx);
 }
 
@@ -273,7 +274,7 @@ void PreReleaseRequest<I>::handle_close_object_map(int r) {
 
   // object map shouldn't return errors
   assert(r == 0);
-  delete m_object_map;
+  m_object_map->put();
 
   send_unlock();
 }

--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -134,17 +134,18 @@ void RemoveRequest<I>::acquire_exclusive_lock() {
     m_image_ctx->set_journal_policy(new journal::DisabledPolicy());
   }
 
+  m_exclusive_lock = m_image_ctx->exclusive_lock;
+
   using klass = RemoveRequest<I>;
   if (m_force) {
     Context *ctx = create_context_callback<
-      klass, &klass::handle_exclusive_lock_force>(this);
-    m_exclusive_lock = m_image_ctx->exclusive_lock;
+      klass, &klass::handle_exclusive_lock_force>(this, m_exclusive_lock);
     m_exclusive_lock->shut_down(ctx);
   } else {
     Context *ctx = create_context_callback<
-      klass, &klass::handle_exclusive_lock>(this);
+      klass, &klass::handle_exclusive_lock>(this, m_exclusive_lock);
     RWLock::WLocker owner_lock(m_image_ctx->owner_lock);
-    m_image_ctx->exclusive_lock->try_acquire_lock(ctx);
+    m_exclusive_lock->try_acquire_lock(ctx);
   }
 }
 
@@ -152,7 +153,7 @@ template<typename I>
 void RemoveRequest<I>::handle_exclusive_lock_force(int r) {
   ldout(m_cct, 20) << "r=" << r << dendl;
 
-  delete m_exclusive_lock;
+  m_exclusive_lock->put();
   m_exclusive_lock = nullptr;
 
   if (r < 0) {

--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -32,8 +32,12 @@ template <typename I>
 SetSnapRequest<I>::~SetSnapRequest() {
   assert(!m_writes_blocked);
   delete m_refresh_parent;
-  delete m_object_map;
-  delete m_exclusive_lock;
+  if (m_object_map) {
+    m_object_map->put();
+  }
+  if (m_exclusive_lock) {
+    m_exclusive_lock->put();
+  }
 }
 
 template <typename I>
@@ -72,7 +76,7 @@ void SetSnapRequest<I>::send_init_exclusive_lock() {
 
   using klass = SetSnapRequest<I>;
   Context *ctx = create_context_callback<
-    klass, &klass::handle_init_exclusive_lock>(this);
+    klass, &klass::handle_init_exclusive_lock>(this, m_exclusive_lock);
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   m_exclusive_lock->init(m_image_ctx.features, ctx);
@@ -151,7 +155,7 @@ Context *SetSnapRequest<I>::send_shut_down_exclusive_lock(int *result) {
 
   using klass = SetSnapRequest<I>;
   Context *ctx = create_context_callback<
-    klass, &klass::handle_shut_down_exclusive_lock>(this);
+    klass, &klass::handle_shut_down_exclusive_lock>(this, m_exclusive_lock);
   m_exclusive_lock->shut_down(ctx);
   return nullptr;
 }
@@ -259,10 +263,11 @@ Context *SetSnapRequest<I>::send_open_object_map(int *result) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 10) << __func__ << dendl;
 
+  m_object_map = ObjectMap<I>::create(m_image_ctx, m_snap_id);
+
   using klass = SetSnapRequest<I>;
   Context *ctx = create_context_callback<
-    klass, &klass::handle_open_object_map>(this);
-  m_object_map = ObjectMap<I>::create(m_image_ctx, m_snap_id);
+    klass, &klass::handle_open_object_map>(this, m_object_map);
   m_object_map->open(ctx);
   return nullptr;
 }
@@ -275,7 +280,7 @@ Context *SetSnapRequest<I>::handle_open_object_map(int *result) {
   if (*result < 0) {
     lderr(cct) << "failed to open object map: " << cpp_strerror(*result)
                << dendl;
-    delete m_object_map;
+    m_object_map->put();
     m_object_map = nullptr;
   }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1258,14 +1258,19 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
     CephContext *cct = ictx->cct;
     ldout(cct, 20) << __func__ << ": ictx=" << ictx << dendl;
 
-    if (!ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
-      lderr(cct) << "exclusive-lock feature is not enabled" << dendl;
-      return -EINVAL;
-    }
-
     managed_lock::Locker locker;
     C_SaferCond get_owner_ctx;
-    ExclusiveLock<>(*ictx).get_locker(&locker, &get_owner_ctx);
+    {
+      RWLock::RLocker l(ictx->owner_lock);
+
+      if (ictx->exclusive_lock == nullptr) {
+        lderr(cct) << "exclusive-lock feature is not enabled" << dendl;
+        return -EINVAL;
+      }
+
+      ictx->exclusive_lock->get_locker(&locker, &get_owner_ctx);
+    }
+
     int r = get_owner_ctx.wait();
     if (r == -ENOENT) {
       return r;

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -24,6 +24,9 @@
                            << " " << __func__ << ": "
 
 namespace librbd {
+
+using util::create_context_callback;
+
 namespace io {
 
 using librbd::util::get_image_ctx;
@@ -473,10 +476,15 @@ void ImageFlushRequest<I>::send_request() {
         image_ctx.journal->commit_io_event(journal_tid, r);
         ctx->complete(r);
       });
+
     ctx = new FunctionContext(
       [&image_ctx, journal_tid, ctx](int r) {
         image_ctx.journal->flush_event(journal_tid, ctx);
       });
+    ctx = create_context_callback<
+      Context, &Context::complete,
+      typename std::decay<decltype(*image_ctx.journal)>::type>(
+        ctx, image_ctx.journal);
   } else {
     // flush rbd cache only when journaling is not enabled
     auto object_dispatch_spec = ObjectDispatchSpec::create_flush(

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -21,6 +21,9 @@
                            << " " << __func__ << ": "
 
 namespace librbd {
+
+using util::create_context_callback;
+
 namespace io {
 
 namespace {
@@ -654,7 +657,12 @@ void *ImageRequestWQ<I>::_void_dequeue() {
       } else {
         // stall IO until the acquire completes
         ++m_io_blockers;
-        m_image_ctx.exclusive_lock->acquire_lock(new C_AcquireLock(this, item));
+        Context *ctx = new C_AcquireLock(this, item);
+        ctx = create_context_callback<
+          Context, &Context::complete,
+          typename std::decay<decltype(*m_image_ctx.exclusive_lock)>::type>(
+            ctx, m_image_ctx.exclusive_lock);
+        m_image_ctx.exclusive_lock->acquire_lock(ctx);
       }
     } else {
       // raced with the exclusive lock being disabled

--- a/src/librbd/mirror/DemoteRequest.cc
+++ b/src/librbd/mirror/DemoteRequest.cc
@@ -88,7 +88,8 @@ void DemoteRequest<I>::acquire_lock() {
   ldout(cct, 20) << dendl;
 
   auto ctx = create_context_callback<
-    DemoteRequest<I>, &DemoteRequest<I>::handle_acquire_lock>(this);
+    DemoteRequest<I>,
+    &DemoteRequest<I>::handle_acquire_lock>(this, m_image_ctx.exclusive_lock);
   m_image_ctx.exclusive_lock->acquire_lock(ctx);
   m_image_ctx.owner_lock.put_read();
 }
@@ -153,7 +154,8 @@ void DemoteRequest<I>::release_lock() {
   }
 
   auto ctx = create_context_callback<
-    DemoteRequest<I>, &DemoteRequest<I>::handle_release_lock>(this);
+    DemoteRequest<I>,
+    &DemoteRequest<I>::handle_release_lock>(this, m_image_ctx.exclusive_lock);
   m_image_ctx.exclusive_lock->release_lock(ctx);
   m_image_ctx.owner_lock.put_read();
 }

--- a/src/librbd/operation/DisableFeaturesRequest.cc
+++ b/src/librbd/operation/DisableFeaturesRequest.cc
@@ -124,34 +124,33 @@ Context *DisableFeaturesRequest<I>::handle_block_writes(int *result) {
     }
   }
 
-  send_acquire_exclusive_lock();
-  return nullptr;
+  return send_acquire_exclusive_lock(result);
 }
 
 template <typename I>
-void DisableFeaturesRequest<I>::send_acquire_exclusive_lock() {
+Context *DisableFeaturesRequest<I>::send_acquire_exclusive_lock(int *result) {
   I &image_ctx = this->m_image_ctx;
   CephContext *cct = image_ctx.cct;
   ldout(cct, 20) << this << " " << __func__ << dendl;
-
-  Context *ctx = create_context_callback<
-    DisableFeaturesRequest<I>,
-    &DisableFeaturesRequest<I>::handle_acquire_exclusive_lock>(this);
 
   {
     RWLock::WLocker locker(image_ctx.owner_lock);
     // if disabling features w/ exclusive lock supported, we need to
     // acquire the lock to temporarily block IO against the image
     if (image_ctx.exclusive_lock != nullptr &&
-	!image_ctx.exclusive_lock->is_lock_owner()) {
+        !image_ctx.exclusive_lock->is_lock_owner()) {
       m_acquired_lock = true;
 
+      Context *ctx = create_context_callback<
+        DisableFeaturesRequest<I>,
+        &DisableFeaturesRequest<I>::handle_acquire_exclusive_lock>(
+          this, image_ctx.exclusive_lock);
       image_ctx.exclusive_lock->acquire_lock(ctx);
-      return;
+      return nullptr;
     }
   }
 
-  ctx->complete(0);
+  return handle_acquire_exclusive_lock(result);
 }
 
 template <typename I>
@@ -359,7 +358,7 @@ void DisableFeaturesRequest<I>::send_close_journal() {
       std::swap(m_journal, image_ctx.journal);
       Context *ctx = create_context_callback<
 	DisableFeaturesRequest<I>,
-	&DisableFeaturesRequest<I>::handle_close_journal>(this);
+	&DisableFeaturesRequest<I>::handle_close_journal>(this, m_journal);
 
       m_journal->close(ctx);
       return;
@@ -381,7 +380,7 @@ Context *DisableFeaturesRequest<I>::handle_close_journal(int *result) {
   }
 
   assert(m_journal != nullptr);
-  delete m_journal;
+  m_journal->put();
   m_journal = nullptr;
 
   send_remove_journal();
@@ -603,7 +602,8 @@ void DisableFeaturesRequest<I>::send_release_exclusive_lock() {
 
   Context *ctx = create_context_callback<
     DisableFeaturesRequest<I>,
-    &DisableFeaturesRequest<I>::handle_release_exclusive_lock>(this);
+    &DisableFeaturesRequest<I>::handle_release_exclusive_lock>(
+      this, image_ctx.exclusive_lock);
 
   image_ctx.exclusive_lock->release_lock(ctx);
 }

--- a/src/librbd/operation/DisableFeaturesRequest.h
+++ b/src/librbd/operation/DisableFeaturesRequest.h
@@ -124,7 +124,7 @@ private:
   void send_block_writes();
   Context *handle_block_writes(int *result);
 
-  void send_acquire_exclusive_lock();
+  Context *send_acquire_exclusive_lock(int *result);
   Context *handle_acquire_exclusive_lock(int *result);
 
   void send_get_mirror_mode();

--- a/src/librbd/operation/ResizeRequest.cc
+++ b/src/librbd/operation/ResizeRequest.cc
@@ -281,9 +281,11 @@ Context *ResizeRequest<I>::send_grow_object_map() {
   assert(image_ctx.exclusive_lock == nullptr ||
          image_ctx.exclusive_lock->is_lock_owner());
 
-  image_ctx.object_map->aio_resize(
-    m_new_size, OBJECT_NONEXISTENT, create_context_callback<
-      ResizeRequest<I>, &ResizeRequest<I>::handle_grow_object_map>(this));
+  Context *ctx = create_context_callback<
+    ResizeRequest<I>, &ResizeRequest<I>::handle_grow_object_map>(
+      this, image_ctx.object_map);
+  image_ctx.object_map->aio_resize(m_new_size, OBJECT_NONEXISTENT, ctx);
+
   image_ctx.snap_lock.put_read();
   image_ctx.owner_lock.put_read();
   return nullptr;
@@ -323,9 +325,11 @@ Context *ResizeRequest<I>::send_shrink_object_map() {
   assert(image_ctx.exclusive_lock == nullptr ||
          image_ctx.exclusive_lock->is_lock_owner());
 
-  image_ctx.object_map->aio_resize(
-    m_new_size, OBJECT_NONEXISTENT, create_context_callback<
-      ResizeRequest<I>, &ResizeRequest<I>::handle_shrink_object_map>(this));
+  Context *ctx = create_context_callback<
+    ResizeRequest<I>, &ResizeRequest<I>::handle_shrink_object_map>(
+      this, image_ctx.object_map);
+  image_ctx.object_map->aio_resize(m_new_size, OBJECT_NONEXISTENT, ctx);
+
   image_ctx.snap_lock.put_read();
   image_ctx.owner_lock.put_read();
   return nullptr;

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -223,10 +223,10 @@ Context *SnapshotCreateRequest<I>::send_create_object_map() {
 
   {
     RWLock::RLocker object_map_lock(image_ctx.object_map_lock);
-    image_ctx.object_map->snapshot_add(
-      m_snap_id, create_context_callback<
-        SnapshotCreateRequest<I>,
-        &SnapshotCreateRequest<I>::handle_create_object_map>(this));
+    Context *ctx = create_context_callback<
+      SnapshotCreateRequest<I>,
+      &SnapshotCreateRequest<I>::handle_create_object_map>(this, image_ctx.object_map);
+    image_ctx.object_map->snapshot_add(m_snap_id, ctx);
   }
   image_ctx.snap_lock.put_read();
   return nullptr;

--- a/src/librbd/operation/SnapshotRemoveRequest.cc
+++ b/src/librbd/operation/SnapshotRemoveRequest.cc
@@ -5,7 +5,6 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "cls/rbd/cls_rbd_client.h"
-#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/Utils.h"

--- a/src/librbd/operation/SnapshotRemoveRequest.cc
+++ b/src/librbd/operation/SnapshotRemoveRequest.cc
@@ -234,7 +234,7 @@ void SnapshotRemoveRequest<I>::remove_object_map() {
 
       auto ctx = create_context_callback<
         SnapshotRemoveRequest<I>,
-        &SnapshotRemoveRequest<I>::handle_remove_object_map>(this);
+        &SnapshotRemoveRequest<I>::handle_remove_object_map>(this, image_ctx.object_map);
       image_ctx.object_map->snapshot_remove(m_snap_id, ctx);
       return;
     }

--- a/src/librbd/operation/SnapshotRenameRequest.cc
+++ b/src/librbd/operation/SnapshotRenameRequest.cc
@@ -4,7 +4,6 @@
 #include "librbd/operation/SnapshotRenameRequest.h"
 #include "common/dout.h"
 #include "common/errno.h"
-#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 
 #define dout_subsys ceph_subsys_rbd

--- a/src/librbd/operation/SnapshotRollbackRequest.cc
+++ b/src/librbd/operation/SnapshotRollbackRequest.cc
@@ -81,7 +81,9 @@ SnapshotRollbackRequest<I>::~SnapshotRollbackRequest() {
   if (m_blocking_writes) {
     image_ctx.io_work_queue->unblock_writes();
   }
-  delete m_object_map;
+  if (m_object_map) {
+    m_object_map->put();
+  }
 }
 
 template <typename I>
@@ -174,7 +176,7 @@ void SnapshotRollbackRequest<I>::send_rollback_object_map() {
 
       Context *ctx = create_context_callback<
         SnapshotRollbackRequest<I>,
-        &SnapshotRollbackRequest<I>::handle_rollback_object_map>(this);
+        &SnapshotRollbackRequest<I>::handle_rollback_object_map>(this, image_ctx.object_map);
       image_ctx.object_map->rollback(m_snap_id, ctx);
       return;
     }
@@ -258,7 +260,7 @@ Context *SnapshotRollbackRequest<I>::send_refresh_object_map() {
 
   Context *ctx = create_context_callback<
     SnapshotRollbackRequest<I>,
-    &SnapshotRollbackRequest<I>::handle_refresh_object_map>(this);
+    &SnapshotRollbackRequest<I>::handle_refresh_object_map>(this, m_object_map);
   m_object_map->open(ctx);
   return nullptr;
 }

--- a/src/librbd/trash/MoveRequest.cc
+++ b/src/librbd/trash/MoveRequest.cc
@@ -5,7 +5,6 @@
 #include "common/dout.h"
 #include "common/errno.h"
 #include "cls/rbd/cls_rbd_client.h"
-#include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "librbd/Utils.h"

--- a/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
@@ -376,22 +376,22 @@ TEST_F(TestMockExclusiveLockPostAcquireRequest, JournalError) {
   InSequence seq;
   expect_is_refresh_required(mock_image_ctx, false);
 
-  MockObjectMap *mock_object_map = new MockObjectMap();
+  MockObjectMap mock_object_map;
   expect_test_features(mock_image_ctx, RBD_FEATURE_OBJECT_MAP, true);
-  expect_create_object_map(mock_image_ctx, mock_object_map);
-  expect_open_object_map(mock_image_ctx, *mock_object_map, 0);
+  expect_create_object_map(mock_image_ctx, &mock_object_map);
+  expect_open_object_map(mock_image_ctx, mock_object_map, 0);
 
-  MockJournal *mock_journal = new MockJournal();
+  MockJournal mock_journal;
   MockJournalPolicy mock_journal_policy;
   expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING,
                        mock_image_ctx.snap_lock, true);
   expect_get_journal_policy(mock_image_ctx, mock_journal_policy);
   expect_journal_disabled(mock_journal_policy, false);
-  expect_create_journal(mock_image_ctx, mock_journal);
+  expect_create_journal(mock_image_ctx, &mock_journal);
   expect_handle_prepare_lock_complete(mock_image_ctx);
-  expect_open_journal(mock_image_ctx, *mock_journal, -EINVAL);
-  expect_close_journal(mock_image_ctx, *mock_journal);
-  expect_close_object_map(mock_image_ctx, *mock_object_map);
+  expect_open_journal(mock_image_ctx, mock_journal, -EINVAL);
+  expect_close_journal(mock_image_ctx, mock_journal);
+  expect_close_object_map(mock_image_ctx, mock_object_map);
 
   C_SaferCond acquire_ctx;
   C_SaferCond ctx;
@@ -414,24 +414,24 @@ TEST_F(TestMockExclusiveLockPostAcquireRequest, AllocateJournalTagError) {
   InSequence seq;
   expect_is_refresh_required(mock_image_ctx, false);
 
-  MockObjectMap *mock_object_map = new MockObjectMap();
+  MockObjectMap mock_object_map;
   expect_test_features(mock_image_ctx, RBD_FEATURE_OBJECT_MAP, true);
-  expect_create_object_map(mock_image_ctx, mock_object_map);
-  expect_open_object_map(mock_image_ctx, *mock_object_map, 0);
+  expect_create_object_map(mock_image_ctx, &mock_object_map);
+  expect_open_object_map(mock_image_ctx, mock_object_map, 0);
 
-  MockJournal *mock_journal = new MockJournal();
+  MockJournal mock_journal;
   MockJournalPolicy mock_journal_policy;
   expect_test_features(mock_image_ctx, RBD_FEATURE_JOURNALING,
                        mock_image_ctx.snap_lock, true);
   expect_get_journal_policy(mock_image_ctx, mock_journal_policy);
   expect_journal_disabled(mock_journal_policy, false);
-  expect_create_journal(mock_image_ctx, mock_journal);
+  expect_create_journal(mock_image_ctx, &mock_journal);
   expect_handle_prepare_lock_complete(mock_image_ctx);
-  expect_open_journal(mock_image_ctx, *mock_journal, 0);
+  expect_open_journal(mock_image_ctx, mock_journal, 0);
   expect_get_journal_policy(mock_image_ctx, mock_journal_policy);
   expect_allocate_journal_tag(mock_image_ctx, mock_journal_policy, -EPERM);
-  expect_close_journal(mock_image_ctx, *mock_journal);
-  expect_close_object_map(mock_image_ctx, *mock_object_map);
+  expect_close_journal(mock_image_ctx, mock_journal);
+  expect_close_object_map(mock_image_ctx, mock_object_map);
 
   C_SaferCond acquire_ctx;
   C_SaferCond ctx;
@@ -454,10 +454,10 @@ TEST_F(TestMockExclusiveLockPostAcquireRequest, OpenObjectMapError) {
   InSequence seq;
   expect_is_refresh_required(mock_image_ctx, false);
 
-  MockObjectMap *mock_object_map = new MockObjectMap();
+  MockObjectMap mock_object_map;
   expect_test_features(mock_image_ctx, RBD_FEATURE_OBJECT_MAP, true);
-  expect_create_object_map(mock_image_ctx, mock_object_map);
-  expect_open_object_map(mock_image_ctx, *mock_object_map, -EFBIG);
+  expect_create_object_map(mock_image_ctx, &mock_object_map);
+  expect_open_object_map(mock_image_ctx, mock_object_map, -EFBIG);
 
   MockJournal mock_journal;
   MockJournalPolicy mock_journal_policy;

--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -138,13 +138,13 @@ TEST_F(TestMockExclusiveLockPreReleaseRequest, Success) {
 
   expect_flush_notifies(mock_image_ctx);
 
-  MockJournal *mock_journal = new MockJournal();
-  mock_image_ctx.journal = mock_journal;
-  expect_close_journal(mock_image_ctx, *mock_journal, -EINVAL);
+  MockJournal mock_journal;
+  mock_image_ctx.journal = &mock_journal;
+  expect_close_journal(mock_image_ctx, mock_journal, -EINVAL);
 
-  MockObjectMap *mock_object_map = new MockObjectMap();
-  mock_image_ctx.object_map = mock_object_map;
-  expect_close_object_map(mock_image_ctx, *mock_object_map);
+  MockObjectMap mock_object_map;
+  mock_image_ctx.object_map = &mock_object_map;
+  expect_close_object_map(mock_image_ctx, mock_object_map);
 
   expect_handle_prepare_lock_complete(mock_image_ctx);
 
@@ -173,9 +173,9 @@ TEST_F(TestMockExclusiveLockPreReleaseRequest, SuccessJournalDisabled) {
 
   expect_flush_notifies(mock_image_ctx);
 
-  MockObjectMap *mock_object_map = new MockObjectMap();
-  mock_image_ctx.object_map = mock_object_map;
-  expect_close_object_map(mock_image_ctx, *mock_object_map);
+  MockObjectMap mock_object_map;
+  mock_image_ctx.object_map = &mock_object_map;
+  expect_close_object_map(mock_image_ctx, mock_object_map);
 
   expect_handle_prepare_lock_complete(mock_image_ctx);
 
@@ -228,13 +228,13 @@ TEST_F(TestMockExclusiveLockPreReleaseRequest, Blacklisted) {
 
   expect_flush_notifies(mock_image_ctx);
 
-  MockJournal *mock_journal = new MockJournal();
-  mock_image_ctx.journal = mock_journal;
-  expect_close_journal(mock_image_ctx, *mock_journal, -EBLACKLISTED);
+  MockJournal mock_journal;
+  mock_image_ctx.journal = &mock_journal;
+  expect_close_journal(mock_image_ctx, mock_journal, -EBLACKLISTED);
 
-  MockObjectMap *mock_object_map = new MockObjectMap();
-  mock_image_ctx.object_map = mock_object_map;
-  expect_close_object_map(mock_image_ctx, *mock_object_map);
+  MockObjectMap mock_object_map;
+  mock_image_ctx.object_map = &mock_object_map;
+  expect_close_object_map(mock_image_ctx, mock_object_map);
 
   expect_handle_prepare_lock_complete(mock_image_ctx);
 

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -758,8 +758,8 @@ TEST_F(TestMockImageRefreshRequest, DisableExclusiveLock) {
   MockRefreshImageCtx mock_image_ctx(*ictx);
   MockRefreshParentRequest mock_refresh_parent_request;
 
-  MockExclusiveLock *mock_exclusive_lock = new MockExclusiveLock();
-  mock_image_ctx.exclusive_lock = mock_exclusive_lock;
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
 
   MockObjectMap mock_object_map;
   if (ictx->test_features(RBD_FEATURE_OBJECT_MAP)) {
@@ -805,7 +805,7 @@ TEST_F(TestMockImageRefreshRequest, DisableExclusiveLock) {
   expect_get_flags(mock_image_ctx, 0);
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
-  expect_shut_down_exclusive_lock(mock_image_ctx, *mock_exclusive_lock, 0);
+  expect_shut_down_exclusive_lock(mock_image_ctx, mock_exclusive_lock, 0);
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -1030,8 +1030,8 @@ TEST_F(TestMockImageRefreshRequest, DisableJournal) {
     mock_image_ctx.object_map = &mock_object_map;
   }
 
-  MockJournal *mock_journal = new MockJournal();
-  mock_image_ctx.journal = mock_journal;
+  MockJournal mock_journal;
+  mock_image_ctx.journal = &mock_journal;
 
   if (ictx->test_features(RBD_FEATURE_JOURNALING)) {
     ASSERT_EQ(0, ictx->operations->update_features(RBD_FEATURE_JOURNALING,
@@ -1055,7 +1055,7 @@ TEST_F(TestMockImageRefreshRequest, DisableJournal) {
   if (!mock_image_ctx.clone_copy_on_read) {
     expect_set_require_lock(mock_image_ctx, librbd::io::DIRECTION_READ, false);
   }
-  expect_close_journal(mock_image_ctx, *mock_journal, 0);
+  expect_close_journal(mock_image_ctx, mock_journal, 0);
   expect_unblock_writes(mock_image_ctx);
 
   C_SaferCond ctx;
@@ -1158,8 +1158,8 @@ TEST_F(TestMockImageRefreshRequest, DisableObjectMap) {
   MockExclusiveLock mock_exclusive_lock;
   mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
 
-  MockObjectMap *mock_object_map = new MockObjectMap();
-  mock_image_ctx.object_map = mock_object_map;
+  MockObjectMap mock_object_map;
+  mock_image_ctx.object_map = &mock_object_map;
 
   MockJournal mock_journal;
   if (ictx->test_features(RBD_FEATURE_JOURNALING)) {
@@ -1189,7 +1189,7 @@ TEST_F(TestMockImageRefreshRequest, DisableObjectMap) {
   expect_get_flags(mock_image_ctx, 0);
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
-  expect_close_object_map(mock_image_ctx, *mock_object_map, 0);
+  expect_close_object_map(mock_image_ctx, mock_object_map, 0);
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);
@@ -1217,7 +1217,7 @@ TEST_F(TestMockImageRefreshRequest, OpenObjectMapError) {
   MockExclusiveLock mock_exclusive_lock;
   mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
 
-  MockObjectMap *mock_object_map = new MockObjectMap();
+  MockObjectMap mock_object_map;
 
   expect_op_work_queue(mock_image_ctx);
   expect_test_features(mock_image_ctx);
@@ -1231,7 +1231,7 @@ TEST_F(TestMockImageRefreshRequest, OpenObjectMapError) {
   expect_get_flags(mock_image_ctx, 0);
   expect_get_group(mock_image_ctx, 0);
   expect_refresh_parent_is_required(mock_refresh_parent_request, false);
-  expect_open_object_map(mock_image_ctx, mock_object_map, -EFBIG);
+  expect_open_object_map(mock_image_ctx, &mock_object_map, -EFBIG);
 
   C_SaferCond ctx;
   MockRefreshRequest *req = new MockRefreshRequest(mock_image_ctx, false, false, &ctx);

--- a/src/test/librbd/image/test_mock_RemoveRequest.cc
+++ b/src/test/librbd/image/test_mock_RemoveRequest.cc
@@ -403,9 +403,9 @@ TEST_F(TestMockImageRemoveRequest, OpenFailV1) {
 TEST_F(TestMockImageRemoveRequest, SuccessV2CloneV1) {
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
-  MockExclusiveLock *mock_exclusive_lock = new MockExclusiveLock();
+  MockExclusiveLock mock_exclusive_lock;
   if (m_test_imctx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
-    m_mock_imctx->exclusive_lock = mock_exclusive_lock;
+    m_mock_imctx->exclusive_lock = &mock_exclusive_lock;
   }
 
   expect_op_work_queue(*m_mock_imctx);
@@ -419,7 +419,7 @@ TEST_F(TestMockImageRemoveRequest, SuccessV2CloneV1) {
 
   expect_test_features(*m_mock_imctx);
   expect_set_journal_policy(*m_mock_imctx);
-  expect_shut_down_exclusive_lock(*m_mock_imctx, *mock_exclusive_lock, 0);
+  expect_shut_down_exclusive_lock(*m_mock_imctx, mock_exclusive_lock, 0);
 
   expect_mirror_image_get(*m_mock_imctx, 0);
   expect_get_group(*m_mock_imctx, 0);
@@ -454,9 +454,9 @@ TEST_F(TestMockImageRemoveRequest, SuccessV2CloneV1) {
 TEST_F(TestMockImageRemoveRequest, SuccessV2CloneV2) {
   REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
 
-  MockExclusiveLock *mock_exclusive_lock = new MockExclusiveLock();
+  MockExclusiveLock mock_exclusive_lock;
   if (m_test_imctx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
-    m_mock_imctx->exclusive_lock = mock_exclusive_lock;
+    m_mock_imctx->exclusive_lock = &mock_exclusive_lock;
   }
 
   expect_op_work_queue(*m_mock_imctx);
@@ -470,7 +470,7 @@ TEST_F(TestMockImageRemoveRequest, SuccessV2CloneV2) {
 
   expect_test_features(*m_mock_imctx);
   expect_set_journal_policy(*m_mock_imctx);
-  expect_shut_down_exclusive_lock(*m_mock_imctx, *mock_exclusive_lock, 0);
+  expect_shut_down_exclusive_lock(*m_mock_imctx, mock_exclusive_lock, 0);
 
   expect_mirror_image_get(*m_mock_imctx, 0);
   expect_get_group(*m_mock_imctx, 0);
@@ -505,9 +505,9 @@ TEST_F(TestMockImageRemoveRequest, SuccessV2CloneV2) {
 TEST_F(TestMockImageRemoveRequest, NotExistsV2) {
   REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
 
-  MockExclusiveLock *mock_exclusive_lock = new MockExclusiveLock();
+  MockExclusiveLock mock_exclusive_lock;
   if (m_test_imctx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
-    m_mock_imctx->exclusive_lock = mock_exclusive_lock;
+    m_mock_imctx->exclusive_lock = &mock_exclusive_lock;
   }
 
   expect_op_work_queue(*m_mock_imctx);
@@ -521,7 +521,7 @@ TEST_F(TestMockImageRemoveRequest, NotExistsV2) {
 
   expect_test_features(*m_mock_imctx);
   expect_set_journal_policy(*m_mock_imctx);
-  expect_shut_down_exclusive_lock(*m_mock_imctx, *mock_exclusive_lock, 0);
+  expect_shut_down_exclusive_lock(*m_mock_imctx, mock_exclusive_lock, 0);
 
   expect_mirror_image_get(*m_mock_imctx, 0);
   expect_get_group(*m_mock_imctx, 0);
@@ -595,9 +595,9 @@ TEST_F(TestMockImageRemoveRequest, Snapshots) {
 TEST_F(TestMockImageRemoveRequest, AutoDeleteSnapshots) {
   REQUIRE_FORMAT_V2();
 
-  MockExclusiveLock *mock_exclusive_lock = new MockExclusiveLock();
+  MockExclusiveLock mock_exclusive_lock;
   if (m_test_imctx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
-    m_mock_imctx->exclusive_lock = mock_exclusive_lock;
+    m_mock_imctx->exclusive_lock = &mock_exclusive_lock;
   }
 
   expect_op_work_queue(*m_mock_imctx);
@@ -610,7 +610,7 @@ TEST_F(TestMockImageRemoveRequest, AutoDeleteSnapshots) {
 
   expect_test_features(*m_mock_imctx);
   expect_set_journal_policy(*m_mock_imctx);
-  expect_shut_down_exclusive_lock(*m_mock_imctx, *mock_exclusive_lock, 0);
+  expect_shut_down_exclusive_lock(*m_mock_imctx, mock_exclusive_lock, 0);
 
   expect_mirror_image_get(*m_mock_imctx, 0);
   expect_get_group(*m_mock_imctx, 0);

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -65,7 +65,8 @@ public:
     C_SaferCond close_cond;
     ictx->journal->close(&close_cond);
     ASSERT_EQ(0, close_cond.wait());
-    delete ictx->journal;
+
+    ictx->journal->put();
     ictx->journal = nullptr;
 
     C_SaferCond cond;

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -838,6 +838,7 @@ TEST_F(TestMockJournalReplay, MissingOpFinishEvent) {
 					  "snap")},
                &on_snap_remove_ready,
 	       &on_snap_remove_safe);
+  ictx->op_work_queue->drain();
   ASSERT_EQ(0, on_snap_remove_ready.wait());
 
   C_SaferCond on_snap_create_ready;
@@ -848,6 +849,7 @@ TEST_F(TestMockJournalReplay, MissingOpFinishEvent) {
 					  "snap")},
                &on_snap_create_ready,
 	       &on_snap_create_safe);
+  ictx->op_work_queue->drain();
 
   C_SaferCond on_shut_down;
   mock_journal_replay.shut_down(false, &on_shut_down);
@@ -894,6 +896,7 @@ TEST_F(TestMockJournalReplay, MissingOpFinishEventCancelOps) {
 					  "snap")},
                &on_snap_remove_ready,
 	       &on_snap_remove_safe);
+  ictx->op_work_queue->drain();
   ASSERT_EQ(0, on_snap_remove_ready.wait());
 
   C_SaferCond on_snap_create_ready;
@@ -904,6 +907,7 @@ TEST_F(TestMockJournalReplay, MissingOpFinishEventCancelOps) {
 					  "snap")},
                &on_snap_create_ready,
 	       &on_snap_create_safe);
+  ictx->op_work_queue->drain();
 
   C_SaferCond on_resume;
   when_replay_op_ready(mock_journal_replay, 123, &on_resume);

--- a/src/test/librbd/mock/MockExclusiveLock.h
+++ b/src/test/librbd/mock/MockExclusiveLock.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_TEST_LIBRBD_MOCK_EXCLUSIVE_LOCK_H
 #define CEPH_TEST_LIBRBD_MOCK_EXCLUSIVE_LOCK_H
 
+#include "common/RefCountedObj.h"
 #include "include/int_types.h"
 #include "include/rados/librados.hpp"
 #include "gmock/gmock.h"
@@ -31,6 +32,9 @@ struct MockExclusiveLock {
   MOCK_METHOD0(accept_ops, bool());
 
   MOCK_METHOD0(start_op, Context*());
+
+  void get() {}
+  void put() {}
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockJournal.h
+++ b/src/test/librbd/mock/MockJournal.h
@@ -4,6 +4,7 @@
 #ifndef CEPH_TEST_LIBRBD_MOCK_JOURNAL_H
 #define CEPH_TEST_LIBRBD_MOCK_JOURNAL_H
 
+#include "common/RefCountedObj.h"
 #include "gmock/gmock.h"
 #include "librbd/Journal.h"
 #include "librbd/journal/Types.h"
@@ -40,6 +41,9 @@ struct MockJournal {
   MockJournal() {
     s_instance = this;
   }
+
+  void get() {}
+  void put() {}
 
   MOCK_CONST_METHOD0(is_journal_ready, bool());
   MOCK_CONST_METHOD0(is_journal_replaying, bool());

--- a/src/test/librbd/mock/MockObjectMap.h
+++ b/src/test/librbd/mock/MockObjectMap.h
@@ -19,6 +19,9 @@ struct MockObjectMap {
   MOCK_METHOD3(aio_resize, void(uint64_t new_size, uint8_t default_object_state,
                                 Context *on_finish));
 
+  void get() {}
+  void put() {}
+
   template <typename T, void(T::*MF)(int) = &T::complete>
   bool aio_update(uint64_t snap_id, uint64_t start_object_no, uint8_t new_state,
                   const boost::optional<uint8_t> &current_state,

--- a/src/test/librbd/object_map/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotRemoveRequest.cc
@@ -281,11 +281,12 @@ TEST_F(TestMockObjectMapSnapshotRemoveRequest, ScrubCleanObjects) {
   
   C_SaferCond cond_ctx1;
   {
-    librbd::ObjectMap om(*ictx, ictx->snap_id);
+    librbd::ObjectMap<> *om = new librbd::ObjectMap<>(*ictx, ictx->snap_id);
     RWLock::RLocker owner_locker(ictx->owner_lock);
     RWLock::WLocker snap_locker(ictx->snap_lock);
-    om.set_object_map(object_map);
-    om.aio_save(&cond_ctx1);
+    om->set_object_map(object_map);
+    om->aio_save(&cond_ctx1);
+    om->put();
   }
   ASSERT_EQ(0, cond_ctx1.wait());
   ASSERT_EQ(0, snap_create(*ictx, "snap1"));

--- a/src/test/librbd/operation/test_mock_DisableFeaturesRequest.cc
+++ b/src/test/librbd/operation/test_mock_DisableFeaturesRequest.cc
@@ -292,13 +292,9 @@ TEST_F(TestMockOperationDisableFeaturesRequest, All) {
 
   MockOperationImageCtx mock_image_ctx(*ictx);
   MockExclusiveLock mock_exclusive_lock;
-  MockJournal mock_journal_stack;
-  MockJournal *mock_journal = &mock_journal_stack;
-  if (features_to_disable & RBD_FEATURE_JOURNALING) {
-    mock_journal = new MockJournal();
-  }
+  MockJournal mock_journal;
   MockObjectMap mock_object_map;
-  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, *mock_journal,
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
 		      mock_object_map);
 
   expect_verify_lock_ownership(mock_image_ctx);
@@ -444,9 +440,9 @@ TEST_F(TestMockOperationDisableFeaturesRequest, Mirroring) {
 
   MockOperationImageCtx mock_image_ctx(*ictx);
   MockExclusiveLock mock_exclusive_lock;
-  MockJournal *mock_journal = new MockJournal();
+  MockJournal mock_journal;
   MockObjectMap mock_object_map;
-  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, *mock_journal,
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
 		      mock_object_map);
 
   expect_verify_lock_ownership(mock_image_ctx);
@@ -487,9 +483,9 @@ TEST_F(TestMockOperationDisableFeaturesRequest, MirroringError) {
 
   MockOperationImageCtx mock_image_ctx(*ictx);
   MockExclusiveLock mock_exclusive_lock;
-  MockJournal *mock_journal = new MockJournal();
+  MockJournal mock_journal;
   MockObjectMap mock_object_map;
-  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, *mock_journal,
+  initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
 		      mock_object_map);
 
   expect_verify_lock_ownership(mock_image_ctx);

--- a/src/test/librbd/operation/test_mock_SnapshotRollbackRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRollbackRequest.cc
@@ -189,9 +189,9 @@ TEST_F(TestMockOperationSnapshotRollbackRequest, Success) {
   MockOperationImageCtx mock_image_ctx(*ictx);
   MockExclusiveLock mock_exclusive_lock;
   MockJournal mock_journal;
-  MockObjectMap *mock_object_map = new MockObjectMap();
+  MockObjectMap mock_object_map;
   initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
-                      *mock_object_map);
+                      mock_object_map);
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
@@ -199,9 +199,9 @@ TEST_F(TestMockOperationSnapshotRollbackRequest, Success) {
   expect_append_op_event(mock_image_ctx, false, 0);
   expect_block_writes(mock_image_ctx, 0);
   expect_resize(mock_image_ctx, mock_resize_request, 0);
-  expect_rollback_object_map(mock_image_ctx, *mock_object_map);
+  expect_rollback_object_map(mock_image_ctx, mock_object_map);
   expect_rollback(mock_image_ctx, 0);
-  expect_refresh_object_map(mock_image_ctx, *mock_object_map);
+  expect_refresh_object_map(mock_image_ctx, mock_object_map);
   expect_invalidate_cache(mock_image_ctx, 0);
   expect_commit_op_event(mock_image_ctx, 0);
   expect_unblock_writes(mock_image_ctx);
@@ -235,18 +235,18 @@ TEST_F(TestMockOperationSnapshotRollbackRequest, SkipResize) {
   MockOperationImageCtx mock_image_ctx(*ictx);
   MockExclusiveLock mock_exclusive_lock;
   MockJournal mock_journal;
-  MockObjectMap *mock_object_map = new MockObjectMap();
+  MockObjectMap mock_object_map;
   initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
-                      *mock_object_map);
+                      mock_object_map);
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
   expect_append_op_event(mock_image_ctx, false, 0);
   expect_block_writes(mock_image_ctx, 0);
   expect_get_image_size(mock_image_ctx, 345);
-  expect_rollback_object_map(mock_image_ctx, *mock_object_map);
+  expect_rollback_object_map(mock_image_ctx, mock_object_map);
   expect_rollback(mock_image_ctx, 0);
-  expect_refresh_object_map(mock_image_ctx, *mock_object_map);
+  expect_refresh_object_map(mock_image_ctx, mock_object_map);
   expect_invalidate_cache(mock_image_ctx, 0);
   expect_commit_op_event(mock_image_ctx, 0);
   expect_unblock_writes(mock_image_ctx);
@@ -307,9 +307,9 @@ TEST_F(TestMockOperationSnapshotRollbackRequest, InvalidateCacheError) {
   MockOperationImageCtx mock_image_ctx(*ictx);
   MockExclusiveLock mock_exclusive_lock;
   MockJournal mock_journal;
-  MockObjectMap *mock_object_map = new MockObjectMap();
+  MockObjectMap mock_object_map;
   initialize_features(ictx, mock_image_ctx, mock_exclusive_lock, mock_journal,
-                      *mock_object_map);
+                      mock_object_map);
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
@@ -317,9 +317,9 @@ TEST_F(TestMockOperationSnapshotRollbackRequest, InvalidateCacheError) {
   expect_append_op_event(mock_image_ctx, false, 0);
   expect_block_writes(mock_image_ctx, 0);
   expect_resize(mock_image_ctx, mock_resize_request, 0);
-  expect_rollback_object_map(mock_image_ctx, *mock_object_map);
+  expect_rollback_object_map(mock_image_ctx, mock_object_map);
   expect_rollback(mock_image_ctx, 0);
-  expect_refresh_object_map(mock_image_ctx, *mock_object_map);
+  expect_refresh_object_map(mock_image_ctx, mock_object_map);
   expect_invalidate_cache(mock_image_ctx, -EINVAL);
   expect_commit_op_event(mock_image_ctx, -EINVAL);
   expect_unblock_writes(mock_image_ctx);

--- a/src/test/librbd/test_ObjectMap.cc
+++ b/src/test/librbd/test_ObjectMap.cc
@@ -18,9 +18,12 @@ public:
 
   int when_open_object_map(librbd::ImageCtx *ictx) {
     C_SaferCond ctx;
-    librbd::ObjectMap<> object_map(*ictx, ictx->snap_id);
-    object_map.open(&ctx);
-    return ctx.wait();
+    librbd::ObjectMap<> *object_map = new librbd::ObjectMap<>(*ictx, ictx->snap_id);
+    object_map->open(&ctx);
+    int r = ctx.wait();
+    object_map->put();
+
+    return r;
   }
 };
 

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -656,13 +656,14 @@ TEST_F(TestInternal, SnapshotCopyup)
         state = OBJECT_EXISTS_CLEAN;
       }
 
-      librbd::ObjectMap<> object_map(*ictx2, ictx2->snap_id);
+      librbd::ObjectMap<> *object_map = new librbd::ObjectMap<>(*ictx2, ictx2->snap_id);
       C_SaferCond ctx;
-      object_map.open(&ctx);
+      object_map->open(&ctx);
       ASSERT_EQ(0, ctx.wait());
 
       RWLock::WLocker object_map_locker(ictx2->object_map_lock);
-      ASSERT_EQ(state, object_map[0]);
+      ASSERT_EQ(state, (*object_map)[0]);
+      object_map->put();
     }
   }
 }

--- a/src/test/librbd/test_mock_DeepCopyRequest.cc
+++ b/src/test/librbd/test_mock_DeepCopyRequest.cc
@@ -17,6 +17,7 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <boost/scope_exit.hpp>
 
 namespace librbd {
 
@@ -242,18 +243,20 @@ TEST_F(TestMockDeepCopyRequest, SimpleCopy) {
   librbd::MockExclusiveLock mock_exclusive_lock;
   mock_dst_image_ctx.exclusive_lock = &mock_exclusive_lock;
 
-  librbd::MockObjectMap *mock_object_map =
-    is_feature_enabled(RBD_FEATURE_OBJECT_MAP) ?
-    new librbd::MockObjectMap() : nullptr;
-  mock_dst_image_ctx.object_map = mock_object_map;
+  librbd::MockObjectMap mock_object_map;
+
+  mock_dst_image_ctx.object_map = nullptr;
+  if (is_feature_enabled(RBD_FEATURE_OBJECT_MAP)) {
+    mock_dst_image_ctx.object_map = &mock_object_map;
+  }
 
   expect_test_features(mock_dst_image_ctx);
 
   InSequence seq;
   expect_copy_snapshots(mock_snapshot_copy_request, 0);
   expect_copy_image(mock_image_copy_request, 0);
-  if (mock_object_map != nullptr) {
-    expect_refresh_object_map(mock_dst_image_ctx, mock_object_map);
+  if (mock_dst_image_ctx.object_map != nullptr) {
+    expect_refresh_object_map(mock_dst_image_ctx, &mock_object_map);
   }
   expect_copy_metadata(mock_metadata_copy_request, 0);
 
@@ -315,18 +318,20 @@ TEST_F(TestMockDeepCopyRequest, ErrorOnCopyMetadata) {
   librbd::MockExclusiveLock mock_exclusive_lock;
   mock_dst_image_ctx.exclusive_lock = &mock_exclusive_lock;
 
-  librbd::MockObjectMap *mock_object_map =
-    is_feature_enabled(RBD_FEATURE_OBJECT_MAP) ?
-    new librbd::MockObjectMap() : nullptr;
-  mock_dst_image_ctx.object_map = mock_object_map;
+  librbd::MockObjectMap mock_object_map;
+
+  mock_dst_image_ctx.object_map = nullptr;
+  if (is_feature_enabled(RBD_FEATURE_OBJECT_MAP)) {
+    mock_dst_image_ctx.object_map = &mock_object_map;
+  }
 
   expect_test_features(mock_dst_image_ctx);
 
   InSequence seq;
   expect_copy_snapshots(mock_snapshot_copy_request, 0);
   expect_copy_image(mock_image_copy_request, 0);
-  if (mock_object_map != nullptr) {
-    expect_refresh_object_map(mock_dst_image_ctx, mock_object_map);
+  if (mock_dst_image_ctx.object_map != nullptr) {
+    expect_refresh_object_map(mock_dst_image_ctx, &mock_object_map);
   }
   expect_copy_metadata(mock_metadata_copy_request, -EINVAL);
 
@@ -355,19 +360,19 @@ TEST_F(TestMockDeepCopyRequest, Snap) {
   librbd::MockExclusiveLock mock_exclusive_lock;
   mock_dst_image_ctx.exclusive_lock = &mock_exclusive_lock;
 
-  librbd::MockObjectMap *mock_object_map =
-    is_feature_enabled(RBD_FEATURE_OBJECT_MAP) ?
-    new librbd::MockObjectMap() : nullptr;
-  mock_dst_image_ctx.object_map = mock_object_map;
+  librbd::MockObjectMap mock_object_map;
+  if (is_feature_enabled(RBD_FEATURE_OBJECT_MAP)) {
+    mock_dst_image_ctx.object_map = &mock_object_map;
+  }
 
   expect_test_features(mock_dst_image_ctx);
 
   InSequence seq;
   expect_copy_snapshots(mock_snapshot_copy_request, 0);
   expect_copy_image(mock_image_copy_request, 0);
-  if (mock_object_map != nullptr) {
-    expect_copy_object_map(mock_exclusive_lock, mock_object_map);
-    expect_refresh_object_map(mock_dst_image_ctx, mock_object_map);
+  if (mock_dst_image_ctx.object_map != nullptr) {
+    expect_copy_object_map(mock_exclusive_lock, &mock_object_map);
+    expect_refresh_object_map(mock_dst_image_ctx, &mock_object_map);
   }
   expect_copy_metadata(mock_metadata_copy_request, 0);
 

--- a/src/test/librbd/test_mock_ExclusiveLock.cc
+++ b/src/test/librbd/test_mock_ExclusiveLock.cc
@@ -12,6 +12,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include <list>
+#include <boost/scope_exit.hpp>
 
 namespace librbd {
 
@@ -164,57 +165,57 @@ public:
   typedef exclusive_lock::PostAcquireRequest<MockExclusiveLockImageCtx> MockPostAcquireRequest;
   typedef exclusive_lock::PreReleaseRequest<MockExclusiveLockImageCtx> MockPreReleaseRequest;
 
-  void expect_set_state_initializing(MockManagedLock &managed_lock) {
-    EXPECT_CALL(managed_lock, set_state_initializing());
+  void expect_set_state_initializing(MockManagedLock *managed_lock) {
+    EXPECT_CALL(*managed_lock, set_state_initializing());
   }
 
-  void expect_set_state_unlocked(MockManagedLock &managed_lock) {
-    EXPECT_CALL(managed_lock, set_state_unlocked());
+  void expect_set_state_unlocked(MockManagedLock *managed_lock) {
+    EXPECT_CALL(*managed_lock, set_state_unlocked());
   }
 
-  void expect_set_state_waiting_for_lock(MockManagedLock &managed_lock) {
-    EXPECT_CALL(managed_lock, set_state_waiting_for_lock());
+  void expect_set_state_waiting_for_lock(MockManagedLock *managed_lock) {
+    EXPECT_CALL(*managed_lock, set_state_waiting_for_lock());
   }
 
-  void expect_set_state_post_acquiring(MockManagedLock &managed_lock) {
-    EXPECT_CALL(managed_lock, set_state_post_acquiring());
+  void expect_set_state_post_acquiring(MockManagedLock *managed_lock) {
+    EXPECT_CALL(*managed_lock, set_state_post_acquiring());
   }
 
-  void expect_is_state_acquiring(MockManagedLock &managed_lock, bool ret_val) {
-    EXPECT_CALL(managed_lock, is_state_acquiring())
+  void expect_is_state_acquiring(MockManagedLock *managed_lock, bool ret_val) {
+    EXPECT_CALL(*managed_lock, is_state_acquiring())
       .WillOnce(Return(ret_val));
   }
 
-  void expect_is_state_waiting_for_lock(MockManagedLock &managed_lock,
+  void expect_is_state_waiting_for_lock(MockManagedLock *managed_lock,
                                         bool ret_val) {
-    EXPECT_CALL(managed_lock, is_state_waiting_for_lock())
+    EXPECT_CALL(*managed_lock, is_state_waiting_for_lock())
       .WillOnce(Return(ret_val));
   }
 
-  void expect_is_state_pre_releasing(MockManagedLock &managed_lock,
+  void expect_is_state_pre_releasing(MockManagedLock *managed_lock,
                                      bool ret_val) {
-    EXPECT_CALL(managed_lock, is_state_pre_releasing())
+    EXPECT_CALL(*managed_lock, is_state_pre_releasing())
       .WillOnce(Return(ret_val));
   }
 
-  void expect_is_state_releasing(MockManagedLock &managed_lock, bool ret_val) {
-    EXPECT_CALL(managed_lock, is_state_releasing())
+  void expect_is_state_releasing(MockManagedLock *managed_lock, bool ret_val) {
+    EXPECT_CALL(*managed_lock, is_state_releasing())
       .WillOnce(Return(ret_val));
   }
 
-  void expect_is_state_locked(MockManagedLock &managed_lock, bool ret_val) {
-    EXPECT_CALL(managed_lock, is_state_locked())
+  void expect_is_state_locked(MockManagedLock *managed_lock, bool ret_val) {
+    EXPECT_CALL(*managed_lock, is_state_locked())
       .WillOnce(Return(ret_val));
   }
 
-  void expect_is_state_shutdown(MockManagedLock &managed_lock, bool ret_val) {
-    EXPECT_CALL(managed_lock, is_state_shutdown())
+  void expect_is_state_shutdown(MockManagedLock *managed_lock, bool ret_val) {
+    EXPECT_CALL(*managed_lock, is_state_shutdown())
       .WillOnce(Return(ret_val));
   }
 
-  void expect_is_action_acquire_lock(MockManagedLock &managed_lock,
+  void expect_is_action_acquire_lock(MockManagedLock *managed_lock,
                                      bool ret_val) {
-    EXPECT_CALL(managed_lock, is_action_acquire_lock())
+    EXPECT_CALL(*managed_lock, is_action_acquire_lock())
       .WillOnce(Return(ret_val));
   }
 
@@ -250,7 +251,7 @@ public:
       .WillOnce(CompleteRequest(&pre_acquire_request, r));
   }
 
-  void expect_post_acquire_request(MockExclusiveLock &mock_exclusive_lock,
+  void expect_post_acquire_request(MockExclusiveLock *mock_exclusive_lock,
                                    MockPostAcquireRequest &post_acquire_request,
                                    int r) {
     EXPECT_CALL(post_acquire_request, send())
@@ -266,7 +267,7 @@ public:
   }
 
   void expect_notify_request_lock(MockExclusiveLockImageCtx &mock_image_ctx,
-                                  MockExclusiveLock &mock_exclusive_lock) {
+                                  MockExclusiveLock *mock_exclusive_lock) {
     EXPECT_CALL(*mock_image_ctx.image_watcher, notify_request_lock());
   }
 
@@ -285,67 +286,67 @@ public:
                   .WillOnce(CompleteContext(0, mock_image_ctx.image_ctx->op_work_queue));
   }
 
-  void expect_shut_down(MockManagedLock &managed_lock) {
-    EXPECT_CALL(managed_lock, shut_down(_))
+  void expect_shut_down(MockManagedLock *managed_lock) {
+    EXPECT_CALL(*managed_lock, shut_down(_))
       .WillOnce(CompleteContext(0, static_cast<ContextWQ*>(nullptr)));
   }
 
   int when_init(MockExclusiveLockImageCtx &mock_image_ctx,
-                MockExclusiveLock &exclusive_lock) {
+                MockExclusiveLock *exclusive_lock) {
     C_SaferCond ctx;
     {
       RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
-      exclusive_lock.init(mock_image_ctx.features, &ctx);
+      exclusive_lock->init(mock_image_ctx.features, &ctx);
     }
     return ctx.wait();
   }
 
-  int when_pre_acquire_lock_handler(MockManagedLock &managed_lock) {
+  int when_pre_acquire_lock_handler(MockManagedLock *managed_lock) {
     C_SaferCond ctx;
-    managed_lock.pre_acquire_lock_handler(&ctx);
+    managed_lock->pre_acquire_lock_handler(&ctx);
     return ctx.wait();
   }
 
-  int when_post_acquire_lock_handler(MockManagedLock &managed_lock, int r) {
+  int when_post_acquire_lock_handler(MockManagedLock *managed_lock, int r) {
     C_SaferCond ctx;
-    managed_lock.post_acquire_lock_handler(r, &ctx);
+    managed_lock->post_acquire_lock_handler(r, &ctx);
     return ctx.wait();
   }
 
-  int when_pre_release_lock_handler(MockManagedLock &managed_lock,
+  int when_pre_release_lock_handler(MockManagedLock *managed_lock,
                                     bool shutting_down) {
     C_SaferCond ctx;
-    managed_lock.pre_release_lock_handler(shutting_down, &ctx);
+    managed_lock->pre_release_lock_handler(shutting_down, &ctx);
     return ctx.wait();
   }
 
-  int when_post_release_lock_handler(MockManagedLock &managed_lock,
+  int when_post_release_lock_handler(MockManagedLock *managed_lock,
                                      bool shutting_down, int r) {
     C_SaferCond ctx;
-    managed_lock.post_release_lock_handler(shutting_down, r, &ctx);
+    managed_lock->post_release_lock_handler(shutting_down, r, &ctx);
     return ctx.wait();
   }
 
-  int when_post_reacquire_lock_handler(MockManagedLock &managed_lock, int r) {
+  int when_post_reacquire_lock_handler(MockManagedLock *managed_lock, int r) {
     C_SaferCond ctx;
-    managed_lock.post_reacquire_lock_handler(r, &ctx);
+    managed_lock->post_reacquire_lock_handler(r, &ctx);
     return ctx.wait();
   }
 
   int when_shut_down(MockExclusiveLockImageCtx &mock_image_ctx,
-                     MockExclusiveLock &exclusive_lock) {
+                     MockExclusiveLock *exclusive_lock) {
     C_SaferCond ctx;
     {
       RWLock::WLocker owner_locker(mock_image_ctx.owner_lock);
-      exclusive_lock.shut_down(&ctx);
+      exclusive_lock->shut_down(&ctx);
     }
     return ctx.wait();
   }
 
   bool is_lock_owner(MockExclusiveLockImageCtx &mock_image_ctx,
-                     MockExclusiveLock &exclusive_lock) {
+                     MockExclusiveLock *exclusive_lock) {
     RWLock::RLocker owner_locker(mock_image_ctx.owner_lock);
-    return exclusive_lock.is_lock_owner();
+    return exclusive_lock->is_lock_owner();
   }
 };
 
@@ -356,8 +357,12 @@ TEST_F(TestMockExclusiveLock, StateTransitions) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
+
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
 
   InSequence seq;
   expect_set_state_initializing(exclusive_lock);
@@ -420,10 +425,13 @@ TEST_F(TestMockExclusiveLock, TryLockAlreadyLocked) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
-  InSequence seq;
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
+
   expect_set_state_initializing(exclusive_lock);
   expect_block_writes(mock_image_ctx);
   expect_set_state_unlocked(exclusive_lock);
@@ -447,8 +455,12 @@ TEST_F(TestMockExclusiveLock, TryLockError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
+
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
 
   InSequence seq;
   expect_set_state_initializing(exclusive_lock);
@@ -474,8 +486,12 @@ TEST_F(TestMockExclusiveLock, AcquireLockAlreadyLocked) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
+
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
 
   InSequence seq;
   expect_set_state_initializing(exclusive_lock);
@@ -504,8 +520,12 @@ TEST_F(TestMockExclusiveLock, AcquireLockBusy) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
+
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
 
   InSequence seq;
   expect_set_state_initializing(exclusive_lock);
@@ -534,8 +554,12 @@ TEST_F(TestMockExclusiveLock, AcquireLockError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
+
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
 
   InSequence seq;
   expect_set_state_initializing(exclusive_lock);
@@ -562,8 +586,12 @@ TEST_F(TestMockExclusiveLock, PostAcquireLockError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
+
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
 
   InSequence seq;
   expect_set_state_initializing(exclusive_lock);
@@ -590,8 +618,12 @@ TEST_F(TestMockExclusiveLock, PreReleaseLockError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
+
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
 
   InSequence seq;
   expect_set_state_initializing(exclusive_lock);
@@ -616,8 +648,12 @@ TEST_F(TestMockExclusiveLock, ReacquireLock) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
+
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
 
   InSequence seq;
   expect_set_state_initializing(exclusive_lock);
@@ -662,9 +698,12 @@ TEST_F(TestMockExclusiveLock, BlockRequests) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockExclusiveLockImageCtx mock_image_ctx(*ictx);
-  MockExclusiveLock exclusive_lock(mock_image_ctx);
-
+  MockExclusiveLock *exclusive_lock = new MockExclusiveLock(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
+
+  BOOST_SCOPE_EXIT(&exclusive_lock) {
+    exclusive_lock->put();
+  } BOOST_SCOPE_EXIT_END
 
   InSequence seq;
   expect_set_state_initializing(exclusive_lock);
@@ -675,19 +714,19 @@ TEST_F(TestMockExclusiveLock, BlockRequests) {
   int ret_val;
   expect_is_state_shutdown(exclusive_lock, false);
   expect_is_state_locked(exclusive_lock, true);
-  ASSERT_TRUE(exclusive_lock.accept_requests(&ret_val));
+  ASSERT_TRUE(exclusive_lock->accept_requests(&ret_val));
   ASSERT_EQ(0, ret_val);
 
-  exclusive_lock.block_requests(-EROFS);
+  exclusive_lock->block_requests(-EROFS);
   expect_is_state_shutdown(exclusive_lock, false);
   expect_is_state_locked(exclusive_lock, true);
-  ASSERT_FALSE(exclusive_lock.accept_requests(&ret_val));
+  ASSERT_FALSE(exclusive_lock->accept_requests(&ret_val));
   ASSERT_EQ(-EROFS, ret_val);
 
-  exclusive_lock.unblock_requests();
+  exclusive_lock->unblock_requests();
   expect_is_state_shutdown(exclusive_lock, false);
   expect_is_state_locked(exclusive_lock, true);
-  ASSERT_TRUE(exclusive_lock.accept_requests(&ret_val));
+  ASSERT_TRUE(exclusive_lock->accept_requests(&ret_val));
   ASSERT_EQ(0, ret_val);
 }
 


### PR DESCRIPTION
First posting of a series of patches that aim to support configurable worker threads (via "rbd op threads"). This pr introduces refcounting for reference counting state machines.

