### PR TITLE
osd/osd_types: fix ideal lower bound object-id of pg

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -547,7 +547,7 @@ pg_t pg_t::get_parent() const
 
 hobject_t pg_t::get_hobj_start() const
 {
-  return hobject_t(object_t(), string(), CEPH_NOSNAP, m_seed, m_pool,
+  return hobject_t(object_t(), string(), 0, m_seed, m_pool,
 		   string());
 }
 


### PR DESCRIPTION
CEPH_NOSNAP is translated into a large unsigned 64-bit integer
which is bigger than any valid snap-id. So the ideal smallest
object of a specific PG would be a clone of snap-id 0, not a head object.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>