### PR TITLE
common: fix potential memory leak in HTMLFormatter

### DIFF
--- a/src/common/HTMLFormatter.cc
+++ b/src/common/HTMLFormatter.cc
@@ -57,6 +57,9 @@ void HTMLFormatter::set_status(int status, const char* status_name)
 {
   m_status = status;
   if (status_name) {
+    if (m_status_name) {
+      free((void*)m_status_name);
+    }
     m_status_name = strdup(status_name);
   }
 };


### PR DESCRIPTION
If HTMLFormatter::set_status called twice, memory will leaked,
so fix it.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>