### PR TITLE
 client: return 0 when Client::_read() exceeds EOF

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8796,10 +8796,13 @@ retry:
           bl->substr_of(in->inline_data, offset, len - offset);
           bl->append_zero(endoff - len);
         }
+	r = endoff - offset;
       } else if ((uint64_t)offset < endoff) {
         bl->append_zero(endoff - offset);
+	r = endoff - offset;
+      } else {
+	r = 0;
       }
-      r = endoff - offset;
       goto success;
     }
   }


### PR DESCRIPTION
Commit a2a10b34 "client: fix Client::_read return" introduced a bug.
Negative number is returned when read position exceeds EOF

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>
Fixes: http://tracker.ceph.com/issues/23436