### PR TITLE
ceph-volume: add ANSIBLE_SSH_RETRIES=5 to functional tests

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -12,6 +12,7 @@ setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
   ANSIBLE_STDOUT_CALLBACK = debug
   ANSIBLE_RETRY_FILES_ENABLED = False
+  ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
 deps=

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -13,6 +13,7 @@ setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
   ANSIBLE_STDOUT_CALLBACK = debug
   ANSIBLE_RETRY_FILES_ENABLED = False
+  ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
 deps=


### PR DESCRIPTION
Occasionally we get tests that fail because a test node becomes
'unreachable'. This should avoid those ssh connection issues we see sometimes
by increasing the amount of times ansible will try to reconnect to a node
after an ssh failure.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>