### PR TITLE
cmake: define HAVE_STDLIB_MAP_SPLICING for both libstdc++ and libc++

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -167,9 +167,8 @@ else()
   set(C_STANDARD_REQUIRED ON)
 endif()
 
-if(CXX_STDLIB STREQUAL "libc++")
-  include(CheckCXXSourceCompiles)
-  CHECK_CXX_SOURCE_COMPILES("
+include(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("
 #include <map>
 using Map = std::map<int, int>;
 int main() {
@@ -177,7 +176,6 @@ int main() {
   m.merge(Map{});
 }
 " HAVE_STDLIB_MAP_SPLICING)
-endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX AND
     CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>