### PR TITLE
common: calculate stddev on the fly

### DIFF
--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -25,14 +25,14 @@ using ceph::mono_clock;
 struct bench_interval_data {
   double min_bandwidth = DBL_MAX;
   double max_bandwidth = 0;
+  double avg_bandwidth = 0;
+  int bandwidth_cycles = 0;
+  double bandwidth_diff_sum = 0;
   int min_iops = INT_MAX;
   int max_iops = 0;
-};
-
-struct bench_history {
-  vector<double> bandwidth;
-  vector<double> latency;
-  vector<long> iops;
+  double avg_iops = 0;
+  int iops_cycles = 0;
+  double iops_diff_sum = 0;
 };
 
 struct bench_data {
@@ -48,7 +48,7 @@ struct bench_data {
   double max_latency;
   double avg_latency;
   struct bench_interval_data idata; // data that is updated by time intervals and not by events
-  struct bench_history history; // data history, used to calculate stddev
+  double latency_diff_sum;
   std::chrono::duration<double> cur_latency; //latency of last completed transaction - in seconds by default
   mono_time start_time; //start time for benchmark - use the monotonic clock as we'll measure the passage of time
   char *object_contents; //pointer to the contents written to each object


### PR DESCRIPTION
Calculate stddev on the fly using rapid calculation methods:
https://en.wikipedia.org/wiki/Standard_deviation#Rapid_calculation_methods
no need to keep the bench history.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>