### PR TITLE
librados_test_stub: s/RTLD_NOW/RTLD_LAZY/

### DIFF
--- a/src/test/librados_test_stub/TestClassHandler.cc
+++ b/src/test/librados_test_stub/TestClassHandler.cc
@@ -28,7 +28,7 @@ TestClassHandler::~TestClassHandler() {
 
 void TestClassHandler::open_class(const std::string& name,
                                   const std::string& path) {
-  void *handle = dlopen(path.c_str(), RTLD_NOW);
+  void *handle = dlopen(path.c_str(), RTLD_LAZY);
   if (handle == NULL) {
     derr << "Failed to load class: " << dlerror() << dendl;
     return;


### PR DESCRIPTION
librados_test_stub: s/RTLD_LAZY/RTLD_NOW/

do not try to resolve all functions until they are used.

Fixes: http://tracker.ceph.com/issues/23517
Signed-off-by: Kefu Chai <kchai@redhat.com>