### PR TITLE
rgw: comparison between signed and unsigned integer expressions

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -51,7 +51,8 @@ RGWCivetWeb::RGWCivetWeb(mg_connection* const conn)
 
 size_t RGWCivetWeb::read_data(char *buf, size_t len)
 {
-  int c, ret;
+  size_t c;
+  int ret;
   if (got_eof_on_read) {
     return 0;
   }


### PR DESCRIPTION
Fixes: Change the data type of 'c' from int to size_t in
src/rgw/rgw_civetweb.cc RGWCivetWeb::read_data

Signed-off-by: ashitakasam <694240887@qq.com>