### PR TITLE
mgr: allow service daemons to unregister from ServiceMap

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4803,6 +4803,10 @@ std::vector<Option> get_global_options() {
     .set_description("Period in seconds from last beacon to manager dropping "
                      "state about a monitored service (RGW, rbd-mirror etc)"),
 
+    Option("mgr_client_service_daemon_unregister_timeout", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(1.0)
+    .set_description("Time to wait during shutdown to deregister service with mgr"),
+
     Option("mon_mgr_digest_period", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(5)
     .add_service("mon")

--- a/src/messages/MMgrClose.h
+++ b/src/messages/MMgrClose.h
@@ -1,0 +1,45 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include "msg/Message.h"
+
+class MMgrClose : public Message
+{
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+
+public:
+  std::string daemon_name;
+  std::string service_name;  // optional; otherwise infer from entity type
+
+  void decode_payload() override
+  {
+    bufferlist::iterator p = payload.begin();
+    decode(daemon_name, p);
+    decode(service_name, p);
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(daemon_name, payload);
+    encode(service_name, payload);
+  }
+
+  const char *get_type_name() const override { return "mgrclose"; }
+  void print(ostream& out) const override {
+    out << get_type_name() << "(";
+    if (service_name.length()) {
+      out << service_name;
+    } else {
+      out << ceph_entity_type_name(get_source().type());
+    }
+    out << "." << daemon_name;
+    out << ")";
+  }
+
+  MMgrClose()
+    : Message(MSG_MGR_CLOSE, HEAD_VERSION, COMPAT_VERSION)
+  {}
+};

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -24,6 +24,7 @@
 #include "mon/MonCommand.h"
 
 #include "messages/MMgrOpen.h"
+#include "messages/MMgrClose.h"
 #include "messages/MMgrConfigure.h"
 #include "messages/MMonMgrReport.h"
 #include "messages/MCommand.h"
@@ -284,6 +285,8 @@ bool DaemonServer::ms_dispatch(Message *m)
       return handle_report(static_cast<MMgrReport*>(m));
     case MSG_MGR_OPEN:
       return handle_open(static_cast<MMgrOpen*>(m));
+    case MSG_MGR_CLOSE:
+      return handle_close(static_cast<MMgrClose*>(m));
     case MSG_COMMAND:
       return handle_command(static_cast<MCommand*>(m));
     default:
@@ -414,6 +417,37 @@ bool DaemonServer::handle_open(MMgrOpen *m)
   }
 
   m->put();
+  return true;
+}
+
+bool DaemonServer::handle_close(MMgrClose *m)
+{
+  Mutex::Locker l(lock);
+
+  DaemonKey key;
+  if (!m->service_name.empty()) {
+    key.first = m->service_name;
+  } else {
+    key.first = ceph_entity_type_name(m->get_connection()->get_peer_type());
+  }
+  key.second = m->daemon_name;
+
+  dout(4) << "from " << m->get_connection() << "  " << key << dendl;
+
+  if (daemon_state.exists(key)) {
+    DaemonStatePtr daemon = daemon_state.get(key);
+    daemon_state.rm(key);
+    {
+      Mutex::Locker l(daemon->lock);
+      if (daemon->service_daemon) {
+	pending_service_map.rm_daemon(m->service_name, m->daemon_name);
+	pending_service_map_dirty = pending_service_map.epoch;
+      }
+    }
+  }
+
+  // send same message back as a reply
+  m->get_connection()->send_message(m);
   return true;
 }
 

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -33,6 +33,7 @@
 
 class MMgrReport;
 class MMgrOpen;
+class MMgrClose;
 class MMonMgrReport;
 class MCommand;
 struct MonCommand;
@@ -132,6 +133,7 @@ public:
       CryptoKey& session_key) override;
 
   bool handle_open(MMgrOpen *m);
+  bool handle_close(MMgrClose *m);
   bool handle_report(MMgrReport *m);
   bool handle_command(MCommand *m);
   void send_report();

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -95,6 +95,14 @@ DaemonStatePtr DaemonStateIndex::get(const DaemonKey &key)
   }
 }
 
+void DaemonStateIndex::rm(const DaemonKey &key)
+{
+  RWLock::WLocker l(lock);
+  if (all.count(key)) {
+    _erase(key);
+  }
+}
+
 void DaemonStateIndex::cull(const std::string& svc_name,
 			    const std::set<std::string>& names_exist)
 {

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -169,6 +169,7 @@ class DaemonStateIndex
   void insert(DaemonStatePtr dm);
   bool exists(const DaemonKey &key) const;
   DaemonStatePtr get(const DaemonKey &key);
+  void rm(const DaemonKey &key);
 
   // Note that these return by value rather than reference to avoid
   // callers needing to stay in lock while using result.  Callers must

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -25,6 +25,7 @@
 
 class MMgrMap;
 class MMgrConfigure;
+class MMgrClose;
 class Messenger;
 class MCommandReply;
 class MPGStats;
@@ -57,6 +58,7 @@ protected:
   unique_ptr<MgrSessionState> session;
 
   Mutex lock = {"MgrClient::lock"};
+  Cond shutdown_cond;
 
   uint32_t stats_period = 0;
   uint32_t stats_threshold = 0;
@@ -101,6 +103,7 @@ public:
 
   bool handle_mgr_map(MMgrMap *m);
   bool handle_mgr_configure(MMgrConfigure *m);
+  bool handle_mgr_close(MMgrClose *m);
   bool handle_command_reply(MCommandReply *m);
 
   void send_pgstats();

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -173,6 +173,7 @@
 #include "messages/MMgrDigest.h"
 #include "messages/MMgrReport.h"
 #include "messages/MMgrOpen.h"
+#include "messages/MMgrClose.h"
 #include "messages/MMgrConfigure.h"
 #include "messages/MMonMgrReport.h"
 #include "messages/MServiceMap.h"
@@ -791,6 +792,10 @@ Message *decode_message(CephContext *cct, int crcflags,
 
   case MSG_MGR_OPEN:
     m = new MMgrOpen();
+    break;
+
+  case MSG_MGR_CLOSE:
+    m = new MMgrClose();
     break;
 
   case MSG_MGR_REPORT:

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -212,6 +212,8 @@
 #define MSG_MON_MGR_REPORT        0x706
 #define MSG_SERVICE_MAP           0x707
 
+#define MSG_MGR_CLOSE             0x708
+
 // ======================================================
 
 // abstract Message class

--- a/src/test/librados/service.cc
+++ b/src/test/librados/service.cc
@@ -5,6 +5,7 @@
 #include "include/stringify.h"
 
 #include <algorithm>
+#include <thread>
 #include <errno.h>
 #include "gtest/gtest.h"
 #include "test/unit.cc"
@@ -113,4 +114,48 @@ TEST(LibRadosServicePP, Status) {
     sleep(1);
   }
   cluster.shutdown();
+}
+
+TEST(LibRadosServicePP, Close) {
+  int tries = 20;
+  string name = string("close-test-pid") + stringify(getpid());
+  int i;
+  for (i = 0; i < tries; ++i) {
+    cout << "attempt " << i << " of " << tries << std::endl;
+    {
+      Rados cluster;
+      cluster.init("admin");
+      ASSERT_EQ(0, cluster.conf_read_file(NULL));
+      cluster.conf_parse_env(NULL);
+      ASSERT_EQ(0, cluster.connect());
+      ASSERT_EQ(0, cluster.service_daemon_register(
+		  "laundry", name, {{"foo", "bar"}, {"this", "that"}}));
+      sleep(3); // let it register
+      cluster.shutdown();
+    }
+    // mgr updates servicemap every tick
+    //sleep(g_conf->get_val<int64_t>("mgr_tick_period"));
+    std::this_thread::sleep_for(g_conf->get_val<std::chrono::seconds>(
+				  "mgr_tick_period"));
+    // make sure we are deregistered
+    {
+      Rados cluster;
+      cluster.init("admin");
+      ASSERT_EQ(0, cluster.conf_read_file(NULL));
+      cluster.conf_parse_env(NULL);
+      ASSERT_EQ(0, cluster.connect());
+      bufferlist inbl, outbl;
+      ASSERT_EQ(0, cluster.mon_command("{\"prefix\": \"service dump\"}",
+				       inbl, &outbl, NULL));
+      string s = outbl.to_str();
+      cluster.shutdown();
+
+      if (s.find(name) != string::npos) {
+	cout << " failed to deregister:\n" << s << std::endl;
+      } else {
+	break;
+      }
+    }
+  }
+  ASSERT_LT(i, tries);
 }


### PR DESCRIPTION
Version 2:
- service daemons send a MMgrClose message during shutdown and wait up to 1 second
- mgr queues up the service removal in ServiceMap

Flaws:
- mgr may not be avaiable; client does not wait
- mgr only updates ServiceMap every tick, so the removal may not be immediately visible

We could synchronously update the servicemap on shutdown.  Downside is that it could lead to a string of servicemap updates if lots of daemons are shutting down at once.

We could also make the daemon block on shutdown if the mgr is unavailable until the removal is durable.  