### PR TITLE
qa/workunits/rados/test-upgrade-to-mimic.sh: fix tee output

### DIFF
--- a/qa/workunits/rados/test-upgrade-to-mimic.sh
+++ b/qa/workunits/rados/test-upgrade-to-mimic.sh
@@ -26,7 +26,8 @@ for f in \
 do
     if [ $parallel -eq 1 ]; then
 	r=`printf '%25s' $f`
-	bash -o pipefail -exc "ceph_test_rados_$f $color 2>&1 | tee ceph_test_rados_$f.log | sed \"s/^/$r: /\"" &
+	ff=`echo $f | awk '{print $1}'`
+	bash -o pipefail -exc "ceph_test_rados_$f $color 2>&1 | tee ceph_test_rados_$ff.log | sed \"s/^/$r: /\"" &
 	pid=$!
 	echo "test $f on pid $pid"
 	pids[$f]=$pid


### PR DESCRIPTION
upgade test failure was
<pre>
2018-04-18T09:31:52.450 INFO:tasks.workunit.client.1.smithi179.stderr:+ tee ceph_test_rados_api_c_read_operations --gtest_filter=-CReadOpsTest.Exec.log
2018-04-18T09:31:52.451 INFO:tasks.workunit.client.1.smithi179.stderr:tee: unrecognized option '--gtest_filter=-CReadOpsTest.Exec.log'
2018-04-18T09:31:52.451 INFO:tasks.workunit.client.1.smithi179.stderr:Try 'tee --help' for more information.
</pre>