### PR TITLE
rpm,debian: Ensure all ceph-disk runtime dependencies are declared for ceph-base

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -290,6 +290,7 @@ Requires:      cryptsetup
 Requires:      findutils
 Requires:      grep
 Requires:      logrotate
+Requires:      parted
 Requires:      psmisc
 Requires:      python%{_python_buildid}-requests
 Requires:      python%{_python_buildid}-setuptools
@@ -473,7 +474,6 @@ Summary:	Ceph Object Storage Daemon
 Group:		System/Filesystems
 %endif
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
-Requires:	parted
 Requires:	lvm2
 %description osd
 ceph-osd is the object storage daemon for the Ceph distributed file

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -296,8 +296,12 @@ Requires:      python%{_python_buildid}-setuptools
 Requires:      util-linux
 Requires:      xfsprogs
 Requires:      which
+%if 0%{?fedora} || 0%{?rhel}
+Requires:      gdisk
+%endif
 %if 0%{?suse_version}
 Recommends:    chrony
+Requires:      gptfdisk
 %endif
 %description base
 Base is the package that includes all the files shared amongst ceph servers
@@ -469,13 +473,6 @@ Summary:	Ceph Object Storage Daemon
 Group:		System/Filesystems
 %endif
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
-# for sgdisk, used by ceph-disk
-%if 0%{?fedora} || 0%{?rhel}
-Requires:	gdisk
-%endif
-%if 0%{?suse_version}
-Requires:	gptfdisk
-%endif
 Requires:	parted
 Requires:	lvm2
 %description osd

--- a/debian/control
+++ b/debian/control
@@ -96,6 +96,7 @@ Depends: binutils,
          gdisk,
          grep,
          logrotate,
+         parted,
          psmisc,
          xfsprogs,
          ${misc:Depends},
@@ -239,7 +240,6 @@ Description: debugging symbols for ceph-mon
 Package: ceph-osd
 Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
-         parted,
          lvm2,
          ${misc:Depends},
          ${python:Depends},


### PR DESCRIPTION
The sgdisk and parted dependencies are not used by ceph-volume, or by anything other than ceph-disk, so move them to ceph-base.

Fixes: http://tracker.ceph.com/issues/23657