### PR TITLE
ceph-volume: allow parallel creates

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -189,11 +189,7 @@ class Prepare(object):
         """
         if disk.is_partition(arg) or disk.is_device(arg):
             # we must create a vg, and then a single lv
-            vg_name = "ceph-%s" % cluster_fsid
-            if api.get_vg(vg_name=vg_name):
-                # means we already have a group for this, make a different one
-                # XXX this could end up being annoying for an operator, maybe?
-                vg_name = "ceph-%s" % str(uuid.uuid4())
+            vg_name = "ceph-%s" % str(uuid.uuid4())
             api.create_vg(vg_name, arg)
             lv_name = "osd-%s-%s" % (device_type, osd_fsid)
             return api.create_lv(


### PR DESCRIPTION
Currently the create code decides the vg_name "ceph-$cluster_fsid" as
the primary vg_name and creates a new name if this already exists.

If this code is run N times in parallel, the script will try to
create N times the vg with the name "ceph-$cluster_fsid" and it
will fail to create the N osds successfully.

Creating vgs with names like "ceph-$uuid4" lets our scripts to run
in parallel without any problems.

Fixes: http://tracker.ceph.com/issues/23757

Signed-off-by: Theofilos Mouratidis <t.mour@cern.ch>