### PR TITLE
luminous: tests: ENGINE Error in 'start' listener <bound  in rados

### DIFF
--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -31,6 +31,7 @@ class TestModuleSelftest(MgrTestCase):
         self._selftest_plugin("zabbix")
 
     def test_prometheus(self):
+        self._assign_ports("prometheus", "server_port", min_port=8100)
         self._selftest_plugin("prometheus")
 
     def test_influx(self):


### PR DESCRIPTION
http://tracker.ceph.com/issues/23606