### PR TITLE
librados: fix buffer overflow for aio_exec python binding

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -2020,9 +2020,11 @@ void librados::IoCtxImpl::C_aio_Complete::finish(int r)
   c->cond.Signal();
 
   if (r == 0 && c->blp && c->blp->length() > 0) {
-    if (c->out_buf && !c->blp->is_provided_buffer(c->out_buf))
-      c->blp->copy(0, c->blp->length(), c->out_buf);
-    c->rval = c->blp->length();
+    if (c->out_buf && !c->blp->is_contiguous()) {
+      c->rval = -ERANGE;
+    } else {
+      c->rval = c->blp->length();
+    }
   }
 
   if (c->callback_complete ||


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/23964

Signed-off-by: Aleksei Gutikov <aleksey.gutikov@synesis.ru>

C_aio_Complete::finish() checks if bufferlist contains out_buf pointer,
but is_provided_buffer also checks if bufferlist is contiguous.
So if operation returns more data than length of buffer - than bufferlist will be extended
and is_provided_buffer() will return false.
So copy() will be called and overwrites malloc metadata.