### PR TITLE
os/filestore: fix do_copy_range replay bug

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3939,7 +3939,7 @@ int FileStore::_do_copy_range(int from, int to, uint64_t srcoff, uint64_t len, u
   if (r < 0 && replaying) {
     assert(r == -ERANGE);
     derr << __FUNC__ << ": short source tolerated because we are replaying" << dendl;
-    r = pos - from;;
+    r = len;
   }
   assert(replaying || pos == end);
   if (r >= 0 && !skip_sloppycrc && m_filestore_sloppy_crc) {


### PR DESCRIPTION
The 'from' value is an fd, not an offset.  We want 'r' to be the number of
bytes copied, or len.

It looks like this has been broken since 9499cdcd87ddac4a91abffe401baddb91f8a11d5

Fixes: http://tracker.ceph.com/issues/23298
Signed-off-by: Sage Weil <sage@redhat.com>