### PR TITLE
mgr/dashboard: Replace font-awesome with fork-awesome

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/.angular-cli.json
+++ b/src/pybind/mgr/dashboard/frontend/.angular-cli.json
@@ -21,7 +21,7 @@
       "styles": [
         "../node_modules/bootstrap/dist/css/bootstrap.css",
         "../node_modules/ng2-toastr/bundles/ng2-toastr.min.css",
-        "../node_modules/font-awesome/css/font-awesome.css",
+        "../node_modules/fork-awesome/css/fork-awesome.css",
         "../node_modules/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css",
         "styles.scss"
       ],

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -27,7 +27,7 @@
     "bootstrap": "^3.3.7",
     "chart.js": "^2.7.1",
     "core-js": "^2.4.1",
-    "font-awesome": "4.7.0",
+    "fork-awesome": "1.0.11",
     "lodash": "^4.17.4",
     "moment": "2.20.1",
     "ng2-charts": "^1.6.0",

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -133,7 +133,7 @@
       font-weight: bold;
       .datatable-header-cell-label {
         &:after {
-          font-family: FontAwesome;
+          font-family: ForkAwesome;
           font-weight: 400;
           height: 9px;
           left: 10px;

--- a/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
@@ -32,8 +32,8 @@
 
 @import 'defaults';
 
-$fa-font-path: "../node_modules/font-awesome/fonts";
-@import "../node_modules/font-awesome/scss/font-awesome";
+$fa-font-path: "../node_modules/fork-awesome/fonts";
+@import "../node_modules/fork-awesome/scss/fork-awesome";
 
 /* Basics */
 html {
@@ -141,7 +141,7 @@ option {
 .breadcrumb>li+li:before {
   padding: 0 5px 0 7px;
   color: #474544;
-  font-family: "FontAwesome";
+  font-family: "ForkAwesome";
   content: "\f101";
 }
 .breadcrumb>li>span {


### PR DESCRIPTION
Replaces the dependency on Font Awesome with [Fork Awesome](https://forkawesome.github.io/), which is a plug-in replacement for font-awesome 4.7.0 and adds a few more icons (see [this page](https://forkawesome.github.io/Fork-Awesome/whats-new/) for background information about this fork).

It is licensed under the [following licenses](https://forkawesome.github.io/Fork-Awesome/license/):

* Fonts: SIL OFL 1.1
* Code: MIT License
* Documentation: CC BY 3.0

Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>