### PR TITLE
client: fixup warning

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8747,7 +8747,7 @@ int64_t Client::_read(Fh *f, int64_t offset, uint64_t size, bufferlist *bl)
   int have = 0;
   bool movepos = false;
   std::unique_ptr<C_SaferCond> onuninline;
-  int64_t r;
+  int64_t r = 0;
   const md_config_t *conf = cct->_conf;
   Inode *in = f->inode.get();
 
@@ -8763,7 +8763,7 @@ int64_t Client::_read(Fh *f, int64_t offset, uint64_t size, bufferlist *bl)
   loff_t start_pos = offset;
 
   if (in->inline_version == 0) {
-    int r = _getattr(in, CEPH_STAT_CAP_INLINE_DATA, f->actor_perms, true);
+    r = _getattr(in, CEPH_STAT_CAP_INLINE_DATA, f->actor_perms, true);
     if (r < 0) {
       goto done;
     }


### PR DESCRIPTION
/src/client/Client.cc:8750:11: warning: 'r' may be used uninitialized in this function [-Wmaybe-uninitialized]
int64_t r;

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>