### PR TITLE
ceph_test_rados_api_aio: fix race with full pool and osdmap

### DIFF
--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -236,6 +236,9 @@ TEST(LibRadosAio, PoolQuotaPP) {
   }
   ASSERT_LT(n, 1024);
 
+  // make sure we have latest map that marked the pool full
+  test_data.m_cluster.wait_for_latest_osdmap();
+
   // make sure we block without FULL_TRY
   {
     ObjectWriteOperation op;


### PR DESCRIPTION
We send ops until we get a EDQUOT, and then assert our next op to
a different object also gets EDQUOT.  However, if the second osd
doesn't have as new a map it may succeed.  Make sure the client has
the latest (mon) map, and thus the one marking the pool full, before
we send the second op.  That ensures the second OSD also has that
newer map and also returns EDQUOT.

Fixes: http://tracker.ceph.com/issues/23916
Signed-off-by: Sage Weil <sage@redhat.com>