### PR TITLE
[RFC] rgw: fix sync use too much tcp connections

### DIFF
--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -689,7 +689,7 @@ int RGWRESTStreamRWRequest::send_request(RGWAccessKey *key, map<string, string>&
   if (r < 0)
     return r;
 
-  if (!mgr) {
+  if (!mgr || !pmanager->is_enable_threaded()) {
     r = pmanager->complete_requests();
     if (r < 0)
       return r;

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -58,11 +58,14 @@ class RGWRESTConn
   string remote_id;
   std::atomic<int64_t> counter = { 0 };
 
+  RGWHTTPManager *http_manager;
+
 public:
 
   RGWRESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints);
   // custom move needed for atomic
   RGWRESTConn(RGWRESTConn&& other);
+  ~RGWRESTConn();
   RGWRESTConn& operator=(RGWRESTConn&& other);
 
   int get_url(string& endpoint);


### PR DESCRIPTION
manitain a CURL easy_handle pool in RGWHTTPManager,
and RGWRESTConn keep a RGWHTTPManager, send_request will
use the same http manager.

Signed-off-by: Tianshan Qu <tianshan@xsky.com>