### PR TITLE
rbd: fix snapshot unprotect hang

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -507,7 +507,7 @@ CEPH_RBD_API int rbd_snap_protect(rbd_image_t image, const char *snap_name);
  * @returns 0 on success, negative error code on failure
  * @returns -EINVAL if snap is not protected
  */
-CEPH_RBD_API int rbd_snap_unprotect(rbd_image_t image, const char *snap_name);
+CEPH_RBD_API int rbd_snap_unprotect(rbd_image_t image, const char *snap_name, bool force_unprotect);
 /**
  * Determine whether a snapshot is protected.
  *

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -378,7 +378,7 @@ public:
   int snap_rollback(const char *snap_name);
   int snap_rollback_with_progress(const char *snap_name, ProgressContext& pctx);
   int snap_protect(const char *snap_name);
-  int snap_unprotect(const char *snap_name);
+  int snap_unprotect(const char *snap_name, bool force_unprotect = false);
   int snap_is_protected(const char *snap_name, bool *is_protected);
   int snap_set(const char *snap_name);
   int snap_set_by_id(uint64_t snap_id);

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -81,10 +81,10 @@ public:
 			    Context *on_finish);
 
   int snap_unprotect(const cls::rbd::SnapshotNamespace& snap_namespace,
-		     const std::string& snap_name);
+		     const std::string& snap_name, bool force_unprotect = false);
   void execute_snap_unprotect(const cls::rbd::SnapshotNamespace& snap_namespace,
 			      const std::string &snap_name,
-			      Context *on_finish);
+			      Context *on_finish, bool force_unprotect = false);
 
   int snap_set_limit(uint64_t limit);
   void execute_snap_set_limit(uint64_t limit, Context *on_finish);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1546,11 +1546,11 @@ namespace librbd {
     return r;
   }
 
-  int Image::snap_unprotect(const char *snap_name)
+  int Image::snap_unprotect(const char *snap_name, bool force_unprotect)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, snap_unprotect_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, snap_name);
-    int r = ictx->operations->snap_unprotect(cls::rbd::UserSnapshotNamespace(), snap_name);
+    int r = ictx->operations->snap_unprotect(cls::rbd::UserSnapshotNamespace(), snap_name, force_unprotect);
     tracepoint(librbd, snap_unprotect_exit, r);
     return r;
   }
@@ -3532,11 +3532,11 @@ extern "C" int rbd_snap_protect(rbd_image_t image, const char *snap_name)
   return r;
 }
 
-extern "C" int rbd_snap_unprotect(rbd_image_t image, const char *snap_name)
+extern "C" int rbd_snap_unprotect(rbd_image_t image, const char *snap_name, bool force_unprotect)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   tracepoint(librbd, snap_unprotect_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, snap_name);
-  int r = ictx->operations->snap_unprotect(cls::rbd::UserSnapshotNamespace(), snap_name);
+  int r = ictx->operations->snap_unprotect(cls::rbd::UserSnapshotNamespace(), snap_name, force_unprotect);
   tracepoint(librbd, snap_unprotect_exit, r);
   return r;
 }

--- a/src/librbd/operation/SnapshotUnprotectRequest.h
+++ b/src/librbd/operation/SnapshotUnprotectRequest.h
@@ -51,7 +51,7 @@ public:
 
   SnapshotUnprotectRequest(ImageCtxT &image_ctx, Context *on_finish,
 		           const cls::rbd::SnapshotNamespace &snap_namespace,
-			   const std::string &snap_name);
+			   const std::string &snap_name, bool force_unprotect = false);
 
 protected:
   void send_op() override;
@@ -75,6 +75,7 @@ private:
 
   int m_ret_val;
   uint64_t m_snap_id;
+  bool m_force_unprotect;
 
   bool should_complete_error();
 

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -25,6 +25,7 @@ from libc.string cimport strdup
 
 from collections import Iterable
 from datetime import datetime
+from cpython cimport bool
 
 cimport rados
 
@@ -321,7 +322,7 @@ cdef extern from "rbd/librbd.h" nogil:
     int rbd_snap_rename(rbd_image_t image, const char *snapname,
                         const char* dstsnapsname)
     int rbd_snap_protect(rbd_image_t image, const char *snap_name)
-    int rbd_snap_unprotect(rbd_image_t image, const char *snap_name)
+    int rbd_snap_unprotect(rbd_image_t image, const char *snap_name, bool force_unprotect)
     int rbd_snap_is_protected(rbd_image_t image, const char *snap_name,
                               int *is_protected)
     int rbd_snap_get_limit(rbd_image_t image, uint64_t *limit)
@@ -2424,7 +2425,7 @@ cdef class Image(object):
         if ret != 0:
             raise make_ex(ret, 'error protecting snapshot %s@%s' % (self.name, name))
 
-    def unprotect_snap(self, name):
+    def unprotect_snap(self, name, force_unprotect):
         """
         Mark a snapshot unprotected. This allows it to be deleted if
         it was protected.
@@ -2435,8 +2436,9 @@ cdef class Image(object):
         """
         name = cstr(name, 'name')
         cdef char *_name = name
+        cdef bool _force_unprotect = force_unprotect
         with nogil:
-            ret = rbd_snap_unprotect(self.image, _name)
+            ret = rbd_snap_unprotect(self.image, _name, _force_unprotect)
         if ret != 0:
             raise make_ex(ret, 'error unprotecting snapshot %s@%s' % (self.name, name))
 

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -804,7 +804,7 @@ __librbd_deep_copy(struct rbd_ctx *ctx, const char *src_snapname,
 		return ret;
 	}
 
-	ret = rbd_snap_unprotect(image, src_snapname);
+	ret = rbd_snap_unprotect(image, src_snapname, false);
 	if (ret < 0) {
 		prt("rbd_snap_unprotect(%s@%s) failed\n", dst_imagename,
 		    src_snapname);
@@ -2969,7 +2969,7 @@ void remove_image(rados_ioctx_t ioctx, char *imagename, bool remove_snap,
 		report_failure(101);
 	}
 	if (remove_snap) {
-		if ((ret = rbd_snap_unprotect(image, "snap")) < 0) {
+		if ((ret = rbd_snap_unprotect(image, "snap", false)) < 0) {
 			sprintf(errmsg, "rbd_snap_unprotect %s@snap",
 				imagename);
 			prterrcode(errmsg, ret);

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -2918,7 +2918,7 @@ TEST_F(TestLibRBD, TestClone)
                                  ioctx, child_name.c_str(), features, &order));
 
   // unprotected image should fail unprotect
-  ASSERT_EQ(-EINVAL, rbd_snap_unprotect(parent, "parent_snap"));
+  ASSERT_EQ(-EINVAL, rbd_snap_unprotect(parent, "parent_snap", false));
   printf("can't unprotect an unprotected snap\n");
 
   ASSERT_EQ(0, rbd_snap_protect(parent, "parent_snap"));
@@ -3002,7 +3002,7 @@ TEST_F(TestLibRBD, TestClone)
   ASSERT_EQ(0, rbd_remove(ioctx, child_name.c_str()));
   ASSERT_EQ(-EBUSY, rbd_snap_remove(parent, "parent_snap"));
   printf("can't remove parent while still protected\n");
-  ASSERT_EQ(0, rbd_snap_unprotect(parent, "parent_snap"));
+  ASSERT_EQ(0, rbd_snap_unprotect(parent, "parent_snap", false));
   ASSERT_EQ(0, rbd_snap_remove(parent, "parent_snap"));
   printf("removed parent snap after unprotecting\n");
 
@@ -3371,7 +3371,7 @@ TEST_F(TestLibRBD, ListChildren)
   test_list_children(parent, 0);
   test_list_children2(parent, 0);
 
-  ASSERT_EQ(0, rbd_snap_unprotect(parent, "parent_snap"));
+  ASSERT_EQ(0, rbd_snap_unprotect(parent, "parent_snap", false));
   ASSERT_EQ(0, rbd_snap_remove(parent, "parent_snap"));
   ASSERT_EQ(0, rbd_close(parent));
   ASSERT_EQ(0, rbd_remove(ioctx1, parent_name.c_str()));
@@ -3555,7 +3555,7 @@ TEST_F(TestLibRBD, ListChildrenTiered)
   test_list_children(parent, 0);
   test_list_children2(parent, 0);
 
-  ASSERT_EQ(0, rbd_snap_unprotect(parent, "parent_snap"));
+  ASSERT_EQ(0, rbd_snap_unprotect(parent, "parent_snap", false));
   ASSERT_EQ(0, rbd_snap_remove(parent, "parent_snap"));
   ASSERT_EQ(0, rbd_close(parent));
   ASSERT_EQ(0, rbd_remove(ioctx1, parent_name.c_str()));

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -367,6 +367,11 @@ void add_export_format_option(boost::program_options::options_description *opt) 
     ("export-format", po::value<ExportFormat>(), "format of image file");
 }
 
+void add_force_option(boost::program_options::options_description *opt) {
+  opt->add_options()
+    (FORCE.c_str(), po::bool_switch(), "force to operate");
+}
+
 std::string get_short_features_help(bool append_suffix) {
   std::ostringstream oss;
   bool first_feature = true;

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -86,6 +86,8 @@ static const std::string NO_ERROR("no-error");
 
 static const std::string LIMIT("limit");
 
+static const std::string FORCE("force");
+
 static const std::set<std::string> SWITCH_ARGUMENTS = {
   WHOLE_OBJECT, NO_PROGRESS, PRETTY_FORMAT, VERBOSE, NO_ERROR};
 
@@ -204,6 +206,8 @@ void add_format_options(boost::program_options::options_description *opt);
 void add_verbose_option(boost::program_options::options_description *opt);
 
 void add_no_error_option(boost::program_options::options_description *opt);
+
+void add_force_option(boost::program_options::options_description *opt);
 
 std::string get_short_features_help(bool append_suffix);
 std::string get_long_features_help();


### PR DESCRIPTION
Currently, when do snapshot unprotect, it will query all the other pools to check if there are some clones dependent on this snapshot. If for some reason, for example, pg inactive, the rbd_children object in some pool could not be accessed, the unprotect operation will hang. That is not elegant, since the snapshot could not be unprotected, and as a result, the volume could not be deleted, even the snapshot is independent on the inaccessible pool. This patch adds an option to allow skip querying other pools when unprotecting snapshot