### PR TITLE
test,qa: s/.libs/lib/

### DIFF
--- a/src/java/README
+++ b/src/java/README
@@ -39,7 +39,7 @@ Ant is used to run the unit test (apt-get install ant). For example:
 1. The tests depend on the compiled wrappers. If the wrappers are installed as
 part of a package (e.g. Debian package) then this should 'just work'. Ant will
 also look in the current directory for 'libcephfs.jar' and 'libcephfs-test.jar';
-and in ../.libs for the
+and in ../build/lib for the
 JNI library.  If all else fails, set the environment variables CEPHFS_JAR, and
 CEPHFS_JNI_LIB accordingly.
 

--- a/src/java/build.xml
+++ b/src/java/build.xml
@@ -45,7 +45,7 @@
 
   <target name="test" depends="compile-tests-jar">
     <junit printsummary="yes" haltonfailure="yes" showoutput="yes" fork="true">
-      <sysproperty key="java.library.path" path="${env.CEPHFS_JNI_LIB}:../.libs/"/>
+      <sysproperty key="java.library.path" path="${env.CEPHFS_JNI_LIB}:../../build/lib/"/>
       <sysproperty key="CEPH_CONF_FILE" path="${env.CEPHFS_CONF}"/>
       <jvmarg value="-Xcheck:jni"/>
       <classpath>
@@ -60,7 +60,7 @@
 
   <target name="test-compat" depends="compile-tests-jar">
     <junit printsummary="yes" haltonfailure="yes" showoutput="yes" fork="true">
-      <sysproperty key="java.library.path" path="${env.CEPHFS_JNI_LIB}:../.libs/"/>
+      <sysproperty key="java.library.path" path="${env.CEPHFS_JNI_LIB}:../../build/lib/"/>
       <sysproperty key="CEPH_CONF_FILE" path="${env.CEPHFS_CONF}"/>
       <classpath>
         <pathelement location="${env.CEPHFS_JAR}"/>

--- a/src/test/erasure-code/TestErasureCodePlugin.cc
+++ b/src/test/erasure-code/TestErasureCodePlugin.cc
@@ -126,10 +126,10 @@ TEST_F(ErasureCodePluginRegistryTest, all)
 
 /*
  * Local Variables:
- * compile-command: "cd ../.. ; make -j4 && 
+ * compile-command: "cd ../../../build ; make -j4 &&
  *   make unittest_erasure_code_plugin && 
  *   valgrind --tool=memcheck \
- *      ./unittest_erasure_code_plugin \
+ *      ./bin/unittest_erasure_code_plugin \
  *      --gtest_filter=*.* --log-to-stderr=true --debug-osd=20"
  * End:
  */

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -341,9 +341,9 @@ int main(int argc, char** argv) {
 
 /*
  * Local Variables:
- * compile-command: "cd ../.. ; make -j4 ceph_erasure_code_benchmark &&
+ * compile-command: "cd ../../../build ; make -j4 ceph_erasure_code_benchmark &&
  *   valgrind --tool=memcheck --leak-check=full \
- *      ./ceph_erasure_code_benchmark \
+ *      ./bin/ceph_erasure_code_benchmark \
  *      --plugin jerasure \
  *      --parameter directory=lib \
  *      --parameter technique=reed_sol_van \


### PR DESCRIPTION
after switching to cmake, the libraries are put in build/lib, instead of
.libs. so point the default settings to ".lib".

Signed-off-by: Kefu Chai <kchai@redhat.com>