### PR TITLE
log: Fix AddressSanitizer: new-delete-type-mismatch

### DIFF
--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -48,6 +48,10 @@ struct Entry {
     }
   }
 
+private:
+  ~Entry() = default;
+
+public:
   std::ostream& get_ostream() {
     return m_streambuf->get_ostream();
   }
@@ -87,6 +91,15 @@ struct Entry {
 
   void finish() {
     m_streambuf->finish();
+  }
+
+  void destroy() {
+    if (m_exp_len != NULL) {
+      this->~Entry();
+      ::operator delete(this);
+    } else {
+      delete(this);
+    }
   }
 };
 

--- a/src/log/EntryQueue.h
+++ b/src/log/EntryQueue.h
@@ -59,7 +59,7 @@ struct EntryQueue {
     Entry *t;
     while (m_head) {
       t = m_head->m_next;
-      delete m_head;
+      m_head->destroy();
       m_head = t;
     }      
   }

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -289,7 +289,7 @@ void Log::flush()
 
   // trim
   while (m_recent.m_len > m_max_recent) {
-    delete m_recent.dequeue();
+    m_recent.dequeue()->destroy();
   }
 
   m_flush_mutex_holder = 0;


### PR DESCRIPTION
 If you directly call the operator new function, you must also directly
 call the operator delete function, and must manually call the
 destructor as well.

Fixes: http://tracker.ceph.com/issues/23324

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>