### PR TITLE
[DNM] os/bluestore: add periodic discard feature to StupidAllocator

### DIFF
--- a/qa/objectstore/bluestore-bitmap.yaml
+++ b/qa/objectstore/bluestore-bitmap.yaml
@@ -20,8 +20,7 @@ overrides:
         osd failsafe full ratio: .95
 # this doesn't work with failures bc the log writes are not atomic across the two backends
 #        bluestore bluefs env mirror: true
-        bdev enable discard: true
-        bdev async discard: true
+        bluestore bdev discard: async
   ceph-deploy:
     fs: xfs
     bluestore: yes
@@ -38,6 +37,5 @@ overrides:
         mon osd backfillfull_ratio: .85
         mon osd nearfull ratio: .8
         osd failsafe full ratio: .95
-        bdev enable discard: true
-        bdev async discard: true
+        bluestore bdev discard: async
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -922,8 +922,6 @@ OPTION(bdev_debug_aio_suicide_timeout, OPT_FLOAT)
 // NVMe driver is loaded while osd is running.
 OPTION(bdev_nvme_unbind_from_kernel, OPT_BOOL)
 OPTION(bdev_nvme_retry_count, OPT_INT) // -1 means by default which is 4
-OPTION(bdev_enable_discard, OPT_BOOL)
-OPTION(bdev_async_discard, OPT_BOOL)
 
 OPTION(objectstore_blackhole, OPT_BOOL)
 
@@ -954,6 +952,8 @@ OPTION(bluestore_bluefs_alloc_failure_dump_interval, OPT_FLOAT)
 // Enforces db sync with legacy bluefs extents information on close.
 // Enables downgrades to pre-nautilus releases
 OPTION(bluestore_bluefs_db_compatibility, OPT_BOOL)
+
+OPTION(bluefs_bdev_discard, OPT_STR)
 
 // If you want to use spdk driver, you need to specify NVMe serial number here
 // with "spdk:" prefix.
@@ -1054,6 +1054,7 @@ OPTION(bluestore_blobid_prealloc, OPT_U64)
 OPTION(bluestore_clone_cow, OPT_BOOL)  // do copy-on-write for clones
 OPTION(bluestore_default_buffered_read, OPT_BOOL)
 OPTION(bluestore_default_buffered_write, OPT_BOOL)
+OPTION(bluestore_bdev_discard, OPT_STR)
 OPTION(bluestore_debug_misc, OPT_BOOL)
 OPTION(bluestore_debug_no_reuse_blocks, OPT_BOOL)
 OPTION(bluestore_debug_small_allocations, OPT_INT)

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -954,6 +954,8 @@ OPTION(bluestore_bluefs_alloc_failure_dump_interval, OPT_FLOAT)
 OPTION(bluestore_bluefs_db_compatibility, OPT_BOOL)
 
 OPTION(bluefs_bdev_discard, OPT_STR)
+OPTION(bluefs_bdev_periodic_discard_timeout, OPT_INT)
+OPTION(bluefs_bdev_periodic_discard_free_ratio, OPT_FLOAT)
 
 // If you want to use spdk driver, you need to specify NVMe serial number here
 // with "spdk:" prefix.
@@ -1055,6 +1057,10 @@ OPTION(bluestore_clone_cow, OPT_BOOL)  // do copy-on-write for clones
 OPTION(bluestore_default_buffered_read, OPT_BOOL)
 OPTION(bluestore_default_buffered_write, OPT_BOOL)
 OPTION(bluestore_bdev_discard, OPT_STR)
+OPTION(bluestore_bdev_periodic_discard_timeout, OPT_INT)
+OPTION(bluestore_bdev_periodic_discard_free_ratio, OPT_FLOAT)
+
+
 OPTION(bluestore_debug_misc, OPT_BOOL)
 OPTION(bluestore_debug_no_reuse_blocks, OPT_BOOL)
 OPTION(bluestore_debug_small_allocations, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4154,6 +4154,7 @@ std::vector<Option> get_global_options() {
 
     Option("bluefs_allocator", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("bitmap")
+    .set_enum_allowed({"bitmap", "stupid"})
     .set_description(""),
 
     Option("bluefs_preextend_wal_files", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4205,7 +4205,15 @@ std::vector<Option> get_global_options() {
     
     Option("bluefs_bdev_discard", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("none")
-    .set_enum_allowed({"none", "sync", "async"})
+    .set_enum_allowed({"none", "sync", "async", "periodic"})
+    .set_description(""),
+
+    Option("bluefs_bdev_periodic_discard_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(30)
+    .set_description(""),
+
+    Option("bluefs_bdev_periodic_discard_free_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0.5)
     .set_description(""),
 
     Option("bluestore_spdk_mem", Option::TYPE_SIZE, Option::LEVEL_DEV)
@@ -4641,7 +4649,15 @@ std::vector<Option> get_global_options() {
 
     Option("bluestore_bdev_discard", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("none")
-    .set_enum_allowed({"none", "sync", "async"})
+    .set_enum_allowed({"none", "sync", "async", "periodic"})
+    .set_description(""),
+
+    Option("bluestore_bdev_periodic_discard_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(30)
+    .set_description(""),
+
+    Option("bluestore_bdev_periodic_discard_free_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0.5)
     .set_description(""),
 
     Option("bluestore_debug_misc", Option::TYPE_BOOL, Option::LEVEL_DEV)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4104,14 +4104,6 @@ std::vector<Option> get_global_options() {
     .set_default(-1)
     .set_description(""),
 
-    Option("bdev_enable_discard", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
-    .set_description(""),
-
-    Option("bdev_async_discard", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(false)
-    .set_description(""),
-
     Option("bluefs_alloc_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(1_M)
     .set_description(""),
@@ -4210,6 +4202,11 @@ std::vector<Option> get_global_options() {
     .set_description("Sync db with legacy bluefs extents info")
     .set_long_description("Enforces db sync with legacy bluefs extents information on close."
                           " Enables downgrades to pre-nautilus releases"),
+    
+    Option("bluefs_bdev_discard", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("none")
+    .set_enum_allowed({"none", "sync", "async"})
+    .set_description(""),
 
     Option("bluestore_spdk_mem", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(512)
@@ -4641,6 +4638,11 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_flag(Option::FLAG_RUNTIME)
     .set_description("Cache writes by default (unless hinted NOCACHE or WONTNEED)"),
+
+    Option("bluestore_bdev_discard", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("none")
+    .set_enum_allowed({"none", "sync", "async"})
+    .set_description(""),
 
     Option("bluestore_debug_misc", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)

--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -9,10 +9,10 @@
 #define dout_subsys ceph_subsys_bluestore
 
 Allocator *Allocator::create(CephContext* cct, string type,
-                             int64_t size, int64_t block_size)
+                             int64_t size, int64_t block_size, bool periodic_discard)
 {
   if (type == "stupid") {
-    return new StupidAllocator(cct);
+    return new StupidAllocator(cct, periodic_discard);
   } else if (type == "bitmap") {
     return new BitmapAllocator(cct, size, block_size);
   }

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -43,6 +43,9 @@ public:
   virtual void release(const interval_set<uint64_t>& release_set) = 0;
   void release(const PExtentVector& release_set);
 
+  virtual int64_t allocate_for_discard(float ratio, interval_set<uint64_t>& to_discard) { return 0; }
+  virtual void release_for_discarded(interval_set<uint64_t>& discarded) { }
+
   virtual void dump() = 0;
 
   virtual void init_add_free(uint64_t offset, uint64_t length) = 0;
@@ -56,7 +59,7 @@ public:
 
   virtual void shutdown() = 0;
   static Allocator *create(CephContext* cct, string type, int64_t size,
-			   int64_t block_size);
+			   int64_t block_size, bool periodic_discard=false);
 };
 
 #endif

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -43,7 +43,7 @@ public:
   virtual void release(const interval_set<uint64_t>& release_set) = 0;
   void release(const PExtentVector& release_set);
 
-  virtual int64_t allocate_for_discard(float ratio, interval_set<uint64_t>& to_discard) { return 0; }
+  virtual int64_t allocate_for_discard(float free_ratio, interval_set<uint64_t>& to_discard) { return 0; }
   virtual void release_for_discarded(interval_set<uint64_t>& discarded) { }
 
   virtual void dump() = 0;

--- a/src/os/bluestore/BlockDevice.cc
+++ b/src/os/bluestore/BlockDevice.cc
@@ -84,7 +84,8 @@ void IOContext::release_running_aios()
 }
 
 BlockDevice *BlockDevice::create(CephContext* cct, const string& path,
-				 aio_callback_t cb, void *cbpriv, aio_callback_t d_cb, void *d_cbpriv)
+				 aio_callback_t cb, void *cbpriv, discard_callback_t d_cb, void *d_cbpriv,
+				 discard_t discard_mode, int discard_delay)
 {
   string type = "kernel";
   char buf[PATH_MAX + 1];
@@ -122,7 +123,7 @@ BlockDevice *BlockDevice::create(CephContext* cct, const string& path,
 #endif
 #if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
   if (type == "kernel") {
-    return new KernelDevice(cct, cb, cbpriv, d_cb, d_cbpriv);
+    return new KernelDevice(cct, cb, cbpriv, d_cb, d_cbpriv, discard_mode, discard_delay);
   }
 #endif
 #if defined(HAVE_SPDK)

--- a/src/os/bluestore/BlockDevice.cc
+++ b/src/os/bluestore/BlockDevice.cc
@@ -138,6 +138,20 @@ BlockDevice *BlockDevice::create(CephContext* cct, const string& path,
   return NULL;
 }
 
+BlockDevice::discard_t BlockDevice::get_discard_t(string str_discard_mode)
+{
+  discard_t ret = BlockDevice::DISCARD_NONE;
+
+  if (str_discard_mode == "sync")
+    ret = BlockDevice::DISCARD_SYNC;
+  else if (str_discard_mode == "async")
+    ret = BlockDevice::DISCARD_ASYNC;
+  else if (str_discard_mode == "periodic")
+    ret = BlockDevice::DISCARD_PERIODIC;
+
+  return ret;
+}
+
 void BlockDevice::queue_reap_ioc(IOContext *ioc)
 {
   std::lock_guard l(ioc_reap_lock);

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -168,6 +168,9 @@ public:
   static BlockDevice *create(
     CephContext* cct, const std::string& path, aio_callback_t cb, void *cbpriv, discard_callback_t d_cb, void *d_cbpriv,
     discard_t discard_mode, int discard_delay);
+
+  static discard_t get_discard_t(string str_discard_mode);
+
   virtual bool supported_bdev_label() { return true; }
   virtual bool is_rotational() { return rotational; }
 

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -138,7 +138,9 @@ public:
     DISCARD_ASYNC,
     DISCARD_PERIODIC,
   } discard_t;
+
   typedef void (*aio_callback_t)(void *handle, void *aio);
+  typedef void (*discard_callback_t)(discard_t discard_mode, void *handle, void *aio);
 private:
   ceph::mutex ioc_reap_lock = ceph::make_mutex("BlockDevice::ioc_reap_lock");
   std::vector<IOContext*> ioc_reap_queue;
@@ -164,7 +166,8 @@ public:
   virtual ~BlockDevice() = default;
 
   static BlockDevice *create(
-    CephContext* cct, const std::string& path, aio_callback_t cb, void *cbpriv, aio_callback_t d_cb, void *d_cbpriv);
+    CephContext* cct, const std::string& path, aio_callback_t cb, void *cbpriv, discard_callback_t d_cb, void *d_cbpriv,
+    discard_t discard_mode, int discard_delay);
   virtual bool supported_bdev_label() { return true; }
   virtual bool is_rotational() { return rotational; }
 

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -131,6 +131,12 @@ public:
 class BlockDevice {
 public:
   CephContext* cct;
+
+  typedef enum {
+    DISCARD_NONE,
+    DISCARD_SYNC,
+    DISCARD_ASYNC,
+  } discard_t;
   typedef void (*aio_callback_t)(void *handle, void *aio);
 private:
   ceph::mutex ioc_reap_lock = ceph::make_mutex("BlockDevice::ioc_reap_lock");

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -136,6 +136,7 @@ public:
     DISCARD_NONE,
     DISCARD_SYNC,
     DISCARD_ASYNC,
+    DISCARD_PERIODIC,
   } discard_t;
   typedef void (*aio_callback_t)(void *handle, void *aio);
 private:

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -51,14 +51,7 @@ BlueFS::BlueFS(CephContext* cct)
   discard_cb[BDEV_WAL] = wal_discard_cb;
   discard_cb[BDEV_DB] = db_discard_cb;
   discard_cb[BDEV_SLOW] = slow_discard_cb;
-  if (cct->_conf->bluefs_bdev_discard == "sync")
-    discard_mode = BlockDevice::DISCARD_SYNC;
-  else if (cct->_conf->bluefs_bdev_discard == "async")
-    discard_mode = BlockDevice::DISCARD_ASYNC;
-  else if (cct->_conf->bluefs_bdev_discard == "periodic")
-    discard_mode = BlockDevice::DISCARD_PERIODIC;
-  else
-    discard_mode = BlockDevice::DISCARD_NONE;
+  discard_mode = BlockDevice::get_discard_t(cct->_conf->bluefs_bdev_discard);
 }
 
 BlueFS::~BlueFS()

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -175,7 +175,7 @@ int BlueFS::add_block_device(unsigned id, const string& path, bool trim,
     delete b;
     return r;
   }
-  if (trim) {
+  if (trim && discard_mode != BlockDevice::DISCARD_NONE) {
     b->discard(0, b->get_size());
   }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -42,6 +42,18 @@ static void slow_discard_cb(BlockDevice::discard_t discard_mode, void *priv, voi
   bluefs->handle_discard(discard_mode, BlueFS::BDEV_SLOW, *tmp);
 }
 
+static void newwal_discard_cb(BlockDevice::discard_t discard_mode, void *priv, void* priv2) {
+  BlueFS *bluefs = static_cast<BlueFS*>(priv);
+  interval_set<uint64_t> *tmp = static_cast<interval_set<uint64_t>*>(priv2);
+  bluefs->handle_discard(discard_mode, BlueFS::BDEV_NEWWAL, *tmp);
+}
+
+static void newdb_discard_cb(BlockDevice::discard_t discard_mode, void *priv, void* priv2) {
+  BlueFS *bluefs = static_cast<BlueFS*>(priv);
+  interval_set<uint64_t> *tmp = static_cast<interval_set<uint64_t>*>(priv2);
+  bluefs->handle_discard(discard_mode, BlueFS::BDEV_NEWDB, *tmp);
+}
+
 BlueFS::BlueFS(CephContext* cct)
   : cct(cct),
     bdev(MAX_BDEV),
@@ -51,6 +63,9 @@ BlueFS::BlueFS(CephContext* cct)
   discard_cb[BDEV_WAL] = wal_discard_cb;
   discard_cb[BDEV_DB] = db_discard_cb;
   discard_cb[BDEV_SLOW] = slow_discard_cb;
+  discard_cb[BDEV_NEWWAL] = newwal_discard_cb;
+  discard_cb[BDEV_NEWDB] = newdb_discard_cb;
+
   discard_mode = BlockDevice::get_discard_t(cct->_conf->bluefs_bdev_discard);
 }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -55,6 +55,8 @@ BlueFS::BlueFS(CephContext* cct)
     discard_mode = BlockDevice::DISCARD_SYNC;
   else if (cct->_conf->bluefs_bdev_discard == "async")
     discard_mode = BlockDevice::DISCARD_ASYNC;
+  else if (cct->_conf->bluefs_bdev_discard == "periodic")
+    discard_mode = BlockDevice::DISCARD_PERIODIC;
   else
     discard_mode = BlockDevice::DISCARD_NONE;
 }
@@ -419,7 +421,8 @@ void BlueFS::_init_alloc()
     ceph_assert(bdev[id]->get_size());
     alloc[id] = Allocator::create(cct, cct->_conf->bluefs_allocator,
 				  bdev[id]->get_size(),
-				  cct->_conf->bluefs_alloc_size);
+				  cct->_conf->bluefs_alloc_size,
+				  discard_mode == BlockDevice::DISCARD_PERIODIC);
     interval_set<uint64_t>& p = block_all[id];
     for (interval_set<uint64_t>::iterator q = p.begin(); q != p.end(); ++q) {
       alloc[id]->init_add_free(q.get_start(), q.get_len());

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -283,7 +283,7 @@ private:
   vector<interval_set<uint64_t>> pending_release; ///< extents to release
 
   BlockDevice::discard_t discard_mode;
-  BlockDevice::aio_callback_t discard_cb[3]; //discard callbacks for each dev
+  BlockDevice::discard_callback_t discard_cb[3]; //discard callbacks for each dev
 
   BlueFSDeviceExpander* slow_dev_expander = nullptr;
 
@@ -477,7 +477,7 @@ public:
 		     PExtentVector *extents);
 
   // handler for discard event
-  void handle_discard(unsigned dev, interval_set<uint64_t>& to_release);
+  void handle_discard(BlockDevice::discard_t mode, unsigned dev, interval_set<uint64_t>& to_discard);
 
   void flush(FileWriter *h) {
     std::lock_guard l(lock);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -283,7 +283,7 @@ private:
   vector<interval_set<uint64_t>> pending_release; ///< extents to release
 
   BlockDevice::discard_t discard_mode;
-  BlockDevice::discard_callback_t discard_cb[3]; //discard callbacks for each dev
+  BlockDevice::discard_callback_t discard_cb[MAX_BDEV]; //discard callbacks for each dev
 
   BlueFSDeviceExpander* slow_dev_expander = nullptr;
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -280,6 +280,9 @@ private:
   vector<IOContext*> ioc;                     ///< IOContexts for bdevs
   vector<interval_set<uint64_t> > block_all;  ///< extents in bdev we own
   vector<Allocator*> alloc;                   ///< allocators for bdevs
+  vector<ceph::mutex*> alloc_lock;            ///< lock for alloc pointers
+  const string alloc_lock_name_prefix = "BlueFS::alloc_lock_";
+
   vector<interval_set<uint64_t>> pending_release; ///< extents to release
 
   BlockDevice::discard_t discard_mode;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -282,6 +282,7 @@ private:
   vector<Allocator*> alloc;                   ///< allocators for bdevs
   vector<interval_set<uint64_t>> pending_release; ///< extents to release
 
+  BlockDevice::discard_t discard_mode;
   BlockDevice::aio_callback_t discard_cb[3]; //discard callbacks for each dev
 
   BlueFSDeviceExpander* slow_dev_expander = nullptr;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3900,15 +3900,7 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
   _init_logger();
   cct->_conf.add_observer(this);
   set_cache_shards(1);
-
-  if (cct->_conf->bluestore_bdev_discard == "sync")
-    discard_mode = BlockDevice::DISCARD_SYNC;
-  else if (cct->_conf->bluestore_bdev_discard == "async")
-    discard_mode = BlockDevice::DISCARD_ASYNC;
-  else if (cct->_conf->bluestore_bdev_discard == "periodic")
-    discard_mode = BlockDevice::DISCARD_PERIODIC;
-  else
-    discard_mode = BlockDevice::DISCARD_NONE;
+  discard_mode = BlockDevice::get_discard_t(cct->_conf->bluestore_bdev_discard);
 }
 
 BlueStore::BlueStore(CephContext *cct,
@@ -3931,15 +3923,7 @@ BlueStore::BlueStore(CephContext *cct,
   _init_logger();
   cct->_conf.add_observer(this);
   set_cache_shards(1);
-
-  if (cct->_conf->bluestore_bdev_discard == "sync")
-    discard_mode = BlockDevice::DISCARD_SYNC;
-  else if (cct->_conf->bluestore_bdev_discard == "async")
-    discard_mode = BlockDevice::DISCARD_ASYNC;
-  else if (cct->_conf->bluestore_bdev_discard == "periodic")
-    discard_mode = BlockDevice::DISCARD_PERIODIC;
-  else
-    discard_mode = BlockDevice::DISCARD_NONE;
+  discard_mode = BlockDevice::get_discard_t(cct->_conf->bluestore_bdev_discard);
 }
 
 BlueStore::~BlueStore()

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3894,6 +3894,8 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
     discard_mode = BlockDevice::DISCARD_SYNC;
   else if (cct->_conf->bluestore_bdev_discard == "async")
     discard_mode = BlockDevice::DISCARD_ASYNC;
+  else if (cct->_conf->bluestore_bdev_discard == "periodic")
+    discard_mode = BlockDevice::DISCARD_PERIODIC;
   else
     discard_mode = BlockDevice::DISCARD_NONE;
 }
@@ -3923,6 +3925,8 @@ BlueStore::BlueStore(CephContext *cct,
     discard_mode = BlockDevice::DISCARD_SYNC;
   else if (cct->_conf->bluestore_bdev_discard == "async")
     discard_mode = BlockDevice::DISCARD_ASYNC;
+  else if (cct->_conf->bluestore_bdev_discard == "periodic")
+    discard_mode = BlockDevice::DISCARD_PERIODIC;
   else
     discard_mode = BlockDevice::DISCARD_NONE;
 }
@@ -4758,7 +4762,8 @@ int BlueStore::_open_alloc()
 
   alloc = Allocator::create(cct, cct->_conf->bluestore_allocator,
                             bdev->get_size(),
-                            min_alloc_size);
+                            min_alloc_size,
+                            discard_mode == BlockDevice::DISCARD_PERIODIC);
   if (!alloc) {
     lderr(cct) << __func__ << " Allocator::unknown alloc type "
                << cct->_conf->bluestore_allocator

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4588,7 +4588,7 @@ int BlueStore::_open_bdev(bool create)
   if (r < 0)
     goto fail;
 
-  if (create && cct->_conf->bdev_enable_discard) {
+  if (create && discard_mode != BlockDevice::DISCARD_NONE) {
     bdev->discard(0, bdev->get_size());
   }
 
@@ -4958,8 +4958,7 @@ int BlueStore::_minimal_open_bluefs(bool create)
 
   bfn = path + "/block.db";
   if (::stat(bfn.c_str(), &st) == 0) {
-    r = bluefs->add_block_device(BlueFS::BDEV_DB, bfn,
-	  create && cct->_conf->bdev_enable_discard);
+    r = bluefs->add_block_device(BlueFS::BDEV_DB, bfn, create);
     if (r < 0) {
       derr << __func__ << " add block device(" << bfn << ") returned: "
             << cpp_strerror(r) << dendl;
@@ -5037,8 +5036,7 @@ int BlueStore::_minimal_open_bluefs(bool create)
 
   bfn = path + "/block.wal";
   if (::stat(bfn.c_str(), &st) == 0) {
-    r = bluefs->add_block_device(BlueFS::BDEV_WAL, bfn,
-      create && cct->_conf->bdev_enable_discard);
+    r = bluefs->add_block_device(BlueFS::BDEV_WAL, bfn, create);
     if (r < 0) {
       derr << __func__ << " add block device(" << bfn << ") returned: "
 	    << cpp_strerror(r) << dendl;
@@ -6061,8 +6059,7 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
 	true);
     ceph_assert(r == 0);
 
-    r = bluefs->add_block_device(BlueFS::BDEV_NEWWAL, p,
-      cct->_conf->bdev_enable_discard);
+    r = bluefs->add_block_device(BlueFS::BDEV_NEWWAL, p, true);
     ceph_assert(r == 0);
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWWAL)) {
@@ -6082,8 +6079,7 @@ int BlueStore::add_new_bluefs_device(int id, const string& dev_path)
 	true);
     ceph_assert(r == 0);
 
-    r = bluefs->add_block_device(BlueFS::BDEV_NEWDB, p,
-      cct->_conf->bdev_enable_discard);
+    r = bluefs->add_block_device(BlueFS::BDEV_NEWDB, p, true);
     ceph_assert(r == 0);
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWDB)) {
@@ -6222,8 +6218,7 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
     target_name = "block.wal";
     target_size = cct->_conf->bluestore_block_wal_size;
 
-    r = bluefs->add_block_device(BlueFS::BDEV_NEWWAL, dev_path,
-      cct->_conf->bdev_enable_discard);
+    r = bluefs->add_block_device(BlueFS::BDEV_NEWWAL, dev_path, true);
     ceph_assert(r == 0);
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWWAL)) {
@@ -6239,8 +6234,7 @@ int BlueStore::migrate_to_new_bluefs_device(const set<int>& devs_source,
     target_name = "block.db";
     target_size = cct->_conf->bluestore_block_db_size;
 
-    r = bluefs->add_block_device(BlueFS::BDEV_NEWDB, dev_path,
-      cct->_conf->bdev_enable_discard);
+    r = bluefs->add_block_device(BlueFS::BDEV_NEWDB, dev_path, true);
     ceph_assert(r == 0);
 
     if (bluefs->bdev_support_label(BlueFS::BDEV_NEWDB)) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3859,18 +3859,29 @@ static void aio_cb(void *priv, void *priv2)
   c->aio_finish(store);
 }
 
-static void discard_cb(void *priv, void *priv2)
+static void discard_cb(BlockDevice::discard_t discard_mode, void *priv, void *priv2)
 {
   BlueStore *store = static_cast<BlueStore*>(priv);
   interval_set<uint64_t> *tmp = static_cast<interval_set<uint64_t>*>(priv2);
-  store->handle_discard(*tmp);
+  store->handle_discard(discard_mode, *tmp);
 }
 
-void BlueStore::handle_discard(interval_set<uint64_t>& to_release)
+void BlueStore::handle_discard(BlockDevice::discard_t mode, interval_set<uint64_t>& to_discard)
 {
-  dout(10) << __func__ << dendl;
+  dout(10) << __func__ << " discard mode " << mode << dendl;
   ceph_assert(alloc);
-  alloc->release(to_release);
+
+  if (mode == BlockDevice::DISCARD_ASYNC) {
+    for (auto p = to_discard.begin();p != to_discard.end(); ++p)
+      bdev->discard(p.get_start(), p.get_len());
+    alloc->release(to_discard);
+  } else if (mode == BlockDevice::DISCARD_PERIODIC) {
+    float free_ratio = cct->_conf->bluestore_bdev_periodic_discard_free_ratio;
+    alloc->allocate_for_discard(free_ratio, to_discard);
+    for (auto p = to_discard.begin();p != to_discard.end(); ++p)
+      bdev->discard(p.get_start(), p.get_len());
+    alloc->release_for_discarded(to_discard);
+  }
 }
 
 BlueStore::BlueStore(CephContext *cct, const string& path)
@@ -4587,7 +4598,8 @@ int BlueStore::_open_bdev(bool create)
 {
   ceph_assert(bdev == NULL);
   string p = path + "/block";
-  bdev = BlockDevice::create(cct, p, aio_cb, static_cast<void*>(this), discard_cb, static_cast<void*>(this));
+  bdev = BlockDevice::create(cct, p, aio_cb, static_cast<void*>(this), discard_cb, static_cast<void*>(this),
+			    discard_mode, cct->_conf->bluestore_bdev_periodic_discard_timeout);
   int r = bdev->open(p);
   if (r < 0)
     goto fail;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -140,7 +140,7 @@ public:
 			  const std::set<std::string> &changed) override;
 
   //handler for discard event
-  void handle_discard(interval_set<uint64_t>& to_release);
+  void handle_discard(BlockDevice::discard_t mode, interval_set<uint64_t>& to_discard);
 
   void _set_csum();
   void _set_compression();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1886,6 +1886,7 @@ private:
 
   KeyValueDB *db = nullptr;
   BlockDevice *bdev = nullptr;
+  BlockDevice::discard_t discard_mode;
   std::string freelist_type;
   FreelistManager *fm = nullptr;
   Allocator *alloc = nullptr;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1889,6 +1889,7 @@ private:
   BlockDevice::discard_t discard_mode;
   std::string freelist_type;
   FreelistManager *fm = nullptr;
+  ceph::mutex alloc_lock = ceph::make_mutex("BlueStore::alloc_lock");
   Allocator *alloc = nullptr;
   uuid_d fsid;
   int path_fd = -1;  ///< open handle to $path

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -461,6 +461,11 @@ void KernelDevice::discard_drain()
   while (!discard_queued.empty() || discard_running) {
     discard_cond.wait(l);
   }
+  if (discard_mode == DISCARD_PERIODIC) {
+    // to prevent periodic thread from using allocator after deleting it
+    discard_stop = true;
+    discard_cond.notify_all();
+  }
 }
 
 static bool is_expected_ioerr(const int r)

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -43,9 +43,11 @@ class KernelDevice : public BlockDevice {
   ceph::mutex flush_mutex = ceph::make_mutex("KernelDevice::flush_mutex");
 
   aio_queue_t aio_queue;
-  aio_callback_t discard_callback;
+  discard_callback_t discard_callback;
   void *discard_callback_priv;
   bool aio_stop;
+  discard_t discard_mode;
+  int discard_delay;
   bool discard_started;
   bool discard_stop;
 
@@ -106,7 +108,8 @@ class KernelDevice : public BlockDevice {
   int choose_fd(bool buffered, int write_hint) const;
 
 public:
-  KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, aio_callback_t d_cb, void *d_cbpriv);
+  KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv, discard_callback_t d_cb, void *d_cbpriv,
+	      discard_t discard_mode, int discard_delay);
 
   void aio_submit(IOContext *ioc) override;
   void discard_drain() override;

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -266,13 +266,18 @@ void StupidAllocator::release(
   }
 }
 
-int64_t StupidAllocator::allocate_for_discard(float ratio, interval_set<uint64_t>& to_discard)
+int64_t StupidAllocator::allocate_for_discard(float free_ratio, interval_set<uint64_t>& to_discard)
 {
   int64_t want;
   int64_t allocated = 0;
+  float cur_clean_ratio;
   std::lock_guard l(lock);
+  cur_clean_ratio = (float) (num_free - to_discard_set.size()) / num_free;
 
-  want = (int64_t) to_discard_set.size() * ratio;
+  if (cur_clean_ratio >= free_ratio)
+    want = to_discard_set.size();
+  else
+    want = (int64_t) to_discard_set.size() * free_ratio;
 
   for (auto p = to_discard_set.begin();
       p != to_discard_set.end() && allocated < want;

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -54,7 +54,7 @@ public:
   void release(
     const interval_set<uint64_t>& release_set) override;
 
-  int64_t allocate_for_discard(float ratio, interval_set<uint64_t>& to_discard) override;
+  int64_t allocate_for_discard(float free_ratio, interval_set<uint64_t>& to_discard) override;
   void release_for_discarded(interval_set<uint64_t>& discarded) override;
 
   uint64_t get_free() override;


### PR DESCRIPTION
- add periodic discard feature to StupidAllocator.
- bdev_enable_discard and bdev_async_discard boolean options have been merged into [bluestore or bluefs]_bdev_discard string options.
- [bluestore or bluefs]_periodic_discard_timeout and [bluestore or bluefs]_periodic_discard_free_ratio have been added.

Signed-off-by: Taeksang Kim voidbag@gmail.com