### PR TITLE
dout: DoutPrefixProvider operates directly on stream

### DIFF
--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -37,7 +37,7 @@ inline std::ostream& operator<<(std::ostream& out, _bad_endl_use_dendl_t) {
 
 class DoutPrefixProvider {
 public:
-  virtual string gen_prefix() const = 0;
+  virtual std::ostream& gen_prefix(std::ostream& out) const = 0;
   virtual CephContext *get_cct() const = 0;
   virtual unsigned get_subsys() const = 0;
   virtual ~DoutPrefixProvider() {}
@@ -99,7 +99,7 @@ struct is_dynamic<dynamic_marker_t<T>> : public std::true_type {};
 #define ldpp_dout(dpp, v) 						\
   if (dpp) 								\
     dout_impl(dpp->get_cct(), ceph::dout::need_dynamic(dpp->get_subsys()), v)				\
-    (*_dout << dpp->gen_prefix())
+    dpp->gen_prefix(*_dout)
 
 #define lgeneric_subdout(cct, sub, v) dout_impl(cct, ceph_subsys_##sub, v) *_dout
 #define lgeneric_dout(cct, v) dout_impl(cct, ceph_subsys_, v) *_dout

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -32,7 +32,7 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
 static ostream& _prefix(std::ostream *_dout, ECBackend *pgb) {
-  return *_dout << pgb->get_parent()->gen_dbg_prefix();
+  return pgb->get_parent()->gen_dbg_prefix(*_dout);
 }
 
 struct ECRecoveryHandle : public PGBackend::RecoveryHandle {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -87,7 +87,7 @@ const string fastinfo_key("_fastinfo");
 template <class T>
 static ostream& _prefix(std::ostream *_dout, T *t)
 {
-  return *_dout << t->gen_prefix();
+  return t->gen_prefix(*_dout);
 }
 
 void PGStateHistory::enter(PG* pg, const utime_t entime, const char* state)
@@ -383,9 +383,8 @@ void PG::lock(bool no_lockdep) const
   dout(30) << "lock" << dendl;
 }
 
-std::string PG::gen_prefix() const
+std::ostream& PG::gen_prefix(std::ostream& out) const
 {
-  stringstream out;
   OSDMapRef mapref = osdmap_ref;
   if (_lock.is_locked_by_me()) {
     out << "osd." << osd->whoami
@@ -396,7 +395,7 @@ std::string PG::gen_prefix() const
 	<< " pg_epoch: " << (mapref ? mapref->get_epoch():0)
 	<< " pg[" << info.pgid << "(unlocked)] ";
   }
-  return out.str();
+  return out;
 }
   
 /********* PG **********/
@@ -6558,7 +6557,7 @@ void PG::_delete_some(ObjectStore::Transaction *t)
 
 /*------------ Recovery State Machine----------------*/
 #undef dout_prefix
-#define dout_prefix (*_dout << context< RecoveryMachine >().pg->gen_prefix() \
+#define dout_prefix (context< RecoveryMachine >().pg->gen_prefix(*_dout) \
 		     << "state<" << get_state_name() << ">: ")
 
 /*------Crashed-------*/
@@ -9159,7 +9158,7 @@ void PG::RecoveryState::WaitUpThru::exit()
 
 /*----RecoveryState::RecoveryMachine Methods-----*/
 #undef dout_prefix
-#define dout_prefix *_dout << pg->gen_prefix()
+#define dout_prefix pg->gen_prefix(*_dout)
 
 void PG::RecoveryState::RecoveryMachine::log_enter(const char *state_name)
 {
@@ -9182,7 +9181,7 @@ void PG::RecoveryState::RecoveryMachine::log_exit(const char *state_name, utime_
 
 /*---------------------------------------------------*/
 #undef dout_prefix
-#define dout_prefix (*_dout << (debug_pg ? debug_pg->gen_prefix() : string()) << " PriorSet: ")
+#define dout_prefix ((debug_pg ? debug_pg->gen_prefix(*_dout) : *_dout) << " PriorSet: ")
 
 void PG::RecoveryState::start_handle(RecoveryCtx *new_ctx) {
   assert(!rctx);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -259,7 +259,7 @@ public:
   class RecoveryCtx;
 
   // -- methods --
-  std::string gen_prefix() const override;
+  std::ostream& gen_prefix(std::ostream& out) const override;
   CephContext *get_cct() const override {
     return cct;
   }
@@ -703,7 +703,9 @@ protected:
       is_readable.reset(_is_readable);
       is_recoverable.reset(_is_recoverable);
     }
-    string gen_prefix() const { return pg->gen_prefix(); }
+    std::ostream& gen_prefix(std::ostream& out) const {
+      return pg->gen_prefix(out);
+    }
     bool needs_recovery(
       const hobject_t &hoid,
       eversion_t *v = 0) const {

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -36,7 +36,7 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
 static ostream& _prefix(std::ostream *_dout, PGBackend *pgb) {
-  return *_dout << pgb->get_parent()->gen_dbg_prefix();
+  return pgb->get_parent()->gen_dbg_prefix(*_dout);
 }
 
 void PGBackend::recover_delete_object(const hobject_t &oid, eversion_t v,

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -162,7 +162,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      virtual const set<pg_shard_t> &get_acting_shards() const = 0;
      virtual const set<pg_shard_t> &get_backfill_shards() const = 0;
 
-     virtual std::string gen_dbg_prefix() const = 0;
+     virtual std::ostream& gen_dbg_prefix(std::ostream& out) const = 0;
 
      virtual const map<hobject_t, set<pg_shard_t>> &get_missing_loc_shards()
        const = 0;
@@ -310,8 +310,8 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
    OSDMapRef get_osdmap() const { return get_parent()->pgb_get_osdmap(); }
    const pg_info_t &get_info() { return get_parent()->get_info(); }
 
-   std::string gen_prefix() const {
-     return parent->gen_dbg_prefix();
+   std::ostream& gen_prefix(std::ostream& out) const {
+     return parent->gen_dbg_prefix(out);
    }
 
    /**

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -26,7 +26,7 @@
 
 static ostream& _prefix(std::ostream *_dout, const PGLog *pglog)
 {
-  return *_dout << pglog->gen_prefix();
+  return pglog->gen_prefix(*_dout);
 }
 
 //////////////////// PGLog::IndexedLog ////////////////////

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -34,8 +34,8 @@ constexpr auto PGLOG_INDEXED_ALL              = PGLOG_INDEXED_OBJECTS
 class CephContext;
 
 struct PGLog : DoutPrefixProvider {
-  string gen_prefix() const override {
-    return "";
+  std::ostream& gen_prefix(std::ostream& out) const override {
+    return out;
   }
   unsigned get_subsys() const override {
     return static_cast<unsigned>(ceph_subsys_osd);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -65,7 +65,7 @@
 #define dout_prefix _prefix(_dout, this)
 template <typename T>
 static ostream& _prefix(std::ostream *_dout, T *pg) {
-  return *_dout << pg->gen_prefix();
+  return pg->gen_prefix(*_dout);
 }
 
 
@@ -14987,7 +14987,7 @@ int PrimaryLogPG::rep_repair_primary_object(const hobject_t& soid, OpRequestRef 
 
 /*---SnapTrimmer Logging---*/
 #undef dout_prefix
-#define dout_prefix *_dout << pg->gen_prefix() 
+#define dout_prefix pg->gen_prefix(*_dout)
 
 void PrimaryLogPG::SnapTrimmer::log_enter(const char *state_name)
 {
@@ -15001,7 +15001,7 @@ void PrimaryLogPG::SnapTrimmer::log_exit(const char *state_name, utime_t enter_t
 
 /*---SnapTrimmer states---*/
 #undef dout_prefix
-#define dout_prefix (*_dout << context< SnapTrimmer >().pg->gen_prefix() \
+#define dout_prefix (context< SnapTrimmer >().pg->gen_prefix(*_dout) \
 		     << "SnapTrimmer state<" << get_state_name() << ">: ")
 
 /* NotTrimming */

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -339,8 +339,10 @@ public:
     return backfill_targets;
   }
 
-  std::string gen_dbg_prefix() const override { return gen_prefix(); }
-  
+  std::ostream& gen_dbg_prefix(std::ostream& out) const override {
+    return gen_prefix(out);
+  }
+
   const map<hobject_t, set<pg_shard_t>>
     &get_missing_loc_shards() const override {
     return missing_loc.get_missing_locs();

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -28,7 +28,7 @@
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
 static ostream& _prefix(std::ostream *_dout, ReplicatedBackend *pgb) {
-  return *_dout << pgb->get_parent()->gen_dbg_prefix();
+  return pgb->get_parent()->gen_dbg_prefix(*_dout);
 }
 
 namespace {

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -25,7 +25,7 @@ struct CancelableContext : public Context {
 static ostream& _prefix(
   std::ostream* _dout,
   Notify *notify) {
-  return *_dout << notify->gen_dbg_prefix();
+  return notify->gen_dbg_prefix(*_dout);
 }
 
 Notify::Notify(
@@ -229,7 +229,7 @@ void Notify::init()
 static ostream& _prefix(
   std::ostream* _dout,
   Watch *watch) {
-  return *_dout << watch->gen_dbg_prefix();
+  return watch->gen_dbg_prefix(*_dout);
 }
 
 class HandleWatchTimeout : public CancelableContext {
@@ -278,11 +278,9 @@ public:
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
 
-string Watch::gen_dbg_prefix() {
-  stringstream ss;
-  ss << pg->gen_prefix() << " -- Watch(" 
-     << make_pair(cookie, entity) << ") ";
-  return ss.str();
+std::ostream& Watch::gen_dbg_prefix(std::ostream& out) {
+  return pg->gen_prefix(out) << " -- Watch("
+      << make_pair(cookie, entity) << ") ";
 }
 
 Watch::Watch(

--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -99,12 +99,10 @@ class Notify {
   void unregister_cb();
 public:
 
-  string gen_dbg_prefix() {
-    stringstream ss;
-    ss << "Notify(" << make_pair(cookie, notify_id) << " "
-       << " watchers=" << watchers.size()
-       << ") ";
-    return ss.str();
+  std::ostream& gen_dbg_prefix(std::ostream& out) {
+    return out << "Notify(" << make_pair(cookie, notify_id) << " "
+        << " watchers=" << watchers.size()
+        << ") ";
   }
   void set_self(NotifyRef _self) {
     self = _self;
@@ -210,7 +208,7 @@ public:
     return entity.num();
   }
 
-  string gen_dbg_prefix();
+  std::ostream& gen_dbg_prefix(std::ostream& out);
   static WatchRef makeWatchRef(
     PrimaryLogPG *pg, OSDService *osd,
     ceph::shared_ptr<ObjectContext> obc, uint32_t timeout, uint64_t cookie, entity_name_t entity, const entity_addr_t &addr);

--- a/src/test/osd/test_ec_transaction.cc
+++ b/src/test/osd/test_ec_transaction.cc
@@ -19,7 +19,7 @@
 #include "test/unit.cc"
 
 struct mydpp : public DoutPrefixProvider {
-  string gen_prefix() const override { return "foo"; }
+  std::ostream& gen_prefix(std::ostream& out) const override { return out << "foo"; }
   CephContext *get_cct() const override { return g_ceph_context; }
   unsigned get_subsys() const override { return ceph_subsys_osd; }
 } dpp;


### PR DESCRIPTION
removes the need for stringstream in more complicated prefixes