### PR TITLE
os/bluestore: fix misleading debug message in bdev.

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -421,7 +421,7 @@ void KernelDevice::_aio_thread()
           if (ioc->allow_eio && r == -EIO) {
             ioc->set_return_value(r);
           } else {
-            assert(0 == "got unexpected error from io_getevents");
+            assert(0 == "got unexpected error from aio_t::get_return_value");
           }
         } else if (aio[i]->length != (uint64_t)r) {
           derr << "aio to " << aio[i]->offset << "~" << aio[i]->length


### PR DESCRIPTION
Currently it's an exact duplicate of the debug that is placed several lines above and directly depends and on the result of `get_next_completed`.