### PR TITLE
common/Formatter: fix string_view usage for {json,xml}_stream_escaper

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -163,7 +163,7 @@ void JSONFormatter::print_comma(json_formatter_stack_entry_d& entry)
 
 void JSONFormatter::print_quoted_string(std::string_view s)
 {
-  m_ss << '\"' << json_stream_escaper(s.data()) << '\"';
+  m_ss << '\"' << json_stream_escaper(s) << '\"';
 }
 
 void JSONFormatter::print_name(const char *name)
@@ -447,7 +447,7 @@ void XMLFormatter::dump_string(const char *name, std::string_view s)
       [this](char c) { return this->to_lower_underscore(c); });
 
   print_spaces();
-  m_ss << "<" << e << ">" << xml_stream_escaper(s.data()) << "</" << e << ">";
+  m_ss << "<" << e << ">" << xml_stream_escaper(s) << "</" << e << ">";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -461,7 +461,7 @@ void XMLFormatter::dump_string_with_attrs(const char *name, std::string_view s, 
   std::string attrs_str;
   get_attrs_str(&attrs, attrs_str);
   print_spaces();
-  m_ss << "<" << e << attrs_str << ">" << xml_stream_escaper(s.data()) << "</" << e << ">";
+  m_ss << "<" << e << attrs_str << ">" << xml_stream_escaper(s) << "</" << e << ">";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -477,7 +477,7 @@ std::ostream& XMLFormatter::dump_stream(const char *name)
 void XMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
-  vsnprintf(buf, LARGE_SIZE, fmt, ap);
+  size_t len = vsnprintf(buf, LARGE_SIZE, fmt, ap);
   std::string e(name);
   std::transform(e.begin(), e.end(), e.begin(),
       [this](char c) { return this->to_lower_underscore(c); });
@@ -486,7 +486,7 @@ void XMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted,
   if (ns) {
     m_ss << "<" << e << " xmlns=\"" << ns << "\">" << buf << "</" << e << ">";
   } else {
-    m_ss << "<" << e << ">" << xml_stream_escaper(buf) << "</" << e << ">";
+    m_ss << "<" << e << ">" << xml_stream_escaper(std::string_view(buf, len)) << "</" << e << ">";
   }
 
   if (m_pretty)

--- a/src/common/HTMLFormatter.cc
+++ b/src/common/HTMLFormatter.cc
@@ -114,7 +114,7 @@ void HTMLFormatter::dump_float(const char *name, double d)
 
 void HTMLFormatter::dump_string(const char *name, std::string_view s)
 {
-  dump_template(name, xml_stream_escaper(s.data()));
+  dump_template(name, xml_stream_escaper(s));
 }
 
 void HTMLFormatter::dump_string_with_attrs(const char *name, std::string_view s, const FormatterAttrs& attrs)
@@ -123,7 +123,7 @@ void HTMLFormatter::dump_string_with_attrs(const char *name, std::string_view s,
   std::string attrs_str;
   get_attrs_str(&attrs, attrs_str);
   print_spaces();
-  m_ss << "<li>" << e << ": " << xml_stream_escaper(s.data()) << attrs_str << "</li>";
+  m_ss << "<li>" << e << ": " << xml_stream_escaper(s) << attrs_str << "</li>";
   if (m_pretty)
     m_ss << "\n";
 }
@@ -139,14 +139,16 @@ std::ostream& HTMLFormatter::dump_stream(const char *name)
 void HTMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   char buf[LARGE_SIZE];
-  vsnprintf(buf, LARGE_SIZE, fmt, ap);
+  size_t len = vsnprintf(buf, LARGE_SIZE, fmt, ap);
 
   std::string e(name);
   print_spaces();
   if (ns) {
-    m_ss << "<li xmlns=\"" << ns << "\">" << e << ": " << xml_stream_escaper(buf) << "</li>";
+    m_ss << "<li xmlns=\"" << ns << "\">" << e << ": "
+	 << xml_stream_escaper(std::string_view(buf, len)) << "</li>";
   } else {
-    m_ss << "<li>" << e << ": " << xml_stream_escaper(buf) << "</li>";
+    m_ss << "<li>" << e << ": "
+	 << xml_stream_escaper(std::string_view(buf, len)) << "</li>";
   }
 
   if (m_pretty)

--- a/src/common/escape.h
+++ b/src/common/escape.h
@@ -51,13 +51,13 @@ void escape_json_attr(const char *buf, size_t src_len, char *out);
 
 struct xml_stream_escaper {
   boost::string_view str;
-  xml_stream_escaper(boost::string_view str) : str(str) {}
+  xml_stream_escaper(std::string_view str) : str(str.data(), str.size()) {}
 };
 std::ostream& operator<<(std::ostream& out, const xml_stream_escaper& e);
 
 struct json_stream_escaper {
   boost::string_view str;
-  json_stream_escaper(boost::string_view str) : str(str) {}
+  json_stream_escaper(std::string_view str) : str(str.data(), str.size()) {}
 };
 std::ostream& operator<<(std::ostream& out, const json_stream_escaper& e);
 


### PR DESCRIPTION
These are passing a simple const char* without a length, which breaks for
binary strings with \0 in them.

Broken by b40f76a7a0cf460f2a851b001885a4831a6f6503.

This code is still a mess because there is a mix of boost::string_view
and std::string_view throughout the code.  A cleanup is in order!

Signed-off-by: Sage Weil <sage@redhat.com>


This is motivated by http://tracker.ceph.com/issues/23622, but the real problem there is that config-key contains binary data and JSON isn't capable of representing that.