### PR TITLE
test:qa:infra - Run update daily and use bash

### DIFF
--- a/qa/crontab/teuthology-cronjobs
+++ b/qa/crontab/teuthology-cronjobs
@@ -10,7 +10,7 @@ CEPH_QA_EMAIL="ceph-qa@ceph.com"
 ## crontab is in https://github.com/ceph/ceph/master/qa/crontab/teuthology-cronjobs
 # chkcrontab: disable-msg=INVALID_USER
 # chkcrontab: disable-msg=USER_NOT_FOUND
-@hourly /bin/sh /home/teuthology/bin/update-crontab.sh
+@daily /bin/bash /home/teuthology/bin/update-crontab.sh
 ### !!!!!!!!!!!!!!!!!!!!!!!!!!
 
 


### PR DESCRIPTION
bash has the path for `source` to activate the virtualenv.  sh doesn't.

Signed-off-by: David Galloway <dgallowa@redhat.com>