### PR TITLE
tools/cephfs: instantiate MDSUtility after global_init()

### DIFF
--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -316,7 +316,7 @@ class DataScan : public MDSUtility, public MetadataTool
         std::function<int(std::string, uint64_t, uint64_t)> handler);
 
   public:
-    void usage();
+    static void usage();
     int main(const std::vector<const char *> &args);
 
     DataScan()

--- a/src/tools/cephfs/JournalTool.h
+++ b/src/tools/cephfs/JournalTool.h
@@ -83,7 +83,7 @@ class JournalTool : public MDSUtility
     //validate type
     int validate_type(const std::string &type);
   public:
-    void usage();
+    static void usage();
     JournalTool() :
       rank(0), other_pool(false) {}
     int main(std::vector<const char*> &argv);

--- a/src/tools/cephfs/TableTool.h
+++ b/src/tools/cephfs/TableTool.h
@@ -33,7 +33,7 @@ class TableTool : public MDSUtility
     int apply_role_fn(std::function<int(mds_role_t, Formatter *)> fptr, Formatter *f);
 
   public:
-    void usage();
+    static void usage();
     int main(std::vector<const char*> &argv);
 
 };

--- a/src/tools/cephfs/cephfs-data-scan.cc
+++ b/src/tools/cephfs/cephfs-data-scan.cc
@@ -13,19 +13,20 @@ int main(int argc, const char **argv)
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
 
-  DataScan data_scan;
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
   }
   if (ceph_argparse_need_usage(args)) {
-    data_scan.usage();
+    DataScan::usage();
     exit(0);
   }
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
                          CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
+
+  DataScan data_scan;
 
   // Connect to mon cluster, download MDS map etc
   int rc = data_scan.init();

--- a/src/tools/cephfs/cephfs-journal-tool.cc
+++ b/src/tools/cephfs/cephfs-journal-tool.cc
@@ -25,13 +25,12 @@ int main(int argc, const char **argv)
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
-  JournalTool jt;
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
   }
   if (ceph_argparse_need_usage(args)) {
-    jt.usage();
+    JournalTool::usage();
     exit(0);
   }
 
@@ -39,6 +38,7 @@ int main(int argc, const char **argv)
 			     CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
+  JournalTool jt;
 
   // Connect to mon cluster, download MDS map etc
   int rc = jt.init();

--- a/src/tools/cephfs/cephfs-table-tool.cc
+++ b/src/tools/cephfs/cephfs-table-tool.cc
@@ -13,13 +13,12 @@ int main(int argc, const char **argv)
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
 
-  TableTool tt;
   if (args.empty()) {
     cerr << argv[0] << ": -h or --help for usage" << std::endl;
     exit(1);
   }
   if (ceph_argparse_need_usage(args)) {
-    tt.usage();
+    TableTool::usage();
     exit(0);
   }
 
@@ -27,6 +26,7 @@ int main(int argc, const char **argv)
                          CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 
+  TableTool tt;
 
   // Connect to mon cluster, download MDS map etc
   int rc = tt.init();


### PR DESCRIPTION
cephfs-foo-tool from current master crashes immediately it starts.

Introduced by commit 6972273d53d "global: output usage on -h, --help,
or no args before contacting mons"

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>
Fixes: http://tracker.ceph.com/issues/23624