### PR TITLE
rgw: cloud sync fixes

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -616,6 +616,7 @@ int RGWAsyncStatRemoteObj::_send_request()
                        nullptr, /* const char *if_match, */
                        nullptr, /* const char *if_nomatch, */
                        pattrs,
+                       pheaders,
                        nullptr,
                        nullptr, /* string *ptag, */
                        petag); /* string *petag, */

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -832,6 +832,7 @@ class RGWAsyncStatRemoteObj : public RGWAsyncRadosRequest {
   uint64_t *psize;
   string *petag;
   map<string, bufferlist> *pattrs;
+  map<string, string> *pheaders;
 
 protected:
   int _send_request() override;
@@ -843,14 +844,16 @@ public:
                          ceph::real_time *_pmtime,
                          uint64_t *_psize,
                          string *_petag,
-                         map<string, bufferlist> *_pattrs) : RGWAsyncRadosRequest(caller, cn), store(_store),
+                         map<string, bufferlist> *_pattrs,
+                         map<string, string> *_pheaders) : RGWAsyncRadosRequest(caller, cn), store(_store),
                                                       source_zone(_source_zone),
                                                       bucket_info(_bucket_info),
                                                       key(_key),
                                                       pmtime(_pmtime),
                                                       psize(_psize),
                                                       petag(_petag),
-                                                      pattrs(_pattrs) {}
+                                                      pattrs(_pattrs),
+                                                      pheaders(_pheaders) {}
 };
 
 class RGWStatRemoteObjCR : public RGWSimpleCoroutine {
@@ -867,6 +870,7 @@ class RGWStatRemoteObjCR : public RGWSimpleCoroutine {
   uint64_t *psize;
   string *petag;
   map<string, bufferlist> *pattrs;
+  map<string, string> *pheaders;
 
   RGWAsyncStatRemoteObj *req;
 
@@ -878,7 +882,8 @@ public:
                       ceph::real_time *_pmtime,
                       uint64_t *_psize,
                       string *_petag,
-                      map<string, bufferlist> *_pattrs) : RGWSimpleCoroutine(_store->ctx()), cct(_store->ctx()),
+                      map<string, bufferlist> *_pattrs,
+                      map<string, string> *_pheaders) : RGWSimpleCoroutine(_store->ctx()), cct(_store->ctx()),
                                        async_rados(_async_rados), store(_store),
                                        source_zone(_source_zone),
                                        bucket_info(_bucket_info),
@@ -887,6 +892,7 @@ public:
                                        psize(_psize),
                                        petag(_petag),
                                        pattrs(_pattrs),
+                                       pheaders(_pheaders),
                                        req(NULL) {}
 
 
@@ -903,7 +909,7 @@ public:
 
   int send_request() override {
     req = new RGWAsyncStatRemoteObj(this, stack->create_completion_notifier(), store, source_zone,
-                                    bucket_info, key, pmtime, psize, petag, pattrs);
+                                    bucket_info, key, pmtime, psize, petag, pattrs, pheaders);
     async_rados->queue(req);
     return 0;
   }

--- a/src/rgw/rgw_cr_rest.cc
+++ b/src/rgw/rgw_cr_rest.cc
@@ -212,6 +212,7 @@ int RGWStreamWriteHTTPResourceCRF::write(bufferlist& data, bool *io_pending)
       }
       yield req->add_send_data(data);
     }
+    return req->get_status();
   }
   return 0;
 }

--- a/src/rgw/rgw_cr_rest.cc
+++ b/src/rgw/rgw_cr_rest.cc
@@ -113,7 +113,7 @@ void RGWStreamReadHTTPResourceCRF::get_attrs(std::map<string, string> *attrs)
   req->get_out_headers(attrs);
 }
 
-int RGWStreamReadHTTPResourceCRF::decode_rest_obj(map<string, string>& headers, bufferlist& extra_data, rgw_rest_obj *info) {
+int RGWStreamReadHTTPResourceCRF::decode_rest_obj(map<string, string>& headers, bufferlist& extra_data) {
   /* basic generic implementation */
   for (auto header : headers) {
     const string& val = header.second;
@@ -142,7 +142,7 @@ int RGWStreamReadHTTPResourceCRF::read(bufferlist *out, uint64_t max_size, bool 
         extra_data.claim_append(in_cb->get_extra_data());
         map<string, string> attrs;
         req->get_out_headers(&attrs);
-        int ret = decode_rest_obj(attrs, extra_data, &rest_obj);
+        int ret = decode_rest_obj(attrs, extra_data);
         if (ret < 0) {
           ldout(cct, 0) << "ERROR: " << __func__ << " decode_rest_obj() returned ret=" << ret << dendl;
           return ret;

--- a/src/rgw/rgw_cr_rest.cc
+++ b/src/rgw/rgw_cr_rest.cc
@@ -75,6 +75,15 @@ void RGWCRHTTPGetDataCB::claim_data(bufferlist *dest, uint64_t max) {
   }
 }
 
+RGWStreamReadHTTPResourceCRF::~RGWStreamReadHTTPResourceCRF()
+{
+  if (req) {
+    req->cancel();
+    req->wait();
+    delete req;
+  }
+}
+
 int RGWStreamReadHTTPResourceCRF::init()
 {
   env->stack->init_new_io(req);
@@ -168,6 +177,15 @@ int RGWStreamReadHTTPResourceCRF::read(bufferlist *out, uint64_t max_size, bool 
 bool RGWStreamReadHTTPResourceCRF::is_done()
 {
   return req->is_done();
+}
+
+RGWStreamWriteHTTPResourceCRF::~RGWStreamWriteHTTPResourceCRF()
+{
+  if (req) {
+    req->cancel();
+    req->wait();
+    delete req;
+  }
 }
 
 void RGWStreamWriteHTTPResourceCRF::send_ready(const rgw_rest_obj& rest_obj)

--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -332,6 +332,7 @@ class RGWCRHTTPGetDataCB : public RGWHTTPStreamRWRequest::ReceiveCB {
   bufferlist extra_data;
   bool got_all_extra_data{false};
   bool paused{false};
+  bool notified{false};
 public:
   RGWCRHTTPGetDataCB(RGWCoroutinesEnv *_env, RGWCoroutine *_cr, RGWHTTPStreamRWRequest *_req);
 

--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -430,6 +430,7 @@ public:
                                                                 http_manager(_http_manager) {
     rest_obj.init(_src_key);
   }
+  ~RGWStreamReadHTTPResourceCRF();
 
   int init() override;
   int read(bufferlist *data, uint64_t max, bool *need_retry) override; /* reentrant */
@@ -489,7 +490,7 @@ public:
                                                                caller(_caller),
                                                                http_manager(_http_manager),
                                                                write_drain_notify_cb(this) {}
-  virtual ~RGWStreamWriteHTTPResourceCRF() = default;
+  virtual ~RGWStreamWriteHTTPResourceCRF();
 
   int init() override {
     return 0;

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -177,6 +177,7 @@ public:
   int process();
 
   int wait();
+  void cancel();
   bool is_done();
 
   rgw_http_req_data *get_req_data() { return req_data; }
@@ -315,7 +316,7 @@ class RGWHTTPManager {
   void register_request(rgw_http_req_data *req_data);
   void complete_request(rgw_http_req_data *req_data);
   void _complete_request(rgw_http_req_data *req_data);
-  void unregister_request(rgw_http_req_data *req_data);
+  bool unregister_request(rgw_http_req_data *req_data);
   void _unlink_request(rgw_http_req_data *req_data);
   void unlink_request(rgw_http_req_data *req_data);
   void finish_request(rgw_http_req_data *req_data, int r);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7851,7 +7851,6 @@ int RGWRados::stat_remote_obj(RGWObjectCtx& obj_ctx,
   }
 
   RGWGetExtraDataCB cb;
-  string etag;
   map<string, string> req_headers;
   real_time set_mtime;
 
@@ -7873,7 +7872,7 @@ int RGWRados::stat_remote_obj(RGWObjectCtx& obj_ctx,
     return ret;
   }
 
-  ret = conn->complete_request(in_stream_req, etag, &set_mtime, psize, req_headers);
+  ret = conn->complete_request(in_stream_req, nullptr, &set_mtime, psize, nullptr, pheaders);
   if (ret < 0) {
     return ret;
   }
@@ -7908,10 +7907,6 @@ int RGWRados::stat_remote_obj(RGWObjectCtx& obj_ctx,
 
   if (pattrs) {
     *pattrs = std::move(src_attrs);
-  }
-
-  if (pheaders) {
-    *pheaders = std::move(req_headers);
   }
 
   return 0;
@@ -8022,7 +8017,6 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   RGWRadosPutObj cb(cct, plugin, compressor, &processor, opstate, progress_cb, progress_data);
 
   string etag;
-  map<string, string> req_headers;
   real_time set_mtime;
 
   RGWObjState *dest_state = NULL;
@@ -8058,7 +8052,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
     goto set_err_state;
   }
 
-  ret = conn->complete_request(in_stream_req, etag, &set_mtime, nullptr, req_headers);
+  ret = conn->complete_request(in_stream_req, &etag, &set_mtime, nullptr, nullptr, nullptr);
   if (ret < 0) {
     goto set_err_state;
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7814,6 +7814,7 @@ int RGWRados::stat_remote_obj(RGWObjectCtx& obj_ctx,
                const char *if_match,
                const char *if_nomatch,
                map<string, bufferlist> *pattrs,
+               map<string, string> *pheaders,
                string *version_id,
                string *ptag,
                string *petag)
@@ -7906,7 +7907,11 @@ int RGWRados::stat_remote_obj(RGWObjectCtx& obj_ctx,
   }
 
   if (pattrs) {
-    *pattrs = src_attrs;
+    *pattrs = std::move(src_attrs);
+  }
+
+  if (pheaders) {
+    *pheaders = std::move(req_headers);
   }
 
   return 0;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3161,6 +3161,7 @@ public:
                const char *if_match,
                const char *if_nomatch,
                map<string, bufferlist> *pattrs,
+               map<string, string> *pheaders,
                string *version_id,
                string *ptag,
                string *petag);

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -534,10 +534,6 @@ int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, const map<string, strin
     }
   }
 
-  for (const auto& kv: new_env.get_map()) {
-    headers.emplace_back(kv);
-  }
-
   /* update acl headers */
   RGWAccessControlList& acl = policy.get_acl();
   multimap<string, ACLGrant>& grant_map = acl.get_grant_map();

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -190,10 +190,9 @@ int RGWHTTPSimpleRequest::receive_data(void *ptr, size_t len, bool *pause)
   response.append(p);
 
   return 0;
-
 }
 
-void RGWHTTPSimpleRequest::append_param(string& dest, const string& name, const string& val)
+static void append_param(string& dest, const string& name, const string& val)
 {
   if (dest.empty()) {
     dest.append("?");
@@ -212,16 +211,20 @@ void RGWHTTPSimpleRequest::append_param(string& dest, const string& name, const 
   }
 }
 
-void RGWHTTPSimpleRequest::get_params_str(map<string, string>& extra_args, string& dest)
+static void do_get_params_str(const param_vec_t& params, map<string, string>& extra_args, string& dest)
 {
   map<string, string>::iterator miter;
   for (miter = extra_args.begin(); miter != extra_args.end(); ++miter) {
     append_param(dest, miter->first, miter->second);
   }
-  param_vec_t::iterator iter;
-  for (iter = params.begin(); iter != params.end(); ++iter) {
+  for (auto iter = params.begin(); iter != params.end(); ++iter) {
     append_param(dest, iter->first, iter->second);
   }
+}
+
+void RGWHTTPSimpleRequest::get_params_str(map<string, string>& extra_args, string& dest)
+{
+  do_get_params_str(params, extra_args, dest);
 }
 
 void RGWHTTPSimpleRequest::get_out_headers(map<string, string> *pheaders)
@@ -436,58 +439,51 @@ static void add_grants_headers(map<int, string>& grants, RGWEnv& env, map<string
   }
 }
 
-void RGWRESTStreamS3PutObj::send_init(rgw_obj& obj)
+void RGWRESTGenerateHTTPHeaders::init(const string& _method, const string& _url, const string& resource, const param_vec_t& params)
 {
-  string resource_str;
-  string resource;
-  string new_url = url;
+  string params_str;
+  map<string, string>& args = new_info->args.get_params();
+  do_get_params_str(params, args, params_str);
 
-  if (host_style == VirtualStyle) {
-    resource_str = obj.get_oid();
-    new_url = obj.bucket.name + "."  + new_url;
-  } else {
-    resource_str = obj.bucket.name + "/" + obj.get_oid();
+  /* merge params with extra args so that we can sign correctly */
+  for (auto iter = params.begin(); iter != params.end(); ++iter) {
+    new_info->args.append(iter->first, iter->second);
   }
 
-  //do not encode slash in object key name
-  url_encode(resource_str, resource, false);
-
-  string uri;
-  //do not encode slash in object key name
-  url_encode(obj.bucket.name + "/" + obj.get_oid(), uri, false);
-
-  if (new_url[new_url.size() - 1] != '/')
-    new_url.append("/");
+  url = _url + resource + params_str;
 
   string date_str;
   get_gmt_date_str(date_str);
 
-  string params_str;
-  map<string, string>& args = new_info.args.get_params();
-  get_params_str(args, params_str);
+  new_env->set("HTTP_DATE", date_str.c_str());
 
-  /* merge params with extra args so that we can sign correctly */
-  for (param_vec_t::iterator iter = params.begin(); iter != params.end(); ++iter) {
-    new_info.args.append(iter->first, iter->second);
-  }
+  method = _method;
+  new_info->method = method.c_str();
 
-  new_url.append(resource + params_str);
-
-  new_env.set("HTTP_DATE", date_str.c_str());
-
-  new_info.method = "PUT";
-
-  new_info.script_uri = "/";
-  new_info.script_uri.append(uri);
-  new_info.request_uri = new_info.script_uri;
-
-  method = new_info.method;
-  url = new_url;
+  new_info->script_uri = "/";
+  new_info->script_uri.append(resource);
+  new_info->request_uri = new_info->script_uri;
 }
 
-int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, map<string, bufferlist>& rgw_attrs, bool send)
+static bool is_x_amz(const string& s) {
+  return boost::algorithm::starts_with(s, "x-amz-");
+}
+
+void RGWRESTGenerateHTTPHeaders::set_extra_headers(const map<string, string>& extra_headers)
+{
+  for (auto iter : extra_headers) {
+    const string& name = lowercase_dash_http_attr(iter.first);
+    new_env->set(name, iter.second.c_str());
+    if (is_x_amz(name)) {
+      new_info->x_meta_map[name] = iter.second;
+    }
+  }
+}
+
+int RGWRESTGenerateHTTPHeaders::set_obj_attrs(map<string, bufferlist>& rgw_attrs)
 {
   map<string, string> new_attrs;
+
   /* merge send headers */
   for (auto& attr: rgw_attrs) {
     bufferlist& bl = attr.second;
@@ -507,7 +503,10 @@ int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, map<string, bufferlist>
     return ret;
   }
 
-  return send_ready(key, new_attrs, policy, send);
+  set_http_attrs(new_attrs);
+  set_policy(policy);
+
+  return 0;
 }
 
 static std::set<string> keep_headers = { "content-type",
@@ -515,25 +514,25 @@ static std::set<string> keep_headers = { "content-type",
                                          "content-disposition",
                                          "content-language" };
 
-int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, const map<string, string>& http_attrs,
-                                      RGWAccessControlPolicy& policy, bool send)
+void RGWRESTGenerateHTTPHeaders::set_http_attrs(const map<string, string>& http_attrs)
 {
-  map<string, string> other_headers;
-
   /* merge send headers */
   for (auto& attr: http_attrs) {
     const string& val = attr.second;
     const string& name = lowercase_dash_http_attr(attr.first);
-    if (name.compare(0, sizeof(RGW_AMZ_PREFIX) - 1, RGW_AMZ_PREFIX) == 0) {
-      new_env.set(name, val);
-      new_info.x_meta_map[name] = val;
-    } else if (keep_headers.find(name) != keep_headers.end()) {
-      new_env.set(attr.first, val); /* Ugh, using the uppercase representation,
+    if (is_x_amz(name)) {
+      new_env->set(name, val);
+      new_info->x_meta_map[name] = val;
+    } else {
+      new_env->set(attr.first, val); /* Ugh, using the uppercase representation,
                                        as the signing function calls info.env.get("CONTENT_TYPE").
                                        This needs to be cleaned up! */
     }
   }
+}
 
+void RGWRESTGenerateHTTPHeaders::set_policy(RGWAccessControlPolicy& policy)
+{
   /* update acl headers */
   RGWAccessControlList& acl = policy.get_acl();
   multimap<string, ACLGrant>& grant_map = acl.get_grant_map();
@@ -544,12 +543,64 @@ int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, const map<string, strin
     ACLPermission& perm = grant.get_permission();
     grants_by_type_add_perm(grants_by_type, perm.get_permissions(), grant);
   }
-  add_grants_headers(grants_by_type, new_env, new_info.x_meta_map);
-  int ret = sign_request(cct, key, new_env, new_info);
+  add_grants_headers(grants_by_type, *new_env, new_info->x_meta_map);
+}
+
+int RGWRESTGenerateHTTPHeaders::sign(RGWAccessKey& key)
+{
+  int ret = sign_request(cct, key, *new_env, *new_info);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: failed to sign request" << dendl;
     return ret;
   }
+
+  return 0;
+}
+
+void RGWRESTStreamS3PutObj::send_init(rgw_obj& obj)
+{
+  string resource_str;
+  string resource;
+  string new_url = url;
+
+  if (host_style == VirtualStyle) {
+    resource_str = obj.get_oid();
+    new_url = obj.bucket.name + "."  + new_url;
+  } else {
+    resource_str = obj.bucket.name + "/" + obj.get_oid();
+  }
+
+  //do not encode slash in object key name
+  url_encode(resource_str, resource, false);
+
+  if (new_url[new_url.size() - 1] != '/')
+    new_url.append("/");
+
+  method = "PUT";
+  headers_gen.init(method, new_url, resource, params);
+
+  url = headers_gen.get_url();
+}
+
+int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, map<string, bufferlist>& rgw_attrs, bool send)
+{
+  headers_gen.set_obj_attrs(rgw_attrs);
+
+  return send_ready(key, send);
+}
+
+int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, const map<string, string>& http_attrs,
+                                      RGWAccessControlPolicy& policy, bool send)
+{
+  headers_gen.set_http_attrs(http_attrs);
+  headers_gen.set_policy(policy);
+
+  return send_ready(key, send);
+}
+
+int RGWRESTStreamS3PutObj::send_ready(RGWAccessKey& key, bool send)
+{
+  headers_gen.sign(key);
 
   for (const auto& kv: new_env.get_map()) {
     headers.emplace_back(kv);
@@ -654,21 +705,9 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
   if (new_url[new_url.size() - 1] != '/')
     new_url.append("/");
   
-  string date_str;
-  get_gmt_date_str(date_str);
-
   RGWEnv new_env;
   req_info new_info(cct, &new_env);
   
-  string params_str;
-  map<string, string>& args = new_info.args.get_params();
-  get_params_str(args, params_str);
-
-  /* merge params with extra args so that we can sign correctly */
-  for (param_vec_t::iterator iter = params.begin(); iter != params.end(); ++iter) {
-    new_info.args.append(iter->first, iter->second);
-  }
-
   string new_resource;
   string bucket_name;
   string old_resource = resource;
@@ -679,14 +718,12 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
     new_resource = resource;
   }
 
-  string uri = new_resource;
-
   size_t pos = new_resource.find("/");
   bucket_name = new_resource.substr(0, pos);
 
   //when dest is a bucket with out other params, uri should end up with '/'
   if(pos == string::npos && params.size() == 0 && host_style == VirtualStyle) {
-    uri.append("/");
+    new_resource.append("/");
   }
 
   if (host_style == VirtualStyle) {
@@ -698,25 +735,18 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
     }
   }
 
-  new_url.append(new_resource + params_str);
+  RGWRESTGenerateHTTPHeaders headers_gen(cct, &new_env, &new_info);
 
-  new_env.set("HTTP_DATE", date_str.c_str());
+  headers_gen.init(method, new_url, new_resource, params);
 
-  for (map<string, string>::iterator iter = extra_headers.begin();
-       iter != extra_headers.end(); ++iter) {
-    new_env.set(iter->first.c_str(), iter->second.c_str());
-  }
-
-  new_info.method = method.c_str();
-
-  new_info.script_uri = "/";
-  new_info.script_uri.append(uri);
-  new_info.request_uri = new_info.script_uri;
-
-  new_info.init_meta_info(NULL);
+  headers_gen.set_http_attrs(extra_headers);
 
   if (key) {
-    int ret = sign_request(cct, *key, new_env, new_info);
+#if 0
+    new_info.init_meta_info(nullptr);
+#endif
+
+    int ret = headers_gen.sign(*key);
     if (ret < 0) {
       ldout(cct, 0) << "ERROR: failed to sign request" << dendl;
       return ret;
@@ -735,7 +765,7 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
   
 
   method = new_info.method;
-  url = new_url;
+  url = headers_gen.get_url();
 
   return 0;
 }
@@ -765,7 +795,11 @@ int RGWRESTStreamRWRequest::send(RGWHTTPManager *mgr)
   return 0;
 }
 
-int RGWRESTStreamRWRequest::complete_request(string& etag, real_time *mtime, uint64_t *psize, map<string, string>& attrs)
+int RGWRESTStreamRWRequest::complete_request(string *etag,
+                                             real_time *mtime,
+                                             uint64_t *psize,
+                                             map<string, string> *pattrs,
+                                             map<string, string> *pheaders)
 {
   int ret = wait();
   if (ret < 0) {
@@ -774,7 +808,9 @@ int RGWRESTStreamRWRequest::complete_request(string& etag, real_time *mtime, uin
 
   unique_lock guard(out_headers_lock);
 
-  set_str_from_headers(out_headers, "ETAG", etag);
+  if (etag) {
+    set_str_from_headers(out_headers, "ETAG", *etag);
+  }
   if (status >= 0) {
     if (mtime) {
       string mtime_str;
@@ -800,8 +836,7 @@ int RGWRESTStreamRWRequest::complete_request(string& etag, real_time *mtime, uin
     }
   }
 
-  map<string, string>::iterator iter;
-  for (iter = out_headers.begin(); iter != out_headers.end(); ++iter) {
+  for (auto iter = out_headers.begin(); pattrs && iter != out_headers.end(); ++iter) {
     const string& attr_name = iter->first;
     if (attr_name.compare(0, sizeof(RGW_HTTP_RGWX_ATTR_PREFIX) - 1, RGW_HTTP_RGWX_ATTR_PREFIX) == 0) {
       string name = attr_name.substr(sizeof(RGW_HTTP_RGWX_ATTR_PREFIX) - 1);
@@ -818,8 +853,12 @@ int RGWRESTStreamRWRequest::complete_request(string& etag, real_time *mtime, uin
         }
       }
       *dest = '\0';
-      attrs[buf] = iter->second;
+      (*pattrs)[buf] = iter->second;
     }
+  }
+
+  if (pheaders) {
+    *pheaders = std::move(out_headers);
   }
   return status;
 }

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -157,8 +157,7 @@ int RGWRESTConn::put_obj_async(const rgw_user& uid, rgw_obj& obj, uint64_t obj_s
 
 int RGWRESTConn::complete_request(RGWRESTStreamS3PutObj *req, string& etag, real_time *mtime)
 {
-  map<string, string> attrs;
-  int ret = req->complete_request(etag, mtime, nullptr, attrs);
+  int ret = req->complete_request(&etag, mtime);
   delete req;
 
   return ret;
@@ -292,10 +291,14 @@ done_err:
   return r;
 }
 
-int RGWRESTConn::complete_request(RGWRESTStreamRWRequest *req, string& etag, real_time *mtime,
-                                  uint64_t *psize, map<string, string>& attrs)
+int RGWRESTConn::complete_request(RGWRESTStreamRWRequest *req,
+                                  string *etag,
+                                  real_time *mtime,
+                                  uint64_t *psize,
+                                  map<string, string> *pattrs,
+                                  map<string, string> *pheaders)
 {
-  int ret = req->complete_request(etag, mtime, psize, attrs);
+  int ret = req->complete_request(etag, mtime, psize, pattrs, pheaders);
   delete req;
 
   return ret;
@@ -336,9 +339,7 @@ int RGWRESTConn::get_resource(const string& resource,
     return ret;
   }
 
-  string etag;
-  map<string, string> attrs;
-  return req.complete_request(etag, NULL, NULL, attrs);
+  return req.complete_request();
 }
 
 RGWRESTReadResource::RGWRESTReadResource(RGWRESTConn *_conn,
@@ -383,9 +384,7 @@ int RGWRESTReadResource::read()
     return ret;
   }
 
-  string etag;
-  map<string, string> attrs;
-  return req.complete_request(etag, NULL, NULL, attrs);
+  return req.complete_request();
 }
 
 int RGWRESTReadResource::aio_read()
@@ -446,9 +445,7 @@ int RGWRESTSendResource::send(bufferlist& outbl)
     return ret;
   }
 
-  string etag;
-  map<string, string> attrs;
-  return req.complete_request(etag, NULL, NULL, attrs);
+  return req.complete_request();
 }
 
 int RGWRESTSendResource::aio_send(bufferlist& outbl)

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -55,6 +55,18 @@ inline param_vec_t make_param_list(const rgw_http_param_pair* pp)
   return params;
 }
 
+inline param_vec_t make_param_list(const map<string, string> *pp)
+{
+  param_vec_t params;
+  if (!pp) {
+    return params;
+  }
+  for (auto iter : *pp) {
+    params.emplace_back(make_pair(iter.first, iter.second));
+  }
+  return params;
+}
+
 class RGWRESTConn
 {
   CephContext *cct;

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -152,7 +152,12 @@ public:
               uint32_t mod_zone_id, uint64_t mod_pg_ver,
               bool prepend_metadata, bool get_op, bool rgwx_stat, bool sync_manifest,
               bool skip_decrypt, bool send, RGWHTTPStreamRWRequest::ReceiveCB *cb, RGWRESTStreamRWRequest **req);
-  int complete_request(RGWRESTStreamRWRequest *req, string& etag, ceph::real_time *mtime, uint64_t *psize, map<string, string>& attrs);
+  int complete_request(RGWRESTStreamRWRequest *req,
+                       string *etag,
+                       ceph::real_time *mtime,
+                       uint64_t *psize,
+                       map<string, string> *pattrs,
+                       map<string, string> *pheaders);
 
   int get_resource(const string& resource,
 		   param_vec_t *extra_params,

--- a/src/rgw/rgw_sync_module.cc
+++ b/src/rgw/rgw_sync_module.cc
@@ -29,7 +29,7 @@ int RGWCallStatRemoteObjCR::operate() {
     yield {
       call(new RGWStatRemoteObjCR(sync_env->async_rados, sync_env->store,
                                   sync_env->source_zone,
-                                  bucket_info, key, &mtime, &size, &etag, &attrs));
+                                  bucket_info, key, &mtime, &size, &etag, &attrs, &headers));
     }
     if (retcode < 0) {
       ldout(sync_env->cct, 0) << "RGWStatRemoteObjCR() returned " << retcode << dendl;
@@ -37,11 +37,11 @@ int RGWCallStatRemoteObjCR::operate() {
     }
     ldout(sync_env->cct, 20) << "stat of remote obj: z=" << sync_env->source_zone
       << " b=" << bucket_info.bucket << " k=" << key << " size=" << size << " mtime=" << mtime
-      << " attrs=" << attrs << dendl;
+      << " attrs=" << attrs << " headers=" << headers << dendl;
     yield {
       RGWStatRemoteObjCBCR *cb = allocate_callback();
       if (cb) {
-        cb->set_result(mtime, size, etag, std::move(attrs));
+        cb->set_result(mtime, size, etag, std::move(attrs), std::move(headers));
         call(cb);
       }
     }

--- a/src/rgw/rgw_sync_module.h
+++ b/src/rgw/rgw_sync_module.h
@@ -141,6 +141,7 @@ public:
     size = _size;
     etag = _etag;
     attrs = std::move(_attrs);
+    headers = std::move(_headers);
   }
 };
 

--- a/src/rgw/rgw_sync_module.h
+++ b/src/rgw/rgw_sync_module.h
@@ -126,6 +126,7 @@ protected:
   uint64_t size = 0;
   string etag;
   map<string, bufferlist> attrs;
+  map<string, string> headers;
 public:
   RGWStatRemoteObjCBCR(RGWDataSyncEnv *_sync_env,
                        RGWBucketInfo& _bucket_info, rgw_obj_key& _key);
@@ -134,7 +135,8 @@ public:
   void set_result(ceph::real_time& _mtime,
                   uint64_t _size,
                   const string& _etag,
-                  map<string, bufferlist>&& _attrs) {
+                  map<string, bufferlist>&& _attrs,
+                  map<string, string>&& _headers) {
     mtime = _mtime;
     size = _size;
     etag = _etag;
@@ -147,6 +149,7 @@ class RGWCallStatRemoteObjCR : public RGWCoroutine {
   uint64_t size{0};
   string etag;
   map<string, bufferlist> attrs;
+  map<string, string> headers;
 
 protected:
   RGWDataSyncEnv *sync_env;

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -676,6 +676,35 @@ struct AWSSyncInstanceEnv {
   }
 };
 
+int do_decode_rest_obj(CephContext *cct, map<string, bufferlist>& attrs, map<string, string>& headers, rgw_rest_obj *info)
+{
+  for (auto header : headers) {
+    const string& val = header.second;
+    if (header.first == "RGWX_OBJECT_SIZE") {
+      info->content_len = atoi(val.c_str());
+    } else {
+      info->attrs[header.first] = val;
+    }
+  }
+
+  info->acls.set_ctx(cct);
+  auto aiter = attrs.find(RGW_ATTR_ACL);
+  if (aiter != attrs.end()) {
+    bufferlist& bl = aiter->second;
+    bufferlist::iterator bliter = bl.begin();
+    try {
+      info->acls.decode(bliter);
+    } catch (buffer::error& err) {
+      ldout(cct, 0) << "ERROR: failed to decode policy off attrs" << dendl;
+      return -EIO;
+    }
+  } else {
+    ldout(cct, 0) << "WARNING: acl attrs not provided" << dendl;
+  }
+
+  return 0;
+}
+
 class RGWRESTStreamGetCRF : public RGWStreamReadHTTPResourceCRF
 {
   RGWDataSyncEnv *sync_env;
@@ -727,15 +756,8 @@ public:
     return RGWStreamReadHTTPResourceCRF::init();
   }
 
-  int decode_rest_obj(map<string, string>& headers, bufferlist& extra_data, rgw_rest_obj *info) override {
-    for (auto header : headers) {
-      const string& val = header.second;
-      if (header.first == "RGWX_OBJECT_SIZE") {
-        rest_obj.content_len = atoi(val.c_str());
-      } else {
-        rest_obj.attrs[header.first] = val;
-      }
-    }
+  int decode_rest_obj(map<string, string>& headers, bufferlist& extra_data) override {
+    map<string, bufferlist> src_attrs;
 
     ldout(sync_env->cct, 20) << __func__ << ":" << " headers=" << headers << " extra_data.length()=" << extra_data.length() << dendl;
 
@@ -746,28 +768,9 @@ public:
         return -EIO;
       }
 
-      map<string, bufferlist> src_attrs;
-
       JSONDecoder::decode_json("attrs", src_attrs, &jp);
-
-      info->acls.set_ctx(sync_env->cct);
-      auto aiter = src_attrs.find(RGW_ATTR_ACL);
-      if (aiter != src_attrs.end()) {
-        bufferlist& bl = aiter->second;
-        bufferlist::iterator bliter = bl.begin();
-        try {
-          info->acls.decode(bliter);
-        } catch (buffer::error& err) {
-          ldout(sync_env->cct, 0) << "ERROR: failed to decode policy off extra data" << dendl;
-          return -EIO;
-        }
-      } else {
-        ldout(sync_env->cct, 0) << "WARNING: acl attrs not provided in extra data" << dendl;
-      }
     }
-
-    return 0;
-
+    return do_decode_rest_obj(sync_env->cct, src_attrs, headers, &rest_obj);
   }
 
   bool need_extra_data() override {
@@ -813,10 +816,14 @@ public:
     return RGWStreamWriteHTTPResourceCRF::init();
   }
 
-  void send_ready(const rgw_rest_obj& rest_obj) override {
-    RGWRESTStreamS3PutObj *r = (RGWRESTStreamS3PutObj *)req;
+  static void init_send_attrs(CephContext *cct,
+                              const rgw_rest_obj& rest_obj,
+                              const rgw_sync_aws_src_obj_properties& src_properties,
+                              const AWSSyncConfig_Profile *target,
+                              map<string, string> *attrs) {
+    auto& new_attrs = *attrs;
 
-    map<string, string> new_attrs = rest_obj.attrs;
+    new_attrs = rest_obj.attrs;
 
     auto acl = rest_obj.acls.get_acl();
 
@@ -833,7 +840,7 @@ public:
 
         auto iter = am.find(orig_grantee);
         if (iter == am.end()) {
-          ldout(sync_env->cct, 20) << "acl_mappings: Could not find " << orig_grantee << " .. ignoring" << dendl;
+          ldout(cct, 20) << "acl_mappings: Could not find " << orig_grantee << " .. ignoring" << dendl;
           continue;
         }
 
@@ -903,7 +910,7 @@ public:
         s.append(viter);
       }
 
-      ldout(sync_env->cct, 20) << "acl_mappings: set acl: " << header_str << "=" << s << dendl;
+      ldout(cct, 20) << "acl_mappings: set acl: " << header_str << "=" << s << dendl;
 
       new_attrs[header_str] = s;
     }
@@ -922,6 +929,17 @@ public:
     new_attrs["x-amz-meta-rgwx-source-key"] = rest_obj.key.name;
     if (!rest_obj.key.instance.empty()) {
       new_attrs["x-amz-meta-rgwx-source-version-id"] = rest_obj.key.instance;
+    }
+  }
+
+  void send_ready(const rgw_rest_obj& rest_obj) override {
+    RGWRESTStreamS3PutObj *r = (RGWRESTStreamS3PutObj *)req;
+
+    map<string, string> new_attrs;
+    if (!multipart.is_multipart) {
+      init_send_attrs(sync_env->cct, rest_obj, src_properties, target.get(), &new_attrs);
+    } else {
+      new_attrs = rest_obj.attrs;
     }
 
     r->set_send_length(rest_obj.content_len);
@@ -1113,6 +1131,7 @@ class RGWAWSInitMultipartCR : public RGWCoroutine {
   rgw_obj dest_obj;
 
   uint64_t obj_size;
+  map<string, string> obj_headers;
 
   bufferlist out_bl;
 
@@ -1135,11 +1154,13 @@ public:
                         RGWRESTConn *_dest_conn,
                         const rgw_obj& _dest_obj,
                         uint64_t _obj_size,
+                        const map<string, string>& _obj_headers,
                         string *_upload_id) : RGWCoroutine(_sync_env->cct),
                                                    sync_env(_sync_env),
                                                    dest_conn(_dest_conn),
                                                    dest_obj(_dest_obj),
                                                    obj_size(_obj_size),
+                                                   obj_headers(_obj_headers),
                                                    upload_id(_upload_id) {}
 
   int operate() {
@@ -1149,7 +1170,7 @@ public:
         rgw_http_param_pair params[] = { { "uploads", nullptr }, {nullptr, nullptr} };
         bufferlist bl;
         call(new RGWPostRawRESTResourceCR <bufferlist> (sync_env->cct, dest_conn, sync_env->http_manager,
-                                                 obj_to_aws_path(dest_obj), params, bl, &out_bl));
+                                                 obj_to_aws_path(dest_obj), params, &obj_headers, bl, &out_bl));
       }
 
       if (retcode < 0) {
@@ -1260,7 +1281,7 @@ public:
         bl.append(ss.str());
 
         call(new RGWPostRawRESTResourceCR <bufferlist> (sync_env->cct, dest_conn, sync_env->http_manager,
-                                                 obj_to_aws_path(dest_obj), params, bl, &out_bl));
+                                                 obj_to_aws_path(dest_obj), params, nullptr, bl, &out_bl));
       }
 
       if (retcode < 0) {
@@ -1354,8 +1375,11 @@ class RGWAWSStreamObjToCloudMultipartCR : public RGWCoroutine {
   uint64_t obj_size;
   string src_etag;
   rgw_sync_aws_src_obj_properties src_properties;
+  rgw_rest_obj rest_obj;
 
   rgw_sync_aws_multipart_upload_info status;
+
+  map<string, string> obj_headers;
 
   rgw_sync_aws_multipart_part_info *pcur_part_info{nullptr};
 
@@ -1371,7 +1395,8 @@ public:
                                 std::shared_ptr<AWSSyncConfig_Profile>& _target,
                                 const rgw_obj& _dest_obj,
                                 uint64_t _obj_size,
-                                const rgw_sync_aws_src_obj_properties& _src_properties) : RGWCoroutine(_sync_env->cct),
+                                const rgw_sync_aws_src_obj_properties& _src_properties,
+                                const rgw_rest_obj& _rest_obj) : RGWCoroutine(_sync_env->cct),
                                                    sync_env(_sync_env),
                                                    conf(_conf),
                                                    source_conn(_source_conn),
@@ -1380,6 +1405,7 @@ public:
                                                    dest_obj(_dest_obj),
                                                    obj_size(_obj_size),
                                                    src_properties(_src_properties),
+                                                   rest_obj(_rest_obj),
                                                    status_obj(sync_env->store->get_zone_params().log_pool,
                                                               RGWBucketSyncStatusManager::obj_status_oid(sync_env->source_zone, src_obj)) {
   }
@@ -1406,7 +1432,9 @@ public:
       }
 
       if (retcode == -ENOENT) {
-        yield call(new RGWAWSInitMultipartCR(sync_env, target->conn.get(), dest_obj, status.obj_size, &status.upload_id));
+        RGWAWSStreamPutCRF::init_send_attrs(sync_env->cct, rest_obj, src_properties, target.get(), &obj_headers);
+
+        yield call(new RGWAWSInitMultipartCR(sync_env, target->conn.get(), dest_obj, status.obj_size, std::move(obj_headers), &status.upload_id));
         if (retcode < 0) {
           return set_cr_error(retcode);
         }
@@ -1626,8 +1654,13 @@ public:
                                                  target,
                                                  dest_obj));
         } else {
+          rgw_rest_obj rest_obj;
+          if (do_decode_rest_obj(sync_env->cct, attrs, headers, &rest_obj)) {
+            ldout(sync_env->cct, 0) << "ERROR: failed to decode rest obj out of headers=" << headers << ", attrs=" << attrs << dendl;
+            return set_cr_error(-EINVAL);
+          }
           call(new RGWAWSStreamObjToCloudMultipartCR(sync_env, instance.conf, source_conn, src_obj,
-                                                     target, dest_obj, size, src_properties));
+                                                     target, dest_obj, size, src_properties, rest_obj));
         }
       }
       if (retcode < 0) {

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -676,7 +676,7 @@ struct AWSSyncInstanceEnv {
   }
 };
 
-int do_decode_rest_obj(CephContext *cct, map<string, bufferlist>& attrs, map<string, string>& headers, rgw_rest_obj *info)
+static int do_decode_rest_obj(CephContext *cct, map<string, bufferlist>& attrs, map<string, string>& headers, rgw_rest_obj *info)
 {
   for (auto header : headers) {
     const string& val = header.second;
@@ -778,6 +778,11 @@ public:
   }
 };
 
+static std::set<string> keep_headers = { "CONTENT_TYPE",
+                                         "CONTENT_ENCODING",
+                                         "CONTENT_DISPOSITION",
+                                         "CONTENT_LANGUAGE" };
+
 class RGWAWSStreamPutCRF : public RGWStreamWriteHTTPResourceCRF
 {
   RGWDataSyncEnv *sync_env;
@@ -816,6 +821,11 @@ public:
     return RGWStreamWriteHTTPResourceCRF::init();
   }
 
+  static bool keep_attr(const string& h) {
+    return (keep_headers.find(h) != keep_headers.end() ||
+            boost::algorithm::starts_with(h, "X_AMZ_"));
+  }
+
   static void init_send_attrs(CephContext *cct,
                               const rgw_rest_obj& rest_obj,
                               const rgw_sync_aws_src_obj_properties& src_properties,
@@ -823,7 +833,13 @@ public:
                               map<string, string> *attrs) {
     auto& new_attrs = *attrs;
 
-    new_attrs = rest_obj.attrs;
+    new_attrs.clear();
+
+    for (auto& hi : rest_obj.attrs) {
+      if (keep_attr(hi.first)) {
+        new_attrs.insert(hi);
+      }
+    }
 
     auto acl = rest_obj.acls.get_acl();
 
@@ -938,8 +954,6 @@ public:
     map<string, string> new_attrs;
     if (!multipart.is_multipart) {
       init_send_attrs(sync_env->cct, rest_obj, src_properties, target.get(), &new_attrs);
-    } else {
-      new_attrs = rest_obj.attrs;
     }
 
     r->set_send_length(rest_obj.content_len);
@@ -1131,7 +1145,7 @@ class RGWAWSInitMultipartCR : public RGWCoroutine {
   rgw_obj dest_obj;
 
   uint64_t obj_size;
-  map<string, string> obj_headers;
+  map<string, string> attrs;
 
   bufferlist out_bl;
 
@@ -1154,13 +1168,13 @@ public:
                         RGWRESTConn *_dest_conn,
                         const rgw_obj& _dest_obj,
                         uint64_t _obj_size,
-                        const map<string, string>& _obj_headers,
+                        const map<string, string>& _attrs,
                         string *_upload_id) : RGWCoroutine(_sync_env->cct),
                                                    sync_env(_sync_env),
                                                    dest_conn(_dest_conn),
                                                    dest_obj(_dest_obj),
                                                    obj_size(_obj_size),
-                                                   obj_headers(_obj_headers),
+                                                   attrs(_attrs),
                                                    upload_id(_upload_id) {}
 
   int operate() {
@@ -1170,7 +1184,7 @@ public:
         rgw_http_param_pair params[] = { { "uploads", nullptr }, {nullptr, nullptr} };
         bufferlist bl;
         call(new RGWPostRawRESTResourceCR <bufferlist> (sync_env->cct, dest_conn, sync_env->http_manager,
-                                                 obj_to_aws_path(dest_obj), params, &obj_headers, bl, &out_bl));
+                                                 obj_to_aws_path(dest_obj), params, &attrs, bl, &out_bl));
       }
 
       if (retcode < 0) {
@@ -1379,7 +1393,7 @@ class RGWAWSStreamObjToCloudMultipartCR : public RGWCoroutine {
 
   rgw_sync_aws_multipart_upload_info status;
 
-  map<string, string> obj_headers;
+  map<string, string> new_attrs;
 
   rgw_sync_aws_multipart_part_info *pcur_part_info{nullptr};
 
@@ -1432,9 +1446,9 @@ public:
       }
 
       if (retcode == -ENOENT) {
-        RGWAWSStreamPutCRF::init_send_attrs(sync_env->cct, rest_obj, src_properties, target.get(), &obj_headers);
+        RGWAWSStreamPutCRF::init_send_attrs(sync_env->cct, rest_obj, src_properties, target.get(), &new_attrs);
 
-        yield call(new RGWAWSInitMultipartCR(sync_env, target->conn.get(), dest_obj, status.obj_size, std::move(obj_headers), &status.upload_id));
+        yield call(new RGWAWSInitMultipartCR(sync_env, target->conn.get(), dest_obj, status.obj_size, std::move(new_attrs), &status.upload_id));
         if (retcode < 0) {
           return set_cr_error(retcode);
         }
@@ -1655,6 +1669,7 @@ public:
                                                  dest_obj));
         } else {
           rgw_rest_obj rest_obj;
+          rest_obj.init(key);
           if (do_decode_rest_obj(sync_env->cct, attrs, headers, &rest_obj)) {
             ldout(sync_env->cct, 0) << "ERROR: failed to decode rest obj out of headers=" << headers << ", attrs=" << attrs << dendl;
             return set_cr_error(-EINVAL);


### PR DESCRIPTION
 - aws compatibility fixes (header was sent twice)
 - fix busy loop when dealing with asymmetric  splice (writes slower than reads)
 - fix splice handling of remote end shutdown in middle of operation
 - cloud sync, when uploading using multipart upload, set attributes on the multipart create operation (and related refactoring)
 - cancel http requests used in splice when deleting cr(f)s (fixes a crash)