### PR TITLE
mgr/dashboard: run-tox: pass CEPH_BUILD_DIR value into tox script

### DIFF
--- a/src/pybind/mgr/dashboard/run-tox.sh
+++ b/src/pybind/mgr/dashboard/run-tox.sh
@@ -13,9 +13,7 @@ else
     TOX_PATH=`readlink -f $(dirname $0)/tox.ini`
 fi
 
-if [ -z $CEPH_BUILD_DIR ]; then
-    export CEPH_BUILD_DIR=$(dirname ${TOX_PATH})
-fi
+export CEPH_BUILD_DIR=$CEPH_BUILD_DIR
 
 if [ "$WITH_PYTHON2" = "ON" ]; then
   ENV_LIST+="py27-cov,py27-lint,"


### PR DESCRIPTION
This PR fixes an error when running the `run-tox.sh` script manually from the dashboard source directory.

Error output:

```
Traceback (most recent call last):
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 1055, in _replace
    replaced = Replacer(self, crossonly=crossonly).do_replace(value)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 1087, in do_replace
    expanded = substitute_once(value)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 1085, in substitute_once
    return self.RE_ITEM_REF.sub(self._replace_match, x)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 1122, in _replace_match
    return self._replace_env(match)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 1138, in _replace_env
    raise tox.exception.MissingSubstitution(envkey)
tox.MissingSubstitution: MissingSubstitution: CEPH_BUILD_DIR

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/bin/tox", line 11, in <module>
    sys.exit(cmdline())
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/session.py", line 39, in main
    config = prepare(args)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/session.py", line 27, in prepare
    config = parseconfig(args)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 245, in parseconfig
    parseini(config, inipath)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 748, in __init__
    config.toxworkdir = reader.getpath("toxworkdir", "{toxinidir}/.tox")
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 959, in getpath
    path = self.getstring(name, defaultpath, replace=replace)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 1031, in getstring
    x = self._replace(x, name=name, crossonly=crossonly)
  File "/home/rdias/Work/ceph/src/pybind/mgr/dashboard/venv/lib/python3.6/site-packages/tox/config.py", line 1061, in _replace
    "section %r." % (value, section_name))
tox.ConfigError: ConfigError: substitution env:'{env:CEPH_BUILD_DIR}': unknown or recursive definition in section 'tox'.
```

Signed-off-by: Ricardo Dias <rdias@suse.com>