### PR TITLE
build-doc: Upgrade ceph python libraries

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -86,7 +86,7 @@ for bind in rados rbd cephfs rgw; do
         CFLAGS="-iquote$TOPDIR/src/include" \
         CPPFLAGS="-iquote$TOPDIR/src/include" \
         LDFLAGS="-L$vdir/lib -Wl,--no-as-needed" \
-        $vdir/bin/pip install $TOPDIR/src/pybind/${bind}
+        $vdir/bin/pip install --upgrade $TOPDIR/src/pybind/${bind}
     # rgwfile_version(), librgw_create(), rgw_mount()
     # since py3.5, distutils adds postfix in between ${bind} and so
     lib_fn=$vdir/lib/python*/*-packages/${bind}.*.so


### PR DESCRIPTION
If you have python ceph bindings installed on your system, the doc-build
script will fail since pip detects them and fails to install the updated
bindings in the virtualenv. This fixes the issue by adding --upgrade
flag to pip so that it overrides the system-installed libraries.

Signed-off-by: Boris Ranto <branto@redhat.com>