### PR TITLE
[DNM] mgr/dashboard: Use npx to build frontend

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -84,7 +84,7 @@ build_dashboard_frontend() {
   cd src/pybind/mgr/dashboard/frontend
   . $TEMP_DIR/bin/activate
   npm install
-  npm run build -- --prod
+  npx ng build --prod
   deactivate
   cd $CURR_DIR
   rm -rf $TEMP_DIR

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -48,9 +48,9 @@ file(
   frontend/src/*/*/*/*/*/*.html)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(npm_command npm run build -- --prod)
+  set(npm_command npx ng build --prod)
 else()
-  set(npm_command npm run build)
+  set(npm_command npx ng build)
 endif()
 
 add_custom_command(


### PR DESCRIPTION
'npm run build' doesn't work when the path to the dashboard frontend has
special character, like ':'.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`