### PR TITLE
common/config: support to save and re-expand special metavariables

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -156,6 +156,7 @@ int main(int argc, const char **argv, const char *envp[]) {
   }
 
   {
+    g_ceph_context->_conf->finalize_reexpand_meta();
     common_init_finish(g_ceph_context);
    
     init_async_signal_handler();

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1076,6 +1076,17 @@ void md_config_t::early_expand_meta(
   conf_stringify(v, &val);
 }
 
+void md_config_t::finalize_reexpand_meta()
+{
+  Mutex::Locker l(lock);
+  for (auto &i : may_reexpand_meta) {
+    set_val(i.first, i.second);
+  }
+  
+  if (may_reexpand_meta.size())
+    _apply_changes(NULL);
+}
+
 Option::value_t md_config_t::_expand_meta(
   const Option::value_t& in,
   const Option *o,
@@ -1155,6 +1166,9 @@ Option::value_t md_config_t::_expand_meta(
 	out += name.get_id();
       } else if (var == "pid") {
 	out += stringify(getpid());
+        if (o) {
+          may_reexpand_meta[o->name] = *str;
+        }
       } else if (var == "cctid") {
 	out += stringify((unsigned long long)this);
       } else if (var == "home") {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -107,6 +107,9 @@ public:
   /// values from mon that we failed to set
   std::map<std::string,std::string> ignored_mon_values;
 
+  /// original raw values saved that may need to re-expand at certain time
+  mutable std::map<std::string, std::string> may_reexpand_meta;
+
   /// encoded, cached copy of of values + ignored_mon_values
   bufferlist values_bl;
 
@@ -301,6 +304,9 @@ private:
 public:  // for global_init
   void early_expand_meta(std::string &val,
 			 std::ostream *oss) const;
+
+  // for those want to reexpand special meta, e.g, $pid
+  void finalize_reexpand_meta();
 private:
 
   /// expand all metavariables in config structure.


### PR DESCRIPTION
Support to save and re-expand special metavariables according to daemon needs.
Currently only special meta $pid is added, so ceph-fuse daemon can re-expand
its configurations that contain $pid (e.g, admin_socket, log_file, etc) to the
correct value in child process.

Fixes: http://tracker.ceph.com/issues/21848

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>