### PR TITLE
test: Replace bc command with printf command

### DIFF
--- a/qa/standalone/scrub/osd-recovery-scrub.sh
+++ b/qa/standalone/scrub/osd-recovery-scrub.sh
@@ -65,7 +65,7 @@ function TEST_recovery_scrub() {
     pids=""
     for pg in $(seq 0 $(expr $PGS - 1))
     do
-        run_in_background pids pg_scrub $poolid.$(echo "{ obase=16; $pg }" | bc | tr '[:upper:]' '[:lower:]')
+        run_in_background pids pg_scrub $poolid.$(printf "%x" $pg)
     done
     ceph pg dump pgs
     wait_background pids


### PR DESCRIPTION
The bc command is not part of install-deps.sh and printf command works even better.