### PR TITLE
ceph: amend decode language

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -27,6 +27,9 @@ import subprocess
 import time
 import platform
 
+reload(sys)
+sys.setdefaultencoding('utf8')
+
 try:
     input = raw_input
 except NameError:


### PR DESCRIPTION
ceph daemon mds.01 dump cache
admin_socket: 'ascii' codec can't decode byte 0xc3 in position 17213457: ordinal not in range(128)
admin_socket: 'ascii' codec can't decode byte 0xc3 in position 17213457: ordinal not in range(128)

setdefaultencoding utf-8  to ceph will dump cache ok 


Fixes: http://tracker.ceph.com/issues/23185

Signed-off-by: Wang Yong <wang.yong@datatom.com>