### PR TITLE
luminous docs fix ceph-volume missing sub-commands

### DIFF
--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -311,36 +311,90 @@ a Ceph Node.
 Short Form
 ----------
 
-Ceph provides the ``ceph-disk`` utility, which can prepare a disk, partition or
-directory for use with Ceph. The ``ceph-disk`` utility creates the OSD ID by
-incrementing the index. Additionally, ``ceph-disk`` will add the new OSD to the
-CRUSH map under the host for you. Execute ``ceph-disk -h`` for CLI details.
-The ``ceph-disk`` utility automates the steps of the `Long Form`_ below. To
+Ceph provides the ``ceph-volume`` utility, which can prepare a logical volume, disk, or partition
+for use with Ceph. The ``ceph-volume`` utility creates the OSD ID by
+incrementing the index. Additionally, ``ceph-volume`` will add the new OSD to the
+CRUSH map under the host for you. Execute ``ceph-volume -h`` for CLI details.
+The ``ceph-volume`` utility automates the steps of the `Long Form`_ below. To
 create the first two OSDs with the short form procedure, execute the following
 on  ``node2`` and ``node3``:
 
-
-#. Prepare the OSD. ::
+bluestore
+^^^^^^^^^
+#. Create the OSD. ::
 
 	ssh {node-name}
-	sudo ceph-disk prepare --cluster {cluster-name} --cluster-uuid {uuid} {data-path} [{journal-path}]
+	sudo ceph-volume lvm create --data {data-path}
 
    For example::
 
 	ssh node1
-	sudo ceph-disk prepare --cluster ceph --cluster-uuid a7f64266-0894-4f1e-a635-d0aeaca0e993 --fs-type ext4 /dev/hdd1
+	sudo ceph-volume lvm create --data /dev/hdd1
 
+Alternatively, the creation process can be split in two phases (prepare, and
+activate):
 
-#. Activate the OSD::
+#. Prepare the OSD. ::
 
-	sudo ceph-disk activate {data-path} [--activate-key {path}]
+	ssh {node-name}
+	sudo ceph-volume lvm prepare --data {data-path} {data-path}
 
    For example::
 
-	sudo ceph-disk activate /dev/hdd1
+	ssh node1
+	sudo ceph-volume prepare --data /dev/hdd1
 
-   **Note:** Use the ``--activate-key`` argument if you do not have a copy
-   of ``/var/lib/ceph/bootstrap-osd/{cluster}.keyring`` on the Ceph Node.
+   Once prepared, the ``ID`` and ``FSID`` of the prepared OSD are required for
+   activation. These can be obtained by listing OSDs in the current server::
+
+    sudo ceph-volume lvm list
+
+#. Activate the OSD::
+
+	sudo ceph-volume lvm activate {ID} {FSID}
+
+   For example::
+
+	sudo ceph-volume lvm activate 0 a7f64266-0894-4f1e-a635-d0aeaca0e993
+
+
+filestore
+^^^^^^^^^
+#. Create the OSD. ::
+
+	ssh {node-name}
+	sudo ceph-volume lvm create --filestore --data {data-path} --journal {journal-path}
+
+   For example::
+
+	ssh node1
+	sudo ceph-volume lvm create --filestore --data /dev/hdd1 --journal /dev/hdd2
+
+Alternatively, the creation process can be split in two phases (prepare, and
+activate):
+
+#. Prepare the OSD. ::
+
+	ssh {node-name}
+	sudo ceph-volume lvm prepare --filestore --data {data-path} --journal {journal-path}
+
+   For example::
+
+	ssh node1
+	sudo ceph-volume prepare --filestore --data /dev/hdd1 --journal /dev/hdd2
+
+   Once prepared, the ``ID`` and ``FSID`` of the prepared OSD are required for
+   activation. These can be obtained by listing OSDs in the current server::
+
+    sudo ceph-volume lvm list
+
+#. Activate the OSD::
+
+	sudo ceph-volume lvm activate --filestore {ID} {FSID}
+
+   For example::
+
+	sudo ceph-volume lvm activate --filestore 0 a7f64266-0894-4f1e-a635-d0aeaca0e993
 
 
 Long Form

--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -230,8 +230,8 @@ The procedure is as follows:
 	auth service required = cephx
 	auth client required = cephx
 	osd journal size = 1024
-	osd pool default size = 2
-	osd pool default min size = 1
+	osd pool default size = 3
+	osd pool default min size = 2
 	osd pool default pg num = 333
 	osd pool default pgp num = 333
 	osd crush chooseleaf type = 1

--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -342,7 +342,7 @@ activate):
    For example::
 
 	ssh node1
-	sudo ceph-volume prepare --data /dev/hdd1
+	sudo ceph-volume lvm prepare --data /dev/hdd1
 
    Once prepared, the ``ID`` and ``FSID`` of the prepared OSD are required for
    activation. These can be obtained by listing OSDs in the current server::
@@ -381,7 +381,7 @@ activate):
    For example::
 
 	ssh node1
-	sudo ceph-volume prepare --filestore --data /dev/hdd1 --journal /dev/hdd2
+	sudo ceph-volume lvm prepare --filestore --data /dev/hdd1 --journal /dev/hdd2
 
    Once prepared, the ``ID`` and ``FSID`` of the prepared OSD are required for
    activation. These can be obtained by listing OSDs in the current server::

--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -14,7 +14,7 @@ device.  The storage device is normally partitioned into two parts:
 #. A small partition is formatted with XFS and contains basic metadata
    for the OSD.  This *data directory* includes information about the
    OSD (its identifier, which cluster it belongs to, and its private
-   keyring.
+   keyring).
 
 #. The rest of the device is normally a large partition occupying the
    rest of the device that is managed directly by BlueStore contains
@@ -143,8 +143,8 @@ value (usually 4 bytes) for every 4 kilobyte block of data.
 It is possible to use a smaller checksum value by truncating the
 checksum to two or one byte, reducing the metadata overhead.  The
 trade-off is that the probability that a random error will not be
-detected is higher with a smaller checksum, going from about one if
-four billion with a 32-bit (4 byte) checksum to one is 65,536 for a
+detected is higher with a smaller checksum, going from about one in
+four billion with a 32-bit (4 byte) checksum to one in 65,536 for a
 16-bit (2 byte) checksum or one in 256 for an 8-bit (1 byte) checksum.
 The smaller checksum values can be used by selecting `crc32c_16` or
 `crc32c_8` as the checksum algorithm.

--- a/doc/rados/configuration/storage-devices.rst
+++ b/doc/rados/configuration/storage-devices.rst
@@ -60,7 +60,7 @@ last ten years.  Key BlueStore features include:
   and for erasure coded pools (which rely on cloning to implement
   efficient two-phase commits).
 
-For more information, see :doc:`bluestore-config-ref`.
+For more information, see :doc:`bluestore-config-ref` and :doc:`/rados/operations/bluestore-migration`.
 
 FileStore
 ---------

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -84,7 +84,7 @@ more data migration than should be necessary, so it is not optimal.
    This requires you do identify which device to wipe based on what you saw
    mounted above. BE CAREFUL! ::
 
-     ceph-volume create --bluestore --data $DEVICE --osd-id $ID
+     ceph-volume lvm create --bluestore --data $DEVICE --osd-id $ID
 
 #. Repeat.
 

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -69,11 +69,11 @@ more data migration than should be necessary, so it is not optimal.
 
      umount /var/lib/ceph/osd/ceph-$ID
 
-#. Destroy the OSD data.  Be *EXTREMELY CAREFUL* as this will destroy
+#. Destroy the OSD data. Be *EXTREMELY CAREFUL* as this will destroy
    the contents of the device; be certain the data on the device is
    not needed (i.e., that the cluster is healthy) before proceeding. ::
 
-     ceph-disk zap $DEVICE
+     ceph-volume lvm zap $DEVICE
 
 #. Tell the cluster the OSD has been destroyed (and a new OSD can be
    reprovisioned with the same ID)::
@@ -84,7 +84,7 @@ more data migration than should be necessary, so it is not optimal.
    This requires you do identify which device to wipe based on what you saw
    mounted above. BE CAREFUL! ::
 
-     ceph-disk prepare --bluestore $DEVICE --osd-id $ID
+     ceph-volume create --bluestore --data $DEVICE --osd-id $ID
 
 #. Repeat.
 
@@ -171,10 +171,10 @@ Migration process
 
 If you're using a new host, start at step #1.  For an existing host,
 jump to step #5 below.
-     
+
 #. Provision new BlueStore OSDs for all devices::
 
-     ceph-disk prepare --bluestore /dev/$DEVICE
+     ceph-volume lvm create --bluestore --data /dev/$DEVICE
 
 #. Verify OSDs join the cluster with::
 
@@ -231,7 +231,7 @@ jump to step #5 below.
 #. Wipe the old OSD devices. This requires you do identify which
    devices are to be wiped manually (BE CAREFUL!). For each device,::
 
-     ceph-disk zap $DEVICE
+     ceph-volume lvm zap $DEVICE
 
 #. Use the now-empty host as the new host, and repeat::
 
@@ -265,7 +265,7 @@ old device is reclaimed to convert the next OSD.
 Caveats:
 
 * This strategy requires that a blank BlueStore OSD be prepared
-  without allocating a new OSD ID, something that the ``ceph-disk``
+  without allocating a new OSD ID, something that the ``ceph-volume``
   tool doesn't support.  More importantly, the setup of *dmcrypt* is
   closely tied to the OSD identity, which means that this approach
   does not work with encrypted OSDs.

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -126,6 +126,20 @@ the data migrating only once.
 
      ceph osd crush add-bucket $NEWHOST host
 
+   If you would like to use an existing host that is already part of the cluster,
+   and there is sufficient free space on that host so that all of its data can
+   be migrated off, then you can instead do::
+
+     ceph osd crush unlink $NEWHOST default
+
+   where "default" is the immediate ancestor in the CRUSH map. (For smaller
+   clusters with unmodified configurations this will normally be "default", but
+   it might also be a rack name.) This will move the host out of the CRUSH
+   hierarchy and cause all data to be migrated off. Once it is completely empty of
+   data, you can proceed::
+
+     while ! ceph osd safe-to-destroy $(ceph osd ls-tree $NEWHOST); do sleep 60 ; done
+
 #. Provision new BlueStore OSDs for all devices::
 
      ceph-disk prepare --bluestore /dev/$DEVICE

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -9,7 +9,7 @@ take advantage of the improved performance and robustness.  There are
 several strategies for making such a transition.
 
 An individual OSD cannot be converted in place in isolation, however:
-BlueStore and FileStore are simply to different for that to be
+BlueStore and FileStore are simply too different for that to be
 practical.  "Conversion" will rely either on the cluster's normal
 replication and healing support or tools and strategies that copy OSD
 content from and old (FileStore) device to a new (BlueStore) one.
@@ -77,7 +77,7 @@ more data migration than should be necessary, so it is not optimal.
 
 #. Tell the cluster the OSD has been destroyed (and a new OSD can be
    reprovisioned with the same ID)::
-     
+
      ceph osd destroy $ID --yes-i-really-mean-it
 
 #. Reprovision a BlueStore OSD in its place with the same OSD ID.
@@ -140,16 +140,16 @@ the data migrating only once.
    the empty host, you might see something like::
 
      $ bin/ceph osd tree
-     ID CLASS WEIGHT  TYPE NAME     STATUS REWEIGHT PRI-AFF 
-     -5             0 host newhost                          
-     10   ssd 1.00000     osd.0         up  1.00000 1.00000 
-     11   ssd 1.00000     osd.1         up  1.00000 1.00000 
-     12   ssd 1.00000     osd.2         up  1.00000 1.00000 
-     -1       3.00000 root default                          
+     ID CLASS WEIGHT  TYPE NAME     STATUS REWEIGHT PRI-AFF
+     -5             0 host newhost
+     10   ssd 1.00000     osd.0         up  1.00000 1.00000
+     11   ssd 1.00000     osd.1         up  1.00000 1.00000
+     12   ssd 1.00000     osd.2         up  1.00000 1.00000
+     -1       3.00000 root default
      -2       3.00000     host oldhost1
-      0   ssd 1.00000         osd.0     up  1.00000 1.00000 
-      1   ssd 1.00000         osd.1     up  1.00000 1.00000 
-      2   ssd 1.00000         osd.2     up  1.00000 1.00000 
+      0   ssd 1.00000         osd.0     up  1.00000 1.00000
+      1   ssd 1.00000         osd.1     up  1.00000 1.00000
+      2   ssd 1.00000         osd.2     up  1.00000 1.00000
      ...
 
 #. Identify the first target host to convert ::

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -12,7 +12,7 @@ An individual OSD cannot be converted in place in isolation, however:
 BlueStore and FileStore are simply too different for that to be
 practical.  "Conversion" will rely either on the cluster's normal
 replication and healing support or tools and strategies that copy OSD
-content from and old (FileStore) device to a new (BlueStore) one.
+content from an old (FileStore) device to a new (BlueStore) one.
 
 
 Deploy new OSDs with BlueStore

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -116,30 +116,62 @@ to evacuate an entire host in order to use it as a spare, then the
 conversion can be done on a host-by-host basis with each stored copy of
 the data migrating only once.
 
-#. Identify an empty host.  Ideally the host should have roughly the
-   same capacity as other hosts you will be converting (although it
-   doesn't strictly matter). ::
+First, you need have empty host that has no data.  There are two ways to do this: either by starting with a new, empty host that isn't yet part of the cluster, or by offloading data from an existing host that in the cluster.
 
-     NEWHOST=<empty-host-name>
+Use a new, empty host
+^^^^^^^^^^^^^^^^^^^^^
 
-#. Add the host to the CRUSH hierarchy, but do not attach it to the root::
+Ideally the host should have roughly the
+same capacity as other hosts you will be converting (although it
+doesn't strictly matter). ::
 
-     ceph osd crush add-bucket $NEWHOST host
+  NEWHOST=<empty-host-name>
 
-   If you would like to use an existing host that is already part of the cluster,
-   and there is sufficient free space on that host so that all of its data can
-   be migrated off, then you can instead do::
+Add the host to the CRUSH hierarchy, but do not attach it to the root::
 
-     ceph osd crush unlink $NEWHOST default
+  ceph osd crush add-bucket $NEWHOST host
 
-   where "default" is the immediate ancestor in the CRUSH map. (For smaller
-   clusters with unmodified configurations this will normally be "default", but
-   it might also be a rack name.) This will move the host out of the CRUSH
-   hierarchy and cause all data to be migrated off. Once it is completely empty of
-   data, you can proceed::
+Make sure the ceph packages are installed.
 
-     while ! ceph osd safe-to-destroy $(ceph osd ls-tree $NEWHOST); do sleep 60 ; done
+Use an existing host
+^^^^^^^^^^^^^^^^^^^^
 
+If you would like to use an existing host
+that is already part of the cluster, and there is sufficient free
+space on that host so that all of its data can be migrated off,
+then you can instead do::
+
+  OLDHOST=<existing-cluster-host-to-offload>
+  ceph osd crush unlink $OLDHOST default
+
+where "default" is the immediate ancestor in the CRUSH map. (For
+smaller clusters with unmodified configurations this will normally
+be "default", but it might also be a rack name.)  You should now
+see the host at the top of the OSD tree output with no parent::
+
+  $ bin/ceph osd tree
+  ID CLASS WEIGHT  TYPE NAME     STATUS REWEIGHT PRI-AFF
+  -5             0 host oldhost
+  10   ssd 1.00000     osd.10        up  1.00000 1.00000
+  11   ssd 1.00000     osd.11        up  1.00000 1.00000
+  12   ssd 1.00000     osd.12        up  1.00000 1.00000
+  -1       3.00000 root default
+  -2       3.00000     host foo
+   0   ssd 1.00000         osd.0     up  1.00000 1.00000
+   1   ssd 1.00000         osd.1     up  1.00000 1.00000
+   2   ssd 1.00000         osd.2     up  1.00000 1.00000
+  ...
+
+If everything looks good, jump directly to the "Wait for data
+migration to complete" step below and proceed from there to clean up
+the old OSDs.
+
+Migration process
+^^^^^^^^^^^^^^^^^
+
+If you're using a new host, start at step #1.  For an existing host,
+jump to step #5 below.
+     
 #. Provision new BlueStore OSDs for all devices::
 
      ceph-disk prepare --bluestore /dev/$DEVICE
@@ -168,7 +200,7 @@ the data migrating only once.
 
 #. Identify the first target host to convert ::
 
-     OLDHOST=<old-host-name>
+     OLDHOST=<existing-cluster-host-to-convert>
 
 #. Swap the new host into the old host's position in the cluster::
 

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -55,7 +55,7 @@ more data migration than should be necessary, so it is not optimal.
 
 #. Wait for the data to migrate off the OSD in question::
 
-     while ! ceph health | grep HEALTH_OK ; do sleep 60 ; done
+     while ! ceph osd safe-to-destroy $ID ; sleep 60 ; done
 
 #. Stop the OSD::
 
@@ -168,7 +168,7 @@ the data migrating only once.
 
 #. Wait for data migration to complete::
 
-     while ! ceph health | grep HEALTH_OK ; do sleep 60 ; done
+     while ! ceph osd safe-to-destroy $(ceph osd ls-tree $OLDHOST); do sleep 60 ; done
 
 #. Stop all old OSDs on the now-empty ``$OLDHOST``::
 
@@ -178,7 +178,7 @@ the data migrating only once.
 
 #. Destroy and purge the old OSDs::
 
-     for osd in `ceph osd crush ls $OLDHOST`; do
+     for osd in `ceph osd ls-tree $OLDHOST`; do
          ceph osd purge $osd --yes-i-really-mean-it
      done
 

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -174,7 +174,7 @@ the data migrating only once.
 
      ssh $OLDHOST
      systemctl kill ceph-osd.target
-     umount /var/log/ceph/osd/ceph-*
+     umount /var/lib/ceph/osd/ceph-*
 
 #. Destroy and purge the old OSDs::
 

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -1,0 +1,246 @@
+=====================
+ BlueStore Migration
+=====================
+
+Each OSD can run either BlueStore or FileStore, and a single Ceph
+cluster can contain a mix of both.  Users who have previously deployed
+FileStore are likely to want to transition to BlueStore in order to
+take advantage of the improved performance and robustness.  There are
+several strategies for making such a transition.
+
+An individual OSD cannot be converted in place in isolation, however:
+BlueStore and FileStore are simply to different for that to be
+practical.  "Conversion" will rely either on the cluster's normal
+replication and healing support or tools and strategies that copy OSD
+content from and old (FileStore) device to a new (BlueStore) one.
+
+
+Deploy new OSDs with BlueStore
+==============================
+
+Any new OSDs (e.g., when the cluster is expanded) can be deployed
+using BlueStore.  This is the default behavior so no specific change
+is needed.
+
+Similarly, any OSDs that are reprovisioned after replacing a failed drive
+can use BlueStore.
+
+Convert existing OSDs
+=====================
+
+Mark out and replace
+--------------------
+
+The simplest approach is to mark out each device in turn, wait for the
+data to rereplicate across the cluster, reprovision the OSD, and mark
+it back in again.  It is simple and easy to automate.  However, it requires
+more data migration than should be necessary, so it is not optimal.
+
+#. Identify a FileStore OSD to replace::
+
+     ID=<osd-id-number>
+     DEVICE=<disk-device>
+
+   You can tell whether a given OSD is FileStore or BlueStore with::
+
+     ceph osd metadata $ID | grep osd_objectstore
+
+   You can get a current count of filestore vs bluestore with::
+
+     ceph osd count-metadata osd_objectstore
+
+#. Mark the filestore OSD out::
+
+     ceph osd out $ID
+
+#. Wait for the data to migrate off the OSD in question::
+
+     while ! ceph health | grep HEALTH_OK ; do sleep 60 ; done
+
+#. Stop the OSD::
+
+     systemctl kill ceph-osd@$ID
+
+#. Make note of which device this OSD is using::
+
+     mount | grep /var/lib/ceph/osd/ceph-$ID
+
+#. Unmount the OSD::
+
+     umount /var/lib/ceph/osd/ceph-$ID
+
+#. Destroy the OSD data.  Be *EXTREMELY CAREUL* as this will destroy
+   the contents of the device; be certain the data on the device is
+   not needed (i.e., that the cluster is healthy) before proceeding. ::
+
+     ceph-disk zap $DEVICE
+
+#. Tell the cluster the OSD has been destroyed (and a new OSD can be
+   reprovisioned with the same ID)::
+     
+     ceph osd destroy $ID --yes-i-really-mean-it
+
+#. Reprovision a BlueStore OSD in its place with the same OSD ID.
+   This requires you do identify which device to wipe based on what you saw
+   mounted above. BE CAREFUL! ::
+
+     ceph-disk prepare --bluestore $DEVICE --osd-id $ID
+
+#. Repeat.
+
+You can allow the refilling of the replacement OSD to happen
+concurrently with the draining of the next OSD, or follow the same
+procedure for multiple OSDs in parallel, as long as you ensure the
+cluster is fully clean (all data has all replicas) before destroying
+any OSDs.  Failure to do so will reduce the redundancy of your data
+and increase the risk of (or potentially even cause) data loss.
+
+Advantages:
+
+* Simple.
+* Can be done on a device-by-device basis.
+* No spare devices or hosts are required.
+
+Disadvantages:
+
+* Data is copied over the network twice: once to some other OSD in the
+  cluster (to maintain the desired number of replicas), and then again
+  back to the reprovisioned BlueStore OSD.
+
+
+Whole host replacement
+----------------------
+
+If you have a spare host in the cluster, or have sufficient free space
+to evacuate an entire host in order to use it as a spare, then the
+conversion can be done on a host-by-host basis with each stored copy of
+the data migrating only once.
+
+#. Identify an empty host.  Ideally the host should have roughly the
+   same capacity as other hosts you will be converting (although it
+   doesn't strictly matter). ::
+
+     NEWHOST=<empty-host-name>
+
+#. Add the host to the CRUSH hierarchy, but do not attach it to the root::
+
+     ceph osd crush add-bucket $NEWHOST host
+
+#. Provision new BlueStore OSDs for all devices::
+
+     ceph-disk prepare --bluestore /dev/$DEVICE
+
+#. Verify OSDs join the cluster with::
+
+     ceph osd tree
+
+   You should see the new host ``$NEWHOST`` with all of the OSDs beneath
+   it, but the host should *not* be nested beneath any other node in
+   hierarchy (like ``root default``).  For example, if ``newhost`` is
+   the empty host, you might see something like::
+
+     $ bin/ceph osd tree
+     ID CLASS WEIGHT  TYPE NAME     STATUS REWEIGHT PRI-AFF 
+     -5             0 host newhost                          
+     10   ssd 1.00000     osd.0         up  1.00000 1.00000 
+     11   ssd 1.00000     osd.1         up  1.00000 1.00000 
+     12   ssd 1.00000     osd.2         up  1.00000 1.00000 
+     -1       3.00000 root default                          
+     -2       3.00000     host oldhost1
+      0   ssd 1.00000         osd.0     up  1.00000 1.00000 
+      1   ssd 1.00000         osd.1     up  1.00000 1.00000 
+      2   ssd 1.00000         osd.2     up  1.00000 1.00000 
+     ...
+
+#. Identify the first target host to convert ::
+
+     OLDHOST=<old-host-name>
+
+#. Swap the new host into the old host's position in the cluster::
+
+     ceph osd crush swap-bucket $NEWHOST $OLDHOST
+
+   At this point all data on ``$OLDHOST`` will start migrating to OSDs
+   on ``$NEWHOST``.  If there is a difference in the total capacity of
+   the old and new hosts you may also see some data migrate to or from
+   other nodes in the cluster, but as long as the hosts are similarly
+   sized this will be a relatively small amount of data.
+
+#. Wait for data migration to complete::
+
+     while ! ceph health | grep HEALTH_OK ; do sleep 60 ; done
+
+#. Stop all old OSDs on the now-empty ``$OLDHOST``::
+
+     ssh $OLDHOST
+     systemctl kill ceph-osd.target
+     umount /var/log/ceph/osd/ceph-*
+
+#. Destroy and purge the old OSDs::
+
+     for osd in `ceph osd crush ls $OLDHOST`; do
+         ceph osd purge $osd --yes-i-really-mean-it
+     done
+
+#. Wipe the old OSD devices. This requires you do identify which
+   devices are to be wiped manually (BE CAREFUL!). For each device,::
+
+     ceph-disk zap $DEVICE
+
+#. Use the now-empty host as the new host, and repeat::
+
+     NEWHOST=$OLDHOST
+
+Advantages:
+
+* Data is copied over the network only once.
+* Converts an entire host's OSDs at once.
+* Can parallelize to converting multiple hosts at a time.
+* No spare devices are required on each host.
+
+Disadvantages:
+
+* A spare host is required.
+* An entire host's worth of OSDs will be migrating data at a time.  This
+  is like likely to impact overall cluster performance.
+* All migrated data still makes one full hop over the network.
+
+
+Per-OSD device copy
+-------------------
+
+A single logical OSD can be converted by using the ``copy`` function
+of ``ceph-objectstore-tool``.  This requires that the host have a free
+device (or devices) to provision a new, empty BlueStore OSD.  For
+example, if each host in your cluster has 12 OSDs, then you'd need a
+13th available device so that each OSD can be converted in turn before the
+old device is reclaimed to convert the next OSD.
+
+Caveats:
+
+* This strategy requires that a blank BlueStore OSD be prepared
+  without allocating a new OSD ID, something that the ``ceph-disk``
+  tool doesn't support.  More importantly, the setup of *dmcrypt* is
+  closely tied to the OSD identity, which means that this approach
+  does not work with encrypted OSDs.
+
+* The device must be manually partitioned.
+
+* Tooling not implemented!
+
+* Not documented!
+
+Advantages:
+
+* Little or no data migrates over the network during the conversion.
+
+Disadvantages:
+
+* Tooling not fully implemented.
+* Process not documented.
+* Each host must have a spare or empty device.
+* The OSD is offline during the conversion, which means new writes will
+  be written to only a subset of the OSDs.  This increases the risk of data
+  loss due to a subsequent failure.  (However, if there is a failure before
+  conversion is complete, the original FileStore OSD can be started to provide
+  access to its original data.)

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -142,9 +142,9 @@ the data migrating only once.
      $ bin/ceph osd tree
      ID CLASS WEIGHT  TYPE NAME     STATUS REWEIGHT PRI-AFF
      -5             0 host newhost
-     10   ssd 1.00000     osd.0         up  1.00000 1.00000
-     11   ssd 1.00000     osd.1         up  1.00000 1.00000
-     12   ssd 1.00000     osd.2         up  1.00000 1.00000
+     10   ssd 1.00000     osd.10        up  1.00000 1.00000
+     11   ssd 1.00000     osd.11        up  1.00000 1.00000
+     12   ssd 1.00000     osd.12        up  1.00000 1.00000
      -1       3.00000 root default
      -2       3.00000     host oldhost1
       0   ssd 1.00000         osd.0     up  1.00000 1.00000

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -69,7 +69,7 @@ more data migration than should be necessary, so it is not optimal.
 
      umount /var/lib/ceph/osd/ceph-$ID
 
-#. Destroy the OSD data.  Be *EXTREMELY CAREUL* as this will destroy
+#. Destroy the OSD data.  Be *EXTREMELY CAREFUL* as this will destroy
    the contents of the device; be certain the data on the device is
    not needed (i.e., that the cluster is healthy) before proceeding. ::
 

--- a/doc/rados/operations/index.rst
+++ b/doc/rados/operations/index.rst
@@ -58,6 +58,7 @@ with new hardware.
 
 	add-or-rm-osds
 	add-or-rm-mons
+	bluestore-migration
 	Command Reference <control>
 
 	


### PR DESCRIPTION
I wasn't able to apply the two commits from the original PR merged to master (https://github.com/ceph/ceph/pull/20673) because not only commits were missing, but because bluestore-migration.rst did not exist in the luminous branch at all.

So this PR also backports all the commits for bluestore-migration.rst

Fixes: https://tracker.ceph.com/issues/23148
