### PR TITLE
common/OpHistory: move insert/cleanup into separate thread

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -36,9 +36,10 @@ void OpHistory::insert(utime_t now, TrackedOpRef op)
   Mutex::Locker history_lock(ops_history_lock);
   if (shutdown)
     return;
-  duration.insert(make_pair(op->get_duration(), op));
+  double opduration = op->get_duration();
+  duration.insert(make_pair(opduration, op));
   arrived.insert(make_pair(op->get_initiated(), op));
-  if (op->get_duration() >= history_slow_op_threshold)
+  if (opduration >= history_slow_op_threshold)
     slow_op.insert(make_pair(op->get_initiated(), op));
   cleanup(now);
 }

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -22,8 +22,47 @@ static ostream& _prefix(std::ostream* _dout)
   return *_dout << "-- op tracker -- ";
 }
 
+void OpHistoryServiceThread::break_thread() {
+  queue_spinlock.lock();
+  _external_queue.clear();
+  _break_thread = true;
+  queue_spinlock.unlock();
+}
+
+void* OpHistoryServiceThread::entry() {
+  int sleep_time = 1000;
+  list<pair<utime_t, TrackedOpRef>> internal_queue;
+  while (1) {
+    queue_spinlock.lock();
+    if (_break_thread) {
+      queue_spinlock.unlock();
+      break;
+    }
+    internal_queue.swap(_external_queue);
+    queue_spinlock.unlock();
+    if (internal_queue.empty()) {
+      usleep(sleep_time);
+      if (sleep_time < 128000) {
+        sleep_time <<= 2;
+      }
+    } else {
+      sleep_time = 1000;
+    }
+
+    while (!internal_queue.empty()) {
+      pair<utime_t, TrackedOpRef> op = internal_queue.front();
+      _ophistory->_insert_delayed(op.first, op.second);
+      internal_queue.pop_front();
+    }
+  }
+  return nullptr;
+}
+
+
 void OpHistory::on_shutdown()
 {
+  opsvc.break_thread();
+  opsvc.join();
   Mutex::Locker history_lock(ops_history_lock);
   arrived.clear();
   duration.clear();
@@ -31,7 +70,7 @@ void OpHistory::on_shutdown()
   shutdown = true;
 }
 
-void OpHistory::insert(utime_t now, TrackedOpRef op)
+void OpHistory::_insert_delayed(const utime_t& now, TrackedOpRef op)
 {
   Mutex::Locker history_lock(ops_history_lock);
   if (shutdown)

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -434,7 +434,7 @@ void TrackedOp::mark_event_string(const string &event, utime_t stamp)
 
   {
     Mutex::Locker l(lock);
-    events.push_back(Event(stamp, event));
+    events.emplace_back(stamp, event);
     current = events.back().c_str();
   }
   dout(6) << " seq: " << seq
@@ -452,7 +452,7 @@ void TrackedOp::mark_event(const char *event, utime_t stamp)
 
   {
     Mutex::Locker l(lock);
-    events.push_back(Event(stamp, event));
+    events.emplace_back(stamp, event);
     current = event;
   }
   dout(6) << " seq: " << seq

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -332,7 +332,7 @@ public:
 
   void tracking_start() {
     if (tracker->register_inflight_op(this)) {
-      events.push_back(Event(initiated_at, "initiated"));
+      events.emplace_back(initiated_at, "initiated");
       state = STATE_LIVE;
     }
   }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -213,6 +213,8 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
 
 Monitor::~Monitor()
 {
+  op_tracker.on_shutdown();
+
   for (vector<PaxosService*>::iterator p = paxos_service.begin(); p != paxos_service.end(); ++p)
     delete *p;
   delete config_key_service;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -189,8 +189,7 @@ OSDMonitor::OSDMonitor(
    inc_osd_cache(g_conf->mon_osd_cache_size),
    full_osd_cache(g_conf->mon_osd_cache_size),
    last_attempted_minwait_time(utime_t()),
-   mapper(mn->cct, &mn->cpu_tp),
-   op_tracker(cct, true, 1)
+   mapper(mn->cct, &mn->cpu_tp)
 {}
 
 bool OSDMonitor::_have_pending_crush()

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -434,8 +434,6 @@ private:
   bool preprocess_remove_snaps(MonOpRequestRef op);
   bool prepare_remove_snaps(MonOpRequestRef op);
 
-  OpTracker op_tracker;
-
   int load_metadata(int osd, map<string, string>& m, ostream *err);
   void count_metadata(const string& field, Formatter *f);
 public:


### PR DESCRIPTION
Cluster that's flooded with incoming ops (and enabled optracker) is bottlenecked by OpHistory::insert. Reduce that by:

- pushing incoming ops into separate queue that'll be processed by separate thread.
- using std::atomic_bool for shutdown flag so ops_history_lock doesn't need to be taken as often

My initial testing has shown this noticeably reduced optracker impact on cluster perfornance:

![optracker](https://user-images.githubusercontent.com/12440680/36543611-8846cf44-17e4-11e8-8593-1f6f6a5fefdf.png)

Using separate thread ("threaded optracker") didn't improve things by much, neither did replacing OpHistorySvc thread mutex with spinlock ("threaded optracker + spin"). Removing the ops_history_lock from the processing path (by either removing it entirely or replacing ```shutdown``` bool flag with atomic) did the trick and the optracker perf impact is still there, albeit much smaller.
Note that I intentionally used spin loop with scaling sleep, as conditional variables/signaling turned out to be too slow for this purpose and it actually made it work much worse. Side effect of scaling sleep is that it reduces cpu time consumed by OpHistorySvc thread as it processes data in batches. This might incur some data latency in OpHistory, but up to around 128ms - data is still guaranteed to go in FIFO order.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>