### PR TITLE
doc/cephfs: update kernel client quotas support info

### DIFF
--- a/doc/cephfs/quota.rst
+++ b/doc/cephfs/quota.rst
@@ -23,9 +23,12 @@ Limitations
    of data.  Generally speaking writers will be stopped within 10s of
    seconds of crossing the configured limit.
 
-#. *Quotas are not yet implemented in the kernel client.* Quotas are
-   supported by the userspace client (libcephfs, ceph-fuse) but are
-   not yet implemented in the Linux kernel client.
+#. *Quotas are implemented in the kernel client 4.17 and higher.*
+   Quotas are supported by the userspace client (libcephfs, ceph-fuse).
+   Linux kernel clients >= 4.17 support CephFS quotas but only on
+   mimic+ clusters.  Kernel clients (even recent versions) will fail
+   to handle quotas on older clusters, even if they may be able to set
+   the quotas extended attributes.
 
 #. *Quotas must be configured carefully when used with path-based
    mount restrictions.* The client needs to have access to the


### PR DESCRIPTION
Please consider updating the cephfs quotas documentation with these notes, specially if the following kernel client commit is merged into mainline:

commit e2311baa73a883eb8501c895cc817d3c96c3b896
Author: Yan, Zheng <zyan@redhat.com>
Date:   Sun Apr 8 09:54:39 2018 +0800

    ceph: check if mds create snaprealm when setting quota

    If mds does not, return -EOPNOTSUPP.
