### PR TITLE
jewel: rgw: tcmalloc

### DIFF
--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -151,8 +151,8 @@ radosgw_SOURCES = \
 	rgw/rgw_main.cc
 
 radosgw_CFLAGS = -I$(srcdir)/civetweb/include -fPIC -I$(srcdir)/xxHash ${CIVETWEB_INCLUDE} $(SONAME_DEFINES)
-radosgw_LDADD = $(LIBRGW) $(LIBCIVETWEB) $(LIBCIVETWEB_DEPS) $(LIBRGW_DEPS) $(RESOLV_LIBS) \
-	$(CEPH_GLOBAL)
+radosgw_LDADD = $(LIBRGW) $(LIBCIVETWEB) $(LIBCIVETWEB_DEPS) $(LIBRGW_DEPS) \
+	$(RESOLV_LIBS) $(CEPH_GLOBAL) $(LIBTCMALLOC)
 bin_PROGRAMS += radosgw
 
 radosgw_admin_SOURCES = rgw/rgw_admin.cc rgw/rgw_orphan.cc


### PR DESCRIPTION
The radosgw program should be linked with tcmalloc (or
tcmalloc_minimal) when selected by the build (i.e, whenever other
Ceph daemons such as ceph-osd would be.

Just adding $(LIBTCMALLOC) to the linkage directive is sufficient
to do this.

Fixes: http://tracker.ceph.com/issues/23469

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>