### PR TITLE
cmake: include frontend build in 'all' target

### DIFF
--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -71,6 +71,7 @@ add_custom_command(
   COMMENT "dashboard frontend is being created"
 )
 add_custom_target(mgr-dashboard-frontend-build
+  ALL
   DEPENDS frontend/dist mgr-dashboard-frontend-deps
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
 )


### PR DESCRIPTION
The frontend wasn't getting included in a default build
since it was removed as a dependency of ceph-mgr and
made a dependency of vstart instead.

Signed-off-by: John Spray <john.spray@redhat.com>