### PR TITLE
RGWCivetWeb::read_data: fix arguments to mg_read() call

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -57,7 +57,7 @@ size_t RGWCivetWeb::read_data(char *buf, size_t len)
     return 0;
   }
   for (c = 0; c < len; c += ret) {
-    ret = mg_read(conn, buf, len);
+    ret = mg_read(conn, buf+c, len-c);
     if (ret < 0) {
       throw rgw::io::Exception(EIO, std::system_category());
     }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23596

Following up on https://github.com/ceph/ceph/pull/21098#issuecomment-379209739 and @mdw-at-linuxbox 's review of that PR.