### PR TITLE
jewel: rbd: clean up warnings when mirror commands used on non-setup pool

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -3006,6 +3006,22 @@ int uuid_get(cls_method_context_t hctx, std::string *mirror_uuid) {
   return 0;
 }
 
+int list_watchers(cls_method_context_t hctx,
+                  std::set<entity_inst_t> *entities) {
+  obj_list_watch_response_t watchers;
+  int r = cls_cxx_list_watchers(hctx, &watchers);
+  if (r < 0 && r != -ENOENT) {
+    CLS_ERR("error listing watchers: '%s'", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  entities->clear();
+  for (auto &w : watchers.entries) {
+    entities->emplace(w.name, w.addr);
+  }
+  return 0;
+}
+
 int read_peers(cls_method_context_t hctx,
                std::vector<cls::rbd::MirrorPeer> *peers) {
   std::string last_read = PEER_KEY_PREFIX;
@@ -3249,7 +3265,8 @@ int image_status_remove(cls_method_context_t hctx,
 }
 
 int image_status_get(cls_method_context_t hctx, const string &global_image_id,
-		     cls::rbd::MirrorImageStatus *status) {
+                     const std::set<entity_inst_t> &watchers,
+                     cls::rbd::MirrorImageStatus *status) {
 
   bufferlist bl;
   int r = cls_cxx_map_get_val(hctx, status_global_key(global_image_id), &bl);
@@ -3271,23 +3288,9 @@ int image_status_get(cls_method_context_t hctx, const string &global_image_id,
     return -EIO;
   }
 
-  obj_list_watch_response_t watchers;
-  r = cls_cxx_list_watchers(hctx, &watchers);
-  if (r < 0 && r != -ENOENT) {
-    CLS_ERR("error listing watchers: '%s'", cpp_strerror(r).c_str());
-    return r;
-  }
 
   *status = static_cast<cls::rbd::MirrorImageStatus>(ondisk_status);
-  status->up = false;
-  for (auto &w : watchers.entries) {
-    if (w.name == ondisk_status.origin.name &&
-	w.addr == ondisk_status.origin.addr) {
-      status->up = true;
-      break;
-    }
-  }
-
+  status->up = (watchers.find(ondisk_status.origin) != watchers.end());
   return 0;
 }
 
@@ -3295,9 +3298,15 @@ int image_status_list(cls_method_context_t hctx,
 	const std::string &start_after, uint64_t max_return,
 	map<std::string, cls::rbd::MirrorImage> *mirror_images,
         map<std::string, cls::rbd::MirrorImageStatus> *mirror_statuses) {
+  std::set<entity_inst_t> watchers;
+  int r = list_watchers(hctx, &watchers);
+  if (r < 0) {
+    return r;
+  }
+
   std::string last_read = image_key(start_after);
   int max_read = RBD_MAX_KEYS_READ;
-  int r = max_read;
+  r = max_read;
 
   while (r == max_read && mirror_images->size() < max_return) {
     std::map<std::string, bufferlist> vals;
@@ -3326,7 +3335,8 @@ int image_status_list(cls_method_context_t hctx,
       (*mirror_images)[image_id] = mirror_image;
 
       cls::rbd::MirrorImageStatus status;
-      int r1 = image_status_get(hctx, mirror_image.global_image_id, &status);
+      int r1 = image_status_get(hctx, mirror_image.global_image_id, watchers,
+                                &status);
       if (r1 < 0) {
 	continue;
       }
@@ -3343,18 +3353,10 @@ int image_status_list(cls_method_context_t hctx,
 
 int image_status_get_summary(cls_method_context_t hctx,
 	std::map<cls::rbd::MirrorImageStatusState, int> *states) {
-  obj_list_watch_response_t watchers_;
-  int r = cls_cxx_list_watchers(hctx, &watchers_);
+  std::set<entity_inst_t> watchers;
+  int r = list_watchers(hctx, &watchers);
   if (r < 0) {
-    if (r != -ENOENT) {
-      CLS_ERR("error listing watchers: '%s'", cpp_strerror(r).c_str());
-    }
     return r;
-  }
-
-  set<entity_inst_t> watchers;
-  for (auto &w : watchers_.entries) {
-    watchers.insert(entity_inst_t(w.name, w.addr));
   }
 
   states->clear();
@@ -3389,7 +3391,7 @@ int image_status_get_summary(cls_method_context_t hctx,
       }
 
       cls::rbd::MirrorImageStatus status;
-      image_status_get(hctx, mirror_image.global_image_id, &status);
+      image_status_get(hctx, mirror_image.global_image_id, watchers, &status);
 
       cls::rbd::MirrorImageStatusState state = status.up ? status.state :
 	cls::rbd::MIRROR_IMAGE_STATUS_STATE_UNKNOWN;
@@ -3405,18 +3407,10 @@ int image_status_get_summary(cls_method_context_t hctx,
 }
 
 int image_status_remove_down(cls_method_context_t hctx) {
-  obj_list_watch_response_t watchers_;
-  int r = cls_cxx_list_watchers(hctx, &watchers_);
+  std::set<entity_inst_t> watchers;
+  int r = list_watchers(hctx, &watchers);
   if (r < 0) {
-    if (r != -ENOENT) {
-      CLS_ERR("error listing watchers: '%s'", cpp_strerror(r).c_str());
-    }
     return r;
-  }
-
-  set<entity_inst_t> watchers;
-  for (auto &w : watchers_.entries) {
-    watchers.insert(entity_inst_t(w.name, w.addr));
   }
 
   string last_read = STATUS_GLOBAL_KEY_PREFIX;
@@ -4052,8 +4046,14 @@ int mirror_image_status_get(cls_method_context_t hctx, bufferlist *in,
     return -EINVAL;
   }
 
+  std::set<entity_inst_t> watchers;
+  int r = mirror::list_watchers(hctx, &watchers);
+  if (r < 0) {
+    return r;
+  }
+
   cls::rbd::MirrorImageStatus status;
-  int r = mirror::image_status_get(hctx, global_image_id, &status);
+  r = mirror::image_status_get(hctx, global_image_id, watchers, &status);
   if (r < 0) {
     return r;
   }

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -3548,11 +3548,11 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
     int r;
     do {
       std::map<std::string, std::string> mirror_images;
-      r =  cls_client::mirror_image_list(&io_ctx, last_read, max_read,
-                                             &mirror_images);
-      if (r < 0) {
+      r = cls_client::mirror_image_list(&io_ctx, last_read, max_read,
+                                        &mirror_images);
+      if (r < 0 && r != -ENOENT) {
         lderr(cct) << "error listing mirrored image directory: "
-             << cpp_strerror(r) << dendl;
+                   << cpp_strerror(r) << dendl;
         return r;
       }
       for (auto it = mirror_images.begin(); it != mirror_images.end(); ++it) {
@@ -3908,7 +3908,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
 
     std::map<cls::rbd::MirrorImageStatusState, int> states_;
     int r = cls_client::mirror_image_status_get_summary(&io_ctx, &states_);
-    if (r < 0) {
+    if (r < 0 && r != -ENOENT) {
       lderr(cct) << "Failed to get mirror status summary: "
                  << cpp_strerror(r) << dendl;
       return r;

--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -31,6 +31,25 @@ namespace mirror_image {
 namespace at = argument_types;
 namespace po = boost::program_options;
 
+namespace {
+
+int validate_mirroring_enabled(librbd::Image& image) {
+  librbd::mirror_image_info_t mirror_image;
+  int r = image.mirror_image_get_info(&mirror_image, sizeof(mirror_image));
+  if (r < 0) {
+    std::cerr << "rbd: failed to retrieve mirror mode: "
+              << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  if (mirror_image.state != RBD_MIRROR_IMAGE_ENABLED) {
+    std::cerr << "rbd: mirroring not enabled on the image" << std::endl;
+    return -EINVAL;
+  }
+  return 0;
+}
+
+} // anonymous namespace
 
 void get_arguments(po::options_description *positional,
                            po::options_description *options) {
@@ -115,6 +134,11 @@ int execute_promote(const po::variables_map &vm) {
     return r;
   }
 
+  r = validate_mirroring_enabled(image);
+  if (r < 0) {
+    return r;
+  }
+
   r = image.mirror_image_promote(force);
   if (r < 0) {
     std::cerr << "rbd: error promoting image to primary" << std::endl;
@@ -146,6 +170,11 @@ int execute_demote(const po::variables_map &vm) {
     return r;
   }
 
+  r = validate_mirroring_enabled(image);
+  if (r < 0) {
+    return r;
+  }
+
   r = image.mirror_image_demote();
   if (r < 0) {
     std::cerr << "rbd: error demoting image to non-primary" << std::endl;
@@ -173,6 +202,11 @@ int execute_resync(const po::variables_map &vm) {
   librbd::Image image;
   r = utils::init_and_open_image(pool_name, image_name, "", false,
                                  &rados, &io_ctx, &image);
+  if (r < 0) {
+    return r;
+  }
+
+  r = validate_mirroring_enabled(image);
   if (r < 0) {
     return r;
   }
@@ -216,6 +250,11 @@ int execute_status(const po::variables_map &vm) {
   librbd::Image image;
   r = utils::init_and_open_image(pool_name, image_name, "", false,
                                  &rados, &io_ctx, &image);
+  if (r < 0) {
+    return r;
+  }
+
+  r = validate_mirroring_enabled(image);
   if (r < 0) {
     return r;
   }

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -23,6 +23,23 @@ namespace po = boost::program_options;
 
 namespace {
 
+int validate_mirroring_enabled(librados::IoCtx& io_ctx) {
+  librbd::RBD rbd;
+  rbd_mirror_mode_t mirror_mode;
+  int r = rbd.mirror_mode_get(io_ctx, &mirror_mode);
+  if (r < 0) {
+    std::cerr << "rbd: failed to retrieve mirror mode: "
+              << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  if (mirror_mode == RBD_MIRROR_MODE_DISABLED) {
+    std::cerr << "rbd: mirroring not enabled on the pool" << std::endl;
+    return -EINVAL;
+  }
+  return 0;
+}
+
 int validate_uuid(const std::string &uuid) {
   boost::regex pattern("^[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}$",
                        boost::regex::icase);
@@ -153,6 +170,11 @@ int execute_peer_add(const po::variables_map &vm) {
     return r;
   }
 
+  r = validate_mirroring_enabled(io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
   // TODO: temporary restriction to prevent adding multiple peers
   // until rbd-mirror daemon can properly handle the scenario
   librbd::RBD rbd;
@@ -201,6 +223,11 @@ int execute_peer_remove(const po::variables_map &vm) {
     return r;
   }
 
+  r = validate_mirroring_enabled(io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
   librbd::RBD rbd;
   r = rbd.mirror_peer_remove(io_ctx, uuid);
   if (r < 0) {
@@ -243,6 +270,11 @@ int execute_peer_set(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   r = utils::init(pool_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  r = validate_mirroring_enabled(io_ctx);
   if (r < 0) {
     return r;
   }
@@ -418,6 +450,11 @@ int execute_status(const po::variables_map &vm) {
     return r;
   }
 
+  r = validate_mirroring_enabled(io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
   librbd::RBD rbd;
 
   std::map<librbd::mirror_image_status_state_t, int> states;
@@ -489,6 +526,10 @@ int execute_status(const po::variables_map &vm) {
       }
       for (auto it = mirror_images.begin(); it != mirror_images.end(); ++it) {
 	librbd::mirror_image_status_t &status = it->second;
+        if (status.info.global_id.empty()) {
+          continue;
+        }
+
 	const std::string &image_name = status.name;
 	std::string &global_image_id = status.info.global_id;
 	std::string state = utils::mirror_image_status_state(status);


### PR DESCRIPTION
http://tracker.ceph.com/issues/21442