### PR TITLE
Wip 22963 truncation

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2954,12 +2954,18 @@ static int usage_iterate_range(cls_method_context_t hctx, uint64_t start, uint64
 
     if (!by_user && key.compare(end_key) >= 0) {
       CLS_LOG(20, "usage_iterate_range reached key=%s, done", key.c_str());
+      if (truncated) {
+	*truncated = false;
+      }
       key_iter = key;
       return 0;
     }
 
     if (by_user && key.compare(0, user_key.size(), user_key) != 0) {
       CLS_LOG(20, "usage_iterate_range reached key=%s, done", key.c_str());
+      if (truncated) {
+	*truncated = false;
+      }
       key_iter = key;
       return 0;
     }
@@ -3076,7 +3082,7 @@ int rgw_user_usage_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlis
   if (ret < 0)
     return ret;
 
-  if (!more && iter.empty())
+  if (!more)
     return -ENODATA;
 
   return 0;


### PR DESCRIPTION
Fix a couple of different issues with usage_iterate_range() and its callers in cls_rgw.

I very much wish I could find a way to do a client-side-only fix for handling this as well, but since the only data we get back is the return code, that doesn't seem feasible. :(