### PR TITLE
osd/PGBackend: drop input "snapid_t" from objects_list_range()

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4361,9 +4361,7 @@ void PG::scrub_unreserve_replicas()
   }
 }
 
-void PG::_scan_rollback_obs(
-  const vector<ghobject_t> &rollback_obs,
-  ThreadPool::TPHandle &handle)
+void PG::_scan_rollback_obs(const vector<ghobject_t> &rollback_obs)
 {
   ObjectStore::Transaction t;
   eversion_t trimmed_to = last_rollback_info_trimmed_to_applied;
@@ -4549,7 +4547,7 @@ int PG::build_scrub_map_chunk(
     if (pos.ls.empty()) {
       break;
     }
-    _scan_rollback_obs(rollback_obs, handle);
+    _scan_rollback_obs(rollback_obs);
     pos.pos = 0;
     return -EINPROGRESS;
   }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4540,7 +4540,6 @@ int PG::build_scrub_map_chunk(
     pos.ret = get_pgbackend()->objects_list_range(
       start,
       end,
-      0,
       &pos.ls,
       &rollback_obs);
     if (pos.ret < 0) {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1728,9 +1728,7 @@ protected:
   void scrub_clear_state();
   void _scan_snaps(ScrubMap &map);
   void _repair_oinfo_oid(ScrubMap &map);
-  void _scan_rollback_obs(
-    const vector<ghobject_t> &rollback_obs,
-    ThreadPool::TPHandle &handle);
+  void _scan_rollback_obs(const vector<ghobject_t> &rollback_obs);
   void _request_scrub_map(pg_shard_t replica, eversion_t version,
                           hobject_t start, hobject_t end, bool deep,
 			  bool allow_preemption);

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -380,7 +380,6 @@ int PGBackend::objects_list_partial(
 int PGBackend::objects_list_range(
   const hobject_t &start,
   const hobject_t &end,
-  snapid_t seq,
   vector<hobject_t> *ls,
   vector<ghobject_t> *gen_obs)
 {

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -531,7 +531,6 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
    int objects_list_range(
      const hobject_t &start,
      const hobject_t &end,
-     snapid_t seq,
      vector<hobject_t> *ls,
      vector<ghobject_t> *gen_obs=0);
 


### PR DESCRIPTION
Not only because it is useless, but because it is actually misleading..

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>