### PR TITLE
pybind/ceph_argparse: wait for mgrmap before erroring out

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -20,6 +20,7 @@ import socket
 import stat
 import sys
 import threading
+import time
 import uuid
 
 
@@ -1264,8 +1265,14 @@ def send_command(cluster, target=('mon', ''), cmd=None, inbuf=b'', timeout=0,
                 cluster.osd_command, osdid, cmd, inbuf, timeout)
 
         elif target[0] == 'mgr':
-            ret, outbuf, outs = run_in_thread(
-                cluster.mgr_command, cmd, inbuf, timeout)
+            while True:
+                # waiting for the mgrmap
+                ret, outbuf, outs = run_in_thread(
+                    cluster.mgr_command, cmd, inbuf, timeout)
+                if ret != -errno.EACCES or outbuf or outs:
+                    break
+                else:
+                    time.sleep(0.1)
 
         elif target[0] == 'pg':
             pgid = target[1]


### PR DESCRIPTION
there is chance that the MgrClient has not received the mgrmap before
the ceph cli tries to send a mgr command via it. in that case, MgrClient
simply returns -EACCESS to the caller, so we just need to wait a little
bit longer before retrying. we could add an API in librados, like
rados_wait_for_mgrmap(), but i think it's overkill just for this
usecase.

Fixes: https://tracker.ceph.com/issues/23627
Signed-off-by: Kefu Chai <kchai@redhat.com>