### PR TITLE
mgr/dashboard: Adapt help text if server_addr is not set

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -115,7 +115,7 @@ class Module(MgrModule):
         if server_addr is None:
             raise RuntimeError(
                 'no server_addr configured; '
-                'try "ceph config-key put mgr/{}/{}/server_addr <ip>"'
+                'try "ceph config set mgr mgr/{}/{}/server_addr <ip>"'
                 .format(self.module_name, self.get_mgr_id()))
         self.log.info('server_addr: %s server_port: %s', server_addr,
                       server_port)


### PR DESCRIPTION
After 'ceph config-key set' is deprecated the help text must be adapted.

Signed-off-by: Volker Theile <vtheile@suse.com>