### PR TITLE
common,rbd-nbd: fix up prefork behavior vs AsyncMessenger singletons

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -35,6 +35,7 @@
 #include "common/Timer.h"
 #include "common/ceph_argparse.h"
 #include "common/pick_address.h"
+#include "common/Preforker.h"
 
 #include "global/global_init.h"
 #include "global/signal_handler.h"
@@ -125,16 +126,18 @@ int main(int argc, const char **argv)
     }
     else {
       derr << "Error: can't understand argument: " << *i << "\n" << dendl;
-      usage();
+      exit(1);
     }
   }
+
+  Preforker forker;
 
   pick_addresses(g_ceph_context, CEPH_PICK_ADDRESS_PUBLIC);
 
   // Normal startup
   if (g_conf->name.has_default_id()) {
     derr << "must specify '-i name' with the ceph-mds instance name" << dendl;
-    usage();
+    exit(1);
   }
 
   if (g_conf->name.get_id().empty() ||

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -147,6 +147,24 @@ int main(int argc, const char **argv)
       "MDS names may not start with a numeric digit." << dendl;
   }
 
+  if (global_init_prefork(g_ceph_context) >= 0) {
+    std::string err;
+    int r = forker.prefork(err);
+    if (r < 0) {
+      cerr << err << std::endl;
+      return r;
+    }
+    if (forker.is_parent()) {
+      if (forker.parent_wait(err) != 0) {
+        return -ENXIO;
+      }
+      return 0;
+    }
+    global_init_postfork_start(g_ceph_context);
+  }
+  common_init_finish(g_ceph_context);
+  global_init_chdir(g_ceph_context);
+
   auto nonce = ceph::util::generate_random_number<uint64_t>();
 
   std::string public_msgr_type = g_conf->ms_public_type.empty() ? g_conf->get_val<std::string>("ms_type") : g_conf->ms_public_type;
@@ -154,7 +172,7 @@ int main(int argc, const char **argv)
 				      entity_name_t::MDS(-1), "mds",
 				      nonce, Messenger::HAS_MANY_CONNECTIONS);
   if (!msgr)
-    exit(1);
+    forker.exit(1);
   msgr->set_cluster_protocol(CEPH_MDS_PROTOCOL);
 
   cout << "starting " << g_conf->name << " at " << msgr->get_myaddr()
@@ -173,11 +191,8 @@ int main(int argc, const char **argv)
 
   int r = msgr->bind(g_conf->public_addr);
   if (r < 0)
-    exit(1);
+    forker.exit(1);
 
-  global_init_daemonize(g_ceph_context);
-  common_init_finish(g_ceph_context);
-  
   // set up signal handlers, now that we've daemonized/forked.
   init_async_signal_handler();
   register_async_signal_handler(SIGHUP, sighup_handler);
@@ -185,7 +200,7 @@ int main(int argc, const char **argv)
   // get monmap
   MonClient mc(g_ceph_context);
   if (mc.build_initial_monmap() < 0)
-    return -1;
+    forker.exit(1);
   global_init_chdir(g_ceph_context);
 
   msgr->start();
@@ -196,6 +211,11 @@ int main(int argc, const char **argv)
   // in case we have to respawn...
   mds->orig_argc = argc;
   mds->orig_argv = argv;
+
+  if (g_conf->daemonize) {
+    global_init_postfork_finish(g_ceph_context);
+    forker.daemonize();
+  }
 
   r = mds->init();
   if (r < 0) {

--- a/src/common/TracepointProvider.h
+++ b/src/common/TracepointProvider.h
@@ -58,7 +58,7 @@ public:
   static void initialize(CephContext *cct) {
 #ifdef WITH_LTTNG
      cct->lookup_or_create_singleton_object<TypedSingleton<traits>>(
-       traits.library, cct);
+       traits.library, false, cct);
 #endif
   }
 

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -644,7 +644,7 @@ CephContext::CephContext(uint32_t module_type_,
   _crypto_aes = CryptoHandler::create(CEPH_CRYPTO_AES);
   _crypto_random.reset(new CryptoRandom());
 
-  lookup_or_create_singleton_object<MempoolObs>("mempool_obs", this);
+  lookup_or_create_singleton_object<MempoolObs>("mempool_obs", false, this);
 }
 
 CephContext::~CephContext()
@@ -850,4 +850,34 @@ CryptoHandler *CephContext::get_crypto_handler(int type)
   default:
     return NULL;
   }
+}
+
+void CephContext::notify_pre_fork()
+{
+  {
+    std::lock_guard<ceph::spinlock> lg(_fork_watchers_lock);
+    for (auto &&t : _fork_watchers) {
+      t->handle_pre_fork();
+    }
+  }
+  {
+    // note: we don't hold a lock here, but we assume we are idle at
+    // fork time, which happens during process init and startup.
+    auto i = associated_objs.begin();
+    while (i != associated_objs.end()) {
+      if (associated_objs_drop_on_fork.count(i->first.first)) {
+	i = associated_objs.erase(i);
+      } else {
+	++i;
+      }
+    }
+    associated_objs_drop_on_fork.clear();
+  }
+}
+
+void CephContext::notify_post_fork()
+{
+  ceph::spin_unlock(&_fork_watchers_lock);
+  for (auto &&t : _fork_watchers)
+    t->handle_post_fork();
 }

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1178,7 +1178,7 @@ struct C_InvalidateCache : public Context {
                                           ContextWQ **op_work_queue) {
     auto thread_pool_singleton =
       &cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
-	"librbd::thread_pool", cct);
+	"librbd::thread_pool", false, cct);
     *thread_pool = thread_pool_singleton;
     *op_work_queue = thread_pool_singleton->op_work_queue;
   }
@@ -1187,7 +1187,7 @@ struct C_InvalidateCache : public Context {
                                     Mutex **timer_lock) {
     auto safe_timer_singleton =
       &cct->lookup_or_create_singleton_object<SafeTimerSingleton>(
-	"librbd::journal::safe_timer", cct);
+	"librbd::journal::safe_timer", false, cct);
     *timer = safe_timer_singleton;
     *timer_lock = &safe_timer_singleton->lock;
   }

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -213,7 +213,8 @@ private:
       return;
     }
     auto& thread_pool = m_cct->lookup_or_create_singleton_object<
-      ThreadPoolSingleton>("librbd::ImageUpdateWatchers::thread_pool", m_cct);
+      ThreadPoolSingleton>("librbd::ImageUpdateWatchers::thread_pool",
+			   false, m_cct);
     m_work_queue = new ContextWQ("librbd::ImageUpdateWatchers::op_work_queue",
 				 m_cct->_conf->get_val<int64_t>("rbd_op_thread_timeout"),
 				 &thread_pool);

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -336,7 +336,7 @@ Journal<I>::Journal(I &image_ctx)
 
   auto thread_pool_singleton =
     &cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
-      "librbd::journal::thread_pool", cct);
+      "librbd::journal::thread_pool", false, cct);
   m_work_queue = new ContextWQ("librbd::journal::work_queue",
                                cct->_conf->get_val<int64_t>("rbd_op_thread_timeout"),
                                thread_pool_singleton);

--- a/src/librbd/TaskFinisher.h
+++ b/src/librbd/TaskFinisher.h
@@ -46,7 +46,7 @@ public:
   TaskFinisher(CephContext &cct) : m_cct(cct) {
     auto& singleton =
       cct.lookup_or_create_singleton_object<TaskFinisherSingleton>(
-	"librbd::TaskFinisher::m_safe_timer", &cct);
+	"librbd::TaskFinisher::m_safe_timer", false, &cct);
     m_lock = &singleton.m_lock;
     m_safe_timer = singleton.m_safe_timer;
     m_finisher = singleton.m_finisher;

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -440,13 +440,14 @@ void Log::start()
 
 void Log::stop()
 {
-  assert(is_started());
-  pthread_mutex_lock(&m_queue_mutex);
-  m_stop = true;
-  pthread_cond_signal(&m_cond_flusher);
-  pthread_cond_broadcast(&m_cond_loggers);
-  pthread_mutex_unlock(&m_queue_mutex);
-  join();
+  if (is_started()) {
+    pthread_mutex_lock(&m_queue_mutex);
+    m_stop = true;
+    pthread_cond_signal(&m_cond_flusher);
+    pthread_cond_broadcast(&m_cond_loggers);
+    pthread_mutex_unlock(&m_queue_mutex);
+    join();
+  }
 }
 
 void *Log::entry()

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -260,7 +260,7 @@ AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
     transport_type = "dpdk";
 
   auto single = &cct->lookup_or_create_singleton_object<StackSingleton>(
-    "AsyncMessenger::NetworkStack::" + transport_type, cct);
+    "AsyncMessenger::NetworkStack::" + transport_type, true, cct);
   single->ready(transport_type);
   stack = single->stack.get();
   stack->start();

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -191,7 +191,7 @@ void EventCenter::set_owner()
   if (!global_centers) {
     global_centers = &cct->lookup_or_create_singleton_object<
       EventCenter::AssociatedCenters>(
-	"AsyncMessenger::EventCenter::global_center::" + type);
+	"AsyncMessenger::EventCenter::global_center::" + type, true);
     assert(global_centers);
     global_centers->centers[idx] = this;
     if (driver->need_wakeup()) {

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -120,7 +120,6 @@ NetworkStack::NetworkStack(CephContext *c, const string &t): type(t), started(fa
     w->center.init(InitEventNumber, i, type);
     workers.push_back(w);
   }
-  cct->register_fork_watcher(this);
 }
 
 void NetworkStack::start()

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -284,7 +284,7 @@ class Worker {
   }
 };
 
-class NetworkStack : public CephContext::ForkWatcher {
+class NetworkStack {
   std::string type;
   unsigned num_workers = 0;
   ceph::spinlock pool_spin;
@@ -300,7 +300,7 @@ class NetworkStack : public CephContext::ForkWatcher {
  public:
   NetworkStack(const NetworkStack &) = delete;
   NetworkStack& operator=(const NetworkStack &) = delete;
-  ~NetworkStack() override {
+  virtual ~NetworkStack() {
     for (auto &&w : workers)
       delete w;
   }
@@ -335,14 +335,6 @@ class NetworkStack : public CephContext::ForkWatcher {
   // direct is used in tests only
   virtual void spawn_worker(unsigned i, std::function<void ()> &&) = 0;
   virtual void join_worker(unsigned i) = 0;
-
-  void handle_pre_fork() override {
-    stop();
-  }
-
-  void handle_post_fork() override {
-    start();
-  }
 
   virtual bool is_ready() { return true; };
   virtual void ready() { };

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -206,7 +206,7 @@ Mirror::Mirror(CephContext *cct, const std::vector<const char*> &args) :
 {
   m_threads =
     &(cct->lookup_or_create_singleton_object<Threads<librbd::ImageCtx>>(
-	"rbd_mirror::threads", cct));
+	"rbd_mirror::threads", false, cct));
   m_service_daemon.reset(new ServiceDaemon<>(m_cct, m_local, m_threads));
 }
 

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -679,14 +679,13 @@ static int do_map(int argc, const char *argv[], Config *cfg)
       cerr << err << std::endl;
       return r;
     }
-
     if (forker.is_parent()) {
-      global_init_postfork_start(g_ceph_context);
       if (forker.parent_wait(err) != 0) {
         return -ENXIO;
       }
       return 0;
     }
+    global_init_postfork_start(g_ceph_context);
   }
 
   common_init_finish(g_ceph_context);
@@ -855,9 +854,8 @@ static int do_map(int argc, const char *argv[], Config *cfg)
     cout << cfg->devpath << std::endl;
 
     if (g_conf->daemonize) {
-      forker.daemonize();
-      global_init_postfork_start(g_ceph_context);
       global_init_postfork_finish(g_ceph_context);
+      forker.daemonize();
     }
 
     {


### PR DESCRIPTION
http://tracker.ceph.com/issues/23143

There seems to be something wrong with the code that shuts down the Stack singleton and starts it up again.  I was having trouble debugging the stop()->start() sequence.  This PR aims to avoid it entirely by destroying and recreating the Stack item, and then eliminating the cases where we have a messenger that survives across a fork.  Mostly this means adding preforker to osd and mds.  rbd-nbd also had semi-broken behavior here that we fix.

This is manifesting now because the wip-config branch (which should merge shortly) creates a messenger during early startup and tears it down again.