### PR TITLE
doc/start/os-recommendations.rst: bump krbd kernels

### DIFF
--- a/doc/start/os-recommendations.rst
+++ b/doc/start/os-recommendations.rst
@@ -21,8 +21,8 @@ Linux Kernel
   For RBD, if you choose to *track* long-term kernels, we currently recommend
   4.x-based "longterm maintenance" kernel series:
 
+  - 4.14.z
   - 4.9.z
-  - 4.4.z
 
   For CephFS, see `CephFS best practices`_ for kernel version guidance.
 


### PR DESCRIPTION
Drop 4.4 -- even though it is an "Extended LTS" release, it predates
the OSD client rewrite and should no longer be recommended.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>