### PR TITLE
jewel: ceph.in: bypass codec when writing raw binary data

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -639,7 +639,7 @@ def main():
         return 0
     elif sockpath:
         try:
-            print(admin_socket(sockpath, childargs, format))
+            raw_stdout.write(admin_socket(sockpath, childargs, format))
         except Exception as e:
             print('admin_socket: {0}'.format(e))
             print('admin_socket: {0}'.format(e), file=sys.stderr)


### PR DESCRIPTION
See-also: 615f8f45
Fixes: http://tracker.ceph.com/issues/23185
Signed-off-by: Oleh Prypin <oleh@pryp.in>
(cherry picked from commit 8fc67075c6d7d4443747f53687e498439f80b57a)

Conflicts: this change was introduced to master by 8fc67075. but that commit
  involves a lot of py3 compatibility changes, which are not the focus of
  jewel or this fix. so i am only cherry-pick the change writing buffer
  returned by asock to stdout.