### PR TITLE
mon/AuthMonitor: create bootstrap keys on create_initial()

### DIFF
--- a/doc/dev/mon-on-disk-formats.rst
+++ b/doc/dev/mon-on-disk-formats.rst
@@ -1,0 +1,91 @@
+##############
+ON-DISK FORMAT
+##############
+
+
+************
+UPGRADE PATH
+************
+
+On-disk formats, or even data structure formats, may be changed during an
+upgrade. Services wishing to do so, may so do it via the
+`PaxosService::upgrade_format()` call path. There is no formalized, unified
+format versioning; the `PaxosService` class keeps track of its
+`format_version` through a key in the store, assumed an `unsigned int`,  but
+it will be the service's responsibility to give meaning to those versions.
+
+AUTH MONITOR
+============
+
+versions
+--------
+
+versions are represented with a single `unsigned int`. By default, the value
+zero represents the absence of a formal upgraded format. The first format
+version was introduced in Dumpling; clusters upgrading to Dumpling saw their
+format version being increased from zero to one.::
+
+  0 to 1 - introduced in v0.65, dev release for v0.67 dumpling
+  1 to 2 - introduced in v12.0.2, dev release for luminous
+  2 to 3 - introduced in mimic
+
+  0 - all clusters pre-dumpling
+  1 - all clusters dumpling+ and pre-luminous
+  2 - all clusters luminous+ and pre-mimic
+  3 - all clusters mimic+
+
+  version 1: introduces new-style monitor caps (i.e., profiles)
+  version 2: introduces mgr caps and bootstrap-mgr key
+  version 3: creates all bootstrap and admin keys if they don't yet exist
+
+callstack
+---------
+
+format_version set on `PaxosService::refresh()`:::
+
+  - initially called from Monitor::refresh_from_paxos
+    - initially called from Monitor::init_paxos()
+      - initially called from Monitor::preinit()
+
+AuthMonitor::upgrade_format() called by `PaxosService::_active()`:::
+
+  - called from C_Committed callback, from PaxosService::propose_pending()
+  - called from C_Active callback, from PaxosService::_active()
+  - called from PaxosService::election_finished()
+
+  - on a freshly deployed cluster, upgrade_format() will be first called
+    *after* create_initial().
+  - on an existing cluster, upgrade_format() will be called after the first
+    election.
+
+  - upgrade_format() is irrelevant on a freshly deployed cluster, as there is
+    no format to upgrade at this point.
+
+boil down
+---------
+
+* if `format_version >= current_version` then format is uptodate, return.
+* if `features doesn't contain LUMINOUS` then `current_version = 1`
+* else if `features doesn't contain MIMIC` then `current_version = 2`
+* else `current_version = 3`
+
+if `format_version == 0`:::
+
+  - upgrade to format version 1
+    - move to new-style monitor caps (i.e., profiles):
+      - set daemon profiles for existing entities
+      - set profile for existing bootstrap keys
+
+if `format_version == 1`:::
+
+  - upgrade to format version 2
+    - for existing entities:
+      - add new cap for mgr
+    - for existing 'mgr' entities, fix 'mon' caps due to bug from kraken
+      setting 'allow \*', and set 'allow profile mgr' instead.
+    - add bootstrap-mgr key.
+
+if `format_version == 2`:::
+
+  - upgrade to format version 3
+    - create all bootstrap keys if they don't currently exist

--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -38,6 +38,10 @@ public:
   void print(ostream& out);
 
   // accessors
+  bool exists(const EntityName& name) const {
+    auto p = keys.find(name);
+    return p != keys.end();
+  }
   bool get_auth(const EntityName& name, EntityAuth &a) const {
     map<EntityName, EntityAuth>::const_iterator k = keys.find(name);
     if (k == keys.end())

--- a/src/auth/KeyRing.h
+++ b/src/auth/KeyRing.h
@@ -71,6 +71,9 @@ public:
     }
     return true;
   }
+  size_t size() const {
+    return keys.size();
+  }
 
   // modifiers
   void add(const EntityName& name, EntityAuth &a) {

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1334,8 +1334,11 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       for (const auto &sys_cap : wanted_caps) {
 	if (entity_auth.caps.count(sys_cap.first) == 0 ||
 	    !entity_auth.caps[sys_cap.first].contents_equal(sys_cap.second)) {
-	  ss << entity << " already has fs capabilities that differ from those supplied. To generate a new auth key for "
-	     << entity << ", first remove " << entity << " from configuration files, execute 'ceph auth rm " << entity << "', then execute this command again.";
+	  ss << entity << " already has fs capabilities that differ from "
+	     << "those supplied. To generate a new auth key for " << entity
+	     << ", first remove " << entity << " from configuration files, "
+	     << "execute 'ceph auth rm " << entity << "', then execute this "
+	     << "command again.";
 	  err = -EINVAL;
 	  goto done;
 	}

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -115,6 +115,9 @@ private:
   uint64_t max_global_id;
   uint64_t last_allocated_id;
 
+  bool _upgrade_format_to_dumpling();
+  bool _upgrade_format_to_luminous();
+  bool _upgrade_format_to_mimic();
   void upgrade_format() override;
 
   void export_keyring(KeyRing& keyring);

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -144,6 +144,8 @@ private:
 
   void on_active() override;
   bool should_propose(double& delay) override;
+  void get_initial_keyring(KeyRing *keyring);
+  void create_initial_keys(KeyRing *keyring);
   void create_initial() override;
   void update_from_paxos(bool *need_bootstrap) override;
   void create_pending() override;  // prepare a new pending


### PR DESCRIPTION
This patch set serves two purposes:

1) creating the set of bootstrap keys for a freshly deployed cluster on create_initial(), ensuring the initial cluster state contains the necessary keys for bootstrapping operations; and

2) ensuring that bootstrap keys are also created for upgraded clusters, in case they are missing.

The patch set is now open for reviews, but still requires upgrade testing. Currently debating myself whether we should simply drop the upgrade path for clusters prior to Kraken, so opinions are most welcome.