### PR TITLE
osdc/Objecter: fix warning

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -4955,7 +4955,6 @@ void Objecter::_finish_command(CommandOp *c, int r, string rs)
   if (c->ontimeout && r != -ETIMEDOUT)
     timer.cancel_event(c->ontimeout);
 
-  OSDSession *s = c->session;
   _session_command_op_remove(c->session, c);
 
   c->put();


### PR DESCRIPTION
Fallout from 891f5192427a4a783d5d7194fc2556dfdc1a0ed2

Signed-off-by: Sage Weil <sage@redhat.com>