### PR TITLE
mgr/influx: Various time fixes

### DIFF
--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -77,6 +77,8 @@ class Module(MgrModule):
         df = self.get("df")
         data = []
 
+        now = datetime.utcnow().isoformat() + 'Z'
+
         df_types = [
             'bytes_used',
             'kb_used',
@@ -102,7 +104,7 @@ class Module(MgrModule):
                         "type_instance": df_type,
                         "fsid": self.get_fsid()
                     },
-                    "time": datetime.utcnow().isoformat() + 'Z',
+                    "time": now,
                     "fields": {
                         "value": pool['stats'][df_type],
                     }
@@ -112,6 +114,8 @@ class Module(MgrModule):
 
     def get_daemon_stats(self):
         data = []
+
+        now = datetime.utcnow().isoformat() + 'Z'
 
         for daemon, counters in self.get_all_perf_counters().iteritems():
             svc_type, svc_id = daemon.split(".")
@@ -131,7 +135,7 @@ class Module(MgrModule):
                         "host": metadata['hostname'],
                         "fsid": self.get_fsid()
                     },
-                    "time": datetime.utcnow().isoformat() + 'Z',
+                    "time": now,
                     "fields": {
                         "value": value
                     }

--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -45,7 +45,7 @@ class Module(MgrModule):
         'database': 'ceph',
         'username': None,
         'password': None,
-        'interval': 5,
+        'interval': 30,
         'ssl': 'false',
         'verify_ssl': 'true'
     }

--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -230,6 +230,9 @@ class Module(MgrModule):
                               "'%s'", self.config['database'],
                               self.config['username'])
                 client.create_database(self.config['database'])
+                client.create_retention_policy(name='8_weeks', duration='8w',
+                                               replication='1', default=True,
+                                               database=self.config['database'])
             else:
                 self.set_health_checks({
                     'MGR_INFLUX_SEND_FAILED': {


### PR DESCRIPTION
This PR fixes three things:

- Make the default interval 30 seconds
- Make sure all values have the same timestamp and reduce syscalls for fetching the current time
- Set a retention period by default in InfluxDB

The default interval of 5 seconds is a nice to have, but it breaks large systems. Collecting and sending all this information on a 2000 OSD cluster is killing for the Manager. We shouldn't set that by default.

In addition a optimization here is to only fetch the time once, store it in a variable and us it in that run. Otherwise values have different times, but we also perform a lot of syscalls for fetching the time.

The last fix is to set a default retention of 8 weeks in InfluxDB. Users can change this however they like, it will not be modified afterwards, but it's to prevent users setting this up and having a DB grow for ever and breaking at some point in the future.