### PR TITLE
ceph-volume: remove extra space

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/create.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/create.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 
 class Create(object):
 
-    help = 'Create a new OSD from  an LVM device'
+    help = 'Create a new OSD from an LVM device'
 
     def __init__(self, argv):
         self.argv = argv


### PR DESCRIPTION
The space had 2 spaces instead of one.

Signed-off-by: Sébastien Han <seb@redhat.com>