### PR TITLE
debian: let ceph-mgr depend on python-influxdb

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -185,6 +185,7 @@ Depends: ceph-base (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
+Suggests: python-influxdb
 Replaces: ceph (<< 0.93-417),
 Breaks: ceph (<< 0.93-417),
 Description: manager for the ceph distributed storage system

--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -118,7 +118,7 @@ class MgrTestCase(CephTestCase):
 
         initial_gid = cls.mgr_cluster.get_mgr_map()['active_gid']
         cls.mgr_cluster.mon_manager.raw_cluster_cmd("mgr", "module", "enable",
-                                         module_name)
+                                                    module_name, "--force")
 
         # Wait for the module to load
         def has_restarted():


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>