### PR TITLE
luminous  ceph-volume failed ceph-osd --mkfs command doesn't halt the OSD creation process

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -10,9 +10,15 @@ class Capture(object):
         self.a = a
         self.kw = kw
         self.calls = []
+        self.return_values = kw.get('return_values', False)
+        self.always_returns = kw.get('always_returns', False)
 
     def __call__(self, *a, **kw):
         self.calls.append({'args': a, 'kwargs': kw})
+        if self.always_returns:
+            return self.always_returns
+        if self.return_values:
+            return self.return_values.pop()
 
 
 class Factory(object):
@@ -41,7 +47,7 @@ def fake_run(monkeypatch):
 
 @pytest.fixture
 def fake_call(monkeypatch):
-    fake_call = Capture()
+    fake_call = Capture(always_returns=([], [], 0))
     monkeypatch.setattr('ceph_volume.process.call', fake_call)
     return fake_call
 
@@ -51,10 +57,12 @@ def stub_call(monkeypatch):
     """
     Monkeypatches process.call, so that a caller can add behavior to the response
     """
-    def apply(return_value):
-        monkeypatch.setattr(
-            'ceph_volume.process.call',
-            lambda *a, **kw: return_value)
+    def apply(return_values):
+        if isinstance(return_values, tuple):
+            return_values = [return_values]
+        stubbed_call = Capture(return_values=return_values)
+        monkeypatch.setattr('ceph_volume.process.call', stubbed_call)
+        return stubbed_call
 
     return apply
 

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -322,7 +322,9 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
 
     command = base_command + supplementary_command
 
-    process.call(command, stdin=keyring, show_command=True)
+    _, _, returncode = process.call(command, stdin=keyring, show_command=True)
+    if returncode != 0:
+        raise RuntimeError('Command failed with exit code %s: %s' % (returncode, ' '.join(command)))
 
 
 def osd_mkfs_filestore(osd_id, fsid):


### PR DESCRIPTION
Note that this backport is not 100% identical to the PR in master, because for Luminous, the config changes in master (pr https://github.com/ceph/ceph/pull/20787) do not apply for Luminous. So only the `mkfs_bluestore` utility is affected and corrected by this PR.

Fixes: Fixes: http://tracker.ceph.com/issues/23874

Backport of https://github.com/ceph/ceph/pull/21685