### PR TITLE
rgw: fix error handling for GET with ?torrent

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6054,7 +6054,9 @@ std::vector<Option> get_rgw_options() {
 
     Option("rgw_torrent_flag", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
-    .set_description("Produce torrent function flag"),
+    .set_description("When true, uploaded objects will calculate and store "
+                     "a SHA256 hash of object data so the object can be "
+                     "retrieved as a torrent file"),
 
     Option("rgw_torrent_tracker", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1763,7 +1763,9 @@ void RGWGetObj::execute()
   {
     attr_iter = attrs.find(RGW_ATTR_CRYPT_MODE);
     if (attr_iter != attrs.end() && attr_iter->second.to_str() == "SSE-C-AES256") {
-      op_ret = -ERR_INVALID_REQUEST;
+      ldout(s->cct, 0) << "ERROR: torrents are not supported for objects "
+          "encrypted with SSE-C" << dendl;
+      op_ret = -EINVAL;
       goto done_err;
     }
     torrent.init(s, store);

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -812,20 +812,9 @@ int RGWGetObj_ObjStore::get_params()
     get_data &= (!rgwx_stat);
   }
 
-  /* start gettorrent */
-  bool is_torrent = s->info.args.exists(GET_TORRENT);
-  bool torrent_flag = s->cct->_conf->rgw_torrent_flag;
-  if (torrent_flag && is_torrent)
-  {
-    int ret = 0;
-    ret = torrent.get_params();
-    if (ret < 0)
-    {
-      return ret;
-    }
+  if (s->info.args.exists(GET_TORRENT)) {
+    return torrent.get_params();
   }
-  /* end gettorrent */
-
   return 0;
 }
 


### PR DESCRIPTION
GET requests with ?torrent should never be treated as a normal GET request. if rgw_torrent_flag wasn't true when the object was uploaded, we'll detect the lack of torrent data when reading from omap

conversely, if rgw_torrent_flag was true during upload but disabled afterwards, we can still return the torrent data

Fixes: http://tracker.ceph.com/issues/23506