### PR TITLE
lumious: test/ceph-disk: drop coverage test

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -5,7 +5,6 @@ skip_missing_interpreters = True
 [testenv]
 setenv =
        VIRTUAL_ENV={envdir}
-       CEPH_DISK={envbindir}/coverage run --append --source=ceph_disk -- {envbindir}/ceph-disk
        PYTHONWARNINGS=ignore
 usedevelop = true
 deps =
@@ -20,10 +19,9 @@ deps =
 sitepackages=True
 passenv = CEPH_ROOT CEPH_BIN CEPH_LIB CEPH_BUILD_VIRTUALENV
 changedir = {env:CEPH_BUILD_DIR}
-commands = coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_main.py
-           coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_prepare.py
+commands = py.test -vv {toxinidir}/tests/test_main.py
+           py.test -vv {toxinidir}/tests/test_prepare.py
            {toxinidir}/tests/ceph-disk.sh
-           coverage report --show-missing
 
 [testenv:flake8]
 commands = flake8 --ignore=H105,H405,E127,E722 ceph_disk tests


### PR DESCRIPTION
run-tox-ceph-disk always fails with following error

py27 runtests: commands[0] | coverage run --append --source=ceph_disk
/home/jenkins-build/build/workspace/ceph-pull-requests/src/ceph-disk/.tox/py27/bin/py.test
-vv
/home/jenkins-build/build/workspace/ceph-pull-requests/src/ceph-disk/tests/test_main.py
ERROR: InvocationError: could not find executable 'coverage'

but the log shows that coverage==3.7.1 was indeed installed in the py27
env. i tried to specify the full path of coverage in "commands" section
in tox.ini, but the problem persisted -- this time the backtrace was
printed, and the raised exception was 'OSError: [Errno 2] No such file
or directory'. since ceph-disk is deprecated and luminous only accepts
bug fixes and critical features, i think it's fine to disable the
coverage test of ceph-disk.

Fixes: http://tracker.ceph.com/issues/23281
Signed-off-by: Kefu Chai <kchai@redhat.com>
Conflicts:
	src/ceph-disk/tox.ini: the issue described above only exists
in luminous branch, so this change is not cherry-picked from master.