### PR TITLE
stop.sh: use --no-mon-config when trying to unmap rbd devices

### DIFF
--- a/src/stop.sh
+++ b/src/stop.sh
@@ -80,8 +80,8 @@ while [ $# -ge 1 ]; do
 done
 
 if [ $stop_all -eq 1 ]; then
-    if "${CEPH_BIN}"/rbd device list -c $conf_fn >/dev/null 2>&1; then
-        "${CEPH_BIN}"/rbd device list -c $conf_fn | tail -n +2 |
+    if "${CEPH_BIN}"/rbd device list -c $conf_fn --no-mon-config >/dev/null 2>&1; then
+        "${CEPH_BIN}"/rbd device list -c $conf_fn --no-mon-config | tail -n +2 |
         while read DEV; do
             # While it is currently possible to create an rbd image with
             # whitespace chars in its name, krbd will refuse mapping such
@@ -89,10 +89,10 @@ if [ $stop_all -eq 1 ]; then
             # same goes for whitespace chars in names of the pools that
             # contain rbd images).
             DEV="$(echo "${DEV}" | tr -s '[:space:]' | awk '{ print $5 }')"
-            sudo "${CEPH_BIN}"/rbd device unmap "${DEV}" -c $conf_fn
+            sudo "${CEPH_BIN}"/rbd device unmap "${DEV}" -c $conf_fn --no-mon-config
         done
 
-        if [ -n "$("${CEPH_BIN}"/rbd device list -c $conf_fn)" ]; then
+	if [ -n "$("${CEPH_BIN}"/rbd device list -c $conf_fn --no-mon-config)" ]; then
             echo "WARNING: Some rbd images are still mapped!" >&2
         fi
     fi


### PR DESCRIPTION
Otherwise if stop.sh is run for already stopped cluster it will get
stuck trying to get mon config.

Signed-off-by: Mykola Golub <mgolub@suse.com>