### PR TITLE
mgr/dashboard: replace configuration html table with cd-table

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
@@ -5,11 +5,13 @@
         aria-current="page">Configuration Documentation</li>
   </ol>
 </nav>
-
-<div class="dataTables_wrapper">
-  <div class="dataTables_header clearfix form-inline">
-    <!-- filters -->
-    <div class="form-group pull-right filter"
+<cd-table [data]="data | filter:filters"
+          (fetchData)="getConfigurationList()"
+          [columns]="columns"
+          selectionType="single"
+          (updateSelection)="updateSelection($event)">
+  <div class="table-actions form-inline">
+    <div class="form-group filter"
          *ngFor="let filter of filters">
       <label>{{ filter.label }}: </label>
       <select class="form-control input-sm"
@@ -18,50 +20,12 @@
         <option *ngFor="let opt of filter.options">{{ opt }}</option>
       </select>
     </div>
-    <!-- end filters -->
   </div>
-
-  <table class="oadatatable table table-striped table-condensed table-bordered table-hover">
-    <thead class="datatable-header">
-      <tr>
-        <th >Name</th>
-        <th style="width:400px;">Description</th>
-        <th>Type</th>
-        <th>Level</th>
-        <th style="width: 200px">Default</th>
-        <th>Tags</th>
-        <th>Services</th>
-        <th>See_also</th>
-        <th>Max</th>
-        <th>Min</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let row of data | filter:filters">
-        <td >{{ row.name }}</td>
-        <td>
-          <p>
-            {{ row.desc }}</p>
-          <p *ngIf="row.long_desc"
-             class=text-muted>{{ row.long_desc }}</p>
-        </td>
-        <td>{{ row.type }}</td>
-        <td>{{ row.level }}</td>
-        <td class="wrap">
-          {{ row.default }} {{ row.daemon_default }}
-        </td>
-        <td>
-          <p *ngFor="let item of row.tags">{{ item }}</p>
-        </td>
-        <td>
-          <p *ngFor="let item of row.services">{{ item }}</p>
-        </td>
-        <td class="wrap">
-          <p *ngFor="let item of row.see_also">{{ item }}</p>
-        </td>
-        <td>{{ row.max }}</td>
-        <td>{{ row.min }}</td>
-      </tr>
-    </tbody>
-  </table>
-</div>
+  <tabset cdTableDetail *ngIf="selection.hasSingleSelection">
+    <tab i18n-heading
+         heading="Details">
+      <cd-table-key-value [data]="selection.first()" [autoReload]="false">
+      </cd-table-key-value>
+    </tab>
+  </tabset>
+</cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.scss
@@ -1,5 +1,8 @@
-@import '../../../shared/datatable/table/table.component.scss';
 
-td.wrap {
+.filter {
+  padding-right: 8px;
+}
+
+::ng-deep datatable-body-cell.wrap {
   word-break: break-all;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
@@ -1,6 +1,7 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
+import { TabsModule } from 'ngx-bootstrap/tabs/tabs.module';
 import { Observable } from 'rxjs/Observable';
 
 import { ConfigurationService } from '../../../shared/api/configuration.service';
@@ -24,7 +25,7 @@ describe('ConfigurationComponent', () => {
       TestBed.configureTestingModule({
         declarations: [ConfigurationComponent],
         providers: [{ provide: ConfigurationService, useValue: fakeService }],
-        imports: [SharedModule, FormsModule]
+        imports: [SharedModule, FormsModule, TabsModule.forRoot()]
       }).compileComponents();
     })
   );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
@@ -1,17 +1,18 @@
-import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { ConfigurationService } from '../../../shared/api/configuration.service';
+import { CdTableColumn } from '../../../shared/models/cd-table-column';
+import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 
 @Component({
   selector: 'cd-configuration',
   templateUrl: './configuration.component.html',
   styleUrls: ['./configuration.component.scss']
 })
-export class ConfigurationComponent implements OnInit {
-  @ViewChild('arrayTmpl') arrayTmpl: TemplateRef<any>;
-
+export class ConfigurationComponent {
   data = [];
-  columns: any;
+  columns: CdTableColumn[];
+  selection = new CdTableSelection();
 
   filters = [
     {
@@ -35,7 +36,7 @@ export class ConfigurationComponent implements OnInit {
       label: 'Service',
       prop: 'services',
       value: 'any',
-      options: ['mon', 'mgr', 'osd', 'mds', 'common', 'mds_client', 'rgw', 'any'],
+      options: ['any', 'mon', 'mgr', 'osd', 'mds', 'common', 'mds_client', 'rgw'],
       applyFilter: (row, value) => {
         if (value === 'any') {
           return true;
@@ -46,28 +47,30 @@ export class ConfigurationComponent implements OnInit {
     }
   ];
 
-  constructor(private configurationService: ConfigurationService) {}
-
-  ngOnInit() {
+  constructor(
+    private configurationService: ConfigurationService,
+  ) {
     this.columns = [
       { flexGrow: 2, canAutoResize: true, prop: 'name' },
-      { flexGrow: 2, prop: 'desc', name: 'Description' },
-      { flexGrow: 2, prop: 'long_desc', name: 'Long description' },
+      { flexGrow: 2, prop: 'desc', name: 'Description', cellClass: 'wrap' },
+      { flexGrow: 2, prop: 'long_desc', name: 'Long description', cellClass: 'wrap' },
       { flexGrow: 1, prop: 'type' },
       { flexGrow: 1, prop: 'level' },
-      { flexGrow: 1, prop: 'default' },
+      { flexGrow: 1, prop: 'default', cellClass: 'wrap'},
       { flexGrow: 2, prop: 'daemon_default', name: 'Daemon default' },
-      { flexGrow: 1, prop: 'tags', name: 'Tags', cellTemplate: this.arrayTmpl },
-      { flexGrow: 1, prop: 'services', name: 'Services', cellTemplate: this.arrayTmpl },
-      { flexGrow: 1, prop: 'see_also', name: 'See_also', cellTemplate: this.arrayTmpl },
+      { flexGrow: 1, prop: 'tags', name: 'Tags' },
+      { flexGrow: 1, prop: 'services', name: 'Services' },
+      { flexGrow: 1, prop: 'see_also', name: 'See_also', cellClass: 'wrap' },
       { flexGrow: 1, prop: 'max', name: 'Max' },
       { flexGrow: 1, prop: 'min', name: 'Min' }
     ];
-
-    this.fetchData();
   }
 
-  fetchData() {
+  updateSelection(selection: CdTableSelection) {
+    this.selection = selection;
+  }
+
+  getConfigurationList() {
     this.configurationService.getConfigData().subscribe((data: any) => {
       this.data = data;
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -17,7 +17,8 @@ describe('TableComponent', () => {
       data.push({
         a: i,
         b: i * i,
-        c: [-(i % 10), 'score' + (i % 16 + 6) ]
+        c: [-(i % 10), 'score' + (i % 16 + 6) ],
+        d: !(i % 2)
       });
     }
     return data;
@@ -50,7 +51,8 @@ describe('TableComponent', () => {
     component.columns = [
       {prop: 'a', name: 'Index'},
       {prop: 'b', name: 'Power ofA'},
-      {prop: 'c', name: 'Poker array'}
+      {prop: 'c', name: 'Poker array'},
+      {prop: 'd', name: 'Boolean value'}
     ];
   });
 
@@ -77,9 +79,21 @@ describe('TableComponent', () => {
   });
 
   it('should search for 13', () => {
-    doSearch('13', 9, {a: 7, b: 49, c: [ -7, 'score13'] });
+    doSearch('13', 9, {a: 7, b: 49, c: [ -7, 'score13'], d: false});
     expect(component.rows[1].a).toBe(13);
     expect(component.rows[8].a).toBe(87);
+  });
+
+  it('should search for true', () => {
+    doSearch('true', 50, {a: 0, b: 0, c: [ -0, 'score6'], d: true});
+    expect(component.rows[0].d).toBe(true);
+    expect(component.rows[1].d).toBe(true);
+  });
+
+  it('should search for false', () => {
+    doSearch('false', 50, {a: 1, b: 1, c: [ -1, 'score7'], d: false});
+    expect(component.rows[0].d).toBe(false);
+    expect(component.rows[1].d).toBe(false);
   });
 
   it('should test search manipulation', () => {
@@ -100,28 +114,28 @@ describe('TableComponent', () => {
   });
 
   it('should search for multiple values', () => {
-    doSearch('7 5 3', 5, {a: 57, b: 3249, c: [ -7, 'score15']});
+    doSearch('7 5 3', 5, {a: 57, b: 3249, c: [ -7, 'score15'], d: false});
   });
 
   it('should search with column filter', () => {
-    doSearch('power:1369', 1, {a: 37, b: 1369, c: [ -7, 'score11']});
-    doSearch('ndex:7 ofa:5 poker:3', 3, {a: 71, b: 5041, c: [-1, 'score13']});
+    doSearch('power:1369', 1, {a: 37, b: 1369, c: [ -7, 'score11'], d: false});
+    doSearch('ndex:7 ofa:5 poker:3', 3, {a: 71, b: 5041, c: [-1, 'score13'], d: false});
   });
 
   it('should search with through array', () => {
-    doSearch('array:score21', 6, {a: 15, b: 225, c: [-5, 'score21']});
+    doSearch('array:score21', 6, {a: 15, b: 225, c: [-5, 'score21'], d: false});
   });
 
   it('should search with spaces', () => {
-    doSearch('\'poker array\':score21', 6, {a: 15, b: 225, c: [-5, 'score21']});
-    doSearch('"poker array":score21', 6, {a: 15, b: 225, c: [-5, 'score21']});
-    doSearch('poker+array:score21', 6, {a: 15, b: 225, c: [-5, 'score21']});
+    doSearch('\'poker array\':score21', 6, {a: 15, b: 225, c: [-5, 'score21'], d: false});
+    doSearch('"poker array":score21', 6, {a: 15, b: 225, c: [-5, 'score21'], d: false});
+    doSearch('poker+array:score21', 6, {a: 15, b: 225, c: [-5, 'score21'], d: false});
   });
 
   it('should not search if column name is incomplete', () => {
-    doSearch('\'poker array\'', 100, {a: 0, b: 0, c: [-0, 'score6']});
-    doSearch('pok', 100, {a: 0, b: 0, c: [-0, 'score6']});
-    doSearch('pok:', 100, {a: 0, b: 0, c: [-0, 'score6']});
+    doSearch('\'poker array\'', 100, {a: 0, b: 0, c: [-0, 'score6'], d: true});
+    doSearch('pok', 100, {a: 0, b: 0, c: [-0, 'score6'], d: true});
+    doSearch('pok:', 100, {a: 0, b: 0, c: [-0, 'score6'], d: true});
   });
 
   it('should restore full table after search', () => {
@@ -165,7 +179,7 @@ describe('TableComponent', () => {
     });
 
     it('should have table columns', () => {
-      expect(component.tableColumns.length).toBe(3);
+      expect(component.tableColumns.length).toBe(4);
       expect(component.tableColumns).toEqual(component.columns);
     });
 
@@ -178,14 +192,15 @@ describe('TableComponent', () => {
     it('should remove column "a"', () => {
       toggleColumn('a', false);
       expect(component.table.sorts[0].prop).toBe('b');
-      expect(component.tableColumns.length).toBe(2);
+      expect(component.tableColumns.length).toBe(3);
     });
 
     it('should not be able to remove all columns', () => {
       toggleColumn('a', false);
       toggleColumn('b', false);
       toggleColumn('c', false);
-      expect(component.table.sorts[0].prop).toBe('c');
+      toggleColumn('d', false);
+      expect(component.table.sorts[0].prop).toBe('d');
       expect(component.tableColumns.length).toBe(1);
     });
 
@@ -193,7 +208,7 @@ describe('TableComponent', () => {
       toggleColumn('a', false);
       toggleColumn('a', true);
       expect(component.table.sorts[0].prop).toBe('b');
-      expect(component.tableColumns.length).toBe(3);
+      expect(component.tableColumns.length).toBe(4);
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -352,7 +352,7 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
         }
         if (_.isArray(cellValue)) {
           cellValue = cellValue.join(' ');
-        } else if (_.isNumber(cellValue)) {
+        } else if (_.isNumber(cellValue) || _.isBoolean(cellValue)) {
           cellValue = cellValue.toString();
         }
         return cellValue.toLowerCase().indexOf(searchTerm) !== -1;


### PR DESCRIPTION
The configuration documentation page still uses a normal html table.
In preparation for displaying and editing configuration options (e.g. PR #21460) this pull request replaces the table with the cd-table to make use of its advanced features here.

![config_documentation](https://user-images.githubusercontent.com/8761082/39248790-4e4bd426-489d-11e8-84df-7c8ff54dc771.jpg)

Signed-off-by: Tatjana Dehler <tdehler@suse.com>