### PR TITLE
rgw: download object might fail for local invariable uninitialized

### DIFF
--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -79,7 +79,7 @@ int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len
   bufferlist out_bl, in_bl, temp_in_bl;
   bl.copy(bl_ofs, bl_len, temp_in_bl); 
   bl_ofs = 0;
-  int r;
+  int r = 0;
   if (waiting.length() != 0) {
     in_bl.append(waiting);
     in_bl.append(temp_in_bl);        


### PR DESCRIPTION
@cbodley @aclamk  sorry, there was an omission in #20226 , codes may reach `return r;` with `r` uninitialized
