### PR TITLE
luminous: os/bluestore: recalc_allocated() when decoding bluefs_fnode_t

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -780,7 +780,6 @@ int BlueFS::_replay(bool noop)
         {
 	  bluefs_fnode_t fnode;
 	  ::decode(fnode, p);
-	  fnode.recalc_allocated();
 	  dout(20) << __func__ << " 0x" << std::hex << pos << std::dec
                    << ":  op_file_update " << " " << fnode << dendl;
 	  if (!noop) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -322,8 +322,7 @@ int BlueFS::mkfs(uuid_d osd_uuid)
   int r = _allocate(
     log_file->fnode.prefer_bdev,
     cct->_conf->bluefs_max_log_runway,
-    &log_file->fnode.extents);
-  log_file->fnode.recalc_allocated();
+    &log_file->fnode);
   assert(r == 0);
   log_writer = _create_writer(log_file);
 
@@ -781,6 +780,7 @@ int BlueFS::_replay(bool noop)
         {
 	  bluefs_fnode_t fnode;
 	  ::decode(fnode, p);
+	  fnode.recalc_allocated();
 	  dout(20) << __func__ << " 0x" << std::hex << pos << std::dec
                    << ":  op_file_update " << " " << fnode << dendl;
 	  if (!noop) {
@@ -871,7 +871,7 @@ void BlueFS::_drop_link(FileRef file)
     }
     file_map.erase(file->fnode.ino);
     file->deleted = true;
-    file->fnode.recalc_allocated();
+
     if (file->dirty_seq) {
       assert(file->dirty_seq > log_seq_stable);
       assert(dirty_files.count(file->dirty_seq));
@@ -1129,13 +1129,12 @@ void BlueFS::_compact_log_sync()
   dout(20) << __func__ << " need " << need << dendl;
 
   mempool::bluefs::vector<bluefs_extent_t> old_extents;
-  old_extents.swap(log_file->fnode.extents);
-  log_file->fnode.recalc_allocated();
+  uint64_t old_allocated = 0;
+  log_file->fnode.swap_extents(old_extents, old_allocated);
   while (log_file->fnode.get_allocated() < need) {
     int r = _allocate(log_file->fnode.prefer_bdev,
 		      need - log_file->fnode.get_allocated(),
-		      &log_file->fnode.extents);
-    log_file->fnode.recalc_allocated();
+		      &log_file->fnode);
     assert(r == 0);
   }
 
@@ -1217,9 +1216,8 @@ void BlueFS::_compact_log_async(std::unique_lock<std::mutex>& l)
   while (log_file->fnode.get_allocated() < need) {
     int r = _allocate(log_file->fnode.prefer_bdev,
 		      cct->_conf->bluefs_max_log_runway,
-		      &log_file->fnode.extents);
+		      &log_file->fnode);
     assert(r == 0);
-    log_file->fnode.recalc_allocated();
   }
   dout(10) << __func__ << " log extents " << log_file->fnode.extents << dendl;
 
@@ -1252,9 +1250,8 @@ void BlueFS::_compact_log_async(std::unique_lock<std::mutex>& l)
 
   // allocate
   int r = _allocate(BlueFS::BDEV_DB, new_log_jump_to,
-                    &new_log->fnode.extents);
+                    &new_log->fnode);
   assert(r == 0);
-  new_log->fnode.recalc_allocated();
   new_log_writer = _create_writer(new_log);
   new_log_writer->append(bl);
 
@@ -1288,7 +1285,7 @@ void BlueFS::_compact_log_async(std::unique_lock<std::mutex>& l)
     if (discarded + e.length <= old_log_jump_to) {
       dout(10) << __func__ << " remove old log extent " << e << dendl;
       discarded += e.length;
-      log_file->fnode.extents.erase(log_file->fnode.extents.begin());
+      log_file->fnode.pop_front_extent();
     } else {
       dout(10) << __func__ << " remove front of old log extent " << e << dendl;
       uint64_t drop = old_log_jump_to - discarded;
@@ -1300,17 +1297,18 @@ void BlueFS::_compact_log_async(std::unique_lock<std::mutex>& l)
     }
     old_extents.push_back(temp);
   }
-  new_log->fnode.extents.insert(new_log->fnode.extents.end(),
-				log_file->fnode.extents.begin(),
-				log_file->fnode.extents.end());
+  auto from = log_file->fnode.extents.begin();
+  auto to = log_file->fnode.extents.end();
+  while (from != to) {
+    new_log->fnode.append_extent(*from);
+    ++from;
+  }
 
   // clear the extents from old log file, they are added to new log
-  log_file->fnode.extents.clear();
-
+  log_file->fnode.clear_extents();
   // swap the log files. New log file is the log file now.
-  log_file->fnode.extents.swap(new_log->fnode.extents);
-  log_file->fnode.recalc_allocated();
-  new_log->fnode.recalc_allocated();
+  new_log->fnode.swap_extents(log_file->fnode);
+
   log_writer->pos = log_writer->file->fnode.size =
     log_writer->pos - old_log_jump_to + new_log_jump_to;
 
@@ -1414,9 +1412,8 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<std::mutex>& l,
     }
     int r = _allocate(log_writer->file->fnode.prefer_bdev,
 		      cct->_conf->bluefs_max_log_runway,
-		      &log_writer->file->fnode.extents);
+		      &log_writer->file->fnode);
     assert(r == 0);
-    log_writer->file->fnode.recalc_allocated();
     log_t.op_file_update(log_writer->file->fnode);
   }
 
@@ -1521,7 +1518,7 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     assert(h->file->fnode.ino != 1);
     int r = _allocate(h->file->fnode.prefer_bdev,
 		      offset + length - allocated,
-		      &h->file->fnode.extents);
+		      &h->file->fnode);
     if (r < 0) {
       derr << __func__ << " allocated: 0x" << std::hex << allocated
            << " offset: 0x" << offset << " length: 0x" << length << std::dec
@@ -1529,7 +1526,6 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
       assert(0 == "bluefs enospc");
       return r;
     }
-    h->file->fnode.recalc_allocated();
     if (cct->_conf->bluefs_preextend_wal_files &&
 	h->writer_type == WRITER_WAL) {
       // NOTE: this *requires* that rocksdb also has log recycling
@@ -1825,7 +1821,7 @@ void BlueFS::flush_bdev()
 }
 
 int BlueFS::_allocate(uint8_t id, uint64_t len,
-		      mempool::bluefs::vector<bluefs_extent_t> *ev)
+		      bluefs_fnode_t* node)
 {
   dout(10) << __func__ << " len 0x" << std::hex << len << std::dec
            << " from " << (int)id << dendl;
@@ -1843,9 +1839,9 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   
   if (r == 0) {
     uint64_t hint = 0;
-    if (!ev->empty()) {
-      hint = ev->back().end();
-    }   
+    if (!node->extents.empty() && node->extents.back().bdev == id) {
+      hint = node->extents.back().end();
+    }
     extents.reserve(4);  // 4 should be (more than) enough for most allocations
     alloc_len = alloc[id]->allocate(left, min_alloc_size, hint, &extents);
   }
@@ -1864,7 +1860,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
 		<< "; fallback to bdev " << (int)id + 1
 		<< std::dec << dendl;
       }
-      return _allocate(id + 1, len, ev);
+      return _allocate(id + 1, len, node);
     }
     if (bdev[id])
       derr << __func__ << " failed to allocate 0x" << std::hex << left
@@ -1879,14 +1875,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   }
 
   for (auto& p : extents) {
-    bluefs_extent_t e = bluefs_extent_t(id, p.offset, p.length);
-    if (!ev->empty() &&
-	ev->back().bdev == e.bdev &&
-	ev->back().end() == (uint64_t) e.offset) {
-      ev->back().length += e.length;
-    } else {
-      ev->push_back(e);
-    }
+    node->append_extent(bluefs_extent_t(id, p.offset, p.length));
   }
    
   return 0;
@@ -1904,10 +1893,9 @@ int BlueFS::_preallocate(FileRef f, uint64_t off, uint64_t len)
   uint64_t allocated = f->fnode.get_allocated();
   if (off + len > allocated) {
     uint64_t want = off + len - allocated;
-    int r = _allocate(f->fnode.prefer_bdev, want, &f->fnode.extents);
+    int r = _allocate(f->fnode.prefer_bdev, want, &f->fnode);
     if (r < 0)
       return r;
-    f->fnode.recalc_allocated();
     log_t.op_file_update(f->fnode);
   }
   return 0;
@@ -1995,8 +1983,8 @@ int BlueFS::open_for_write(
       for (auto& p : file->fnode.extents) {
 	pending_release[p.bdev].insert(p.offset, p.length);
       }
-      file->fnode.extents.clear();
-      file->fnode.recalc_allocated();
+
+      file->fnode.clear_extents();
     }
   }
   assert(file->fnode.ino > 1);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -268,7 +268,7 @@ private:
   void _drop_link(FileRef f);
 
   int _allocate(uint8_t bdev, uint64_t len,
-		mempool::bluefs::vector<bluefs_extent_t> *ev);
+		bluefs_fnode_t* node);
   int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
   int _flush(FileWriter *h, bool force);
   int _fsync(FileWriter *h, std::unique_lock<std::mutex>& l);

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -127,6 +127,7 @@ ostream& operator<<(ostream& out, const bluefs_fnode_t& file)
 	     << " size 0x" << std::hex << file.size << std::dec
 	     << " mtime " << file.mtime
 	     << " bdev " << (int)file.prefer_bdev
+	     << " allocated " << std::hex << file.allocated << std::dec
 	     << " extents " << file.extents
 	     << ")";
 }

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -51,7 +51,24 @@ struct bluefs_fnode_t {
       allocated += p.length;
   }
 
-  DENC(bluefs_fnode_t, v, p) {
+  DENC_HELPERS
+  void bound_encode(size_t& p) const {
+    _denc_friend(*this, p);
+  }
+  void encode(bufferlist::contiguous_appender& p) const {
+    DENC_DUMP_PRE(bluefs_fnode_t);
+    _denc_friend(*this, p);
+    DENC_DUMP_POST(bluefs_fnode_t);
+  }
+  void decode(buffer::ptr::iterator& p) {
+    _denc_friend(*this, p);
+    recalc_allocated();
+  }
+  template<typename T, typename P>
+  friend typename std::enable_if<
+    boost::is_same<T,bluefs_fnode_t>::value ||
+    boost::is_same<T,const bluefs_fnode_t>::value>::type
+  _denc_friend(T& v, P& p) {
     DENC_START(1, 1, p);
     denc_varint(v.ino, p);
     denc_varint(v.size, p);

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -61,11 +61,36 @@ struct bluefs_fnode_t {
     DENC_FINISH(p);
   }
 
+  void append_extent(const bluefs_extent_t& ext) {
+    extents.push_back(ext);
+    allocated += ext.length;
+  }
+
+  void pop_front_extent() {
+    auto it = extents.begin();
+    allocated -= it->length;
+    extents.erase(it);
+  }
+  
+  void swap_extents(bluefs_fnode_t& other) {
+    other.extents.swap(extents);
+    std::swap(allocated, other.allocated);
+  }
+  void swap_extents(mempool::bluefs::vector<bluefs_extent_t>& swap_to, uint64_t& new_allocated) {
+    swap_to.swap(extents);
+    std::swap(allocated, new_allocated);
+  }
+  void clear_extents() {
+    extents.clear();
+    allocated = 0;
+  }
+
   mempool::bluefs::vector<bluefs_extent_t>::iterator seek(
     uint64_t off, uint64_t *x_off);
 
   void dump(Formatter *f) const;
   static void generate_test_instances(list<bluefs_fnode_t*>& ls);
+
 };
 WRITE_CLASS_DENC(bluefs_fnode_t)
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/23256