### PR TITLE
src: Added const references to various function parameters

### DIFF
--- a/src/auth/AuthAuthorizeHandler.h
+++ b/src/auth/AuthAuthorizeHandler.h
@@ -44,7 +44,7 @@ class AuthAuthorizeHandlerRegistry {
   AuthMethodList supported;
 
 public:
-  AuthAuthorizeHandlerRegistry(CephContext *cct_, std::string methods)
+  AuthAuthorizeHandlerRegistry(CephContext *cct_, const std::string &methods)
     : m_lock("AuthAuthorizeHandlerRegistry::m_lock"), supported(cct_, methods)
   {}
   ~AuthAuthorizeHandlerRegistry();

--- a/src/cls/cephfs/cls_cephfs.h
+++ b/src/cls/cephfs/cls_cephfs.h
@@ -68,9 +68,9 @@ public:
       uint64_t obj_index_,
       uint64_t obj_size_,
       time_t mtime_,
-      std::string obj_xattr_name_,
-      std::string mtime_xattr_name_,
-      std::string obj_size_xattr_name_)
+      const std::string &obj_xattr_name_,
+      const std::string &mtime_xattr_name_,
+      const std::string &obj_size_xattr_name_)
    : obj_index(obj_index_),
      obj_size(obj_size_),
      mtime(mtime_),

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -5191,7 +5191,7 @@ int dir_remove(cls_method_context_t hctx,
 
 static const string RBD_GROUP_SNAP_KEY_PREFIX = "snapshot_";
 
-std::string snap_key(std::string snap_id) {
+std::string snap_key(const std::string &snap_id) {
   ostringstream oss;
   oss << RBD_GROUP_SNAP_KEY_PREFIX << snap_id;
   return oss.str();
@@ -5238,8 +5238,8 @@ int snap_list(cls_method_context_t hctx, cls::rbd::GroupSnapshot start_after,
 }
 
 static int check_duplicate_snap_name(cls_method_context_t hctx,
-				     std::string snap_name,
-				     std::string snap_id)
+				     const std::string &snap_name,
+				     const std::string &snap_id)
 {
   const int max_read = 1024;
   cls::rbd::GroupSnapshot snap_last;

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1109,14 +1109,14 @@ namespace librbd {
       return get_id_finish(&it, id);
     }
 
-    void set_id(librados::ObjectWriteOperation *op, const std::string id)
+    void set_id(librados::ObjectWriteOperation *op, const std::string &id)
     {
       bufferlist bl;
       encode(id, bl);
       op->exec("rbd", "set_id", bl);
     }
 
-    int set_id(librados::IoCtx *ioctx, const std::string &oid, std::string id)
+    int set_id(librados::IoCtx *ioctx, const std::string &oid, const std::string &id)
     {
       librados::ObjectWriteOperation op;
       set_id(&op, id);

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -257,8 +257,8 @@ namespace librbd {
     int get_id_finish(bufferlist::iterator *it, std::string *id);
     int get_id(librados::IoCtx *ioctx, const std::string &oid, std::string *id);
 
-    void set_id(librados::ObjectWriteOperation *op, std::string id);
-    int set_id(librados::IoCtx *ioctx, const std::string &oid, std::string id);
+    void set_id(librados::ObjectWriteOperation *op, const std::string &id);
+    int set_id(librados::IoCtx *ioctx, const std::string &oid, const std::string &id);
 
     // operations on rbd_directory objects
     int dir_get_id(librados::IoCtx *ioctx, const std::string &oid,

--- a/src/common/Cond.h
+++ b/src/common/Cond.h
@@ -177,7 +177,7 @@ class C_SaferCond : public Context {
   int rval;      ///< return value
 public:
   C_SaferCond() : lock("C_SaferCond"), done(false), rval(0) {}
-  C_SaferCond(std::string name) : lock(name), done(false), rval(0) {}
+  C_SaferCond(const std::string &name) : lock(name), done(false), rval(0) {}
   void finish(int r) override { complete(r); }
 
   /// We overload complete in order to not delete the context

--- a/src/common/Graylog.cc
+++ b/src/common/Graylog.cc
@@ -10,7 +10,7 @@
 namespace ceph {
 namespace logging {
 
-Graylog::Graylog(const SubsystemMap * const s, std::string logger)
+Graylog::Graylog(const SubsystemMap * const s, const std::string &logger)
     : m_subs(s),
       m_log_dst_valid(false),
       m_hostname(""),
@@ -24,7 +24,7 @@ Graylog::Graylog(const SubsystemMap * const s, std::string logger)
   m_formatter_section = std::unique_ptr<Formatter>(Formatter::create("json"));
 }
 
-Graylog::Graylog(std::string logger)
+Graylog::Graylog(const std::string &logger)
     : m_subs(NULL),
       m_log_dst_valid(false),
       m_hostname(""),

--- a/src/common/Graylog.h
+++ b/src/common/Graylog.h
@@ -37,14 +37,14 @@ class Graylog
    * @param s SubsystemMap
    * @param logger Value for key "_logger" in GELF
    */
-  Graylog(const SubsystemMap * const s, std::string logger);
+  Graylog(const SubsystemMap * const s, const std::string &logger);
 
   /**
    * Create Graylog without SubsystemMap. Logging will not be ready
    * until set_destination is called
    * @param logger Value for key "_logger" in GELF
    */
-  explicit Graylog(std::string logger);
+  explicit Graylog(const std::string &logger);
   virtual ~Graylog();
 
   void set_hostname(const std::string& host);

--- a/src/common/TextTable.h
+++ b/src/common/TextTable.h
@@ -45,7 +45,7 @@ private:
     Align col_align;
 
     TextTableColumn() {}
-    TextTableColumn(std::string h, int w, Align ha, Align ca) :
+    TextTableColumn(const std::string &h, int w, Align ha, Align ca) :
 		    heading(h), width(w), hd_align(ha), col_align(ca) { }
     ~TextTableColumn() {}
   };

--- a/src/common/bit_str.cc
+++ b/src/common/bit_str.cc
@@ -56,7 +56,7 @@ static void _dump_bit_str(
 void print_bit_str(
     uint64_t bits,
     std::ostream &out,
-    std::function<const char*(uint64_t)> func,
+    const std::function<const char*(uint64_t)> &func,
     bool dump_bit_val)
 {
   _dump_bit_str(bits, &out, NULL, func, dump_bit_val);
@@ -65,7 +65,7 @@ void print_bit_str(
 void dump_bit_str(
     uint64_t bits,
     ceph::Formatter *f,
-    std::function<const char*(uint64_t)> func,
+    const std::function<const char*(uint64_t)> &func,
     bool dump_bit_val)
 {
   _dump_bit_str(bits, NULL, f, func, dump_bit_val);

--- a/src/common/bit_str.h
+++ b/src/common/bit_str.h
@@ -23,13 +23,13 @@ namespace ceph {
 extern void print_bit_str(
     uint64_t bits,
     std::ostream &out,
-    std::function<const char*(uint64_t)> func,
+    const std::function<const char*(uint64_t)> &func,
     bool dump_bit_val = false);
 
 extern void dump_bit_str(
     uint64_t bits,
     ceph::Formatter *f,
-    std::function<const char*(uint64_t)> func,
+    const std::function<const char*(uint64_t)> &func,
     bool dump_bit_val = false);
 
 #endif /* CEPH_COMMON_BIT_STR_H */

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -197,7 +197,7 @@ public:
     return _set_gid;
   }
 
-  void set_uid_gid_strings(std::string u, std::string g) {
+  void set_uid_gid_strings(const std::string &u, const std::string &g) {
     _set_uid_string = u;
     _set_gid_string = g;
   }

--- a/src/common/hex.cc
+++ b/src/common/hex.cc
@@ -26,7 +26,7 @@ void hex2str(const char *s, int len, char *buf, int dest_len)
   }
 }
 
-std::string hexdump(std::string msg, const char *s, int len)
+std::string hexdump(const std::string &msg, const char *s, int len)
 {
   int buf_len = len*4;
   char buf[buf_len];

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -142,7 +142,7 @@ int ErasureCodeLrc::layers_description(const ErasureCodeProfile &profile,
   return 0;
 }
 
-int ErasureCodeLrc::layers_parse(string description_string,
+int ErasureCodeLrc::layers_parse(const string &description_string,
 				 json_spirit::mArray description,
 				 ostream *ss)
 {
@@ -251,7 +251,7 @@ int ErasureCodeLrc::layers_init(ostream *ss)
   return 0;
 }
 
-int ErasureCodeLrc::layers_sanity_checks(string description_string,
+int ErasureCodeLrc::layers_sanity_checks(const string &description_string,
 					 ostream *ss) const
 {
   int position = 0;
@@ -452,7 +452,7 @@ int ErasureCodeLrc::parse_rule(ErasureCodeProfile &profile,
   return 0;
 }
 
-int ErasureCodeLrc::parse_rule_step(string description_string,
+int ErasureCodeLrc::parse_rule_step(const string &description_string,
 				       json_spirit::mArray description,
 				       ostream *ss)
 {

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -49,7 +49,7 @@ public:
   static const std::string DEFAULT_KML;
 
   struct Layer {
-    explicit Layer(std::string _chunks_map) : chunks_map(_chunks_map) { }
+    explicit Layer(const std::string &_chunks_map) : chunks_map(_chunks_map) { }
     ErasureCodeInterfaceRef erasure_code;
     std::vector<int> data;
     std::vector<int> coding;
@@ -65,7 +65,7 @@ public:
   std::string rule_root;
   std::string rule_device_class;
   struct Step {
-    Step(std::string _op, std::string _type, int _n) :
+    Step(const std::string &_op, const std::string &_type, int _n) :
       op(_op),
       type(_type),
       n(_n) {}
@@ -120,18 +120,18 @@ public:
 
   int parse_rule(ErasureCodeProfile &profile, std::ostream *ss);
 
-  int parse_rule_step(std::string description_string,
+  int parse_rule_step(const std::string &description_string,
 		      json_spirit::mArray description,
 		      std::ostream *ss);
 
   int layers_description(const ErasureCodeProfile &profile,
 			 json_spirit::mArray *description,
 			 std::ostream *ss) const;
-  int layers_parse(std::string description_string,
+  int layers_parse(const std::string &description_string,
 		   json_spirit::mArray description,
 		   std::ostream *ss);
   int layers_init(std::ostream *ss);
-  int layers_sanity_checks(std::string description_string,
+  int layers_sanity_checks(const std::string &description_string,
 			   std::ostream *ss) const;
 };
 

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -318,7 +318,7 @@ int MemDB::_rmkey(ms_op_t &op)
   return m_map.erase(key);
 }
 
-std::shared_ptr<KeyValueDB::MergeOperator> MemDB::_find_merge_op(std::string prefix)
+std::shared_ptr<KeyValueDB::MergeOperator> MemDB::_find_merge_op(const std::string &prefix)
 {
   for (const auto& i : merge_ops) {
     if (i.first == prefix) {

--- a/src/kv/MemDB.h
+++ b/src/kv/MemDB.h
@@ -65,7 +65,7 @@ public:
   int set_merge_operator(const std::string& prefix,
          std::shared_ptr<MergeOperator> mop) override;
 
-  std::shared_ptr<MergeOperator> _find_merge_op(std::string prefix);
+  std::shared_ptr<MergeOperator> _find_merge_op(const std::string &prefix);
 
   static
   int _test_init(const string& dir) { return 0; };

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -124,7 +124,7 @@ class RocksDBStore::MergeOperatorLinker
 private:
   std::shared_ptr<KeyValueDB::MergeOperator> mop;
 public:
-  MergeOperatorLinker(std::shared_ptr<KeyValueDB::MergeOperator> o) : mop(o) {}
+  MergeOperatorLinker(const std::shared_ptr<KeyValueDB::MergeOperator> &o) : mop(o) {}
 
   const char *Name() const override {
     return mop->name().c_str();

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -100,8 +100,8 @@ int group_snap_list(librados::IoCtx& group_ioctx, const char *group_name,
 }
 
 std::string calc_ind_image_snap_name(uint64_t pool_id,
-				     std::string group_id,
-				     std::string snap_id)
+				     const std::string &group_id,
+				     const std::string &snap_id)
 {
   std::stringstream ind_snap_name_stream;
   ind_snap_name_stream << ".group." << std::hex << pool_id << "_"

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2624,7 +2624,7 @@ bool CDir::contains(CDir *x)
 
 /** set_dir_auth
  */
-void CDir::set_dir_auth(mds_authority_t a)
+void CDir::set_dir_auth(const mds_authority_t &a)
 { 
   dout(10) << "setting dir_auth=" << a
 	   << " from " << dir_auth

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -521,7 +521,7 @@ private:
  public:
   mds_authority_t authority() const override;
   mds_authority_t get_dir_auth() const { return dir_auth; }
-  void set_dir_auth(mds_authority_t a);
+  void set_dir_auth(const mds_authority_t &a);
   void set_dir_auth(mds_rank_t a) { set_dir_auth(mds_authority_t(a, CDIR_AUTH_UNKNOWN)); }
   bool is_ambiguous_dir_auth() const {
     return dir_auth.second != CDIR_AUTH_UNKNOWN;

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -405,7 +405,7 @@ public:
   /**
    * A daemon has informed us of its offload targets
    */
-  void update_export_targets(mds_gid_t who, const std::set<mds_rank_t> targets)
+  void update_export_targets(mds_gid_t who, const std::set<mds_rank_t> &targets)
   {
     auto fscid = mds_roles.at(who);
     modify_filesystem(fscid, [who, &targets](std::shared_ptr<Filesystem> fs) {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -1163,7 +1163,7 @@ void MDCache::get_force_dirfrag_bound_set(vector<dirfrag_t>& dfs, set<CDir*>& bo
   }
 }
 
-void MDCache::adjust_bounded_subtree_auth(CDir *dir, vector<dirfrag_t>& bound_dfs, mds_authority_t auth)
+void MDCache::adjust_bounded_subtree_auth(CDir *dir, vector<dirfrag_t>& bound_dfs, const mds_authority_t &auth)
 {
   dout(7) << "adjust_bounded_subtree_auth " << dir->get_dir_auth() << " -> " << auth
 	  << " on " << *dir << " bound_dfs " << bound_dfs << dendl;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -323,7 +323,7 @@ public:
   void adjust_bounded_subtree_auth(CDir *dir, set<CDir*>& bounds, mds_rank_t a) {
     adjust_bounded_subtree_auth(dir, bounds, mds_authority_t(a, CDIR_AUTH_UNKNOWN));
   }
-  void adjust_bounded_subtree_auth(CDir *dir, vector<dirfrag_t>& bounds, mds_authority_t auth);
+  void adjust_bounded_subtree_auth(CDir *dir, vector<dirfrag_t>& bounds, const mds_authority_t &auth);
   void adjust_bounded_subtree_auth(CDir *dir, vector<dirfrag_t>& bounds, mds_rank_t a) {
     adjust_bounded_subtree_auth(dir, bounds, mds_authority_t(a, CDIR_AUTH_UNKNOWN));
   }

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -76,11 +76,11 @@ struct MDSCapMatch {
 
   MDSCapMatch() : uid(MDS_AUTH_UID_ANY) {}
   MDSCapMatch(int64_t uid_, std::vector<gid_t>& gids_) : uid(uid_), gids(gids_) {}
-  explicit MDSCapMatch(std::string path_)
+  explicit MDSCapMatch(const std::string &path_)
     : uid(MDS_AUTH_UID_ANY), path(path_) {
     normalize_path();
   }
-  MDSCapMatch(std::string path_, int64_t uid_, std::vector<gid_t>& gids_)
+  MDSCapMatch(const std::string& path_, int64_t uid_, std::vector<gid_t>& gids_)
     : uid(uid_), gids(gids_), path(path_) {
     normalize_path();
   }

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -89,7 +89,7 @@ public:
   // keep our default values synced with MDRequestParam's
   MutationImpl() : TrackedOp(nullptr, utime_t()) {}
   MutationImpl(OpTracker *tracker, utime_t initiated,
-	       metareqid_t ri, __u32 att=0, mds_rank_t slave_to=MDS_RANK_NONE)
+	       const metareqid_t &ri, __u32 att=0, mds_rank_t slave_to=MDS_RANK_NONE)
     : TrackedOp(tracker, initiated),
       reqid(ri), attempt(att),
       slave_to_mds(slave_to) { }

--- a/src/mgr/ActivePyModule.h
+++ b/src/mgr/ActivePyModule.h
@@ -43,7 +43,7 @@ private:
   std::string uri;
 
 public:
-  ActivePyModule(PyModuleRef py_module_,
+  ActivePyModule(const PyModuleRef &py_module_,
       LogChannelRef clog_)
     : PyModuleRunner(py_module_, clog_)
   {}

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -552,7 +552,7 @@ PyObject* ActivePyModules::get_counter_python(
 }
 
 PyObject* ActivePyModules::get_perf_schema_python(
-    const std::string svc_type,
+    const std::string &svc_type,
     const std::string &svc_id)
 {
   PyThreadState *tstate = PyEval_SaveThread();

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -72,7 +72,7 @@ public:
     const std::string &svc_id,
     const std::string &path);
   PyObject *get_perf_schema_python(
-     const std::string svc_type,
+     const std::string &svc_type,
      const std::string &svc_id);
   PyObject *get_context();
   PyObject *get_osdmap();

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -672,7 +672,7 @@ bool DaemonServer::handle_command(MCommand *m)
     bufferlist from_mon;
     string outs;
 
-    ReplyOnFinish(std::shared_ptr<CommandContext> cmdctx_)
+    ReplyOnFinish(const std::shared_ptr<CommandContext> &cmdctx_)
       : cmdctx(cmdctx_)
     {}
     void finish(int r) override {

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -104,10 +104,10 @@ public:
   bool handle_command_reply(MCommandReply *m);
 
   void send_pgstats();
-  void set_pgstats_cb(std::function<MPGStats*()> cb_)
+  void set_pgstats_cb(std::function<MPGStats*()>&& cb_)
   {
     Mutex::Locker l(lock);
-    pgstats_cb = cb_;
+    pgstats_cb = std::move(cb_);
   }
 
   int start_command(const vector<string>& cmd, const bufferlist& inbl,

--- a/src/mgr/PyModuleRunner.h
+++ b/src/mgr/PyModuleRunner.h
@@ -53,7 +53,7 @@ public:
   void log(int level, const std::string &record);
 
   PyModuleRunner(
-      PyModuleRef py_module_,
+      const PyModuleRef &py_module_,
       LogChannelRef clog_)
     : 
       py_module(py_module_),

--- a/src/mgr/StandbyPyModules.h
+++ b/src/mgr/StandbyPyModules.h
@@ -89,7 +89,7 @@ class StandbyPyModule : public PyModuleRunner
 
   StandbyPyModule(
       StandbyPyModuleState &state_,
-      PyModuleRef py_module_,
+      const PyModuleRef &py_module_,
       LogChannelRef clog_)
     :
       PyModuleRunner(py_module_, clog_),

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -133,7 +133,7 @@ struct MonCap {
   std::vector<MonCapGrant> grants;
 
   MonCap() {}
-  explicit MonCap(std::vector<MonCapGrant> g) : grants(g) {}
+  explicit MonCap(const std::vector<MonCapGrant> &g) : grants(g) {}
 
   string get_str() const {
     return text;

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -343,7 +343,7 @@ void MonMap::dump(Formatter *f) const
 }
 
 
-int MonMap::build_from_host_list(std::string hostlist, std::string prefix)
+int MonMap::build_from_host_list(std::string hostlist, const std::string &prefix)
 {
   vector<entity_addr_t> addrs;
   if (parse_ip_port_vec(hostlist.c_str(), addrs)) {

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -317,7 +317,7 @@ public:
    * @param prefix prefix to prepend to generated mon names
    * @return 0 for success, -errno on error
    */
-  int build_from_host_list(std::string hosts, std::string prefix);
+  int build_from_host_list(std::string hosts, const std::string &prefix);
 
   /**
    * filter monmap given a set of initial members.

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2146,13 +2146,13 @@ void PGMap::get_health_checks(
     stuck_cb stuck_since;
     bool invert;
 
-    PgStateResponse(const pg_consequence_t &c, stuck_cb s)
-      : consequence(c), stuck_since(s), invert(false)
+    PgStateResponse(const pg_consequence_t& c, stuck_cb&& s)
+      : consequence(c), stuck_since(std::move(s)), invert(false)
     {
     }
 
-    PgStateResponse(const pg_consequence_t &c, stuck_cb s, bool i)
-      : consequence(c), stuck_since(s), invert(i)
+    PgStateResponse(const pg_consequence_t& c, stuck_cb&& s, bool i)
+      : consequence(c), stuck_since(std::move(s)), invert(i)
     {
     }
   };

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -539,7 +539,7 @@ namespace ceph {
           );
       }
 
-      static inline mon_feature_t get_feature_by_name(std::string n);
+      static inline mon_feature_t get_feature_by_name(const std::string &n);
     }
   }
 }
@@ -561,7 +561,7 @@ static inline const char *ceph::features::mon::get_feature_name(uint64_t b) {
   return "unknown";
 }
 
-inline mon_feature_t ceph::features::mon::get_feature_by_name(std::string n) {
+inline mon_feature_t ceph::features::mon::get_feature_by_name(const std::string &n) {
 
   if (n == "kraken") {
     return FEATURE_KRAKEN;

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1207,7 +1207,7 @@ public:
       _op->cid = _get_coll_id(cid);
       data.ops++;
     }
-    void collection_move(const coll_t& cid, coll_t oldcid, const ghobject_t& oid)
+    void collection_move(const coll_t& cid, const coll_t &oldcid, const ghobject_t& oid)
       __attribute__ ((deprecated)) {
 	// NOTE: we encode this as a fixed combo of ADD + REMOVE.  they
 	// always appear together, so this is effectively a single MOVE.
@@ -1225,7 +1225,7 @@ public:
 	data.ops++;
       }
     void collection_move_rename(const coll_t& oldcid, const ghobject_t& oldoid,
-				coll_t cid, const ghobject_t& oid) {
+				const coll_t &cid, const ghobject_t& oid) {
       Op* _op = _get_next_op();
       _op->op = OP_COLL_MOVE_RENAME;
       _op->cid = _get_coll_id(oldcid);
@@ -1234,7 +1234,7 @@ public:
       _op->dest_oid = _get_object_id(oid);
       data.ops++;
     }
-    void try_rename(coll_t cid, const ghobject_t& oldoid,
+    void try_rename(const coll_t &cid, const ghobject_t& oldoid,
                     const ghobject_t& oid) {
       Op* _op = _get_next_op();
       _op->op = OP_TRY_RENAME;
@@ -1246,7 +1246,7 @@ public:
 
     /// Remove omap from oid
     void omap_clear(
-      coll_t cid,           ///< [in] Collection containing oid
+      const coll_t &cid,           ///< [in] Collection containing oid
       const ghobject_t &oid  ///< [in] Object from which to remove omap
       ) {
       Op* _op = _get_next_op();
@@ -1272,7 +1272,7 @@ public:
 
     /// Set keys on an oid omap (bufferlist variant).
     void omap_setkeys(
-      coll_t cid,                           ///< [in] Collection containing oid
+      const coll_t &cid,                           ///< [in] Collection containing oid
       const ghobject_t &oid,                ///< [in] Object to update
       const bufferlist &attrset_bl          ///< [in] Replacement keys and values
       ) {
@@ -1286,7 +1286,7 @@ public:
 
     /// Remove keys from oid omap
     void omap_rmkeys(
-      coll_t cid,             ///< [in] Collection containing oid
+      const coll_t &cid,             ///< [in] Collection containing oid
       const ghobject_t &oid,  ///< [in] Object from which to remove the omap
       const set<string> &keys ///< [in] Keys to clear
       ) {
@@ -1301,7 +1301,7 @@ public:
 
     /// Remove keys from oid omap
     void omap_rmkeys(
-      coll_t cid,             ///< [in] Collection containing oid
+      const coll_t &cid,             ///< [in] Collection containing oid
       const ghobject_t &oid,  ///< [in] Object from which to remove the omap
       const bufferlist &keys_bl ///< [in] Keys to clear
       ) {
@@ -1315,7 +1315,7 @@ public:
 
     /// Remove key range from oid omap
     void omap_rmkeyrange(
-      coll_t cid,             ///< [in] Collection containing oid
+      const coll_t &cid,             ///< [in] Collection containing oid
       const ghobject_t &oid,  ///< [in] Object from which to remove the omap keys
       const string& first,    ///< [in] first key in range
       const string& last      ///< [in] first key past range, range is [first,last)
@@ -1332,7 +1332,7 @@ public:
 
     /// Set omap header
     void omap_setheader(
-      coll_t cid,             ///< [in] Collection containing oid
+      const coll_t &cid,             ///< [in] Collection containing oid
       const ghobject_t &oid,  ///< [in] Object
       const bufferlist &bl    ///< [in] Header value
       ) {
@@ -1348,10 +1348,10 @@ public:
     /// Split collection based on given prefixes, objects matching the specified bits/rem are
     /// moved to the new collection
     void split_collection(
-      coll_t cid,
+      const coll_t &cid,
       uint32_t bits,
       uint32_t rem,
-      coll_t destination) {
+      const coll_t &destination) {
       Op* _op = _get_next_op();
       _op->op = OP_SPLIT_COLLECTION2;
       _op->cid = _get_coll_id(cid);
@@ -1362,7 +1362,7 @@ public:
     }
 
     void collection_set_bits(
-      coll_t cid,
+      const coll_t &cid,
       int bits) {
       Op* _op = _get_next_op();
       _op->op = OP_COLL_SET_BITS;
@@ -1374,7 +1374,7 @@ public:
     /// Set allocation hint for an object
     /// make 0 values(expected_object_size, expected_write_size) noops for all implementations
     void set_alloc_hint(
-      coll_t cid,
+      const coll_t &cid,
       const ghobject_t &oid,
       uint64_t expected_object_size,
       uint64_t expected_write_size,

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -190,7 +190,7 @@ void ECBackend::RecoveryOp::dump(Formatter *f) const
 
 ECBackend::ECBackend(
   PGBackend::Listener *pg,
-  coll_t coll,
+  const coll_t &coll,
   ObjectStore::CollectionHandle &ch,
   ObjectStore *store,
   CephContext *cct,

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -626,7 +626,7 @@ public:
 public:
   ECBackend(
     PGBackend::Listener *pg,
-    coll_t coll,
+    const coll_t &coll,
     ObjectStore::CollectionHandle &ch,
     ObjectStore *store,
     CephContext *cct,

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -297,7 +297,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
    };
    Listener *parent;
    Listener *get_parent() const { return parent; }
-   PGBackend(CephContext* cct, Listener *l, ObjectStore *store, coll_t coll,
+   PGBackend(CephContext* cct, Listener *l, ObjectStore *store, const coll_t &coll,
 	     ObjectStore::CollectionHandle &ch) :
      cct(cct),
      store(store),

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -100,7 +100,7 @@ static void log_subop_stats(
 
 ReplicatedBackend::ReplicatedBackend(
   PGBackend::Listener *pg,
-  coll_t coll,
+  const coll_t &coll,
   ObjectStore::CollectionHandle &c,
   ObjectStore *store,
   CephContext *cct) :

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -29,7 +29,7 @@ class ReplicatedBackend : public PGBackend {
 public:
   ReplicatedBackend(
     PGBackend::Listener *pg,
-    coll_t coll,
+    const coll_t &coll,
     ObjectStore::CollectionHandle &ch,
     ObjectStore *store,
     CephContext *cct);

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -39,7 +39,7 @@ public:
     ghobject_t hoid;
     ObjectStore::Transaction *t;
     OSTransaction(
-      coll_t cid,
+      const coll_t &cid,
       const ghobject_t &hoid,
       ObjectStore::Transaction *t)
       : cid(cid), hoid(hoid), t(t) {}

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1084,7 +1084,7 @@ class pool_opts_encoder_t : public boost::static_visitor<>
 public:
   explicit pool_opts_encoder_t(bufferlist& bl_) : bl(bl_) {}
 
-  void operator()(std::string s) const {
+  void operator()(const std::string &s) const {
     encode(static_cast<int32_t>(pool_opts_t::STR), bl);
     encode(s, bl);
   }

--- a/src/rbd_replay/ios.cc
+++ b/src/rbd_replay/ios.cc
@@ -47,7 +47,7 @@ action::Dependencies convert_dependencies(uint64_t start_time,
 
 } // anonymous namespace
 
-void IO::write_debug_base(ostream& out, string type) const {
+void IO::write_debug_base(ostream& out, const string &type) const {
   out << m_ionum << ": " << m_start_time / 1000000.0 << ": " << type << ", thread = " << m_thread_id << ", deps = {";
   bool first = true;
   for (io_set_t::iterator itr = m_dependencies.begin(), end = m_dependencies.end(); itr != end; ++itr) {

--- a/src/rbd_replay/ios.hpp
+++ b/src/rbd_replay/ios.hpp
@@ -94,7 +94,7 @@ public:
   virtual void write_debug(std::ostream& out) const = 0;
 
 protected:
-  void write_debug_base(std::ostream& out, std::string iotype) const;
+  void write_debug_base(std::ostream& out, const std::string &iotype) const;
 
 private:
   action_id_t m_ionum;

--- a/src/rbd_replay/rbd-replay-prep.cc
+++ b/src/rbd_replay/rbd-replay-prep.cc
@@ -88,7 +88,7 @@ private:
 
 class AnonymizedImage {
 public:
-  void init(string image_name, int index) {
+  void init(const string &image_name, int index) {
     assert(m_image_name == "");
     m_image_name = image_name;
     ostringstream oss;
@@ -119,14 +119,14 @@ private:
   map<string, string> m_snaps;
 };
 
-static void usage(string prog) {
+static void usage(const string &prog) {
   std::stringstream str;
   str << "Usage: " << prog << " ";
   std::cout << str.str() << "[ --window <seconds> ] [ --anonymize ] [ --verbose ]" << std::endl
             << std::string(str.str().size(), ' ') << "<trace-input> <replay-output>" << endl;
 }
 
-__attribute__((noreturn)) static void usage_exit(string prog, string msg) {
+__attribute__((noreturn)) static void usage_exit(const string &prog, const string &msg) {
   cerr << msg << endl;
   usage(prog);
   exit(1);

--- a/src/rbd_replay/rbd_loc.cc
+++ b/src/rbd_replay/rbd_loc.cc
@@ -23,7 +23,7 @@ using namespace rbd_replay;
 rbd_loc::rbd_loc() {
 }
 
-rbd_loc::rbd_loc(string pool, string image, string snap)
+rbd_loc::rbd_loc(const string &pool, const string &image, const string &snap)
   : pool(pool),
     image(image),
     snap(snap) {

--- a/src/rbd_replay/rbd_loc.hpp
+++ b/src/rbd_replay/rbd_loc.hpp
@@ -49,7 +49,7 @@ struct rbd_loc {
   /**
      Constructs an rbd_loc with the given pool, image, and snap.
    */
-  rbd_loc(std::string pool, std::string image, std::string snap);
+  rbd_loc(const std::string &pool, const std::string &image, const std::string &snap);
 
   /**
      Parses an rbd_loc from the given string.

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2289,7 +2289,7 @@ static void parse_tier_config_param(const string& s, map<string, string, ltstr_n
   }
 }
 
-static int check_pool_support_omap(rgw_pool pool) 
+static int check_pool_support_omap(const rgw_pool& pool)
 {
   librados::IoCtx io_ctx;
   int ret = store->get_rados_handle()->ioctx_create(pool.to_str().c_str(), io_ctx);

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -431,7 +431,7 @@ public:
     virtual aplptr_t create_apl_remote(CephContext* cct,
                                        const req_state* s,
                                        acl_strategy_t&& extra_acl_strategy,
-                                       const AuthInfo info) const = 0;
+                                       const AuthInfo &info) const = 0;
   };
 };
 

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -112,7 +112,7 @@ public:
 
   template <typename U>
   ThirdPartyAccountApplier(RGWRados* const store,
-                           const rgw_user acct_user_override,
+                           const rgw_user &acct_user_override,
                            U&& decoratee)
     : DecoratedApplier<T>(std::move(decoratee)),
       store(store),
@@ -175,7 +175,7 @@ void ThirdPartyAccountApplier<T>::load_acct_info(RGWUserInfo& user_info) const
 
 template <typename T> static inline
 ThirdPartyAccountApplier<T> add_3rdparty(RGWRados* const store,
-                                         const rgw_user acct_user_override,
+                                         const rgw_user &acct_user_override,
                                          T&& t) {
   return ThirdPartyAccountApplier<T>(store, acct_user_override,
                                      std::forward<T>(t));

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -47,7 +47,7 @@ class ExternalAuthStrategy : public rgw::auth::Strategy,
   aplptr_t create_apl_remote(CephContext* const cct,
                              const req_state* const s,
                              rgw::auth::RemoteApplier::acl_strategy_t&& acl_alg,
-                             const rgw::auth::RemoteApplier::AuthInfo info
+                             const rgw::auth::RemoteApplier::AuthInfo &info
                             ) const override {
     auto apl = rgw::auth::add_sysreq(cct, store, s,
       rgw::auth::RemoteApplier(cct, store, std::move(acl_alg), info,

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -143,7 +143,7 @@ public:
   typedef std::set<header_name_t, ltstr_nocase> header_spec_t;
 
   RGWHTTPHeadersCollector(CephContext * const cct,
-                          const header_spec_t relevant_headers)
+                          const header_spec_t &relevant_headers)
     : RGWHTTPClient(cct),
       relevant_headers(relevant_headers) {
   }

--- a/src/rgw/rgw_ldap.cc
+++ b/src/rgw/rgw_ldap.cc
@@ -41,7 +41,7 @@ std::string parse_rgw_ldap_bindpw(CephContext* ctx)
 #if defined(HAVE_OPENLDAP)
 namespace rgw {
 
-  int LDAPHelper::auth(const std::string uid, const std::string pwd) {
+  int LDAPHelper::auth(const std::string &uid, const std::string &pwd) {
     int ret;
     std::string filter;
     if (msad) {

--- a/src/rgw/rgw_ldap.h
+++ b/src/rgw/rgw_ldap.h
@@ -38,7 +38,7 @@ namespace rgw {
     using lock_guard = std::lock_guard<std::mutex>;
 
     LDAPHelper(std::string _uri, std::string _binddn, std::string _bindpw,
-	       std::string _searchdn, std::string _searchfilter, std::string _dnattr)
+	       const std::string &_searchdn, const std::string &_searchfilter, const std::string &_dnattr)
       : uri(std::move(_uri)), binddn(std::move(_binddn)),
 	bindpw(std::move(_bindpw)), searchdn(_searchdn), searchfilter(_searchfilter), dnattr(_dnattr),
 	ldap(nullptr) {
@@ -91,7 +91,7 @@ namespace rgw {
       return ret; // OpenLDAP client error space
     }
 
-    int auth(const std::string uid, const std::string pwd);
+    int auth(const std::string &uid, const std::string &pwd);
 
     ~LDAPHelper() {
       if (ldap)
@@ -105,8 +105,8 @@ namespace rgw {
   class LDAPHelper
   {
   public:
-    LDAPHelper(std::string _uri, std::string _binddn, std::string _bindpw,
-	       std::string _searchdn, std::string _searchfilter, std::string _dnattr)
+    LDAPHelper(const std::string &_uri, const std::string &_binddn, const std::string &_bindpw,
+	       const std::string &_searchdn, const std::string &_searchfilter, const std::string &_dnattr)
       {}
 
     int init() {
@@ -117,7 +117,7 @@ namespace rgw {
       return -ENOTSUP;
     }
 
-    int auth(const std::string uid, const std::string pwd) {
+    int auth(const std::string &uid, const std::string &pwd) {
       return -EACCES;
     }
 

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -904,7 +904,7 @@ public:
   aplptr_t create_apl_remote(CephContext* const cct,
                              const req_state* const s,
                              rgw::auth::RemoteApplier::acl_strategy_t&& acl_alg,
-                             const rgw::auth::RemoteApplier::AuthInfo info
+                             const rgw::auth::RemoteApplier::AuthInfo &info
                             ) const override {
     return aplptr_t(
       new rgw::auth::RemoteApplier(cct, store, std::move(acl_alg), info,

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -80,7 +80,7 @@ int RGWListBuckets_ObjStore_SWIFT::get_params()
 
 static void dump_account_metadata(struct req_state * const s,
                                   const RGWUsageStats& global_stats,
-                                  const std::map<std::string, RGWUsageStats> policies_stats,
+                                  const std::map<std::string, RGWUsageStats> &policies_stats,
                                   /* const */map<string, bufferlist>& attrs,
                                   const RGWQuotaInfo& quota,
                                   const RGWAccessControlPolicy_SWIFTAcct &policy)

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -187,7 +187,7 @@ class DefaultStrategy : public rgw::auth::Strategy,
   aplptr_t create_apl_remote(CephContext* const cct,
                              const req_state* const s,
                              acl_strategy_t&& extra_acl_strategy,
-                             const rgw::auth::RemoteApplier::AuthInfo info) const override {
+                             const rgw::auth::RemoteApplier::AuthInfo &info) const override {
     auto apl = \
       rgw::auth::add_3rdparty(store, s->account_name,
         rgw::auth::add_sysreq(cct, store, s,

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1875,7 +1875,7 @@ class RGWMetaSyncCR : public RGWCoroutine {
   int ret{0};
 
 public:
-  RGWMetaSyncCR(RGWMetaSyncEnv *_sync_env, RGWPeriodHistory::Cursor cursor,
+  RGWMetaSyncCR(RGWMetaSyncEnv *_sync_env, const RGWPeriodHistory::Cursor &cursor,
                 const rgw_meta_sync_status& _sync_status, RGWSyncTraceNodeRef& _tn)
     : RGWCoroutine(_sync_env->cct), sync_env(_sync_env),
       pool(sync_env->store->get_zone_params().log_pool),

--- a/src/rgw/rgw_tag_s3.h
+++ b/src/rgw/rgw_tag_s3.h
@@ -28,7 +28,7 @@ class RGWObjTagEntry_S3: public XMLObj
   std::string val;
 public:
   RGWObjTagEntry_S3() {}
-  RGWObjTagEntry_S3(std::string k,std::string v):key(k),val(v) {};
+  RGWObjTagEntry_S3(const std::string &k, const std::string &v):key(k),val(v) {};
   ~RGWObjTagEntry_S3() {}
 
   bool xml_end(const char*) override;

--- a/src/test/ObjectMap/test_keyvaluedb_iterators.cc
+++ b/src/test/ObjectMap/test_keyvaluedb_iterators.cc
@@ -93,8 +93,8 @@ public:
   ::testing::AssertionResult validate_iterator(
 				KeyValueDB::WholeSpaceIterator it,
 				string expected_prefix,
-				string expected_key,
-				string expected_value) {
+				const string &expected_key,
+				const string &expected_value) {
     if (!it->valid()) {
       return ::testing::AssertionFailure()
 	      << __func__
@@ -214,13 +214,13 @@ public:
     return str;
   }
 
-  string _gen_val_str(string key) {
+  string _gen_val_str(const string &key) {
     ostringstream ss;
     ss << "##value##" << key << "##";
     return ss.str();
  }
 
-  bufferlist _gen_val(string key) {
+  bufferlist _gen_val(const string &key) {
     bufferlist bl;
     bl.append(_gen_val_str(key));
     return bl;

--- a/src/test/admin_socket_output.cc
+++ b/src/test/admin_socket_output.cc
@@ -98,7 +98,7 @@ bool AdminSocketOutput::init_sockets() {
 
 std::pair<std::string, std::string>
 AdminSocketOutput::run_command(AdminSocketClient &client,
-                               const std::string raw_command,
+                               const std::string &raw_command,
                                bool send_untouched) {
   std::cout << "Sending command \"" << raw_command << "\"" << std::endl;
   std::string command;
@@ -188,8 +188,8 @@ bool AdminSocketOutput::gather_socket_output() {
   return true;
 }
 
-std::string AdminSocketOutput::get_result(const std::string target,
-                                          const std::string command) const {
+std::string AdminSocketOutput::get_result(const std::string &target,
+                                          const std::string &command) const {
   const auto& target_results = results.find(target);
   if (target_results == results.end())
     return std::string("");

--- a/src/test/admin_socket_output.h
+++ b/src/test/admin_socket_output.h
@@ -54,10 +54,10 @@ private:
 
   bool init_sockets();
   bool gather_socket_output();
-  std::string get_result(const std::string target, const std::string command) const;
+  std::string get_result(const std::string &target, const std::string &command) const;
 
   std::pair<std::string, std::string>
-  run_command(AdminSocketClient &client, const std::string raw_command,
+  run_command(AdminSocketClient &client, const std::string &raw_command,
               bool send_untouched = false);
 
   bool run_tests() const;

--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -142,7 +142,7 @@ TEST_F(LibRadosListPP, ListObjectsEndIter) {
 static void check_list(
   std::set<std::string>& myset,
   rados_list_ctx_t& ctx,
-  std::string check_nspace)
+  const std::string &check_nspace)
 {
   const char *entry, *nspace;
   cout << "myset " << myset << std::endl;
@@ -227,7 +227,7 @@ TEST_F(LibRadosList, ListObjectsNS) {
   rados_nobjects_list_close(ctx);
 }
 
-static void check_listpp(std::set<std::string>& myset, IoCtx& ioctx, std::string check_nspace)
+static void check_listpp(std::set<std::string>& myset, IoCtx& ioctx, const std::string &check_nspace)
 {
   NObjectIterator iter(ioctx.nobjects_begin());
   std::set<std::string> orig_set(myset);

--- a/src/test/librados/test.cc
+++ b/src/test/librados/test.cc
@@ -83,7 +83,7 @@ int destroy_ec_profile(rados_t *cluster,
 }
 
 int destroy_ruleset(rados_t *cluster,
-                    std::string ruleset,
+                    const std::string &ruleset,
                     std::ostream &oss)
 {
   char *cmd[2];
@@ -98,7 +98,7 @@ int destroy_ruleset(rados_t *cluster,
 }
 
 int destroy_ec_profile_and_ruleset(rados_t *cluster,
-                                   std::string ruleset,
+                                   const std::string &ruleset,
                                    std::ostream &oss)
 {
   int ret;
@@ -181,7 +181,7 @@ std::string create_one_pool_pp(const std::string &pool_name, Rados &cluster,
 }
 
 int destroy_ruleset_pp(Rados &cluster,
-                       std::string ruleset,
+                       const std::string &ruleset,
                        std::ostream &oss)
 {
   bufferlist inbl;
@@ -204,7 +204,7 @@ int destroy_ec_profile_pp(Rados &cluster, const std::string& pool_name,
 }
 
 int destroy_ec_profile_and_ruleset_pp(Rados &cluster,
-                                      std::string ruleset,
+                                      const std::string &ruleset,
                                       std::ostream &oss)
 {
   int ret;

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -67,7 +67,7 @@ using namespace std;
 #define dout_subsys ceph_subsys_
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, get_name())
-static ostream& _prefix(std::ostream *_dout, string n) {
+static ostream& _prefix(std::ostream *_dout, const string &n) {
   return *_dout << " stub(" << n << ") ";
 }
 

--- a/src/test/msgr/perf_msgr_client.cc
+++ b/src/test/msgr/perf_msgr_client.cc
@@ -119,7 +119,7 @@ class MessengerClient {
   vector<ClientThread*> clients;
 
  public:
-  MessengerClient(string t, string addr, int delay):
+  MessengerClient(const string &t, const string &addr, int delay):
       type(t), serveraddr(addr), think_time_us(delay) {
   }
   ~MessengerClient() {

--- a/src/test/msgr/perf_msgr_server.cc
+++ b/src/test/msgr/perf_msgr_server.cc
@@ -113,7 +113,7 @@ class MessengerServer {
   ServerDispatcher dispatcher;
 
  public:
-  MessengerServer(string t, string addr, int threads, int delay):
+  MessengerServer(const string &t, const string &addr, int threads, int delay):
       msgr(NULL), type(t), bindaddr(addr), dispatcher(threads, delay) {
     msgr = Messenger::create(g_ceph_context, type, entity_name_t::OSD(0), "server", 0, 0);
     msgr->set_default_policy(Messenger::Policy::stateless_server(0));

--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -940,7 +940,7 @@ class StressFactory {
   bool zero_copy_read;
   SocketOptions options;
 
-  explicit StressFactory(std::shared_ptr<NetworkStack> s, const string &addr,
+  explicit StressFactory(const std::shared_ptr<NetworkStack> &s, const string &addr,
                          size_t cli, size_t qd, size_t mc, size_t l, bool zero_copy)
       : stack(s), rs(128), client_num(cli), queue_depth(qd),
         max_message_length(l), message_count(mc), message_left(mc),

--- a/src/test/multi_stress_watch.cc
+++ b/src/test/multi_stress_watch.cc
@@ -76,7 +76,7 @@ test_loop(Rados &cluster, std::string pool_name, std::string obj_name)
 #pragma GCC diagnostic warning "-Wpragmas"
 
 void
-test_replicated(Rados &cluster, std::string pool_name, std::string obj_name)
+test_replicated(Rados &cluster, std::string pool_name, const std::string &obj_name)
 {
   // May already exist
   cluster.pool_create(pool_name.c_str());
@@ -85,7 +85,7 @@ test_replicated(Rados &cluster, std::string pool_name, std::string obj_name)
 }
 
 void
-test_erasure(Rados &cluster, std::string pool_name, std::string obj_name)
+test_erasure(Rados &cluster, const std::string &pool_name, const std::string &obj_name)
 {
   string outs;
   bufferlist inbl;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -227,7 +227,7 @@ protected:
 
   void do_matrix(const char *matrix[][10],
 	         boost::scoped_ptr<ObjectStore>& store,
-                 MatrixTest fn) {
+                 const MatrixTest &fn) {
     map<string,string> old;
     for (unsigned i=0; matrix[i][0]; ++i) {
       old[matrix[i][0]] = matrix_get(matrix[i][0]);

--- a/src/test/old/testfilepath.cc
+++ b/src/test/old/testfilepath.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 using namespace std;
 
-int print(string s) {
+int print(const string &s) {
   filepath fp = s;
   cout << "s = " << s << "   filepath = " << fp << endl;
   cout << "  depth " << fp.depth() << endl;

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -333,7 +333,7 @@ public:
       ContentsGenerator::iterator iter;
 
       ContState(
-	ContDesc _cont,
+	const ContDesc &_cont,
 	ceph::shared_ptr<ContentsGenerator> _gen,
 	ContentsGenerator::iterator _iter)
 	: size(_gen->get_length(_cont)), cont(_cont), gen(_gen), iter(_iter) {

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -500,7 +500,7 @@ public:
     redirect_objs[oid] = target;
   }
 
-  void update_object_chunk_target(const string &oid, uint64_t offset, ChunkDesc info)
+  void update_object_chunk_target(const string &oid, uint64_t offset, const ChunkDesc &info)
   {
     for (map<int, map<string,ObjectDesc> >::const_reverse_iterator i = 
 	   pool_obj_cont.rbegin();
@@ -2013,7 +2013,7 @@ public:
   ChunkReadOp(int n,
 	 RadosTestContext *context,
 	 const string &oid,
-	 string tgt_pool_name,
+	 const string &tgt_pool_name,
 	 bool balance_reads,
 	 TestOpStat *stat = 0)
     : TestOp(n, context, stat),

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -1318,7 +1318,7 @@ using namespace std;
 struct MapPredicate {
   map<int, pair<PastIntervals::osd_state_t, epoch_t>> states;
   MapPredicate(
-    vector<pair<int, pair<PastIntervals::osd_state_t, epoch_t>>> _states)
+    const vector<pair<int, pair<PastIntervals::osd_state_t, epoch_t>>> &_states)
    : states(_states.begin(), _states.end()) {}
   PastIntervals::osd_state_t operator()(epoch_t start, int osd, epoch_t *lost_at) {
     auto val = states.at(osd);

--- a/src/test/osdc/object_cacher_stress.cc
+++ b/src/test/osdc/object_cacher_stress.cc
@@ -26,7 +26,7 @@
 
 // XXX: Only tests default namespace
 struct op_data {
-  op_data(std::string oid, uint64_t offset, uint64_t len, bool read)
+  op_data(const std::string &oid, uint64_t offset, uint64_t len, bool read)
     : extent(oid, 0, offset, len, 0), is_read(read)
   {
     extent.oloc.pool = 0;

--- a/src/test/test_cors.cc
+++ b/src/test/test_cors.cc
@@ -170,7 +170,7 @@ static void calc_hmac_sha1(const char *key, int key_len,
   buf_to_hex((unsigned char *)dest, CEPH_CRYPTO_HMACSHA1_DIGESTSIZE, hex_str);
 }
 
-static int get_s3_auth(string method, string creds, string date, string res, string& out){
+static int get_s3_auth(const string &method, string creds, const string &date, const string &res, string& out){
   string aid, secret, auth_hdr;
   size_t off = creds.find(":");
   out = "";

--- a/src/test/test_rgw_admin_log.cc
+++ b/src/test/test_rgw_admin_log.cc
@@ -195,7 +195,7 @@ static void calc_hmac_sha1(const char *key, int key_len,
   admin_log::buf_to_hex((unsigned char *)dest, CEPH_CRYPTO_HMACSHA1_DIGESTSIZE, hex_str);
 }
 
-static int get_s3_auth(string method, string creds, string date, string res, string& out){
+static int get_s3_auth(const string &method, string creds, const string &date, string res, string& out){
   string aid, secret, auth_hdr;
   string tmp_res;
   size_t off = creds.find(":");

--- a/src/test/test_rgw_admin_meta.cc
+++ b/src/test/test_rgw_admin_meta.cc
@@ -189,7 +189,7 @@ static void calc_hmac_sha1(const char *key, int key_len,
   admin_meta::buf_to_hex((unsigned char *)dest, CEPH_CRYPTO_HMACSHA1_DIGESTSIZE, hex_str);
 }
 
-static int get_s3_auth(string method, string creds, string date, string res, string& out){
+static int get_s3_auth(const string &method, string creds, const string &date, string res, string& out){
   string aid, secret, auth_hdr;
   string tmp_res;
   size_t off = creds.find(":");

--- a/src/test/test_rgw_admin_opstate.cc
+++ b/src/test/test_rgw_admin_opstate.cc
@@ -192,7 +192,7 @@ static void calc_hmac_sha1(const char *key, int key_len,
   admin_log::buf_to_hex((unsigned char *)dest, CEPH_CRYPTO_HMACSHA1_DIGESTSIZE, hex_str);
 }
 
-static int get_s3_auth(string method, string creds, string date, string res, string& out){
+static int get_s3_auth(const string &method, string creds, const string &date, string res, string& out){
   string aid, secret, auth_hdr;
   string tmp_res;
   size_t off = creds.find(":");

--- a/src/tools/cephfs/PgFiles.cc
+++ b/src/tools/cephfs/PgFiles.cc
@@ -33,7 +33,7 @@ int PgFiles::init()
   return ceph_init(cmount);
 }
 
-PgFiles::PgFiles(Objecter *o, std::set<pg_t> pgs_)
+PgFiles::PgFiles(Objecter *o, const std::set<pg_t> &pgs_)
   : objecter(o), pgs(pgs_)
 {
   for (const auto &i : pgs) {

--- a/src/tools/cephfs/PgFiles.h
+++ b/src/tools/cephfs/PgFiles.h
@@ -40,7 +40,7 @@ private:
 
 
 public:
-  PgFiles(Objecter *o, std::set<pg_t> pgs_);
+  PgFiles(Objecter *o, const std::set<pg_t> &pgs_);
   ~PgFiles();
 
   int init();

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -61,7 +61,7 @@ std::string get_description_prefix(ArgumentModifier modifier) {
 }
 
 void add_special_pool_option(po::options_description *opt,
-			     std::string prefix) {
+			     const std::string &prefix) {
   std::string name = prefix + "-" + POOL_NAME;
   std::string description = prefix + " pool name";
 

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -128,7 +128,7 @@ std::string get_description_prefix(ArgumentModifier modifier);
 
 
 void add_special_pool_option(boost::program_options::options_description *opt,
-			     std::string prefix);
+			     const std::string &prefix);
 
 void add_all_option(boost::program_options::options_description *opt,
 		    std::string description);

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -64,7 +64,7 @@ static std::string map_option_int_cb(const char *value_char)
   return stringify(d);
 }
 
-static void put_map_option(const std::string &key, std::string val)
+static void put_map_option(const std::string &key, const std::string &val)
 {
   map_options[key] = val;
 }

--- a/src/tools/rbd/action/Watch.cc
+++ b/src/tools/rbd/action/Watch.cc
@@ -20,7 +20,7 @@ namespace po = boost::program_options;
 class RbdWatchCtx : public librados::WatchCtx2 {
 public:
   RbdWatchCtx(librados::IoCtx& io_ctx, const char *image_name,
-              std::string header_oid)
+              const std::string &header_oid)
     : m_io_ctx(io_ctx), m_image_name(image_name), m_header_oid(header_oid)
   {
   }

--- a/src/tools/rbd_mirror/image_map/Policy.h
+++ b/src/tools/rbd_mirror/image_map/Policy.h
@@ -158,7 +158,7 @@ protected:
   RWLock m_map_lock;        // protects m_map, m_shuffled_timestamp
   InstanceToImageMap m_map; // instance_id -> global_id map
 
-  bool is_dead_instance(const std::string instance_id) {
+  bool is_dead_instance(const std::string &instance_id) {
     assert(m_map_lock.is_locked());
     return m_dead_instances.find(instance_id) != m_dead_instances.end();
   }


### PR DESCRIPTION
This pull request adds a small enhancement by avoiding copying data when unnecessary and mitigates the following `cppcheck` messages:

```
[src/auth/AuthAuthorizeHandler.h:47]: (performance) Function parameter 'methods' should be passed by reference.
[src/common/Cond.h:180]: (performance) Function parameter 'name' should be passed by reference.
[src/mds/Mutation.h:91]: (performance) Function parameter 'ri' should be passed by reference.
[src/mon/mon_types.h:552]: (performance) Function parameter 'n' should be passed by reference.
[src/mon/MonCap.h:136]: (performance) Function parameter 'g' should be passed by reference.
[src/osd/SnapMapper.h:42]: (performance) Function parameter 'cid' should be passed by reference.
[src/osd/PGBackend.h:300]: (performance) Function parameter 'coll' should be passed by reference.
[src/os/ObjectStore.h:1210]: (performance) Function parameter 'oldcid' should be passed by reference.
[src/os/ObjectStore.h:1228]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1237]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1249]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1275]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1289]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1304]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1318]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1335]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1351]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1354]: (performance) Function parameter 'destination' should be passed by reference.
[src/os/ObjectStore.h:1365]: (performance) Function parameter 'cid' should be passed by reference.
[src/os/ObjectStore.h:1377]: (performance) Function parameter 'cid' should be passed by reference.
[src/cls/cephfs/cls_cephfs.h:71]: (performance) Function parameter 'obj_xattr_name_' should be passed by reference.
[src/cls/cephfs/cls_cephfs.h:72]: (performance) Function parameter 'mtime_xattr_name_' should be passed by reference.
[src/cls/cephfs/cls_cephfs.h:73]: (performance) Function parameter 'obj_size_xattr_name_' should be passed by reference.
[src/cls/rbd/cls_rbd.cc:5194]: (performance) Function parameter 'snap_id' should be passed by reference.
[src/cls/rbd/cls_rbd.cc:5241]: (performance) Function parameter 'snap_name' should be passed by reference.
[src/cls/rbd/cls_rbd.cc:5242]: (performance) Function parameter 'snap_id' should be passed by reference.
[src/cls/rbd/cls_rbd_client.cc:1112]: (performance) Function parameter 'id' should be passed by reference.
[src/cls/rbd/cls_rbd_client.cc:1119]: (performance) Function parameter 'id' should be passed by reference.
[src/common/Graylog.cc:13]: (performance) Function parameter 'logger' should be passed by reference.
[src/common/Graylog.cc:27]: (performance) Function parameter 'logger' should be passed by reference.
[src/common/ceph_context.h:200]: (performance) Function parameter 'u' should be passed by reference.
[src/common/ceph_context.h:200]: (performance) Function parameter 'g' should be passed by reference.
[src/common/TextTable.h:48]: (performance) Function parameter 'h' should be passed by reference.
[src/common/bit_str.cc:59]: (performance) Function parameter 'func' should be passed by reference.
[src/common/bit_str.cc:68]: (performance) Function parameter 'func' should be passed by reference.
[src/common/hex.cc:29]: (performance) Function parameter 'msg' should be passed by reference.
[src/erasure-code/lrc/ErasureCodeLrc.h:52]: (performance) Function parameter '_chunks_map' should be passed by reference.
[src/erasure-code/lrc/ErasureCodeLrc.h:68]: (performance) Function parameter '_op' should be passed by reference.
[src/erasure-code/lrc/ErasureCodeLrc.h:68]: (performance) Function parameter '_type' should be passed by reference.
[src/erasure-code/lrc/ErasureCodeLrc.cc:145]: (performance) Function parameter 'description_string' should be passed by reference.
[src/erasure-code/lrc/ErasureCodeLrc.cc:254]: (performance) Function parameter 'description_string' should be passed by reference.
[src/erasure-code/lrc/ErasureCodeLrc.cc:455]: (performance) Function parameter 'description_string' should be passed by reference.
[src/kv/MemDB.cc:321]: (performance) Function parameter 'prefix' should be passed by reference.
[src/kv/RocksDBStore.cc:127]: (performance) Function parameter 'o' should be passed by reference.
[src/librbd/api/Group.cc:103]: (performance) Function parameter 'group_id' should be passed by reference.
[src/librbd/api/Group.cc:104]: (performance) Function parameter 'snap_id' should be passed by reference.
[src/mds/CDir.cc:2601]: (performance) Function parameter 'a' should be passed by reference.
[src/mds/FSMap.h:408]: (performance) Function parameter 'targets' should be passed by reference.
[src/mds/MDCache.cc:1167]: (performance) Function parameter 'auth' should be passed by reference.
[src/mds/MDSAuthCaps.h:79]: (performance) Function parameter 'path_' should be passed by reference.
[src/mds/MDSAuthCaps.h:83]: (performance) Function parameter 'path_' should be passed by reference.
[src/mgr/PyModuleRunner.h:56]: (performance) Function parameter 'py_module_' should be passed by reference.
[src/mgr/ActivePyModule.h:46]: (performance) Function parameter 'py_module_' should be passed by reference.
[src/mgr/StandbyPyModules.h:92]: (performance) Function parameter 'py_module_' should be passed by reference.
[src/mgr/ActivePyModules.cc:555]: (performance) Function parameter 'svc_type' should be passed by reference.
[src/mgr/ActivePyModules.h:75]: (performance) Function parameter 'svc_type' should be passed by reference.
[src/mgr/DaemonServer.cc:675]: (performance) Function parameter 'cmdctx_' should be passed by reference.
[src/mgr/MgrClient.h:107]: (performance) Function parameter 'cb_' should be passed by reference.
[src/mon/MonMap.cc:346]: (performance) Function parameter 'prefix' should be passed by reference.
[src/mon/PGMap.cc:2149]: (performance) Function parameter 's' should be passed by reference.
[src/mon/PGMap.cc:2154]: (performance) Function parameter 's' should be passed by reference.
[src/osd/ECBackend.cc:193]: (performance) Function parameter 'coll' should be passed by reference.
[src/osd/ReplicatedBackend.cc:103]: (performance) Function parameter 'coll' should be passed by reference.
[src/osd/osd_types.cc:1087]: (performance) Function parameter 's' should be passed by reference.
[src/rbd_replay/ios.cc:50]: (performance) Function parameter 'type' should be passed by reference.
[src/rbd_replay/rbd-replay-prep.cc:91]: (performance) Function parameter 'image_name' should be passed by reference.
[src/rbd_replay/rbd-replay-prep.cc:122]: (performance) Function parameter 'prog' should be passed by reference.
[src/rbd_replay/rbd-replay-prep.cc:129]: (performance) Function parameter 'prog' should be passed by reference.
[src/rbd_replay/rbd-replay-prep.cc:129]: (performance) Function parameter 'msg' should be passed by reference.
[src/rbd_replay/rbd_loc.cc:26]: (performance) Function parameter 'pool' should be passed by reference.
[src/rbd_replay/rbd_loc.cc:26]: (performance) Function parameter 'image' should be passed by reference.
[src/rbd_replay/rbd_loc.cc:26]: (performance) Function parameter 'snap' should be passed by reference.
[src/rgw/rgw_http_client.h:146]: (performance) Function parameter 'relevant_headers' should be passed by reference.
[src/rgw/rgw_tag_s3.h:31]: (performance) Function parameter 'k' should be passed by reference.
[src/rgw/rgw_tag_s3.h:31]: (performance) Function parameter 'v' should be passed by reference.
[src/rgw/rgw_auth_filters.h:178]: (performance) Function parameter 'acct_user_override' should be passed by reference.
[src/rgw/rgw_rest_s3.h:907]: (performance) Function parameter 'info' should be passed by reference.
[src/rgw/rgw_auth_s3.h:50]: (performance) Function parameter 'info' should be passed by reference.
[src/rgw/rgw_swift_auth.h:190]: (performance) Function parameter 'info' should be passed by reference.
[src/rgw/rgw_auth_filters.h:115]: (performance) Function parameter 'acct_user_override' should be passed by reference.
[src/rgw/rgw_ldap.cc:44]: (performance) Function parameter 'uid' should be passed by reference.
[src/rgw/rgw_ldap.cc:44]: (performance) Function parameter 'pwd' should be passed by reference.
[src/rgw/rgw_sync.cc:1878]: (performance) Function parameter 'cursor' should be passed by reference.
[src/test/ObjectMap/test_keyvaluedb_iterators.cc:96]: (performance) Function parameter 'expected_key' should be passed by reference.
[src/test/ObjectMap/test_keyvaluedb_iterators.cc:97]: (performance) Function parameter 'expected_value' should be passed by reference.
[src/test/ObjectMap/test_keyvaluedb_iterators.cc:217]: (performance) Function parameter 'key' should be passed by reference.
[src/test/ObjectMap/test_keyvaluedb_iterators.cc:223]: (performance) Function parameter 'key' should be passed by reference.
[src/test/admin_socket_output.cc:101]: (performance) Function parameter 'raw_command' should be passed by reference.
[src/test/admin_socket_output.cc:191]: (performance) Function parameter 'target' should be passed by reference.
[src/test/admin_socket_output.cc:192]: (performance) Function parameter 'command' should be passed by reference.
[src/test/librados/list.cc:145]: (performance) Function parameter 'check_nspace' should be passed by reference.
[src/test/librados/list.cc:230]: (performance) Function parameter 'check_nspace' should be passed by reference.
[src/test/librados/test.cc:86]: (performance) Function parameter 'ruleset' should be passed by reference.
[src/test/librados/test.cc:101]: (performance) Function parameter 'ruleset' should be passed by reference.
[src/test/librados/test.cc:184]: (performance) Function parameter 'ruleset' should be passed by reference.
[src/test/librados/test.cc:207]: (performance) Function parameter 'ruleset' should be passed by reference.
[src/test/mon/test_mon_workloadgen.cc:70]: (performance) Function parameter 'n' should be passed by reference.
[src/test/mon/test_mon_workloadgen.cc:176]: (performance) Function parameter 'who' should be passed by reference.
[src/test/msgr/perf_msgr_client.cc:122]: (performance) Function parameter 't' should be passed by reference.
[src/test/msgr/perf_msgr_client.cc:122]: (performance) Function parameter 'addr' should be passed by reference.
[src/test/msgr/perf_msgr_server.cc:116]: (performance) Function parameter 't' should be passed by reference.
[src/test/msgr/perf_msgr_server.cc:116]: (performance) Function parameter 'addr' should be passed by reference.
[src/test/msgr/test_async_networkstack.cc:943]: (performance) Function parameter 's' should be passed by reference.
[src/test/multi_stress_watch.cc:79]: (performance) Function parameter 'obj_name' should be passed by reference.
[src/test/multi_stress_watch.cc:88]: (performance) Function parameter 'pool_name' should be passed by reference.
[src/test/multi_stress_watch.cc:88]: (performance) Function parameter 'obj_name' should be passed by reference.
[src/test/objectstore/store_test.cc:230]: (performance) Function parameter 'fn' should be passed by reference.
[src/test/old/testfilepath.cc:6]: (performance) Function parameter 's' should be passed by reference.
[src/test/osd/Object.h:336]: (performance) Function parameter '_cont' should be passed by reference.
[src/test/osd/RadosModel.h:503]: (performance) Function parameter 'info' should be passed by reference.
[src/test/osd/RadosModel.h:2016]: (performance) Function parameter 'tgt_pool_name' should be passed by reference.
[src/test/osd/types.cc:1321]: (performance) Function parameter '_states' should be passed by reference.
[src/test/osdc/object_cacher_stress.cc:29]: (performance) Function parameter 'oid' should be passed by reference.
[src/test/admin_socket_output.h:57]: (performance) Function parameter 'target' should be passed by reference.
[src/test/admin_socket_output.h:57]: (performance) Function parameter 'command' should be passed by reference.
[src/test/admin_socket_output.h:60]: (performance) Function parameter 'raw_command' should be passed by reference.
[src/test/test_cors.cc:173]: (performance) Function parameter 'method' should be passed by reference.
[src/test/test_cors.cc:173]: (performance) Function parameter 'date' should be passed by reference.
[src/test/test_cors.cc:173]: (performance) Function parameter 'res' should be passed by reference.
[src/test/test_rgw_admin_log.cc:198]: (performance) Function parameter 'method' should be passed by reference.
[src/test/test_rgw_admin_log.cc:198]: (performance) Function parameter 'date' should be passed by reference.
[src/test/test_rgw_admin_meta.cc:192]: (performance) Function parameter 'method' should be passed by reference.
[src/test/test_rgw_admin_meta.cc:192]: (performance) Function parameter 'date' should be passed by reference.
[src/test/test_rgw_admin_opstate.cc:195]: (performance) Function parameter 'method' should be passed by reference.
[src/test/test_rgw_admin_opstate.cc:195]: (performance) Function parameter 'date' should be passed by reference.
[src/tools/cephfs/PgFiles.cc:36]: (performance) Function parameter 'pgs_' should be passed by reference.
[src/tools/rbd/ArgumentTypes.cc:64]: (performance) Function parameter 'prefix' should be passed by reference.
[src/tools/rbd/action/Kernel.cc:67]: (performance) Function parameter 'val' should be passed by reference.
[src/tools/rbd/action/Watch.cc:23]: (performance) Function parameter 'header_oid' should be passed by reference.
[src/tools/rbd_mirror/image_map/Policy.h:161]: (performance) Function parameter 'instance_id' should be passed by reference.
```

The following were not implemented due to `std::move` being used on the variable later on:

```
[src/osd/OSDCap.h:71]: (performance) Function parameter 'class_name' should be passed by reference.
[src/osd/OSDCap.h:71]: (performance) Function parameter 'method_name' should be passed by reference.
[src/osd/OSDCap.h:216]: (performance) Function parameter 'g' should be passed by reference.
[src/rgw/rgw_basic_types.h:125]: (performance) Function parameter 'i' should be passed by reference.
[src/rgw/rgw_iam_policy.h:211]: (performance) Function parameter 'region' should be passed by reference.
[src/rgw/rgw_iam_policy.h:212]: (performance) Function parameter 'account' should be passed by reference.
[src/rgw/rgw_iam_policy.h:212]: (performance) Function parameter 'resource' should be passed by reference.
[src/rgw/rgw_common.h:518]: (performance) Function parameter '_id' should be passed by reference.
[src/rgw/rgw_common.h:518]: (performance) Function parameter '_key' should be passed by reference.
[src/rgw/rgw_auth.h:434]: (performance) Function parameter 'info' should be passed by reference.
[src/rgw/rgw_auth.h:458]: (performance) Function parameter 'subuser' should be passed by reference.
[src/rgw/rgw_formats.h:73]: (performance) Function parameter 'prefix' should be passed by reference.
[src/rgw/rgw_op.h:458]: (performance) Function parameter 'path' should be passed by reference.
[src/rgw/rgw_ldap.h:108]: (performance) Function parameter '_uri' should be passed by reference.
[src/rgw/rgw_ldap.h:108]: (performance) Function parameter '_binddn' should be passed by reference.
[src/rgw/rgw_ldap.h:108]: (performance) Function parameter '_bindpw' should be passed by reference.
[src/rgw/rgw_ldap.h:109]: (performance) Function parameter '_searchdn' should be passed by reference.
[src/rgw/rgw_ldap.h:109]: (performance) Function parameter '_searchfilter' should be passed by reference.
[src/rgw/rgw_ldap.h:109]: (performance) Function parameter '_dnattr' should be passed by reference.
[src/rgw/rgw_ldap.h:120]: (performance) Function parameter 'uid' should be passed by reference.
[src/rgw/rgw_ldap.h:120]: (performance) Function parameter 'pwd' should be passed by reference.
[src/rgw/rgw_ldap.h:40]: (performance) Function parameter '_uri' should be passed by reference.
[src/rgw/rgw_ldap.h:40]: (performance) Function parameter '_binddn' should be passed by reference.
[src/rgw/rgw_ldap.h:40]: (performance) Function parameter '_bindpw' should be passed by reference.
[src/rgw/rgw_ldap.h:41]: (performance) Function parameter '_searchdn' should be passed by reference.
[src/rgw/rgw_ldap.h:41]: (performance) Function parameter '_searchfilter' should be passed by reference.
[src/rgw/rgw_ldap.h:41]: (performance) Function parameter '_dnattr' should be passed by reference.
[src/rgw/rgw_ldap.h:94]: (performance) Function parameter 'uid' should be passed by reference.
[src/rgw/rgw_ldap.h:94]: (performance) Function parameter 'pwd' should be passed by reference.
[src/rgw/rgw_admin.cc:2292]: (performance) Function parameter 'pool' should be passed by reference.
[src/rgw/rgw_rest_swift.cc:83]: (performance) Function parameter 'policies_stats' should be passed by reference.
[src/rgw/rgw_rest_swift.cc:2414]: (performance) Function parameter 'prefix_override' should be passed by reference.
[src/test/direct_messenger/test_direct_messenger.cc:23]: (performance) Function parameter 'callback' should be passed by reference.
```