### PR TITLE
osd/OSDMap: ignore PGs from pools of failure-domain OSD

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1638,6 +1638,11 @@ void OSDMap::maybe_remove_pg_upmaps(CephContext *cct,
       lderr(cct) << __func__ << " unable to load failure-domain-type of pg "
                  << p.first << dendl;
       continue;
+    } else if (type == 0) {
+      ldout(cct, 10) << __func__ << " failure-domain of pg " << p.first
+                     << " is osd-level, skipping"
+                     << dendl;
+      continue;
     }
     ldout(cct, 10) << __func__ << " pg " << p.first
                    << " crush-rule-id " << crush_rule
@@ -1647,16 +1652,24 @@ void OSDMap::maybe_remove_pg_upmaps(CephContext *cct,
     int primary;
     tmpmap.pg_to_raw_up(p.first, &raw, &primary);
     set<int> parents;
+    bool error = false;
     bool collide = false;
     for (auto osd : raw) {
       auto parent = tmpmap.crush->get_parent_of_type(osd, type);
+      if (parent >= 0) {
+        lderr(cct) << __func__ << " unable to get parent of raw osd." << osd
+                   << ", pg " << p.first
+                   << dendl;
+        error = true;
+        break;
+      }
       auto r = parents.insert(parent);
       if (!r.second) {
         collide = true;
         break;
       }
     }
-    if (collide) {
+    if (!error && collide) {
       ldout(cct, 10) << __func__ << " removing invalid pg_upmap "
                      << "[" << p.first << ":" << p.second << "]"
                      << ", final mapping result will be: " << raw
@@ -1685,6 +1698,11 @@ void OSDMap::maybe_remove_pg_upmaps(CephContext *cct,
       lderr(cct) << __func__ << " unable to load failure-domain-type of pg "
                  << p.first << dendl;
       continue;
+    } else if (type == 0) {
+      ldout(cct, 10) << __func__ << " failure-domain of pg " << p.first
+                     << " is osd-level, skipping"
+                     << dendl;
+      continue;
     }
     ldout(cct, 10) << __func__ << " pg " << p.first
                    << " crush_rule_id " << crush_rule
@@ -1694,16 +1712,24 @@ void OSDMap::maybe_remove_pg_upmaps(CephContext *cct,
     int primary;
     tmpmap.pg_to_raw_up(p.first, &raw, &primary);
     set<int> parents;
+    bool error = false;
     bool collide = false;
     for (auto osd : raw) {
       auto parent = tmpmap.crush->get_parent_of_type(osd, type);
+      if (parent >= 0) {
+        lderr(cct) << __func__ << " unable to get parent of raw osd." << osd
+                   << ", pg " << p.first
+                   << dendl;
+        error = true;
+        break;
+      }
       auto r = parents.insert(parent);
       if (!r.second) {
         collide = true;
         break;
       }
     }
-    if (collide) {
+    if (!error && collide) {
       ldout(cct, 10) << __func__ << " removing invalid pg_upmap_items "
                      << "[" << p.first << ":" << p.second << "]"
                      << ", final mapping result will be: " << raw


### PR DESCRIPTION
For testing purpose, we may create pools of failure-domain OSD.
In this case get_parent_of_type() will always return 0 and all
parents of these PGs' *up set* are considered as collided, and
hence the relevant pg_upmap/items are incorrectly removed during
the maybe_remove_pg_upmaps() procedure.

Fix the above problem by skipping these PGs and also try to be
more specific if we are unable to load the parent of a specified
PG.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>