### PR TITLE
KStore: statfs needs extra includes on FreeBSD

### DIFF
--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -18,6 +18,10 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+#if defined(__FreeBSD__)
+#include <sys/param.h>
+#include <sys/mount.h>
+#endif
 
 #include "KStore.h"
 #include "osd/osd_types.h"


### PR DESCRIPTION
It neets:
    sys/param.h
    sys/mount.h

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>