### PR TITLE
mgr: fixes python error handling

### DIFF
--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -40,10 +40,30 @@ std::string handle_pyerror()
     object traceback(import("traceback"));
     if (!tb) {
         object format_exception_only(traceback.attr("format_exception_only"));
-        formatted_list = format_exception_only(hexc, hval);
+        try {
+          formatted_list = format_exception_only(hexc, hval);
+        } catch (error_already_set const &) {
+          // error while processing exception object
+          // returning only the exception string value
+          PyObject *name_attr = PyObject_GetAttrString(exc, "__name__");
+          std::stringstream ss;
+          ss << PyString_AsString(name_attr) << ": " << PyString_AsString(val);
+          Py_XDECREF(name_attr);
+          return ss.str();
+        }
     } else {
         object format_exception(traceback.attr("format_exception"));
-        formatted_list = format_exception(hexc,hval, htb);
+        try {
+          formatted_list = format_exception(hexc, hval, htb);
+        } catch (error_already_set const &) {
+          // error while processing exception object
+          // returning only the exception string value
+          PyObject *name_attr = PyObject_GetAttrString(exc, "__name__");
+          std::stringstream ss;
+          ss << PyString_AsString(name_attr) << ": " << PyString_AsString(val);
+          Py_XDECREF(name_attr);
+          return ss.str();
+        }
     }
     formatted = str("").join(formatted_list);
     return extract<std::string>(formatted);


### PR DESCRIPTION
The current `handle_pyerror` function implementation relies in the
`traceback.format_exception_only` python function to format the
exception object. The problem is that this python function might also
raise an exception. This commit fixes it by enclosing that python
function call in try...catch block.

Fixes: http://tracker.ceph.com/issues/23406

Signed-off-by: Ricardo Dias <rdias@suse.com>