### PR TITLE
rbd: allow remove all unprotected snapshots

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -510,7 +510,7 @@ Commands
   This requires image format 2.
 
 :command:`snap purge` *image-spec*
-  Remove all snapshots from an image.
+  Remove all unprotected snapshots from an image.
 
 :command:`snap rename` *src-snap-spec* *dest-snap-spec*
   Rename a snapshot. Note: rename across pools and images is not supported.

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -93,7 +93,7 @@
       snap limit set                      Limit the number of snapshots.
       snap list (snap ls)                 Dump list of image snapshots.
       snap protect                        Prevent a snapshot from being deleted.
-      snap purge                          Delete all snapshots.
+      snap purge                          Delete all unprotected snapshots.
       snap remove (snap rm)               Delete a snapshot.
       snap rename                         Rename a snapshot.
       snap rollback (snap revert)         Rollback image to snapshot.
@@ -1480,7 +1480,7 @@
                         [--image-id <image-id>] [--no-progress] 
                         <image-spec> 
   
-  Delete all snapshots.
+  Delete all unprotected snapshots.
   
   Positional arguments
     <image-spec>         image specification


### PR DESCRIPTION
allow remove all unprotected snapshots when exiting
protected snapshots in the same image.
Fixes: http://tracker.ceph.com/issues/23126

Signed-off-by: songweibin <song.weibin@zte.com.cn>