### PR TITLE
rbd: add notrim option to rbd map

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -661,6 +661,11 @@ Per mapping (block device) `rbd device map` options:
 
 * exclusive - Disable automatic exclusive lock transitions (since 4.12).
 
+* notrim - Turn off discard and write zeroes offload support to avoid
+  deprovisioning a fully provisioned image (since 4.17). When enabled, discard
+  requests will fail with -EOPNOTSUPP, write zeroes requests will fall back to
+  manually zeroing.
+
 `rbd device unmap` options:
 
 * force - Force the unmapping of a block device that is open (since 4.9).  The

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -143,6 +143,8 @@ static int parse_map_options(const std::string &options_string)
       put_map_option("lock_on_read", this_char);
     } else if (!strcmp(this_char, "exclusive")) {
       put_map_option("exclusive", this_char);
+    } else if (!strcmp(this_char, "notrim")) {
+      put_map_option("notrim", this_char);
     } else {
       std::cerr << "rbd: unknown map option '" << this_char << "'" << std::endl;
       return -EINVAL;


### PR DESCRIPTION
This patch adds the notrim option to rbd map command.
This patch is useful for fully provisioned image to avoid
deprovisioning allocated blocks.

Hitoshi Kamei (1):
  rbd: add notrim option to rbd map

 doc/man/8/rbd.rst              | 5 +++++
 src/tools/rbd/action/Kernel.cc | 2 ++
 2 files changed, 7 insertions(+)

-- 
2.15.1