### PR TITLE
mgr: Expose rgw perf counters

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -604,7 +604,7 @@ class MgrModule(ceph_module.BaseMgrModule):
 
         for server in self.list_servers():
             for service in server['services']:
-                if service['type'] not in ("mds", "osd", "mon"):
+                if service['type'] not in ("rgw", "mds", "osd", "mon"):
                     continue
 
                 schema = self.get_perf_schema(service['type'], service['id'])

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -137,7 +137,7 @@ rgw_http_errors rgw_http_swift_errors({
 
 int rgw_perf_start(CephContext *cct)
 {
-  PerfCountersBuilder plb(cct, cct->_conf->name.to_str(), l_rgw_first, l_rgw_last);
+  PerfCountersBuilder plb(cct, "rgw", l_rgw_first, l_rgw_last);
 
   // RGW emits comparatively few metrics, so let's be generous
   // and mark them all USEFUL to get transmission to ceph-mgr by default.


### PR DESCRIPTION
We are filtering rgw perf counters in mgr_module. This commit allows us
to expose perf counters to the mgr modules. This also directly exports
the rgw perf counters via prometheus module since the module calls the
get_all_perf_counters method to get all the counters and then exports them.

Signed-off-by: Boris Ranto <branto@redhat.com>