### PR TITLE
auth: switch CryptoKey to OpenSSL and extend it with no-bl encrypt/decrypt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,9 +341,12 @@ CHECK_SYMBOL_EXISTS(curl_multi_wait curl/curl.h HAVE_CURL_MULTI_WAIT)
 
 find_package(NSS REQUIRED)
 find_package(NSPR REQUIRED)
+find_package(OpenSSL REQUIRED)
+# TODO: use NSS only for validation of the OpenSSL-based implementations
 set(USE_NSS 1)
-set(CRYPTO_LIBS ${NSS_LIBRARIES} ${NSPR_LIBRARIES})
-set(SSL_LIBRARIES ${NSS_LIBRARIES})
+set(USE_OPENSSL 1)
+set(CRYPTO_LIBS ${NSS_LIBRARIES} ${NSPR_LIBRARIES} ${OPENSSL_LIBRARIES})
+set(SSL_LIBRARIES ${NSS_LIBRARIES} ${OPENSSL_LIBRARIES})
 
 option(WITH_XIO "Enable XIO messaging" OFF)
 if(WITH_XIO)

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -11,7 +11,10 @@
  * 
  */
 
+#include <array>
 #include <sstream>
+#include <limits>
+
 #include "Crypto.h"
 #ifdef USE_OPENSSL
 # include <openssl/aes.h>
@@ -184,8 +187,8 @@ public:
 
 #ifdef USE_OPENSSL
 // when we say AES, we mean AES-128
-# define AES_KEY_LEN	16
-# define AES_BLOCK_LEN   16
+static constexpr const std::size_t AES_KEY_LEN{16};
+static constexpr const std::size_t AES_BLOCK_LEN{16};
 
 class CryptoAESKeyHandler : public CryptoKeyHandler {
   AES_KEY enc_key;
@@ -227,8 +230,8 @@ public:
     // To exemplify:
     //   16 + p2align(10, 16) -> 16
     //   16 + p2align(16, 16) -> 32 including 16 bytes for padding.
-    ceph::bufferptr out_tmp{
-      AES_BLOCK_LEN + p2align(in.length(), AES_BLOCK_LEN)};
+    ceph::bufferptr out_tmp{static_cast<unsigned>(
+      AES_BLOCK_LEN + p2align(in.length(), AES_BLOCK_LEN))};
 
     // let's pad the data
     std::uint8_t pad_len = out_tmp.length() - in.length();
@@ -292,11 +295,71 @@ public:
 
   std::size_t encrypt(const in_slice_t& in,
 		      const out_slice_t& out) const override {
-    return 0;
+    if (out.buf == nullptr) {
+      // 16 + p2align(10, 16) -> 16
+      // 16 + p2align(16, 16) -> 32
+      const std::size_t needed = \
+        AES_BLOCK_LEN + p2align(in.length, AES_BLOCK_LEN);
+      return needed;
+    }
+
+    // how many bytes of in.buf hang outside the alignment boundary and how
+    // much padding we need.
+    //   length = 23 -> tail_len = 7, pad_len = 9
+    //   length = 32 -> tail_len = 0, pad_len = 16
+    const std::uint8_t tail_len = in.length % AES_BLOCK_LEN;
+    const std::uint8_t pad_len = AES_BLOCK_LEN - tail_len;
+    static_assert(std::numeric_limits<std::uint8_t>::max() > AES_BLOCK_LEN);
+
+    std::array<unsigned char, AES_BLOCK_LEN> last_block;
+    memcpy(last_block.data(), in.buf + in.length - tail_len, tail_len);
+    memset(last_block.data() + tail_len, pad_len, pad_len);
+
+    // need a local copy because AES_cbc_encrypt takes `iv` as non-const.
+    // Useful because it allows us to encrypt in two steps: main + tail.
+    static_assert(strlen_ct(CEPH_AES_IV) == AES_BLOCK_LEN);
+    std::array<unsigned char, AES_BLOCK_LEN> iv;
+    memcpy(iv.data(), CEPH_AES_IV, AES_BLOCK_LEN);
+
+    const std::size_t main_encrypt_size = \
+      std::min(in.length - tail_len, out.max_length);
+    AES_cbc_encrypt(in.buf, out.buf, main_encrypt_size, &enc_key, iv.data(),
+		    AES_ENCRYPT);
+
+    const std::size_t tail_encrypt_size = \
+      std::min(AES_BLOCK_LEN, out.max_length - main_encrypt_size);
+    AES_cbc_encrypt(last_block.data(), out.buf + main_encrypt_size,
+		    tail_encrypt_size, &enc_key, iv.data(), AES_ENCRYPT);
+
+    return main_encrypt_size + tail_encrypt_size;
   }
+
   std::size_t decrypt(const in_slice_t& in,
 		      const out_slice_t& out) const override {
-    return 0;
+    if (in.length % AES_BLOCK_LEN != 0 || in.length < AES_BLOCK_LEN) {
+      throw std::runtime_error("input not aligned to AES_BLOCK_LEN");
+    } else if (out.buf == nullptr) {
+      // essentially it would be possible to decrypt into a buffer that
+      // doesn't include space for any PKCS#7 padding. We don't do that
+      // for the sake of performance and simplicity.
+      return in.length;
+    } else if (out.max_length < in.length) {
+      throw std::runtime_error("output buffer too small");
+    }
+
+    static_assert(strlen_ct(CEPH_AES_IV) == AES_BLOCK_LEN);
+    std::array<unsigned char, AES_BLOCK_LEN> iv;
+    memcpy(iv.data(), CEPH_AES_IV, AES_BLOCK_LEN);
+
+    AES_cbc_encrypt(in.buf, out.buf, in.length, &dec_key, iv.data(),
+		    AES_DECRYPT);
+
+    // NOTE: we aren't handling partial decrypt. PKCS#7 padding must be
+    // at the end. If it's malformed, don't say a word to avoid risk of
+    // having an oracle. All we need to ensure is valid buffer boundary.
+    const auto pad_len = \
+      std::min<std::uint8_t>(out.buf[in.length - 1], AES_BLOCK_LEN);
+    return in.length - pad_len;
   }
 };
 
@@ -318,7 +381,7 @@ int CryptoAES::create(CryptoRandom *random, bufferptr& secret)
 
 int CryptoAES::validate_secret(const bufferptr& secret)
 {
-  if (secret.length() < (size_t)AES_KEY_LEN) {
+  if (secret.length() < AES_KEY_LEN) {
     return -EINVAL;
   }
 

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -135,9 +135,9 @@ static int nss_aes_operation(
 			     const bufferlist& in, bufferlist& out,
 			     std::string *error)
 {
-  // sample source said this has to be at least size of input + 8,
-  // but i see 15 still fail with SEC_ERROR_OUTPUT_LEN
-  bufferptr out_tmp(in.length()+16);
+  // we are using CEPH_AES_IV for the IV param, so take it into consideration.
+  bufferptr out_tmp{round_up_to(in.length() + sizeof(CEPH_AES_IV),
+                                AES_BLOCK_LEN)};
   bufferlist incopy;
 
   SECStatus ret;

--- a/src/auth/cephx/CephxSessionHandler.cc
+++ b/src/auth/cephx/CephxSessionHandler.cc
@@ -45,17 +45,26 @@ int CephxSessionHandler::_calc_signature(Message *m, uint64_t *psig)
     mswab<uint32_t>(header.crc), mswab<uint32_t>(footer.front_crc),
     mswab<uint32_t>(footer.middle_crc), mswab<uint32_t>(footer.data_crc)
   };
-  bufferlist bl_plaintext;
-  bl_plaintext.append(buffer::create_static(sizeof(sigblock), (char*)&sigblock));
 
-  bufferlist bl_ciphertext;
-  if (key.encrypt(cct, bl_plaintext, bl_ciphertext, NULL) < 0) {
+  char exp_buf[CryptoKey::get_max_outbuf_size(sizeof(sigblock))];
+
+  try {
+    const CryptoKey::in_slice_t in {
+      sizeof(sigblock),
+      reinterpret_cast<const unsigned char*>(&sigblock)
+    };
+    const CryptoKey::out_slice_t out {
+      sizeof(exp_buf),
+      reinterpret_cast<unsigned char*>(&exp_buf)
+    };
+
+    key.encrypt(cct, in, out);
+  } catch (std::exception& e) {
     lderr(cct) << __func__ << " failed to encrypt signature block" << dendl;
     return -1;
   }
 
-  auto ci = bl_ciphertext.cbegin();
-  decode(*psig, ci);
+  *psig = *reinterpret_cast<__le64*>(exp_buf);
 
   ldout(cct, 10) << __func__ << " seq " << m->get_seq()
 		 << " front_crc_ = " << footer.front_crc

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -126,6 +126,9 @@
 /* Define if using NSS. */
 #cmakedefine USE_NSS
 
+/* Define if using OpenSSL. */
+#cmakedefine USE_OPENSSL
+
 /* Accelio conditional compilation */
 #cmakedefine HAVE_XIO
 

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -199,6 +199,8 @@ TEST(AES, ValidateLegacy) {
   ASSERT_EQ(plaintext, restored_plaintext);
 }
 
+#else
+# warning "NSS is not available. Skipping the AES.ValidateLegacy testcase!"
 #endif // USE_NSS
 
 TEST(AES, ValidateSecret) {


### PR DESCRIPTION
Summary
=======

This pull request tries to deal with the overhead of `CephxSessionHandler` that severely impact the `async messanger` performance on my box. It extends #21537 with eradication of the `ceph::bufferlist` on its very hot `CryptoKey::encrypt` path. This definitely requires refination (plenty of `FIXME` at the moment) and further discussion about a new interface.

I believe there is still a lot to squeeze. Even with reusing the `PK11Context` many resources (not only pure CPU cycles; I saw critical sections which makes me curious about a scenario with many `msgr-worker` threads) is spent in `libnss` on things that don't look like crypto crunching. This directs my thinking towards bigger `CephxSessionHandler`/`CryptoAESKeyHandler` rework.

**UPDATE**: Kefu has already tried reusing `PK11Context`. It's not thread safe. Bigger rework looks necessary.

**UPDATE2**: the simplest, fastest and safest can be skip the PKCS#11 abstraction and go directly to the NSS's freebl API (`blapi.h`, `blapit.h`) for things like `AES_Encrypt`. That's why:

```
                              - 0,99% PK11_CipherOp                                                                                                                                                          ▒
                                 - 0,81% NSC_EncryptUpdate                                                                                                                                                   ▒
                                    - 0,50% sftk_GetContext                                                                                                                                                  ▒
                                       - 0,30% sftk_SessionFromHandle                                                                                                                                        ▒
                                          + 0,09% sftk_SlotFromID                                                                                                                                            ▒
                                          + 0,08% PR_Lock                                                                                                                                                    ▒
                                          + 0,07% PR_Unlock                                                                                                                                                  ▒
                                            0,02% sftk_SlotFromSessionHandle                                                                                                                                 ▒
                                       + 0,09% sftk_FreeSession                                                                                                                                              ▒
                                       - 0,08% PR_Unlock                                                                                                                                                     ▒
                                            pthread_mutex_unlock                                                                                                                                             ▒
                                         0,01% sftk_ReturnContextByType                                                                                                                                      ▒
                                      0,16% AES_Decrypt.localalias.3                                                                                                                                         ▒
                                      0,04% AES_Encrypt                                                                                                                                                      ▒
                                      0,01% __memcpy_avx_unaligned   
```
**Beware**: on my machine `PK11_CipherOp` is small part of the NSS overhead, for full picture please consult the profiling section.

**UPDATE3** (Fri, 20 Apr 2018 17:41:54 +0000): it appears NSS is just a very costly library for doing simple crypto. This applies even to its lower-layer bits (`freebl`):
```
-    1,54%     0,10%  msgr-worker-0  libfreeblpriv3.so  [.] AES_CreateContext  ▒
   - 1,44% AES_CreateContext                                                   ▒
      - 1,00% PORT_ZAlloc_Util                                                 ◆
         + 0,98% tc_calloc                                                     ▒
           0,01% PR_Calloc                                                     ▒
        0,22% AES_InitContext                                                  ▒
        0,20% PORT_ZAlloc_stub                                                 ▒
        0,02% AES_AllocateContext                                              
```

While the real crunching is:
```
+    0,09%     0,09%  msgr-worker-0  libfreeblpriv3.so  [.] AES_Encrypt
```

I would assume we'll need to recreate the context each time. Moreover, accessing the `libfreebl3`/headers looks awfully cumbersome: an extra loader + private gizmos. Maybe let's treat NSS just as a fallback and, for typical case, go with e.g. Intel's `isa-l_crypto` we already have in the tree? There are even helpers in type of `ISALCryptoAccel` that were made because of the encryption feature in RadosGW. I'm researching this possibility.

**UPDATE4** (Fri, 20 Apr 2018 20:10:06 +0000): with the very dirty hack for replacing `PK11` with `isal_crypto` the overhead of Cephx is almost gone. Added a new chapter with results to the *Performance comparison & profiling* section. I guess we'll need to find an elegant way for keeping NSS as a fallback.

**UPDATE5** (Mon, 23 Apr 2018 17:57:02 +0000): gave a try to OpenSSL. Its lower layers are easily accessible and offer pretty decent performance. Added a new chapter with results to the *Performance comparison & profiling* section

TODO
=====
* [x] Research OpenSSL according to @mattbenjamin's advice.
* [ ] Take a look on locking in NSS.

Performance comparison & profiling
==========================
This times solely on laptop - my *incerta* node/CBT operate without the overhead of Cephx and most likely won't see benefits from this PR at all.

The base scenario is *a-lot-of-ones* which means:
  * one FIO-rbd client,
  * one OSD,
  * one `msgr-worker` thread,
  * one  `tp_osd_tp`,
  * 1 GB RBD image to fit entirely in BlueStore's cache (results are taken after warm-up).

The cluster has been deployed *by hand* with following `vstart.sh` invocation:
```
MDS=0 MGR=0 OSD=1 ../src/vstart.sh -l -n -b -o debug_ms=0 -o rbd_cache=false -o debug_osd=0  -o osd_op_num_threads_per_shard=1 -o osd_op_num_shards=1 -o ms_async_op_threads=1 --nolockdep
```

Reference point: 8e8c5e2a3849c90f4f16892e1150d22de8f4de34
---------------------------


```
$ LD_LIBRARY_PATH=/work/ceph-2/build/lib/ /work/fio/fio /work/rbd_randread_1G.fio 
rbd_iodepth32: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=rbd, iodepth=32
fio-3.0-32-g83070-dirty
Starting 1 process
Jobs: 1 (f=1): [r(1)][100.0%][r=104MiB/s,w=0KiB/s][r=26.5k,w=0 IOPS][eta 00m:00s]
rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=29329: Fri Apr 20 04:25:25 2018
   read: IOPS=26.3k, BW=103MiB/s (108MB/s)(6160MiB/60002msec)
   bw (  KiB/s): min=98304, max=114669, per=100.00%, avg=105142.19, stdev=3784.18, samples=120
   iops        : min=24576, max=28667, avg=26285.53, stdev=946.05, samples=120
  cpu          : usr=37.00%, sys=61.60%, ctx=732347, majf=0, minf=7
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=1576958,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=103MiB/s (108MB/s), 103MiB/s-103MiB/s (108MB/s-108MB/s), io=6160MiB (6459MB), run=60002-60002msec

```

```
-   79,40%     0,00%  msgr-worker-0  [unknown]             [k] 0xffffffffffffffff
   - 0xffffffffffffffff
      - 58,50% __clone
           start_thread
           0xbc16e
         - std::_Function_handler<void (), NetworkStack::add_thread(unsigned int)::{lambda()#1}>::_M_invoke
            - 58,44% EventCenter::process_events
               - 28,53% AsyncConnection::process
                  - 11,14% CephxSessionHandler::check_message_signature
                     - CephxSessionHandler::_calc_signature
                        - 9,44% CryptoAESKeyHandler::encrypt
                           - nss_aes_operation
                              + 5,16% PK11_CreateContextBySymKey
                              + 1,37% PK11_DestroyContext
                              + 0,93% PK11_DigestFinal
                              + 0,76% PK11_CipherOp
                              + 0,33% ceph::buffer::ptr::ptr
                              + 0,28% std::__cxx11::list<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::operator=
                                0,16% ceph::buffer::list::append
                                0,13% std::__cxx11::_List_base<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::_M_clear
                                0,10% ceph::buffer::ptr::release
                        + 0,82% std::__cxx11::_List_base<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::_M_clear
                        + 0,42% ceph::buffer::create_static
                  + 6,61% DispatchQueue::fast_dispatch
                 ...
               - 25,44% AsyncConnection::handle_write
                  - 17,58% AsyncConnection::write_message
                     - 12,75% CephxSessionHandler::sign_message
                        - CephxSessionHandler::_calc_signature
                           - 11,10% CryptoAESKeyHandler::encrypt
                              - nss_aes_operation
                                 + 5,90% PK11_CreateContextBySymKey
                                 + 1,44% PK11_DestroyContext
                                 + 1,27% PK11_DigestFinal
                                 + 0,90% PK11_CipherOp
                                 + 0,42% ceph::buffer::ptr::ptr
                                 + 0,33% std::__cxx11::list<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::operator=
                                   0,21% ceph::buffer::list::append
                                 + 0,17% std::__cxx11::_List_base<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::_M_clear
                                   0,14% ceph::buffer::ptr::release
                           + 0,75% std::__cxx11::_List_base<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::_M_clear
                           + 0,40% ceph::buffer::create_static

```

#### `msgr-worker-0` of the FIO's librbd engine

The overhead is visible also on client-side (added on Wed, 25 Apr 2018 13:12:40 +0000):
```
-   80,61%     0,00%  msgr-worker-0  [unknown]            [k] 0xffffffffffffffff
   - 0xffffffffffffffff
      - 73,09% __clone
           start_thread
           0xbc16e
           std::_Function_handler<void (), NetworkStack::add_thread(unsigned int)::{lambda()#1}>::_M_invoke
         - EventCenter::process_events
            - 55,72% AsyncConnection::process
               + 18,32% DispatchQueue::fast_dispatch
               - 12,79% CephxSessionHandler::check_message_signature
                  - CephxSessionHandler::_calc_signature
                     - 10,76% CryptoAESKeyHandler::encrypt
                        - nss_aes_operation
                           + 6,00% PK11_CreateContextBySymKey
                           + 1,34% PK11_DestroyContext
                           + 1,05% PK11_DigestFinal
                           + 0,58% PK11_CipherOp
                           + 0,48% ceph::buffer::list::append
                           + 0,47% ceph::buffer::ptr::ptr
                           + 0,29% std::__cxx11::list<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::operator=
                           + 0,24% std::__cxx11::_List_base<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::_M_clear
                     + 0,81% std::__cxx11::_List_base<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::_M_clear
                     + 0,67% ceph::buffer::create_static
                     + 0,20% ceph::buffer::list::append
            ...
            - 16,36% AsyncConnection::handle_write
               - 11,14% AsyncConnection::write_message
                  - 7,96% CephxSessionHandler::sign_message
                     - CephxSessionHandler::_calc_signature
                        - 6,70% CryptoAESKeyHandler::encrypt
                           - nss_aes_operation
                              + 3,45% PK11_CreateContextBySymKey
                              + 1,02% PK11_DestroyContext
                              + 0,66% PK11_DigestFinal
                              + 0,42% PK11_CipherOp
                              + 0,32% ceph::buffer::ptr::ptr
                              + 0,26% ceph::buffer::list::append
                              + 0,23% std::__cxx11::list<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::operator=
                                0,12% std::__cxx11::_List_base<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::_M_clear
                        + 0,64% std::__cxx11::_List_base<ceph::buffer::ptr, std::allocator<ceph::buffer::ptr> >::_M_clear
                        + 0,29% ceph::buffer::create_static
                        + 0,14% ceph::buffer::list::append
```

[Historic] After the changes: 92f9bb7fd2e8978ff46be8d5a93554d23afa4b57
--------------------------------
Reusing `PK11Context` altogether with eradication the `ceph::bufferlist` overhead.
```
LD_LIBRARY_PATH=/work/ceph-1/build/lib/ /work/fio/fio /work/rbd_randread_1G.fio 
rbd_iodepth32: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=rbd, iodepth=32
fio-3.0-32-g83070-dirty
Starting 1 process
Jobs: 1 (f=1): [r(1)][100.0%][r=127MiB/s,w=0KiB/s][r=32.6k,w=0 IOPS][eta 00m:00s]
rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=22702: Fri Apr 20 03:43:26 2018
   read: IOPS=32.9k, BW=128MiB/s (135MB/s)(7707MiB/60003msec)
   bw (  KiB/s): min=118765, max=154504, per=100.00%, avg=131539.34, stdev=8467.69, samples=120
   iops        : min=29691, max=38626, avg=32884.85, stdev=2116.92, samples=120
  cpu          : usr=37.64%, sys=60.40%, ctx=1013589, majf=0, minf=7
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=1972990,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=128MiB/s (135MB/s), 128MiB/s-128MiB/s (135MB/s-135MB/s), io=7707MiB (8081MB), run=60003-60003msec

```
```
-   82,86%     0,00%  msgr-worker-0  [unknown]             [k] 0xffffffffffffffff
   - 0xffffffffffffffff
      - 53,76% __clone
           start_thread
           0xbc16e
         - std::_Function_handler<void (), NetworkStack::add_thread(unsigned int)::{lambda()#1}>::_M_invoke
            - 53,60% EventCenter::process_events
               - 22,33% AsyncConnection::handle_write
                  - 12,96% AsyncConnection::write_message
                     - 7,23% CephxSessionHandler::sign_message
                        - CephxSessionHandler::_calc_signature
                           - CryptoAESKeyHandler::encrypt
                              - nss_aes_operation
                                 + 5,19% PK11_DigestBegin
                                 + 0,99% PK11_DigestFinal
                                 + 0,84% PK11_CipherOp
                    ...
               - 21,32% AsyncConnection::process
                  + 6,22% DispatchQueue::fast_dispatch
                  - 5,20% CephxSessionHandler::check_message_signature
                     - 5,14% CephxSessionHandler::_calc_signature
                        - 5,06% CryptoAESKeyHandler::encrypt
                           - nss_aes_operation
                              + 3,43% PK11_DigestBegin
                              + 0,85% PK11_DigestFinal
                              + 0,73% PK11_CipherOp

```

After the changes: 80d3dff7a8d2fd6a4122325d8c62b04b74d22853
---------------------------------------------------------------------
ISAL Crypto instead of NSS on the Cephx path + no `ceph::bufferlist` overhead.

```
$ LD_LIBRARY_PATH=/work/ceph-1/build/lib/ /work/fio/fio /work/rbd_randread_1G.fio 
rbd_iodepth32: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=rbd, iodepth=32
fio-3.0-32-g83070-dirty
Starting 1 process
Jobs: 1 (f=1): [r(1)][100.0%][r=158MiB/s,w=0KiB/s][r=40.3k,w=0 IOPS][eta 00m:00s]
rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=23934: Fri Apr 20 21:49:48 2018
   read: IOPS=41.6k, BW=163MiB/s (170MB/s)(9752MiB/60002msec)
   bw (  KiB/s): min=148432, max=193976, per=100.00%, avg=166444.67, stdev=9873.89, samples=120
   iops        : min=37108, max=48494, avg=41611.15, stdev=2468.44, samples=120
  cpu          : usr=40.33%, sys=56.93%, ctx=1420645, majf=0, minf=7
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=2496446,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=163MiB/s (170MB/s), 163MiB/s-163MiB/s (170MB/s-170MB/s), io=9752MiB (10.2GB), run=60002-60002msec
```

```
-   84,69%     0,00%  msgr-worker-0  [unknown]             [k] 0xffffffffffffffff
   - 0xffffffffffffffff
      - 50,11% __clone
           start_thread
           0xbc16e
         - std::_Function_handler<void (), NetworkStack::add_thread(unsigned int)::{lambda()#1}>::_M_invoke
            - 49,79% EventCenter::process_events
               - 17,77% AsyncConnection::process
                  + 6,46% DispatchQueue::fast_dispatch
                  + 3,31% decode_message
                  + 2,21% AsyncConnection::read_until
                  + 1,34% Throttle::get_or_fail
                  + 0,77% __clock_gettime
                  + 0,67% ceph::buffer::create_aligned_in_mempool
                    0,42% ceph::buffer::list::clear
                  - 0,22% CephxSessionHandler::check_message_signature
                     - CephxSessionHandler::_calc_signature
                          CryptoAESKeyHandler::encrypt
                ...
               - 17,20% AsyncConnection::handle_write
                  + 6,86% AsyncConnection::prepare_send_message
                  - 6,12% AsyncConnection::write_message
                     + 2,27% RefCountedObject::put
                     + 1,45% AsyncConnection::_try_send
                     + 0,85% ceph::buffer::list::append
                     + 0,45% ceph::buffer::list::append
                       0,33% PerfCounters::inc
                     - 0,30% CephxSessionHandler::sign_message
                        - 0,23% CephxSessionHandler::_calc_signature
                           - CryptoAESKeyHandler::encrypt
                                nss_aes_operation
```

After the changes: bacc2528b2c77c0b3ae7fb89243f73630941946f
---------------------------------------------------------------------
OpenSSL instead of NSS on the Cephx path + no `ceph::bufferlist` overhead.

```
$ LD_LIBRARY_PATH=/work/ceph-1/build/lib/ /work/fio/fio /work/rbd_randread_1G.fio 
rbd_iodepth32: (g=0): rw=randread, bs=(R) 4096B-4096B, (W) 4096B-4096B, (T) 4096B-4096B, ioengine=rbd, iodepth=32
fio-3.0-32-g83070-dirty
Starting 1 process
Jobs: 1 (f=1): [r(1)][100.0%][r=157MiB/s,w=0KiB/s][r=40.1k,w=0 IOPS][eta 00m:00s]
rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=12262: Mon Apr 23 19:50:09 2018
   read: IOPS=40.4k, BW=158MiB/s (165MB/s)(9468MiB/60002msec)
   bw (  KiB/s): min=141616, max=212288, per=100.00%, avg=161592.94, stdev=11942.44, samples=120
   iops        : min=35404, max=53072, avg=40398.24, stdev=2985.67, samples=120
  cpu          : usr=39.40%, sys=57.93%, ctx=1349950, majf=0, minf=7
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=2423806,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=158MiB/s (165MB/s), 158MiB/s-158MiB/s (165MB/s-165MB/s), io=9468MiB (9928MB), run=60002-60002msec

```

Performance comparison on `incerta07`
=============================
The same scenario and deployment methodology like in the previous chapter. The sole difference is machine - `incerta07` instead of my laptop.

Reference point: 8e8c5e2a3849c90f4f16892e1150d22de8f4de34
---------------------------
```
[perf@incerta07 build]$ LD_LIBRARY_PATH=${CEPHBIN}/../lib ~/src/fio/fio ~/incerta/radek/tools/rbd_randread_1G.fio 
rbd_iodepth32: (g=0): rw=randread, bs=4096B-4096B,4096B-4096B,4096B-4096B, ioengine=rbd, iodepth=32
fio-2.18-1-g4ed2
Starting 1 process
rbd engine: RBD version: 1.12.0
Jobs: 1 (f=1): [r(1)][100.0%][r=77.9MiB/s,w=0KiB/s][r=19.1k,w=0 IOPS][eta 00m:00s]
rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=4605: Thu May 10 12:39:34 2018
   read: IOPS=19.7k, BW=76.9MiB/s (80.6MB/s)(4612MiB/60004msec)
  cpu          : usr=30.42%, sys=68.67%, ctx=420990, majf=0, minf=161
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=1180670,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=76.9MiB/s (80.6MB/s), 76.9MiB/s-76.9MiB/s (80.6MB/s-80.6MB/s), io=4612MiB (4836MB), run=60004-60004msec

Disk stats (read/write):
sda: ios=0/343, merge=0/266, ticks=0/3207, in_queue=3206, util=5.29%
```

After the changes: `ee9e84e7fb1270baf91f40da407885bde32dd8a6`
------------------------------
```
[perf@incerta07 build]$ LD_LIBRARY_PATH=${CEPHBIN}/../lib ~/src/fio/fio ~/incerta/radek/tools/rbd_randread_1G.fio 
rbd_iodepth32: (g=0): rw=randread, bs=4096B-4096B,4096B-4096B,4096B-4096B, ioengine=rbd, iodepth=32
fio-2.18-1-g4ed2
Starting 1 process
rbd engine: RBD version: 1.12.0
Jobs: 1 (f=1): [r(1)][100.0%][r=120MiB/s,w=0KiB/s][r=30.7k,w=0 IOPS][eta 00m:00s]
rbd_iodepth32: (groupid=0, jobs=1): err= 0: pid=35741: Thu May 10 12:21:32 2018
   read: IOPS=29.6k, BW=115MiB/s (121MB/s)(6923MiB/60002msec)
  cpu          : usr=32.74%, sys=63.89%, ctx=1128770, majf=0, minf=161
  IO depths    : 1=0.1%, 2=0.1%, 4=0.1%, 8=0.1%, 16=0.1%, 32=100.0%, >=64=0.0%
     submit    : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=100.0%, 8=0.0%, 16=0.0%, 32=0.1%, 64=0.0%, >=64=0.0%
     issued rwt: total=1772350,0,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=32

Run status group 0 (all jobs):
   READ: bw=115MiB/s (121MB/s), 115MiB/s-115MiB/s (121MB/s-121MB/s), io=6923MiB (7260MB), run=60002-60002msec

Disk stats (read/write):
sda: ios=0/387, merge=0/283, ticks=0/5010, in_queue=5010, util=7.43%
```