### PR TITLE
luminous: pybind/ceph_argparse: Fix UnboundLocalError if command doesn't validate

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1085,7 +1085,7 @@ def validate_command(sigdict, args, verbose=False):
 
         if found:
             if not valid_dict:
-                print("Invalid command:", e, file=sys.stderr)
+                print("Invalid command:", ex, file=sys.stderr)
                 print(concise_sig(sig), ': ', cmd['help'], file=sys.stderr)
         else:
             bestcmds = bestcmds[:10]


### PR DESCRIPTION
http://tracker.ceph.com/issues/23708