### PR TITLE
doc: erasure-code-jerasure: removed default section of crush-device-class

### DIFF
--- a/doc/rados/operations/erasure-code-jerasure.rst
+++ b/doc/rados/operations/erasure-code-jerasure.rst
@@ -100,9 +100,8 @@ Where:
 
 :Type: String
 :Required: No.
-:Default:
 
- ``directory={directory}``
+``directory={directory}``
 
 :Description: Set the **directory** name from which the erasure code
               plugin is loaded.


### PR DESCRIPTION
I found little Invalid format in erasure-code-jerasure documentation.

http://docs.ceph.com/docs/master/rados/operations/erasure-code-jerasure/
![2018-04-07 10 53 21](https://user-images.githubusercontent.com/16697306/38450041-ead0407a-3a51-11e8-8d6e-e33624b717e3.png)

it caused by empty `Default:`. 