### PR TITLE
common/admin_socket: add new api unregister_commands(AdminSocketHook …

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -545,12 +545,7 @@ void Client::shutdown()
 
   cct->_conf->remove_observer(this);
 
-  AdminSocket* admin_socket = cct->get_admin_socket();
-  admin_socket->unregister_command("mds_requests");
-  admin_socket->unregister_command("mds_sessions");
-  admin_socket->unregister_command("dump_cache");
-  admin_socket->unregister_command("kick_stale_sessions");
-  admin_socket->unregister_command("status");
+  cct->get_admin_socket()->unregister_commands(&m_command_hook);
 
   if (ino_invalidate_cb) {
     ldout(cct, 10) << "shutdown stopping cache invalidator finisher" << dendl;

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -85,6 +85,11 @@ public:
    */
   int unregister_command(std::string_view command);
 
+  /*
+   * unregister all commands belong to hook.
+   */
+  void unregister_commands(const AdminSocketHook *hook);
+
   bool init(const std::string& path);
 
   void chown(uid_t uid, gid_t gid);

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -626,25 +626,7 @@ CephContext::~CephContext()
 
   delete _plugin_registry;
 
-  _admin_socket->unregister_command("perfcounters_dump");
-  _admin_socket->unregister_command("1");
-  _admin_socket->unregister_command("perf dump");
-  _admin_socket->unregister_command("perfcounters_schema");
-  _admin_socket->unregister_command("perf histogram dump");
-  _admin_socket->unregister_command("2");
-  _admin_socket->unregister_command("perf schema");
-  _admin_socket->unregister_command("perf histogram schema");
-  _admin_socket->unregister_command("perf reset");
-  _admin_socket->unregister_command("config show");
-  _admin_socket->unregister_command("config unset");
-  _admin_socket->unregister_command("config set");
-  _admin_socket->unregister_command("config get");
-  _admin_socket->unregister_command("config help");
-  _admin_socket->unregister_command("config diff");
-  _admin_socket->unregister_command("config diff get");
-  _admin_socket->unregister_command("log flush");
-  _admin_socket->unregister_command("log dump");
-  _admin_socket->unregister_command("log reopen");
+  _admin_socket->unregister_commands(_admin_hook);
   delete _admin_hook;
   delete _admin_socket;
 

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -327,32 +327,7 @@ void MDSDaemon::set_up_admin_socket()
 
 void MDSDaemon::clean_up_admin_socket()
 {
-  AdminSocket *admin_socket = g_ceph_context->get_admin_socket();
-  admin_socket->unregister_command("status");
-  admin_socket->unregister_command("dump_ops_in_flight");
-  admin_socket->unregister_command("ops");
-  admin_socket->unregister_command("dump_blocked_ops");
-  admin_socket->unregister_command("dump_historic_ops");
-  admin_socket->unregister_command("dump_historic_ops_by_duration");
-  admin_socket->unregister_command("scrub_path");
-  admin_socket->unregister_command("tag path");
-  admin_socket->unregister_command("flush_path");
-  admin_socket->unregister_command("export dir");
-  admin_socket->unregister_command("dump cache");
-  admin_socket->unregister_command("cache status");
-  admin_socket->unregister_command("dump tree");
-  admin_socket->unregister_command("dump loads");
-  admin_socket->unregister_command("dump snaps");
-  admin_socket->unregister_command("session evict");
-  admin_socket->unregister_command("osdmap barrier");
-  admin_socket->unregister_command("session ls");
-  admin_socket->unregister_command("flush journal");
-  admin_socket->unregister_command("force_readonly");
-  admin_socket->unregister_command("get subtrees");
-  admin_socket->unregister_command("dirfrag split");
-  admin_socket->unregister_command("dirfrag merge");
-  admin_socket->unregister_command("dirfrag ls");
-  admin_socket->unregister_command("openfiles ls");
+  g_ceph_context->get_admin_socket()->unregister_commands(asok_hook);
   delete asok_hook;
   asok_hook = NULL;
 }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -923,18 +923,7 @@ void Monitor::shutdown()
   g_conf->remove_observer(this);
 
   if (admin_hook) {
-    AdminSocket* admin_socket = cct->get_admin_socket();
-    admin_socket->unregister_command("mon_status");
-    admin_socket->unregister_command("quorum_status");
-    admin_socket->unregister_command("sync_force");
-    admin_socket->unregister_command("add_bootstrap_peer_hint");
-    admin_socket->unregister_command("quorum enter");
-    admin_socket->unregister_command("quorum exit");
-    admin_socket->unregister_command("ops");
-    admin_socket->unregister_command("sessions");
-    admin_socket->unregister_command("dump_historic_ops");
-    admin_socket->unregister_command("dump_historic_ops_by_duration");
-    admin_socket->unregister_command("dump_historic_slow_ops");
+    cct->get_admin_socket()->unregister_commands(admin_hook);
     delete admin_hook;
     admin_hook = NULL;
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3300,44 +3300,11 @@ int OSD::shutdown()
   }
 
   // unregister commands
-  cct->get_admin_socket()->unregister_command("status");
-  cct->get_admin_socket()->unregister_command("flush_journal");
-  cct->get_admin_socket()->unregister_command("dump_ops_in_flight");
-  cct->get_admin_socket()->unregister_command("ops");
-  cct->get_admin_socket()->unregister_command("dump_blocked_ops");
-  cct->get_admin_socket()->unregister_command("dump_historic_ops");
-  cct->get_admin_socket()->unregister_command("dump_historic_ops_by_duration");
-  cct->get_admin_socket()->unregister_command("dump_historic_slow_ops");
-  cct->get_admin_socket()->unregister_command("dump_op_pq_state");
-  cct->get_admin_socket()->unregister_command("dump_blacklist");
-  cct->get_admin_socket()->unregister_command("dump_watchers");
-  cct->get_admin_socket()->unregister_command("dump_reservations");
-  cct->get_admin_socket()->unregister_command("get_latest_osdmap");
-  cct->get_admin_socket()->unregister_command("heap");
-  cct->get_admin_socket()->unregister_command("set_heap_property");
-  cct->get_admin_socket()->unregister_command("get_heap_property");
-  cct->get_admin_socket()->unregister_command("dump_objectstore_kv_stats");
-  cct->get_admin_socket()->unregister_command("dump_scrubs");
-  cct->get_admin_socket()->unregister_command("calc_objectstore_db_histogram");
-  cct->get_admin_socket()->unregister_command("flush_store_cache");
-  cct->get_admin_socket()->unregister_command("dump_pgstate_history");
-  cct->get_admin_socket()->unregister_command("compact");
-  cct->get_admin_socket()->unregister_command("get_mapped_pools");
-  cct->get_admin_socket()->unregister_command("smart");
-  cct->get_admin_socket()->unregister_command("list_devices");
+  cct->get_admin_socket()->unregister_commands(asok_hook);
   delete asok_hook;
   asok_hook = NULL;
 
-  cct->get_admin_socket()->unregister_command("setomapval");
-  cct->get_admin_socket()->unregister_command("rmomapkey");
-  cct->get_admin_socket()->unregister_command("setomapheader");
-  cct->get_admin_socket()->unregister_command("getomap");
-  cct->get_admin_socket()->unregister_command("truncobj");
-  cct->get_admin_socket()->unregister_command("injectdataerr");
-  cct->get_admin_socket()->unregister_command("injectmdataerr");
-  cct->get_admin_socket()->unregister_command("set_recovery_delay");
-  cct->get_admin_socket()->unregister_command("trigger_scrub");
-  cct->get_admin_socket()->unregister_command("injectfull");
+  cct->get_admin_socket()->unregister_commands(test_ops_hook);
   delete test_ops_hook;
   test_ops_hook = NULL;
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3683,14 +3683,7 @@ bool RGWIndexCompletionManager::handle_completion(completion_t cb, complete_op_d
 
 void RGWRados::finalize()
 {
-  auto admin_socket = cct->get_admin_socket();
-  for (auto cmd : admin_commands) {
-    int r = admin_socket->unregister_command(cmd[0]);
-    if (r < 0) {
-      lderr(cct) << "ERROR: fail to unregister admin socket command (r=" << r
-                 << ")" << dendl;
-    }
-  }
+  cct->get_admin_socket()->unregister_commands(this);
 
   if (run_sync_thread) {
     Mutex::Locker l(meta_sync_thread_lock);

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -127,11 +127,7 @@ void RGWSyncTraceManager::init(RGWRados *store)
 
 RGWSyncTraceManager::~RGWSyncTraceManager()
 {
-  AdminSocket *admin_socket = cct->get_admin_socket();
-  for (auto cmd : admin_commands) {
-    admin_socket->unregister_command(cmd[0]);
-  }
-
+  cct->get_admin_socket()->unregister_commands(this);
   service_map_thread->stop();
   delete service_map_thread;
 }


### PR DESCRIPTION
…*hook)

We can unregister all commands which belong to this hook. Make code
looks clean and avoid forgeting unregister command.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>