### PR TITLE
rgw: fix use of libcurl with empty header values

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -352,8 +352,13 @@ static curl_slist *headers_to_slist(param_vec_t& headers)
     
     val = camelcase_dash_http_attr(val);
 
-    val.append(": ");
-    val.append(p.second);
+    // curl won't send headers with empty values unless it ends with a ; instead
+    if (p.second.empty()) {
+      val.append(1, ';');
+    } else {
+      val.append(": ");
+      val.append(p.second);
+    }
     h = curl_slist_append(h, val.c_str());
   }
 


### PR DESCRIPTION
curl won't send headers with empty values unless they end with a `;` instead of `:`

Fixes: http://tracker.ceph.com/issues/23663