### PR TITLE
luminous:client: flush the mdlog in _fsync before waiting on unstable reqs

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9478,6 +9478,8 @@ int Client::_fsync(Inode *in, bool syncdataonly)
   } else ldout(cct, 10) << "no metadata needs to commit" << dendl;
 
   if (!syncdataonly && !in->unsafe_ops.empty()) {
+    flush_mdlog_sync();
+
     MetaRequest *req = in->unsafe_ops.back();
     ldout(cct, 15) << "waiting on unsafe requests, last tid " << req->get_tid() <<  dendl;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/23802