### PR TITLE
rbd-fuse: look for ceph.conf in standard locations

### DIFF
--- a/src/rbd_fuse/CMakeLists.txt
+++ b/src/rbd_fuse/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(rbd-fuse
   rbd-fuse.cc)
 target_link_libraries(rbd-fuse
-  ceph-common librbd librados ${FUSE_LIBRARIES})
+  ceph-common librbd librados global ${FUSE_LIBRARIES})
 install(TARGETS rbd-fuse DESTINATION bin)


### PR DESCRIPTION
When ceph.conf is absent in /etc/ceph/ and it is not being passed as an
argument, look at the environment variable $CEPH_CONF, and in ~/.ceph/,
current working directory to find one. If all these are present, unlike
now, do report it to the user.

Signed-off-by: Rishabh Dave <ridave@redhat.com>