### PR TITLE
jewel: rgw: s3website error handler uses original object name

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4300,6 +4300,32 @@ RGWHandler_REST* RGWRESTMgr_S3::get_handler(struct req_state *s)
   return handler;
 }
 
+bool RGWHandler_REST_S3Website::web_dir() const {
+  std::string subdir_name;
+  url_decode(s->object.name, subdir_name);
+
+  if (subdir_name.empty()) {
+    return false;
+  } else if (subdir_name.back() == '/') {
+    subdir_name.pop_back();
+  }
+
+  rgw_obj obj(s->bucket, subdir_name);
+
+  RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
+  obj_ctx.set_atomic(obj);
+  obj_ctx.set_prefetch_data(obj);
+
+  RGWObjState* state = nullptr;
+  if (store->get_obj_state(&obj_ctx, obj, &state, false) < 0) {
+    return false;
+  }
+  if (! state->exists) {
+    return false;
+  }
+  return state->exists;
+}
+
 int RGWHandler_REST_S3Website::retarget(RGWOp* op, RGWOp** new_op) {
   *new_op = op;
   ldout(s->cct, 10) << __func__ << "Starting retarget" << dendl;
@@ -4321,7 +4347,7 @@ int RGWHandler_REST_S3Website::retarget(RGWOp* op, RGWOp** new_op) {
   }
 
   rgw_obj_key new_obj;
-  s->bucket_info.website_conf.get_effective_key(s->object.name, &new_obj.name);
+  s->bucket_info.website_conf.get_effective_key(s->object.name, &new_obj.name, web_dir());
   ldout(s->cct, 10) << "retarget get_effective_key " << s->object << " -> "
 		    << new_obj << dendl;
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4326,6 +4326,17 @@ bool RGWHandler_REST_S3Website::web_dir() const {
   return state->exists;
 }
 
+int RGWHandler_REST_S3Website::init(RGWRados *store, req_state *s,
+                                    RGWClientIO* cio)
+{
+  // save the original object name before retarget() replaces it with the
+  // result of get_effective_key(). the error_handler() needs the original
+  // object name for redirect handling
+  original_object_name = s->object.name;
+
+  return RGWHandler_REST_S3::init(store, s, cio);
+}
+
 int RGWHandler_REST_S3Website::retarget(RGWOp* op, RGWOp** new_op) {
   *new_op = op;
   ldout(s->cct, 10) << __func__ << "Starting retarget" << dendl;
@@ -4475,16 +4486,16 @@ int RGWHandler_REST_S3Website::error_handler(int err_no,
 
   RGWBWRoutingRule rrule;
   bool should_redirect =
-    s->bucket_info.website_conf.should_redirect(s->object.name, http_error_code,
-						&rrule);
+    s->bucket_info.website_conf.should_redirect(original_object_name,
+                                                http_error_code, &rrule);
 
   if (should_redirect) {
     const string& hostname = s->info.env->get("HTTP_HOST", "");
     const string& protocol =
       (s->info.env->get("SERVER_PORT_SECURE") ? "https" : "http");
     int redirect_code = 0;
-    rrule.apply_rule(protocol, hostname, s->object.name, &s->redirect,
-		    &redirect_code);
+    rrule.apply_rule(protocol, hostname, original_object_name,
+                     &s->redirect, &redirect_code);
     // Apply a custom HTTP response code
     if (redirect_code > 0)
       s->err.http_ret = redirect_code; // Apply a custom HTTP response code

--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -17,6 +17,7 @@
 #include "rgw_rest_s3.h"
 
 class RGWHandler_REST_S3Website : public RGWHandler_REST_S3 {
+  bool web_dir() const;
 protected:
   int retarget(RGWOp *op, RGWOp **new_op);
   // TODO: this should be virtual I think, and ensure that it's always

--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -17,6 +17,7 @@
 #include "rgw_rest_s3.h"
 
 class RGWHandler_REST_S3Website : public RGWHandler_REST_S3 {
+  std::string original_object_name; // object name before retarget()
   bool web_dir() const;
 protected:
   int retarget(RGWOp *op, RGWOp **new_op);
@@ -37,6 +38,7 @@ protected:
 public:
   RGWHandler_REST_S3Website() : RGWHandler_REST_S3() {}
   virtual ~RGWHandler_REST_S3Website() {}
+  int init(RGWRados *store, req_state *s, RGWClientIO* cio) override;
   virtual int error_handler(int err_no, string *error_content);
 };
 

--- a/src/rgw/rgw_website.cc
+++ b/src/rgw/rgw_website.cc
@@ -106,13 +106,15 @@ bool RGWBucketWebsiteConf::should_redirect(const string& key, const int http_err
   return true;
 }
 
-void RGWBucketWebsiteConf::get_effective_key(const string& key, string *effective_key)
+void RGWBucketWebsiteConf::get_effective_key(const string& key, string *effective_key, bool is_file)
 {
 
   if (key.empty()) {
     *effective_key = index_doc_suffix;
   } else if (key[key.size() - 1] == '/') {
     *effective_key = key + index_doc_suffix;
+  } else if (! is_file) {
+    *effective_key = key + "/" + index_doc_suffix; 
   } else {
     *effective_key = key;
   }

--- a/src/rgw/rgw_website.h
+++ b/src/rgw/rgw_website.h
@@ -202,7 +202,7 @@ struct RGWBucketWebsiteConf
   void dump_xml(Formatter *f) const;
 
   bool should_redirect(const string& key, const int http_error_code, RGWBWRoutingRule *redirect);
-  void get_effective_key(const string& key, string *effective_key);
+  void get_effective_key(const string& key, string *effective_key, bool is_file);
 };
 WRITE_CLASS_ENCODER(RGWBucketWebsiteConf)
 


### PR DESCRIPTION
backport tracker http://tracker.ceph.com/issues/23311

includes the commit from https://github.com/ceph/ceph/pull/15703