### PR TITLE
osd/PrimaryLogPG: fix the oi size mismatch with real object size

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7899,7 +7899,8 @@ void PrimaryLogPG::write_update_size_and_usage(object_stat_sum_t& delta_stats, o
   } else if (length)
     ch.insert(offset, length);
   modified.union_of(ch);
-  if (write_full || offset + length > oi.size) {
+  if (write_full ||
+      (offset + length > oi.size && length)) {
     uint64_t new_size = offset + length;
     delta_stats.num_bytes -= oi.size;
     delta_stats.num_bytes += new_size;


### PR DESCRIPTION
oi (object_info_t) size mismatch with the real object size on the
persistent backend, which was introduced by the old write with
a smaller truncate_seq falsefully modified the oi size.

Fixes: http://tracker.ceph.com/issues/23701
Signed-off-by: Peng Xie peng.hse@xtaotech.com