### PR TITLE
doc: updated add primary storage documentation for latest CloudStack release (4.11)

### DIFF
--- a/doc/rbd/rbd-cloudstack.rst
+++ b/doc/rbd/rbd-cloudstack.rst
@@ -91,21 +91,41 @@ See `User Management`_ for additional details.
 Add Primary Storage
 ===================
 
-To add primary storage, refer to `Add Primary Storage (4.2.0)`_ to add a Ceph block device, the steps
-include: 
+To add a Ceph block device as Primary Storage, the steps include: 
 
 #. Log in to the CloudStack UI.
 #. Click **Infrastructure** on the left side navigation bar. 
-#. Select the Zone you want to use for Primary Storage.
-#. Click the **Compute** tab.
-#. Select **View All** on the `Primary Storage` node in the diagram.
-#. Click **Add Primary Storage**.
-#. Follow the CloudStack instructions.
+#. Select **View All** under **Primary Storage**.
+#. Click the **Add Primary Storage** button on the top right hand side.
+#. Fill in the following information, according to your infrastructure setup:
 
+   - Scope ``(i.e. Cluster or Zone-Wide)``.
+   
+   - Zone.
+   
+   - Pod.
+   
+   - Cluster.
+   
+   - Name of Primary Storage.
+   
    - For **Protocol**, select ``RBD``.
-   - Add cluster information (cephx is supported). Note: Do not include the ``client.`` part of the user.
-   - Add ``rbd`` as a tag.
+   
+   - For **Provider**, select the appropriate provider type ``(i.e. DefaultPrimary, SolidFire, SolidFireShared, or CloudByte)``.  Depending on the provider chosen, fill out the information pertinent to your setup.
+   
+#. Add cluster information (cephx is supported).
 
+   - For **RADOS Monitor**, provide the IP address of a Ceph monitor node.
+   
+   - For **RADOS Pool**, provide the name of a RBD pool.
+   
+   - For **RADOS User**, provide an user that has sufficient rights to the RBD pool. Note: Do not include the ``client.`` part of the user.
+   
+   - For **RADOS Secret**, provide the secret associated to the RBD user chosen.
+   
+   - **Storage Tags** are optional. Use tags at your own discretion. For more information about storage tags in CloudStack, refer to `Storage Tags`_.
+   
+#. Click **OK**.
 
 Create a Disk Offering
 ======================
@@ -130,6 +150,6 @@ Limitations
 .. _Install and Configure QEMU: ../qemu-rbd
 .. _Install and Configure libvirt: ../libvirt
 .. _KVM Hypervisor Host Installation: http://cloudstack.apache.org/docs/en-US/Apache_CloudStack/4.2.0/html/Installation_Guide/hypervisor-kvm-install-flow.html
-.. _Add Primary Storage (4.2.0): http://cloudstack.apache.org/docs/en-US/Apache_CloudStack/4.2.0/html/Admin_Guide/primary-storage-add.html
+.. _Storage Tags: http://docs.cloudstack.apache.org/projects/cloudstack-administration/en/4.11/storage.html#storage-tags
 .. _Create a New Disk Offering (4.2.0): http://cloudstack.apache.org/docs/en-US/Apache_CloudStack/4.2.0/html/Admin_Guide/compute-disk-service-offerings.html#creating-disk-offerings
 .. _User Management: ../../rados/operations/user-management

--- a/doc/rbd/rbd-cloudstack.rst
+++ b/doc/rbd/rbd-cloudstack.rst
@@ -99,7 +99,7 @@ To add a Ceph block device as Primary Storage, the steps include:
 #. Click the **Add Primary Storage** button on the top right hand side.
 #. Fill in the following information, according to your infrastructure setup:
 
-   - Scope ``(i.e. Cluster or Zone-Wide)``.
+   - Scope (i.e. Cluster or Zone-Wide).
    
    - Zone.
    
@@ -111,17 +111,17 @@ To add a Ceph block device as Primary Storage, the steps include:
    
    - For **Protocol**, select ``RBD``.
    
-   - For **Provider**, select the appropriate provider type ``(i.e. DefaultPrimary, SolidFire, SolidFireShared, or CloudByte)``.  Depending on the provider chosen, fill out the information pertinent to your setup.
+   - For **Provider**, select the appropriate provider type (i.e. DefaultPrimary, SolidFire, SolidFireShared, or CloudByte).  Depending on the provider chosen, fill out the information pertinent to your setup.
    
-#. Add cluster information (cephx is supported).
+#. Add cluster information (``cephx`` is supported).
 
    - For **RADOS Monitor**, provide the IP address of a Ceph monitor node.
    
-   - For **RADOS Pool**, provide the name of a RBD pool.
+   - For **RADOS Pool**, provide the name of an RBD pool.
    
-   - For **RADOS User**, provide an user that has sufficient rights to the RBD pool. Note: Do not include the ``client.`` part of the user.
+   - For **RADOS User**, provide a user that has sufficient rights to the RBD pool. Note: Do not include the ``client.`` part of the user.
    
-   - For **RADOS Secret**, provide the secret associated to the RBD user chosen.
+   - For **RADOS Secret**, provide the secret the user's secret.
    
    - **Storage Tags** are optional. Use tags at your own discretion. For more information about storage tags in CloudStack, refer to `Storage Tags`_.
    


### PR DESCRIPTION
doc: Update CloudStack docs.

Hello Ceph Community!

I updated the CloudStack section of the Ceph RBD documentation. I explained how to add a Ceph block device/cluster as primary storage. This documentation is up-to-date with the latest Apache CloudStack release (4.11). My grammar may be a bit off, however, the steps should be accurate.

I tried following the Ceph contribution guidelines. If I messed up something, please let me know and I'll address immediately. I updated the documentation because the Add Primary Storage (4.2.0) link is broken. The link appears to go back to ACS, however, this results in a 404 error. I didn't see any documentation on Apache CloudStack that is current for this. If there is, please let me know and I'll update the pull request. Thanks!

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>