### PR TITLE
mgr/dashboard: Convert the RBD feature names to a list of strings

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -33,7 +33,7 @@ class RbdTest(DashboardTestCase):
         self.assertEqual(img1['num_objs'], 256)
         self.assertEqual(img1['obj_size'], 4194304)
         self.assertEqual(img1['features_name'],
-                         'deep-flatten, exclusive-lock, fast-diff, layering, object-map')
+                         ['deep-flatten', 'exclusive-lock', 'fast-diff', 'layering', 'object-map'])
 
         img2 = data['value'][1]
         self.assertEqual(img2['name'], 'img2')
@@ -41,7 +41,7 @@ class RbdTest(DashboardTestCase):
         self.assertEqual(img2['num_objs'], 512)
         self.assertEqual(img2['obj_size'], 4194304)
         self.assertEqual(img2['features_name'],
-                         'deep-flatten, exclusive-lock, fast-diff, layering, object-map')
+                         ['deep-flatten', 'exclusive-lock', 'fast-diff', 'layering', 'object-map'])
 
     @authenticate
     def test_create(self):
@@ -63,7 +63,8 @@ class RbdTest(DashboardTestCase):
                 self.assertEqual(rbd['num_objs'], 1)
                 self.assertEqual(rbd['obj_size'], 4194304)
                 self.assertEqual(rbd['features_name'],
-                                 'deep-flatten, exclusive-lock, fast-diff, layering, object-map')
+                                 ['deep-flatten', 'exclusive-lock', 'fast-diff', 'layering',
+                                  'object-map'])
                 break
 
     # TODO: Re-enable this test for bluestore cluster by figuring out how to skip none-bluestore
@@ -93,8 +94,9 @@ class RbdTest(DashboardTestCase):
                 self.assertEqual(rbd['size'], 10240)
                 self.assertEqual(rbd['num_objs'], 1)
                 self.assertEqual(rbd['obj_size'], 4194304)
-                self.assertEqual(rbd['features_name'], 'data-pool, deep-flatten, exclusive-lock, '
-                                                       'fast-diff, layering, object-map')
+                self.assertEqual(rbd['features_name'],
+                                 ['data-pool', 'deep-flatten', 'exclusive-lock', 'fast-diff',
+                                  'layering', 'object-map'])
                 break
 
         self._ceph_cmd(['osd', 'pool', 'delete', 'data_pool', 'data_pool',

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -34,11 +34,11 @@ class Rbd(RESTController):
         Formats the bitmask:
 
         >>> Rbd._format_bitmask(45)
-        'deep-flatten, exclusive-lock, layering, object-map'
+        ['deep-flatten', 'exclusive-lock', 'layering', 'object-map']
         """
         names = [val for key, val in Rbd.RBD_FEATURES_NAME_MAPPING.items()
                  if key & features == key]
-        return ', '.join(sorted(names))
+        return sorted(names)
 
     @staticmethod
     def _format_features(features):


### PR DESCRIPTION
Until now the API returns the features provided by an RBD as one comma separated string. It's more usable for the frontend to receive a list of strings instead.

Signed-off-by: Tatjana Dehler <tdehler@suse.com>