### PR TITLE
rgw: radosgw-admin abort early for user stats for empty uids

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6140,6 +6140,11 @@ next:
   }
 
   if (opt_cmd == OPT_USER_STATS) {
+    if (user_id.empty()) {
+      cerr << "ERROR: uid not specified" << std::endl;
+      return EINVAL;
+    }
+
     if (sync_stats) {
       if (!bucket_name.empty()) {
         int ret = rgw_bucket_sync_user_stats(store, tenant, bucket_name);
@@ -6156,10 +6161,6 @@ next:
       }
     }
 
-    if (user_id.empty()) {
-      cerr << "ERROR: uid not specified" << std::endl;
-      return EINVAL;
-    }
     cls_user_header header;
     string user_str = user_id.to_str();
     int ret = store->cls_user_get_header(user_str, &header);


### PR DESCRIPTION
Otherwise we'll call sync stats with an empty argument which results in creation
of an empty ".buckets" object

Fixes: http://tracker.ceph.com/issues/23322
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>