### PR TITLE
rbd: support osd_request_timeout in rbd map command

### DIFF
--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -125,6 +125,9 @@ static int parse_map_options(const std::string &options_string)
     } else if (!strcmp(this_char, "mount_timeout")) {
       if (put_map_option_value("mount_timeout", value_char, map_option_int_cb))
         return -EINVAL;
+    } else if (!strcmp(this_char, "osd_request_timeout")) {
+      if (put_map_option_value("osd_request_timeout", value_char, map_option_int_cb))
+        return -EINVAL;
     } else if (!strcmp(this_char, "osdkeepalive")) {
       if (put_map_option_value("osdkeepalive", value_char, map_option_int_cb))
         return -EINVAL;


### PR DESCRIPTION
Default of osd_request_timeout in krbd is 0 means no timeout,
but we sometimes need to set this value by rbd command. then
pass osd_request_timeout to kernel rbd in rbd mapping.

Fixes: http://tracker.ceph.com/issues/23073
Signed-off-by: Dongsheng Yang <yangds.fnst@cn.fujitsu.com>