### PR TITLE
qa/workunits/rbd: remove sanity check in journal.sh test

### DIFF
--- a/qa/workunits/rbd/journal.sh
+++ b/qa/workunits/rbd/journal.sh
@@ -13,7 +13,7 @@ function list_tests()
 
 function usage()
 {
-  echo "usage: $0 [-h|-l|-t <testname> [-t <testname>...] [--no-sanity-check] [--no-cleanup]]"
+  echo "usage: $0 [-h|-l|-t <testname> [-t <testname>...] [--no-cleanup]]"
 }
 
 function expect_false()
@@ -273,7 +273,6 @@ TESTS+=" rbd_feature"
 
 tests_to_run=()
 
-sanity_check=true
 cleanup=true
 
 while [[ $# -gt 0 ]]; do
@@ -282,9 +281,6 @@ while [[ $# -gt 0 ]]; do
     case "$opt" in
 	"-l" )
 	    do_list=1
-	    ;;
-	"--no-sanity-check" )
-	    sanity_check=false
 	    ;;
 	"--no-cleanup" )
 	    cleanup=false
@@ -322,15 +318,9 @@ if test -z "$tests_to_run" ; then
 fi
 
 for i in $tests_to_run; do
-    if $sanity_check ; then
-	wait_for_clean
-    fi
     set -x
     test_${i}
     set +x
 done
-if $sanity_check ; then
-    wait_for_clean
-fi
 
 echo OK


### PR DESCRIPTION
When the OSDs are being concurrently thrashed, this can result in
sporadic failures due to the admin socket disappearing.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>