### PR TITLE
osd: avoid unnecessary ref-counting across PrimaryLogPG::get_rw_locks.

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -13846,11 +13846,12 @@ bool PrimaryLogPG::agent_maybe_evict(ObjectContextRef& obc, bool after_flush)
   dout(10) << __func__ << " evicting " << obc->obs.oi << dendl;
   OpContextUPtr ctx = simple_opc_create(obc);
 
+  auto null_op_req = OpRequestRef();
   if (!ctx->lock_manager.get_lock_type(
 	ObjectContext::RWState::RWWRITE,
 	obc->obs.oi.soid,
 	obc,
-	OpRequestRef())) {
+	null_op_req)) {
     close_op_ctx(ctx.release());
     dout(20) << __func__ << " skip (cannot get lock) " << obc->obs.oi << dendl;
     return false;


### PR DESCRIPTION
Profiling in the domain of `MEM_INST_RETIRED.LOCK_LOADS`
-------------------------------------------------------------------------------------

### Before
```
Samples: 14K of event 'r21d0:pp', Event count (approx.): 4456165
  Children      Self  Command    Shared Object         Symbol                                    ◆
-   96,87%     0,00%  tp_osd_tp  [unknown]             [.] 0xffffffffffffffff                    ▒
   - 0xffffffffffffffff                                                                          ▒
      - 96,63% __clone                                                                           ▒
           start_thread                                                                          ▒
           ShardedThreadPool::WorkThreadSharded::entry                                           ▒
         - ShardedThreadPool::shardedthreadpool_worker                                           ▒
            - 96,63% OSD::ShardedOpWQ::_process                                                  ▒
               - 83,66% PGOpItem::run                                                            ▒
                  - 80,40% OSD::dequeue_op                                                       ▒
                     - 74,94% PrimaryLogPG::do_request                                           ▒
                        - 71,45% PrimaryLogPG::do_op                                             ▒
                           + 48,71% PrimaryLogPG::execute_ctx                                    ▒
                           - 3,92% PrimaryLogPG::get_rw_locks                                    ▒
                              - 2,75% ObcLockManager::get_lock_type                              ▒
                                   0,91% TrackedOp::put                                          ▒
                                   0,63% std::__shared_ptr<ObjectContext, (__gnu_cxx::_Lock_polic▒
```

### After
```
Samples: 16K of event 'r21d0:pp', Event count (approx.): 4709977
  Children      Self  Command    Shared Object         Symbol                                    ◆
-   96,66%     0,00%  tp_osd_tp  [unknown]             [.] 0xffffffffffffffff                    ▒
   - 0xffffffffffffffff                                                                          ▒
      - 96,43% __clone                                                                           ▒
           start_thread                                                                          ▒
           ShardedThreadPool::WorkThreadSharded::entry                                           ▒
         - ShardedThreadPool::shardedthreadpool_worker                                           ▒
            - 96,42% OSD::ShardedOpWQ::_process                                                  ▒
               - 79,22% PGOpItem::run                                                            ▒
                  - 76,34% OSD::dequeue_op                                                       ▒
                     - 71,06% PrimaryLogPG::do_request                                           ▒
                        - 67,74% PrimaryLogPG::do_op                                             ▒
                           + 47,47% PrimaryLogPG::execute_ctx                                    ▒
                           + 2,63% std::__cxx11::basic_ostringstream<char, std::char_traits<char>▒
                           + 2,03% PrimaryLogPG::find_object_context                             ▒
                           + 1,78% Throttle::put                                                 ▒
                             1,66% PerfCounters::tinc                                            ▒
                             1,27% PG::op_has_sufficient_caps                                    ▒
                             1,20% TrackedOp::put                                                ▒
                             1,13% std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release ▒
                           + 1,08% PrimaryLogPG::maybe_await_blocked_head                        ▒
                             0,94% Connection::get_priv                                          ▒
                           + 0,92% ceph::buffer::list::clear                                     ▒
                             0,62% PrimaryLogPG::OpContext::OpContext                            ▒
                           + 0,56% MOSDOp::finish_decode                                         ▒
                           + 0,55% OpRequest::mark_flag_point    
```

The `PrimaryLogPG::get_rw_locks` isn't exposed in the list above as it went under the 0.5% threshold.
Let's search for it:

```
Samples: 16K of event 'r21d0:pp', Event count (approx.): 4709977
  Children      Self  Command    Shared O  Symbol                                                ◆
     0,29%     0,00%  tp_osd_tp  ceph-osd  [.] PrimaryLogPG::get_rw_locks
```


Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>