### PR TITLE
qa/suites/upgrade/luminous-x/stress-split: avoid enospc

### DIFF
--- a/qa/suites/upgrade/luminous-x/stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split/0-cluster/start.yaml
@@ -23,7 +23,9 @@ roles:
   - osd.0
   - osd.1
   - osd.2
-- - osd.3
-  - osd.4
+  - osd.3
+- - osd.4
   - osd.5
+  - osd.6
+  - osd.7
 - - client.0

--- a/qa/suites/upgrade/luminous-x/stress-split/2-partial-upgrade/firsthalf.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split/2-partial-upgrade/firsthalf.yaml
@@ -2,12 +2,12 @@ meta:
 - desc: |
    install upgrade ceph/-x on one node only
    1st half
-   restart : osd.0,1,2
+   restart : osd.0,1,2,3
 tasks:
 - install.upgrade:
     osd.0:
 - print: "**** done install.upgrade osd.0"
 - ceph.restart:
-    daemons: [mon.a,mon.b,mon.c,mgr.x,osd.0,osd.1,osd.2]
+    daemons: [mon.a,mon.b,mon.c,mgr.x,osd.0,osd.1,osd.2,osd.3]
     mon-health-to-clog: false
 - print: "**** done ceph.restart 1st half"

--- a/qa/suites/upgrade/luminous-x/stress-split/4-workload/radosbench.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split/4-workload/radosbench.yaml
@@ -6,35 +6,47 @@ stress-tasks:
 - full_sequential:
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
 - print: "**** done radosbench 7-workload"

--- a/qa/suites/upgrade/luminous-x/stress-split/5-finish-upgrade.yaml
+++ b/qa/suites/upgrade/luminous-x/stress-split/5-finish-upgrade.yaml
@@ -1,9 +1,9 @@
 tasks:
 - install.upgrade:
-    osd.3:
+    osd.4:
     client.0:
 - ceph.restart:
-    daemons: [osd.3, osd.4, osd.5]
+    daemons: [osd.4, osd.5, osd.6, osd.7]
     wait-for-healthy: false
     wait-for-osds-up: true
 


### PR DESCRIPTION
See http://pulpito.ceph.com/sage-2018-05-01_02:11:21-upgrade:luminous-x-wip-sage3-testing-2018-04-30-1610-distro-basic-smithi/2459106