### PR TITLE
build/ops: make-dist: fall back to python3

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -61,10 +61,24 @@ download_boost() {
     rm -rf src/boost
 }
 
+_python_autoselect() {
+  python_command=
+  for interpreter in python2.7 python3 ; do
+    type $interpreter > /dev/null 2>&1 || continue
+    python_command=$interpreter
+    break
+  done
+  if [ -z "$python_command" ] ; then
+    echo "Could not find a suitable python interpreter! Bailing out."
+    exit 1
+  fi
+  echo $python_command
+}
+
 build_dashboard_frontend() {
   CURR_DIR=`pwd`
   TEMP_DIR=`mktemp -d`
-  $CURR_DIR/src/tools/setup-virtualenv.sh --python=python2.7 $TEMP_DIR
+  $CURR_DIR/src/tools/setup-virtualenv.sh --python=$(_python_autoselect) $TEMP_DIR
   $TEMP_DIR/bin/pip install nodeenv
   $TEMP_DIR/bin/nodeenv -p -n 8.10.0
   cd src/pybind/mgr/dashboard/frontend


### PR DESCRIPTION
If python2.7 is not available, we might be building in a Python 3-only
environment.

Signed-off-by: Nathan Cutler <ncutler@suse.com>