### PR TITLE
ceph-fuse: return proper exit code

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -276,9 +276,11 @@ int main(int argc, const char **argv, const char *envp[]) {
         "fuse_require_active_mds");
       r = client->mount(mountpoint, perms, fuse_require_active_mds);
       if (r < 0) {
-        if (r == CEPH_FUSE_NO_MDS_UP)
+        if (r == CEPH_FUSE_NO_MDS_UP) {
           cerr << "ceph-fuse[" << getpid() << "]: probably no MDS server is up?" << std::endl;
+        }
         cerr << "ceph-fuse[" << getpid() << "]: ceph mount failed with " << cpp_strerror(-r) << std::endl;
+        r = EXIT_FAILURE;
         goto out_shutdown;
       }
     }

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -91,7 +91,8 @@ class MDSCommandOp : public CommandOp
 };
 
 /* error code for ceph_fuse */
-#define CEPH_FUSE_NO_MDS_UP    -(1<<2) /* no mds up deteced in ceph_fuse */
+#define CEPH_FUSE_NO_MDS_UP    -(1<<16+0) /* no mds up deteced in ceph_fuse */
+#define CEPH_FUSE_LAST         -(1<<16+1) /* (unused) */
 
 // ============================================
 // types for my local metadata cache

--- a/src/common/Preforker.h
+++ b/src/common/Preforker.h
@@ -107,11 +107,8 @@ public:
 
   int signal_exit(int r) {
     if (forked) {
-      // tell parent.  this shouldn't fail, but if it does, pass the
-      // error back to the parent.
-      int ret = safe_write(fd[1], &r, sizeof(r));
-      if (ret <= 0)
-	return ret;
+      /* If we get an error here, it's too late to do anything reasonable about it. */
+      (void)safe_write(fd[1], &r, sizeof(r));
     }
     return r;
   }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/23665

````
pdonnell@senta02 ~/ceph/build$ D=$(mktemp -d -p ~/mnt/); mkdir -p "$D"; run bin/ceph-fuse --client_die_on_failed_dentry_invalidate=false -f --id fs -c ceph.conf foo
bin/ceph-fuse --client_die_on_failed_dentry_invalidate=false -f --id fs -c ceph.conf foo
2018-04-12 15:18:04.927 7fe0aeab4c00 -1 WARNING: all dangerous and experimental features are enabled.
2018-04-12 15:18:04.939 7fe0aeab4c00 -1 WARNING: all dangerous and experimental features are enabled.
2018-04-12 15:18:04.939 7fe0aeab4c00 -1 WARNING: all dangerous and experimental features are enabled.
2018-04-12 15:18:04.939 7fe0aeab4c00 -1 init, newargv = 0x37803b5320 newargc=7
ceph-fuse[25137]: starting ceph client
ceph-fuse[25137]: probably no MDS server is up?
ceph-fuse[25137]: ceph mount failed with (65536) Unknown error 65536
pdonnell@senta02 ~/ceph/build$ echo $?
1
````