### PR TITLE
global: output usage on -h, --help, or no args before contacting mons

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -75,7 +75,12 @@ int main(int argc, const char **argv, const char *envp[]) {
   std::vector<const char*> args;
   argv_to_vec(argc, argv, args);
   if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
     usage();
+    exit(0);
   }
 
   std::map<std::string,std::string> defaults = {
@@ -95,8 +100,6 @@ int main(int argc, const char **argv, const char *envp[]) {
     } else if (ceph_argparse_flag(args, i, "--localize-reads", (char*)nullptr)) {
       cerr << "setting CEPH_OSD_FLAG_LOCALIZE_READS" << std::endl;
       filer_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)nullptr)) {
-      usage();
     } else {
       ++i;
     }
@@ -210,8 +213,10 @@ int main(int argc, const char **argv, const char *envp[]) {
 
     MonClient *mc = new MonClient(g_ceph_context);
     int r = mc->build_initial_monmap();
-    if (r == -EINVAL)
-      usage();
+    if (r == -EINVAL) {
+      cerr << "failed to generate initial mon list" << std::endl;
+      exit(1);
+    }
     if (r < 0)
       goto out_mc_start_failed;
 

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -73,7 +73,7 @@ static int parse_rank(const char *opt_name, const std::string &val)
   if (!err.empty()) {
     derr << "error parsing " << opt_name << ": failed to parse rank. "
 	 << "It must be an int." << "\n" << dendl;
-    usage();
+    exit(1);
   }
   return ret;
 }
@@ -99,6 +99,14 @@ int main(int argc, const char **argv)
 
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args,
 			 CEPH_ENTITY_TYPE_MDS, CODE_ENVIRONMENT_DAEMON,
@@ -109,10 +117,6 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    }
-    else if (ceph_argparse_flag(args, i, "--help", "-h", (char*)NULL)) {
-      // exit(1) will be called in the usage()
-      usage();
     }
     else if (ceph_argparse_witharg(args, i, &val, "--hot-standby", (char*)NULL)) {
       int r = parse_rank("hot-standby", val);

--- a/src/ceph_mgr.cc
+++ b/src/ceph_mgr.cc
@@ -45,6 +45,13 @@ int main(int argc, const char **argv)
 
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+  }
 
   map<string,string> defaults = {
     { "keyring", "$mgr_data/keyring" }
@@ -52,12 +59,6 @@ int main(int argc, const char **argv)
   auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_MGR,
 			 CODE_ENVIRONMENT_DAEMON, 0,
 			 "mgr_data");
-
-  // Handle --help
-  if ((args.size() == 1 && (std::string(args[0]) == "--help" ||
-			    std::string(args[0]) == "-h"))) {
-    usage();
-  }
 
   pick_addresses(g_ceph_context, CEPH_PICK_ADDRESS_PUBLIC);
 

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -197,6 +197,14 @@ int main(int argc, const char **argv)
 
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   // We need to specify some default values that may be overridden by the
   // user, that are specific to the monitor.  The options we are overriding
@@ -253,8 +261,6 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
     } else if (ceph_argparse_flag(args, i, "--mkfs", (char*)NULL)) {
       mkfs = true;
     } else if (ceph_argparse_flag(args, i, "--compact", (char*)NULL)) {
@@ -274,24 +280,24 @@ int main(int argc, const char **argv)
     }
   }
   if (!args.empty()) {
-    derr << "too many arguments: " << args << dendl;
-    usage();
+    cerr << "too many arguments: " << args << std::endl;
+    exit(1);
   }
 
   if (force_sync && !yes_really) {
-    derr << "are you SURE you want to force a sync?  this will erase local data and may\n"
-	 << "break your mon cluster.  pass --yes-i-really-mean-it if you do." << dendl;
+    cerr << "are you SURE you want to force a sync?  this will erase local data and may\n"
+	 << "break your mon cluster.  pass --yes-i-really-mean-it if you do." << std::endl;
     exit(1);
   }
 
   if (g_conf->mon_data.empty()) {
-    derr << "must specify '--mon-data=foo' data path" << dendl;
-    usage();
+    cerr << "must specify '--mon-data=foo' data path" << std::endl;
+    exit(1);
   }
 
   if (g_conf->name.get_id().empty()) {
-    derr << "must specify id (--id <id> or --name mon.<id>)" << dendl;
-    usage();
+    cerr << "must specify id (--id <id> or --name mon.<id>)" << std::endl;
+    exit(1);
   }
 
   // -- mkfs --
@@ -664,7 +670,6 @@ int main(int argc, const char **argv)
       if (err < 0) {
 	derr << argv[0] << ": error generating initial monmap: "
              << cpp_strerror(err) << dendl;
-	usage();
 	prefork.exit(1);
       }
       if (tmpmap.contains(g_conf->name.get_id())) {

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -110,6 +110,14 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   map<string,string> defaults = {
     // We want to enable leveldb's log, while allowing users to override this
@@ -146,8 +154,6 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
     } else if (ceph_argparse_flag(args, i, "--mkfs", (char*)NULL)) {
       mkfs = true;
     } else if (ceph_argparse_flag(args, i, "--mkjournal", (char*)NULL)) {

--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -544,13 +544,26 @@ static void generic_usage(bool is_server)
   cout.flush();
 }
 
+bool ceph_argparse_need_usage(const std::vector<const char*>& args)
+{
+  if (args.empty()) {
+    return true;
+  }
+  for (auto a : args) {
+    if (strcmp(a, "-h") == 0 ||
+	strcmp(a, "--help") == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void generic_server_usage()
 {
   generic_usage(true);
-  exit(1);
 }
+
 void generic_client_usage()
 {
   generic_usage(false);
-  exit(1);
 }

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -68,6 +68,7 @@ bool ceph_argparse_binary_flag(std::vector<const char*> &args,
 extern CephInitParameters ceph_argparse_early_args
 	    (std::vector<const char*>& args, uint32_t module_type,
 	     std::string *cluster, std::string *conf_file_list);
+extern bool ceph_argparse_need_usage(const std::vector<const char*>& args);
 extern void generic_server_usage();
 extern void generic_client_usage();
 

--- a/src/librados-config.cc
+++ b/src/librados-config.cc
@@ -37,6 +37,13 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage_exit();
+  }
 
   bool opt_version = false;
   bool opt_vernum = false;

--- a/src/rbd_replay/rbd-replay.cc
+++ b/src/rbd_replay/rbd-replay.cc
@@ -58,6 +58,14 @@ int main(int argc, const char **argv) {
   vector<const char*> args;
 
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage(argv[0]);
+    exit(0);
+  }
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY, 0);
 
@@ -90,9 +98,6 @@ int main(int argc, const char **argv) {
 	cerr << "Unable to parse mapping string: '" << val << "'" << std::endl;
 	return 1;
       }
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage(argv[0]);
-      return 0;
     } else if (ceph_argparse_flag(args, i, "--dump-perf-counters", (char*)NULL)) {
       dump_perf_counters = true;
     } else if (get_remainder(*i, "-")) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2382,6 +2382,14 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, (const char **)argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY, 0);
@@ -2537,9 +2545,6 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
-      ceph_abort();
     } else if (ceph_argparse_witharg(args, i, &val, "-i", "--uid", (char*)NULL)) {
       user_id.from_str(val);
     } else if (ceph_argparse_witharg(args, i, &val, "--tenant", (char*)NULL)) {
@@ -2580,8 +2585,7 @@ int main(int argc, const char **argv)
         key_type = KEY_TYPE_S3;
       } else {
         cerr << "bad key type: " << key_type_str << std::endl;
-        usage();
-	ceph_abort();
+        exit(1);
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--job-id", (char*)NULL)) {
       job_id = val;
@@ -2695,8 +2699,7 @@ int main(int argc, const char **argv)
       bucket_id = val;
       if (bucket_id.empty()) {
         cerr << "bad bucket-id" << std::endl;
-        usage();
-	ceph_abort();
+        exit(1);
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--format", (char*)NULL)) {
       format = val;
@@ -2870,7 +2873,7 @@ int main(int argc, const char **argv)
 
   if (args.empty()) {
     usage();
-    ceph_abort();
+    exit(1);
   }
   else {
     const char *prev_cmd = NULL;
@@ -2880,8 +2883,7 @@ int main(int argc, const char **argv)
       opt_cmd = get_cmd(*i, prev_cmd, prev_prev_cmd, &need_more);
       if (opt_cmd < 0) {
 	cerr << "unrecognized arg " << *i << std::endl;
-	usage();
-	ceph_abort();
+	exit(1);
       }
       if (!need_more) {
 	++i;
@@ -2892,8 +2894,8 @@ int main(int argc, const char **argv)
     }
 
     if (opt_cmd == OPT_NO_CMD) {
-      usage();
-      ceph_abort();
+      cerr << "no command" << std::endl;
+      exit(1);
     }
 
     /* some commands may have an optional extra param */
@@ -2953,8 +2955,7 @@ int main(int argc, const char **argv)
     formatter = new JSONFormatter(pretty_format);
   else {
     cerr << "unrecognized format: " << format << std::endl;
-    usage();
-    ceph_abort();
+    exit(1);
   }
 
   realm_name = g_conf->rgw_realm;
@@ -5113,8 +5114,7 @@ int main(int argc, const char **argv)
   if (opt_cmd == OPT_LOG_SHOW || opt_cmd == OPT_LOG_RM) {
     if (object.empty() && (date.empty() || bucket_name.empty() || bucket_id.empty())) {
       cerr << "specify an object or a date, bucket and bucket-id" << std::endl;
-      usage();
-      ceph_abort();
+      exit(1);
     }
 
     string oid;
@@ -5212,8 +5212,7 @@ next:
   if (opt_cmd == OPT_POOL_ADD) {
     if (pool_name.empty()) {
       cerr << "need to specify pool to add!" << std::endl;
-      usage();
-      ceph_abort();
+      exit(1);
     }
 
     int ret = store->add_bucket_placement(pool);
@@ -5224,8 +5223,7 @@ next:
   if (opt_cmd == OPT_POOL_RM) {
     if (pool_name.empty()) {
       cerr << "need to specify pool to remove!" << std::endl;
-      usage();
-      ceph_abort();
+      exit(1);
     }
 
     int ret = store->remove_bucket_placement(pool);

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -122,15 +122,15 @@ public:
 
 static int usage()
 {
-  cerr << "usage: radosgw [options...]" << std::endl;
-  cerr << "options:\n";
-  cerr << "  --rgw-region=<region>     region in which radosgw runs\n";
-  cerr << "  --rgw-zone=<zone>         zone in which radosgw runs\n";
-  cerr << "  --rgw-socket-path=<path>  specify a unix domain socket path\n";
-  cerr << "  -m monaddress[:port]      connect to specified monitor\n";
-  cerr << "  --keyring=<path>          path to radosgw keyring\n";
-  cerr << "  --logfile=<logfile>       file to log debug output\n";
-  cerr << "  --debug-rgw=<log-level>/<memory-level>  set radosgw debug level\n";
+  cout << "usage: radosgw [options...]" << std::endl;
+  cout << "options:\n";
+  cout << "  --rgw-region=<region>     region in which radosgw runs\n";
+  cout << "  --rgw-zone=<zone>         zone in which radosgw runs\n";
+  cout << "  --rgw-socket-path=<path>  specify a unix domain socket path\n";
+  cout << "  -m monaddress[:port]      connect to specified monitor\n";
+  cout << "  --keyring=<path>          path to radosgw keyring\n";
+  cout << "  --logfile=<logfile>       file to log debug output\n";
+  cout << "  --debug-rgw=<log-level>/<memory-level>  set radosgw debug level\n";
   generic_server_usage();
 
   return 0;
@@ -179,6 +179,14 @@ int main(int argc, const char **argv)
 
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   // First, let's determine which frontends are configured.
   int flags = CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS;
@@ -233,13 +241,6 @@ int main(int argc, const char **argv)
   auto cct = global_init(&defaults, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_DAEMON,
 			 flags, "rgw_data", false);
-
-  for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ++i) {
-    if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
-      return 0;
-    }
-  }
 
   // maintain existing region root pool for new multisite objects
   if (!g_conf->rgw_region_root_pool.empty()) {

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -57,6 +57,14 @@ int main(const int argc, const char **argv)
 {
   vector<const char *> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_DAEMON,
@@ -65,9 +73,6 @@ int main(const int argc, const char **argv)
   for (std::vector<const char *>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
-      return 0;
     }
   }
 

--- a/src/rgw/rgw_token.cc
+++ b/src/rgw/rgw_token.cc
@@ -62,6 +62,14 @@ int main(int argc, char **argv)
   std::string val;
   vector<const char*> args;
   argv_to_vec(argc, (const char **)argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY, 0);
@@ -109,7 +117,6 @@ int main(int argc, char **argv)
 
   if ((! do_encode) ||
       (type == RGWToken::TOKEN_NONE)) {
-    usage();
     return -EINVAL;
   }
 

--- a/src/test/TestSignalHandlers.cc
+++ b/src/test/TestSignalHandlers.cc
@@ -66,10 +66,10 @@ static void infinite_recursion_test()
 
 static void usage()
 {
-  cerr << "usage: TestSignalHandlers [test]" << std::endl;
-  cerr << "--simple_segv: run simple_segv test" << std::endl;
-  cerr << "--infinite_recursion: run infinite_recursion test" << std::endl;
-  generic_client_usage(); // Will exit()
+  cout << "usage: TestSignalHandlers [test]" << std::endl;
+  cout << "--simple_segv: run simple_segv test" << std::endl;
+  cout << "--infinite_recursion: run infinite_recursion test" << std::endl;
+  generic_client_usage();
 }
 
 typedef void (*test_fn_t)(void);
@@ -78,6 +78,14 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
@@ -88,20 +96,18 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
     } else if (ceph_argparse_flag(args, i, "--infinite_recursion", (char*)NULL)) {
       fn = infinite_recursion_test;
     } else if (ceph_argparse_flag(args, i, "-s", "--simple_segv", (char*)NULL)) {
       fn = simple_segv_test;
     } else {
-      cerr << "Garbage at end of command line." << std::endl;
-      usage();
+      cerr << "unrecognized argument: " << *i << std::endl;
+      exit(1);
     }
   }
   if (!fn) {
     std::cerr << "Please select a test to run. Type -h for help." << std::endl;
-    usage();
+    exit(1);
   }
   fn();
   return 0;

--- a/src/test/cli/ceph-authtool/help.t
+++ b/src/test/cli/ceph-authtool/help.t
@@ -1,6 +1,5 @@
 # TODO synchronize with man page
   $ ceph-authtool --help
-  no command specified
   usage: ceph-authtool keyringfile [OPTIONS]...
   where the options are:
     -l, --list                    will list all keys and capabilities present in

--- a/src/test/cli/ceph-authtool/manpage.t
+++ b/src/test/cli/ceph-authtool/manpage.t
@@ -1,27 +1,5 @@
   $ ceph-authtool
-  ceph-authtool: must specify filename
-  usage: ceph-authtool keyringfile [OPTIONS]...
-  where the options are:
-    -l, --list                    will list all keys and capabilities present in
-                                  the keyring
-    -p, --print-key               will print an encoded key for the specified
-                                  entityname. This is suitable for the
-                                  'mount -o secret=..' argument
-    -C, --create-keyring          will create a new keyring, overwriting any
-                                  existing keyringfile
-    -g, --gen-key                 will generate a new secret key for the
-                                  specified entityname
-    --gen-print-key               will generate a new secret key without set it
-                                  to the keyringfile, prints the secret to stdout
-    --import-keyring FILE         will import the content of a given keyring
-                                  into the keyringfile
-    -n NAME, --name NAME          specify entityname to operate on
-    -u AUID, --set-uid AUID       sets the auid (authenticated user id) for the
-                                  specified entityname
-    -a BASE64, --add-key BASE64   will add an encoded key to the keyring
-    --cap SUBSYSTEM CAPABILITY    will set the capability for given subsystem
-    --caps CAPSFILE               will set all of capabilities associated with a
-                                  given key, for all subsystems
+  ceph-authtool: -h or --help for usage
   [1]
 
 # demonstrate that manpage examples fail without config

--- a/src/test/cli/ceph-authtool/simple.t
+++ b/src/test/cli/ceph-authtool/simple.t
@@ -1,25 +1,3 @@
   $ ceph-authtool
-  ceph-authtool: must specify filename
-  usage: ceph-authtool keyringfile [OPTIONS]...
-  where the options are:
-    -l, --list                    will list all keys and capabilities present in
-                                  the keyring
-    -p, --print-key               will print an encoded key for the specified
-                                  entityname. This is suitable for the
-                                  'mount -o secret=..' argument
-    -C, --create-keyring          will create a new keyring, overwriting any
-                                  existing keyringfile
-    -g, --gen-key                 will generate a new secret key for the
-                                  specified entityname
-    --gen-print-key               will generate a new secret key without set it
-                                  to the keyringfile, prints the secret to stdout
-    --import-keyring FILE         will import the content of a given keyring
-                                  into the keyringfile
-    -n NAME, --name NAME          specify entityname to operate on
-    -u AUID, --set-uid AUID       sets the auid (authenticated user id) for the
-                                  specified entityname
-    -a BASE64, --add-key BASE64   will add an encoded key to the keyring
-    --cap SUBSYSTEM CAPABILITY    will set the capability for given subsystem
-    --caps CAPSFILE               will set all of capabilities associated with a
-                                  given key, for all subsystems
+  ceph-authtool: -h or --help for usage
   [1]

--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -18,4 +18,3 @@
     compact-range <prefix> <start> <end>
     repair
   
-  [1]

--- a/src/test/cli/monmaptool/simple.t
+++ b/src/test/cli/monmaptool/simple.t
@@ -1,9 +1,3 @@
   $ monmaptool
-  monmaptool: must specify monmap filename
-   usage: [--print] [--create [--clobber][--fsid uuid]]
-          [--generate] [--set-initial-members]
-          [--add name 1.2.3.4:567] [--rm name]
-          [--feature-list [plain|parseable]]
-          [--feature-set <value> [--optional|--persistent]]
-          [--feature-unset <value> [--optional|--persistent]] <mapfilename>
+  monmaptool: -h or --help for usage
   [1]

--- a/src/test/cli/osdmaptool/missing-argument.t
+++ b/src/test/cli/osdmaptool/missing-argument.t
@@ -1,26 +1,3 @@
   $ osdmaptool
-  osdmaptool: must specify osdmap filename
-   usage: [--print] [--createsimple <numosd> [--clobber] [--pg_bits <bitsperosd>]] <mapfilename>
-     --export-crush <file>   write osdmap's crush map to <file>
-     --import-crush <file>   replace osdmap's crush map with <file>
-     --test-map-pgs [--pool <poolid>] [--pg_num <pg_num>] map all pgs
-     --test-map-pgs-dump [--pool <poolid>] map all pgs
-     --test-map-pgs-dump-all [--pool <poolid>] map all pgs to osds
-     --health                dump health checks
-     --mark-up-in            mark osds up and in (but do not persist)
-     --mark-out <osdid>      mark an osd as out (but do not persist)
-     --with-default-pool     include default pool when creating map
-     --clear-temp            clear pg_temp and primary_temp
-     --test-random           do random placements
-     --test-map-pg <pgid>    map a pgid to osds
-     --test-map-object <objectname> [--pool <poolid>] map an object to osds
-     --upmap-cleanup <file>  clean up pg_upmap[_items] entries, writing
-                             commands to <file> [default: - for stdout]
-     --upmap <file>          calculate pg upmap entries to balance pg layout
-                             writing commands to <file> [default: - for stdout]
-     --upmap-max <max-count> set max upmap entries to calculate [default: 100]
-     --upmap-deviation <max-deviation>
-                             max deviation from target [default: .01]
-     --upmap-pool <poolname> restrict upmap balancing to 1 or more pools
-     --upmap-save            write modified OSDMap with upmap changes
+  osdmaptool: -h or --help for usage
   [1]

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -294,6 +294,5 @@
     --setgroup GROUP  set gid to group or gid
     --version         show version and quit
   
-  [1]
 
 

--- a/src/test/objectstore_bench.cc
+++ b/src/test/objectstore_bench.cc
@@ -20,7 +20,7 @@
 
 static void usage()
 {
-  derr << "usage: ceph_objectstore_bench [flags]\n"
+  cout << "usage: ceph_objectstore_bench [flags]\n"
       "	 --size\n"
       "	       total size in bytes\n"
       "	 --block-size\n"
@@ -30,7 +30,7 @@ static void usage()
       "	 --threads\n"
       "	       number of threads to carry out this workload\n"
       "	 --multi-object\n"
-      "	       have each thread write to a separate object\n" << dendl;
+    "	       have each thread write to a separate object\n" << std::endl;
   generic_server_usage();
 }
 
@@ -167,13 +167,13 @@ int main(int argc, const char *argv[])
       std::string err;
       if (!cfg.size.parse(val, &err)) {
         derr << "error parsing size: " << err << dendl;
-        usage();
+        exit(1);
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--block-size", (char*)nullptr)) {
       std::string err;
       if (!cfg.block_size.parse(val, &err)) {
         derr << "error parsing block-size: " << err << dendl;
-        usage();
+        exit(1);
       }
     } else if (ceph_argparse_witharg(args, i, &val, "--repeats", (char*)nullptr)) {
       cfg.repeats = atoi(val.c_str());
@@ -183,7 +183,7 @@ int main(int argc, const char *argv[])
       cfg.multi_object = true;
     } else {
       derr << "Error: can't understand argument: " << *i << "\n" << dendl;
-      usage();
+      exit(1);
     }
   }
 

--- a/src/test/rbd_mirror/random_write.cc
+++ b/src/test/rbd_mirror/random_write.cc
@@ -154,17 +154,18 @@ int main(int argc, const char **argv)
 {
   std::vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
-
-  for (auto i = args.begin(); i != args.end(); ++i) {
-    if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
-      return EXIT_SUCCESS;
-    }
-  }
 
   if (args.size() < 2) {
     usage();

--- a/src/test/xattr_bench.cc
+++ b/src/test/xattr_bench.cc
@@ -151,6 +151,14 @@ uint64_t do_run(ObjectStore *store, int attrsize, int numattrs,
 int main(int argc, char **argv) {
   vector<const char*> args;
   argv_to_vec(argc, (const char **)argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage(argv[0]);
+    exit(0);
+  }
 
   auto cct = global_init(0, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,

--- a/src/tools/ceph-client-debug.cc
+++ b/src/tools/ceph-client-debug.cc
@@ -84,6 +84,14 @@ int main(int argc, const char **argv)
   // Argument handling
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
@@ -94,7 +102,8 @@ int main(int argc, const char **argv)
 
   // Expect exactly one positional argument (inode number)
   if (args.size() != 1) {
-    usage();
+    cerr << "missing position argument (inode number)" << std::endl;
+    exit(1);
   }
   char const *inode_str = args[0];
   inodeno_t inode = strtoll(inode_str, NULL, 0);

--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -62,6 +62,15 @@ int main(int argc, const char **argv)
   map<string,bufferlist> caps;
   std::string fn;
 
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
+
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -292,7 +292,7 @@ class StoreTool
 
 void usage(const char *pname)
 {
-  std::cerr << "Usage: " << pname << " <leveldb|rocksdb|bluestore-kv> <store path> command [args...]\n"
+  std::cout << "Usage: " << pname << " <leveldb|rocksdb|bluestore-kv> <store path> command [args...]\n"
     << "\n"
     << "Commands:\n"
     << "  list [prefix]\n"
@@ -317,6 +317,14 @@ int main(int argc, const char *argv[])
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage(argv[0]);
+    exit(0);
+  }
 
   auto cct = global_init(
       NULL, args,

--- a/src/tools/ceph_osdomap_tool.cc
+++ b/src/tools/ceph_osdomap_tool.cc
@@ -70,6 +70,11 @@ int main(int argc, char **argv) {
 
   if (vm.count("debug")) debug = true;
 
+  if (vm.count("help")) {
+    std::cerr << desc << std::endl;
+    return 1;
+  }
+
   auto cct = global_init(
     NULL, ceph_options, CEPH_ENTITY_TYPE_OSD,
     CODE_ENVIRONMENT_UTILITY_NODOUT, 0);
@@ -81,11 +86,6 @@ int main(int argc, char **argv) {
     g_conf->set_val_or_die("err_to_stderr", "true");
   }
   g_conf->apply_changes(NULL);
-
-  if (vm.count("help")) {
-    std::cerr << desc << std::endl;
-    return 1;
-  }
 
   if (vm.count("omap-path") == 0) {
     std::cerr << "Required argument --omap-path" << std::endl;

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -136,7 +136,7 @@ int DataScan::main(const std::vector<const char*> &args)
   // Parse args
   // ==========
   if (args.size() < 1) {
-    usage();
+    cerr << "missing position argument" << std::endl;
     return -EINVAL;
   }
 
@@ -248,7 +248,6 @@ int DataScan::main(const std::vector<const char*> &args)
       command == "cleanup") {
     if (data_pool_name.empty()) {
       std::cerr << "Data pool not specified" << std::endl;
-      usage();
       return -EINVAL;
     }
 

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -88,7 +88,7 @@ int JournalTool::main(std::vector<const char*> &argv)
   // Common arg parsing
   // ==================
   if (argv.empty()) {
-    usage();
+    cerr << "missing positional argument" << std::endl;
     return -EINVAL;
   }
 
@@ -171,8 +171,7 @@ int JournalTool::main(std::vector<const char*> &argv)
     } else if (type == std::string("mdlog") && mode == std::string("event")) {
       r = main_event(argv);
     } else {
-      derr << "Bad command '" << mode << "'" << dendl;
-      usage();
+      cerr << "Bad command '" << mode << "'" << std::endl;
       return -EINVAL;
     }
 
@@ -217,12 +216,10 @@ int JournalTool::main_journal(std::vector<const char*> &argv)
         force = true;
       } else {
         std::cerr << "Unknown argument " << argv[1] << std::endl;
-        usage();
         return -EINVAL;
       }
     } else if (argv.size() > 2) {
       std::cerr << "Too many arguments!" << std::endl;
-      usage();
       return -EINVAL;
     }
     return journal_reset(force);
@@ -340,13 +337,11 @@ int JournalTool::main_event(std::vector<const char*> &argv)
   std::string command = *(arg++);
   if (command != "get" && command != "splice" && command != "recover_dentries") {
     derr << "Unknown argument '" << command << "'" << dendl;
-    usage();
     return -EINVAL;
   }
 
   if (arg == argv.end()) {
     derr << "Incomplete command line" << dendl;
-    usage();
     return -EINVAL;
   }
 
@@ -361,15 +356,14 @@ int JournalTool::main_event(std::vector<const char*> &argv)
   // Parse output options
   // ====================
   if (arg == argv.end()) {
-    derr << "Missing output command" << dendl;
-    usage();
+    cerr << "Missing output command" << std::endl;
+    return -EINVAL;
   }
   std::string output_style = *(arg++);
   if (output_style != "binary" && output_style != "json" &&
       output_style != "summary" && output_style != "list") {
-      derr << "Unknown argument: '" << output_style << "'" << dendl;
-      usage();
-      return -EINVAL;
+    cerr << "Unknown argument: '" << output_style << "'" << std::endl;
+    return -EINVAL;
   }
 
   std::string output_path = "dump";
@@ -384,8 +378,7 @@ int JournalTool::main_event(std::vector<const char*> &argv)
       assert(r == 0);
       other_pool = true;
     } else {
-      derr << "Unknown argument: '" << *arg << "'" << dendl;
-      usage();
+      cerr << "Unknown argument: '" << *arg << "'" << std::endl;
       return -EINVAL;
     }
   }
@@ -500,8 +493,7 @@ int JournalTool::main_event(std::vector<const char*> &argv)
 
 
   } else {
-    derr << "Unknown argument '" << command << "'" << dendl;
-    usage();
+    cerr << "Unknown argument '" << command << "'" << std::endl;
     return -EINVAL;
   }
 

--- a/src/tools/cephfs/TableTool.cc
+++ b/src/tools/cephfs/TableTool.cc
@@ -319,7 +319,7 @@ int TableTool::main(std::vector<const char*> &argv)
 
   // Require at least 3 args <rank> <mode> <arg> [args...]
   if (argv.size() < 3) {
-    usage();
+    cerr << "missing required 3 arguments" << std::endl;
     return -EINVAL;
   }
 
@@ -368,8 +368,7 @@ int TableTool::main(std::vector<const char*> &argv)
       jf.dump_int("result", r);
       jf.close_section();
     } else {
-      derr << "Invalid table '" << table << "'" << dendl;
-      usage();
+      cerr << "Invalid table '" << table << "'" << std::endl;
       return -EINVAL;
     }
   } else if (mode == "show") {
@@ -391,8 +390,7 @@ int TableTool::main(std::vector<const char*> &argv)
       }
       jf.close_section();
     } else {
-      derr << "Invalid table '" << table << "'" << dendl;
-      usage();
+      cerr << "Invalid table '" << table << "'" << std::endl;
       return -EINVAL;
     }
   } else if (mode == "take_inos") {
@@ -407,8 +405,7 @@ int TableTool::main(std::vector<const char*> &argv)
       return InoTableHandler(rank).take_inos(&io, ino, f);
     }, &jf);
   } else {
-    derr << "Invalid mode '" << mode << "'" << dendl;
-    usage();
+    cerr << "Invalid mode '" << mode << "'" << std::endl;
     return -EINVAL;
   }
 

--- a/src/tools/cephfs/cephfs-data-scan.cc
+++ b/src/tools/cephfs/cephfs-data-scan.cc
@@ -13,17 +13,19 @@ int main(int argc, const char **argv)
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
 
+  DataScan data_scan;
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    data_scan.usage();
+    exit(0);
+  }
+
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
-
-  DataScan data_scan;
-
-  // Handle --help before calling init() so we don't depend on network.
-  if (args.empty() || (args.size() == 1 && (std::string(args[0]) == "--help" || std::string(args[0]) == "-h"))) {
-    data_scan.usage();
-    return 0;
-  }
 
   // Connect to mon cluster, download MDS map etc
   int rc = data_scan.init();

--- a/src/tools/cephfs/cephfs-journal-tool.cc
+++ b/src/tools/cephfs/cephfs-journal-tool.cc
@@ -25,18 +25,20 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  JournalTool jt;
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    jt.usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			     CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
-  JournalTool jt;
-
-  // Handle --help before calling init() so we don't depend on network.
-  if (args.empty() || (args.size() == 1 && (std::string(args[0]) == "--help" || std::string(args[0]) == "-h"))) {
-    jt.usage();
-    return 0;
-  }
 
   // Connect to mon cluster, download MDS map etc
   int rc = jt.init();

--- a/src/tools/cephfs/cephfs-table-tool.cc
+++ b/src/tools/cephfs/cephfs-table-tool.cc
@@ -13,17 +13,20 @@ int main(int argc, const char **argv)
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
 
+  TableTool tt;
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    tt.usage();
+    exit(0);
+  }
+
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
-  TableTool tt;
-
-  // Handle --help before calling init() so we don't depend on network.
-  if (args.empty() || (args.size() == 1 && (std::string(args[0]) == "--help" || std::string(args[0]) == "-h"))) {
-    tt.usage();
-    return 0;
-  }
 
   // Connect to mon cluster, download MDS map etc
   int rc = tt.init();

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -355,6 +355,14 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   const char *me = argv[0];
   std::string infn, srcfn, outfn, add_name, add_type, remove_name, reweight_name;
@@ -425,9 +433,6 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
-      return EXIT_SUCCESS;
     } else if (ceph_argparse_witharg(args, i, &val, "-d", "--decompile", (char*)NULL)) {
       infn = val;
       decompile = true;

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -167,6 +167,14 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   const char *me = argv[0];
 
@@ -190,8 +198,6 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
     } else if (ceph_argparse_flag(args, i, "-p", "--print", (char*)NULL)) {
       print = true;
     } else if (ceph_argparse_flag(args, i, "--create", (char*)NULL)) {

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -88,6 +88,14 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY,
@@ -136,8 +144,6 @@ int main(int argc, const char **argv)
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
     } else if (ceph_argparse_flag(args, i, "-p", "--print", (char*)NULL)) {
       print = true;
     } else if (ceph_argparse_witharg(args, i, &val, err, "--dump", (char*)NULL)) {

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -3707,6 +3707,14 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage(cout);
+    exit(0);
+  }
 
   std::map < std::string, std::string > opts;
   std::string val;
@@ -3742,9 +3750,6 @@ int main(int argc, const char **argv)
   for (i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
-    } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage(cout);
-      exit(0);
     } else if (ceph_argparse_flag(args, i, "--force-full", (char*)NULL)) {
       opts["force-full"] = "true";
     } else if (ceph_argparse_flag(args, i, "-d", "--delete-after", (char*)NULL)) {

--- a/src/tools/rbd_ggate/main.cc
+++ b/src/tools/rbd_ggate/main.cc
@@ -396,6 +396,14 @@ int main(int argc, const char *argv[]) {
   vector<const char*> args;
 
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   std::string conf_file_list;
   std::string cluster;

--- a/src/tools/rbd_mirror/main.cc
+++ b/src/tools/rbd_mirror/main.cc
@@ -33,17 +33,18 @@ int main(int argc, const char **argv)
 {
   std::vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_DAEMON,
 			 CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
-
-  for (auto i = args.begin(); i != args.end(); ++i) {
-    if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
-      usage();
-      return EXIT_SUCCESS;
-    }
-  }
 
   if (g_conf->daemonize) {
     global_init_daemonize(g_ceph_context);

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -665,6 +665,14 @@ static int do_map(int argc, const char *argv[], Config *cfg)
 
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
+  if (args.empty()) {
+    cerr << argv[0] << ": -h or --help for usage" << std::endl;
+    exit(1);
+  }
+  if (ceph_argparse_need_usage(args)) {
+    usage();
+    exit(0);
+  }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_DAEMON,


### PR DESCRIPTION
- when there are no arguments, print a short invitation to stderr to use -h or --help and exit with an error.
- if we get -h or --help, print usage to stdout, and exit with success.
- do the above *before* making any contact with the cluster.  we should not fail to explain usage because the mons are down.
- if there is some other error with the arguments, print an error message, but do not spam the user with usage.  Try to use cerr instead of derr.

