### PR TITLE
mgr/dashboard: Adapt RBD form to new application_metadata type

### DIFF
--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -32,6 +32,7 @@ class PoolTest(DashboardTestCase):
             self.assertIn('pool_name', pool)
             self.assertIn('type', pool)
             self.assertIn('application_metadata', pool)
+            self.assertIsInstance(pool['application_metadata'], list)
             self.assertIn('flags', pool)
             self.assertIn('flags_names', pool)
             self.assertNotIn('stats', pool)
@@ -94,6 +95,7 @@ class PoolTest(DashboardTestCase):
                     elif k == 'pg_num':
                         self.assertEqual(pool[k], int(v), '{}: {} != {}'.format(k, pool[k], v))
                     elif k == 'application_metadata':
+                        self.assertIsInstance(pool[k], list)
                         self.assertEqual(pool[k],
                                          data['application_metadata'].split(','))
                     elif k == 'pool':

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -197,7 +197,7 @@ export class RbdFormComponent implements OnInit {
         const pools = [];
         const dataPools = [];
         for (const pool of resp) {
-          if (!_.isUndefined(pool.application_metadata.rbd)) {
+          if (_.indexOf(pool.application_metadata, 'rbd') !== -1) {
             if (pool.type === 'replicated') {
               pools.push(pool);
               dataPools.push(pool);


### PR DESCRIPTION
The pools ``application_metadata`` was previously returned as a set, but has been changed to a list/array. The UI has not been adapted until now. Additionally the unit test has been improved to check the type if ``application_metadata``.


Signed-off-by: Volker Theile <vtheile@suse.com>