### PR TITLE
msg/async: keep connection alive only actually sending

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1914,7 +1914,6 @@ int AsyncConnection::send_message(Message *m)
     return 0;
   }
 
-  last_active = ceph::coarse_mono_clock::now();
   // we don't want to consider local message here, it's too lightweight which
   // may disturb users
   logger->inc(l_msgr_send_messages);
@@ -2176,6 +2175,7 @@ ssize_t AsyncConnection::write_message(Message *m, bufferlist& bl, bool more)
   FUNCTRACE(async_msgr->cct);
   assert(center->in_thread());
   m->set_seq(++out_seq);
+  last_active = ceph::coarse_mono_clock::now();
 
   if (msgr->crcflags & MSG_CRC_HEADER)
     m->calc_header_crc();


### PR DESCRIPTION
When connection stuck into odd state, we need to let connection timeout.
If send_message could update last_active, it won't play the role as expected.
So we move last_active updated to the place actually should.

Signed-off-by: Haomai Wang <haomai@xsky.com>