### PR TITLE
rgw: fix radosgw linkage with WITH_RADOSGW_BEAST_FRONTEND=OFF

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -163,9 +163,9 @@ if (WITH_RADOSGW_BEAST_FRONTEND)
   target_link_libraries(rgw_a Boost::coroutine Boost::context)
 endif()
 
-if (WITH_CURL_OPENSSL)
+if (WITH_CURL_OPENSSL OR (WITH_RADOSGW_BEAST_FRONTEND AND WITH_RADOSGW_BEAST_OPENSSL))
   target_link_libraries(rgw_a ${OPENSSL_LIBRARIES})
-endif (WITH_CURL_OPENSSL)
+endif()
 
 set(radosgw_srcs
   rgw_loadgen_process.cc
@@ -185,9 +185,7 @@ endif (WITH_RADOSGW_BEAST_FRONTEND)
 
 add_library(radosgw_a STATIC ${radosgw_srcs}
   $<TARGET_OBJECTS:civetweb_common_objs>)
-if (WITH_RADOSGW_BEAST_FRONTEND AND WITH_RADOSGW_BEAST_OPENSSL)
-  target_link_libraries(radosgw_a rgw_a ${SSL_LIBRARIES})
-endif()
+target_link_libraries(radosgw_a rgw_a ${SSL_LIBRARIES})
 
 add_executable(radosgw rgw_main.cc)
 target_link_libraries(radosgw radosgw_a librados
@@ -202,10 +200,6 @@ add_dependencies(radosgw cls_rgw cls_lock cls_refcount
   cls_log cls_statelog cls_timeindex
   cls_version cls_replica_log cls_user)
 install(TARGETS radosgw DESTINATION bin)
-
-if (WITH_RADOSGW_BEAST_FRONTEND)
-  target_link_libraries(radosgw_a ${OPENSSL_LIBRARIES})
-endif()
 
 set(radosgw_admin_srcs
   rgw_admin.cc


### PR DESCRIPTION
Oops! I had broken the linkage between radosgw_a and rgw_a when adding openssl in https://github.com/ceph/ceph/pull/20464.

Fixes: http://tracker.ceph.com/issues/23680