### PR TITLE
luminous: mon/LogMonitor: do not crash on log sub w/ no messages

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -647,7 +647,7 @@ void LogMonitor::_create_sub_incremental(MLog *mlog, int level, version_t sv)
   }
 
   version_t summary_ver = summary.version;
-  while (sv <= summary_ver) {
+  while (sv && sv <= summary_ver) {
     bufferlist bl;
     int err = get_version(sv, bl);
     assert(err == 0);


### PR DESCRIPTION
If sv == 0, we will fail to fetch a value and assert out.  Skip the loop
in that case.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 9cc7e451c5cbc6961cf5a12e8d7fc335ae130b71)