### PR TITLE
crush/create_or_move: Adjust weight of destroyed item if different

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8578,6 +8578,22 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 	ss << "create-or-move updated item name '" << osd_name
 	   << "' weight " << weight
 	   << " at location " << loc << " to crush map";
+
+        // If the OSD is destroyed use initial_weight to adjust the weight of the
+        // item in the CRUSHMap as the underlying device might be a different size
+        // For example a 4TB device was replaced by a 6TB device, the CRUSH weight
+        // then needs to be adjusted accordingly
+        //
+        // The OSD will be in the 'new' state at that moment as it has already been
+        // booted and the 'destroyed' state has been removed from the OSD.
+        // At this point it is marked as 'exists,new'
+        if (osdmap.is_new(osdid)) {
+          if (osdmap.crush->get_item_weightf(osdid) != weight) {
+            ss << "create-or-move adjusting weight of destroyed item " << osd_name
+               << " to " << weight;
+            newcrush.adjust_item_weightf_in_loc(cct, osdid, weight, loc);
+          }
+        }
 	break;
       }
       if (err > 0) {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -796,6 +796,10 @@ public:
     return exists(osd) && (osd_state[osd] & CEPH_OSD_DESTROYED);
   }
 
+  bool is_new(int osd) const {
+    return exists(osd) && (osd_state[osd] & CEPH_OSD_NEW);
+  }
+
   bool is_up(int osd) const {
     return exists(osd) && (osd_state[osd] & CEPH_OSD_UP);
   }


### PR DESCRIPTION
If an OSD is restarted/re-added with a different weight we should
adjust the CRUSH weight of the item since it could be a different
weight than it was before.

An OSD might be destroyed and re-added with a differently sized
medium (SSD / HDD) underneath and we should adjust the weight
accordingly.

Fixes: http://tracker.ceph.com/issues/23467

Signed-off-by: Wido den Hollander <wido@42on.com>