### PR TITLE
qa/suites/rados/thrash-old-clients: add rbd tests

### DIFF
--- a/qa/suites/rados/thrash-old-clients/workloads/rbd_cls.yaml
+++ b/qa/suites/rados/thrash-old-clients/workloads/rbd_cls.yaml
@@ -1,0 +1,10 @@
+meta:
+- desc: |
+   rbd object class functional tests
+tasks:
+- workunit:
+    env:
+      CLS_RBD_GTEST_FILTER: -TestClsRbd.get_features
+    clients:
+      client.2:
+        - cls/test_cls_rbd.sh

--- a/qa/suites/rados/thrash-old-clients/workloads/test_rbd_api.yaml
+++ b/qa/suites/rados/thrash-old-clients/workloads/test_rbd_api.yaml
@@ -1,0 +1,8 @@
+meta:
+- desc: |
+   librbd C and C++ api tests
+workload:
+- workunit:
+    clients:
+      client.2:
+        - rbd/test_librbd.sh


### PR DESCRIPTION
The python rbd tests were failing for annoying reasons, see e.g. http://pulpito.ceph.com/sage-2018-04-27_17:34:10-rados:thrash-old-clients-wip-sage-testing-2018-04-27-0852-distro-basic-smithi/2445555/

I think these should be sufficient, though?

Note this collection is doing luminous, jewel, and hammer versions of the clients (against master/mimic).