### PR TITLE
osd: remove cost from mclock op queues; cost not handled well in dmcl…

### DIFF
--- a/src/osd/mClockClientQueue.cc
+++ b/src/osd/mClockClientQueue.cc
@@ -78,7 +78,7 @@ namespace ceph {
 					 unsigned priority,
 					 unsigned cost,
 					 Request&& item) {
-    queue.enqueue(get_inner_client(cl, item), priority, cost, std::move(item));
+    queue.enqueue(get_inner_client(cl, item), priority, 0u, std::move(item));
   }
 
   // Enqueue the op in the front of the regular queue
@@ -86,7 +86,7 @@ namespace ceph {
 					       unsigned priority,
 					       unsigned cost,
 					       Request&& item) {
-    queue.enqueue_front(get_inner_client(cl, item), priority, cost,
+    queue.enqueue_front(get_inner_client(cl, item), priority, 0u,
 			std::move(item));
   }
 

--- a/src/osd/mClockOpClassQueue.h
+++ b/src/osd/mClockOpClassQueue.h
@@ -94,7 +94,7 @@ namespace ceph {
 			Request&& item) override final {
       queue.enqueue(client_info_mgr.osd_op_type(item),
 		    priority,
-		    cost,
+		    0u,
 		    std::move(item));
     }
 
@@ -105,7 +105,7 @@ namespace ceph {
 			      Request&& item) override final {
       queue.enqueue_front(client_info_mgr.osd_op_type(item),
 			  priority,
-			  cost,
+			  0u,
 			  std::move(item));
     }
 


### PR DESCRIPTION
osd: remove cost from mclock op queues; cost not handled well in dmcock library

The current version of the dmclock library does not handle operation
cost well. Therefore cost should not be passed into the library when
enqueuing operations; instead 0 should be passed in.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>