### PR TITLE
ceph-volume process the abspath of the executable first

### DIFF
--- a/src/ceph-volume/ceph_volume/process.py
+++ b/src/ceph-volume/ceph_volume/process.py
@@ -108,11 +108,11 @@ def run(command, **kw):
     :param stop_on_error: If a nonzero exit status is return, it raises a ``RuntimeError``
     :param fail_msg: If a nonzero exit status is returned this message will be included in the log
     """
+    executable = which(command.pop(0))
+    command.insert(0, executable)
     stop_on_error = kw.pop('stop_on_error', True)
     command_msg = obfuscate(command, kw.pop('obfuscate', None))
     fail_msg = kw.pop('fail_msg', None)
-    executable = which(command.pop(0))
-    command.insert(0, executable)
     logger.info(command_msg)
     terminal.write(command_msg)
     terminal_logging = kw.pop('terminal_logging', True)
@@ -174,11 +174,11 @@ def call(command, **kw):
                              it is forcefully set to True if a return code is non-zero
     :param logfile_verbose: Log stderr/stdout output to log file. Defaults to True
     """
+    executable = which(command.pop(0))
+    command.insert(0, executable)
     terminal_verbose = kw.pop('terminal_verbose', False)
     logfile_verbose = kw.pop('logfile_verbose', True)
     show_command = kw.pop('show_command', False)
-    executable = which(command.pop(0))
-    command.insert(0, executable)
     command_msg = "Running command: %s" % ' '.join(command)
     stdin = kw.pop('stdin', None)
     logger.info(command_msg)


### PR DESCRIPTION
So that it can always log the full path to the executable when it is
logging the 'Running command:' line

The tracker ticket is a bit misleading, because the output in ceph-volume would show:

    Running command: ln -snf /dev/ceph-08dc79cd-db94-4477-8557-8203ad86fc11/osd-block-6355001f-11ad-4430-aed8-21720d866f6d /var/lib/ceph/osd/ceph-2/block
    Running command: chown -R ceph:ceph /dev/dm-2
    Running command: chown -R ceph:ceph /var/lib/ceph/osd/ceph-2
    Running command: systemctl enable ceph-volume@lvm-2-6355001f-11ad-4430-aed8-21720d866f6d

Giving the false impression the some executables aren't found, but the thing is that the logging of the command might omit the resolving of the absolute path.

Fixes http://tracker.ceph.com/issues/23259