### PR TITLE
mds: unset deleted vars in shutdown_pass

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7818,11 +7818,15 @@ bool MDCache::shutdown_pass()
   }
   assert(subtrees.empty());
 
-  if (myin)
+  if (myin) {
     remove_inode(myin);
+    assert(!myin);
+  }
 
-  if (global_snaprealm)
+  if (global_snaprealm) {
     remove_inode(global_snaprealm->inode);
+    global_snaprealm = nullptr;
+  }
   
   // done!
   dout(2) << "shutdown done." << dendl;


### PR DESCRIPTION
So future passes do not try to delete again.

Fixes: http://tracker.ceph.com/issues/23766

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>