### PR TITLE
osd: publish osdmap to OSDService before starting wq threads

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2606,6 +2606,11 @@ int OSD::init()
   monc->set_log_client(&log_client);
   update_log_config();
 
+  service.init();
+  service.publish_map(osdmap);
+  service.publish_superblock(superblock);
+  service.max_oldest_map = superblock.oldest_map;
+
   osd_op_tp.start();
   command_tp.start();
 
@@ -2618,11 +2623,6 @@ int OSD::init()
     Mutex::Locker l(tick_timer_lock);
     tick_timer_without_osd_lock.add_event_after(cct->_conf->osd_heartbeat_interval, new C_Tick_WithoutOSDLock(this));
   }
-
-  service.init();
-  service.publish_map(osdmap);
-  service.publish_superblock(superblock);
-  service.max_oldest_map = superblock.oldest_map;
 
   osd_lock.Unlock();
 


### PR DESCRIPTION
The worker threads may request the map from the service (notably,
advance_pg() does this).

Fixes: http://tracker.ceph.com/issues/21977
Signed-off-by: Sage Weil <sage@redhat.com>