### PR TITLE
osdc/Objecter: add ignore overlay flag if got redirect reply

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3454,7 +3454,7 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     op->tid = 0;
     m->get_redirect().combine_with_locator(op->target.target_oloc,
 					   op->target.target_oid.name);
-    op->target.flags |= CEPH_OSD_FLAG_REDIRECTED;
+    op->target.flags |= (CEPH_OSD_FLAG_REDIRECTED | CEPH_OSD_FLAG_IGNORE_OVERLAY);
     _op_submit(op, sul, NULL);
     m->put();
     return;


### PR DESCRIPTION
This fix got merged to luminous first by mistake, so this is (a bit unconventionally) a forward-port cherry-pick from luminous to master.

Fixes: https://tracker.ceph.com/issues/23296
