### PR TITLE
client: fix Client::_read return

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8788,7 +8788,6 @@ retry:
       uninline_data(in, onuninline.get());
     } else {
       uint32_t len = in->inline_data.length();
-
       uint64_t endoff = offset + size;
       if (endoff > in->size)
         endoff = in->size;
@@ -8803,7 +8802,7 @@ retry:
       } else if ((uint64_t)offset < endoff) {
         bl->append_zero(endoff - offset);
       }
-
+      r = endoff - offset;
       goto success;
     }
   }


### PR DESCRIPTION
when reading from inline data, it return 0. introduced by commit
608aafb9 "client: cleanup ::_read return"

Fixes: http://tracker.ceph.com/issues/23436
Signed-off-by: Yan, Zheng <zyan@redhat.com>