### PR TITLE
ceph-fuse: trim ceph-fuse -V output

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -97,6 +97,19 @@ int main(int argc, const char **argv, const char *envp[]) {
       filer_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;
     } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)nullptr)) {
       usage();
+    } else if (ceph_argparse_flag(args, i, "-V", (char*)nullptr)) {
+      const char* tmpargv[] = {
+	"ceph-fuse",
+	"-V"
+      };
+
+      struct fuse_args fargs = FUSE_ARGS_INIT(2, (char**)tmpargv);
+      if (fuse_parse_cmdline(&fargs, nullptr, nullptr, nullptr) == -1) {
+       derr << "fuse_parse_cmdline failed." << dendl;
+      }
+      assert(fargs.allocated);
+      fuse_opt_free_args(&fargs);
+      exit(0);
     } else {
       ++i;
     }


### PR DESCRIPTION
Trim 'ceph-fuse -V' output to print only the FUSE library version.

Previous output:
```
$ ./bin/ceph-fuse -V
FUSE library version: 2.9.7
ceph-fuse[11200]: starting ceph client
fusermount version: 2.9.7
using FUSE kernel interface version 7.19
ceph-fuse[11200]: fuse failed to start
2018-03-08 18:06:56.745 7f63fa883cc0 -1 fuse_lowlevel_new failed
```

New output:
```
$ ./bin/ceph-fuse -V
FUSE library version: 2.9.7
```
Fixes: http://tracker.ceph.com/issues/23248
Signed-off-by: Jos Collin <jcollin@redhat.com>