### PR TITLE
common/hobject: preserve the order of hobject

### DIFF
--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -336,10 +336,14 @@ int cmp(const hobject_t& l, const hobject_t& r)
     return -1;
   if (l.nspace > r.nspace)
     return 1;
-  if (l.get_key() < r.get_key())
-    return -1;
-  if (l.get_key() > r.get_key())
-    return 1;
+  if (!(l.get_key().empty() && r.get_key().empty())) {
+    if (l.get_effective_key() < r.get_effective_key()) {
+      return -1;
+    }
+    if (l.get_effective_key() > r.get_effective_key()) {
+      return 1;
+    }
+  }
   if (l.oid < r.oid)
     return -1;
   if (l.oid > r.oid)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -277,3 +277,8 @@ add_ceph_unittest(unittest_bounded_key_counter)
 
 add_executable(unittest_static_ptr test_static_ptr.cc)
 add_ceph_unittest(unittest_static_ptr)
+
+add_executable(unittest_hobject test_hobject.cc
+  $<TARGET_OBJECTS:unit-main>)
+target_link_libraries(unittest_hobject global ceph-common)
+add_ceph_unittest(unittest_hobject)

--- a/src/test/common/test_hobject.cc
+++ b/src/test/common/test_hobject.cc
@@ -1,0 +1,11 @@
+#include "common/hobject.h"
+#include "gtest/gtest.h"
+
+TEST(HObject, cmp)
+{
+  hobject_t c{object_t{"fooc"}, "food", CEPH_NOSNAP, 42, 0, "nspace"};
+  hobject_t d{object_t{"food"}, "",     CEPH_NOSNAP, 42, 0, "nspace"};
+  hobject_t e{object_t{"fooe"}, "food", CEPH_NOSNAP, 42, 0, "nspace"};
+  ASSERT_EQ(-1, cmp(c, d));
+  ASSERT_EQ(-1, cmp(d, e));
+}


### PR DESCRIPTION
we *cannot* change the sort order of hobject. and to avoid duplicated
comparisions, we can check for empty keys, and do not compare the names
again if both hobjects being compared have empty keys.

Signed-off-by: Kefu Chai <kchai@redhat.com>