### PR TITLE
qa/suites/upgrade/luminous-x: skip librbd default feature test

### DIFF
--- a/qa/suites/upgrade/luminous-x/parallel/2-workload/test_rbd_python.yaml
+++ b/qa/suites/upgrade/luminous-x/parallel/2-workload/test_rbd_python.yaml
@@ -7,5 +7,5 @@ workload:
         branch: luminous
         clients:
           client.0:
-            - rbd/test_librbd_python.sh
+            - rbd/test_librbd_python-upgrade.sh
     - print: "**** done rbd/test_librbd_python.sh 2-workload"

--- a/qa/suites/upgrade/luminous-x/stress-split/7-final-workload/rbd-python.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split/7-final-workload/rbd-python.yaml
@@ -6,5 +6,5 @@ tasks:
     branch: luminous
     clients:
       client.0:
-        - rbd/test_librbd_python.sh
+        - rbd/test_librbd_python-upgrade.sh
 - print: "**** done rbd/test_librbd_python.sh 9-workload"


### PR DESCRIPTION
If we are running the luminous test against a mimic cluster, skip the
default feature test.  We changed the default features in mimic.

Signed-off-by: Sage Weil <sage@redhat.com>

Needs https://github.com/ceph/ceph/pull/21422