### PR TITLE
test/cli/osdmaptool/test-map-pgs.t: remove nondetermimistic test

### DIFF
--- a/src/test/cli/osdmaptool/test-map-pgs.t
+++ b/src/test/cli/osdmaptool/test-map-pgs.t
@@ -37,9 +37,6 @@
   $ grep -E "size $SIZE[[:space:]]$TOTAL" $OUT || cat $OUT
   size 3\t8000 (esc)
   $ STATS_RANDOM=$(grep '^ avg ' "$OUT")
-# it is almost impossible to get the same stats with random and crush
-# if they are, it most probably means something went wrong somewhere
-  $ test "$STATS_CRUSH" != "$STATS_RANDOM"
 #
 # cleanup
 #


### PR DESCRIPTION
This fails randomly; determinism is good!

Signed-off-by: Sage Weil <sage@redhat.com>