### PR TITLE
mon: keep history of config changes; implement reset (rollback)

### DIFF
--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -168,3 +168,43 @@ bool ConfigMap::parse_mask(
   }
   return true;
 }
+
+
+// --------------
+
+void ConfigChangeSet::dump(Formatter *f) const
+{
+  f->dump_int("version", version);
+  f->dump_stream("timestamp") << stamp;
+  f->dump_string("name", name);
+  f->open_array_section("changes");
+  for (auto& i : diff) {
+    f->open_object_section("change");
+    f->dump_string("name", i.first);
+    if (i.second.first) {
+      f->dump_string("previous_value", *i.second.first);
+    }
+    if (i.second.second) {
+      f->dump_string("new_value", *i.second.second);
+    }
+    f->close_section();
+  }
+  f->close_section();
+}
+
+void ConfigChangeSet::print(ostream& out) const
+{
+  out << "--- " << version << " --- " << stamp;
+  if (name.size()) {
+    out << " --- " << name;
+  }
+  out << " ---\n";
+  for (auto& i : diff) {
+    if (i.second.first) {
+      out << "- " << i.first << " = " << *i.second.first << "\n";
+    }
+    if (i.second.second) {
+      out << "+ " << i.first << " = " << *i.second.second << "\n";
+    }
+  }
+}

--- a/src/mon/ConfigMap.h
+++ b/src/mon/ConfigMap.h
@@ -7,6 +7,7 @@
 #include <ostream>
 #include <string>
 
+#include "include/utime.h"
 #include "common/options.h"
 #include "common/entity_name.h"
 
@@ -124,4 +125,17 @@ struct ConfigMap {
     const std::string& in,
     std::string *section,
     OptionMask *mask);
+};
+
+
+struct ConfigChangeSet {
+  version_t version;
+  utime_t stamp;
+  string name;
+
+  // key -> (old value, new value)
+  map<string,pair<boost::optional<string>,boost::optional<string>>> diff;
+
+  void dump(Formatter *f) const;
+  void print(ostream& out) const;
 };

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -308,6 +308,28 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 	f->flush(odata);
       }
     }
+  } else if (prefix == "config log") {
+    int64_t num = 10;
+    cmd_getval(g_ceph_context, cmdmap, "num", num);
+    ostringstream ds;
+    if (f) {
+      f->open_array_section("changesets");
+    }
+    for (version_t v = version; v > version - std::min(version, (version_t)num); --v) {
+      ConfigChangeSet ch;
+      load_changeset(v, &ch);
+      if (f) {
+	f->dump_object("changeset", ch);
+      } else {
+	ch.print(ds);
+      }
+    }
+    if (f) {
+      f->close_section();
+      f->flush(odata);
+    } else {
+      odata.append(ds.str());
+    }
   } else {
     return false;
   }

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -506,6 +506,24 @@ reply:
   return false;
 
 update:
+  // see if there is an actual change
+  auto p = pending.begin();
+  while (p != pending.end()) {
+    auto q = current.find(p->first);
+    if (p->second && q != current.end() && *p->second == q->second) {
+      // set to same value
+      p = pending.erase(p);
+    } else if (!p->second && q == current.end()) {
+      // erasing non-existent value
+      p = pending.erase(p);
+    } else {
+      ++p;
+    }
+  }
+  if (pending.empty()) {
+    err = 0;
+    goto reply;
+  }
   force_immediate_propose();  // faster response
   wait_for_finished_proposal(
     op,

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -25,6 +25,7 @@ public:
   void init() override;
 
   void load_config();
+  void load_changeset(version_t v, ConfigChangeSet *ch);
 
   bool preprocess_query(MonOpRequestRef op) override;
   bool prepare_update(MonOpRequestRef op) override;

--- a/src/mon/ConfigMonitor.h
+++ b/src/mon/ConfigMonitor.h
@@ -15,6 +15,9 @@ class ConfigMonitor : public PaxosService
   version_t version = 0;
   ConfigMap config_map;
   map<string,boost::optional<bufferlist>> pending;
+  string pending_description;
+
+  map<string,bufferlist> current;
 
 public:
   ConfigMonitor(Monitor *m, Paxos *p, const string& service_name);

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1117,3 +1117,7 @@ COMMAND("config help " \
 COMMAND("config assimilate-conf",
 	"Assimilate options from a conf, and return a new, minimal conf file",
 	"config", "rw", "cli,rest")
+COMMAND("config log name=num,type=CephInt,req=False",
+	"Show recent history of config changes",
+	"config", "r", "cli,rest")
+

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1120,4 +1120,7 @@ COMMAND("config assimilate-conf",
 COMMAND("config log name=num,type=CephInt,req=False",
 	"Show recent history of config changes",
 	"config", "r", "cli,rest")
-
+COMMAND("config reset" \
+	" name=num,type=CephInt",
+	"Revert configuration to previous state",
+	"config", "rw", "cli,rest")


### PR DESCRIPTION
- keep config history
- 'config log' command to view history
- 'config reset' command to roll back recent changes

To follow later, maybe:
- 'config diff &lt;who>'?
- 'config revert &lt;version>' roll back a single change
