### PR TITLE
qa: reduce "mon client hunt interval max multiple" to 2 for all clients

### DIFF
--- a/qa/suites/rados/singleton/msgr-failures/many.yaml
+++ b/qa/suites/rados/singleton/msgr-failures/many.yaml
@@ -4,6 +4,6 @@ overrides:
       global:
         ms inject socket failures: 1000
         mon mgr beacon grace: 90
+        mon client hunt interval max multiple: 2
       mgr:
         debug monc: 10
-        mon client hunt interval max multiple: 2


### PR DESCRIPTION
because with high failure rate, we need to connect to mon more
frequently if the connection fails.

Signed-off-by: Kefu Chai <kchai@redhat.com>