### PR TITLE
qa/libceph: Fix path in usage

### DIFF
--- a/qa/libceph/trivial_libceph.c
+++ b/qa/libceph/trivial_libceph.c
@@ -17,7 +17,7 @@ int main(int argc, const char **argv)
         char buf[1024];
 
         if (argc < 3) {
-                fprintf(stderr, "usage: ./%s <conf> <file>\n", argv[0]);
+                fprintf(stderr, "usage: %s <conf> <file>\n", argv[0]);
                 exit(1);
         }
 


### PR DESCRIPTION
Found this while communicating with @simransinghal 

Signed-off-by: Jos Collin <jcollin@redhat.com>