### PR TITLE
client: add new ceph_mount_perms_set function

### DIFF
--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -165,6 +165,20 @@ void ceph_userperm_destroy(UserPerm *perm);
 struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount);
 
 /**
+ * Set cmount's default permissions
+ *
+ * @param cmount the mount info handle
+ * @param perm permissions to set to default for mount
+ *
+ * Every cmount has a default set of credentials. This does a deep copy of
+ * the given permissions to the ones in the cmount. Must be done after
+ * ceph_init but before ceph_mount.
+ *
+ * Returns 0 on success, and -EISCONN if the cmount is already mounted.
+ */
+int ceph_mount_perms_set(struct ceph_mount_info *cmount, UserPerm *perm);
+
+/**
  * @defgroup libcephfs_h_init Setup and Teardown
  * These are the first and last functions that should be called
  * when using libcephfs.

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -462,6 +462,15 @@ extern "C" struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount)
   return &cmount->default_perms;
 }
 
+extern "C" int ceph_mount_perms_set(struct ceph_mount_info *cmount,
+				    struct UserPerm *perms)
+{
+  if (cmount->is_mounted())
+    return -EISCONN;
+  cmount->default_perms = *perms;
+  return 0;
+}
+
 extern "C" int ceph_statfs(struct ceph_mount_info *cmount, const char *path,
 			   struct statvfs *stbuf)
 {

--- a/src/test/libcephfs/access.cc
+++ b/src/test/libcephfs/access.cc
@@ -265,8 +265,13 @@ TEST(AccessTest, User) {
   ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
   ASSERT_EQ(0, ceph_conf_set(cmount, "key", key.c_str()));
   ASSERT_EQ(-EACCES, ceph_mount(cmount, "/"));
-  ASSERT_EQ(0, ceph_conf_set(cmount, "client_mount_uid", "123"));
-  ASSERT_EQ(0, ceph_conf_set(cmount, "client_mount_gid", "456"));
+  ASSERT_EQ(0, ceph_init(cmount));
+
+  UserPerm *perms = ceph_userperm_new(123, 456, 0, NULL);
+  ASSERT_NE(nullptr, perms);
+  ASSERT_EQ(0, ceph_mount_perms_set(cmount, perms));
+  ceph_userperm_destroy(perms);
+
   ASSERT_EQ(0, ceph_conf_set(cmount, "client_permissions", "0"));
   ASSERT_EQ(0, ceph_mount(cmount, "/"));
 


### PR DESCRIPTION
Allow programs to craft a UserPerm structure to use as the default
perms on the mount. The UserPerm is copied, so the caller can delete
the model UserPerm once the call is complete.

Note that we do not currently allow setting this once ceph_mount has
been called, as there are potential races that could occur while copying
it. We could eventually allow that, but we'd have to ensure that the
default_perms remain valid for accessors operating during and after the
copy.

Tracker: http://tracker.ceph.com/issues/22802
Signed-off-by: Jeff Layton <jlayton@redhat.com>