### PR TITLE
luminous: mds: make sure that MDBalancer uses heartbeat info from the same epoch

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -300,9 +300,11 @@ void MDBalancer::send_heartbeat()
     return;
   }
 
-  mds_load.clear();
-  if (mds->get_nodeid() == 0)
+  if (mds->get_nodeid() == 0) {
     beat_epoch++;
+   
+    mds_load.clear();
+  }
 
   // my load
   mds_load_t load = get_load(now);
@@ -367,8 +369,19 @@ void MDBalancer::handle_heartbeat(MHeartbeat *m)
     goto out;
   }
 
+  if (mds->get_nodeid() != 0 && m->get_beat() > beat_epoch) {
+    dout(10) << "receive next epoch " << m->get_beat() << " from mds." << who << " before mds0" << dendl;
+
+    beat_epoch = m->get_beat();
+    // clear the mds load info whose epoch is less than beat_epoch 
+    mds_load.clear();
+  }
+
   if (who == 0) {
-    dout(20) << " from mds0, new epoch" << dendl;
+    dout(20) << " from mds0, new epoch " << m->get_beat() << dendl;
+    if (beat_epoch != m->get_beat()) {
+      mds_load.clear();
+    }
     beat_epoch = m->get_beat();
     send_heartbeat();
 
@@ -400,6 +413,8 @@ void MDBalancer::handle_heartbeat(MHeartbeat *m)
                           << " : " << cpp_strerror(r);
       }
       prep_rebalance(m->get_beat());
+    
+      mds_load.clear();
     }
   }
 

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -413,8 +413,6 @@ void MDBalancer::handle_heartbeat(MHeartbeat *m)
                           << " : " << cpp_strerror(r);
       }
       prep_rebalance(m->get_beat());
-    
-      mds_load.clear();
     }
   }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/23572