### PR TITLE
buffer: kill off push_front and claim_prepend

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1839,19 +1839,6 @@ public:
     bl.last_p = bl.begin();
   }
 
-  void buffer::list::claim_prepend(list& bl, unsigned int flags)
-  {
-    // steal the other guy's buffers
-    _len += bl._len;
-    if (!(flags & CLAIM_ALLOW_NONSHAREABLE))
-      bl.make_shareable();
-    _buffers.splice(_buffers.begin(), bl._buffers );
-    bl._len = 0;
-    bl.last_p = bl.begin();
-    // we modified _buffers
-    last_p = begin();
-  }
-
   void buffer::list::claim_append_piecewise(list& bl)
   {
     // steal the other guy's buffers

--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -221,8 +221,11 @@ int ErasureCode::_decode(const set<int> &want_to_read,
   unsigned blocksize = (*chunks.begin()).second.length();
   for (unsigned int i =  0; i < k + m; i++) {
     if (chunks.find(i) == chunks.end()) {
+      bufferlist tmp;
       bufferptr ptr(buffer::create_aligned(blocksize, SIMD_ALIGN));
-      (*decoded)[i].push_front(ptr);
+      tmp.push_back(ptr);
+      tmp.claim_append((*decoded)[i]);
+      (*decoded)[i].swap(tmp);
     } else {
       (*decoded)[i] = chunks.find(i)->second;
       (*decoded)[i].rebuild_aligned(SIMD_ALIGN);

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -198,8 +198,11 @@ int ErasureCodeShec::_decode(const set<int> &want_to_read,
   unsigned blocksize = (*chunks.begin()).second.length();
   for (unsigned int i =  0; i < k + m; i++) {
     if (chunks.find(i) == chunks.end()) {
+      bufferlist tmp;
       bufferptr ptr(buffer::create_aligned(blocksize, SIMD_ALIGN));
-      (*decoded)[i].push_front(ptr);
+      tmp.push_back(ptr);
+      tmp.claim_append((*decoded)[i]);
+      (*decoded)[i].swap(tmp);
     } else {
       (*decoded)[i] = chunks.find(i)->second;
       (*decoded)[i].rebuild_aligned(SIMD_ALIGN);

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -804,7 +804,6 @@ namespace buffer CEPH_BUFFER_API {
 
     void claim(list& bl, unsigned int flags = CLAIM_DEFAULT);
     void claim_append(list& bl, unsigned int flags = CLAIM_DEFAULT);
-    void claim_prepend(list& bl, unsigned int flags = CLAIM_DEFAULT);
     // only for bl is bufferlist::page_aligned_appender
     void claim_append_piecewise(list& bl);
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -751,21 +751,6 @@ namespace buffer CEPH_BUFFER_API {
       last_p = begin();
       append_buffer = ptr();
     }
-    void push_front(ptr& bp) {
-      if (bp.length() == 0)
-	return;
-      _buffers.push_front(bp);
-      _len += bp.length();
-    }
-    void push_front(ptr&& bp) {
-      if (bp.length() == 0)
-	return;
-      _len += bp.length();
-      _buffers.push_front(std::move(bp));
-    }
-    void push_front(raw *r) {
-      push_front(ptr(r));
-    }
     void push_back(const ptr& bp) {
       if (bp.length() == 0)
 	return;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10201,7 +10201,8 @@ void BlueStore::_do_write_small(
 	      head_bl.append_zero(zlen);
 	      logger->inc(l_bluestore_write_pad_bytes, zlen);
 	    }
-	    bl.claim_prepend(head_bl);
+	    head_bl.claim_append(bl);
+	    bl.swap(head_bl);
 	    logger->inc(l_bluestore_write_penalty_read_ops);
 	  }
 	  if (tail_read) {

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1079,7 +1079,10 @@ void FileJournal::do_write(bufferlist& bl)
     // header too?
     if (hbp.length()) {
       // be sneaky: include the header in the second fragment
-      second.push_front(hbp);
+      bufferlist tmp;
+      tmp.push_back(hbp);
+      tmp.claim_append(second);
+      second.swap(tmp);
       pos = 0;          // we included the header
     }
     // Write the second portion first possible with the header, so
@@ -1335,7 +1338,10 @@ void FileJournal::do_aio_write(bufferlist& bl)
     assert(pos == header.max_size);
     if (hbp.length()) {
       // be sneaky: include the header in the second fragment
-      second.push_front(hbp);
+      bufferlist tmp;
+      tmp.push_back(hbp);
+      tmp.claim_append(second);
+      second.swap(tmp);
       pos = 0;          // we included the header
     } else
       pos = get_top();  // no header, start after that

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2106,56 +2106,6 @@ TEST(BufferList, claim_append) {
   EXPECT_EQ((unsigned)0, from.length());
 }
 
-TEST(BufferList, claim_prepend) {
-  bufferlist from;
-  {
-    bufferptr ptr(2);
-    from.append(ptr);
-  }
-  bufferlist to;
-  {
-    bufferptr ptr(4);
-    to.append(ptr);
-  }
-  EXPECT_EQ((unsigned)4, to.length());
-  EXPECT_EQ((unsigned)1, to.get_num_buffers());
-  to.claim_prepend(from);
-  EXPECT_EQ((unsigned)(2 + 4), to.length());
-  EXPECT_EQ((unsigned)2, to.front().length());
-  EXPECT_EQ((unsigned)4, to.back().length());
-  EXPECT_EQ((unsigned)2, to.get_num_buffers());
-  EXPECT_EQ((unsigned)0, from.get_num_buffers());
-  EXPECT_EQ((unsigned)0, from.length());
-}
-
-TEST(BufferList, claim_prepend_misc) {
-  bufferlist src_buf;
-  bufferlist dest_buf;
-  
-  bufferlist b1;
-  b1.append("12345", 5);
-  bufferlist b2;
-  b2.append("123456", 6);
-  bufferlist b3;
-  b3.append("1234567", 7);
-
-  EXPECT_EQ(5u, b1.length());
-  EXPECT_EQ(6u, b2.length());
-  EXPECT_EQ(7u, b3.length());
-  src_buf.claim_append(b1);
-  src_buf.claim_append(b2);
-  EXPECT_EQ((unsigned)(5+6), src_buf.length());
-  src_buf.splice(0, 3);
-  EXPECT_EQ((unsigned)(5-3), src_buf.front().length());
-  EXPECT_EQ((unsigned)(11-3), src_buf.length());
-  src_buf.claim_prepend(b3);
-  EXPECT_EQ((unsigned)(8+7), src_buf.length());
-  EXPECT_EQ(0u, b3.get_num_buffers());
-  EXPECT_EQ(0u, b3.length());
-  src_buf.copy(0, src_buf.length(), dest_buf);
-  EXPECT_EQ(3u, dest_buf.get_num_buffers()); 
-}
-
 TEST(BufferList, claim_append_piecewise) {
   bufferlist bl, t, dst;
   auto a = bl.get_page_aligned_appender(4);

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1817,66 +1817,6 @@ TEST(BufferList, clear) {
   EXPECT_EQ((unsigned)0, bl.get_num_buffers());
 }
 
-TEST(BufferList, push_front) {
-  //
-  // void push_front(ptr& bp)
-  //
-  {
-    bufferlist bl;
-    bufferptr ptr;
-    bl.push_front(ptr);
-    EXPECT_EQ((unsigned)0, bl.length());
-    EXPECT_EQ((unsigned)0, bl.get_num_buffers());
-  }
-  unsigned len = 17;
-  {
-    bufferlist bl;
-    bl.append('A');
-    bufferptr ptr(len);
-    ptr.c_str()[0] = 'B';
-    bl.push_front(ptr);
-    EXPECT_EQ((unsigned)(1 + len), bl.length());
-    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
-    EXPECT_EQ('B', bl.front()[0]);
-    EXPECT_EQ(ptr.get_raw(), bl.front().get_raw());
-  }
-  //
-  // void push_front(raw *r)
-  //
-  {
-    bufferlist bl;
-    bl.append('A');
-    bufferptr ptr(len);
-    ptr.c_str()[0] = 'B';
-    bl.push_front(ptr.get_raw());
-    EXPECT_EQ((unsigned)(1 + len), bl.length());
-    EXPECT_EQ((unsigned)2, bl.get_num_buffers());
-    EXPECT_EQ('B', bl.front()[0]);
-    EXPECT_EQ(ptr.get_raw(), bl.front().get_raw());
-  }
-  //
-  // void push_front(ptr&& bp)
-  //
-  {
-    bufferlist bl;
-    bufferptr ptr;
-    bl.push_front(std::move(ptr));
-    EXPECT_EQ((unsigned)0, bl.length());
-    EXPECT_EQ((unsigned)0, bl.buffers().size());
-  }
-  {
-    bufferlist bl;
-    bl.append('A');
-    bufferptr ptr(len);
-    ptr.c_str()[0] = 'B';
-    bl.push_front(std::move(ptr));
-    EXPECT_EQ((unsigned)(1 + len), bl.length());
-    EXPECT_EQ((unsigned)2, bl.buffers().size());
-    EXPECT_EQ('B', bl.buffers().front()[0]);
-    EXPECT_FALSE(ptr.get_raw());
-  }
-}
-
 TEST(BufferList, push_back) {
   //
   // void push_back(ptr& bp)

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -197,7 +197,8 @@ TEST_P(CompressorTest, compress_decompress)
   bufferlist prefix;
   prefix.append(string("some prefix"));
   size_t prefix_len = prefix.length();
-  out.claim_prepend(prefix);
+  prefix.claim_append(out);
+  out.swap(prefix);
   it = out.begin();
   it.advance(prefix_len);
   res = compressor->decompress(it, compressed_len, after);

--- a/src/test/erasure-code/ErasureCodeExample.h
+++ b/src/test/erasure-code/ErasureCodeExample.h
@@ -117,8 +117,11 @@ public:
     for (set<int>::iterator j = want_to_encode.begin();
          j != want_to_encode.end();
          ++j) {
+      bufferlist tmp;
       bufferptr chunk(ptr, (*j) * chunk_length, chunk_length);
-      (*encoded)[*j].push_front(chunk);
+      tmp.push_back(chunk);
+      tmp.claim_append((*encoded)[*j]);
+      (*encoded)[*j].swap(tmp);
     }
     return 0;
   }
@@ -165,7 +168,11 @@ public:
         for (unsigned j = 0; j < chunk_length; j++) {
           c[j] = a[j] ^ b[j];
         }
-        (*decoded)[*i].push_front(chunk);
+
+	bufferlist tmp;
+	tmp.append(chunk);
+	tmp.claim_append((*decoded)[*i]);
+	(*decoded)[*i].swap(tmp);
       }
     }
     return 0;

--- a/src/test/erasure-code/TestErasureCodeExample.cc
+++ b/src/test/erasure-code/TestErasureCodeExample.cc
@@ -180,7 +180,7 @@ TEST(ErasureCodeExample, decode)
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   in_ptr.append(payload, strlen(payload));
   bufferlist in;
-  in.push_front(in_ptr);
+  in.push_back(in_ptr);
   int want_to_encode[] = { 0, 1, 2 };
   map<int, bufferlist> encoded;
   EXPECT_EQ(0, example.encode(set<int>(want_to_encode, want_to_encode+3),

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -442,7 +442,7 @@ TEST_F(IsaErasureCodeTest, isa_vandermonde_exhaustive)
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   in_ptr.append(payload, strlen(payload));
   bufferlist in;
-  in.push_front(in_ptr);
+  in.push_back(in_ptr);
 
   set<int>want_to_encode;
 
@@ -569,7 +569,7 @@ TEST_F(IsaErasureCodeTest, isa_cauchy_exhaustive)
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   in_ptr.append(payload, strlen(payload));
   bufferlist in;
-  in.push_front(in_ptr);
+  in.push_back(in_ptr);
 
   set<int>want_to_encode;
 
@@ -696,7 +696,7 @@ TEST_F(IsaErasureCodeTest, isa_cauchy_cache_trash)
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   in_ptr.append(payload, strlen(payload));
   bufferlist in;
-  in.push_front(in_ptr);
+  in.push_back(in_ptr);
 
   set<int>want_to_encode;
 
@@ -822,7 +822,7 @@ TEST_F(IsaErasureCodeTest, isa_xor_codec)
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
   in_ptr.append(payload, strlen(payload));
   bufferlist in;
-  in.push_front(in_ptr);
+  in.push_back(in_ptr);
 
   set<int>want_to_encode;
 

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -81,7 +81,7 @@ TYPED_TEST(ErasureCodeTest, encode_decode)
       "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     in_ptr.append(payload, strlen(payload));
     bufferlist in;
-    in.push_front(in_ptr);
+    in.push_back(in_ptr);
     int want_to_encode[] = { 0, 1, 2, 3 };
     map<int, bufferlist> encoded;
     EXPECT_EQ(0, jerasure.encode(set<int>(want_to_encode, want_to_encode+4),

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -623,7 +623,10 @@ TEST(ErasureCodeLrc, encode_decode)
   for (unsigned int i = 0; i < lrc.get_chunk_count(); ++i) {
     want_to_encode.insert(i);
     bufferptr ptr(buffer::create_page_aligned(chunk_size));
-    encoded[i].push_front(ptr);
+    bufferlist tmp;
+    tmp.push_back(ptr);
+    tmp.claim_append(encoded[i]);
+    encoded[i].swap(tmp);
   }
   const vector<int> &mapping = lrc.get_chunk_mapping();
   char c = 'A';
@@ -753,7 +756,10 @@ TEST(ErasureCodeLrc, encode_decode_2)
   for (unsigned int i = 0; i < lrc.get_chunk_count(); ++i) {
     want_to_encode.insert(i);
     bufferptr ptr(buffer::create_page_aligned(chunk_size));
-    encoded[i].push_front(ptr);
+    bufferlist tmp;
+    tmp.push_back(ptr);
+    tmp.claim_append(encoded[i]);
+    encoded[i].swap(tmp);
   }
   const vector<int> &mapping = lrc.get_chunk_mapping();
   char c = 'A';

--- a/src/tools/RadosDump.h
+++ b/src/tools/RadosDump.h
@@ -226,7 +226,7 @@ struct attr_section {
     for (std::map<std::string, bufferptr>::iterator i = data_.begin();
          i != data_.end(); ++i) {
       bufferlist bl;
-      bl.push_front(i->second);
+      bl.push_back(i->second);
       data[i->first] = bl;
     }
   }


### PR DESCRIPTION
These unnecessarily complicate the interface and don't map to a (future) std::vector-based implementation.