### PR TITLE
ceph_authtool: add mode option

### DIFF
--- a/doc/man/8/ceph-authtool.rst
+++ b/doc/man/8/ceph-authtool.rst
@@ -21,6 +21,7 @@ Synopsis
   [ -a | --add-key *base64_key* ]
   [ --cap *subsystem* *capability* ]
   [ --caps *capfile* ]
+  [ --mode *mode* ]
 
 
 Description
@@ -86,6 +87,10 @@ Options
 .. option:: --caps *capsfile*
 
    will set all of capabilities associated with a given key, for all subsystems
+
+ .. option:: --mode *mode*
+
+    will set the desired file mode to the keyring e.g: 0644, defaults to 0600
 
 
 Capabilities
@@ -174,9 +179,9 @@ value is the capability string (see above).
 Example
 =======
 
-To create a new keyring containing a key for client.foo::
+To create a new keyring containing a key for client.foo with a 0644 file mode::
 
-        ceph-authtool -C -n client.foo --gen-key keyring
+        ceph-authtool -C -n client.foo --gen-key keyring --mode 0644
 
 To associate some capabilities with the key (namely, the ability to
 mount a Ceph filesystem)::

--- a/src/test/cli/ceph-authtool/add-key-segv.t
+++ b/src/test/cli/ceph-authtool/add-key-segv.t
@@ -1,4 +1,4 @@
-  $ ceph-authtool kring --create-keyring
+  $ ceph-authtool kring --create-keyring --mode 0644
   creating kring
 
   $ ceph-authtool kring --add-key 'FAKEBASE64 foo'

--- a/src/test/cli/ceph-authtool/add-key.t
+++ b/src/test/cli/ceph-authtool/add-key.t
@@ -1,4 +1,4 @@
-  $ ceph-authtool kring --create-keyring
+  $ ceph-authtool kring --create-keyring --mode 0644
   creating kring
 
   $ ceph-authtool kring --add-key 'AQAK7yxNeF+nHBAA0SgSdbs8IkJrxroDeJ6SwQ== 18446744073709551615'

--- a/src/test/cli/ceph-authtool/cap-bin.t
+++ b/src/test/cli/ceph-authtool/cap-bin.t
@@ -1,4 +1,4 @@
-  $ ceph-authtool kring --create-keyring --gen-key
+  $ ceph-authtool kring --create-keyring --gen-key --mode 0644
   creating kring
 
   $ ceph-authtool --cap osd 'allow rx pool=swimming' kring

--- a/src/test/cli/ceph-authtool/cap-invalid.t
+++ b/src/test/cli/ceph-authtool/cap-invalid.t
@@ -1,4 +1,4 @@
-  $ ceph-authtool kring --create-keyring --gen-key
+  $ ceph-authtool kring --create-keyring --gen-key --mode 0644
   creating kring
 
 # TODO is this nice?

--- a/src/test/cli/ceph-authtool/cap-overwrite.t
+++ b/src/test/cli/ceph-authtool/cap-overwrite.t
@@ -1,4 +1,4 @@
-  $ ceph-authtool kring --create-keyring --gen-key
+  $ ceph-authtool kring --create-keyring --gen-key --mode 0644
   creating kring
 
   $ ceph-authtool --cap osd 'allow rx pool=swimming' kring

--- a/src/test/cli/ceph-authtool/cap.t
+++ b/src/test/cli/ceph-authtool/cap.t
@@ -1,4 +1,4 @@
-  $ ceph-authtool kring --create-keyring --gen-key
+  $ ceph-authtool kring --create-keyring --gen-key --mode 0644
   creating kring
 
   $ ceph-authtool --cap osd 'allow rx pool=swimming' kring

--- a/src/test/cli/ceph-authtool/create-gen-list-bin.t
+++ b/src/test/cli/ceph-authtool/create-gen-list-bin.t
@@ -1,4 +1,4 @@
-  $ ceph-authtool kring --create-keyring
+  $ ceph-authtool kring --create-keyring --mode 0600
   creating kring
 
   $ ceph-authtool kring --list
@@ -14,4 +14,3 @@
   $ ceph-authtool kring -l
   [client.admin]
   \\tkey = [a-zA-Z0-9+/]+=* \(esc\) (re)
-

--- a/src/test/cli/ceph-authtool/create-gen-list.t
+++ b/src/test/cli/ceph-authtool/create-gen-list.t
@@ -1,4 +1,4 @@
-  $ ceph-authtool kring --create-keyring
+  $ ceph-authtool kring --create-keyring --mode 0644
   creating kring
 
   $ ceph-authtool kring --list

--- a/src/test/cli/ceph-authtool/help.t
+++ b/src/test/cli/ceph-authtool/help.t
@@ -23,4 +23,6 @@
     --cap SUBSYSTEM CAPABILITY    will set the capability for given subsystem
     --caps CAPSFILE               will set all of capabilities associated with a
                                   given key, for all subsystems
+    --mode MODE                   will set the desired file mode to the keyring
+                                  e.g: '0644', defaults to '0600'
   [1]

--- a/src/test/cli/ceph-authtool/manpage.t
+++ b/src/test/cli/ceph-authtool/manpage.t
@@ -22,6 +22,8 @@
     --cap SUBSYSTEM CAPABILITY    will set the capability for given subsystem
     --caps CAPSFILE               will set all of capabilities associated with a
                                   given key, for all subsystems
+    --mode MODE                   will set the desired file mode to the keyring
+                                  e.g: '0644', defaults to '0600'
   [1]
 
 # demonstrate that manpage examples fail without config

--- a/src/test/cli/ceph-authtool/simple.t
+++ b/src/test/cli/ceph-authtool/simple.t
@@ -22,4 +22,6 @@
     --cap SUBSYSTEM CAPABILITY    will set the capability for given subsystem
     --caps CAPSFILE               will set all of capabilities associated with a
                                   given key, for all subsystems
+    --mode MODE                   will set the desired file mode to the keyring
+                                  e.g: '0644', defaults to '0600'
   [1]

--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -45,7 +45,9 @@ void usage()
        << "  -a BASE64, --add-key BASE64   will add an encoded key to the keyring\n"
        << "  --cap SUBSYSTEM CAPABILITY    will set the capability for given subsystem\n"
        << "  --caps CAPSFILE               will set all of capabilities associated with a\n"
-       << "                                given key, for all subsystems"
+       << "                                given key, for all subsystems\n"
+       << "  --mode MODE                   will set the desired file mode to the keyring\n"
+       << "                                e.g: '0644', defaults to '0600'"
        << std::endl;
   exit(1);
 }
@@ -72,6 +74,7 @@ int main(int argc, const char **argv)
   bool print_key = false;
   bool create_keyring = false;
   bool set_auid = false;
+  int mode = 0600; // keyring file mode
   std::vector<const char*>::iterator i;
 
   /* Handle options unique to ceph-authtool
@@ -118,6 +121,13 @@ int main(int argc, const char **argv)
 	exit(1);
       }
       set_auid = true;
+    } else if (ceph_argparse_witharg(args, i, &val, "--mode", (char*)NULL)) {
+      std::string err;
+      mode = strict_strtoll(val.c_str(), 8, &err);
+      if (!err.empty()) {
+        cerr << "Option --mode requires an argument" << std::endl;
+        exit(1);
+      }
     } else if (fn.empty()) {
       fn = *i++;
     } else {
@@ -298,7 +308,7 @@ int main(int argc, const char **argv)
   if (modified) {
     bufferlist bl;
     keyring.encode_plaintext(bl);
-    r = bl.write_file(fn.c_str(), 0600);
+    r = bl.write_file(fn.c_str(), mode);
     if (r < 0) {
       cerr << "could not write " << fn << std::endl;
       exit(1);


### PR DESCRIPTION
We now have the ability to set the keyring file mode with the help of
'--mode MODE'. The mode needs to be specified in octal using the format:
0600.

Closes: http://tracker.ceph.com/issues/23513
Signed-off-by: Sébastien Han <seb@redhat.com>