### PR TITLE
rbd: pool_percent_used should not divided by 100

### DIFF
--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -421,7 +421,7 @@ int execute_purge (const po::variables_map &vm,
     for(uint8_t i = 0; i < arr.size(); ++i) {
       if(arr[i].get_obj()["name"] == pool_name) {
         json_spirit::mObject stats =  arr[i].get_obj()["stats"].get_obj();
-        pool_percent_used = stats["percent_used"].get_real() / 100;
+        pool_percent_used = stats["percent_used"].get_real();
         if(pool_percent_used <= threshold) {
           std::cout << "rbd: pool usage is lower than or equal to "
                     << (threshold*100)


### PR DESCRIPTION
```
root@s222:/ceph-dev/build# ceph df
GLOBAL:
    SIZE     AVAIL     RAW USED     %RAW USED 
     30G     24.0G        6.01G         20.05 
POOLS:
    NAME                  ID     USED      %USED     MAX AVAIL     OBJECTS 
    cephfs_data_a         1          0         0         7.90G           0 
    cephfs_metadata_a     2      2.19K         0         7.90G          21 
    rbd                   3      1.00G     11.24         7.90G         262 
root@s222:/ceph-dev/build# rbd trash purge --threshold 0.1     # 10%
rbd: pool usage is lower than or equal to 10%
Nothing to do
```
The actual pool usage of 'rbd' is 11.24%.

Signed-off-by: songweibin <song.weibin@zte.com.cn>