### PR TITLE
os/bluestore/bluefs_types: make block_mask 64-bit

### DIFF
--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -128,7 +128,7 @@ struct bluefs_super_t {
       block_size(4096) { }
 
   uint64_t block_mask() const {
-    return ~(block_size - 1);
+    return ~((uint64_t)block_size - 1);
   }
 
   void encode(bufferlist& bl) const;


### PR DESCRIPTION
Since block_size is 32 bits, we return 0x00000000fffff000 (or similar).
This breaks things if you get a file (e.g., bluefs metadata log file)
over 4GB.

Fixes: https://tracker.ceph.com/issues/23840
Signed-off-by: Sage Weil <sage@redhat.com>