### PR TITLE
Revert "cmake: build dashboard frontend in `vstart` target, not `ceph-mgr`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1126,10 +1126,6 @@ if(WITH_LTTNG)
   add_dependencies(vstart tracepoint_libraries)
 endif(WITH_LTTNG)
 
-if(WITH_MGR_DASHBOARD_FRONTEND AND CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
-  add_dependencies(vstart mgr-dashboard-frontend-build)
-endif()
-
 # Everything you need to run CephFS tests
 add_custom_target(cephfs_testing DEPENDS
     vstart

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -64,4 +64,5 @@ add_custom_target(mgr-dashboard-frontend-build
   DEPENDS frontend/dist mgr-dashboard-frontend-deps
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
 )
+add_dependencies(ceph-mgr mgr-dashboard-frontend-build)
 endif(WITH_MGR_DASHBOARD_FRONTEND AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64|arm|ARM")


### PR DESCRIPTION
This reverts commit 1ec206d1cd329eb03e2a1e65b38f3bc562da70c9.

The `vstart` taget is not built by default, and hence, the dashboard
frontend is not built as well.