### PR TITLE
qa/suites/rados/thrash-old-clients: ms_type=simple

### DIFF
--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -4,6 +4,8 @@ overrides:
     conf:
       mon:
         mon osd initial require min compat client: hammer
+      client:
+        ms type: simple
 tasks:
 - install:
     branch: hammer


### PR DESCRIPTION
hammer does not support async messenger, so set ms_type to "simple" for
hammer client.

Fixes: http://tracker.ceph.com/issues/23922
Signed-off-by: Kefu Chai <kchai@redhat.com>