### PR TITLE
doc: remove unused config: "osd op threads"

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -357,24 +357,6 @@ scrubbing operations.
 Operations
 ==========
 
-Operations settings allow you to configure the number of threads for servicing
-requests. If you set ``osd op threads`` to ``0``, it disables multi-threading.
-By default, Ceph  uses two threads with a 30 second timeout and a 30 second
-complaint time if an operation doesn't complete within those time parameters.
-You can set operations priority weights between client operations and
-recovery operations to ensure optimal performance during recovery.
-
-
-``osd op threads`` 
-
-:Description: The number of threads to service Ceph OSD Daemon operations. 
-              Set to ``0`` to disable it. Increasing the number may increase 
-              the request processing rate.
-
-:Type: 32-bit Integer
-:Default: ``2`` 
-
-
 ``osd op queue``
 
 :Description: This sets the type of queue to be used for prioritizing ops

--- a/src/sample.ceph.conf
+++ b/src/sample.ceph.conf
@@ -411,11 +411,6 @@
     # Default:  2
     ;filestore op threads         = 4
 
-    # The number of threads to service Ceph OSD Daemon operations. Set to 0 to disable it. Increasing the number may increase the request processing rate.
-    # Type: 32-bit Integer
-    # Default:  2
-    ;osd op threads               = 2
-
     ## CRUSH
 
     # By default OSDs update their details (location, weight and root) on the CRUSH map during startup


### PR DESCRIPTION
This option already removed.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>