### PR TITLE
rgw: create sync-module instance when radosgw-admin sync run

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6480,17 +6480,9 @@ next:
       return EINVAL;
     }
 
-    RGWSyncModuleInstanceRef sync_module;
-    int ret = store->get_sync_modules_manager()->create_instance(g_ceph_context, store->get_zone().tier_type, 
-        store->get_zone_params().tier_config, &sync_module);
-    if (ret < 0) {
-      lderr(cct) << "ERROR: failed to init sync module instance, ret=" << ret << dendl;
-      return ret;
-    }
+    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone);
 
-    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone, sync_module);
-
-    ret = sync.init();
+    int ret = sync.init();
     if (ret < 0) {
       cerr << "ERROR: sync.init() returned ret=" << ret << std::endl;
       return -ret;
@@ -6508,9 +6500,18 @@ next:
       cerr << "ERROR: source zone not specified" << std::endl;
       return EINVAL;
     }
-    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone);
 
-    int ret = sync.init();
+    RGWSyncModuleInstanceRef sync_module;
+    int ret = store->get_sync_modules_manager()->create_instance(g_ceph_context, store->get_zone().tier_type, 
+        store->get_zone_params().tier_config, &sync_module);
+    if (ret < 0) {
+      lderr(cct) << "ERROR: failed to init sync module instance, ret=" << ret << dendl;
+      return ret;
+    }
+
+    RGWDataSyncStatusManager sync(store, store->get_async_rados(), source_zone, sync_module);
+
+    ret = sync.init();
     if (ret < 0) {
       cerr << "ERROR: sync.init() returned ret=" << ret << std::endl;
       return -ret;


### PR DESCRIPTION
By my mistake on #18898, the related logic have been add in radosgw-admin data sync init, but the right place should be data sync run, so I put this PR to modify it. 
Sorry for my mistake, would you please take a look? @cbodley 
Signed-off-by: lvshanchun <lvshanchun@gmail.com>