### PR TITLE
common, osd: duplicated "start" event in OpTracker, improve OpTracker::dump_ops

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -117,8 +117,7 @@ void OpHistory::dump_ops(utime_t now, Formatter *f, set<string> filters)
   f->dump_int("duration", history_duration);
   {
     f->open_array_section("ops");
-    for (set<pair<utime_t, TrackedOpRef> >::const_iterator i =
-	   arrived.begin();
+    for (auto i = arrived.begin();
 	 i != arrived.end();
 	 ++i) {
       if (!i->second->filter_out(filters))
@@ -141,26 +140,12 @@ void OpHistory::dump_ops_by_duration(utime_t now, Formatter *f, set<string> filt
   f->dump_int("duration", history_duration);
   {
     f->open_array_section("ops");
-    if (arrived.size()) {
-      vector<pair<double, TrackedOpRef> > durationvec;
-      durationvec.reserve(arrived.size());
-
-      for (set<pair<utime_t, TrackedOpRef> >::const_iterator i =
-	     arrived.begin();
-	   i != arrived.end();
-	   ++i) {
-	if (!i->second->filter_out(filters))
-	  continue;
-	durationvec.push_back(pair<double, TrackedOpRef>(i->second->get_duration(), i->second));
-      }
-
-      sort(durationvec.begin(), durationvec.end());
-
-      for (auto i = durationvec.rbegin(); i != durationvec.rend(); ++i) {
-	f->open_object_section("op");
-	i->second->dump(now, f);
-	f->close_section();
-      }
+    for (auto i = duration.rbegin(); i != duration.rend(); ++i) {
+      f->open_object_section("op");
+      if (!i->second->filter_out(filters))
+        continue;
+      i->second->dump(now, f);
+      f->close_section();
     }
     f->close_section();
   }

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -108,7 +108,7 @@ void OpHistory::cleanup(utime_t now)
   }
 }
 
-void OpHistory::dump_ops(utime_t now, Formatter *f, set<string> filters)
+void OpHistory::dump_ops(utime_t now, Formatter *f, set<string> filters, bool by_duration)
 {
   Mutex::Locker history_lock(ops_history_lock);
   cleanup(now);
@@ -117,35 +117,20 @@ void OpHistory::dump_ops(utime_t now, Formatter *f, set<string> filters)
   f->dump_int("duration", history_duration);
   {
     f->open_array_section("ops");
-    for (auto i = arrived.begin();
-	 i != arrived.end();
-	 ++i) {
-      if (!i->second->filter_out(filters))
-        continue;
-      f->open_object_section("op");
-      i->second->dump(now, f);
-      f->close_section();
-    }
-    f->close_section();
-  }
-  f->close_section();
-}
+    auto dump_fn = [&f, &now, &filters](auto begin_iter, auto end_iter) {
+      for (auto i=begin_iter; i!=end_iter; ++i) {
+	if (!i->second->filter_out(filters))
+	  continue;
+	f->open_object_section("op");
+	i->second->dump(now, f);
+	f->close_section();
+      }
+    };
 
-void OpHistory::dump_ops_by_duration(utime_t now, Formatter *f, set<string> filters)
-{
-  Mutex::Locker history_lock(ops_history_lock);
-  cleanup(now);
-  f->open_object_section("op_history");
-  f->dump_int("size", history_size);
-  f->dump_int("duration", history_duration);
-  {
-    f->open_array_section("ops");
-    for (auto i = duration.rbegin(); i != duration.rend(); ++i) {
-      f->open_object_section("op");
-      if (!i->second->filter_out(filters))
-        continue;
-      i->second->dump(now, f);
-      f->close_section();
+    if (by_duration) {
+      dump_fn(duration.rbegin(), duration.rend());
+    } else {
+      dump_fn(arrived.begin(), arrived.end());
     }
     f->close_section();
   }
@@ -188,11 +173,7 @@ bool OpTracker::dump_historic_ops(Formatter *f, bool by_duration, set<string> fi
 
   RWLock::RLocker l(lock);
   utime_t now = ceph_clock_now();
-  if (by_duration) {
-    history.dump_ops_by_duration(now, f, filters);
-  } else {
-    history.dump_ops(now, f, filters);
-  }
+  history.dump_ops(now, f, filters, by_duration);
   return true;
 }
 

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -84,8 +84,7 @@ public:
   }
 
   void _insert_delayed(const utime_t& now, TrackedOpRef op);
-  void dump_ops(utime_t now, Formatter *f, set<string> filters = {""});
-  void dump_ops_by_duration(utime_t now, Formatter *f, set<string> filters = {""});
+  void dump_ops(utime_t now, Formatter *f, set<string> filters = {""}, bool by_duration=false);
   void dump_slow_ops(utime_t now, Formatter *f, set<string> filters = {""});
   void on_shutdown();
   void set_size_and_duration(uint32_t new_size, uint32_t new_duration) {

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -881,7 +881,7 @@ void ECBackend::handle_sub_write(
   const ZTracer::Trace &trace)
 {
   if (msg)
-    msg->mark_started();
+    msg->mark_event("sub_op_started");
   trace.event("handle_sub_write");
   if (!get_parent()->pgb_is_primary())
     get_parent()->update_stats(op.stats);


### PR DESCRIPTION
1. there are two "started" event in EC osd_op : [PrimaryLogPG::do_op](https://github.com/ceph/ceph/blob/6aceb66524fe633dce0707f624e625d5beb6ee04/src/osd/PrimaryLogPG.cc#L2355), [ECBackend::handle_sub_write](https://github.com/ceph/ceph/blob/6aceb66524fe633dce0707f624e625d5beb6ee04/src/osd/ECBackend.cc#L884). 

2. no need to sort events in OpHistory::dump_ops_by_duration. We could use OpHistory::duration directly
3. refine OpHistory::dump_ops & OpHistory::dump_ops_by_duration 


```
[

                  {
                        "time": "2018-03-29 17:30:30.343031",
                        "event": "initiated"
                    },  
                    {
                        "time": "2018-03-29 17:30:30.343031",
                        "event": "header_read"
                    },  
                    {
                        "time": "2018-03-29 17:30:30.343035",
                        "event": "throttled"
                    },  
                    {
                        "time": "2018-03-29 17:30:30.345821",
                        "event": "all_read"
                    },  
                    {
                        "time": "2018-03-29 17:30:30.345873",
                        "event": "dispatched"
                    },  
                    {
                        "time": "2018-03-29 17:30:30.345913",
                        "event": "queued_for_pg"
                    },  
                    {
                        "time": "2018-03-29 17:30:31.783523",
                        "event": "reached_pg"
                    },  
                    {
                        "time": "2018-03-29 17:30:31.783610",
                        "event": "started"
                    },  
                    {
                        "time": "2018-03-29 17:30:31.790104",
                        "event": "sub_op_started"          # <-- here is "started" without this patch
                    },  
                    {
                        "time": "2018-03-29 17:30:32.367766",
                        "event": "sub_op_committed"
                    },  
                    {
                        "time": "2018-03-29 17:30:32.367797",
                        "event": "commit_sent"
                    },  
                    {
                        "time": "2018-03-29 17:30:32.367830",
                        "event": "done"
                    }
]
```
