### PR TITLE
mgr/dashboard: Allow sourcing `run-backend-api-tests.sh`

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -118,7 +118,15 @@ If you're using the `ceph-dev-docker development environment
 <https://github.com/ricardoasmarques/ceph-dev-docker/>`_, simply run
 ``./install_deps.sh`` from the toplevel directory to install them.
 
-Unit Testing and Linting
+Unit Testing
+~~~~~~~~~~~~
+
+In dashboard we have two different kinds of backend tests:
+
+1. Unit tests based on ``tox``
+2. API tests based on Teuthology.
+
+Unit tests based on tox
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 We included a ``tox`` configuration file that will run the unit tests under
@@ -134,18 +142,8 @@ Alternatively, you can use Python's native package installation method::
   $ pip install tox
   $ pip install coverage
 
-The unit tests must run against a real Ceph cluster (no mocks are used). This
-has the advantage of catching bugs originated from changes in the internal Ceph
-code.
-
-Our ``tox.ini`` script will start a ``vstart`` Ceph cluster before running the
-python unit tests, and then it stops the cluster after the tests are run. Of
-course this implies that you have built/compiled Ceph previously.
-
-To run tox, run the following command in the root directory (where ``tox.ini``
-is located)::
-
-  $ PATH=../../../../build/bin:$PATH tox
+To run the tests, run ``tox`` in the dashboard directory (where ``tox.ini``
+is located).
 
 We also collect coverage information from the backend code. You can check the
 coverage information provided by the tox output, or by running the following
@@ -159,37 +157,33 @@ the code coverage of the backend.
 You can also run a single step of the tox script (aka tox environment), for
 instance if you only want to run the linting tools, do::
 
-  $ PATH=../../../../build/bin:$PATH tox -e lint
+  $ tox -e lint
 
-How to run a single unit test without using ``tox``?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+API tests based on Teuthology
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-When developing the code of a controller and respective test code, it's useful
-to be able to run that single test file without going through the whole ``tox``
-workflow.
+To run our API tests against a real Ceph cluster, we leverage the Teuthology framework. This
+has the advantage of catching bugs originated from changes in the internal Ceph
+code.
 
-Since the tests must run against a real Ceph cluster, the first thing is to have
-a Ceph cluster running. For that we can leverage the tox environment that starts
-a Ceph cluster::
 
-  $ PATH=../../../../build/bin:$PATH tox -e ceph-cluster-start
+Our ``run-backend-api-tests.sh`` script will start a ``vstart`` Ceph cluster before running the
+Teuthology tests, and then it stops the cluster after the tests are run. Of
+course this implies that you have built/compiled Ceph previously.
 
-The command above uses ``vstart.sh`` script to start a Ceph cluster and
-automatically enables the ``dashboard`` module, and configures its cherrypy
-web server to listen in port ``9865``.
+Start all dashboard tests by running::
 
-After starting the Ceph cluster we can run our test file using ``py.test`` like
-this::
+  $ ./run-backend-api-tests.sh
 
-  DASHBOARD_PORT=9865 UNITTEST=true py.test -s tests/test_mycontroller.py
+Or, start one or multiple specific tests by specifying the test name::
 
-You can run tests multiple times without having to start and stop the Ceph
-cluster.
+  $ ./run-backend-api-tests.sh tasks.mgr.dashboard.test_pool.DashboardTest
 
-After you finish your tests, you can stop the Ceph cluster using another tox
-environment::
+Or, ``source`` the script and run the tests manually::
 
-  $ tox -e ceph-cluster-stop
+  $ source run-backend-api-tests.sh
+  $ run_teuthology_tests [tests]...
+  $ cleanup_teuthology
 
 How to add a new controller?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This allows us to re-run tests faster.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

```
Usage (run from ./):
./run-backend-api-tests.sh
./run-backend-api-tests.sh [tests]...

Example:
./run-backend-api-tests.sh tasks.mgr.dashboard.test_pool.DashboardTest

Or source this script. Allows to re-run tests faster:
$ source run-backend-api-tests.sh
$ setup_teuthology
$ run_teuthology_tests [tests]...
$ cleanup_teuthology
```
