### PR TITLE
mon/AuthMonitor: don't validate `fs authorize` caps with `valid_caps()`

### DIFF
--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1083,6 +1083,35 @@ int AuthMonitor::do_osd_new(
   return 0;
 }
 
+bool AuthMonitor::valid_caps(
+    const string& type,
+    const string& caps,
+    ostream *out)
+{
+  if (type == "mon" || type == "mgr") {
+    MonCap tmp;
+    if (!tmp.parse(caps, out)) {
+      return false;
+    }
+  } else if (type == "osd") {
+    OSDCap ocap;
+    if (!ocap.parse(caps, out)) {
+      return false;
+    }
+  } else if (type == "mds") {
+    MDSAuthCaps mdscap;
+    if (!mdscap.parse(g_ceph_context, caps, out)) {
+      return false;
+    }
+  } else {
+    if (out) {
+      *out << "unknown cap type '" << type << "'";
+    }
+    return false;
+  }
+  return true;
+}
+
 bool AuthMonitor::valid_caps(const vector<string>& caps, ostream *out)
 {
   for (vector<string>::const_iterator p = caps.begin();
@@ -1091,23 +1120,7 @@ bool AuthMonitor::valid_caps(const vector<string>& caps, ostream *out)
       *out << "cap '" << *p << "' has no value";
       return false;
     }
-    if (*p == "mon" || *p == "mgr") {
-      MonCap tmp;
-      if (!tmp.parse(*(p+1), out)) {
-	return false;
-      }
-    } else if (*p == "osd") {
-      OSDCap ocap;
-      if (!ocap.parse(*(p+1), out)) {
-	return false;
-      }
-    } else if (*p == "mds") {
-      MDSAuthCaps mdscap;
-      if (!mdscap.parse(g_ceph_context, *(p+1), out)) {
-	return false;
-      }
-    } else {
-      *out << "unknown cap type '" << *p << "'";
+    if (!valid_caps(*p, *(p+1), out)) {
       return false;
     }
   }
@@ -1395,11 +1408,6 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
     string mds_cap_string, osd_cap_string;
     string osd_cap_wanted = "r";
 
-    if (!valid_caps(caps_vec, &ss)) {
-      err = -EINVAL;
-      goto done;
-    }
-
     for (auto it = caps_vec.begin();
 	 it != caps_vec.end() && (it + 1) != caps_vec.end();
 	 it += 2) {
@@ -1440,6 +1448,12 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       { "osd", _encode_cap(osd_cap_string) },
       { "mds", _encode_cap(mds_cap_string) }
     };
+
+    if (!valid_caps("osd", osd_cap_string, &ss) ||
+	!valid_caps("mds", mds_cap_string, &ss)) {
+      err = -EINVAL;
+      goto done;
+    }
 
     EntityAuth entity_auth;
     if (mon->key_server.get_auth(entity, entity_auth)) {

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -132,8 +132,8 @@ private:
     pending_auth.push_back(inc);
   }
 
-  /* validate mon/osd/mds caps ; don't care about caps for other services as
-   * we don't know how to validate them */
+  /* validate mon/osd/mds caps; fail on unrecognized service/type */
+  bool valid_caps(const string& type, const string& caps, ostream *out);
   bool valid_caps(const vector<string>& caps, ostream *out);
 
   void on_active() override;


### PR DESCRIPTION
`Signed-off-by: Joao Eduardo Luis <joao@suse.com>`