### PR TITLE
luminous: ceph-volume: add ANSIBLE_SSH_RETRIES=5 to functional tests

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -12,6 +12,7 @@ setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
   ANSIBLE_STDOUT_CALLBACK = debug
   ANSIBLE_RETRY_FILES_ENABLED = False
+  ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
 deps=

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -13,6 +13,7 @@ setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
   ANSIBLE_STDOUT_CALLBACK = debug
   ANSIBLE_RETRY_FILES_ENABLED = False
+  ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
 deps=


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/20592