### PR TITLE
doc: update iSCSI upstream kernel to 4.16

### DIFF
--- a/doc/rbd/iscsi-target-ansible.rst
+++ b/doc/rbd/iscsi-target-ansible.rst
@@ -11,7 +11,7 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
 -  A running Ceph Luminous (12.2.x) cluster or newer
 
--  RHEL/CentOS 7.5; Linux kernel v4.17 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
+-  RHEL/CentOS 7.5; Linux kernel v4.16 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
 
 -  The ``ceph-iscsi-config`` package installed on all the iSCSI gateway nodes
 

--- a/doc/rbd/iscsi-target-cli-manual-install.rst
+++ b/doc/rbd/iscsi-target-cli-manual-install.rst
@@ -34,7 +34,7 @@ on each machine that will be a iSCSI gateway:
 -  Linux Kernel
 
    If not using a distro kernel that contains the required Ceph iSCSI patches,
-   then Linux kernel v4.17 or newer or the ceph-client ceph-iscsi-test
+   then Linux kernel v4.16 or newer or the ceph-client ceph-iscsi-test
    branch must be used. To get the branch run:
 
    ::

--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -11,7 +11,7 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
 -  A running Ceph Luminous or later storage cluster
 
--  RHEL/CentOS 7.5; Linux kernel v4.17 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
+-  RHEL/CentOS 7.5; Linux kernel v4.16 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
 
 -  The following packages must be installed from your Linux distribution's software repository:
 

--- a/doc/rbd/iscsi-targets.rst
+++ b/doc/rbd/iscsi-targets.rst
@@ -8,7 +8,7 @@ within OpenStack environments. Starting with the Ceph Luminous release,
 block-level access is expanding to offer standard iSCSI support allowing
 wider platform usage, and potentially opening new use cases.
 
--  RHEL/CentOS 7.5; Linux kernel v4.17 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
+-  RHEL/CentOS 7.5; Linux kernel v4.16 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
 
 -  A working Ceph Storage cluster, deployed with ``ceph-ansible`` or using the command-line interface
 


### PR DESCRIPTION
The kernel patches needed for ceph iSCSI supported got merged sooner than expected. This patch changes the required upstream kernel version from 4.17 to 4.16.