### PR TITLE
rbd: 'trash ls -l' will display column titles if existed non-USER trash image only

### DIFF
--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <sstream>
 #include <boost/program_options.hpp>
+#include <boost/bind.hpp>
 #include <json_spirit/json_spirit.h>
 
 namespace rbd {
@@ -36,6 +37,10 @@ namespace po = boost::program_options;
 static const std::string EXPIRES_AT("expires-at");
 static const std::string EXPIRED_BEFORE("expired-before");
 static const std::string THRESHOLD("threshold");
+
+static bool is_not_trash_user(const librbd::trash_image_info_t &trash_info) {
+  return trash_info.source != RBD_TRASH_IMAGE_SOURCE_USER;
+}
 
 void get_move_arguments(po::options_description *positional,
                         po::options_description *options) {
@@ -191,15 +196,18 @@ int do_list(librbd::RBD &rbd, librados::IoCtx& io_ctx, bool long_flag,
     return r;
   }
 
+  if (!all_flag) {
+    trash_entries.erase(remove_if(trash_entries.begin(),
+                                  trash_entries.end(),
+                                  boost::bind(is_not_trash_user, _1)),
+                        trash_entries.end());
+  }
+
   if (!long_flag) {
     if (f) {
       f->open_array_section("trash");
     }
     for (const auto& entry : trash_entries) {
-      if (!all_flag &&
-          entry.source == RBD_TRASH_IMAGE_SOURCE_MIRRORING) {
-        continue;
-      }
        if (f) {
          f->dump_string("id", entry.id);
          f->dump_string("name", entry.name);
@@ -228,10 +236,6 @@ int do_list(librbd::RBD &rbd, librados::IoCtx& io_ctx, bool long_flag,
   }
 
   for (const auto& entry : trash_entries) {
-    if (!all_flag &&
-        entry.source == RBD_TRASH_IMAGE_SOURCE_MIRRORING) {
-      continue;
-    }
     librbd::Image im;
 
     r = rbd.open_by_id_read_only(io_ctx, im, entry.id.c_str(), NULL);

--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -209,8 +209,10 @@ int do_list(librbd::RBD &rbd, librados::IoCtx& io_ctx, bool long_flag,
     }
     for (const auto& entry : trash_entries) {
        if (f) {
+         f->open_object_section("image");
          f->dump_string("id", entry.id);
          f->dump_string("name", entry.name);
+         f->close_section();
        } else {
          std::cout << entry.id << " " << entry.name << std::endl;
        }


### PR DESCRIPTION
Fixes:
```
root@s222:/ceph-dev/build# rbd trash ls -l
ID NAME SOURCE DELETED_AT STATUS PARENT
root@s222:/ceph-dev/build# rbd trash ls -l -a
ID            NAME   SOURCE    DELETED_AT               STATUS                              PARENT
36e282ae8944a img1   MIRRORING Wed Apr 11 09:44:11 2018 expired at Wed Apr 11 09:44:11 2018
root@s222:/ceph-dev/build# 
root@s222:/ceph-dev/build# rbd trash ls -a --format=json
["36e282ae8944a","img1"]
```