### PR TITLE
osd/ECMsgTypes: fix ECSubRead compat decode

### DIFF
--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -219,8 +219,8 @@ void ECSubRead::decode(bufferlist::iterator &bl)
   if (struct_v > 2 && struct_v > struct_compat) {
     decode(subchunks, bl);
   } else {
-    for (auto &&i : attrs_to_read) {
-      subchunks[i].push_back(make_pair(0, 1));
+    for (auto &i : to_read) {
+      subchunks[i.first].push_back(make_pair(0, 1));
     }
   }
   DECODE_FINISH(bl);


### PR DESCRIPTION
Populate subchunks based on to_read, not attrs_to_read.

Signed-off-by: Sage Weil <sage@redhat.com>