### PR TITLE
luminous: osd: PrimaryLogPG: defer evict if head *or* object intersect scrub int…

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4831,6 +4831,13 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	   << " [" << scrubber.start << "," << scrubber.end << ")" << dendl;
 }
 
+bool PG::range_intersects_scrub(const hobject_t &start, const hobject_t& end)
+{
+  // does [start, end] intersect [scrubber.start, scrubber.end)
+  return (start < scrubber.end &&
+	  end >= scrubber.start);
+}
+
 void PG::scrub_clear_state()
 {
   assert(is_locked());

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1352,6 +1352,9 @@ public:
 
   int active_pushes;
 
+  /// true if the given range intersects the scrub interval in any way
+  bool range_intersects_scrub(const hobject_t &start, const hobject_t& end);
+
   void repair_object(
     const hobject_t& soid, list<pair<ScrubMap::object, pg_shard_t> > *ok_peers,
     pg_shard_t bad_peer);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -13055,7 +13055,8 @@ bool PrimaryLogPG::agent_work(int start_max, int agent_flush_quota)
       osd->logger->inc(l_osd_agent_skip);
       continue;
     }
-    if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid)) {
+    if (range_intersects_scrub(obc->obs.oi.soid,
+			       obc->obs.oi.soid.get_head())) {
       dout(20) << __func__ << " skip (scrubbing) " << obc->obs.oi << dendl;
       osd->logger->inc(l_osd_agent_skip);
       continue;


### PR DESCRIPTION
http://tracker.ceph.com/issues/23863