### PR TITLE
client: change vxattr flags field to unsigned int

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -885,7 +885,7 @@ private:
 	  size_t (Client::*getxattr_cb)(Inode *in, char *val, size_t size);
 	  bool readonly, hidden;
 	  bool (Client::*exists_cb)(Inode *in);
-	  int flags;
+	  unsigned int flags;
   };
 
 /* Flags for VXattr */


### PR DESCRIPTION
We use bit to define vxattr flags, so it should be unsigned.
Change vxattr flags to be uint16 for the consideration of more room to
define other flags.

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>