### PR TITLE
ceph: print output of "status" as string not as bytes

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -998,7 +998,7 @@ def main():
             # Filter on channel
             if (channel == parsed_args.watch_channel or \
                            parsed_args.watch_channel == "*"):
-                print(line)
+                print(line.decode('utf-8'))
                 sys.stdout.flush()
 
         # first do a ceph status
@@ -1006,7 +1006,7 @@ def main():
         if ret:
             print("status query failed: ", outs, file=sys.stderr)
             return ret
-        print(outbuf)
+        print(outbuf.decode('utf-8'))
 
         # this instance keeps the watch connection alive, but is
         # otherwise unused


### PR DESCRIPTION
in python3, the stuff read from wire is represented as "bytes", but
the output of "ceph -w" is supposed to be consumed by human. so decode
it as utf-8.

Signed-off-by: Kefu Chai <kchai@redhat.com>