### PR TITLE
mon: fix clang error

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -76,7 +76,7 @@ template<> bool cmd_getval(CephContext *cct, const cmdmap_t& cmdmap,
 
 // my methods
 
-template <int dblV = 7>
+template <int dblV>
 void MDSMonitor::print_map(FSMap &m)
 {
   dout(dblV) << "print_map\n";


### PR DESCRIPTION
The specific specialisations in both .h and .cc does not really fly
with Clang

/home/jenkins/workspace/ceph-master/src/mon/MDSMonitor.cc:79:22: error: template parameter redefines default argument
template <int dblV = 7>
                     ^
/home/jenkins/workspace/ceph-master/src/mon/MDSMonitor.h:76:23: note: previous default template argument defined here
  template<int dblV = 7>
                      ^
1 error generated.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>