### PR TITLE
prometheus: Handle the TIME perf counter type metrics

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -229,7 +229,7 @@ class MgrModule(ceph_module.BaseMgrModule):
     PERFCOUNTER_LONGRUNAVG = 4
     PERFCOUNTER_COUNTER = 8
     PERFCOUNTER_HISTOGRAM = 0x10
-    PERFCOUNTER_TYPE_MASK = ~2
+    PERFCOUNTER_TYPE_MASK = ~3
 
     # units supported
     BYTES = 0
@@ -336,6 +336,13 @@ class MgrModule(ceph_module.BaseMgrModule):
             return 'histogram'
         
         return ''
+
+    def _perfvalue_to_value(self, stattype, value):
+        if stattype & self.PERFCOUNTER_TIME:
+            # Convert from ns to seconds
+            return value / 1000000000.0
+        else:
+            return value
 
     def _unit_to_str(self, unit):
         if unit == self.NONE:

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -554,7 +554,8 @@ class Module(MgrModule):
                         ("ceph_daemon",),
                     ))
 
-                self.metrics.append(path, counter_info['value'], (daemon,))
+                value = self._perfvalue_to_value(counter_info['type'], counter_info['value'])
+                self.metrics.append(path, value, (daemon,))
         # It is sufficient to reset the pending metrics once per scrape
         self.metrics.reset()
 


### PR DESCRIPTION
This patch correctly sets the PERFCOUNTER_MASK to 3 so that the
PERFCOUNTER_TIME metrics are not ignored by the mgr_module code. It also
converts the TIME metrics from nanoseconds to seconds just like the ceph
perf dump does and exposes the metrics via prometheus module.

Signed-off-by: Boris Ranto <branto@redhat.com>