### PR TITLE
common: optimize OpTracker

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -167,33 +167,24 @@ void OpHistory::dump_ops_by_duration(utime_t now, Formatter *f, set<string> filt
   f->close_section();
 }
 
-struct ShardedTrackingData {
-  Mutex ops_in_flight_lock_sharded;
-  TrackedOp::tracked_op_list_t ops_in_flight_sharded;
-  explicit ShardedTrackingData(string lock_name):
-      ops_in_flight_lock_sharded(lock_name.c_str()) {}
-};
-
 OpTracker::OpTracker(CephContext *cct_, bool tracking, uint32_t num_shards):
   seq(0),
-  num_optracker_shards(num_shards),
-  complaint_time(0), log_threshold(0),
+  sharded_in_flight_list(num_shards, [](const size_t i, auto emplacer) {
+    char lock_name[32] = {0};
+    snprintf(lock_name, sizeof(lock_name), "%s:%zd",
+	     "OpTracker::ShardedLock", i);
+    emplacer.emplace(lock_name);
+  }),
+  complaint_time(0),
+  log_threshold(0),
   tracking_enabled(tracking),
   lock("OpTracker::lock", false /* track_lock */),
   cct(cct_) {
-    for (uint32_t i = 0; i < num_optracker_shards; i++) {
-      char lock_name[32] = {0};
-      snprintf(lock_name, sizeof(lock_name), "%s:%d", "OpTracker::ShardedLock", i);
-      ShardedTrackingData* one_shard = new ShardedTrackingData(lock_name);
-      sharded_in_flight_list.push_back(one_shard);
-    }
 }
 
 OpTracker::~OpTracker() {
-  while (!sharded_in_flight_list.empty()) {
-    assert((sharded_in_flight_list.back())->ops_in_flight_sharded.empty());
-    delete sharded_in_flight_list.back();
-    sharded_in_flight_list.pop_back();
+  for (const auto& shard : sharded_in_flight_list) {
+    assert(shard.ops_in_flight_sharded.empty());
   }
 }
 
@@ -257,11 +248,9 @@ bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked, set<st
   uint64_t total_ops_in_flight = 0;
   f->open_array_section("ops"); // list of TrackedOps
   utime_t now = ceph_clock_now();
-  for (uint32_t i = 0; i < num_optracker_shards; i++) {
-    ShardedTrackingData* sdata = sharded_in_flight_list[i];
-    assert(NULL != sdata); 
-    Mutex::Locker locker(sdata->ops_in_flight_lock_sharded);
-    for (auto& op : sdata->ops_in_flight_sharded) {
+  for (auto& sdata : sharded_in_flight_list) {
+    Mutex::Locker locker(sdata.ops_in_flight_lock_sharded);
+    for (auto& op : sdata.ops_in_flight_sharded) {
       if (print_only_blocked && (now - op.get_initiated() <= complaint_time))
         break;
       if (!op.filter_out(filters))
@@ -289,12 +278,11 @@ bool OpTracker::register_inflight_op(TrackedOp *i)
 
   RWLock::RLocker l(lock);
   uint64_t current_seq = ++seq;
-  uint32_t shard_index = current_seq % num_optracker_shards;
-  ShardedTrackingData* sdata = sharded_in_flight_list[shard_index];
-  assert(NULL != sdata);
+  uint32_t shard_index = current_seq % sharded_in_flight_list.size();
+  ShardedTrackingData& sdata = sharded_in_flight_list[shard_index];
   {
-    Mutex::Locker locker(sdata->ops_in_flight_lock_sharded);
-    sdata->ops_in_flight_sharded.push_back(*i);
+    Mutex::Locker locker(sdata.ops_in_flight_lock_sharded);
+    sdata.ops_in_flight_sharded.push_back(*i);
     i->seq = current_seq;
   }
   return true;
@@ -305,13 +293,12 @@ void OpTracker::unregister_inflight_op(TrackedOp *i)
   // caller checks;
   assert(i->state);
 
-  uint32_t shard_index = i->seq % num_optracker_shards;
-  ShardedTrackingData* sdata = sharded_in_flight_list[shard_index];
-  assert(NULL != sdata);
+  uint32_t shard_index = i->seq % sharded_in_flight_list.size();
+  ShardedTrackingData& sdata = sharded_in_flight_list[shard_index];
   {
-    Mutex::Locker locker(sdata->ops_in_flight_lock_sharded);
-    auto p = sdata->ops_in_flight_sharded.iterator_to(*i);
-    sdata->ops_in_flight_sharded.erase(p);
+    Mutex::Locker locker(sdata.ops_in_flight_lock_sharded);
+    auto p = sdata.ops_in_flight_sharded.iterator_to(*i);
+    sdata.ops_in_flight_sharded.erase(p);
   }
   i->_unregistered();
 
@@ -336,17 +323,16 @@ bool OpTracker::visit_ops_in_flight(utime_t* oldest_secs,
   uint64_t total_ops_in_flight = 0;
 
   RWLock::RLocker l(lock);
-  for (const auto sdata : sharded_in_flight_list) {
-    assert(sdata);
-    Mutex::Locker locker(sdata->ops_in_flight_lock_sharded);
-    if (!sdata->ops_in_flight_sharded.empty()) {
+  for (const auto& sdata : sharded_in_flight_list) {
+    Mutex::Locker locker(sdata.ops_in_flight_lock_sharded);
+    if (!sdata.ops_in_flight_sharded.empty()) {
       utime_t oldest_op_tmp =
-	sdata->ops_in_flight_sharded.front().get_initiated();
+	sdata.ops_in_flight_sharded.front().get_initiated();
       if (oldest_op_tmp < oldest_op) {
         oldest_op = oldest_op_tmp;
       }
     }
-    total_ops_in_flight += sdata->ops_in_flight_sharded.size();
+    total_ops_in_flight += sdata.ops_in_flight_sharded.size();
   }
   if (!total_ops_in_flight)
     return false;
@@ -358,11 +344,9 @@ bool OpTracker::visit_ops_in_flight(utime_t* oldest_secs,
   if (*oldest_secs < complaint_time)
     return false;
 
-  for (uint32_t iter = 0; iter < num_optracker_shards; iter++) {
-    ShardedTrackingData* sdata = sharded_in_flight_list[iter];
-    assert(NULL != sdata);
-    Mutex::Locker locker(sdata->ops_in_flight_lock_sharded);
-    for (auto& op : sdata->ops_in_flight_sharded) {
+  for (auto& sdata : sharded_in_flight_list) {
+    Mutex::Locker locker(sdata.ops_in_flight_lock_sharded);
+    for (auto& op : sdata.ops_in_flight_sharded) {
       if (!visit(op))
 	break;
     }
@@ -451,12 +435,10 @@ void OpTracker::get_age_ms_histogram(pow2_hist_t *h)
   h->clear();
   utime_t now = ceph_clock_now();
 
-  for (uint32_t iter = 0; iter < num_optracker_shards; iter++) {
-    ShardedTrackingData* sdata = sharded_in_flight_list[iter];
-    assert(NULL != sdata);
-    Mutex::Locker locker(sdata->ops_in_flight_lock_sharded);
+  for (const auto& sdata : sharded_in_flight_list) {
+    Mutex::Locker locker(sdata.ops_in_flight_lock_sharded);
 
-    for (auto& i : sdata->ops_in_flight_sharded) {
+    for (auto& i : sdata.ops_in_flight_sharded) {
       utime_t age = now - i.get_initiated();
       uint32_t ms = (long)(age * 1000.0);
       h->add(ms);

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -190,6 +190,7 @@ OpTracker::OpTracker(CephContext *cct_, bool tracking, uint32_t num_shards):
   log_threshold(0),
   tracking_enabled(tracking),
   cct(cct_) {
+  assert(ISP2(num_shards));
 }
 
 OpTracker::~OpTracker() {
@@ -284,7 +285,7 @@ bool OpTracker::register_inflight_op(TrackedOp *i)
     return false;
 
   uint64_t current_seq = ++seq;
-  uint32_t shard_index = current_seq % sharded_in_flight_list.size();
+  uint32_t shard_index = current_seq & (sharded_in_flight_list.size() - 1);
   ShardedTrackingData& sdata = sharded_in_flight_list[shard_index];
   {
     Mutex::Locker locker(sdata.ops_in_flight_lock_sharded);
@@ -299,7 +300,7 @@ void OpTracker::unregister_inflight_op(TrackedOp *i)
   // caller checks;
   assert(i->state);
 
-  uint32_t shard_index = i->seq % sharded_in_flight_list.size();
+  uint32_t shard_index = i->seq & (sharded_in_flight_list.size() - 1);
   ShardedTrackingData& sdata = sharded_in_flight_list[shard_index];
   {
     Mutex::Locker locker(sdata.ops_in_flight_lock_sharded);

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -179,7 +179,8 @@ OpTracker::OpTracker(CephContext *cct_, bool tracking, uint32_t num_shards):
   num_optracker_shards(num_shards),
   complaint_time(0), log_threshold(0),
   tracking_enabled(tracking),
-  lock("OpTracker::lock"), cct(cct_) {
+  lock("OpTracker::lock", false /* track_lock */),
+  cct(cct_) {
     for (uint32_t i = 0; i < num_optracker_shards; i++) {
       char lock_name[32] = {0};
       snprintf(lock_name, sizeof(lock_name), "%s:%d", "OpTracker::ShardedLock", i);

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -314,7 +314,7 @@ void OpTracker::unregister_inflight_op(TrackedOp *i)
   else {
     i->state = TrackedOp::STATE_HISTORY;
     const utime_t now = ceph_clock_now();
-    history.insert(now, TrackedOpRef(i));
+    history.insert(now, i);
   }
 }
 

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -292,7 +292,7 @@ class OpTracker {
   std::atomic<int64_t> seq = { 0 };
   // preallocate space for 32 shards because of the default
   // value for osd_num_op_tracker_shard
-  ceph::containers::tiny_vector<
+  ceph::containers::shard_vector<
     ShardedTrackingData, 32> sharded_in_flight_list;
   OpHistory history;
   float complaint_time;

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -23,6 +23,7 @@
 
 class TrackedOp;
 class OpHistory;
+class OpTracker;
 
 typedef boost::intrusive_ptr<TrackedOp> TrackedOpRef;
 
@@ -203,28 +204,8 @@ public:
   void get() {
     ++nref;
   }
-  void put() {
-    if (--nref == 0) {
-      switch (state.load()) {
-      case STATE_UNTRACKED:
-	_unregistered();
-	delete this;
-	break;
 
-      case STATE_LIVE:
-	mark_event("done");
-	tracker->unregister_inflight_op(this);
-	break;
-
-      case STATE_HISTORY:
-	delete this;
-	break;
-
-      default:
-	ceph_abort();
-      }
-    }
-  }
+  void put();
 
   const char *get_desc() const {
     if (!desc || want_new_desc.load()) {
@@ -270,12 +251,7 @@ public:
 
   void dump(utime_t now, Formatter *f) const;
 
-  void tracking_start() {
-    if (tracker->register_inflight_op(this)) {
-      events.emplace_back(initiated_at, "initiated");
-      state = STATE_LIVE;
-    }
-  }
+  void tracking_start();
 
   // ref counting via intrusive_ptr, with special behavior on final
   // put for historical op tracking
@@ -385,5 +361,46 @@ public:
     return retval;
   }
 };
+
+/* Defining the methods outside the TrackedOp to avoid circular
+ * dependency with OpTracker while preserving their inlineability.
+ * The `inline` marking allows to bypass the ODR rule:
+ *
+ *   "3.2/3 Every program shall contain exactly one definition
+ *   of every non-inline function or object that is used in that
+ *   program"
+ *
+ * See: https://stackoverflow.com/questions/7833941/putting- \
+        function-definitions-in-header-files#comment9553758_7834555
+ */
+inline void TrackedOp::tracking_start() {
+  if (tracker->register_inflight_op(this)) {
+    events.emplace_back(initiated_at, "initiated");
+    state = STATE_LIVE;
+  }
+}
+
+inline void TrackedOp::put() {
+  if (--nref == 0) {
+    switch (state.load()) {
+    case STATE_UNTRACKED:
+      _unregistered();
+      delete this;
+      break;
+
+    case STATE_LIVE:
+      mark_event("done");
+      tracker->unregister_inflight_op(this);
+      break;
+
+    case STATE_HISTORY:
+      delete this;
+      break;
+
+    default:
+      ceph_abort();
+    }
+  }
+}
 
 #endif

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -284,7 +284,6 @@ class OpTracker {
   float complaint_time;
   int log_threshold;
   std::atomic<bool> tracking_enabled;
-  RWLock       lock;
 
 public:
   CephContext *cct;

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -34,9 +34,9 @@ class OpHistoryServiceThread : public Thread
     utime_t time;
     TrackedOpRef op;
 
-    queue_item_t(utime_t time, TrackedOpRef op)
+    queue_item_t(utime_t time, TrackedOp* op)
       : time(std::move(time)),
-        op(std::move(op)) {
+        op(TrackedOpRef(op)) {
     }
   };
   typedef boost::intrusive::list<queue_item_t> queue_t;
@@ -53,8 +53,8 @@ public:
   ~OpHistoryServiceThread();
 
   void break_thread();
-  void insert_op(const utime_t& now, TrackedOpRef op) {
-    auto item = new queue_item_t(now, std::move(op));
+  void insert_op(const utime_t& now, TrackedOp* op) {
+    auto item = new queue_item_t(now, op);
     queue_spinlock.lock();
     _external_queue.push_back(*item);
     queue_spinlock.unlock();
@@ -90,7 +90,7 @@ public:
     assert(duration.empty());
     assert(slow_op.empty());
   }
-  void insert(const utime_t& now, TrackedOpRef op)
+  void insert(const utime_t& now, TrackedOp* op)
   {
     if (shutdown)
       return;

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include "common/histogram.h"
+#include "common/containers.h"
 #include "msg/Message.h"
 #include "common/RWLock.h"
 
@@ -264,13 +265,22 @@ public:
 };
 
 
-struct ShardedTrackingData;
 class OpTracker {
+  struct ShardedTrackingData {
+    mutable Mutex ops_in_flight_lock_sharded;
+    TrackedOp::tracked_op_list_t ops_in_flight_sharded;
+    explicit ShardedTrackingData(string lock_name):
+      ops_in_flight_lock_sharded(lock_name.c_str()) {
+    }
+  };
+
   friend class OpHistory;
   std::atomic<int64_t> seq = { 0 };
-  vector<ShardedTrackingData*> sharded_in_flight_list;
+  // preallocate space for 32 shards because of the default
+  // value for osd_num_op_tracker_shard
+  ceph::containers::tiny_vector<
+    ShardedTrackingData, 32> sharded_in_flight_list;
   OpHistory history;
-  uint32_t num_optracker_shards;
   float complaint_time;
   int log_threshold;
   std::atomic<bool> tracking_enabled;

--- a/src/common/align.h
+++ b/src/common/align.h
@@ -17,14 +17,18 @@
 #ifndef CEPH_COMMON_ALIGN_H
 #define CEPH_COMMON_ALIGN_H
 
-template <typename T>
-inline constexpr T align_up(T v, T align) {
+#include <type_traits>
+
+template <typename T, typename U>
+inline constexpr T align_up(T v, U align) {
+  static_assert(std::is_convertible_v<U, T>);
   return (v + align - 1) & ~(align - 1);
 }
 
-template <typename T>
-inline constexpr T align_down(T v, T align) {
-  return v & ~(align - 1);
+template <typename T, typename U>
+inline constexpr T align_down(T v, U align) {
+  static_assert(std::is_convertible_v<U, T>);
+  return v & ~(static_cast<T>(align) - 1);
 }
 
 #endif /* CEPH_COMMON_ALIGN_H */

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -852,7 +852,7 @@ void CephContext::notify_pre_fork()
 
 void CephContext::notify_post_fork()
 {
-  ceph::spin_unlock(&_fork_watchers_lock);
+  _fork_watchers_lock.unlock();
   for (auto &&t : _fork_watchers)
     t->handle_post_fork();
 }

--- a/src/common/containers.h
+++ b/src/common/containers.h
@@ -1,0 +1,145 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+//
+// Ceph - scalable distributed file system
+//
+// Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+//
+// This is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1, as published by the Free Software
+// Foundation.  See file COPYING.
+//
+
+#ifndef CEPH_COMMON_CONTAINERS_H
+#define CEPH_COMMON_CONTAINERS_H
+
+#include <type_traits>
+
+namespace ceph::containers {
+
+// tiny_vector - a CPU-friendly container like small_vector but for
+// mutexes, atomics and other non-movable things.
+//
+// The purpose of the container is store arbitrary number of objects
+// with absolutely minimal requirements regarding constructibility
+// and assignability while minimizing memory indirection.
+// There is no obligation for MoveConstructibility, CopyConstructibility,
+// MoveAssignability, CopyAssignability nor even DefaultConstructibility
+// which allows to handle std::mutexes, std::atomics or any type embedding
+// them.
+//
+// Few requirements translate into tiny interface. The container isn't
+// Copy- nor MoveConstructible. Although it does offer random access
+// iterator, insertion in the middle is not allowed. The maximum number
+// of elements must be known at run-time. This shouldn't be an issue in
+// the intended use case: sharding.
+//
+// Alternatives:
+//  1. std::vector<boost::optional<ValueT>> initialized with the known
+//     size and emplace_backed(). boost::optional inside provides
+//     the DefaultConstructibility. Imposes extra memory indirection.
+//  2. boost::container::small_vector + boost::optional always
+//     requires MoveConstructibility.
+//  3. boost::container::static_vector feed via emplace_back().
+//     Good for performance but enforces upper limit on elements count.
+//     For sharding this means we can't handle arbitrary number of
+//     shards (weird configs).
+//  4. std::unique_ptr<ValueT>: extra indirection together with memory
+//     fragmentation.
+
+template<typename Value, std::size_t Capacity>
+class tiny_vector {
+  using storage_unit_t = \
+    std::aligned_storage_t<sizeof(Value), alignof(Value)>;
+
+  std::size_t _size = 0;
+  storage_unit_t* const data = nullptr;
+  storage_unit_t internal[Capacity];
+
+public:
+  typedef std::size_t size_type;
+  typedef std::add_lvalue_reference_t<Value> reference;
+  typedef std::add_const_t<reference> const_reference;
+  typedef std::add_pointer_t<Value> pointer;
+
+  class emplacer {
+    friend class tiny_vector;
+
+    tiny_vector* parent;
+    emplacer(tiny_vector* const parent)
+      : parent(parent) {
+    }
+
+  public:
+    template<class... Args>
+    void emplace(Args&&... args) {
+      if (!parent) {
+        return;
+      }
+      new (&parent->data[parent->_size++]) Value(std::forward<Args>(args)...);
+      parent = nullptr;
+    }
+  };
+
+  template<typename F>
+  tiny_vector(const std::size_t count, F&& f)
+    : data(count <= Capacity ? internal
+                             : new storage_unit_t[count]) {
+    for (std::size_t i = 0; i < count; ++i) {
+      // caller MAY emplace up to `count` elements but it IS NOT
+      // obliged to do so. The emplacer guarantees that the limit
+      // will never be exceeded.
+      f(i, emplacer(this));
+    }
+  }
+
+  ~tiny_vector() {
+    for (auto& elem : *this) {
+      elem.~Value();
+    }
+
+    const auto data_addr = reinterpret_cast<uintptr_t>(data);
+    const auto this_addr = reinterpret_cast<uintptr_t>(this);
+    if (data_addr < this_addr ||
+        data_addr >= this_addr + sizeof(*this)) {
+      delete[] data;
+    }
+  }
+
+  reference       operator[](size_type pos) {
+    return reinterpret_cast<reference>(data[pos]);
+  }
+  const_reference operator[](size_type pos) const {
+    return reinterpret_cast<const_reference>(data[pos]);
+  }
+
+  size_type size() const {
+    return _size;
+  }
+
+  pointer begin() {
+    return reinterpret_cast<pointer>(&data[0]);
+  }
+  pointer end() {
+    return reinterpret_cast<pointer>(&data[_size]);
+  }
+
+  const pointer begin() const {
+    return reinterpret_cast<pointer>(&data[0]);
+  }
+  const pointer end() const {
+    return reinterpret_cast<pointer>(&data[_size]);
+  }
+
+  const pointer cbegin() const {
+    return reinterpret_cast<pointer>(&data[0]);
+  }
+  const pointer cend() const {
+    return reinterpret_cast<pointer>(&data[_size]);
+  }
+};
+
+} // namespace ceph::containers
+
+#endif // CEPH_COMMON_CONTAINERS_H

--- a/src/common/containers.h
+++ b/src/common/containers.h
@@ -16,6 +16,8 @@
 
 #include <type_traits>
 
+#include "include/intarith.h"
+
 namespace ceph::containers {
 
 // tiny_vector - a CPU-friendly container like small_vector but for
@@ -137,6 +139,66 @@ public:
   }
   const pointer cend() const {
     return reinterpret_cast<pointer>(&data[_size]);
+  }
+};
+
+
+static constexpr const std::size_t CACHE_LINE_SIZE = 64;
+
+// align_wrapper - helper class for providing cache line alignment to
+// any Value type.
+//
+// We're going with extended alignment here. AFAIK the standard makes
+// it non-obligatory for compiler vendors, albeit this feature should
+// be hopefully available on most platforms.
+
+template <typename Value>
+struct alignas(CACHE_LINE_SIZE) align_wrapper : public Value {
+  template<class... Args>
+  align_wrapper(Args&&... args)
+    : Value(std::forward<Args>(args)...) {
+  }
+};
+
+
+// shard_vector - a tiny_vector specially designated for shard handling.
+//
+// The container puts the same requirements on Value as tiny_vector but
+// provides interface enriched with facilities for fast shard accesses.
+// It is possible because assuming (end enforcing in run-time) Capacity
+// is power-of-2. Thanks to that, the modulo operation is implementable
+// with bit twiddling in place of costly divisions.
+//
+// Additionally, the shard_vector takes care of aligning shards to cache
+// line boundary. This is useful as, typically, handled type has a mutex
+// or plain atomic inside. The optimization allows to avoid costly ping-
+// pong between CPUs as well as memory fencing.
+
+template<typename Value, std::size_t Capacity>
+class shard_vector : public tiny_vector<align_wrapper<Value>, Capacity> {
+  typedef tiny_vector<align_wrapper<Value>, Capacity> base_t;
+  typedef typename base_t::size_type size_type;
+  typedef typename base_t::reference reference;
+  typedef typename base_t::const_reference const_reference;
+
+public:
+  template<typename F>
+  shard_vector(const ceph::math::p2_t<size_type> count, F&& f)
+    : base_t(count, std::forward<F>(f)) {
+    assert(count == base_t::size());
+  }
+
+  // Yes, we're overriding (not hiding!) the size() from base_t.
+  ceph::math::p2_t<size_type> size() const {
+    return ceph::math::p2_t<size_type>::from_p2(base_t::size());
+  }
+
+  reference get_shard(const size_type selector) {
+    return (*this)[selector % size()];
+  }
+
+  const_reference get_shard(const size_type selector) const {
+    return (*this)[selector % size()];
   }
 };
 

--- a/src/include/intarith.h
+++ b/src/include/intarith.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_INTARITH_H
 #define CEPH_INTARITH_H
 
+#include <limits>
 #include <type_traits>
 
 #ifndef DIV_ROUND_UP
@@ -211,5 +212,65 @@ template<class T>
     return 0;
   return (sizeof(v) * 8) - __builtin_clzll(v);
 }
+
+namespace ceph::math {
+
+template<class UnsignedValueT>
+class p2_t {
+  typedef uint8_t exponent_type;
+  typedef UnsignedValueT value_type;
+
+  static_assert(std::is_unsigned_v<value_type>);
+  static_assert(std::numeric_limits<exponent_type>::max() >
+		std::numeric_limits<value_type>::digits);
+
+  value_type value;
+
+  struct _check_skipper_t {};
+  p2_t(const value_type value, _check_skipper_t)
+    : value(value) {
+  }
+
+public:
+  p2_t(const value_type value)
+    : value(value) {
+    // 0 isn't a power of two. Additional validation is necessary as
+    // the isp2 routine doesn't sanitize that case.
+    //assert(value != 0);
+    assert(isp2(value));
+  }
+
+  static p2_t<value_type> from_p2(const value_type p2) {
+    return p2_t(p2, _check_skipper_t());
+  }
+
+  static p2_t<value_type> from_exponent(const exponent_type exponent) {
+    return p2_t(1 << exponent, _check_skipper_t());
+  }
+
+  exponent_type get_exponent() const {
+    return ctz(value);
+  }
+
+  value_type get_value() const {
+    return value;
+  }
+
+  operator value_type() const {
+    return value;
+  }
+
+  friend value_type operator/(const value_type& l,
+                              const p2_t<value_type>& r) {
+    return l >> (cbits(r.value) - 1);
+  }
+
+  friend value_type operator%(const value_type& l,
+                              const p2_t<value_type>& r) {
+    return l & (r.value - 1);
+  }
+};
+
+} // namespace ceph::math
 
 #endif

--- a/src/include/spinlock.h
+++ b/src/include/spinlock.h
@@ -18,52 +18,119 @@
 #define CEPH_SPINLOCK_HPP
 
 #include <atomic>
+#include <thread>
+
+#if defined(__i386__) || defined(__x86_64__)
+#  include <immintrin.h>
+#endif
+
+#include "common/likely.h"
 
 namespace ceph {
 inline namespace version_1_0 {
 
+static inline void emit_pause() {
+#if defined(__i386__) || defined(__x86_64__)
+  // The spinning part is indistinguishable for CPU without
+  // additional hint. On x86 there is PAUSE instruction for
+  // that. We definitely want to use it because of:
+  //   * not disturbing second thread on the same core (SMT),
+  //   * saving power.
+  // Although the instruction is available since P4, binary
+  // transcription into `rep; nop` allows its decoding even
+  // on i386, so no need for `cpuid` or other costly things.
+  // For details please refer to:
+  //  * "Long Duration Spin-wait Loops on Hyper-Threading
+  //     Technology Enabled Intel Processors",
+  //  * "Benefitting Power and Performance Sleep Loops".
+  _mm_pause();
+#endif
+}
+
 class spinlock;
 
-inline void spin_lock(std::atomic_flag& lock);
-inline void spin_unlock(std::atomic_flag& lock);
-inline void spin_lock(ceph::spinlock& lock);
-inline void spin_unlock(ceph::spinlock& lock);
+inline void spin_lock(std::atomic_bool& locked);
+inline void spin_unlock(std::atomic_bool& locked);
+inline void spin_lock(ceph::spinlock& locked);
+inline void spin_unlock(ceph::spinlock& locked);
 
 /* A pre-packaged spinlock type modelling BasicLockable: */
 class spinlock final
 {
-  std::atomic_flag af = ATOMIC_FLAG_INIT;
+  // Not using atomic_flag anymore because it doesn't
+  // provide the load nor store operation.
+  std::atomic_bool locked = false;
 
-  public:
+  // In contrast to atomic_flag, atomic_bool might be
+  // implemented on top of e.g. mutex. However, it is
+  // very unlikely we'll face such situation in Ceph.
+  static_assert(std::atomic_bool::is_always_lock_free);
+
+public:
   void lock() {
-    ceph::spin_lock(af);
+    ceph::spin_lock(locked);
   }
  
   void unlock() noexcept {
-    ceph::spin_unlock(af);
+    ceph::spin_unlock(locked);
   }
 };
 
 // Free functions:
-inline void spin_lock(std::atomic_flag& lock)
+inline void spin_lock(std::atomic_bool& locked)
 {
- while(lock.test_and_set(std::memory_order_acquire))
-  ;
+  bool expected = false;
+  if (likely(locked.compare_exchange_weak(expected, true,
+                                          std::memory_order_acquire,
+                                          std::memory_order_relaxed))) {
+    return;
+  }
+
+  // The contention part.
+  do {
+    std::size_t tries = 0;
+
+    // There is no need to constantly try LOCK CMPXCHG and enforce
+    // x86 CPUs to do costly mem fencing. The algorithm comes from
+    // NPTL's pthread_spin_lock() implementation of glibc.
+    do {
+      emit_pause();
+
+      if if (++tries == 32) {
+        // Oops, things went really bad. There was no state change
+        // for many iterations. This could happen when lock holder
+        // gets stuck because of e.g. being preempted. Most likely
+        // other waiters started spinning as well. The best we can
+        // do is to limit our losses and yield CPU. Luckily kernel
+        // (it's perfectly unaware about the whole situation) will
+        // switch to something useful or, at least, blocked holder
+        // will get its time quantum faster.
+        std::this_thread::yield();
+        tries = 0;
+      }
+    } while (locked.load(std::memory_order_relaxed));
+
+    // The specification of compare_exchange() does not say a word
+    // that the value of `expected` can't change, so let's refresh.
+    expected = false;
+  } while (!locked.compare_exchange_weak(expected, true,
+                                         std::memory_order_acquire,
+                                         std::memory_order_relaxed));
 }
 
-inline void spin_unlock(std::atomic_flag& lock)
+inline void spin_unlock(std::atomic_bool& locked)
 {
- lock.clear(std::memory_order_release);
+  locked.store(false, std::memory_order_release);
 }
 
-inline void spin_lock(std::atomic_flag *lock)
+inline void spin_lock(std::atomic_bool *locked)
 {
- spin_lock(*lock);
+ spin_lock(*locked);
 }
 
-inline void spin_unlock(std::atomic_flag *lock)
+inline void spin_unlock(std::atomic_bool *locked)
 {
- spin_unlock(*lock);
+ spin_unlock(*locked);
 }
 
 inline void spin_lock(ceph::spinlock& lock)


### PR DESCRIPTION
Summary
=======
Last week the `OpHistory` overhead has been wisely removed from the main path. I observe several % less `futex` syscalls per read on the fresh `master` :-). This pull request tries to deal with `OpTracker`, an entity that sits above the `OpHistory` and remains a hot spot.

In the matter of `cycles:pp` before the PR #20540 (quite old `master`):
```
         - 3,16% PGOpItem::~PGOpItem
            - 2,91% OpTracker::unregister_inflight_op
                 1,25% OpHistory::insert
                 0,58% OpRequest::~OpRequest
```

After PR #20540 but before this one:
```
         - 2,34% PGOpItem::~PGOpItem
            - TrackedOp::put
                 2,10% OpTracker::unregister_inflight_op
```

Notable changes
============
* Eradicate the `RWLock`-typed `OpTracker::lock` that is being used on the main path but **never gets locked exclusively**. This suggests it's virtually a no-op associated with non-zero cost, higher in comparison to plain mutex. For details please refer to [the discussion](http://permalink.gmane.org/gmane.comp.lib.boost.devel/211180) regarding real functionality of `std::shared_mutex` and the lack of its standardization in C++11. The extra ref counting we do by default in `RWLock` rises the cost further.
* Change the way how `tp_osd_tp` threads synchronize with the new `OpHistory` management thread. The optimizing started from improving the `ceph::spinlock` implementation but ultimately moved to plain `std::mutex` treated as a spinlock-with-backoff-ability. The main idea is to prevent situations when e.g. preemption of single worker thread makes all others (up to 16 - 1 by default) burning CPU and starving everything else. That's the purpose of introducing `ceph::spin::adapt_guard`. It might be useful in other places as the `pthread_mutex_lock` from glibc  effectively `try_lock` once and then fallback to kernel (applies to the `PTHREAD_MUTEX_NORMAL`).
* Improve `ceph::spinlock`. Although ultimately dropped from `OpHistoryServiceThread`, optimization in this area still could be beneficial for other users (e.g. `AsyncMessanger`, `CephContext`).
The current implementation uses `lock cmpxchg` in very tight loop which isn't the way to go, especially on SMT systems. Please refer to [Long Duration Spin-wait Loops on Hyper-Threading Technology Enabled Intel Processors](https://software.intel.com/en-us/articles/long-duration-spin-wait-loops-on-hyper-threading-technology-enabled-intel-processors/) and [Benefitting Power and Performance Sleep Loops](https://software.intel.com/en-us/articles/benefitting-power-and-performance-sleep-loops). Although being Intel's papers, I believe they apply to recent AMD's CPUs as well. Additionally, relaxation of memory ordering in the lock phase *might* (untested!) benefit machines with weaker memory model than x86.
* Remove the nasty pattern of `division-missed load-missed load` during shard access with `ceph::tiny_vector` and through making the assumption that number of `OpTracker`'s shards is p2. The further idea is to combine `ceph::tiny_vector` with `ceph::math::p2_t` to form `ceph::containers::shard_vector` which would also take care of enforcing cache line alignment.
* Kill the ref counting on op deregistration. On x86 locked instructions are necessary for the sake of atomicity. They act just like a memory barrier.

Performance comparison
==================

All tests have been conducted on a single, physical *incerta* node in 5 rounds. The result for each round is sum of **bandwidth** 4 separated FIO-librbd clients get from the cluster.


Reference point: 8e8c5e2a3849c90f4f16892e1150d22de8f4de34.
-----------------------------------------------------------------------------------
```
randread,  4 KiB:  355585,  348867,  353343,  356998,  347209
randread, 64 KiB: 3176554, 3183690, 3189953, 3181545, 3046893
```

After the changes: ee8ed2bc48c6bc8dbc9cd70fb1c515fd6642429a.
---------------------------------------------------------------------------------------
```
randread,  4 KiB:  371652,  377484,  371640,  371964,  372908
randread, 64 KiB: 3262052, 3236116, 3256350, 3244601, 3229833

```

Profiling in the domain of `cycles:pp`
==========================
Everything happened on my development machine (Intel Core i7-6820HQ, Samsung SM961 NVMe).

### Before PR #20540
```
   - 54,36% ShardedThreadPool::shardedthreadpool_worker
      - 54,19% OSD::ShardedOpWQ::_process
         + 45,25% PGOpItem::run
         - 3,16% PGOpItem::~PGOpItem
            - 2,91% OpTracker::unregister_inflight_op
                 1,25% OpHistory::insert
                 0,58% OpRequest::~OpRequest
         + 1,48% Cond::Wait
         + 1,40% PG::lock
         + 0,87% WeightedPriorityQueue<OpQueueItem, unsigned long>::dequeue
           0,52% Mutex::Unlock
```


### After PR #20540 but before this one
```
-   52,51%     0,13%  tp_osd_tp        libceph-common.so.0   [.] ShardedThreadPool::shardedthreadpool_worker
   - 52,38% ShardedThreadPool::shardedthreadpool_worker
      - 52,23% OSD::ShardedOpWQ::_process
         + 43,90% PGOpItem::run
         - 2,34% PGOpItem::~PGOpItem
            - TrackedOp::put
                 2,10% OpTracker::unregister_inflight_op
         + 1,57% Cond::Wait
         + 1,47% PG::lock
         + 0,76% WeightedPriorityQueue<OpQueueItem, unsigned long>::dequeue
           0,55% Mutex::Unlock
```


### Killing the `OpTracker::lock` has exposed the spinlock contention

This varies greatly. I observed values between 5-11%.
```
-   56,13%     0,11%  tp_osd_tp        libceph-common.so.0   [.] ShardedThreadPool::shardedthreadpool_worker
   - 56,02% ShardedThreadPool::shardedthreadpool_worker
      - 55,89% OSD::ShardedOpWQ::_process
         + 40,99% PGOpItem::run
         - 9,50% PGOpItem::~PGOpItem
            - TrackedOp::put
                 9,29% OpTracker::unregister_inflight_op
         + 1,50% Cond::Wait
         + 1,32% PG::lock
         + 0,67% WeightedPriorityQueue<OpQueueItem, unsigned long>::dequeue
```


### At the moment
Hopefully not finished yet -- there is the `register_inflight_op` part to deal with. :-)
```
   - 51,51% ShardedThreadPool::shardedthreadpool_worker
      - 51,34% OSD::ShardedOpWQ::_process
         + 44,12% PGOpItem::run
         + 1,64% Cond::Wait
         + 1,52% PG::lock
         - 1,12% PGOpItem::~PGOpItem
            - TrackedOp::put
               - 0,87% OpTracker::unregister_inflight_op
                    0,54% OpRequest::_unregistered
         + 0,75% WeightedPriorityQueue<OpQueueItem, unsigned long>::dequeue
           0,55% Mutex::Unlock
```

**UPDATE**: I plan to continue with `register_inflight_op` after PR #19973 gets merged. The idea is to establish a binding between shards of `OpTracker`  and `ShardedOpWQ` with `spg_t` as a selector. At least for the OSD use case, this would make the `std::atomic<int64_t>`-typed `OpTracker::seq` unnecessary.