### PR TITLE
luminous:qa: ignore MON_DOWN while thrashing mons

### DIFF
--- a/qa/suites/kcephfs/thrash/thrashers/mon.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/mon.yaml
@@ -1,3 +1,7 @@
+overrides:
+  ceph:
+    log-whitelist:
+    - \(MON_DOWN\)
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
http://tracker.ceph.com/issues/23061