### PR TITLE
rgw: delete_obj() does not complete on ECANCELED

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4415,6 +4415,10 @@ void RGWDeleteObj::execute()
         op_ret = -ENOENT;
         return;
       }
+      // if delete raced with another write, we can regard it as removed
+      if (op_ret == -ECANCELED) {
+        op_ret = 0;
+      }
     }
 
     if (op_ret == -ERR_PRECONDITION_FAILED && no_precondition_error) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9014,12 +9014,9 @@ int RGWRados::Object::Delete::delete_obj()
 
   store->remove_rgw_head_obj(op);
   r = ref.ioctx.operate(ref.oid, &op);
-  bool need_invalidate = false;
-  if (r == -ECANCELED) {
-    /* raced with another operation, we can regard it as removed */
-    need_invalidate = true;
-    r = 0;
-  }
+
+  /* raced with another operation, object state is indeterminate */
+  const bool need_invalidate = (r == -ECANCELED);
 
   int64_t poolid = ref.ioctx.get_id();
   if (r >= 0) {


### PR DESCRIPTION
if we detect a racing operation with ECANCELED but still complete the delete op, other zones cannot resolve this race during data sync

Fixes: http://tracker.ceph.com/issues/22804