### PR TITLE
msg/async/Stack: change the type of EventMaxWaitUs from uint64_t to int

### DIFF
--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -41,7 +41,7 @@ std::function<void ()> NetworkStack::add_thread(unsigned i)
       char tp_name[16];
       sprintf(tp_name, "msgr-worker-%u", w->id);
       ceph_pthread_setname(pthread_self(), tp_name);
-      const uint64_t EventMaxWaitUs = 30000000;
+      const int EventMaxWaitUs = 30000000;
       w->center.set_owner();
       ldout(cct, 10) << __func__ << " starting" << dendl;
       w->initialize();


### PR DESCRIPTION
in the function of "EventCenter::process_events(int timeout_microseconds)",the type of incoming parameter is int, so change the type of EventMaxWaitUs  from uint64_t to int