### PR TITLE
[RFC] rgw: Libcurl+NSS memory leak mitigation when performing keystone SSL auth

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,6 +448,19 @@ if (WITH_RADOSGW)
   else()
     message(WARNING "ssl not found: rgw civetweb may fail to dlopen libssl libcrypto")
   endif()  # OPENSSL_FOUND
+
+  # curl-nss memory leak mitigation
+  execute_process(
+    COMMAND "curl-config --configure | grep \"\\-\\-with\\-nss\""
+      RESULT_VARIABLE RES
+  )
+  if (RES EQUAL 0)
+      message(STATUS "libcurl is configured with NSS as TLS backend")
+      set(LIBCURL_CONFIG_WITH_NSS ON)
+  else()
+      message(STATUS "libcurl is not configured with NSS as TLS backend")
+      set(LIBCURL_CONFIG_WITH_NSS OFF)
+  endif()
 endif (WITH_RADOSGW)
 
 #option for CephFS

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6080,6 +6080,19 @@ std::vector<Option> get_rgw_options() {
 			  "of RGW instances under heavy use. If you would like "
 			  "to turn off cache expiry, set this value to zero."),
 
+    // curl-nss memory leak mitigation
+#if defined(LIBCURL_CONFIG_WITH_NSS)
+    Option("rgw_curl_https_ops_per_global_cleanup", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .add_service("rgw")
+    .set_description("Per how many curl operations to free libcurl memory.")
+    .set_long_description("Configures per how many https curl_easy_perform operation "
+      "to free the Curl/Nss accumulated memory in PK11_CreateGenericObject. "
+      "Applicable to keystone users authority authentication using ssl "
+      "and libcurl configured with NSS (--with-nss) as TLS backend "
+      "(in ceph.conf: rgw_s3_auth_use_keystone=true & rgw_keystone_verify_ssl=true). "
+      "Warning - Only single zone configuration is supported."),
+#endif
   });
 }
 

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -126,6 +126,9 @@
 /* Define if using NSS. */
 #cmakedefine USE_NSS
 
+/* Define if libcurl was configured with --with-nss. */
+#cmakedefine LIBCURL_CONFIG_WITH_NSS
+
 /* Accelio conditional compilation */
 #cmakedefine HAVE_XIO
 

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -36,6 +36,18 @@ class RGWHTTPClient
 
   std::atomic<unsigned> stopped { 0 };
 
+  // curl-nss memory leak mitigation
+#if defined(LIBCURL_CONFIG_WITH_NSS)
+  static std::mutex libcurl_global_cleanup_lock;
+  static int curleasy_performs_count;
+  static int curleasy_in_progress_count;
+  static std::mutex curleasy_in_progress_lock;
+  static std::condition_variable curleasy_in_progress_cond;
+
+  void libcurl_global_cleanup(const char *url);
+  void libcurl_global_cleanup_signal_reqs_complete();
+#endif
+
 protected:
   CephContext *cct;
   param_vec_t headers;


### PR DESCRIPTION
Tracker issue:
http://tracker.ceph.com/issues/23375

When libcurl is configured with --with-nss
There is a memory leak in the PK11_CreateGenericObject() function (in libnss3.so)
that occurs when keystone users authority authentication is using ssl.
(rgw_keystone_verify_ssl = true)

By calling the curl_global_cleanup() its possible to release the memory in libcurl.

(This patch is currently only for the curl_easy_* flow, can be extended to the curl_multi_* flow also)