### PR TITLE
qa/run-standalone.sh: set PYTHONPATH for FreeBSD also

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -17,7 +17,7 @@ function get_cmake_variable() {
     grep "$variable" CMakeCache.txt | cut -d "=" -f 2
 }
 
-function cython_module_path() {
+function get_python_path() {
     local ceph_lib=$1
     shift
     local py_ver=$(get_cmake_variable MGR_PYTHON_VERSION | cut -d '.' -f1)
@@ -28,17 +28,17 @@ function cython_module_path() {
             py_ver=3
         fi
     fi
-    echo $ceph_lib/cython_modules/lib.$py_ver
+    echo $(realpath ../src/pybind):$ceph_lib/cython_modules/lib.$py_ver
 }
 
 if [ `uname` = FreeBSD ]; then
     # otherwise module prettytable will not be found
-    export PYTHONPATH=/usr/local/lib/python2.7/site-packages
+    export PYTHONPATH=$(get_python_path):/usr/local/lib/python2.7/site-packages
     exec_mode=+111
     KERNCORE="kern.corefile"
     COREPATTERN="core.%N.%P"
 else
-    export PYTHONPATH=/usr/lib/python2.7/dist-packages
+    export PYTHONPATH=$(get_python_path)
     exec_mode=/111
     KERNCORE="kernel.core_pattern"
     COREPATTERN="core.%e.%p.%t"
@@ -123,7 +123,6 @@ do
         if ! PATH=$PATH:bin \
 	    CEPH_ROOT=.. \
 	    CEPH_LIB=lib \
-	    PYTHONPATH=$(realpath ../src/pybind):$(cython_module_path lib) \
 	    LOCALRUN=yes \
 	    $cmd ; then
           echo "$f .............. FAILED"


### PR DESCRIPTION
do not set PYTHONPATH=/usr/lib/python2.7/dist-packages anymore, it will
be overridden later on anyway.

Signed-off-by: Kefu Chai <kchai@redhat.com>