### PR TITLE
os/bluestore: reorder members of bluefs_extent_t for space efficiency

### DIFF
--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -10,12 +10,12 @@
 
 class bluefs_extent_t {
 public:
-  uint8_t bdev;
   uint64_t offset = 0;
   uint32_t length = 0;
+  uint8_t bdev;
 
   bluefs_extent_t(uint8_t b = 0, uint64_t o = 0, uint32_t l = 0)
-    : bdev(b), offset(o), length(l) {}
+    : offset(o), length(l), bdev(b) {}
 
   uint64_t end() const { return  offset + length; }
   DENC(bluefs_extent_t, v, p) {


### PR DESCRIPTION
Just an reordering. I haven't profiled the patch. Sending as a clean-up.