### PR TITLE
pybind/mgr/prometheus: add file_sd_config command

### DIFF
--- a/qa/tasks/mgr/test_prometheus.py
+++ b/qa/tasks/mgr/test_prometheus.py
@@ -2,6 +2,7 @@
 
 from mgr_test_case import MgrTestCase
 
+import json
 import logging
 import requests
 
@@ -14,6 +15,17 @@ class TestPrometheus(MgrTestCase):
 
     def setUp(self):
         self.setup_mgrs()
+
+    def test_file_sd_command(self):
+        self._assign_ports("prometheus", "server_port")
+        self._load_module("prometheus")
+
+        result = json.loads(self.mgr_cluster.mon_manager.raw_cluster_cmd(
+            "prometheus", "file_sd_config"))
+        mgr_map = self.mgr_cluster.get_mgr_map()
+        self.assertEqual(len(result[0]['targets']), len(mgr_map['standbys']) + 1)
+
+
 
     def test_standby(self):
         self._assign_ports("prometheus", "server_port")

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -5,7 +5,7 @@ import math
 import os
 import socket
 from collections import OrderedDict
-from mgr_module import MgrModule, MgrStandbyModule
+from mgr_module import MgrModule, MgrStandbyModule, CommandResult
 
 # Defaults for the Prometheus HTTP server.  Can also set in config-key
 # see https://github.com/prometheus/prometheus/wiki/Default-port-allocations
@@ -335,6 +335,11 @@ class Module(MgrModule):
             "desc": "Run a self test on the prometheus module",
             "perm": "rw"
         },
+        {
+            "cmd": "prometheus file_sd_config",
+            "desc": "Return file_sd compatible prometheus config for mgr cluster",
+            "perm": "r"
+        },
     ]
 
     OPTIONS = [
@@ -565,10 +570,48 @@ class Module(MgrModule):
 
         return self.metrics.metrics
 
+    def get_file_sd_config(self):
+        servers = self.list_servers()
+        targets = []
+        for server in servers:
+            hostname = server.get('hostname', '')
+            for service in server.get('services', []):
+                if service['type'] != 'mgr':
+                    continue
+                id_ = service['id']
+                # get port for prometheus module at mgr with id_
+                # TODO use get_config_prefix or get_config here once
+                # https://github.com/ceph/ceph/pull/20458 is merged
+                result = CommandResult("")
+                global_instance().send_command(
+                    result, "mon", '',
+                    json.dumps({
+                        "prefix": "config-key get",
+                        'key': "config/mgr/mgr/prometheus/{}/server_port".format(id_),
+                    }),
+                                               "")
+                r, outb, outs = result.wait()
+                if r != 0:
+                    global_instance().log.error("Failed to retrieve port for mgr {}: {}".format(id_, outs))
+                else:
+                    port = json.loads(outb)
+                    targets.append('{}:{}'.format(hostname, port))
+
+        ret = [
+            {
+                "targets": targets,
+                "labels": {}
+            }
+        ]
+        return 0, json.dumps(ret), ""
+
     def handle_command(self, cmd):
         if cmd['prefix'] == 'prometheus self-test':
             self.collect()
+            self.get_file_sd_config()
             return 0, '', 'Self-test OK'
+        elif cmd['prefix'] == 'prometheus file_sd_config':
+            return self.get_file_sd_config()
         else:
             return (-errno.EINVAL, '',
                     "Command not found '{0}'".format(cmd['prefix']))


### PR DESCRIPTION
This command returns a valid list of static targets pointing to the mgr
prometheus modules for a cluster. The output can be stored in a
file and the file be listed under the file_sd_config stanza in the
prometheus configuration.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>