### PR TITLE
jewel: osd/PrimaryLogPG: dump snap_trimq size

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -716,6 +716,7 @@ int ReplicatedPG::do_command(
     f->open_object_section("pg");
     f->dump_string("state", pg_state_string(get_state()));
     f->dump_stream("snap_trimq") << snap_trimq;
+    f->dump_unsigned("snap_trimq_len", snap_trimq.size());
     f->dump_unsigned("epoch", get_osdmap()->get_epoch());
     f->open_array_section("up");
     for (vector<int>::iterator p = up.begin(); p != up.end(); ++p)


### PR DESCRIPTION
Backport tracker: http://tracker.ceph.com/issues/22449

One can just parse the snap_trimq string, but that's much more
expensive than just reading an unsigned int.

This is adaptation of commit dc7781cf17d11cb09067656cb25c0d710ab60d71
for Jewel - cherrypick is not possible due to code differences.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>