### PR TITLE
luminous: tests: ceph-deploy: create the rbd pool right after install

### DIFF
--- a/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
+++ b/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
@@ -1,3 +1,9 @@
+openstack:
+  - machine:
+      disk: 10
+    volumes:
+      count: 2
+      size: 20
 roles:
 - - mon.a
   - mgr.x
@@ -6,14 +12,6 @@ roles:
 - - osd.1
   - mon.b
   - client.0
-openstack:
-  - machine:
-      disk: 10 # GB
-      ram: 2000 # MB
-      cpus: 1
-    volumes: # attached to each instance
-      count: 2
-      size: 10 # GB
 tasks:
 - ssh_keys:
 - print: "**** done ssh_keys"

--- a/qa/suites/ceph-deploy/ceph-volume/cluster/4node.yaml
+++ b/qa/suites/ceph-deploy/ceph-volume/cluster/4node.yaml
@@ -2,6 +2,12 @@ overrides:
  ansible.cephlab: 
   vars: 
    quick_lvs_to_create: 4
+openstack:
+  - machine:
+      disk: 10
+    volumes:
+      count: 4
+      size: 20
 roles:
 - [mon.a, mgr.y, osd.0, osd.1]
 - [mon.b, osd.2, osd.3]

--- a/qa/tasks/ceph_deploy.py
+++ b/qa/tasks/ceph_deploy.py
@@ -483,6 +483,19 @@ def build_ceph_cluster(ctx, config):
         elif not config.get('only_mon'):
             raise RuntimeError(
                 "The cluster is NOT operational due to insufficient OSDs")
+        # create rbd pool
+        ceph_admin.run(
+            args=[
+                'sudo', 'ceph', '--cluster', 'ceph',
+                'osd', 'pool', 'create', 'rbd', '128', '128'],
+            check_status=False)
+        ceph_admin.run(
+            args=[
+                'sudo', 'ceph', '--cluster', 'ceph',
+                'osd', 'pool', 'application', 'enable',
+                'rbd', 'rbd', '--yes-i-really-mean-it'
+                ],
+            check_status=False)
         yield
 
     except Exception:

--- a/qa/workunits/ceph-tests/ceph-admin-commands.sh
+++ b/qa/workunits/ceph-tests/ceph-admin-commands.sh
@@ -5,7 +5,6 @@ ceph -s
 #list pools
 rados lspools
 #lisr rbd images
-ceph osd pool create rbd 128 128
 rbd ls
 #check that the monitors work
 ceph osd set nodown


### PR DESCRIPTION
rbd pool should exist for many rbd tests to work properly, create
the pool right after install is successful.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>