### PR TITLE
MDSMonitor: do not wipe old_max_mds when marked down twice

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -389,8 +389,10 @@ public:
           [is_down](std::shared_ptr<Filesystem> fs)
       {
 	if (is_down) {
-	  fs->mds_map.set_old_max_mds();
-	  fs->mds_map.set_max_mds(0);
+          if (fs->mds_map.get_max_mds() > 0) {
+	    fs->mds_map.set_old_max_mds();
+	    fs->mds_map.set_max_mds(0);
+          } /* else already down! */
 	} else {
 	  mds_rank_t oldmax = fs->mds_map.get_old_max_mds();
 	  fs->mds_map.set_max_mds(oldmax ? oldmax : 1);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23800

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>