### PR TITLE
[DNM] jewel: rgw: fix memory fragmentation problem reading data from client.

### DIFF
--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -25,6 +25,7 @@ class RGWMongoose : public RGWStreamIO
   bool has_content_length;
   bool explicit_keepalive;
   bool explicit_conn_close;
+  bool got_eof_on_read;
 
 public:
   void init_env(CephContext *cct);


### PR DESCRIPTION
STREAM_IO(s)->read() can, and nearly always returns "short" reads.
(Experimentally, about 1% of a 1m buffer gets filled.)  The resulting
buffer append operations result in constructing a list of buffers
of mostly unused data, which bloats up memory usage considerably.
The fix here is to loop and try to fill the buffer more aggressively
to start with.

mg_read() returns 0 upon EOF.  The next read to mg_read()
returns -1.  The above change that improved buffer filling logic
also makes it possible for it to try to read past the end of
the actual data.  So, add a flag to remember that
an actual EOF was seen and another mg_read should not be attempted.

Fixes: https://tracker.ceph.com/issues/23207

Signed-off-by: Marcus Watts <mwatts@redhat.com>