### PR TITLE
qa/suites: mds.0 -> mds.a

### DIFF
--- a/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
+++ b/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
@@ -7,7 +7,7 @@ openstack:
 roles:
 - - mon.a
   - mgr.x
-  - mds.0
+  - mds.a
   - osd.0
 - - osd.1
   - mon.b

--- a/qa/suites/hadoop/basic/clusters/fixed-3.yaml
+++ b/qa/suites/hadoop/basic/clusters/fixed-3.yaml
@@ -4,7 +4,7 @@ overrides:
       client:
         client permissions: false
 roles:
-- [mon.0, mds.0, osd.0, hadoop.master.0]
+- [mon.0, mds.a, osd.0, hadoop.master.0]
 - [mon.1, mgr.x, osd.1, hadoop.slave.0]
 - [mon.2, mgr.y, hadoop.slave.1, client.0]
 openstack:

--- a/qa/suites/powercycle/osd/clusters/3osd-1per-target.yaml
+++ b/qa/suites/powercycle/osd/clusters/3osd-1per-target.yaml
@@ -1,5 +1,5 @@
 roles:
-- [mon.a, mon.b, mon.c, mgr.x, mgr.y, mds.0, client.0]
+- [mon.a, mon.b, mon.c, mgr.x, mgr.y, mds.a, client.0]
 - [osd.0]
 - [osd.1]
 - [osd.2]


### PR DESCRIPTION
2018-03-09T21:39:26.284 INFO:tasks.ceph.mds.0.smithi136.stderr:2018-03-09 21:39:26.281 7fc7de1a0480 -1 MDS id 'mds.0' is invalid. MDS names may not start with a numeric digit.
