### PR TITLE
mgr/dashboard: Fix missing $event on deletion modal

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.html
@@ -7,7 +7,7 @@
   <ng-container class="modal-content">
     <form name="deletionForm"
           #formDir="ngForm"
-          (submit)="delete()"
+          (submit)="delete($event)"
           [formGroup]="deletionForm"
           novalidate>
       <div class="modal-body">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.ts
@@ -74,8 +74,8 @@ export class DeletionModalComponent implements OnInit {
     this.confirmation.updateValueAndValidity();
   }
 
-  delete () {
-    this.submitButton.submit();
+  delete ($event) {
+    this.submitButton.submit($event);
   }
 
   deletionCall() {


### PR DESCRIPTION
This PR fixes the following frontend error:

`ERROR in src/app/shared/components/deletion-modal/deletion-modal.component.ts(78,5): error TS2554: Expected 1 arguments, but got 0.`

This error was introduces because of a "silent conflict" between:

- https://github.com/ceph/ceph/pull/20899
- https://github.com/ceph/ceph/pull/21529


Signed-off-by: Ricardo Marques <rimarques@suse.com>