### PR TITLE
jewel: rbd-mirror: ignore permission errors on rbd_mirroring object

### DIFF
--- a/src/tools/rbd_mirror/ClusterWatcher.cc
+++ b/src/tools/rbd_mirror/ClusterWatcher.cc
@@ -1,12 +1,11 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "ClusterWatcher.h"
 #include "common/debug.h"
 #include "common/errno.h"
-
+#include "cls/rbd/cls_rbd_client.h"
 #include "librbd/internal.h"
-
-#include "ClusterWatcher.h"
 
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
@@ -102,14 +101,17 @@ void ClusterWatcher::read_pool_peers(PoolPeers *pool_peers,
       continue;
     }
 
-    rbd_mirror_mode_t mirror_mode;
-    r = librbd::mirror_mode_get(ioctx, &mirror_mode);
-    if (r < 0) {
+    cls::rbd::MirrorMode mirror_mode_internal;
+    r = librbd::cls_client::mirror_mode_get(&ioctx, &mirror_mode_internal);
+    if (r == -EPERM) {
+      dout(10) << "access denied querying pool " << pool_name << dendl;
+      continue;
+    } else if (r < 0) {
       derr << "could not tell whether mirroring was enabled for " << pool_name
 	   << " : " << cpp_strerror(r) << dendl;
       continue;
     }
-    if (mirror_mode == RBD_MIRROR_MODE_DISABLED) {
+    if (mirror_mode_internal == cls::rbd::MIRROR_MODE_DISABLED) {
       dout(10) << "mirroring is disabled for pool " << pool_name << dendl;
       continue;
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/20637