### PR TITLE
Revert commits that added LibCephFS.ShutdownRace test to luminous

### DIFF
--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1862,26 +1862,23 @@ TEST(LibCephFS, OperationsOnRoot)
   ceph_shutdown(cmount);
 }
 
+#define NTHREADS 128
+
 static void shutdown_racer_func()
 {
-  const int niter = 32;
   struct ceph_mount_info *cmount;
-  int i;
 
-  for (i = 0; i < niter; ++i) {
-    ASSERT_EQ(ceph_create(&cmount, NULL), 0);
-    ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
-    ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
-    ASSERT_EQ(ceph_mount(cmount, "/"), 0);
-    ceph_shutdown(cmount);
-  }
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+  ceph_shutdown(cmount);
 }
 
 // See tracker #20988
 TEST(LibCephFS, ShutdownRace)
 {
-  const int nthreads = 128;
-  std::thread threads[nthreads];
+  std::thread threads[NTHREADS];
 
   // Need a bunch of fd's for this test
   struct rlimit rold, rnew;
@@ -1890,10 +1887,10 @@ TEST(LibCephFS, ShutdownRace)
   rnew.rlim_cur = rnew.rlim_max;
   ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rnew), 0);
 
-  for (int i = 0; i < nthreads; ++i)
+  for (int i = 0; i < NTHREADS; ++i)
     threads[i] = std::thread(shutdown_racer_func);
 
-  for (int i = 0; i < nthreads; ++i)
+  for (int i = 0; i < NTHREADS; ++i)
     threads[i].join();
   ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rold), 0);
 }

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -23,8 +23,6 @@
 #include <dirent.h>
 #include <sys/xattr.h>
 #include <sys/uio.h>
-#include <sys/time.h>
-#include <sys/resource.h>
 
 #ifdef __linux__
 #include <limits.h>
@@ -32,7 +30,6 @@
 
 #include <map>
 #include <vector>
-#include <thread>
 
 TEST(LibCephFS, OpenEmptyComponent) {
 
@@ -1860,37 +1857,4 @@ TEST(LibCephFS, OperationsOnRoot)
   ASSERT_EQ(ceph_symlink(cmount, "nonExistingDir", "/"), -EEXIST);
 
   ceph_shutdown(cmount);
-}
-
-#define NTHREADS 128
-
-static void shutdown_racer_func()
-{
-  struct ceph_mount_info *cmount;
-
-  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
-  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
-  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
-  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
-  ceph_shutdown(cmount);
-}
-
-// See tracker #20988
-TEST(LibCephFS, ShutdownRace)
-{
-  std::thread threads[NTHREADS];
-
-  // Need a bunch of fd's for this test
-  struct rlimit rold, rnew;
-  ASSERT_EQ(getrlimit(RLIMIT_NOFILE, &rold), 0);
-  rnew = rold;
-  rnew.rlim_cur = rnew.rlim_max;
-  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rnew), 0);
-
-  for (int i = 0; i < NTHREADS; ++i)
-    threads[i] = std::thread(shutdown_racer_func);
-
-  for (int i = 0; i < NTHREADS; ++i)
-    threads[i].join();
-  ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rold), 0);
 }


### PR DESCRIPTION
I overlooked what Jeff Layton wrote in http://tracker.ceph.com/issues/20988#note-24

To be clear, I think we may want to leave off the patch that adds the new testcase from this series as it's uncovering some other races (see tracker #21512). Until we shake those out, let's not add the new testcase to the stable releases just yet (not sure if that's routinely done or not).