### PR TITLE
Luminous

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -759,7 +759,7 @@ int FileStore::dump_journal(ostream& out)
   return r;
 }
 
-FileStoreBackend *FileStoreBackend::create(long f_type, FileStore *fs)
+FileStoreBackend *FileStoreBackend::create(unsigned long f_type, FileStore *fs)
 {
   switch (f_type) {
 #if defined(__linux__)
@@ -779,7 +779,7 @@ FileStoreBackend *FileStoreBackend::create(long f_type, FileStore *fs)
   }
 }
 
-void FileStore::create_backend(long f_type)
+void FileStore::create_backend(unsigned long f_type)
 {
   m_fs_type = f_type;
 

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -57,13 +57,13 @@ using namespace std;
 
 #if defined(__linux__)
 # ifndef BTRFS_SUPER_MAGIC
-#define BTRFS_SUPER_MAGIC 0x9123683EL
+#define BTRFS_SUPER_MAGIC 0x9123683EUL
 # endif
 # ifndef XFS_SUPER_MAGIC
-#define XFS_SUPER_MAGIC 0x58465342L
+#define XFS_SUPER_MAGIC 0x58465342UL
 # endif
 # ifndef ZFS_SUPER_MAGIC
-#define ZFS_SUPER_MAGIC 0x2fc12fc1L
+#define ZFS_SUPER_MAGIC 0x2fc12fc1UL
 # endif
 #endif
 
@@ -165,7 +165,7 @@ private:
 
   FileStoreBackend *backend;
 
-  void create_backend(long f_type);
+  void create_backend(unsigned long f_type);
 
   deque<uint64_t> snaps;
 
@@ -783,7 +783,7 @@ private:
   bool m_filestore_sloppy_crc;
   int m_filestore_sloppy_crc_block_size;
   uint64_t m_filestore_max_alloc_hint_size;
-  long m_fs_type;
+  unsigned long m_fs_type;
 
   //Determined xattr handling based on fs type
   void set_xattr_limits_via_conf();
@@ -863,7 +863,7 @@ public:
     return filestore->cct;
   }
 
-  static FileStoreBackend *create(long f_type, FileStore *fs);
+  static FileStoreBackend *create(unsigned long f_type, FileStore *fs);
 
   virtual const char *get_name() = 0;
   virtual int detect_features() = 0;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3808,7 +3808,7 @@ int RGWRados::init_rados()
     }
   }
 
-  auto handles = std::vector<librados::Rados>{cct->_conf->rgw_num_rados_handles};
+  auto handles = std::vector<librados::Rados>{static_cast<size_t>(cct->_conf->rgw_num_rados_handles)};
 
   for (auto& r : handles) {
     ret = r.init_with_context(cct);

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -893,7 +893,7 @@ int BucketTrimPollCR::operate()
   reenter(this) {
     for (;;) {
       set_status("sleeping");
-      wait(utime_t{config.trim_interval_sec, 0});
+      wait(utime_t{static_cast<time_t>(config.trim_interval_sec), 0});
 
       // prevent others from trimming for our entire wait interval
       set_status("acquiring trim lock");

--- a/src/test/filestore/TestFileStore.cc
+++ b/src/test/filestore/TestFileStore.cc
@@ -21,7 +21,7 @@
 
 class TestFileStore {
 public:
-  static void create_backend(FileStore &fs, long f_type) {
+  static void create_backend(FileStore &fs, unsigned long f_type) {
     fs.create_backend(f_type);
   }
 };


### PR DESCRIPTION
I fixed a few type bugs that arose when compiling ceph using clang on 32-bit ARM by executing ./make-debs. They get hidden when building on 64-bit platforms due to the larger long type.

I'm not sure if the bugs break the things with GCC, but GGC itself seems to be broken, since it eats up all the VMEM during compile and breaks much earlier (see my [Bug-Report](http://tracker.ceph.com/issues/23387)). So I was forced to use Clang to get it somehow compiled.