### PR TITLE
mgr/dashboard: add image id to mgr rbd info instead of block_name_prefix

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -41,6 +41,7 @@ class RbdTest(DashboardTestCase):
         self.assertEqual(img1['obj_size'], 4194304)
         self.assertEqual(img1['features_name'],
                          ['deep-flatten', 'exclusive-lock', 'fast-diff', 'layering', 'object-map'])
+        self.assertIn('id', img1)
 
         img2 = data['value'][1]
         self.assertEqual(img2['name'], 'img2')
@@ -49,6 +50,7 @@ class RbdTest(DashboardTestCase):
         self.assertEqual(img2['obj_size'], 4194304)
         self.assertEqual(img2['features_name'],
                          ['deep-flatten', 'exclusive-lock', 'fast-diff', 'layering', 'object-map'])
+        self.assertIn('id', img2)
 
     @authenticate
     def test_create(self):

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -73,6 +73,7 @@ class Rbd(RESTController):
             i = rbd.Image(ioctx, name)
             stat = i.stat()
             stat['name'] = name
+            stat['id'] = i.id()
             features = i.features()
             stat['features'] = features
             stat['features_name'] = self._format_bitmask(features)


### PR DESCRIPTION
when create images use data_pool parameter, such as:
rbd create -p pool1 -s 1G --data-pool pool2  image1

then get image info from mgr use request http://192.7.7.36:7000/rbd_pool_data/pool1
we got the response
[{"parent_name": "", "parent_pool": 18446744073709551615, "name": "image1", "num_objs": 256, "block_name_prefix": "rbd_data.14.f561643c986", "obj_size": 4194304, "features": 189, "features_name": "fast-diff, layering, exclusive-lock, deep-flatten, object-map, data-pool", "order": 22, "size": 1073741824}]

notice
since block_name_prefix is deprecated,
from block_name_prefix we can not get image id(the real id is ''f561643c9869')
we need add image id to rbd info instead block_name_prefix

Python 2.7.5 (default, Jun 17 2014, 18:11:42)
[GCC 4.8.2 20140120 (Red Hat 4.8.2-16)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import rados
>>> import rbd
>>> RADOS_NAME = 'client.admin'
>>> cluster_name="ceph"
>>> cluster_handle = rados.Rados(name=RADOS_NAME, clustername=cluster_name, conffile='')
>>> cluster_handle.connect()
>>> ioctx = cluster_handle.open_ioctx("pool1")
>>> image_inst = rbd.Image(ioctx, "image1")
>>> image_inst.stat()
{'parent_name': '', 'parent_pool': 18446744073709551615L, 'num_objs': 256L, 'block_name_prefix': u'rbd_data.14.f561643c986', 'obj_size': 4194304L, 'order': 22, 'size': 1073741824L}
>>> image_inst.id()
u'f561643c9869'

after fix:

[root@tfg36 site-packages]# curl http://192.7.7.36:7000/rbd_pool_data/pool1
[{"parent_name": "", "parent_pool": 18446744073709551615, "name": "image1", "num_objs": 256, "block_name_prefix": "rbd_data.14.f561643c986", "obj_size": 4194304, "features": 189, "id": "f561643c9869", "features_name": "fast-diff, layering, exclusive-lock, deep-flatten, object-map, data-pool", "order": 22, "size": 1073741824}]

Signed-off-by: zouaiguo <zou.aiguo@zte.com.cn>