### PR TITLE
os/bluestore: add perf counter for allocator fragmentation.

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -51,6 +51,10 @@ public:
   virtual void init_rm_free(uint64_t offset, uint64_t length) = 0;
 
   virtual uint64_t get_free() = 0;
+  virtual double get_fragmentation(uint64_t alloc_unit)
+  {
+    return 0.0;
+  }
 
   virtual void shutdown() = 0;
   static Allocator *create(CephContext* cct, string type, int64_t size,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4107,6 +4107,8 @@ void BlueStore::_init_logger()
 		    "collection");
   b.add_u64_counter(l_bluestore_read_eio, "bluestore_read_eio",
                     "Read EIO errors propagated to high level callers");
+  b.add_u64(l_bluestore_fragmentation, "bluestore_fragmentation_percentage",
+            "How fragmented bluestore free space is");
   logger = b.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
 }
@@ -8740,6 +8742,8 @@ void BlueStore::_txc_finish(TransContext *txc)
       dout(10) << __func__ << " empty zombie osr " << osr << " already reaped" << dendl;
     }
   }
+  logger->set(l_bluestore_fragmentation,
+    (uint64_t)alloc->get_fragmentation(min_alloc_size));
 }
 
 void BlueStore::_txc_release_alloc(TransContext *txc)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -119,6 +119,7 @@ enum {
   l_bluestore_extent_compress,
   l_bluestore_gc_merged,
   l_bluestore_read_eio,
+  l_bluestore_fragmentation,
   l_bluestore_last
 };
 

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -53,6 +53,7 @@ public:
     const interval_set<uint64_t>& release_set) override;
 
   uint64_t get_free() override;
+  double get_fragmentation(uint64_t alloc_unit) override;
 
   void dump() override;
 


### PR DESCRIPTION
The fragmentation ratio calculation is a bit different from the classical(?) one ( i,e, = 1 - max_contiguous_extent / free_space). But the proposed one is computational cheaper - it's equal to
(current_num_intervals-1) / (max_num_intervals_for_free_space-1)

Signed-off-by: Igor Fedotov <ifedotov@suse.com>