### PR TITLE
msg/async: fix variable type to make it same to EventCenter::init() incoming parameter type

### DIFF
--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -105,7 +105,7 @@ NetworkStack::NetworkStack(CephContext *c, const string &t): type(t), started(fa
 {
   assert(cct->_conf->ms_async_op_threads > 0);
 
-  const uint64_t InitEventNumber = 5000;
+  const int InitEventNumber = 5000;
   num_workers = cct->_conf->ms_async_op_threads;
   if (num_workers >= EventCenter::MAX_EVENTCENTER) {
     ldout(cct, 0) << __func__ << " max thread limit is "


### PR DESCRIPTION
The function EventCenter::init() first incoming parameter type is "int", but variable InitEventNumber's type is "uint64_t", this modification  makes them same. 

Signed-off-by: shangfufei <shangfufei@inspur.com>