### PR TITLE
build/ops: rpm: Revert "ceph.spec: work around build.opensuse.org"

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -860,7 +860,6 @@ done
 # the following setting fixed an OOM condition we once encountered in the OBS
 RPM_OPT_FLAGS="$RPM_OPT_FLAGS --param ggc-min-expand=20 --param ggc-min-heapsize=32768"
 %endif
-export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 
 export CPPFLAGS="$java_inc"
 export CFLAGS="$RPM_OPT_FLAGS"


### PR DESCRIPTION
This reverts commit 21d941e83b168fa297aed58e27b4c11193468293 which introduced a
"kludge" to make 32-bit x86 builds work in the openSUSE Build Service (OBS).

The OBS no longer uses i386 in RPM_OPT_FLAGS when the i586 build target is
specified. The current value of RPM_OPT_FLAGS for i586 is:

-fomit-frame-pointer -fmessage-length=0 -grecord-gcc-switches -O2 -Wall
-D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables
-fasynchronous-unwind-tables -fstack-clash-protection -g

(Side note: we are not currently building Ceph for any 32-bit architectures
in the OBS, and there are no plans to start doing so. That doesn't mean it
won't ever happen, but even if it does, this "kludge" will not be needed.)

Signed-off-by: Nathan Cutler <ncutler@suse.com>

Conflicts:
	ceph.spec.in