### PR TITLE
krbd: include sys/sysmacros.h for major, minor and makedev

### DIFF
--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -21,6 +21,7 @@
 #include <string.h>
 #include <string>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <unistd.h>
 


### PR DESCRIPTION
Previously we got these through sys/types.h, but that's now deprecated:

  warning: In the GNU C Library, "major" is defined
   by <sys/sysmacros.h>. For historical compatibility, it is
   currently defined by <sys/types.h> as well, but we plan to
   remove this soon. To use "major", include <sys/sysmacros.h>
   directly. If you did not intend to use a system-defined macro
   "major", you should undefine it after including <sys/types.h>.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>