### PR TITLE
rgw: don't hold data_lock over frontend io

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -10663,9 +10663,7 @@ int RGWRados::get_obj_iterate_cb(RGWObjectCtx *ctx, RGWObjState *astate,
         obj_ofs < astate->data.length()) {
       unsigned chunk_len = std::min((uint64_t)astate->data.length() - obj_ofs, (uint64_t)len);
 
-      d->data_lock.Lock();
       r = d->client_cb->handle_data(astate->data, obj_ofs, chunk_len);
-      d->data_lock.Unlock();
       if (r < 0)
         return r;
 


### PR DESCRIPTION
get_obj_data::data_lock protects access to the read_list, which the
librados finisher thread appends to on completions

locking isn't needed over calls to d->client_cb->handle_data() in
get_obj_iterate_cb(), because this callback is called synchronously
from the frontend/process_request() thread - no other thread will
be submitting io to the d->client_cb callback