### PR TITLE
cmake: fix frontend cmake build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1126,8 +1126,8 @@ if(WITH_LTTNG)
   add_dependencies(vstart tracepoint_libraries)
 endif(WITH_LTTNG)
 
-if(WITH_MGR_DASHBOARD_V2_FRONTEND AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-  add_dependencies(vstart mgr-dashboard_v2-frontend-build)
+if(WITH_MGR_DASHBOARD_FRONTEND AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
+  add_dependencies(vstart mgr-dashboard-frontend-build)
 endif()
 
 # Everything you need to run CephFS tests


### PR DESCRIPTION
This PR fixes the "make check" failure due to frontend unittests failure.

Signed-off-by: Ricardo Dias <rdias@suse.com>