### PR TITLE
test/librados_test_stub: always create copy of buffers passed to operation

### DIFF
--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -69,7 +69,9 @@ int TestMemIoCtxImpl::append(const std::string& oid, const bufferlist &bl,
   }
 
   RWLock::WLocker l(file->lock);
-  file->data.append(bl);
+  auto off = file->data.length();
+  ensure_minimum_length(off + bl.length(), &file->data);
+  file->data.copy_in(off, bl.length(), bl);
   return 0;
 }
 
@@ -579,7 +581,8 @@ int TestMemIoCtxImpl::write_full(const std::string& oid, bufferlist& bl,
   }
 
   file->data.clear();
-  file->data.append(bl);
+  ensure_minimum_length(bl.length(), &file->data);
+  file->data.copy_in(0, bl.length(), bl);
   return 0;
 }
 


### PR DESCRIPTION
Otherwise the buffers may be shared between object files if the same
bufferlist was passed to several operations (append and write_full were
affected).

Signed-off-by: Mykola Golub <mgolub@suse.com>