### PR TITLE
luminous: tests: unittest_pglog timeout

### DIFF
--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -1388,27 +1388,6 @@ TEST_F(PGLogTest, merge_log) {
     EXPECT_TRUE(dirty_big_info);
   }
 
-  // If our log is empty, the incoming log needs to have not been trimmed.
-  {
-    clear();
-
-    pg_log_t olog;
-    pg_info_t oinfo;
-    pg_shard_t fromosd;
-    pg_info_t info;
-    list<hobject_t> remove_snap;
-    bool dirty_info = false;
-    bool dirty_big_info = false;
-
-    // olog has been trimmed
-    olog.tail = eversion_t(1, 1);
-
-    TestHandler h(remove_snap);
-    PrCtl unset_dumpable;
-    ASSERT_DEATH(merge_log(oinfo, olog, fromosd, info, &h,
-			   dirty_info, dirty_big_info), "");
-  }
-
 }
 
 TEST_F(PGLogTest, proc_replica_log) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/23522