### PR TITLE
rgw:  should recode  canonical_uri when caculate s3 v4 auth 

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -292,7 +292,6 @@ static inline int parse_v4_query_string(const req_info& info,              /* in
   return 0;
 }
 
-namespace {
 static bool get_next_token(const boost::string_view& s,
                            size_t& pos,
                            const char* const delims,
@@ -341,7 +340,6 @@ get_str_vec(const boost::string_view& str)
   const char delims[] = ";,= \t";
   return get_str_vec<ExpectedStrNum>(str, delims);
 }
-};
 
 static inline int parse_v4_auth_header(const req_info& info,               /* in */
                                        boost::string_view& credential,     /* out */
@@ -457,45 +455,6 @@ int parse_credentials(const req_info& info,                     /* in */
   return 0;
 }
 
-static inline bool char_needs_aws4_escaping(const char c)
-{
-  if ((c >= 'a' && c <= 'z') ||
-      (c >= 'A' && c <= 'Z') ||
-      (c >= '0' && c <= '9')) {
-    return false;
-  }
-
-  switch (c) {
-    case '-':
-    case '_':
-    case '.':
-    case '~':
-      return false;
-  }
-  return true;
-}
-
-static inline std::string aws4_uri_encode(const std::string& src)
-{
-  std::string result;
-
-  for (const std::string::value_type c : src) {
-    if (char_needs_aws4_escaping(c)) {
-      rgw_uri_escape_char(c, result);
-    } else {
-      result.push_back(c);
-    }
-  }
-
-  return result;
-}
-
-static inline std::string aws4_uri_recode(const boost::string_view& src)
-{
-  std::string decoded = url_decode(src);
-  return aws4_uri_encode(decoded);
-}
-
 std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)
 {
   const std::string *params = &info.request_params;
@@ -536,7 +495,7 @@ std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)
        * way. */
       canonical_qs_map[key.to_string()] = val.to_string();
     } else {
-      canonical_qs_map[aws4_uri_recode(key)] = aws4_uri_recode(val);
+      canonical_qs_map[aws4_uri_recode(key, true)] = aws4_uri_recode(val, true);
     }
   }
 

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -384,12 +384,55 @@ int parse_credentials(const req_info& info,                     /* in */
                       boost::string_view& date,                 /* out */
                       const bool using_qs);                     /* in */
 
+static inline bool char_needs_aws4_escaping(const char c, bool encode_slash)
+{
+  if ((c >= 'a' && c <= 'z') ||
+      (c >= 'A' && c <= 'Z') ||
+      (c >= '0' && c <= '9')) {
+    return false;
+  }
+
+  switch (c) {
+    case '-':
+    case '_':
+    case '.':
+    case '~':
+      return false;
+  }
+
+  if (c == '/' && !encode_slash)
+    return false;
+
+  return true;
+}
+
+static inline std::string aws4_uri_encode(const std::string& src, bool encode_slash)
+{
+  std::string result;
+
+  for (const std::string::value_type c : src) {
+    if (char_needs_aws4_escaping(c, encode_slash)) {
+      rgw_uri_escape_char(c, result);
+    } else {
+      result.push_back(c);
+    }
+  }
+
+  return result;
+}
+
+static inline std::string aws4_uri_recode(const boost::string_view& src, bool encode_slash)
+{
+  std::string decoded = url_decode(src);
+  return aws4_uri_encode(decoded, encode_slash);
+}
+
 static inline std::string get_v4_canonical_uri(const req_info& info) {
   /* The code should normalize according to RFC 3986 but S3 does NOT do path
    * normalization that SigV4 typically does. This code follows the same
    * approach that boto library. See auth.py:canonical_uri(...). */
 
-  std::string canonical_uri = info.request_uri_aws4;
+  std::string canonical_uri = aws4_uri_recode(info.request_uri_aws4, false);
 
   if (canonical_uri.empty()) {
     canonical_uri = "/";
@@ -480,7 +523,6 @@ extern AWSEngine::VersionAbstractor::server_signature_t
 get_v2_signature(CephContext*,
                  const std::string& secret_key,
                  const AWSEngine::VersionAbstractor::string_to_sign_t& string_to_sign);
-
 } /* namespace s3 */
 } /* namespace auth */
 } /* namespace rgw */


### PR DESCRIPTION
i run s3test in ceph master branch and failed to pass test_bucket_create_naming_bad_punctuation

it raise 403 signature not match rather 400 bad bucket name, the bucket name alpha!soup should uri recode for s3v4 authorization in canonical_uri

```
S3_USE_SIGV4=1  S3TEST_CONF=./cluster1.conf  ./virtualenv/bin/nosetests s3tests.functional.test_s3:test_bucket_create_naming_bad_punctuation
```


fix: http://tracker.ceph.com/issues/23587

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>