### PR TITLE
os/bluestore/BlueFS: reduce bufferlist rebuilds during WAL writes

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1815,7 +1815,7 @@ public:
   void buffer::list::reserve(size_t prealloc)
   {
     if (append_buffer.unused_tail_length() < prealloc) {
-      append_buffer = buffer::create_in_mempool(prealloc, get_mempool());
+      append_buffer = buffer::create_page_aligned(prealloc);
       append_buffer.set_length(0);   // unused, so far.
     }
   }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1080,6 +1080,16 @@ public:
     return _len + _off;
   }
 
+  unsigned buffer::ptr::append_zeros(unsigned l)
+  {
+    assert(_raw);
+    assert(l <= unused_tail_length());
+    char* c = _raw->data + _off + _len;
+    memset(c, 0, l);
+    _len += l;
+    return _len + _off;
+  }
+
   void buffer::ptr::copy_in(unsigned o, unsigned l, const char *src)
   {
     copy_in(o, l, src, true);
@@ -1994,9 +2004,17 @@ public:
   
   void buffer::list::append_zero(unsigned len)
   {
-    ptr bp(len);
-    bp.zero(false);
-    append(std::move(bp));
+    unsigned need = std::min(append_buffer.unused_tail_length(), len);
+    if (need) {
+      append_buffer.append_zeros(need);
+      append(append_buffer, append_buffer.length() - need, need);
+      len -= need;
+    }
+    if (len) {
+      ptr bp = buffer::create_page_aligned(len);
+      bp.zero(false);
+      append(std::move(bp));
+    }
   }
 
   

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -349,6 +349,7 @@ namespace buffer CEPH_BUFFER_API {
     void zero(bool crc_reset);
     void zero(unsigned o, unsigned l);
     void zero(unsigned o, unsigned l, bool crc_reset);
+    unsigned append_zeros(unsigned l);
 
   };
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1537,10 +1537,13 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<std::mutex>& l,
   }
 
   bufferlist bl;
+  bl.reserve(super.block_size);
   encode(log_t, bl);
-
   // pad to block boundary
-  _pad_bl(bl);
+  size_t realign = super.block_size - (bl.length() % super.block_size);
+  if (realign && realign != super.block_size)
+    bl.append_zero(realign);
+
   logger->inc(l_bluefs_logged_bytes, bl.length());
 
   log_writer->append(bl);

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -141,7 +141,13 @@ void bluefs_transaction_t::encode(bufferlist& bl) const
   ENCODE_START(1, 1, bl);
   encode(uuid, bl);
   encode(seq, bl);
-  encode(op_bl, bl);
+  // not using bufferlist encode method, as it merely copies the bufferptr and not
+  // contents, meaning we're left with fragmented target bl
+  __u32 len = op_bl.length();
+  encode(len, bl);
+  for (auto& it : op_bl.buffers()) {
+    bl.append(it.c_str(),  it.length());
+  }
   encode(crc, bl);
   ENCODE_FINISH(bl);
 }

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2284,7 +2284,7 @@ TEST(BufferList, append_zero) {
   EXPECT_EQ((unsigned)1, bl.get_num_buffers());
   EXPECT_EQ((unsigned)1, bl.length());
   bl.append_zero(1);
-  EXPECT_EQ((unsigned)2, bl.get_num_buffers());
+  EXPECT_EQ((unsigned)1, bl.get_num_buffers());
   EXPECT_EQ((unsigned)2, bl.length());
   EXPECT_EQ('\0', bl[1]);
 }


### PR DESCRIPTION
WAL write performance is hindered by bufferlist rebuild done just before doing aio_write. This PR fixes most common case of that and also reworks how bufferlist's `append_zero` works, so it's more efficient in regard to the bufferlist rebuilding potential (i. e. when used in conjunction with `bufferlist::reserve` as shown in last commit). That can be a foundation for further optimization of functions that need to pad bufferlists. Also see https://github.com/ceph/ceph/pull/19032.