### PR TITLE
mgr/dashboard: fix two type errors found by mypy

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -286,6 +286,7 @@ class Task(object):
                 if arg in kwargs:
                     arg_map[arg] = kwargs[arg]
             if arg in arg_map:
+                # This is not a type error. We are using the index here.
                 arg_map[idx] = arg_map[arg]
 
         return arg_map

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -119,7 +119,7 @@ class ControllerTestCase(helper.CPWebCase):
                 self.status = thread.res_task['exception']['status']
             else:
                 self.status = 500
-            self.body = json.dumps(thread.rest_task['exception'])
+            self.body = json.dumps(thread.res_task['exception'])
             return
 
     def _task_post(self, url, data=None, timeout=60):

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -113,8 +113,8 @@ class ViewCache(object):
 
         # pylint: disable=broad-except
         def run(self):
-            t0 = 0
-            t1 = 0
+            t0 = 0.0
+            t1 = 0.0
             try:
                 t0 = time.time()
                 logger.debug("VC: starting execution of %s", self.fn)


### PR DESCRIPTION
Minor issues found by running `mypy` on the dashboard code. 

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>