### PR TITLE
luminous: cmake: rbd resource agent needs to be executable.

### DIFF
--- a/src/ocf/CMakeLists.txt
+++ b/src/ocf/CMakeLists.txt
@@ -7,4 +7,4 @@ set(ocf_dir ${CMAKE_INSTALL_PREFIX}/lib/ocf)
 set(ra_dir ${ocf_dir}/resource.d/${PROJECT_NAME})
 
 configure_file(rbd.in rbd @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/rbd DESTINATION ${ra_dir})
+install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/rbd DESTINATION ${ra_dir})


### PR DESCRIPTION
Without this the resource fails in Pacemaker with the error:

Feb 11 12:48:30 mypacemakerhost crmd[5154]:    error: Failed to retrieve meta-data for ocf:ceph:rbd
Feb 11 12:48:30 mypacemakerhost crmd[5154]:   notice: Operation p_rbd_myres_monitor_0: insufficient privileges (node=mypacemakerhost, call=228, rc=4, cib-update=60, confirmed=true)

This worked fine in the jewel version of the package, but is broken in
the luminous one, presumably because of the build changes.

Fixes: http://tracker.ceph.com/issues/22980
Signed-off-by: Tim Bishop <tim@bishnet.net>
(cherry picked from commit 567d15682ecaf873cf40d41ee8eaad28d6e59fa8)