### PR TITLE
rgw: policy: modify some operation permission keyword

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -422,7 +422,7 @@ static const actpair actpairs[] =
  { "s3:GetObjectVersionTagging", s3GetObjectVersionTagging},
  { "s3:GetReplicationConfiguration", s3GetReplicationConfiguration },
  { "s3:ListAllMyBuckets", s3ListAllMyBuckets },
- { "s3:ListBucketMultiPartUploads", s3ListBucketMultiPartUploads },
+ { "s3:ListBucketMultipartUploads", s3ListBucketMultipartUploads },
  { "s3:ListBucket", s3ListBucket },
  { "s3:ListBucketVersions", s3ListBucketVersions },
  { "s3:ListMultipartUploadParts", s3ListMultipartUploadParts },
@@ -1325,8 +1325,8 @@ const char* action_bit_string(uint64_t action) {
   case s3ListAllMyBuckets:
     return "s3:ListAllMyBuckets";
 
-  case s3ListBucketMultiPartUploads:
-    return "s3:ListBucketMultiPartUploads";
+  case s3ListBucketMultipartUploads:
+    return "s3:ListBucketMultipartUploads";
 
   case s3GetAccelerateConfiguration:
     return "s3:GetAccelerateConfiguration";

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -60,7 +60,7 @@ static constexpr std::uint64_t s3DeleteBucket = 1ULL << 15;
 static constexpr std::uint64_t s3ListBucket = 1ULL << 16;
 static constexpr std::uint64_t s3ListBucketVersions = 1ULL << 17;
 static constexpr std::uint64_t s3ListAllMyBuckets = 1ULL << 18;
-static constexpr std::uint64_t s3ListBucketMultiPartUploads = 1ULL << 19;
+static constexpr std::uint64_t s3ListBucketMultipartUploads = 1ULL << 19;
 static constexpr std::uint64_t s3GetAccelerateConfiguration = 1ULL << 20;
 static constexpr std::uint64_t s3PutAccelerateConfiguration = 1ULL << 21;
 static constexpr std::uint64_t s3GetBucketAcl = 1ULL << 22;
@@ -109,7 +109,7 @@ inline int op_to_perm(std::uint64_t op) {
   case s3GetObjectVersionTagging:
   case s3ListAllMyBuckets:
   case s3ListBucket:
-  case s3ListBucketMultiPartUploads:
+  case s3ListBucketMultipartUploads:
   case s3ListBucketVersions:
   case s3ListMultipartUploadParts:
     return RGW_PERM_READ;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5808,7 +5808,7 @@ void RGWListMultipart::execute()
 int RGWListBucketMultiparts::verify_permission()
 {
   if (!verify_bucket_permission(s,
-				rgw::IAM::s3ListBucketMultiPartUploads))
+				rgw::IAM::s3ListBucketMultipartUploads))
     return -EACCES;
 
   return 0;

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -70,7 +70,7 @@ using rgw::IAM::s3GetReplicationConfiguration;
 using rgw::IAM::s3ListAllMyBuckets;
 using rgw::IAM::s3ListBucket;
 using rgw::IAM::s3ListBucket;
-using rgw::IAM::s3ListBucketMultiPartUploads;
+using rgw::IAM::s3ListBucketMultipartUploads;
 using rgw::IAM::s3ListBucketVersions;
 using rgw::IAM::s3ListMultipartUploadParts;
 using rgw::IAM::s3None;
@@ -314,7 +314,7 @@ TEST_F(PolicyTest, Parse3) {
   EXPECT_EQ(p->statements[2].action, (s3ListMultipartUploadParts |
 				      s3ListBucket | s3ListBucketVersions |
 				      s3ListAllMyBuckets |
-				      s3ListBucketMultiPartUploads |
+				      s3ListBucketMultipartUploads |
 				      s3GetObject | s3GetObjectVersion |
 				      s3GetObjectAcl | s3GetObjectVersionAcl |
 				      s3GetObjectTorrent |
@@ -369,7 +369,7 @@ TEST_F(PolicyTest, Eval3) {
 
   auto s3allow = (s3ListMultipartUploadParts | s3ListBucket |
 		  s3ListBucketVersions | s3ListAllMyBuckets |
-		  s3ListBucketMultiPartUploads | s3GetObject |
+		  s3ListBucketMultipartUploads | s3GetObject |
 		  s3GetObjectVersion | s3GetObjectAcl | s3GetObjectVersionAcl |
 		  s3GetObjectTorrent | s3GetObjectVersionTorrent |
 		  s3GetAccelerateConfiguration | s3GetBucketAcl |


### PR DESCRIPTION
according to AWS S3, the permission keyword should be s3ListBucketMultipartUploads
rather than s3:ListBucketMultiPartUploads.

all operation permission list in AWS S3 as follows:
  https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html?shortFooter=true

Signed-off-by: xiangxiang <xiangxiang@xsky.com>