### PR TITLE
qa/tasks/mgr/dashboard: Fix login expires too soon

### DIFF
--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -10,7 +10,6 @@ from .helper import DashboardTestCase
 class AuthTest(DashboardTestCase):
     def setUp(self):
         self.reset_session()
-        self._ceph_cmd(['dashboard', 'set-session-expire', '2'])
         self._ceph_cmd(['dashboard', 'set-login-credentials', 'admin', 'admin'])
 
     def test_a_set_login_credentials(self):
@@ -60,6 +59,7 @@ class AuthTest(DashboardTestCase):
         self.assertStatus(401)
 
     def test_session_expire(self):
+        self._ceph_cmd(['dashboard', 'set-session-expire', '2'])
         self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
         self.assertStatus(201)
         self._get("/api/host")
@@ -67,6 +67,7 @@ class AuthTest(DashboardTestCase):
         time.sleep(3)
         self._get("/api/host")
         self.assertStatus(401)
+        self._ceph_cmd(['dashboard', 'set-session-expire', '1200'])
 
     def test_unauthorized(self):
         self._get("/api/host")


### PR DESCRIPTION
Change `set-session-expire` back to original value running `test_session_expire`.

This fixes:
```
======================================================================
FAIL: test_create (tasks.mgr.dashboard.test_rbd.RbdTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/sebastian/Repos/ceph/qa/tasks/mgr/dashboard/helper.py", line 23, in decorate
    return func(self, *args, **kwargs)
  File "/home/sebastian/Repos/ceph/qa/tasks/mgr/dashboard/test_rbd.py", line 58, in test_create
    self.assertStatus(200)
  File "/home/sebastian/Repos/ceph/qa/tasks/mgr/dashboard/helper.py", line 119, in assertStatus
    self.assertEqual(self._resp.status_code, status)
AssertionError: 401 != 200
```

Relates to #20865

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>