### PR TITLE
ceph-fuse: Fix Segmentation fault --localize-reads

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -87,9 +87,7 @@ int main(int argc, const char **argv, const char *envp[]) {
 			 CODE_ENVIRONMENT_DAEMON,
 			 CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
 
-  auto i = args.begin();
-  auto end = args.end();
-  for (; i != end;) {
+  for (auto i = args.begin(); i != args.end();) {
     if (ceph_argparse_double_dash(args, i)) {
       break;
     } else if (ceph_argparse_flag(args, i, "--localize-reads", (char*)nullptr)) {


### PR DESCRIPTION
After fixing, the output of the commands mentioned in the tracker:
```
$ sudo ./bin/ceph-fuse -m localhost:40292  /mnt/stratcephfs/ --localize-reads 
setting CEPH_OSD_FLAG_LOCALIZE_READS
ceph-fuse[7590]: starting ceph client
2018-03-15 09:48:41.532 7fc513436cc0 -1 init, newargv = 0x562c44862300 newargc=7
ceph-fuse[7590]: starting fuse
```
```
$ sudo fusermount -u /mnt/stratcephfs/
```
```
$ sudo ./bin/ceph-fuse --localize-reads
setting CEPH_OSD_FLAG_LOCALIZE_READS
2018-03-15 09:55:27.225 7f7893b3ecc0 -1 init, newargv = 0x561ad74be540 newargc=6
ceph-fuse[7955]: starting ceph client
fuse: missing mountpoint parameter
ceph-fuse[7955]: fuse failed to start
2018-03-15 09:55:27.237 7f7893b3ecc0 -1 fuse_mount(mountpoint=
```
I think this ^ failure message is reasonable. What do you think?

Fixes: http://tracker.ceph.com/issues/23288
Signed-off-by: Jos Collin <jcollin@redhat.com>