### PR TITLE
os/bluestore: free the spdk qpair resource correctly in destructor of SharedDriverQueueData

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -194,7 +194,7 @@ class SharedDriverQueueData {
 
   ~SharedDriverQueueData() {
     g_ceph_context->get_perfcounters_collection()->remove(logger);
-    if (!qpair) {
+    if (qpair) {
       spdk_nvme_ctrlr_free_io_qpair(qpair);
       bdev->queue_number--;
     }


### PR DESCRIPTION
Currently ‘if (!qpair)’ condition wouldn't free spdk qpair resource in destructor of SharedDriverQueueData

Signed-off-by: Jianyu Li <joannyli@foxmail.com>