### PR TITLE
librados: check before deallocating RadosXattrsIter::val

### DIFF
--- a/src/ceph-detect-init/CMakeLists.txt
+++ b/src/ceph-detect-init/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CEPH_DETECT_INIT_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtua
 add_custom_target(ceph-detect-init
   COMMAND
   ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=python2.7 ${CEPH_DETECT_INIT_VIRTUALENV} &&
-  ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-detect-init/wheelhouse -e .
+  ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install --no-index --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-detect-init/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-detect-init
   COMMENT "ceph-detect-init is being created")
 add_dependencies(tests ceph-detect-init)

--- a/src/ceph-detect-init/tox.ini
+++ b/src/ceph-detect-init/tox.ini
@@ -10,7 +10,6 @@ setenv = VIRTUAL_ENV={envdir}
 usedevelop = true
 deps =
   {env:NO_INDEX:}
-  --use-wheel
   --find-links=file://{toxinidir}/wheelhouse
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt

--- a/src/ceph-disk/CMakeLists.txt
+++ b/src/ceph-disk/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CEPH_DISK_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv)
 add_custom_target(ceph-disk
   COMMAND
   ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=python2.7 ${CEPH_DISK_VIRTUALENV} &&
-  ${CEPH_DISK_VIRTUALENV}/bin/pip install --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-disk/wheelhouse -e .
+  ${CEPH_DISK_VIRTUALENV}/bin/pip install --no-index --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-disk/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-disk
   COMMENT "ceph-disk is being created")
 add_dependencies(tests ceph-disk)

--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -10,7 +10,6 @@ setenv =
 usedevelop = true
 deps =
   {env:NO_INDEX:}
-  --use-wheel
   --find-links=file://{toxinidir}/wheelhouse
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt

--- a/src/librados/RadosXattrIter.cc
+++ b/src/librados/RadosXattrIter.cc
@@ -24,6 +24,7 @@ librados::RadosXattrsIter::RadosXattrsIter()
 
 librados::RadosXattrsIter::~RadosXattrsIter()
 {
-  free(val);
-  val = NULL;
+  if (val) {
+    free(val);
+  }
 }

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -3,7 +3,7 @@ set(MGR_DASHBOARD_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/mgr-dashboard-virtualenv)
 add_custom_target(mgr-dashboard-test-venv
   COMMAND
   ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=python2.7 ${MGR_DASHBOARD_VIRTUALENV} &&
-  ${MGR_DASHBOARD_VIRTUALENV}/bin/pip install --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/wheelhouse -r requirements.txt
+  ${MGR_DASHBOARD_VIRTUALENV}/bin/pip install --no-index --find-links=file:${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/wheelhouse -r requirements.txt
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard
   COMMENT "dashboard tests virtualenv is being created")
 add_dependencies(tests mgr-dashboard-test-venv)

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -79,7 +79,7 @@ if test -d wheelhouse ; then
     export NO_INDEX=--no-index
 fi
 
-pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
+pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
 if test -f requirements.txt ; then
-    pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt
+    pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse -r requirements.txt
 fi


### PR DESCRIPTION
this issue could crash librados client if it calls
rados_getxattrs_end() which an xattrs ending with an
empty (i.e. '') attributes.

See-also: http://tracker.ceph.com/issues/22042
Signed-off-by: Greg Farnum <gfarnum@redhat.com>
Signed-off-by: Kefu Chai <kchai@redhat.com>