### PR TITLE
Allow ceph-volume and ceph-disk to run on loop devices.

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -892,13 +892,14 @@ def is_partition(dev):
     if not stmode_is_diskdevice(st.st_mode):
         raise Error('not a block device', dev)
 
+    major = os.major(st.st_rdev)
+    minor = os.minor(st.st_rdev)
+
     name = get_dev_name(dev)
-    if os.path.exists(os.path.join(BLOCKDIR, name)):
+    if os.path.exists(os.path.join(BLOCKDIR, name)) or os.path.exists(os.path.join(BLOCKDIR, "loop%d" % minor)):
         return False
 
     # make sure it is a partition of something else
-    major = os.major(st.st_rdev)
-    minor = os.minor(st.st_rdev)
     if os.path.exists('/sys/dev/block/%d:%d/partition' % (major, minor)):
         return True
 

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -203,7 +203,7 @@ def is_device(dev):
     # use lsblk first, fall back to using stat
     TYPE = lsblk(dev).get('TYPE')
     if TYPE:
-        return TYPE == 'disk'
+        return TYPE == 'disk' or TYPE == 'loop'
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)


### PR DESCRIPTION
This makes it possible to use bluestore on devices backed by files,
e.g.:

    rm -f /cephdisk.img
    truncate --size=10G /cephdisk.img
    losetup /dev/loop0 /cephdisko
    ceph-volume lvm prepare --bluestore --data /dev/loop0

now works.

Before, ceph-volume would die with the error:

    RuntimeError: Cannot use device (/dev/loop0). A vg/lv path or an existing device is needed
