### PR TITLE
Revert "make-dist: add OBS-specific release suffix on SUSE"

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -105,14 +105,6 @@ for spec in ceph.spec.in alpine/APKBUILD.in; do
         sed "s/@RPM_RELEASE@/$rpm_release/g" |
         sed "s/@TARBALL_BASENAME@/ceph-$version/g" > `echo $spec | sed 's/.in$//'`
 done
-
-. /etc/os-release
-case $ID in
-    opensuse|suse|sles)
-        sed -i -e "s/^Release:.*/&.<B_CNT>/" ceph.spec
-        ;;
-esac
-
 ln -s . $outfile
 tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec $outfile/alpine/APKBUILD
 # NOTE: If you change this version number make sure the package is available


### PR DESCRIPTION
This reverts commit ca6c92b3ec2f715cf247e9c1009d315d9de9c55a.

The OBS-specific suffix potentially causes trouble when building outside of
OBS. Also, the OBS build process already includes a spec-file munging step
where this can be done.

Signed-off-by: Nathan Cutler <ncutler@suse.com>