### PR TITLE
mgr/dashboard: Fix table without fetchData

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -65,7 +65,8 @@
     <!-- end show hide columns -->
 
     <!-- refresh button -->
-    <div class="widget-toolbar tc_refreshBtn">
+    <div class="widget-toolbar tc_refreshBtn"
+         *ngIf="fetchData.observers.length > 0">
       <a (click)="refreshBtn()">
         <i class="fa fa-lg fa-refresh"
            [class.fa-spin]="updating || loadingIndicator"></i>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -142,7 +142,9 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
       // Also if nothing is bound to fetchData nothing will be triggered
       // Force showing the loading indicator because it has been set to False in
       // useData() when this method was triggered by ngOnChanges().
-      this.loadingIndicator = true;
+      if (this.fetchData.observers.length > 0) {
+        this.loadingIndicator = true;
+      }
       this.ngZone.runOutsideAngular(() => {
         this.subscriber = Observable.timer(0, this.autoReload).subscribe(x => {
           this.ngZone.run(() => {


### PR DESCRIPTION
This PR fixes 2 issues on datatable, when **no fetchData is provided**:

- Loading indicator should not be displayed forever

- Refresh button should be hidden