### PR TITLE
src: common: code cleanup to conform the coding style

### DIFF
--- a/src/common/addr_parsing.c
+++ b/src/common/addr_parsing.c
@@ -32,6 +32,7 @@ int safe_cat(char **pstr, int *plen, int pos, const char *str2)
     *plen += BUF_SIZE;
 
     void *_realloc = NULL;
+
     if ((_realloc = realloc(*pstr, (size_t)*plen)) == NULL) {
       printf("Out of memory\n");
       exit(1);
@@ -78,6 +79,7 @@ char *resolve_addrs(const char *orig_str)
     bracecolon = strstr(tok, "]:");
 
     char *port_str = 0;
+
     if (firstcolon && firstcolon == lastcolon) {
       /* host:port or a.b.c.d:port */
       *firstcolon = 0;
@@ -118,6 +120,7 @@ char *resolve_addrs(const char *orig_str)
     ores = res;
     while (res) {
       char host[40], port[40];
+
       getnameinfo(res->ai_addr, res->ai_addrlen,
 		  host, sizeof(host),
 		  port, sizeof(port),

--- a/src/common/mime.c
+++ b/src/common/mime.c
@@ -20,9 +20,11 @@ int mime_encode_as_qp(const char *input, char *output, int outlen)
 {
 	int ret = 1;
 	char *o = output;
-	const unsigned char *i = (const unsigned char*)input;
+	const unsigned char *i = (const unsigned char *)input;
+
 	while (1) {
 		int c = *i;
+
 		if (c == '\0') {
 			break;
 		}
@@ -101,8 +103,10 @@ int mime_decode_from_qp(const char *input, char *output, int outlen)
 	int ret = 1;
 	char *o = output;
 	const unsigned char *i = (const unsigned char*)input;
+
 	while (1) {
 		unsigned int c = *i;
+
 		if (c == '\0') {
 			break;
 		}
@@ -112,9 +116,11 @@ int mime_decode_from_qp(const char *input, char *output, int outlen)
 		}
 		else if (c == '=') {
 			int high = hexchar_to_int(*++i);
+
 			if (high < 0)
 				return -EINVAL;
 			int low = hexchar_to_int(*++i);
+
 			if (low < 0)
 				return -EINVAL;
 			c = (high << 4) + low;

--- a/src/common/safe_io.c
+++ b/src/common/safe_io.c
@@ -28,6 +28,7 @@ ssize_t safe_read(int fd, void *buf, size_t count)
 
 	while (cnt < count) {
 		ssize_t r = read(fd, buf, count - cnt);
+
 		if (r <= 0) {
 			if (r == 0) {
 				// EOF
@@ -71,10 +72,11 @@ ssize_t safe_write(int fd, const void *buf, size_t count)
 ssize_t safe_pread(int fd, void *buf, size_t count, off_t offset)
 {
 	size_t cnt = 0;
-	char *b = (char*)buf;
+	char *b = (char *)buf;
 
 	while (cnt < count) {
 		ssize_t r = pread(fd, b + cnt, count - cnt, offset + cnt);
+
 		if (r <= 0) {
 			if (r == 0) {
 				// EOF
@@ -93,6 +95,7 @@ ssize_t safe_pread(int fd, void *buf, size_t count, off_t offset)
 ssize_t safe_pread_exact(int fd, void *buf, size_t count, off_t offset)
 {
 	ssize_t ret = safe_pread(fd, buf, count, offset);
+
 	if (ret < 0)
 		return ret;
 	if ((size_t)ret != count)
@@ -104,6 +107,7 @@ ssize_t safe_pwrite(int fd, const void *buf, size_t count, off_t offset)
 {
 	while (count > 0) {
 		ssize_t r = pwrite(fd, buf, count, offset);
+
 		if (r < 0) {
 			if (errno == EINTR)
 				continue;
@@ -124,6 +128,7 @@ ssize_t safe_splice(int fd_in, off_t *off_in, int fd_out, off_t *off_out,
 
   while (cnt < len) {
     ssize_t r = splice(fd_in, off_in, fd_out, off_out, len - cnt, flags);
+
     if (r <= 0) {
       if (r == 0) {
 	// EOF
@@ -144,6 +149,7 @@ ssize_t safe_splice_exact(int fd_in, off_t *off_in, int fd_out,
 			  off_t *off_out, size_t len, unsigned int flags)
 {
   ssize_t ret = safe_splice(fd_in, off_in, fd_out, off_out, len, flags);
+
   if (ret < 0)
     return ret;
   if ((size_t)ret != len)
@@ -162,6 +168,7 @@ int safe_write_file(const char *base, const char *file,
 
   // does the file already have correct content?
   char oldval[80];
+
   ret = safe_read_file(base, file, oldval, sizeof(oldval));
   if (ret == (int)vallen && memcmp(oldval, val, vallen) == 0)
     return 0;  // yes.


### PR DESCRIPTION
According to Linux kernel coding style, there should be a blank line after declaration(s) and  "(foo*)" should be written as "(foo *)"

Signed-off-by: Simran Singhal <singhalsimran0@gmail.com>