### PR TITLE
tools: fix problem when calling get_pool_group_names without a snapshot name 

### DIFF
--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -388,11 +388,6 @@ int get_pool_group_names(const po::variables_map &vm,
     return -EINVAL;
   }
 
-  if (snap_name != nullptr && snap_name->empty()) {
-    std::cerr << "rbd: snapshot name was not specified" << std::endl;
-    return -EINVAL;
-  }
-
   return 0;
 }
 


### PR DESCRIPTION
snapshot name is possible to be NULL for original group, should let the upper layer decide if prompt a error message.
Signed-off-by: ZeQing Tyler Qi <qizeqing048@pingan.com.cn>