### PR TITLE
test: remove distro_version assert in distro detect test

### DIFF
--- a/src/test/common/test_util.cc
+++ b/src/test/common/test_util.cc
@@ -41,7 +41,6 @@ TEST(util, collect_sys_info)
   collect_sys_info(&sys_info, cct);
 
   ASSERT_TRUE(sys_info.find("distro") != sys_info.end());
-  ASSERT_TRUE(sys_info.find("distro_version") != sys_info.end());
   ASSERT_TRUE(sys_info.find("distro_description") != sys_info.end());
 
   cct->put();


### PR DESCRIPTION
VERSION_ID is optional in /etc/os-release, we removed the error
log in #17787, and the test also needs to be fixed.