### PR TITLE
mgr/dashboard_v2: fix cluster configuration page

### DIFF
--- a/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
+++ b/src/pybind/mgr/dashboard_v2/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
@@ -18,12 +18,12 @@ export class ConfigurationComponent implements OnInit {
       label: 'Level',
       prop: 'level',
       value: 'basic',
-      options: ['basic', 'advanced', 'developer'],
+      options: ['basic', 'advanced', 'dev'],
       applyFilter: (row, value) => {
         enum Level {
           basic = 0,
           advanced = 1,
-          developer = 2
+          dev = 2
         }
 
         const levelVal = Level[value];


### PR DESCRIPTION
Configuration level 'develop' was changed to 'dev' in
1717d4c578be108d5b2c651305941974b2201b0f.

Because of this all the dev configurations were not showing.
