### PR TITLE
ceph-volume tests alleviate libvirt timeouts when reloading

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/Vagrantfile
+++ b/src/ceph-volume/ceph_volume/tests/functional/Vagrantfile
@@ -84,6 +84,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       client.vm.provider :libvirt do |lv|
         lv.memory = MEMORY
         lv.random_hostname = true
+        lv.nic_model_type = "e1000"
       end
 
       # Parallels
@@ -122,6 +123,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       rgw.vm.provider :libvirt do |lv|
         lv.memory = MEMORY
         lv.random_hostname = true
+        lv.nic_model_type = "e1000"
       end
 
       # Parallels
@@ -160,6 +162,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       nfs.vm.provider :libvirt do |lv|
         lv.memory = MEMORY
         lv.random_hostname = true
+        lv.nic_model_type = "e1000"
       end
 
       # Parallels
@@ -197,6 +200,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       mds.vm.provider :libvirt do |lv|
         lv.memory = MEMORY
         lv.random_hostname = true
+        lv.nic_model_type = "e1000"
       end
       # Parallels
       mds.vm.provider "parallels" do |prl|
@@ -233,6 +237,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       rbd_mirror.vm.provider :libvirt do |lv|
         lv.memory = MEMORY
         lv.random_hostname = true
+        lv.nic_model_type = "e1000"
       end
       # Parallels
       rbd_mirror.vm.provider "parallels" do |prl|
@@ -269,6 +274,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       iscsi_gw.vm.provider :libvirt do |lv|
         lv.memory = MEMORY
         lv.random_hostname = true
+        lv.nic_model_type = "e1000"
       end
       # Parallels
       iscsi_gw.vm.provider "parallels" do |prl|
@@ -305,6 +311,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       mon.vm.provider :libvirt do |lv|
         lv.memory = MEMORY
         lv.random_hostname = true
+        lv.nic_model_type = "e1000"
       end
 
       # Parallels
@@ -374,6 +381,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         end
         lv.memory = MEMORY
         lv.random_hostname = true
+        lv.nic_model_type = "e1000"
       end
 
       # Parallels


### PR DESCRIPTION
See vagrant-libvirt comment:

https://github.com/vagrant-libvirt/vagrant-libvirt/issues/510#issuecomment-195326272

And ceph-ansible commit:

https://github.com/ceph/ceph-ansible/commit/eae6ad6d40561f70679b4973d1bd4b39febd941c

Fixes http://tracker.ceph.com/issues/23163

Signed-off-by: Alfredo Deza <adeza@redhat.com>