### PR TITLE
systemd: Wait 10 seconds before restarting ceph-mgr

### DIFF
--- a/systemd/ceph-mgr@.service
+++ b/systemd/ceph-mgr@.service
@@ -13,6 +13,7 @@ Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mgr -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
+RestartSec=10
 StartLimitInterval=30min
 StartLimitBurst=3
 


### PR DESCRIPTION
We do this for the MON and OSD as well, wait for a few
seconds before we try to attempt a restart.

On boot in IPv6 networks it might take a few seconds longer
before a IP-address is usable and this does not allow the mgr
to start right away.

Fixes: http://tracker.ceph.com/issues/23083

Signed-off-by: Wido den Hollander <wido@42on.com>