### PR TITLE
luminous: common: should not check for VERSION_ID

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -182,7 +182,7 @@ static void distro_detect(map<string, string> *m, CephContext *cct)
     lderr(cct) << "distro_detect - /etc/os-release is required" << dendl;
   }
 
-  for (const char* rk: {"distro", "distro_version"}) {
+  for (const char* rk: {"distro", "distro_description"}) {
     if (m->find(rk) == m->end())
       lderr(cct) << "distro_detect - can't detect " << rk << dendl;
   }

--- a/src/test/common/test_util.cc
+++ b/src/test/common/test_util.cc
@@ -41,7 +41,6 @@ TEST(util, collect_sys_info)
   collect_sys_info(&sys_info, cct);
 
   ASSERT_TRUE(sys_info.find("distro") != sys_info.end());
-  ASSERT_TRUE(sys_info.find("distro_version") != sys_info.end());
   ASSERT_TRUE(sys_info.find("distro_description") != sys_info.end());
 
   cct->put();


### PR DESCRIPTION
http://tracker.ceph.com/issues/23478