### PR TITLE
mgr/dashboard: skip data pool testcase for none-bluestore clusters

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1955,6 +1955,14 @@ class CephManager:
         """
         return self.get_osd_dump_json()['osds']
 
+    def get_osd_metadata(self):
+        """
+        osd metadata --format=json converted to a python object
+        :returns: the python object containing osd metadata information
+        """
+        out = self.raw_cluster_cmd('osd', 'metadata', '--format=json')
+        return json.loads('\n'.join(out.split('\n')[1:]))
+
     def get_mgr_dump(self):
         out = self.raw_cluster_cmd('mgr', 'dump', '--format=json')
         return json.loads(out)


### PR DESCRIPTION
This pull request enhances the 'test_create_rbd_in_data_pool' test case so that it won't always be skipped. It will only be skipped if the cluster does not support bluestore.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>