### PR TITLE
Don't hardcode executable paths in module.c

### DIFF
--- a/src/common/module.c
+++ b/src/common/module.c
@@ -66,7 +66,7 @@ int module_has_param(const char *module, const char *param)
 	char command[128];
 
 	snprintf(command, sizeof(command),
-		 "/sbin/modinfo -F parm %s | /bin/grep -q ^%s:",
+		 "modinfo -F parm %s | grep -q ^%s:",
 		 module, param);
 
 	return run_command(command) == 0;
@@ -76,7 +76,7 @@ int module_load(const char *module, const char *options)
 {
 	char command[128];
 
-	snprintf(command, sizeof(command), "/sbin/modprobe %s %s",
+	snprintf(command, sizeof(command), "modprobe %s %s",
 		 module, (options ? options : ""));
 
 	return run_command(command);


### PR DESCRIPTION
Removes hardcoding of the paths to `modinfo`, `grep` and `modprobe` in `module.c`, as this doesn't work on systems such as NixOS where these binaries are located elsewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ceph/ceph/20938)
<!-- Reviewable:end -->
