### PR TITLE
build: Fix broken SIMD tests on ARM

### DIFF
--- a/cmake/modules/SIMDExt.cmake
+++ b/cmake/modules/SIMDExt.cmake
@@ -15,26 +15,27 @@
 #
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
-  set(HAVE_ARM 1) 
+  set(HAVE_ARM 1)
   set(save_quiet ${CMAKE_REQUIRED_QUIET})
   set(CMAKE_REQUIRED_QUIET true)
   include(CheckCXXSourceCompiles)
 
   check_cxx_source_compiles("
     #define CRC32CX(crc, value) __asm__(\"crc32cx %w[c], %w[c], %x[v]\":[c]\"+r\"(crc):[v]\"r\"(value))
-    asm(\".arch_extension crc\");
     unsigned int foo(unsigned int ret) {
       CRC32CX(ret, 0);
       return ret;
     }
-    int main() { foo(0); }" HAVE_ARMV8_CRC)
-    check_cxx_source_compiles("
-    asm(\".arch_extension crypto\");
+    int main() { foo(0); }
+  " HAVE_ARMV8_CRC)
+
+  check_cxx_source_compiles("
     unsigned int foo(unsigned int ret) {
       __asm__(\"pmull  v2.1q,          v2.1d,  v1.1d\");
       return ret;
     }
-    int main() { foo(0); }" HAVE_ARMV8_CRYPTO)
+    int main() { foo(0); }
+  " HAVE_ARMV8_CRYPTO)
 
   set(CMAKE_REQUIRED_QUIET ${save_quiet})
   if(HAVE_ARMV8_CRC)
@@ -44,34 +45,34 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
   if(HAVE_ARMV8_CRYPTO)
     message(STATUS " aarch64 crypto extensions supported")
   endif()
-  CHECK_C_COMPILER_FLAG(-march=armv8-a+crc+crypto HAVE_ARMV8_CRC_CRYPTO_MARCH)
 
-  # don't believe only the -march support; gcc 4.8.5 on RHEL/CentOS says
-  # it supports +crc but hasn't got the intrinsics or arm_acle.h.  Test for
-  # the actual presence of one of the intrinsic functions.
-  if(HAVE_ARMV8_CRC_CRYPTO_MARCH)
-    check_cxx_source_compiles("
-      #include <inttypes.h>
-      int main() { uint32_t a; uint8_t b; __builtin_aarch64_crc32b(a, b); }
-    " HAVE_ARMV8_CRC_CRYPTO_INTRINSICS)
-  endif()
+  check_cxx_source_compiles("
+    #include <inttypes.h>
+    int main() { uint32_t a; uint8_t b; __builtin_aarch64_crc32b(a, b); }
+  " HAVE_ARMV8_CRC_CRYPTO_INTRINSICS)
 
   if(HAVE_ARMV8_CRC_CRYPTO_INTRINSICS)
     message(STATUS " aarch64 crc+crypto intrinsics supported")
-    set(ARMV8_CRC_COMPILE_FLAGS "${ARMV8_CRC_COMPILE_FLAGS} -march=armv8-a+crc+crypto")
   endif()
 
-  CHECK_C_COMPILER_FLAG(-march=armv8-a+simd HAVE_ARMV8_SIMD)
-  if(HAVE_ARMV8_SIMD)
-    set(SIMD_COMPILE_FLAGS "${SIMD_COMPILE_FLAGS} -march=armv8-a+simd")
-  endif()
+  check_cxx_source_compiles("
+    unsigned int foo(unsigned int ret) {
+      __asm__(\"add v2.1q, v2.1d, v1.1d\");
+      return ret;
+    }
+    int main() { foo(0); }
+  " HAVE_ARMV8_SIMD)
 
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM")
   set(HAVE_ARM 1)
-  CHECK_C_COMPILER_FLAG(-mfpu=neon HAVE_ARM_NEON)
-  if(HAVE_ARM_NEON)
-    set(SIMD_COMPILE_FLAGS "${SIMD_COMPILE_FLAGS} -mfpu=neon")
-  endif()
+
+  check_cxx_source_compiles("
+    unsigned int foo(unsigned int ret) {
+      __asm__(\"vadd q2.i32, q2.i32, q1.i32\");
+      return ret;
+    }
+    int main() { foo(0); }
+  " HAVE_ARM_NEON)
 
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i686|amd64|x86_64|AMD64")
   set(HAVE_INTEL 1)


### PR DESCRIPTION
The existing feature tests were checking if the compiler is capable of
generating code with given features, not if the target architecture
specificed by march/mcpu supports the features. This lead to Ceph
crashing due to illegal instructions.

This patch replaces the tests with actual checks for the target
architecture, and removes any explicit setting of march since that is
now inferred from the environment.

Signed-off-by: Robin McCorkell <robin@mccorkell.me.uk>

Fixes https://tracker.ceph.com/issues/23464

Also see https://github.com/archlinuxarm/PKGBUILDs/blob/master/community/ceph/0001-no-neon.patch for an example of how packagers built workarounds for this broken behaviour.