### PR TITLE
mgr/dashboard: Support aditional info on 'cd-view-cache'

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.html
@@ -1,17 +1,17 @@
 <alert i18n
        type="info"
        *ngIf="status === vcs.ValueNone">
-  Retrieving data, please wait.
+  Retrieving data<span *ngIf="statusFor"> for <span [innerHtml]="statusFor"></span></span>. Please wait...
 </alert>
 
 <alert i18n
        type="warning"
        *ngIf="status === vcs.ValueStale">
-  Displaying previously cached data.
+  Displaying previously cached data<span *ngIf="statusFor"> for <span [innerHtml]="statusFor"></span></span>.
 </alert>
 
 <alert i18n
        type="danger"
        *ngIf="status === vcs.ValueException">
-  Could not load data. Please check the cluster health.
+  Could not load data<span *ngIf="statusFor"> for <span [innerHtml]="statusFor"></span></span>. Please check the cluster health.
 </alert>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.ts
@@ -9,6 +9,7 @@ import { ViewCacheStatus } from '../../../shared/enum/view-cache-status.enum';
 })
 export class ViewCacheComponent implements OnInit {
   @Input() status: ViewCacheStatus;
+  @Input() statusFor: string;
   vcs = ViewCacheStatus;
 
   constructor() {}


### PR DESCRIPTION
This PR adds support for addition information on `cd-cache-view` component.

By using the `statusFor` attribute, the developer will be able to add additional information text that will be displayed by the component.

**Usage:**
`<cd-view-cache [status]="2" statusFor="pool <strong>rbd1</strong>"></cd-view-cache>`
![screenshot from 2018-03-27 11-09-54](https://user-images.githubusercontent.com/14297426/37961155-6da3c36a-31af-11e8-91f7-2f13c7dc0d37.png)


Signed-off-by: Ricardo Marques <rimarques@suse.com>