### PR TITLE
mgr/dashboard: Add 'cd-error-panel' component to display error messages

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -7,6 +7,7 @@ import { AlertModule, ModalModule, PopoverModule, TooltipModule } from 'ngx-boot
 
 import { PipesModule } from '../pipes/pipes.module';
 import { DeletionModalComponent } from './deletion-modal/deletion-modal.component';
+import { ErrorPanelComponent } from './error-panel/error-panel.component';
 import { HelperComponent } from './helper/helper.component';
 import { LoadingPanelComponent } from './loading-panel/loading-panel.component';
 import { ModalComponent } from './modal/modal.component';
@@ -34,6 +35,7 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     HelperComponent,
     SubmitButtonComponent,
     UsageBarComponent,
+    ErrorPanelComponent,
     LoadingPanelComponent,
     ModalComponent,
     DeletionModalComponent
@@ -44,6 +46,7 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     SparklineComponent,
     HelperComponent,
     SubmitButtonComponent,
+    ErrorPanelComponent,
     LoadingPanelComponent,
     UsageBarComponent
   ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.html
@@ -1,0 +1,23 @@
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">
+      <i class="fa fa-exclamation-triangle fa-fw icon-danger"
+         aria-hidden="true"></i> {{ title }}
+    </h3>
+  </div>
+  <div class="panel-body">
+    <ng-content></ng-content>
+  </div>
+  <div class="panel-footer"
+       *ngIf="backAction.observers.length > 0">
+    <div class="button-group text-right">
+      <button class="btn btn-sm btn-default tc_backButton"
+              type="button"
+              (click)="backAction.emit()"
+              autofocus
+              i18n>
+        Back
+      </button>
+    </div>
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.html
@@ -1,23 +1,18 @@
-<div class="panel panel-default">
-  <div class="panel-heading">
-    <h3 class="panel-title">
-      <i class="fa fa-exclamation-triangle fa-fw icon-danger"
-         aria-hidden="true"></i> {{ title }}
-    </h3>
-  </div>
-  <div class="panel-body">
-    <ng-content></ng-content>
-  </div>
-  <div class="panel-footer"
-       *ngIf="backAction.observers.length > 0">
-    <div class="button-group text-right">
-      <button class="btn btn-sm btn-default tc_backButton"
-              type="button"
-              (click)="backAction.emit()"
-              autofocus
-              i18n>
-        Back
-      </button>
-    </div>
-  </div>
+<alert type="danger">
+  <strong>
+    <i class="fa fa-exclamation-triangle fa-fw icon-danger"
+       aria-hidden="true"></i> {{ title }}
+  </strong>
+  <ng-content></ng-content>
+</alert>
+
+<div class="button-group text-right"
+     *ngIf="backAction.observers.length > 0">
+  <button class="btn btn-sm btn-default tc_backButton"
+          type="button"
+          (click)="backAction.emit()"
+          autofocus
+          i18n>
+    Back
+  </button>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ErrorPanelComponent } from './error-panel.component';
+
+describe('ErrorPanelComponent', () => {
+  let component: ErrorPanelComponent;
+  let fixture: ComponentFixture<ErrorPanelComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ErrorPanelComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ErrorPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.spec.ts
@@ -1,5 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { AlertModule } from 'ngx-bootstrap';
+
 import { ErrorPanelComponent } from './error-panel.component';
 
 describe('ErrorPanelComponent', () => {
@@ -8,7 +10,8 @@ describe('ErrorPanelComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ ErrorPanelComponent ]
+      declarations: [ ErrorPanelComponent ],
+      imports: [ AlertModule.forRoot() ]
     })
     .compileComponents();
   }));

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.ts
@@ -8,10 +8,10 @@ import { Component, EventEmitter, Input, Output } from '@angular/core';
 export class ErrorPanelComponent {
 
   /**
-   * The title to be displayed. Defaults to 'Error'.
+   * The title to be displayed. Defaults to 'Error!'.
    * @type {string}
    */
-  @Input() title = 'Error';
+  @Input() title = 'Error!';
 
   /**
    * The event that is triggered when the 'Back' button is pressed.

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.ts
@@ -1,0 +1,21 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'cd-error-panel',
+  templateUrl: './error-panel.component.html',
+  styleUrls: ['./error-panel.component.scss']
+})
+export class ErrorPanelComponent {
+
+  /**
+   * The title to be displayed. Defaults to 'Error'.
+   * @type {string}
+   */
+  @Input() title = 'Error';
+
+  /**
+   * The event that is triggered when the 'Back' button is pressed.
+   * @type {EventEmitter<any>}
+   */
+  @Output() backAction = new EventEmitter();
+}


### PR DESCRIPTION
```
<cd-error-panel *ngIf="editing && error"
                (backAction)="goToListView()">
  <ng-container i18n>The user data could not be loaded.</ng-container>
</cd-error-panel>
```
![fireshot capture 23 - ceph_ - http___localhost_4200_ _rgw_user_e](https://user-images.githubusercontent.com/1897962/39183539-a3869c4c-47c0-11e8-8600-845e136117e9.png)

Old style:
![bildschirmfoto von 2018-04-20 14-01-27](https://user-images.githubusercontent.com/1897962/39049866-6d2cc88a-44a3-11e8-8ed1-5b59c0791676.png)

Signed-off-by: Volker Theile <vtheile@suse.com>