### PR TITLE
os/bluestore: BlueFS::FileWriter uses huge pages to limit page faults.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -557,6 +557,7 @@ set(libcommon_files
   common/hostname.cc
   common/util.cc
   common/PriorityCache.cc
+  common/huge_page_pool.cc
   librbd/Features.cc
   arch/probe.cc
   ${auth_files}

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -34,6 +34,7 @@
 #include "common/Timer.h"
 #include "common/TracepointProvider.h"
 #include "common/ceph_argparse.h"
+#include "common/huge_page_pool.h"
 
 #include "global/global_init.h"
 #include "global/signal_handler.h"
@@ -246,6 +247,8 @@ int main(int argc, const char **argv)
     }
     forker.exit(0);
   }
+
+  ceph_init_huge_page_pools(g_conf);
 
   // whoami
   char *end;

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -282,8 +282,8 @@ using namespace ceph;
     MEMPOOL_CLASS_HELPERS();
 
     raw_huge_pages(const unsigned l)
-      : raw(p2roundup(l, ceph::huge_page_pool<64>::huge_page_size)) {
-      data = (char*)ceph::huge_page_pool<64>::get_instance().get_page();
+      : raw(p2roundup(l, ceph::huge_page_pool::huge_page_size)) {
+      data = (char*)ceph_get_huge_page_pool().get_page();
       if (!data) {
         const int r = ::posix_memalign((void**)(void*)&data,
 				       CEPH_PAGE_SIZE, len);
@@ -299,13 +299,13 @@ using namespace ceph;
 
       bdout << "raw_huge_pages " << this << " alloc " << (void *)data
 	    << " l=" << l << ", align="
-	    << ceph::huge_page_pool<64>::huge_page_size
+	    << ceph::huge_page_pool::huge_page_size
 	    << " total_alloc=" << buffer::get_total_alloc() << bendl;
     }
 
     ~raw_huge_pages() override {
       if (is_hugepage) {
-        ceph::huge_page_pool<64>::get_instance().put_page(data);
+        ceph_get_huge_page_pool().put_page(data);
       } else {
 	free(data);
       }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -282,7 +282,7 @@ using namespace ceph;
     MEMPOOL_CLASS_HELPERS();
 
     raw_huge_pages(const unsigned l)
-      : raw(p2roundup(l, ceph::huge_page_pool::huge_page_size)) {
+      : raw(p2roundup(l, ceph_get_huge_page_pool().get_size())) {
       data = (char*)ceph_get_huge_page_pool().get_page();
       if (!data) {
         const int r = ::posix_memalign((void**)(void*)&data,
@@ -299,7 +299,7 @@ using namespace ceph;
 
       bdout << "raw_huge_pages " << this << " alloc " << (void *)data
 	    << " l=" << l << ", align="
-	    << ceph::huge_page_pool::huge_page_size
+	    << ceph_get_huge_page_pool().get_size()
 	    << " total_alloc=" << buffer::get_total_alloc() << bendl;
     }
 

--- a/src/common/containers.h
+++ b/src/common/containers.h
@@ -1,0 +1,145 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+//
+// Ceph - scalable distributed file system
+//
+// Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+//
+// This is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License version 2.1, as published by the Free Software
+// Foundation.  See file COPYING.
+//
+
+#ifndef CEPH_COMMON_CONTAINERS_H
+#define CEPH_COMMON_CONTAINERS_H
+
+#include <type_traits>
+
+namespace ceph::containers {
+
+// tiny_vector - a CPU-friendly container like small_vector but for
+// mutexes, atomics and other non-movable things.
+//
+// The purpose of the container is store arbitrary number of objects
+// with absolutely minimal requirements regarding constructibility
+// and assignability while minimizing memory indirection.
+// There is no obligation for MoveConstructibility, CopyConstructibility,
+// MoveAssignability, CopyAssignability nor even DefaultConstructibility
+// which allows to handle std::mutexes, std::atomics or any type embedding
+// them.
+//
+// Few requirements translate into tiny interface. The container isn't
+// Copy- nor MoveConstructible. Although it does offer random access
+// iterator, insertion in the middle is not allowed. The maximum number
+// of elements must be known at run-time. This shouldn't be an issue in
+// the intended use case: sharding.
+//
+// Alternatives:
+//  1. std::vector<boost::optional<ValueT>> initialized with the known
+//     size and emplace_backed(). boost::optional inside provides
+//     the DefaultConstructibility. Imposes extra memory indirection.
+//  2. boost::container::small_vector + boost::optional always
+//     requires MoveConstructibility.
+//  3. boost::container::static_vector feed via emplace_back().
+//     Good for performance but enforces upper limit on elements count.
+//     For sharding this means we can't handle arbitrary number of
+//     shards (weird configs).
+//  4. std::unique_ptr<ValueT>: extra indirection together with memory
+//     fragmentation.
+
+template<typename Value, std::size_t Capacity>
+class tiny_vector {
+  using storage_unit_t = \
+    std::aligned_storage_t<sizeof(Value), alignof(Value)>;
+
+  std::size_t _size = 0;
+  storage_unit_t* const data = nullptr;
+  storage_unit_t internal[Capacity];
+
+public:
+  typedef std::size_t size_type;
+  typedef std::add_lvalue_reference_t<Value> reference;
+  typedef std::add_const_t<reference> const_reference;
+  typedef std::add_pointer_t<Value> pointer;
+
+  class emplacer {
+    friend class tiny_vector;
+
+    tiny_vector* parent;
+    emplacer(tiny_vector* const parent)
+      : parent(parent) {
+    }
+
+  public:
+    template<class... Args>
+    void emplace(Args&&... args) {
+      if (!parent) {
+        return;
+      }
+      new (&parent->data[parent->_size++]) Value(std::forward<Args>(args)...);
+      parent = nullptr;
+    }
+  };
+
+  template<typename F>
+  tiny_vector(const std::size_t count, F&& f)
+    : data(count <= Capacity ? internal
+                             : new storage_unit_t[count]) {
+    for (std::size_t i = 0; i < count; ++i) {
+      // caller MAY emplace up to `count` elements but it IS NOT
+      // obliged to do so. The emplacer guarantees that the limit
+      // will never be exceeded.
+      f(i, emplacer(this));
+    }
+  }
+
+  ~tiny_vector() {
+    for (auto& elem : *this) {
+      elem.~Value();
+    }
+
+    const auto data_addr = reinterpret_cast<uintptr_t>(data);
+    const auto this_addr = reinterpret_cast<uintptr_t>(this);
+    if (data_addr < this_addr ||
+        data_addr >= this_addr + sizeof(*this)) {
+      delete[] data;
+    }
+  }
+
+  reference       operator[](size_type pos) {
+    return reinterpret_cast<reference>(data[pos]);
+  }
+  const_reference operator[](size_type pos) const {
+    return reinterpret_cast<const_reference>(data[pos]);
+  }
+
+  size_type size() const {
+    return _size;
+  }
+
+  pointer begin() {
+    return reinterpret_cast<pointer>(&data[0]);
+  }
+  pointer end() {
+    return reinterpret_cast<pointer>(&data[_size]);
+  }
+
+  const pointer begin() const {
+    return reinterpret_cast<pointer>(&data[0]);
+  }
+  const pointer end() const {
+    return reinterpret_cast<pointer>(&data[_size]);
+  }
+
+  const pointer cbegin() const {
+    return reinterpret_cast<pointer>(&data[0]);
+  }
+  const pointer cend() const {
+    return reinterpret_cast<pointer>(&data[_size]);
+  }
+};
+
+} // namespace ceph::containers
+
+#endif // CEPH_COMMON_CONTAINERS_H

--- a/src/common/huge_page_pool.cc
+++ b/src/common/huge_page_pool.cc
@@ -1,0 +1,31 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#include <optional>
+
+#include "common/config.h"
+#include "common/huge_page_pool.h"
+
+
+static std::optional<ceph::huge_page_pool> hp_pool;
+ 
+void ceph_init_huge_page_pools(class md_config_t* conf) {
+  assert(conf);
+  hp_pool.emplace(conf->get_val<std::size_t>("huge_page_pool_size"));
+}
+
+ceph::huge_page_pool& ceph_get_huge_page_pool() {
+  assert(hp_pool);
+  return *hp_pool;
+}

--- a/src/common/huge_page_pool.cc
+++ b/src/common/huge_page_pool.cc
@@ -22,7 +22,8 @@ static std::optional<ceph::huge_page_pool> hp_pool;
  
 void ceph_init_huge_page_pools(class md_config_t* conf) {
   assert(conf);
-  hp_pool.emplace(conf->get_val<std::size_t>("huge_page_pool_size"));
+  hp_pool.emplace(conf->get_val<std::size_t>("huge_page_pool_size"),
+		  conf->get_val<std::size_t>("huge_page_size"));
 }
 
 ceph::huge_page_pool& ceph_get_huge_page_pool() {

--- a/src/common/huge_page_pool.h
+++ b/src/common/huge_page_pool.h
@@ -1,0 +1,101 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#include <boost/container/flat_map.hpp>
+
+constexpr unsigned long long operator"" _M (unsigned long long n) {
+  return n << 20;
+}
+
+namespace ceph {
+
+template <std::size_t N>
+class huge_page_pool {
+public:
+  static constexpr std::size_t huge_page_size { 2_M };
+  // TOOD: align to cache line boundary
+  // TODO: this should a vector of atomic address for the sake
+  // of correctness.
+  std::array<std::atomic<void*>, N> pages;
+  boost::container::flat_map<void*, std::uint8_t> page2owner;
+
+  static huge_page_pool& get_instance() {
+    static huge_page_pool page_pool;
+    return page_pool;
+  }
+
+  huge_page_pool() {
+    for (std::size_t i = 0; i < pages.size(); i++) {
+      pages[i] = ::mmap(nullptr, huge_page_size, PROT_READ | PROT_WRITE,
+      		  MAP_PRIVATE | MAP_ANONYMOUS | MAP_POPULATE |
+      		  MAP_HUGETLB, -1, 0);
+      if (pages[i] == MAP_FAILED) {
+        // let's fallback-allocate in a way that stil allows the kernel
+        // to give us a THP (transparent huge page).
+        const int r = \
+          ::posix_memalign((void**)(void*)&pages[i],
+      		     huge_page_size, huge_page_size);
+        if (r) {
+          // there is no jumbo, sorry.
+          pages[i] = nullptr;
+        }
+      }
+
+      if (pages[i] != nullptr) {
+        page2owner[pages[i]] = i;
+      }
+    }
+  }
+
+  ~huge_page_pool() {
+    // move this to ptr's deleter, handle free()
+    for (const auto& p : pages) {
+      if (p) {
+        ::munmap(p, huge_page_size);
+      }
+    }
+  }
+
+  void* get_page() {
+    // let's check our slot own slot first
+    // TODO: cache the id calculation in TLS?
+    const std::uint8_t tidx = \
+      std::hash<std::thread::id>()(std::this_thread::get_id()) % pages.size();
+    void* const tval = pages[tidx].exchange(nullptr);
+    if (nullptr != tval) {
+      return tval;
+    }
+
+    // oops, it's not available. Let's iterate through the pool
+    // keeping in mind this can cause a cacheline ping-pong
+    // between CPUs.
+    for (std::size_t idx = 0; idx < pages.size(); idx++) {
+      void* const val = pages[idx].exchange(nullptr);
+      if (nullptr != val) {
+        return val;
+      }
+    }
+
+    // sorry, pool depleted.
+    return nullptr;
+  }
+
+  void put_page(void* p) {
+    const std::uint8_t owner_idx = page2owner.at(p);
+    const void* const oldval = pages[owner_idx].exchange(p);
+    assert(oldval == nullptr);
+  }
+};
+
+}

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -789,6 +789,11 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_NO_MON_UPDATE)
     .set_description(""),
 
+    Option("huge_page_pool_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(64)
+    .set_flag(Option::FLAG_STARTUP)
+    .set_description("Number of huge pages to preallocate for each HP pool"),
+
     Option("key", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description("Authentication key")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3701,7 +3701,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("bluefs_alloc_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1_M)
+    .set_default(2_M)
     .set_description(""),
 
     Option("bluefs_max_prefetch", Option::TYPE_UINT, Option::LEVEL_ADVANCED)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -789,6 +789,11 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_NO_MON_UPDATE)
     .set_description(""),
 
+    Option("huge_page_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(2_M)
+    .set_flag(Option::FLAG_STARTUP)
+    .set_description("Size (in bytes) of huge page in the system"),
+
     Option("huge_page_pool_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(64)
     .set_flag(Option::FLAG_STARTUP)

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -121,7 +121,7 @@ public:
     uint64_t pos;           ///< start offset for buffer
     bufferlist buffer;      ///< new data to write (at end of file)
     bufferlist tail_block;  ///< existing partial block at end of file, if any
-    bufferlist::page_aligned_appender buffer_appender;  //< for const char* only
+    bufferlist::huge_page_appender buffer_appender;  //< for const char* only
     int writer_type = 0;    ///< WRITER_*
 
     std::mutex lock;
@@ -131,8 +131,7 @@ public:
     FileWriter(FileRef f)
       : file(f),
 	pos(0),
-	buffer_appender(buffer.get_page_aligned_appender(
-			  g_conf->bluefs_alloc_size / CEPH_PAGE_SIZE)) {
+	buffer_appender(buffer.get_huge_page_appender()) {
       ++file->num_writers;
       iocv.fill(nullptr);
       dirty_devs.fill(false);


### PR DESCRIPTION
Summary
------------
TBD

Profiling in the cycles domain
--------------------------------------
### Before
```
-   87,79%     0,47%  bstore_kv_sync  ceph-osd              [.] BlueStore::_kv_sync_thread       ▒
   - 87,32% BlueStore::_kv_sync_thread                                                           ▒
      - 69,56% RocksDBStore::submit_transaction                                                  ▒
         - 69,07% RocksDBStore::submit_common                                                    ▒
            - rocksdb::DBImpl::Write                                                             ▒
               - 68,90% rocksdb::DBImpl::WriteImpl                                               ▒
                  + 54,53% rocksdb::WriteBatchInternal::InsertInto                               ▒
                  - 12,40% rocksdb::DBImpl::WriteToWAL                                           ▒
                     - 12,20% rocksdb::DBImpl::WriteToWAL                                        ▒
                        - 12,13% rocksdb::log::Writer::AddRecord                                 ▒
                           - 11,89% rocksdb::log::Writer::EmitPhysicalRecord                     ▒
                              - 6,05% rocksdb::WritableFileWriter::Append                        ▒
                                 - 5,43% rocksdb::WritableFileWriter::WriteBuffered              ▒
                                    - BlueRocksWritableFile::Append                              ▒
                                       - 4,97% __memcpy_avx_unaligned                            ▒
                                          - 4,59% page_fault                                     ▒
                                             - 4,55% do_page_fault                               ▒
                                                - 4,44% __do_page_fault                          ▒
                                                   - 3,84% handle_mm_fault                       ▒
                                                      - 3,50% __handle_mm_fault                  ▒
                                                         - 1,07% alloc_pages_vma                 ▒
                                                            + 0,83% __alloc_pages_nodemask       ▒
                                                         + 0,78% lru_cache_add_active_or_unevicta▒
                                5,16% rocksdb::crc32c::ExtendImpl<&rocksdb::crc32c::Fast_CRC32>  ▒
                                0,50% rocksdb::WritableFileWriter::Flush                         ▒
```

### After
```
-   87,91%     0,46%  bstore_kv_sync  ceph-osd              [.] BlueStore::_kv_sync_thread       ▒
   - 87,45% BlueStore::_kv_sync_thread                                                           ▒
      - 70,26% RocksDBStore::submit_transaction                                                  ▒
         - 69,72% RocksDBStore::submit_common                                                    ▒
            - rocksdb::DBImpl::Write                                                             ▒
               - 69,61% rocksdb::DBImpl::WriteImpl                                               ▒
                  + 59,95% rocksdb::WriteBatchInternal::InsertInto                               ▒
                  - 7,71% rocksdb::DBImpl::WriteToWAL                                            ▒
                     - 7,47% rocksdb::DBImpl::WriteToWAL                                         ▒
                        - rocksdb::log::Writer::AddRecord                                        ▒
                           - rocksdb::log::Writer::EmitPhysicalRecord                            ▒
                                5,17% rocksdb::crc32c::ExtendImpl<&rocksdb::crc32c::Fast_CRC32>  ▒
                              - 1,34% rocksdb::WritableFileWriter::Append                        ▒
                                   0,77% rocksdb::WritableFileWriter::WriteBuffered              ▒
```


Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>