### PR TITLE
mds: fix unhealth heartbeat during rejoin

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5310,6 +5310,8 @@ bool MDCache::process_imported_caps()
     cap_imports_num_opening++;
     dout(10) << "  opening missing ino " << p->first << dendl;
     open_ino(p->first, (int64_t)-1, new C_MDC_RejoinOpenInoFinish(this, p->first), false);
+    if (!(cap_imports_num_opening % 1000))
+      mds->heartbeat_reset();
   }
 
   if (cap_imports_num_opening > 0)


### PR DESCRIPTION
function process_imported_caps might hold mds_lock too long,
mds tick thread will be starved, and leads to unhealth heartbeat check.
which would eventually make the mds been kicked by the monitor during rejoin phase.

Fixes: https://tracker.ceph.com/issues/23530
Signed-off-by: dongdong tao <tdd21151186@gmail.com>