### PR TITLE
mgr/dashboard: Use Bootstrap CSS

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.html
@@ -1,6 +1,6 @@
 <alert type="danger">
   <strong>
-    <i class="fa fa-exclamation-triangle fa-fw icon-danger"
+    <i class="fa fa-exclamation-triangle fa-fw alert-danger"
        aria-hidden="true"></i> {{ title }}
   </strong>
   <ng-content></ng-content>

--- a/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
@@ -148,14 +148,6 @@ option {
   color: #474544;
 }
 
-/* Icons */
-.icon-warning {
-  color: #f0ad4e;
-}
-.icon-danger {
-  color: #c9302c;
-}
-
 /* Buttons */
 .btn-openattic {
   color: #ececec;


### PR DESCRIPTION
Replace custom CSS class by Bootstrap.

Signed-off-by: Volker Theile <vtheile@suse.com>