### PR TITLE
Revert "core: hint the dout()'s message crafting as a cold code."

### DIFF
--- a/src/common/compiler_extensions.h
+++ b/src/common/compiler_extensions.h
@@ -22,15 +22,9 @@
 #ifdef __GNUC__
 // GCC
 #define WARN_UNUSED_RESULT __attribute__((warn_unused_result))
-
-#define HINT_COLD_CODE __attribute__((cold))
-#define HINT_NO_INLINE __attribute__((noinline))
 #else
 // some other compiler - just make it a no-op
 #define WARN_UNUSED_RESULT
-
-#define HINT_COLD_CODE
-#define HINT_NO_INLINE
 #endif
 
 #endif

--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -20,7 +20,6 @@
 
 #include "global/global_context.h"
 #include "common/config.h"
-#include "common/compiler_extensions.h"
 #include "common/likely.h"
 #include "common/Clock.h"
 #include "log/Log.h"
@@ -83,8 +82,7 @@ struct is_dynamic<dynamic_marker_t<T>> : public std::true_type {};
     }									\
   }(cct);								\
 									\
-  if (unlikely(should_gather)) {					\
-    [&]() HINT_NO_INLINE HINT_COLD_CODE {				\
+  if (should_gather) {							\
     static size_t _log_exp_length = 80; 				\
     ceph::logging::Entry *_dout_e = 					\
       cct->_log->create_entry(v, sub, &_log_exp_length);		\
@@ -114,8 +112,7 @@ struct is_dynamic<dynamic_marker_t<T>> : public std::true_type {};
 // /usr/include/assert.h clobbers our fancier version.
 #define dendl_impl std::flush;				\
   _ASSERT_H->_log->submit_entry(_dout_e);		\
-    }();						\
-    }							\
+    }						\
   } while (0)
 
 #define dendl dendl_impl

--- a/src/common/likely.h
+++ b/src/common/likely.h
@@ -18,7 +18,7 @@
 /*
  * Likely / Unlikely macros
  */
-#define likely(x)       __builtin_expect((const bool)(x),1)
-#define unlikely(x)     __builtin_expect((const bool)(x),0)
+#define likely(x)       __builtin_expect((x),1)
+#define unlikely(x)     __builtin_expect((x),0)
 
 #endif


### PR DESCRIPTION
This reverts commit b265ed2955570c17b954270e6a1449637790e9b8.

with b265ed29, we cannot use `dout(10) << __func__ << ...` anymore for
logging the name of the inner most function. what we will have is
always `operator()`, because the lambda closure will be the inner most
function with the the hinting change.

Fixes: http://tracker.ceph.com/issues/23169
Signed-off-by: Kefu Chai <kchai@redhat.com>