### PR TITLE
mon: cleanups to optracker code

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1105,9 +1105,10 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description("enable/disable MON op tracking"),
 
-    Option("mon_op_complaint_time", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    Option("mon_op_complaint_time", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
     .set_default(30)
-    .set_description("time in seconds to consider a MON OP blocked after no updates"),
+    .set_description("time after which to consider a monitor operation blocked "
+                     "after no updates"),
 
     Option("mon_op_log_threshold", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(5)
@@ -1117,7 +1118,7 @@ std::vector<Option> get_global_options() {
     .set_default(20)
     .set_description("max number of completed ops to track"),
 
-    Option("mon_op_history_duration", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    Option("mon_op_history_duration", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
     .set_default(600)
     .set_description("expiration time in seconds of historical MON OPS"),
 
@@ -1125,9 +1126,9 @@ std::vector<Option> get_global_options() {
     .set_default(20)
     .set_description("max number of slow historical MON OPS to keep"),
 
-    Option("mon_op_history_slow_op_threshold", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(10.0)
-    .set_description("duration time in seconds of an op to be considered as a historical slow op"),
+    Option("mon_op_history_slow_op_threshold", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
+    .set_default(10)
+    .set_description("duration of an op to be considered as a historical slow op"),
 
     Option("mon_data", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_flag(Option::FLAG_NO_MON_UPDATE)


### PR DESCRIPTION
* Make the types of the configuration options
  TYPE_SECS instead of numbers.
* Remove unused 'filterstr' argument handling,
  this argument is not part of the mon's admin
  socket command definitions.

Signed-off-by: John Spray <john.spray@redhat.com>