### PR TITLE
legal: "correct" license from LGPL2 to LGPL2.1

### DIFF
--- a/CodingStyle
+++ b/CodingStyle
@@ -70,7 +70,7 @@ by section.
 * Comments > File Comments:
 
    Don't sweat it, unless the license varies from that of the project
-   (LGPL2) or the code origin isn't reflected by the git history.
+   (LGPL2.1) or the code origin isn't reflected by the git history.
 
 * Formatting > Tabs:
   Indent width is two spaces.  When runs of 8 spaces can be compressed

--- a/debian/copyright
+++ b/debian/copyright
@@ -102,7 +102,7 @@ License:
 
 Files: src/test/common/Throttle.cc src/test/filestore/chain_xattr.cc
 Copyright: Copyright (C) 2013 Cloudwatt <libre.licensing@cloudwatt.com>
-License: LGPL2 or later
+License: LGPL2.1 or later
 
 Files: src/osd/ErasureCodePluginJerasure/*.{c,h}
 Copyright: Copyright (c) 2011, James S. Plank <plank@cs.utk.edu>

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -17,7 +17,7 @@
  *
  *     http://www.ssrc.ucsc.edu/Papers/weil-sc06.pdf
  *
- * LGPL2
+ * LGPL2.1
  */
 
 

--- a/src/crush/mapper.h
+++ b/src/crush/mapper.h
@@ -5,7 +5,7 @@
  * CRUSH functions for find rules and then mapping an input to an
  * output set.
  *
- * LGPL2
+ * LGPL2.1
  */
 
 #include "crush.h"

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -6,7 +6,7 @@
  * primarily intended to describe data structures that pass over the
  * wire or that are stored on disk.
  *
- * LGPL2
+ * LGPL2.1
  */
 
 #ifndef CEPH_FS_H

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -7,7 +7,7 @@ daemon.
 
 Copyright (C) 2013 Inktank Storage, Inc.
 
-LGPL2.  See file COPYING.
+LGPL2.1.  See file COPYING.
 """
 from __future__ import print_function
 import copy

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -1,7 +1,7 @@
 """
 Copyright (C) 2015 Red Hat, Inc.
 
-LGPL2.  See file COPYING.
+LGPL2.1.  See file COPYING.
 """
 
 from contextlib import contextmanager


### PR DESCRIPTION
Back in commit 7469f26a33c072169d6ed929352eda06562ffe3f when the COPYING
file was added to the repository and the project was "licensed," the
license file was

```
                 GNU LESSER GENERAL PUBLIC LICENSE
                      Version 2.1, February 1999
```
However, the license was abbreviated as LGPL2 in various places (pretty
much everywhere, actually), due to my own ignorance/carelessness.  (I was
distinguishing it from shiny new version 3, released 6 months earlier.)

Version 2 of LGPL is the "Library General Public License," published in
June 1991: https://www.gnu.org/licenses/old-licenses/lgpl-2.0.html

"Correct" the record by documenting the license as 2.1.

Signed-off-by: Sage Weil <sage@redhat.com>