### PR TITLE
jewel: rocksdb: disable jemalloc explicitly

### DIFF
--- a/src/kv/Makefile.am
+++ b/src/kv/Makefile.am
@@ -20,8 +20,15 @@ NPROC = nproc
 if FREEBSD
         NPROC = sysctl -n hw.ncpu
 endif
+
+ROCKSDB_MAKE_VARS = CC="${CC}" CXX="${CXX}" EXTRA_CXXFLAGS=-fPIC
+ROCKSDB_MAKE_VARS += PORTABLE=1
+if !WITH_JEMALLOC
+ROCKSDB_MAKE_VARS += DISABLE_JEMALLOC=1
+endif
+
 rocksdb/librocksdb.a:
-	cd rocksdb && CC="${CC}" CXX="${CXX}" EXTRA_CXXFLAGS=-fPIC PORTABLE=1 $(MAKE) -j$(shell ${NPROC}) static_lib
+	cd rocksdb && $(ROCKSDB_MAKE_VARS) $(MAKE) -j$(shell ${NPROC}) static_lib
 libkv_a_CXXFLAGS += -I rocksdb/include -fPIC
 libkv_a_SOURCES += kv/RocksDBStore.cc
 libkv_a_LIBADD += rocksdb/librocksdb.a


### PR DESCRIPTION
rocksdb's makefile tries to detect jemalloc automatically and compiles
with it enabled if it's found, but if ceph disable jemalloc, it won't
link against jemalloc. this causes link failure if we compile ceph
without jemalloc enabled in a host with jemalloc library installed.

Signed-off-by: Kefu Chai <kchai@redhat.com>
Conflicts:
	src/kv/Makefile.am: this change is not cherry-picked from
master. as master does not use autotools anymore. and master is
using rocksdb's cmake script for building, the latter does not
jemalloc by default.