### PR TITLE
mgr/dashboard_v2: fix test_perf_counters_mgr_get

### DIFF
--- a/qa/tasks/mgr/dashboard_v2/test_perf_counters.py
+++ b/qa/tasks/mgr/dashboard_v2/test_perf_counters.py
@@ -47,4 +47,10 @@ class PerfCountersControllerTest(DashboardTestCase):
         self.assertEqual('mgr', data['service']['type'])
         self.assertEqual(mgr, data['service']['id'])
         self.assertIsInstance(data['counters'], list)
-        self.assertEqual(len(data['counters']), 0)
+        self.assertGreater(len(data['counters']), 0)
+        counter = data['counters'][0]
+        self.assertIsInstance(counter, dict)
+        self.assertIn('description', counter)
+        self.assertIn('name', counter)
+        self.assertIn('unit', counter)
+        self.assertIn('value', counter)


### PR DESCRIPTION
Now that we can obtain perf counters for the mgr, we need to assert that we get
more than 0 counters and that they have the desired structure.

Fixes: https://tracker.ceph.com/issues/23378

`Signed-off-by: Tiago Melo <tmelo@suse.com>`