### PR TITLE
librados: make OPERATION_FULL_FORCE the default for rados_remove()

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1282,7 +1282,7 @@ int librados::IoCtxImpl::remove(const object_t& oid)
   ::ObjectOperation op;
   prepare_assert_ops(&op);
   op.remove();
-  return operate(oid, &op, NULL);
+  return operate(oid, &op, nullptr, librados::OPERATION_FULL_FORCE);
 }
 
 int librados::IoCtxImpl::remove(const object_t& oid, int flags)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22413
Signed-off-by: Kefu Chai <kchai@redhat.com>