### PR TITLE
mgr/dashboard_v2: Fix cephfs template table usage

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cephfs/cephfs/cephfs.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cephfs/cephfs/cephfs.component.html
@@ -26,7 +26,7 @@
       <cd-table [data]="ranks.data"
                 [columns]="ranks.columns"
                 (fetchData)="refresh()"
-                toolHeader="false">
+                [toolHeader]="false">
       </cd-table>
     </fieldset>
 
@@ -40,7 +40,7 @@
 
       <cd-table [data]="pools.data"
                 [columns]="pools.columns"
-                toolHeader="false">
+                [toolHeader]="false">
       </cd-table>
 
     </fieldset>


### PR DESCRIPTION
The option 'toolHeader' wasn't recognized by the table directive.
So it showed the wrong behavior showing the tool bar of the table.

Signed-off-by: Stephan Müller <smueller@suse.com>