### PR TITLE
luminous: os/bluestore: avoid overhead of std::function in blob_t.

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -732,8 +732,6 @@ public:
 
   template<class F>
   int map(uint64_t x_off, uint64_t x_len, F&& f) const {
-    static_assert(std::is_invocable_r_v<int, F, uint64_t, uint64_t>);
-
     auto p = extents.begin();
     assert(p != extents.end());
     while (x_off >= p->length) {
@@ -757,8 +755,6 @@ public:
   void map_bl(uint64_t x_off,
 	      bufferlist& bl,
 	      F&& f) const {
-    static_assert(std::is_invocable_v<F, uint64_t, bufferlist&>);
-
     auto p = extents.begin();
     assert(p != extents.end());
     while (x_off >= p->length) {

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -17,6 +17,7 @@
 
 #include <ostream>
 #include <bitset>
+#include <type_traits>
 #include "include/types.h"
 #include "include/interval_set.h"
 #include "include/utime.h"
@@ -729,8 +730,10 @@ public:
     }
   }
 
-  int map(uint64_t x_off, uint64_t x_len,
-	   std::function<int(uint64_t,uint64_t)> f) const {
+  template<class F>
+  int map(uint64_t x_off, uint64_t x_len, F&& f) const {
+    static_assert(std::is_invocable_r_v<int, F, uint64_t, uint64_t>);
+
     auto p = extents.begin();
     assert(p != extents.end());
     while (x_off >= p->length) {
@@ -750,9 +753,12 @@ public:
     }
     return 0;
   }
+  template<class F>
   void map_bl(uint64_t x_off,
 	      bufferlist& bl,
-	      std::function<void(uint64_t,bufferlist&)> f) const {
+	      F&& f) const {
+    static_assert(std::is_invocable_v<F, uint64_t, bufferlist&>);
+
     auto p = extents.begin();
     assert(p != extents.end());
     while (x_off >= p->length) {


### PR DESCRIPTION
This is luminous backport of PR #20294. The extra commit that brings the compliance with C++11's `static_assert()` is only to make reviewing easier. I plan to squash it afterward. Apart from that there is no other change.