### PR TITLE
librbd: release lock executing deep copy progress callback

### DIFF
--- a/src/librbd/deep_copy/ImageCopyRequest.h
+++ b/src/librbd/deep_copy/ImageCopyRequest.h
@@ -82,6 +82,7 @@ private:
   uint64_t m_current_ops = 0;
   std::priority_queue<
     uint64_t, std::vector<uint64_t>, std::greater<uint64_t>> m_copied_objects;
+  bool m_updating_progress = false;
   SnapMap m_snap_map;
   int m_ret_val = 0;
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23929
Signed-off-by: Mykola Golub <mgolub@suse.com>