### PR TITLE
luminous: cls/rgw: fix bi_log_iterate_entries return wrong truncated

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2611,6 +2611,9 @@ static int bi_log_iterate_entries(cls_method_context_t hctx, const string& marke
 
     if (key.compare(end_key) > 0) {
       key_iter = key;
+      if (truncated) {
+        *truncated = false;
+      }
       return 0;
     }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/23225