### PR TITLE
ceph-volume improve robustness when reloading vms in tests

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -58,8 +58,8 @@ commands=
   # test cluster state using ceph-ansible tests
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/tests
 
-  # reboot all vms
-  vagrant reload {env:VAGRANT_RELOAD_FLAGS:"--no-provision"}
+  # reboot all vms - attempt
+  bash {toxinidir}/../scripts/vagrant_reload.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
 
   # retest to ensure cluster came back up correctly after rebooting
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/tests

--- a/src/ceph-volume/ceph_volume/tests/functional/scripts/vagrant_reload.sh
+++ b/src/ceph-volume/ceph_volume/tests/functional/scripts/vagrant_reload.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# vagrant-libvirt has a common behavior where it times out when "reloading" vms. Instead
+# of calling `vagrant reload` attempt to halt everything, and then start everything, which gives
+# this script the ability to try the `vagrant up` again in case of failure
+#
+
+vagrant halt
+# This should not really be needed, but in case of a possible race condition between halt
+# and up, it might improve things
+sleep 5
+
+
+retries=0
+until [ $retries -ge 5 ]
+do
+  echo "Attempting to start VMs. Attempts: $retries"
+  timeout 10m vagrant up "$@" && break
+  retries=$[$retries+1]
+  sleep 5
+done

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -53,7 +53,7 @@ commands=
   ansible-playbook -vv -i {changedir}/hosts {changedir}/test.yml
 
   # reboot all vms
-  vagrant reload {env:VAGRANT_RELOAD_FLAGS:"--no-provision"}
+  bash {toxinidir}/../scripts/vagrant_reload.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
 
   # wait 2 minutes for services to be ready
   sleep 120


### PR DESCRIPTION
It will timeout when bringing them up, and retry for up to five times. Helping with this issue:

    ==> osd0: Waiting for domain to get an IP address...
    /home/jenkins-build/.vagrant.d/gems/2.4.3/gems/fog-core-1.43.0/lib/fog/core/wait_for.rb:9:in `block in wait_for': The specified wait_for timeout (2 seconds) was exceeded (Fog::Errors::TimeoutError)