### PR TITLE
osd/PGBackend: fix large_omap_objects checking

### DIFF
--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -1121,7 +1121,10 @@ void PGBackend::be_large_omap_check(const map<pg_shard_t,ScrubMap*> &maps,
   // Iterate through objects and check large omap object flag
   for (const auto& k : master_set) {
     for (const auto& map : maps) {
-      ScrubMap::object& obj = map.second->objects[k];
+      auto it = map.second->objects.find(k);
+      if (it == map.second->objects.end())
+        continue;
+      ScrubMap::object& obj = it->second;
       if (obj.large_omap_object_found) {
         large_omap_objects++;
         warnstream << "Large omap object found. Object: " << k << " Key count: "


### PR DESCRIPTION
We should avoid creating **new** objects into shard's map,
because replicas may get divergent view of objects they should
have with each other, though the chance is rare.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>