### PR TITLE
luminous: MDSMonitor: initialize new Filesystem epoch from pending

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -230,6 +230,7 @@ void FSMap::create_filesystem(boost::string_view name,
                               uint64_t features)
 {
   auto fs = std::make_shared<Filesystem>();
+  fs->mds_map.epoch = epoch;
   fs->mds_map.fs_name = std::string(name);
   fs->mds_map.max_mds = 1;
   fs->mds_map.data_pools.push_back(data_pool);


### PR DESCRIPTION
http://tracker.ceph.com/issues/23791