### PR TITLE
jewel: osd: OSDMap cache assert on shutdown

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1485,5 +1485,6 @@ OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf 
 OPTION(internal_safe_to_start_threads, OPT_BOOL, false)
 
 OPTION(debug_deliberately_leak_memory, OPT_BOOL, false)
+OPTION(debug_asserts_on_shutdown, OPT_BOOL, false)
 
 OPTION(rgw_swift_custom_header, OPT_STR, "") // option to enable swift custom headers

--- a/src/common/shared_cache.hpp
+++ b/src/common/shared_cache.hpp
@@ -104,7 +104,9 @@ public:
       lderr(cct) << "leaked refs:\n";
       dump_weak_refs(*_dout);
       *_dout << dendl;
-      assert(weak_refs.empty());
+      if (cct->_conf->debug_asserts_on_shutdown) {
+	assert(weak_refs.empty());
+      }
     }
   }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/21786