### PR TITLE
misc: mark constructors as explicit

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -87,7 +87,7 @@ class MDSCommandOp : public CommandOp
   public:
   mds_gid_t     mds_gid;
 
-  MDSCommandOp(ceph_tid_t t) : CommandOp(t) {}
+  explicit MDSCommandOp(ceph_tid_t t) : CommandOp(t) {}
 };
 
 /* error code for ceph_fuse */
@@ -204,7 +204,7 @@ struct dir_result_t {
     int64_t offset;
     string name;
     InodeRef inode;
-    dentry(int64_t o) : offset(o) {}
+    explicit dentry(int64_t o) : offset(o) {}
     dentry(int64_t o, const string& n, const InodeRef& in) :
       offset(o), name(n), inode(in) {}
   };

--- a/src/common/Cond.h
+++ b/src/common/Cond.h
@@ -177,7 +177,7 @@ class C_SaferCond : public Context {
   int rval;      ///< return value
 public:
   C_SaferCond() : lock("C_SaferCond"), done(false), rval(0) {}
-  C_SaferCond(const std::string &name) : lock(name), done(false), rval(0) {}
+  explicit C_SaferCond(const std::string &name) : lock(name), done(false), rval(0) {}
   void finish(int r) override { complete(r); }
 
   /// We overload complete in order to not delete the context

--- a/src/common/ceph_json.cc
+++ b/src/common/ceph_json.cc
@@ -643,8 +643,8 @@ struct field_entity {
   bool append{false};
 
   field_entity() {}
-  field_entity(const string& n) : is_obj(true), name(n) {}
-  field_entity(int i) : is_obj(false), index(i) {}
+  explicit field_entity(const string& n) : is_obj(true), name(n) {}
+  explicit field_entity(int i) : is_obj(false), index(i) {}
 };
 
 static int parse_entity(const string& s, vector<field_entity> *result)

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -127,7 +127,7 @@ public:
   } opt_type_t;
 
   // Create a new md_config_t structure.
-  md_config_t(bool is_daemon=false);
+  explicit md_config_t(bool is_daemon=false);
   ~md_config_t();
 
   // Adds a new observer to this configuration. You can do this at any time,

--- a/src/common/escape.cc
+++ b/src/common/escape.cc
@@ -120,7 +120,7 @@ struct hex_formatter {
   const char old_fill;
   const std::ostream::fmtflags old_flags;
 
-  hex_formatter(std::ostream& out)
+  explicit hex_formatter(std::ostream& out)
     : out(out),
       old_fill(out.fill('0')),
       old_flags(out.setf(out.hex, out.basefield))

--- a/src/common/scrub_types.h
+++ b/src/common/scrub_types.h
@@ -9,7 +9,7 @@
 // wrappers around scrub types to offer the necessary bits other than
 // the minimal set that the lirados requires
 struct object_id_wrapper : public librados::object_id_t {
-  object_id_wrapper(const hobject_t& hoid)
+  explicit object_id_wrapper(const hobject_t& hoid)
     : object_id_t{hoid.oid.name, hoid.nspace, hoid.get_key(), hoid.snap}
   {}
   void encode(bufferlist& bl) const;
@@ -40,7 +40,7 @@ namespace librados {
 struct shard_info_wrapper : public librados::shard_info_t {
 public:
   shard_info_wrapper() = default;
-  shard_info_wrapper(const ScrubMap::object& object) {
+  explicit shard_info_wrapper(const ScrubMap::object& object) {
     set_object(object);
   }
   void set_object(const ScrubMap::object& object);
@@ -103,7 +103,7 @@ namespace librados {
 }
 
 struct inconsistent_obj_wrapper : librados::inconsistent_obj_t {
-  inconsistent_obj_wrapper(const hobject_t& hoid);
+  explicit inconsistent_obj_wrapper(const hobject_t& hoid);
 
   void set_object_info_inconsistency() {
     errors |= obj_err_t::OBJECT_INFO_INCONSISTENCY;
@@ -149,7 +149,7 @@ inline void decode(librados::inconsistent_obj_t& obj,
 
 struct inconsistent_snapset_wrapper : public librados::inconsistent_snapset_t {
   inconsistent_snapset_wrapper() = default;
-  inconsistent_snapset_wrapper(const hobject_t& head);
+  explicit inconsistent_snapset_wrapper(const hobject_t& head);
   void set_headless();
   // soid claims that it is a head or a snapdir, but its SS_ATTR
   // is missing.

--- a/src/crush/CrushLocation.h
+++ b/src/crush/CrushLocation.h
@@ -18,7 +18,7 @@ class CrushLocation {
   int _parse(const std::string& s);
 
 public:
-  CrushLocation(CephContext *c) : cct(c) {
+  explicit CrushLocation(CephContext *c) : cct(c) {
     init_on_startup();
   }
 

--- a/src/kv/MemDB.h
+++ b/src/kv/MemDB.h
@@ -98,7 +98,7 @@ public:
     void clear() {
       ops.clear();
     }
-    MDBTransactionImpl(MemDB* _db) :m_db(_db)
+    explicit MDBTransactionImpl(MemDB* _db) :m_db(_db)
     {
       ops.clear();
     }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -85,7 +85,7 @@ public:
     return store.assoc_name.c_str();
   }
 
-  MergeOperatorRouter(RocksDBStore &_store) : store(_store) {}
+  explicit MergeOperatorRouter(RocksDBStore &_store) : store(_store) {}
 
   bool Merge(const rocksdb::Slice& key,
 	     const rocksdb::Slice* existing_value,
@@ -124,7 +124,7 @@ class RocksDBStore::MergeOperatorLinker
 private:
   std::shared_ptr<KeyValueDB::MergeOperator> mop;
 public:
-  MergeOperatorLinker(const std::shared_ptr<KeyValueDB::MergeOperator> &o) : mop(o) {}
+  explicit MergeOperatorLinker(const std::shared_ptr<KeyValueDB::MergeOperator> &o) : mop(o) {}
 
   const char *Name() const override {
     return mop->name().c_str();

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -26,7 +26,7 @@ using util::create_context_callback;
 class ImageUpdateWatchers {
 public:
 
-  ImageUpdateWatchers(CephContext *cct) : m_cct(cct),
+  explicit ImageUpdateWatchers(CephContext *cct) : m_cct(cct),
     m_lock(util::unique_lock_name("librbd::ImageUpdateWatchers::m_lock", this)) {
   }
 

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -1620,7 +1620,7 @@ struct C_RefreshTags : public Context {
   uint64_t tag_tid = 0;
   journal::TagData tag_data;
 
-  C_RefreshTags(util::AsyncOpTracker &async_op_tracker)
+  explicit C_RefreshTags(util::AsyncOpTracker &async_op_tracker)
     : async_op_tracker(async_op_tracker),
       lock("librbd::Journal::C_RefreshTags::lock") {
     async_op_tracker.start_op();

--- a/src/librbd/cache/ImageWriteback.h
+++ b/src/librbd/cache/ImageWriteback.h
@@ -24,7 +24,7 @@ class ImageWriteback {
 public:
   typedef std::vector<std::pair<uint64_t,uint64_t> > Extents;
 
-  ImageWriteback(ImageCtxT &image_ctx);
+  explicit ImageWriteback(ImageCtxT &image_ctx);
 
   void aio_read(Extents &&image_extents, ceph::bufferlist *bl,
                 int fadvise_flags, Context *on_finish);

--- a/src/librbd/cache/PassthroughImageCache.h
+++ b/src/librbd/cache/PassthroughImageCache.h
@@ -19,7 +19,7 @@ namespace cache {
 template <typename ImageCtxT = librbd::ImageCtx>
 class PassthroughImageCache : public ImageCache {
 public:
-  PassthroughImageCache(ImageCtx &image_ctx);
+  explicit PassthroughImageCache(ImageCtx &image_ctx);
 
   /// client AIO methods
   void aio_read(Extents&& image_extents, ceph::bufferlist *bl,

--- a/src/librbd/io/ReadResult.cc
+++ b/src/librbd/io/ReadResult.cc
@@ -19,7 +19,7 @@ namespace io {
 struct ReadResult::SetClipLengthVisitor : public boost::static_visitor<void> {
   size_t length;
 
-  SetClipLengthVisitor(size_t length) : length(length) {
+  explicit SetClipLengthVisitor(size_t length) : length(length) {
   }
 
   void operator()(Linear &linear) const {

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -427,7 +427,7 @@ public:
     sr_t *snapnode = UNDEF_SRNODE;
 
     projected_inode() = delete;
-    projected_inode(const mempool_inode &in) : inode(in) {}
+    explicit projected_inode(const mempool_inode &in) : inode(in) {}
   };
 
 private:

--- a/src/mds/DamageTable.h
+++ b/src/mds/DamageTable.h
@@ -192,7 +192,7 @@ public:
       const inodeno_t ino) const;
 
 
-  DamageTable(const mds_rank_t rank_)
+  explicit DamageTable(const mds_rank_t rank_)
     : rank(rank_)
   {
     assert(rank_ != MDS_RANK_NONE);

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -26,7 +26,7 @@ class MDSInternalContextBase;
 class OpenFileTable
 {
 public:
-  OpenFileTable(MDSRank *m) : mds(m) {}
+  explicit OpenFileTable(MDSRank *m) : mds(m) {}
 
   void add_inode(CInode *in);
   void remove_inode(CInode *in);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -664,7 +664,7 @@ bool DaemonServer::handle_command(MCommand *m)
     bufferlist odata;
     cmdmap_t cmdmap;
 
-    CommandContext(MCommand *m_)
+    explicit CommandContext(MCommand *m_)
       : m(m_)
     {
     }
@@ -708,7 +708,7 @@ bool DaemonServer::handle_command(MCommand *m)
     bufferlist from_mon;
     string outs;
 
-    ReplyOnFinish(const std::shared_ptr<CommandContext> &cmdctx_)
+    explicit ReplyOnFinish(const std::shared_ptr<CommandContext> &cmdctx_)
       : cmdctx(cmdctx_)
     {}
     void finish(int r) override {

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -68,7 +68,7 @@ class DaemonPerfCounters
   // The record of perf stat types, shared between daemons
   PerfCounterTypes &types;
 
-  DaemonPerfCounters(PerfCounterTypes &types_)
+  explicit DaemonPerfCounters(PerfCounterTypes &types_)
     : types(types_)
   {}
 
@@ -119,7 +119,7 @@ class DaemonState
   // The perf counters received in MMgrReport messages
   DaemonPerfCounters perf_counters;
 
-  DaemonState(PerfCounterTypes &types_)
+  explicit DaemonState(PerfCounterTypes &types_)
     : perf_counters(types_)
   {
   }

--- a/src/mgr/Gil.h
+++ b/src/mgr/Gil.h
@@ -28,7 +28,7 @@ typedef struct _ts PyThreadState;
 class SafeThreadState
 {
   public:
-  SafeThreadState(PyThreadState *ts_);
+  explicit SafeThreadState(PyThreadState *ts_);
 
   SafeThreadState()
     : ts(nullptr), thread(0)

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -44,7 +44,7 @@ class MgrCommand : public CommandOp
 {
   public:
 
-  MgrCommand(ceph_tid_t t) : CommandOp(t) {}
+  explicit MgrCommand(ceph_tid_t t) : CommandOp(t) {}
   MgrCommand() : CommandOp() {}
 };
 

--- a/src/mgr/MgrSession.h
+++ b/src/mgr/MgrSession.h
@@ -25,7 +25,7 @@ struct MgrSession : public RefCountedObject {
 
   std::set<std::string> declared_types;
 
-  MgrSession(CephContext *cct) : RefCountedObject(cct, 0) {}
+  explicit MgrSession(CephContext *cct) : RefCountedObject(cct, 0) {}
   ~MgrSession() override {}
 };
 

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -94,7 +94,7 @@ public:
   PyObject *pClass = nullptr;
   PyObject *pStandbyClass = nullptr;
 
-  PyModule(const std::string &module_name_)
+  explicit PyModule(const std::string &module_name_)
     : module_name(module_name_)
   {
   }

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -76,7 +76,7 @@ public:
     return modules_out;
   }
 
-  PyModuleRegistry(LogChannelRef clog_)
+  explicit PyModuleRegistry(LogChannelRef clog_)
     : clog(clog_)
   {}
 

--- a/src/mgr/PyModuleRunner.h
+++ b/src/mgr/PyModuleRunner.h
@@ -40,7 +40,7 @@ protected:
     PyModuleRunner *mod;
 
   public:
-    PyModuleRunnerThread(PyModuleRunner *mod_)
+    explicit PyModuleRunnerThread(PyModuleRunner *mod_)
       : mod(mod_) {}
 
     void *entry() override;

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -79,7 +79,7 @@ class FlagSetHandler : public FileSystemCommandHandler
 class FsNewHandler : public FileSystemCommandHandler
 {
   public:
-  FsNewHandler(Paxos *paxos)
+  explicit FsNewHandler(Paxos *paxos)
     : FileSystemCommandHandler("fs new"), m_paxos(paxos)
   {
   }
@@ -494,7 +494,7 @@ public:
 class AddDataPoolHandler : public FileSystemCommandHandler
 {
   public:
-  AddDataPoolHandler(Paxos *paxos)
+  explicit AddDataPoolHandler(Paxos *paxos)
     : FileSystemCommandHandler("fs add_data_pool"), m_paxos(paxos)
   {}
 
@@ -790,7 +790,7 @@ class AliasHandler : public T
   std::string alias_prefix;
 
   public:
-  AliasHandler(const std::string &new_prefix)
+  explicit AliasHandler(const std::string &new_prefix)
     : T()
   {
     alias_prefix = new_prefix;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -218,7 +218,7 @@ struct StackSingleton {
   CephContext *cct;
   std::shared_ptr<NetworkStack> stack;
 
-  StackSingleton(CephContext *c): cct(c) {}
+  explicit StackSingleton(CephContext *c): cct(c) {}
   void ready(std::string &type) {
     if (!stack)
       stack = NetworkStack::create(cct, type);

--- a/src/msg/async/dpdk/EventDPDK.h
+++ b/src/msg/async/dpdk/EventDPDK.h
@@ -26,7 +26,7 @@ class DPDKDriver : public EventDriver {
  public:
   UserspaceEventManager manager;
 
-  DPDKDriver(CephContext *c): cct(c), manager(c) {}
+  explicit DPDKDriver(CephContext *c): cct(c), manager(c) {}
   virtual ~DPDKDriver() { }
 
   int init(EventCenter *c, int nevent) override;

--- a/src/msg/async/dpdk/Packet.h
+++ b/src/msg/async/dpdk/Packet.h
@@ -104,7 +104,7 @@ class Packet {
 
     fragment frags[];
 
-    impl(size_t nr_frags = default_nr_frags);
+    explicit impl(size_t nr_frags = default_nr_frags);
     impl(const impl&) = delete;
     impl(fragment frag, size_t nr_frags = default_nr_frags);
 
@@ -180,7 +180,7 @@ class Packet {
               to->frags[0].base);
     }
   };
-  Packet(std::unique_ptr<impl>&& impl) : _impl(std::move(impl)) {}
+  explicit Packet(std::unique_ptr<impl>&& impl) : _impl(std::move(impl)) {}
   std::unique_ptr<impl> _impl;
 public:
   static Packet from_static_data(const char* data, size_t len) {
@@ -190,13 +190,13 @@ public:
   // build empty Packet
   Packet();
   // build empty Packet with nr_frags allocated
-  Packet(size_t nr_frags);
+  explicit Packet(size_t nr_frags);
   // move existing Packet
   Packet(Packet&& x) noexcept;
   // copy data into Packet
   Packet(const char* data, size_t len);
   // copy data into Packet
-  Packet(fragment frag);
+  explicit Packet(fragment frag);
   // zero-copy single fragment
   Packet(fragment frag, deleter del);
   // zero-copy multiple fragments

--- a/src/msg/async/dpdk/UserspaceEvent.h
+++ b/src/msg/async/dpdk/UserspaceEvent.h
@@ -46,7 +46,7 @@ class UserspaceEventManager {
   std::list<uint32_t> unused_fds;
 
  public:
-  UserspaceEventManager(CephContext *c): cct(c) {
+  explicit UserspaceEventManager(CephContext *c): cct(c) {
     waiting_fds.resize(1024);
   }
 

--- a/src/msg/async/dpdk/ethernet.h
+++ b/src/msg/async/dpdk/ethernet.h
@@ -32,11 +32,11 @@
 struct ethernet_address {
   ethernet_address() {}
 
-  ethernet_address(const uint8_t *eaddr) {
+  explicit ethernet_address(const uint8_t *eaddr) {
     std::copy(eaddr, eaddr + 6, mac.begin());
   }
 
-  ethernet_address(std::initializer_list<uint8_t> eaddr) {
+  explicit ethernet_address(std::initializer_list<uint8_t> eaddr) {
     assert(eaddr.size() == mac.size());
     std::copy(eaddr.begin(), eaddr.end(), mac.begin());
   }

--- a/src/msg/async/dpdk/net.h
+++ b/src/msg/async/dpdk/net.h
@@ -105,7 +105,7 @@ class interface {
     stream<Packet, ethernet_address> packet_stream;
     std::function<bool (forward_hash&, Packet&, size_t)> forward;
     bool ready() { return packet_stream.started(); }
-    l3_rx_stream(std::function<bool (forward_hash&, Packet&, size_t)>&& fw) : forward(fw) {}
+    explicit l3_rx_stream(std::function<bool (forward_hash&, Packet&, size_t)>&& fw) : forward(fw) {}
   };
   std::unordered_map<uint16_t, l3_rx_stream> _proto_map;
   std::shared_ptr<DPDKDevice> _dev;

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -99,7 +99,7 @@ class DeviceList {
   int num;
   Device** devices;
  public:
-  DeviceList(CephContext *cct): device_list(ibv_get_device_list(&num)) {
+  explicit DeviceList(CephContext *cct): device_list(ibv_get_device_list(&num)) {
     if (device_list == NULL || num == 0) {
       lderr(cct) << __func__ << " failed to get rdma device list.  " << cpp_strerror(errno) << dendl;
       ceph_abort();
@@ -250,7 +250,7 @@ class Infiniband {
       unsigned n_bufs_allocated;
       // true if it is possible to alloc
       // more memory for the pool
-      MemPoolContext(MemoryManager *m) :
+      explicit MemPoolContext(MemoryManager *m) :
         perf_logger(nullptr),
         manager(m),
         n_bufs_allocated(0) {}

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -80,7 +80,7 @@ class RDMADispatcher {
   class C_handle_cq_async : public EventCallback {
     RDMADispatcher *dispatcher;
    public:
-    C_handle_cq_async(RDMADispatcher *w): dispatcher(w) {}
+    explicit C_handle_cq_async(RDMADispatcher *w): dispatcher(w) {}
     void do_request(uint64_t fd) {
       // worker->handle_tx_event();
       dispatcher->handle_async_event();
@@ -138,7 +138,7 @@ class RDMAWorker : public Worker {
   class C_handle_cq_tx : public EventCallback {
     RDMAWorker *worker;
     public:
-    C_handle_cq_tx(RDMAWorker *w): worker(w) {}
+    explicit C_handle_cq_tx(RDMAWorker *w): worker(w) {}
     void do_request(uint64_t fd) {
       worker->handle_pending_message();
     }
@@ -226,7 +226,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
     RDMAConnectedSocketImpl *csi;
     bool active;
    public:
-    C_handle_connection(RDMAConnectedSocketImpl *w): csi(w), active(true) {}
+    explicit C_handle_connection(RDMAConnectedSocketImpl *w): csi(w), active(true) {}
     void do_request(uint64_t fd) {
       if (active)
         csi->handle_connection();

--- a/src/msg/xio/XioMessenger.h
+++ b/src/msg/xio/XioMessenger.h
@@ -36,7 +36,7 @@ class XioInit {
   void package_init(CephContext *cct);
 
 protected:
-  XioInit(CephContext *cct) {
+  explicit XioInit(CephContext *cct) {
     this->package_init(cct);
   }
 };

--- a/src/osd/ExtentCache.h
+++ b/src/osd/ExtentCache.h
@@ -172,7 +172,7 @@ private:
 
   struct object_extent_set : boost::intrusive::set_base_hook<> {
     hobject_t oid;
-    object_extent_set(const hobject_t &oid) : oid(oid) {}
+    explicit object_extent_set(const hobject_t &oid) : oid(oid) {}
 
     using set_member_options = boost::intrusive::member_hook<
       extent,

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4150,7 +4150,7 @@ void OSD::build_initial_pg_history(
       bool operator()(const set<pg_shard_t> &have) const {
 	return have.size() >= pi->min_size;
       }
-      min_size_predicate_t(const pg_pool_t *i) : pi(i) {}
+      explicit min_size_predicate_t(const pg_pool_t *i) : pi(i) {}
     } min_size_predicate(osdmap->get_pg_pool(pgid.pgid.pool()));
 
     bool new_interval = PastIntervals::check_new_interval(

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -127,8 +127,8 @@ struct OSDCapMatch {
   std::string object_prefix;
 
   OSDCapMatch() {}
-  OSDCapMatch(const OSDCapPoolTag& pt) : pool_tag(pt) {}
-  OSDCapMatch(const OSDCapPoolNamespace& pns) : pool_namespace(pns) {}
+  explicit OSDCapMatch(const OSDCapPoolTag& pt) : pool_tag(pt) {}
+  explicit OSDCapMatch(const OSDCapPoolNamespace& pns) : pool_namespace(pns) {}
   OSDCapMatch(const OSDCapPoolNamespace& pns, const std::string& pre)
     : pool_namespace(pns), object_prefix(pre) {}
   OSDCapMatch(const std::string& pl, const std::string& pre)
@@ -192,7 +192,7 @@ struct OSDCapGrant {
 
   OSDCapGrant() {}
   OSDCapGrant(const OSDCapMatch& m, const OSDCapSpec& s) : match(m), spec(s) {}
-  OSDCapGrant(const OSDCapProfile& profile) : profile(profile) {
+  explicit OSDCapGrant(const OSDCapProfile& profile) : profile(profile) {
     expand_profile();
   }
 

--- a/src/osd/OpQueueItem.h
+++ b/src/osd/OpQueueItem.h
@@ -172,7 +172,7 @@ protected:
     return pgid;
   }
 public:
-  PGOpQueueable(spg_t pg) : pgid(pg) {}
+  explicit PGOpQueueable(spg_t pg) : pgid(pg) {}
   uint32_t get_queue_token() const override final {
     return get_pgid().ps();
   }
@@ -185,7 +185,7 @@ public:
     class Locker : public OpQueueItem::OrderLocker {
       PGRef pg;
     public:
-      Locker(PGRef pg) : pg(pg) {}
+      explicit Locker(PGRef pg) : pg(pg) {}
       void lock() override final {
 	pg->lock();
       }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4569,7 +4569,7 @@ void PG::Scrubber::cleanup_store(ObjectStore::Transaction *t) {
     return;
   struct OnComplete : Context {
     std::unique_ptr<Scrub::Store> store;
-    OnComplete(
+    explicit OnComplete(
       std::unique_ptr<Scrub::Store> &&store)
       : store(std::move(store)) {}
     void finish(int) override {}

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -136,7 +136,7 @@ public:
     { }
 
     template <typename... Args>
-    IndexedLog(Args&&... args) :
+    explicit IndexedLog(Args&&... args) :
       pg_log_t(std::forward<Args>(args)...),
       complete_to(log.end()),
       last_requested(0),

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -330,7 +330,7 @@ public:
 struct CopyFromFinisher : public PrimaryLogPG::OpFinisher {
   CopyFromCallback *copy_from_callback;
 
-  CopyFromFinisher(CopyFromCallback *copy_from_callback)
+  explicit CopyFromFinisher(CopyFromCallback *copy_from_callback)
     : copy_from_callback(copy_from_callback) {
   }
 
@@ -837,7 +837,7 @@ class PGLSParentFilter : public PGLSFilter {
   inodeno_t parent_ino;
 public:
   CephContext* cct;
-  PGLSParentFilter(CephContext* cct) : cct(cct) {
+  explicit PGLSParentFilter(CephContext* cct) : cct(cct) {
     xattr = "_parent";
   }
   int init(bufferlist::iterator &params) override
@@ -3422,7 +3422,7 @@ public:
 struct SetManifestFinisher : public PrimaryLogPG::OpFinisher {
   OSDOp& osd_op;
 
-  SetManifestFinisher(OSDOp& osd_op) : osd_op(osd_op) {
+  explicit SetManifestFinisher(OSDOp& osd_op) : osd_op(osd_op) {
   }
 
   int execute() override {
@@ -3703,7 +3703,7 @@ public:
 struct PromoteFinisher : public PrimaryLogPG::OpFinisher {
   PromoteManifestCallback *promote_callback;
 
-  PromoteFinisher(PromoteManifestCallback *promote_callback)
+  explicit PromoteFinisher(PromoteManifestCallback *promote_callback)
     : promote_callback(promote_callback) {
   }
 
@@ -5032,7 +5032,7 @@ void PrimaryLogPG::maybe_create_new_object(
 struct ReadFinisher : public PrimaryLogPG::OpFinisher {
   OSDOp& osd_op;
 
-  ReadFinisher(OSDOp& osd_op) : osd_op(osd_op) {
+  explicit ReadFinisher(OSDOp& osd_op) : osd_op(osd_op) {
   }
 
   int execute() override {

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1700,7 +1700,7 @@ private:
     struct ReservationCB : public Context {
       PrimaryLogPGRef pg;
       bool canceled;
-      ReservationCB(PrimaryLogPG *pg) : pg(pg), canceled(false) {}
+      explicit ReservationCB(PrimaryLogPG *pg) : pg(pg), canceled(false) {}
       void finish(int) override {
 	pg->lock();
 	if (!canceled)

--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -276,7 +276,7 @@ class WatchConState {
   std::set<WatchRef> watches;
 public:
   CephContext* cct;
-  WatchConState(CephContext* cct) : lock("WatchConState"), cct(cct) {}
+  explicit WatchConState(CephContext* cct) : lock("WatchConState"), cct(cct) {}
 
   /// Add a watch
   void addWatch(

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2690,7 +2690,7 @@ private:
 
   unique_ptr<interval_rep> past_intervals;
 
-  PastIntervals(interval_rep *rep) : past_intervals(rep) {}
+  explicit PastIntervals(interval_rep *rep) : past_intervals(rep) {}
 
 public:
   void add_interval(bool ec_pool, const pg_interval_t &interval) {

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -32,7 +32,7 @@ using std::chrono::seconds;
 class Journaler::C_DelayFlush : public Context {
   Journaler *journaler;
   public:
-  C_DelayFlush(Journaler *j) : journaler(j) {}
+  explicit C_DelayFlush(Journaler *j) : journaler(j) {}
   void finish(int r) override {
     journaler->_do_delayed_flush();
   }

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -284,7 +284,7 @@ struct ObjectOperation {
   // object cmpext
   struct C_ObjectOperation_cmpext : public Context {
     int *prval;
-    C_ObjectOperation_cmpext(int *prval)
+    explicit C_ObjectOperation_cmpext(int *prval)
       : prval(prval) {}
 
     void finish(int r) {
@@ -1313,7 +1313,7 @@ public:
 	base_oloc(oloc)
       {}
 
-    op_target_t(pg_t pgid)
+    explicit op_target_t(pg_t pgid)
       : base_oloc(pgid.pool(), pgid.ps()),
 	precalc_pgid(true),
 	base_pgid(pgid)
@@ -1732,7 +1732,7 @@ public:
       watch_pending_async.pop_front();
     }
 
-    LingerOp(Objecter *o) : linger_id(0),
+    explicit LingerOp(Objecter *o) : linger_id(0),
 			    target(object_t(), object_locator_t(), 0),
 			    snap(CEPH_NOSNAP), poutbl(NULL), pobjver(NULL),
 			    is_watch(false), last_error(0),

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -38,7 +38,7 @@ public:
 class RGWAccessControlPolicy_SWIFTAcct : public RGWAccessControlPolicy
 {
 public:
-  RGWAccessControlPolicy_SWIFTAcct(CephContext * const cct)
+  explicit RGWAccessControlPolicy_SWIFTAcct(CephContext * const cct)
     : RGWAccessControlPolicy(cct) {
   }
   ~RGWAccessControlPolicy_SWIFTAcct() override {}

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -217,7 +217,7 @@ class AsioFrontend {
     tcp::socket socket;
     bool use_ssl = false;
 
-    Listener(boost::asio::io_service& service)
+    explicit Listener(boost::asio::io_service& service)
       : acceptor(service), socket(service) {}
   };
   std::vector<Listener> listeners;

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -188,7 +188,7 @@ public:
 
     std::pair<IdentityApplier::aplptr_t, Completer::cmplptr_t> result_pair;
 
-    AuthResult(const int reason)
+    explicit AuthResult(const int reason)
       : reason(reason) {
     }
 
@@ -199,7 +199,7 @@ public:
 
     /* Allow only the reasonable combintations - returning just Completer
      * without accompanying IdentityApplier is strictly prohibited! */
-    AuthResult(IdentityApplier::aplptr_t&& applier)
+    explicit AuthResult(IdentityApplier::aplptr_t&& applier)
       : result_pair(std::move(applier), nullptr) {
     }
 

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -60,7 +60,7 @@ class DecoratedApplier : public rgw::auth::IdentityApplier {
   }
 
 public:
-  DecoratedApplier(DecorateeT&& decoratee)
+  explicit DecoratedApplier(DecorateeT&& decoratee)
     : decoratee(std::forward<DecorateeT>(decoratee)) {
   }
 

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -213,7 +213,7 @@ TokenEngine::authenticate(const std::string& token,
   /* This will be initialized on the first call to this method. In C++11 it's
    * also thread-safe. */
   static const struct RolesCacher {
-    RolesCacher(CephContext* const cct) {
+    explicit RolesCacher(CephContext* const cct) {
       get_str_vec(cct->_conf->rgw_keystone_accepted_roles, plain);
       get_str_vec(cct->_conf->rgw_keystone_accepted_admin_roles, admin);
 
@@ -429,7 +429,7 @@ rgw::auth::Engine::result_t EC2Engine::authenticate(
   /* This will be initialized on the first call to this method. In C++11 it's
    * also thread-safe. */
   static const struct RolesCacher {
-    RolesCacher(CephContext* const cct) {
+    explicit RolesCacher(CephContext* const cct) {
       get_str_vec(cct->_conf->rgw_keystone_accepted_roles, plain);
       get_str_vec(cct->_conf->rgw_keystone_accepted_admin_roles, admin);
 

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -177,7 +177,7 @@ class AWSv4ComplMulti : public rgw::auth::Completer,
         signature(signature.to_string()) {
     }
 
-    ChunkMeta(const boost::string_view& signature)
+    explicit ChunkMeta(const boost::string_view& signature)
       : signature(signature.to_string()) {
     }
 
@@ -281,7 +281,7 @@ public:
   /* Defined in rgw_auth_s3.cc because of get_v4_exp_payload_hash(). We need
    * the constructor to be public because of the std::make_shared employed by
    * the create() method. */
-  AWSv4ComplSingle(const req_state* const s);
+  explicit AWSv4ComplSingle(const req_state* const s);
 
   ~AWSv4ComplSingle() {
     if (sha256_hash) {

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -119,7 +119,7 @@ class Principal {
   types t;
   rgw_user u;
 
-  Principal(types t)
+  explicit Principal(types t)
     : t(t) {}
 
   Principal(types t, std::string&& n, std::string i)

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -53,7 +53,7 @@ public:
     return env;
   }
 
-  RGWCivetWeb(mg_connection *_conn);
+  explicit RGWCivetWeb(mg_connection *_conn);
 };
 
 #endif

--- a/src/rgw/rgw_client_io.h
+++ b/src/rgw/rgw_client_io.h
@@ -202,7 +202,7 @@ protected:
   }
 
 public:
-  DecoratedRestfulClient(DecorateeT&& decoratee)
+  explicit DecoratedRestfulClient(DecorateeT&& decoratee)
     : decoratee(std::forward<DecorateeT>(decoratee)) {
   }
 
@@ -308,7 +308,7 @@ class StaticOutputBufferer : public std::streambuf {
   std::streambuf::char_type buffer[BufferSizeV];
 
 public:
-  StaticOutputBufferer(BuffererSink& sink)
+  explicit StaticOutputBufferer(BuffererSink& sink)
     : sink(sink) {
     constexpr size_t len = sizeof(buffer) - sizeof(std::streambuf::char_type);
     std::streambuf::setp(buffer, buffer + len);

--- a/src/rgw/rgw_client_io_filters.h
+++ b/src/rgw/rgw_client_io_filters.h
@@ -269,7 +269,7 @@ protected:
 
 public:
   template <typename U>
-  ChunkingFilter(U&& decoratee)
+  explicit ChunkingFilter(U&& decoratee)
     : DecoratedRestfulClient<T>(std::forward<U>(decoratee)),
       chunking_enabled(false) {
   }
@@ -331,7 +331,7 @@ protected:
 
 public:
   template <typename U>
-  ConLenControllingFilter(U&& decoratee)
+  explicit ConLenControllingFilter(U&& decoratee)
     : DecoratedRestfulClient<T>(std::forward<U>(decoratee)),
       action(ContentLengthAction::UNKNOWN) {
   }
@@ -399,7 +399,7 @@ protected:
 
 public:
   template <typename U>
-  ReorderingFilter(U&& decoratee)
+  explicit ReorderingFilter(U&& decoratee)
     : DecoratedRestfulClient<T>(std::forward<U>(decoratee)),
       phase(ReorderState::RGW_EARLY_HEADERS) {
   }

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -62,7 +62,7 @@ protected:
   void _wakeup(void *opaque);
   void _complete(RGWAioCompletionNotifier *cn, const rgw_io_id& io_id, void *user_info);
 public:
-  RGWCompletionManager(CephContext *_cct);
+  explicit RGWCompletionManager(CephContext *_cct);
   ~RGWCompletionManager() override;
 
   void complete(RGWAioCompletionNotifier *cn, const rgw_io_id& io_id, void *user_info);
@@ -192,7 +192,7 @@ class RGWCoroutine : public RefCountedObject, public boost::asio::coroutine {
     utime_t timestamp;
     stringstream status;
 
-    Status(CephContext *_cct) : cct(_cct), lock("RGWCoroutine::Status::lock"), max_history(MAX_COROUTINE_HISTORY) {}
+    explicit Status(CephContext *_cct) : cct(_cct), lock("RGWCoroutine::Status::lock"), max_history(MAX_COROUTINE_HISTORY) {}
 
     deque<StatusItem> history;
 
@@ -334,7 +334,7 @@ class RGWConsumerCR : public RGWCoroutine {
   list<T> product;
 
 public:
-  RGWConsumerCR(CephContext *_cct) : RGWCoroutine(_cct) {}
+  explicit RGWConsumerCR(CephContext *_cct) : RGWCoroutine(_cct) {}
 
   bool has_product() {
     return !product.empty();
@@ -531,7 +531,7 @@ class RGWCoroutinesManagerRegistry : public RefCountedObject, public AdminSocket
   string admin_command;
 
 public:
-  RGWCoroutinesManagerRegistry(CephContext *_cct) : cct(_cct), lock("RGWCoroutinesRegistry::lock") {}
+  explicit RGWCoroutinesManagerRegistry(CephContext *_cct) : cct(_cct), lock("RGWCoroutinesRegistry::lock") {}
   ~RGWCoroutinesManagerRegistry() override;
 
   void add(RGWCoroutinesManager *mgr);

--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -478,7 +478,7 @@ protected:
   class WriteDrainNotify : public RGWWriteDrainCB {
     RGWStreamWriteHTTPResourceCRF *crf;
   public:
-    WriteDrainNotify(RGWStreamWriteHTTPResourceCRF *_crf) : crf(_crf) {}
+    explicit WriteDrainNotify(RGWStreamWriteHTTPResourceCRF *_crf) : crf(_crf) {}
     void notify(uint64_t pending_size) override;
   } write_drain_notify_cb;
 

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -37,7 +37,7 @@ private:
   CephContext* cct;
   uint8_t key[AES_256_KEYSIZE];
 public:
-  AES_256_CTR(CephContext* cct): cct(cct) {
+  explicit AES_256_CTR(CephContext* cct): cct(cct) {
   }
   ~AES_256_CTR() {
     memset(key, 0, AES_256_KEYSIZE);
@@ -200,7 +200,7 @@ private:
   CephContext* cct;
   uint8_t key[AES_256_KEYSIZE];
 public:
-  AES_256_CBC(CephContext* cct): cct(cct) {
+  explicit AES_256_CBC(CephContext* cct): cct(cct) {
   }
   ~AES_256_CBC() {
     memset(key, 0, AES_256_KEYSIZE);

--- a/src/rgw/rgw_crypt_sanitize.h
+++ b/src/rgw/rgw_crypt_sanitize.h
@@ -57,7 +57,7 @@ struct auth {
  */
 struct log_content {
   const boost::string_view buf;
-  log_content(const boost::string_view buf)
+  explicit log_content(const boost::string_view buf)
   : buf(buf) {}
 };
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -963,7 +963,7 @@ public:
 // ostream wrappers to print buckets without copying strings
 struct bucket_str {
   const rgw_bucket& b;
-  bucket_str(const rgw_bucket& b) : b(b) {}
+  explicit bucket_str(const rgw_bucket& b) : b(b) {}
 };
 std::ostream& operator<<(std::ostream& out, const bucket_str& rhs) {
   auto& b = rhs.b;
@@ -979,7 +979,7 @@ std::ostream& operator<<(std::ostream& out, const bucket_str& rhs) {
 
 struct bucket_str_noinstance {
   const rgw_bucket& b;
-  bucket_str_noinstance(const rgw_bucket& b) : b(b) {}
+  explicit bucket_str_noinstance(const rgw_bucket& b) : b(b) {}
 };
 std::ostream& operator<<(std::ostream& out, const bucket_str_noinstance& rhs) {
   auto& b = rhs.b;
@@ -992,7 +992,7 @@ std::ostream& operator<<(std::ostream& out, const bucket_str_noinstance& rhs) {
 
 struct bucket_shard_str {
   const rgw_bucket_shard& bs;
-  bucket_shard_str(const rgw_bucket_shard& bs) : bs(bs) {}
+  explicit bucket_shard_str(const rgw_bucket_shard& bs) : bs(bs) {}
 };
 std::ostream& operator<<(std::ostream& out, const bucket_shard_str& rhs) {
   auto& bs = rhs.bs;

--- a/src/rgw/rgw_es_query.cc
+++ b/src/rgw/rgw_es_query.cc
@@ -127,7 +127,7 @@ class ESQueryNode_Bool : public ESQueryNode {
   ESQueryNode *first{nullptr};
   ESQueryNode *second{nullptr};
 public:
-  ESQueryNode_Bool(ESQueryCompiler *compiler) : ESQueryNode(compiler) {}
+  explicit ESQueryNode_Bool(ESQueryCompiler *compiler) : ESQueryNode(compiler) {}
   ESQueryNode_Bool(ESQueryCompiler *compiler, const string& _op, ESQueryNode *_first, ESQueryNode *_second) :ESQueryNode(compiler), op(_op), first(_first), second(_second) {}
   bool init(ESQueryStack *s, ESQueryNode **pnode, string *perr) override {
     bool valid = s->pop(&op);
@@ -279,7 +279,7 @@ public:
 
 class ESQueryNode_Op_Equal : public ESQueryNode_Op {
 public:
-  ESQueryNode_Op_Equal(ESQueryCompiler *compiler) : ESQueryNode_Op(compiler) {}
+  explicit ESQueryNode_Op_Equal(ESQueryCompiler *compiler) : ESQueryNode_Op(compiler) {}
   ESQueryNode_Op_Equal(ESQueryCompiler *compiler, const string& f, const string& v) : ESQueryNode_Op(compiler) {
     op = "==";
     field = f;

--- a/src/rgw/rgw_es_query.h
+++ b/src/rgw/rgw_es_query.h
@@ -8,7 +8,7 @@ class ESQueryStack {
   list<string>::iterator iter;
 
 public:
-  ESQueryStack(list<string>& src) {
+  explicit ESQueryStack(list<string>& src) {
     assign(src);
   }
 
@@ -58,7 +58,7 @@ class ESInfixQueryParser {
   bool parse_close_bracket();
 
 public:
-  ESInfixQueryParser(const string& _query) : query(_query), size(query.size()), str(query.c_str()) {}
+  explicit ESInfixQueryParser(const string& _query) : query(_query), size(query.size()), str(query.c_str()) {}
   bool parse(list<string> *result);
 };
 
@@ -74,7 +74,7 @@ struct ESEntityTypeMap {
 
   map<string, EntityType> m;
 
-  ESEntityTypeMap(map<string, EntityType>& _m) : m(_m) {}
+  explicit ESEntityTypeMap(map<string, EntityType>& _m) : m(_m) {}
 
   bool find(const string& entity, EntityType *ptype) {
     auto i = m.find(entity);

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -786,7 +786,7 @@ namespace rgw {
     {
       RGWLibFS* fs;
     public:
-      ObjUnref(RGWLibFS* _fs) : fs(_fs) {}
+      explicit ObjUnref(RGWLibFS* _fs) : fs(_fs) {}
       void operator()(RGWFileHandle* fh) const {
 	lsubdout(fs->get_context(), rgw, 5)
 	  << __func__

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -261,7 +261,7 @@ namespace rgw {
     friend class RGWLibFS;
 
   private:
-    RGWFileHandle(RGWLibFS* _fs)
+    explicit RGWFileHandle(RGWLibFS* _fs)
       : fs(_fs), bucket(nullptr), parent(nullptr), variant_type{directory()},
 	depth(0), flags(FLAG_NONE)
       {
@@ -819,7 +819,7 @@ namespace rgw {
     {
       RGWFileHandle& rgw_fh;
 
-      WriteCompletion(RGWFileHandle& _fh) : rgw_fh(_fh) {
+      explicit WriteCompletion(RGWFileHandle& _fh) : rgw_fh(_fh) {
 	rgw_fh.get_fs()->ref(&rgw_fh);
       }
 

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -29,7 +29,7 @@ class RGWFrontendConfig {
                    std::multimap<std::string, std::string>& config_map);
 
 public:
-  RGWFrontendConfig(const std::string& config)
+  explicit RGWFrontendConfig(const std::string& config)
     : config(config) {
   }
 
@@ -85,7 +85,7 @@ struct RGWMongooseEnv : public RGWProcessEnv {
   static constexpr bool prioritize_write = true;
   RWLock mutex;
 
-  RGWMongooseEnv(const RGWProcessEnv &env)
+  explicit RGWMongooseEnv(const RGWProcessEnv &env)
     : RGWProcessEnv(env),
       mutex("RGWCivetWebFrontend", false, true, prioritize_write) {
   }

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -99,7 +99,7 @@ struct RGWCurlHandle {
   mono_time lastuse;
   CURL* h;
 
-  RGWCurlHandle(CURL* h) : uses(0), h(h) {};
+  explicit RGWCurlHandle(CURL* h) : uses(0), h(h) {};
   CURL* operator*() {
     return this->h;
   }

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -330,7 +330,7 @@ class RGWHTTPManager {
     RGWHTTPManager *manager;
 
   public:
-    ReqsThread(RGWHTTPManager *_m) : manager(_m) {}
+    explicit ReqsThread(RGWHTTPManager *_m) : manager(_m) {}
     void *entry() override;
   };
 

--- a/src/rgw/rgw_http_client_curl.cc
+++ b/src/rgw/rgw_http_client_curl.cc
@@ -21,7 +21,7 @@ class RGWSSLSetup
 {
   std::vector <std::mutex> locks;
 public:
-  RGWSSLSetup(int n) : locks (n){}
+  explicit RGWSSLSetup(int n) : locks (n){}
 
   void set_lock(int id){
     try {

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -438,7 +438,7 @@ std::ostream& operator <<(ostream& m, const Statement& s);
 struct PolicyParseException : public std::exception {
   rapidjson::ParseResult pr;
 
-  PolicyParseException(rapidjson::ParseResult&& pr)
+  explicit PolicyParseException(rapidjson::ParseResult&& pr)
     : pr(pr) { }
   const char* what() const noexcept override {
     return rapidjson::GetParseError_En(pr.Code());

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -259,7 +259,7 @@ class TokenCache {
 
   const size_t max;
 
-  TokenCache(const rgw::keystone::Config& config)
+  explicit TokenCache(const rgw::keystone::Config& config)
     : revocator(g_ceph_context, this, config),
       cct(g_ceph_context),
       lock("rgw::keystone::TokenCache"),
@@ -332,7 +332,7 @@ class AdminTokenRequestVer2 : public AdminTokenRequest {
   const Config& conf;
 
 public:
-  AdminTokenRequestVer2(const Config& conf)
+  explicit AdminTokenRequestVer2(const Config& conf)
     : conf(conf) {
   }
   void dump(Formatter *f) const override;
@@ -342,7 +342,7 @@ class AdminTokenRequestVer3 : public AdminTokenRequest {
   const Config& conf;
 
 public:
-  AdminTokenRequestVer3(const Config& conf)
+  explicit AdminTokenRequestVer3(const Config& conf)
     : conf(conf) {
   }
   void dump(Formatter *f) const override;
@@ -352,7 +352,7 @@ class BarbicanTokenRequestVer2 : public AdminTokenRequest {
   CephContext *cct;
 
 public:
-  BarbicanTokenRequestVer2(CephContext * const _cct)
+  explicit BarbicanTokenRequestVer2(CephContext * const _cct)
     : cct(_cct) {
   }
   void dump(Formatter *f) const;
@@ -362,7 +362,7 @@ class BarbicanTokenRequestVer3 : public AdminTokenRequest {
   CephContext *cct;
 
 public:
-  BarbicanTokenRequestVer3(CephContext * const _cct)
+  explicit BarbicanTokenRequestVer3(CephContext * const _cct)
     : cct(_cct) {
   }
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -289,7 +289,7 @@ protected:
   bool _add_rule(LCRule *rule);
   bool has_same_action(const lc_op& first, const lc_op& second);
 public:
-  RGWLifecycleConfiguration(CephContext *_cct) : cct(_cct) {}
+  explicit RGWLifecycleConfiguration(CephContext *_cct) : cct(_cct) {}
   RGWLifecycleConfiguration() : cct(NULL) {}
 
   void set_ctx(CephContext *ctx) {

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -189,7 +189,7 @@ private:
   CephContext *cct;
 public:
   LCRule_S3(): cct(nullptr) {}
-  LCRule_S3(CephContext *_cct): cct(_cct) {}
+  explicit LCRule_S3(CephContext *_cct): cct(_cct) {}
   ~LCRule_S3() override {}
 
   void to_xml(ostream& out);
@@ -233,13 +233,13 @@ class RGWLCXMLParser_S3 : public RGWXMLParser
 
   XMLObj *alloc_obj(const char *el) override;
 public:
-  RGWLCXMLParser_S3(CephContext *_cct) : cct(_cct) {}
+  explicit RGWLCXMLParser_S3(CephContext *_cct) : cct(_cct) {}
 };
 
 class RGWLifecycleConfiguration_S3 : public RGWLifecycleConfiguration, public XMLObj
 {
 public:
-  RGWLifecycleConfiguration_S3(CephContext *_cct) : RGWLifecycleConfiguration(_cct) {}
+  explicit RGWLifecycleConfiguration_S3(CephContext *_cct) : RGWLifecycleConfiguration(_cct) {}
   RGWLifecycleConfiguration_S3() : RGWLifecycleConfiguration(NULL) {}
   ~RGWLifecycleConfiguration_S3() override {}
 

--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -60,7 +60,7 @@ namespace rgw {
     RGWLibIO() {
       get_env().set("HTTP_HOST", "");
     }
-    RGWLibIO(const RGWUserInfo &_user_info)
+    explicit RGWLibIO(const RGWUserInfo &_user_info)
       : user_info(_user_info) {}
 
     int init_env(CephContext *cct) override {

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -167,7 +167,7 @@ class RGWMetadataLogInfoCompletion : public RefCountedObject {
   std::mutex mutex; //< protects callback between cancel/complete
   boost::optional<info_callback_t> callback; //< cleared on cancel
  public:
-  RGWMetadataLogInfoCompletion(info_callback_t callback);
+  explicit RGWMetadataLogInfoCompletion(info_callback_t callback);
   ~RGWMetadataLogInfoCompletion() override;
 
   librados::IoCtx& get_io_ctx() { return io_ctx; }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3324,7 +3324,7 @@ class RGWPutObj_CB : public RGWGetObj_Filter
 {
   RGWPutObj *op;
 public:
-  RGWPutObj_CB(RGWPutObj *_op) : op(_op) {}
+  explicit RGWPutObj_CB(RGWPutObj *_op) : op(_op) {}
   ~RGWPutObj_CB() override {}
 
   int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) override {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -186,7 +186,7 @@ protected:
   RGWGetObj_Filter *next{nullptr};
 public:
   RGWGetObj_Filter() {}
-  RGWGetObj_Filter(RGWGetObj_Filter *next): next(next) {}
+  explicit RGWGetObj_Filter(RGWGetObj_Filter *next): next(next) {}
   ~RGWGetObj_Filter() override {}
   /**
    * Passes data through filter.
@@ -555,7 +555,7 @@ protected:
   }
 
 public:
-  DecoratedStreamGetter(StreamGetter& decoratee)
+  explicit DecoratedStreamGetter(StreamGetter& decoratee)
     : decoratee(decoratee) {
   }
   virtual ~DecoratedStreamGetter() = default;
@@ -1081,7 +1081,7 @@ class RGWPutObj_Filter : public RGWPutObjDataProcessor
 protected:
   RGWPutObjDataProcessor* next;
 public:
-  RGWPutObj_Filter(RGWPutObjDataProcessor* next) :
+  explicit RGWPutObj_Filter(RGWPutObjDataProcessor* next) :
   next(next){}
   ~RGWPutObj_Filter() override {}
   int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) override {

--- a/src/rgw/rgw_period_puller.h
+++ b/src/rgw/rgw_period_puller.h
@@ -12,7 +12,7 @@ class RGWPeriod;
 class RGWPeriodPuller : public RGWPeriodHistory::Puller {
   RGWRados *const store;
  public:
-  RGWPeriodPuller(RGWRados* store) : store(store) {}
+  explicit RGWPeriodPuller(RGWRados* store) : store(store) {}
 
   int pull(const std::string& period_id, RGWPeriod& period) override;
 };

--- a/src/rgw/rgw_period_pusher.h
+++ b/src/rgw/rgw_period_pusher.h
@@ -23,7 +23,7 @@ using RGWZonesNeedPeriod = RGWPeriod;
 class RGWPeriodPusher final : public RGWRealmWatcher::Watcher,
                               public RGWRealmReloader::Pauser {
  public:
-  RGWPeriodPusher(RGWRados* store);
+  explicit RGWPeriodPusher(RGWRados* store);
   ~RGWPeriodPusher() override;
 
   /// respond to realm notifications by pushing new periods to other zones

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -166,7 +166,7 @@ public:
 class RGWProcessControlThread : public Thread {
   RGWProcess *pprocess;
 public:
-  RGWProcessControlThread(RGWProcess *_pprocess) : pprocess(_pprocess) {}
+  explicit RGWProcessControlThread(RGWProcess *_pprocess) : pprocess(_pprocess) {}
 
   void *entry() override {
     pprocess->run();

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -147,8 +147,8 @@ class rgw_obj_select {
 
 public:
   rgw_obj_select() : is_raw(false) {}
-  rgw_obj_select(const rgw_obj& _obj) : obj(_obj), is_raw(false) {}
-  rgw_obj_select(const rgw_raw_obj& _raw_obj) : raw_obj(_raw_obj), is_raw(true) {}
+  explicit rgw_obj_select(const rgw_obj& _obj) : obj(_obj), is_raw(false) {}
+  explicit rgw_obj_select(const rgw_raw_obj& _raw_obj) : raw_obj(_raw_obj), is_raw(true) {}
   rgw_obj_select(const rgw_obj_select& rhs) {
     placement_rule = rhs.placement_rule;
     is_raw = rhs.is_raw;
@@ -1185,7 +1185,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   JSONFormattable tier_config;
 
   RGWZoneParams() : RGWSystemMetaObj() {}
-  RGWZoneParams(const string& name) : RGWSystemMetaObj(name){}
+  explicit RGWZoneParams(const string& name) : RGWSystemMetaObj(name){}
   RGWZoneParams(const string& id, const string& name) : RGWSystemMetaObj(id, name) {}
   RGWZoneParams(const string& id, const string& name, const string& _realm_id)
     : RGWSystemMetaObj(id, name), realm_id(_realm_id) {}
@@ -1510,7 +1510,7 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
 
   RGWZoneGroup(): is_master(false){}
   RGWZoneGroup(const std::string &id, const std::string &name):RGWSystemMetaObj(id, name) {}
-  RGWZoneGroup(const std::string &_name):RGWSystemMetaObj(_name) {}
+  explicit RGWZoneGroup(const std::string &_name):RGWSystemMetaObj(_name) {}
   RGWZoneGroup(const std::string &_name, bool _is_master, CephContext *cct, RGWRados* store,
 	       const string& _realm_id, const list<string>& _endpoints)
     : RGWSystemMetaObj(_name, cct , store), endpoints(_endpoints), is_master(_is_master),
@@ -2138,7 +2138,7 @@ class RGWObjectCtxImpl {
   RWLock lock;
 
 public:
-  RGWObjectCtxImpl(RGWRados *_store) : store(_store), lock("RGWObjectCtxImpl") {}
+  explicit RGWObjectCtxImpl(RGWRados *_store) : store(_store), lock("RGWObjectCtxImpl") {}
 
   S *get_state(const T& obj) {
     S *result;
@@ -2222,7 +2222,7 @@ struct tombstone_entry {
   uint64_t pg_ver;
 
   tombstone_entry() = default;
-  tombstone_entry(const RGWObjState& state)
+  explicit tombstone_entry(const RGWObjState& state)
     : mtime(state.mtime), zone_short_id(state.zone_short_id),
       pg_ver(state.pg_ver) {}
 };

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -44,7 +44,7 @@ RGWRealmReloader::~RGWRealmReloader()
 class RGWRealmReloader::C_Reload : public Context {
   RGWRealmReloader* reloader;
  public:
-  C_Reload(RGWRealmReloader* reloader) : reloader(reloader) {}
+  explicit C_Reload(RGWRealmReloader* reloader) : reloader(reloader) {}
   void finish(int r) override { reloader->reload(); }
 };
 

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -112,7 +112,7 @@ class RGWReshardWait {
 
   int do_wait();
 public:
-  RGWReshardWait(RGWRados *_store) : store(_store) {}
+  explicit RGWReshardWait(RGWRados *_store) : store(_store) {}
   ~RGWReshardWait() {
     assert(going_down);
   }

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -980,7 +980,7 @@ int RGWHTTPStreamRWRequest::send_data(void *ptr, size_t len, bool *pause)
 class StreamIntoBufferlist : public RGWGetDataCB {
   bufferlist& bl;
 public:
-  StreamIntoBufferlist(bufferlist& _bl) : bl(_bl) {}
+  explicit StreamIntoBufferlist(bufferlist& _bl) : bl(_bl) {}
   int handle_data(bufferlist& inbl, off_t bl_ofs, off_t bl_len) override {
     bl.claim_append(inbl);
     return bl_len;

--- a/src/rgw/rgw_rest_config.h
+++ b/src/rgw/rgw_rest_config.h
@@ -19,7 +19,7 @@ class RGWOp_ZoneGroupMap_Get : public RGWRESTOp {
   RGWZoneGroupMap zonegroup_map;
   bool old_format;
 public:
-  RGWOp_ZoneGroupMap_Get(bool _old_format):old_format(_old_format) {}
+  explicit RGWOp_ZoneGroupMap_Get(bool _old_format):old_format(_old_format) {}
   ~RGWOp_ZoneGroupMap_Get() override {}
 
   int verify_permission() override {

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -240,7 +240,7 @@ int RGWRESTConn::get_json_resource(const string& resource,  const rgw_http_param
 class RGWStreamIntoBufferlist : public RGWHTTPStreamRWRequest::ReceiveCB {
   bufferlist& bl;
 public:
-  RGWStreamIntoBufferlist(bufferlist& _bl) : bl(_bl) {}
+  explicit RGWStreamIntoBufferlist(bufferlist& _bl) : bl(_bl) {}
   int handle_data(bufferlist& inbl, bool *pause) override {
     bl.claim_append(inbl);
     return inbl.length();

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -478,7 +478,7 @@ class RGWHandler_Auth_S3 : public RGWHandler_REST {
   const rgw::auth::StrategyRegistry& auth_registry;
 
 public:
-  RGWHandler_Auth_S3(const rgw::auth::StrategyRegistry& auth_registry)
+  explicit RGWHandler_Auth_S3(const rgw::auth::StrategyRegistry& auth_registry)
     : RGWHandler_REST(),
       auth_registry(auth_registry) {
   }
@@ -503,7 +503,7 @@ class RGWHandler_REST_S3 : public RGWHandler_REST {
 public:
   static int init_from_header(struct req_state *s, int default_formatter, bool configurable_format);
 
-  RGWHandler_REST_S3(const rgw::auth::StrategyRegistry& auth_registry)
+  explicit RGWHandler_REST_S3(const rgw::auth::StrategyRegistry& auth_registry)
     : RGWHandler_REST(),
       auth_registry(auth_registry) {
   }
@@ -772,7 +772,7 @@ class AWSGeneralAbstractor : public AWSEngine::VersionAbstractor {
   auth_data_t get_auth_data_v4(const req_state* s, const bool using_qs) const;
 
 public:
-  AWSGeneralAbstractor(CephContext* const cct)
+  explicit AWSGeneralAbstractor(CephContext* const cct)
     : cct(cct) {
   }
 
@@ -799,7 +799,7 @@ class AWSBrowserUploadAbstractor : public AWSEngine::VersionAbstractor {
   auth_data_t get_auth_data_v4(const req_state* s) const;
 
 public:
-  AWSBrowserUploadAbstractor(CephContext*) {
+  explicit AWSBrowserUploadAbstractor(CephContext*) {
   }
 
   auth_data_t get_auth_data(const req_state* s) const override;
@@ -897,7 +897,7 @@ class S3AuthFactory : public rgw::auth::RemoteApplier::Factory,
   RGWRados* const store;
 
 public:
-  S3AuthFactory(RGWRados* const store)
+  explicit S3AuthFactory(RGWRados* const store)
     : store(store) {
   }
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2317,7 +2317,7 @@ RGWOp* RGWSwiftWebsiteHandler::get_ws_redirect_op()
   class RGWMovedPermanently: public RGWOp {
     const std::string location;
   public:
-    RGWMovedPermanently(const std::string& location)
+    explicit RGWMovedPermanently(const std::string& location)
       : location(location) {
     }
 
@@ -2418,7 +2418,7 @@ RGWOp* RGWSwiftWebsiteHandler::get_ws_listing_op()
   public:
     /* Taking prefix_override by value to leverage std::string r-value ref
      * ctor and thus avoid extra memory copying/increasing ref counter. */
-    RGWWebsiteListing(std::string prefix_override)
+    explicit RGWWebsiteListing(std::string prefix_override)
       : prefix_override(std::move(prefix_override)) {
     }
   };

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -385,7 +385,7 @@ protected:
   static int init_from_header(struct req_state* s,
                               const std::string& frontend_prefix);
 public:
-  RGWHandler_REST_SWIFT(const rgw::auth::Strategy& auth_strategy)
+  explicit RGWHandler_REST_SWIFT(const rgw::auth::Strategy& auth_strategy)
     : auth_strategy(auth_strategy) {
   }
   ~RGWHandler_REST_SWIFT() override = default;

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -2740,7 +2740,7 @@ class MetaMasterStatusCollectCR : public RGWShardCollectCR {
   connection_map::iterator c;
   std::vector<rgw_meta_sync_status>::iterator s;
  public:
-  MetaMasterStatusCollectCR(MasterTrimEnv& env)
+  explicit MetaMasterStatusCollectCR(MasterTrimEnv& env)
     : RGWShardCollectCR(env.store->ctx(), MAX_CONCURRENT_SHARDS),
       env(env), c(env.connections.begin()), s(env.peer_status.begin())
   {}
@@ -2772,7 +2772,7 @@ class MetaMasterTrimCR : public RGWCoroutine {
   int ret{0};
 
  public:
-  MetaMasterTrimCR(MasterTrimEnv& env)
+  explicit MetaMasterTrimCR(MasterTrimEnv& env)
     : RGWCoroutine(env.store->ctx()), env(env)
   {}
 
@@ -2976,7 +2976,7 @@ class MetaPeerTrimCR : public RGWCoroutine {
   rgw_mdlog_info mdlog_info; //< master's mdlog info
 
  public:
-  MetaPeerTrimCR(PeerTrimEnv& env) : RGWCoroutine(env.store->ctx()), env(env) {}
+  explicit MetaPeerTrimCR(PeerTrimEnv& env) : RGWCoroutine(env.store->ctx()), env(env) {}
 
   int operate();
 };

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -116,7 +116,7 @@ class RGWSyncBackoff {
 
   void update_wait_time();
 public:
-  RGWSyncBackoff(int _max_secs = DEFAULT_BACKOFF_MAX) : cur_wait(0), max_secs(_max_secs) {}
+  explicit RGWSyncBackoff(int _max_secs = DEFAULT_BACKOFF_MAX) : cur_wait(0), max_secs(_max_secs) {}
 
   void backoff_sleep();
   void reset() {
@@ -302,7 +302,7 @@ class RGWLastCallerWinsCR : public RGWOrderCallCR
   RGWCoroutine *cr{nullptr};
 
 public:
-  RGWLastCallerWinsCR(CephContext *cct) : RGWOrderCallCR(cct) {}
+  explicit RGWLastCallerWinsCR(CephContext *cct) : RGWOrderCallCR(cct) {}
   ~RGWLastCallerWinsCR() {
     if (cr) {
       cr->put();

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -101,7 +101,7 @@ struct TrimCounters {
   class Handler : public TrimNotifyHandler {
     Server *const server;
    public:
-    Handler(Server *server) : server(server) {}
+    explicit Handler(Server *server) : server(server) {}
 
     void handle(bufferlist::iterator& input, bufferlist& output) override;
   };
@@ -185,7 +185,7 @@ struct TrimComplete {
   class Handler : public TrimNotifyHandler {
     Server *const server;
    public:
-    Handler(Server *server) : server(server) {}
+    explicit Handler(Server *server) : server(server) {}
 
     void handle(bufferlist::iterator& input, bufferlist& output) override;
   };

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -660,7 +660,7 @@ struct AWSSyncInstanceEnv {
   AWSSyncConfig conf;
   string id;
 
-  AWSSyncInstanceEnv(AWSSyncConfig& _conf) : conf(_conf) {}
+  explicit AWSSyncInstanceEnv(AWSSyncConfig& _conf) : conf(_conf) {}
 
   void init(RGWDataSyncEnv *sync_env, uint64_t instance_id) {
     char buf[32];
@@ -1241,7 +1241,7 @@ class RGWAWSCompleteMultipartCR : public RGWCoroutine {
   struct CompleteMultipartReq {
     map<int, rgw_sync_aws_multipart_part_info> parts;
 
-    CompleteMultipartReq(const map<int, rgw_sync_aws_multipart_part_info>& _parts) : parts(_parts) {}
+    explicit CompleteMultipartReq(const map<int, rgw_sync_aws_multipart_part_info>& _parts) : parts(_parts) {}
 
     void dump_xml(Formatter *f) const {
       for (auto p : parts) {

--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -263,7 +263,7 @@ void RGWMetadataSearchOp::execute()
 
 class RGWMetadataSearch_ObjStore_S3 : public RGWMetadataSearchOp {
 public:
-  RGWMetadataSearch_ObjStore_S3(const RGWSyncModuleInstanceRef& _sync_module) : RGWMetadataSearchOp(_sync_module) {
+  explicit RGWMetadataSearch_ObjStore_S3(const RGWSyncModuleInstanceRef& _sync_module) : RGWMetadataSearchOp(_sync_module) {
     custom_prefix = "x-amz-meta-";
   }
 
@@ -383,7 +383,7 @@ protected:
     return nullptr;
   }
 public:
-  RGWHandler_REST_MDSearch_S3(const rgw::auth::StrategyRegistry& auth_registry) : RGWHandler_REST_S3(auth_registry) {}
+  explicit RGWHandler_REST_MDSearch_S3(const rgw::auth::StrategyRegistry& auth_registry) : RGWHandler_REST_S3(auth_registry) {}
   virtual ~RGWHandler_REST_MDSearch_S3() {}
 };
 

--- a/src/rgw/rgw_sync_module_log.cc
+++ b/src/rgw/rgw_sync_module_log.cc
@@ -36,7 +36,7 @@ public:
 class RGWLogDataSyncModule : public RGWDataSyncModule {
   string prefix;
 public:
-  RGWLogDataSyncModule(const string& _prefix) : prefix(_prefix) {}
+  explicit RGWLogDataSyncModule(const string& _prefix) : prefix(_prefix) {}
 
   RGWCoroutine *sync_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override {
     ldout(sync_env->cct, 0) << prefix << ": SYNC_LOG: sync_object: b=" << bucket_info.bucket << " k=" << key << " versioned_epoch=" << versioned_epoch << dendl;
@@ -57,7 +57,7 @@ public:
 class RGWLogSyncModuleInstance : public RGWSyncModuleInstance {
   RGWLogDataSyncModule data_handler;
 public:
-  RGWLogSyncModuleInstance(const string& prefix) : data_handler(prefix) {}
+  explicit RGWLogSyncModuleInstance(const string& prefix) : data_handler(prefix) {}
   RGWDataSyncModule *get_data_handler() override {
     return &data_handler;
   }

--- a/src/rgw/rgw_tar.h
+++ b/src/rgw/rgw_tar.h
@@ -92,7 +92,7 @@ protected:
   }
 
 public:
-  HeaderView(const char (&header)[BLOCK_SIZE])
+  explicit HeaderView(const char (&header)[BLOCK_SIZE])
     : header(reinterpret_cast<const header_t*>(header)) {
   }
 

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1616,7 +1616,7 @@ TEST_F(TestClsRbd, mirror_image_status) {
   struct WatchCtx : public librados::WatchCtx2 {
     librados::IoCtx *m_ioctx;
 
-    WatchCtx(librados::IoCtx *ioctx) : m_ioctx(ioctx) {}
+    explicit WatchCtx(librados::IoCtx *ioctx) : m_ioctx(ioctx) {}
     void handle_notify(uint64_t notify_id, uint64_t cookie,
 			     uint64_t notifier_id, bufferlist& bl_) override {
       bufferlist bl;

--- a/src/test/common/test_lru.cc
+++ b/src/test/common/test_lru.cc
@@ -24,7 +24,7 @@ class Item : public LRUObject {
 public:
   int id;
   Item() : id(0) {}
-  Item(int i) : id(i) {}
+  explicit Item(int i) : id(i) {}
   void set(int i) {id = i;}
 };
 

--- a/src/test/common/test_mclock_priority_queue.cc
+++ b/src/test/common/test_mclock_priority_queue.cc
@@ -25,7 +25,7 @@ struct Request {
     value(0)
   {}
   Request(const Request& o) = default;
-  Request(int value) :
+  explicit Request(int value) :
     value(value)
   {}
 };

--- a/src/test/common/test_static_ptr.cc
+++ b/src/test/common/test_static_ptr.cc
@@ -45,7 +45,7 @@ public:
 
 class great_grandchild : public grandchild {
 public:
-  great_grandchild(int val) : grandchild(val) {}
+  explicit great_grandchild(int val) : grandchild(val) {}
   int call(int n) override { return n + val; }
 };
 

--- a/src/test/encoding/test_ceph_time.h
+++ b/src/test/encoding/test_ceph_time.h
@@ -12,7 +12,7 @@ class real_time_wrapper {
   ceph::real_time t;
  public:
   real_time_wrapper() = default;
-  real_time_wrapper(const ceph::real_time& t) : t(t) {}
+  explicit real_time_wrapper(const ceph::real_time& t) : t(t) {}
 
   void encode(bufferlist& bl) const {
     using ceph::encode;

--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -254,7 +254,7 @@ struct Engine {
   int ref_count;
   const bool unlink; //< unlink objects on destruction
 
-  Engine(thread_data* td);
+  explicit Engine(thread_data* td);
   ~Engine();
 
   static Engine* get_instance(thread_data* td) {
@@ -531,7 +531,7 @@ int fio_ceph_os_getevents(thread_data* td, unsigned int min,
 class UnitComplete : public Context {
   io_u* u;
  public:
-  UnitComplete(io_u* u) : u(u) {}
+  explicit UnitComplete(io_u* u) : u(u) {}
   void finish(int r) {
     // mark the pointer to indicate completion for fio_ceph_os_getevents()
     u->engine_data = reinterpret_cast<void*>(1ull);

--- a/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
@@ -19,7 +19,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -21,7 +21,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/librbd/deep_copy/test_mock_SetHeadRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SetHeadRequest.cc
@@ -15,7 +15,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCopyRequest.cc
@@ -18,7 +18,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_SnapshotCreateRequest.cc
@@ -17,7 +17,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
@@ -21,7 +21,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/librbd/exclusive_lock/test_mock_PreAcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreAcquireRequest.cc
@@ -16,7 +16,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/librbd/journal/test_mock_OpenRequest.cc
+++ b/src/test/librbd/journal/test_mock_OpenRequest.cc
@@ -15,7 +15,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx& image_ctx) : MockImageCtx(image_ctx) {
+  explicit MockTestImageCtx(librbd::ImageCtx& image_ctx) : MockImageCtx(image_ctx) {
   }
 };
 

--- a/src/test/librbd/journal/test_mock_PromoteRequest.cc
+++ b/src/test/librbd/journal/test_mock_PromoteRequest.cc
@@ -13,7 +13,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx& image_ctx) : MockImageCtx(image_ctx) {
+  explicit MockTestImageCtx(librbd::ImageCtx& image_ctx) : MockImageCtx(image_ctx) {
   }
 };
 

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -16,7 +16,7 @@ namespace librbd {
 namespace {
 
 struct MockReplayImageCtx : public MockImageCtx {
-  MockReplayImageCtx(ImageCtx &image_ctx) : MockImageCtx(image_ctx) {
+  explicit MockReplayImageCtx(ImageCtx &image_ctx) : MockImageCtx(image_ctx) {
   }
 };
 

--- a/src/test/librbd/mirror/test_mock_DisableRequest.cc
+++ b/src/test/librbd/mirror/test_mock_DisableRequest.cc
@@ -17,7 +17,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx& image_ctx) : MockImageCtx(image_ctx) {
+  explicit MockTestImageCtx(librbd::ImageCtx& image_ctx) : MockImageCtx(image_ctx) {
   }
 };
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -712,7 +712,7 @@ TEST_F(TestLibRBD, UpdateWatchAndResize)
       Watcher *watcher = static_cast<Watcher *>(arg);
       watcher->handle_notify();
     }
-    Watcher(rbd_image_t &image) : m_image(image) {}
+    explicit Watcher(rbd_image_t &image) : m_image(image) {}
     void handle_notify() {
       rbd_image_info_t info;
       ASSERT_EQ(0, rbd_stat(m_image, &info, sizeof(info)));
@@ -758,7 +758,7 @@ TEST_F(TestLibRBD, UpdateWatchAndResizePP)
     std::string name = get_temp_image_name();
     uint64_t size = 2 << 20;
     struct Watcher : public librbd::UpdateWatchCtx {
-      Watcher(librbd::Image &image) : m_image(image) {
+      explicit Watcher(librbd::Image &image) : m_image(image) {
       }
       void handle_notify() override {
         librbd::image_info_t info;

--- a/src/test/librbd/test_mirroring.cc
+++ b/src/test/librbd/test_mirroring.cc
@@ -660,7 +660,7 @@ TEST_F(TestMirroring, RemoveBootstrapped)
   // simulate the image is open by rbd-mirror bootstrap
   uint64_t handle;
   struct MirrorWatcher : public librados::WatchCtx2 {
-    MirrorWatcher(librados::IoCtx &ioctx) : m_ioctx(ioctx) {
+    explicit MirrorWatcher(librados::IoCtx &ioctx) : m_ioctx(ioctx) {
     }
     void handle_notify(uint64_t notify_id, uint64_t cookie,
                                uint64_t notifier_id, bufferlist& bl) override {

--- a/src/test/librbd/test_mock_DeepCopyRequest.cc
+++ b/src/test/librbd/test_mock_DeepCopyRequest.cc
@@ -23,7 +23,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/librbd/test_mock_ManagedLock.cc
+++ b/src/test/librbd/test_mock_ManagedLock.cc
@@ -16,7 +16,7 @@
 namespace librbd {
 
 struct MockManagedLockImageCtx : public MockImageCtx {
-  MockManagedLockImageCtx(ImageCtx &image_ctx) : MockImageCtx(image_ctx) {}
+  explicit MockManagedLockImageCtx(ImageCtx &image_ctx) : MockImageCtx(image_ctx) {}
 };
 
 namespace watcher {

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -75,7 +75,7 @@ namespace {
     std::vector<ZPage*> pages;
     struct iovec* iovs;
 
-    ZPageSet(int n) {
+    explicit ZPageSet(int n) {
       pages.reserve(n);
       iovs = (struct iovec*) calloc(n, sizeof(struct iovec));
       for (int page_ix = 0; page_ix < n; ++page_ix) {

--- a/src/test/librgw_file_gp.cc
+++ b/src/test/librgw_file_gp.cc
@@ -78,7 +78,7 @@ namespace {
     std::vector<ZPage*> pages;
     struct iovec* iovs;
 
-    ZPageSet(int n) {
+    explicit ZPageSet(int n) {
       pages.reserve(n);
       iovs = (struct iovec*) calloc(n, sizeof(struct iovec));
       for (int page_ix = 0; page_ix < n; ++page_ix) {

--- a/src/test/mon/PGMap.cc
+++ b/src/test/mon/PGMap.cc
@@ -20,7 +20,7 @@
 namespace {
   class CheckTextTable : public TextTable {
   public:
-    CheckTextTable(bool verbose) {
+    explicit CheckTextTable(bool verbose) {
       for (int i = 0; i < 4; i++) {
         define_column("", TextTable::LEFT, TextTable::LEFT);
       }

--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -125,7 +125,7 @@ class C_poll : public EventCallback {
   static const int sleepus = 500;
 
  public:
-  C_poll(EventCenter *c): center(c), woken(false) {}
+  explicit C_poll(EventCenter *c): center(c), woken(false) {}
   void do_request(uint64_t r) override {
     woken = true;
   }
@@ -573,7 +573,7 @@ class StressFactory {
     std::random_device rd;
     std::default_random_engine rng;
 
-    RandomString(size_t s): slen(s), rng(rd()) {}
+    explicit RandomString(size_t s): slen(s), rng(rd()) {}
     void prepare(size_t n) {
       static const char alphabet[] =
           "abcdefghijklmnopqrstuvwxyz"
@@ -631,7 +631,7 @@ class StressFactory {
   class C_delete : public EventCallback {
     T *ctxt;
    public:
-    C_delete(T *c): ctxt(c) {}
+    explicit C_delete(T *c): ctxt(c) {}
     void do_request(uint64_t id) override {
       delete ctxt;
       delete this;
@@ -656,7 +656,7 @@ class StressFactory {
     class Client_read_handle : public EventCallback {
       Client *c;
      public:
-      Client_read_handle(Client *_c): c(_c) {}
+      explicit Client_read_handle(Client *_c): c(_c) {}
       void do_request(uint64_t id) override {
         c->do_read_request();
       }
@@ -665,7 +665,7 @@ class StressFactory {
     class Client_write_handle : public EventCallback {
       Client *c;
      public:
-      Client_write_handle(Client *_c): c(_c) {}
+      explicit Client_write_handle(Client *_c): c(_c) {}
       void do_request(uint64_t id) override {
         c->do_write_request();
       }
@@ -795,7 +795,7 @@ class StressFactory {
     class Server_read_handle : public EventCallback {
       Server *s;
      public:
-      Server_read_handle(Server *_s): s(_s) {}
+      explicit Server_read_handle(Server *_s): s(_s) {}
       void do_request(uint64_t id) override {
         s->do_read_request();
       }
@@ -804,7 +804,7 @@ class StressFactory {
     class Server_write_handle : public EventCallback {
       Server *s;
      public:
-      Server_write_handle(Server *_s): s(_s) {}
+      explicit Server_write_handle(Server *_s): s(_s) {}
       void do_request(uint64_t id) override {
         s->do_write_request();
       }

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -34,7 +34,7 @@ TEST(BitAllocator, test_bmap_iter)
       BmapEntityTmp() {
 
       }
-      BmapEntityTmp(int num) {
+      explicit BmapEntityTmp(int num) {
         m_num = num;
         m_len = num;
       }

--- a/src/test/objectstore/store_test_fixture.h
+++ b/src/test/objectstore/store_test_fixture.h
@@ -17,7 +17,7 @@ public:
   boost::scoped_ptr<ObjectStore> store;
   ObjectStore::CollectionHandle ch;
 
-  StoreTestFixture(const std::string& type)
+  explicit StoreTestFixture(const std::string& type)
     : type(type), data_dir(type + ".test_temp_dir")
   {}
 

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -1308,7 +1308,7 @@ TEST(pool_opts_t, deep_scrub_interval) {
 
 struct RequiredPredicate : IsPGRecoverablePredicate {
   unsigned required_size;
-  RequiredPredicate(unsigned required_size) : required_size(required_size) {}
+  explicit RequiredPredicate(unsigned required_size) : required_size(required_size) {}
   bool operator()(const set<pg_shard_t> &have) const override {
     return have.size() >= required_size;
   }
@@ -1317,7 +1317,7 @@ struct RequiredPredicate : IsPGRecoverablePredicate {
 using namespace std;
 struct MapPredicate {
   map<int, pair<PastIntervals::osd_state_t, epoch_t>> states;
-  MapPredicate(
+  explicit MapPredicate(
     const vector<pair<int, pair<PastIntervals::osd_state_t, epoch_t>>> &_states)
    : states(_states.begin(), _states.end()) {}
   PastIntervals::osd_state_t operator()(epoch_t start, int osd, epoch_t *lost_at) {

--- a/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
@@ -21,7 +21,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/rbd_mirror/image_replayer/test_mock_EventPreprocessor.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_EventPreprocessor.cc
@@ -14,7 +14,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/rbd_mirror/image_sync/test_mock_SyncPointCreateRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SyncPointCreateRequest.cc
@@ -15,7 +15,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/rbd_mirror/image_sync/test_mock_SyncPointPruneRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SyncPointPruneRequest.cc
@@ -15,7 +15,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/rbd_mirror/pool_watcher/test_mock_RefreshImagesRequest.cc
+++ b/src/test/rbd_mirror/pool_watcher/test_mock_RefreshImagesRequest.cc
@@ -12,7 +12,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/rbd_mirror/test_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_PoolWatcher.cc
@@ -73,7 +73,7 @@ public:
     Cond cond;
     ImageIds image_ids;
 
-    PoolWatcherListener(TestPoolWatcher *test) : test(test) {
+    explicit PoolWatcherListener(TestPoolWatcher *test) : test(test) {
     }
 
     void handle_update(const std::string &mirror_uuid,

--- a/src/test/rbd_mirror/test_mock_ImageSync.cc
+++ b/src/test/rbd_mirror/test_mock_ImageSync.cc
@@ -19,7 +19,7 @@ namespace librbd {
 namespace {
 
 struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+  explicit MockTestImageCtx(librbd::ImageCtx &image_ctx)
     : librbd::MockImageCtx(image_ctx) {
   }
 };

--- a/src/test/rgw/test_rgw_common.h
+++ b/src/test/rgw/test_rgw_common.h
@@ -39,7 +39,7 @@ struct old_rgw_bucket {
     data_pool = index_pool = s;
     marker = "";
   }
-  old_rgw_bucket(const char *n) : name(n) {
+  explicit old_rgw_bucket(const char *n) : name(n) {
     data_pool = index_pool = n;
     marker = "";
   }

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -84,7 +84,7 @@ class FakeIdentity : public Identity {
   const Principal id;
 public:
 
-  FakeIdentity(Principal&& id) : id(std::move(id)) {}
+  explicit FakeIdentity(Principal&& id) : id(std::move(id)) {}
   uint32_t get_perms_from_aclspec(const aclspec_t& aclspec) const override {
     abort();
     return 0;

--- a/src/test/rgw/test_rgw_period_history.cc
+++ b/src/test/rgw/test_rgw_period_history.cc
@@ -45,7 +45,7 @@ using Ids = std::vector<std::string>;
 class RecordingPuller : public RGWPeriodHistory::Puller {
   const int error;
  public:
-  RecordingPuller(int error) : error(error) {}
+  explicit RecordingPuller(int error) : error(error) {}
   Ids ids;
   int pull(const std::string& id, RGWPeriod& period) override {
     ids.push_back(id);

--- a/src/test/test_any.cc
+++ b/src/test/test_any.cc
@@ -126,7 +126,7 @@ struct not_noexcept {
   }
 
   template<typename ...Args>
-  not_noexcept(Args&& ...) noexcept(false) {
+  explicit not_noexcept(Args&& ...) noexcept(false) {
   }
 
   template<typename U, typename ...Args>
@@ -395,11 +395,11 @@ struct unmoving {
   unmoving() noexcept {}
 
   template<typename... Args>
-  unmoving(Args&& ...args) noexcept
+  explicit unmoving(Args&& ...args) noexcept
     : a(sizeof...(Args)) {}
 
   template<typename U, typename... Args>
-  unmoving(std::initializer_list<U> l) noexcept
+  explicit unmoving(std::initializer_list<U> l) noexcept
     : a(-l.size()) {}
 
   template<typename U, typename... Args>

--- a/src/test/test_denc.cc
+++ b/src/test/test_denc.cc
@@ -191,7 +191,7 @@ struct legacy_t {
     decode(a, p);
   }
   legacy_t() {}
-  legacy_t(int32_t i) : a(i) {}
+  explicit legacy_t(int32_t i) : a(i) {}
   friend bool operator<(const legacy_t& l, const legacy_t& r) {
     return l.a < r.a;
   }

--- a/src/test/test_mempool.cc
+++ b/src/test/test_mempool.cc
@@ -176,7 +176,7 @@ struct obj {
   int a;
   int b;
   obj() : a(1), b(1) {}
-  obj(int _a) : a(_a), b(2) {}
+  explicit obj(int _a) : a(_a), b(2) {}
   obj(int _a,int _b) : a(_a), b(_b) {}
   friend inline bool operator<(const obj& l, const obj& r) {
     return l.a < r.a;


### PR DESCRIPTION
Set 222 constructors as explicit to avoid implicit usage.

Fix for cppcheck warning:
 Class has a constructor with 1 argument that is
 not explicit. Such constructors should in general be explicit for
 type safety reasons. Using the explicit keyword in the constructor
 means some mistakes when using the class can be avoided.

 For more information check:
  https://www.codeproject.com/Articles/28663/Explicit-Constructor-in-C

Signed-off-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>