### PR TITLE
msg/async/EventKqueue: Clang want realloc return to be typed

### DIFF
--- a/src/msg/async/EventKqueue.cc
+++ b/src/msg/async/EventKqueue.cc
@@ -199,7 +199,7 @@ int KqueueDriver::resize_events(int newsize)
   ldout(cct,30) << __func__ << " kqfd = " << kqfd << "newsize = " << newsize 
                 << dendl;
   if (newsize > sav_max) {
-    sav_events = realloc(sav_events, sizeof(struct SaveEvent)*newsize);
+    sav_events = (struct SaveEvent*)realloc(sav_events, sizeof(struct SaveEvent)*newsize);
     if (!sav_events) {
       lderr(cct) << __func__ << " unable to realloc memory: "
                              << cpp_strerror(errno) << dendl;


### PR DESCRIPTION
Otherwise Clang start complaining:
src/msg/async/EventKqueue.cc:202:18: error: assigning to 'struct SaveEvent *' from incompatible type 'void *'
    sav_events = realloc(sav_events, sizeof(struct SaveEvent)*newsize);
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.`

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>