### PR TITLE
rgw_file: conditionally unlink handles when direct deleted

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -951,6 +951,11 @@ namespace rgw {
   }
 
   RGWFileHandle::~RGWFileHandle() {
+    /* !recycle case, handle may STILL be in handle table, BUT
+     * the partition lock is not held in this path */
+    if (fh_hook.is_linked()) {
+      fs->fh_cache.remove(fh.fh_hk.object, this, FHCache::FLAG_LOCK);
+    }
     /* cond-unref parent */
     if (parent && (! parent->is_mount())) {
       /* safe because if parent->unref causes its deletion,


### PR DESCRIPTION
The deadlock fix in 3cf0880 deals correctly deals with the
recycle-path locking, but incorrectly removed handle table cleanup
in the !recycle-path case.

The conditional handle removal is predicated on not being in the
recycle path, so this cannot deadlock.

Fixes: http://tracker.ceph.com/issues/23299

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>