### PR TITLE
mgr/dashboard: Update selected items on table refresh

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -8,7 +8,8 @@
           (fetchData)="getOsdList()"
           [columns]="columns"
           selectionType="single"
-          (updateSelection)="updateSelection($event)">
+          (updateSelection)="updateSelection($event)"
+          [updateSelectionOnRefresh]="false">
   <cd-osd-details cdTableDetail
                   [selection]="selection">
   </cd-osd-details>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -69,6 +69,9 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
   // e.g. 'single' or 'multi'.
   @Input() selectionType: string = undefined;
 
+  // If `true` selected item details will be updated on table refresh
+  @Input() updateSelectionOnRefresh = true;
+
   /**
    * Should be a function to update the input data if undefined nothing will be triggered
    *
@@ -223,6 +226,27 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
     }
     this.loadingIndicator = false;
     this.updating = false;
+    if (this.updateSelectionOnRefresh) {
+      this.updateSelected();
+    }
+  }
+
+  /**
+   * After updating the data, we have to update the selected items
+   * because details may have changed,
+   * or some selected items may have been removed.
+   */
+  updateSelected() {
+    const newSelected = [];
+    this.selection.selected.forEach((selectedItem) => {
+      for (const row of this.data) {
+        if (selectedItem[this.identifier] === row[this.identifier]) {
+          newSelected.push(row);
+        }
+      }
+    });
+    this.selection.selected = newSelected;
+    this.onSelect();
   }
 
   onSelect() {


### PR DESCRIPTION
After updating table data (either by pressing refresh button or by automatic refresh), selected rows should be updated to guarantee that user will see the updated details of the selected row.

Signed-off-by: Ricardo Marques <rimarques@suse.com>