### PR TITLE
pybind/ceph_argparse: accept flexible req

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -618,7 +618,7 @@ class argdesc(object):
         else:
             self.t = t
             self.typeargs = kwargs
-            self.req = bool(req == True or req == 'True')
+            self.req = req in (True, 'True', 'true')
 
         self.name = name
         self.N = (n in ['n', 'N'])


### PR DESCRIPTION
python bool var is 'True/False' not 'true/false'
found this bug while using cmd 'ceph osd ls-tree'
with weird output:

$ ceph osd ls-tree
Error ENOENT: "" does not exist

Signed-off-by: Gu Zhongyan <guzhongyan@360.cn>