### PR TITLE
mgr/dashboard: Refactor perf counters

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.spec.ts
@@ -4,8 +4,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BsDropdownModule } from 'ngx-bootstrap';
 
 import {
-  TablePerformanceCounterService
-} from '../../../shared/api/table-performance-counter.service';
+  PerformanceCounterService
+} from '../../../shared/api/performance-counter.service';
 import { PerformanceCounterModule } from '../performance-counter.module';
 import { PerformanceCounterComponent } from './performance-counter.component';
 
@@ -30,7 +30,7 @@ describe('PerformanceCounterComponent', () => {
     async(() => {
       TestBed.configureTestingModule({
         imports: [PerformanceCounterModule, BsDropdownModule.forRoot(), RouterTestingModule],
-        providers: [{ provide: TablePerformanceCounterService, useValue: fakeService }]
+        providers: [{ provide: PerformanceCounterService, useValue: fakeService }]
       }).compileComponents();
     })
   );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
 import {
-  TablePerformanceCounterService
-} from '../../../shared/api/table-performance-counter.service';
+  PerformanceCounterService
+} from '../../../shared/api/performance-counter.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
 
 /**
@@ -30,7 +30,7 @@ export class TablePerformanceCounterComponent implements OnInit {
    */
   @Input() serviceId: string;
 
-  constructor(private performanceCounterService: TablePerformanceCounterService) { }
+  constructor(private performanceCounterService: PerformanceCounterService) { }
 
   ngOnInit() {
     this.columns = [
@@ -54,7 +54,7 @@ export class TablePerformanceCounterComponent implements OnInit {
 
   getCounters() {
     this.performanceCounterService.get(this.serviceType, this.serviceId)
-      .then((resp) => {
+      .subscribe((resp: object[]) => {
         this.counters = resp;
       });
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/api.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/api.module.ts
@@ -8,13 +8,13 @@ import { DashboardService } from './dashboard.service';
 import { HostService } from './host.service';
 import { MonitorService } from './monitor.service';
 import { OsdService } from './osd.service';
+import { PerformanceCounterService } from './performance-counter.service';
 import { PoolService } from './pool.service';
 import { RbdMirroringService } from './rbd-mirroring.service';
 import { RbdService } from './rbd.service';
 import { RgwBucketService } from './rgw-bucket.service';
 import { RgwDaemonService } from './rgw-daemon.service';
 import { RgwUserService } from './rgw-user.service';
-import { TablePerformanceCounterService } from './table-performance-counter.service';
 import { TcmuIscsiService } from './tcmu-iscsi.service';
 
 @NgModule({
@@ -34,7 +34,7 @@ import { TcmuIscsiService } from './tcmu-iscsi.service';
     RgwBucketService,
     RgwDaemonService,
     RgwUserService,
-    TablePerformanceCounterService,
+    PerformanceCounterService,
     TcmuIscsiService
   ]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.spec.ts
@@ -4,12 +4,12 @@ import { inject, TestBed } from '@angular/core/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap';
 
-import { TablePerformanceCounterService } from './table-performance-counter.service';
+import { PerformanceCounterService } from './performance-counter.service';
 
-describe('TablePerformanceCounterService', () => {
+describe('PerformanceCounterService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [TablePerformanceCounterService],
+      providers: [PerformanceCounterService],
       imports: [
         HttpClientTestingModule,
         BsDropdownModule.forRoot(),
@@ -20,7 +20,7 @@ describe('TablePerformanceCounterService', () => {
 
   it(
     'should be created',
-    inject([TablePerformanceCounterService], (service: TablePerformanceCounterService) => {
+    inject([PerformanceCounterService], (service: PerformanceCounterService) => {
       expect(service).toBeTruthy();
     })
   );

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.ts
@@ -1,28 +1,25 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
+import 'rxjs/add/observable/of';
+import { Observable } from 'rxjs/Observable';
+
 @Injectable()
-export class TablePerformanceCounterService {
+export class PerformanceCounterService {
 
   private url = 'api/perf_counters';
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   list() {
-    return this.http.get(this.url)
-      .toPromise()
-      .then((resp: object): object => {
-        return resp;
-      });
+    return this.http.get(this.url);
   }
 
   get(service_type: string, service_id: string) {
     const serviceType = service_type.replace('-', '_');
-
     return this.http.get(`${this.url}/${serviceType}/${service_id}`)
-      .toPromise()
-      .then((resp: object): Array<object> => {
-        return resp['counters'];
+      .flatMap((resp) => {
+        return Observable.of(resp['counters']);
       });
   }
 }


### PR DESCRIPTION
- Rename performance counter service
- Return an Observable instead of a Promise object

Signed-off-by: Volker Theile <vtheile@suse.com>
