### PR TITLE
mgr/dashboard_v2: add mgr to the list of perf counters

### DIFF
--- a/qa/tasks/mgr/dashboard_v2/test_perf_counters.py
+++ b/qa/tasks/mgr/dashboard_v2/test_perf_counters.py
@@ -20,13 +20,14 @@ class PerfCountersControllerTest(DashboardTestCase):
             self.assertIn('osd.{}'.format(osd['osd']), data)
 
     @authenticate
-    def test_perf_counters_mon_a_get(self):
-        data = self._get('/api/perf_counters/mon/a')
+    def test_perf_counters_mon_get(self):
+        mon = self.mons()[0]
+        data = self._get('/api/perf_counters/mon/{}'.format(mon))
         self.assertStatus(200)
 
         self.assertIsInstance(data, dict)
         self.assertEqual('mon', data['service']['type'])
-        self.assertEqual('a', data['service']['id'])
+        self.assertEqual(mon, data['service']['id'])
         self.assertIsInstance(data['counters'], list)
         self.assertGreater(len(data['counters']), 0)
         counter = data['counters'][0]
@@ -35,3 +36,15 @@ class PerfCountersControllerTest(DashboardTestCase):
         self.assertIn('name', counter)
         self.assertIn('unit', counter)
         self.assertIn('value', counter)
+
+    @authenticate
+    def test_perf_counters_mgr_get(self):
+        mgr = self.mgr_cluster.mgr_ids[0]
+        data = self._get('/api/perf_counters/mgr/{}'.format(mgr))
+        self.assertStatus(200)
+
+        self.assertIsInstance(data, dict)
+        self.assertEqual('mgr', data['service']['type'])
+        self.assertEqual(mgr, data['service']['id'])
+        self.assertIsInstance(data['counters'], list)
+        self.assertEqual(len(data['counters']), 0)

--- a/src/pybind/mgr/dashboard_v2/controllers/perf_counters.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/perf_counters.py
@@ -59,6 +59,7 @@ class PerfCounters(RESTController):
         self.osd = PerfCounter('osd')
         self.rgw = PerfCounter('rgw')
         self.rbd_mirror = PerfCounter('rbd-mirror')
+        self.mgr = PerfCounter('mgr')
 
     def list(self):
         counters = mgr.get_all_perf_counters()


### PR DESCRIPTION
Opening the perf counter page for a mgr service was throwing a 404.