### PR TITLE
osd/OSDMap: fix HAVE_FEATURE logic in encode()

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -486,8 +486,7 @@ void OSDMap::Incremental::encode(bufferlist& bl, uint64_t features) const
     uint8_t v = 6;
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       v = 3;
-    }
-    if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
+    } else if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
       v = 5;
     }
     ENCODE_START(v, 1, bl); // client-usable data
@@ -2523,8 +2522,7 @@ void OSDMap::encode(bufferlist& bl, uint64_t features) const
     uint8_t v = 7;
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       v = 3;
-    }
-    if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
+    } else if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
       v = 6;
     }
     ENCODE_START(v, 1, bl); // client-usable data
@@ -2600,8 +2598,7 @@ void OSDMap::encode(bufferlist& bl, uint64_t features) const
     uint8_t target_v = 6;
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       target_v = 1;
-    }
-    if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
+    } else if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
       target_v = 5;
     }
     ENCODE_START(target_v, 1, bl); // extended, osd-only data


### PR DESCRIPTION
Currently clients that don't have SERVER_LUMINOUS end up being fed
v6 (i.e. luminous) encoding because they also don't have SERVER_MIMIC.
This was introduced in commit 553048fbf97a ("osd/OSDMap: track newly
removed and purged snaps in each epoch").

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>