### PR TITLE
cmake: fix building without mgr module

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -578,21 +578,12 @@ add_ceph_test(unittest_bufferlist.sh ${CMAKE_SOURCE_DIR}/src/unittest_bufferlist
 
 add_test(NAME run-tox-ceph-disk COMMAND bash ${CMAKE_SOURCE_DIR}/src/ceph-disk/run-tox.sh)
 add_test(NAME run-tox-ceph-detect-init COMMAND bash ${CMAKE_SOURCE_DIR}/src/ceph-detect-init/run-tox.sh)
-if(WITH_MGR)
-    add_test(NAME run-tox-mgr-dashboard COMMAND bash ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/run-tox.sh)
-endif(WITH_MGR)
 
 set(CEPH_DISK_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv)
 set(CEPH_DETECT_INIT_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtualenv)
-if(WITH_MGR)
-  set(MGR_DASHBOARD_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/mgr-dashboard-virtualenv)
-endif()
 
-set_property(TEST 
-  run-tox-ceph-disk
-  run-tox-ceph-detect-init
-  run-tox-mgr-dashboard
-  PROPERTY ENVIRONMENT
+set(tox_tests run-tox-ceph-disk run-tox-ceph-detect-init)
+set(env_vars_for_tox_tests
   CEPH_BUILD_DIR=${CMAKE_BINARY_DIR}
   CEPH_ROOT=${CMAKE_SOURCE_DIR}
   CEPH_BIN=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}
@@ -600,13 +591,22 @@ set_property(TEST
   CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV}
   CEPH_DISK_VIRTUALENV=${CEPH_DISK_VIRTUALENV}
   CEPH_DETECT_INIT_VIRTUALENV=${CEPH_DETECT_INIT_VIRTUALENV}
-  MGR_DASHBOARD_VIRTUALENV=${MGR_DASHBOARD_VIRTUALENV}
   LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
   PATH=$ENV{PATH}:${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:${CMAKE_SOURCE_DIR}/src
   PYTHONPATH=${CMAKE_SOURCE_DIR}/src/pybind
   WITH_PYTHON2=${WITH_PYTHON2}
-  WITH_PYTHON3=${WITH_PYTHON3}
-  )
+  WITH_PYTHON3=${WITH_PYTHON3})
+
+if(WITH_MGR)
+  add_test(NAME run-tox-mgr-dashboard COMMAND bash ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/run-tox.sh)
+  list(APPEND tox_tests run-tox-mgr-dashboard)
+  set(MGR_DASHBOARD_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/mgr-dashboard-virtualenv)
+  list(APPEND env_vars_for_tox_tests MGR_DASHBOARD_VIRTUALENV=${MGR_DASHBOARD_VIRTUALENV})
+endif()
+
+set_property(
+  TEST ${tox_tests}
+  PROPERTY ENVIRONMENT ${env_vars_for_tox_tests})
 
 # unittest_admin_socket
 add_executable(unittest_admin_socket


### PR DESCRIPTION
cmake fails if WITH_MGR=OFF due to an null test job

$ cmake .. -DWITH_MGR=OFF
...
CMake Error at src/test/CMakeLists.txt:591 (set_property):
  set_property given TEST names that do not exist:

    run-tox-mgr-dashboard

This patch skips the run-tox-mgr-dashboard test if mgr is not enabled.

Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>