### PR TITLE
mgr/dashboard_v2: Pool controller

### DIFF
--- a/qa/suites/rados/mgr/tasks/dashboard_v2.yaml
+++ b/qa/suites/rados/mgr/tasks/dashboard_v2.yaml
@@ -31,3 +31,4 @@ tasks:
         - tasks.mgr.dashboard_v2.test_summary
         - tasks.mgr.dashboard_v2.test_rgw
         - tasks.mgr.dashboard_v2.test_rbd
+        - tasks.mgr.dashboard_v2.test_pool

--- a/qa/tasks/mgr/dashboard_v2/test_pool.py
+++ b/qa/tasks/mgr/dashboard_v2/test_pool.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from .helper import DashboardTestCase, authenticate
+
+
+class DashboardTest(DashboardTestCase):
+    @authenticate
+    def test_pool_list(self):
+        data = self._get("/api/pool")
+        self.assertStatus(200)
+
+        cluster_pools = self.ceph_cluster.mon_manager.list_pools()
+        self.assertEqual(len(cluster_pools), len(data))
+        for pool in data:
+            self.assertIn('pool_name', pool)
+            self.assertIn('type', pool)
+            self.assertIn('flags', pool)
+            self.assertIn('flags_names', pool)
+            self.assertNotIn('stats', pool)
+            self.assertIn(pool['pool_name'], cluster_pools)
+
+    @authenticate
+    def test_pool_list_attrs(self):
+        data = self._get("/api/pool?attrs=type,flags")
+        self.assertStatus(200)
+
+        cluster_pools = self.ceph_cluster.mon_manager.list_pools()
+        self.assertEqual(len(cluster_pools), len(data))
+        for pool in data:
+            self.assertIn('pool_name', pool)
+            self.assertIn('type', pool)
+            self.assertIn('flags', pool)
+            self.assertNotIn('flags_names', pool)
+            self.assertNotIn('stats', pool)
+            self.assertIn(pool['pool_name'], cluster_pools)
+
+    @authenticate
+    def test_pool_list_stats(self):
+        data = self._get("/api/pool?stats=true")
+        self.assertStatus(200)
+
+        cluster_pools = self.ceph_cluster.mon_manager.list_pools()
+        self.assertEqual(len(cluster_pools), len(data))
+        for pool in data:
+            self.assertIn('pool_name', pool)
+            self.assertIn('type', pool)
+            self.assertIn('flags', pool)
+            self.assertIn('stats', pool)
+            self.assertIn('flags_names', pool)
+            self.assertIn(pool['pool_name'], cluster_pools)
+
+    @authenticate
+    def test_pool_get(self):
+        cluster_pools = self.ceph_cluster.mon_manager.list_pools()
+        pool = self._get("/api/pool/{}?stats=true&attrs=type,flags,stats"
+                         .format(cluster_pools[0]))
+        self.assertEqual(pool['pool_name'], cluster_pools[0])
+        self.assertIn('type', pool)
+        self.assertIn('flags', pool)
+        self.assertIn('stats', pool)
+        self.assertNotIn('flags_names', pool)

--- a/src/pybind/mgr/dashboard_v2/controllers/pool.py
+++ b/src/pybind/mgr/dashboard_v2/controllers/pool.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from ..services.ceph_service import CephService
+from ..tools import ApiController, RESTController, AuthRequired
+
+
+@ApiController('pool')
+@AuthRequired()
+class Pool(RESTController):
+
+    @classmethod
+    def _serialize_pool(cls, pool, attrs):
+        if not attrs or not isinstance(attrs, list):
+            return pool
+
+        res = {}
+        for attr in attrs:
+            if attr not in pool:
+                continue
+            if attr == 'type':
+                res[attr] = {1: 'replicated', 3: 'erasure'}[pool[attr]]
+            else:
+                res[attr] = pool[attr]
+
+        # pool_name is mandatory
+        res['pool_name'] = pool['pool_name']
+        return res
+
+    @staticmethod
+    def _str_to_bool(var):
+        if isinstance(var, bool):
+            return var
+        return var.lower() in ("true", "yes", "1", 1)
+
+    def list(self, attrs=None, stats=False):
+        if attrs:
+            attrs = attrs.split(',')
+
+        if self._str_to_bool(stats):
+            pools = CephService.get_pool_list_with_stats()
+        else:
+            pools = CephService.get_pool_list()
+
+        return [self._serialize_pool(pool, attrs) for pool in pools]
+
+    def get(self, pool_name, attrs=None, stats=False):
+        pools = self.list(attrs, stats)
+        return [pool for pool in pools if pool['pool_name'] == pool_name][0]

--- a/src/pybind/mgr/dashboard_v2/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard_v2/run-backend-api-tests.sh
@@ -80,12 +80,20 @@ sleep 10
 source $TEMP_DIR/venv/bin/activate
 BUILD_DIR=`pwd`
 
-TEST_CASES=`for i in \`ls $BUILD_DIR/../qa/tasks/mgr/dashboard_v2/test_*\`; do F=$(basename $i); M="${F%.*}"; echo -n " tasks.mgr.dashboard_v2.$M"; done`
+if [ "$#" -gt 0 ]; then
+  TEST_CASES=""
+  for t in "$@"; do
+    TEST_CASES="$TESTS_CASES $t"
+  done
+else
+  TEST_CASES=`for i in \`ls $BUILD_DIR/../qa/tasks/mgr/dashboard_v2/test_*\`; do F=$(basename $i); M="${F%.*}"; echo -n " tasks.mgr.dashboard_v2.$M"; done`
+  TEST_CASES="tasks.mgr.test_dashboard_v2 $TEST_CASES"
+fi
 
 export PATH=$BUILD_DIR/bin:$PATH
 export LD_LIBRARY_PATH=$BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/:$BUILD_DIR/lib
 export PYTHONPATH=$TEMP_DIR/teuthology:$BUILD_DIR/../qa:$BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/
-eval python ../qa/tasks/vstart_runner.py tasks.mgr.test_dashboard_v2 $TEST_CASES
+eval python ../qa/tasks/vstart_runner.py $TEST_CASES
 
 deactivate
 killall ceph-mgr


### PR DESCRIPTION
This PR implements the pool controller that can be used to retrive OSD pools info.

Two endpoints are enabled by this controller: `/api/pool` and `/api/pool/<pool_name>`

The endpoints support two parameters:
* `attrs`: comma separated list of pool info attributes (to filter which attributes should be returned)
* `stats`: boolean (to include pools stats in the response)

Example:

```
curl -H "Content-Type: application/json" -X GET  http://localhost:43216/api/pool/cephfs_metadata_a\?stats\=true\&attrs\=type,stats | jq

{
  "stats": {
    "quota_objects": {
      "series": [
        [
          1520614275.325569,
          0
        ]
      ],
      "rate": 0,
      "latest": 0
    },
    "bytes_used": {
      "series": [
        [
          1520614275.325569,
          2246
        ]
      ],
      "rate": 0,
      "latest": 2246
    },
    "max_avail": {
      "series": [
        [
          1520614275.325569,
          9554860032
        ]
      ],
      "rate": 0,
      "latest": 9554860032
    },
    # ...
  },
  "type": "replicated",
  "pool_name": "cephfs_metadata_a"
}
```

Signed-off-by: Ricardo Dias <rdias@suse.com>