### PR TITLE
replace rgw_namespace_expire_secs with rgw_nfs_namespace_expire_secs

### DIFF
--- a/doc/radosgw/nfs.rst
+++ b/doc/radosgw/nfs.rst
@@ -121,7 +121,7 @@ Other config variables are optional, front-end-specific and front-end
 selection variables (e.g., ``rgw data`` and ``rgw frontends``) are
 optional and in some cases ignored.
 
-A small number of config variables (e.g., ``rgw_namespace_expire_secs``)
+A small number of config variables (e.g., ``rgw_nfs_namespace_expire_secs``)
 are unique to RGW NFS.
 
 ganesha.conf


### PR DESCRIPTION
The option's name is `rgw_nfs_namespace_expire_secs`, instead of `rgw_namespace_expire_secs`.

Signed-off-by: chnmagnus <chnmagnus@qq.com>