### PR TITLE
qa: fix typo in test_full

### DIFF
--- a/qa/tasks/cephfs/test_full.py
+++ b/qa/tasks/cephfs/test_full.py
@@ -134,7 +134,7 @@ class FullnessTestCase(CephFSTestCase):
                           the failed write.
         """
 
-        osd_mon_report_interval = int(self.fs.get_config("osd_mon_report_inverval", service_type='osd'))
+        osd_mon_report_interval = int(self.fs.get_config("osd_mon_report_interval", service_type='osd'))
 
         log.info("Writing {0}MB should fill this cluster".format(self.fill_mb))
 


### PR DESCRIPTION
Cause: 577737d007c05bc7a3972158be8c520ab73a1517

Fixes: http://tracker.ceph.com/issues/23643

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>