### PR TITLE
ceph-volume: automatic VDO detection 

### DIFF
--- a/doc/dev/ceph-volume/lvm.rst
+++ b/doc/dev/ceph-volume/lvm.rst
@@ -166,3 +166,14 @@ the partition UUID.
 Example::
 
     ceph.wal_uuid=A58D1C68-0D6E-4CB3-8E99-B261AD47CC39
+
+
+``vdo``
+-------
+A VDO-enabled device is detected when device is getting prepared, and then
+stored for later checks when activating. This affects mount options by
+appending the ``discard`` mount flag, regardless of mount flags being used.
+
+Example for an enabled VDO device::
+
+    ceph.vdo=1

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -21,6 +21,7 @@ def activate_filestore(lvs):
     if not osd_lv:
         raise RuntimeError('Unable to find a data LV for filestore activation')
     is_encrypted = osd_lv.tags.get('ceph.encrypted', '0') == '1'
+    is_vdo = osd_lv.tags.get('ceph.vdo', '0')
 
     osd_id = osd_lv.tags['ceph.osd_id']
     conf.cluster = osd_lv.tags['ceph.cluster_name']
@@ -55,10 +56,11 @@ def activate_filestore(lvs):
         source = '/dev/mapper/%s' % osd_lv.lv_uuid
     else:
         source = osd_lv.lv_path
+
     # mount the osd
     destination = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
     if not system.device_is_mounted(source, destination=destination):
-        process.run(['mount', '-v', source, destination])
+        prepare_utils.mount_osd(source, osd_id, is_vdo=is_vdo)
 
     # always re-do the symlink regardless if it exists, so that the journal
     # device path that may have changed can be mapped correctly every time

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -56,12 +56,14 @@ def prepare_filestore(device, journal, secrets, tags, osd_id, fsid):
         device = prepare_dmcrypt(key, device, 'data', tags)
         journal = prepare_dmcrypt(key, journal, 'journal', tags)
 
+    # vdo detection
+    is_vdo = api.is_vdo(device)
     # create the directory
     prepare_utils.create_osd_path(osd_id)
     # format the device
     prepare_utils.format_device(device)
     # mount the data device
-    prepare_utils.mount_osd(device, osd_id)
+    prepare_utils.mount_osd(device, osd_id, is_vdo=is_vdo)
     # symlink the journal
     prepare_utils.link_journal(journal, osd_id)
     # get the latest monmap

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -160,6 +160,7 @@ class Prepare(object):
         if device_name is None:
             return '', '', tags
         tags['ceph.type'] = device_type
+        tags['ceph.vdo'] = api.is_vdo(device_name)
         lv = self.get_lv(device_name)
         if lv:
             uuid = lv.lv_uuid
@@ -263,6 +264,7 @@ class Prepare(object):
             tags['ceph.data_uuid'] = data_lv.lv_uuid
             tags['ceph.cephx_lockbox_secret'] = cephx_lockbox_secret
             tags['ceph.encrypted'] = encrypted
+            tags['ceph.vdo'] = api.is_vdo(data_lv.lv_path)
 
             journal_device, journal_uuid, tags = self.setup_device('journal', args.journal, tags)
 
@@ -286,6 +288,7 @@ class Prepare(object):
             tags['ceph.block_uuid'] = block_lv.lv_uuid
             tags['ceph.cephx_lockbox_secret'] = cephx_lockbox_secret
             tags['ceph.encrypted'] = encrypted
+            tags['ceph.vdo'] = api.is_vdo(block_lv.lv_path)
 
             wal_device, wal_uuid, tags = self.setup_device('wal', args.block_wal, tags)
             db_device, db_uuid, tags = self.setup_device('db', args.block_db, tags)

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -175,7 +175,7 @@ class TestMountOSD(object):
         prepare.mount_osd('/dev/sda1', 1)
         expected = [
             'mount', '-t', 'xfs', '-o',
-            'rw,inode64,noatime', # default flags
+            'rw,noatime,inode64', # default flags
             '/dev/sda1', '/var/lib/ceph/osd/ceph-1']
         assert expected == fake_run.calls[0]['args'][0]
 
@@ -201,7 +201,7 @@ class TestMountOSD(object):
         prepare.mount_osd('/dev/sda1', 1)
         expected = [
             'mount', '-t', 'xfs', '-o',
-            'auto,rw,exec',
+            'rw,auto,exec',
             '/dev/sda1', '/var/lib/ceph/osd/ceph-1']
         assert expected == fake_run.calls[0]['args'][0]
 
@@ -214,7 +214,7 @@ class TestMountOSD(object):
         prepare.mount_osd('/dev/sda1', 1)
         expected = [
             'mount', '-t', 'xfs', '-o',
-            'auto,rw,exec',
+            'rw,auto,exec',
             '/dev/sda1', '/var/lib/ceph/osd/ceph-1']
         assert expected == fake_run.calls[0]['args'][0]
 

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -175,7 +175,7 @@ class TestMountOSD(object):
         prepare.mount_osd('/dev/sda1', 1)
         expected = [
             'mount', '-t', 'xfs', '-o',
-            'rw,noatime,inode64', # default flags
+            'rw,inode64,noatime', # default flags
             '/dev/sda1', '/var/lib/ceph/osd/ceph-1']
         assert expected == fake_run.calls[0]['args'][0]
 
@@ -201,7 +201,7 @@ class TestMountOSD(object):
         prepare.mount_osd('/dev/sda1', 1)
         expected = [
             'mount', '-t', 'xfs', '-o',
-            'rw,auto,exec',
+            'auto,rw,exec',
             '/dev/sda1', '/var/lib/ceph/osd/ceph-1']
         assert expected == fake_run.calls[0]['args'][0]
 
@@ -214,7 +214,7 @@ class TestMountOSD(object):
         prepare.mount_osd('/dev/sda1', 1)
         expected = [
             'mount', '-t', 'xfs', '-o',
-            'rw,auto,exec',
+            'auto,rw,exec',
             '/dev/sda1', '/var/lib/ceph/osd/ceph-1']
         assert expected == fake_run.calls[0]['args'][0]
 
@@ -260,10 +260,30 @@ class TestNormalizeFlags(object):
 
     @pytest.mark.parametrize("flags", ceph_conf_mount_values)
     def test_normalize_lists(self, flags):
-        result = prepare._normalize_mount_flags(flags)
-        assert result == 'rw,auto,exec'
+        result = sorted(prepare._normalize_mount_flags(flags).split(','))
+        assert ','.join(result) == 'auto,exec,rw'
 
     @pytest.mark.parametrize("flags", string_mount_values)
     def test_normalize_strings(self, flags):
-        result = prepare._normalize_mount_flags(flags)
-        assert result == 'rw,auto,exec'
+        result = sorted(prepare._normalize_mount_flags(flags).split(','))
+        assert ','.join(result) == 'auto,exec,rw'
+
+    @pytest.mark.parametrize("flags", ceph_conf_mount_values)
+    def test_normalize_extra_flags(self, flags):
+        result = prepare._normalize_mount_flags(flags, extras=['discard'])
+        assert sorted(result.split(',')) == ['auto', 'discard', 'exec', 'rw']
+
+    @pytest.mark.parametrize("flags", ceph_conf_mount_values)
+    def test_normalize_duplicate_extra_flags(self, flags):
+        result = prepare._normalize_mount_flags(flags, extras=['rw', 'discard'])
+        assert sorted(result.split(',')) == ['auto', 'discard', 'exec', 'rw']
+
+    @pytest.mark.parametrize("flags", string_mount_values)
+    def test_normalize_strings_flags(self, flags):
+        result = sorted(prepare._normalize_mount_flags(flags, extras=['discard']).split(','))
+        assert ','.join(result) == 'auto,discard,exec,rw'
+
+    @pytest.mark.parametrize("flags", string_mount_values)
+    def test_normalize_strings_duplicate_flags(self, flags):
+        result = sorted(prepare._normalize_mount_flags(flags, extras=['discard','rw']).split(','))
+        assert ','.join(result) == 'auto,discard,exec,rw'

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -162,13 +162,21 @@ def _normalize_mount_flags(flags, extras=None):
     :param extras: Extra set of mount flags, useful when custom devices like VDO need
                    ad-hoc mount configurations
     """
+    # Instead of using set(), we append to this new list here, because set()
+    # will create an arbitrary order on the items that is made worst when
+    # testing with tools like tox that includes a randomizer seed. By
+    # controlling the order, it is easier to correctly assert the expectation
+    unique_flags = []
     if isinstance(flags, list):
         if extras:
             flags.extend(extras)
+
         # ensure that spaces and commas are removed so that they can join
         # correctly, remove duplicates
-        flags = set([f.strip().strip(',') for f in flags if f])
-        return ','.join(flags)
+        for f in flags:
+            if f and f not in unique_flags:
+                unique_flags.append(f.strip().strip(','))
+        return ','.join(unique_flags)
 
     # split them, clean them, and join them back again
     flags = flags.strip().split(' ')
@@ -176,7 +184,10 @@ def _normalize_mount_flags(flags, extras=None):
         flags.extend(extras)
 
     # remove possible duplicates
-    flags = ','.join([f.strip().strip(',') for f in flags if f])
+    for f in flags:
+        if f and f not in unique_flags:
+            unique_flags.append(f.strip().strip(','))
+    flags = ','.join(unique_flags)
     # Before returning, split them again, since strings can be mashed up
     # together, preventing removal of duplicate entries
     return ','.join(set(flags.split(',')))


### PR DESCRIPTION
The process will do a disk detection when first preparing the device, and will store it in the LVM tags, which will later be read by the activation process (instead of always relying on disk detection).

Since there aren't any functional tests for VDO, a proxy function is doing the work that in case of failure if will just inform that the device is not VDO. The full exception will be logged to the file.

Finally, a bug was fixed where `activate` would not use any pre-configured flags and would just mount directly. This affects filestore only on subsequent activations (it uses the right flags on `create`)

Fixes: http://tracker.ceph.com/issues/23581