### PR TITLE
mgr/iostat: print output as a table

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -533,16 +533,22 @@ def do_command(parsed_args, target, cmdargs, sigdict, inbuf, verbose):
     else:
         return -errno.EINVAL, '', 'invalid command'
 
+    next_header_print = 0
+    # Set extra options for polling commands only:
+    if valid_dict.get('poll', False):
+        valid_dict['width'] = Termsize().cols
     while True:
         try:
-            if next_header_print == 0:
+            # Only print the header for polling commands
+            if next_header_print == 0 and valid_dict.get('poll', False):
                 valid_dict['print_header'] = True
                 next_header_print = Termsize().rows - 3
             next_header_print -= 1
             ret, outbuf, outs = json_command(cluster_handle, target=target,
                 argdict=valid_dict, inbuf=inbuf)
-            valid_dict['print_header'] = False
-            if 'poll' not in valid_dict or not valid_dict['poll']:
+            if valid_dict.get('poll', False):
+                valid_dict['print_header'] = False
+            if not valid_dict.get('poll', False):
                 # Don't print here if it's not a polling command
                 break
             if ret:

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -534,23 +534,32 @@ def do_command(parsed_args, target, cmdargs, sigdict, inbuf, verbose):
         return -errno.EINVAL, '', 'invalid command'
 
     while True:
-        ret, outbuf, outs = json_command(cluster_handle, target=target, argdict=valid_dict,
-                inbuf=inbuf)
-        if 'poll' not in valid_dict or not valid_dict['poll']:
-            # Don't print here if it's not a polling command
-            break
-        if ret:
-            ret = abs(ret)
-            print('Error: {0} {1}'.format(ret, errno.errorcode.get(ret, 'Unknown')),
-                    file=sys.stderr)
-            break
-        if outbuf:
-            print(outbuf.decode('utf-8'))
-        if outs:
-            print(outs, file=sys.stderr)
-        if parsed_args.period <= 0:
-            break
-        sleep(parsed_args.period)
+        try:
+            if next_header_print == 0:
+                valid_dict['print_header'] = True
+                next_header_print = Termsize().rows - 3
+            next_header_print -= 1
+            ret, outbuf, outs = json_command(cluster_handle, target=target,
+                argdict=valid_dict, inbuf=inbuf)
+            valid_dict['print_header'] = False
+            if 'poll' not in valid_dict or not valid_dict['poll']:
+                # Don't print here if it's not a polling command
+                break
+            if ret:
+                ret = abs(ret)
+                print('Error: {0} {1}'.format(ret, errno.errorcode.get(ret, 'Unknown')),
+                        file=sys.stderr)
+                break
+            if outbuf:
+                print(outbuf.decode('utf-8'))
+            if outs:
+                print(outs, file=sys.stderr)
+            if parsed_args.period <= 0:
+                break
+            sleep(parsed_args.period)
+        except KeyboardInterrupt:
+            print('Interrupted')
+            return ret, '', ''
 
     return ret, outbuf, outs
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -342,7 +342,59 @@ class MgrModule(ceph_module.BaseMgrModule):
             return "/s"
         elif unit == self.BYTES:
             return "B/s"  
-    
+
+    def to_pretty_iec(self, n):
+        for bits, suffix in [(60, 'Ei'), (50, 'Pi'), (40, 'Ti'), (30, 'Gi'),
+                (20, 'Mi'), (10, 'Ki')]:
+            if n > 10 << bits:
+                return str(n >> bits) + ' ' + suffix
+        return str(n) + ' '
+
+    def get_pretty_row(self, elems, width):
+        """
+        Takes an array of elements and returns a string with those elements
+        formatted as a table row. Useful for polling modules.
+
+        :param elems: the elements to be printed
+        :param width: the width of the terminal
+        """
+        n = len(elems)
+        column_width = width / n
+
+        ret = '|'
+        for elem in elems:
+            ret += '{0:>{w}} |'.format(elem, w=column_width - 2)
+
+        return ret
+
+    def get_pretty_header(self, elems, width):
+        """
+        Like ``get_pretty_row`` but adds dashes, to be used as a table title.
+
+        :param elems: the elements to be printed
+        :param width: the width of the terminal
+        """
+        n = len(elems)
+        column_width = width / n
+
+        # dash line
+        ret = '+'
+        for i in range(0, n):
+            ret += '-' * (column_width - 1) + '+'
+        ret += '\n'
+
+        # title
+        ret += self.get_pretty_row(elems, width)
+        ret += '\n'
+
+        # dash line
+        ret += '+'
+        for i in range(0, n):
+            ret += '-' * (column_width - 1) + '+'
+        ret += '\n'
+
+        return ret
+
     def get_server(self, hostname):
         """
         Called by the plugin to fetch metadata about a particular hostname from


### PR DESCRIPTION
Based on https://github.com/ceph/ceph/pull/20100.
```
$> ./bin/ceph iostat 
+----------------+----------------+----------------+----------------+----------------+----------------+
|           Read |          Write |          Total |      Read IOPS |     Write IOPS |     Total IOPS |
+----------------+----------------+----------------+----------------+----------------+----------------+
|          0 B/s |          0 B/s |          0 B/s |              0 |              0 |              0 |
|          0 B/s |          0 B/s |          0 B/s |              0 |              0 |              0 |
|          0 B/s |        66 MB/s |        66 MB/s |              0 |             33 |             33 |
|          0 B/s |        66 MB/s |        66 MB/s |              0 |             33 |             33 |
|          0 B/s |        66 MB/s |        66 MB/s |              0 |             33 |             33 |
```