### PR TITLE
jewel: osdc/Objecter: prevent double-invocation of linger op callback

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1527,6 +1527,7 @@ void Objecter::_check_linger_pool_dne(LingerOp *op, bool *need_unregister)
     if (osdmap->get_epoch() >= op->map_dne_bound) {
       if (op->on_reg_commit) {
 	op->on_reg_commit->complete(-ENOENT);
+	op->on_reg_commit = nullptr;
       }
       *need_unregister = true;
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/23905