### PR TITLE
doc: fix error in osd scrub load threshold

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -273,8 +273,8 @@ scrubbing operations.
 
 ``osd scrub load threshold`` 
 
-:Description: The maximum load. Ceph will not scrub when the system load 
-              (as defined by ``getloadavg()``) is higher than this number. 
+:Description: The normalized maximum load. Ceph will not scrub when the system load
+              (as defined by ``getloadavg() / number of online cpus``) is higher than this number.
               Default is ``0.5``.
 
 :Type: Float


### PR DESCRIPTION
OSD::scrub_load_below_threshold divides the 1 min load by the number of
online cpus.  The documentation said it would use the load without
division by number of cpus.