### PR TITLE
doc: updated add primary storage documentation for latest CloudStack release (4.11)

### DIFF
--- a/doc/rbd/rbd-cloudstack.rst
+++ b/doc/rbd/rbd-cloudstack.rst
@@ -101,7 +101,7 @@ To add a Ceph block device as Primary Storage, the steps include:
 
    - Scope ``(i.e. Cluster or Zone-Wide)``.
    
-   - Zone
+   - Zone.
    
    - Pod.
    

--- a/doc/rbd/rbd-cloudstack.rst
+++ b/doc/rbd/rbd-cloudstack.rst
@@ -103,7 +103,7 @@ To add a Ceph block device as Primary Storage, the steps include:
    
    - Zone.
    
-   - Pod.
+   - Pod
    
    - Cluster.
    

--- a/doc/rbd/rbd-cloudstack.rst
+++ b/doc/rbd/rbd-cloudstack.rst
@@ -101,7 +101,7 @@ To add a Ceph block device as Primary Storage, the steps include:
 
    - Scope ``(i.e. Cluster or Zone-Wide)``.
    
-   - Zone.
+   - Zone
    
    - Pod.
    

--- a/doc/rbd/rbd-cloudstack.rst
+++ b/doc/rbd/rbd-cloudstack.rst
@@ -103,7 +103,7 @@ To add a Ceph block device as Primary Storage, the steps include:
    
    - Zone.
    
-   - Pod
+   - Pod.
    
    - Cluster.
    


### PR DESCRIPTION
Hello Ceph Community!

I updated the CloudStack section of the Ceph RBD documentation. I explained how to add a Ceph block device/cluster as primary storage. This documentation is up-to-date with the latest Apache CloudStack release (4.11). My grammar may be a bit off, however, the steps should be accurate.

I tried following the Ceph contribution guidelines. If I messed up something, please let me know and I'll address immediately. I updated the documentation because the Add Primary Storage (4.2.0) link is broken. The link appears to go back to ACS, however, this results in a 404 error. I didn't see any documentation on Apache CloudStack that is current for this. If there is, please let me know and I'll update the pull request.  Thanks!