### PR TITLE
 rbd: set a default value for options in `nbd map`

### DIFF
--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -221,7 +221,8 @@ int execute_map_deprecated(const po::variables_map &vm_deprecated,
   options.add_options()
     ("read-only", po::bool_switch(), "")
     ("exclusive", po::bool_switch(), "")
-    ("options,o", po::value<std::vector<std::string>>(), "");
+    ("options,o", po::value<std::vector<std::string>>()
+                  ->default_value(std::vector<std::string>(), ""), "");
 
   po::variables_map vm;
   po::store(po::command_line_parser({}).options(options).run(), vm);

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -219,32 +219,23 @@ int execute_map_deprecated(const po::variables_map &vm_deprecated,
 
   po::options_description options;
   options.add_options()
-    ("read-only", po::bool_switch(), "")
-    ("exclusive", po::bool_switch(), "")
     ("options,o", po::value<std::vector<std::string>>()
                   ->default_value(std::vector<std::string>(), ""), "");
 
-  po::variables_map vm;
+  po::variables_map vm = vm_deprecated;
   po::store(po::command_line_parser({}).options(options).run(), vm);
-
-  if (vm_deprecated["read-only"].as<bool>()) {
-    vm.at("read-only").value() = boost::any(true);
-  }
-  if (vm_deprecated["exclusive"].as<bool>()) {
-    vm.at("exclusive").value() = boost::any(true);
-  }
 
   std::vector<std::string> opts;
   if (vm_deprecated.count("device")) {
     opts.push_back("device=" + vm_deprecated["device"].as<std::string>());
   }
-  if (vm.count("nbds_max")) {
+  if (vm_deprecated.count("nbds_max")) {
     opts.push_back("nbds_max=" + vm_deprecated["nbds_max"].as<std::string>());
   }
-  if (vm.count("max_part")) {
+  if (vm_deprecated.count("max_part")) {
     opts.push_back("max_part=" + vm_deprecated["max_part"].as<std::string>());
   }
-  if (vm.count("timeout")) {
+  if (vm_deprecated.count("timeout")) {
     opts.push_back("timeout=" + vm_deprecated["timeout"].as<std::string>());
   }
 


### PR DESCRIPTION
Since `vm` does not contain an `options` item and
`vm.at("options").value()` will throw an exception.
```
root@s222:/ceph-dev/build# rbd nbd map img1
rbd: 'nbd map' command is deprecated, use 'device map -t nbd' instead
terminate called after throwing an instance of 'std::out_of_range'
  what():  map::at
*** Caught signal (Aborted) **
 in thread 7f0e5e046400 thread_name:rbd
 ceph version 12.0.3-11022-ga09b319 (a09b319) mimic (dev)
 1: (()+0x1afb00) [0x55a07d677b00]
 2: (()+0x10340) [0x7f0e545a0340]
 3: (gsignal()+0x39) [0x7f0e531b0cc9]
 4: (abort()+0x148) [0x7f0e531b40d8]
 5: (__gnu_cxx::__verbose_terminate_handler()+0x125) [0x7f0e53ac8415]
 6: (()+0x6a206) [0x7f0e53ac6206]
 7: (()+0x6a251) [0x7f0e53ac6251]
 8: (()+0x6a493) [0x7f0e53ac6493]
 9: (std::__throw_out_of_range(char const*)+0x3f) [0x7f0e53aeac3f]
 10: (rbd::action::nbd::execute_map_deprecated(boost::program_options::variables_map const&, std::vector<std::string, std::allocator<std::string> > const&)+0xa35) [0x55a07d5f6a15]
 11: (rbd::Shell::execute(int, char const**)+0xb5b) [0x55a07d581adb]
 12: (main()+0x15) [0x55a07d546615]
 13: (__libc_start_main()+0xf5) [0x7f0e5319bec5]
 14: (()+0xa141f) [0x55a07d56941f]
2018-02-22 13:43:59.212 7f0e5e046400 -1 *** Caught signal (Aborted) **
 in thread 7f0e5e046400 thread_name:rbd
```