### PR TITLE
rgw: improve sync status: display lagging objects

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -742,6 +742,10 @@ Options
 	Option for 'user stats' command. When specified, it will update user stats with
 	the current stats reported by user's buckets indexes.
 
+.. option:: --sync-detail
+
+	Option to 'bucket sync status', display lagging objcets
+
 .. option:: --show-log-entries=<flag>
 
 	Enable/disable dump of log entries on log show.

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -484,6 +484,7 @@ public:
   void finish();
 
   RGWCoroutine *read_sync_status_cr(rgw_bucket_shard_sync_info *sync_status);
+  RGWCoroutine *read_lagging_objects_cr(rgw_bucket_shard_sync_info *sync_status, set<rgw_obj_key>& lagging_objects, const int max_entries);
   RGWCoroutine *init_sync_status_cr();
   RGWCoroutine *run_sync_cr();
 
@@ -510,6 +511,7 @@ class RGWBucketSyncStatusManager {
   string source_shard_status_oid_prefix;
 
   map<int, rgw_bucket_shard_sync_info> sync_status;
+  map<int, set<rgw_obj_key>> lagging_objects;
   rgw_raw_obj status_obj;
 
   int num_shards;
@@ -528,11 +530,13 @@ public:
   int init();
 
   map<int, rgw_bucket_shard_sync_info>& get_sync_status() { return sync_status; }
+  map<int, set<rgw_obj_key>>& get_lagging_objects() { return lagging_objects; }
   int init_sync_status();
 
   static string status_oid(const string& source_zone, const rgw_bucket_shard& bs);
 
   int read_sync_status();
+  int read_sync_status_detail(const int max_entries);
   int run();
 };
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -239,6 +239,7 @@
                                (NOTE: required to delete a non-empty bucket)
      --sync-stats              option to 'user stats', update user stats with current
                                stats reported by user's buckets indexes
+     --sync-detail             option to 'bucket sync status', display lagging objcets
      --show-log-entries=<flag> enable/disable dump of log entries on log show
      --show-log-sum=<flag>     enable/disable dump of log summation on log show
      --skip-zero-entries       log show only dumps entries that don't have zero value


### PR DESCRIPTION
http://tracker.ceph.com/issues/22914

This PR is together with #19573 and #20027 , it's mainly about to display the lagging objects that are belong to a specified bucket, the overall work flow to get lagging objects is as below:
- use sync status to get the behind or recovering datalog shards(see #19573)
- use data sync status --shard-id=x to lists which bucket shards are left to process(see #20027)
- use bucket sync status --sync-detail to list lagging objects of a specified bucket  
 