### PR TITLE
os/bluestore: fix exceeding the max IO queue depth in KernelDevice.

### DIFF
--- a/src/os/bluestore/aio.cc
+++ b/src/os/bluestore/aio.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <algorithm>
 #include "aio.h"
 
 std::ostream& operator<<(std::ostream& os, const aio_t& aio)
@@ -34,7 +35,7 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
   assert(aios_size >= left);
   int done = 0;
   while (left > 0) {
-    int r = io_submit(ctx, left, piocb + done);
+    int r = io_submit(ctx, std::min(left, max_iodepth), piocb + done);
     if (r < 0) {
       if (r == -EAGAIN && attempts-- > 0) {
 	usleep(delay);
@@ -47,6 +48,8 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
     assert(r > 0);
     done += r;
     left -= r;
+    attempts = 16;
+    delay = 125;
   }
   return done;
 }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23246
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>