### PR TITLE
qa/tasks/mgr/test_failover: fix for id -> name rename in mgr metadata

### DIFF
--- a/qa/tasks/mgr/test_failover.py
+++ b/qa/tasks/mgr/test_failover.py
@@ -100,7 +100,7 @@ class TestFailover(MgrTestCase):
         # (regression test for http://tracker.ceph.com/issues/21260)
         meta = json.loads(self.mgr_cluster.mon_manager.raw_cluster_cmd(
             "mgr", "metadata"))
-        id_to_meta = dict([(i['id'], i) for i in meta])
+        id_to_meta = dict([(i['name'], i) for i in meta])
         for i in [original_active] + original_standbys:
             self.assertIn(i, id_to_meta)
             self.assertIn('ceph_version', id_to_meta[i])


### PR DESCRIPTION
This was changed by 428236de8b4155beffb5a4ffa8dd206230325a01

Signed-off-by: Sage Weil <sage@redhat.com>