### PR TITLE
mon/OSDMonitor: txsize should be greater or eq to prune_interval - 1

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1776,10 +1776,10 @@ bool OSDMonitor::_prune_sanitize_options() const
     r = false;
   }
 
-  if (txsize <= prune_interval) {
+  if (txsize < prune_interval - 1) {
     derr << __func__
          << "'mon_osdmap_full_prune_txsize' (" << txsize
-         << ") <= 'mon_osdmap_full_prune_interval' (" << prune_interval
+         << ") < 'mon_osdmap_full_prune_interval-1' (" << prune_interval - 1
          << "); abort." << dendl;
     r = false;
   }


### PR DESCRIPTION
so we can prune 1 or more intervals in a single iteration. and in each
interval, we prune (prune_interval - 1) versions of osdmap.

Signed-off-by: Kefu Chai <kchai@redhat.com>