### PR TITLE
mgr/dashboard: Improve karma config to fix Chrome issue

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/karma.conf.js
+++ b/src/pybind/mgr/dashboard/frontend/karma.conf.js
@@ -34,7 +34,13 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['ChromeNoSandbox'],
+    customLaunchers: {
+      ChromeNoSandbox: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
     singleRun: false
   });
 };


### PR DESCRIPTION
This improvement will fix the error message:
```
21 03 2018 09:59:29.186:ERROR [launcher]: Cannot start Chrome [19871:19871:0321/095929.160854:ERROR:zygote_host_impl_linux.cc(90)] Running as root without --no-sandbox is not supported. See https://crbug.com/638180.
```

Signed-off-by: Volker Theile <vtheile@suse.com>