### PR TITLE
test: delete asok directories correctly

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -80,7 +80,7 @@ function run() {
     fi
  
     if ! $DRY_RUN ctest $CHECK_MAKEOPTS --output-on-failure; then
-        rm -f ${TMPDIR:-/tmp}/ceph-asok.*
+        rm -fr ${TMPDIR:-/tmp}/ceph-asok.*
         return 1
     fi
 }


### PR DESCRIPTION
```
+ rm -f /tmp/ceph-asok.20394 /tmp/ceph-asok.3933
rm: cannot remove '/tmp/ceph-asok.20394': Is a directory
rm: cannot remove '/tmp/ceph-asok.3933': Is a directory
```
Signed-off-by: Chang Liu <liuchang0812@gmail.com>