### PR TITLE
[DNM]rgw: Minor fix for action parsing in Bucket Policy Statements.

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -803,6 +803,7 @@ bool ParseState::do_string(CephContext* cct, const char* s, size_t l) {
       if (match_policy({s, l}, p.name, MATCH_POLICY_ACTION)) {
         is_validaction = true;
 	(w->id == TokenID::Action ? t->action : t->notaction) |= p.bit;
+        break;
       }
     }
   } else if (w->id == TokenID::Resource || w->id == TokenID::NotResource) {


### PR DESCRIPTION
Added a break to the loop when a match for Action is found.

Fixes: http://tracker.ceph.com/issues/23197

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>