### PR TITLE
osdc/Objecter: apply throttle on enumerate_objects.

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -5036,7 +5036,7 @@ struct C_EnumerateReply : public Context {
       const hobject_t end_, const int64_t pool_id_, Context *on_finish_) :
     objecter(objecter_), next(next_), result(result_),
     end(end_), pool_id(pool_id_), on_finish(on_finish_),
-    epoch(0), budget(0)
+    epoch(0), budget(-1)
   {}
 
   void finish(int r) override {
@@ -5120,7 +5120,7 @@ void Objecter::_enumerate_reply(
     hobject_t *next,
     Context *on_finish)
 {
-  if (budget > 0) {
+  if (budget >= 0) {
     put_op_budget_bytes(budget);
   }
 


### PR DESCRIPTION
In func Objecter::_op_submit_with_budget, only condition
"if (!op->ctx_budgeted || (ctx_budget && (*ctx_budget == -1)))" is ture.
It will take throttle. But the default value of budget of C_EnumerateReply is zero.
So it don't take throttle. Set the default is -1 to take throttle.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>