### PR TITLE
luminous: qa/rgw: swift tests target ceph-luminous branch 

### DIFF
--- a/qa/tasks/swift.py
+++ b/qa/tasks/swift.py
@@ -28,7 +28,10 @@ def download(ctx, config):
     for client in config:
         ctx.cluster.only(client).run(
             args=[
-                'git', 'clone',
+                'git',
+                'clone',
+                '--branch',
+                'ceph-luminous',
                 teuth_config.ceph_git_base_url + 'swift.git',
                 '{tdir}/swift'.format(tdir=testdir),
                 ],


### PR DESCRIPTION
preparation for https://github.com/ceph/swift/pull/4, which is a swift test that will only pass against radosgw from master. the ceph-luminous branch of the swift repo will not contain this test until/unless the feature is backported