### PR TITLE
msg: Add heartbeat timeout  for osd thread

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -175,6 +175,14 @@ OPTION(ms_async_rdma_dscp, OPT_INT)            // in RoCE, this means DSCP
 OPTION(ms_async_rdma_cm, OPT_BOOL)
 OPTION(ms_async_rdma_type, OPT_STR)
 
+// In simple Accepter:entry, when there more than 4 accept errors
+// then break out accepter entry thread. Here we make it configurable.
+OPTION(ms_accept_error_nums, OPT_INT)
+// In simple Accepter:entry, when there are some unrecoverable error
+// break out the Accepter:entry, But for osd daemons, we want the 
+// Accepter:entry to continue to work so that the unhealthy state can
+// last before the monitor mark it down.
+OPTION(ms_simple_accepter_sleep_time, OPT_INT)
 OPTION(ms_dpdk_port_id, OPT_INT)
 SAFE_OPTION(ms_dpdk_coremask, OPT_STR)        // it is modified in unittest so that use SAFE_OPTION to declare 
 OPTION(ms_dpdk_memory_channel, OPT_STR)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1099,6 +1099,14 @@ std::vector<Option> get_global_options() {
     Option("ms_async_rdma_dscp", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(96)
     .set_description(""),
+    
+    Option("ms_simple_accepter_sleep_time", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(1)
+    .set_description("sleep times which allow the heartbeat mechanism to take effect."),
+
+    Option("ms_accept_error_nums", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(4)
+    .set_description("error numbers before triggering heartbeat mechanism "),
 
     Option("ms_async_rdma_cm", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -407,6 +407,12 @@ public:
    */
   virtual int shutdown() { started = false; return 0; }
   /**
+   * Add the accepter to heartbeat check
+   * if accepter fails to receive any new connections, 
+   * suicide the osd thread.
+   */
+  virtual void add_heartbeat_check() {}
+  /**
    * @} // Startup/Shutdown
    */
 

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -29,6 +29,7 @@
 #include "common/Mutex.h"
 #include "common/Cond.h"
 #include "common/Thread.h"
+#include "common/HeartbeatMap.h"
 
 #include "msg/SimplePolicyMessenger.h"
 #include "msg/DispatchQueue.h"
@@ -48,6 +49,8 @@ class Processor {
   NetHandler net;
   Worker *worker;
   vector<ServerSocket> listen_sockets;
+  unsigned accept_error_num = 0;
+  heartbeat_handle_d *hb = nullptr;
   EventCallbackRef listen_handler;
 
   class C_processor_accept;
@@ -62,6 +65,7 @@ class Processor {
 	   entity_addrvec_t* bound_addrs);
   void start();
   void accept();
+  void set_hb(int idx);
 };
 
 /*
@@ -118,6 +122,7 @@ public:
   int bind(const entity_addr_t& bind_addr) override;
   int rebind(const set<int>& avoid_ports) override;
   int client_bind(const entity_addr_t& bind_addr) override;
+  void add_heartbeat_check() override;
 
   int bindv(const entity_addrvec_t& bind_addrs) override;
 

--- a/src/msg/simple/Accepter.h
+++ b/src/msg/simple/Accepter.h
@@ -16,6 +16,7 @@
 #define CEPH_MSG_ACCEPTER_H
 
 #include "common/Thread.h"
+#include "common/HeartbeatMap.h"
 
 class SimpleMessenger;
 struct entity_addr_t;
@@ -31,6 +32,7 @@ class Accepter : public Thread {
   uint64_t nonce;
   int shutdown_rd_fd;
   int shutdown_wr_fd;
+  heartbeat_handle_d *hb = nullptr;
   int create_selfpipe(int *pipe_rd, int *pipe_wr);
 
 public:
@@ -44,6 +46,7 @@ public:
   int bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports);
   int rebind(const set<int>& avoid_port);
   int start();
+  void set_hb();
 };
 
 

--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -775,3 +775,8 @@ void SimpleMessenger::init_local_connection()
   local_connection->set_features(CEPH_FEATURES_ALL);
   ms_deliver_handle_fast_connect(local_connection.get());
 }
+
+void SimpleMessenger::add_heartbeat_check()
+{
+  accepter.set_hb();
+}

--- a/src/msg/simple/SimpleMessenger.h
+++ b/src/msg/simple/SimpleMessenger.h
@@ -118,6 +118,7 @@ public:
   int bind(const entity_addr_t& bind_addr) override;
   int rebind(const set<int>& avoid_ports) override;
   int client_bind(const entity_addr_t& bind_addr) override;
+  void add_heartbeat_check() override;
 
   /** @} Configuration functions */
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2570,6 +2570,7 @@ int OSD::init()
   create_logger();
 
   // i'm ready!
+  client_messenger->add_heartbeat_check();
   client_messenger->add_dispatcher_head(this);
   cluster_messenger->add_dispatcher_head(this);
 


### PR DESCRIPTION
In some extrem cases(we have met one in our production cluster), when Accepter thread break out , new client can not connect to the osd. Because the former heartbeat connections are already connected, other osd can not detect failure then notify monitor to mark the failed osd down.
In the patch, when there are abnormal communication errors ,we reset timeout so that osd can detect itself unhealthy and other osds can notify monitor to mark the failed osd down.
Signed-off-by: penglaiyxy  penglaiyxy@gmail.com