### PR TITLE
mon/MonCommands: mgr metadata - improve parameter naming consistency

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -739,7 +739,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     f->flush(rdata);
   } else if (prefix == "mgr metadata") {
     string name;
-    cmd_getval(g_ceph_context, cmdmap, "id", name);
+    cmd_getval(g_ceph_context, cmdmap, "who", name);
     if (name.size() > 0 && !map.have_name(name)) {
       ss << "mgr." << name << " does not exist";
       r = -ENOENT;
@@ -750,7 +750,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
     boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     if (name.size()) {
       f->open_object_section("mgr_metadata");
-      f->dump_string("id", name);
+      f->dump_string("name", name);
       r = dump_metadata(name, f.get(), &ss);
       if (r < 0)
         goto reply;
@@ -760,7 +760,7 @@ bool MgrMonitor::preprocess_command(MonOpRequestRef op)
       f->open_array_section("mgr_metadata");
       for (auto& i : map.get_all_names()) {
 	f->open_object_section("mgr");
-	f->dump_string("id", i);
+	f->dump_string("name", i);
 	r = dump_metadata(i, f.get(), NULL);
 	if (r == -EINVAL || r == -ENOENT) {
 	  // Drop error, continue to get other daemons' metadata

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1087,7 +1087,7 @@ COMMAND("mgr module enable "						\
 COMMAND("mgr module disable "						\
 	"name=module,type=CephString",
 	"disable mgr module", "mgr", "rw", "cli,rest")
-COMMAND("mgr metadata name=id,type=CephString,req=false",
+COMMAND("mgr metadata name=who,type=CephString,req=false",
 	"dump metadata for all daemons or a specific daemon",
 	"mgr", "r", "cli,rest")
 COMMAND("mgr count-metadata name=property,type=CephString",


### PR DESCRIPTION
Other then the fix I changed id -> name in the metadata as I understand that daemons generally have a name, not an id (at least mons and mds' do).

Fixes: http://tracker.ceph.com/issues/23330

Signed-off-by: Jan Fajerski <jfajerski@suse.com>