### PR TITLE
osdc: Drop unused function

### DIFF
--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -464,8 +464,6 @@ class ObjectCacher {
 
   size_t stat_nr_dirty_waiters;
 
-  void verify_stats() const;
-
   void bh_stat_add(BufferHead *bh);
   void bh_stat_sub(BufferHead *bh);
   loff_t get_stat_tx() const { return stat_tx; }


### PR DESCRIPTION
Dropped unused verify_stats(). Found this while grepping `stats`. 