### PR TITLE
rgw: fix help message of radosgw

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -141,7 +141,9 @@ static int usage()
   cerr << "options:\n";
   cerr << "  --rgw-region=<region>     region in which radosgw runs\n";
   cerr << "  --rgw-zone=<zone>         zone in which radosgw runs\n";
+#if defined(WITH_RADOSGW_FCGI_FRONTEND)
   cerr << "  --rgw-socket-path=<path>  specify a unix domain socket path\n";
+#endif
   cerr << "  -m monaddress[:port]      connect to specified monitor\n";
   cerr << "  --keyring=<path>          path to radosgw keyring\n";
   cerr << "  --logfile=<logfile>       file to log debug output\n";


### PR DESCRIPTION
This patch fixes the help message of the radosgw.

The radosgw always outputs "--rgw-socket-path=<path> ..." in 
the help message, but the option is only used by FastCGI.

If the radosgw is compiled without FastCGI, the option
does not affect behavior. So, this patch removes 
the unnecessary help message to avoid confusion in that case.

Hitoshi Kamei (1):
  rgw: fix help message of radosgw

 src/rgw/rgw_main.cc | 2 ++
 1 file changed, 2 insertions(+)