### PR TITLE
luminous: osd/osd_types: fix pg_pool_t encoding for hammer

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1543,8 +1543,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     // this was the first post-hammer thing we added; if it's missing, encode
     // like hammer.
     v = 21;
-  }
-  if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+  } else if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
     v = 24;
   }
 


### PR DESCRIPTION
If we are missing the hammer feature, we will also be missing the
luminous feature, but we should still encode like hammer.

Analogous fix to e28e0c617af8825ae92cced5d87cc4f403709e48

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 37c22b273959c6ca54808f3cb8d22a2d250d0c1b)