### PR TITLE
mon/OSDMonitor: fix min_size default for replicated pools

### DIFF
--- a/qa/standalone/mon/misc.sh
+++ b/qa/standalone/mon/misc.sh
@@ -61,6 +61,11 @@ function TEST_osd_pool_get_set() {
 
     local size=$(ceph osd pool get $TEST_POOL size|awk '{print $2}')
     local min_size=$(ceph osd pool get $TEST_POOL min_size|awk '{print $2}')
+    local expected_min_size=$(expr $size - $size / 2)
+    if [ $min_size -ne $expected_min_size ]; then
+	echo "default min_size is wrong: expected $expected_min_size, got $min_size"
+	return 1
+    fi
 
     ceph osd pool set $TEST_POOL scrub_min_interval 123456 || return 1
     ceph osd dump | grep 'pool ' | grep 'scrub_min_interval 123456' || return 1

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5521,7 +5521,7 @@ int OSDMonitor::prepare_pool_size(const unsigned pool_type,
   switch (pool_type) {
   case pg_pool_t::TYPE_REPLICATED:
     *size = g_conf->get_val<uint64_t>("osd_pool_default_size");
-    *min_size = g_conf->get_val<uint64_t>("osd_pool_default_min_size");
+    *min_size = g_conf->get_osd_pool_default_min_size();
     break;
   case pg_pool_t::TYPE_ERASURE:
     {


### PR DESCRIPTION
This was accidentally changed to 0 by using the config value
directly in 582e567c93f7656a1f3e16f473c583e6cb3d5926

Signed-off-by: Josh Durgin <jdurgin@redhat.com>