### PR TITLE
luminous: rgw_log, rgw_file: account for new required envvars

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -246,6 +246,11 @@ namespace rgw {
       goto done;
     }
 
+    /* now expected by rgw_log_op() */
+    rgw_env.set("REQUEST_METHOD", s->info.method);
+    rgw_env.set("REQUEST_URI", s->info.request_uri);
+    rgw_env.set("QUERY_STRING", "");
+
     /* XXX authorize does less here then in the REST path, e.g.,
      * the user's info is cached, but still incomplete */
     req->log(s, "authorizing");

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -357,19 +357,29 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
   else
     set_param_str(s, "HTTP_REFERER", entry.referrer);
 
-  std::string uri(s->info.env->get("REQUEST_METHOD"));
-  uri.append(" ");
-
-  uri.append(s->info.env->get("REQUEST_URI"));
-  const char* qs = s->info.env->get("QUERY_STRING");
-  if(qs && (*qs != '\0')) {
-    uri.append("?");
-    uri.append(qs);
+  std::string uri;
+  if (s->info.env->exists("REQUEST_METHOD")) {
+    uri.append(s->info.env->get("REQUEST_METHOD"));
+    uri.append(" ");
   }
 
-  uri.append(" ");
-  uri.append("HTTP/");
-  uri.append(s->info.env->get("HTTP_VERSION"));
+  if (s->info.env->exists("REQUEST_URI")) {
+    uri.append(s->info.env->get("REQUEST_URI"));
+  }
+
+  if (s->info.env->exists("QUERY_STRING")) {
+    const char* qs = s->info.env->get("QUERY_STRING");
+    if(qs && (*qs != '\0')) {
+      uri.append("?");
+      uri.append(qs);
+    }
+  }
+
+  if (s->info.env->exists("HTTP_VERSION")) {
+    uri.append(" ");
+    uri.append("HTTP/");
+    uri.append(s->info.env->get("HTTP_VERSION"));
+  }
 
   entry.uri = std::move(uri);
 


### PR DESCRIPTION
Backport tracker http://tracker.ceph.com/issues/23192

rgw_log_op() expects more server and request variables from the
request environment.  Fix rgw_lib to set more that it can
usefully, but also make rgw_log_op() check for the existence
of all keys it will use.

Fixes: http://tracker.ceph.com/issues/21942

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
(cherry picked from commit f9d5528a1990b5bcc33948284136c2d349aa838e)