### PR TITLE
mon/ConfigKeyService: dump: print placeholder value for binary blobs

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -165,3 +165,8 @@ method. See http://docs.ceph.com/docs/luminous/mgr/restful for details.
     has an error.  This head object is there to show the snapset that was used in
     determining errors.
 
+
+* The config-key interface can store arbitrary binary blobs but JSON
+  can only express printable strings.  If binary blobs are present,
+  the 'ceph config-key dump' command will show them as something like
+  ``<<< binary blob of length N >>>``.

--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -109,6 +109,17 @@ bool ConfigKeyService::store_has_prefix(const string &prefix)
   return false;
 }
 
+static bool is_binary_string(const string& s)
+{
+  for (auto c : s) {
+    // \n and \t are escaped in JSON; other control characters are not.
+    if ((c < 0x20 && c != '\n' && c != '\t') || c >= 0x7f) {
+      return true;
+    }
+  }
+  return false;
+}
+
 void ConfigKeyService::store_dump(stringstream &ss, const string& prefix)
 {
   KeyValueDB::Iterator iter =
@@ -127,7 +138,14 @@ void ConfigKeyService::store_dump(stringstream &ss, const string& prefix)
 	iter->key().find(prefix) != 0) {
       break;
     }
-    f.dump_string(iter->key().c_str(), iter->value().to_str());
+    string s = iter->value().to_str();
+    if (is_binary_string(s)) {
+      ostringstream ss;
+      ss << "<<< binary blob of length " << s.size() << " >>>";
+      f.dump_string(iter->key().c_str(), ss.str());
+    } else {
+      f.dump_string(iter->key().c_str(), s);
+    }
     iter->next();
   }
   f.close_section();


### PR DESCRIPTION
JSON cannot express arbitrary binary blobs.  Instead of outputting invalid
and unparseable JSON, represent the value of blobs as something like
'<<< binary blob of length 12 >>>'.

Since this interface is fundamentally useless for non-humans and of
dubious value for humans as more data is stored in config-key, deprecate
it.

Fixes: http://tracker.ceph.com/issues/23622
Signed-off-by: Sage Weil <sage@redhat.com>