### PR TITLE
vstart: set osd_pool_default_erasure_code_profile in initial ceph.conf

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -522,6 +522,7 @@ $DAEMONOPTS
 $CMONDEBUG
 $extra_conf
         mon cluster log file = $CEPH_OUT_DIR/cluster.mon.\$id.log
+        osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd
 EOF
 }
 
@@ -860,7 +861,6 @@ mon_pg_warn_min_per_osd = 3
 mon_osd_reporter_subtree_level = osd
 mon_data_avail_warn = 2
 mon_data_avail_crit = 1
-osd_pool_default_erasure_code_profile = plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd
 mon_allow_pool_delete = true
 
 [osd]


### PR DESCRIPTION
Setting it via `ceph config`, when the cluster is already built and
started is too late, because it is used when building the initial osd
map.

Fixes: https://tracker.ceph.com/issues/23430
Signed-off-by: Mykola Golub <mgolub@suse.com>