### PR TITLE
common/options: bluefs_buffered_io=true by default

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3431,7 +3431,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("bluefs_buffered_io", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
+    .set_default(true)
     .set_description(""),
 
     Option("bluefs_sync_write", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
This sends bluefs (rocksdb) io through the host's page cache.  It reduces
some of our exposure to bad cache size tuning (since misses in rocksdb's
cache may be caught by the host's page cache) and also mitigates the
cache invalidation that happens during compression.

I originally pushed to get this disabled with an eye toward removing
support for buffered IOs completely, and to avoid a behavior disparity
with the SPDK backend (which has no page cache).  In reality this code
isn't going away, and this has a measurable positive impact for users
today.

See 7f568fa1dda080fe106d5a0070e8ee1fcb364d8c for when it was originally
turned off.

Signed-off-by: Sage Weil <sage@redhat.com>