### PR TITLE
osd/PG: perfer EC async_recovery_targets in reverse order of cost

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1528,8 +1528,9 @@ void PG::choose_async_recovery_ec(const map<pg_shard_t, pg_info_t> &all_info,
            << dendl;
 
   // take out as many osds as we can for async recovery, in order of cost
-  for (auto weighted_shard : candidates_by_cost) {
-    pg_shard_t cur_shard = weighted_shard.second;
+  for (auto rit = candidates_by_cost.rbegin();
+       rit != candidates_by_cost.rend(); ++rit) {
+    pg_shard_t cur_shard = rit->second;
     vector<int> candidate_want(*want);
     candidate_want[cur_shard.shard.id] = CRUSH_ITEM_NONE;
     if (recoverable_and_ge_min_size(candidate_want)) {


### PR DESCRIPTION
This is a follow-up fix of https://github.com/ceph/ceph/pull/21578,
in which I forget that erasure-coded-pools share the same logic
when determining the async_recovery_targets..

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>