### PR TITLE
mon: do not use 'osd crush set' to set crushmap from input file

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -511,9 +511,6 @@ COMMAND("osd crush dump", \
 COMMAND("osd setcrushmap name=prior_version,type=CephInt,req=false", \
 	"set crush map from input file",	\
 	"osd", "rw", "cli,rest")
-COMMAND("osd crush set name=prior_version,type=CephInt,req=false", \
-	"set crush map from input file",	\
-	"osd", "rw", "cli,rest")
 COMMAND("osd crush add-bucket " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
         "name=type,type=CephString " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7346,8 +7346,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
   // this is the expected behavior.
    
  
-  if (prefix == "osd setcrushmap" ||
-      (prefix == "osd crush set" && !osdid_present)) {
+  if (prefix == "osd setcrushmap") {
     if (pending_inc.crush.length()) {
       dout(10) << __func__ << " waiting for pending crush update " << dendl;
       wait_for_finished_proposal(op, new C_RetryMessage(this, op));

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7354,6 +7354,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     }
     dout(10) << "prepare_command setting new crush map" << dendl;
     bufferlist data(m->get_data());
+    if (data.length() == 0) {
+      ss << "osd setcrushmap: no data supplied";
+      err = -EINVAL;
+      goto reply;
+    }
     CrushWrapper crush;
     try {
       bufferlist::iterator bl(data.begin());


### PR DESCRIPTION
for 'osd crush set',currently two COMMOND macros
are defined, first one is to set crushmap from input file,
second one is used to update crushmap position and weight.

when user type 'osd crush set', hint message for first one
will show up, no chance for the second one.Also we've already
have 'osd setcrushmap' doing the same thing for the first one.

so remove 'osd crush set' to set crushmap from input file.

Signed-off-by: Gu Zhongyan <guzhongyan@360.cn>