### PR TITLE
librbd: missing 'return' in deep_copy::ObjectCopyRequest::send_read_object

### DIFF
--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -173,6 +173,7 @@ void ObjectCopyRequest<I>::send_read_object() {
   if (!read_required) {
     // nothing written to this object for this snapshot (must be trunc/remove)
     handle_read_object(0);
+    return;
   }
 
   auto ctx = create_context_callback<


### PR DESCRIPTION

Signed-off-by: Mykola Golub <mgolub@suse.com>