### PR TITLE
cmake: use CMAKE_CXX_STANDARD if cmake's version >= 3.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -142,7 +142,7 @@ else(no_yasm)
 endif(no_yasm)
 
 # require c++17
-if(CMAKE_VERSION VERSION_LESS "3.8")
+if(CMAKE_VERSION VERSION_LESS "3.1")
   include(CheckCXXCompilerFlag)
   CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
   if(NOT COMPILER_SUPPORTS_CXX17)


### PR DESCRIPTION
see https://cmake.org/cmake/help/v3.1/release/3.1.0.html#properties

Signed-off-by: Kefu Chai <kchai@redhat.com>