### PR TITLE
test/librbd: ensure OutOfOrder test has enough concurrent management ops

### DIFF
--- a/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
@@ -221,6 +221,14 @@ TEST_F(TestMockDeepCopyImageCopyRequest, SimpleImage) {
 }
 
 TEST_F(TestMockDeepCopyImageCopyRequest, OutOfOrder) {
+  std::string max_ops_str;
+  ASSERT_EQ(0, _rados.conf_get("rbd_concurrent_management_ops", max_ops_str));
+  ASSERT_EQ(0, _rados.conf_set("rbd_concurrent_management_ops", "10"));
+  BOOST_SCOPE_EXIT( (max_ops_str) ) {
+    ASSERT_EQ(0, _rados.conf_set("rbd_concurrent_management_ops",
+                                 max_ops_str.c_str()));
+  } BOOST_SCOPE_EXIT_END;
+
   librados::snap_t snap_id_end;
   ASSERT_EQ(0, create_snap("copy", &snap_id_end));
 


### PR DESCRIPTION
The test relies on large enough number of concurrent_management_ops.

Signed-off-by: Mykola Golub <mgolub@suse.com>