### PR TITLE
test/dashboard: hardcode .coverage path to workaround tox bugs

### DIFF
--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -14,11 +14,10 @@ setenv=
     py27: PYTHONPATH = {toxinidir}/../../../../build/lib/cython_modules/lib.2
     py3:  PYTHONPATH = {toxinidir}/../../../../build/lib/cython_modules/lib.3
     cov:  UNITTEST = true
-    cov:  COVERAGE_FILE = .coverage.{envname}
 commands=
     cov: coverage erase
     cov: {envbindir}/py.test --cov=. --cov-report= --junitxml=junit.{envname}.xml --doctest-modules controllers/rbd.py services/ tests/ tools.py
-    cov: coverage combine {toxinidir}/{env:COVERAGE_FILE}
+    cov: coverage combine {toxinidir}/.coverage
     cov: coverage report
     cov: coverage xml
     lint: pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests services


### PR DESCRIPTION
rhel/centos 7.3 comes with tox 1.4.2, which has a bunch of issues related
to environment variable substitution. for instance, see
- https://github.com/tox-dev/tox/issues/515
so, instead of having different coverage files for py3 and py2.7, it
would be simpler to just use the same path for coverage. this approach
works because pytest-cov plugin erases the coverage data file at the
beginning of test[1].

---
[1] https://pypi.org/project/pytest-cov/#coverage-data-file .

Signed-off-by: Kefu Chai <kchai@redhat.com>