### PR TITLE
librbd: fix the max string length of block_name_prefix[]

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -81,7 +81,7 @@ typedef struct {
 } rbd_child_info_t;
 
 #define RBD_MAX_IMAGE_NAME_SIZE 96
-#define RBD_MAX_BLOCK_NAME_SIZE 24
+#define RBD_MAX_BLOCK_NAME_PREFIX_LENGTH 43
 
 #define RBD_SNAP_REMOVE_UNPROTECT	1 << 0
 #define RBD_SNAP_REMOVE_FLATTEN		1 << 1
@@ -101,7 +101,7 @@ typedef struct {
   uint64_t obj_size;
   uint64_t num_objs;
   int order;
-  char block_name_prefix[RBD_MAX_BLOCK_NAME_SIZE]; /* deprecated */
+  char block_name_prefix[RBD_MAX_BLOCK_NAME_PREFIX_LENGTH]; /* deprecated */
   int64_t parent_pool;			           /* deprecated */
   char parent_name[RBD_MAX_IMAGE_NAME_SIZE];       /* deprecated */
 } rbd_image_info_t;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -187,8 +187,8 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
     info.num_objs = Striper::get_num_objects(ictx->layout, info.size);
     info.order = obj_order;
     strncpy(info.block_name_prefix, ictx->object_prefix.c_str(),
-            RBD_MAX_BLOCK_NAME_SIZE);
-    info.block_name_prefix[RBD_MAX_BLOCK_NAME_SIZE - 1] = '\0';
+            RBD_MAX_BLOCK_NAME_PREFIX_LENGTH);
+    info.block_name_prefix[RBD_MAX_BLOCK_NAME_PREFIX_LENGTH - 1] = '\0';
 
     // clear deprecated fields
     info.parent_pool = -1L;

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -80,7 +80,7 @@ cdef extern from "rbd/librbd.h" nogil:
         _RBD_IMAGE_OPTION_STRIPE_COUNT "RBD_IMAGE_OPTION_STRIPE_COUNT"
         _RBD_IMAGE_OPTION_DATA_POOL "RBD_IMAGE_OPTION_DATA_POOL"
 
-        RBD_MAX_BLOCK_NAME_SIZE
+        RBD_MAX_BLOCK_NAME_PREFIX_LENGTH
         RBD_MAX_IMAGE_NAME_SIZE
 
     ctypedef void* rados_ioctx_t
@@ -93,7 +93,7 @@ cdef extern from "rbd/librbd.h" nogil:
         uint64_t obj_size
         uint64_t num_objs
         int order
-        char block_name_prefix[RBD_MAX_BLOCK_NAME_SIZE]
+        char block_name_prefix[RBD_MAX_BLOCK_NAME_PREFIX_LENGTH]
         uint64_t parent_pool
         char parent_name[RBD_MAX_IMAGE_NAME_SIZE]
 

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -2307,7 +2307,7 @@ TRACEPOINT_EVENT(librbd, stat_exit,
         ctf_integer(uint64_t, obj_size, info->obj_size)
         ctf_integer(uint64_t, num_objs, info->num_objs)
         ctf_integer(int, order, info->order)
-        ctf_array_text(char, block_name_prefix, info->block_name_prefix, RBD_MAX_BLOCK_NAME_SIZE)
+        ctf_array_text(char, block_name_prefix, info->block_name_prefix, RBD_MAX_BLOCK_NAME_PREFIX_LENGTH)
         ctf_integer(int64_t, parent_pool, info->parent_pool)
         ctf_array_text(char, parent_name, info->parent_name, RBD_MAX_IMAGE_NAME_SIZE)
     )


### PR DESCRIPTION
The value of `image.stat().get('block_name_prefix')` is
truncated due to the limit of RBD_MAX_BLOCK_NAME_SIZE=24.
**Before:**
```
>>> image.block_name_prefix()
u'rbd_data.102.10f02ae8944a'
>>> image.stat().get('block_name_prefix')
u'rbd_data.102.10f02ae894'
>>> 
```
**After:**
```
>>> image.block_name_prefix()
u'rbd_data.102.10f02ae8944a'
>>> image.stat().get('block_name_prefix')
u'rbd_data.102.10f02ae8944a'
>>> 
```
Signed-off-by: songweibin <song.weibin@zte.com.cn>