### PR TITLE
luminous: mon: update PaxosService::cached_first_committed in PaxosService::may…

### DIFF
--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -399,6 +399,7 @@ void PaxosService::maybe_trim()
   MonitorDBStore::TransactionRef t = paxos->get_pending_transaction();
   trim(t, get_first_committed(), trim_to);
   put_first_committed(t, trim_to);
+  cached_first_committed = trim_to;
 
   // let the service add any extra stuff
   encode_trim_extra(t, trim_to);


### PR DESCRIPTION
…be_trim()

This should be able to avoid interleaving execution of Paxos::commit_finish() and
check_sub(), which could lead to unexpected failure of ceph-mon.

Fixes: http://tracker.ceph.com/issues/11332
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>
Signed-off-by: yupeng chen <chenyupeng-it@360.cn>
(cherry picked from commit c3c88d84d696016d56a04f95662dc1f4f937ebec)