### PR TITLE
common/strtol: fix strict_strtoll() so it accepts hex starting with 0x

### DIFF
--- a/src/test/cli/monmaptool/feature-set-unset-list.t
+++ b/src/test/cli/monmaptool/feature-set-unset-list.t
@@ -28,7 +28,7 @@
   available:persistent:[kraken(1),luminous(2),mimic(4),osdmap-prune(8)]
 
   $ monmaptool --feature-set foo /tmp/test.monmap.1234
-  unknown features name 'foo' or unable to parse value: The option value 'foo' contains invalid digits
+  unknown features name 'foo' or unable to parse value: Expected option value to be integer, got 'foo'
    usage: [--print] [--create [--clobber][--fsid uuid]]
           [--generate] [--set-initial-members]
           [--add name 1.2.3.4:567] [--rm name]


### PR DESCRIPTION
- simplify the error handling of strtoll().
- only instantiate ostringstream when handling errors.

Signed-off-by: Kefu Chai <kchai@redhat.com>