### PR TITLE
luminous: last-stat-seq returns 0 because osd stats are cleared

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1398,7 +1398,7 @@ function wait_for_clean() {
     local -a delays=($(get_timeout_delays $TIMEOUT .1))
     local -i loop=0
 
-    flush_pg_stats
+    flush_pg_stats || return 1
     while test $(get_num_pgs) == 0 ; do
 	sleep 1
     done
@@ -1829,7 +1829,7 @@ function test_flush_pg_stats()
     run_osd $dir 0 || return 1
     create_rbd_pool || return 1
     rados -p rbd put obj /etc/group
-    flush_pg_stats
+    flush_pg_stats || return 1
     local jq_filter='.pools | .[] | select(.name == "rbd") | .stats'
     raw_bytes_used=`ceph df detail --format=json | jq "$jq_filter.raw_bytes_used"`
     bytes_used=`ceph df detail --format=json | jq "$jq_filter.bytes_used"`

--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -70,16 +70,8 @@ void ClusterState::ingest_pgstats(MPGStats *stats)
   Mutex::Locker l(lock);
 
   const int from = stats->get_orig_source().num();
-  bool is_in = false;
-  objecter->with_osdmap([&is_in, from](const OSDMap &osd_map){
-      is_in = osd_map.is_in(from);
-  });
 
-  if (is_in) {
-    pending_inc.update_stat(from, stats->epoch, std::move(stats->osd_stat));
-  } else {
-    pending_inc.update_stat(from, stats->epoch, osd_stat_t());
-  }
+  pending_inc.update_stat(from, stats->epoch, std::move(stats->osd_stat));
 
   for (auto p : stats->pg_stat) {
     pg_t pgid = p.first;


### PR DESCRIPTION

Backport that fixes: http://tracker.ceph.com/issues/23093