### PR TITLE
ceph-mds: exit if invalid id

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -139,9 +139,9 @@ int main(int argc, const char **argv)
 
   if (g_conf->name.get_id().empty() ||
       (g_conf->name.get_id()[0] >= '0' && g_conf->name.get_id()[0] <= '9')) {
-    derr << "deprecation warning: MDS id '" << g_conf->name
-      << "' is invalid and will be forbidden in a future version.  "
+    derr << "MDS id '" << g_conf->name << "' is invalid. "
       "MDS names may not start with a numeric digit." << dendl;
+    exit(1);
   }
 
   auto nonce = ceph::util::generate_random_number<uint64_t>();


### PR DESCRIPTION
ceph-mds shows `starting * at` for invalid MDS id.

```
$ ./bin/ceph-mds -i 42
2018-02-22 20:23:25.624 7f11d628b080 -1 deprecation warning: MDS id 'mds.42' is invalid and will be forbidden in a future version.  MDS names may not start with a numeric digit.
starting mds.42 at -
```
Signed-off-by: Jos Collin <jcollin@redhat.com>