### PR TITLE
osd/PrimaryLogPG: refresh local last-complete iter for async_recovery_targets properly

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -902,6 +902,13 @@ void ECBackend::handle_sub_write(
     }
   }
   clear_temp_objs(op.temp_removed);
+  get_parent()->log_operation(
+    op.log_entries,
+    op.updated_hit_set_history,
+    op.trim_to,
+    op.roll_forward_to,
+    !op.backfill_or_async_recovery,
+    localt);
   dout(30) << __func__ << " missing before " << get_parent()->get_log().get_missing().get_items() << dendl;
   pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
   if (pmissing.is_missing(op.soid)) {
@@ -912,13 +919,6 @@ void ECBackend::handle_sub_write(
       dout(30) << " entry is_delete " << e.is_delete() << dendl;
     }
   }
-  get_parent()->log_operation(
-    op.log_entries,
-    op.updated_hit_set_history,
-    op.trim_to,
-    op.roll_forward_to,
-    !op.backfill_or_async_recovery,
-    localt);
 
   if (!get_parent()->pg_is_undersized() &&
       (unsigned)get_parent()->whoami_shard().shard >=

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -361,6 +361,9 @@ public:
   }
   void add_local_next_event(const pg_log_entry_t& e) {
     pg_log.missing_add_next_entry(e);
+    // might need to reset **complete_to**
+    // and advance **last_complete** too
+    pg_log.reset_complete_to(&info);
   }
   bool pgb_is_primary() const override {
     return is_primary();

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1051,6 +1051,14 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
     update_snaps = true;
   }
 
+  parent->log_operation(
+    log,
+    m->updated_hit_set_history,
+    m->pg_trim_to,
+    m->pg_roll_forward_to,
+    update_snaps,
+    rm->localt);
+
   pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
   if (pmissing.is_missing(soid)) {
     dout(30) << __func__ << " is_missing " << pmissing.is_missing(soid) << dendl;
@@ -1062,13 +1070,6 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   }
 
   parent->update_stats(m->pg_stats);
-  parent->log_operation(
-    log,
-    m->updated_hit_set_history,
-    m->pg_trim_to,
-    m->pg_roll_forward_to,
-    update_snaps,
-    rm->localt);
 
   rm->opt.register_on_commit(
     parent->bless_context(


### PR DESCRIPTION
Upon overwritting an already-missing object on async_recovery_targets,
besides updating the **missing** set async_recovery_targets should
call reset_complete_to() simultaneously to reset **complete-to** iter and
advance **last_complete** properly, as those old log entries which we used
to rely on for recovery are now getting replaced by new **committed** ones.

Since the recovery process of an async_recovery_target can be arbitrarily
delayed until we hit the osd_max_pg_log_entries limit, the main befenit
of an extra call to reset_complete_to() here is to make sure primary perform
log-trim in time. Otherwise accumulating of huge amounts of **obsolete** log
entries can slow the system down obviously.

Signed-off-by: xiexingguo <xie.xingguo@zte.com.cn>