### PR TITLE
objclass-sdk: expose __cls_init() to the world

### DIFF
--- a/src/cls/sdk/cls_sdk.cc
+++ b/src/cls/sdk/cls_sdk.cc
@@ -115,7 +115,7 @@ static int test_coverage_replay(cls_method_context_t hctx, bufferlist *in, buffe
   return 0;
 }
 
-void __cls_init()
+CLS_INIT(sdk)
 {
   CLS_LOG(0, "loading cls_sdk");
 

--- a/src/include/rados/objclass.h
+++ b/src/include/rados/objclass.h
@@ -20,13 +20,15 @@ int __cls_ver_min = min;
 #define CLS_NAME(name) \
 int __cls_name__## name = 0; \
 const char *__cls_name = #name;
+
+#define CEPH_CLS_API [[gnu::visibility("default")]]
 #define CLS_INIT(name) \
-void CEPH_CLS_API __cls_init()
+CEPH_CLS_API void __cls_init()
 #else
 #define CLS_VER(maj,min)
 #define CLS_NAME(name)
 #define CLS_INIT(name) \
-void CEPH_CLS_API name##_cls_init()
+CEPH_CLS_API void name##_cls_init()
 #endif
 
 #define CLS_METHOD_RD       0x1 /// method executes read operations

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -14,12 +14,6 @@
 
 struct obj_list_watch_response_t;
 
-#if __GNUC__ >= 4
-  #define CEPH_CLS_API    __attribute__ ((visibility ("default")))
-#else
-  #define CEPH_CLS_API
-#endif
-
 extern "C" {
 #endif
 


### PR DESCRIPTION
the __cls_init() function should be visible. otherwise we cannot call it
to register the cls methods

Signed-off-by: Kefu Chai <kchai@redhat.com>