### PR TITLE
qa/tasks/filestore_idempotent: shorter test

### DIFF
--- a/qa/tasks/filestore_idempotent.py
+++ b/qa/tasks/filestore_idempotent.py
@@ -40,7 +40,7 @@ def task(ctx, config):
 
     seed = int(random.uniform(1,100))
     start = 800 + random.randint(800,1200)
-    end = start + 150
+    end = start + 50
 
     try:
         log.info('creating a working dir')


### PR DESCRIPTION
Test a shorter sequence of events.  Currently the test is taking
more than 5 hours; we don't need to run quite that long.

Signed-off-by: Sage Weil <sage@redhat.com>