### PR TITLE
qa/suites: add minimal performance suite

### DIFF
--- a/qa/suites/perf-basic/ceph.yaml
+++ b/qa/suites/perf-basic/ceph.yaml
@@ -1,0 +1,18 @@
+meta:
+- desc: |
+   Run ceph on a single node.
+   Use xfs beneath the osds.
+
+roles:
+- [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
+tasks:
+- install:
+- ceph:
+    fs: xfs
+    wait-for-scrub: false
+    log-whitelist:
+      - \(PG_
+      - \(OSD_
+      - \(OBJECT_
+      - overall HEALTH
+- ssh_keys:

--- a/qa/suites/perf-basic/objectstore/bluestore.yaml
+++ b/qa/suites/perf-basic/objectstore/bluestore.yaml
@@ -1,0 +1,15 @@
+overrides:
+  ceph:
+    fs: xfs
+    conf:
+      osd:
+        osd objectstore: bluestore
+        bluestore block size: 96636764160
+  ceph-deploy:
+    fs: xfs
+    bluestore: yes
+    conf:
+      osd:
+        osd objectstore: bluestore
+        bluestore block size: 96636764160
+

--- a/qa/suites/perf-basic/objectstore/filestore-xfs.yaml
+++ b/qa/suites/perf-basic/objectstore/filestore-xfs.yaml
@@ -1,0 +1,15 @@
+overrides:
+  ceph:
+    fs: xfs
+    conf:
+      osd:
+        osd objectstore: filestore
+        osd sloppy crc: true
+  ceph-deploy:
+    fs: xfs
+    filestore: True
+    conf:
+      osd:
+        osd objectstore: filestore
+        osd sloppy crc: true
+

--- a/qa/suites/perf-basic/settings/optimized.yaml
+++ b/qa/suites/perf-basic/settings/optimized.yaml
@@ -1,0 +1,71 @@
+meta:
+- desc: |
+   Use debug level 0/0 for performance tests.
+
+overrides:
+  ceph:
+    conf:
+      global:
+        auth client required: none
+        auth cluster required: none
+        auth service required: none
+        auth supported: none
+
+        debug lockdep: "0/0"
+        debug context: "0/0"
+        debug crush: "0/0"
+        debug mds: "0/0"
+        debug mds balancer: "0/0"
+        debug mds locker: "0/0"
+        debug mds log: "0/0"
+        debug mds log expire: "0/0"
+        debug mds migrator: "0/0"
+        debug buffer: "0/0"
+        debug timer: "0/0"
+        debug filer: "0/0"
+        debug striper: "0/0"
+        debug objecter: "0/0"
+        debug rados: "0/0"
+        debug rbd: "0/0"
+        debug rbd mirror: "0/0"
+        debug rbd replay: "0/0"
+        debug journaler: "0/0"
+        debug objectcacher: "0/0"
+        debug client: "0/0"
+        debug osd: "0/0"
+        debug optracker: "0/0"
+        debug objclass: "0/0"
+        debug filestore: "0/0"
+        debug journal: "0/0"
+        debug ms: "0/0"
+        debug mon: "0/0"
+        debug monc: "0/0"
+        debug paxos: "0/0"
+        debug tp: "0/0"
+        debug auth: "0/0"
+        debug crypto: "0/0"
+        debug finisher: "0/0"
+        debug heartbeatmap: "0/0"
+        debug perfcounter: "0/0"
+        debug rgw: "0/0"
+        debug rgw sync: "0/0"
+        debug civetweb: "0/0"
+        debug javaclient: "0/0"
+        debug asok: "0/0"
+        debug throttle: "0/0"
+        debug refs: "0/0"
+        debug xio: "0/0"
+        debug compressor: "0/0"
+        debug bluestore: "0/0"
+        debug bluefs: "0/0"
+        debug bdev: "0/0"
+        debug kstore: "0/0"
+        debug rocksdb: "0/0"
+        debug leveldb: "0/0"
+        debug memdb: "0/0"
+        debug kinetic: "0/0"
+        debug fuse: "0/0"
+        debug mgr: "0/0"
+        debug mgrc: "0/0"
+        debug dpdk: "0/0"
+        debug eventtrace: "0/0"

--- a/qa/suites/perf-basic/workloads/fio_4K_rand_write.yaml
+++ b/qa/suites/perf-basic/workloads/fio_4K_rand_write.yaml
@@ -1,0 +1,29 @@
+meta:
+- desc: |
+   Run librbdfio benchmark using cbt.
+   4K randwrite workload.
+
+tasks:
+- cbt:
+    benchmarks:
+      librbdfio:
+        op_size: [4096]
+        time: 300
+        mode: ['randwrite']
+        norandommap: True
+        vol_size: 4096
+        procs_per_volume: [1]
+        volumes_per_client: [2]
+        iodepth: [32]
+        osd_ra: [4096]
+        pool_profile: 'rbd'
+        log_avg_msec: 100
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        rbd:
+          pg_size: 256
+          pgp_size: 256
+          replication: 3

--- a/qa/suites/perf-basic/workloads/radosbench_4K_write.yaml
+++ b/qa/suites/perf-basic/workloads/radosbench_4K_write.yaml
@@ -1,0 +1,28 @@
+meta:
+- desc: |
+   Run radosbench benchmark using cbt.
+   4K write workload.
+
+tasks:
+- cbt:
+    benchmarks:
+      radosbench:
+        concurrent_ops: 4
+        concurrent_procs: 2
+        op_size: [4096]
+        pool_monitoring_list:
+        - collectl
+        pool_profile: 'replicated'
+        run_monitoring_list:
+        - collectl
+        time: 300
+        write_only: true
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        replicated:
+          pg_size: 256
+          pgp_size: 256
+          replication: 'replicated'


### PR DESCRIPTION
This PR adds a perf-basic suite to be run as a part of teuthology nightly runs. This is a subset of the rados/perf suite and generates 4 jobs.

Signed-off-by: Neha Ojha <nojha@redhat.com>