### PR TITLE
qa/suites/rados/singleton/all/random-eio: whitelist eio error message

### DIFF
--- a/qa/suites/rados/singleton/all/random-eio.yaml
+++ b/qa/suites/rados/singleton/all/random-eio.yaml
@@ -18,6 +18,7 @@ tasks:
     log-whitelist:
     - missing primary copy of
     - objects unfound and apparently lost
+    - had a read error
     - overall HEALTH_
     - (POOL_APP_NOT_ENABLED)
     - (PG_DEGRADED)


### PR DESCRIPTION
"cluster [ERR] 2.1 shard 1: soid 2:8007ad8d:::benchmark_data_smithi115_12935_object2439:head candidate had a read error"

is normal when we're injecting EIO.

Signed-off-by: Sage Weil <sage@redhat.com>