### PR TITLE
common/bluestore: Lower bluestore_cache_size_ssd to 1GB

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -87,3 +87,6 @@ method. See http://docs.ceph.com/docs/luminous/mgr/restful for details.
   now reflects the source of each config option (e.g., default, config file,
   command line) as well as the final (active) value.
 
+* The default BlueStore cache size for OSDs backed by SSDs (bluestore_cache_size_ssd)
+  has been lowered from 3GB to 1GB. 3GB might be a too large value for systems
+  being upgraded from FileStore to BlueStore.

--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -104,7 +104,7 @@ certain point.
 :Description: The default amount of memory BlueStore will use for its cache when backed by an SSD.
 :Type: Unsigned Integer
 :Required: Yes
-:Default: ``3 * 1024 * 1024 * 1024`` (3 GB)
+:Default: ``1 * 1024 * 1024 * 1024`` (1 GB)
 
 ``bluestore_cache_meta_ratio``
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3979,7 +3979,7 @@ std::vector<Option> get_global_options() {
     .set_description("Default bluestore_cache_size for rotational media"),
 
     Option("bluestore_cache_size_ssd", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(3_G)
+    .set_default(1_G)
     .set_description("Default bluestore_cache_size for non-rotational (solid state) media"),
 
     Option("bluestore_cache_meta_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
The default value of 3GB for bluestore_cache_size_ssd might be too
large for older systems migrating from FileStore to BlueStore.

It's very common to have a system with roughly 4GB of memory per OSD,
for example a system with 8 SSDs and 32GB of Memory.

This is not enough memory to safely run 8 OSDs with a cache size set
to 3GB.

To prevent users from having a bad experience when migrating to
BlueStore the default value is lowered to 1GB.

Admins can change this value to something matching their environment.

Signed-off-by: Wido den Hollander <wido@42on.com>