### PR TITLE
rgw: civetweb fixes for v1.1 upgrade

### DIFF
--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -248,10 +248,8 @@ def run_tests(ctx, config):
     """
     assert isinstance(config, dict)
     testdir = teuthology.get_testdir(ctx)
-    attrs = ["!fails_on_rgw", "!lifecycle_expiration"]
-    # beast parser is strict about unreadable headers
-    if ctx.rgw.frontend == 'beast':
-        attrs.append("!fails_strict_rfc2616")
+    # civetweb > 1.8 && beast parsers are strict on rfc2616
+    attrs = ["!fails_on_rgw", "!lifecycle_expiration", "!fails_strict_rfc2616"]
     for client, client_config in config.iteritems():
         (remote,) = ctx.cluster.only(client).remotes.keys()
         args = [

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1078,6 +1078,15 @@ if(WITH_RADOSGW)
       APPEND PROPERTY COMPILE_DEFINITIONS CRYPTO_LIB="${LIBCRYPTO_SONAME}")
   endif()
 
+  if (OPENSSL_FOUND)
+    # Use cmake to determine openssl version, a TODO is to make
+    # civetweb itself do this based on openssl_api_compat strings
+    if (NOT (OPENSSL_VERSION VERSION_LESS "1.1"))
+      message(STATUS "Setting civetweb to use OPENSSL >= 1.1")
+      set_property(TARGET civetweb_common_objs
+        APPEND PROPERTY COMPILE_DEFINITIONS OPENSSL_API_1_1=1)
+    endif()
+  endif(OPENSSL_FOUND)
   add_subdirectory(rgw)
 
 endif(WITH_RADOSGW)

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -92,7 +92,7 @@ int RGWCivetWeb::init_env(CephContext *cct)
   }
 
   for (int i = 0; i < info->num_headers; i++) {
-    const struct mg_request_info::mg_header* header = &info->http_headers[i];
+    const auto header = &info->http_headers[i];
 
     if (header->name == nullptr || header->value==nullptr) {
       lderr(cct) << "client supplied malformatted headers" << dendl;
@@ -138,7 +138,7 @@ int RGWCivetWeb::init_env(CephContext *cct)
   env.set("REQUEST_METHOD", info->request_method);
   env.set("HTTP_VERSION", info->http_version);
   env.set("REQUEST_URI", info->request_uri); // get the full uri, we anyway handle abs uris later
-  env.set("SCRIPT_URI", info->uri); /* FIXME */
+  env.set("SCRIPT_URI", info->local_uri);
   if (info->query_string) {
     env.set("QUERY_STRING", info->query_string);
   }

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -58,6 +58,7 @@ int RGWCivetWebFrontend::run()
   set_conf_default(conf_map, "validate_http_method", "no");
   set_conf_default(conf_map, "canonicalize_url_path", "no");
   set_conf_default(conf_map, "enable_auth_domain_check", "no");
+  set_conf_default(conf_map, "allow_unicode_in_urls", "yes");
 
   std::string listening_ports;
   // support multiple port= entries


### PR DESCRIPTION
- [x]  Update civetweb sha1 
- [x]  Resolve "validate_http_method" based on discussions in https://github.com/ceph/civetweb/pull/24
(update: this was readded as swift tests depend on this)
This changeset does the following:
- mg_request_info::mg_header is no longer a type (it is just mg_header, used auto instead)
- request_info->uri is deprecated, move to request_info->local_uri
- tentatively dropping `validate_http_method`, needs discussion