### PR TITLE
common/hobject: compare two objects' key directly

### DIFF
--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -336,9 +336,9 @@ int cmp(const hobject_t& l, const hobject_t& r)
     return -1;
   if (l.nspace > r.nspace)
     return 1;
-  if (l.get_effective_key() < r.get_effective_key())
+  if (l.get_key() < r.get_key())
     return -1;
-  if (l.get_effective_key() > r.get_effective_key())
+  if (l.get_key() > r.get_key())
     return 1;
   if (l.oid < r.oid)
     return -1;


### PR DESCRIPTION
The original implement does not appear to be a problem for two different
objects which are usually of different oids/names.
However, for a specific head object and its posterity snap objects, this
is not very effective since we are going to compare oids/names twice
(because they are definitely equivalent).

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>