### PR TITLE
osd/PrimaryLogPG: clear data digest on WRITEFULL if skip_data_digest

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6428,7 +6428,9 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	}
         if (!skip_data_digest) {
 	  obs.oi.set_data_digest(osd_op.indata.crc32c(-1));
-        }
+        } else {
+	  obs.oi.clear_data_digest();
+	}
 
 	write_update_size_and_usage(ctx->delta_stats, oi, ctx->modified_ranges,
 	    0, op.extent.length, true);


### PR DESCRIPTION
If we detect we are on bluestore and should skip the data digest, we
need to clear any old digest on WRITEFULL.  This aligns us with the
WRITE behavior, which is also either an update or a clear (but never
neither!).

Fixes: https://tracker.ceph.com/issues/23871
Signed-off-by: Sage Weil <sage@redhat.com>