### PR TITLE
rgw; [jewel] change gc process from single thread to thread pool

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3312,11 +3312,9 @@ static int rgw_cls_gc_list(cls_method_context_t hctx, bufferlist *in, bufferlist
   return 0;
 }
 
-static int gc_remove(cls_method_context_t hctx, list<string>& tags)
+static int gc_remove(cls_method_context_t hctx, vector<string>& tags)
 {
-  list<string>::iterator iter;
-
-  for (iter = tags.begin(); iter != tags.end(); ++iter) {
+  for (auto iter = tags.begin(); iter != tags.end(); ++iter) {
     string& tag = *iter;
     cls_rgw_gc_obj_info info;
     int ret = gc_omap_get(hctx, GC_OBJ_NAME_INDEX, tag, &info);

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -662,7 +662,7 @@ int cls_rgw_gc_list(IoCtx& io_ctx, string& oid, string& marker, uint32_t max, bo
   return r;
 }
 
-void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const list<string>& tags)
+void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const vector<string>& tags)
 {
   bufferlist in;
   cls_rgw_gc_remove_op call;

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -476,6 +476,6 @@ void cls_rgw_gc_defer_entry(librados::ObjectWriteOperation& op, uint32_t expirat
 int cls_rgw_gc_list(librados::IoCtx& io_ctx, string& oid, string& marker, uint32_t max, bool expired_only,
                     list<cls_rgw_gc_obj_info>& entries, bool *truncated, string& next_marker);
 
-void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const list<string>& tags);
+void cls_rgw_gc_remove(librados::ObjectWriteOperation& op, const vector<string>& tags);
 
 #endif

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -869,7 +869,7 @@ struct cls_rgw_gc_list_ret {
 WRITE_CLASS_ENCODER(cls_rgw_gc_list_ret)
 
 struct cls_rgw_gc_remove_op {
-  list<string> tags;
+  vector<string> tags;
 
   cls_rgw_gc_remove_op() {}
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1402,6 +1402,8 @@ OPTION(rgw_gc_max_objs, OPT_INT, 32)
 OPTION(rgw_gc_obj_min_wait, OPT_INT, 2 * 3600)    // wait time before object may be handled by gc
 OPTION(rgw_gc_processor_max_time, OPT_INT, 3600)  // total run time for a single gc processor work
 OPTION(rgw_gc_processor_period, OPT_INT, 3600)  // gc processor cycle time
+OPTION(rgw_gc_max_concurrent_io, OPT_INT, 10)  // gc processor cycle time
+OPTION(rgw_gc_max_trim_chunk, OPT_INT, 16)  // gc trim chunk size
 OPTION(rgw_s3_success_create_obj_status, OPT_INT, 0) // alternative success status response for create-obj (0 - default)
 OPTION(rgw_resolve_cname, OPT_BOOL, false)  // should rgw try to resolve hostname as a dns cname record
 OPTION(rgw_obj_stripe_size, OPT_INT, 4 << 20)

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -143,7 +143,8 @@ void _usage()
   cout << "  usage trim                 trim usage (by user, date range)\n";
   cout << "  gc list                    dump expired garbage collection objects (specify\n";
   cout << "                             --include-all to list all entries, including unexpired)\n";
-  cout << "  gc process                 manually process garbage\n";
+  cout << "  gc process                 manually process garbage (specify\n";
+  cout << "                             --include-all to process all entries, including unexpired)\n";
   cout << "  metadata get               get metadata info\n";
   cout << "  metadata put               put metadata info\n";
   cout << "  metadata rm                remove metadata info\n";
@@ -5350,7 +5351,7 @@ next:
   }
 
   if (opt_cmd == OPT_GC_PROCESS) {
-    int ret = store->process_gc();
+    int ret = store->process_gc(!include_all);
     if (ret < 0) {
       cerr << "ERROR: gc processing returned error: " << cpp_strerror(-ret) << std::endl;
       return 1;

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -147,15 +147,16 @@ class RGWGCIOManager {
     string tag;
   };
 
-  list<IO> ios;
-  map<int, std::list<string> > remove_tags;
+  deque<IO> ios;
+  vector<std::list<string> > remove_tags;
 
 #define MAX_AIO_DEFAULT 10
   size_t max_aio{MAX_AIO_DEFAULT};
 
 public:
   RGWGCIOManager(CephContext *_cct, RGWGC *_gc) : cct(_cct),
-                                                  gc(_gc) {
+                                                  gc(_gc),
+                                                  remove_tags(cct->_conf->rgw_gc_max_objs) {
     max_aio = cct->_conf->rgw_gc_max_concurrent_io;
   }
   ~RGWGCIOManager() {
@@ -257,8 +258,10 @@ done:
   }
 
   void flush_remove_tags() {
-    for (auto iter : remove_tags) {
-      flush_remove_tags(iter.first, iter.second);
+    int index = 0;
+    for (auto& rt : remove_tags) {
+      flush_remove_tags(index, rt);
+      ++index;
     }
   }
 };

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -150,9 +150,14 @@ class RGWGCIOManager {
   list<IO> ios;
   map<int, std::list<string> > remove_tags;
 
+#define MAX_AIO_DEFAULT 10
+  size_t max_aio{MAX_AIO_DEFAULT};
+
 public:
   RGWGCIOManager(CephContext *_cct, RGWGC *_gc) : cct(_cct),
-                                                  gc(_gc) {}
+                                                  gc(_gc) {
+    max_aio = cct->_conf->rgw_gc_max_concurrent_io;
+  }
   ~RGWGCIOManager() {
     for (auto io : ios) {
       io.c->release();
@@ -160,9 +165,7 @@ public:
   }
 
   int schedule_io(IoCtx *ioctx, const string& oid, ObjectWriteOperation *op, int index, const string& tag) {
-#warning configurable
-#define MAX_CONCURRENT_IO 5
-    while (ios.size() > MAX_CONCURRENT_IO) {
+    while (ios.size() > max_aio) {
       if (gc->going_down()) {
         return 0;
       }
@@ -213,8 +216,7 @@ public:
     }
 
     rt.push_back(io.tag);
-#define MAX_REMOVE_CHUNK 16
-    if (rt.size() > MAX_REMOVE_CHUNK) {
+    if (rt.size() > (size_t)cct->_conf->rgw_gc_max_trim_chunk) {
       flush_remove_tags(io.index, rt);
     }
 done:

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -84,7 +84,7 @@ int RGWGC::defer_chain(const string& tag, bool sync)
   return store->gc_aio_operate(obj_names[i], &op);
 }
 
-int RGWGC::remove(int index, const std::list<string>& tags, AioCompletion **pc)
+int RGWGC::remove(int index, const std::vector<string>& tags, AioCompletion **pc)
 {
   ObjectWriteOperation op;
   cls_rgw_gc_remove(op, tags);
@@ -148,7 +148,7 @@ class RGWGCIOManager {
   };
 
   deque<IO> ios;
-  vector<std::list<string> > remove_tags;
+  vector<std::vector<string> > remove_tags;
 
 #define MAX_AIO_DEFAULT 10
   size_t max_aio{MAX_AIO_DEFAULT};
@@ -240,7 +240,7 @@ done:
     drain_ios();
   }
 
-  void flush_remove_tags(int index, list<string>& rt) {
+  void flush_remove_tags(int index, vector<string>& rt) {
     IO index_io;
     index_io.type = IO::IndexIO;
     index_io.index = index;

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -134,28 +134,27 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
 class RGWGCIOManager {
   CephContext *cct;
   RGWGC *gc;
-  int index;
 
   struct IO {
     librados::AioCompletion *c{nullptr};
     string oid;
+    int index{-1};
     string tag;
   };
 
   list<IO> ios;
-  std::list<string> remove_tags;
+  map<int, std::list<string> > remove_tags;
 
 public:
-  RGWGCIOManager(CephContext *_cct, RGWGC *_gc, int _index) : cct(_cct),
-                                                              gc(_gc),
-                                                              index(_index) {}
+  RGWGCIOManager(CephContext *_cct, RGWGC *_gc) : cct(_cct),
+                                                  gc(_gc) {}
   ~RGWGCIOManager() {
     for (auto io : ios) {
       io.c->release();
     }
   }
 
-  int schedule_io(IoCtx *ioctx, const string& oid, ObjectWriteOperation *op, const string& tag) {
+  int schedule_io(IoCtx *ioctx, const string& oid, ObjectWriteOperation *op, int index, const string& tag) {
 #warning configurable
 #define MAX_CONCURRENT_IO 5
     while (ios.size() > MAX_CONCURRENT_IO) {
@@ -170,7 +169,7 @@ public:
     if (ret < 0) {
       return ret;
     }
-    ios.push_back(IO{c, oid, tag});
+    ios.push_back(IO{c, oid, index, tag});
 
     return 0;
   }
@@ -182,6 +181,8 @@ public:
     int ret = io.c->get_return_value();
     io.c->release();
 
+    auto& rt = remove_tags[io.index];
+
     if (ret == -ENOENT) {
       ret = 0;
     }
@@ -190,10 +191,10 @@ public:
       goto done;
     }
 
-    remove_tags.push_back(io.tag);
+    rt.push_back(io.tag);
 #define MAX_REMOVE_CHUNK 16
-    if (remove_tags.size() > MAX_REMOVE_CHUNK) {
-      drain_remove_tags();
+    if (rt.size() > MAX_REMOVE_CHUNK) {
+      drain_remove_tags(io.index, rt);
     }
 done:
     ios.pop_front();
@@ -210,18 +211,23 @@ done:
     drain_remove_tags();
   }
 
+  void drain_remove_tags(int index, list<string>& rt) {
+    gc->remove(index, rt);
+    rt.clear();
+  }
+
   void drain_remove_tags() {
-    gc->remove(index, remove_tags);
-    remove_tags.clear();
+    for (auto iter : remove_tags) {
+      drain_remove_tags(iter.first, iter.second);
+    }
   }
 };
 
-int RGWGC::process(int index, int max_secs, bool expired_only)
+int RGWGC::process(int index, int max_secs, bool expired_only,
+                   RGWGCIOManager& io_manager)
 {
   rados::cls::lock::Lock l(gc_index_lock_name);
   utime_t end = ceph_clock_now(g_ceph_context);
-
-  RGWGCIOManager io_manager(store->ctx(), this, index);
 
   /* max_secs should be greater than zero. We don't want a zero max_secs
    * to be translated as no timeout, since we'd then need to break the
@@ -291,7 +297,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only)
 	ObjectWriteOperation op;
 	cls_refcount_put(op, info.tag, true);
 
-        ret = io_manager.schedule_io(ctx, key_obj.get_object(), &op, info.tag);
+        ret = io_manager.schedule_io(ctx, key_obj.get_object(), &op, index, info.tag);
         if (ret < 0) {
           ldout(store->ctx(), 0) << "WARNING: failed to schedule deletion for oid=" << key_obj.get_object() << dendl;
         }
@@ -301,8 +307,6 @@ int RGWGC::process(int index, int max_secs, bool expired_only)
       }
     }
   } while (truncated);
-
-  io_manager.drain();
 
 done:
   /* we don't drain here, because if we're going down we don't want to hold the system
@@ -322,11 +326,16 @@ int RGWGC::process(bool expired_only)
   if (ret < 0)
     return ret;
 
+  RGWGCIOManager io_manager(store->ctx(), this);
+
   for (int i = 0; i < max_objs; i++) {
     int index = (i + start) % max_objs;
-    ret = process(index, max_secs, expired_only);
+    ret = process(index, max_secs, expired_only, io_manager);
     if (ret < 0)
       return ret;
+  }
+  if (!going_down()) {
+    io_manager.drain();
   }
 
   return 0;

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -131,11 +131,97 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
   return 0;
 }
 
+class RGWGCIOManager {
+  CephContext *cct;
+  RGWGC *gc;
+  int index;
+
+  struct IO {
+    librados::AioCompletion *c{nullptr};
+    string oid;
+    string tag;
+  };
+
+  list<IO> ios;
+  std::list<string> remove_tags;
+
+public:
+  RGWGCIOManager(CephContext *_cct, RGWGC *_gc, int _index) : cct(_cct),
+                                                              gc(_gc),
+                                                              index(_index) {}
+  ~RGWGCIOManager() {
+    for (auto io : ios) {
+      io.c->release();
+    }
+  }
+
+  int schedule_io(IoCtx *ioctx, const string& oid, ObjectWriteOperation *op, const string& tag) {
+#warning configurable
+#define MAX_CONCURRENT_IO 5
+    while (ios.size() > MAX_CONCURRENT_IO) {
+      if (gc->going_down()) {
+        return 0;
+      }
+      handle_next_completion();
+    }
+
+    AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
+    int ret = ioctx->aio_operate(oid, c, op);
+    if (ret < 0) {
+      return ret;
+    }
+    ios.push_back(IO{c, oid, tag});
+
+    return 0;
+  }
+
+  void handle_next_completion() {
+    assert(!ios.empty());
+    IO& io = ios.front();
+    io.c->wait_for_safe();
+    int ret = io.c->get_return_value();
+    io.c->release();
+
+    if (ret == -ENOENT) {
+      ret = 0;
+    }
+    if (ret < 0) {
+      ldout(cct, 0) << "WARNING: could not remove oid=" << io.oid << ", ret=" << ret << dendl;
+      goto done;
+    }
+
+    remove_tags.push_back(io.tag);
+#define MAX_REMOVE_CHUNK 16
+    if (remove_tags.size() > MAX_REMOVE_CHUNK) {
+      drain_remove_tags();
+    }
+done:
+    ios.pop_front();
+  }
+
+  void drain() {
+    while (!ios.empty()) {
+      if (gc->going_down()) {
+        return;
+      }
+      handle_next_completion();
+    }
+
+    drain_remove_tags();
+  }
+
+  void drain_remove_tags() {
+    gc->remove(index, remove_tags);
+    remove_tags.clear();
+  }
+};
+
 int RGWGC::process(int index, int max_secs, bool expired_only)
 {
   rados::cls::lock::Lock l(gc_index_lock_name);
   utime_t end = ceph_clock_now(g_ceph_context);
-  std::list<string> remove_tags;
+
+  RGWGCIOManager io_manager(store->ctx(), this, index);
 
   /* max_secs should be greater than zero. We don't want a zero max_secs
    * to be translated as no timeout, since we'd then need to break the
@@ -174,7 +260,6 @@ int RGWGC::process(int index, int max_secs, bool expired_only)
     string last_pool;
     std::list<cls_rgw_gc_obj_info>::iterator iter;
     for (iter = entries.begin(); iter != entries.end(); ++iter) {
-      bool remove_tag;
       cls_rgw_gc_obj_info& info = *iter;
       std::list<cls_rgw_obj>::iterator liter;
       cls_rgw_obj_chain& chain = info.chain;
@@ -183,7 +268,6 @@ int RGWGC::process(int index, int max_secs, bool expired_only)
       if (now >= end)
         goto done;
 
-      remove_tag = true;
       for (liter = chain.objs.begin(); liter != chain.objs.end(); ++liter) {
         cls_rgw_obj& obj = *liter;
 
@@ -206,35 +290,24 @@ int RGWGC::process(int index, int max_secs, bool expired_only)
 	dout(0) << "gc::process: removing " << obj.pool << ":" << key_obj.get_object() << dendl;
 	ObjectWriteOperation op;
 	cls_refcount_put(op, info.tag, true);
-        ret = ctx->operate(key_obj.get_object(), &op);
-	if (ret == -ENOENT)
-	  ret = 0;
+
+        ret = io_manager.schedule_io(ctx, key_obj.get_object(), &op, info.tag);
         if (ret < 0) {
-          remove_tag = false;
-          dout(0) << "failed to remove " << obj.pool << ":" << key_obj.get_object() << "@" << obj.loc << dendl;
+          ldout(store->ctx(), 0) << "WARNING: failed to schedule deletion for oid=" << key_obj.get_object() << dendl;
         }
 
         if (going_down()) // leave early, even if tag isn't removed, it's ok
           goto done;
       }
-      if (remove_tag) {
-        remove_tags.push_back(info.tag);
-#define MAX_REMOVE_CHUNK 16
-        if (remove_tags.size() > MAX_REMOVE_CHUNK) {
-          RGWGC::remove(index, remove_tags);
-          remove_tags.clear();
-        }
-      }
-    }
-    if (!remove_tags.empty()) {
-      RGWGC::remove(index, remove_tags);
-      remove_tags.clear();
     }
   } while (truncated);
 
+  io_manager.drain();
+
 done:
-  if (!remove_tags.empty())
-    RGWGC::remove(index, remove_tags);
+  /* we don't drain here, because if we're going down we don't want to hold the system
+   * if backend is unresponsive
+   */
   l.unlock(&store->gc_pool_ctx, obj_names[index]);
   delete ctx;
   return 0;

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -131,7 +131,7 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
   return 0;
 }
 
-int RGWGC::process(int index, int max_secs)
+int RGWGC::process(int index, int max_secs, bool expired_only)
 {
   rados::cls::lock::Lock l(gc_index_lock_name);
   utime_t end = ceph_clock_now(g_ceph_context);
@@ -163,7 +163,7 @@ int RGWGC::process(int index, int max_secs)
   do {
     int max = 100;
     std::list<cls_rgw_gc_obj_info> entries;
-    ret = cls_rgw_gc_list(store->gc_pool_ctx, obj_names[index], marker, max, true, entries, &truncated, next_marker);
+    ret = cls_rgw_gc_list(store->gc_pool_ctx, obj_names[index], marker, max, expired_only, entries, &truncated, next_marker);
     if (ret == -ENOENT) {
       ret = 0;
       goto done;
@@ -240,7 +240,7 @@ done:
   return 0;
 }
 
-int RGWGC::process()
+int RGWGC::process(bool expired_only)
 {
   int max_secs = cct->_conf->rgw_gc_processor_max_time;
 
@@ -251,7 +251,7 @@ int RGWGC::process()
 
   for (int i = 0; i < max_objs; i++) {
     int index = (i + start) % max_objs;
-    ret = process(index, max_secs);
+    ret = process(index, max_secs, expired_only);
     if (ret < 0)
       return ret;
   }
@@ -285,7 +285,7 @@ void *RGWGC::GCWorker::entry() {
   do {
     utime_t start = ceph_clock_now(cct);
     dout(2) << "garbage collection: start" << dendl;
-    int r = gc->process();
+    int r = gc->process(true);
     if (r < 0) {
       dout(0) << "ERROR: garbage collection process() returned error r=" << r << dendl;
     }

--- a/src/rgw/rgw_gc.h
+++ b/src/rgw/rgw_gc.h
@@ -49,7 +49,7 @@ public:
   void add_chain(librados::ObjectWriteOperation& op, cls_rgw_obj_chain& chain, const string& tag);
   int send_chain(cls_rgw_obj_chain& chain, const string& tag, bool sync);
   int defer_chain(const string& tag, bool sync);
-  int remove(int index, const std::list<string>& tags, librados::AioCompletion **pc);
+  int remove(int index, const std::vector<string>& tags, librados::AioCompletion **pc);
 
   void initialize(CephContext *_cct, RGWRados *_store);
   void finalize();

--- a/src/rgw/rgw_gc.h
+++ b/src/rgw/rgw_gc.h
@@ -49,7 +49,7 @@ public:
   void add_chain(librados::ObjectWriteOperation& op, cls_rgw_obj_chain& chain, const string& tag);
   int send_chain(cls_rgw_obj_chain& chain, const string& tag, bool sync);
   int defer_chain(const string& tag, bool sync);
-  int remove(int index, const std::list<string>& tags);
+  int remove(int index, const std::list<string>& tags, librados::AioCompletion **pc);
 
   void initialize(CephContext *_cct, RGWRados *_store);
   void finalize();

--- a/src/rgw/rgw_gc.h
+++ b/src/rgw/rgw_gc.h
@@ -15,6 +15,8 @@
 #include "rgw_rados.h"
 #include "cls/rgw/cls_rgw_types.h"
 
+class RGWGCIOManager;
+
 class RGWGC {
   CephContext *cct;
   RGWRados *store;
@@ -54,7 +56,8 @@ public:
 
   int list(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated);
   void list_init(int *index) { *index = 0; }
-  int process(int index, int process_max_secs, bool expired_only);
+  int process(int index, int process_max_secs, bool expired_only,
+              RGWGCIOManager& io_manager);
   int process(bool expired_only);
 
   bool going_down();

--- a/src/rgw/rgw_gc.h
+++ b/src/rgw/rgw_gc.h
@@ -54,8 +54,8 @@ public:
 
   int list(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated);
   void list_init(int *index) { *index = 0; }
-  int process(int index, int process_max_secs);
-  int process();
+  int process(int index, int process_max_secs, bool expired_only);
+  int process(bool expired_only);
 
   bool going_down();
   void start_processor();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -11699,9 +11699,9 @@ int RGWRados::list_gc_objs(int *index, string& marker, uint32_t max, bool expire
   return gc->list(index, marker, max, expired_only, result, truncated);
 }
 
-int RGWRados::process_gc()
+int RGWRados::process_gc(bool expired_only)
 {
-  return gc->process();
+  return gc->process(expired_only);
 }
 
 int RGWRados::process_expire_objects()

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -11681,11 +11681,15 @@ int RGWRados::gc_operate(string& oid, librados::ObjectWriteOperation *op)
   return gc_pool_ctx.operate(oid, op);
 }
 
-int RGWRados::gc_aio_operate(string& oid, librados::ObjectWriteOperation *op)
+int RGWRados::gc_aio_operate(string& oid, librados::ObjectWriteOperation *op, AioCompletion **pc)
 {
   AioCompletion *c = librados::Rados::aio_create_completion(NULL, NULL, NULL);
   int r = gc_pool_ctx.aio_operate(oid, c, op);
-  c->release();
+  if (!pc) {
+    c->release();
+  } else {
+    *pc = c;
+  }
   return r;
 }
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2979,7 +2979,7 @@ public:
   int gc_operate(string& oid, librados::ObjectReadOperation *op, bufferlist *pbl);
 
   int list_gc_objs(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated);
-  int process_gc();
+  int process_gc(bool expired_only);
   int process_expire_objects();
   int defer_gc(void *ctx, rgw_obj& obj);
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2975,7 +2975,7 @@ public:
   void update_gc_chain(rgw_obj& head_obj, RGWObjManifest& manifest, cls_rgw_obj_chain *chain);
   int send_chain_to_gc(cls_rgw_obj_chain& chain, const string& tag, bool sync);
   int gc_operate(string& oid, librados::ObjectWriteOperation *op);
-  int gc_aio_operate(string& oid, librados::ObjectWriteOperation *op);
+  int gc_aio_operate(string& oid, librados::ObjectWriteOperation *op, librados::AioCompletion **pc = nullptr);
   int gc_operate(string& oid, librados::ObjectReadOperation *op, bufferlist *pbl);
 
   int list_gc_objs(int *index, string& marker, uint32_t max, bool expired_only, std::list<cls_rgw_gc_obj_info>& result, bool *truncated);

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -93,7 +93,8 @@
     usage trim                 trim usage (by user, date range)
     gc list                    dump expired garbage collection objects (specify
                                --include-all to list all entries, including unexpired)
-    gc process                 manually process garbage
+    gc process                 manually process garbage (specify
+                               --include-all to process all entries, including unexpired)
     metadata get               get metadata info
     metadata put               put metadata info
     metadata rm                remove metadata info

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -607,7 +607,7 @@ TEST(cls_rgw, gc_defer)
   ASSERT_EQ(0, truncated);
 
   librados::ObjectWriteOperation op3;
-  list<string> tags;
+  vector<string> tags;
   tags.push_back(tag);
 
   /* remove chain */


### PR DESCRIPTION
This is a backport of https://github.com/ceph/ceph/pull/20546 to jewel.

00be9f24b8 rgw-admin: support for processing all gc objects including unexpired.
c32df3dfb7 rgw: use aio for gc processing
5fac5efa39 rgw: use a single gc io manager for all shards
eb79645187 rgw: trim gc index using aio
e93977c8af rgw: make gc concurrenct io size configurable
8b731e178d rgw: gc aio, replace lists with other types
1b4ec8d046 rgw: use vector for remove_tags in gc aio

00be9f24b8 was not part of the original PR, but appears to be a dependency.  I probably could have factored this out, but it looked like it was probably also relevant/useful and not worth factoring out.
