### PR TITLE
client: use either dentry_invalidate_cb or remount_cb to invalidate kernel dcache

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4022,12 +4022,14 @@ void Client::_invalidate_kernel_dcache()
 {
   if (unmounting)
     return;
-  if (can_invalidate_dentries && dentry_invalidate_cb && root->dir) {
-    for (ceph::unordered_map<string, Dentry*>::iterator p = root->dir->dentries.begin();
-	 p != root->dir->dentries.end();
-	 ++p) {
-      if (p->second->inode)
-	_schedule_invalidate_dentry_callback(p->second, false);
+  if (can_invalidate_dentries) {
+    if (dentry_invalidate_cb && root->dir) {
+      for (ceph::unordered_map<string, Dentry*>::iterator p = root->dir->dentries.begin();
+         p != root->dir->dentries.end();
+         ++p) {
+       if (p->second->inode)
+        _schedule_invalidate_dentry_callback(p->second, false);
+      }
     }
   } else if (remount_cb) {
     // Hacky:


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23211

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>