### PR TITLE
bluestore: fix aio_t::rval  type

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -408,7 +408,7 @@ void KernelDevice::_aio_thread()
 	// later flush() occurs.
 	io_since_flush.store(true);
 
-	int r = aio[i]->get_return_value();
+	long r = aio[i]->get_return_value();
         if (r < 0) {
           derr << __func__ << " got " << cpp_strerror(r) << dendl;
           if (ioc->allow_eio && r == -EIO) {

--- a/src/os/bluestore/aio.h
+++ b/src/os/bluestore/aio.h
@@ -16,7 +16,7 @@ struct aio_t {
   int fd;
   boost::container::small_vector<iovec,4> iov;
   uint64_t offset, length;
-  int rval;
+  long rval;
   bufferlist bl;  ///< write payload (so that it remains stable for duration)
 
   boost::intrusive::list_member_hook<> queue_item;
@@ -37,7 +37,7 @@ struct aio_t {
     bl.append(std::move(p));
   }
 
-  int get_return_value() {
+  long get_return_value() {
     return rval;
   }
 };


### PR DESCRIPTION
io_event::res was assigned to io_t::rval , but io_event::res is
unsigned long, if rval is int, this will cause overflow.
and fix this  coredump:
    -1> 2018-03-30 01:53:27.511964 7fc903ecb700 -1 bdev(0x565100d73800 /var/lib/ceph/osd/ceph-3/block.db) **aio to 12845056000~2170155008 but returned: 2147479552**
     0> 2018-03-30 01:53:27.529402 7fc903ecb700 -1 /root/rpmbuild/BUILD/ceph-12.2.4-1/src/os/bluestore/KernelDevice.cc: In function 'void KernelDevice::_aio_thread()' thread 7fc903ecb700 time 2018-03-30 01:53:27.512011
/root/rpmbuild/BUILD/ceph-12.2.4-1/src/os/bluestore/KernelDevice.cc: 384: FAILED assert(0 == "unexpected aio error")

 ceph version 12.2.4-1 (f1c14f03ac0a6ea8271f8a62acde37aba126b14e) luminous (stable)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x110) [0x5650f66c9820]
 2: (KernelDevice::_aio_thread()+0xd05) [0x5650f666cdb5]
 3: (KernelDevice::AioCompletionThread::entry()+0xd) [0x5650f66721fd]
 4: (()+0x7e25) [0x7fc90d38ce25]
 5: (clone()+0x6d) [0x7fc90c48034d]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to interpret this.

==============
linux (/usr/include/libaio.h) defines io_event like this:
struct io_event {
    PADDEDptr(void *data, __pad1);
    PADDEDptr(struct iocb *obj,  __pad2);
    PADDEDul(res,  __pad3);
    PADDEDul(res2, __pad4);
}; 
the PADDEDul resolves as:
#define PADDEDul(x, y)  unsigned long x; unsigned y

Signed-off-by: kungf <yang.wang@easystack.cn>
@yangdongsheng 