### PR TITLE
osd: resend osd_pgtemp if it's not acked

### DIFF
--- a/src/mds/OpenFileTable.cc
+++ b/src/mds/OpenFileTable.cc
@@ -347,8 +347,10 @@ void OpenFileTable::commit(MDSInternalContextBase *c, uint64_t log_seq, int op_p
     ctl.journaled_update.merge(ctl.to_update);
     ctl.journaled_remove.merge(ctl.to_remove);
 #else
-    ctl.journaled_update.insert(ctl.to_update.begin(), ctl.to_update.end());
-    ctl.journaled_remove.insert(ctl.to_remove.begin(), ctl.to_remove.end());
+    ctl.journaled_update.insert(make_move_iterator(begin(ctl.to_update)),
+				make_move_iterator(end(ctl.to_update)));
+    ctl.journaled_remove.insert(make_move_iterator(begin(ctl.to_remove)),
+				make_move_iterator(end(ctl.to_remove)));
 #endif
     ctl.to_update.clear();
     ctl.to_remove.clear();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -940,8 +940,12 @@ void OSDService::remove_want_pg_temp(pg_t pgid)
 
 void OSDService::_sent_pg_temp()
 {
+#ifdef HAVE_STDLIB_MAP_SPLICING
+  pg_temp_pending.merge(pg_temp_wanted);
+#else
   pg_temp_pending.insert(make_move_iterator(begin(pg_temp_wanted)),
 			 make_move_iterator(end(pg_temp_wanted)));
+#endif
   pg_temp_wanted.clear();
 }
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -718,11 +718,17 @@ public:
   // -- pg_temp --
 private:
   Mutex pg_temp_lock;
-  map<pg_t, vector<int> > pg_temp_wanted;
-  map<pg_t, vector<int> > pg_temp_pending;
+  struct pg_temp_t {
+    vector<int> acting;
+    bool forced = false;
+  };
+  map<pg_t, pg_temp_t> pg_temp_wanted;
+  map<pg_t, pg_temp_t> pg_temp_pending;
   void _sent_pg_temp();
+  friend std::ostream& operator<<(std::ostream&, const pg_temp_t&);
 public:
-  void queue_want_pg_temp(pg_t pgid, const vector<int>& want);
+  void queue_want_pg_temp(pg_t pgid, const vector<int>& want,
+			  bool forced = false);
   void remove_want_pg_temp(pg_t pgid);
   void requeue_pg_temp();
   void send_pg_temp();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5828,6 +5828,7 @@ void PG::start_peering_interval(
   pg_shard_t old_acting_primary = get_primary();
   pg_shard_t old_up_primary = up_primary;
   bool was_old_primary = is_primary();
+  bool was_old_replica = is_replica();
 
   acting.swap(oldacting);
   up.swap(oldup);
@@ -5947,8 +5948,10 @@ void PG::start_peering_interval(
   acting_recovery_backfill.clear();
   scrub_queued = false;
 
-  // reset primary state?
+  // reset primary/replica state?
   if (was_old_primary || is_primary()) {
+    osd->remove_want_pg_temp(info.pgid.pgid);
+  } else if (was_old_replica || is_replica()) {
     osd->remove_want_pg_temp(info.pgid.pgid);
   }
   clear_primary_state();


### PR DESCRIPTION
if the osd_pgtemp message is dropped before monitor receives it, we need
to resend it. otherwise a pg could be stuck in activating state if the
pg creation was withheld by the max-pg-per-osd on the replica, and then
the replica osd removes some existing pg.

Fixes: http://tracker.ceph.com/issues/23610
Signed-off-by: Kefu Chai <kchai@redhat.com>