### PR TITLE
qa/suites/rados/singleton/all/recovery_preemption: whitelist SLOW_OPS

### DIFF
--- a/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
+++ b/qa/suites/rados/singleton/all/ec-lost-unfound.yaml
@@ -21,4 +21,5 @@ tasks:
       - \(OSD_
       - \(PG_
       - \(OBJECT_
+      - \(SLOW_OPS\)
 - ec_lost_unfound:

--- a/qa/suites/rados/singleton/all/recovery-preemption.yaml
+++ b/qa/suites/rados/singleton/all/recovery-preemption.yaml
@@ -25,6 +25,7 @@ tasks:
       - \(OSD_
       - \(OBJECT_
       - \(PG_
+      - \(SLOW_OPS\)
       - overall HEALTH
 - exec:
     osd.0:


### PR DESCRIPTION
Recovery and peering can be slow enough with all the logging enabled to
trigger a slow ops warning.

Signed-off-by: Sage Weil <sage@redhat.com>