### PR TITLE
client: fix error operator precedence

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -91,8 +91,8 @@ class MDSCommandOp : public CommandOp
 };
 
 /* error code for ceph_fuse */
-#define CEPH_FUSE_NO_MDS_UP    -(1<<16+0) /* no mds up deteced in ceph_fuse */
-#define CEPH_FUSE_LAST         -(1<<16+1) /* (unused) */
+#define CEPH_FUSE_NO_MDS_UP    -((1<<16)+0) /* no mds up deteced in ceph_fuse */
+#define CEPH_FUSE_LAST         -((1<<16)+1) /* (unused) */
 
 // ============================================
 // types for my local metadata cache


### PR DESCRIPTION
    /home/pdonnell/ceph/src/client/Client.cc: In member function ‘int Client::mount(const string&, const UserPerm&, bool)’:
    /home/pdonnell/ceph/src/client/Client.cc:5681:23: warning: suggest parentheses around ‘+’ inside ‘<<’ [-Wparentheses]
        return CEPH_FUSE_NO_MDS_UP;
                    ~~^~

Found by gcc. I am ashamed.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>