### PR TITLE
msg/async/dpdk: remove xsky copyright and LGPL copying

### DIFF
--- a/src/msg/async/dpdk/ARP.cc
+++ b/src/msg/async/dpdk/ARP.cc
@@ -19,19 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #include "ARP.h"
 

--- a/src/msg/async/dpdk/ARP.h
+++ b/src/msg/async/dpdk/ARP.h
@@ -20,19 +20,6 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  *
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #ifndef CEPH_MSG_ARP_H_
 #define CEPH_MSG_ARP_H_

--- a/src/msg/async/dpdk/DPDK.cc
+++ b/src/msg/async/dpdk/DPDK.cc
@@ -19,19 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #include <atomic>
 #include <vector>

--- a/src/msg/async/dpdk/DPDK.h
+++ b/src/msg/async/dpdk/DPDK.h
@@ -19,19 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #ifndef CEPH_DPDK_DEV_H
 #define CEPH_DPDK_DEV_H

--- a/src/msg/async/dpdk/IP.h
+++ b/src/msg/async/dpdk/IP.h
@@ -20,19 +20,6 @@
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  *
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #ifndef CEPH_MSG_IP_H_
 #define CEPH_MSG_IP_H_

--- a/src/msg/async/dpdk/IPChecksum.cc
+++ b/src/msg/async/dpdk/IPChecksum.cc
@@ -19,19 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #include <arpa/inet.h>
 #include "net.h"

--- a/src/msg/async/dpdk/IPChecksum.h
+++ b/src/msg/async/dpdk/IPChecksum.h
@@ -19,19 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #ifndef CEPH_MSG_CHECKSUM_H_
 #define CEPH_MSG_CHECKSUM_H_

--- a/src/msg/async/dpdk/Packet.h
+++ b/src/msg/async/dpdk/Packet.h
@@ -19,20 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
-
 
 #ifndef CEPH_MSG_PACKET_H_
 #define CEPH_MSG_PACKET_H_

--- a/src/msg/async/dpdk/PacketUtil.h
+++ b/src/msg/async/dpdk/PacketUtil.h
@@ -19,19 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #ifndef CEPH_MSG_PACKET_UTIL_H_
 #define CEPH_MSG_PACKET_UTIL_H_

--- a/src/msg/async/dpdk/byteorder.h
+++ b/src/msg/async/dpdk/byteorder.h
@@ -19,19 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #ifndef CEPH_MSG_BYTEORDER_H_
 #define CEPH_MSG_BYTEORDER_H_

--- a/src/msg/async/dpdk/const.h
+++ b/src/msg/async/dpdk/const.h
@@ -19,19 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #ifndef CEPH_MSG_CONST_H_
 #define CEPH_MSG_CONST_H_

--- a/src/msg/async/dpdk/net.cc
+++ b/src/msg/async/dpdk/net.cc
@@ -26,11 +26,6 @@
  *
  * Author: Haomai Wang <haomaiwang@gmail.com>
  *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
  */
 
 #include "net.h"

--- a/src/msg/async/dpdk/net.h
+++ b/src/msg/async/dpdk/net.h
@@ -1,17 +1,24 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 /*
- * Ceph - scalable distributed file system
+ * This file is open source software, licensed to you under the terms
+ * of the Apache License, Version 2.0 (the "License").  See the NOTICE file
+ * distributed with this work for additional information regarding copyright
+ * ownership.  You may not use this file except in compliance with the License.
  *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
+ * You may obtain a copy of the License at
  *
- * Author: Haomai Wang <haomaiwang@gmail.com>
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
+/*
+ * Copyright (C) 2014 Cloudius Systems, Ltd.
+ */
+
 #ifndef CEPH_MSG_DPDK_NET_H
 #define CEPH_MSG_DPDK_NET_H
 

--- a/src/msg/async/dpdk/stream.h
+++ b/src/msg/async/dpdk/stream.h
@@ -19,19 +19,6 @@
 /*
  * Copyright (C) 2014 Cloudius Systems, Ltd.
  */
-/*
- * Ceph - scalable distributed file system
- *
- * Copyright (C) 2015 XSky <haomai@xsky.com>
- *
- * Author: Haomai Wang <haomaiwang@gmail.com>
- *
- * This is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software
- * Foundation.  See file COPYING.
- *
- */
 
 #ifndef CEPH_MSG_STREAM_H_
 #define CEPH_MSG_STREAM_H_


### PR DESCRIPTION
it's not legitimate to relicense without original author's permission.
some of the source files are coped from seastar project with minor
changes. so xsky cannot claim the copyright of them.

Signed-off-by: Kefu Chai <kchai@redhat.com>