### PR TITLE
mgr/dashboard: Add 'forceIdentifier' attribute to datatable

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -15,7 +15,8 @@
 <cd-table [data]="images"
           columnMode="flex"
           [columns]="columns"
-          identifier="name"
+          identifier="id"
+          forceIdentifier="true"
           selectionType="single"
           (updateSelection)="updateSelection($event)">
   <div class="table-actions">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -134,6 +134,15 @@ describe('TableComponent', () => {
     expect(component.rows.length).toBe(100);
   });
 
+  it('should force an identifier', () => {
+    component.identifier = 'x';
+    component.forceIdentifier = true;
+    component.ngOnInit();
+    expect(component.identifier).toBe('x');
+    expect(component.sorts[0].prop).toBe('a');
+    expect(component.sorts).toEqual(component.createSortingDefinition('a'));
+  });
+
   describe('after ngInit', () => {
     const toggleColumn = (prop, checked) => {
       component.toggleColumn({


### PR DESCRIPTION
In some cases it is necessary to specify an identifier that is not specified in the column config and hence not displayed but is used to tell the datatable which row property shall be used to identify the uniqueness of a row.

With forceIdentifier='true' the default behaviour can be deactivated to use the first column property if the identifier does not exist.

The auto-build of the sorting config is not affected by this, here the property of the first column is still used if the identifier does not exist.

Signed-off-by: Volker Theile <vtheile@suse.com>