### PR TITLE
test/dashboard: specify workdir using tox.ini

### DIFF
--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -28,6 +28,5 @@ Routes==2.4.1
 singledispatch==3.4.0.3
 six==1.11.0
 tempora==1.10
-tox==2.9.1
 virtualenv==15.1.0
 wrapt==1.10.11

--- a/src/pybind/mgr/dashboard/run-tox.sh
+++ b/src/pybind/mgr/dashboard/run-tox.sh
@@ -24,4 +24,4 @@ if [ "$WITH_PYTHON3" = "ON" ]; then
   ENV_LIST+="py3-cov,py3-lint"
 fi
 
-tox -c ${TOX_PATH} -e $ENV_LIST --workdir ${CEPH_BUILD_DIR}
+tox -c ${TOX_PATH} -e $ENV_LIST

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist = {py27,py3}-cov,{py27,py3}-lint
 skipsdist = true
+toxworkdir = {env:CEPH_BUILD_DIR}
 
 [testenv]
 deps =


### PR DESCRIPTION
--workdir was introduced in tox v2.4.0, but the tox shipped by
ubuntu/xenial is 2.3.1. also because i removed the step to prepare the
tox using "pip install -r requirements.txt", what we have is the tox
v2.3.1 . so, instead of passing workdir in the command line, we specify
this setting in tox.ini.

Fixes: http://tracker.ceph.com/issues/23709
Signed-off-by: Kefu Chai <kchai@redhat.com>