### PR TITLE
rgw: beast frontend uses yield_context to read/write body

### DIFF
--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -23,6 +23,7 @@ class ClientIO : public io::RestfulClient,
   tcp::socket& socket;
   parser_type& parser;
   beast::flat_buffer& buffer; //< parse buffer
+  boost::asio::yield_context yield;
 
   RGWEnv env;
 
@@ -33,7 +34,7 @@ class ClientIO : public io::RestfulClient,
 
  public:
   ClientIO(tcp::socket& socket, parser_type& parser,
-           beast::flat_buffer& buffer);
+           beast::flat_buffer& buffer, boost::asio::yield_context yield);
   ~ClientIO() override;
 
   int init_env(CephContext *cct) override;

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -106,7 +106,7 @@ void handle_connection(RGWProcessEnv& env, tcp::socket& socket,
     // process the request
     RGWRequest req{env.store->get_new_req_id()};
 
-    rgw::asio::ClientIO real_client{socket, parser, buffer};
+    rgw::asio::ClientIO real_client{socket, parser, buffer, yield};
 
     auto real_client_io = rgw::io::add_reordering(
                             rgw::io::add_buffering(cct,


### PR DESCRIPTION
the beast frontend's ClientIO implementation uses its yield_context to suspend the frontend thread during body io