### PR TITLE
qa/tests - added tag: v12.2.2 to be used by client.1 ...

### DIFF
--- a/qa/suites/upgrade/luminous-x/point-to-point-x/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/luminous-x/point-to-point-x/point-to-point-upgrade.yaml
@@ -109,7 +109,7 @@ workload:
 workload_luminous:
    full_sequential:
    - workunit:
-       branch: luminous
+       tag: v12.2.2
        clients:
          client.1:
          - rados/test.sh
@@ -166,14 +166,14 @@ workload_x:
        branch: luminous
        clients:
          client.1:
-         - rados/test.sh
+         - rados/test-upgrade-to-mimic.sh
          - cls
-   - print: "**** done rados/test.sh &  cls workload_x NOT upgraded  client"
+   - print: "**** done rados/test-upgrade-to-mimic.sh &  cls workload_x NOT upgraded  client"
    - workunit:
        branch: luminous
        clients:
          client.0:
-         - rados/test.sh
+         - rados/test-upgrade-to-mimic.sh
          - cls
    - print: "**** done rados/test.sh &  cls workload_x upgraded client"
    - rgw: [client.1]

--- a/qa/workunits/rados/test-upgrade-to-mimic.sh
+++ b/qa/workunits/rados/test-upgrade-to-mimic.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -ex
+
+parallel=1
+[ "$1" = "--serial" ] && parallel=0
+
+color=""
+[ -t 1 ] && color="--gtest_color=yes"
+
+function cleanup() {
+    pkill -P $$ || true
+}
+trap cleanup EXIT ERR HUP INT QUIT
+
+declare -A pids
+
+for f in \
+    api_aio api_io api_list api_lock api_misc \
+    api_tier api_pool api_snapshots api_stat api_watch_notify api_cmd \
+    api_service \
+    api_c_write_operations \
+    'api_c_read_operations --gtest_filter=-CReadOpsTest.Exec' \
+    list_parallel \
+    open_pools_parallel \
+    delete_pools_parallel \
+    watch_notify
+do
+    if [ $parallel -eq 1 ]; then
+	r=`printf '%25s' $f`
+	bash -o pipefail -exc "ceph_test_rados_$f $color 2>&1 | tee ceph_test_rados_$f.log | sed \"s/^/$r: /\"" &
+	pid=$!
+	echo "test $f on pid $pid"
+	pids[$f]=$pid
+    else
+	ceph_test_rados_$f
+    fi
+done
+
+ret=0
+if [ $parallel -eq 1 ]; then
+for t in "${!pids[@]}"
+do
+  pid=${pids[$t]}
+  if ! wait $pid
+  then
+    echo "error in $t ($pid)"
+    ret=1
+  fi
+done
+fi
+
+exit $ret


### PR DESCRIPTION
…under workload_luminous to avoid failures.

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>