### PR TITLE
cephfs-journal-tool: add event time output

### DIFF
--- a/src/tools/cephfs/EventOutput.cc
+++ b/src/tools/cephfs/EventOutput.cc
@@ -98,7 +98,7 @@ void EventOutput::list() const
       detail = eu->type;
     }
 
-    std::cout << "0x"
+    std::cout <<i->second.log_event->get_stamp() << " 0x"
       << std::hex << i->first << std::dec << " "
       << i->second.log_event->get_type_str() << ": "
       << " (" << detail << ")" << std::endl;


### PR DESCRIPTION
add event timestamp for tool output is useful, such as analyze the damaged mds journal
cephfs-journal-tool event get list
0x400000 SUBTREEMAP: ()
cephfs-journal-tool event get list
2018-02-07 12:37:02.417835 0x400000 SUBTREEMAP: ()

Fixes: http://tracker.ceph.com/issues/23116
cephfs-journal-tool: output a hidden fileds journal event time
Signed-off-by: "Wang,Yong" wang.yong@datatom.com