### PR TITLE
luminous: [rbd-mirror] asok hook for image replayer not re-registered after bootstrap

### DIFF
--- a/src/test/rbd_mirror/image_replayer/test_mock_PrepareLocalImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_PrepareLocalImageRequest.cc
@@ -87,6 +87,19 @@ public:
                 }));
   }
 
+  void expect_dir_get_name(librados::IoCtx &io_ctx,
+                           const std::string &image_name, int r) {
+    bufferlist bl;
+    encode(image_name, bl);
+
+    EXPECT_CALL(get_mock_io_ctx(io_ctx),
+                exec(RBD_DIRECTORY, _, StrEq("rbd"), StrEq("dir_get_name"), _, _, _))
+      .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
+                                          *out_bl = bl;
+                                        })),
+                      Return(r)));
+  }
+
   void expect_mirror_image_get(librados::IoCtx &io_ctx,
                                cls::rbd::MirrorImageState state,
                                const std::string &global_id, int r) {
@@ -122,6 +135,7 @@ TEST_F(TestMockImageReplayerPrepareLocalImageRequest, Success) {
   MockGetMirrorImageIdRequest mock_get_mirror_image_id_request;
   expect_get_mirror_image_id(mock_get_mirror_image_id_request, "local image id",
                              0);
+  expect_dir_get_name(m_local_io_ctx, "local image name", 0);
   expect_mirror_image_get(m_local_io_ctx, cls::rbd::MIRROR_IMAGE_STATE_ENABLED,
                           "global image id", 0);
 
@@ -129,11 +143,13 @@ TEST_F(TestMockImageReplayerPrepareLocalImageRequest, Success) {
   expect_get_tag_owner(mock_journal, "local image id", "remote mirror uuid", 0);
 
   std::string local_image_id;
+  std::string local_image_name;
   std::string tag_owner;
   C_SaferCond ctx;
   auto req = MockPrepareLocalImageRequest::create(m_local_io_ctx,
                                                   "global image id",
                                                   &local_image_id,
+                                                  &local_image_name,
                                                   &tag_owner,
                                                   m_threads->work_queue,
                                                   &ctx);
@@ -141,6 +157,7 @@ TEST_F(TestMockImageReplayerPrepareLocalImageRequest, Success) {
 
   ASSERT_EQ(0, ctx.wait());
   ASSERT_EQ(std::string("local image id"), local_image_id);
+  ASSERT_EQ(std::string("local image name"), local_image_name);
   ASSERT_EQ(std::string("remote mirror uuid"), tag_owner);
 }
 
@@ -150,11 +167,13 @@ TEST_F(TestMockImageReplayerPrepareLocalImageRequest, MirrorImageIdError) {
   expect_get_mirror_image_id(mock_get_mirror_image_id_request, "", -EINVAL);
 
   std::string local_image_id;
+  std::string local_image_name;
   std::string tag_owner;
   C_SaferCond ctx;
   auto req = MockPrepareLocalImageRequest::create(m_local_io_ctx,
                                                   "global image id",
                                                   &local_image_id,
+                                                  &local_image_name,
                                                   &tag_owner,
                                                   m_threads->work_queue,
                                                   &ctx);
@@ -163,20 +182,46 @@ TEST_F(TestMockImageReplayerPrepareLocalImageRequest, MirrorImageIdError) {
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
-TEST_F(TestMockImageReplayerPrepareLocalImageRequest, MirrorImageError) {
+TEST_F(TestMockImageReplayerPrepareLocalImageRequest, DirGetNameError) {
   InSequence seq;
   MockGetMirrorImageIdRequest mock_get_mirror_image_id_request;
   expect_get_mirror_image_id(mock_get_mirror_image_id_request, "local image id",
                              0);
-  expect_mirror_image_get(m_local_io_ctx, cls::rbd::MIRROR_IMAGE_STATE_DISABLED,
-                          "", -EINVAL);
+  expect_dir_get_name(m_local_io_ctx, "", -ENOENT);
 
   std::string local_image_id;
+  std::string local_image_name;
   std::string tag_owner;
   C_SaferCond ctx;
   auto req = MockPrepareLocalImageRequest::create(m_local_io_ctx,
                                                   "global image id",
                                                   &local_image_id,
+                                                  &local_image_name,
+                                                  &tag_owner,
+                                                  m_threads->work_queue,
+                                                  &ctx);
+  req->send();
+
+  ASSERT_EQ(-ENOENT, ctx.wait());
+}
+
+TEST_F(TestMockImageReplayerPrepareLocalImageRequest, MirrorImageError) {
+  InSequence seq;
+  MockGetMirrorImageIdRequest mock_get_mirror_image_id_request;
+  expect_get_mirror_image_id(mock_get_mirror_image_id_request, "local image id",
+                             0);
+  expect_dir_get_name(m_local_io_ctx, "local image name", 0);
+  expect_mirror_image_get(m_local_io_ctx, cls::rbd::MIRROR_IMAGE_STATE_DISABLED,
+                          "", -EINVAL);
+
+  std::string local_image_id;
+  std::string local_image_name;
+  std::string tag_owner;
+  C_SaferCond ctx;
+  auto req = MockPrepareLocalImageRequest::create(m_local_io_ctx,
+                                                  "global image id",
+                                                  &local_image_id,
+                                                  &local_image_name,
                                                   &tag_owner,
                                                   m_threads->work_queue,
                                                   &ctx);
@@ -190,6 +235,7 @@ TEST_F(TestMockImageReplayerPrepareLocalImageRequest, TagOwnerError) {
   MockGetMirrorImageIdRequest mock_get_mirror_image_id_request;
   expect_get_mirror_image_id(mock_get_mirror_image_id_request, "local image id",
                              0);
+  expect_dir_get_name(m_local_io_ctx, "local image name", 0);
   expect_mirror_image_get(m_local_io_ctx, cls::rbd::MIRROR_IMAGE_STATE_ENABLED,
                           "global image id", 0);
 
@@ -198,11 +244,13 @@ TEST_F(TestMockImageReplayerPrepareLocalImageRequest, TagOwnerError) {
                        -ENOENT);
 
   std::string local_image_id;
+  std::string local_image_name;
   std::string tag_owner;
   C_SaferCond ctx;
   auto req = MockPrepareLocalImageRequest::create(m_local_io_ctx,
                                                   "global image id",
                                                   &local_image_id,
+                                                  &local_image_name,
                                                   &tag_owner,
                                                   m_threads->work_queue,
                                                   &ctx);

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -287,6 +287,7 @@ private:
   int64_t m_local_pool_id;
   std::string m_local_image_id;
   std::string m_global_image_id;
+  std::string m_local_image_name;
   std::string m_name;
 
   mutable Mutex m_lock;
@@ -427,8 +428,7 @@ private:
 
   void register_admin_socket_hook();
   void unregister_admin_socket_hook();
-
-  void on_name_changed();
+  void reregister_admin_socket_hook();
 };
 
 } // namespace mirror

--- a/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.cc
@@ -54,6 +54,42 @@ void PrepareLocalImageRequest<I>::handle_get_local_image_id(int r) {
     return;
   }
 
+  get_local_image_name();
+}
+
+template <typename I>
+void PrepareLocalImageRequest<I>::get_local_image_name() {
+  dout(20) << dendl;
+
+  librados::ObjectReadOperation op;
+  librbd::cls_client::dir_get_name_start(&op, *m_local_image_id);
+
+  m_out_bl.clear();
+  librados::AioCompletion *aio_comp = create_rados_callback<
+    PrepareLocalImageRequest<I>,
+    &PrepareLocalImageRequest<I>::handle_get_local_image_name>(this);
+  int r = m_io_ctx.aio_operate(RBD_DIRECTORY, aio_comp, &op, &m_out_bl);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void PrepareLocalImageRequest<I>::handle_get_local_image_name(int r) {
+  dout(20) << "r=" << r << dendl;
+
+  if (r == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    r = librbd::cls_client::dir_get_name_finish(&it, m_local_image_name);
+  }
+
+  if (r < 0) {
+    if (r != -ENOENT) {
+      derr << "failed to retrieve image name: " << cpp_strerror(r) << dendl;
+    }
+    finish(r);
+    return;
+  }
+
   get_mirror_state();
 }
 

--- a/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/PrepareLocalImageRequest.h
@@ -23,22 +23,25 @@ public:
   static PrepareLocalImageRequest *create(librados::IoCtx &io_ctx,
                                           const std::string &global_image_id,
                                           std::string *local_image_id,
+                                          std::string *local_image_name,
                                           std::string *tag_owner,
                                           ContextWQ *work_queue,
                                           Context *on_finish) {
     return new PrepareLocalImageRequest(io_ctx, global_image_id, local_image_id,
-                                        tag_owner, work_queue, on_finish);
+                                        local_image_name, tag_owner, work_queue,
+                                        on_finish);
   }
 
   PrepareLocalImageRequest(librados::IoCtx &io_ctx,
                            const std::string &global_image_id,
                            std::string *local_image_id,
+                           std::string *local_image_name,
                            std::string *tag_owner,
                            ContextWQ *work_queue,
                            Context *on_finish)
     : m_io_ctx(io_ctx), m_global_image_id(global_image_id),
-      m_local_image_id(local_image_id), m_tag_owner(tag_owner),
-      m_work_queue(work_queue), m_on_finish(on_finish) {
+      m_local_image_id(local_image_id), m_local_image_name(local_image_name),
+      m_tag_owner(tag_owner), m_work_queue(work_queue), m_on_finish(on_finish) {
   }
 
   void send();
@@ -53,6 +56,9 @@ private:
    * GET_LOCAL_IMAGE_ID
    *    |
    *    v
+   * GET_LOCAL_IMAGE_NAME
+   *    |
+   *    v
    * GET_MIRROR_STATE
    *    |
    *    v
@@ -64,6 +70,7 @@ private:
   librados::IoCtx &m_io_ctx;
   std::string m_global_image_id;
   std::string *m_local_image_id;
+  std::string *m_local_image_name;
   std::string *m_tag_owner;
   ContextWQ *m_work_queue;
   Context *m_on_finish;
@@ -72,6 +79,9 @@ private:
 
   void get_local_image_id();
   void handle_get_local_image_id(int r);
+
+  void get_local_image_name();
+  void handle_get_local_image_name(int r);
 
   void get_mirror_state();
   void handle_get_mirror_state(int r);


### PR DESCRIPTION
http://tracker.ceph.com/issues/23900