### PR TITLE
qa/tests: use ceph-deploy stable branch for single node tests

### DIFF
--- a/qa/suites/smoke/1node/tasks/ceph-deploy.yaml
+++ b/qa/suites/smoke/1node/tasks/ceph-deploy.yaml
@@ -4,4 +4,5 @@ meta:
    and verify all the cli works and cluster can reach
    HEALTH_OK state(implicty verifying the daemons via init).
 tasks:
-- ceph_deploy.single_node_test: null
+- ceph_deploy.single_node_test:
+    ceph-deploy-branch: '1.5.39-stable'


### PR DESCRIPTION
Signed-off-by: Vasu Kulkarni <vasu@redhat.com>