### PR TITLE
qa: add cosbench workloads and override teuthology default settings

### DIFF
--- a/qa/suites/perf-basic/ceph.yaml
+++ b/qa/suites/perf-basic/ceph.yaml
@@ -6,6 +6,7 @@ meta:
    and can't be compared across runs.
    Run ceph on a single node.
    Use xfs beneath the osds.
+   Setup rgw on client.0
 
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
@@ -19,4 +20,5 @@ tasks:
       - \(OSD_
       - \(OBJECT_
       - overall HEALTH
+- rgw: [client.0]
 - ssh_keys:

--- a/qa/suites/perf-basic/settings/optimized.yaml
+++ b/qa/suites/perf-basic/settings/optimized.yaml
@@ -5,6 +5,15 @@ meta:
 overrides:
   ceph:
     conf:
+      mon:
+        debug mon: "0/0"
+        debug ms: "0/0"
+        debug paxos: "0/0"
+      osd:
+        debug filestore: "0/0"
+        debug journal: "0/0"
+        debug ms: "0/0"
+        debug osd: "0/0"
       global:
         auth client required: none
         auth cluster required: none

--- a/qa/suites/perf-basic/workloads/cosbench_64K_write.yaml
+++ b/qa/suites/perf-basic/workloads/cosbench_64K_write.yaml
@@ -1,0 +1,30 @@
+meta:
+- desc: |
+   Run cosbench benchmark using cbt.
+   64K write workload.
+
+overrides:
+  rgw:
+    data_pool_pg_size: 64
+    index_pool_pg_size: 64
+tasks:
+- cbt:
+    benchmarks:
+      cosbench:
+        obj_size: [64KB]
+        osd_ra: [4096]
+        workers: 1
+        containers_max: 1000
+        objects_max: 100
+        mode: [write]
+        template: [default]
+        rampup: 30
+        runtime: 300
+        rampdown: 30
+        containers: ["u(1,100)"]
+        objects: ["u(1,100)"]
+        ratio: [100]
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 1
+      iterations: 1

--- a/qa/suites/rados/perf/ceph.yaml
+++ b/qa/suites/rados/perf/ceph.yaml
@@ -10,4 +10,5 @@ tasks:
       - \(OSD_
       - \(OBJECT_
       - overall HEALTH
+- rgw: [client.0]
 - ssh_keys:

--- a/qa/suites/rados/perf/settings/optimized.yaml
+++ b/qa/suites/rados/perf/settings/optimized.yaml
@@ -1,6 +1,15 @@
 overrides:
   ceph:
     conf:
+      mon:
+        debug mon: "0/0"
+        debug ms: "0/0"
+        debug paxos: "0/0"
+      osd:
+        debug filestore: "0/0"
+        debug journal: "0/0"
+        debug ms: "0/0"
+        debug osd: "0/0"
       global:
         auth client required: none
         auth cluster required: none

--- a/qa/suites/rados/perf/workloads/cosbench_64K_read_write.yaml
+++ b/qa/suites/rados/perf/workloads/cosbench_64K_read_write.yaml
@@ -1,0 +1,25 @@
+overrides:
+  rgw:
+    data_pool_pg_size: 64
+    index_pool_pg_size: 64
+tasks:
+- cbt:
+    benchmarks:
+      cosbench:
+        obj_size: [64KB]
+        osd_ra: [4096]
+        workers: 1
+        containers_max: 1000
+        objects_max: 100
+        mode: [mix]
+        template: [default]
+        rampup: 30
+        runtime: 300
+        rampdown: 30
+        containers: ["u(1,100)"]
+        objects: ["u(1,100)"]
+        ratio: [60]
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 1
+      iterations: 1

--- a/qa/suites/rados/perf/workloads/cosbench_64K_write.yaml
+++ b/qa/suites/rados/perf/workloads/cosbench_64K_write.yaml
@@ -1,0 +1,25 @@
+overrides:
+  rgw:
+    data_pool_pg_size: 64
+    index_pool_pg_size: 64
+tasks:
+- cbt:
+    benchmarks:
+      cosbench:
+        obj_size: [64KB]
+        osd_ra: [4096]
+        workers: 1
+        containers_max: 1000
+        objects_max: 100
+        mode: [write]
+        template: [default]
+        rampup: 30
+        runtime: 300
+        rampdown: 30
+        containers: ["u(1,100)"]
+        objects: ["u(1,100)"]
+        ratio: [100]
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 1
+      iterations: 1


### PR DESCRIPTION
This PR adds 2 cosbench workload profiles to the `rados/perf` suite:

- 64K write workload
- 64K mix(read:write=60:40)

and 1 workload to the `perf-basic` suite:

- 64K write workload

It also overrides some of the default teuthology settings for `mon` and `osd` for performance suite runs.

Signed-off-by: Neha Ojha <nojha@redhat.com>