### PR TITLE
mgr/dashboard v2: Add CSS class for required form fields

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/openattic-theme.scss
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/openattic-theme.scss
@@ -32,6 +32,9 @@
 
 @import 'defaults';
 
+$fa-font-path: "../node_modules/font-awesome/fonts";
+@import "../node_modules/font-awesome/scss/font-awesome";
+
 /* Basics */
 html {
   background-color: #ffffff;
@@ -1168,4 +1171,14 @@ hr.oa-hr-small {
     -webkit-border-radius: 6px 0 6px 6px;
     -moz-border-radius: 6px 0 6px 6px;
     border-radius: 6px 0 6px 6px;
+}
+
+/* Forms */
+.form-group>.control-label>span.required {
+  @extend .fa;
+  @extend .fa-asterisk;
+  @extend .required;
+  font-size: 6px;
+  padding-left: 4px;
+  vertical-align: text-top;
 }


### PR DESCRIPTION
Developers should implement form fields that are required the following way:
```
<div class="form-group"
  <label i18n
         class="control-label col-sm-3"
         for="bucket">Name
    <span class="required"></span>  <----- Add this line
  </label>
  <div class="col-sm-9">
    <input id="bucket"
           name="bucket"
           class="form-control"
           formControlName="bucket">
    ...
  </div>
</div>
```
![bildschirmfoto vom 2018-03-07 16-31-16](https://user-images.githubusercontent.com/1897962/37101142-24612e20-2225-11e8-8c84-17cb52a52d9e.png)

Signed-off-by: Volker Theile <vtheile@suse.com>