### PR TITLE
osd: fix s390x build failure

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -821,6 +821,7 @@ public:
 #if defined(CEPH_LITTLE_ENDIAN)
     bl.append((char *)this, sizeof(version_t) + sizeof(epoch_t));
 #else
+    using ceph::encode;
     encode(version, bl);
     encode(epoch, bl);
 #endif
@@ -829,6 +830,7 @@ public:
 #if defined(CEPH_LITTLE_ENDIAN)
     bl.copy(sizeof(version_t) + sizeof(epoch_t), (char *)this);
 #else
+    using ceph::decode;
     decode(version, bl);
     decode(epoch, bl);
 #endif


### PR DESCRIPTION
46de629c3d0bfae5eba3f6b810808938b5a9af1f introduced a regression: on big-endian
machines, there was no matching function for call to 'eversion_t::encode(const
version_t&, ceph::bufferlist&) const' and 'eversion_t::decode(version_t&,
ceph::buffer::list::iterator&)'

Fixes: http://tracker.ceph.com/issues/23238
Signed-off-by: Nathan Cutler <ncutler@suse.com>