### PR TITLE
librbd: minor cleanup of the IO pathway

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -62,6 +62,7 @@ set(librbd_internal_srcs
   io/ImageRequestWQ.cc
   io/ObjectRequest.cc
   io/ReadResult.cc
+  io/Utils.cc
   journal/CreateRequest.cc
   journal/DemoteRequest.cc
   journal/OpenRequest.cc

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -57,6 +57,7 @@ set(librbd_internal_srcs
   io/AioCompletion.cc
   io/AsyncOperation.cc
   io/CopyupRequest.cc
+  io/ImageDispatchSpec.cc
   io/ImageRequest.cc
   io/ImageRequestWQ.cc
   io/ObjectRequest.cc

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -223,12 +223,12 @@ namespace librbd {
     aio_comp->read_result = io::ReadResult{pbl};
     aio_comp->set_request_count(1);
 
-    auto req_comp = new io::ReadResult::C_SparseReadRequest<>(
-      aio_comp, {{0, len}}, false);
+    auto req_comp = new io::ReadResult::C_ObjectReadRequest(
+      aio_comp, off, len, {{0, len}}, false);
     auto req = io::ObjectReadRequest<>::create(m_ictx, oid.name, object_no, off,
                                                len, snapid, op_flags, true,
-                                               trace, req_comp);
-    req_comp->request = req;
+                                               trace, &req_comp->bl,
+                                               &req_comp->extent_map, req_comp);
     req->send();
   }
 

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -100,6 +100,7 @@ namespace librbd {
     std::string oid;
     uint64_t object_no;
     uint64_t off;
+    uint64_t length;
     bufferlist bl;
     SnapContext snapc;
     uint64_t journal_tid;
@@ -109,12 +110,12 @@ namespace librbd {
 
     C_WriteJournalCommit(ImageCtx *_image_ctx, const std::string &_oid,
                          uint64_t _object_no, uint64_t _off,
-                         const bufferlist &_bl, const SnapContext& _snapc,
+                         bufferlist&& _bl, const SnapContext& _snapc,
                          uint64_t _journal_tid,
 			 const ZTracer::Trace &trace, Context *_req_comp)
       : image_ctx(_image_ctx), oid(_oid), object_no(_object_no), off(_off),
-        bl(_bl), snapc(_snapc), journal_tid(_journal_tid),
-        trace(trace), req_comp(_req_comp) {
+        length(_bl.length()), bl(std::move(_bl)), snapc(_snapc),
+        journal_tid(_journal_tid), trace(trace), req_comp(_req_comp) {
       CephContext *cct = image_ctx->cct;
       ldout(cct, 20) << this << " C_WriteJournalCommit: "
                      << "delaying write until journal tid "
@@ -150,7 +151,7 @@ namespace librbd {
 
       Extents file_extents;
       Striper::extent_to_file(cct, &image_ctx->layout, object_no, off,
-                              bl.length(), file_extents);
+                              length, file_extents);
       for (Extents::iterator it = file_extents.begin();
            it != file_extents.end(); ++it) {
         image_ctx->journal->commit_io_event_extent(journal_tid, it->first,
@@ -167,7 +168,8 @@ namespace librbd {
 
       request_sent = true;
       auto req = new io::ObjectWriteRequest<>(image_ctx, oid, object_no, off,
-                                              bl, snapc, 0, trace, this);
+                                              std::move(bl), snapc, 0, trace,
+                                              this);
       req->send();
     }
   };
@@ -281,14 +283,16 @@ namespace librbd {
 
     // all IO operations are flushed prior to closing the journal
     assert(journal_tid == 0 || m_ictx->journal != NULL);
+    bufferlist bl_copy(bl);
     if (journal_tid != 0) {
       m_ictx->journal->flush_event(
         journal_tid, new C_WriteJournalCommit(
-	  m_ictx, oid.name, object_no, off, bl, snapc, journal_tid, trace,
-          req_comp));
+          m_ictx, oid.name, object_no, off, std::move(bl_copy), snapc,
+          journal_tid, trace, req_comp));
     } else {
       auto req = new io::ObjectWriteRequest<>(
-	m_ictx, oid.name, object_no, off, bl, snapc, 0, trace, req_comp);
+        m_ictx, oid.name, object_no, off, std::move(bl_copy), snapc, 0, trace,
+        req_comp);
       req->send();
     }
     return ++m_tid;

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -75,7 +75,8 @@ void ImageWriteback<I>::aio_flush(Context *on_finish) {
 
   auto aio_comp = io::AioCompletion::create_and_start(on_finish, &m_image_ctx,
                                                       io::AIO_TYPE_FLUSH);
-  io::ImageFlushRequest<I> req(m_image_ctx, aio_comp, {});
+  io::ImageFlushRequest<I> req(m_image_ctx, aio_comp, io::FLUSH_SOURCE_INTERNAL,
+                               {});
   req.set_bypass_image_cache();
   req.send();
 }

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -62,7 +62,7 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
 
   auto aio_comp = io::AioCompletion::create_and_start(on_finish, &m_image_ctx,
                                                       io::AIO_TYPE_DISCARD);
-  io::ImageDiscardRequest<I> req(m_image_ctx, aio_comp, offset, length,
+  io::ImageDiscardRequest<I> req(m_image_ctx, aio_comp, {{offset, length}},
                                  skip_partial_discard, {});
   req.set_bypass_image_cache();
   req.send();
@@ -92,7 +92,7 @@ void ImageWriteback<I>::aio_writesame(uint64_t offset, uint64_t length,
 
   auto aio_comp = io::AioCompletion::create_and_start(on_finish, &m_image_ctx,
                                                       io::AIO_TYPE_WRITESAME);
-  io::ImageWriteSameRequest<I> req(m_image_ctx, aio_comp, offset, length,
+  io::ImageWriteSameRequest<I> req(m_image_ctx, aio_comp, {{offset, length}},
                                    std::move(bl), fadvise_flags, {});
   req.set_bypass_image_cache();
   req.send();

--- a/src/librbd/io/ImageDispatchSpec.cc
+++ b/src/librbd/io/ImageDispatchSpec.cc
@@ -1,0 +1,98 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/io/ImageDispatchSpec.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/io/AioCompletion.h"
+#include "librbd/io/ImageRequest.h"
+#include <boost/variant.hpp>
+
+namespace librbd {
+namespace io {
+
+template <typename I>
+struct ImageDispatchSpec<I>::SendVisitor
+  : public boost::static_visitor<void> {
+  ImageDispatchSpec* spec;
+
+  SendVisitor(ImageDispatchSpec* spec)
+    : spec(spec) {
+  }
+
+  void operator()(Read& read) const {
+    ImageRequest<I>::aio_read(
+      &spec->m_image_ctx, spec->m_aio_comp, std::move(spec->m_image_extents),
+      std::move(read.read_result), spec->m_op_flags, spec->m_parent_trace);
+  }
+
+  void operator()(Discard& discard) const {
+    ImageRequest<I>::aio_discard(
+      &spec->m_image_ctx, spec->m_aio_comp, std::move(spec->m_image_extents),
+      discard.skip_partial_discard, spec->m_parent_trace);
+  }
+
+  void operator()(Write& write) const {
+    ImageRequest<I>::aio_write(
+      &spec->m_image_ctx, spec->m_aio_comp, std::move(spec->m_image_extents),
+      std::move(write.bl), spec->m_op_flags, spec->m_parent_trace);
+  }
+
+  void operator()(WriteSame& write_same) const {
+    ImageRequest<I>::aio_writesame(
+      &spec->m_image_ctx, spec->m_aio_comp, std::move(spec->m_image_extents),
+      std::move(write_same.bl), spec->m_op_flags, spec->m_parent_trace);
+  }
+
+  void operator()(CompareAndWrite& compare_and_write) const {
+    ImageRequest<I>::aio_compare_and_write(
+      &spec->m_image_ctx, spec->m_aio_comp, std::move(spec->m_image_extents),
+      std::move(compare_and_write.cmp_bl), std::move(compare_and_write.bl),
+      compare_and_write.mismatch_offset, spec->m_op_flags,
+      spec->m_parent_trace);
+  }
+
+  void operator()(Flush& flush) const {
+    ImageRequest<I>::aio_flush(
+      &spec->m_image_ctx, spec->m_aio_comp,
+      spec->m_parent_trace);
+  }
+};
+
+template <typename I>
+struct ImageDispatchSpec<I>::IsWriteOpVisitor
+  : public boost::static_visitor<bool> {
+  bool operator()(const Read&) const {
+    return false;
+  }
+
+  template <typename T>
+  bool operator()(const T&) const {
+    return true;
+  }
+};
+
+template <typename I>
+void ImageDispatchSpec<I>::send() {
+  boost::apply_visitor(SendVisitor{this}, m_request);
+}
+
+template <typename I>
+void ImageDispatchSpec<I>::fail(int r) {
+  m_aio_comp->get();
+  m_aio_comp->fail(r);
+}
+
+template <typename I>
+bool ImageDispatchSpec<I>::is_write_op() const {
+  return boost::apply_visitor(IsWriteOpVisitor{}, m_request);
+}
+
+template <typename I>
+void ImageDispatchSpec<I>::start_op() {
+  m_aio_comp->start_op();
+}
+
+} // namespace io
+} // namespace librbd
+
+template class librbd::io::ImageDispatchSpec<librbd::ImageCtx>;

--- a/src/librbd/io/ImageDispatchSpec.cc
+++ b/src/librbd/io/ImageDispatchSpec.cc
@@ -53,7 +53,7 @@ struct ImageDispatchSpec<I>::SendVisitor
 
   void operator()(Flush& flush) const {
     ImageRequest<I>::aio_flush(
-      &spec->m_image_ctx, spec->m_aio_comp,
+      &spec->m_image_ctx, spec->m_aio_comp, FLUSH_SOURCE_USER,
       spec->m_parent_trace);
   }
 };

--- a/src/librbd/io/ImageDispatchSpec.h
+++ b/src/librbd/io/ImageDispatchSpec.h
@@ -1,0 +1,170 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IO_IMAGE_DISPATCH_SPEC_H
+#define CEPH_LIBRBD_IO_IMAGE_DISPATCH_SPEC_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+#include "common/zipkin_trace.h"
+#include "librbd/io/Types.h"
+#include "librbd/io/ReadResult.h"
+#include <boost/variant/variant.hpp>
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace io {
+
+class AioCompletion;
+
+template <typename ImageCtxT = ImageCtx>
+class ImageDispatchSpec {
+public:
+  struct Read {
+    ReadResult read_result;
+
+    Read(ReadResult &&read_result) : read_result(std::move(read_result)) {
+    }
+  };
+
+  struct Discard {
+    bool skip_partial_discard;
+
+    Discard(bool skip_partial_discard)
+      : skip_partial_discard(skip_partial_discard) {
+    }
+  };
+
+  struct Write {
+    bufferlist bl;
+
+    Write(bufferlist&& bl) : bl(std::move(bl)) {
+    }
+  };
+
+  struct WriteSame {
+    bufferlist bl;
+
+    WriteSame(bufferlist&& bl) : bl(std::move(bl)) {
+    }
+  };
+
+  struct CompareAndWrite {
+    bufferlist cmp_bl;
+    bufferlist bl;
+    uint64_t *mismatch_offset;
+
+    CompareAndWrite(bufferlist&& cmp_bl, bufferlist&& bl,
+                    uint64_t *mismatch_offset)
+      : cmp_bl(std::move(cmp_bl)), bl(std::move(bl)),
+        mismatch_offset(mismatch_offset) {
+    }
+  };
+
+  struct Flush {
+  };
+
+  static ImageDispatchSpec* create_read_request(
+      ImageCtxT &image_ctx, AioCompletion *aio_comp, Extents &&image_extents,
+      ReadResult &&read_result, int op_flags,
+      const ZTracer::Trace &parent_trace) {
+    return new ImageDispatchSpec(image_ctx, aio_comp,
+                                  std::move(image_extents),
+                                  Read{std::move(read_result)},
+                                  op_flags, parent_trace);
+  }
+
+  static ImageDispatchSpec* create_discard_request(
+      ImageCtxT &image_ctx, AioCompletion *aio_comp, uint64_t off, uint64_t len,
+      bool skip_partial_discard, const ZTracer::Trace &parent_trace) {
+    return new ImageDispatchSpec(image_ctx, aio_comp, {{off, len}},
+                                  Discard{skip_partial_discard}, 0,
+                                  parent_trace);
+  }
+
+  static ImageDispatchSpec* create_write_request(
+      ImageCtxT &image_ctx, AioCompletion *aio_comp, Extents &&image_extents,
+      bufferlist &&bl, int op_flags, const ZTracer::Trace &parent_trace) {
+    return new ImageDispatchSpec(image_ctx, aio_comp, std::move(image_extents),
+                                  Write{std::move(bl)}, op_flags, parent_trace);
+  }
+
+  static ImageDispatchSpec* create_write_same_request(
+      ImageCtxT &image_ctx, AioCompletion *aio_comp, uint64_t off, uint64_t len,
+      bufferlist &&bl, int op_flags, const ZTracer::Trace &parent_trace) {
+    return new ImageDispatchSpec(image_ctx, aio_comp, {{off, len}},
+                                  WriteSame{std::move(bl)}, op_flags,
+                                  parent_trace);
+  }
+
+  static ImageDispatchSpec* create_compare_and_write_request(
+      ImageCtxT &image_ctx, AioCompletion *aio_comp, Extents &&image_extents,
+      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
+      int op_flags, const ZTracer::Trace &parent_trace) {
+    return new ImageDispatchSpec(image_ctx, aio_comp,
+                                  std::move(image_extents),
+                                  CompareAndWrite{std::move(cmp_bl),
+                                                  std::move(bl),
+                                                  mismatch_offset},
+                                  op_flags, parent_trace);
+  }
+
+  static ImageDispatchSpec* create_flush_request(
+      ImageCtxT &image_ctx, AioCompletion *aio_comp,
+      const ZTracer::Trace &parent_trace) {
+    return new ImageDispatchSpec(image_ctx, aio_comp, {}, Flush{}, 0,
+                                  parent_trace);
+  }
+
+  void send();
+  void fail(int r);
+
+  bool is_write_op() const;
+
+  void start_op();
+
+  bool was_throttled() {
+    return m_throttled;
+  }
+  void set_throttled() {
+    m_throttled = true;
+  }
+
+private:
+  typedef boost::variant<Read,
+                         Discard,
+                         Write,
+                         WriteSame,
+                         CompareAndWrite,
+                         Flush> Request;
+
+  struct SendVisitor;
+  struct IsWriteOpVisitor;
+
+  ImageDispatchSpec(ImageCtxT& image_ctx, AioCompletion* aio_comp,
+                     Extents&& image_extents, Request&& request,
+                     int op_flags, const ZTracer::Trace& parent_trace)
+    : m_image_ctx(image_ctx), m_aio_comp(aio_comp),
+      m_image_extents(std::move(image_extents)), m_request(std::move(request)),
+      m_op_flags(op_flags), m_parent_trace(parent_trace) {
+  }
+
+  ImageCtxT& m_image_ctx;
+  AioCompletion* m_aio_comp;
+  Extents m_image_extents;
+  Request m_request;
+  int m_op_flags;
+  ZTracer::Trace m_parent_trace;
+
+  bool m_throttled = false;
+
+};
+
+} // namespace io
+} // namespace librbd
+
+extern template class librbd::io::ImageDispatchSpec<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IO_IMAGE_DISPATCH_SPEC_H

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -259,12 +259,13 @@ void ImageReadRequest<I>::send_request() {
                      << extent.length << " from " << extent.buffer_extents
                      << dendl;
 
-      auto req_comp = new io::ReadResult::C_SparseReadRequest<I>(
-        aio_comp, std::move(extent.buffer_extents), true);
+      auto req_comp = new io::ReadResult::C_ObjectReadRequest(
+        aio_comp, extent.offset, extent.length,
+        std::move(extent.buffer_extents), true);
       ObjectReadRequest<I> *req = ObjectReadRequest<I>::create(
         &image_ctx, extent.oid.name, extent.objectno, extent.offset,
-        extent.length, snap_id, m_op_flags, false, this->m_trace, req_comp);
-      req_comp->request = req;
+        extent.length, snap_id, m_op_flags, false, this->m_trace,
+        &req_comp->bl, &req_comp->extent_map, req_comp);
       req->send();
     }
   }

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -478,7 +478,8 @@ ObjectRequestHandle *ImageWriteRequest<I>::create_object_request(
   assemble_extent(object_extent, &bl);
   ObjectRequest<I> *req = ObjectRequest<I>::create_write(
     &image_ctx, object_extent.oid.name, object_extent.objectno,
-    object_extent.offset, bl, snapc, m_op_flags, this->m_trace, on_finish);
+    object_extent.offset, std::move(bl), snapc, m_op_flags, this->m_trace,
+    on_finish);
   return req;
 }
 
@@ -781,12 +782,13 @@ ObjectRequestHandle *ImageWriteSameRequest<I>::create_object_request(
     req = ObjectRequest<I>::create_writesame(
       &image_ctx, object_extent.oid.name, object_extent.objectno,
       object_extent.offset, object_extent.length,
-      bl, snapc, m_op_flags, this->m_trace, on_finish);
+      std::move(bl), snapc, m_op_flags, this->m_trace, on_finish);
     return req;
   }
   req = ObjectRequest<I>::create_write(
     &image_ctx, object_extent.oid.name, object_extent.objectno,
-    object_extent.offset, bl, snapc, m_op_flags, this->m_trace, on_finish);
+    object_extent.offset, std::move(bl), snapc, m_op_flags, this->m_trace,
+    on_finish);
   return req;
 }
 
@@ -862,13 +864,16 @@ ObjectRequestHandle *ImageCompareAndWriteRequest<I>::create_object_request(
     Context *on_finish) {
   I &image_ctx = this->m_image_ctx;
 
+  // NOTE: safe to move m_cmp_bl since we only support this op against
+  // a single object
   bufferlist bl;
   assemble_extent(object_extent, &bl);
   ObjectRequest<I> *req = ObjectRequest<I>::create_compare_and_write(
                                   &image_ctx, object_extent.oid.name,
                                   object_extent.objectno, object_extent.offset,
-                                  m_cmp_bl, bl, snapc, m_mismatch_offset,
-                                  m_op_flags, this->m_trace, on_finish);
+                                  std::move(m_cmp_bl), std::move(bl), snapc,
+                                  m_mismatch_offset, m_op_flags, this->m_trace,
+                                  on_finish);
   return req;
 }
 

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -43,7 +43,8 @@ public:
                           Extents &&image_extents, bool skip_partial_discard,
 			  const ZTracer::Trace &parent_trace);
   static void aio_flush(ImageCtxT *ictx, AioCompletion *c,
-			const ZTracer::Trace &parent_trace);
+                        FlushSource flush_source,
+                        const ZTracer::Trace &parent_trace);
   static void aio_writesame(ImageCtxT *ictx, AioCompletion *c,
                             Extents &&image_extents, bufferlist &&bl,
                             int op_flags, const ZTracer::Trace &parent_trace);
@@ -255,8 +256,10 @@ template <typename ImageCtxT = ImageCtx>
 class ImageFlushRequest : public ImageRequest<ImageCtxT> {
 public:
   ImageFlushRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
-		    const ZTracer::Trace &parent_trace)
-    : ImageRequest<ImageCtxT>(image_ctx, aio_comp, {}, "flush", parent_trace) {
+                    FlushSource flush_source,
+                    const ZTracer::Trace &parent_trace)
+    : ImageRequest<ImageCtxT>(image_ctx, aio_comp, {}, "flush", parent_trace),
+      m_flush_source(flush_source) {
   }
 
 protected:
@@ -274,6 +277,10 @@ protected:
   const char *get_request_type() const override {
     return "aio_flush";
   }
+
+private:
+  FlushSource m_flush_source;
+
 };
 
 template <typename ImageCtxT = ImageCtx>

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -33,63 +33,27 @@ public:
     m_trace.event("finish");
   }
 
-  static ImageRequest* create_read_request(ImageCtxT &image_ctx,
-                                           AioCompletion *aio_comp,
-                                           Extents &&image_extents,
-                                           ReadResult &&read_result,
-                                           int op_flags,
-                                           const ZTracer::Trace &parent_trace);
-  static ImageRequest* create_write_request(ImageCtxT &image_ctx,
-                                            AioCompletion *aio_comp,
-                                            Extents &&image_extents,
-                                            bufferlist &&bl, int op_flags,
-                                            const ZTracer::Trace &parent_trace);
-  static ImageRequest* create_discard_request(ImageCtxT &image_ctx,
-                                              AioCompletion *aio_comp,
-                                              uint64_t off, uint64_t len,
-                                              bool skip_partial_discard,
-                                              const ZTracer::Trace &parent_trace);
-  static ImageRequest* create_flush_request(ImageCtxT &image_ctx,
-                                            AioCompletion *aio_comp,
-                                            const ZTracer::Trace &parent_trace);
-  static ImageRequest* create_writesame_request(ImageCtxT &image_ctx,
-                                                AioCompletion *aio_comp,
-                                                uint64_t off, uint64_t len,
-                                                bufferlist &&bl, int op_flags,
-                                                const ZTracer::Trace &parent_trace);
-  static ImageRequest* create_compare_and_write_request(
-      ImageCtxT &image_ctx, AioCompletion *c, Extents &&image_extents,
-      bufferlist &&cmp_bl, bufferlist &&bl, uint64_t *mismatch_offset,
-      int op_flags, const ZTracer::Trace &parent_trace);
-
   static void aio_read(ImageCtxT *ictx, AioCompletion *c,
                        Extents &&image_extents, ReadResult &&read_result,
                        int op_flags, const ZTracer::Trace &parent_trace);
   static void aio_write(ImageCtxT *ictx, AioCompletion *c,
                         Extents &&image_extents, bufferlist &&bl, int op_flags,
 			const ZTracer::Trace &parent_trace);
-  static void aio_discard(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
-                          uint64_t len, bool skip_partial_discard,
+  static void aio_discard(ImageCtxT *ictx, AioCompletion *c,
+                          Extents &&image_extents, bool skip_partial_discard,
 			  const ZTracer::Trace &parent_trace);
   static void aio_flush(ImageCtxT *ictx, AioCompletion *c,
 			const ZTracer::Trace &parent_trace);
-  static void aio_writesame(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
-                            uint64_t len, bufferlist &&bl, int op_flags,
-			    const ZTracer::Trace &parent_trace);
+  static void aio_writesame(ImageCtxT *ictx, AioCompletion *c,
+                            Extents &&image_extents, bufferlist &&bl,
+                            int op_flags, const ZTracer::Trace &parent_trace);
 
   static void aio_compare_and_write(ImageCtxT *ictx, AioCompletion *c,
                                     Extents &&image_extents, bufferlist &&cmp_bl,
                                     bufferlist &&bl, uint64_t *mismatch_offset,
                                     int op_flags, const ZTracer::Trace &parent_trace);
 
-  virtual bool is_write_op() const {
-    return false;
-  }
-
-  void start_op();
-
   void send();
-  void fail(int r);
 
   void set_bypass_image_cache() {
     m_bypass_image_cache = true;
@@ -97,14 +61,6 @@ public:
 
   inline const ZTracer::Trace &get_trace() const {
     return m_trace;
-  }
-
-  bool was_throttled() {
-    return m_throttled;
-  }
-
-  void set_throttled() {
-    m_throttled = true;
   }
 
 protected:
@@ -115,7 +71,6 @@ protected:
   Extents m_image_extents;
   ZTracer::Trace m_trace;
   bool m_bypass_image_cache = false;
-  bool m_throttled = false;
 
   ImageRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                Extents &&image_extents, const char *trace_name,
@@ -125,7 +80,7 @@ protected:
       m_trace(util::create_trace(image_ctx, trace_name, parent_trace)) {
     m_trace.event("start");
   }
-  
+
 
   virtual int clip_request();
   virtual void send_request() = 0;
@@ -163,10 +118,6 @@ private:
 template <typename ImageCtxT = ImageCtx>
 class AbstractImageWriteRequest : public ImageRequest<ImageCtxT> {
 public:
-  bool is_write_op() const override {
-    return true;
-  }
-
   inline void flag_synchronous() {
     m_synchronous = true;
   }
@@ -263,10 +214,10 @@ template <typename ImageCtxT = ImageCtx>
 class ImageDiscardRequest : public AbstractImageWriteRequest<ImageCtxT> {
 public:
   ImageDiscardRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
-                      uint64_t off, uint64_t len, bool skip_partial_discard,
+                      Extents&& image_extents, bool skip_partial_discard,
 		      const ZTracer::Trace &parent_trace)
     : AbstractImageWriteRequest<ImageCtxT>(
-	image_ctx, aio_comp, {{off, len}}, "discard", parent_trace),
+	image_ctx, aio_comp, std::move(image_extents), "discard", parent_trace),
       m_skip_partial_discard(skip_partial_discard) {
   }
 
@@ -308,10 +259,6 @@ public:
     : ImageRequest<ImageCtxT>(image_ctx, aio_comp, {}, "flush", parent_trace) {
   }
 
-  bool is_write_op() const override {
-    return true;
-  }
-
 protected:
   using typename ImageRequest<ImageCtxT>::ObjectRequests;
 
@@ -333,10 +280,11 @@ template <typename ImageCtxT = ImageCtx>
 class ImageWriteSameRequest : public AbstractImageWriteRequest<ImageCtxT> {
 public:
   ImageWriteSameRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
-                        uint64_t off, uint64_t len, bufferlist &&bl,
+                        Extents&& image_extents, bufferlist &&bl,
                         int op_flags, const ZTracer::Trace &parent_trace)
     : AbstractImageWriteRequest<ImageCtxT>(
-	image_ctx, aio_comp, {{off, len}}, "writesame", parent_trace),
+	image_ctx, aio_comp, std::move(image_extents), "writesame",
+        parent_trace),
       m_data_bl(std::move(bl)), m_op_flags(op_flags) {
   }
 

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -306,9 +306,6 @@ protected:
     return "aio_writesame";
   }
 
-  bool assemble_writesame_extent(const ObjectExtent &object_extent,
-                                 bufferlist *bl, bool force_write);
-
   void send_image_cache_request() override;
 
   void send_object_cache_requests(const ObjectExtents &object_extents,

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -369,7 +369,7 @@ void ImageRequestWQ<I>::aio_flush(AioCompletion *c, bool native_async) {
   if (m_image_ctx.non_blocking_aio || writes_blocked() || !writes_empty()) {
     queue(ImageDispatchSpec<I>::create_flush_request(m_image_ctx, c, trace));
   } else {
-    ImageRequest<I>::aio_flush(&m_image_ctx, c, trace);
+    ImageRequest<I>::aio_flush(&m_image_ctx, c, FLUSH_SOURCE_USER, trace);
     finish_in_flight_io();
   }
   trace.event("finish");

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -12,6 +12,7 @@
 #include "librbd/exclusive_lock/Policy.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageRequest.h"
+#include "librbd/io/ImageDispatchSpec.h"
 #include "common/EventTrace.h"
 
 #define dout_subsys ceph_subsys_rbd
@@ -25,9 +26,9 @@ namespace io {
 template <typename I>
 struct ImageRequestWQ<I>::C_AcquireLock : public Context {
   ImageRequestWQ *work_queue;
-  ImageRequest<I> *image_request;
+  ImageDispatchSpec<I> *image_request;
 
-  C_AcquireLock(ImageRequestWQ *work_queue, ImageRequest<I> *image_request)
+  C_AcquireLock(ImageRequestWQ *work_queue, ImageDispatchSpec<I> *image_request)
     : work_queue(work_queue), image_request(image_request) {
   }
 
@@ -51,10 +52,10 @@ struct ImageRequestWQ<I>::C_BlockedWrites : public Context {
 template <typename I>
 struct ImageRequestWQ<I>::C_RefreshFinish : public Context {
   ImageRequestWQ *work_queue;
-  ImageRequest<I> *image_request;
+  ImageDispatchSpec<I> *image_request;
 
   C_RefreshFinish(ImageRequestWQ *work_queue,
-                  ImageRequest<I> *image_request)
+                  ImageDispatchSpec<I> *image_request)
     : work_queue(work_queue), image_request(image_request) {
   }
   void finish(int r) override {
@@ -65,7 +66,7 @@ struct ImageRequestWQ<I>::C_RefreshFinish : public Context {
 template <typename I>
 ImageRequestWQ<I>::ImageRequestWQ(I *image_ctx, const string &name,
 				  time_t ti, ThreadPool *tp)
-  : ThreadPool::PointerWQ<ImageRequest<I> >(name, ti, 0, tp),
+  : ThreadPool::PointerWQ<ImageDispatchSpec<I> >(name, ti, 0, tp),
     m_image_ctx(*image_ctx),
     m_lock(util::unique_lock_name("ImageRequestWQ<I>::m_lock", this)) {
   CephContext *cct = m_image_ctx.cct;
@@ -254,7 +255,7 @@ void ImageRequestWQ<I>::aio_read(AioCompletion *c, uint64_t off, uint64_t len,
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   if (m_image_ctx.non_blocking_aio || writes_blocked() || !writes_empty() ||
       require_lock_on_read()) {
-    queue(ImageRequest<I>::create_read_request(
+    queue(ImageDispatchSpec<I>::create_read_request(
             m_image_ctx, c, {{off, len}}, std::move(read_result), op_flags,
             trace));
   } else {
@@ -293,7 +294,7 @@ void ImageRequestWQ<I>::aio_write(AioCompletion *c, uint64_t off, uint64_t len,
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   if (m_image_ctx.non_blocking_aio || writes_blocked()) {
-    queue(ImageRequest<I>::create_write_request(
+    queue(ImageDispatchSpec<I>::create_write_request(
             m_image_ctx, c, {{off, len}}, std::move(bl), op_flags, trace));
   } else {
     c->start_op();
@@ -331,11 +332,11 @@ void ImageRequestWQ<I>::aio_discard(AioCompletion *c, uint64_t off,
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   if (m_image_ctx.non_blocking_aio || writes_blocked()) {
-    queue(ImageRequest<I>::create_discard_request(
+    queue(ImageDispatchSpec<I>::create_discard_request(
             m_image_ctx, c, off, len, skip_partial_discard, trace));
   } else {
     c->start_op();
-    ImageRequest<I>::aio_discard(&m_image_ctx, c, off, len,
+    ImageRequest<I>::aio_discard(&m_image_ctx, c, {{off, len}},
 				 skip_partial_discard, trace);
     finish_in_flight_io();
   }
@@ -366,7 +367,7 @@ void ImageRequestWQ<I>::aio_flush(AioCompletion *c, bool native_async) {
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   if (m_image_ctx.non_blocking_aio || writes_blocked() || !writes_empty()) {
-    queue(ImageRequest<I>::create_flush_request(m_image_ctx, c, trace));
+    queue(ImageDispatchSpec<I>::create_flush_request(m_image_ctx, c, trace));
   } else {
     ImageRequest<I>::aio_flush(&m_image_ctx, c, trace);
     finish_in_flight_io();
@@ -402,11 +403,11 @@ void ImageRequestWQ<I>::aio_writesame(AioCompletion *c, uint64_t off,
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   if (m_image_ctx.non_blocking_aio || writes_blocked()) {
-    queue(ImageRequest<I>::create_writesame_request(
+    queue(ImageDispatchSpec<I>::create_write_same_request(
             m_image_ctx, c, off, len, std::move(bl), op_flags, trace));
   } else {
     c->start_op();
-    ImageRequest<I>::aio_writesame(&m_image_ctx, c, off, len, std::move(bl),
+    ImageRequest<I>::aio_writesame(&m_image_ctx, c, {{off, len}}, std::move(bl),
 				   op_flags, trace);
     finish_in_flight_io();
   }
@@ -443,7 +444,7 @@ void ImageRequestWQ<I>::aio_compare_and_write(AioCompletion *c,
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   if (m_image_ctx.non_blocking_aio || writes_blocked()) {
-    queue(ImageRequest<I>::create_compare_and_write_request(
+    queue(ImageDispatchSpec<I>::create_compare_and_write_request(
             m_image_ctx, c, {{off, len}}, std::move(cmp_bl), std::move(bl),
             mismatch_off, op_flags, trace));
   } else {
@@ -567,8 +568,8 @@ void ImageRequestWQ<I>::apply_qos_iops_limit(uint64_t limit) {
 }
 
 template <typename I>
-void ImageRequestWQ<I>::handle_iops_throttle_ready(int r,
-                                                   ImageRequest<I> *item) {
+void ImageRequestWQ<I>::handle_iops_throttle_ready(
+    int r, ImageDispatchSpec<I> *item) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 15) << "r=" << r << ", " << "req=" << item << dendl;
 
@@ -582,7 +583,7 @@ void ImageRequestWQ<I>::handle_iops_throttle_ready(int r,
 template <typename I>
 void *ImageRequestWQ<I>::_void_dequeue() {
   CephContext *cct = m_image_ctx.cct;
-  ImageRequest<I> *peek_item = this->front();
+  ImageDispatchSpec<I> *peek_item = this->front();
 
   // no queued IO requests or all IO is blocked/stalled
   if (peek_item == nullptr || m_io_blockers.load() > 0) {
@@ -591,12 +592,12 @@ void *ImageRequestWQ<I>::_void_dequeue() {
 
   if (!peek_item->was_throttled() &&
       iops_throttle->get<
-        ImageRequestWQ<I>, ImageRequest<I>,
+        ImageRequestWQ<I>, ImageDispatchSpec<I>,
         &ImageRequestWQ<I>::handle_iops_throttle_ready>(1, this, peek_item)) {
     ldout(cct, 15) << "throttling IO " << peek_item << dendl;
 
     // dequeue the throttled item and block future IO
-    ThreadPool::PointerWQ<ImageRequest<I> >::_void_dequeue();
+    ThreadPool::PointerWQ<ImageDispatchSpec<I> >::_void_dequeue();
     ++m_io_blockers;
     return nullptr;
   }
@@ -620,8 +621,8 @@ void *ImageRequestWQ<I>::_void_dequeue() {
     }
   }
 
-  ImageRequest<I> *item = reinterpret_cast<ImageRequest<I> *>(
-    ThreadPool::PointerWQ<ImageRequest<I> >::_void_dequeue());
+  auto item = reinterpret_cast<ImageDispatchSpec<I> *>(
+    ThreadPool::PointerWQ<ImageDispatchSpec<I> >::_void_dequeue());
   assert(peek_item == item);
 
   if (lock_required) {
@@ -669,7 +670,7 @@ void *ImageRequestWQ<I>::_void_dequeue() {
 }
 
 template <typename I>
-void ImageRequestWQ<I>::process(ImageRequest<I> *req) {
+void ImageRequestWQ<I>::process(ImageDispatchSpec<I> *req) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "ictx=" << &m_image_ctx << ", "
                  << "req=" << req << dendl;
@@ -686,7 +687,7 @@ void ImageRequestWQ<I>::process(ImageRequest<I> *req) {
 }
 
 template <typename I>
-void ImageRequestWQ<I>::finish_queued_io(ImageRequest<I> *req) {
+void ImageRequestWQ<I>::finish_queued_io(ImageDispatchSpec<I> *req) {
   RWLock::RLocker locker(m_lock);
   if (req->is_write_op()) {
     assert(m_queued_writes > 0);
@@ -750,7 +751,8 @@ void ImageRequestWQ<I>::finish_in_flight_io() {
 }
 
 template <typename I>
-void ImageRequestWQ<I>::fail_in_flight_io(int r, ImageRequest<I> *req) {
+void ImageRequestWQ<I>::fail_in_flight_io(
+    int r, ImageDispatchSpec<I> *req) {
   this->process_finish();
   req->fail(r);
   finish_queued_io(req);
@@ -766,7 +768,7 @@ bool ImageRequestWQ<I>::is_lock_required(bool write_op) const {
 }
 
 template <typename I>
-void ImageRequestWQ<I>::queue(ImageRequest<I> *req) {
+void ImageRequestWQ<I>::queue(ImageDispatchSpec<I> *req) {
   assert(m_image_ctx.owner_lock.is_locked());
 
   CephContext *cct = m_image_ctx.cct;
@@ -779,11 +781,12 @@ void ImageRequestWQ<I>::queue(ImageRequest<I> *req) {
     m_queued_reads++;
   }
 
-  ThreadPool::PointerWQ<ImageRequest<I> >::queue(req);
+  ThreadPool::PointerWQ<ImageDispatchSpec<I> >::queue(req);
 }
 
 template <typename I>
-void ImageRequestWQ<I>::handle_acquire_lock(int r, ImageRequest<I> *req) {
+void ImageRequestWQ<I>::handle_acquire_lock(
+    int r, ImageDispatchSpec<I> *req) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 5) << "r=" << r << ", " << "req=" << req << dendl;
 
@@ -801,7 +804,8 @@ void ImageRequestWQ<I>::handle_acquire_lock(int r, ImageRequest<I> *req) {
 }
 
 template <typename I>
-void ImageRequestWQ<I>::handle_refreshed(int r, ImageRequest<I> *req) {
+void ImageRequestWQ<I>::handle_refreshed(
+    int r, ImageDispatchSpec<I> *req) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 5) << "resuming IO after image refresh: r=" << r << ", "
                 << "req=" << req << dendl;

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -20,12 +20,12 @@ class ImageCtx;
 namespace io {
 
 class AioCompletion;
-template <typename> class ImageRequest;
+template <typename> class ImageDispatchSpec;
 class ReadResult;
 
 template <typename ImageCtxT = librbd::ImageCtx>
 class ImageRequestWQ
-  : public ThreadPool::PointerWQ<ImageRequest<ImageCtxT> > {
+  : public ThreadPool::PointerWQ<ImageDispatchSpec<ImageCtxT> > {
 public:
   ImageRequestWQ(ImageCtxT *image_ctx, const string &name, time_t ti,
                  ThreadPool *tp);
@@ -55,9 +55,8 @@ public:
                              bufferlist &&bl, uint64_t *mismatch_off,
                              int op_flags, bool native_async=true);
 
-  using ThreadPool::PointerWQ<ImageRequest<ImageCtxT> >::drain;
-
-  using ThreadPool::PointerWQ<ImageRequest<ImageCtxT> >::empty;
+  using ThreadPool::PointerWQ<ImageDispatchSpec<ImageCtxT> >::drain;
+  using ThreadPool::PointerWQ<ImageDispatchSpec<ImageCtxT> >::empty;
 
   void shut_down(Context *on_shutdown);
 
@@ -76,7 +75,7 @@ public:
 
 protected:
   void *_void_dequeue() override;
-  void process(ImageRequest<ImageCtxT> *req) override;
+  void process(ImageDispatchSpec<ImageCtxT> *req) override;
 
 private:
   typedef std::list<Context *> Contexts;
@@ -113,20 +112,20 @@ private:
     return (m_queued_writes == 0);
   }
 
-  void finish_queued_io(ImageRequest<ImageCtxT> *req);
+  void finish_queued_io(ImageDispatchSpec<ImageCtxT> *req);
   void finish_in_flight_write();
 
   int start_in_flight_io(AioCompletion *c);
   void finish_in_flight_io();
-  void fail_in_flight_io(int r, ImageRequest<ImageCtxT> *req);
+  void fail_in_flight_io(int r, ImageDispatchSpec<ImageCtxT> *req);
 
-  void queue(ImageRequest<ImageCtxT> *req);
+  void queue(ImageDispatchSpec<ImageCtxT> *req);
 
-  void handle_acquire_lock(int r, ImageRequest<ImageCtxT> *req);
-  void handle_refreshed(int r, ImageRequest<ImageCtxT> *req);
+  void handle_acquire_lock(int r, ImageDispatchSpec<ImageCtxT> *req);
+  void handle_refreshed(int r, ImageDispatchSpec<ImageCtxT> *req);
   void handle_blocked_writes(int r);
 
-  void handle_iops_throttle_ready(int r, ImageRequest<ImageCtxT> *item);
+  void handle_iops_throttle_ready(int r, ImageDispatchSpec<ImageCtxT> *item);
 };
 
 } // namespace io

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -48,12 +48,13 @@ template <typename I>
 ObjectRequest<I>*
 ObjectRequest<I>::create_write(I *ictx, const std::string &oid,
                                uint64_t object_no, uint64_t object_off,
-                               const ceph::bufferlist &data,
+                               ceph::bufferlist&& data,
                                const ::SnapContext &snapc, int op_flags,
 			       const ZTracer::Trace &parent_trace,
                                Context *completion) {
-  return new ObjectWriteRequest<I>(ictx, oid, object_no, object_off, data,
-                                   snapc, op_flags, parent_trace, completion);
+  return new ObjectWriteRequest<I>(ictx, oid, object_no, object_off,
+                                   std::move(data), snapc, op_flags,
+                                   parent_trace, completion);
 }
 
 template <typename I>
@@ -77,13 +78,13 @@ ObjectRequest<I>*
 ObjectRequest<I>::create_writesame(I *ictx, const std::string &oid,
                                    uint64_t object_no, uint64_t object_off,
                                    uint64_t object_len,
-                                   const ceph::bufferlist &data,
+                                   ceph::bufferlist&& data,
                                    const ::SnapContext &snapc, int op_flags,
 				   const ZTracer::Trace &parent_trace,
                                    Context *completion) {
   return new ObjectWriteSameRequest<I>(ictx, oid, object_no, object_off,
-                                       object_len, data, snapc, op_flags,
-                                       parent_trace, completion);
+                                       object_len, std::move(data), snapc,
+                                       op_flags, parent_trace, completion);
 }
 
 template <typename I>
@@ -91,15 +92,16 @@ ObjectRequest<I>*
 ObjectRequest<I>::create_compare_and_write(I *ictx, const std::string &oid,
                                            uint64_t object_no,
                                            uint64_t object_off,
-                                           const ceph::bufferlist &cmp_data,
-                                           const ceph::bufferlist &write_data,
+                                           ceph::bufferlist&& cmp_data,
+                                           ceph::bufferlist&& write_data,
                                            const ::SnapContext &snapc,
                                            uint64_t *mismatch_offset,
                                            int op_flags,
                                            const ZTracer::Trace &parent_trace,
                                            Context *completion) {
   return new ObjectCompareAndWriteRequest<I>(ictx, oid, object_no, object_off,
-                                             cmp_data, write_data, snapc,
+                                             std::move(cmp_data),
+                                             std::move(write_data), snapc,
                                              mismatch_offset, op_flags,
                                              parent_trace, completion);
 }

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -186,10 +186,13 @@ ObjectReadRequest<I>::ObjectReadRequest(I *ictx, const std::string &oid,
                                         uint64_t len, librados::snap_t snap_id,
                                         int op_flags, bool cache_initiated,
                                         const ZTracer::Trace &parent_trace,
+                                        bufferlist* read_data,
+                                        ExtentMap* extent_map,
                                         Context *completion)
   : ObjectRequest<I>(ictx, oid, objectno, offset, len, snap_id, "read",
                      parent_trace, completion),
-    m_op_flags(op_flags), m_cache_initiated(cache_initiated) {
+    m_op_flags(op_flags), m_cache_initiated(cache_initiated),
+    m_read_data(read_data), m_extent_map(extent_map) {
 }
 
 template <typename I>
@@ -214,7 +217,7 @@ void ObjectReadRequest<I>::read_cache() {
     *image_ctx, util::create_context_callback<
       ObjectReadRequest<I>, &ObjectReadRequest<I>::handle_read_cache>(this));
   image_ctx->aio_read_from_cache(
-    this->m_oid, this->m_object_no, &m_read_data, this->m_object_len,
+    this->m_oid, this->m_object_no, m_read_data, this->m_object_len,
     this->m_object_off, cache_ctx, m_op_flags,
     (this->m_trace.valid() ? &this->m_trace : nullptr));
 }
@@ -255,10 +258,10 @@ void ObjectReadRequest<I>::read_object() {
 
   librados::ObjectReadOperation op;
   if (this->m_object_len >= image_ctx->sparse_read_threshold_bytes) {
-    op.sparse_read(this->m_object_off, this->m_object_len, &m_ext_map,
-                   &m_read_data, nullptr);
+    op.sparse_read(this->m_object_off, this->m_object_len, m_extent_map,
+                   m_read_data, nullptr);
   } else {
-    op.read(this->m_object_off, this->m_object_len, &m_read_data, nullptr);
+    op.read(this->m_object_off, this->m_object_len, m_read_data, nullptr);
   }
   op.set_op_flags2(m_op_flags);
 
@@ -329,7 +332,7 @@ void ObjectReadRequest<I>::read_parent() {
     ObjectReadRequest<I>, &ObjectReadRequest<I>::handle_read_parent>(
       this, util::get_image_ctx(image_ctx->parent), AIO_TYPE_READ);
   ImageRequest<I>::aio_read(image_ctx->parent, parent_completion,
-                            std::move(parent_extents), ReadResult{&m_read_data},
+                            std::move(parent_extents), ReadResult{m_read_data},
                             0, this->m_trace);
 }
 

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -10,6 +10,7 @@
 #include "common/WorkQueue.h"
 #include "include/Context.h"
 #include "include/err.h"
+#include "osd/osd_types.h"
 
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -126,32 +126,22 @@ public:
                                    uint64_t len, librados::snap_t snap_id,
                                    int op_flags, bool cache_initiated,
                                    const ZTracer::Trace &parent_trace,
-                                   Context *completion) {
+                                   ceph::bufferlist* read_data,
+                                   ExtentMap* extent_map, Context *completion) {
     return new ObjectReadRequest(ictx, oid, objectno, offset, len,
                                  snap_id, op_flags, cache_initiated,
-                                 parent_trace, completion);
+                                 parent_trace, read_data, extent_map,
+                                 completion);
   }
 
   ObjectReadRequest(ImageCtxT *ictx, const std::string &oid,
                     uint64_t objectno, uint64_t offset, uint64_t len,
                     librados::snap_t snap_id, int op_flags,
                     bool cache_initiated, const ZTracer::Trace &parent_trace,
+                    ceph::bufferlist* read_data, ExtentMap* extent_map,
                     Context *completion);
 
   void send() override;
-
-  inline uint64_t get_offset() const {
-    return this->m_object_off;
-  }
-  inline uint64_t get_length() const {
-    return this->m_object_len;
-  }
-  ceph::bufferlist &data() {
-    return m_read_data;
-  }
-  ExtentMap &get_extent_map() {
-    return m_ext_map;
-  }
 
   const char *get_op_type() const override {
     return "read";
@@ -187,8 +177,8 @@ private:
   int m_op_flags;
   bool m_cache_initiated;
 
-  ceph::bufferlist m_read_data;
-  ExtentMap m_ext_map;
+  ceph::bufferlist* m_read_data;
+  ExtentMap* m_extent_map;
 
   void read_cache();
   void handle_read_cache(int r);

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -43,7 +43,7 @@ public:
   static ObjectRequest* create_write(ImageCtxT *ictx, const std::string &oid,
                                      uint64_t object_no,
                                      uint64_t object_off,
-                                     const ceph::bufferlist &data,
+                                     ceph::bufferlist&& data,
                                      const ::SnapContext &snapc, int op_flags,
 				     const ZTracer::Trace &parent_trace,
                                      Context *completion);
@@ -60,7 +60,7 @@ public:
                                          uint64_t object_no,
                                          uint64_t object_off,
                                          uint64_t object_len,
-                                         const ceph::bufferlist &data,
+                                         ceph::bufferlist&& data,
                                          const ::SnapContext &snapc,
 					 int op_flags,
 					 const ZTracer::Trace &parent_trace,
@@ -69,8 +69,8 @@ public:
                                                  const std::string &oid,
                                                  uint64_t object_no,
                                                  uint64_t object_off,
-                                                 const ceph::bufferlist &cmp_data,
-                                                 const ceph::bufferlist &write_data,
+                                                 ceph::bufferlist&& cmp_data,
+                                                 ceph::bufferlist&& write_data,
                                                  const ::SnapContext &snapc,
                                                  uint64_t *mismatch_offset, int op_flags,
                                                  const ZTracer::Trace &parent_trace,
@@ -309,13 +309,13 @@ class ObjectWriteRequest : public AbstractObjectWriteRequest<ImageCtxT> {
 public:
   ObjectWriteRequest(ImageCtxT *ictx, const std::string &oid,
                      uint64_t object_no, uint64_t object_off,
-                     const ceph::bufferlist &data, const ::SnapContext &snapc,
+                     ceph::bufferlist&& data, const ::SnapContext &snapc,
                      int op_flags, const ZTracer::Trace &parent_trace,
                      Context *completion)
     : AbstractObjectWriteRequest<ImageCtxT>(ictx, oid, object_no, object_off,
                                             data.length(), snapc, "write",
                                             parent_trace, completion),
-      m_write_data(data), m_op_flags(op_flags) {
+      m_write_data(std::move(data)), m_op_flags(op_flags) {
   }
 
   bool is_empty_write_op() const override {
@@ -434,14 +434,14 @@ class ObjectWriteSameRequest : public AbstractObjectWriteRequest<ImageCtxT> {
 public:
   ObjectWriteSameRequest(ImageCtxT *ictx, const std::string &oid,
 			 uint64_t object_no, uint64_t object_off,
-			 uint64_t object_len, const ceph::bufferlist &data,
+			 uint64_t object_len, ceph::bufferlist&& data,
                          const ::SnapContext &snapc, int op_flags,
 			 const ZTracer::Trace &parent_trace,
 			 Context *completion)
     : AbstractObjectWriteRequest<ImageCtxT>(ictx, oid, object_no, object_off,
                                             object_len, snapc, "writesame",
                                             parent_trace, completion),
-      m_write_data(data), m_op_flags(op_flags) {
+      m_write_data(std::move(data)), m_op_flags(op_flags) {
   }
 
   const char *get_op_type() const override {
@@ -461,8 +461,8 @@ class ObjectCompareAndWriteRequest : public AbstractObjectWriteRequest<ImageCtxT
 public:
   ObjectCompareAndWriteRequest(ImageCtxT *ictx, const std::string &oid,
                                uint64_t object_no, uint64_t object_off,
-                               const ceph::bufferlist &cmp_bl,
-                               const ceph::bufferlist &write_bl,
+                               ceph::bufferlist&& cmp_bl,
+                               ceph::bufferlist&& write_bl,
                                const ::SnapContext &snapc,
                                uint64_t *mismatch_offset, int op_flags,
                                const ZTracer::Trace &parent_trace,
@@ -471,7 +471,7 @@ public:
                                            cmp_bl.length(), snapc,
                                            "compare_and_write", parent_trace,
                                            completion),
-    m_cmp_bl(cmp_bl), m_write_bl(write_bl),
+    m_cmp_bl(std::move(cmp_bl)), m_write_bl(std::move(write_bl)),
     m_mismatch_offset(mismatch_offset), m_op_flags(op_flags) {
   }
 

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -14,6 +14,7 @@
 #include <map>
 
 class Context;
+class ObjectExtent;
 
 namespace librbd {
 

--- a/src/librbd/io/ReadResult.cc
+++ b/src/librbd/io/ReadResult.cc
@@ -79,13 +79,10 @@ struct ReadResult::AssembleResultVisitor : public boost::static_visitor<void> {
   }
 };
 
-ReadResult::C_ReadRequest::C_ReadRequest(AioCompletion *aio_completion)
-  : aio_completion(aio_completion) {
+ReadResult::C_ImageReadRequest::C_ImageReadRequest(
+    AioCompletion *aio_completion, const Extents image_extents)
+  : aio_completion(aio_completion), image_extents(image_extents) {
   aio_completion->add_request();
-}
-
-void ReadResult::C_ReadRequest::finish(int r) {
-  aio_completion->complete_request(r);
 }
 
 void ReadResult::C_ImageReadRequest::finish(int r) {
@@ -106,15 +103,21 @@ void ReadResult::C_ImageReadRequest::finish(int r) {
     r = length;
   }
 
-  C_ReadRequest::finish(r);
+  aio_completion->complete_request(r);
 }
 
-void ReadResult::C_SparseReadRequestBase::finish(ExtentMap &extent_map,
-                                                 const Extents &buffer_extents,
-                                                 uint64_t offset, size_t length,
-                                                 bufferlist &bl, int r) {
+ReadResult::C_ObjectReadRequest::C_ObjectReadRequest(
+    AioCompletion *aio_completion, uint64_t object_off, uint64_t object_len,
+    Extents&& buffer_extents, bool ignore_enoent)
+  : aio_completion(aio_completion), object_off(object_off),
+    object_len(object_len), buffer_extents(std::move(buffer_extents)),
+    ignore_enoent(ignore_enoent) {
+  aio_completion->add_request();
+}
+
+void ReadResult::C_ObjectReadRequest::finish(int r) {
   CephContext *cct = aio_completion->ictx->cct;
-  ldout(cct, 10) << "C_SparseReadRequestBase: r = " << r
+  ldout(cct, 10) << "C_ObjectReadRequest: r=" << r
                  << dendl;
 
   if (ignore_enoent && r == -ENOENT) {
@@ -126,18 +129,18 @@ void ReadResult::C_SparseReadRequestBase::finish(ExtentMap &extent_map,
                    << " bl " << bl.length() << dendl;
     // handle the case where a sparse-read wasn't issued
     if (extent_map.empty()) {
-      extent_map[offset] = bl.length();
+      extent_map[object_off] = bl.length();
     }
 
     aio_completion->lock.Lock();
     aio_completion->read_result.m_destriper.add_partial_sparse_result(
-      cct, bl, extent_map, offset, buffer_extents);
+      cct, bl, extent_map, object_off, buffer_extents);
     aio_completion->lock.Unlock();
 
-    r = length;
+    r = object_len;
   }
 
-  C_ReadRequest::finish(r);
+  aio_completion->complete_request(r);
 }
 
 ReadResult::ReadResult() : m_buffer(Empty()) {

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -24,58 +24,33 @@ struct AioCompletion;
 template <typename> struct ObjectReadRequest;
 
 class ReadResult {
-private:
-  struct C_ReadRequest : public Context {
+public:
+  struct C_ImageReadRequest : public Context {
     AioCompletion *aio_completion;
+    Extents image_extents;
     bufferlist bl;
 
-    C_ReadRequest(AioCompletion *aio_completion);
-
-    void finish(int r) override;
-  };
-
-public:
-
-  struct C_ImageReadRequest : public C_ReadRequest {
-    Extents image_extents;
-
     C_ImageReadRequest(AioCompletion *aio_completion,
-                       const Extents image_extents)
-      : C_ReadRequest(aio_completion), image_extents(image_extents) {
-    }
+                       const Extents image_extents);
 
     void finish(int r) override;
   };
 
-  struct C_SparseReadRequestBase : public C_ReadRequest {
+  struct C_ObjectReadRequest : public Context {
+    AioCompletion *aio_completion;
+    uint64_t object_off;
+    uint64_t object_len;
+    Extents buffer_extents;
     bool ignore_enoent;
 
-    C_SparseReadRequestBase(AioCompletion *aio_completion, bool ignore_enoent)
-      : C_ReadRequest(aio_completion), ignore_enoent(ignore_enoent) {
-    }
+    bufferlist bl;
+    ExtentMap extent_map;
 
-    using C_ReadRequest::finish;
-    void finish(ExtentMap &extent_map, const Extents &buffer_extents,
-                uint64_t offset, size_t length, bufferlist &bl, int r);
-  };
+    C_ObjectReadRequest(AioCompletion *aio_completion, uint64_t object_off,
+                        uint64_t object_len, Extents&& buffer_extents,
+                        bool ignore_enoent);
 
-  template <typename ImageCtxT = ImageCtx>
-  struct C_SparseReadRequest : public C_SparseReadRequestBase {
-    ObjectReadRequest<ImageCtxT> *request = nullptr;
-    Extents buffer_extents;
-
-    C_SparseReadRequest(AioCompletion *aio_completion, Extents&& buffer_extents,
-                        bool ignore_enoent)
-      : C_SparseReadRequestBase(aio_completion, ignore_enoent),
-        buffer_extents(std::move(buffer_extents)) {
-    }
-
-    void finish(int r) override {
-      C_SparseReadRequestBase::finish(request->get_extent_map(), buffer_extents,
-                                      request->get_offset(),
-                                      request->get_length(), request->data(),
-                                      r);
-    }
+    void finish(int r) override;
   };
 
   ReadResult();

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -24,6 +24,12 @@ typedef enum {
   AIO_TYPE_COMPARE_AND_WRITE,
 } aio_type_t;
 
+enum FlushSource {
+  FLUSH_SOURCE_USER,
+  FLUSH_SOURCE_INTERNAL,
+  FLUSH_SOURCE_SHUTDOWN
+};
+
 enum Direction {
   DIRECTION_READ,
   DIRECTION_WRITE,

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -43,4 +43,3 @@ typedef std::map<uint64_t, uint64_t> ExtentMap;
 } // namespace librbd
 
 #endif // CEPH_LIBRBD_IO_TYPES_H
-

--- a/src/librbd/io/Utils.cc
+++ b/src/librbd/io/Utils.cc
@@ -1,0 +1,57 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/io/Utils.h"
+#include "include/buffer.h"
+#include "osd/osd_types.h"
+
+namespace librbd {
+namespace io {
+namespace util {
+
+bool assemble_write_same_extent(
+    const ObjectExtent &object_extent, const ceph::bufferlist& data,
+    ceph::bufferlist *ws_data, bool force_write) {
+  size_t data_len = data.length();
+
+  if (!force_write) {
+    bool may_writesame = true;
+    for (auto& q : object_extent.buffer_extents) {
+      if (!(q.first % data_len == 0 && q.second % data_len == 0)) {
+        may_writesame = false;
+        break;
+      }
+    }
+
+    if (may_writesame) {
+      ws_data->append(data);
+      return true;
+    }
+  }
+
+  for (auto& q : object_extent.buffer_extents) {
+    bufferlist sub_bl;
+    uint64_t sub_off = q.first % data_len;
+    uint64_t sub_len = data_len - sub_off;
+    uint64_t extent_left = q.second;
+    while (extent_left >= sub_len) {
+      sub_bl.substr_of(data, sub_off, sub_len);
+      ws_data->claim_append(sub_bl);
+      extent_left -= sub_len;
+      if (sub_off) {
+	sub_off = 0;
+	sub_len = data_len;
+      }
+    }
+    if (extent_left) {
+      sub_bl.substr_of(data, sub_off, extent_left);
+      ws_data->claim_append(sub_bl);
+    }
+  }
+  return false;
+}
+
+} // namespace util
+} // namespace io
+} // namespace librbd
+

--- a/src/librbd/io/Utils.h
+++ b/src/librbd/io/Utils.h
@@ -1,0 +1,26 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IO_UTILS_H
+#define CEPH_LIBRBD_IO_UTILS_H
+
+#include "include/int_types.h"
+#include "include/buffer_fwd.h"
+#include <map>
+
+class ObjectExtent;
+
+namespace librbd {
+namespace io {
+namespace util {
+
+bool assemble_write_same_extent(const ObjectExtent &object_extent,
+                                const ceph::bufferlist& data,
+                                ceph::bufferlist *ws_data,
+                                bool force_write);
+
+} // namespace util
+} // namespace io
+} // namespace librbd
+
+#endif // CEPH_LIBRBD_IO_UTILS_H

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -271,7 +271,8 @@ void Replay<I>::shut_down(bool cancel_ops, Context *on_finish) {
   // execute the following outside of lock scope
   if (flush_comp != nullptr) {
     RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-    io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+    io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
+                                   io::FLUSH_SOURCE_INTERNAL, {});
   }
   if (on_finish != nullptr) {
     on_finish->complete(0);
@@ -291,7 +292,8 @@ void Replay<I>::flush(Context *on_finish) {
   }
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
-  io::ImageRequest<I>::aio_flush(&m_image_ctx, aio_comp, {});
+  io::ImageRequest<I>::aio_flush(&m_image_ctx, aio_comp,
+                                 io::FLUSH_SOURCE_INTERNAL, {});
 }
 
 template <typename I>
@@ -357,7 +359,8 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
     m_lock.Unlock();
 
     if (flush_comp != nullptr) {
-      io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+      io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
+                                     io::FLUSH_SOURCE_INTERNAL, {});
     }
   }
 }
@@ -387,7 +390,8 @@ void Replay<I>::handle_event(const journal::AioWriteEvent &event,
     m_lock.Unlock();
 
     if (flush_comp != nullptr) {
-      io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+      io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
+                                     io::FLUSH_SOURCE_INTERNAL, {});
     }
   }
 }
@@ -405,7 +409,8 @@ void Replay<I>::handle_event(const journal::AioFlushEvent &event,
   }
 
   if (aio_comp != nullptr) {
-    io::ImageRequest<I>::aio_flush(&m_image_ctx, aio_comp, {});
+    io::ImageRequest<I>::aio_flush(&m_image_ctx, aio_comp,
+                                   io::FLUSH_SOURCE_INTERNAL, {});
   }
   on_ready->complete(0);
 }
@@ -435,7 +440,8 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
     m_lock.Unlock();
 
     if (flush_comp != nullptr) {
-      io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+      io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
+                                     io::FLUSH_SOURCE_INTERNAL, {});
     }
   }
 }
@@ -463,7 +469,8 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
     auto flush_comp = create_aio_flush_completion(nullptr);
     m_lock.Unlock();
 
-    io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+    io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp,
+                                   io::FLUSH_SOURCE_INTERNAL, {});
   }
 }
 

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -348,9 +348,9 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
     return;
   }
 
-  io::ImageRequest<I>::aio_discard(&m_image_ctx, aio_comp, event.offset,
-                                   event.length, event.skip_partial_discard,
-				   {});
+  io::ImageRequest<I>::aio_discard(&m_image_ctx, aio_comp,
+                                   {{event.offset, event.length}},
+                                   event.skip_partial_discard, {});
   if (flush_required) {
     m_lock.Lock();
     auto flush_comp = create_aio_flush_completion(nullptr);
@@ -426,8 +426,9 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
     return;
   }
 
-  io::ImageRequest<I>::aio_writesame(&m_image_ctx, aio_comp, event.offset,
-                                     event.length, std::move(data), 0, {});
+  io::ImageRequest<I>::aio_writesame(&m_image_ctx, aio_comp,
+                                     {{event.offset, event.length}},
+                                     std::move(data), 0, {});
   if (flush_required) {
     m_lock.Lock();
     auto flush_comp = create_aio_flush_completion(nullptr);

--- a/src/librbd/operation/FlattenRequest.cc
+++ b/src/librbd/operation/FlattenRequest.cc
@@ -43,7 +43,8 @@ public:
     bufferlist bl;
     string oid = image_ctx.get_object_name(m_object_no);
     auto req = new io::ObjectWriteRequest<I>(&image_ctx, oid, m_object_no, 0,
-                                             bl, m_snapc, 0, {}, this);
+                                             std::move(bl), m_snapc, 0, {},
+                                             this);
     if (!req->has_parent()) {
       // stop early if the parent went away - it just means
       // another flatten finished first or the image was resized

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -258,7 +258,7 @@ TEST_F(TestMockIoImageRequest, AioDiscardJournalAppendDisabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
   MockImageDiscardRequest mock_aio_image_discard(mock_image_ctx, aio_comp,
-                                                 0, 1,
+                                                 {{0, 1}},
                                                  ictx->skip_partial_discard,
                                                  {});
   {
@@ -322,7 +322,7 @@ TEST_F(TestMockIoImageRequest, AioWriteSameJournalAppendDisabled) {
   bufferlist bl;
   bl.append("1");
   MockImageWriteSameRequest mock_aio_image_writesame(mock_image_ctx, aio_comp,
-                                                     0, 1, std::move(bl), 0,
+                                                     {{0, 1}}, std::move(bl), 0,
                                                      {});
   {
     RWLock::RLocker owner_locker(mock_image_ctx.owner_lock);

--- a/src/test/librbd/io/test_mock_ImageRequestWQ.cc
+++ b/src/test/librbd/io/test_mock_ImageRequestWQ.cc
@@ -5,6 +5,7 @@
 #include "test/librbd/test_support.h"
 #include "test/librbd/mock/MockImageCtx.h"
 #include "test/librbd/mock/exclusive_lock/MockPolicy.h"
+#include "librbd/io/ImageDispatchSpec.h"
 #include "librbd/io/ImageRequestWQ.h"
 #include "librbd/io/ImageRequest.h"
 
@@ -25,20 +26,29 @@ struct ImageRequest<librbd::MockTestImageCtx> {
   static ImageRequest* s_instance;
   AioCompletion *aio_comp = nullptr;
 
-  static ImageRequest* create_write_request(librbd::MockTestImageCtx &image_ctx,
-                                            AioCompletion *aio_comp,
-                                            Extents &&image_extents,
-                                            bufferlist &&bl, int op_flags,
-                                            const ZTracer::Trace &parent_trace) {
-    assert(s_instance != nullptr);
-    s_instance->aio_comp = aio_comp;
-    return s_instance;
-  }
   static void aio_write(librbd::MockTestImageCtx *ictx, AioCompletion *c,
                         Extents &&image_extents, bufferlist &&bl, int op_flags,
                         const ZTracer::Trace &parent_trace) {
   }
 
+  ImageRequest() {
+    s_instance = this;
+  }
+};
+
+template <>
+struct ImageDispatchSpec<librbd::MockTestImageCtx> {
+  static ImageDispatchSpec* s_instance;
+  AioCompletion *aio_comp = nullptr;
+
+  static ImageDispatchSpec* create_write_request(
+      librbd::MockTestImageCtx &image_ctx, AioCompletion *aio_comp,
+      Extents &&image_extents, bufferlist &&bl, int op_flags,
+      const ZTracer::Trace &parent_trace) {
+    assert(s_instance != nullptr);
+    s_instance->aio_comp = aio_comp;
+    return s_instance;
+  }
 
   MOCK_CONST_METHOD0(is_write_op, bool());
   MOCK_CONST_METHOD0(start_op, void());
@@ -47,11 +57,10 @@ struct ImageRequest<librbd::MockTestImageCtx> {
   MOCK_CONST_METHOD0(was_throttled, bool());
   MOCK_CONST_METHOD0(set_throttled, void());
 
-  ImageRequest() {
+  ImageDispatchSpec() {
     s_instance = this;
   }
 };
-
 } // namespace io
 
 namespace util {
@@ -65,8 +74,8 @@ inline ImageCtx *get_image_ctx(MockTestImageCtx *image_ctx) {
 } // namespace librbd
 
 template <>
-struct ThreadPool::PointerWQ<librbd::io::ImageRequest<librbd::MockTestImageCtx>> {
-  typedef librbd::io::ImageRequest<librbd::MockTestImageCtx> ImageRequest;
+struct ThreadPool::PointerWQ<librbd::io::ImageDispatchSpec<librbd::MockTestImageCtx>> {
+  typedef librbd::io::ImageDispatchSpec<librbd::MockTestImageCtx> ImageDispatchSpec;
   static PointerWQ* s_instance;
 
   Mutex m_lock;
@@ -83,11 +92,11 @@ struct ThreadPool::PointerWQ<librbd::io::ImageRequest<librbd::MockTestImageCtx>>
   MOCK_METHOD0(signal, void());
   MOCK_METHOD0(process_finish, void());
 
-  MOCK_METHOD0(front, ImageRequest*());
-  MOCK_METHOD1(requeue, void(ImageRequest*));
+  MOCK_METHOD0(front, ImageDispatchSpec*());
+  MOCK_METHOD1(requeue, void(ImageDispatchSpec*));
 
   MOCK_METHOD0(dequeue, void*());
-  MOCK_METHOD1(queue, void(ImageRequest*));
+  MOCK_METHOD1(queue, void(ImageDispatchSpec*));
 
   void register_work_queue() {
     // no-op
@@ -100,21 +109,23 @@ struct ThreadPool::PointerWQ<librbd::io::ImageRequest<librbd::MockTestImageCtx>>
     Mutex::Locker locker(m_lock);
     return _void_dequeue();
   }
-  void invoke_process(ImageRequest *image_request) {
+  void invoke_process(ImageDispatchSpec *image_request) {
     process(image_request);
   }
 
   virtual void *_void_dequeue() {
     return dequeue();
   }
-  virtual void process(ImageRequest *req) = 0;
+  virtual void process(ImageDispatchSpec *req) = 0;
 
 };
 
-ThreadPool::PointerWQ<librbd::io::ImageRequest<librbd::MockTestImageCtx>>*
-  ThreadPool::PointerWQ<librbd::io::ImageRequest<librbd::MockTestImageCtx>>::s_instance = nullptr;
+ThreadPool::PointerWQ<librbd::io::ImageDispatchSpec<librbd::MockTestImageCtx>>*
+  ThreadPool::PointerWQ<librbd::io::ImageDispatchSpec<librbd::MockTestImageCtx>>::s_instance = nullptr;
 librbd::io::ImageRequest<librbd::MockTestImageCtx>*
   librbd::io::ImageRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
+librbd::io::ImageDispatchSpec<librbd::MockTestImageCtx>*
+  librbd::io::ImageDispatchSpec<librbd::MockTestImageCtx>::s_instance = nullptr;
 
 #include "librbd/io/ImageRequestWQ.cc"
 
@@ -130,8 +141,10 @@ using ::testing::WithArg;
 struct TestMockIoImageRequestWQ : public TestMockFixture {
   typedef ImageRequestWQ<librbd::MockTestImageCtx> MockImageRequestWQ;
   typedef ImageRequest<librbd::MockTestImageCtx> MockImageRequest;
+  typedef ImageDispatchSpec<librbd::MockTestImageCtx> MockImageDispatchSpec;
 
-  void expect_is_write_op(MockImageRequest &image_request, bool write_op) {
+  void expect_is_write_op(MockImageDispatchSpec &image_request,
+                          bool write_op) {
     EXPECT_CALL(image_request, is_write_op()).WillOnce(Return(write_op));
   }
 
@@ -144,7 +157,7 @@ struct TestMockIoImageRequestWQ : public TestMockFixture {
   }
 
   void expect_front(MockImageRequestWQ &image_request_wq,
-                    MockImageRequest *image_request) {
+                    MockImageDispatchSpec *image_request) {
     EXPECT_CALL(image_request_wq, front()).WillOnce(Return(image_request));
   }
 
@@ -155,7 +168,7 @@ struct TestMockIoImageRequestWQ : public TestMockFixture {
   }
 
   void expect_dequeue(MockImageRequestWQ &image_request_wq,
-                      MockImageRequest *image_request) {
+                      MockImageDispatchSpec *image_request) {
     EXPECT_CALL(image_request_wq, dequeue()).WillOnce(Return(image_request));
   }
 
@@ -182,7 +195,7 @@ struct TestMockIoImageRequestWQ : public TestMockFixture {
     EXPECT_CALL(mock_image_request_wq, process_finish()).Times(1);
   }
 
-  void expect_fail(MockImageRequest &mock_image_request, int r) {
+  void expect_fail(MockImageDispatchSpec &mock_image_request, int r) {
     EXPECT_CALL(mock_image_request, fail(r))
       .WillOnce(Invoke([&mock_image_request](int r) {
                     mock_image_request.aio_comp->get();
@@ -197,7 +210,7 @@ struct TestMockIoImageRequestWQ : public TestMockFixture {
                   }));
   }
 
-  void expect_was_throttled(MockImageRequest &mock_image_request,
+  void expect_was_throttled(MockImageDispatchSpec &mock_image_request,
                             bool throttled) {
     EXPECT_CALL(mock_image_request, was_throttled())
       .WillOnce(Return(throttled));
@@ -219,18 +232,18 @@ TEST_F(TestMockIoImageRequestWQ, AcquireLockError) {
   expect_signal(mock_image_request_wq);
   mock_image_request_wq.set_require_lock(DIRECTION_WRITE, true);
 
-  auto mock_image_request = new MockImageRequest();
-  expect_is_write_op(*mock_image_request, true);
+  auto mock_queued_image_request = new MockImageDispatchSpec();
+  expect_is_write_op(*mock_queued_image_request, true);
   expect_queue(mock_image_request_wq);
   auto *aio_comp = new librbd::io::AioCompletion();
   mock_image_request_wq.aio_write(aio_comp, 0, 0, {}, 0);
 
   librbd::exclusive_lock::MockPolicy mock_exclusive_lock_policy;
-  expect_front(mock_image_request_wq, mock_image_request);
-  expect_was_throttled(*mock_image_request, false);
+  expect_front(mock_image_request_wq, mock_queued_image_request);
+  expect_was_throttled(*mock_queued_image_request, false);
   expect_is_refresh_request(mock_image_ctx, false);
-  expect_is_write_op(*mock_image_request, true);
-  expect_dequeue(mock_image_request_wq, mock_image_request);
+  expect_is_write_op(*mock_queued_image_request, true);
+  expect_dequeue(mock_image_request_wq, mock_queued_image_request);
   expect_get_exclusive_lock_policy(mock_image_ctx, mock_exclusive_lock_policy);
   expect_may_auto_request_lock(mock_exclusive_lock_policy, true);
   Context *on_acquire = nullptr;
@@ -239,8 +252,8 @@ TEST_F(TestMockIoImageRequestWQ, AcquireLockError) {
   ASSERT_TRUE(on_acquire != nullptr);
 
   expect_process_finish(mock_image_request_wq);
-  expect_fail(*mock_image_request, -EPERM);
-  expect_is_write_op(*mock_image_request, true);
+  expect_fail(*mock_queued_image_request, -EPERM);
+  expect_is_write_op(*mock_queued_image_request, true);
   expect_signal(mock_image_request_wq);
   on_acquire->complete(-EPERM);
 
@@ -258,25 +271,25 @@ TEST_F(TestMockIoImageRequestWQ, RefreshError) {
   InSequence seq;
   MockImageRequestWQ mock_image_request_wq(&mock_image_ctx, "io", 60, nullptr);
 
-  auto mock_image_request = new MockImageRequest();
-  expect_is_write_op(*mock_image_request, true);
+  auto mock_queued_image_request = new MockImageDispatchSpec();
+  expect_is_write_op(*mock_queued_image_request, true);
   expect_queue(mock_image_request_wq);
   auto *aio_comp = new librbd::io::AioCompletion();
   mock_image_request_wq.aio_write(aio_comp, 0, 0, {}, 0);
 
-  expect_front(mock_image_request_wq, mock_image_request);
-  expect_was_throttled(*mock_image_request, false);
+  expect_front(mock_image_request_wq, mock_queued_image_request);
+  expect_was_throttled(*mock_queued_image_request, false);
   expect_is_refresh_request(mock_image_ctx, true);
-  expect_is_write_op(*mock_image_request, true);
-  expect_dequeue(mock_image_request_wq, mock_image_request);
+  expect_is_write_op(*mock_queued_image_request, true);
+  expect_dequeue(mock_image_request_wq, mock_queued_image_request);
   Context *on_refresh = nullptr;
   expect_refresh(mock_image_ctx, &on_refresh);
   ASSERT_TRUE(mock_image_request_wq.invoke_dequeue() == nullptr);
   ASSERT_TRUE(on_refresh != nullptr);
 
   expect_process_finish(mock_image_request_wq);
-  expect_fail(*mock_image_request, -EPERM);
-  expect_is_write_op(*mock_image_request, true);
+  expect_fail(*mock_queued_image_request, -EPERM);
+  expect_is_write_op(*mock_queued_image_request, true);
   expect_signal(mock_image_request_wq);
   on_refresh->complete(-EPERM);
 

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -667,8 +667,8 @@ TEST_F(TestMockIoObjectRequest, Write) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, bl, mock_image_ctx.snapc,
-    0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
+    mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -702,8 +702,8 @@ TEST_F(TestMockIoObjectRequest, WriteFull) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, bl, mock_image_ctx.snapc,
-    0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
+    mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -736,8 +736,8 @@ TEST_F(TestMockIoObjectRequest, WriteObjectMap) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, bl, mock_image_ctx.snapc,
-    0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
+    mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -758,8 +758,8 @@ TEST_F(TestMockIoObjectRequest, WriteError) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, bl, mock_image_ctx.snapc,
-    0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
+    mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -812,8 +812,8 @@ TEST_F(TestMockIoObjectRequest, Copyup) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, bl, mock_image_ctx.snapc,
-    0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
+    mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -860,8 +860,8 @@ TEST_F(TestMockIoObjectRequest, CopyupOptimization) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, bl, mock_image_ctx.snapc,
-    0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
+    mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -901,8 +901,8 @@ TEST_F(TestMockIoObjectRequest, CopyupError) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteRequest::create_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, bl, mock_image_ctx.snapc,
-    0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(bl),
+    mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -1143,7 +1143,7 @@ TEST_F(TestMockIoObjectRequest, WriteSame) {
 
   C_SaferCond ctx;
   auto req = MockObjectWriteSameRequest::create_writesame(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, bl,
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, std::move(bl),
     mock_image_ctx.snapc, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -1183,8 +1183,8 @@ TEST_F(TestMockIoObjectRequest, CompareAndWrite) {
   C_SaferCond ctx;
   uint64_t mismatch_offset;
   auto req = MockObjectWriteSameRequest::create_compare_and_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, cmp_bl, bl,
-    mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(cmp_bl),
+    std::move(bl), mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1223,8 +1223,8 @@ TEST_F(TestMockIoObjectRequest, CompareAndWriteFull) {
   C_SaferCond ctx;
   uint64_t mismatch_offset;
   auto req = MockObjectWriteSameRequest::create_compare_and_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, cmp_bl, bl,
-    mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(cmp_bl),
+    std::move(bl), mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1285,8 +1285,8 @@ TEST_F(TestMockIoObjectRequest, CompareAndWriteCopyup) {
   C_SaferCond ctx;
   uint64_t mismatch_offset;
   auto req = MockObjectWriteSameRequest::create_compare_and_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, cmp_bl, bl,
-    mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(cmp_bl),
+    std::move(bl), mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1324,8 +1324,8 @@ TEST_F(TestMockIoObjectRequest, CompareAndWriteMismatch) {
   C_SaferCond ctx;
   uint64_t mismatch_offset;
   auto req = MockObjectWriteSameRequest::create_compare_and_write(
-    &mock_image_ctx, ictx->get_object_name(0), 0, 0, cmp_bl, bl,
-    mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
+    &mock_image_ctx, ictx->get_object_name(0), 0, 0, std::move(cmp_bl),
+    std::move(bl), mock_image_ctx.snapc, &mismatch_offset, 0, {}, &ctx);
   req->send();
   ASSERT_EQ(-EILSEQ, ctx.wait());
   ASSERT_EQ(1ULL, mismatch_offset);

--- a/src/test/librbd/io/test_mock_ObjectRequest.cc
+++ b/src/test/librbd/io/test_mock_ObjectRequest.cc
@@ -339,10 +339,12 @@ TEST_F(TestMockIoObjectRequest, Read) {
   expect_read(mock_image_ctx, ictx->get_object_name(0), 0, 4096,
               std::string(4096, '1'), 0);
 
+  bufferlist bl;
+  ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0,
-    false, {}, &ctx);
+    false, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -367,10 +369,13 @@ TEST_F(TestMockIoObjectRequest, SparseReadThreshold) {
                      ictx->sparse_read_threshold_bytes,
                      std::string(ictx->sparse_read_threshold_bytes, '1'), 0);
 
+  bufferlist bl;
+  ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, ictx->get_object_name(0), 0, 0,
-    ictx->sparse_read_threshold_bytes, CEPH_NOSNAP, 0, false, {}, &ctx);
+    ictx->sparse_read_threshold_bytes, CEPH_NOSNAP, 0, false, {},
+    &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -393,10 +398,12 @@ TEST_F(TestMockIoObjectRequest, ReadError) {
   expect_get_read_flags(mock_image_ctx, CEPH_NOSNAP, 0);
   expect_read(mock_image_ctx, ictx->get_object_name(0), 0, 4096, "", -EPERM);
 
+  bufferlist bl;
+  ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0,
-    false, {}, &ctx);
+    false, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -418,10 +425,12 @@ TEST_F(TestMockIoObjectRequest, CacheRead) {
   expect_cache_read(mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096,
                     std::string(4096, '1'), 0);
 
+  bufferlist bl;
+  ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0,
-    false, {}, &ctx);
+    false, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -443,10 +452,12 @@ TEST_F(TestMockIoObjectRequest, CacheReadError) {
   expect_cache_read(mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096,
                     "", -EPERM);
 
+  bufferlist bl;
+  ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0,
-    false, {}, &ctx);
+    false, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -490,10 +501,12 @@ TEST_F(TestMockIoObjectRequest, ParentRead) {
   expect_prune_parent_extents(mock_image_ctx, {{0, 4096}}, 4096, 4096);
   expect_aio_read(mock_image_request, {{0, 4096}}, 0);
 
+  bufferlist bl;
+  ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0,
-    false, {}, &ctx);
+    false, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -537,10 +550,12 @@ TEST_F(TestMockIoObjectRequest, ParentReadError) {
   expect_prune_parent_extents(mock_image_ctx, {{0, 4096}}, 4096, 4096);
   expect_aio_read(mock_image_request, {{0, 4096}}, -EPERM);
 
+  bufferlist bl;
+  ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0,
-    false,  {}, &ctx);
+    false,  {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(-EPERM, ctx.wait());
 }
@@ -578,10 +593,12 @@ TEST_F(TestMockIoObjectRequest, CacheInitiated) {
   expect_get_read_flags(mock_image_ctx, CEPH_NOSNAP, 0);
   expect_read(mock_image_ctx, ictx->get_object_name(0), 0, 4096, "", -ENOENT);
 
+  bufferlist bl;
+  ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0, true,
-    {}, &ctx);
+    {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -630,10 +647,12 @@ TEST_F(TestMockIoObjectRequest, CopyOnRead) {
   expect_prune_parent_extents(mock_image_ctx, {{0, 4096}}, 4096, 4096);
   expect_copyup(mock_copyup_request, 0);
 
+  bufferlist bl;
+  ExtentMap extent_map;
   C_SaferCond ctx;
   auto req = MockObjectReadRequest::create(
     &mock_image_ctx, ictx->get_object_name(0), 0, 0, 4096, CEPH_NOSNAP, 0,
-    false, {}, &ctx);
+    false, {}, &bl, &extent_map, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -37,14 +37,13 @@ struct ImageRequest<MockReplayImageCtx> {
     s_instance->aio_write(c, image_extents, bl, op_flags);
   }
 
-  MOCK_METHOD4(aio_discard, void(AioCompletion *c, uint64_t off, uint64_t len,
+  MOCK_METHOD3(aio_discard, void(AioCompletion *c, const Extents& image_extents,
                                  bool skip_partial_discard));
   static void aio_discard(MockReplayImageCtx *ictx, AioCompletion *c,
-                          uint64_t off, uint64_t len,
-                          bool skip_partial_discard,
+                          Extents&& image_extents, bool skip_partial_discard,
                           const ZTracer::Trace &parent_trace) {
     assert(s_instance != nullptr);
-    s_instance->aio_discard(c, off, len, skip_partial_discard);
+    s_instance->aio_discard(c, image_extents, skip_partial_discard);
   }
 
   MOCK_METHOD1(aio_flush, void(AioCompletion *c));
@@ -54,13 +53,14 @@ struct ImageRequest<MockReplayImageCtx> {
     s_instance->aio_flush(c);
   }
 
-  MOCK_METHOD5(aio_writesame, void(AioCompletion *c, uint64_t off, uint64_t len,
+  MOCK_METHOD4(aio_writesame, void(AioCompletion *c,
+                                   const Extents& image_extents,
                                    const bufferlist &bl, int op_flags));
   static void aio_writesame(MockReplayImageCtx *ictx, AioCompletion *c,
-                            uint64_t off, uint64_t len, bufferlist &&bl,
+                            Extents&& image_extents, bufferlist &&bl,
                             int op_flags, const ZTracer::Trace &parent_trace) {
     assert(s_instance != nullptr);
-    s_instance->aio_writesame(c, off, len, bl, op_flags);
+    s_instance->aio_writesame(c, image_extents, bl, op_flags);
   }
 
   MOCK_METHOD6(aio_compare_and_write, void(AioCompletion *c, const Extents &image_extents,
@@ -148,7 +148,8 @@ public:
   void expect_aio_discard(MockIoImageRequest &mock_io_image_request,
                           io::AioCompletion **aio_comp, uint64_t off,
                           uint64_t len, bool skip_partial_discard) {
-    EXPECT_CALL(mock_io_image_request, aio_discard(_, off, len, skip_partial_discard))
+    EXPECT_CALL(mock_io_image_request, aio_discard(_, io::Extents{{off, len}},
+                                                   skip_partial_discard))
                   .WillOnce(SaveArg<0>(aio_comp));
   }
 
@@ -176,17 +177,21 @@ public:
                             io::AioCompletion **aio_comp, uint64_t off,
                             uint64_t len, const char *data) {
     EXPECT_CALL(mock_io_image_request,
-                aio_writesame(_, off, len, BufferlistEqual(data), _))
+                aio_writesame(_, io::Extents{{off, len}},
+                              BufferlistEqual(data), _))
                   .WillOnce(SaveArg<0>(aio_comp));
   }
 
   void expect_aio_compare_and_write(MockIoImageRequest &mock_io_image_request,
                                     io::AioCompletion **aio_comp, uint64_t off,
-                                    uint64_t len, const char *cmp_data, const char *data,
+                                    uint64_t len, const char *cmp_data,
+                                    const char *data,
                                     uint64_t *mismatch_offset) {
     EXPECT_CALL(mock_io_image_request,
                 aio_compare_and_write(_, io::Extents{{off, len}},
-                  BufferlistEqual(cmp_data), BufferlistEqual(data), mismatch_offset, _))
+                                      BufferlistEqual(cmp_data),
+                                      BufferlistEqual(data),
+                                      mismatch_offset, _))
                   .WillOnce(SaveArg<0>(aio_comp));
   }
 

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -48,7 +48,7 @@ struct ImageRequest<MockReplayImageCtx> {
 
   MOCK_METHOD1(aio_flush, void(AioCompletion *c));
   static void aio_flush(MockReplayImageCtx *ictx, AioCompletion *c,
-                        const ZTracer::Trace &parent_trace) {
+                        FlushSource, const ZTracer::Trace &parent_trace) {
     assert(s_instance != nullptr);
     s_instance->aio_flush(c);
   }


### PR DESCRIPTION
This is the first part in a series that aims to remove the tied coupling of the object cacher from the IO pathway (to permit a plugable IO dispatcher). 