### PR TITLE
osd: don't memcpy hobject_t in PrimaryLogPG::close_op_ctx().

### DIFF
--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -814,7 +814,7 @@ protected:
    */
   void release_object_locks(
     ObcLockManager &lock_manager) {
-    list<pair<hobject_t, list<OpRequestRef> > > to_req;
+    list<pair<ObjectContextRef, list<OpRequestRef> > > to_req;
     bool requeue_recovery = false;
     bool requeue_snaptrim = false;
     lock_manager.put_locks(
@@ -829,7 +829,7 @@ protected:
     if (!to_req.empty()) {
       // requeue at front of scrub blocking queue if we are blocked by scrub
       for (auto &&p: to_req) {
-	if (write_blocked_by_scrub(p.first.get_head())) {
+	if (write_blocked_by_scrub(p.first->obs.oi.soid.get_head())) {
           for (auto& op : p.second) {
             op->mark_delayed("waiting for scrub");
           }

--- a/src/osd/osd_internal_types.h
+++ b/src/osd/osd_internal_types.h
@@ -434,10 +434,10 @@ public:
   }
 
   void put_locks(
-    list<pair<hobject_t, list<OpRequestRef> > > *to_requeue,
+    list<pair<ObjectContextRef, list<OpRequestRef> > > *to_requeue,
     bool *requeue_recovery,
     bool *requeue_snaptrimmer) {
-    for (auto p: locks) {
+    for (auto& p: locks) {
       list<OpRequestRef> _to_requeue;
       p.second.obc->put_lock_type(
 	p.second.type,
@@ -445,10 +445,10 @@ public:
 	requeue_recovery,
 	requeue_snaptrimmer);
       if (to_requeue) {
-	to_requeue->push_back(
-	  make_pair(
-	    p.second.obc->obs.oi.soid,
-	    std::move(_to_requeue)));
+        // We can safely std::move here as the whole `locks` is going
+        // to die just after the loop.
+	to_requeue->emplace_back(std::move(p.second.obc),
+				 std::move(_to_requeue));
       }
     }
     locks.clear();


### PR DESCRIPTION
Summary
------------
Small but cheap modification to save some cycles spent just on copying `hobject_t` instances multiple times.

Profiling in the cycles domain
---------------------------------------
### Before
```
Samples: 14K of event 'r01c0:pp', Event count (approx.): 680008887
  Children      Self  Command    Shared Object         Symbol                                    ◆
-   79,50%     0,07%  tp_osd_tp  libceph-common.so.0   [.] ShardedThreadPool::shardedthreadpool_w▒
   - 79,44% ShardedThreadPool::shardedthreadpool_worker                                          ▒
      - 79,26% OSD::ShardedOpWQ::_process                                                        ▒
         - 64,02% PGOpItem::run                                                                  ▒
            - 61,40% OSD::dequeue_op                                                             ▒
               - 59,98% PrimaryLogPG::do_request                                                 ▒
                  - 58,57% PrimaryLogPG::do_op                                                   ▒
                     - 42,12% PrimaryLogPG::execute_ctx                                          ▒
                        + 28,64% PrimaryLogPG::prepare_transaction                               ▒
                        + 7,36% PrimaryLogPG::complete_read_ctx                                  ▒
                        - 2,25% PrimaryLogPG::close_op_ctx                                       ▒
                             1,80% PrimaryLogPG::release_object_locks                            ▒
```

### After

#### Commit 2c30b7b6420fb6808d24f0392b8f2e3409ec9c45
```
-   80,10%     0,05%  tp_osd_tp  libceph-common.so.0   [.] ShardedThreadPool::shardedthreadpool_w▒
   - 80,04% ShardedThreadPool::shardedthreadpool_worker                                          ▒
      - 79,94% OSD::ShardedOpWQ::_process                                                        ▒
         - 63,50% PGOpItem::run                                                                  ▒
            - 61,10% OSD::dequeue_op                                                             ▒
               - 59,81% PrimaryLogPG::do_request                                                 ▒
                  - 58,59% PrimaryLogPG::do_op                                                   ▒
                     - 41,89% PrimaryLogPG::execute_ctx                                          ▒
                        + 29,75% PrimaryLogPG::prepare_transaction                               ▒
                        + 7,35% PrimaryLogPG::complete_read_ctx                                  ▒
                        - 1,09% PrimaryLogPG::close_op_ctx                                       ▒
                             0,63% PrimaryLogPG::release_object_locks                            ▒
```

#### Commit 3f3f8a15cb7fb6b99693d1c607b4bdd5acb89432
```
Samples: 13K of event 'r01c0:pp', Event count (approx.): 579225284
  Children      Self  Command    Shared Object         Symbol                                    ◆
-   79,41%     0,08%  tp_osd_tp  libceph-common.so.0   [.] ShardedThreadPool::shardedthreadpool_w▒
   - 79,33% ShardedThreadPool::shardedthreadpool_worker                                          ▒
      - 79,16% OSD::ShardedOpWQ::_process                                                        ▒
         - 65,75% PGOpItem::run                                                                  ▒
            - 63,05% OSD::dequeue_op                                                             ▒
               - 61,62% PrimaryLogPG::do_request                                                 ▒
                  - 60,26% PrimaryLogPG::do_op                                                   ▒
                     - 42,96% PrimaryLogPG::execute_ctx                                          ▒
                        + 30,32% PrimaryLogPG::prepare_transaction                               ▒
                        + 7,25% PrimaryLogPG::complete_read_ctx                                  ▒
                        - 1,45% PrimaryLogPG::close_op_ctx                                       ▒
                             0,97% PrimaryLogPG::release_object_locks                            ▒
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>