### PR TITLE
osd: detect VDO and advertise meaningful utilization numbers

### DIFF
--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -31,4 +31,11 @@ extern int block_device_model(const char *devname, char *model, size_t max);
 
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
 
+// for VDO
+
+/// return an op fd for the sysfs stats dir, if this is a VDO device
+extern int get_vdo_stats_handle(const char *devname, std::string *vdo_name);
+extern int64_t get_vdo_stat(int fd, const char *property);
+extern bool get_vdo_utilization(int fd, uint64_t *total, uint64_t *avail);
+
 #endif

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -138,6 +138,11 @@ public:
   uint64_t get_size() const { return size; }
   uint64_t get_block_size() const { return block_size; }
 
+  /// hook to provide utilization of thinly-provisioned device
+  virtual bool get_thin_utilization(uint64_t *total, uint64_t *avail) const {
+    return false;
+  }
+
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const = 0;
 
   virtual int get_devname(std::string *out) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6404,9 +6404,8 @@ int BlueStore::get_devices(set<string> *ls)
 int BlueStore::statfs(struct store_statfs_t *buf)
 {
   buf->reset();
-  buf->total = bdev->get_size();
-  buf->available = alloc->get_free();
 
+  uint64_t bfree = alloc->get_free();
   if (bluefs) {
     // part of our shared device is "free" according to BlueFS, but we
     // can't touch bluestore_bluefs_min of it.
@@ -6414,13 +6413,31 @@ int BlueStore::statfs(struct store_statfs_t *buf)
       bluefs->get_free(bluefs_shared_bdev),
       bluefs->get_total(bluefs_shared_bdev) - cct->_conf->bluestore_bluefs_min);
     if (shared_available > 0) {
-      buf->available += shared_available;
+      bfree += shared_available;
+    }
+  }
+
+  uint64_t thin_total, thin_avail;
+  if (bdev->get_thin_utilization(&thin_total, &thin_avail)) {
+    buf->total += thin_total;
+
+    // we are limited by both the size of the virtual device and the
+    // underlying physical device.
+    bfree = std::min(bfree, thin_avail);
+  } else {
+    buf->total = bdev->get_size();
+  }
+  buf->available += bfree;
+
+  if (bluefs) {
+    // include dedicated db, too, if that isn't the shared device.
+    if (bluefs_shared_bdev != BlueFS::BDEV_DB) {
+      buf->total += bluefs->get_total(BlueFS::BDEV_DB);
     }
   }
 
   {
     std::lock_guard<std::mutex> l(vstatfs_lock);
-    
     buf->allocated = vstatfs.allocated();
     buf->stored = vstatfs.stored();
     buf->compressed = vstatfs.compressed();
@@ -6428,7 +6445,7 @@ int BlueStore::statfs(struct store_statfs_t *buf)
     buf->compressed_allocated = vstatfs.compressed_allocated();
   }
 
-  dout(20) << __func__ << *buf << dendl;
+  dout(20) << __func__ << " " << *buf << dendl;
   return 0;
 }
 

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -138,6 +138,8 @@ int KernelDevice::open(const string& p)
       dout(20) << __func__ << " devname " << devname << dendl;
       rotational = block_device_is_rotational(devname);
       this->devname = devname;
+
+      _detect_vdo();
     }
   }
 
@@ -191,6 +193,11 @@ void KernelDevice::close()
   assert(fs);
   delete fs;
   fs = NULL;
+
+  if (vdo_fd >= 0) {
+    VOID_TEMP_FAILURE_RETRY(::close(vdo_fd));
+    vdo_fd = -1;
+  }
 
   assert(fd_direct >= 0);
   VOID_TEMP_FAILURE_RETRY(::close(fd_direct));
@@ -267,6 +274,26 @@ int KernelDevice::collect_metadata(const string& prefix, map<string,string> *pm)
     (*pm)[prefix + "path"] = path;
   }
   return 0;
+}
+
+void KernelDevice::_detect_vdo()
+{
+  vdo_fd = get_vdo_stats_handle(devname.c_str(), &vdo_name);
+  if (vdo_fd >= 0) {
+    dout(1) << __func__ << " VDO volume " << vdo_name
+	    << " maps to " << devname << dendl;
+  } else {
+    dout(20) << __func__ << " no VDO volume maps to " << devname << dendl;
+  }
+  return;
+}
+
+bool KernelDevice::get_thin_utilization(uint64_t *total, uint64_t *avail) const
+{
+  if (vdo_fd < 0) {
+    return false;
+  }
+  return get_vdo_utilization(vdo_fd, total, avail);
 }
 
 int KernelDevice::flush()

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -228,6 +228,12 @@ int KernelDevice::collect_metadata(const string& prefix, map<string,string> *pm)
   } else {
     (*pm)[prefix + "type"] = "ssd";
   }
+  if (vdo_fd >= 0) {
+    (*pm)[prefix + "vdo"] = "true";
+    uint64_t total, avail;
+    get_vdo_utilization(vdo_fd, &total, &avail);
+    (*pm)[prefix + "vdo_physical_size"] = stringify(total);
+  }
 
   struct stat st;
   int r = ::fstat(fd_buffered, &st);

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -29,6 +29,9 @@ class KernelDevice : public BlockDevice {
   FS *fs;
   bool aio, dio;
 
+  int vdo_fd = -1;      ///< fd for vdo sysfs directory
+  string vdo_name;
+
   std::string devname;  ///< kernel dev name (/sys/block/$devname), if any
 
   Mutex debug_lock;
@@ -72,6 +75,8 @@ class KernelDevice : public BlockDevice {
   void debug_aio_link(aio_t& aio);
   void debug_aio_unlink(aio_t& aio);
 
+  void _detect_vdo();
+
 public:
   KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 
@@ -86,6 +91,8 @@ public:
     return 0;
   }
   int get_devices(std::set<std::string> *ls) override;
+
+  bool get_thin_utilization(uint64_t *total, uint64_t *avail) const override;
 
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
 	   IOContext *ioc,

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -707,6 +707,11 @@ void FileStore::collect_metadata(map<string,string> *pm)
     default:
       (*pm)["backend_filestore_partition_path"] = string(partition_path);
       (*pm)["backend_filestore_dev_node"] = string(dev_node);
+      if (vdo_fd >= 0) {
+	(*pm)["vdo"] = "true";
+	(*pm)["vdo_physical_size"] =
+	  stringify(4096 * get_vdo_stat(vdo_fd, "physical_blocks"));
+      }
   }
 }
 

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -735,8 +735,17 @@ int FileStore::statfs(struct store_statfs_t *buf0)
     assert(r != -ENOENT);
     return r;
   }
-  buf0->total = buf.f_blocks * buf.f_bsize;
-  buf0->available = buf.f_bavail * buf.f_bsize;
+
+  uint64_t bfree = buf.f_bavail * buf.f_bsize;
+  uint64_t thin_total, thin_avail;
+  if (get_vdo_utilization(vdo_fd, &thin_total, &thin_avail)) {
+    buf0->total = thin_total;
+    bfree = std::min(bfree, thin_avail);
+  } else {
+    buf0->total = buf.f_blocks * buf.f_bsize;
+  }
+  buf0->available = bfree;
+
   // Adjust for writes pending in the journal
   if (journal) {
     uint64_t estimate = journal->get_journal_size_estimate();
@@ -1221,6 +1230,20 @@ int FileStore::_detect_fs()
   if (r < 0) {
     derr << __FUNC__ << ": detect_features error: " << cpp_strerror(r) << dendl;
     return r;
+  }
+
+  // vdo
+  {
+    char partition_path[PATH_MAX];
+    char dev_node[PATH_MAX];
+    int rc = get_device_by_fd(fsid_fd, partition_path, dev_node, PATH_MAX);
+    if (rc == 0) {
+      vdo_fd = get_vdo_stats_handle(dev_node, &vdo_name);
+      if (vdo_fd >= 0) {
+	dout(0) << __func__ << " VDO volume " << vdo_name << " for " << dev_node
+		<< dendl;
+      }
+    }
   }
 
   // test xattrs
@@ -1984,6 +2007,10 @@ int FileStore::umount()
     (*it)->stop();
   }
 
+  if (vdo_fd >= 0) {
+    VOID_TEMP_FAILURE_RETRY(::close(vdo_fd));
+    vdo_fd = -1;
+  }
   if (fsid_fd >= 0) {
     VOID_TEMP_FAILURE_RETRY(::close(fsid_fd));
     fsid_fd = -1;

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -166,6 +166,9 @@ private:
 
   void create_backend(long f_type);
 
+  int vdo_fd = -1;
+  string vdo_name;
+
   deque<uint64_t> snaps;
 
   // Indexed Collections


### PR DESCRIPTION
VDO is a thinly provisioned device, which means our real OSD utilization depends on the size and utilization of the VDO volume's physical device as well as the virtual device layered over it.  Free space isthe min of the two.

TODO
- [x] allow vdo code to look "through" LV devices to underlying VDO
- [ ] test with ceph-volume and ensure it detects VDO properly