### PR TITLE
mgr: reconcile can_run checks and selftest

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -185,6 +185,7 @@ Depends: ceph-base (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
+Suggests: python-influxdb
 Replaces: ceph (<< 0.93-417),
 Breaks: ceph (<< 0.93-417),
 Description: manager for the ceph distributed storage system

--- a/qa/tasks/mgr/mgr_test_case.py
+++ b/qa/tasks/mgr/mgr_test_case.py
@@ -118,7 +118,7 @@ class MgrTestCase(CephTestCase):
 
         initial_gid = cls.mgr_cluster.get_mgr_map()['active_gid']
         cls.mgr_cluster.mon_manager.raw_cluster_cmd("mgr", "module", "enable",
-                                         module_name)
+                                                    module_name, "--force")
 
         # Wait for the module to load
         def has_restarted():

--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -110,6 +110,13 @@ int ActivePyModule::handle_command(
   assert(ss != nullptr);
   assert(ds != nullptr);
 
+  if (pClassInstance == nullptr) {
+    // Not the friendliest error string, but we could only
+    // hit this in quite niche cases, if at all.
+    *ss << "Module not instantiated";
+    return -EINVAL;
+  }
+
   Gil gil(py_module->pMyThreadState, true);
 
   PyFormatter f;

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -756,9 +756,14 @@ int ActivePyModules::handle_command(
   std::stringstream *ss)
 {
   lock.Lock();
-  auto mod = modules.at(module_name).get();
+  auto mod_iter = modules.find(module_name);
+  if (mod_iter == modules.end()) {
+    *ss << "Module '" << module_name << "' is not available";
+    return -ENOENT;
+  }
+
   lock.Unlock();
-  return mod->handle_command(cmdmap, ds, ss);
+  return mod_iter->second->handle_command(cmdmap, ds, ss);
 }
 
 void ActivePyModules::get_health_checks(health_check_map_t *checks)


### PR DESCRIPTION
Extension to https://github.com/ceph/ceph/pull/21594 that reinstates the loading of modules even if they have missing dependencies, so that we can get at their selftest hooks.

The testing on #21594 also showed a crash in ceph-mgr when it was sent commands for a module that was missing from ActivePyModules::modules, so strengthen checks on that path too.

This is passing test_module_selftest on vstart