### PR TITLE
mon: add MMonHealth back

### DIFF
--- a/src/messages/MMonHealth.h
+++ b/src/messages/MMonHealth.h
@@ -1,0 +1,63 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2012 Inktank, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#ifndef CEPH_MMON_HEALTH_H
+#define CEPH_MMON_HEALTH_H
+
+#include "msg/Message.h"
+#include "messages/MMonQuorumService.h"
+#include "mon/mon_types.h"
+
+struct MMonHealth : public MMonQuorumService
+{
+  static const int HEAD_VERSION = 1;
+
+  int service_type = 0;
+  int service_op = 0;
+
+  // service specific data
+  DataStats data_stats;
+
+  MMonHealth() : MMonQuorumService(MSG_MON_HEALTH, HEAD_VERSION) { }
+
+private:
+  ~MMonHealth() override { }
+
+public:
+  const char *get_type_name() const override { return "mon_health"; }
+  void print(ostream &o) const override {
+    o << "mon_health("
+      << " e " << get_epoch()
+      << " r " << get_round()
+      << " )";
+  }
+
+  void decode_payload() override {
+    bufferlist::iterator p = payload.begin();
+    service_decode(p);
+    decode(service_type, p);
+    decode(service_op, p);
+    decode(data_stats, p);
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    service_encode();
+    encode(service_type, payload);
+    encode(service_op, payload);
+    encode(data_stats, payload);
+  }
+
+};
+
+#endif /* CEPH_MMON_HEALTH_H */

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4233,6 +4233,10 @@ void Monitor::dispatch_op(MonOpRequestRef op)
       handle_timecheck(op);
       break;
 
+    case MSG_MON_HEALTH:
+      dout(5) << __func__ << " dropping deprecated message: "
+	      << *op->get_req() << dendl;
+      break;
     case MSG_MON_HEALTH_CHECKS:
       op->set_type_service();
       paxos_service[PAXOS_HEALTH]->dispatch(op);

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -95,6 +95,7 @@
 #include "messages/MMonGetMap.h"
 #include "messages/MMonGetVersion.h"
 #include "messages/MMonGetVersionReply.h"
+#include "messages/MMonHealth.h"
 #include "messages/MMonHealthChecks.h"
 #include "messages/MMonMetadata.h"
 #include "messages/MDataPing.h"
@@ -781,6 +782,10 @@ Message *decode_message(CephContext *cct, int crcflags,
 
   case MSG_TIMECHECK:
     m = new MTimeCheck();
+    break;
+
+  case MSG_MON_HEALTH:
+    m = new MMonHealth();
     break;
 
   case MSG_MON_HEALTH_CHECKS:

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -172,7 +172,7 @@
 
 // *** generic ***
 #define MSG_TIMECHECK             0x600
-//#define MSG_MON_HEALTH            0x601  // remove post-luminous
+#define MSG_MON_HEALTH            0x601
 
 // *** Message::encode() crcflags bits ***
 #define MSG_CRC_DATA           (1 << 0)


### PR DESCRIPTION
This partially reverts commit 7b4a741fbda4dc817a003c694e96c8df7c1d2092.

we need to at least decode MMonHealth sent from luminous monitors in
mimic. and in luminous, we could drop the support of this message, if we
can only upgrade from mimic.

Fixes: http://tracker.ceph.com/issues/22462
Signed-off-by: Kefu Chai <kchai@redhat.com>