### PR TITLE
rgw: guard against racing writes head object from null version to ver…

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -10889,6 +10889,11 @@ int RGWRados::olh_init_modification_impl(const RGWBucketInfo& bucket_info, RGWOb
   }
 
   if (!has_tag) {
+    if (state.exists) {
+      /* guard against racing writes head object from null version to version */
+      op.cmpxattr(RGW_ATTR_ID_TAG, LIBRADOS_CMPXATTR_OP_EQ, state.obj_tag);
+    }
+
     /* obj tag */
     string obj_tag;
     gen_rand_alphanumeric_lower(cct, &obj_tag, 32);


### PR DESCRIPTION
…sion

normal head object have obj_tag only, after turn on bucket versioning,
it will add a new olh_tag, which is same with olh_key in bucket index.
if we are racing writes, we may get different olh_tag in head object and
olh_key, lead to write failure.

Signed-off-by: Tianshan Qu <tianshan@xsky.com>