### PR TITLE
client: fix request send_to_auth was never really used

### DIFF
--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -199,7 +199,7 @@ public:
   }
   bool auth_is_best() {
     if ((head.op & CEPH_MDS_OP_WRITE) || head.op == CEPH_MDS_OP_OPEN ||
-	head.op == CEPH_MDS_OP_READDIR) 
+	head.op == CEPH_MDS_OP_READDIR || send_to_auth) 
       return true;
     return false;    
   }


### PR DESCRIPTION
Client request's send_to_auth was never really used in choose_target_mds, although it would be set to true when getting STALE reply. So try to find auth MDS if possible for a request whose send_to_auth is true.  

Fixes: #http://tracker.ceph.com/issues/23541

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>