### PR TITLE
[DNM] mgr/dashboard: fix cmake npm binary search

### DIFF
--- a/src/pybind/mgr/dashboard_v2/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard_v2/CMakeLists.txt
@@ -11,7 +11,7 @@ add_dependencies(tests mgr-dashboard_v2-test-venv)
 if(WITH_MGR_DASHBOARD_V2_FRONTEND AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64|arm|ARM")
   find_program(NPM_BIN
     NAMES npm
-    HINTS $ENV{NPM_ROOT}/bin)
+    HINTS $ENV{NPM_ROOT}/bin /usr/local/bin)
   if(NOT NPM_BIN)
     message(FATAL_ERROR "WITH_MGR_DASHBOARD_V2_FRONTEND not npm not found")
   endif()


### PR DESCRIPTION
Let cmake give precedence to /usr/local/bin over /usr/bin.

In some systems the npm 3.x version that is in /usr/bin is being used over the more recent version installed in /usr/local/bin and makes build to fail.



Signed-off-by: Ricardo Dias <rdias@suse.com>