### PR TITLE
qa/standalone/osd/repro-long-log: skip mon config

### DIFF
--- a/qa/standalone/osd/repro_long_log.sh
+++ b/qa/standalone/osd/repro_long_log.sh
@@ -92,7 +92,7 @@ function do_repro_long_log() {
     else
         PRIMARY=$(ceph pg $PGID query  | jq '.info.stats.up_primary')
         kill_daemons $dir TERM osd.$PRIMARY || return 1
-        CEPH_ARGS="--osd-max-pg-log-entries=30 --osd-pg-log-trim-max=5" ceph-objectstore-tool --data-path $dir/$PRIMARY --pgid $PGID --op trim-pg-log || return 1
+        CEPH_ARGS="--osd-max-pg-log-entries=30 --osd-pg-log-trim-max=5 --no-mon-config" ceph-objectstore-tool --data-path $dir/$PRIMARY --pgid $PGID --op trim-pg-log || return 1
         run_osd $dir $PRIMARY || return 1
         wait_for_clean || return 1
         test_log_size $PGID 30 || return 1


### PR DESCRIPTION
ceph.conf is in non-default location, so we don't find it

Signed-off-by: Sage Weil <sage@redhat.com>