### PR TITLE
qa: disable -Werror when compiling env_librados_test

### DIFF
--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -73,7 +73,7 @@ git clone https://github.com/facebook/rocksdb.git --depth 1
 
 # compile code
 cd rocksdb
-make env_librados_test ROCKSDB_USE_LIBRADOS=1 -j8
+make env_librados_test ROCKSDB_USE_LIBRADOS=1 DISABLE_WARNING_AS_ERROR=1 -j8
 
 echo "Copy ceph.conf"
 # prepare ceph.conf


### PR DESCRIPTION
to silence warnings like

utilities/env_librados.cc:175:33: warning: unused parameter ‘offset’ [-Wunused-parameter]
   Status InvalidateCache(size_t offset, size_t length) {
                                 ^~~~~~

Signed-off-by: Kefu Chai <kchai@redhat.com>