### PR TITLE
librados/snap_set_diff: don't assert on empty snapset

### DIFF
--- a/src/librados/snap_set_diff.cc
+++ b/src/librados/snap_set_diff.cc
@@ -17,7 +17,8 @@
 void calc_snap_set_diff(CephContext *cct, const librados::snap_set_t& snap_set,
 			librados::snap_t start, librados::snap_t end,
 			interval_set<uint64_t> *diff, uint64_t *end_size,
-                        bool *end_exists, librados::snap_t *clone_end_snap_id)
+                        bool *end_exists, librados::snap_t *clone_end_snap_id,
+                        bool *whole_object)
 {
   ldout(cct, 10) << "calc_snap_set_diff start " << start << " end " << end
 		 << ", snap_set seq " << snap_set.seq << dendl;
@@ -27,6 +28,7 @@ void calc_snap_set_diff(CephContext *cct, const librados::snap_set_t& snap_set,
   *end_size = 0;
   *end_exists = false;
   *clone_end_snap_id = 0;
+  *whole_object = false;
 
   for (vector<librados::clone_info_t>::const_iterator r = snap_set.clones.begin();
        r != snap_set.clones.end();
@@ -38,6 +40,11 @@ void calc_snap_set_diff(CephContext *cct, const librados::snap_set_t& snap_set,
       // head is valid starting from right after the last seen seq
       a = snap_set.seq + 1;
       b = librados::SNAP_HEAD;
+    } else if (r->snaps.empty()) {
+      ldout(cct, 1) << "clone " << r->cloneid
+                    << ": empty snaps, return whole object" << dendl;
+      *whole_object = true;
+      return;
     } else {
       a = r->snaps[0];
       // note: b might be < r->cloneid if a snap has been trimmed.

--- a/src/librados/snap_set_diff.h
+++ b/src/librados/snap_set_diff.h
@@ -12,6 +12,7 @@ void calc_snap_set_diff(CephContext *cct,
 			const librados::snap_set_t& snap_set,
 			librados::snap_t start, librados::snap_t end,
 			interval_set<uint64_t> *diff, uint64_t *end_size,
-			bool *end_exists, librados::snap_t *clone_end_snap_id);
+			bool *end_exists, librados::snap_t *clone_end_snap_id,
+			bool *whole_object);
 
 #endif

--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -142,6 +142,7 @@ private:
   int m_snap_ret = 0;
   bool m_retry_missing_read = false;
   librados::snap_set_t m_retry_snap_set;
+  bool m_read_whole_object = false;
 
   std::map<WriteReadSnapIds, CopyOps> m_read_ops;
   std::list<WriteReadSnapIds> m_read_snaps;


### PR DESCRIPTION
Instead treat the diff as a full-object delta.

Signed-off-by: Mykola Golub <mgolub@suse.com>