### PR TITLE
jewel: build/ops: rpm: bump epoch ahead of ceph-common in RHEL base

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -58,7 +58,7 @@
 Name:		ceph
 Version:	@VERSION@
 Release:	@RPM_RELEASE@%{?dist}
-Epoch:		1
+Epoch:		2
 Summary:	User space components of the Ceph file system
 License:	LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-autoconf-exception and BSD-3-Clause and MIT
 %if 0%{?suse_version}


### PR DESCRIPTION
http://tracker.ceph.com/issues/21033