### PR TITLE
os/CMakeLists: fix link errro when enable WITH_PMEM=ON.

### DIFF
--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -138,7 +138,8 @@ if(WITH_PMEM)
   add_library(pmem STATIC IMPORTED GLOBAL)
   add_dependencies(pmem nvml_ext)
   set_target_properties(pmem PROPERTIES
-    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/src/nvml/src/nondebug/libpmem.a")
+    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/src/nvml/src/nondebug/libpmem.a"
+    INTERFACE_LINK_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
   target_link_libraries(os pmem)
   target_include_directories(os SYSTEM PRIVATE "${CMAKE_BINARY_DIR}/src/nvml/src/include")
 endif(WITH_PMEM)


### PR DESCRIPTION
On some platform, when enable WITH_PMEM, it met the following errors:

>> 85%] Linking CXX executable ../../../bin/unittest_mclock_op_class_queue
../../nvml/src/nondebug/libpmem.a(libpmem_all.o): In function `os_thread_atfork':
pmem_posix.c:(.text+0x2501): undefined reference to `pthread_atfork'
>> collect2: error: ld returned 1 exit status
>> src/test/osd/CMakeFiles/unittest_mclock_op_class_queue.dir/build.make:145: recipe for target 'bin/unittest_mclock_op_class_queue' failed
>> make[2]: *** [bin/unittest_mclock_op_class_queue] Error 1
>> CMakeFiles/Makefile2:18453: recipe for target 'src/test/osd/CMakeFiles/unittest_mclock_op_class_queue.dir/all' failed
>> make[1]: *** [src/test/osd/CMakeFiles/unittest_mclock_op_class_queue.dir/all] Error 2
>> Makefile:140: recipe for target 'all' failed
>> make: *** [all] Error 2

This because libpmem.a need libpthread and some targets like unitttest_mclock_op_class_queue don't with libpthread.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>