### PR TITLE
mon: cache encoded osdmaps for older clients

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2059,8 +2059,13 @@ bool OSDMonitor::preprocess_get_osdmap(MonOpRequestRef op)
 {
   op->mark_osdmon_event(__func__);
   MMonGetOSDMap *m = static_cast<MMonGetOSDMap*>(op->get_req());
+
+  uint64_t features = mon->get_quorum_con_features();
+  if (m->get_session() && m->get_session()->con_features)
+    features = m->get_session()->con_features;
+
   dout(10) << __func__ << " " << *m << dendl;
-  MOSDMap *reply = new MOSDMap(mon->monmap->fsid);
+  MOSDMap *reply = new MOSDMap(mon->monmap->fsid, features);
   epoch_t first = get_first_committed();
   epoch_t last = osdmap.get_epoch();
   int max = g_conf->osd_map_message_max;
@@ -3346,7 +3351,7 @@ void OSDMonitor::send_latest(MonOpRequestRef op, epoch_t start)
 
 MOSDMap *OSDMonitor::build_latest_full(uint64_t features)
 {
-  MOSDMap *r = new MOSDMap(mon->monmap->fsid);
+  MOSDMap *r = new MOSDMap(mon->monmap->fsid, features);
   get_version_full(osdmap.get_epoch(), features, r->maps[osdmap.get_epoch()]);
   r->oldest_map = get_first_committed();
   r->newest_map = osdmap.get_epoch();
@@ -3356,7 +3361,7 @@ MOSDMap *OSDMonitor::build_latest_full(uint64_t features)
 MOSDMap *OSDMonitor::build_incremental(epoch_t from, epoch_t to, uint64_t features)
 {
   dout(10) << "build_incremental [" << from << ".." << to << "] with features " << std::hex << features << dendl;
-  MOSDMap *m = new MOSDMap(mon->monmap->fsid);
+  MOSDMap *m = new MOSDMap(mon->monmap->fsid, features);
   m->oldest_map = get_first_committed();
   m->newest_map = osdmap.get_epoch();
 
@@ -3432,7 +3437,7 @@ void OSDMonitor::send_incremental(epoch_t first,
   }
 
   if (first < get_first_committed()) {
-    MOSDMap *m = new MOSDMap(osdmap.get_fsid());
+    MOSDMap *m = new MOSDMap(osdmap.get_fsid(), features);
     m->oldest_map = get_first_committed();
     m->newest_map = osdmap.get_epoch();
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -358,8 +358,8 @@ private:
   bool can_mark_in(int o);
 
   // ...
-  MOSDMap *build_latest_full();
-  MOSDMap *build_incremental(epoch_t first, epoch_t last);
+  MOSDMap *build_latest_full(uint64_t features);
+  MOSDMap *build_incremental(epoch_t first, epoch_t last, uint64_t features);
   void send_full(MonOpRequestRef op);
   void send_incremental(MonOpRequestRef op, epoch_t first);
 public:

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -42,20 +42,9 @@ class MOSDMap;
 
 #include "erasure-code/ErasureCodeInterface.h"
 #include "mon/MonOpRequest.h"
-//#include <boost/function.hpp>
-//#include <boost/functional/hash.hpp>
-
-namespace std
-{
-  template<>
-    struct hash<pair<version_t, uint64_t>> {
-      size_t operator()(const pair<version_t, uint64_t>& p) const {
-        size_t seed = hash<version_t>{}(p.first); {}
-        seed ^= hash<uint64_t>{}(p.second) + 0x9e3779b9 + (seed<<6) + (seed>>2);
-        return seed;
-      }
-    };
-};
+#include <boost/functional/hash.hpp>
+// re-include our assert to clobber the system one; fix dout:
+#include "include/assert.h"
 
 /// information about a particular peer's failure reports for one osd
 struct failure_reporter_t {
@@ -237,7 +226,7 @@ public:
   using osdmap_cache_t = SimpleLRU<osdmap_key_t,
                                    bufferlist,
                                    std::less<osdmap_key_t>,
-                                   std::hash<osdmap_key_t>>;
+                                   boost::hash<osdmap_key_t>>;
   osdmap_cache_t inc_osd_cache;
   osdmap_cache_t full_osd_cache;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1300,7 +1300,8 @@ void OSDService::got_stop_ack()
 MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
                                                OSDSuperblock& sblock)
 {
-  MOSDMap *m = new MOSDMap(monc->get_fsid(), osdmap->get_features(entity_name_t::TYPE_OSD, NULL));
+  MOSDMap *m = new MOSDMap(monc->get_fsid(),
+                    osdmap->get_features(entity_name_t::TYPE_OSD, NULL));
   m->oldest_map = max_oldest_map;
   m->newest_map = sblock.newest_map;
 
@@ -1340,7 +1341,8 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
     OSDSuperblock sblock(get_superblock());
     if (since < sblock.oldest_map) {
       // just send latest full map
-      MOSDMap *m = new MOSDMap(monc->get_fsid(), osdmap->get_features(entity_name_t::TYPE_OSD, NULL));
+      MOSDMap *m = new MOSDMap(monc->get_fsid(),
+                            osdmap->get_features(entity_name_t::TYPE_OSD, NULL));
       m->oldest_map = max_oldest_map;
       m->newest_map = sblock.newest_map;
       get_map_bl(to, m->maps[to]);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1300,7 +1300,7 @@ void OSDService::got_stop_ack()
 MOSDMap *OSDService::build_incremental_map_msg(epoch_t since, epoch_t to,
                                                OSDSuperblock& sblock)
 {
-  MOSDMap *m = new MOSDMap(monc->get_fsid());
+  MOSDMap *m = new MOSDMap(monc->get_fsid(), osdmap->get_features(entity_name_t::TYPE_OSD, NULL));
   m->oldest_map = max_oldest_map;
   m->newest_map = sblock.newest_map;
 
@@ -1340,7 +1340,7 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
     OSDSuperblock sblock(get_superblock());
     if (since < sblock.oldest_map) {
       // just send latest full map
-      MOSDMap *m = new MOSDMap(monc->get_fsid());
+      MOSDMap *m = new MOSDMap(monc->get_fsid(), osdmap->get_features(entity_name_t::TYPE_OSD, NULL));
       m->oldest_map = max_oldest_map;
       m->newest_map = sblock.newest_map;
       get_map_bl(to, m->maps[to]);

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -507,6 +507,14 @@ private:
   int32_t max_osd;
   vector<uint32_t> osd_state;
 
+  static constexpr uint64_t SIGNIFICANT_FEATURES =
+            CEPH_FEATUREMASK_PGID64 |
+            CEPH_FEATUREMASK_PGPOOL3 |
+            CEPH_FEATUREMASK_OSDENC |
+            CEPH_FEATUREMASK_OSDMAP_ENC |
+            CEPH_FEATUREMASK_MSG_ADDR2 |
+            CEPH_FEATUREMASK_SERVER_LUMINOUS;
+
   struct addrs_s {
     mempool::osdmap::vector<ceph::shared_ptr<entity_addr_t> > client_addr;
     mempool::osdmap::vector<ceph::shared_ptr<entity_addr_t> > cluster_addr;
@@ -598,6 +606,10 @@ private:
   OSDMap(const OSDMap& other) = default;
   OSDMap& operator=(const OSDMap& other) = default;
 public:
+
+  static uint64_t get_significant_features(uint64_t features) {
+    return SIGNIFICANT_FEATURES & features;
+  }
 
   void deepish_copy_from(const OSDMap& o) {
     *this = o;


### PR DESCRIPTION
By caching the backward-compatible encoded osdmap into LRUCache