### PR TITLE
osd/PG: fix out of order priority for PG deletion

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2388,10 +2388,10 @@ unsigned PG::get_backfill_priority()
 unsigned PG::get_delete_priority()
 {
   auto state = get_osdmap()->get_state(osd->whoami);
-  if (state & (CEPH_OSD_NEARFULL |
-	       CEPH_OSD_FULL)) {
+  if (state & (CEPH_OSD_BACKFILLFULL |
+               CEPH_OSD_FULL)) {
     return OSD_DELETE_PRIORITY_FULL;
-  } else if (state & CEPH_OSD_BACKFILLFULL) {
+  } else if (state & CEPH_OSD_NEARFULL) {
     return OSD_DELETE_PRIORITY_FULLISH;
   } else {
     return OSD_DELETE_PRIORITY_NORMAL;


### PR DESCRIPTION
Backfill-full by definition is fuller than near-full and hence
should deserve a higher priority.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>