### PR TITLE
luminous: mds: bump mds_log_max_segments for trim buffer

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6021,7 +6021,7 @@ std::vector<Option> get_mds_options() {
     .set_description(""),
 
     Option("mds_log_max_segments", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(30)
+    .set_default(128)
     .set_description(""),
 
     Option("mds_bal_export_pin", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
http://tracker.ceph.com/issues/23561