### PR TITLE
client: fix long stalls in _fsync after setattr

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9397,6 +9397,8 @@ int Client::_fsync(Inode *in, bool syncdataonly)
   } else ldout(cct, 10) << "no metadata needs to commit" << dendl;
 
   if (!syncdataonly && !in->unsafe_ops.empty()) {
+    flush_mdlog_sync();
+
     MetaRequest *req = in->unsafe_ops.back();
     ldout(cct, 15) << "waiting on unsafe requests, last tid " << req->get_tid() <<  dendl;
 


### PR DESCRIPTION
The main patch in this series fixes a problem that I've found in testing with ganesha. The fix was suggested by @taodd:

http://tracker.ceph.com/issues/23714

It may also prevent long stalls in other fsync situations.