### PR TITLE
common: Reorganize includes and template for FreeBSD

### DIFF
--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -11,11 +11,11 @@
  * Foundation.  See file COPYING.
  *
  */
-#include "lockdep.h"
-#include "common/dout.h"
-#include "common/valgrind.h"
 
 #if defined(__FreeBSD__) && defined(__LP64__)	// On FreeBSD pthread_t is a pointer.
+#include <pthread.h>
+#include <functional>
+
 namespace std {
   template<>
     struct hash<pthread_t>
@@ -26,6 +26,10 @@ namespace std {
     };
 } // namespace std
 #endif
+
+#include "lockdep.h"
+#include "common/dout.h"
+#include "common/valgrind.h"
 
 /******* Constants **********/
 #define lockdep_dout(v) lsubdout(g_lockdep_ceph_ctx, lockdep, v)


### PR DESCRIPTION
Obviously somewhere in the includes there is already an instantiation
for a conflicting type in the template:
```
/home/jenkins/workspace/ceph-master/src/common/lockdep.cc:21:12: error:
explicit specialization of 'std::__1::hash<pthread *>' after instantiation
   struct hash<pthread_t>
          ^~~~~~~~~~~~~~~
/usr/include/c++/v1/thread:269:16: note: implicit instantiation first
required here
       return hash<__libcpp_thread_id>()(__v.__id_);
              ^
```
And reshuffling fixes this. Could perhaps be fixed in the includes but
better not wait for that.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>