### PR TITLE
msg/async: avoid referencing the temporary string

### DIFF
--- a/src/msg/async/dpdk/dpdk_rte.cc
+++ b/src/msg/async/dpdk/dpdk_rte.cc
@@ -40,7 +40,7 @@ namespace dpdk {
   std::condition_variable eal::cond;
   std::list<std::function<void()>> eal::funcs;
 
-  static int bitcount(unsigned n)
+  static int bitcount(unsigned long long n)
   {
     return std::bitset<CHAR_BIT * sizeof(n)>{n}.count();
   }
@@ -52,8 +52,8 @@ namespace dpdk {
     }
 
     bool done = false;
-    const char *hexstring = c->_conf->get_val<std::string>("ms_dpdk_coremask").c_str();
-    int num = (int)strtol(hexstring, NULL, 0);
+    auto num = std::stoull(c->_conf->get_val<std::string>("ms_dpdk_coremask"),
+                           nullptr, 16);
     unsigned int coremaskbit = bitcount(num);
 
     ceph_assert(coremaskbit > c->_conf->ms_async_op_threads);


### PR DESCRIPTION
* `get_val<std::string>(...)` returns a temporary std::string, so we cannot
  keep a reference to it after evaluating this method. so convert it to
  an integer right away in the same expression.
* use std::stoull() with base = 16, so we can parse a hex string
  representing up to 64 bits.

Signed-off-by: Kefu Chai <kchai@redhat.com>