### PR TITLE
os/bluestore: fix aio pwritev lost data problem.

### DIFF
--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -25,6 +25,11 @@
 #include "ceph_aio.h"
 #include "BlockDevice.h"
 
+#ifndef RW_IO_MAX
+#define RW_IO_MAX 0x7FFFF000
+#endif
+
+
 class KernelDevice : public BlockDevice {
   std::vector<int> fd_directs, fd_buffereds;
   bool enable_wrt = true;


### PR DESCRIPTION
On Linux, write() (and similar system calls) will transfer at most
0x7ffff000 (2,147,479,552) bytes, it will cap data if aio pwritev
more than 0x7ffff000, so we have the split the data to more aio submit.

reference:
http://man7.org/linux/man-pages/man2/write.2.html
```
       On Linux, write() (and similar system calls) will transfer at most
       0x7ffff000 (2,147,479,552) bytes, returning the number of bytes
       actually transferred.  (This is true on both 32-bit and 64-bit
       systems.)
```
once i think  #21136 fix this problem, but i reencounter it, and find this problem.
 fix this coredump:
-1> 2018-03-30 01:53:27.511964 7fc903ecb700 -1 bdev(0x565100d73800 /var/lib/ceph/osd/ceph-3/block.db) aio to 12845056000~2170155008 but returned: 2147479552
0> 2018-03-30 01:53:27.529402 7fc903ecb700 -1 /root/rpmbuild/BUILD/ceph-12.2.4-1/src/os/bluestore/KernelDevice.cc: In function 'void KernelDevice::_aio_thread()' thread 7fc903ecb700 time 2018-03-30 01:53:27.512011
/root/rpmbuild/BUILD/ceph-12.2.4-1/src/os/bluestore/KernelDevice.cc: 384: FAILED assert(0 == "unexpected aio error")

ceph version 12.2.4-1 (f1c14f03ac0a6ea8271f8a62acde37aba126b14e) luminous (stable)
1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x110) [0x5650f66c9820]
2: (KernelDevice::_aio_thread()+0xd05) [0x5650f666cdb5]
3: (KernelDevice::AioCompletionThread::entry()+0xd) [0x5650f66721fd]
4: (()+0x7e25) [0x7fc90d38ce25]
5: (clone()+0x6d) [0x7fc90c48034d]
NOTE: a copy of the executable, or objdump -rdS <executable> is needed to interpret this.
Signed-off-by: kungf <yang.wang@easystack.cn>