### PR TITLE
luminous: mds: properly dirty sessions opened by journal replay

### DIFF
--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -557,13 +557,13 @@ public:
 	s.insert(p->second);
   }
 
-  void open_sessions(map<client_t,entity_inst_t>& client_map) {
+  void replay_open_sessions(map<client_t,entity_inst_t>& client_map) {
     for (map<client_t,entity_inst_t>::iterator p = client_map.begin(); 
 	 p != client_map.end(); 
 	 ++p) {
       Session *s = get_or_add_session(p->second);
       set_state(s, Session::STATE_OPEN);
-      version++;
+      replay_dirty_session(s);
     }
   }
 

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1857,9 +1857,8 @@ void ESessions::replay(MDSRank *mds)
   } else {
     dout(10) << "ESessions.replay sessionmap " << mds->sessionmap.get_version()
 	     << " < " << cmapv << dendl;
-    mds->sessionmap.open_sessions(client_map);
+    mds->sessionmap.replay_open_sessions(client_map);
     assert(mds->sessionmap.get_version() == cmapv);
-    mds->sessionmap.set_projected(mds->sessionmap.get_version());
   }
   update_segment();
 }
@@ -2132,10 +2131,8 @@ void EUpdate::replay(MDSRank *mds)
       map<client_t,entity_inst_t> cm;
       bufferlist::iterator blp = client_map.begin();
       ::decode(cm, blp);
-      mds->sessionmap.open_sessions(cm);
-
+      mds->sessionmap.replay_open_sessions(cm);
       assert(mds->sessionmap.get_version() == cmapv);
-      mds->sessionmap.set_projected(mds->sessionmap.get_version());
     }
   }
   update_segment();
@@ -2960,7 +2957,7 @@ void EImportStart::replay(MDSRank *mds)
     map<client_t,entity_inst_t> cm;
     bufferlist::iterator blp = client_map.begin();
     ::decode(cm, blp);
-    mds->sessionmap.open_sessions(cm);
+    mds->sessionmap.replay_open_sessions(cm);
     if (mds->sessionmap.get_version() != cmapv)
     {
       derr << "sessionmap version " << mds->sessionmap.get_version()
@@ -2969,7 +2966,6 @@ void EImportStart::replay(MDSRank *mds)
       mds->damaged();
       ceph_abort();  // Should be unreachable because damaged() calls respawn()
     }
-    mds->sessionmap.set_projected(mds->sessionmap.get_version());
   }
   update_segment();
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/23702