### PR TITLE
doc: Fix EC k=3 m=2 profile overhead calculation example.

### DIFF
--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -47,7 +47,7 @@ to be created and all objects from the previous pool moved to the new.
 The most important parameters of the profile are *K*, *M* and
 *crush-failure-domain* because they define the storage overhead and
 the data durability. For instance, if the desired architecture must
-sustain the loss of two racks with a storage overhead of 40% overhead,
+sustain the loss of two racks with a storage overhead of 67% overhead,
 the following profile can be defined::
 
     $ ceph osd erasure-code-profile set myprofile \


### PR DESCRIPTION
The EC k=3 m=2 profile overhead example should be 67%.

Signed-off-by: Charles Alva <charlesalva@gmail.com>