### PR TITLE
mgr/dashboard: Improve `npm start` script

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -45,7 +45,7 @@ Setting up a Development Server
 
 Create the ``proxy.conf.json`` file based on ``proxy.conf.json.sample``.
 
-Run ``npm start -- --proxy-config proxy.conf.json`` for a dev server.
+Run ``npm start`` for a dev server.
 Navigate to ``http://localhost:4200/``. The app will automatically
 reload if you change any of the source files.
 

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --delete-output-path false",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --delete-output-path false",
+    "start": "ng serve --delete-output-path false --proxy-config proxy.conf.json",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
Currently the vstart cluster will fail to start after we execute `npm start` during the frontend development, because `ng serve` deletes the frontend assets directory.

This PR will prevent `ng serve` fom deleting the `dist` directory and also simplify the `npm start` comand 