### PR TITLE
 qa/tasks/ceph_manager: use set_config on revived osd

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -384,13 +384,11 @@ class Thrasher:
             skip_admin_check=skip_admin_check)
         self.dead_osds.remove(osd)
         self.live_osds.append(osd)
-        if self.random_eio > 0 and osd is self.rerrosd:
-            self.ceph_manager.inject_args('osd', self.rerrosd,
-                                          'filestore_debug_random_read_err',
-                                          self.random_eio)
-            self.ceph_manager.inject_args('osd', self.rerrosd,
-                                          'bluestore_debug_random_read_err',
-                                          self.random_eio)
+        if self.random_eio > 0 and osd == self.rerrosd:
+            self.ceph_manager.set_config(self.rerrosd,
+                                         filestore_debug_random_read_err = self.random_eio)
+            self.ceph_manager.set_config(self.rerrosd,
+                                         bluestore_debug_random_read_err = self.random_eio)
 
 
     def out_osd(self, osd=None):


### PR DESCRIPTION
This PR addresses the issue caused due to inject_args failing because the osd hasn't finished booting with the monitors.

Failure seen here:  http://pulpito.ceph.com/nojha-2018-03-13_14:32:25-rados-wip-async-recovery-2018-03-12-distro-basic-smithi/2286777/

Signed-off-by: Neha Ojha <nojha@redhat.com>