### PR TITLE
qa/suites/rados/mgr/tasks/dashboard_v2: add fail_on_skip = false

### DIFF
--- a/qa/suites/rados/mgr/tasks/dashboard.yaml
+++ b/qa/suites/rados/mgr/tasks/dashboard.yaml
@@ -18,6 +18,7 @@ tasks:
         - \(MDS_DAMAGE\)
   - rgw: [client.0]
   - cephfs_test_runner:
+      fail_on_skip: false
       modules:
         - tasks.mgr.test_dashboard
         - tasks.mgr.dashboard.test_auth


### PR DESCRIPTION
This commit prevents dashboard API tests to be tagged as failed when
some test is decorated with `@skip`.

Signed-off-by: Ricardo Dias <rdias@suse.com>