### PR TITLE
mds: bump mds_log_max_segments for trim buffer

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6588,7 +6588,7 @@ std::vector<Option> get_mds_options() {
     .set_description("size in bytes of each MDS log segment"),
 
     Option("mds_log_max_segments", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(30)
+    .set_default(128)
     .set_description("maximum number of segments which may be untrimmed"),
 
     Option("mds_bal_export_pin", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
Under create heavy workloads, the MDS will sometimes get behind trimming but
catch up. This avoids unnecessary warnings.

Fixes: http://tracker.ceph.com/issues/23560

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>