### PR TITLE
mgr: Include daemon details in SLOW_OPS output

### DIFF
--- a/src/mgr/DaemonHealthMetricCollector.cc
+++ b/src/mgr/DaemonHealthMetricCollector.cc
@@ -37,15 +37,20 @@ class SlowOps final : public DaemonHealthMetricCollector {
     if (daemons.empty()) {
       return;
     }
-    static const char* fmt = "%1% slow ops, oldest one blocked for %2% sec";
-    check.summary = boost::str(boost::format(fmt) % value.n1 % value.n2);
+    static const char* fmt = "%1% slow ops, oldest one blocked for %2% sec, %3%";
     ostringstream ss;
     if (daemons.size() > 1) {
-      ss << "daemons " << daemons << " have slow ops.";
+      if (daemons.size() > 10) {
+        ss << "daemons " << vector<DaemonKey>(daemons.begin(), daemons.begin()+10)
+           << "..." << " have slow ops.";
+      } else {
+        ss << "daemons " << daemons << " have slow ops.";
+      }
     } else {
       ss << daemons.front() << " has slow ops";
     }
-    check.detail.push_back(ss.str());
+    check.summary = boost::str(boost::format(fmt) % value.n1 % value.n2 % ss.str());
+    // No detail
   }
   vector<DaemonKey> daemons;
 };


### PR DESCRIPTION
Currently there is no way to see which daemons were involved in a slow
op after the op has cleared. This change allows us to record which
daemons were implicated in the logs.

Partially fixes: http://tracker.ceph.com/issues/23205

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>