### PR TITLE
luminous: test/ceph-disk: install coverage in testenv:py27 env

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -20,10 +20,16 @@ deps =
 sitepackages=True
 passenv = CEPH_ROOT CEPH_BIN CEPH_LIB CEPH_BUILD_VIRTUALENV
 changedir = {env:CEPH_BUILD_DIR}
-commands = coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_main.py
-           coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_prepare.py
+commands = {envbindir}/coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_main.py
+           {envbindir}/coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_prepare.py
            {toxinidir}/tests/ceph-disk.sh
-           coverage report --show-missing
+           {envbindir}/coverage report --show-missing
+deps =
+  {[testenv]deps}
+  coverage>=3.6
 
 [testenv:flake8]
 commands = flake8 --ignore=H105,H405,E127,E722 ceph_disk tests
+deps =
+  {[testenv]deps}
+  flake8==3.0.4


### PR DESCRIPTION
and specify the absolute path of coverage cli.

Signed-off-by: Kefu Chai <kchai@redhat.com>