### PR TITLE
mgr/dashboard: Fix duplicate params

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -24,10 +24,11 @@ from ..settings import Settings
 from ..tools import Session, TaskManager
 
 
-def ApiController(path):
+def ApiController(path, dont_add_to_url=None):
     def decorate(cls):
         cls._cp_controller_ = True
         cls._cp_path_ = path
+        cls._cp_dont_add_to_url = dont_add_to_url if dont_add_to_url else []
         config = {
             'tools.sessions.on': True,
             'tools.sessions.name': Session.NAME,
@@ -95,9 +96,12 @@ def generate_controller_routes(ctrl_class, mapper, base_url):
             name = "{}:{}".format(ctrl_class.__name__, url_suffix)
             url = "{}/{}/{}".format(base_url, ctrl_class._cp_path_, url_suffix)
 
-        if params:
-            for param in params:
-                url = "{}/:{}".format(url, param)
+        # We add params to the url, except if they are already specified.
+        params_to_add = [':{}'.format(p) for p in params
+                         if p not in ctrl_class._cp_dont_add_to_url]
+
+        if params_to_add:
+            url += '/' + '/'.join(params_to_add)
 
         conditions = dict(method=methods) if methods else None
 

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -63,7 +63,7 @@ class RgwDaemon(RESTController):
         return daemon
 
 
-@ApiController('rgw/proxy/{path:.*}')
+@ApiController('rgw/proxy/{path:.*}', dont_add_to_url=['path'])
 @AuthRequired()
 class RgwProxy(BaseController):
     @cherrypy.expose


### PR DESCRIPTION
Add params to the url, only if they are not already added.

Right now, we're building urls like `rgw/proxy/{path:.*}/:path` and this is of course broken.

* Fixes http://tracker.ceph.com/issues/23823
* Found-by and needed for #21066

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>