### PR TITLE
luminous: os/bluestore/bluefs_types: make block_mask 64-bit

### DIFF
--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -127,7 +127,7 @@ struct bluefs_super_t {
       block_size(4096) { }
 
   uint64_t block_mask() const {
-    return ~(block_size - 1);
+    return ~((uint64_t)block_size - 1);
   }
 
   void encode(bufferlist& bl) const;


### PR DESCRIPTION
http://tracker.ceph.com/issues/23881