### PR TITLE
mgr: prometheus fix metadata labels

### DIFF
--- a/doc/mgr/prometheus.rst
+++ b/doc/mgr/prometheus.rst
@@ -59,13 +59,13 @@ Pools have a ``ceph_pool_metadata`` field like this:
 
 ::
 
-    ceph_pool_metadata{pool_id="2",name="cephfs_metadata_a"} 0.0
+    ceph_pool_metadata{pool_id="2",name="cephfs_metadata_a"} 1.0
 
 OSDs have a ``ceph_osd_metadata`` field like this:
 
 ::
 
-    ceph_osd_metadata{cluster_addr="172.21.9.34:6802/19096",device_class="ssd",id="0",public_addr="172.21.9.34:6801/19096",weight="1.0"} 0.0
+    ceph_osd_metadata{cluster_addr="172.21.9.34:6802/19096",device_class="ssd",ceph_daemon="osd.0",public_addr="172.21.9.34:6801/19096",weight="1.0"} 1.0
 
 
 Correlating drive statistics with node_exporter
@@ -79,34 +79,46 @@ drive statistics, special series are output like this:
 
 ::
 
-    ceph_disk_occupation{ceph_daemon="osd.0",device="sdd",instance="myhost",job="ceph"}
+    ceph_disk_occupation{ceph_daemon="osd.0",device="sdd", exported_instance="myhost"}
 
-To use this to get disk statistics by OSD ID, use the ``and on`` syntax
-in your prometheus query like this:
+To use this to get disk statistics by OSD ID, use either the ``and`` operator or
+the ``*`` operator in your prometheus query. All metadata metrics (like ``
+ceph_disk_occupation`` have the value 1 so they act neutral with ``*``. Using ``*``
+allows to use ``group_left`` and ``group_right`` grouping modifiers, so that
+the resulting metric has additional labels from one side of the query.
+
+See the
+`prometheus documentation`__ for more information about constructing queries.
+
+__ https://prometheus.io/docs/prometheus/latest/querying/basics
+
+The goal is to run a query like
 
 ::
 
     rate(node_disk_bytes_written[30s]) and on (device,instance) ceph_disk_occupation{ceph_daemon="osd.0"}
 
-See the prometheus documentation for more information about constructing
-queries.
+Out of the box the above query will not return any metrics since the ``instance`` labels of
+both metrics don't match. The ``instance`` label of ``ceph_disk_occupation``
+will be the currently active MGR node.
 
-Note that for this mechanism to work, Ceph and node_exporter must agree
-about the values of the ``instance`` label.  See the following section
-for guidance about to to set up Prometheus in a way that sets
-``instance`` properly.
+ The following two section outline two approaches to remedy this.
+
+Use label_replace
+=================
+
+The ``label_replace`` function (cp.
+`label_replace documentation <https://prometheus.io/docs/prometheus/latest/querying/functions/#label_replace>`_)
+can add a label to, or alter a label of, a metric within a query.
+
+To correlate an OSD and its disks write rate, the following query can be used:
+
+::
+
+    label_replace(rate(node_disk_bytes_written[30s]), "exported_instance", "$1", "instance", "(.*):.*") and on (device,exported_instance) ceph_disk_occupation{ceph_daemon="osd.0"}
 
 Configuring Prometheus server
 =============================
-
-See the prometheus documentation for full details of how to add
-scrape endpoints: the notes
-in this section are tips on how to configure Prometheus to capture
-the Ceph statistics in the most usefully-labelled form.
-
-This configuration is necessary because Ceph is reporting metrics
-from many hosts and services via a single endpoint, and some
-metrics that relate to no physical host (such as pool statistics).
 
 honor_labels
 ------------
@@ -115,27 +127,18 @@ To enable Ceph to output properly-labelled data relating to any host,
 use the ``honor_labels`` setting when adding the ceph-mgr endpoints
 to your prometheus configuration.
 
-Without this setting, any ``instance`` labels that Ceph outputs, such
-as those in ``ceph_disk_occupation`` series, will be overridden
-by Prometheus.
+This allows Ceph to export the proper ``instance`` label without prometheus
+overwriting it. Without this setting, Prometheus applies an ``instance`` label
+that includes the hostname and port of the endpoint that the series game from.
+Because Ceph clusters have multiple manager daemons, this results in an
+``instance`` label that changes spuriously when the active manager daemon
+changes.
 
-Ceph instance label
--------------------
-
-By default, Prometheus applies an ``instance`` label that includes
-the hostname and port of the endpoint that the series game from.  Because
-Ceph clusters have multiple manager daemons, this results in an ``instance``
-label that changes spuriously when the active manager daemon changes.
-
-Set a custom ``instance`` label in your Prometheus target configuration: 
-you might wish to set it to the hostname of your first monitor, or something
-completely arbitrary like "ceph_cluster".
-
-node_exporter instance labels
+node_exporter hostname labels
 -----------------------------
 
 Set your ``instance`` labels to match what appears in Ceph's OSD metadata
-in the ``hostname`` field.  This is generally the short hostname of the node.
+in the ``instance`` field.  This is generally the short hostname of the node.
 
 This is only necessary if you want to correlate Ceph stats with host stats,
 but you may find it useful to do it in all cases in case you want to do
@@ -145,7 +148,8 @@ Example configuration
 ---------------------
 
 This example shows a single node configuration running ceph-mgr and
-node_exporter on a server called ``senta04``.
+node_exporter on a server called ``senta04``. Note that this requires to add the
+appropriate instance label to every ``node_exporter`` target individually.
 
 This is just an example: there are other ways to configure prometheus
 scrape targets and label rewrite rules.
@@ -180,9 +184,7 @@ ceph_targets.yml
     [
         {
             "targets": [ "senta04.mydomain.com:9283" ],
-            "labels": {
-                "instance": "ceph_cluster"
-            }
+            "labels": {}
         }
     ]
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -83,14 +83,15 @@ DF_POOL = ['max_avail', 'bytes_used', 'raw_bytes_used', 'objects', 'dirty',
 OSD_FLAGS = ('noup', 'nodown', 'noout', 'noin', 'nobackfill', 'norebalance',
              'norecover', 'noscrub', 'nodeep-scrub')
 
-FS_METADATA = ('data_pools', 'id', 'metadata_pool', 'name')
+FS_METADATA = ('data_pools', 'fs_id', 'metadata_pool', 'name')
 
-MDS_METADATA = ('id', 'fs', 'hostname', 'public_addr', 'rank', 'ceph_version')
-
-MON_METADATA = ('id', 'hostname', 'public_addr', 'rank', 'ceph_version')
-
-OSD_METADATA = ('cluster_addr', 'device_class', 'id', 'hostname', 'public_addr',
+MDS_METADATA = ('ceph_daemon', 'fs_id', 'hostname', 'public_addr', 'rank',
                 'ceph_version')
+
+MON_METADATA = ('ceph_daemon', 'hostname', 'public_addr', 'rank', 'ceph_version')
+
+OSD_METADATA = ('ceph_daemon', 'cluster_addr', 'device_class', 'hostname',
+                'public_addr', 'ceph_version')
 
 OSD_STATUS = ['weight', 'up', 'in']
 
@@ -98,9 +99,9 @@ OSD_STATS = ['apply_latency_ms', 'commit_latency_ms']
 
 POOL_METADATA = ('pool_id', 'name')
 
-RGW_METADATA = ('id', 'hostname', 'ceph_version')
+RGW_METADATA = ('ceph_daemon', 'hostname', 'ceph_version')
 
-DISK_OCCUPATION = ('instance', 'device', 'ceph_daemon')
+DISK_OCCUPATION = ( 'ceph_daemon', 'device','instance')
 
 
 class Metrics(object):
@@ -373,13 +374,14 @@ class Module(MgrModule):
                                  fs['id'],
                                  fs['mdsmap']['metadata_pool'],
                                  fs['mdsmap']['fs_name']))
+            self.log.debug('mdsmap: {}'.format(fs['mdsmap']))
             for gid, daemon in fs['mdsmap']['info'].items():
                 id_ = daemon['name']
                 host_version = servers.get((id_, 'mds'), ('',''))
                 self.metrics.append('mds_metadata', 1,
-                                    (id_, fs['id'], host_version[0],
-                                     daemon['addr'], daemon['rank'],
-                                     host_version[1]))
+                                    ('mds.{}'.format(id_), fs['id'],
+                                     host_version[0], daemon['addr'],
+                                     daemon['rank'], host_version[1]))
 
     def get_quorum_status(self):
         mon_status = json.loads(self.get('mon_status')['json'])
@@ -389,12 +391,12 @@ class Module(MgrModule):
             id_ = mon['name']
             host_version = servers.get((id_, 'mon'), ('',''))
             self.metrics.append('mon_metadata', 1,
-                                (id_, host_version[0],
+                                ('mon.{}'.format(id_), host_version[0],
                                  mon['public_addr'].split(':')[0], rank,
                                  host_version[1]))
             in_quorum = int(rank in mon_status['quorum'])
             self.metrics.append('mon_quorum_status', in_quorum,
-                                ('mon_{}'.format(id_),))
+                                ('mon.{}'.format(id_),))
 
     def get_pg_status(self):
         # TODO add per pool status?
@@ -477,9 +479,10 @@ class Module(MgrModule):
             host_version = servers.get((str(id_), 'osd'), ('',''))
 
             self.metrics.append('osd_metadata', 1, (
+                'osd.{}'.format(id_),
                 c_addr,
                 dev_class,
-                id_, host_version[0],
+                host_version[0],
                 p_addr, host_version[1]
             ))
 
@@ -505,9 +508,9 @@ class Module(MgrModule):
                 self.log.debug("Got dev for osd {0}: {1}/{2}".format(
                     id_, osd_hostname, osd_dev_node))
                 self.metrics.set('disk_occupation', 1, (
+                    "osd.{0}".format(id_),
                     osd_hostname,
-                    osd_dev_node,
-                    "osd.{0}".format(id_)
+                    osd_dev_node
                 ))
             else:
                 self.log.info("Missing dev node metadata for osd {0}, skipping "
@@ -526,7 +529,7 @@ class Module(MgrModule):
             self.metrics.append(
                 'rgw_metadata',
                 1,
-                (service_id, hostname, version)
+                ('{}.{}'.format(service_type, service_id), hostname, version)
             )
 
     def collect(self):


### PR DESCRIPTION
I changed some label names to make it easier to correlate metrics in prometheus. Most notably this changes the id labels in the metadata metrics to ceph_daemon, as well as the content of these labels to correspond with the values of the daemon metrics (e.g. ```ceph_osd_metadata{ceph_daemon="osd.1"}```). While this adds a bit of redundant information it makes it much easier to correlate metrics in prometheus.

I also renamed the ```instance``` label in the disc_occupation metric and updated the docs on how to correlate metrics with (imho) less complex instructions.