### PR TITLE
rbd-fuse: for "-c" option relative paths too should work

### DIFF
--- a/src/rbd_fuse/rbd-fuse.cc
+++ b/src/rbd_fuse/rbd-fuse.cc
@@ -816,7 +816,14 @@ static int rbdfs_opt_proc(void *data, const char *arg, int key,
 			free(rbd_options.ceph_config);
 			rbd_options.ceph_config = NULL;
 		}
-		rbd_options.ceph_config = strdup(arg+2);
+
+		char *ceph_conf = realpath(arg + 2, ceph_conf);
+		if (access(ceph_conf, R_OK) != 0) {
+			printf("Can't access the provided ceph.conf.");
+			exit(1);
+		}
+
+		rbd_options.ceph_config = ceph_conf;
 		return 0;
 	}
 


### PR DESCRIPTION
Currently, "-c" option works only if the supplied argument is an
absolute path -- relative paths are silently ignored. When a relative
path is received, check if it is accessible and then use the
corresponding absolute path.

Signed-off-by: Rishabh Dave <ridave@redhat.com>