### PR TITLE
luminous: src: s/--use-wheel//

### DIFF
--- a/src/ceph-detect-init/CMakeLists.txt
+++ b/src/ceph-detect-init/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CEPH_DETECT_INIT_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtua
 add_custom_target(ceph-detect-init
   COMMAND
   ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh ${CEPH_DETECT_INIT_VIRTUALENV} &&
-  ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-detect-init/wheelhouse -e .
+  ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install --no-index --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-detect-init/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-detect-init
   COMMENT "ceph-detect-init is being created")
 add_dependencies(tests ceph-detect-init)

--- a/src/ceph-detect-init/tox.ini
+++ b/src/ceph-detect-init/tox.ini
@@ -10,7 +10,6 @@ setenv = VIRTUAL_ENV={envdir}
 usedevelop = true
 deps =
   {env:NO_INDEX:}
-  --use-wheel
   --find-links=file://{toxinidir}/wheelhouse
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt

--- a/src/ceph-disk/CMakeLists.txt
+++ b/src/ceph-disk/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CEPH_DISK_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv)
 add_custom_target(ceph-disk
   COMMAND
   ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh ${CEPH_DISK_VIRTUALENV} &&
-  ${CEPH_DISK_VIRTUALENV}/bin/pip install --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-disk/wheelhouse -e .
+  ${CEPH_DISK_VIRTUALENV}/bin/pip install --no-index --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-disk/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-disk
   COMMENT "ceph-disk is being created")
 add_dependencies(tests ceph-disk)

--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -10,7 +10,6 @@ setenv =
 usedevelop = true
 deps =
   {env:NO_INDEX:}
-  --use-wheel
   --find-links=file://{toxinidir}/wheelhouse
   -r{toxinidir}/requirements.txt
   -r{toxinidir}/test-requirements.txt

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -44,7 +44,7 @@ if test -d wheelhouse ; then
     export NO_INDEX=--no-index
 fi
 
-pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
+pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
 if test -f requirements.txt ; then
-    pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt
+    pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --find-links=file://$(pwd)/wheelhouse -r requirements.txt
 fi


### PR DESCRIPTION
--use-wheel was deprecated in favor of --only-binary in pip v7.0.0. and
--use-wheel was removed in a recent release of pip. but some packages
are source packages, so we cannot simply replace use-wheel with
only-binary. so a simpler approach is to drop --use-wheel option, as pip
respects --find-links, and will find the required package from the
wheelhouse.

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit a80cce4ba6afee921a7c6adce802c91e30f8c0a9)

Conflicts:
	src/ceph-detect-init/CMakeLists.txt
	src/ceph-disk/CMakeLists.txt: trivial resolution
	src/pybind/mgr/dashboard/CMakeLists.txt: dashboard2 is not
in luminous, so drop this change.