### PR TITLE
test/ceph-disk: specify the python used for creating venv

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -17,7 +17,7 @@ deps =
   ../ceph-detect-init
 
 [testenv:py27]
-sitepackages=True
+basepython = python2.7
 passenv = CEPH_ROOT CEPH_BIN CEPH_LIB CEPH_BUILD_VIRTUALENV
 changedir = {env:CEPH_BUILD_DIR}
 commands = coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_main.py


### PR DESCRIPTION
run-tox-ceph-disk always fails with following error

py27 runtests: commands[0] | coverage run --append --source=ceph_disk
/home/jenkins-build/build/workspace/ceph-pull-requests/src/ceph-disk/.tox/py27/bin/py.test
-vv
/home/jenkins-build/build/workspace/ceph-pull-requests/src/ceph-disk/tests/test_main.py
ERROR: InvocationError: could not find executable 'coverage'

but the log shows that coverage==3.7.1 was indeed installed in the py27
env. i tried to specify the full path of coverage in "commands" section
in tox.ini, but the problem persisted -- this time the backtrace was
printed, and the raised exception was 'OSError: [Errno 2] No such file
or directory'. so try to use the specified python for creating venv.

Fixes: http://tracker.ceph.com/issues/23281
Signed-off-by: Kefu Chai <kchai@redhat.com>
Conflicts:
        src/ceph-disk/tox.ini: the issue described above only exists
in luminous branch, so this change is not cherry-picked from master.