### PR TITLE
mgr/dashboard: Angular modules cleanup

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/block.module.ts
@@ -5,9 +5,6 @@ import { FormsModule } from '@angular/forms';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
-import { ComponentsModule } from '../../shared/components/components.module';
-import { PipesModule } from '../../shared/pipes/pipes.module';
-import { ServicesModule } from '../../shared/services/services.module';
 import { SharedModule } from '../../shared/shared.module';
 import { IscsiComponent } from './iscsi/iscsi.component';
 import { MirrorHealthColorPipe } from './mirror-health-color.pipe';
@@ -20,10 +17,7 @@ import { PoolDetailComponent } from './pool-detail/pool-detail.component';
     FormsModule,
     TabsModule.forRoot(),
     ProgressbarModule.forRoot(),
-    SharedModule,
-    ComponentsModule,
-    PipesModule,
-    ServicesModule
+    SharedModule
   ],
   declarations: [
     PoolDetailComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -5,7 +5,6 @@ import { RouterModule } from '@angular/router';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
-import { ComponentsModule } from '../../shared/components/components.module';
 import { SharedModule } from '../../shared/shared.module';
 import { PerformanceCounterModule } from '../performance-counter/performance-counter.module';
 import { ConfigurationComponent } from './configuration/configuration.component';
@@ -24,7 +23,6 @@ import {
   imports: [
     CommonModule,
     PerformanceCounterModule,
-    ComponentsModule,
     TabsModule.forRoot(),
     SharedModule,
     RouterModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/services.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/services.module.ts
@@ -1,9 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ConfigurationService } from '../api/configuration.service';
-import { RbdMirroringService } from '../api/rbd-mirroring.service';
-import { TcmuIscsiService } from '../api/tcmu-iscsi.service';
 import { AuthGuardService } from './auth-guard.service';
 import { AuthStorageService } from './auth-storage.service';
 import { FormatterService } from './formatter.service';
@@ -21,9 +18,6 @@ import { TaskManagerService } from './task-manager.service';
     FormatterService,
     SummaryService,
     NotificationService,
-    TcmuIscsiService,
-    ConfigurationService,
-    RbdMirroringService,
     TaskManagerService,
     TaskManagerMessageService
   ]


### PR DESCRIPTION
Removed the import of modules that were already being imported through the
Shared module.

Removed duplicated providers, those services were already provided in the api
module.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`