### PR TITLE
osdmap: clean down/out or unlinked osd if it in pg upmap

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -482,6 +482,25 @@ bool CrushWrapper::_bucket_is_in_use(int item)
   return false;
 }
 
+bool CrushWrapper::exists_in_rule_bucket(int rule_id, int osd_id)
+{
+  crush_rule *rule = get_rule(rule_id);
+  assert(rule);
+  for (unsigned s = 0; s < rule->len; ++s) {
+    if ((rule->steps[s].op == CRUSH_RULE_TAKE)) {
+      int id = rule->steps[s].arg1;
+      auto *b = get_bucket(id);
+      if (IS_ERR(b))
+        continue;
+
+      for (unsigned n=0; n<b->size; n++)
+        if (osd_id == b->items[n])
+	  return true;
+    }
+  }
+  return false;
+}
+
 int CrushWrapper::_remove_item_under(
   CephContext *cct, int item, int ancestor, bool unlink_only)
 {

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -885,6 +885,7 @@ private:
   int _remove_item_under(CephContext *cct, int id, int ancestor, bool unlink_only);
   bool _bucket_is_in_use(int id);
 public:
+  bool exists_in_rule_bucket(int rule_id, int osd_id);
   int remove_item_under(CephContext *cct, int id, int ancestor, bool unlink_only);
 
   /**


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23878
Signed-off-by: huangjun <huangjun@xsky.com>