### PR TITLE
os/bluestore: trim cache every 50ms (instead of 200ms)

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3692,7 +3692,7 @@ std::vector<Option> get_global_options() {
     .set_description("Preallocated buffer for inline shards"),
 
     Option("bluestore_cache_trim_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(.2)
+    .set_default(.05)
     .set_description("How frequently we trim the bluestore cache"),
 
     Option("bluestore_cache_trim_max_skip_pinned", Option::TYPE_UINT, Option::LEVEL_DEV)


### PR DESCRIPTION
In small cache size situations trimming needs to be more frequent.  See
https://tracker.ceph.com/issues/22616

This isn't a complete solution: in very low memory situations an even lower
value would be needed, or perhaps bluestore_default_buffered_read=false.

Signed-off-by: Sage Weil <sage@redhat.com>