### PR TITLE
interval_set: kill subset_of

### DIFF
--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -680,48 +680,6 @@ class interval_set {
     return true;
   }  
 
- /*
-   * build a subset of @other for given rage [@start, @end)
-   * E.g.:
-   * subset_of([5~10,20~5], 0, 100) -> [5~10,20~5]
-   * subset_of([5~10,20~5], 5, 25)  -> [5~10,20~5]
-   * subset_of([5~10,20~5], 1, 10)  -> [5~5]
-   * subset_of([5~10,20~5], 8, 24)  -> [8~7, 20~4]
-   */
-  void subset_of(const interval_set &other, T start, T end) {
-    assert(end >= start);
-    clear();
-    if (end == start) {
-      return;
-    }
-    typename Map::const_iterator p = other.find_inc(start);
-    if (p == other.m.end())
-      return;
-    if (p->first < start) {
-      if (p->first + p->second >= end) {
-        insert(start, end - start);
-        return;
-      } else {
-        insert(start, p->first + p->second - start);
-        ++p;
-      }
-    }
-    while (p != other.m.end()) {
-      assert(p->first >= start);
-      if (p->first >= end) {
-        return;
-      }
-      if (p->first + p->second >= end) {
-        insert(p->first, end - p->first);
-        return;
-      } else {
-        // whole
-        insert(p->first, p->second);
-        ++p;
-      }
-    }
-  }
-
   /*
    * build a subset of @other, starting at or after @start, and including
    * @len worth of values, skipping holes.  e.g.,

--- a/src/test/common/test_interval_set.cc
+++ b/src/test/common/test_interval_set.cc
@@ -564,53 +564,6 @@ TYPED_TEST(IntervalSetTest, subset_of) {
   iset1.insert( 50, 5);
   iset2.insert( 55, 2);
   ASSERT_FALSE(iset1.subset_of(iset2));
-
-  ISet iset3, iset4, expected;
-  iset3.insert(5, 10);
-  iset3.insert(20, 5);
-
-  iset4.subset_of(iset3, 0, 100);
-  expected.insert(5, 10);
-  expected.insert(20, 5);
-  ASSERT_TRUE(iset4 == expected);
-
-  iset4.clear();
-  iset4.subset_of(iset3, 5, 25);
-  ASSERT_TRUE(iset4 == expected);
-
-  iset4.clear();
-  iset4.subset_of(iset3, 1, 10);
-  expected.clear();
-  expected.insert(5, 5);
-  ASSERT_TRUE(iset4 == expected);
-
-  iset4.clear();
-  iset4.subset_of(iset3, 8, 24);
-  expected.clear();
-  expected.insert(8, 7);
-  expected.insert(20, 4);
-  ASSERT_TRUE(iset4 == expected);
-
-  iset4.clear();
-  iset4.subset_of(iset3, 0, 0);
-  expected.clear();
-  ASSERT_TRUE(iset4 == expected);
-
-  iset4.clear();
-  iset4.subset_of(iset3, 0, 1);
-  ASSERT_TRUE(iset4 == expected);
-
-  iset4.clear();
-  iset4.subset_of(iset3, 0, 5);
-  ASSERT_TRUE(iset4 == expected);
-
-  iset4.clear();
-  iset4.subset_of(iset3, 25, 30);
-  ASSERT_TRUE(iset4 == expected);
-
-  iset4.clear();
-  iset4.subset_of(iset3, 26, 40);
-  ASSERT_TRUE(iset4 == expected);
 }
 
 TYPED_TEST(IntervalSetTest, span_of) {


### PR DESCRIPTION
It is originally introduced in https://github.com/ceph/ceph/pull/15199
aiming at improving the pool-based **du** stats.
For performance concerns, https://github.com/ceph/ceph/pull/19616 did
an incomplete revert of that PR and hence comes the following clean-up job...

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>