### PR TITLE
rgw: avoid race condition in RGWHTTPClient::wait()

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -51,6 +51,9 @@ struct rgw_http_req_data : public RefCountedObject {
 
   int wait() {
     Mutex::Locker l(lock);
+    if (done) {
+      return ret;
+    }
     cond.Wait(lock);
     return ret;
   }
@@ -524,11 +527,7 @@ bool RGWHTTPClient::is_done()
  */
 int RGWHTTPClient::wait()
 {
-  if (!req_data->is_done()) {
-    return req_data->wait();
-  }
-
-  return req_data->ret;
+  return req_data->wait();
 }
 
 RGWHTTPClient::~RGWHTTPClient()


### PR DESCRIPTION
The cond is signaled in RGWHTTPManager's thread, which is
different with the thread executing wait(), so there is a
race condition.

Signed-off-by: cfanz <songxinyingftd@gmail.com>