### PR TITLE
mon: double mon_mgr_mkfs_grace from 60s -> 120s

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4785,7 +4785,7 @@ std::vector<Option> get_global_options() {
                           "failures about managers that aren't online yet"),
 
     Option("mon_mgr_mkfs_grace", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(60)
+    .set_default(120)
     .add_service("mon")
     .set_description("Period in seconds that the cluster may have no active "
                      "manager before this is reported as an ERR rather than "


### PR DESCRIPTION
http://pulpito.ceph.com/sage-2018-03-18_23:30:24-rados-mimic-dev2-distro-basic-smithi/2303550