### PR TITLE
test/CMakeLists: disable test_pidfile.sh

### DIFF
--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -131,7 +131,6 @@ check_SCRIPTS += \
 	test/mon/mon-handle-forward.sh \
 	test/libradosstriper/rados-striper.sh \
 	test/test_objectstore_memstore.sh \
-        test/test_pidfile.sh \
 	test/test_subman.sh
 
 EXTRA_DIST += \


### PR DESCRIPTION
Too flaky, see http://tracker.ceph.com/issues/20975

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit ff3de2304497544033837bb8d0c809a9e54a3e6e)

Conflicts:
    src/test/Makefile.am: applied change manually because jewel uses autotools