### PR TITLE
common/lockdep: drop hash<pthread_t> specialization

### DIFF
--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -15,18 +15,6 @@
 #include "common/dout.h"
 #include "common/valgrind.h"
 
-#if defined(__FreeBSD__) && defined(__LP64__)	// On FreeBSD pthread_t is a pointer.
-namespace std {
-  template<>
-    struct hash<pthread_t>
-    {
-      size_t
-      operator()(pthread_t __x) const
-      { return (uintptr_t)__x; }
-    };
-} // namespace std
-#endif
-
 /******* Constants **********/
 #define lockdep_dout(v) lsubdout(g_lockdep_ceph_ctx, lockdep, v)
 #define MAX_LOCKS  4096   // increase me as needed


### PR DESCRIPTION
quote from http://en.cppreference.com/w/cpp/utility/hash:

> Each standard library header that declares the template std::hash
> provides enabled specializations of std::hash for std::nullptr
> and all cv-unqualified arithmetic types (including any extended
> integer types), all enumeration types, and all pointer types.

since we've switched to C++17. this full specialization is not necessary
anymore.

Signed-off-by: Kefu Chai <kchai@redhat.com>