### PR TITLE
osd: remove cost from mclock op queues; cost not handled well in dmcl…

### DIFF
--- a/src/osd/mClockClientQueue.cc
+++ b/src/osd/mClockClientQueue.cc
@@ -147,7 +147,7 @@ namespace ceph {
 					 unsigned priority,
 					 unsigned cost,
 					 Request item) {
-    queue.enqueue(get_inner_client(cl, item), priority, cost, item);
+    queue.enqueue(get_inner_client(cl, item), priority, 0u, item);
   }
 
   // Enqueue the op in the front of the regular queue
@@ -155,7 +155,7 @@ namespace ceph {
 					       unsigned priority,
 					       unsigned cost,
 					       Request item) {
-    queue.enqueue_front(get_inner_client(cl, item), priority, cost, item);
+    queue.enqueue_front(get_inner_client(cl, item), priority, 0u, item);
   }
 
   // Return an op to be dispatched

--- a/src/osd/mClockOpClassQueue.h
+++ b/src/osd/mClockOpClassQueue.h
@@ -100,7 +100,7 @@ namespace ceph {
 			unsigned priority,
 			unsigned cost,
 			Request item) override final {
-      queue.enqueue(get_osd_op_type(item), priority, cost, item);
+      queue.enqueue(get_osd_op_type(item), priority, 0u, item);
     }
 
     // Enqueue the op in the front of the regular queue
@@ -108,7 +108,7 @@ namespace ceph {
 			      unsigned priority,
 			      unsigned cost,
 			      Request item) override final {
-      queue.enqueue_front(get_osd_op_type(item), priority, cost, item);
+      queue.enqueue_front(get_osd_op_type(item), priority, 0u, item);
     }
 
     // Returns if the queue is empty


### PR DESCRIPTION
osd: remove cost from mclock op queues; cost not handled well in dmclock library

The current version of the dmclock library does not handle operation
cost well. Therefore cost should not be passed into the library when
enqueuing operations; instead 0 should be passed in.

Backport of: https://github.com/ceph/ceph/pull/21428

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>