### PR TITLE
luminous: cmake: disable DOWNLOAD_NO_PROGRESS if cmake ver is lower than 3.1

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -99,7 +99,7 @@ function(do_build_boost version)
     set(source_dir
       URL ${boost_url}
       URL_MD5 ${boost_md5})
-    if(CMAKE_VERSION VERSION_GREATER 3.0)
+    if(CMAKE_VERSION VERSION_GREATER 3.1)
       list(APPEND source_dir DOWNLOAD_NO_PROGRESS 1)
     endif()
   endif()


### PR DESCRIPTION
see https://cmake.org/cmake/help/v3.1/module/ExternalProject.html and
https://cmake.org/cmake/help/v3.0/module/ExternalProject.html. the
former has DOWNLOAD_NO_PROGRESS, while the latter does not.

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit d051bf0441c933e27fb0f54bc6ed999d1e8eca89)