### PR TITLE
luminous: rgw: parse old rgw_obj with namespace correctly

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2046,7 +2046,7 @@ struct rgw_obj {
           if (pos < 0) {
             throw buffer::error();
           }
-          key.name = key.name.substr(pos);
+          key.name = key.name.substr(pos + 1);
         }
       }
     } else {


### PR DESCRIPTION
http://tracker.ceph.com/issues/23102