### PR TITLE
config: notify config observers on set_mon_vals()

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -302,6 +302,7 @@ int md_config_t::set_mon_vals(CephContext *cct, const map<string,string>& kv)
     }
   }
   values_bl.clear();
+  _apply_changes(nullptr);
   return 0;
 }
 


### PR DESCRIPTION
`md_config_obs_t` callbacks aren't being made for config changes that come through `MonClient::handle_config()` from `ceph config set`