### PR TITLE
mgr/dashboard: Fix data race and use-before-assignment

### DIFF
--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -113,18 +113,21 @@ class ViewCache(object):
 
         # pylint: disable=broad-except
         def run(self):
+            t0 = 0
+            t1 = 0
             try:
                 t0 = time.time()
                 logger.debug("VC: starting execution of %s", self.fn)
                 val = self.fn(*self.args, **self.kwargs)
                 t1 = time.time()
             except Exception as ex:
-                logger.exception("Error while calling fn=%s ex=%s", self.fn,
-                                 str(ex))
-                self._view.value = None
-                self._view.value_when = None
-                self._view.getter_thread = None
-                self._view.exception = ex
+                with self._view.lock:
+                    logger.exception("Error while calling fn=%s ex=%s", self.fn,
+                                     str(ex))
+                    self._view.value = None
+                    self._view.value_when = None
+                    self._view.getter_thread = None
+                    self._view.exception = ex
             else:
                 with self._view.lock:
                     self._view.latency = t1 - t0


### PR DESCRIPTION
The race happens, if a task raises an exception very early.
Then, `self.getter_thread.event` fails as `getter_thread` is
already `None`

Also fix use-before-assignment, as `t0` and `t1` are only defined,
if no exception was raised.

Found-by and required for #21066 . See also [#21066/tools.py Line 127](https://github.com/ceph/ceph/pull/21066/files#diff-baf1e07da5b5ebf5293ee77bf0364f04R127)

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>