### PR TITLE
osd: calc_min_last_complete_ondisk() should use actingset

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3134,7 +3134,7 @@ std::vector<Option> get_global_options() {
     .add_see_also("osd_pg_log_dups_tracked"),
 
     Option("osd_max_pg_log_entries", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(3000)
+    .set_default(10000)
     .set_description("maximum number of entries to maintain in the PG log when degraded before we trim")
     .add_service("osd")
     .add_see_also("osd_min_pg_log_entries")

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1345,9 +1345,9 @@ protected:
 
   bool calc_min_last_complete_ondisk() {
     eversion_t min = last_complete_ondisk;
-    assert(!acting_recovery_backfill.empty());
-    for (set<pg_shard_t>::iterator i = acting_recovery_backfill.begin();
-	 i != acting_recovery_backfill.end();
+    assert(!actingset.empty());
+    for (set<pg_shard_t>::iterator i = actingset.begin();
+	 i != actingset.end();
 	 ++i) {
       if (*i == get_primary()) continue;
       if (peer_last_complete_ondisk.count(*i) == 0)


### PR DESCRIPTION
Allow pg log to trim because min_last_complete_ondisk can advance
