### PR TITLE
osd,compressor: Expose compression algorithms via MOSDBoot.

### DIFF
--- a/src/compressor/Compressor.cc
+++ b/src/compressor/Compressor.cc
@@ -14,6 +14,8 @@
 
 #include <random>
 #include <sstream>
+#include <iterator>
+#include <algorithm>
 
 #include "CompressionPlugin.h"
 #include "Compressor.h"
@@ -22,41 +24,23 @@
 #include "common/debug.h"
 #include "common/dout.h"
 
-const char * Compressor::get_comp_alg_name(int a) {
-  switch (a) {
-  case COMP_ALG_NONE: return "none";
-  case COMP_ALG_SNAPPY: return "snappy";
-  case COMP_ALG_ZLIB: return "zlib";
-  case COMP_ALG_ZSTD: return "zstd";
-#ifdef HAVE_LZ4
-  case COMP_ALG_LZ4: return "lz4";
-#endif
-#ifdef HAVE_BROTLI
-  case COMP_ALG_BROTLI: return "brotli";
-#endif
-  default: return "???";
-  }
+std::string Compressor::get_comp_alg_name(int a) {
+
+  auto p = std::find_if(std::cbegin(compression_algorithms), std::cend(compression_algorithms),
+		   [a](const auto& kv) { return kv.second == a; });
+
+  if (std::cend(compression_algorithms) == p)
+   return "???"; // It would be nice to revise this...
+
+  return std::string { p->first };
 }
 
 boost::optional<Compressor::CompressionAlgorithm> Compressor::get_comp_alg_type(const std::string &s) {
-  if (s == "snappy")
-    return COMP_ALG_SNAPPY;
-  if (s == "zlib")
-    return COMP_ALG_ZLIB;
-  if (s == "zstd")
-    return COMP_ALG_ZSTD;
-#ifdef HAVE_LZ4
-  if (s == "lz4")
-    return COMP_ALG_LZ4;
-#endif
-#ifdef HAVE_BROTLI
-  if (s == "brotli")
-    return COMP_ALG_BROTLI;
-#endif
-  if (s == "" || s == "none")
-    return COMP_ALG_NONE;
 
-  return boost::optional<CompressionAlgorithm>();
+  if (auto pos = compression_algorithms.find(s.c_str()); std::end(compression_algorithms) != pos)
+   return pos->second;
+
+  return boost::optional<Compressor::CompressionAlgorithm> {};
 }
 
 const char *Compressor::get_comp_mode_name(int m) {

--- a/src/compressor/Compressor.h
+++ b/src/compressor/Compressor.h
@@ -15,11 +15,12 @@
 #ifndef CEPH_COMPRESSOR_H
 #define CEPH_COMPRESSOR_H
 
-
+#include <map>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <boost/optional.hpp>
-#include "include/assert.h"	// boost clobbers this
+#include "include/assert.h"    // boost clobbers this
 #include "include/buffer.h"
 #include "include/int_types.h"
 
@@ -40,8 +41,21 @@ public:
 #ifdef HAVE_BROTLI
     COMP_ALG_BROTLI = 5,
 #endif
-    COMP_ALG_LAST	//the last value for range checks
+    COMP_ALG_LAST   //the last value for range checks
   };
+
+  inline static const std::map<const std::string, const CompressionAlgorithm> compression_algorithms {
+	{ "none",	COMP_ALG_NONE },
+	{ "snappy",	COMP_ALG_SNAPPY },
+	{ "zlib",	COMP_ALG_ZLIB },
+#ifdef HAVE_LZ4
+	{ "lz4",	COMP_ALG_LZ4 },
+#endif
+#ifdef HAVE_BROTLI
+	{ "brotli",	COMP_ALG_BROTLI },
+#endif
+  };
+
   // compression options
   enum CompressionMode {
     COMP_NONE,                  ///< compress never
@@ -50,7 +64,7 @@ public:
     COMP_FORCE                  ///< compress always
   };
 
-  static const char * get_comp_alg_name(int a);
+  static std::string get_comp_alg_name(int a);
   static boost::optional<CompressionAlgorithm> get_comp_alg_type(const std::string &s);
 
   static const char *get_comp_mode_name(int m);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -12,14 +12,21 @@
  * Foundation.  See file COPYING.
  *
  */
+
 #include "acconfig.h"
-#include <unistd.h>
+
+#include <cerrno>
+#include <cctype>
 #include <fstream>
 #include <iostream>
-#include <errno.h>
+#include <algorithm>
+
+#include <experimental/iterator>
+
+#include <unistd.h>
+
 #include <sys/stat.h>
 #include <signal.h>
-#include <ctype.h>
 #include <boost/scoped_ptr.hpp>
 
 #ifdef HAVE_SYS_PARAM_H
@@ -47,6 +54,7 @@
 #include "common/io_priority.h"
 #include "common/pick_address.h"
 #include "common/SubProcess.h"
+#include "common/PluginRegistry.h"
 
 #include "os/ObjectStore.h"
 #ifdef HAVE_LIBFUSE
@@ -54,7 +62,6 @@
 #endif
 
 #include "PrimaryLogPG.h"
-
 
 #include "msg/Messenger.h"
 #include "msg/Message.h"
@@ -5536,6 +5543,27 @@ void OSD::_send_boot()
   set_state(STATE_BOOTING);
 }
 
+std::string OSD::_collect_compression_algorithms()
+{
+  using std::experimental::make_ostream_joiner;
+
+  const auto& compression_algorithms = Compressor::compression_algorithms;
+  const auto& plugin_registry = cct->get_plugin_registry()->plugins;
+
+  if (plugin_registry.empty())
+   return {};
+
+  ostringstream os;
+
+  copy_if(begin(compression_algorithms), end(compression_algorithms),
+          make_ostream_joiner(os, ", "),
+          [&plugin_registry](const auto& algorithm) {
+            return plugin_registry.end() != plugin_registry.find(algorithm.first);
+         });
+  
+  return os.str();
+}
+
 void OSD::_collect_metadata(map<string,string> *pm)
 {
   // config info
@@ -5566,6 +5594,10 @@ void OSD::_collect_metadata(map<string,string> *pm)
   set<string> devnames;
   store->get_devices(&devnames);
   (*pm)["devices"] = stringify(devnames);
+
+  // Other information:
+  (*pm)["supported_compression_algorithms"] = _collect_compression_algorithms();
+
   dout(10) << __func__ << " " << *pm << dendl;
 }
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1927,6 +1927,7 @@ protected:
   void _preboot(epoch_t oldest, epoch_t newest);
   void _send_boot();
   void _collect_metadata(map<string,string> *pmeta);
+  std::string _collect_compression_algorithms();
 
   void start_waiting_for_healthy();
   bool _is_healthy();


### PR DESCRIPTION
Modifies Compressor to expose a set of strings (already hardcoded)
that are accessible elsewhere.

Adds metadata to MOSDBoost containing a list of compression algorithms
made available via the plugin interface.

http://tracker.ceph.com/issues/22420

Signed-off-by: Jesse Williamson <jwilliamson@suse.de>