### PR TITLE
pybind/ceph_argparse: Fix UnboundLocalError if command doesn't validate

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1087,7 +1087,7 @@ def validate_command(sigdict, args, verbose=False):
 
         if found:
             if not valid_dict:
-                print("Invalid command:", e, file=sys.stderr)
+                print("Invalid command:", ex, file=sys.stderr)
                 print(concise_sig(sig), ': ', cmd['help'], file=sys.stderr)
         else:
             bestcmds = bestcmds[:10]


### PR DESCRIPTION
The error case in validate_command() where the command is found but the
command itself is somehow invalid raises an UnboundLocalError, because it
tries to refer to a variable named 'e', but it should be 'ex'.  For example:

````
  # ceph balancer mode
  Traceback (most recent call last):
    File "/usr/bin/ceph", line 1178, in <module>
      retval = main()
    File "/usr/bin/ceph", line 1109, in main
      verbose)
    File "/usr/bin/ceph", line 535, in new_style_command
      valid_dict = validate_command(sigdict, cmdargs, verbose)
    File "/usr/lib/python3.6/site-packages/ceph_argparse.py", line 1090, in validate_command
      print("Invalid command:", e, file=sys.stderr)
  UnboundLocalError: local variable 'e' referenced before assignment
````

Replacing 'e' with 'ex' gives the desired output:

````
  # ceph balancer mode
  Invalid command: missing required parameter mode(none|crush-compat|upmap)
  balancer mode none|crush-compat|upmap :  Set balancer mode
  Error EINVAL: invalid command
````

Signed-off-by: Tim Serong <tserong@suse.com>