### PR TITLE
qa: Replace 'ceph' with cluster name in restart()

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1431,20 +1431,21 @@ def restart(ctx, config):
 
     daemons = ctx.daemons.resolve_role_list(config.get('daemons', None), CEPH_ROLE_TYPES, True)
     clusters = set()
-    manager = ctx.managers['ceph']
 
     with tweaked_option(ctx, config):
         for role in daemons:
             cluster, type_, id_ = teuthology.split_role(role)
             ctx.daemons.get_daemon(type_, id_, cluster).restart()
             clusters.add(cluster)
-
-    for dmon in daemons:
-        if '.' in dmon:
-            dm_parts = dmon.split('.')
-            if dm_parts[1].isdigit():
-                if dm_parts[0] == 'osd':
-                    manager.mark_down_osd(int(dm_parts[1]))
+    
+    for cluster in clusters:
+        manager = ctx.managers[cluster]
+        for dmon in daemons:
+            if '.' in dmon:
+                dm_parts = dmon.split('.')
+                if dm_parts[1].isdigit():
+                    if dm_parts[0] == 'osd':
+                        manager.mark_down_osd(int(dm_parts[1]))
 
     if config.get('wait-for-healthy', True):
         for cluster in clusters:


### PR DESCRIPTION
Enabled ctx.managers to take cluster name from config in restart() method instead of default 'ceph'.
Signed-off-by: Shilpa Jagannath <smanjara@redhat.com>