### PR TITLE
mgr/dashboard_v2: Rotate the refresh icon on load

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/shared/datatable/table/table.component.html
@@ -42,7 +42,8 @@
     <!-- refresh button -->
     <div class="widget-toolbar tc_refreshBtn">
       <a (click)="refreshBtn()">
-        <i class="fa fa-lg fa-refresh"></i>
+        <i class="fa fa-lg fa-refresh"
+           [class.fa-spin]="updating || loadingIndicator"></i>
       </a>
     </div>
     <!-- end refresh button -->


### PR DESCRIPTION
The refresh icon of the data table will now rotate on loading events.

Signed-off-by: Stephan Müller <smueller@suse.com>