### PR TITLE
mgr/dashboard: Load the datatable content on component initialization

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -2,7 +2,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { NgxDatatableModule, TableColumn } from '@swimlane/ngx-datatable';
+import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 
 import { ComponentsModule } from '../../components/components.module';
 import { TableComponent } from './table.component';
@@ -10,7 +10,6 @@ import { TableComponent } from './table.component';
 describe('TableComponent', () => {
   let component: TableComponent;
   let fixture: ComponentFixture<TableComponent>;
-  const columns: TableColumn[] = [];
 
   const createFakeData = (n) => {
     const data = [];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -152,13 +152,14 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
       return c;
     });
     this.tableColumns = this.columns.filter(c => !c.isHidden);
-    if (this.autoReload) {
-      // Also if nothing is bound to fetchData nothing will be triggered
-      // Force showing the loading indicator because it has been set to False in
-      // useData() when this method was triggered by ngOnChanges().
-      if (this.fetchData.observers.length > 0) {
-        this.loadingIndicator = true;
-      }
+    // Load the data table content every N ms or at least once.
+    // Force showing the loading indicator if there are subscribers to the fetchData
+    // event. This is necessary because it has been set to False in useData() when
+    // this method was triggered by ngOnChanges().
+    if (this.fetchData.observers.length > 0) {
+      this.loadingIndicator = true;
+    }
+    if (_.isInteger(this.autoReload) && (this.autoReload > 0)) {
       this.ngZone.runOutsideAngular(() => {
         this.subscriber = Observable.timer(0, this.autoReload).subscribe(x => {
           this.ngZone.run(() => {
@@ -166,6 +167,8 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
           });
         });
       });
+    } else {
+      this.reloadData();
     }
   }
 


### PR DESCRIPTION
If ``autoReload`` is disabled the data table content is not loaded at least once anymore when the component is initialized. This PR will fix that. Additionally useless code has been removed in the unit test.

The ``_.isIniteger()`` test has been introduced to validate the input. If you do not use property binding, e.g. ``autoReload="false"`` the autoReload code path is still executed because ``autoReload`` contains ``"false"`` (a quoted string) then which is not an expected and correct value here.

Signed-off-by: Volker Theile <vtheile@suse.com>