### PR TITLE
rados/objclass.h: fix build define CEPH_CLS_API in all cases

### DIFF
--- a/src/include/rados/objclass.h
+++ b/src/include/rados/objclass.h
@@ -11,6 +11,8 @@
 extern "C" {
 #endif
 
+#define CEPH_CLS_API [[gnu::visibility("default")]]
+
 #ifndef BUILDING_FOR_EMBEDDED
 #define CLS_VER(maj,min) \
 int __cls_ver__## maj ## _ ##min = 0; \
@@ -21,7 +23,6 @@ int __cls_ver_min = min;
 int __cls_name__## name = 0; \
 const char *__cls_name = #name;
 
-#define CEPH_CLS_API [[gnu::visibility("default")]]
 #define CLS_INIT(name) \
 CEPH_CLS_API void __cls_init()
 #else


### PR DESCRIPTION
Fix for bug introduced with 096668ec5df93725a0726b53bbd30b4d4ab50f49:

In file included from src/objclass/objclass.h:13:0,
                 from src/cls/hello/cls_hello.cc:37:
src/include/rados/objclass.h:31:1: error: ‘CEPH_CLS_API’ does not name a
type; did you mean ‘CEPH_CAP_ANY’?
 CEPH_CLS_API void name##_cls_init()
 ^
/develop/ceph/source/ceph/src/include/rados/objclass.h:31:1: note: in
definition of macro ‘CLS_INIT’
 CEPH_CLS_API void name##_cls_init()
 ^~~~~~~~~~~~

Signed-off-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>