### PR TITLE
install-deps: Add support for 'opensuse-tumbleweed'

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -256,7 +256,7 @@ else
 	fi
         ! grep -q -i error: $DIR/yum-builddep.out || exit 1
         ;;
-    opensuse|suse|sles)
+    opensuse|suse|sles|opensuse-tumbleweed)
         echo "Using zypper to install dependencies"
         zypp_install="zypper --gpg-auto-import-keys --non-interactive install --no-recommends"
         $SUDO $zypp_install lsb-release systemd-rpm-macros


### PR DESCRIPTION
In the latest version of **openSUSE Tumbleweed**, the ID was renamed from `opensuse` to `opensuse-tumbleweed`:

```
# cat /etc/os-release

NAME="openSUSE Tumbleweed"
# VERSION="20180424"
ID="opensuse-tumbleweed"
ID_LIKE="opensuse suse"
VERSION_ID="20180424"
PRETTY_NAME="openSUSE Tumbleweed"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:tumbleweed:20180424"
BUG_REPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
```
This PR addaps the `install-deps.sh` script accordingly.

Signed-off-by: Ricardo Marques <rimarques@suse.com>