### PR TITLE
client: Take reference for operator= function parameter

### DIFF
--- a/src/client/UserPerm.h
+++ b/src/client/UserPerm.h
@@ -61,7 +61,7 @@ public:
     if (alloced_gids)
       delete[] gids;
   }
-  UserPerm& operator=(const UserPerm o) {
+  UserPerm& operator=(const UserPerm& o) {
     deep_copy_from(o);
     return *this;
   }


### PR DESCRIPTION
Why copy? Take a reference for the operator=() function parameter.

Signed-off-by: Jos Collin <jcollin@redhat.com>