### PR TITLE
rados: fix error message for cache(-try)-flush-evict-all commands

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -3499,8 +3499,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       usage_exit();
     ret = do_cache_flush_evict_all(io_ctx, true);
     if (ret < 0) {
-      cerr << "error from cache-flush-evict-all: "
-	   << cpp_strerror(ret) << std::endl;
+      cerr << "cache-flush-evict-all finished with errors" << std::endl;
       goto out;
     }
   } else if (strcmp(nargs[0], "cache-try-flush-evict-all") == 0) {
@@ -3508,8 +3507,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       usage_exit();
     ret = do_cache_flush_evict_all(io_ctx, false);
     if (ret < 0) {
-      cerr << "error from cache-try-flush-evict-all: "
-	   << cpp_strerror(ret) << std::endl;
+      cerr << "cache-try-flush-evict-all finished with errors" << std::endl;
       goto out;
     }
   } else if (strcmp(nargs[0], "set-redirect") == 0) {


### PR DESCRIPTION
do_cache_flush_evict_all returns -1 on an error, not an error code.
The actual error is printed by do_cache_flush_evict_all for every
failed object.

Signed-off-by: Mykola Golub <mgolub@suse.com>