### PR TITLE
luminous: os/bluestore: change the type of aio_t:res to long

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -370,7 +370,7 @@ void KernelDevice::_aio_thread()
 	// later flush() occurs.
 	io_since_flush.store(true);
 
-	int r = aio[i]->get_return_value();
+	long r = aio[i]->get_return_value();
         if (r < 0) {
           derr << __func__ << " got " << cpp_strerror(r) << dendl;
           if (ioc->allow_eio && r == -EIO) {

--- a/src/os/bluestore/aio.h
+++ b/src/os/bluestore/aio.h
@@ -19,7 +19,7 @@ struct aio_t {
   int fd;
   boost::container::small_vector<iovec,4> iov;
   uint64_t offset, length;
-  int rval;
+  long rval;
   bufferlist bl;  ///< write payload (so that it remains stable for duration)
 
   boost::intrusive::list_member_hook<> queue_item;
@@ -40,7 +40,7 @@ struct aio_t {
     bl.append(std::move(p));
   }
 
-  int get_return_value() {
+  long get_return_value() {
     return rval;
   }
 };


### PR DESCRIPTION
http://tracker.ceph.com/issues/23544