### PR TITLE
mon: call apply_changes() after set_mon_vals

### DIFF
--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -586,6 +586,7 @@ void ConfigMonitor::load_config()
       string(), // no device class
       &out);
     g_conf->set_mon_vals(g_ceph_context, out);
+    g_conf->apply_changes(NULL);
   }
 }
 

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -376,6 +376,7 @@ void MonClient::handle_config(MConfig *m)
 {
   ldout(cct,10) << __func__ << " " << *m << dendl;
   cct->_conf->set_mon_vals(cct, m->config);
+  cct->_conf->apply_changes(NULL);
   m->put();
   got_config = true;
   map_cond.Signal();


### PR DESCRIPTION
otherwise the config oberservers are failed to call.
also some format cleanup.
Signed-off-by: Gu Zhongyan <guzhongyan@360.cn>