### PR TITLE
luminous: ceph-volume lvm.activate error if no bluestore OSDs are found

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -111,6 +111,8 @@ def get_osd_device_path(osd_lv, lvs, device_type, dmcrypt_secret=None):
 def activate_bluestore(lvs):
     # find the osd
     osd_lv = lvs.get(lv_tags={'ceph.type': 'block'})
+    if not osd_lv:
+        raise RuntimeError('could not find a bluestore OSD to activate')
     is_encrypted = osd_lv.tags.get('ceph.encrypted', '0') == '1'
     dmcrypt_secret = None
     osd_id = osd_lv.tags['ceph.osd_id']


### PR DESCRIPTION
Signed-off-by: Alfredo Deza <adeza@redhat.com>
(cherry picked from commit b1920d6e731f194c4829810d849dba6b087ce3a4)

Resolves ticket: http://tracker.ceph.com/issues/23644