### PR TITLE
luminous: osd/OSDMap: skip out/crush-out osds

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3872,6 +3872,9 @@ int OSDMap::calc_pg_upmaps(
       ldout(cct,30) << __func__ << " pool " << i.first << " ruleno " << ruleno << dendl;
       for (auto p : pmap) {
 	auto adjusted_weight = tmp.get_weightf(p.first) * p.second;
+        if (adjusted_weight == 0) {
+          continue;
+        }
 	osd_weight[p.first] += adjusted_weight;
 	osd_weight_total += adjusted_weight;
       }


### PR DESCRIPTION
We might do 'ceph osd out <osd.x>' or 'ceph osd crush reweight <osd.x> 0'
for various reasons, and hence can produce 0-weighted OSDs.
Skip those OSDs when trying to calculdate PG upmaps so we won't be able to
hit the *assert* below:

/build/ceph-13.0.1-2232-g64665c7/src/osd/OSDMap.cc: 4179: FAILED assert(target > 0)

See also:

http://pulpito.ceph.com/xxg-2018-02-28_09:02:53-rados-wip-fix-upmap-distro-basic-smithi/2235497/

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>
(cherry picked from commit 1f78ca221d0f85c589214cb8bbc86743e6a90ec5)