### PR TITLE
cmake: disable TBB linking when building rocksdb statically

### DIFF
--- a/cmake/modules/BuildRocksDB.cmake
+++ b/cmake/modules/BuildRocksDB.cmake
@@ -18,6 +18,7 @@ function(do_build_rocksdb)
   list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_AR=${CMAKE_AR})
   list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   list(APPEND ROCKSDB_CMAKE_ARGS -DFAIL_ON_WARNINGS=OFF)
+  list(APPEND ROCKSDB_CMAKE_ARGS -DROCKSDB_DISABLE_TBB=ON)
 
   # we use an external project and copy the sources to bin directory to ensure
   # that object files are built outside of the source tree.


### PR DESCRIPTION
librocksdb.a can not link with libtbb.so. This gets conflict with
some application with TBB depedency.

https://github.com/facebook/rocksdb/issues/3036

This commit adds a ROCKSDB_DISABLE_TBB environment variable to disable
linking with TBB when building rocksdb in Ceph.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>