### PR TITLE
osd/osd_types: kill preferred field in pg_t

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1414,7 +1414,7 @@ bool OSDMonitor::is_pool_currently_all_bluestore(int64_t pool_id,
   set<int> checked_osds;
   for (unsigned ps = 0; ps < std::min(8u, pool.get_pg_num()); ++ps) {
     vector<int> up, acting;
-    pg_t pgid(ps, pool_id, -1);
+    pg_t pgid(ps, pool_id);
     osdmap.pg_to_up_acting_osds(pgid, up, acting);
     for (int osd : up) {
       if (checked_osds.find(osd) != checked_osds.end())

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1023,15 +1023,15 @@ void PGMap::Incremental::generate_test_instances(list<PGMap::Incremental*>& o)
   o.back()->stamp = utime_t(123,345);
   o.push_back(new Incremental);
   o.back()->version = 2;
-  o.back()->pg_stat_updates[pg_t(1,2,3)] = pg_stat_t();
+  o.back()->pg_stat_updates[pg_t(1,2)] = pg_stat_t();
   o.back()->osd_stat_updates[5] = osd_stat_t();
   o.push_back(new Incremental);
   o.back()->version = 3;
   o.back()->osdmap_epoch = 1;
   o.back()->pg_scan = 2;
-  o.back()->pg_stat_updates[pg_t(4,5,6)] = pg_stat_t();
+  o.back()->pg_stat_updates[pg_t(4,5)] = pg_stat_t();
   o.back()->osd_stat_updates[6] = osd_stat_t();
-  o.back()->pg_remove.insert(pg_t(1,2,3));
+  o.back()->pg_remove.insert(pg_t(1,2));
   o.back()->osd_stat_rm.insert(5);
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3964,12 +3964,6 @@ void OSD::load_pgs()
       continue;
     }
 
-    if (pgid.preferred() >= 0) {
-      dout(10) << __func__ << ": skipping localized PG " << pgid << dendl;
-      // FIXME: delete it too, eventually
-      continue;
-    }
-
     dout(10) << "pgid " << pgid << " coll " << coll_t(pgid) << dendl;
     epoch_t map_epoch = 0;
     int r = PG::peek_map_epoch(store, pgid, &map_epoch);
@@ -8171,11 +8165,6 @@ void OSD::handle_pg_create(OpRequestRef op)
       continue;
     pg_t on = p->first;
 
-    if (on.preferred() >= 0) {
-      dout(20) << "ignoring localized pg " << on << dendl;
-      continue;
-    }
-
     if (!osdmap->have_pg_pool(on.pool())) {
       dout(20) << "ignoring pg on deleted pool " << on << dendl;
       continue;
@@ -8446,11 +8435,6 @@ void OSD::handle_pg_notify(OpRequestRef op)
   for (auto it = m->get_pg_list().begin();
        it != m->get_pg_list().end();
        ++it) {
-    if (it->first.info.pgid.preferred() >= 0) {
-      dout(20) << "ignoring localized pg " << it->first.info.pgid << dendl;
-      continue;
-    }
-
     handle_pg_peering_evt(
       spg_t(it->first.info.pgid.pgid, it->first.to),
       it->first.info.history, it->second,
@@ -8476,11 +8460,6 @@ void OSD::handle_pg_log(OpRequestRef op)
   int from = m->get_source().num();
   if (!require_same_or_newer_map(op, m->get_epoch(), false))
     return;
-
-  if (m->get_pgid().preferred() >= 0) {
-    dout(10) << "ignoring localized pg " << m->get_pgid() << dendl;
-    return;
-  }
 
   op->mark_started();
   handle_pg_peering_evt(
@@ -8511,11 +8490,6 @@ void OSD::handle_pg_info(OpRequestRef op)
   for (auto p = m->pg_list.begin();
        p != m->pg_list.end();
        ++p) {
-    if (p->first.info.pgid.preferred() >= 0) {
-      dout(10) << "ignoring localized pg " << p->first.info.pgid << dendl;
-      continue;
-    }
-
     handle_pg_peering_evt(
       spg_t(p->first.info.pgid.pgid, p->first.to),
       p->first.info.history, p->second, p->first.epoch_sent,
@@ -8542,11 +8516,6 @@ void OSD::handle_pg_trim(OpRequestRef op)
   int from = m->get_source().num();
   if (!require_same_or_newer_map(op, m->epoch, false))
     return;
-
-  if (m->pgid.preferred() >= 0) {
-    dout(10) << "ignoring localized pg " << m->pgid << dendl;
-    return;
-  }
 
   op->mark_started();
 
@@ -8717,11 +8686,6 @@ void OSD::handle_pg_query(OpRequestRef op)
        ++it) {
     spg_t pgid = it->first;
 
-    if (pgid.preferred() >= 0) {
-      dout(10) << "ignoring localized pg " << pgid << dendl;
-      continue;
-    }
-
     if (service.splitting(pgid)) {
       peering_wait_for_split[pgid].push_back(
 	PGPeeringEventRef(
@@ -8817,11 +8781,6 @@ void OSD::handle_pg_remove(OpRequestRef op)
        it != m->pg_list.end();
        ++it) {
     spg_t pgid = *it;
-    if (pgid.preferred() >= 0) {
-      dout(10) << "ignoring localized pg " << pgid << dendl;
-      continue;
-    }
-
     enqueue_peering_evt(
       pgid,
       PGPeeringEventRef(

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3731,7 +3731,7 @@ int OSDMap::summarize_mapping_stats(
     vector<int> up, up2;
     int up_primary;
     for (unsigned ps = 0; ps < pi->get_pg_num(); ++ps) {
-      pg_t pgid(ps, pool_id, -1);
+      pg_t pgid(ps, pool_id);
       total_pg += pi->get_size();
       pg_to_up_acting_osds(pgid, &up, &up_primary, nullptr, nullptr);
       for (int osd : up) {

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -412,26 +412,18 @@ void osd_stat_t::generate_test_instances(std::list<osd_stat_t*>& o)
 
 int pg_t::print(char *o, int maxlen) const
 {
-  if (preferred() >= 0)
-    return snprintf(o, maxlen, "%llu.%xp%d", (unsigned long long)pool(), ps(), preferred());
-  else
-    return snprintf(o, maxlen, "%llu.%x", (unsigned long long)pool(), ps());
+  return snprintf(o, maxlen, "%llu.%x", (unsigned long long)pool(), ps());
 }
 
 bool pg_t::parse(const char *s)
 {
   uint64_t ppool;
   uint32_t pseed;
-  int32_t pref;
-  int r = sscanf(s, "%llu.%xp%d", (long long unsigned *)&ppool, &pseed, &pref);
+  int r = sscanf(s, "%llu.%x", (long long unsigned *)&ppool, &pseed);
   if (r < 2)
     return false;
   m_pool = ppool;
   m_seed = pseed;
-  if (r == 3)
-    m_preferred = pref;
-  else
-    m_preferred = -1;
   return true;
 }
 
@@ -440,7 +432,6 @@ bool spg_t::parse(const char *s)
   shard = shard_id_t::NO_SHARD;
   uint64_t ppool;
   uint32_t pseed;
-  int32_t pref;
   uint32_t pshard;
   int r = sscanf(s, "%llu.%x", (long long unsigned *)&ppool, &pseed);
   if (r < 2)
@@ -448,13 +439,7 @@ bool spg_t::parse(const char *s)
   pgid.set_pool(ppool);
   pgid.set_ps(pseed);
 
-  const char *p = strchr(s, 'p');
-  if (p) {
-    // preferred PGs were removed years ago
-    return false;
-  }
-
-  p = strchr(s, 's');
+  const char *p = strchr(s, 's');
   if (p) {
     r = sscanf(p, "s%u", &pshard);
     if (r == 1) {
@@ -517,7 +502,7 @@ bool pg_t::is_split(unsigned old_pg_num, unsigned new_pg_num, set<pg_t> *childre
       if ((unsigned)ceph_stable_mod(s, old_pg_num, old_mask) == m_seed) {
 	split = true;
 	if (children)
-	  children->insert(pg_t(s, m_pool, m_preferred));
+	  children->insert(pg_t(s, m_pool));
       }
     }
   }
@@ -529,7 +514,7 @@ bool pg_t::is_split(unsigned old_pg_num, unsigned new_pg_num, set<pg_t> *childre
       unsigned o = ceph_stable_mod(x, old_pg_num, old_mask);
       if (o == m_seed) {
 	split = true;
-	children->insert(pg_t(x, m_pool, m_preferred));
+	children->insert(pg_t(x, m_pool));
       }
     }
   }
@@ -588,24 +573,20 @@ void pg_t::dump(Formatter *f) const
 {
   f->dump_unsigned("pool", m_pool);
   f->dump_unsigned("seed", m_seed);
-  f->dump_int("preferred_osd", m_preferred);
 }
 
 void pg_t::generate_test_instances(list<pg_t*>& o)
 {
   o.push_back(new pg_t);
-  o.push_back(new pg_t(1, 2, -1));
-  o.push_back(new pg_t(13123, 3, -1));
-  o.push_back(new pg_t(131223, 4, 23));
+  o.push_back(new pg_t(1, 2));
+  o.push_back(new pg_t(13123, 3));
+  o.push_back(new pg_t(131223, 4));
 }
 
 char *pg_t::calc_name(char *buf, const char *suffix_backwords) const
 {
   while (*suffix_backwords)
     *--buf = *suffix_backwords++;
-
-  if (m_preferred >= 0)
-    *--buf ='p';
 
   buf = ritoa<uint32_t, 16>(m_seed, buf);
 
@@ -2523,7 +2504,7 @@ void pg_stat_t::generate_test_instances(list<pg_stat_t*>& o)
   a.ondisk_log_start = eversion_t(1, 5);
   a.created = 6;
   a.last_epoch_clean = 7;
-  a.parent = pg_t(1, 2, 3);
+  a.parent = pg_t(1, 2);
   a.parent_split_bits = 12;
   a.last_scrub = eversion_t(9, 10);
   a.last_scrub_stamp = utime_t(11, 12);
@@ -2901,7 +2882,7 @@ void pg_info_t::generate_test_instances(list<pg_info_t*>& o)
   list<pg_history_t*> h;
   pg_history_t::generate_test_instances(h);
   o.back()->history = *h.back();
-  o.back()->pgid = spg_t(pg_t(1, 2, -1), shard_id_t::NO_SHARD);
+  o.back()->pgid = spg_t(pg_t(1, 2), shard_id_t::NO_SHARD);
   o.back()->last_update = eversion_t(3, 4);
   o.back()->last_complete = eversion_t(5, 6);
   o.back()->last_user_version = 2;
@@ -4522,7 +4503,7 @@ void pg_create_t::dump(Formatter *f) const
 void pg_create_t::generate_test_instances(list<pg_create_t*>& o)
 {
   o.push_back(new pg_create_t);
-  o.push_back(new pg_create_t(1, pg_t(3, 4, -1), 2));
+  o.push_back(new pg_create_t(1, pg_t(3, 4), 2));
 }
 
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -437,7 +437,6 @@ bool pg_t::parse(const char *s)
 
 bool spg_t::parse(const char *s)
 {
-  pgid.set_preferred(-1);
   shard = shard_id_t::NO_SHARD;
   uint64_t ppool;
   uint32_t pseed;
@@ -451,12 +450,8 @@ bool spg_t::parse(const char *s)
 
   const char *p = strchr(s, 'p');
   if (p) {
-    r = sscanf(p, "p%d", &pref);
-    if (r == 1) {
-      pgid.set_preferred(pref);
-    } else {
-      return false;
-    }
+    // preferred PGs were removed years ago
+    return false;
   }
 
   p = strchr(s, 's');

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -407,9 +407,6 @@ struct pg_t {
   void set_pool(uint64_t p) {
     m_pool = p;
   }
-  void set_preferred(int32_t osd) {
-    m_preferred = osd;
-  }
 
   pg_t get_parent() const;
   pg_t get_ancestor(unsigned old_pg_num) const;

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -514,7 +514,7 @@ class OSDStub : public TestStub
 	       << " epoch " << pool_epoch << dendl;
 
       for (ps_t ps = 0; ps < pool.get_pg_num(); ++ps) {
-	pg_t pgid(ps, pool_id, -1);
+	pg_t pgid(ps, pool_id);
 	pg_t parent;
 	dout(20) << __func__
 		 << " pgid " << pgid << " parent " << parent << dendl;

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -177,7 +177,7 @@ TEST_F(OSDMapTest, MapPG) {
   set_up_map();
 
   std::cerr << " osdmap.pool_max==" << osdmap.get_pool_max() << std::endl;
-  pg_t rawpg(0, my_rep_pool, -1);
+  pg_t rawpg(0, my_rep_pool);
   pg_t pgid = osdmap.raw_pg_to_pg(rawpg);
   vector<int> up_osds, acting_osds;
   int up_primary, acting_primary;
@@ -196,7 +196,7 @@ TEST_F(OSDMapTest, MapPG) {
 TEST_F(OSDMapTest, MapFunctionsMatch) {
   // TODO: make sure pg_to_up_acting_osds and pg_to_acting_osds match
   set_up_map();
-  pg_t rawpg(0, my_rep_pool, -1);
+  pg_t rawpg(0, my_rep_pool);
   pg_t pgid = osdmap.raw_pg_to_pg(rawpg);
   vector<int> up_osds, acting_osds;
   int up_primary, acting_primary;
@@ -224,7 +224,7 @@ TEST_F(OSDMapTest, MapFunctionsMatch) {
 TEST_F(OSDMapTest, PrimaryIsFirst) {
   set_up_map();
 
-  pg_t rawpg(0, my_rep_pool, -1);
+  pg_t rawpg(0, my_rep_pool);
   pg_t pgid = osdmap.raw_pg_to_pg(rawpg);
   vector<int> up_osds, acting_osds;
   int up_primary, acting_primary;
@@ -238,7 +238,7 @@ TEST_F(OSDMapTest, PrimaryIsFirst) {
 TEST_F(OSDMapTest, PGTempRespected) {
   set_up_map();
 
-  pg_t rawpg(0, my_rep_pool, -1);
+  pg_t rawpg(0, my_rep_pool);
   pg_t pgid = osdmap.raw_pg_to_pg(rawpg);
   vector<int> up_osds, acting_osds;
   int up_primary, acting_primary;
@@ -266,7 +266,7 @@ TEST_F(OSDMapTest, PGTempRespected) {
 TEST_F(OSDMapTest, PrimaryTempRespected) {
   set_up_map();
 
-  pg_t rawpg(0, my_rep_pool, -1);
+  pg_t rawpg(0, my_rep_pool);
   pg_t pgid = osdmap.raw_pg_to_pg(rawpg);
   vector<int> up_osds;
   vector<int> acting_osds;
@@ -326,7 +326,7 @@ TEST_F(OSDMapTest, CleanTemps) {
 TEST_F(OSDMapTest, KeepsNecessaryTemps) {
   set_up_map();
 
-  pg_t rawpg(0, my_rep_pool, -1);
+  pg_t rawpg(0, my_rep_pool);
   pg_t pgid = osdmap.raw_pg_to_pg(rawpg);
   vector<int> up_osds, acting_osds;
   int up_primary, acting_primary;

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -554,19 +554,19 @@ for (unsigned i = 0; i < 4; ++i) {
 
 TEST(pg_t, get_ancestor)
 {
-  ASSERT_EQ(pg_t(0, 0, -1), pg_t(16, 0, -1).get_ancestor(16));
-  ASSERT_EQ(pg_t(1, 0, -1), pg_t(17, 0, -1).get_ancestor(16));
-  ASSERT_EQ(pg_t(0, 0, -1), pg_t(16, 0, -1).get_ancestor(8));
-  ASSERT_EQ(pg_t(16, 0, -1), pg_t(16, 0, -1).get_ancestor(80));
-  ASSERT_EQ(pg_t(16, 0, -1), pg_t(16, 0, -1).get_ancestor(83));
-  ASSERT_EQ(pg_t(1, 0, -1), pg_t(1321, 0, -1).get_ancestor(123).get_ancestor(8));
-  ASSERT_EQ(pg_t(3, 0, -1), pg_t(1323, 0, -1).get_ancestor(123).get_ancestor(8));
-  ASSERT_EQ(pg_t(3, 0, -1), pg_t(1323, 0, -1).get_ancestor(8));
+  ASSERT_EQ(pg_t(0, 0), pg_t(16, 0).get_ancestor(16));
+  ASSERT_EQ(pg_t(1, 0), pg_t(17, 0).get_ancestor(16));
+  ASSERT_EQ(pg_t(0, 0), pg_t(16, 0).get_ancestor(8));
+  ASSERT_EQ(pg_t(16, 0), pg_t(16, 0).get_ancestor(80));
+  ASSERT_EQ(pg_t(16, 0), pg_t(16, 0).get_ancestor(83));
+  ASSERT_EQ(pg_t(1, 0), pg_t(1321, 0).get_ancestor(123).get_ancestor(8));
+  ASSERT_EQ(pg_t(3, 0), pg_t(1323, 0).get_ancestor(123).get_ancestor(8));
+  ASSERT_EQ(pg_t(3, 0), pg_t(1323, 0).get_ancestor(8));
 }
 
 TEST(pg_t, split)
 {
-  pg_t pgid(0, 0, -1);
+  pg_t pgid(0, 0);
   set<pg_t> s;
   bool b;
 
@@ -580,21 +580,21 @@ TEST(pg_t, split)
   b = pgid.is_split(2, 4, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(1u, s.size());
-  ASSERT_TRUE(s.count(pg_t(2, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(2, 0)));
 
   s.clear();
   b = pgid.is_split(2, 8, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(3u, s.size());
-  ASSERT_TRUE(s.count(pg_t(2, 0, -1)));
-  ASSERT_TRUE(s.count(pg_t(4, 0, -1)));
-  ASSERT_TRUE(s.count(pg_t(6, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(2, 0)));
+  ASSERT_TRUE(s.count(pg_t(4, 0)));
+  ASSERT_TRUE(s.count(pg_t(6, 0)));
 
   s.clear();
   b = pgid.is_split(3, 8, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(1u, s.size());
-  ASSERT_TRUE(s.count(pg_t(4, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(4, 0)));
 
   s.clear();
   b = pgid.is_split(6, 8, NULL);
@@ -603,68 +603,68 @@ TEST(pg_t, split)
   ASSERT_TRUE(!b);
   ASSERT_EQ(0u, s.size());
 
-  pgid = pg_t(1, 0, -1);
+  pgid = pg_t(1, 0);
 
   s.clear();
   b = pgid.is_split(2, 4, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(1u, s.size());
-  ASSERT_TRUE(s.count(pg_t(3, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(3, 0)));
 
   s.clear();
   b = pgid.is_split(2, 6, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(2u, s.size());
-  ASSERT_TRUE(s.count(pg_t(3, 0, -1)));
-  ASSERT_TRUE(s.count(pg_t(5, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(3, 0)));
+  ASSERT_TRUE(s.count(pg_t(5, 0)));
 
   s.clear();
   b = pgid.is_split(2, 8, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(3u, s.size());
-  ASSERT_TRUE(s.count(pg_t(3, 0, -1)));
-  ASSERT_TRUE(s.count(pg_t(5, 0, -1)));
-  ASSERT_TRUE(s.count(pg_t(7, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(3, 0)));
+  ASSERT_TRUE(s.count(pg_t(5, 0)));
+  ASSERT_TRUE(s.count(pg_t(7, 0)));
 
   s.clear();
   b = pgid.is_split(4, 8, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(1u, s.size());
-  ASSERT_TRUE(s.count(pg_t(5, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(5, 0)));
 
   s.clear();
   b = pgid.is_split(3, 8, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(3u, s.size());
-  ASSERT_TRUE(s.count(pg_t(3, 0, -1)));
-  ASSERT_TRUE(s.count(pg_t(5, 0, -1)));
-  ASSERT_TRUE(s.count(pg_t(7, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(3, 0)));
+  ASSERT_TRUE(s.count(pg_t(5, 0)));
+  ASSERT_TRUE(s.count(pg_t(7, 0)));
 
   s.clear();
   b = pgid.is_split(6, 8, &s);
   ASSERT_TRUE(!b);
   ASSERT_EQ(0u, s.size());
 
-  pgid = pg_t(3, 0, -1);
+  pgid = pg_t(3, 0);
 
   s.clear();
   b = pgid.is_split(7, 8, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(1u, s.size());
-  ASSERT_TRUE(s.count(pg_t(7, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(7, 0)));
 
   s.clear();
   b = pgid.is_split(7, 12, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(2u, s.size());
-  ASSERT_TRUE(s.count(pg_t(7, 0, -1)));
-  ASSERT_TRUE(s.count(pg_t(11, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(7, 0)));
+  ASSERT_TRUE(s.count(pg_t(11, 0)));
 
   s.clear();
   b = pgid.is_split(7, 11, &s);
   ASSERT_TRUE(b);
   ASSERT_EQ(1u, s.size());
-  ASSERT_TRUE(s.count(pg_t(7, 0, -1)));
+  ASSERT_TRUE(s.count(pg_t(7, 0)));
 
 }
 

--- a/src/test/test_snap_mapper.cc
+++ b/src/test/test_snap_mapper.cc
@@ -606,7 +606,7 @@ protected:
   void init(uint32_t to_set) {
     pgnum = to_set;
     for (uint32_t i = 0; i < pgnum; ++i) {
-      pg_t pgid(i, 0, -1);
+      pg_t pgid(i, 0);
       mappers[pgid].reset(
 	new MapperVerifier(
 	  driver.get(),

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -605,7 +605,7 @@ int main(int argc, const char **argv)
 	   ++p) {
 	const pg_pool_t *pool = osdmap.get_pg_pool(p->first);
 	for (ps_t ps = 0; ps < pool->get_pg_num(); ps++) {
-	  pg_t pgid(ps, p->first, -1);
+	  pg_t pgid(ps, p->first);
 	  for (int i=0; i<100; i++) {
 	    cout << pgid << " attempt " << i << std::endl;
 


### PR DESCRIPTION
This was been unused (always -1) for many years.