### PR TITLE
osd/PG: fix backfill-preempted race

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6764,7 +6764,12 @@ PG::RecoveryState::Backfilling::react(const RemoteReservationRevoked &)
   PG *pg = context< RecoveryMachine >().pg;
   pg->state_set(PG_STATE_BACKFILL_WAIT);
   cancel_backfill();
-  return transit<WaitLocalBackfillReserved>();
+  if (pg->needs_backfill()) {
+    return transit<WaitLocalBackfillReserved>();
+  } else {
+    // raced with MOSDPGBackfill::OP_BACKFILL_FINISH, ignore
+    return discard_event();
+  }
 }
 
 void PG::RecoveryState::Backfilling::exit()


### PR DESCRIPTION
The race seires look like (S = Started, P = Primary, A = Active, R = Replica, RA = ReplicaActive):

```

                       MOSDPGBackfill::OP_BACKFILL_FINISH
P(S/P/A/Backifilling)  ----------------------------------> **not arrived at replica yet**

                                                               R(S/RA/RepRecoverying)
                                                                     |
                                                                     | RemoteBackfillPreempted
                                     MBackfillReserve::REVOKE        V
P(S/P/A/Backifilling)               <------------------------  R(S/RA/RepRecoverying)
       |
       | RemoteReservationRevoked
       V                            MBackfillReserve::RELEASE
P(S/P/A/WaitLocalBackfillReserved)  -------------------------> R(S/RA/RepNotRecovering)
       |
       | LocalBackfillReserved
       V                            MBackfillReserve::REQUEST
P(S/P/A/WaitRemoteBackfillReserved) -------------------------> R(S/RA/RepWaitBackfillReserved)
                                                                     | **OP_BACKFILL_FINISH finally processed**
                                                                     | RecoveryDone
                                                                     V
                                                               R(Crashed)
```

Some key points:
- backfill is nearly done; Primary begins to send out OP_BACKFILL_FINISH,
  which has not been seen by Replica yet
- Replica's backfill process preempted; backfill-revoke triggered by Replica
  and Primary now restarts backfill process (e.g., because it
  has not received all OP_BACKFILL_FINISH_ACK(s) yet);
  Replica begins to wait for backfill-reservation (again)
- OP_BACKFILL_FINISH finally dequeued, processed and translated into a
  RecoveryDone event, which now crashes the Replica process..
  (note that the OP_BACKFILL_FINISH messages can be arbitrarily delayed
  because we now process peering events in the same (Op)Queue
  and those events are of the highest priority)

See also:
http://pulpito.ceph.com/xxg-2018-02-28_09:02:53-rados-wip-fix-upmap-distro-basic-smithi/2235497/

Fix the above problem by rechecking backfill status each time
a RemoteReservationRevoked message is received, so we can
restart the backfill process in a more safe and less-likely raced way.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>