### PR TITLE
luminous: client: fix request send_to_auth was never really used

### DIFF
--- a/src/client/MetaRequest.h
+++ b/src/client/MetaRequest.h
@@ -199,7 +199,7 @@ public:
   }
   bool auth_is_best() {
     if ((head.op & CEPH_MDS_OP_WRITE) || head.op == CEPH_MDS_OP_OPEN ||
-	head.op == CEPH_MDS_OP_READDIR) 
+	head.op == CEPH_MDS_OP_READDIR || send_to_auth) 
       return true;
     return false;    
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/23635