### PR TITLE
mgr: block MgrClient::start_command until mgrmap

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -1098,5 +1098,6 @@ int librados::RadosClient::service_daemon_update_status(
 
 mon_feature_t librados::RadosClient::get_required_monitor_features() const
 {
-  return monclient.monmap.get_required_features();
+  return monclient.with_monmap([](const MonMap &monmap) {
+      return monmap.get_required_features(); } );
 }

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -311,6 +311,11 @@ int librados::RadosClient::connect()
   }
   messenger->set_myname(entity_name_t::CLIENT(monclient.get_global_id()));
 
+  // Detect older cluster, put mgrclient into compatible mode
+  mgrclient.set_mgr_optional(
+      !get_required_monitor_features().contains_all(
+        ceph::features::mon::FEATURE_LUMINOUS));
+
   // MgrClient needs this (it doesn't have MonClient reference itself)
   monclient.sub_want("mgrmap", 0, 0);
   monclient.renew_subs();

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -413,7 +413,7 @@ int MgrClient::start_command(const vector<string>& cmd, const bufferlist& inbl,
 
   ldout(cct, 20) << "cmd: " << cmd << dendl;
 
-  if (map.epoch == 0) {
+  if (map.epoch == 0 && mgr_optional) {
     ldout(cct,20) << " no MgrMap, assuming EACCES" << dendl;
     return -EACCES;
   }
@@ -429,6 +429,8 @@ int MgrClient::start_command(const vector<string>& cmd, const bufferlist& inbl,
     // Leaving fsid argument null because it isn't used.
     MCommand *m = op.get_message({});
     session->con->send_message(m);
+  } else {
+    ldout(cct, 4) << "start_command: no mgr session, waiting" << dendl;
   }
   return 0;
 }

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -88,6 +88,10 @@ protected:
   void reconnect();
   void _send_open();
 
+  // In pre-luminous clusters, the ceph-mgr service is absent or optional,
+  // so we must not block in start_command waiting for it.
+  bool mgr_optional = false;
+
 public:
   MgrClient(CephContext *cct_, Messenger *msgr_);
 
@@ -95,6 +99,8 @@ public:
 
   void init();
   void shutdown();
+
+  void set_mgr_optional(bool optional_) {mgr_optional = optional_;}
 
   bool ms_dispatch(Message *m) override;
   bool ms_handle_reset(Connection *con) override;


### PR DESCRIPTION
This EACCESS case was motivated by auth caps issues
when mgr was first being introduced, but now it's
just causing problems in the race condition where
start_command gets called before first MMgrMap from mon.

Fixes: https://tracker.ceph.com/issues/23627
Signed-off-by: John Spray <john.spray@redhat.com>