### PR TITLE
msg/async:fix the incoming parameter type of EventCenter::process_events()

### DIFF
--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -357,7 +357,7 @@ int EventCenter::process_time_events()
   return processed;
 }
 
-int EventCenter::process_events(int timeout_microseconds,  ceph::timespan *working_dur)
+int EventCenter::process_events(unsigned timeout_microseconds,  ceph::timespan *working_dur)
 {
   struct timeval tv;
   int numevents;

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -203,7 +203,7 @@ class EventCenter {
   uint64_t create_time_event(uint64_t milliseconds, EventCallbackRef ctxt);
   void delete_file_event(int fd, int mask);
   void delete_time_event(uint64_t id);
-  int process_events(int timeout_microseconds, ceph::timespan *working_dur = nullptr);
+  int process_events(unsigned timeout_microseconds, ceph::timespan *working_dur = nullptr);
   void wakeup();
 
   // Used by external thread

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -41,7 +41,7 @@ std::function<void ()> NetworkStack::add_thread(unsigned i)
       char tp_name[16];
       sprintf(tp_name, "msgr-worker-%u", w->id);
       ceph_pthread_setname(pthread_self(), tp_name);
-      const uint64_t EventMaxWaitUs = 30000000;
+      const unsigned EventMaxWaitUs = 30000000;
       w->center.set_owner();
       ldout(cct, 10) << __func__ << " starting" << dendl;
       w->initialize();


### PR DESCRIPTION
In the function of "EventCenter::process_events(int timeout_microseconds)",the type of incoming parameter is int, so change the type of EventMaxWaitUs  from uint64_t to int.

Signed-off-by: shangfufei <shangfufei@inspur.com>