### PR TITLE
osd: remove duplicated "commit_queued_for_journal_write" in OpTracker

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1609,8 +1609,6 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
   assert(e.length() > 0);
   assert(e.length() < header.max_size);
 
-  if (osd_op)
-    osd_op->mark_event("commit_queued_for_journal_write");
   if (logger) {
     logger->inc(l_filestore_journal_queue_bytes, orig_len);
     logger->inc(l_filestore_journal_queue_ops, 1);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23440

Signed-off-by: ashitakasam <694240887@qq.com>