### PR TITLE
bluefs: append fragment fallback perf counter

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -35,6 +35,7 @@ enum {
   l_bluefs_files_written_sst,
   l_bluefs_bytes_written_wal,
   l_bluefs_bytes_written_sst,
+  l_bluefs_fragment_fallback,
   l_bluefs_last,
 };
 


### PR DESCRIPTION
append a perf counter in bluefs to watch the count of falling
to slow drive which because of fragmentation

Signed-off-by: Zengran <z13121369189@gmail.com>