### PR TITLE
jewel: rbd: TestLibRBD.RenameViaLockOwner may still fail with -ENOENT

### DIFF
--- a/src/librbd/operation/RenameRequest.cc
+++ b/src/librbd/operation/RenameRequest.cc
@@ -64,7 +64,7 @@ bool RenameRequest<I>::should_complete(int r) {
   CephContext *cct = image_ctx.cct;
   ldout(cct, 5) << this << " " << __func__ << ": state=" << m_state << ", "
                 << "r=" << r << dendl;
-  r = filter_state_return_code(r);
+  r = filter_return_code(r);
   if (r < 0) {
     if (r == -EEXIST) {
       ldout(cct, 1) << "image already exists" << dendl;
@@ -100,7 +100,7 @@ bool RenameRequest<I>::should_complete(int r) {
 }
 
 template <typename I>
-int RenameRequest<I>::filter_state_return_code(int r) {
+int RenameRequest<I>::filter_return_code(int r) const {
   I &image_ctx = this->m_image_ctx;
   CephContext *cct = image_ctx.cct;
 

--- a/src/librbd/operation/RenameRequest.h
+++ b/src/librbd/operation/RenameRequest.h
@@ -57,6 +57,7 @@ public:
 protected:
   virtual void send_op();
   virtual bool should_complete(int r);
+  int filter_return_code(int r) const override;
 
   virtual journal::Event create_event(uint64_t op_tid) const {
     return journal::RenameEvent(op_tid, m_dest_name);
@@ -71,8 +72,6 @@ private:
   State m_state;
 
   bufferlist m_header_bl;
-
-  int filter_state_return_code(int r);
 
   void send_read_source_header();
   void send_write_destination_header();

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3242,7 +3242,7 @@ TEST_F(TestLibRBD, RebuildObjectMapViaLockOwner)
 
 TEST_F(TestLibRBD, RenameViaLockOwner)
 {
-  REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_EXCLUSIVE_LOCK);
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
 
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
@@ -3274,7 +3274,7 @@ TEST_F(TestLibRBD, RenameViaLockOwner)
 
 TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 {
-  REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_EXCLUSIVE_LOCK);
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
@@ -3318,7 +3318,7 @@ TEST_F(TestLibRBD, SnapCreateViaLockOwner)
 
 TEST_F(TestLibRBD, SnapRemoveViaLockOwner)
 {
-  REQUIRE_FEATURE(RBD_FEATURE_LAYERING | RBD_FEATURE_EXCLUSIVE_LOCK);
+  REQUIRE_FEATURE(RBD_FEATURE_FAST_DIFF);
 
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));


### PR DESCRIPTION
http://tracker.ceph.com/issues/23153