### PR TITLE
msg/async: size of EventCenter::file_events should be greater than fd

### DIFF
--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -208,7 +208,7 @@ int EventCenter::create_file_event(int fd, int mask, EventCallbackRef ctxt)
   int r = 0;
   if (fd >= nevent) {
     int new_size = nevent << 2;
-    while (fd > new_size)
+    while (fd >= new_size)
       new_size <<= 2;
     ldout(cct, 20) << __func__ << " event count exceed " << nevent << ", expand to " << new_size << dendl;
     r = driver->resize_events(new_size);


### PR DESCRIPTION
When trying to generate a file event from an FD greater than or equal to the size of file_events vector,
make sure that the resized vector can hold the FD safely.

Fixes: http://tracker.ceph.com/issues/23253

Signed-off-by: Yupeng Chen <chenyupeng-it@360.cn>