### PR TITLE
mgr/dashboard: Add helper component

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -120,6 +120,25 @@ Example:
     import { Credentials } from '../../../shared/models/credentials.model';
     import { HostService } from './services/host.service';
 
+Frontend components
+~~~~~~~~~~~~~~~~~~~
+
+There are several components that can be reused on different pages.
+This components are declared on the components module:
+`src/pybind/mgr/dashboard/frontend/src/app/shared/components`.
+
+Helper
+......
+
+This component should be used to provide additional information to the user.
+
+Example:
+
+.. code:: html
+
+    <cd-helper>
+      Some <strong>helper</strong> html text
+    </cd-helper>
 
 Backend Development
 -------------------

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -2,8 +2,9 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { ChartsModule } from 'ng2-charts/ng2-charts';
-import { AlertModule } from 'ngx-bootstrap';
+import { AlertModule, PopoverModule } from 'ngx-bootstrap';
 
+import { HelperComponent } from './helper/helper.component';
 import { SparklineComponent } from './sparkline/sparkline.component';
 import { ViewCacheComponent } from './view-cache/view-cache.component';
 
@@ -11,16 +12,19 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
   imports: [
     CommonModule,
     AlertModule.forRoot(),
+    PopoverModule.forRoot(),
     ChartsModule
   ],
   declarations: [
     ViewCacheComponent,
-    SparklineComponent
+    SparklineComponent,
+    HelperComponent
   ],
   providers: [],
   exports: [
     ViewCacheComponent,
-    SparklineComponent
+    SparklineComponent,
+    HelperComponent
   ]
 })
 export class ComponentsModule { }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.html
@@ -1,0 +1,11 @@
+<ng-template #popoverTpl>
+  <div [innerHtml]="html"></div>
+  <ng-content></ng-content>
+</ng-template>
+<i class="fa fa-question-circle"
+   aria-hidden="true"
+   [popover]="popoverTpl"
+   placement="bottom"
+   container="body"
+   [outsideClick]="true">
+</i>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.scss
@@ -1,0 +1,6 @@
+@import '../../../../defaults';
+
+i {
+  color: $oa-color-blue;
+  cursor: pointer;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.spec.ts
@@ -1,0 +1,28 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PopoverModule } from 'ngx-bootstrap';
+
+import { HelperComponent } from './helper.component';
+
+describe('HelperComponent', () => {
+  let component: HelperComponent;
+  let fixture: ComponentFixture<HelperComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [ PopoverModule.forRoot() ],
+      declarations: [ HelperComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HelperComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'cd-helper',
+  templateUrl: './helper.component.html',
+  styleUrls: ['./helper.component.scss']
+})
+export class HelperComponent {
+
+  @Input() html: any;
+
+  constructor() { }
+
+}

--- a/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
@@ -1078,12 +1078,6 @@ uib-accordion .panel-title,
   color: #d04437;
 }
 
-/* oa-helper  */
-oa-helper i {
-  color: $oa-color-blue;
-  cursor: pointer;
-}
-
 .page-footer {
   font-size: 12px;
   color: #777;


### PR DESCRIPTION
This PR adds a component that can be used to provide additional information to the user.

Example:

![screenshot from 2018-03-20 10-15-05](https://user-images.githubusercontent.com/14297426/37649040-98bfce7c-2c28-11e8-82c1-e7bf15f2af00.png)


Signed-off-by: Ricardo Marques <rimarques@suse.com>