### PR TITLE
osd: make PG::*Force* event structs public

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1892,14 +1892,15 @@ protected:
   public:
   TrivialEvent(DeleteStart)
   TrivialEvent(DeleteSome)
-  protected:
-  TrivialEvent(DeleteReserved)
-  TrivialEvent(DeleteInterrupted)
 
   TrivialEvent(SetForceRecovery)
   TrivialEvent(UnsetForceRecovery)
   TrivialEvent(SetForceBackfill)
   TrivialEvent(UnsetForceBackfill)
+
+  protected:
+  TrivialEvent(DeleteReserved)
+  TrivialEvent(DeleteInterrupted)
 
   /* Encapsulates PG recovery process */
   class RecoveryState {


### PR DESCRIPTION
Otherwise the compiler complains about it:
```
home/jenkins/workspace/ceph-master/src/osd/OSD.cc:8518:12: error: 'UnsetForceBackfill' is a protected member of 'PG'
              PG::UnsetForceBackfill())));
                  ^
/home/jenkins/workspace/ceph-master/src/osd/PG.h:1902:16: note: declared protected here
  TrivialEvent(UnsetForceBackfill)
               ^
/home/jenkins/workspace/ceph-master/src/osd/OSD.cc:8525:12: error: 'SetForceBackfill' is a protected member of 'PG'
              PG::SetForceBackfill())));
                  ^
/home/jenkins/workspace/ceph-master/src/osd/PG.h:1901:16: note: declared protected here
  TrivialEvent(SetForceBackfill)
               ^
/home/jenkins/workspace/ceph-master/src/osd/OSD.cc:8534:12: error: 'UnsetForceRecovery' is a protected member of 'PG'
              PG::UnsetForceRecovery())));
                  ^
/home/jenkins/workspace/ceph-master/src/osd/PG.h:1900:16: note: declared protected here
  TrivialEvent(UnsetForceRecovery)
               ^
/home/jenkins/workspace/ceph-master/src/osd/OSD.cc:8541:12: error: 'SetForceRecovery' is a protected member of 'PG'
              PG::SetForceRecovery())));
                  ^
/home/jenkins/workspace/ceph-master/src/osd/PG.h:1899:16: note: declared protected here
  TrivialEvent(SetForceRecovery)
               ^
4 errors generated.
```
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>