### PR TITLE
mgr/dashboard: remove node/npm system installation

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -107,68 +107,6 @@ EOF
     fi
 }
 
-function ensure_min_npm_version {
-  local install_npm_pkg_cmd=$1
-
-  if [ "$ARCH" = "aarch64" ]; then
-    # we don't support dashboard frontend development in arm64 architecture
-    return 0
-  fi
-
-  if ! type npm > /dev/null 2>&1; then
-    $SUDO $install_npm_pkg_cmd
-  fi
-
-  NODE_VER=`node -v`
-  NODE_VER_MAJOR=`node -v | sed 's/v\(\w\+\).*/\1/g'`
-  NODE_VER_MINOR=`node -v | sed 's/v\w\+\.\(\w\+\).*/\1/g'`
-
-  # The minimum node version required is 4.8.0 so that we can use yarn below
-  UPDATE_NODE=false
-  if [ $NODE_VER_MAJOR -lt 4 ]; then
-    UPDATE_NODE=true
-  elif [ $NODE_VER_MAJOR -eq 4 ] && [ $NODE_VER_MINOR -lt 8 ]; then
-    UPDATE_NODE=true
-  fi
-  if $UPDATE_NODE; then
-    $SUDO npm install -g n
-    # installs nodejs version 4.8.0
-    $SUDO n 4.8.0
-    $SUDO npm uninstall -g n
-    hash -d node > /dev/null 2>&1 || true
-  fi
-
-  NPM_VER=`npm -v`
-  NPM_VER_MAJOR=`npm -v | sed 's/\(\w\+\).*/\1/g'`
-
-  # The minimum npm version required is 5.0.0 so that we can install and use
-  # a local nodejs installation (required by the dashboard angular2 frontend)
-  if [ $NPM_VER_MAJOR -lt 5 ]; then
-    $SUDO npm install -g yarn
-    $SUDO yarn global add npm@^5.0.0  # install npm version 5.0.0 or later
-  fi
-  hash -d npm > /dev/null 2>&1 || true
-
-  NEW_NODE_VER=`node -v`
-  NEW_NPM_VER=`npm -v`
-  if [ ! "$NODE_VER" = "$NEW_NODE_VER" ]; then
-cat <<EOF
-*****************************************************************************
-      YOUR NODE VERSION WAS UPDATED FROM $NODE_VER TO $NEW_NODE_VER
-*****************************************************************************
-EOF
-  fi
-  if [ ! "$NPM_VER" = "$NEW_NPM_VER" ]; then
-cat <<EOF
-*****************************************************************************
-      YOUR NPM VERSION WAS UPDATED FROM $NPM_VER TO $NEW_NPM_VER
-      TO RETURN TO VERSION $NPM_VER run the following command:
-          $ $SUDO yarn global remove npm && hash -d npm
-*****************************************************************************
-EOF
-  fi
-}
-
 if [ x`uname`x = xFreeBSDx ]; then
     $SUDO pkg install -yq \
         devel/babeltrace \
@@ -254,11 +192,6 @@ else
 	$SUDO env DEBIAN_FRONTEND=noninteractive mk-build-deps --install --remove --tool="apt-get -y --no-install-recommends $backports" $control || exit 1
 	$SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove ceph-build-deps
 	if [ -n "$backports" ] ; then rm $control; fi
-        if [ ! "$ARCH" = "aarch64" ]; then
-          $SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs
-          [ ! -e /usr/bin/node ] && $SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y install nodejs-legacy
-          ensure_min_npm_version "env DEBIAN_FRONTEND=noninteractive apt-get -y install npm"
-        fi
         ;;
     centos|fedora|rhel|ol|virtuozzo)
         yumdnf="yum"
@@ -319,7 +252,6 @@ else
             ensure_decent_gcc_on_rh $dts_ver
 	fi
         ! grep -q -i error: $DIR/yum-builddep.out || exit 1
-        ensure_min_npm_version "$yumdnf install -y npm"
         ;;
     opensuse|suse|sles)
         echo "Using zypper to install dependencies"
@@ -327,7 +259,6 @@ else
         $SUDO $zypp_install lsb-release systemd-rpm-macros
         munge_ceph_spec_in $DIR/ceph.spec
         $SUDO $zypp_install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
-        ensure_min_npm_version "zypper --non-interactive install npm"
         ;;
     alpine)
         # for now we need the testing repo for leveldb

--- a/make-dist
+++ b/make-dist
@@ -63,10 +63,17 @@ download_boost() {
 
 build_dashboard_frontend() {
   CURR_DIR=`pwd`
+  TEMP_DIR=`mktemp -d`
+  $CURR_DIR/src/tools/setup-virtualenv.sh $TEMP_DIR
+  $TEMP_DIR/bin/pip install nodeenv
+  $TEMP_DIR/bin/nodeenv -p -n 8.10.0
   cd src/pybind/mgr/dashboard/frontend
+  . $TEMP_DIR/bin/activate
   npm install
   npm run build -- --prod
+  deactivate
   cd $CURR_DIR
+  rm -rf $TEMP_DIR
   tar cf dashboard_frontend.tar $outfile/src/pybind/mgr/dashboard/frontend/dist
 }
 

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -9,26 +9,35 @@ add_custom_target(mgr-dashboard-test-venv
 add_dependencies(tests mgr-dashboard-test-venv)
 
 if(WITH_MGR_DASHBOARD_FRONTEND AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64|arm|ARM")
-  find_program(NPM_BIN
-    NAMES npm
-    HINTS $ENV{NPM_ROOT}/bin)
-  if(NOT NPM_BIN)
-    message(FATAL_ERROR "WITH_MGR_DASHBOARD_FRONTEND set, but npm not found")
-  endif()
+
+set(mgr-dashboard-nodeenv ${CMAKE_CURRENT_BINARY_DIR}/node-env)
+
+add_custom_command(
+  OUTPUT "${mgr-dashboard-nodeenv}/bin/npm"
+  COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh ${mgr-dashboard-nodeenv}
+  COMMAND ${mgr-dashboard-nodeenv}/bin/pip install nodeenv
+  COMMAND ${mgr-dashboard-nodeenv}/bin/nodeenv -p -n 8.10.0
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  COMMENT "dashboard nodeenv is being installed"
+)
+
+add_custom_target(mgr-dashboard-nodeenv
+  DEPENDS ${mgr-dashboard-nodeenv}/bin/npm
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 add_custom_command(
   OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/node_modules"
-  COMMAND ${NPM_BIN} install
+  COMMAND . ${mgr-dashboard-nodeenv}/bin/activate && npm install && deactivate
   DEPENDS frontend/package.json
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
   COMMENT "dashboard frontend dependencies are being installed"
 )
 
 add_custom_target(mgr-dashboard-frontend-deps
-  DEPENDS frontend/node_modules
+  DEPENDS frontend/node_modules mgr-dashboard-nodeenv
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
 )
-
 
 # Glob some frontend files. With CMake 3.6, this can be simplified
 # to *.ts *.html. Just add:
@@ -49,14 +58,14 @@ file(
   frontend/src/*/*/*/*/*/*.html)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(npm_command ${NPM_BIN} run build -- --prod)
+  set(npm_command npm run build -- --prod)
 else()
-  set(npm_command ${NPM_BIN} run build)
+  set(npm_command npm run build)
 endif()
 
 add_custom_command(
   OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/dist"
-  COMMAND ${npm_command}
+  COMMAND . ${mgr-dashboard-nodeenv}/bin/activate && ${npm_command} && deactivate
   DEPENDS ${frontend_src} frontend/node_modules
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
   COMMENT "dashboard frontend is being created"

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -15,14 +15,30 @@ The build process is based on `Node.js <https://nodejs.org/>`_ and requires the
 Prerequisites
 ~~~~~~~~~~~~~
 
-Run ``npm install`` in directory ``src/pybind/mgr/dashboard/frontend`` to
-install the required packages locally.
+ * Node 6.9.0 or higher
+ * NPM 3 or higher
 
-.. note::
+nodeenv:
+  During Ceph's build we create a virtualenv with ``node`` and ``npm``
+  installed, which can be used as an alternative to installing node/npm in your
+  system.
 
+  If you want to use the node installed in the virtualenv you just need to
+  activate the virtualenv before you run any npm commands. To activate it run
+  ``. build/src/pybind/mgr/dashboard/node-env/bin/activate``.
+
+  Once you finish, you can simply run ``deactivate`` and exit the virtualenv.
+
+Angular CLI:
   If you do not have the `Angular CLI <https://github.com/angular/angular-cli>`_
   installed globally, then you need to execute ``ng`` commands with an
   additional ``npm run`` before it.
+
+Package installation
+~~~~~~~~~~~~~~~~~~~~
+
+Run ``npm install`` in directory ``src/pybind/mgr/dashboard/frontend`` to
+install the required packages locally.
 
 Setting up a Development Server
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -55,7 +55,6 @@
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-junit-reporter": "^1.2.0",
     "karma-phantomjs-launcher": "^1.0.4",
-    "node": "^8.9.4",
     "protractor": "~5.1.2",
     "ts-node": "~3.2.0",
     "tslint": "~5.9.1",

--- a/src/pybind/mgr/dashboard/run-frontend-unittests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-unittests.sh
@@ -4,6 +4,10 @@ set -e
 
 cd $CEPH_ROOT/src/pybind/mgr/dashboard/frontend
 
+.  $CEPH_ROOT/build/src/pybind/mgr/dashboard/node-env/bin/activate
+
 npm run build -- --prod
 npm run test -- --browsers PhantomJS --watch=false
 npm run lint
+
+deactivate


### PR DESCRIPTION
Node and npm are now being installed in a virtualenv, removing the need of
having it installed in the system or as a node dependency.

Now, if you want to use npm, you just need to activate the virtualenv created
on 'build/src/pybind/mgr/dashboard/node-env', and then you can execute
the same commands as you did before.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`