### PR TITLE
os/bluestore: bluestore repair should use interval_set::union_insert

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6463,7 +6463,7 @@ int BlueStore::_fsck(bool deep, bool repair)
 	    
 	    // relying on blob's pextents to decide what to release.
 	    for (auto& p : pext_to_release) {
-	      to_release.insert(p.offset, p.length);
+	      to_release.union_insert(p.offset, p.length);
 	    }
 	  } else {
 	    for (auto& p : pext_to_release) {
@@ -6471,7 +6471,7 @@ int BlueStore::_fsck(bool deep, bool repair)
 	      if (compressed) {
 		expected_statfs.compressed_allocated -= p.length;
 	      }
-	      to_release.insert(p.offset, p.length);
+	      to_release.union_insert(p.offset, p.length);
 	    }
 	  }
 	  if (bypass_rest) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2815,7 +2815,7 @@ public:
   unsigned apply(KeyValueDB* db);
 
   void note_misreference(uint64_t offs, uint64_t len, bool inc_error) {
-    misreferenced_extents.insert(offs, len);
+    misreferenced_extents.union_insert(offs, len);
     if (inc_error) {
       ++to_repair_cnt;
     }


### PR DESCRIPTION
method rather than insert one to handle intersecting/overlapping ranges properly.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>