### PR TITLE
mgr: mgr_stats_period from 5 -> 2

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4428,7 +4428,7 @@ std::vector<Option> get_global_options() {
     .set_description("Period in seconds of beacon messages to monitor"),
 
     Option("mgr_stats_period", Option::TYPE_INT, Option::LEVEL_BASIC)
-    .set_default(5)
+    .set_default(2)
     .add_service("mgr")
     .set_description("Period in seconds of OSD/MDS stats reports to manager")
     .set_long_description("Use this setting to control the granularity of "


### PR DESCRIPTION
This gives a more responsive experience for 'ceph -s' and for the
dashboard.  So far we have not seen significant load on the mgr daemon on
even largish clusters.

Lower the default for now.  We can either make the system auto-tune this
value if the mgr is loady, or we can simply ask large cluster operators to
increase it if the mgr is using too much CPU.

Signed-off-by: Sage Weil <sage@redhat.com>