### PR TITLE
client: drop function _get_inodeno

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5367,13 +5367,6 @@ vinodeno_t Client::_get_vino(Inode *in)
   return vinodeno_t(in->ino, in->snapid);
 }
 
-inodeno_t Client::_get_inodeno(Inode *in)
-{
-  /* The caller must hold the client lock */
-  return in->ino;
-}
-
-
 /**
  * Resolve an MDS spec to a list of MDS daemon GIDs.
  *
@@ -10441,7 +10434,7 @@ void Client::_ll_drop_pins()
 
 bool Client::_ll_forget(Inode *in, int count)
 {
-  inodeno_t ino = _get_inodeno(in);
+  inodeno_t ino = in->ino;
 
   ldout(cct, 3) << __func__ << " " << ino << " " << count << dendl;
   tout(cct) << __func__ << std::endl;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -874,7 +874,6 @@ private:
   int _getattr_for_perm(Inode *in, const UserPerm& perms);
 
   vinodeno_t _get_vino(Inode *in);
-  inodeno_t _get_inodeno(Inode *in);
 
   /*
    * These define virtual xattrs exposing the recursive directory


### PR DESCRIPTION
Drop `_get_inodeno()` as per https://github.com/ceph/ceph/pull/21554#pullrequestreview-115914007.

Signed-off-by: Jos Collin <jcollin@redhat.com>