### PR TITLE
mgr/dashboard: tox: set COVERAGE_FILE and UNITTEST for all envs

### DIFF
--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -11,10 +11,10 @@ setenv=
     WEBTEST_INTERACTIVE = false
     LD_LIBRARY_PATH = {toxinidir}/../../../../build/lib
     PATH = {toxinidir}/../../../../build/bin:$PATH
+    COVERAGE_FILE = .coverage.{envname}
+    UNITTEST = true
     py27: PYTHONPATH = {toxinidir}/../../../../build/lib/cython_modules/lib.2
     py3:  PYTHONPATH = {toxinidir}/../../../../build/lib/cython_modules/lib.3
-    cov:  UNITTEST = true
-    cov:  COVERAGE_FILE = .coverage.{envname}
 commands=
     cov: coverage erase
     cov: {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml --doctest-modules controllers/rbd.py services/ tests/ tools.py


### PR DESCRIPTION
This PR intends to fix the following error (pasted from jenkins make check):

```
Traceback (most recent call last):
  File "/usr/bin/tox", line 9, in <module>
    load_entry_point('tox==1.4.2', 'console_scripts', 'tox')()
  File "/usr/lib/python2.7/site-packages/tox/_cmdline.py", line 24, in main
    config = parseconfig(args, 'tox')
  File "/usr/lib/python2.7/site-packages/tox/_config.py", line 23, in parseconfig
    parseini(config)
  File "/usr/lib/python2.7/site-packages/tox/_config.py", line 174, in __init__
    self._makeenvconfig("python", "_xz_9", reader._subs, config)
  File "/usr/lib/python2.7/site-packages/tox/_config.py", line 221, in _makeenvconfig
    vc.commands = reader.getargvlist(section, "commands")
  File "/usr/lib/python2.7/site-packages/tox/_config.py", line 331, in getargvlist
    commandlist.append(self._processcommand(current_command))
  File "/usr/lib/python2.7/site-packages/tox/_config.py", line 351, in _processcommand
    new_word = re.sub(pat, self._replace_match, word)
  File "/usr/lib64/python2.7/re.py", line 151, in sub
    return _compile(pattern, flags).sub(repl, string, count)
  File "/usr/lib/python2.7/site-packages/tox/_config.py", line 485, in _replace_match
    return handler(match)
  File "/usr/lib/python2.7/site-packages/tox/_config.py", line 447, in _replace_env
    (envkey, envkey))
tox.ConfigError: ConfigError: substitution env:'COVERAGE_FILE': unkown environment variable 'COVERAGE_FILE'
```

Signed-off-by: Ricardo Dias <rdias@suse.com>