### PR TITLE
osd: make scrub wait for ec read/modify/writes to apply

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -929,6 +929,7 @@ void ECBackend::handle_sub_write(
   tls.push_back(std::move(op.t));
   tls.push_back(std::move(localt));
   get_parent()->queue_transactions(tls, msg);
+  get_parent()->op_applied(op.at_version);
 }
 
 void ECBackend::handle_sub_read(

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -929,7 +929,10 @@ void ECBackend::handle_sub_write(
   tls.push_back(std::move(op.t));
   tls.push_back(std::move(localt));
   get_parent()->queue_transactions(tls, msg);
-  get_parent()->op_applied(op.at_version);
+  if (op.at_version != eversion_t()) {
+    // dummy rollforward transaction doesn't get at_version (and doesn't advance it)
+    get_parent()->op_applied(op.at_version);
+  }
 }
 
 void ECBackend::handle_sub_read(

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4720,22 +4720,6 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  }
 	}
 
-        // ask replicas to scan
-        scrubber.waiting_on_whom.insert(pg_whoami);
-
-        // request maps from replicas
-	for (set<pg_shard_t>::iterator i = actingbackfill.begin();
-	     i != actingbackfill.end();
-	     ++i) {
-	  if (*i == pg_whoami) continue;
-          _request_scrub_map(*i, scrubber.subset_last_update,
-                             scrubber.start, scrubber.end, scrubber.deep,
-			     scrubber.preempt_left > 0);
-          scrubber.waiting_on_whom.insert(*i);
-        }
-	dout(10) << __func__ << " waiting_on_whom " << scrubber.waiting_on_whom
-		 << dendl;
-
         scrubber.state = PG::Scrubber::WAIT_PUSHES;
         break;
 
@@ -4755,6 +4739,22 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           done = true;
 	  break;
 	}
+
+        // ask replicas to scan
+        scrubber.waiting_on_whom.insert(pg_whoami);
+
+        // request maps from replicas
+	for (set<pg_shard_t>::iterator i = actingbackfill.begin();
+	     i != actingbackfill.end();
+	     ++i) {
+	  if (*i == pg_whoami) continue;
+          _request_scrub_map(*i, scrubber.subset_last_update,
+                             scrubber.start, scrubber.end, scrubber.deep,
+			     scrubber.preempt_left > 0);
+          scrubber.waiting_on_whom.insert(*i);
+        }
+	dout(10) << __func__ << " waiting_on_whom " << scrubber.waiting_on_whom
+		 << dendl;
 
 	scrubber.state = PG::Scrubber::BUILD_MAP;
 	scrubber.primary_scrubmap_pos.reset();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1615,6 +1615,7 @@ void PG::activate(ObjectStore::Transaction& t,
     last_update_ondisk = info.last_update;
     min_last_complete_ondisk = eversion_t(0,0);  // we don't know (yet)!
   }
+  last_update_applied = info.last_update;
   last_rollback_info_trimmed_to_applied = pg_log.get_can_rollback_to();
 
   need_up_thru = false;
@@ -4353,7 +4354,8 @@ void PG::repair_object(
 
 /* replica_scrub
  *
- * Wait for pushes to complete in case of recent recovery. Build a single
+ * Wait for last_update_applied to match msg->scrub_to as above. Wait
+ * for pushes to complete in case of recent recovery. Build a single
  * scrubmap of objects that are in the range [msg->start, msg->end).
  */
 void PG::replica_scrub(

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -827,6 +827,7 @@ protected:
 protected:
   eversion_t  last_update_ondisk;    // last_update that has committed; ONLY DEFINED WHEN is_active()
   eversion_t  last_complete_ondisk;  // last_complete that has committed.
+  eversion_t  last_update_applied;
 
   // entries <= last_rollback_info_trimmed_to_applied have been trimmed
   eversion_t  last_rollback_info_trimmed_to_applied;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1485,6 +1485,7 @@ public:
       INACTIVE,
       NEW_CHUNK,
       WAIT_PUSHES,
+      WAIT_LAST_UPDATE,
       BUILD_MAP,
       BUILD_MAP_DONE,
       WAIT_REPLICAS,
@@ -1521,6 +1522,7 @@ public:
         case INACTIVE: ret = "INACTIVE"; break;
         case NEW_CHUNK: ret = "NEW_CHUNK"; break;
         case WAIT_PUSHES: ret = "WAIT_PUSHES"; break;
+        case WAIT_LAST_UPDATE: ret = "WAIT_LAST_UPDATE"; break;
         case BUILD_MAP: ret = "BUILD_MAP"; break;
         case BUILD_MAP_DONE: ret = "BUILD_MAP_DONE"; break;
         case WAIT_REPLICAS: ret = "WAIT_REPLICAS"; break;

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -216,6 +216,9 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual void release_locks(ObcLockManager &manager) = 0;
 
+     virtual void op_applied(
+       const eversion_t &applied_version) = 0;
+
      virtual bool should_send_op(
        pg_shard_t peer,
        const hobject_t &hoid) = 0;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9930,6 +9930,7 @@ void PrimaryLogPG::repop_all_committed(RepGather *repop)
 void PrimaryLogPG::op_applied(const eversion_t &applied_version)
 {
   dout(10) << "op_applied version " << applied_version << dendl;
+  assert(applied_version != eversion_t());
   assert(applied_version <= info.last_update);
   last_update_applied = applied_version;
   if (is_primary()) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9932,6 +9932,15 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
   dout(10) << "op_applied version " << applied_version << dendl;
   assert(applied_version <= info.last_update);
   last_update_applied = applied_version;
+  if (is_primary()) {
+    if (scrubber.active) {
+      if (last_update_applied >= scrubber.subset_last_update) {
+	requeue_scrub(ops_blocked_by_scrub());
+      }
+    } else {
+      assert(scrubber.start == scrubber.end);
+    }
+  }
 }
 
 void PrimaryLogPG::eval_repop(RepGather *repop)

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10040,7 +10040,6 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     repop->rep_tid,
     ctx->reqid,
     ctx->op);
-  op_applied(ctx->at_version);
 }
 
 PrimaryLogPG::RepGather *PrimaryLogPG::new_repop(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9927,6 +9927,13 @@ void PrimaryLogPG::repop_all_committed(RepGather *repop)
   }
 }
 
+void PrimaryLogPG::op_applied(const eversion_t &applied_version)
+{
+  dout(10) << "op_applied version " << applied_version << dendl;
+  assert(applied_version <= info.last_update);
+  last_update_applied = applied_version;
+}
+
 void PrimaryLogPG::eval_repop(RepGather *repop)
 {
   const MOSDOp *m = NULL;
@@ -10033,6 +10040,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     repop->rep_tid,
     ctx->reqid,
     ctx->op);
+  op_applied(ctx->at_version);
 }
 
 PrimaryLogPG::RepGather *PrimaryLogPG::new_repop(
@@ -10227,6 +10235,7 @@ void PrimaryLogPG::submit_log_entries(
 	new OnComplete{this, rep_tid, get_osdmap()->get_epoch()});
       int r = osd->store->queue_transaction(ch, std::move(t), NULL);
       assert(r == 0);
+      op_applied(info.last_update);
     });
 }
 
@@ -11202,6 +11211,7 @@ void PrimaryLogPG::do_update_log_missing(OpRequestRef &op)
     std::move(t),
     nullptr);
   assert(tr == 0);
+  op_applied(info.last_update);
 }
 
 void PrimaryLogPG::do_update_log_missing_reply(OpRequestRef &op)

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -414,7 +414,7 @@ public:
     append_log(logv, trim_to, roll_forward_to, t, transaction_applied);
   }
 
-  void op_applied(const eversion_t &applied_version);  // remove me
+  void op_applied(const eversion_t &applied_version) override;
 
   bool should_send_op(
     pg_shard_t peer,

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -414,6 +414,8 @@ public:
     append_log(logv, trim_to, roll_forward_to, t, transaction_applied);
   }
 
+  void op_applied(const eversion_t &applied_version);  // remove me
+
   bool should_send_op(
     pg_shard_t peer,
     const hobject_t &hoid) override {

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -498,6 +498,7 @@ void ReplicatedBackend::submit_transaction(
   tls.push_back(std::move(op_t));
 
   parent->queue_transactions(tls, op.op);
+  parent->op_applied(at_version);
 }
 
 void ReplicatedBackend::op_commit(

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -498,7 +498,9 @@ void ReplicatedBackend::submit_transaction(
   tls.push_back(std::move(op_t));
 
   parent->queue_transactions(tls, op.op);
-  parent->op_applied(at_version);
+  if (at_version != eversion_t()) {
+    parent->op_applied(at_version);
+  }
 }
 
 void ReplicatedBackend::op_commit(


### PR DESCRIPTION
This was broken when we merged the ObjectStore onreadable removal.  The last_update_applied machinery was used to handle writes that weren't yet visible on disk (no longer needed) *and* ec read/modify/write writes that were queued but not yet submitted to the ObjectStore due to an in-progress read (still needed). Restore some of the needed scrub steps to fix it again.

Fixes: http://tracker.ceph.com/issues/23339