### PR TITLE
os/bluestore/BlueFS: defer unlink until all readers have closed

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -35,7 +35,7 @@ class BlueRocksSequentialFile : public rocksdb::SequentialFile {
  public:
   BlueRocksSequentialFile(BlueFS *fs, BlueFS::FileReader *h) : fs(fs), h(h) {}
   ~BlueRocksSequentialFile() override {
-    delete h;
+    fs->close_reader(h);
   }
 
   // Read up to "n" bytes from the file.  "scratch[0..n-1]" may be
@@ -81,7 +81,7 @@ class BlueRocksRandomAccessFile : public rocksdb::RandomAccessFile {
  public:
   BlueRocksRandomAccessFile(BlueFS *fs, BlueFS::FileReader *h) : fs(fs), h(h) {}
   ~BlueRocksRandomAccessFile() override {
-    delete h;
+    fs->close_reader(h);
   }
 
   // Read up to "n" bytes from the file starting at "offset".


### PR DESCRIPTION
Wait until readers have closed the file before deallocating it.

Also, switch num_readers and num_writers to non-atomic since we always
modify them under the lock (open_for_* or _close_*).

Fixes: http://tracker.ceph.com/issues/22102
Signed-off-by: Sage Weil <sage@redhat.com>