### PR TITLE
luminous: rgw: fix memory fragmentation problem reading data from client.

### DIFF
--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -19,6 +19,7 @@ class RGWCivetWeb : public rgw::io::RestfulClient,
 
   bool explicit_keepalive;
   bool explicit_conn_close;
+  bool got_eof_on_read;
 
   rgw::io::StaticOutputBufferer<> txbuf;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/23347