### PR TITLE
mgr/dashboard: Fix backend tests for newer CherryPy versions

### DIFF
--- a/qa/tasks/mgr/dashboard_v2/helper.py
+++ b/qa/tasks/mgr/dashboard_v2/helper.py
@@ -36,7 +36,7 @@ class DashboardTestCase(MgrTestCase):
         super(DashboardTestCase, cls).setUpClass()
         cls._assign_ports("dashboard_v2", "server_port")
         cls._load_module("dashboard_v2")
-        cls.base_uri = cls._get_uri("dashboard_v2")
+        cls.base_uri = cls._get_uri("dashboard_v2").rstrip('/')
 
         if cls.CEPHFS:
             cls.mds_cluster.clear_firewall()


### PR DESCRIPTION
The backend test run by `run-backend-api-tests.sh` fails for CherryPy versions 13.x and 14.x.

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>