### PR TITLE
mgr: prometheus: Don't crash on OSDs without metadata

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -298,6 +298,8 @@ class Module(MgrModule):
                     ('osd.{}'.format(id_),))
 
             osd_metadata = self.get_metadata("osd", str(id_))
+            if osd_metadata is None:
+                continue
             dev_keys = ("backend_filestore_dev_node", "bluestore_bdev_dev_node")
             osd_dev_node = None
             for dev_key in dev_keys:


### PR DESCRIPTION
Fix issue where the prometheus ceph_exporter crashes after a Ceph upgrade with a down OSD - that OSD was never up since the upgrade to Luminous and thus we have no metadata for it

Signed-off-by: Christopher Blum <zeichenanonym@web.de>