### PR TITLE
mds: set journaler iohint correctly when mds daemon going to active

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1812,11 +1812,11 @@ void MDSRankDispatcher::handle_mds_map(
 	found = true;
 	break;
       }
-      if (found)
-	mdlog->set_write_iohint(0);
-      else
-	mdlog->set_write_iohint(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
     }
+    if (found)
+      mdlog->set_write_iohint(0);
+    else
+      mdlog->set_write_iohint(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);
   }
 
   if (oldmap->get_max_mds() != mdsmap->get_max_mds()) {


### PR DESCRIPTION
Although Journaler::write_iohint is not used or fully implemented by design, the set function here should be called outside the for loop, right?

Signed-off-by: Song Xinying <songxinying.ftd@gmail.com>