### PR TITLE
qa/suites/rados/verify/tasks/rados_api_tests: whitelist OBJECT_MISPLACED

### DIFF
--- a/qa/suites/rados/verify/tasks/rados_api_tests.yaml
+++ b/qa/suites/rados/verify/tasks/rados_api_tests.yaml
@@ -10,6 +10,7 @@ overrides:
       - \(CACHE_POOL_NEAR_FULL\)
       - \(POOL_APP_NOT_ENABLED\)
       - \(PG_AVAILABILITY\)
+      - \(OBJECT_MISPLACED\)
     conf:
       client:
         debug ms: 1


### PR DESCRIPTION
The api tests do some splits, which can move data.

Signed-off-by: Sage Weil <sage@redhat.com>