### PR TITLE
osd/PG: decay scrub_chunk_max too if scrub is preempted

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4646,7 +4646,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	   */
 	  int min = std::max<int64_t>(3, cct->_conf->osd_scrub_chunk_min /
 				      scrubber.preempt_divisor);
-	  int max = std::max<int64_t>(min, cct->_conf->osd_scrub_chunk_max);
+	  int max = std::max<int64_t>(min, cct->_conf->osd_scrub_chunk_max /
+                                      scrubber.preempt_divisor);
           hobject_t start = scrubber.start;
 	  hobject_t candidate_end;
 	  vector<hobject_t> objects;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4622,9 +4622,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  scrubber.preempt_divisor *= 2;
 	  dout(10) << __func__ << " preempted, " << scrubber.preempt_left
 		   << " left" << dendl;
-	  scrubber.state = PG::Scrubber::NEW_CHUNK;
+	  scrub_preempted = false;
 	}
-	scrub_preempted = false;
 	scrub_can_preempt = scrubber.preempt_left > 0;
 
         {


### PR DESCRIPTION
In normal case we'll at least scrub as many objects as
osd_scrub_chunk_max specified at a time, so the current
backoff mechanism should have very limit effect.
Decay both osd_scrub_chunk_min and osd_scrub_chunk_max
should instead be a better resolution.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>