### PR TITLE
mgr: quieten logging on missing OSD stats

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -953,7 +953,11 @@ int64_t PGMap::get_rule_avail(const OSDMap& osdmap, int ruleno) const
 	min = proj;
       }
     } else {
-      dout(0) << "Cannot get stat of OSD " << p->first << dendl;
+      if (osdmap.is_up(p->first)) {
+        // This is a level 4 rather than an error, because we might have
+        // only just started, and not received the first stats message yet.
+        dout(4) << "OSD " << p->first << " is up, but has no stats" << dendl;
+      }
     }
   }
   return min;


### PR DESCRIPTION
This is only cause for concern if the OSD is actually up,
and even then it can also happen at startup, so
we shouldn't be logging it as an error.

Fixes: https://tracker.ceph.com/issues/23017
Signed-off-by: John Spray <john.spray@redhat.com>