### PR TITLE
 pybind/ceph_argparse.py:'timeout' must in kwargs when call run_in_thread

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1261,11 +1261,11 @@ def send_command(cluster, target=('mon', ''), cmd=None, inbuf=b'', timeout=0,
                 print('submit {0} to osd.{1}'.format(cmd, osdid),
                       file=sys.stderr)
             ret, outbuf, outs = run_in_thread(
-                cluster.osd_command, osdid, cmd, inbuf, timeout)
+                cluster.osd_command, osdid, cmd, inbuf, timeout=timeout)
 
         elif target[0] == 'mgr':
             ret, outbuf, outs = run_in_thread(
-                cluster.mgr_command, cmd, inbuf, timeout)
+                cluster.mgr_command, cmd, inbuf, timeout=timeout)
 
         elif target[0] == 'pg':
             pgid = target[1]
@@ -1281,7 +1281,7 @@ def send_command(cluster, target=('mon', ''), cmd=None, inbuf=b'', timeout=0,
                 print('submit {0} for pgid {1}'.format(cmd, pgid),
                       file=sys.stderr)
             ret, outbuf, outs = run_in_thread(
-                cluster.pg_command, pgid, cmd, inbuf, timeout)
+                cluster.pg_command, pgid, cmd, inbuf, timeout=timeout)
 
         elif target[0] == 'mon':
             if verbose:
@@ -1289,10 +1289,10 @@ def send_command(cluster, target=('mon', ''), cmd=None, inbuf=b'', timeout=0,
                       file=sys.stderr)
             if len(target) < 2 or target[1] == '':
                 ret, outbuf, outs = run_in_thread(
-                    cluster.mon_command, cmd, inbuf, timeout)
+                    cluster.mon_command, cmd, inbuf, timeout=timeout)
             else:
                 ret, outbuf, outs = run_in_thread(
-                    cluster.mon_command, cmd, inbuf, timeout, target[1])
+                    cluster.mon_command, cmd, inbuf, timeout=timeout, target=target[1])
         elif target[0] == 'mds':
             mds_spec = target[1]
 

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1172,16 +1172,16 @@ def find_cmd_target(childargs):
 
 
 class RadosThread(threading.Thread):
-    def __init__(self, target, *args, **kwargs):
+    def __init__(self, func, *args, **kwargs):
         self.args = args
         self.kwargs = kwargs
-        self.target = target
+        self.func = func
         self.exception = None
         threading.Thread.__init__(self)
 
     def run(self):
         try:
-            self.retval = self.target(*self.args, **self.kwargs)
+            self.retval = self.func(*self.args, **self.kwargs)
         except Exception as e:
             self.exception = e
 
@@ -1190,11 +1190,11 @@ class RadosThread(threading.Thread):
 POLL_TIME_INCR = 0.5
 
 
-def run_in_thread(target, *args, **kwargs):
+def run_in_thread(func, *args, **kwargs):
     interrupt = False
     timeout = kwargs.pop('timeout', 0)
     countdown = timeout
-    t = RadosThread(target, *args, **kwargs)
+    t = RadosThread(func, *args, **kwargs)
 
     # allow the main thread to exit (presumably, avoid a join() on this
     # subthread) before this thread terminates.  This allows SIGINT


### PR DESCRIPTION
fix bug: Function "run_in_thread" get "timeout" from kwargs， but other functions passing "timeout" in args, so "timeout" is 0 forever in run_in_thread.