### PR TITLE
client: add the fuse parameter max_write

### DIFF
--- a/doc/cephfs/client-config-ref.rst
+++ b/doc/cephfs/client-config-ref.rst
@@ -177,6 +177,12 @@
 :Type: Boolean
 :Default: ``true``
 
+``fuse max write``
+
+:Description: Set the maximum number of bytes in a single write operation.  Because the FUSE default is 128kbytes, SO fuse_max_write default set to 0(The default does not take effect)
+:Type: Integer
+:Default: ``0``
+
 Developer Options
 #################
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1095,6 +1095,8 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     "fuse_atomic_o_trunc");
   auto fuse_debug = client->cct->_conf->get_val<bool>(
     "fuse_debug");
+  auto fuse_max_write = client->cct->_conf->get_val<uint64_t>(
+    "fuse_max_write");
 
   if (fuse_allow_other) {
     newargv[newargc++] = "-o";
@@ -1108,6 +1110,13 @@ int CephFuse::Handle::init(int argc, const char *argv[])
   if (fuse_big_writes) {
     newargv[newargc++] = "-o";
     newargv[newargc++] = "big_writes";
+  }
+  if (fuse_max_write > 0) {
+    char strsplice[65];
+    newargv[newargc++] = "-o";
+    newargv[newargc++] = strsplice;
+    sprintf(strsplice, "max_write=%" PRIu64, fuse_max_write);
+    newargv[newargc++] = strsplice;
   }
   if (fuse_atomic_o_trunc) {
     newargv[newargc++] = "-o";

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7047,6 +7047,10 @@ std::vector<Option> get_mds_client_options() {
     .set_default(false)
     .set_description("big_writes is deprecated in libfuse 3.0.0"),
 
+    Option("fuse_max_write", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("Set the maximum number of bytes in a single write operation.  Because the FUSE default is 128kbytes, SO fuse_max_write default set to 0(The default does not take effect)"),
+
     Option("fuse_atomic_o_trunc", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),


### PR DESCRIPTION
This parameter has the following 2 advantages:
1.  FUSE(version > 2.8) the default single IO write size is 128k (controlled by max_write), if I use bs=4M in 
    the FIO tool test,you will find that 4*1024k/128=32 is needed, ie 32 IO operations are needed . If I 
    adjust max_write to 4M,only one operation is needed, which greatly improves the write performance 
    of cephfs during fuse mount.Of course, the above implementation requires libfuse and kernel fuse to 
    support.
2. In addition, we can also limit the single IO write size by setting max_write to less than 128K.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>