### PR TITLE
Wip 22977 fix

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1535,7 +1535,7 @@ BlueStore::OnodeRef BlueStore::OnodeSpace::lookup(const ghobject_t& oid)
 
   {
     std::lock_guard<std::recursive_mutex> l(cache->lock);
-    ceph::unordered_map<ghobject_t,OnodeRef>::iterator p = onode_map.find(oid);
+    auto p = onode_map.find(oid);
     if (p == onode_map.end()) {
       ldout(cache->cct, 30) << __func__ << " " << oid << " miss" << dendl;
     } else {
@@ -1580,9 +1580,8 @@ void BlueStore::OnodeSpace::rename(
   std::lock_guard<std::recursive_mutex> l(cache->lock);
   ldout(cache->cct, 30) << __func__ << " " << old_oid << " -> " << new_oid
 			<< dendl;
-  ceph::unordered_map<ghobject_t,OnodeRef>::iterator po, pn;
-  po = onode_map.find(old_oid);
-  pn = onode_map.find(new_oid);
+  auto po = onode_map.find(old_oid);
+  auto pn = onode_map.find(new_oid);
   assert(po != pn);
 
   assert(po != onode_map.end());

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1313,10 +1313,29 @@ public:
 
   struct OnodeSpace {
   private:
+    struct ghobject_hash_helper_t : public ghobject_t {
+      uint32_t obj_hash;
+
+      ghobject_hash_helper_t(const ghobject_t& o)
+        : ghobject_t(o) {
+        static std::hash<object_t> H;
+        static std::hash<ghobject_t> I;
+        this->obj_hash = H(o.hobj.oid) ^ I(o);
+      }
+    };
+
+    struct onode_hasher_t {
+      size_t operator()(const ghobject_hash_helper_t &r) const {
+        return r.obj_hash;
+      }
+    };
+
     Cache *cache;
 
     /// forward lookups
-    mempool::bluestore_cache_other::unordered_map<ghobject_t,OnodeRef> onode_map;
+    mempool::bluestore_cache_other::unordered_map<ghobject_hash_helper_t,
+						  OnodeRef,
+						  onode_hasher_t> onode_map;
 
     friend class Collection; // for split_cache()
 


### PR DESCRIPTION
This is solution for bug 22977. The == operator had much more fields then hash used to calculation. In result, buckets in unordered_map were very large.