### PR TITLE
osd: fix crash caused by divide by zero in heartbeat code

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2862,7 +2862,8 @@ std::vector<Option> get_global_options() {
 
     Option("osd_heartbeat_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(6)
-    .set_description(""),
+    .set_min_max(1, 86400)
+    .set_description("Interval (in seconds) between peer pings"),
 
     Option("osd_heartbeat_grace", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(20)
@@ -2878,7 +2879,7 @@ std::vector<Option> get_global_options() {
 
     Option("osd_heartbeat_min_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(2000)
-    .set_description(""),
+    .set_description("Minimum heartbeat packet size in bytes. Will add dummy payload if heartbeat packet is smaller than this."),
 
     Option("osd_pg_max_concurrent_snap_trims", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(2)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4690,7 +4690,14 @@ void OSD::heartbeat()
 
   // get CPU load avg
   double loadavgs[1];
-  int n_samples = 86400 / cct->_conf->osd_heartbeat_interval;
+  int hb_interval = cct->_conf->osd_heartbeat_interval;
+  int n_samples = 86400;
+  if (hb_interval > 1) {
+    n_samples /= hb_interval;
+    if (n_samples < 1)
+      n_samples = 1;
+  }
+
   if (getloadavg(loadavgs, 1) == 1) {
     logger->set(l_osd_loadavg, 100 * loadavgs[0]);
     daily_loadavg = (daily_loadavg * (n_samples - 1) + loadavgs[0]) / n_samples;


### PR DESCRIPTION
If the osd_heartbeat_interval is set to 0 or anything above 86400, the osd  will crash because of divide by zero in loadavg gathering code. This PR fixes this and adds run-time config boundaries for osd_heartbeat_interval.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>