### PR TITLE
osd: fix osd smart data collection segment fault issue.

### DIFF
--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -76,13 +76,15 @@ int CrushLocation::update_from_hook()
     lderr(cct) << "stderr:\n";
     err.hexdump(*_dout);
     *_dout << dendl;
-    return ret;
   }
 
   if (hook.join() != 0) {
     lderr(cct) << "error: failed to join: " << hook.err() << dendl;
     return -EINVAL;
   }
+
+  if (ret < 0)
+    return ret;
 
   std::string out;
   bl.copy(0, bl.length(), out);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6301,16 +6301,18 @@ int OSD::probe_smart_device(const char *device, int timeout, std::string *result
   ret = output.read_fd(smartctl.get_stdout(), 100*1024);
   if (ret < 0) {
     derr << "failed read from smartctl: " << cpp_strerror(-ret) << dendl;
-    return ret;
+  } else {
+    *result = output.to_str();
+    dout(10) << "smartctl output is: " << *result << dendl;
   }
-
-  derr << "smartctl output is: " << output.c_str() << dendl;
-  *result = output.c_str(); 
 
   if (smartctl.join() != 0) {
     derr << smartctl.err() << dendl;
     return -EINVAL;
   }
+
+  if (ret < 0)
+    return ret;
 
   return 0;
 }


### PR DESCRIPTION
output.read_fd() could return zero length. it needs to
be handled gracefully.

always call invoke join() if spawn() is successfully returned.
otherwise there will be assert failure in ~SubProcess().

Fixes: http://tracker.ceph.com/issues/23899

Signed-off-by: Gu Zhongyan <guzhongyan@360.cn>