### PR TITLE
mon: ceph health check mute/unmute

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1160,6 +1160,14 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description("Enable POOL_APP_NOT_ENABLED health check"),
 
+    Option("mon_warn_on_noscrub", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(true)
+    .set_description("Enable noscrub health check warn"),
+
+    Option("mon_warn_on_nodeep_scrub", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(true)
+    .set_description("Enable nodeep-scrub health check warn"),
+
     Option("mon_max_snap_prune_per_epoch", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(100)
     .set_description("Max number of pruned snaps we will process in a single OSDMap epoch"),

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4491,6 +4491,32 @@ void print_osd_utilization(const OSDMap& osdmap,
     out << tbl << d.summary() << "\n";
   }
 }
+uint64_t OSDMap::get_warn_flags() const
+{
+    uint64_t warn_flags =
+      CEPH_OSDMAP_NEARFULL |
+      CEPH_OSDMAP_FULL |
+      CEPH_OSDMAP_PAUSERD |
+      CEPH_OSDMAP_PAUSEWR |
+      CEPH_OSDMAP_PAUSEREC |
+      CEPH_OSDMAP_NOUP |
+      CEPH_OSDMAP_NODOWN |
+      CEPH_OSDMAP_NOIN |
+      CEPH_OSDMAP_NOOUT |
+      CEPH_OSDMAP_NOBACKFILL |
+      CEPH_OSDMAP_NORECOVER |
+      CEPH_OSDMAP_NOTIERAGENT |
+      CEPH_OSDMAP_NOSNAPTRIM |
+      CEPH_OSDMAP_NOREBALANCE;
+
+    if (g_conf->get_val<bool>("mon_warn_on_noscrub"))
+      warn_flags |= CEPH_OSDMAP_NOSCRUB;
+
+    if (g_conf->get_val<bool>("mon_warn_on_nodeep_scrub"))
+      warn_flags |= CEPH_OSDMAP_NODEEP_SCRUB;
+
+    return warn_flags;
+}
 
 void OSDMap::check_health(health_check_map_t *checks) const
 {
@@ -4719,23 +4745,8 @@ void OSDMap::check_health(health_check_map_t *checks) const
   // OSDMAP_FLAGS
   {
     // warn about flags
-    uint64_t warn_flags =
-      CEPH_OSDMAP_NEARFULL |
-      CEPH_OSDMAP_FULL |
-      CEPH_OSDMAP_PAUSERD |
-      CEPH_OSDMAP_PAUSEWR |
-      CEPH_OSDMAP_PAUSEREC |
-      CEPH_OSDMAP_NOUP |
-      CEPH_OSDMAP_NODOWN |
-      CEPH_OSDMAP_NOIN |
-      CEPH_OSDMAP_NOOUT |
-      CEPH_OSDMAP_NOBACKFILL |
-      CEPH_OSDMAP_NORECOVER |
-      CEPH_OSDMAP_NOSCRUB |
-      CEPH_OSDMAP_NODEEP_SCRUB |
-      CEPH_OSDMAP_NOTIERAGENT |
-      CEPH_OSDMAP_NOSNAPTRIM |
-      CEPH_OSDMAP_NOREBALANCE;
+    uint64_t warn_flags = get_warn_flags();
+      
     if (test_flag(warn_flags)) {
       ostringstream ss;
       ss << get_flag_string(get_flags() & warn_flags)

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1363,6 +1363,7 @@ public:
 
 private:
   void print_osd_line(int cur, ostream *out, Formatter *f) const;
+  uint64_t get_warn_flags() const;
 public:
   void print(ostream& out) const;
   void print_pools(ostream& out) const;


### PR DESCRIPTION
some times we have to close scrub in  production environment , 
but there will be  warning in "ceph -s" output, so add a config to 
cancel the warning,if someone does not want see this warning.

Signed-off-by: kungf <yang.wang@easystack.cn>
@yangdongsheng 