### PR TITLE
osd/osd_types: fix pg_pool_t encoding for hammer

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -234,6 +234,8 @@ int OSDMap::Incremental::propagate_snaps_to_tiers(CephContext *cct,
 	tier->snap_epoch = base.snap_epoch;
 	tier->snaps = base.snaps;
 	tier->removed_snaps = base.removed_snaps;
+	tier->flags |= base.flags & (pg_pool_t::FLAG_SELFMANAGED_SNAPS|
+				     pg_pool_t::FLAG_POOL_SNAPS);
 
 	if (new_rem_it != new_removed_snaps.end()) {
 	  new_removed_snaps[tier_pool] = new_rem_it->second;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1557,8 +1557,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     // this was the first post-hammer thing we added; if it's missing, encode
     // like hammer.
     v = 21;
-  }
-  if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+  } else if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
     v = 24;
   }
 


### PR DESCRIPTION
If we are missing the hammer feature, we will also be missing the
luminous feature, but we should still encode like hammer.

Analogous fix to e28e0c617af8825ae92cced5d87cc4f403709e48

Signed-off-by: Sage Weil <sage@redhat.com>