### PR TITLE
jewel: ceph-fuse: failure to remount in startup test does not handle client_die_on_failed_remount properly

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -22,3 +22,9 @@
   delete workload, it can lead to high latency when leveldb's
   single-threaded compaction cannot keep up. rocksdb supports multiple
   threads for compaction, which avoids this problem.
+
+* The CephFS client now catches failures to clear dentries during startup
+  and refuses to start as consistency and untrimmable cache issues may
+  develop. The new option client_die_on_failed_dentry_invalidate (default:
+  true) may be turned off to allow the client to proceed (dangerous!).
+

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -153,10 +153,12 @@ int main(int argc, const char **argv, const char *envp[]) {
 #if defined(__linux__)
 	int ver = get_linux_version();
 	assert(ver != 0);
-	bool can_invalidate_dentries = g_conf->client_try_dentry_invalidate &&
-				       ver < KERNEL_VERSION(3, 18, 0);
+        bool client_try_dentry_invalidate = g_conf->client_try_dentry_invalidate;
+	bool can_invalidate_dentries = 
+          client_try_dentry_invalidate && ver < KERNEL_VERSION(3, 18, 0);
 	int tr = client->test_dentry_handling(can_invalidate_dentries);
-	if (tr != 0) {
+        bool client_die_on_failed_dentry_invalidate = g_conf->client_die_on_failed_dentry_invalidate;
+	if (tr != 0 && client_die_on_failed_dentry_invalidate) {
 	  cerr << "ceph-fuse[" << getpid()
 	       << "]: fuse failed dentry invalidate/remount test with error "
 	       << cpp_strerror(tr) << ", stopping" << std::endl;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -247,7 +247,6 @@ Client::Client(Messenger *m, MonClient *mc)
     getgroups_cb(NULL),
     umask_cb(NULL),
     can_invalidate_dentries(false),
-    require_remount(false),
     async_ino_invalidator(m->cct),
     async_dentry_invalidator(m->cct),
     interrupt_finisher(m->cct),
@@ -3944,6 +3943,32 @@ void Client::remove_session_caps(MetaSession *s)
   sync_cond.Signal();
 }
 
+int Client::_do_remount(void)
+{
+  errno = 0;
+  int r = remount_cb(callback_handle);
+  if (r != 0) {
+    int e = errno;
+    client_t whoami = get_nodeid();
+    if (r == -1) {
+      lderr(cct) <<
+          "failed to remount (to trim kernel dentries): "
+          "errno = " << e << " (" << strerror(e) << ")" << dendl;
+    } else {
+      lderr(cct) <<
+          "failed to remount (to trim kernel dentries): "
+          "return code = " << r << dendl;
+    }
+    bool should_abort = cct->_conf->client_die_on_failed_remount ||
+        cct->_conf->client_die_on_failed_dentry_invalidate;
+    if (should_abort && !unmounting) {
+      lderr(cct) << "failed to remount for kernel dentry trimming; quitting!" << dendl;
+      ceph_abort();
+    }
+  }
+  return r;
+}
+
 class C_Client_Remount : public Context  {
 private:
   Client *client;
@@ -3951,15 +3976,7 @@ public:
   explicit C_Client_Remount(Client *c) : client(c) {}
   void finish(int r) {
     assert (r == 0);
-    r = client->remount_cb(client->callback_handle);
-    if (r != 0) {
-      client_t whoami = client->get_nodeid();
-      lderr(client->cct) << "tried to remount (to trim kernel dentries) and got error "
-			 << r << dendl;
-      if (client->require_remount && !client->unmounting) {
-	assert(0 == "failed to remount for kernel dentry trimming");
-      }
-    }
+    client->_do_remount();
   }
 };
 
@@ -9347,21 +9364,19 @@ int Client::test_dentry_handling(bool can_invalidate)
   if (can_invalidate_dentries) {
     assert(dentry_invalidate_cb);
     ldout(cct, 1) << "using dentry_invalidate_cb" << dendl;
+    r = 0;
   } else if (remount_cb) {
     ldout(cct, 1) << "using remount_cb" << dendl;
-    int s = remount_cb(callback_handle);
-    if (s) {
-      lderr(cct) << "Failed to invoke remount, needed to ensure kernel dcache consistency"
-		 << dendl;
+    r = _do_remount();
+  }
+  if (r) {
+    bool should_abort = cct->_conf->client_die_on_failed_dentry_invalidate;
+    if (should_abort) {
+      lderr(cct) << "no method to invalidate kernel dentry cache; quitting!" << dendl;
+      ceph_abort();
+    } else {
+      lderr(cct) << "no method to invalidate kernel dentry cache; expect issues!" << dendl;
     }
-    if (cct->_conf->client_die_on_failed_remount) {
-      require_remount = true;
-      r = s;
-    }
-  } else {
-    lderr(cct) << "no method to invalidate kernel dentry cache; expect issues!" << dendl;
-    if (cct->_conf->client_die_on_failed_remount)
-      assert(0);
   }
   return r;
 }

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -284,7 +284,6 @@ class Client : public Dispatcher, public md_config_obs_t {
   client_getgroups_callback_t getgroups_cb;
   client_umask_callback_t umask_cb;
   bool can_invalidate_dentries;
-  bool require_remount;
 
   Finisher async_ino_invalidator;
   Finisher async_dentry_invalidator;
@@ -740,6 +739,8 @@ private:
   int _release_fh(Fh *fh);
   void _put_fh(Fh *fh);
 
+  int _do_remount(void);
+  friend class C_Client_Remount;
 
   struct C_Readahead : public Context {
     Client *client;

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -415,7 +415,8 @@ OPTION(fuse_require_active_mds, OPT_BOOL, true) // if ceph_fuse requires active 
 OPTION(fuse_syncfs_on_mksnap, OPT_BOOL, true)
 
 OPTION(client_try_dentry_invalidate, OPT_BOOL, false) // the client should try to use dentry invaldation instead of remounting, on kernels it believes that will work for
-OPTION(client_die_on_failed_remount, OPT_BOOL, true)
+OPTION(client_die_on_failed_remount, OPT_BOOL, false)
+OPTION(client_die_on_failed_dentry_invalidate, OPT_BOOL, true)
 OPTION(client_check_pool_perm, OPT_BOOL, true)
 OPTION(client_use_faked_inos, OPT_BOOL, false)
 OPTION(client_mds_namespace, OPT_INT, -1)


### PR DESCRIPTION
http://tracker.ceph.com/issues/22378