### PR TITLE
mgr/dashboard: add TLS

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -82,13 +82,16 @@ class DashboardTestCase(MgrTestCase):
         url = "{}{}".format(cls.base_uri, url)
         log.info("request %s to %s", method, url)
         if method == 'GET':
-            cls._resp = cls._session.get(url, params=params)
+            cls._resp = cls._session.get(url, params=params, verify=False)
         elif method == 'POST':
-            cls._resp = cls._session.post(url, json=data, params=params)
+            cls._resp = cls._session.post(url, json=data, params=params,
+                                          verify=False)
         elif method == 'DELETE':
-            cls._resp = cls._session.delete(url, json=data, params=params)
+            cls._resp = cls._session.delete(url, json=data, params=params,
+                                            verify=False)
         elif method == 'PUT':
-            cls._resp = cls._session.put(url, json=data, params=params)
+            cls._resp = cls._session.put(url, json=data, params=params,
+                                         verify=False)
         else:
             assert False
         try:

--- a/qa/tasks/mgr/test_dashboard.py
+++ b/qa/tasks/mgr/test_dashboard.py
@@ -12,10 +12,15 @@ log = logging.getLogger(__name__)
 class TestDashboard(MgrTestCase):
     MGRS_REQUIRED = 3
 
-    def test_standby(self):
+    def setUp(self):
+        super(TestDashboard, self).setUp()
+
         self._assign_ports("dashboard", "server_port")
         self._load_module("dashboard")
+        self.mgr_cluster.mon_manager.raw_cluster_cmd("dashboard",
+                                                     "create-self-signed-cert")
 
+    def test_standby(self):
         original_active = self.mgr_cluster.get_active_id()
 
         original_uri = self._get_uri("dashboard")
@@ -30,14 +35,11 @@ class TestDashboard(MgrTestCase):
 
         # The original active daemon should have come back up as a standby
         # and be doing redirects to the new active daemon
-        r = requests.get(original_uri, allow_redirects=False)
+        r = requests.get(original_uri, allow_redirects=False, verify=False)
         self.assertEqual(r.status_code, 303)
         self.assertEqual(r.headers['Location'], failed_over_uri)
 
     def test_urls(self):
-        self._assign_ports("dashboard", "server_port")
-        self._load_module("dashboard")
-
         base_uri = self._get_uri("dashboard")
 
         # This is a very simple smoke test to check that the dashboard can
@@ -51,7 +53,8 @@ class TestDashboard(MgrTestCase):
         failures = []
 
         for url in urls:
-            r = requests.get(base_uri + url, allow_redirects=False)
+            r = requests.get(base_uri + url, allow_redirects=False,
+                             verify=False)
             if r.status_code >= 300 and r.status_code < 400:
                 log.error("Unexpected redirect to: {0} (from {1})".format(
                     r.headers['Location'], base_uri))

--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -172,6 +172,8 @@ class TestModuleSelftest(MgrTestCase):
         # Use the dashboard to test that the mgr is still able to do its job
         self._assign_ports("dashboard", "server_port")
         self._load_module("dashboard")
+        self.mgr_cluster.mon_manager.raw_cluster_cmd("dashboard",
+                                                     "create-self-signed-cert")
 
         original_active = self.mgr_cluster.get_active_id()
         original_standbys = self.mgr_cluster.get_standby_ids()
@@ -187,7 +189,7 @@ class TestModuleSelftest(MgrTestCase):
         for i in range(0, periods):
             t1 = time.time()
             # Check that an HTTP module remains responsive
-            r = requests.get(dashboard_uri)
+            r = requests.get(dashboard_uri, verify=False)
             self.assertEqual(r.status_code, 200)
 
             # Check that a native non-module command remains responsive

--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -89,8 +89,14 @@ ceph_store_get(BaseMgrStandbyModule *self, PyObject *args)
     return nullptr;
   }
 
+  // Drop GIL for blocking mon command execution
+  PyThreadState *tstate = PyEval_SaveThread();
+
   std::string value;
   bool found = self->this_module->get_store(what, &value);
+
+  PyEval_RestoreThread(tstate);
+
   if (found) {
     dout(10) << "ceph_store_get " << what << " found: " << value.c_str() << dendl;
     return PyString_FromString(value.c_str());

--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -81,6 +81,26 @@ ceph_config_get(BaseMgrStandbyModule *self, PyObject *args)
 }
 
 static PyObject*
+ceph_store_get(BaseMgrStandbyModule *self, PyObject *args)
+{
+  char *what = nullptr;
+  if (!PyArg_ParseTuple(args, "s:ceph_store_get", &what)) {
+    derr << "Invalid args!" << dendl;
+    return nullptr;
+  }
+
+  std::string value;
+  bool found = self->this_module->get_store(what, &value);
+  if (found) {
+    dout(10) << "ceph_store_get " << what << " found: " << value.c_str() << dendl;
+    return PyString_FromString(value.c_str());
+  } else {
+    dout(4) << "ceph_store_get " << what << " not found " << dendl;
+    Py_RETURN_NONE;
+  }
+}
+
+static PyObject*
 ceph_get_active_uri(BaseMgrStandbyModule *self, PyObject *args)
 {
   return PyString_FromString(self->this_module->get_active_uri().c_str());
@@ -109,6 +129,9 @@ PyMethodDef BaseMgrStandbyModule_methods[] = {
 
   {"_ceph_get_config", (PyCFunction)ceph_config_get, METH_VARARGS,
    "Get a configuration value"},
+
+  {"_ceph_get_store", (PyCFunction)ceph_store_get, METH_VARARGS,
+   "Get a KV store value"},
 
   {"_ceph_get_active_uri", (PyCFunction)ceph_get_active_uri, METH_NOARGS,
    "Get the URI of the active instance of this module, if any"},

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -400,7 +400,7 @@ void MgrStandby::handle_mgr_map(MMgrMap* mmap)
       // I am the standby and someone else is active, start modules
       // in standby mode to do redirects if needed
       if (!py_module_registry.is_standby_running()) {
-        py_module_registry.standby_start();
+        py_module_registry.standby_start(monc);
       }
     }
   }

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -124,7 +124,7 @@ bool PyModuleRegistry::handle_mgr_map(const MgrMap &mgr_map_)
 
 
 
-void PyModuleRegistry::standby_start()
+void PyModuleRegistry::standby_start(MonClient &mc)
 {
   Mutex::Locker l(lock);
   assert(active_modules == nullptr);
@@ -137,7 +137,7 @@ void PyModuleRegistry::standby_start()
   dout(4) << "Starting modules in standby mode" << dendl;
 
   standby_modules.reset(new StandbyPyModules(
-        mgr_map, module_config, clog));
+        mgr_map, module_config, clog, mc));
 
   std::set<std::string> failed_modules;
   for (const auto &i : modules) {

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -96,7 +96,7 @@ public:
                 const std::map<std::string, std::string> &kv_store,
                 MonClient &mc, LogChannelRef clog_, Objecter &objecter_,
                 Client &client_, Finisher &f);
-  void standby_start();
+  void standby_start(MonClient &mc);
 
   bool is_standby_running() const
   {

--- a/src/mgr/StandbyPyModules.cc
+++ b/src/mgr/StandbyPyModules.cc
@@ -33,8 +33,10 @@
 
 StandbyPyModules::StandbyPyModules(
     const MgrMap &mgr_map_,
-    PyModuleConfig &module_config, LogChannelRef clog_)
-    : state(module_config),
+    PyModuleConfig &module_config,
+    LogChannelRef clog_,
+    MonClient &monc_)
+    : state(module_config, monc_),
       clog(clog_)
 {
   state.set_mgr_map(mgr_map_);
@@ -123,9 +125,6 @@ int StandbyPyModule::load()
 bool StandbyPyModule::get_config(const std::string &key,
                                  std::string *value) const
 {
-  PyThreadState *tstate = PyEval_SaveThread();
-  PyEval_RestoreThread(tstate);
-
   const std::string global_key = PyModule::config_prefix
     + get_name() + "/" + key;
 
@@ -139,6 +138,52 @@ bool StandbyPyModule::get_config(const std::string &key,
       return false;
     }
   });
+}
+
+bool StandbyPyModule::get_store(const std::string &key,
+                                std::string *value) const
+{
+
+  const std::string global_key = PyModule::config_prefix
+    + get_name() + "/" + key;
+
+  dout(4) << __func__ << " key: " << global_key << dendl;
+
+  // Active modules use a cache of store values (kept up to date
+  // as writes pass through the active mgr), but standbys
+  // fetch values synchronously to get an up to date value.
+  // It's an acceptable cost because standby modules should not be
+  // doing a lot.
+  
+  MonClient &monc = state.get_monc();
+
+  std::ostringstream cmd_json;
+  cmd_json << "{\"prefix\": \"config-key get\", \"key\": \""
+           << global_key << "\"}";
+
+  bufferlist outbl;
+  std::string outs;
+  C_SaferCond c;
+  monc.start_mon_command(
+      {cmd_json.str()},
+      {},
+      &outbl,
+      &outs,
+      &c);
+
+  int r = c.wait();
+  if (r == -ENOENT) {
+    return false;
+  } else if (r != 0) {
+    // This is some internal error, not meaningful to python modules,
+    // so let them just see no value.
+    derr << __func__ << " error fetching store key '" << global_key << "': "
+         << cpp_strerror(r) << " " << outs << dendl;
+    return false;
+  } else {
+    *value = outbl.to_str();
+    return true;
+  }
 }
 
 std::string StandbyPyModule::get_active_uri() const

--- a/src/mgr/StandbyPyModules.h
+++ b/src/mgr/StandbyPyModules.h
@@ -35,12 +35,13 @@ class StandbyPyModuleState
 
   MgrMap mgr_map;
   PyModuleConfig &module_config;
+  MonClient &monc;
 
 public:
 
   
-  StandbyPyModuleState(PyModuleConfig &module_config_)
-    : module_config(module_config_)
+  StandbyPyModuleState(PyModuleConfig &module_config_, MonClient &monc_)
+    : module_config(module_config_), monc(monc_)
   {}
 
   void set_mgr_map(const MgrMap &mgr_map_)
@@ -49,6 +50,10 @@ public:
 
     mgr_map = mgr_map_;
   }
+
+  // MonClient does all its own locking so we're happy to hand out
+  // references.
+  MonClient &get_monc() {return monc;};
 
   template<typename Callback, typename...Args>
   void with_mgr_map(Callback&& cb, Args&&...args) const
@@ -84,6 +89,7 @@ class StandbyPyModule : public PyModuleRunner
   }
 
   bool get_config(const std::string &key, std::string *value) const;
+  bool get_store(const std::string &key, std::string *value) const;
   std::string get_active_uri() const;
 
   int load();
@@ -104,7 +110,8 @@ public:
   StandbyPyModules(
       const MgrMap &mgr_map_,
       PyModuleConfig &module_config,
-      LogChannelRef clog_);
+      LogChannelRef clog_,
+      MonClient &monc);
 
   int start_one(PyModuleRef py_module);
 

--- a/src/pybind/mgr/dashboard/.pylintrc
+++ b/src/pybind/mgr/dashboard/.pylintrc
@@ -407,7 +407,7 @@ ignored-classes=optparse.Values,thread._local,_thread._local
 # (useful for modules/projects where namespaces are manipulated during runtime
 # and thus existing member attributes cannot be deduced by static analysis. It
 # supports qualified module names, as well as Unix pattern matching.
-ignored-modules=
+ignored-modules=cherrypy,distutils
 
 # Show a hint with possible names when a member name was not found. The aspect
 # of finding the hint is based on edit distance.

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -84,73 +84,28 @@ class ServerConfigException(Exception):
     pass
 
 
-class Module(MgrModule):
+class SSLCherryPyConfig(object):
     """
-    dashboard module entrypoint
+    Class for common server configuration done by both active and
+    standby module, especially setting up SSL.
     """
+    def __init__(self):
+        self._stopping = threading.Event()
+        self._url_prefix = ""
 
-    COMMANDS = [
-        {
-            'cmd': 'dashboard set-login-credentials '
-                   'name=username,type=CephString '
-                   'name=password,type=CephString',
-            'desc': 'Set the login credentials',
-            'perm': 'w'
-        },
-        {
-            'cmd': 'dashboard set-session-expire '
-                   'name=seconds,type=CephInt',
-            'desc': 'Set the session expire timeout',
-            'perm': 'w'
-        },
-        {
-            "cmd": "dashboard create-self-signed-cert",
-            "desc": "Create self signed certificate",
-            "perm": "w"
-        },
-    ]
-    COMMANDS.extend(options_command_list())
-
-    OPTIONS = [
-        {'name': 'server_addr'},
-        {'name': 'server_port'},
-        {'name': 'session-expire'},
-        {'name': 'password'},
-        {'name': 'url_prefix'},
-        {'name': 'username'},
-        {'name': 'key_file'},
-        {'name': 'crt_file'},
-    ]
-    OPTIONS.extend(options_schema_list())
+    def shutdown(self):
+        self._stopping.set()
 
     @property
     def url_prefix(self):
         return self._url_prefix
 
-    def __init__(self, *args, **kwargs):
-        super(Module, self).__init__(*args, **kwargs)
-        mgr.init(self)
-        self._url_prefix = ''
+    def _configure(self):
+        """
+        Configure CherryPy and initialize self.url_prefix
 
-        self._stopping = threading.Event()
-
-    @classmethod
-    def can_run(cls):
-        if cherrypy is None:
-            return False, "Missing dependency: cherrypy"
-
-        if not os.path.exists(cls.get_frontend_path()):
-            return False, "Frontend assets not found: incomplete build?"
-
-        return True, ""
-
-    @classmethod
-    def get_frontend_path(cls):
-        current_dir = os.path.dirname(os.path.abspath(__file__))
-        return os.path.join(current_dir, 'frontend/dist')
-
-    def configure_cherrypy(self):
-        # pylint: disable=too-many-locals
+        :returns our URI
+        """
         server_addr = self.get_localized_config('server_addr', '::')
         server_port = self.get_localized_config('server_port', '8080')
         if server_addr is None:
@@ -160,9 +115,6 @@ class Module(MgrModule):
                 .format(self.module_name, self.get_mgr_id()))
         self.log.info('server_addr: %s server_port: %s', server_addr,
                       server_port)
-
-        self._url_prefix = prepare_url_prefix(self.get_config('url_prefix',
-                                                              default=''))
 
         # Initialize custom handlers.
         cherrypy.tools.authenticate = cherrypy.Tool('before_handler', Auth.check_auth)
@@ -208,13 +160,111 @@ class Module(MgrModule):
         }
         cherrypy.config.update(config)
 
-        # Publish the URI that others may use to access the service we're
-        # about to start serving
-        self.set_uri("https://{0}:{1}{2}/".format(
+        self._url_prefix = prepare_url_prefix(self.get_config('url_prefix',
+                                                              default=''))
+
+        uri = "https://{0}:{1}{2}/".format(
             socket.getfqdn() if server_addr == "::" else server_addr,
             server_port,
             self.url_prefix
-        ))
+        )
+
+        return uri
+
+    def await_configuration(self):
+        """
+        Block until configuration is ready (i.e. all needed keys are set)
+        or self._stopping is set.
+
+        :returns URI of configured webserver
+        """
+        while not self._stopping.is_set():
+            try:
+                uri = self._configure()
+            except ServerConfigException as e:
+                self.log.info("Config not ready to serve, waiting: {0}".format(
+                    e
+                ))
+                # Poll until a non-errored config is present
+                self._stopping.wait(5)
+            else:
+                self.log.info("Configured CherryPy, starting engine...")
+                return uri
+
+class Module(MgrModule, SSLCherryPyConfig):
+    """
+    dashboard module entrypoint
+    """
+
+    COMMANDS = [
+        {
+            'cmd': 'dashboard set-login-credentials '
+                   'name=username,type=CephString '
+                   'name=password,type=CephString',
+            'desc': 'Set the login credentials',
+            'perm': 'w'
+        },
+        {
+            'cmd': 'dashboard set-session-expire '
+                   'name=seconds,type=CephInt',
+            'desc': 'Set the session expire timeout',
+            'perm': 'w'
+        },
+        {
+            "cmd": "dashboard create-self-signed-cert",
+            "desc": "Create self signed certificate",
+            "perm": "w"
+        },
+    ]
+    COMMANDS.extend(options_command_list())
+
+    OPTIONS = [
+        {'name': 'server_addr'},
+        {'name': 'server_port'},
+        {'name': 'session-expire'},
+        {'name': 'password'},
+        {'name': 'url_prefix'},
+        {'name': 'username'},
+        {'name': 'key_file'},
+        {'name': 'crt_file'},
+    ]
+    OPTIONS.extend(options_schema_list())
+
+    def __init__(self, *args, **kwargs):
+        super(Module, self).__init__(*args, **kwargs)
+        SSLCherryPyConfig.__init__(self)
+
+        mgr.init(self)
+
+        self._stopping = threading.Event()
+
+    @classmethod
+    def can_run(cls):
+        if cherrypy is None:
+            return False, "Missing dependency: cherrypy"
+
+        if not os.path.exists(cls.get_frontend_path()):
+            return False, "Frontend assets not found: incomplete build?"
+
+        return True, ""
+
+    @classmethod
+    def get_frontend_path(cls):
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        return os.path.join(current_dir, 'frontend/dist')
+
+    def serve(self):
+        if 'COVERAGE_ENABLED' in os.environ:
+            _cov.start()
+
+        uri = self.await_configuration()
+        if uri is None:
+            # We were shut down while waiting
+            return
+
+        # Publish the URI that others may use to access the service we're
+        # about to start serving
+        self.set_uri(uri)
 
         mapper = generate_routes(self.url_prefix)
 
@@ -227,23 +277,6 @@ class Module(MgrModule):
             '{}/api'.format(self.url_prefix): {'request.dispatch': mapper}
         }
         cherrypy.tree.mount(None, config=config)
-
-    def serve(self):
-        if 'COVERAGE_ENABLED' in os.environ:
-            _cov.start()
-
-        while not self._stopping.is_set():
-            try:
-                self.configure_cherrypy()
-            except ServerConfigException as e:
-                self.log.info("Config not ready to serve, waiting: {0}".format(
-                    e
-                ))
-                # Poll until a non-errored config is present
-                self._stopping.wait(5)
-            else:
-                self.log.info("Configured CherryPy, starting engine...")
-                break
 
         cherrypy.engine.start()
         NotificationQueue.start_queue()
@@ -258,7 +291,7 @@ class Module(MgrModule):
     def shutdown(self):
         super(Module, self).shutdown()
 
-        self._stopping.set()
+        SSLCherryPyConfig.shutdown(self)
 
         logger.info('Stopping server...')
         NotificationQueue.stop()
@@ -308,21 +341,20 @@ class Module(MgrModule):
         NotificationQueue.new_notification(notify_type, notify_id)
 
 
-class StandbyModule(MgrStandbyModule):
+class StandbyModule(MgrStandbyModule, SSLCherryPyConfig):
+    def __init__(self, *args, **kwargs):
+        super(StandbyModule, self).__init__(*args, **kwargs)
+        SSLCherryPyConfig.__init__(self)
+
+        # We can set the global mgr instance to ourselves even though
+        # we're just a standby, because it's enough for logging.
+        mgr.init(self)
+
     def serve(self):
-        server_addr = self.get_localized_config('server_addr', '::')
-        server_port = self.get_localized_config('server_port', '7000')
-        if server_addr is None:
-            msg = 'no server_addr configured; try "ceph config-key set ' \
-                  'mgr/dashboard/server_addr <ip>"'
-            raise RuntimeError(msg)
-        self.log.info("server_addr: %s server_port: %s",
-                      server_addr, server_port)
-        cherrypy.config.update({
-            'server.socket_host': server_addr,
-            'server.socket_port': int(server_port),
-            'engine.autoreload.on': False
-        })
+        uri = self.await_configuration()
+        if uri is None:
+            # We were shut down while waiting
+            return
 
         module = self
 
@@ -352,9 +384,7 @@ class StandbyModule(MgrStandbyModule):
                     """
                     return template.format(delay=5)
 
-        url_prefix = prepare_url_prefix(self.get_config('url_prefix',
-                                                        default=''))
-        cherrypy.tree.mount(Root(), "{}/".format(url_prefix), {})
+        cherrypy.tree.mount(Root(), "{}/".format(self.url_prefix), {})
         self.log.info("Starting engine...")
         cherrypy.engine.start()
         self.log.info("Waiting for engine...")
@@ -362,6 +392,8 @@ class StandbyModule(MgrStandbyModule):
         self.log.info("Engine done.")
 
     def shutdown(self):
+        SSLCherryPyConfig.shutdown(self)
+
         self.log.info("Stopping server...")
         cherrypy.engine.wait(state=cherrypy.engine.states.STARTED)
         cherrypy.engine.stop()

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -17,6 +17,28 @@ except ImportError:
     # To be picked up and reported by .can_run()
     cherrypy = None
 
+
+# The SSL code in CherryPy 3.5.0 is buggy.  It was fixed long ago,
+# but 3.5.0 is still shipping in major linux distributions
+# (Fedora 27, Ubuntu Xenial), so we must monkey patch it to get SSL working.
+from distutils.version import StrictVersion
+if cherrypy is not None:
+    v = StrictVersion(cherrypy.__version__)
+    # It was fixed in 3.7.0.  Exact lower bound version is probably earlier,
+    # but 3.5.0 is what this monkey patch is tested on.
+    if v >= StrictVersion("3.5.0") and v < StrictVersion("3.7.0"):
+        from cherrypy.wsgiserver.wsgiserver2 import HTTPConnection,\
+                                                    CP_fileobject
+        def fixed_init(hc_self, server, sock, makefile=CP_fileobject):
+            hc_self.server = server
+            hc_self.socket = sock
+            hc_self.rfile = makefile(sock, "rb", hc_self.rbufsize)
+            hc_self.wfile = makefile(sock, "wb", hc_self.wbufsize)
+            hc_self.requests_seen = 0
+
+        HTTPConnection.__init__ = fixed_init
+
+
 from mgr_module import MgrModule, MgrStandbyModule
 
 if 'COVERAGE_ENABLED' in os.environ:

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -7,10 +7,16 @@ from __future__ import absolute_import
 import errno
 import os
 import socket
+import tempfile
+import threading
+from uuid import uuid4
+from OpenSSL import crypto
+
 try:
     from urlparse import urljoin
 except ImportError:
     from urllib.parse import urljoin
+
 try:
     import cherrypy
 except ImportError:
@@ -74,6 +80,10 @@ def prepare_url_prefix(url_prefix):
     return url_prefix.rstrip('/')
 
 
+class ServerConfigException(Exception):
+    pass
+
+
 class Module(MgrModule):
     """
     dashboard module entrypoint
@@ -92,7 +102,12 @@ class Module(MgrModule):
                    'name=seconds,type=CephInt',
             'desc': 'Set the session expire timeout',
             'perm': 'w'
-        }
+        },
+        {
+            "cmd": "dashboard create-self-signed-cert",
+            "desc": "Create self signed certificate",
+            "perm": "w"
+        },
     ]
     COMMANDS.extend(options_command_list())
 
@@ -103,6 +118,8 @@ class Module(MgrModule):
         {'name': 'password'},
         {'name': 'url_prefix'},
         {'name': 'username'},
+        {'name': 'key_file'},
+        {'name': 'crt_file'},
     ]
     OPTIONS.extend(options_schema_list())
 
@@ -114,6 +131,8 @@ class Module(MgrModule):
         super(Module, self).__init__(*args, **kwargs)
         mgr.init(self)
         self._url_prefix = ''
+
+        self._stopping = threading.Event()
 
     @classmethod
     def can_run(cls):
@@ -135,7 +154,7 @@ class Module(MgrModule):
         server_addr = self.get_localized_config('server_addr', '::')
         server_port = self.get_localized_config('server_port', '8080')
         if server_addr is None:
-            raise RuntimeError(
+            raise ServerConfigException(
                 'no server_addr configured; '
                 'try "ceph config set mgr mgr/{}/{}/server_addr <ip>"'
                 .format(self.module_name, self.get_mgr_id()))
@@ -150,11 +169,40 @@ class Module(MgrModule):
         cherrypy.tools.session_expire_at_browser_close = SessionExpireAtBrowserCloseTool()
         cherrypy.tools.request_logging = RequestLoggingTool()
 
+        # SSL initialization
+        cert = self.get_store("crt")
+        if cert is not None:
+            self.cert_tmp = tempfile.NamedTemporaryFile()
+            self.cert_tmp.write(cert.encode('utf-8'))
+            self.cert_tmp.flush()  # cert_tmp must not be gc'ed
+            cert_fname = self.cert_tmp.name
+        else:
+            cert_fname = self.get_localized_config('crt_file')
+
+        pkey = self.get_store("key")
+        if pkey is not None:
+            self.pkey_tmp = tempfile.NamedTemporaryFile()
+            self.pkey_tmp.write(pkey.encode('utf-8'))
+            self.pkey_tmp.flush()  # pkey_tmp must not be gc'ed
+            pkey_fname = self.pkey_tmp.name
+        else:
+            pkey_fname = self.get_localized_config('key_file')
+
+        if not cert_fname or not pkey_fname:
+            raise ServerConfigException('no certificate configured')
+        if not os.path.isfile(cert_fname):
+            raise ServerConfigException('certificate %s does not exist' % cert_fname)
+        if not os.path.isfile(pkey_fname):
+            raise ServerConfigException('private key %s does not exist' % pkey_fname)
+
         # Apply the 'global' CherryPy configuration.
         config = {
             'engine.autoreload.on': False,
             'server.socket_host': server_addr,
             'server.socket_port': int(server_port),
+            'server.ssl_module': 'builtin',
+            'server.ssl_certificate': cert_fname,
+            'server.ssl_private_key': pkey_fname,
             'error_page.default': json_error_page,
             'tools.request_logging.on': True
         }
@@ -162,7 +210,7 @@ class Module(MgrModule):
 
         # Publish the URI that others may use to access the service we're
         # about to start serving
-        self.set_uri("http://{0}:{1}{2}/".format(
+        self.set_uri("https://{0}:{1}{2}/".format(
             socket.getfqdn() if server_addr == "::" else server_addr,
             server_port,
             self.url_prefix
@@ -183,7 +231,19 @@ class Module(MgrModule):
     def serve(self):
         if 'COVERAGE_ENABLED' in os.environ:
             _cov.start()
-        self.configure_cherrypy()
+
+        while not self._stopping.is_set():
+            try:
+                self.configure_cherrypy()
+            except ServerConfigException as e:
+                self.log.info("Config not ready to serve, waiting: {0}".format(
+                    e
+                ))
+                # Poll until a non-errored config is present
+                self._stopping.wait(5)
+            else:
+                self.log.info("Configured CherryPy, starting engine...")
+                break
 
         cherrypy.engine.start()
         NotificationQueue.start_queue()
@@ -197,6 +257,9 @@ class Module(MgrModule):
 
     def shutdown(self):
         super(Module, self).shutdown()
+
+        self._stopping.set()
+
         logger.info('Stopping server...')
         NotificationQueue.stop()
         cherrypy.engine.exit()
@@ -212,9 +275,34 @@ class Module(MgrModule):
         elif cmd['prefix'] == 'dashboard set-session-expire':
             self.set_config('session-expire', str(cmd['seconds']))
             return 0, 'Session expiration timeout updated', ''
+        elif cmd['prefix'] == 'dashboard create-self-signed-cert':
+            self.create_self_signed_cert()
+            return 0, 'Self-signed certificate created', ''
 
         return (-errno.EINVAL, '', 'Command not found \'{0}\''
                 .format(cmd['prefix']))
+
+    def create_self_signed_cert(self):
+        # create a key pair
+        pkey = crypto.PKey()
+        pkey.generate_key(crypto.TYPE_RSA, 2048)
+
+        # create a self-signed cert
+        cert = crypto.X509()
+        cert.get_subject().O = "IT"
+        cert.get_subject().CN = "ceph-dashboard"
+        cert.set_serial_number(int(uuid4()))
+        cert.gmtime_adj_notBefore(0)
+        cert.gmtime_adj_notAfter(10*365*24*60*60)
+        cert.set_issuer(cert.get_subject())
+        cert.set_pubkey(pkey)
+        cert.sign(pkey, 'sha512')
+
+        cert = crypto.dump_certificate(crypto.FILETYPE_PEM, cert)
+        self.set_store('crt', cert.decode('utf-8'))
+
+        pkey = crypto.dump_privatekey(crypto.FILETYPE_PEM, pkey)
+        self.set_store('key', pkey.decode('utf-8'))
 
     def notify(self, notify_type, notify_id):
         NotificationQueue.new_notification(notify_type, notify_id)

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -5,12 +5,16 @@ openATTIC mgr plugin (based on CherryPy)
 from __future__ import absolute_import
 
 import errno
+from distutils.version import StrictVersion
 import os
 import socket
 import tempfile
 import threading
 from uuid import uuid4
+
 from OpenSSL import crypto
+
+from mgr_module import MgrModule, MgrStandbyModule
 
 try:
     from urlparse import urljoin
@@ -27,7 +31,6 @@ except ImportError:
 # The SSL code in CherryPy 3.5.0 is buggy.  It was fixed long ago,
 # but 3.5.0 is still shipping in major linux distributions
 # (Fedora 27, Ubuntu Xenial), so we must monkey patch it to get SSL working.
-from distutils.version import StrictVersion
 if cherrypy is not None:
     v = StrictVersion(cherrypy.__version__)
     # It was fixed in 3.7.0.  Exact lower bound version is probably earlier,
@@ -35,6 +38,7 @@ if cherrypy is not None:
     if v >= StrictVersion("3.5.0") and v < StrictVersion("3.7.0"):
         from cherrypy.wsgiserver.wsgiserver2 import HTTPConnection,\
                                                     CP_fileobject
+
         def fixed_init(hc_self, server, sock, makefile=CP_fileobject):
             hc_self.server = server
             hc_self.socket = sock
@@ -44,8 +48,6 @@ if cherrypy is not None:
 
         HTTPConnection.__init__ = fixed_init
 
-
-from mgr_module import MgrModule, MgrStandbyModule
 
 if 'COVERAGE_ENABLED' in os.environ:
     import coverage
@@ -92,6 +94,9 @@ class SSLCherryPyConfig(object):
     def __init__(self):
         self._stopping = threading.Event()
         self._url_prefix = ""
+
+        self.cert_tmp = None
+        self.pkey_tmp = None
 
     def shutdown(self):
         self._stopping.set()
@@ -190,6 +195,7 @@ class SSLCherryPyConfig(object):
             else:
                 self.log.info("Configured CherryPy, starting engine...")
                 return uri
+
 
 class Module(MgrModule, SSLCherryPyConfig):
     """

--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -20,6 +20,7 @@ py==1.5.2
 pycodestyle==2.3.1
 pycparser==2.18
 pylint==1.8.2
+pyopenssl==17.5.0
 pytest==3.3.2
 pytest-cov==2.5.1
 pytz==2017.3

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -23,4 +23,4 @@ commands=
     cov: coverage report
     cov: coverage xml
     lint: pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests services
-    lint: pycodestyle --max-line-length=100 --exclude=.tox,venv,frontend --ignore=E402,E121,E123,E126,E226,E24,E704,W503 .
+    lint: pycodestyle --max-line-length=100 --exclude=.tox,venv,frontend --ignore=E402,E121,E123,E126,E226,E24,E704,W503,E741 .

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -198,6 +198,14 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
         else:
             return r
 
+    def get_store(self, key):
+        """
+        Retrieve the value of a persistent KV store entry
+
+        :param key: String
+        :return: Byte string or None
+        """
+        return self._ceph_get_store(key)
 
     def get_active_uri(self):
         return self._ceph_get_active_uri()

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -686,9 +686,9 @@ EOF
         if $with_mgr_dashboard ; then
             ceph_adm config set mgr mgr/dashboard/$name/server_port $MGR_PORT
             if [ $mgr -eq 1 ]; then
-                DASH_URLS="http://$IP:$MGR_PORT"
+                DASH_URLS="https://$IP:$MGR_PORT"
             else
-                DASH_URLS+=", http://$IP:$MGR_PORT"
+                DASH_URLS+=", https://$IP:$MGR_PORT"
             fi
         fi
 	MGR_PORT=$(($MGR_PORT + 1000))
@@ -711,6 +711,9 @@ EOF
     # setting login credentials for dashboard
     if $with_mgr_dashboard; then
         ceph_adm tell mgr dashboard set-login-credentials admin admin
+        if ! ceph_adm tell mgr dashboard create-self-signed-cert;  then
+            echo dashboard module not working correctly!
+        fi
     fi
 
     if ceph_adm tell mgr restful create-self-signed-cert; then


### PR DESCRIPTION
Hunted down the specific thing that was breaking in CherryPy 3.5.0 (which is old, but it's what's in Xenial and Fedora 27), and added a monkey patch for it.

This is DNM because the standby mode is still just http:// -- writing this made me realise that I neglected to enable standby modules to access `get_store`, so this can't get at its certificates.  Didn't notice this when updating the restful module because it doesn't implement standby mode.