### PR TITLE
qa/workunits/rbd: switch devstack tempest to 17.2.0 tag

### DIFF
--- a/qa/workunits/rbd/run_devstack_tempest.sh
+++ b/qa/workunits/rbd/run_devstack_tempest.sh
@@ -2,6 +2,7 @@
 set -ex
 
 STACK_BRANCH=stable/pike
+TEMPEST_BRANCH=17.2.0
 
 STACK_USER=${STACK_USER:-stack}
 STACK_GROUP=${STACK_GROUP:-stack}
@@ -104,6 +105,7 @@ sed -i 's/appdirs===1.4.0/appdirs===1.4.3/' requirements/upper-constraints.txt
 cd devstack
 cp ${STACK_HOME_PATH}/local.conf .
 
+export TEMPEST_BRANCH=${TEMPEST_BRANCH}
 export PYTHONUNBUFFERED=true
 export PROJECTS="openstack/devstack-plugin-ceph openstack/devstack-plugin-mariadb"
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22961
Signed-off-by: Jason Dillaman <dillaman@redhat.com>