### PR TITLE
tools/cephfs: fix tmap_upgrade crash

### DIFF
--- a/src/test/librados/tmap_migrate.cc
+++ b/src/test/librados/tmap_migrate.cc
@@ -45,7 +45,6 @@ TEST_F(TmapMigratePP, DataScan) {
   ASSERT_EQ(0, ds.init());
   int r = ds.main({"tmap_upgrade", pool_name.c_str()});
   ASSERT_EQ(r, 0);
-  ds.shutdown();
 
   // Check that the TMAP object is now an omap object
   std::map<std::string, bufferlist> read_vals;


### PR DESCRIPTION
MDSUtility::shutdown() is called by deconstructor of MDSUtility.
shouldn't call it manually.

introduced by commit 1c7b6b00 "jewel: cephfs-journal-tool: move
shutdown to the deconstructor of MDSUtility" make

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>
Fixes: http://tracker.ceph.com/issues/23529