### PR TITLE
osd: treat successful and erroroneous writes the same for log trimming

### DIFF
--- a/qa/standalone/osd/repro_long_log.sh
+++ b/qa/standalone/osd/repro_long_log.sh
@@ -36,17 +36,19 @@ function run() {
     done
 }
 
+PGID=
+
 function test_log_size()
 {
-    PGID=$1
-    EXPECTED=$2
+    local PGID=$1
+    local EXPECTED=$2
     ceph tell osd.\* flush_pg_stats
     sleep 3
     ceph pg $PGID query | jq .info.stats.log_size
     ceph pg $PGID query | jq .info.stats.log_size | grep "${EXPECTED}"
 }
 
-function do_repro_long_log() {
+function setup_log_test() {
     local dir=$1
     local which=$2
 
@@ -83,35 +85,63 @@ function do_repro_long_log() {
 
     # log should have been trimmed down to min_entries with one extra
     test_log_size $PGID 21 || return 1
-
-    if [ "$which" = "test1" ];
-    then
-        # regular write should trim the log
-        rados -p test put foo foo || return 1
-        test_log_size $PGID 22 || return 1
-    else
-        PRIMARY=$(ceph pg $PGID query  | jq '.info.stats.up_primary')
-        kill_daemons $dir TERM osd.$PRIMARY || return 1
-
-        CEPH_ARGS="--osd-max-pg-log-entries=2" ceph-objectstore-tool --data-path $dir/$PRIMARY --pgid $PGID --op trim-pg-log || return 1
-        run_osd $dir $PRIMARY || return 1
-        wait_for_clean || return 1
-        test_log_size $PGID 2 || return 1
-    fi
 }
 
 function TEST_repro_long_log1()
 {
     local dir=$1
 
-    do_repro_long_log $dir test1
+    setup_log_test $dir || return 1
+    # regular write should trim the log
+    rados -p test put foo foo || return 1
+    test_log_size $PGID 22 || return 1
 }
 
 function TEST_repro_long_log2()
 {
     local dir=$1
 
-    do_repro_long_log $dir test2
+    setup_log_test $dir || return 1
+    local PRIMARY=$(ceph pg $PGID query  | jq '.info.stats.up_primary')
+    kill_daemons $dir TERM osd.$PRIMARY || return 1
+    CEPH_ARGS="--osd-max-pg-log-entries=2 --no-mon-config" ceph-objectstore-tool --data-path $dir/$PRIMARY --pgid $PGID --op trim-pg-log || return 1
+    run_osd $dir $PRIMARY || return 1
+    wait_for_clean || return 1
+    test_log_size $PGID 2 || return 1
+}
+
+function TEST_trim_max_entries()
+{
+    local dir=$1
+
+    setup_log_test $dir || return 1
+
+    ceph tell osd.\* injectargs -- --osd-min-pg-log-entries 1
+    ceph tell osd.\* injectargs -- --osd-pg-log-trim-min 2
+    ceph tell osd.\* injectargs -- --osd-pg-log-trim-max 4
+
+    # adding log entries, should only trim 4 and add one each time
+    rados -p test rm foo
+    test_log_size $PGID 17
+    rados -p test rm foo
+    test_log_size $PGID 14
+    rados -p test rm foo
+    test_log_size $PGID 11
+    rados -p test rm foo
+    test_log_size $PGID 8
+    rados -p test rm foo
+    test_log_size $PGID 5
+    rados -p test rm foo
+    test_log_size $PGID 2
+
+    # below trim_min
+    rados -p test rm foo
+    test_log_size $PGID 3
+    rados -p test rm foo
+    test_log_size $PGID 4
+
+    rados -p test rm foo
+    test_log_size $PGID 2
 }
 
 main repro-long-log "$@"

--- a/src/messages/MOSDPGUpdateLogMissing.h
+++ b/src/messages/MOSDPGUpdateLogMissing.h
@@ -20,7 +20,7 @@
 
 class MOSDPGUpdateLogMissing : public MOSDFastDispatchOp {
 
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 1;
 
 
@@ -30,6 +30,9 @@ public:
   shard_id_t from;
   ceph_tid_t rep_tid;
   mempool::osd_pglog::list<pg_log_entry_t> entries;
+  // piggybacked osd/pg state
+  eversion_t pg_trim_to; // primary->replica: trim to here
+  eversion_t pg_roll_forward_to; // primary->replica: trim rollback info to here
 
   epoch_t get_epoch() const { return map_epoch; }
   spg_t get_pgid() const { return pgid; }
@@ -55,7 +58,9 @@ public:
     shard_id_t from,
     epoch_t epoch,
     epoch_t min_epoch,
-    ceph_tid_t rep_tid)
+    ceph_tid_t rep_tid,
+    eversion_t pg_trim_to,
+    eversion_t pg_roll_forward_to)
     : MOSDFastDispatchOp(MSG_OSD_PG_UPDATE_LOG_MISSING, HEAD_VERSION,
 			 COMPAT_VERSION),
       map_epoch(epoch),
@@ -63,7 +68,10 @@ public:
       pgid(pgid),
       from(from),
       rep_tid(rep_tid),
-      entries(entries) {}
+      entries(entries),
+      pg_trim_to(pg_trim_to),
+      pg_roll_forward_to(pg_roll_forward_to)
+  {}
 
 private:
   ~MOSDPGUpdateLogMissing() override {}
@@ -74,7 +82,10 @@ public:
     out << "pg_update_log_missing(" << pgid << " epoch " << map_epoch
 	<< "/" << min_epoch
 	<< " rep_tid " << rep_tid
-	<< " entries " << entries << ")";
+	<< " entries " << entries
+	<< " trim_to " << pg_trim_to
+	<< " roll_forward_to " << pg_roll_forward_to
+	<< ")";
   }
 
   void encode_payload(uint64_t features) override {
@@ -84,6 +95,8 @@ public:
     ::encode(rep_tid, payload);
     ::encode(entries, payload);
     ::encode(min_epoch, payload);
+    ::encode(pg_trim_to, payload);
+    ::encode(pg_roll_forward_to, payload);
   }
   void decode_payload() override {
     bufferlist::iterator p = payload.begin();
@@ -96,6 +109,10 @@ public:
       ::decode(min_epoch, p);
     } else {
       min_epoch = map_epoch;
+    }
+    if (header.version >= 3) {
+      ::decode(pg_trim_to, p);
+      ::decode(pg_roll_forward_to, p);
     }
   }
 };

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5130,25 +5130,41 @@ void PG::share_pg_info()
 
 bool PG::append_log_entries_update_missing(
   const mempool::osd_pglog::list<pg_log_entry_t> &entries,
-  ObjectStore::Transaction &t)
+  ObjectStore::Transaction &t, boost::optional<eversion_t> trim_to,
+  boost::optional<eversion_t> roll_forward_to)
 {
   assert(!entries.empty());
   assert(entries.begin()->version > info.last_update);
 
   PGLogEntryHandler rollbacker{this, &t};
+  if (roll_forward_to) {
+    pg_log.roll_forward(&rollbacker);
+  }
   bool invalidate_stats =
     pg_log.append_new_log_entries(info.last_backfill,
 				  info.last_backfill_bitwise,
 				  entries,
 				  &rollbacker);
+
+  if (roll_forward_to && entries.rbegin()->soid > info.last_backfill) {
+    pg_log.roll_forward(&rollbacker);
+  }
+  if (roll_forward_to && *roll_forward_to > pg_log.get_can_rollback_to()) {
+    pg_log.roll_forward_to(*roll_forward_to, &rollbacker);
+    last_rollback_info_trimmed_to_applied = *roll_forward_to;
+  }
+
   info.last_update = pg_log.get_head();
 
   if (pg_log.get_missing().num_missing() == 0) {
     // advance last_complete since nothing else is missing!
     info.last_complete = info.last_update;
   }
-
   info.stats.stats_invalid = info.stats.stats_invalid || invalidate_stats;
+
+  dout(20) << __func__ << "trim_to bool = " << bool(trim_to) << " trim_to = " << (trim_to ? *trim_to : eversion_t()) << dendl;
+  if (trim_to)
+    pg_log.trim(*trim_to, info);
   dirty_info = true;
   write_if_dirty(t);
   return invalidate_stats;
@@ -5157,12 +5173,14 @@ bool PG::append_log_entries_update_missing(
 
 void PG::merge_new_log_entries(
   const mempool::osd_pglog::list<pg_log_entry_t> &entries,
-  ObjectStore::Transaction &t)
+  ObjectStore::Transaction &t,
+  boost::optional<eversion_t> trim_to,
+  boost::optional<eversion_t> roll_forward_to)
 {
   dout(10) << __func__ << " " << entries << dendl;
   assert(is_primary());
 
-  bool rebuild_missing = append_log_entries_update_missing(entries, t);
+  bool rebuild_missing = append_log_entries_update_missing(entries, t, trim_to, roll_forward_to);
   for (set<pg_shard_t>::const_iterator i = actingbackfill.begin();
        i != actingbackfill.end();
        ++i) {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2532,7 +2532,9 @@ public:
 
   bool append_log_entries_update_missing(
     const mempool::osd_pglog::list<pg_log_entry_t> &entries,
-    ObjectStore::Transaction &t);
+    ObjectStore::Transaction &t,
+    boost::optional<eversion_t> trim_to,
+    boost::optional<eversion_t> roll_forward_to);
 
   /**
    * Merge entries updating missing as necessary on all
@@ -2540,7 +2542,9 @@ public:
    */
   void merge_new_log_entries(
     const mempool::osd_pglog::list<pg_log_entry_t> &entries,
-    ObjectStore::Transaction &t);
+    ObjectStore::Transaction &t,
+    boost::optional<eversion_t> trim_to,
+    boost::optional<eversion_t> roll_forward_to);
 
   void reset_interval_flush();
   void start_peering_interval(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1574,8 +1574,10 @@ void PrimaryLogPG::calc_trim_to()
   if (limit != eversion_t() &&
       limit != pg_trim_to &&
       pg_log.get_log().approx_size() > target) {
-    size_t num_to_trim = pg_log.get_log().approx_size() - target;
-    if (num_to_trim < cct->_conf->osd_pg_log_trim_min) {
+    size_t num_to_trim = MIN(pg_log.get_log().approx_size() - target,
+			     cct->_conf->osd_pg_log_trim_max);
+    if (num_to_trim < cct->_conf->osd_pg_log_trim_min &&
+	cct->_conf->osd_pg_log_trim_max >= cct->_conf->osd_pg_log_trim_min) {
       return;
     }
     list<pg_log_entry_t>::const_iterator it = pg_log.get_log().log.begin();


### PR DESCRIPTION
Also add a trim_max config option to prevent excessive work trimming logs that have grown too long due to this bug. This doesn't need a feature bit since we can check for default-constructed eversion_t from the messages to tell whether we are talking to osds with this fix.

Fixes: http://tracker.ceph.com/issues/23323