### PR TITLE
client: avoid second lock on client_lock

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12424,7 +12424,7 @@ int Client::ll_get_stripe_osd(Inode *in, uint64_t blockno,
 {
   Mutex::Locker lock(client_lock);
 
-  inodeno_t ino = ll_get_inodeno(in);
+  inodeno_t ino = in->ino;
   uint32_t object_size = layout->object_size;
   uint32_t su = layout->stripe_unit;
   uint32_t stripe_count = layout->stripe_count;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1131,11 +1131,6 @@ public:
   int get_caps_issued(int fd);
   int get_caps_issued(const char *path, const UserPerm& perms);
 
-  // low-level interface v2
-  inodeno_t ll_get_inodeno(Inode *in) {
-    Mutex::Locker lock(client_lock);
-    return _get_inodeno(in);
-  }
   snapid_t ll_get_snapid(Inode *in);
   vinodeno_t ll_get_vino(Inode *in) {
     Mutex::Locker lock(client_lock);


### PR DESCRIPTION
Avoid a second nested lock on client lock. As a result, drop unused function `ll_get_inodeno()`.

Fixes: http://tracker.ceph.com/issues/23815
Signed-off-by: Supriti Singh <supriti.singh@suse.com>