### PR TITLE
mgr/dashboard_v2: add mocked service provider for TcmuIscsiService

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
@@ -1,18 +1,29 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AppModule } from '../../../app.module';
+import { TcmuIscsiService } from '../../../shared/services/tcmu-iscsi.service';
 import { IscsiComponent } from './iscsi.component';
 
 describe('IscsiComponent', () => {
   let component: IscsiComponent;
   let fixture: ComponentFixture<IscsiComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [AppModule]
+  const fakeService = {
+    tcmuiscsi: () => {
+      return new Promise(function(resolve, reject) {
+        return;
+      });
+    },
+  };
+
+  beforeEach(
+    async(() => {
+      TestBed.configureTestingModule({
+        imports: [AppModule],
+        providers: [{ provide: TcmuIscsiService, useValue: fakeService }]
+      }).compileComponents();
     })
-    .compileComponents();
-  }));
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IscsiComponent);


### PR DESCRIPTION
This removes the warnings shown when running the unit tests with PhantomJS.