### PR TITLE
os/bluestore: don't forget recalc_allocated for log_file when decode(…

### DIFF
--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -51,6 +51,7 @@ void bluefs_super_t::decode(bufferlist::iterator& p)
   decode(block_size, p);
   decode(log_fnode, p);
   DECODE_FINISH(p);
+  log_fnode.recalc_allocated();
 }
 
 void bluefs_super_t::dump(Formatter *f) const


### PR DESCRIPTION
…super)

This cause the following bugs:
     0> 2018-03-01 01:12:07.045 7fe8b7e71e00 -1 /root/ceph/src/os/bluestore/BlueFS.cc: In function 'int BlueFS::_flush_range(BlueFS::FileWriter*, uint64_t, uint64_t)' thread 7fe8b7e71e00 time 2018-03-01 01:12:07.042115
/root/ceph/src/os/bluestore/BlueFS.cc: 1661: FAILED assert(h->file->fnode.ino != 1)

 ceph version 13.0.1-2318-ga14754f1eb (a14754f1eb08b6bd959546a840892d1c525ebecc) mimic (dev)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x105) [0x7fe8af2da1e5]
 2: (BlueFS::_flush_range(BlueFS::FileWriter*, unsigned long, unsigned long)+0xf13) [0x55ba9a71c503]
 3: (BlueFS::_flush(BlueFS::FileWriter*, bool)+0x146) [0x55ba9a71c726]
 4: (BlueFS::_flush_and_sync_log(std::unique_lock<std::mutex>&, unsigned long, unsigned long)+0x4a4) [0x55ba9a71cfb4]
 5: (BlueFS::_fsync(BlueFS::FileWriter*, std::unique_lock<std::mutex>&)+0xa1) [0x55ba9a71d7f1]
 6: (BlueRocksWritableFile::Sync()+0x63) [0x55ba9a730113]
 7: (rocksdb::WritableFileWriter::SyncInternal(bool)+0x256) [0x55ba9a8c5166]
 8: (rocksdb::WritableFileWriter::Sync(bool)+0xd8) [0x55ba9a8c5e38]
 9: (rocksdb::BuildTable(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rocksdb::Env*, rocksdb::ImmutableCFOptions const&, rocksdb::MutableCFOptions const&, rocksdb::EnvOptions const&, rocksdb::TableCache*, rocksdb::InternalIterator*, std::unique_ptr<rocksdb::InternalIterator, std::default_delete<rocksdb::InternalIterator> >, rocksdb::FileMetaData*, rocksdb::InternalKeyComparator const&, std::vector<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<rocksdb::IntTblPropCollectorFactory> >, std::allocator<std::unique_ptr<rocksdb::IntTblPropCollectorFactory, std::default_delete<rocksdb::IntTblPropCollectorFactory> > > > const*, unsigned int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<unsigned long, std::allocator<unsigned long> >, unsigned long, rocksdb::SnapshotChecker*, rocksdb::CompressionType, rocksdb::CompressionOptions const&, bool, rocksdb::InternalStats*, rocksdb::TableFileCreationReason, rocksdb::EventLogger*, int, rocksdb::Env::IOPriority, rocksdb::TableProperties*, int, unsigned long)+0x1c67) [0x55ba9a8e4037]
 10: (rocksdb::DBImpl::WriteLevel0TableForRecovery(int, rocksdb::ColumnFamilyData*, rocksdb::MemTable*, rocksdb::VersionEdit*)+0xc13) [0x55ba9a7c4663]
 11: (rocksdb::DBImpl::RecoverLogFiles(std::vector<unsigned long, std::allocator<unsigned long> > const&, unsigned long*, bool)+0x1552) [0x55ba9a7c6602]
 12: (rocksdb::DBImpl::Recover(std::vector<rocksdb::ColumnFamilyDescriptor, std::allocator<rocksdb::ColumnFamilyDescriptor> > const&, bool, bool, bool)+0x881) [0x55ba9a7c7b71]
 13: (rocksdb::DB::Open(rocksdb::DBOptions const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::vector<rocksdb::ColumnFamilyDescriptor, std::allocator<rocksdb::ColumnFamilyDescriptor> > const&, std::vector<rocksdb::ColumnFamilyHandle*, std::allocator<rocksdb::ColumnFamilyHandle*> >*, rocksdb::DB**)+0x649) [0x55ba9a7c85e9]
 14: (RocksDBStore::do_open(std::ostream&, bool, std::vector<KeyValueDB::ColumnFamily, std::allocator<KeyValueDB::ColumnFamily> > const*)+0xfbc) [0x55ba9a6c927c]
 15: (BlueStore::_open_db(bool, bool)+0xcce) [0x55ba9a666c2e]
 16: (BlueStore::_mount(bool, bool)+0x1ea) [0x55ba9a68dcaa]
 17: (OSD::init()+0x296) [0x55ba9a2e7d26]
 18: (main()+0x2862) [0x55ba9a1e8bb2]
 19: (__libc_start_main()+0xf1) [0x7fe8acf021c1]
 20: (_start()+0x2a) [0x55ba9a2b44ea]

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>