### PR TITLE
luminous: Objecter: add ignore overlay flag if got redirect reply

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3411,7 +3411,7 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     op->tid = 0;
     m->get_redirect().combine_with_locator(op->target.target_oloc,
 					   op->target.target_oid.name);
-    op->target.flags |= CEPH_OSD_FLAG_REDIRECTED;
+    op->target.flags |= (CEPH_OSD_FLAG_REDIRECTED | CEPH_OSD_FLAG_IGNORE_OVERLAY);
     _op_submit(op, sul, NULL);
     m->put();
     return;


### PR DESCRIPTION
Objecter's target calculations should ignore overlays if client got redirect reply.

https://marc.info/?l=ceph-devel&m=151728649217493&w=2

Fixes: https://tracker.ceph.com/issues/23296

Signed-off-by: Ting Yi Lin <wooertim@gmail.com>