### PR TITLE
test/fio: enable objectstore FIO plugin building without the need to install and build FIO source code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,10 +499,16 @@ option(PG_DEBUG_REFS "PG Ref debugging is enabled" OFF)
 
 option(WITH_TESTS "enable the build of ceph-test package scripts/binaries" ON)
 
-option(WITH_FIO "Support for fio engines" OFF)
-if(WITH_FIO)
+# fio
+option(WITH_FIO "build with fio plugin enabled" OFF)
+option(WITH_SYSTEM_FIO "require and build with system fio" OFF)
+if(WITH_SYSTEM_FIO)
   find_package(fio REQUIRED)
-endif(WITH_FIO)
+elseif(WITH_FIO)
+  set(FIO_INCLUDE_DIR ${CMAKE_BINARY_DIR}/src/fio)
+  include(BuildFIO)
+  build_fio()
+endif()
 
 if(LINUX)
   add_definitions(-D__linux__)

--- a/cmake/modules/BuildFIO.cmake
+++ b/cmake/modules/BuildFIO.cmake
@@ -1,0 +1,15 @@
+function(build_fio)
+  # we use an external project and copy the sources to bin directory to ensure
+  # that object files are built outside of the source tree.
+  include(ExternalProject)
+  ExternalProject_Add(fio_ext
+    DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/src/
+    UPDATE_COMMAND "" # this disables rebuild on each run
+    GIT_REPOSITORY "https://github.com/axboe/fio.git"
+    GIT_TAG "fio-3.5"
+    SOURCE_DIR ${CMAKE_BINARY_DIR}/src/fio
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND <SOURCE_DIR>/configure
+    BUILD_COMMAND $(MAKE) fio EXTFLAGS=-Wno-format-truncation
+    INSTALL_COMMAND cp <BINARY_DIR>/fio ${CMAKE_BINARY_DIR}/bin)
+endfunction()

--- a/cmake/modules/Findfio.cmake
+++ b/cmake/modules/Findfio.cmake
@@ -4,7 +4,7 @@
 # FIO_INCLUDE_DIR - where to find fio.h
 # FIO_FOUND - True if fio is found.
 
-find_path(FIO_INCLUDE_DIR NAMES fio.h HINTS ${FIO_ROOT_DIR})
+find_path(FIO_INCLUDE_DIR NAMES fio.h HINTS ENV FIO_ROOT_DIR)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(fio DEFAULT_MSG FIO_INCLUDE_DIR)

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -68,7 +68,7 @@ function run() {
     BUILD_MAKEOPTS=${BUILD_MAKEOPTS:-$DEFAULT_MAKEOPTS}
     CHECK_MAKEOPTS=${CHECK_MAKEOPTS:-$DEFAULT_MAKEOPTS}
 
-    $DRY_RUN ./do_cmake.sh $@ || return 1
+    $DRY_RUN ./do_cmake.sh -DWITH_FIO=ON $@ || return 1
     $DRY_RUN cd build
     $DRY_RUN make $BUILD_MAKEOPTS tests || return 1
     # prevent OSD EMFILE death on tests, make sure large than 1024

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -59,7 +59,7 @@ if(WITH_RBD)
   add_subdirectory(rbd_mirror)
 endif(WITH_RBD)
 add_subdirectory(system)
-if(WITH_FIO)
+if(WITH_FIO OR WITH_SYSTEM_FIO)
   add_subdirectory(fio)
 endif()
 

--- a/src/test/fio/CMakeLists.txt
+++ b/src/test/fio/CMakeLists.txt
@@ -14,5 +14,8 @@ else()
     COMPILE_FLAGS "${FIO_CFLAGS}")
 endif()
 
+if(WITH_FIO)
+  add_dependencies(fio_ceph_objectstore fio_ext)
+endif()
 target_link_libraries(fio_ceph_objectstore os global)
 install(TARGETS fio_ceph_objectstore DESTINATION lib)

--- a/src/test/fio/README.md
+++ b/src/test/fio/README.md
@@ -49,12 +49,19 @@ Because the ObjectStore is not a public-facing interface, we build it inside
 of the ceph tree and load libfio_ceph_objectstore.so into fio as an external
 engine.
 
-To build fio_ceph_objectstore:
+To build fio_ceph_objectstore against external(downloadable) FIO source code:
 ```
-  mkdir build && cd build
-  cmake -DWITH_FIO=ON -DFIO_INCLUDE_DIR=/path/to/fio -DCMAKE_BUILD_TYPE=Release /path/to/ceph
-  make -C src/test/fio install
+  ./do_cmake.sh -DWITH_FIO=ON -DCMAKE_BUILD_TYPE=Release
+  cd build
+  make fio_ceph_objectstore install
 ```
+To build against existing FIO source code:
+```
+  FIO_ROOT_DIR=<path to fio source code> ./do_cmake.sh -DWITH_SYSTEM_FIO=ON
+  cd build
+  make fio_ceph_objectstore install
+```
+
 If you install the ceph libraries to a location that isn't in your
 LD_LIBRARY_PATH, be sure to add it:
 


### PR DESCRIPTION
By default plugin building is still off and one should provide -DWITH_FIO=ON for do_cmake call.
However run_make_check enforces the build hence providing source code validation at jenkins.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>