### PR TITLE
mgr/dashboard: Display RBD form errors on submission

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -296,7 +296,7 @@
       </div>
       <div class="panel-footer">
         <div class="button-group text-right">
-          <cd-submit-button [form]="rbdForm"
+          <cd-submit-button [form]="formDir"
                             type="button"
                             (submitAction)="submit()">
             <span i18n>{editing, select, 1 {Update} other {Create}}</span> RBD

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.html
@@ -1,7 +1,7 @@
 <button [type]="type"
         class="btn btn-sm btn-primary tc_submitButton"
         [disabled]="loading"
-        (click)="submit()">
+        (click)="submit($event)">
   <ng-content></ng-content>
   <span *ngIf="loading">
     <i class="fa fa-spinner fa-spin fa-fw"></i>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.ts
@@ -1,5 +1,5 @@
 import { Component, ElementRef, EventEmitter, Input, OnInit, Output } from '@angular/core';
-import { FormGroup } from '@angular/forms';
+import { AbstractControl, FormGroup, FormGroupDirective, NgForm } from '@angular/forms';
 
 import * as _ from 'lodash';
 
@@ -27,7 +27,7 @@ import * as _ from 'lodash';
   styleUrls: ['./submit-button.component.scss']
 })
 export class SubmitButtonComponent implements OnInit {
-  @Input() form: FormGroup;
+  @Input() form: FormGroup | NgForm;
   @Input() type = 'submit';
   @Output() submitAction = new EventEmitter();
 
@@ -40,13 +40,21 @@ export class SubmitButtonComponent implements OnInit {
       if (_.has(this.form.errors, 'cdSubmitButton')) {
         this.loading = false;
         _.unset(this.form.errors, 'cdSubmitButton');
-        this.form.updateValueAndValidity();
+         // Handle Reactive forms.
+        if (this.form instanceof AbstractControl) {
+          (<AbstractControl>this.form).updateValueAndValidity();
+        }
       }
     });
   }
 
-  submit() {
+  submit($event) {
     this.focusButton();
+
+    // Special handling for Template driven forms.
+    if (this.form instanceof FormGroupDirective) {
+      (<FormGroupDirective>this.form).onSubmit($event);
+    }
 
     if (this.form.invalid) {
       this.focusInvalid();


### PR DESCRIPTION
If we try to submit an RBD form with validation errors, the form is not submitted but the validation errors are not displayed to the user (only happen for fields not touched by the user).

This PR fixes this behaviour.