### PR TITLE
mds: fix CEPH_STAT_RSTAT definition

### DIFF
--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -737,7 +737,7 @@ int ceph_flags_to_mode(int flags);
 				 CEPH_CAP_XATTR_SHARED)
 #define CEPH_STAT_CAP_INLINE_DATA (CEPH_CAP_FILE_SHARED | \
 				   CEPH_CAP_FILE_RD)
-#define CEPH_STAT_RSTAT        (CEPH_CAP_GWREXTEND << 16)  /* for requesting rstat */
+#define CEPH_STAT_RSTAT        CEPH_CAP_FILE_WREXTEND
 
 #define CEPH_CAP_ANY_SHARED (CEPH_CAP_AUTH_SHARED |			\
 			      CEPH_CAP_LINK_SHARED |			\


### PR DESCRIPTION
(CEPH_CAP_GWREXTEND << 16) is (1<<22), which causes gaps in caps bits.
CEPH_CAP_FILE_WREXTEND is an unused bit, reuse it for CEPH_STAT_RSTAT.

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>