### PR TITLE
doc:Update ceph-fuse doc

### DIFF
--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **ceph-fuse** [ -m *monaddr*:*port* ] *mountpoint* [ *fuse options* ]
+| **ceph-fuse** [-n *client.username*] [ -m *monaddr*:*port* ] *mountpoint* [ *fuse options* ]
 
 
 Description
@@ -33,6 +33,10 @@ Options
 
 Any options not recognized by ceph-fuse will be passed on to libfuse.
 
+.. option:: -o opt,[opt...]
+
+   mount options.
+
 .. option:: -d
 
    Detach from console and daemonize after startup.
@@ -46,10 +50,17 @@ Any options not recognized by ceph-fuse will be passed on to libfuse.
 
    Connect to specified monitor (instead of looking through ceph.conf).
 
-.. option:: -r root_directory
+.. option:: --client_mountpoint/-r root_directory
 
    Use root_directory as the mounted root, rather than the full Ceph tree.
 
+.. option:: -f
+
+   Foreground: do not daemonize after startup (run in foreground). Do not generate a pid file.
+
+.. option:: -s
+
+   Disable multi-threaded operation.
 
 Availability
 ============


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23084. 
generic_client_usage() options are avoided.

Signed-off-by: Jos Collin <jcollin@redhat.com>