### PR TITLE
Allow client to do getattr using implemented caps in addition to issued caps

### DIFF
--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -306,7 +306,7 @@ struct Inode {
   bool cap_is_valid(const Cap &cap) const;
   int caps_issued(int *implemented = 0) const;
   void try_touch_cap(mds_rank_t mds);
-  bool caps_issued_mask(unsigned mask);
+  bool caps_issued_mask(unsigned mask, bool allow_impl=false);
   int caps_used();
   int caps_file_wanted();
   int caps_wanted();

--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -27,6 +27,19 @@
 #include <thread>
 #include <atomic>
 
+/* in ms -- 1 minute */
+#define MAX_WAIT	(60 * 1000)
+
+static void wait_for_atomic_bool(std::atomic_bool &recalled)
+{
+  int i = 0;
+
+  while (!recalled.load()) {
+    ASSERT_LT(i++, MAX_WAIT);
+    usleep(1000);
+  }
+}
+
 static int set_default_deleg_timeout(struct ceph_mount_info *cmount)
 {
   uint32_t session_timeout = ceph_get_cap_return_timeout(cmount);
@@ -60,12 +73,13 @@ static void open_breaker_func(struct ceph_mount_info *cmount, const char *filena
   UserPerm *perms = ceph_mount_perms(cmount);
 
   ASSERT_EQ(ceph_ll_lookup(cmount, root, filename, &file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
-  int ret;
+  int ret, i = 0;
   for (;;) {
     ASSERT_EQ(ceph_ll_getattr(cmount, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
     ret = ceph_ll_open(cmount, file, flags, &fh, perms);
     if (ret != -EAGAIN)
       break;
+    ASSERT_LT(i++, MAX_WAIT);
     usleep(1000);
   }
   ASSERT_EQ(ret, 0);
@@ -101,7 +115,7 @@ static void namespace_breaker_func(struct ceph_mount_info *cmount, int cmd, cons
   struct ceph_statx stx;
   UserPerm *perms = ceph_mount_perms(cmount);
 
-  int ret;
+  int ret, i = 0;
   for (;;) {
     switch (cmd) {
     case DelegTestRename:
@@ -122,6 +136,7 @@ static void namespace_breaker_func(struct ceph_mount_info *cmount, int cmd, cons
     }
     if (ret != -EAGAIN)
       break;
+    ASSERT_LT(i++, MAX_WAIT);
     usleep(1000);
   }
   ASSERT_EQ(ret, 0);
@@ -151,8 +166,8 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker1(open_breaker_func, tcmount, filename, O_RDWR, &opened);
-  while (!recalled.load())
-    usleep(1000);
+
+  wait_for_atomic_bool(recalled);
   ASSERT_EQ(opened.load(), false);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
   breaker1.join();
@@ -167,8 +182,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker2(open_breaker_func, tcmount, filename, O_RDONLY, &opened);
-  while (!recalled.load())
-    usleep(1000);
+  wait_for_atomic_bool(recalled);
   ASSERT_EQ(opened.load(), false);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
   breaker2.join();
@@ -188,8 +202,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
   // ensure that r/w open breaks r/o delegation
   opened.store(false);
   std::thread breaker4(open_breaker_func, tcmount, filename, O_WRONLY, &opened);
-  while (!recalled.load())
-    usleep(1000);
+  wait_for_atomic_bool(recalled);
   usleep(1000);
   ASSERT_EQ(opened.load(), false);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
@@ -206,8 +219,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker5(namespace_breaker_func, tcmount, DelegTestLink, filename, newname);
-  while (!recalled.load())
-    usleep(1000);
+  wait_for_atomic_bool(recalled);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
   breaker5.join();
   ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
@@ -220,8 +232,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker6(namespace_breaker_func, tcmount, DelegTestRename, filename, newname);
-  while (!recalled.load())
-    usleep(1000);
+  wait_for_atomic_bool(recalled);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
   breaker6.join();
   ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
@@ -233,8 +244,7 @@ static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_
 		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
   std::thread breaker7(namespace_breaker_func, tcmount, DelegTestUnlink, filename, nullptr);
-  while (!recalled.load())
-    usleep(1000);
+  wait_for_atomic_bool(recalled);
   ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
   breaker7.join();
   ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
@@ -352,8 +362,10 @@ TEST(LibCephFS, RecalledGetattr) {
   ASSERT_EQ(ceph_ll_getattr(cmount2, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
   std::atomic_bool opened(false);
   std::thread breaker1(open_breaker_func, cmount1, filename, O_WRONLY, &opened);
+  int i = 0;
   do {
     ASSERT_EQ(ceph_ll_getattr(cmount2, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
+    ASSERT_LT(i++, MAX_WAIT);
     usleep(1000);
   } while (!recalled.load());
   ASSERT_EQ(opened.load(), false);

--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -59,9 +59,10 @@ static void open_breaker_func(struct ceph_mount_info *cmount, const char *filena
   struct ceph_statx stx;
   UserPerm *perms = ceph_mount_perms(cmount);
 
-  ASSERT_EQ(ceph_ll_lookup(cmount, root, filename, &file, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_lookup(cmount, root, filename, &file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
   int ret;
   for (;;) {
+    ASSERT_EQ(ceph_ll_getattr(cmount, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
     ret = ceph_ll_open(cmount, file, flags, &fh, perms);
     if (ret != -EAGAIN)
       break;
@@ -301,4 +302,67 @@ TEST(LibCephFS, DelegTimeout) {
   ASSERT_EQ(recalled.load(), true);
   ASSERT_EQ(ceph_ll_getattr(cmount, root, &stx, 0, 0, perms), -ENOTCONN);
   ceph_release(cmount);
+}
+
+TEST(LibCephFS, RecalledGetattr) {
+  struct ceph_mount_info *cmount1;
+  ASSERT_EQ(ceph_create(&cmount1, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount1, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount1, NULL));
+  ASSERT_EQ(ceph_mount(cmount1, "/"), 0);
+  ASSERT_EQ(set_default_deleg_timeout(cmount1), 0);
+
+  Inode *root, *file;
+  ASSERT_EQ(ceph_ll_lookup_root(cmount1, &root), 0);
+
+  char filename[32];
+  sprintf(filename, "recalledgetattr%x", getpid());
+
+  Fh *fh;
+  struct ceph_statx stx;
+  UserPerm *perms = ceph_mount_perms(cmount1);
+
+  ASSERT_EQ(ceph_ll_create(cmount1, root, filename, 0666,
+		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_write(cmount1, fh, 0, sizeof(filename), filename), sizeof(filename));
+  ASSERT_EQ(ceph_ll_close(cmount1, fh), 0);
+
+  /* New mount for read delegation */
+  struct ceph_mount_info *cmount2;
+  ASSERT_EQ(ceph_create(&cmount2, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount2, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount2, NULL));
+  ASSERT_EQ(ceph_mount(cmount2, "/"), 0);
+  ASSERT_EQ(set_default_deleg_timeout(cmount2), 0);
+
+  ASSERT_EQ(ceph_ll_lookup_root(cmount2, &root), 0);
+  perms = ceph_mount_perms(cmount2);
+  ASSERT_EQ(ceph_ll_lookup(cmount2, root, filename, &file, &stx, 0, 0, perms), 0);
+
+  ASSERT_EQ(ceph_ll_open(cmount2, file, O_WRONLY, &fh, perms), 0);
+  ASSERT_EQ(ceph_ll_write(cmount2, fh, 0, sizeof(filename), filename), sizeof(filename));
+  ASSERT_EQ(ceph_ll_close(cmount2, fh), 0);
+
+  ASSERT_EQ(ceph_ll_open(cmount2, file, O_RDONLY, &fh, perms), 0);
+
+  /* Break delegation */
+  std::atomic_bool recalled(false);
+  ASSERT_EQ(ceph_ll_delegation(cmount2, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
+  ASSERT_EQ(ceph_ll_read(cmount2, fh, 0, sizeof(filename), filename), sizeof(filename));
+  ASSERT_EQ(ceph_ll_getattr(cmount2, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
+  std::atomic_bool opened(false);
+  std::thread breaker1(open_breaker_func, cmount1, filename, O_WRONLY, &opened);
+  do {
+    ASSERT_EQ(ceph_ll_getattr(cmount2, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
+    usleep(1000);
+  } while (!recalled.load());
+  ASSERT_EQ(opened.load(), false);
+  ASSERT_EQ(ceph_ll_getattr(cmount2, file, &stx, CEPH_STATX_ALL_STATS, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_delegation(cmount2, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, nullptr), 0);
+  breaker1.join();
+  ASSERT_EQ(ceph_ll_close(cmount2, fh), 0);
+  ceph_unmount(cmount2);
+  ceph_release(cmount2);
+  ceph_unmount(cmount1);
+  ceph_release(cmount1);
 }


### PR DESCRIPTION
This fixes a (rather complex) deadlock that I was hitting with delegations when testing with a multi-headed ganesha cluster:

In the event that we have caps that have been revoked, we can still legitimately use them until the point where we return them back to the MDS. We probably don't want to be handing out new references to them, but callers that just use them just to verify attribute validity should be safe.

For now, I've limited this to the getattr codepaths which is enough to fix the deadlock I was seeing. We may eventually need to do the same with other codepaths as well.

This also includes a new testcase that reproduces the problem that the patch fixes.