### PR TITLE
qa/suites/rados: enlarge osd-max-scrubs

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/large-omap-object-warnings.yaml
@@ -15,6 +15,7 @@ overrides:
       - application not enabled
     conf:
       osd:
+        osd max scrubs: 1024
         osd scrub backoff ratio: 0
         osd deep scrub large omap object value sum threshold: 8800000
         osd deep scrub large omap object key threshold: 20000


### PR DESCRIPTION
if the deep-scrub tasks are not blocked by this setting, the test will
finish sooner, and we will be able to have the test result before
check_health_output() timeouts.

Signed-off-by: Kefu Chai <kchai@redhat.com>