### PR TITLE
legal: remove doc license ambiguity

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -9,7 +9,7 @@ License: LGPL2.1 (see COPYING-LGPL2.1)
 
 Files: doc/*
 Copyright: (c) 2010-2012 New Dream Network and contributors
-License: Creative Commons Attribution-ShareAlike (CC BY-SA)
+License: Creative Commons Attribution Share Alike 3.0 (CC-BY-SA-3.0)
 
 Files: bin/git-archive-all.sh
 License: GPL3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please see http://ceph.com/ for current info.
 Most of Ceph is licensed under the LGPL version 2.1.  Some
 miscellaneous code is under BSD-style license or is public domain.
 The documentation is licensed under Creative Commons
-Attribution-ShareAlike (CC BY-SA).  There are a handful of headers
+Attribution Share Alike 3.0 (CC-BY-SA-3.0).  There are a handful of headers
 included here that are licensed under the GPL.  Please see the file
 COPYING for a full inventory of licenses by file.
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -88,7 +88,7 @@ Epoch:		2
 %global _epoch_prefix %{?epoch:%{epoch}:}
 
 Summary:	User space components of the Ceph file system
-License:	LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and BSD-3-Clause and MIT
+License:	LGPL-2.1 and CC-BY-SA-3.0 and GPL-2.0 and BSL-1.0 and BSD-3-Clause and MIT
 %if 0%{?suse_version}
 Group:		System/Filesystems
 %endif

--- a/debian/copyright
+++ b/debian/copyright
@@ -15,7 +15,7 @@ License: BSD 3-clause
 
 Files: doc/*
 Copyright: (c) 2010-2012 New Dream Network and contributors
-License: Creative Commons Attribution-ShareAlike (CC BY-SA)
+License: Creative Commons Attribution Share Alike 3.0 (CC-BY-SA-3.0)
 
 Files: src/mount/canonicalize.c
 Copyright: Copyright (C) 1993 Rick Sladkey <jrs@world.std.com>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -2,7 +2,7 @@ import sys
 import os
 
 project = u'Ceph'
-copyright = u'2016, Red Hat, Inc, and contributors. Licensed under Creative Commons BY-SA'
+copyright = u'2016, Red Hat, Inc, and contributors. Licensed under Creative Commons Attribution Share Alike 3.0 (CC-BY-SA-3.0)'
 version = 'dev'
 release = 'dev'
 

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -4,7 +4,7 @@ Contributing to Ceph: A Guide for Developers
 
 :Author: Loic Dachary
 :Author: Nathan Cutler
-:License: Creative Commons Attribution-ShareAlike (CC BY-SA)
+:License: Creative Commons Attribution Share Alike 3.0 (CC-BY-SA-3.0)
 
 .. note:: The old (pre-2016) developer documentation has been moved to :doc:`/dev/index-old`.
 

--- a/man/conf.py
+++ b/man/conf.py
@@ -1,7 +1,7 @@
 import os
 
 project = u'Ceph'
-copyright = u'2010-2014, Inktank Storage, Inc. and contributors. Licensed under Creative Commons BY-SA'
+copyright = u'2010-2014, Inktank Storage, Inc. and contributors. Licensed under Creative Commons Attribution Share Alike 3.0 (CC-BY-SA-3.0)'
 version = 'dev'
 release = 'dev'
 


### PR DESCRIPTION
Tracker: http://tracker.ceph.com/issues/23336

The license applicable to the files under doc/ was originally declared (in the
top-level file COPYING) to be "Creative Commons Attribution-ShareAlike (CC
BY-SA)" by ed0653b493a3f919a3abc37a0aa9b5aa29ae0b0e

This license declaration omitted a version number.

Some time later ef7418421b3748c712019c8aedd02b8005c1e1ea was merged, mentioning
CC-BY-SA-1.0 as one of the Ceph source code licenses. Although the purpose of that
commit was only to summarize the canonical license information from COPYING, it
unintentionally became the only place in the source code where the doc license
version was specified.

In March 2018, the Debian project warned that CC-BY-SA-1.0 does not meet its
criteria for inclusion in the "free" section of the Debian distribution. (For
that, at least version 3.0 must be used.)

This new commit removes the doc license ambiguity by setting it to CC-BY-SA-3.0
in all three places where the license is mentioned:
- COPYING
- ceph.spec.in
- debian/copyright

The exact spelling of the license name is taken from https://spdx.org/licenses/

Fixes: http://tracker.ceph.com/issues/23336
Signed-off-by: Nathan Cutler <ncutler@suse.com>