### PR TITLE
luminous: os/bluestore: trim cache every 50ms (instead of 200ms)

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3458,7 +3458,7 @@ std::vector<Option> get_global_options() {
     .set_description("Preallocated buffer for inline shards"),
 
     Option("bluestore_cache_trim_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(.2)
+    .set_default(.05)
     .set_description("How frequently we trim the bluestore cache"),
 
     Option("bluestore_cache_trim_max_skip_pinned", Option::TYPE_UINT, Option::LEVEL_DEV)


### PR DESCRIPTION
http://tracker.ceph.com/issues/23226