### PR TITLE
mgr/dashboard: Fix objects named `default` are inaccessible

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/perf_counters.py
+++ b/src/pybind/mgr/dashboard/controllers/perf_counters.py
@@ -6,8 +6,7 @@ from ..tools import ApiController, AuthRequired, RESTController
 
 
 class PerfCounter(RESTController):
-    def __init__(self, service_type):
-        self._service_type = service_type
+    service_type = None  # type: str
 
     def _get_rate(self, daemon_type, daemon_name, stat):
         data = mgr.get_counter(daemon_type, daemon_name, stat)[stat]
@@ -22,8 +21,8 @@ class PerfCounter(RESTController):
         return 0
 
     def get(self, service_id):
-        schema_dict = mgr.get_perf_schema(self._service_type, str(service_id))
-        schema = schema_dict["{}.{}".format(self._service_type, service_id)]
+        schema_dict = mgr.get_perf_schema(self.service_type, str(service_id))
+        schema = schema_dict["{}.{}".format(self.service_type, service_id)]
         counters = []
 
         for key, value in sorted(schema.items()):
@@ -33,34 +32,61 @@ class PerfCounter(RESTController):
             # pylint: disable=W0212
             if mgr._stattype_to_str(value['type']) == 'counter':
                 counter['value'] = self._get_rate(
-                    self._service_type, service_id, key)
+                    self.service_type, service_id, key)
                 counter['unit'] = mgr._unit_to_str(value['units'])
             else:
                 counter['value'] = self._get_latest(
-                    self._service_type, service_id, key)
+                    self.service_type, service_id, key)
                 counter['unit'] = ''
             counters.append(counter)
 
         return {
             'service': {
-                'type': self._service_type,
-                'id': service_id
+                'type': self.service_type,
+                'id': str(service_id)
             },
             'counters': counters
         }
 
 
+@ApiController('perf_counters/mds')
+@AuthRequired()
+class MdsPerfCounter(PerfCounter):
+    service_type = 'mds'
+
+
+@ApiController('perf_counters/mon')
+@AuthRequired()
+class MonPerfCounter(PerfCounter):
+    service_type = 'mon'
+
+
+@ApiController('perf_counters/osd')
+@AuthRequired()
+class OsdPerfCounter(PerfCounter):
+    service_type = 'osd'
+
+
+@ApiController('perf_counters/rgw')
+@AuthRequired()
+class RgwPerfCounter(PerfCounter):
+    service_type = 'rgw'
+
+
+@ApiController('perf_counters/rbd-mirror')
+@AuthRequired()
+class RbdMirrorPerfCounter(PerfCounter):
+    service_type = 'rbd-mirror'
+
+
+@ApiController('perf_counters/mgr')
+@AuthRequired()
+class MgrPerfCounter(PerfCounter):
+    service_type = 'mgr'
+
+
 @ApiController('perf_counters')
 @AuthRequired()
 class PerfCounters(RESTController):
-    def __init__(self):
-        self.mds = PerfCounter('mds')
-        self.mon = PerfCounter('mon')
-        self.osd = PerfCounter('osd')
-        self.rgw = PerfCounter('rgw')
-        self.rbd_mirror = PerfCounter('rbd-mirror')
-        self.mgr = PerfCounter('mgr')
-
     def list(self):
-        counters = mgr.get_all_perf_counters()
-        return counters
+        return mgr.get_all_perf_counters()

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -22,9 +22,7 @@ class FooResource(RESTController):
         return data
 
     def get(self, key, *args, **kwargs):
-        if args:
-            return {'detail': (key, args)}
-        return FooResource.elems[int(key)]
+        return {'detail': (key, args)}
 
     def delete(self, key):
         del FooResource.elems[int(key)]
@@ -37,6 +35,7 @@ class FooResource(RESTController):
         return dict(key=key, **data)
 
 
+@ApiController('fooargs')
 class FooArgs(RESTController):
     @RESTController.args_from_json
     def set(self, code, name, opt1=None, opt2=None):
@@ -103,6 +102,12 @@ class RESTControllerTest(ControllerTestCase):
         self.assertJsonBody({'code': 'hello', 'name': 'world', 'opt1': None, 'opt2': 'opt2'})
 
     def test_detail_route(self):
+        self._get('/foo/default')
+        self.assertJsonBody({'detail': ['default', []]})
+
+        self._get('/foo/default/default')
+        self.assertJsonBody({'detail': ['default', ['default']]})
+
         self._get('/foo/1/detail')
         self.assertJsonBody({'detail': ['1', ['detail']]})
 

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -18,7 +18,7 @@ import cherrypy
 from six import add_metaclass
 
 from .settings import Settings
-from . import logger
+from . import logger, mgr
 
 
 def ApiController(path):
@@ -462,6 +462,18 @@ class RESTController(BaseController):
 
     @cherrypy.expose
     def default(self, *vpath, **params):
+        if cherrypy.request.path_info.startswith(
+                '{}/api/{}/default'.format(mgr.url_prefix, self._cp_path_)) or \
+                cherrypy.request.path_info.startswith('/{}/default'.format(self._cp_path_)):
+            # These two calls to default() are identical: `vpath` and
+            # params` are both empty:
+            # $ curl 'http://localhost/api/cp_path/'
+            # and
+            # $ curl 'http://localhost/api/cp_path/default'
+            # But we need to distinguish them. To fix this, we need
+            # to add the missing `default`
+            vpath = ['default'] + list(vpath)
+
         method, status_code = self._get_method(vpath)
 
         if cherrypy.request.method not in ['GET', 'DELETE']:


### PR DESCRIPTION
These two calls to `default()` are identical: `vpath` and `params` are both empty:

    $ curl 'http://localhost/api/cp_path/'

and

    $ curl 'http://localhost/api/cp_path/default'

But we need to distinguish them. To fix this, we need to add the missing `default`

Also, I had to slightly refactor `PerfCounters` in order to have a reliable `_cp_path_` property.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>