### PR TITLE
mgr: add mgr daemon to DaemonStateIndex with metadata (hostname)

### DIFF
--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -427,7 +427,6 @@ void Mgr::handle_osd_map()
       }
 
       if (update_meta) {
-        daemon_state.notify_updating(k);
         auto c = new MetadataUpdate(daemon_state, k);
         std::ostringstream cmd;
         cmd << "{\"prefix\": \"osd metadata\", \"id\": "
@@ -559,7 +558,6 @@ void Mgr::handle_fs_map(MFSMap* m)
     }
 
     if (update) {
-      daemon_state.notify_updating(k);
       auto c = new MetadataUpdate(daemon_state, k);
 
       // Older MDS daemons don't have addr in the metadata, so

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -72,7 +72,7 @@ void MetadataUpdate::finish(int r)
 {
   daemon_state.clear_updating(key);
   if (r == 0) {
-    if (key.first == "mds" || key.first == "osd") {
+    if (key.first == "mds" || key.first == "osd" || key.first == "mgr") {
       json_spirit::mValue json_result;
       bool read_ok = json_spirit::read(
           outbl.to_str(), json_result);
@@ -97,7 +97,7 @@ void MetadataUpdate::finish(int r)
       if (daemon_state.exists(key)) {
         state = daemon_state.get(key);
 	Mutex::Locker l(state->lock);
-        if (key.first == "mds") {
+        if (key.first == "mds" || key.first == "mgr") {
           daemon_meta.erase("name");
         } else if (key.first == "osd") {
           daemon_meta.erase("id");
@@ -112,7 +112,7 @@ void MetadataUpdate::finish(int r)
         state->key = key;
         state->hostname = daemon_meta.at("hostname").get_str();
 
-        if (key.first == "mds") {
+        if (key.first == "mds" || key.first == "mgr") {
           daemon_meta.erase("name");
         } else if (key.first == "osd") {
           daemon_meta.erase("id");

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -116,7 +116,10 @@ public:
   std::string outs;
 
   MetadataUpdate(DaemonStateIndex &daemon_state_, const DaemonKey &key_)
-    : daemon_state(daemon_state_), key(key_) {}
+    : daemon_state(daemon_state_), key(key_)
+  {
+      daemon_state.notify_updating(key);
+  }
 
   void set_default(const std::string &k, const std::string &v)
   {


### PR DESCRIPTION
This commit changes when (and how) the mgr daemons are added to the
DaemonStateIndex. A change in the mgr map now doesn't immediately
trigger the addition of a mgr daemon, but triggers a MetadataUpdate
operation so that the mgr daemon is added with metadata queried from the
mon (most notably the hostname). Depends on #20866.
Fixes: http://tracker.ceph.com/issues/23286

Signed-off-by: Jan Fajerski <jfajerski@suse.com>