### PR TITLE
mgr/dashboard: RESTController improvements

### DIFF
--- a/src/pybind/mgr/dashboard/.gitignore
+++ b/src/pybind/mgr/dashboard/.gitignore
@@ -12,6 +12,7 @@ wheelhouse*
 .vscode
 .idea
 *.egg
+.env
 
 # virtualenv
 venv

--- a/src/pybind/mgr/dashboard/.pylintrc
+++ b/src/pybind/mgr/dashboard/.pylintrc
@@ -132,7 +132,9 @@ disable=print-statement,
         no-self-use,
         too-few-public-methods,
         no-member,
-        fixme
+        fixme,
+        too-many-arguments,
+        too-many-locals
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -421,6 +421,13 @@ class RESTController(BaseController):
 
     """
 
+    # resource id parameter for using in get, set, and delete methods
+    # should be overriden by subclasses.
+    # to specify a composite id (two parameters) use '/'. e.g., "param1/param2".
+    # If subclasses don't override this property we try to infer the structure of
+    # the resourse ID.
+    RESOURCE_ID = None
+
     _method_mapping = collections.OrderedDict([
         (('GET', False), ('list', 200)),
         (('PUT', False), ('bulk_set', 200)),
@@ -428,9 +435,9 @@ class RESTController(BaseController):
         (('POST', False), ('create', 201)),
         (('DELETE', False), ('bulk_delete', 204)),
         (('GET', True), ('get', 200)),
-        (('PUT', True), ('set', 200)),
-        (('PATCH', True), ('set', 200)),
         (('DELETE', True), ('delete', 204)),
+        (('PUT', True), ('set', 200)),
+        (('PATCH', True), ('set', 200))
     ])
 
     @classmethod
@@ -458,7 +465,10 @@ class RESTController(BaseController):
             if k[1] and hasattr(cls, v[0]):
                 methods.append(k[0])
                 if not args:
-                    args = cls._parse_function_args(getattr(cls, v[0]))
+                    if cls.RESOURCE_ID is None:
+                        args = cls._parse_function_args(getattr(cls, v[0]))
+                    else:
+                        args = cls.RESOURCE_ID.split('/')
         if methods:
             result.append((methods, None, '_element', args))
 

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -26,7 +26,6 @@ class Auth(RESTController):
       |                           | seconds without activity                  |
     """
 
-    @RESTController.args_from_json
     def create(self, username, password, stay_signed_in=False):
         now = time.time()
         config_username = mgr.get_config('username', None)

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -97,7 +97,7 @@ class CephFS(BaseController):
 
         return names
 
-    # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+    # pylint: disable=too-many-statements,too-many-branches
     def fs_status(self, fs_id):
         mds_versions = defaultdict(list)
 

--- a/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
+++ b/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
@@ -36,8 +36,6 @@ class ErasureCodeProfile(RESTController):
         except KeyError:
             raise NotFound('No such erasure code profile')
 
-    # pylint: disable=too-many-arguments
-    @RESTController.args_from_json
     def create(self, name, k, m, plugin=None, ruleset_failure_domain=None, **kwargs):
         kwargs['k'] = k
         kwargs['m'] = m

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -59,8 +59,6 @@ class Pool(RESTController):
         return CephService.send_command('mon', 'osd pool delete', pool=pool_name, pool2=pool_name,
                                         sure='--yes-i-really-really-mean-it')
 
-    # pylint: disable=too-many-arguments, too-many-locals
-    @RESTController.args_from_json
     def create(self, pool, pg_num, pool_type, erasure_code_profile=None, flags=None,
                application_metadata=None, rule_name=None, **kwargs):
         ecp = erasure_code_profile if erasure_code_profile else None

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -114,6 +114,8 @@ def _sort_features(features, enable=True):
 @AuthRequired()
 class Rbd(RESTController):
 
+    RESOURCE_ID = "pool_name/image_name"
+
     # set of image features that can be enable on existing images
     ALLOW_ENABLE_FEATURES = set(["exclusive-lock", "object-map", "fast-diff",
                                  "journaling"])
@@ -353,6 +355,8 @@ class Rbd(RESTController):
 
 @ApiController('block/image/:pool_name/:image_name/snap')
 class RbdSnapshot(RESTController):
+
+    RESOURCE_ID = "snapshot_name"
 
     @RbdTask('snap/create',
              ['{pool_name}', '{image_name}', '{snapshot_name}'], 2.0)

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=too-many-arguments,too-many-locals,unused-argument,
+# pylint: disable=unused-argument
 # pylint: disable=too-many-statements,too-many-branches
 from __future__ import absolute_import
 
@@ -267,7 +267,6 @@ class Rbd(RESTController):
 
     @RbdTask('create',
              {'pool_name': '{pool_name}', 'image_name': '{name}'}, 2.0)
-    @RESTController.args_from_json
     def create(self, name, pool_name, size, obj_size=None, features=None,
                stripe_unit=None, stripe_count=None, data_pool=None):
 
@@ -294,7 +293,6 @@ class Rbd(RESTController):
         return _rbd_call(pool_name, rbd_inst.remove, image_name)
 
     @RbdTask('edit', ['{pool_name}', '{image_name}'], 4.0)
-    @RESTController.args_from_json
     def set(self, pool_name, image_name, name=None, size=None, features=None):
         def _edit(ioctx, image):
             rbd_inst = rbd.RBD()
@@ -330,7 +328,6 @@ class Rbd(RESTController):
               'dest_pool_name': '{dest_pool_name}',
               'dest_image_name': '{dest_image_name}'}, 2.0)
     @RESTController.resource(['POST'])
-    @RESTController.args_from_json
     def copy(self, pool_name, image_name, dest_pool_name, dest_image_name,
              obj_size=None, features=None, stripe_unit=None,
              stripe_count=None, data_pool=None):
@@ -360,7 +357,6 @@ class RbdSnapshot(RESTController):
 
     @RbdTask('snap/create',
              ['{pool_name}', '{image_name}', '{snapshot_name}'], 2.0)
-    @RESTController.args_from_json
     def create(self, pool_name, image_name, snapshot_name):
         def _create_snapshot(ioctx, img, snapshot_name):
             img.create_snap(snapshot_name)
@@ -379,7 +375,6 @@ class RbdSnapshot(RESTController):
 
     @RbdTask('snap/edit',
              ['{pool_name}', '{image_name}', '{snapshot_name}'], 4.0)
-    @RESTController.args_from_json
     def set(self, pool_name, image_name, snapshot_name, new_snap_name=None,
             is_protected=None):
         def _edit(ioctx, img, snapshot_name):
@@ -410,7 +405,6 @@ class RbdSnapshot(RESTController):
               'child_pool_name': '{child_pool_name}',
               'child_image_name': '{child_image_name}'}, 2.0)
     @RESTController.resource(['POST'])
-    @RESTController.args_from_json
     def clone(self, pool_name, image_name, snapshot_name, child_pool_name,
               child_image_name, obj_size=None, features=None,
               stripe_unit=None, stripe_count=None, data_pool=None):

--- a/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
@@ -11,7 +11,7 @@ SERVICE_TYPE = 'tcmu-runner'
 @ApiController('tcmuiscsi')
 @AuthRequired()
 class TcmuIscsi(RESTController):
-    # pylint: disable=too-many-locals,too-many-nested-blocks
+    # pylint: disable=too-many-nested-blocks
     def list(self):  # pylint: disable=unused-argument
         daemons = {}
         images = {}

--- a/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
+++ b/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
@@ -14,32 +14,27 @@ class TaskTest(RESTController):
     sleep_time = 0.0
 
     @Task('task/create', {'param': '{param}'}, wait_for=1.0)
-    @RESTController.args_from_json
     def create(self, param):
         time.sleep(TaskTest.sleep_time)
         return {'my_param': param}
 
     @Task('task/set', {'param': '{2}'}, wait_for=1.0)
-    @RESTController.args_from_json
     def set(self, key, param=None):
         time.sleep(TaskTest.sleep_time)
         return {'key': key, 'my_param': param}
 
     @Task('task/delete', ['{key}'], wait_for=1.0)
-    @RESTController.args_from_json
     def delete(self, key):
         # pylint: disable=unused-argument
         time.sleep(TaskTest.sleep_time)
 
     @Task('task/foo', ['{param}'])
     @RESTController.collection(['POST'])
-    @RESTController.args_from_json
     def foo(self, param):
         return {'my_param': param}
 
     @Task('task/bar', ['{key}', '{param}'])
     @RESTController.resource(['PUT'])
-    @RESTController.args_from_json
     def bar(self, key, param=None):
         return {'my_param': param, 'key': key}
 

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -19,9 +19,9 @@ class FooResource(RESTController):
     def list(self):
         return FooResource.elems
 
-    def create(self, data):
-        FooResource.elems.append(data)
-        return data
+    def create(self, a):
+        FooResource.elems.append({'a': a})
+        return {'a': a}
 
     def get(self, key):
         return {'detail': (key, [])}
@@ -32,9 +32,9 @@ class FooResource(RESTController):
     def bulk_delete(self):
         FooResource.elems = []
 
-    def set(self, key, data):
-        FooResource.elems[int(key)] = data
-        return dict(key=key, **data)
+    def set(self, key, newdata):
+        FooResource.elems[int(key)] = {'newdata': newdata}
+        return dict(key=key, newdata=newdata)
 
 
 @ApiController('foo/:key/:method')
@@ -45,7 +45,6 @@ class FooResourceDetail(RESTController):
 
 @ApiController('fooargs')
 class FooArgs(RESTController):
-    @RESTController.args_from_json
     def set(self, code, name=None, opt1=None, opt2=None):
         return {'code': code, 'name': name, 'opt1': opt1, 'opt2': opt2}
 


### PR DESCRIPTION
This PR introduces two improvements to the RESTController class:

* explicit resource ID specification: this allows to override the resource ID inference algorithm by explicitly specifying the resource ID structure.
* removed `@args_from_json` decorator: all `create` and `set` methods now receive the POST/PUT body params as method named params.

Signed-off-by: Ricardo Dias <rdias@suse.com>