### PR TITLE
common/ipaddr: Do not select link-local IPv6 addresses

### DIFF
--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -89,6 +89,9 @@ const struct ifaddrs *find_ipv6_in_subnet(const struct ifaddrs *addrs,
     if (addrs->ifa_addr->sa_family != net->sin6_family)
       continue;
 
+    if (IN6_IS_ADDR_LINKLOCAL(addrs->ifa_addr))
+      continue;
+
     struct in6_addr *cur = &((struct sockaddr_in6*)addrs->ifa_addr)->sin6_addr;
     netmask_ipv6(cur, prefix_len, &temp);
 


### PR DESCRIPTION
They are not suited to be used with Ceph and should not be selected
as a address to bind on.

Signed-off-by: Wido den Hollander <wido@42on.com>