### PR TITLE
[RFC] mgr/dashboard: Add mypy.ini

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -242,6 +242,19 @@ Or, ``source`` the script and run the tests manually::
   $ run_teuthology_tests [tests]...
   $ cleanup_teuthology
 
+Type checking with mypy
+~~~~~~~~~~~~~~~~~~~~~~~
+
+`mypy <http://mypy-lang.org/>`_ is a tool to statically typecheck Python code. It supports type
+annotations and type deduction. To run mypy, install mypy in your Python 3 environment::
+
+  $ pip install mypy
+
+and then run mypy on the dashboard code::
+
+  $ cd sry/pybind/mgr
+  $ find dashboard -name '*.py' -and -not -path '*frontend*' -and -not -path '*tox*' | xargs mypy --config-file=dashboard/mypy.ini
+
 How to add a new controller?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/pybind/mgr/dashboard/__init__.py
+++ b/src/pybind/mgr/dashboard/__init__.py
@@ -33,7 +33,7 @@ if 'UNITTEST' not in os.environ:
             return getattr(self._mgr, item)
 
     mgr = _ModuleProxy()
-    logger = _LoggerProxy()
+    logger = _LoggerProxy()  # type: logging.getLogger
 
     from .module import Module, StandbyModule
 else:

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -2,6 +2,11 @@
 # pylint: disable=W0212
 from __future__ import absolute_import
 
+try:
+    from typing import List, Tuple, Any, Optional, Dict, Union
+except ImportError:
+    pass
+
 import collections
 from datetime import datetime, timedelta
 import fnmatch
@@ -271,7 +276,7 @@ class Task(object):
 
     def _gen_arg_map(self, func, args, kwargs):
         # pylint: disable=deprecated-method
-        arg_map = {}
+        arg_map = {}  # type: Dict[Union[str, int], Any]
         if sys.version_info > (3, 0):  # pylint: disable=no-else-return
             sig = inspect.signature(func)
             arg_list = [a for a in sig.parameters]
@@ -446,7 +451,7 @@ class RESTController(BaseController):
         def isfunction(m):
             return inspect.isfunction(m) or inspect.ismethod(m)
 
-        result = []
+        result = []  # type: List[Tuple[List[Any], Optional[str], str, List[Any]]]
         for attr, val in inspect.getmembers(cls, predicate=isfunction):
             if hasattr(val, 'exposed') and val.exposed and \
                     attr != '_collection' and attr != '_element':

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+try:
+    from typing import Dict, Any  # pylint: disable=unused-import
+except ImportError:
+    pass
+
 import cherrypy
 
 from . import ApiController, RESTController, AuthRequired
@@ -19,7 +24,7 @@ class Pool(RESTController):
 
         crush_rules = {r['rule_id']: r["rule_name"] for r in mgr.get('osd_map_crush')['rules']}
 
-        res = {}
+        res = {}  # type: Dict[str, Any]
         for attr in attrs:
             if attr not in pool:
                 continue

--- a/src/pybind/mgr/dashboard/mypy.ini
+++ b/src/pybind/mgr/dashboard/mypy.ini
@@ -1,0 +1,7 @@
+[mypy]
+strict_optional = True
+no_implicit_optional = True
+ignore_missing_imports = True
+warn_incomplete_stub = True
+check_untyped_defs = True
+show_error_context = True

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -258,10 +258,10 @@ class SessionExpireAtBrowserCloseTool(cherrypy.Tool):
 
 class NotificationQueue(threading.Thread):
     _ALL_TYPES_ = '__ALL__'
-    _listeners = collections.defaultdict(set)
+    _listeners = collections.defaultdict(set)  # type: dict
     _lock = threading.Lock()
     _cond = threading.Condition()
-    _queue = collections.deque()
+    _queue = collections.deque()  # type: collections.deque
     _running = False
     _instance = None
 
@@ -403,8 +403,8 @@ class TaskManager(object):
     VALUE_DONE = "done"
     VALUE_EXECUTING = "executing"
 
-    _executing_tasks = set()
-    _finished_tasks = []
+    _executing_tasks = set()  # type: set
+    _finished_tasks = []  # type: list
     _lock = threading.Lock()
 
     _task_local_data = threading.local()


### PR DESCRIPTION
Also added some type annotations

These were the changes I did to find #21774

In my system, this generates:

```
find dashboard -name '*.py' -and -not -path '*frontend*' -and -not -path '*tox*' | xargs mypy --config-file=dashboard/mypy.ini
dashboard/services/ceph_service.py:9: note: In module imported here:
mgr_module.py: note: In class "MgrModule":
mgr_module.py:215: error: Need type annotation for 'COMMANDS'
mgr_module.py:216: error: Need type annotation for 'OPTIONS'
mgr_module.py: note: In member "get_all_perf_counters" of class "MgrModule":
mgr_module.py:693: error: Need type annotation for 'result'
dashboard/tools.py: note: In member "run" of class "GetterThread":
dashboard/tools.py:119: error: Incompatible types in assignment (expression has type "float", variable has type "int")
dashboard/tools.py:122: error: Incompatible types in assignment (expression has type "float", variable has type "int")
dashboard/tools.py: note: In member "__init__" of class "ViewCache":
dashboard/tools.py:205: error: Need type annotation for 'cache_by_args'
dashboard/controllers/__init__.py: note: In function "browsable_api_view":
dashboard/controllers/__init__.py:235: error: "BaseController" has no attribute "_cp_path_"
dashboard/controllers/__init__.py:251: error: "BaseController" has no attribute "_cp_path_"
dashboard/controllers/__init__.py:253: error: "BaseController" has no attribute "_cp_path_"
dashboard/controllers/__init__.py:261: error: "Callable[[Any, VarArg(Any), KwArg(Any)], Any]" has no attribute "exposed"
dashboard/controllers/__init__.py:263: error: "Callable[[Any, VarArg(Any), KwArg(Any)], Any]" has no attribute "_cp_config"
dashboard/controllers/__init__.py: note: In member "__call__" of class "Task":
dashboard/controllers/__init__.py:331: error: "Callable[..., Any]" has no attribute "__wrapped__"
dashboard/controllers/__init__.py: note: In member "endpoints" of class "BaseController":
dashboard/controllers/__init__.py:388: error: Need type annotation for 'result'
dashboard/controllers/__init__.py:399: error: Incompatible types in assignment (expression has type "None", variable has type "str")
dashboard/controllers/__init__.py: note: In member "endpoints" of class "RESTController":
dashboard/controllers/__init__.py:467: error: Need type annotation for 'args'
dashboard/tests/test_notification.py: note: In member "__init__" of class "Listener":
dashboard/tests/test_notification.py:15: error: Need type annotation for 'type1'
dashboard/tests/test_notification.py:16: error: Need type annotation for 'type1_ts'
dashboard/tests/test_notification.py:17: error: Need type annotation for 'type2'
dashboard/tests/test_notification.py:18: error: Need type annotation for 'type2_ts'
dashboard/tests/test_notification.py:19: error: Need type annotation for 'type1_3'
dashboard/tests/test_notification.py:20: error: Need type annotation for 'type1_3_ts'
dashboard/tests/test_notification.py:21: error: Need type annotation for 'all'
dashboard/tests/test_notification.py:22: error: Need type annotation for 'all_ts'
dashboard/tests/test_notification.py: note: In member "test_notifications2" of class "NotificationQueueTest":
dashboard/tests/test_notification.py:109: error: Incompatible types in assignment (expression has type "int", variable has type "str")
dashboard/tests/test_settings.py: note: In class "SettingsTest":
dashboard/tests/test_settings.py:13: error: Need type annotation for 'CONFIG_KEY_DICT'
dashboard/tests/test_settings.py: note: In member "setUpClass" of class "SettingsTest":
dashboard/tests/test_settings.py:18: error: "Type[Options]" has no attribute "GRAFANA_API_HOST"
dashboard/tests/test_settings.py:19: error: "Type[Options]" has no attribute "GRAFANA_API_PORT"
dashboard/tests/helper.py: note: In member "_task_request" of class "ControllerTestCase":
dashboard/tests/helper.py:108: error: Value of type "None" is not indexable
dashboard/tests/helper.py:109: error: Value of type "None" is not indexable
dashboard/tests/helper.py:118: error: Value of type "None" is not indexable
dashboard/tests/helper.py:119: error: Value of type "None" is not indexable
dashboard/tests/helper.py:122: error: "Waiter" has no attribute "rest_task"; maybe "res_task"?
dashboard/tests/test_task.py: note: In class "TaskTest":
dashboard/tests/test_task.py:100: error: Need type annotation for 'TASK_FINISHED_MAP'
dashboard/services/ceph_service.py: note: In member "get_service_map" of class "CephService":
dashboard/services/ceph_service.py:26: error: Need type annotation for 'service_map'
dashboard/services/ceph_service.py: note: In member "get_pool_list_with_stats" of class "CephService":
dashboard/services/ceph_service.py:86: error: Need type annotation for 'pool_stats'
dashboard/tests/test_rest_tasks.py: note: In member "setup_server" of class "TaskControllerTest":
dashboard/tests/test_rest_tasks.py:48: error: "Type[Task]" has no attribute "_cp_config"
dashboard/tests/test_tools.py: note: In member "list" of class "FooResource":
dashboard/tests/test_tools.py:17: error: Need type annotation for 'elems'
dashboard/tests/test_tools.py: note: In member "create" of class "FooResource":
dashboard/tests/test_tools.py:17: error: Need type annotation for 'elems'
dashboard/tests/test_tools.py: note: In member "delete" of class "FooResource":
dashboard/tests/test_tools.py:17: error: Need type annotation for 'elems'
dashboard/tests/test_tools.py: note: In member "bulk_delete" of class "FooResource":
dashboard/tests/test_tools.py:17: error: Need type annotation for 'elems'
dashboard/tests/test_tools.py: note: In member "set" of class "FooResource":
dashboard/tests/test_tools.py:17: error: Need type annotation for 'elems'
dashboard/tests/test_tools.py: note: In class "FooResource":
dashboard/tests/test_tools.py:17: error: Need type annotation for 'elems'
dashboard/controllers/rbd.py: note: In class "Rbd":
dashboard/controllers/rbd.py:117: error: Incompatible types in assignment (expression has type "str", base class "RESTController" defined the type as "None")
dashboard/controllers/rbd.py: note: In class "RbdSnapshot":
dashboard/controllers/rbd.py:374: error: Incompatible types in assignment (expression has type "str", base class "RESTController" defined the type as "None")
dashboard/controllers/osd.py: note: In member "list" of class "Osd":
dashboard/controllers/osd.py:35: error: Unsupported target for indexed assignment
dashboard/controllers/osd.py:36: error: Unsupported target for indexed assignment
dashboard/controllers/osd.py:37: error: Invalid tuple index type (actual type "str", expected type "Union[int, slice]")
dashboard/controllers/osd.py:40: error: Invalid tuple index type (actual type "str", expected type "Union[int, slice]")
dashboard/controllers/osd.py:41: error: Invalid tuple index type (actual type "str", expected type "Union[int, slice]")
dashboard/controllers/osd.py:44: error: Invalid tuple index type (actual type "str", expected type "Union[int, slice]")
dashboard/controllers/cephfs.py: note: In member "__init__" of class "CephFS":
dashboard/controllers/cephfs.py:22: error: Need type annotation for 'cephfs_clients'
dashboard/controllers/cephfs.py: note: In member "mds_counters" of class "CephFS":
dashboard/controllers/cephfs.py:64: error: Need type annotation for 'result'
dashboard/controllers/cephfs.py: note: In member "fs_status" of class "CephFS":
dashboard/controllers/cephfs.py:102: error: Need type annotation for 'mds_versions'
dashboard/controllers/rbd_mirroring.py: note: In function "get_daemons_and_pools":
dashboard/controllers/rbd_mirroring.py:116: error: Argument 2 to "get" of "Mapping" has incompatible type "None"; expected "Union[Dict[str, Any], Dict[str, str]]"
dashboard/controllers/rbd_mirroring.py: note: In member "__init__" of class "RbdMirror":
dashboard/controllers/rbd_mirroring.py:162: error: Need type annotation for 'pool_data'
dashboard/controllers/rbd_mirroring.py: note: In member "_get_pool_datum" of class "RbdMirror":
dashboard/controllers/rbd_mirroring.py:226: error: Argument after ** must be a mapping, not "object"
dashboard/controllers/dashboard.py: note: In member "__init__" of class "Dashboard":
dashboard/controllers/dashboard.py:26: error: Need type annotation for 'log_buffer'
dashboard/controllers/dashboard.py:27: error: Need type annotation for 'audit_buffer'
dashboard/controllers/tcmu_iscsi.py: note: In member "list" of class "TcmuIscsi":
dashboard/controllers/tcmu_iscsi.py:16: error: Need type annotation for 'daemons'
dashboard/controllers/tcmu_iscsi.py:17: error: Need type annotation for 'images'
dashboard/tests/test_tcmu_iscsi.py: note: In member "setup_server" of class "TcmuIscsiControllerTest":
dashboard/tests/test_tcmu_iscsi.py:71: error: "_ModuleProxy" has no attribute "url_prefix"
dashboard/tests/test_tcmu_iscsi.py:72: error: "Type[TcmuIscsi]" has no attribute "_cp_config"
dashboard/tests/test_rbd_mirroring.py: note: In member "setup_server" of class "RbdMirroringControllerTest":
dashboard/tests/test_rbd_mirroring.py:59: error: "_ModuleProxy" has no attribute "url_prefix"
dashboard/tests/test_rbd_mirroring.py:63: error: "Type[RbdMirror]" has no attribute "_cp_config"
dashboard/tests/test_rbd_mirroring.py:65: error: "Type[Summary]" has no attribute "_cp_config"
dashboard/rest_client.py:26: error: Name 'SSLError' already defined
dashboard/rest_client.py: note: In member "_validate_level" of class "_ResponseValidator":
dashboard/rest_client.py:173: error: Item "List[Any]" of "Union[Dict[Any, Any], List[Any]]" has no attribute "keys"
dashboard/services/rgw_client.py: note: In member "_load_settings" of class "RgwClient":
dashboard/services/rgw_client.py:82: error: Need type annotation for '_user_instances'
dashboard/services/rgw_client.py: note: In member "instance" of class "RgwClient":
dashboard/services/rgw_client.py:82: error: Need type annotation for '_user_instances'
dashboard/services/rgw_client.py: note: In class "RgwClient":
dashboard/services/rgw_client.py:82: error: Need type annotation for '_user_instances'
```

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>