### PR TITLE
doc: some improvements to ceph-conf.rst

### DIFF
--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -148,7 +148,7 @@ These sections include:
 
 :Description: Settings under ``client`` affect all Ceph Clients
               (e.g., mounted Ceph Filesystems, mounted Ceph Block Devices,
-              etc.).
+              etc.) as well as Rados Gateway (RGW) daemons.
 
 :Example: ``objecter_inflight_ops = 512``
 

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -256,22 +256,9 @@ by preceding comments with a pound sign (#) or a semi-colon (;).  For example:
 Config file section names
 -------------------------
 
-The configuration file is divided into sections like ``[global]`` or
-``[mon.foo]``, where the section is a valid Ceph section name
-(`global`, a daemon type, or a daemon name) surrounded by square
-brackets.
-
-Global settings affect all instances of all daemon in the Ceph Storage Cluster.
-Use the ``[global]`` setting for values that are common for all daemons in the
-Ceph Storage Cluster. You can override each ``[global]`` setting by:
-
-#. Changing the setting in a particular process type
-   (*e.g.,* ``[osd]``, ``[mon]``, ``[mds]`` ).
-
-#. Changing the setting in a particular process (*e.g.,* ``[osd.1]`` ).
-
-Overriding a global setting affects all child processes, except those that
-you specifically override in a particular daemon.  For example,
+The configuration file is divided into sections. Each section must begin with a
+valid configuration section name (see `Configuration sections`_, above)
+surrounded by square brackets. For example,
 
 .. code-block:: ini
 


### PR DESCRIPTION
The "Config file section names" section was duplicating some of the content that is now covered better by the "Configuration sections" section.

RGW configuration goes in the "client" section, which is not intuitive, so mention that.
