### PR TITLE
rgw: add buffering filter to compression for fetch_remote_obj

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7489,12 +7489,44 @@ bool RGWRados::aio_completed(void *handle)
   return c->is_safe();
 }
 
+// PutObj filter that buffers data so we don't try to compress tiny blocks.
+// libcurl reads in 16k at a time, and we need at least 64k to get a good
+// compression ratio
+class RGWPutObj_Buffer : public RGWPutObj_Filter {
+  const unsigned buffer_size;
+  bufferlist buffer;
+ public:
+  RGWPutObj_Buffer(RGWPutObjDataProcessor* next, unsigned buffer_size)
+    : RGWPutObj_Filter(next), buffer_size(buffer_size) {
+    assert(isp2(buffer_size)); // must be power of 2
+  }
+
+  int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj,
+                  bool *again) override {
+    if (*again || !bl.length()) {
+      // flush buffered data
+      return RGWPutObj_Filter::handle_data(buffer, ofs, phandle, pobj, again);
+    }
+    // transform offset to the beginning of the buffer
+    ofs = ofs - buffer.length();
+    buffer.claim_append(bl);
+    if (buffer.length() < buffer_size) {
+      *again = false; // don't come back until there's more data
+      return 0;
+    }
+    const auto count = p2align(buffer.length(), buffer_size);
+    buffer.splice(0, count, &bl);
+    return RGWPutObj_Filter::handle_data(bl, ofs, phandle, pobj, again);
+  }
+};
+
 class RGWRadosPutObj : public RGWHTTPStreamRWRequest::ReceiveCB
 {
   CephContext* cct;
   rgw_obj obj;
   RGWPutObjDataProcessor *filter;
   boost::optional<RGWPutObj_Compress>& compressor;
+  boost::optional<RGWPutObj_Buffer> buffering;
   CompressorRef& plugin;
   RGWPutObjProcessor_Atomic *processor;
   RGWOpStateSingleOp *opstate;
@@ -7542,7 +7574,9 @@ public:
     if (plugin && src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
       //do not compress if object is encrypted
       compressor = boost::in_place(cct, plugin, filter);
-      filter = &*compressor;
+      constexpr unsigned buffer_size = 512 * 1024;
+      buffering = boost::in_place(&*compressor, buffer_size);
+      filter = &*buffering;
     }
     return 0;
   }
@@ -7614,6 +7648,11 @@ public:
     } while (again);
 
     return 0;
+  }
+
+  int flush() {
+    bufferlist bl;
+    return put_data_and_throttle(filter, bl, ofs, false);
   }
 
   bufferlist& get_extra_data() { return extra_data_bl; }
@@ -8048,6 +8087,10 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   }
 
   ret = conn->complete_request(in_stream_req, etag, &set_mtime, nullptr, req_headers);
+  if (ret < 0) {
+    goto set_err_state;
+  }
+  ret = cb.flush();
   if (ret < 0) {
     goto set_err_state;
   }


### PR DESCRIPTION
fetch_remote_obj() only gets 16k blocks from libcurl, which leads to a much worse compression ratio than the 4m blocks in normal PUT requests

Fixes: http://tracker.ceph.com/issues/23547

i tested each compression plugin with various buffer sizes, and 512k seems to be a good compromise. after uploading a 256M zero-filled object to the source zone, the following compressed sizes were observed on the destination zone (reported as `size_utilized` in `radosgw-admin bucket stats`):

| buffer_size  | lz4 | snappy | zlib | zstd |
| --- | --- | --- | --- | --- |
| src (4m)  | 1054144 | 12591360 | 261184 | 25536 |
| dst (4m)  | 1360128 | 12591360 | 261184 | 25728 |
| dst (512k)  | 1371648 | 12592640 | 269312 | 31744 |
| dst (128k)  | 1404928 | 12603392 | 294912 | 53248 |
| dst (64k)  | 1454080 | 12603392 | 323584 | 98304 |
| dst (16k)  | 1425431 | 12664838 | 557063 | 376855 |