### PR TITLE
client: Fix the gid_count check

### DIFF
--- a/src/client/UserPerm.h
+++ b/src/client/UserPerm.h
@@ -31,7 +31,7 @@ private:
     m_uid = b.m_uid;
     m_gid = b.m_gid;
     gid_count = b.gid_count;
-    if (gid_count) {
+    if (gid_count > 0) {
       gids = new gid_t[gid_count];
       alloced_gids = true;
       for (int i = 0; i < gid_count; ++i) {


### PR DESCRIPTION
Make the right check for `gid_count`.
Make it align with
https://github.com/ceph/ceph/blob/master/src/client/fuse_ll.cc#L117
https://github.com/ceph/ceph/blob/master/src/client/fuse_ll.cc#L139

Fixes: http://tracker.ceph.com/issues/23652
Signed-off-by: Jos Collin <jcollin@redhat.com>