### PR TITLE
librbd: disable ENOENT tracking within the object cacher

### DIFF
--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -145,7 +145,7 @@ namespace librbd {
     aio_comp->set_request_count(1);
 
     auto req_comp = new io::ReadResult::C_ObjectReadRequest(
-      aio_comp, off, len, {{0, len}}, false);
+      aio_comp, off, len, {{0, len}});
 
     auto req = io::ObjectDispatchSpec::create_read(
       m_ictx, io::OBJECT_DISPATCH_LAYER_CACHE, oid.name, object_no, off, len,

--- a/src/librbd/cache/ObjectCacherObjectDispatch.cc
+++ b/src/librbd/cache/ObjectCacherObjectDispatch.cc
@@ -132,7 +132,6 @@ void ObjectCacherObjectDispatch<I>::init() {
 
   m_object_set = new ObjectCacher::ObjectSet(nullptr,
                                              m_image_ctx->data_ctx.get_id(), 0);
-  m_object_set->return_enoent = true;
   m_object_cacher->start();
   m_cache_lock.Unlock();
 

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -208,7 +208,7 @@ void ImageReadRequest<I>::send_request() {
 
       auto req_comp = new io::ReadResult::C_ObjectReadRequest(
         aio_comp, extent.offset, extent.length,
-        std::move(extent.buffer_extents), true);
+        std::move(extent.buffer_extents));
       auto req = ObjectDispatchSpec::create_read(
         &image_ctx, OBJECT_DISPATCH_LAYER_NONE, extent.oid.name,
         extent.objectno, extent.offset, extent.length, snap_id, m_op_flags,

--- a/src/librbd/io/ReadResult.cc
+++ b/src/librbd/io/ReadResult.cc
@@ -108,10 +108,9 @@ void ReadResult::C_ImageReadRequest::finish(int r) {
 
 ReadResult::C_ObjectReadRequest::C_ObjectReadRequest(
     AioCompletion *aio_completion, uint64_t object_off, uint64_t object_len,
-    Extents&& buffer_extents, bool ignore_enoent)
+    Extents&& buffer_extents)
   : aio_completion(aio_completion), object_off(object_off),
-    object_len(object_len), buffer_extents(std::move(buffer_extents)),
-    ignore_enoent(ignore_enoent) {
+    object_len(object_len), buffer_extents(std::move(buffer_extents)) {
   aio_completion->add_request();
 }
 
@@ -120,7 +119,7 @@ void ReadResult::C_ObjectReadRequest::finish(int r) {
   ldout(cct, 10) << "C_ObjectReadRequest: r=" << r
                  << dendl;
 
-  if (ignore_enoent && r == -ENOENT) {
+  if (r == -ENOENT) {
     r = 0;
   }
   if (r >= 0) {

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -41,14 +41,12 @@ public:
     uint64_t object_off;
     uint64_t object_len;
     Extents buffer_extents;
-    bool ignore_enoent;
 
     bufferlist bl;
     ExtentMap extent_map;
 
     C_ObjectReadRequest(AioCompletion *aio_completion, uint64_t object_off,
-                        uint64_t object_len, Extents&& buffer_extents,
-                        bool ignore_enoent);
+                        uint64_t object_len, Extents&& buffer_extents);
 
     void finish(int r) override;
   };


### PR DESCRIPTION
Now that the in-memory cache has been flattened, we don't want/need
to track the existence of individual objects within an image and
its parent hierarchy.

Fixes: http://tracker.ceph.com/issues/23597
Signed-off-by: Jason Dillaman <dillaman@redhat.com>