### PR TITLE
luminous: common/ipaddr: Do not select link-local IPv6 addresses

### DIFF
--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -90,6 +90,8 @@ const struct ifaddrs *find_ipv6_in_subnet(const struct ifaddrs *addrs,
       continue;
 
     struct in6_addr *cur = &((struct sockaddr_in6*)addrs->ifa_addr)->sin6_addr;
+    if (IN6_IS_ADDR_LINKLOCAL(cur))
+      continue;
     netmask_ipv6(cur, prefix_len, &temp);
 
     if (IN6_ARE_ADDR_EQUAL(&temp, &want))


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/23501

They are not suited to be used with Ceph and should not be selected
as a address to bind on.

Fixes: http://tracker.ceph.com/issues/21813

Signed-off-by: Wido den Hollander <wido@42on.com>
(cherry picked from commit 9a110662046cb2c2a052b8e1adf062b593955248)