### PR TITLE
rgw: fix for issue #23859

### DIFF
--- a/src/rgw/rgw_otp.cc
+++ b/src/rgw/rgw_otp.cc
@@ -128,7 +128,7 @@ public:
     if (ret == -ENOENT) {
       if (truncated)
         *truncated = false;
-      return -ENOENT;
+      return 0;
     }
 
     return 0;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2793,7 +2793,7 @@ public:
     if (ret == -ENOENT) {
       if (truncated)
         *truncated = false;
-      return -ENOENT;
+      return 0;
     }
 
     // now filter out the buckets entries


### PR DESCRIPTION
metadata sync fails if there is an empty metadata section