### PR TITLE
jewel: rgw: copying part without http header x-amz-copy-source-range will be mistaken for copying object

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2669,9 +2669,28 @@ void RGWPutObj::execute()
 		      << dendl;
     goto done;
   }
+  
+  if (copy_source && !copy_source_range) {
+    rgw_obj_key obj_key(copy_source_object_name, copy_source_version_id);
+    rgw_obj obj(copy_source_bucket_info.bucket, obj_key.name);
+
+    RGWObjState *astate;
+    op_ret = store->get_obj_state(static_cast<RGWObjectCtx *>(s->obj_ctx),
+                                  obj, &astate, true);
+    if (op_ret < 0) {
+      ldout(s->cct, 0) << "ERROR: get copy source obj state returned with error" << op_ret << dendl;
+      goto done;
+    }
+    if (!astate->exists){
+      op_ret = -ENOENT;
+      goto done;
+    }
+    lst = astate->size - 1;
+  } else {
+    lst = copy_source_range_lst;
+  }
 
   fst = copy_source_range_fst;
-  lst = copy_source_range_lst;
 
   do {
     bufferlist data_in;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3228,8 +3228,12 @@ int RGWHandler_REST_S3::init(RGWRados *store, struct req_state *s,
 
   const char *copy_source = s->info.env->get("HTTP_X_AMZ_COPY_SOURCE");
 
-  if (copy_source && !s->info.env->get("HTTP_X_AMZ_COPY_SOURCE_RANGE")) {
-    ret = RGWCopyObj::parse_copy_location(copy_source,
+  if (copy_source && 
+      (! s->info.env->get("HTTP_X_AMZ_COPY_SOURCE_RANGE")) &&
+      (! s->info.args.exists("uploadId"))) {
+    std::string url_decode_copy_source;
+    url_decode(copy_source, url_decode_copy_source);
+    ret = RGWCopyObj::parse_copy_location(url_decode_copy_source,
                                           s->init_state.src_bucket,
                                           s->src_object);
     if (!ret) {


### PR DESCRIPTION
Backport tracker: http://tracker.ceph.com/issues/22904

> https://github.com/ceph/ceph/pull/21209

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>