### PR TITLE
[DNM] rgw: intrusive ldap authentication cache

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -52,3 +52,6 @@
 [submodule "src/rapidjson"]
 	path = src/rapidjson
 	url = https://github.com/ceph/rapidjson
+[submodule "src/blake2"]
+	path = src/blake2
+	url = https://github.com/BLAKE2/BLAKE2.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -534,6 +534,8 @@ set(libcommon_files
   common/util.cc
   librbd/Features.cc
   arch/probe.cc
+  blake2/sse/blake2b.c
+  blake2/sse/blake2bp.c
   ${auth_files}
   ${mds_files})
 
@@ -612,6 +614,8 @@ else()
 endif()
 
 add_library(common-objs OBJECT ${libcommon_files})
+target_include_directories(common-objs PRIVATE
+  "${PROJECT_SOURCE_DIR}/src/blake2/sse")
 set(ceph_common_objs
   $<TARGET_OBJECTS:common_buffer_obj>
   $<TARGET_OBJECTS:common_texttable_obj>

--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -13,6 +13,8 @@
 #ifndef COHORT_LRU_H
 #define COHORT_LRU_H
 
+#include <atomic>
+#include <functional>
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/slist.hpp>
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4923,6 +4923,33 @@ std::vector<Option> get_rgw_options() {
     .set_default(false)
     .set_description("Should S3 authentication use LDAP."),
 
+    Option("rgw_ldap_cache_enabled", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("Enable LDAP auth cache.")
+    .set_long_description(
+      "If enabled, positive and negative auth attempts with given credentials will be cached for rgw_ldap_cache_ttl_s seconds"),
+
+    Option("rgw_ldap_cache_ttl_s", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(300)
+    .set_description("Positive and negative auth cache TTL"),
+
+    Option("rgw_ldap_lru_lanes", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(5)
+    .set_description(""),
+
+    Option("rgw_ldap_lane_hiwat", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(911)
+    .set_description(""),
+
+    Option("rgw_ldap_cache_partitions", Option::TYPE_INT,
+	   Option::LEVEL_ADVANCED)
+    .set_default(3)
+    .set_description(""),
+
+    Option("rgw_ldap_cache_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(1579)
+    .set_description(""),
+
     Option("rgw_ldap_searchfilter", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description("LDAP search filter."),

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -517,16 +517,31 @@ namespace rgw {
     if (r)
       return -EIO;
 
-    const string& ldap_uri = store->ctx()->_conf->rgw_ldap_uri;
-    const string& ldap_binddn = store->ctx()->_conf->rgw_ldap_binddn;
-    const string& ldap_searchdn = store->ctx()->_conf->rgw_ldap_searchdn;
-    const string& ldap_searchfilter = store->ctx()->_conf->rgw_ldap_searchfilter;
-    const string& ldap_dnattr =
-      store->ctx()->_conf->rgw_ldap_dnattr;
+    auto& conf = store->ctx()->_conf;
+    const string& ldap_uri = conf->rgw_ldap_uri;
+    const string& ldap_binddn = conf->rgw_ldap_binddn;
+    const string& ldap_searchdn = conf->rgw_ldap_searchdn;
+    const string& ldap_searchfilter = conf->rgw_ldap_searchfilter;
+    const string& ldap_dnattr = conf->rgw_ldap_dnattr;    
+    const auto enable_cache =
+      conf->get_val<bool>("rgw_ldap_cache_enabled");
+    const auto cache_ttl =
+      conf->get_val<uint64_t>("rgw_ldap_cache_ttl_s");
+    const auto lru_lanes =
+      conf->get_val<uint64_t>("rgw_ldap_lru_lanes");
+    const auto lru_hiwat =
+      conf->get_val<uint64_t>("rgw_ldap_lru_hiwat");
+    const auto cache_npart =
+      conf->get_val<uint64_t>("rgw_ldap_cache_partitions");
+    const auto part_size =
+      conf->get_val<uint64_t>("rgw_ldap_cache_size");
+
     std::string ldap_bindpw = parse_rgw_ldap_bindpw(store->ctx());
 
     ldh = new rgw::LDAPHelper(ldap_uri, ldap_binddn, ldap_bindpw.c_str(),
-			      ldap_searchdn, ldap_searchfilter, ldap_dnattr);
+			      ldap_searchdn, ldap_searchfilter, ldap_dnattr,
+			      enable_cache, cache_ttl, lru_lanes, lru_hiwat,
+			      cache_npart, part_size);
     ldh->init();
     ldh->bind();
 

--- a/src/rgw/rgw_ldap.h
+++ b/src/rgw/rgw_ldap.h
@@ -17,11 +17,197 @@
 #include <string>
 #include <iostream>
 #include <mutex>
+#include <condition_variable>
+#include "xxhash.h"
+#include "common/ceph_time.h"
+#include <boost/intrusive/avl_set.hpp>
+#include "common/cohort_lru.h"
+#include "blake2/sse/blake2.h"
 
 namespace rgw {
 
 #if defined(HAVE_OPENLDAP)
 
+  namespace bi = boost::intrusive;
+
+  class LDAPHelper;
+
+  namespace ldap {
+
+    struct CKey
+    {
+      uint64_t hk; // 1st 8 bytes of the hmac, only used as part selector
+      std::string name; // tracing and convenience only
+      std::string hmac;
+
+      static constexpr uint64_t seed = 1701;
+
+      void hash(const std::string& pwd) {
+	blake2bp_state s;
+	(void) blake2bp_init(&s, BLAKE2B_OUTBYTES /* 64 */);
+	blake2bp_update(&s, name.c_str(), name.length());
+	blake2bp_update(&s, pwd.c_str(), pwd.length());
+	hmac.resize(BLAKE2B_OUTBYTES);
+	blake2bp_final(&s, hmac.data(), BLAKE2B_OUTBYTES);
+	hk = *(reinterpret_cast<const uint64_t*>(hmac.c_str()));
+      }
+
+      CKey(const std::string& _name, const std::string& _pwd)
+	: name(_name) {
+	hash(_pwd);
+      }
+
+      CKey(std::string&& _name, std::string&& _pwd)
+	: name(_name) {
+	hash(_pwd);
+      }
+    };
+
+    inline bool operator< (const CKey& lhs, const CKey& rhs)
+    {
+      return ((lhs.hk < rhs.hk) ||
+	      ((lhs.hk == rhs.hk) &&
+	       (lhs.hmac < rhs.hmac)));
+    }
+
+    inline bool operator> (const CKey& lhs, const CKey& rhs)
+    {
+      return rhs < lhs;
+    }
+
+    inline bool operator<=(const CKey& lhs, const CKey& rhs)
+    {
+      return !(lhs > rhs);
+    }
+
+    inline bool operator>=(const CKey& lhs, const CKey& rhs)
+    {
+      return !(lhs < rhs);
+    }
+
+    inline bool operator==(const CKey& lhs, const CKey& rhs)
+    {
+      return ((lhs.hk == rhs.hk) &&
+	      (lhs.hmac == rhs.hmac));
+    }
+
+    enum class AuthResult
+    {
+      AUTH_SUCCESS = 0,
+      AUTH_FAIL,
+      AUTH_EXPIRED,
+      AUTH_INIT
+    };
+
+    struct Cred : public cohort::lru::Object
+    {
+      CKey key;
+      AuthResult result;
+      LDAPHelper* ldh;
+
+      std::mutex mtx;
+      std::condition_variable cv;
+      uint32_t waiters;
+
+      ceph::coarse_mono_time time_added;
+
+      using lock_guard = std::lock_guard<std::mutex>;
+      using unique_lock = std::unique_lock<std::mutex>;
+      using LRU = cohort::lru::LRU<std::mutex>;
+
+      Cred(const CKey& k, LDAPHelper* _ldh)
+	: key(k), result(AuthResult::AUTH_INIT), ldh(_ldh), waiters(0),
+	  time_added(ceph::coarse_mono_clock::now())
+	{}
+
+      ~Cred() {}
+
+      void reset() {
+	result = AuthResult::AUTH_INIT;
+	time_added = ceph::coarse_mono_clock::now();
+      }
+
+      AuthResult auth_result();
+
+      void cond_notify() {
+	unique_lock uniq(mtx);
+	if (unlikely(waiters > 0)) {
+	  cv.notify_all();
+	}
+      }
+
+      bool reclaim() override;
+
+      struct LT
+      {
+	// for internal ordering
+	bool operator()(const Cred& lhs,
+			const Cred& rhs) const
+	  { return (lhs.key < rhs.key); }
+
+	// for external search by CKey
+	bool operator()(const CKey& k, const Cred& rhs) const
+	  { return k < rhs.key; }
+
+	bool operator()(const Cred& lhs, const CKey& k) const
+	  { return lhs.key < k; }
+      };
+
+      struct EQ
+      {
+	bool operator()(const Cred& lhs,
+			const Cred& rhs) const
+	  { return (lhs.key == rhs.key); }
+
+	bool operator()(const CKey& k, const Cred& rhs) const
+	  { return k == rhs.key; }
+
+	bool operator()(const Cred& lhs, const CKey& k) const
+	  { return lhs.key == k; }
+      };
+
+      typedef bi::link_mode<bi::safe_link> link_mode; /* XXX safe_link */
+      typedef bi::avl_set_member_hook<link_mode> tree_hook_type;
+
+      tree_hook_type cache_hook;
+
+      typedef bi::member_hook<
+	Cred, tree_hook_type, &Cred::cache_hook> CacheHook;
+
+      typedef bi::avltree<Cred, bi::compare<LT>, CacheHook> CacheAVL;
+
+      typedef cohort::lru::TreeX<Cred, CacheAVL, LT, EQ, CKey,
+				 std::mutex> Cache;
+
+      class Factory : public cohort::lru::ObjectFactory
+      {
+      public:
+	const CKey& k;
+	LDAPHelper* ldh;
+	uint32_t flags;
+
+	Factory() = delete;
+
+	Factory(const CKey& _k, LDAPHelper* _ldh)
+	  : k(_k), ldh(_ldh)
+	  {}
+
+	void recycle (cohort::lru::Object* o) override {
+	  /* re-use an existing object */
+	  o->~Object(); // call lru::Object virtual dtor
+	  // placement new!
+	  new (o) Cred(k, ldh);
+	}
+
+	cohort::lru::Object* alloc() override {
+	  return new Cred(k, ldh);
+	}
+      }; /* Factory */
+      
+    }; /* ldap::Cred */
+
+  } /* namespace ldap */
+  
   class LDAPHelper
   {
     std::string uri;
@@ -34,14 +220,29 @@ namespace rgw {
     bool msad = false; /* TODO: possible future specialization */
     std::mutex mtx;
 
+    bool enable_cache;
+    ceph::timespan ttl_s;
+    ldap::Cred::LRU lru;
+    ldap::Cred::Cache cache;
+
+    friend class ldap::Cred;
+
   public:
     using lock_guard = std::lock_guard<std::mutex>;
 
     LDAPHelper(std::string _uri, std::string _binddn, std::string _bindpw,
-	       std::string _searchdn, std::string _searchfilter, std::string _dnattr)
+	       std::string _searchdn, std::string _searchfilter,
+	       std::string _dnattr,
+	       bool enable_cache, uint32_t ttl_s,
+	       uint64_t lru_nlanes, uint64_t lru_hiwat,
+      	       uint64_t cache_npart, uint64_t cache_sz)
       : uri(std::move(_uri)), binddn(std::move(_binddn)),
-	bindpw(std::move(_bindpw)), searchdn(_searchdn), searchfilter(_searchfilter), dnattr(_dnattr),
-	ldap(nullptr) {
+	bindpw(std::move(_bindpw)), searchdn(_searchdn),
+	searchfilter(_searchfilter), dnattr(_dnattr),
+	ldap(nullptr),
+	enable_cache(enable_cache), ttl_s(ttl_s), lru(lru_nlanes, lru_hiwat),
+	cache(cache_npart, cache_sz)
+      {
       // nothing
     }
 
@@ -98,6 +299,9 @@ namespace rgw {
 	(void) ldap_unbind(ldap);
     }
 
+  private:
+    int _auth(const std::string& uid, const std::string& pwd);
+
   }; /* LDAPHelper */
 
 #else
@@ -106,7 +310,8 @@ namespace rgw {
   {
   public:
     LDAPHelper(std::string _uri, std::string _binddn, std::string _bindpw,
-	       std::string _searchdn, std::string _searchfilter, std::string _dnattr)
+	       std::string _searchdn, std::string _searchfilter,
+	       std::string _dnattr)
       {}
 
     int init() {
@@ -115,6 +320,10 @@ namespace rgw {
 
     int bind() {
       return -ENOTSUP;
+    }
+
+    int _auth(const std::string& uid, const std::string& pwd) {
+      return -EACCES;
     }
 
     int auth(const std::string uid, const std::string pwd) {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4037,15 +4037,31 @@ void rgw::auth::s3::LDAPEngine::init(CephContext* const cct)
   if (! ldh) {
     std::lock_guard<std::mutex> lck(mtx);
     if (! ldh) {
-      const string& ldap_uri = cct->_conf->rgw_ldap_uri;
-      const string& ldap_binddn = cct->_conf->rgw_ldap_binddn;
-      const string& ldap_searchdn = cct->_conf->rgw_ldap_searchdn;
-      const string& ldap_searchfilter = cct->_conf->rgw_ldap_searchfilter;
-      const string& ldap_dnattr = cct->_conf->rgw_ldap_dnattr;
+      auto& conf = cct->_conf;
+      const string& ldap_uri = conf->rgw_ldap_uri;
+      const string& ldap_binddn = conf->rgw_ldap_binddn;
+      const string& ldap_searchdn = conf->rgw_ldap_searchdn;
+      const string& ldap_searchfilter = conf->rgw_ldap_searchfilter;
+      const string& ldap_dnattr = conf->rgw_ldap_dnattr;
+      const auto enable_cache =
+	conf->get_val<bool>("rgw_ldap_cache_enabled");
+      const auto cache_ttl =
+	conf->get_val<uint64_t>("rgw_ldap_cache_ttl_s");
+      const auto lru_lanes =
+	conf->get_val<uint64_t>("rgw_ldap_lru_lanes");
+      const auto lru_hiwat =
+	conf->get_val<uint64_t>("rgw_ldap_lru_hiwat");
+      const auto cache_npart =
+	conf->get_val<uint64_t>("rgw_ldap_cache_partitions");
+      const auto part_size =
+	conf->get_val<uint64_t>("rgw_ldap_cache_size");
+
       std::string ldap_bindpw = parse_rgw_ldap_bindpw(cct);
 
       ldh = new rgw::LDAPHelper(ldap_uri, ldap_binddn, ldap_bindpw,
-                                ldap_searchdn, ldap_searchfilter, ldap_dnattr);
+                                ldap_searchdn, ldap_searchfilter, ldap_dnattr,
+				enable_cache, cache_ttl, lru_lanes, lru_hiwat,
+				cache_npart, part_size);
 
       ldh->init();
       ldh->bind();

--- a/src/test/test_rgw_ldap.cc
+++ b/src/test/test_rgw_ldap.cc
@@ -48,8 +48,16 @@ namespace {
   string ldap_searchfilter = "";
   string ldap_dnattr = "uid";
 
+  const auto enable_cache = true;
+  const auto cache_ttl = 300;
+  const auto lru_lanes = 5;
+  const auto lru_hiwat = 911;
+  const auto cache_npart = 3;
+  const auto cache_size = 1579;
+
   rgw::LDAPHelper ldh(ldap_uri, ldap_binddn, ldap_bindpw, ldap_searchdn,
-		      ldap_searchfilter, ldap_dnattr);
+		      ldap_searchfilter, ldap_dnattr, enable_cache, cache_ttl,
+		      lru_lanes, lru_hiwat, cache_npart, cache_size);
 
 } /* namespace */
 


### PR DESCRIPTION
Implements an intrusive cache of positive and negative LDAP
authentication results, with credentials stored as blake2b
hash of name+credential.
