### PR TITLE
rgw: enable 'qlen' & 'qactive' performance counters

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -24,6 +24,9 @@ int ClientIO::init_env(CephContext *cct)
 {
   env.init(cct);
 
+  perfcounter->inc(l_rgw_qlen);
+  perfcounter->inc(l_rgw_qactive);
+
   const auto& request = parser.get();
   const auto& headers = request;
   for (auto header = headers.begin(); header != headers.end(); ++header) {
@@ -123,6 +126,8 @@ size_t ClientIO::read_data(char* buf, size_t max)
 
 size_t ClientIO::complete_request()
 {
+  perfcounter->inc(l_rgw_qlen, -1);
+  perfcounter->inc(l_rgw_qactive, -1);
   return 0;
 }
 

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -64,6 +64,8 @@ void RGWCivetWeb::flush()
 
 size_t RGWCivetWeb::complete_request()
 {
+  perfcounter->inc(l_rgw_qlen, -1);
+  perfcounter->inc(l_rgw_qactive, -1);
   return 0;
 }
 
@@ -116,6 +118,9 @@ int RGWCivetWeb::init_env(CephContext *cct)
 
     env.set(buf, value);
   }
+
+  perfcounter->inc(l_rgw_qlen);
+  perfcounter->inc(l_rgw_qactive);
 
   env.set("REMOTE_ADDR", info->remote_addr);
   env.set("REQUEST_METHOD", info->request_method);


### PR DESCRIPTION
when using the Civetweb and Beast frontends

fixes: https://tracker.ceph.com/issues/23147

Incrementing both counters together as per discussion there is no distinction between them with the new frontends.

Signed-off-by: Mark Kogan <mkogan@redhat.com>