### PR TITLE
mgr/dashboard: Resolve TestBed performance issue

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -66,6 +66,10 @@ production build. Navigate to ``https://localhost:8443``.
 Running Unit Tests
 ~~~~~~~~~~~~~~~~~~
 
+Create ``unit-test-configuration.ts`` file based on
+``unit-test-configuration.ts.sample`` in directory
+``src/pybind/mgr/dashboard/frontend/src``.
+
 Run ``npm run test`` to execute the unit tests via `Jest
 <https://facebook.github.io/jest/>`_.
 

--- a/src/pybind/mgr/dashboard/frontend/.gitignore
+++ b/src/pybind/mgr/dashboard/frontend/.gitignore
@@ -32,6 +32,7 @@
 npm-debug.log
 testem.log
 /typings
+/src/unit-test-configuration.ts
 
 # e2e
 /e2e/*.js

--- a/src/pybind/mgr/dashboard/frontend/src/app/app.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.component.spec.ts
@@ -1,11 +1,12 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ToastModule } from 'ng2-toastr';
 
 import { AppComponent } from './app.component';
 import { AuthStorageService } from './shared/services/auth-storage.service';
+import { configureTestBed } from './shared/unit-test-helper';
 
 describe('AppComponent', () => {
   let component: AppComponent;
@@ -17,14 +18,12 @@ describe('AppComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule, ToastModule.forRoot()],
-      declarations: [AppComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [{ provide: AuthStorageService, useValue: fakeService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [RouterTestingModule, ToastModule.forRoot()],
+    declarations: [AppComponent],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [{ provide: AuthStorageService, useValue: fakeService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(AppComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/flatten-confirmation-modal/flatten-confimation-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/flatten-confirmation-modal/flatten-confimation-modal.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { ToastModule } from 'ng2-toastr';
@@ -8,27 +8,25 @@ import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 import { ApiModule } from '../../../shared/api/api.module';
 import { ServicesModule } from '../../../shared/services/services.module';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { FlattenConfirmationModalComponent } from './flatten-confimation-modal.component';
 
 describe('FlattenConfirmationModalComponent', () => {
   let component: FlattenConfirmationModalComponent;
   let fixture: ComponentFixture<FlattenConfirmationModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        HttpClientTestingModule,
-        SharedModule,
-        ServicesModule,
-        ApiModule,
-        ToastModule.forRoot()
-      ],
-      declarations: [ FlattenConfirmationModalComponent ],
-      providers: [ BsModalRef, BsModalService ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    imports: [
+      ReactiveFormsModule,
+      HttpClientTestingModule,
+      SharedModule,
+      ServicesModule,
+      ApiModule,
+      ToastModule.forRoot()
+    ],
+    declarations: [FlattenConfirmationModalComponent],
+    providers: [BsModalRef, BsModalService]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(FlattenConfirmationModalComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
@@ -1,5 +1,5 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TcmuIscsiService } from '../../../shared/api/tcmu-iscsi.service';
 import { CephShortVersionPipe } from '../../../shared/pipes/ceph-short-version.pipe';
@@ -7,6 +7,7 @@ import { DimlessPipe } from '../../../shared/pipes/dimless.pipe';
 import { ListPipe } from '../../../shared/pipes/list.pipe';
 import { RelativeDatePipe } from '../../../shared/pipes/relative-date.pipe';
 import { FormatterService } from '../../../shared/services/formatter.service';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { IscsiComponent } from './iscsi.component';
 
 describe('IscsiComponent', () => {
@@ -21,21 +22,19 @@ describe('IscsiComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [],
-      declarations: [IscsiComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        CephShortVersionPipe,
-        DimlessPipe,
-        FormatterService,
-        RelativeDatePipe,
-        ListPipe,
-        { provide: TcmuIscsiService, useValue: fakeService }
-      ]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [],
+    declarations: [IscsiComponent],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      CephShortVersionPipe,
+      DimlessPipe,
+      FormatterService,
+      RelativeDatePipe,
+      ListPipe,
+      { provide: TcmuIscsiService, useValue: fakeService }
+    ]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(IscsiComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirroring.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirroring.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BsDropdownModule, TabsModule } from 'ngx-bootstrap';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
@@ -7,6 +7,7 @@ import { Observable } from 'rxjs';
 
 import { RbdMirroringService } from '../../../shared/api/rbd-mirroring.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { MirrorHealthColorPipe } from '../mirror-health-color.pipe';
 import { MirroringComponent } from './mirroring.component';
 
@@ -16,27 +17,23 @@ describe('MirroringComponent', () => {
 
   const fakeService = {
     get: (service_type: string, service_id: string) => {
-      return Observable.create(observer => {
+      return Observable.create((observer) => {
         return () => console.log('disposed');
       });
     }
   };
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        declarations: [MirroringComponent, MirrorHealthColorPipe],
-        imports: [
-          SharedModule,
-          BsDropdownModule.forRoot(),
-          TabsModule.forRoot(),
-          ProgressbarModule.forRoot(),
-          HttpClientTestingModule
-        ],
-        providers: [{ provide: RbdMirroringService, useValue: fakeService }]
-      }).compileComponents();
-    })
-  );
+  configureTestBed({
+    declarations: [MirroringComponent, MirrorHealthColorPipe],
+    imports: [
+      SharedModule,
+      BsDropdownModule.forRoot(),
+      TabsModule.forRoot(),
+      ProgressbarModule.forRoot(),
+      HttpClientTestingModule
+    ],
+    providers: [{ provide: RbdMirroringService, useValue: fakeService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MirroringComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.spec.ts
@@ -1,9 +1,10 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { TabsModule, TooltipModule } from 'ngx-bootstrap';
 
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdSnapshotListComponent } from '../rbd-snapshot-list/rbd-snapshot-list.component';
 import { RbdDetailsComponent } from './rbd-details.component';
 
@@ -11,13 +12,10 @@ describe('RbdDetailsComponent', () => {
   let component: RbdDetailsComponent;
   let fixture: ComponentFixture<RbdDetailsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ RbdDetailsComponent, RbdSnapshotListComponent ],
-      imports: [ SharedModule, TabsModule.forRoot(), TooltipModule.forRoot(), RouterTestingModule]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RbdDetailsComponent, RbdSnapshotListComponent],
+    imports: [SharedModule, TabsModule.forRoot(), TooltipModule.forRoot(), RouterTestingModule]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdDetailsComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -1,5 +1,5 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -12,6 +12,7 @@ import { FormatterService } from '../../../shared/services/formatter.service';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { TaskManagerMessageService } from '../../../shared/services/task-manager-message.service';
 import { TaskManagerService } from '../../../shared/services/task-manager.service';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdFormComponent } from './rbd-form.component';
 
 describe('RbdFormComponent', () => {
@@ -30,22 +31,20 @@ describe('RbdFormComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule, RouterTestingModule],
-      declarations: [RbdFormComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        DimlessBinaryPipe,
-        FormatterService,
-        TaskManagerMessageService,
-        { provide: NotificationService, useValue: fakeService },
-        { provide: PoolService, useValue: fakeService },
-        { provide: RbdService, useValue: fakeService },
-        { provide: TaskManagerService, useValue: fakeService }
-      ]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [ReactiveFormsModule, RouterTestingModule],
+    declarations: [RbdFormComponent],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      DimlessBinaryPipe,
+      FormatterService,
+      TaskManagerMessageService,
+      { provide: NotificationService, useValue: fakeService },
+      { provide: PoolService, useValue: fakeService },
+      { provide: RbdService, useValue: fakeService },
+      { provide: TaskManagerService, useValue: fakeService }
+    ]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdFormComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ToastModule } from 'ng2-toastr';
@@ -17,6 +17,7 @@ import { RbdService } from '../../../shared/api/rbd.service';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdDetailsComponent } from '../rbd-details/rbd-details.component';
 import { RbdSnapshotListComponent } from '../rbd-snapshot-list/rbd-snapshot-list.component';
 import { RbdListComponent } from './rbd-list.component';
@@ -25,23 +26,21 @@ describe('RbdListComponent', () => {
   let component: RbdListComponent;
   let fixture: ComponentFixture<RbdListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        SharedModule,
-        BsDropdownModule.forRoot(),
-        TabsModule.forRoot(),
-        ModalModule.forRoot(),
-        TooltipModule.forRoot(),
-        ToastModule.forRoot(),
-        AlertModule.forRoot(),
-        ComponentsModule,
-        RouterTestingModule,
-        HttpClientTestingModule
-      ],
-      declarations: [RbdListComponent, RbdDetailsComponent, RbdSnapshotListComponent]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [
+      SharedModule,
+      BsDropdownModule.forRoot(),
+      TabsModule.forRoot(),
+      ModalModule.forRoot(),
+      TooltipModule.forRoot(),
+      ToastModule.forRoot(),
+      AlertModule.forRoot(),
+      ComponentsModule,
+      RouterTestingModule,
+      HttpClientTestingModule
+    ],
+    declarations: [RbdListComponent, RbdDetailsComponent, RbdSnapshotListComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdListComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { ToastModule } from 'ng2-toastr';
@@ -9,27 +9,25 @@ import { ApiModule } from '../../../shared/api/api.module';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { ServicesModule } from '../../../shared/services/services.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdSnapshotFormComponent } from './rbd-snapshot-form.component';
 
 describe('RbdSnapshotFormComponent', () => {
   let component: RbdSnapshotFormComponent;
   let fixture: ComponentFixture<RbdSnapshotFormComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        ComponentsModule,
-        HttpClientTestingModule,
-        ServicesModule,
-        ApiModule,
-        ToastModule.forRoot()
-      ],
-      declarations: [ RbdSnapshotFormComponent ],
-      providers: [ BsModalRef, BsModalService, AuthStorageService ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    imports: [
+      ReactiveFormsModule,
+      ComponentsModule,
+      HttpClientTestingModule,
+      ServicesModule,
+      ApiModule,
+      ToastModule.forRoot()
+    ],
+    declarations: [RbdSnapshotFormComponent],
+    providers: [BsModalRef, BsModalService, AuthStorageService]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdSnapshotFormComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ToastModule } from 'ng2-toastr';
@@ -13,28 +13,27 @@ import { DataTableModule } from '../../../shared/datatable/datatable.module';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { ServicesModule } from '../../../shared/services/services.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdSnapshotListComponent } from './rbd-snapshot-list.component';
 
 describe('RbdSnapshotListComponent', () => {
   let component: RbdSnapshotListComponent;
   let fixture: ComponentFixture<RbdSnapshotListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RbdSnapshotListComponent],
-      imports: [
-        DataTableModule,
-        ComponentsModule,
-        ModalModule.forRoot(),
-        ToastModule.forRoot(),
-        ServicesModule,
-        ApiModule,
-        HttpClientTestingModule,
-        RouterTestingModule
-      ],
-      providers: [AuthStorageService]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RbdSnapshotListComponent],
+    imports: [
+      DataTableModule,
+      ComponentsModule,
+      ModalModule.forRoot(),
+      ToastModule.forRoot(),
+      ServicesModule,
+      ApiModule,
+      HttpClientTestingModule,
+      RouterTestingModule
+    ],
+    providers: [AuthStorageService]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdSnapshotListComponent);
@@ -60,7 +59,6 @@ describe('RbdSnapshotListComponent', () => {
         null,
         null,
         rbdService,
-        null,
         null,
         notificationService
       );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rollback-confirmation-modal/rollback-confimation-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rollback-confirmation-modal/rollback-confimation-modal.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { ToastModule } from 'ng2-toastr';
@@ -8,27 +8,25 @@ import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 import { ApiModule } from '../../../shared/api/api.module';
 import { ServicesModule } from '../../../shared/services/services.module';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RollbackConfirmationModalComponent } from './rollback-confimation-modal.component';
 
 describe('RollbackConfirmationModalComponent', () => {
   let component: RollbackConfirmationModalComponent;
   let fixture: ComponentFixture<RollbackConfirmationModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        ReactiveFormsModule,
-        HttpClientTestingModule,
-        SharedModule,
-        ServicesModule,
-        ApiModule,
-        ToastModule.forRoot()
-      ],
-      declarations: [ RollbackConfirmationModalComponent ],
-      providers: [ BsModalRef, BsModalService ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    imports: [
+      ReactiveFormsModule,
+      HttpClientTestingModule,
+      SharedModule,
+      ServicesModule,
+      ApiModule,
+      ToastModule.forRoot()
+    ],
+    declarations: [RollbackConfirmationModalComponent],
+    providers: [BsModalRef, BsModalService]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RollbackConfirmationModalComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-chart/cephfs-chart.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-chart/cephfs-chart.component.spec.ts
@@ -1,21 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ChartsModule } from 'ng2-charts/ng2-charts';
 
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { CephfsChartComponent } from './cephfs-chart.component';
 
 describe('CephfsChartComponent', () => {
   let component: CephfsChartComponent;
   let fixture: ComponentFixture<CephfsChartComponent>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        imports: [ChartsModule],
-        declarations: [CephfsChartComponent]
-      }).compileComponents();
-    })
-  );
+  configureTestBed({
+    imports: [ChartsModule],
+    declarations: [CephfsChartComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CephfsChartComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap';
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 
 import { CephfsService } from '../../../shared/api/cephfs.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { CephfsClientsComponent } from './cephfs-clients.component';
 
 describe('CephfsClientsComponent', () => {
@@ -25,13 +26,11 @@ describe('CephfsClientsComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule, BsDropdownModule.forRoot(), SharedModule],
-      declarations: [CephfsClientsComponent],
-      providers: [{ provide: CephfsService, useValue: fakeFilesystemService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [RouterTestingModule, BsDropdownModule.forRoot(), SharedModule],
+    declarations: [CephfsClientsComponent],
+    providers: [{ provide: CephfsService, useValue: fakeFilesystemService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CephfsClientsComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ChartsModule } from 'ng2-charts/ng2-charts';
@@ -8,6 +8,7 @@ import { Observable } from 'rxjs';
 
 import { CephfsService } from '../../../shared/api/cephfs.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { CephfsDetailComponent } from './cephfs-detail.component';
 
 @Component({ selector: 'cd-cephfs-chart', template: '' })
@@ -37,20 +38,18 @@ describe('CephfsDetailComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        SharedModule,
-        ChartsModule,
-        RouterTestingModule,
-        BsDropdownModule.forRoot(),
-        ProgressbarModule.forRoot(),
-        TabsModule.forRoot()
-      ],
-      declarations: [CephfsDetailComponent, CephfsChartStubComponent, CephfsClientsStubComponent],
-      providers: [{ provide: CephfsService, useValue: fakeFilesystemService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [
+      SharedModule,
+      ChartsModule,
+      RouterTestingModule,
+      BsDropdownModule.forRoot(),
+      ProgressbarModule.forRoot(),
+      TabsModule.forRoot()
+    ],
+    declarations: [CephfsDetailComponent, CephfsChartStubComponent, CephfsClientsStubComponent],
+    providers: [{ provide: CephfsService, useValue: fakeFilesystemService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CephfsDetailComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.spec.ts
@@ -1,11 +1,12 @@
 import { Component, Input } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { Observable } from 'rxjs';
 
 import { CephfsService } from '../../../shared/api/cephfs.service';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { CephfsListComponent } from './cephfs-list.component';
 
 @Component({ selector: 'cd-cephfs-detail', template: '' })
@@ -25,13 +26,11 @@ describe('CephfsListComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [SharedModule],
-      declarations: [CephfsListComponent, CephfsDetailStubComponent],
-      providers: [{ provide: CephfsService, useValue: fakeService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [SharedModule],
+    declarations: [CephfsListComponent, CephfsDetailStubComponent],
+    providers: [{ provide: CephfsService, useValue: fakeService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(CephfsListComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import { TabsModule } from 'ngx-bootstrap/tabs/tabs.module';
@@ -6,6 +6,7 @@ import { Observable } from 'rxjs';
 
 import { ConfigurationService } from '../../../shared/api/configuration.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { ConfigurationComponent } from './configuration.component';
 
 describe('ConfigurationComponent', () => {
@@ -14,21 +15,17 @@ describe('ConfigurationComponent', () => {
 
   const fakeService = {
     getConfigData: () => {
-      return Observable.create(observer => {
+      return Observable.create((observer) => {
         return () => console.log('disposed');
       });
     }
   };
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        declarations: [ConfigurationComponent],
-        providers: [{ provide: ConfigurationService, useValue: fakeService }],
-        imports: [SharedModule, FormsModule, TabsModule.forRoot()]
-      }).compileComponents();
-    })
-  );
+  configureTestBed({
+    declarations: [ConfigurationComponent],
+    providers: [{ provide: ConfigurationService, useValue: fakeService }],
+    imports: [SharedModule, FormsModule, TabsModule.forRoot()]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfigurationComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -1,32 +1,28 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap';
 
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { HostsComponent } from './hosts.component';
 
 describe('HostsComponent', () => {
   let component: HostsComponent;
   let fixture: ComponentFixture<HostsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        SharedModule,
-        HttpClientTestingModule,
-        ComponentsModule,
-        BsDropdownModule.forRoot(),
-        RouterTestingModule
-      ],
-      declarations: [
-        HostsComponent
-      ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    imports: [
+      SharedModule,
+      HttpClientTestingModule,
+      ComponentsModule,
+      BsDropdownModule.forRoot(),
+      RouterTestingModule
+    ],
+    declarations: [HostsComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HostsComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
@@ -1,7 +1,8 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { MonitorService } from '../../../shared/api/monitor.service';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { MonitorComponent } from './monitor.component';
 
 describe('MonitorComponent', () => {
@@ -10,13 +11,11 @@ describe('MonitorComponent', () => {
 
   const fakeService = {};
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [MonitorComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [{ provide: MonitorService, useValue: fakeService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [MonitorComponent],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [{ provide: MonitorService, useValue: fakeService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MonitorComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
@@ -1,37 +1,30 @@
 import { HttpClientModule } from '@angular/common/http';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap';
 
 import { DataTableModule } from '../../../../shared/datatable/datatable.module';
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../../shared/shared.module';
+import { configureTestBed } from '../../../../shared/unit-test-helper';
 import { PerformanceCounterModule } from '../../../performance-counter/performance-counter.module';
-import {
-  OsdPerformanceHistogramComponent
-} from '../osd-performance-histogram/osd-performance-histogram.component';
+import { OsdPerformanceHistogramComponent } from '../osd-performance-histogram/osd-performance-histogram.component';
 import { OsdDetailsComponent } from './osd-details.component';
 
 describe('OsdDetailsComponent', () => {
   let component: OsdDetailsComponent;
   let fixture: ComponentFixture<OsdDetailsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        HttpClientModule,
-        TabsModule.forRoot(),
-        PerformanceCounterModule,
-        DataTableModule,
-        SharedModule
-      ],
-      declarations: [
-        OsdDetailsComponent,
-        OsdPerformanceHistogramComponent
-      ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    imports: [
+      HttpClientModule,
+      TabsModule.forRoot(),
+      PerformanceCounterModule,
+      DataTableModule,
+      SharedModule
+    ],
+    declarations: [OsdDetailsComponent, OsdPerformanceHistogramComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OsdDetailsComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientModule } from '@angular/common/http';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
@@ -8,36 +8,28 @@ import { DataTableModule } from '../../../../shared/datatable/datatable.module';
 import { DimlessPipe } from '../../../../shared/pipes/dimless.pipe';
 import { FormatterService } from '../../../../shared/services/formatter.service';
 import { SharedModule } from '../../../../shared/shared.module';
+import { configureTestBed } from '../../../../shared/unit-test-helper';
 import { PerformanceCounterModule } from '../../../performance-counter/performance-counter.module';
 import { OsdDetailsComponent } from '../osd-details/osd-details.component';
-import {
-  OsdPerformanceHistogramComponent
-} from '../osd-performance-histogram/osd-performance-histogram.component';
+import { OsdPerformanceHistogramComponent } from '../osd-performance-histogram/osd-performance-histogram.component';
 import { OsdListComponent } from './osd-list.component';
 
 describe('OsdListComponent', () => {
   let component: OsdListComponent;
   let fixture: ComponentFixture<OsdListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        HttpClientModule,
-        PerformanceCounterModule,
-        TabsModule.forRoot(),
-        DataTableModule,
-        ComponentsModule,
-        SharedModule
-      ],
-      declarations: [
-        OsdListComponent,
-        OsdDetailsComponent,
-        OsdPerformanceHistogramComponent
-      ],
-      providers: [ DimlessPipe, FormatterService]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    imports: [
+      HttpClientModule,
+      PerformanceCounterModule,
+      TabsModule.forRoot(),
+      DataTableModule,
+      ComponentsModule,
+      SharedModule
+    ],
+    declarations: [OsdListComponent, OsdDetailsComponent, OsdPerformanceHistogramComponent],
+    providers: [DimlessPipe, FormatterService]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OsdListComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-performance-histogram/osd-performance-histogram.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-performance-histogram/osd-performance-histogram.component.spec.ts
@@ -1,17 +1,15 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../../shared/unit-test-helper';
 import { OsdPerformanceHistogramComponent } from './osd-performance-histogram.component';
 
 describe('OsdPerformanceHistogramComponent', () => {
   let component: OsdPerformanceHistogramComponent;
   let fixture: ComponentFixture<OsdPerformanceHistogramComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ OsdPerformanceHistogramComponent ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    declarations: [OsdPerformanceHistogramComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OsdPerformanceHistogramComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.spec.ts
@@ -1,11 +1,12 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap';
 
 import { OsdService } from '../../../../shared/api/osd.service';
 import { NotificationService } from '../../../../shared/services/notification.service';
+import { configureTestBed } from '../../../../shared/unit-test-helper';
 import { OsdScrubModalComponent } from './osd-scrub-modal.component';
 
 describe('OsdScrubModalComponent', () => {
@@ -30,18 +31,16 @@ describe('OsdScrubModalComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [ReactiveFormsModule],
-      declarations: [OsdScrubModalComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        BsModalRef,
-        { provide: OsdService, useValue: fakeService },
-        { provide: NotificationService, useValue: fakeService }
-      ]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [ReactiveFormsModule],
+    declarations: [OsdScrubModalComponent],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      BsModalRef,
+      { provide: OsdService, useValue: fakeService },
+      { provide: NotificationService, useValue: fakeService }
+    ]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(OsdScrubModalComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.spec.ts
@@ -1,18 +1,17 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { DashboardComponent } from './dashboard.component';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
   let fixture: ComponentFixture<DashboardComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [DashboardComponent],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [DashboardComponent],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(DashboardComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.spec.ts
@@ -1,21 +1,20 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DimlessBinaryPipe } from '../../../shared/pipes/dimless-binary.pipe';
 import { FormatterService } from '../../../shared/services/formatter.service';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { HealthPieComponent } from './health-pie.component';
 
 describe('HealthPieComponent', () => {
   let component: HealthPieComponent;
   let fixture: ComponentFixture<HealthPieComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      schemas: [NO_ERRORS_SCHEMA],
-      declarations: [HealthPieComponent],
-      providers: [DimlessBinaryPipe, FormatterService]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    schemas: [NO_ERRORS_SCHEMA],
+    declarations: [HealthPieComponent],
+    providers: [DimlessBinaryPipe, FormatterService]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HealthPieComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
@@ -1,10 +1,11 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { of as observableOf } from 'rxjs';
 
 import { DashboardService } from '../../../shared/api/dashboard.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { LogColorPipe } from '../log-color.pipe';
 import { MdsSummaryPipe } from '../mds-summary.pipe';
 import { MgrSummaryPipe } from '../mgr-summary.pipe';
@@ -30,23 +31,21 @@ describe('HealthComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      providers: [{ provide: DashboardService, useValue: fakeService }],
-      imports: [SharedModule],
-      declarations: [
-        HealthComponent,
-        MonSummaryPipe,
-        OsdSummaryPipe,
-        MdsSummaryPipe,
-        MgrSummaryPipe,
-        PgStatusStylePipe,
-        LogColorPipe,
-        PgStatusPipe
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    providers: [{ provide: DashboardService, useValue: fakeService }],
+    imports: [SharedModule],
+    declarations: [
+      HealthComponent,
+      MonSummaryPipe,
+      OsdSummaryPipe,
+      MdsSummaryPipe,
+      MgrSummaryPipe,
+      PgStatusStylePipe,
+      LogColorPipe,
+      PgStatusPipe
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HealthComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.spec.ts
@@ -1,8 +1,9 @@
 import { Component, Input } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { PerformanceCounterService } from '../../../shared/api/performance-counter.service';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { PerformanceCounterComponent } from './performance-counter.component';
 
 @Component({ selector: 'cd-table-performance-counter', template: '' })
@@ -28,13 +29,11 @@ describe('PerformanceCounterComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [PerformanceCounterComponent, TablePerformanceCounterStubComponent],
-      imports: [RouterTestingModule],
-      providers: [{ provide: PerformanceCounterService, useValue: fakeService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [PerformanceCounterComponent, TablePerformanceCounterStubComponent],
+    imports: [RouterTestingModule],
+    providers: [{ provide: PerformanceCounterService, useValue: fakeService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PerformanceCounterComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.spec.ts
@@ -1,10 +1,11 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PerformanceCounterService } from '../../../shared/api/performance-counter.service';
 import { TableComponent } from '../../../shared/datatable/table/table.component';
 import { DimlessPipe } from '../../../shared/pipes/dimless.pipe';
 import { FormatterService } from '../../../shared/services/formatter.service';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { TablePerformanceCounterComponent } from './table-performance-counter.component';
 
 describe('TablePerformanceCounterComponent', () => {
@@ -13,18 +14,16 @@ describe('TablePerformanceCounterComponent', () => {
 
   const fakeService = {};
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [TablePerformanceCounterComponent, TableComponent, DimlessPipe],
-      imports: [],
-      schemas: [NO_ERRORS_SCHEMA],
-      providers: [
-        { provide: PerformanceCounterService, useValue: fakeService },
-        DimlessPipe,
-        FormatterService
-      ]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [TablePerformanceCounterComponent, TableComponent, DimlessPipe],
+    imports: [],
+    schemas: [NO_ERRORS_SCHEMA],
+    providers: [
+      { provide: PerformanceCounterService, useValue: fakeService },
+      DimlessPipe,
+      FormatterService
+    ]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TablePerformanceCounterComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -1,21 +1,20 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs/tabs.module';
 
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { PoolListComponent } from './pool-list.component';
 
 describe('PoolListComponent', () => {
   let component: PoolListComponent;
   let fixture: ComponentFixture<PoolListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [PoolListComponent],
-      imports: [SharedModule, TabsModule.forRoot(), HttpClientTestingModule]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [PoolListComponent],
+    imports: [SharedModule, TabsModule.forRoot(), HttpClientTestingModule]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(PoolListComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.spec.ts
@@ -1,19 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { Rgw501Component } from './rgw-501.component';
 
 describe('Rgw501Component', () => {
   let component: Rgw501Component;
   let fixture: ComponentFixture<Rgw501Component>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [Rgw501Component],
-      imports: [RouterTestingModule, SharedModule]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [Rgw501Component],
+    imports: [RouterTestingModule, SharedModule]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(Rgw501Component);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.spec.ts
@@ -1,21 +1,20 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwBucketDetailsComponent } from './rgw-bucket-details.component';
 
 describe('RgwBucketDetailsComponent', () => {
   let component: RgwBucketDetailsComponent;
   let fixture: ComponentFixture<RgwBucketDetailsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwBucketDetailsComponent],
-      imports: [SharedModule, TabsModule.forRoot()]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RgwBucketDetailsComponent],
+    imports: [SharedModule, TabsModule.forRoot()]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwBucketDetailsComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -8,6 +8,7 @@ import { of as observableOf } from 'rxjs';
 import { RgwBucketService } from '../../../shared/api/rgw-bucket.service';
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwBucketFormComponent } from './rgw-bucket-form.component';
 
 describe('RgwBucketFormComponent', () => {
@@ -21,13 +22,11 @@ describe('RgwBucketFormComponent', () => {
     }
   }
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwBucketFormComponent],
-      imports: [HttpClientTestingModule, ReactiveFormsModule, RouterTestingModule, SharedModule],
-      providers: [RgwUserService, { provide: RgwBucketService, useClass: MockRgwBucketService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RgwBucketFormComponent],
+    imports: [HttpClientTestingModule, ReactiveFormsModule, RouterTestingModule, SharedModule],
+    providers: [RgwUserService, { provide: RgwBucketService, useClass: MockRgwBucketService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwBucketFormComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ModalModule } from 'ngx-bootstrap';
@@ -7,6 +7,7 @@ import { ModalModule } from 'ngx-bootstrap';
 import { RgwBucketService } from '../../../shared/api/rgw-bucket.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwBucketListComponent } from './rgw-bucket-list.component';
 
 @Component({ selector: 'cd-rgw-bucket-details', template: '' })
@@ -33,13 +34,11 @@ describe('RgwBucketListComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwBucketListComponent, RgwBucketDetailsStubComponent, TableStubComponent],
-      imports: [RouterTestingModule, ModalModule.forRoot()],
-      providers: [{ provide: RgwBucketService, useValue: fakeRgwBucketService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RgwBucketListComponent, RgwBucketDetailsStubComponent, TableStubComponent],
+    imports: [RouterTestingModule, ModalModule.forRoot()],
+    providers: [{ provide: RgwBucketService, useValue: fakeRgwBucketService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwBucketListComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
@@ -1,10 +1,11 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { RgwDaemonService } from '../../../shared/api/rgw-daemon.service';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { PerformanceCounterModule } from '../../performance-counter/performance-counter.module';
 import { RgwDaemonDetailsComponent } from './rgw-daemon-details.component';
 
@@ -20,13 +21,11 @@ describe('RgwDaemonDetailsComponent', () => {
     }
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwDaemonDetailsComponent],
-      imports: [SharedModule, PerformanceCounterModule, TabsModule.forRoot()],
-      providers: [{ provide: RgwDaemonService, useValue: fakeRgwDaemonService }]
-    });
-  }));
+  configureTestBed({
+    declarations: [RgwDaemonDetailsComponent],
+    imports: [SharedModule, PerformanceCounterModule, TabsModule.forRoot()],
+    providers: [{ provide: RgwDaemonService, useValue: fakeRgwDaemonService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwDaemonDetailsComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
@@ -1,9 +1,10 @@
 import { HttpClientModule } from '@angular/common/http';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { PerformanceCounterModule } from '../../performance-counter/performance-counter.module';
 import { RgwDaemonDetailsComponent } from '../rgw-daemon-details/rgw-daemon-details.component';
 import { RgwDaemonListComponent } from './rgw-daemon-list.component';
@@ -12,12 +13,10 @@ describe('RgwDaemonListComponent', () => {
   let component: RgwDaemonListComponent;
   let fixture: ComponentFixture<RgwDaemonListComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwDaemonListComponent, RgwDaemonDetailsComponent],
-      imports: [HttpClientModule, TabsModule.forRoot(), PerformanceCounterModule, SharedModule]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RgwDaemonListComponent, RgwDaemonDetailsComponent],
+    imports: [HttpClientModule, TabsModule.forRoot(), PerformanceCounterModule, SharedModule]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwDaemonListComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.spec.ts
@@ -1,22 +1,21 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserCapabilityModalComponent } from './rgw-user-capability-modal.component';
 
 describe('RgwUserCapabilityModalComponent', () => {
   let component: RgwUserCapabilityModalComponent;
   let fixture: ComponentFixture<RgwUserCapabilityModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwUserCapabilityModalComponent],
-      imports: [ReactiveFormsModule, SharedModule],
-      providers: [BsModalRef]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RgwUserCapabilityModalComponent],
+    imports: [ReactiveFormsModule, SharedModule],
+    providers: [BsModalRef]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwUserCapabilityModalComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
@@ -1,25 +1,24 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserDetailsComponent } from './rgw-user-details.component';
 
 describe('RgwUserDetailsComponent', () => {
   let component: RgwUserDetailsComponent;
   let fixture: ComponentFixture<RgwUserDetailsComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwUserDetailsComponent],
-      imports: [HttpClientTestingModule, HttpClientModule, SharedModule, TabsModule.forRoot()],
-      providers: [BsModalService]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RgwUserDetailsComponent],
+    imports: [HttpClientTestingModule, HttpClientModule, SharedModule, TabsModule.forRoot()],
+    providers: [BsModalService]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwUserDetailsComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -1,5 +1,5 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -8,6 +8,7 @@ import { of as observableOf } from 'rxjs';
 
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserFormComponent } from './rgw-user-form.component';
 
 describe('RgwUserFormComponent', () => {
@@ -21,13 +22,19 @@ describe('RgwUserFormComponent', () => {
     }
   }
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwUserFormComponent],
-      imports: [HttpClientTestingModule, ReactiveFormsModule, RouterTestingModule, SharedModule],
-      providers: [BsModalService, { provide: RgwUserService, useClass: MockRgwUserService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [ RgwUserFormComponent ],
+    imports: [
+      HttpClientTestingModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      SharedModule
+    ],
+    providers: [
+      BsModalService,
+      { provide: RgwUserService, useClass: MockRgwUserService }
+    ]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwUserFormComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.spec.ts
@@ -1,10 +1,11 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsModalService } from 'ngx-bootstrap';
 
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserListComponent } from './rgw-user-list.component';
 
 describe('RgwUserListComponent', () => {
@@ -13,17 +14,15 @@ describe('RgwUserListComponent', () => {
 
   const fakeService = {};
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwUserListComponent],
-      imports: [RouterTestingModule],
-      providers: [
-        { provide: RgwUserService, useValue: fakeService },
-        { provide: BsModalService, useValue: fakeService }
-      ],
-      schemas: [NO_ERRORS_SCHEMA]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RgwUserListComponent],
+    imports: [RouterTestingModule],
+    providers: [
+      { provide: RgwUserService, useValue: fakeService },
+      { provide: BsModalService, useValue: fakeService }
+    ],
+    schemas: [NO_ERRORS_SCHEMA]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwUserListComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.spec.ts
@@ -1,22 +1,21 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserS3KeyModalComponent } from './rgw-user-s3-key-modal.component';
 
 describe('RgwUserS3KeyModalComponent', () => {
   let component: RgwUserS3KeyModalComponent;
   let fixture: ComponentFixture<RgwUserS3KeyModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwUserS3KeyModalComponent],
-      imports: [ReactiveFormsModule, SharedModule],
-      providers: [BsModalRef]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RgwUserS3KeyModalComponent],
+    imports: [ReactiveFormsModule, SharedModule],
+    providers: [BsModalRef]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwUserS3KeyModalComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.spec.ts
@@ -1,22 +1,24 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserSubuserModalComponent } from './rgw-user-subuser-modal.component';
 
 describe('RgwUserSubuserModalComponent', () => {
   let component: RgwUserSubuserModalComponent;
   let fixture: ComponentFixture<RgwUserSubuserModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwUserSubuserModalComponent],
-      imports: [ReactiveFormsModule, SharedModule],
-      providers: [BsModalRef]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [ RgwUserSubuserModalComponent ],
+    imports: [
+      ReactiveFormsModule,
+      SharedModule
+    ],
+    providers: [ BsModalRef ]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwUserSubuserModalComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.spec.ts
@@ -1,21 +1,20 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserSwiftKeyModalComponent } from './rgw-user-swift-key-modal.component';
 
 describe('RgwUserSwiftKeyModalComponent', () => {
   let component: RgwUserSwiftKeyModalComponent;
   let fixture: ComponentFixture<RgwUserSwiftKeyModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [RgwUserSwiftKeyModalComponent],
-      imports: [FormsModule],
-      providers: [BsModalRef]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [RgwUserSwiftKeyModalComponent],
+    imports: [FormsModule],
+    providers: [BsModalRef]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RgwUserSwiftKeyModalComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
@@ -1,9 +1,10 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthService } from '../../../shared/api/auth.service';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { LoginComponent } from './login.component';
 
 describe('LoginComponent', () => {
@@ -12,13 +13,11 @@ describe('LoginComponent', () => {
 
   const fakeService = {};
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [FormsModule, RouterTestingModule],
-      declarations: [LoginComponent],
-      providers: [{ provide: AuthService, useValue: fakeService }, AuthStorageService]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [FormsModule, RouterTestingModule],
+    declarations: [LoginComponent],
+    providers: [{ provide: AuthService, useValue: fakeService }, AuthStorageService]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoginComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/logout/logout.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/logout/logout.component.spec.ts
@@ -1,7 +1,8 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { AuthService } from '../../../shared/api/auth.service';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { LogoutComponent } from './logout.component';
 
 describe('LogoutComponent', () => {
@@ -10,13 +11,11 @@ describe('LogoutComponent', () => {
 
   const fakeService = {};
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      declarations: [LogoutComponent],
-      providers: [{ provide: AuthService, useValue: fakeService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [RouterTestingModule],
+    declarations: [LogoutComponent],
+    providers: [{ provide: AuthService, useValue: fakeService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LogoutComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
@@ -1,11 +1,12 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { CollapseModule, PopoverModule } from 'ngx-bootstrap';
 
 import { NotificationService } from '../../../shared/services/notification.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { LogoutComponent } from '../../auth/logout/logout.component';
 import { NotificationsComponent } from '../notifications/notifications.component';
 import { TaskManagerComponent } from '../task-manager/task-manager.component';
@@ -17,24 +18,22 @@ describe('NavigationComponent', () => {
 
   const fakeService = new NotificationService(null, null);
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        SharedModule,
-        RouterTestingModule,
-        HttpClientTestingModule,
-        CollapseModule.forRoot(),
-        PopoverModule.forRoot()
-      ],
-      declarations: [
-        NavigationComponent,
-        NotificationsComponent,
-        LogoutComponent,
-        TaskManagerComponent
-      ],
-      providers: [{ provide: NotificationService, useValue: fakeService }]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    imports: [
+      SharedModule,
+      RouterTestingModule,
+      HttpClientTestingModule,
+      CollapseModule.forRoot(),
+      PopoverModule.forRoot()
+    ],
+    declarations: [
+      NavigationComponent,
+      NotificationsComponent,
+      LogoutComponent,
+      TaskManagerComponent
+    ],
+    providers: [{ provide: NotificationService, useValue: fakeService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NavigationComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
@@ -1,9 +1,10 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverModule } from 'ngx-bootstrap/popover';
 
 import { NotificationService } from '../../../shared/services/notification.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { NotificationsComponent } from './notifications.component';
 
 describe('NotificationsComponent', () => {
@@ -12,15 +13,11 @@ describe('NotificationsComponent', () => {
 
   const fakeService = new NotificationService(null, null);
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        imports: [PopoverModule.forRoot(), SharedModule],
-        declarations: [NotificationsComponent],
-        providers: [{ provide: NotificationService, useValue: fakeService }]
-      }).compileComponents();
-    })
-  );
+  configureTestBed({
+    imports: [PopoverModule.forRoot(), SharedModule],
+    declarations: [NotificationsComponent],
+    providers: [{ provide: NotificationService, useValue: fakeService }]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NotificationsComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
@@ -1,26 +1,20 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverModule } from 'ngx-bootstrap';
 
 import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
 import { TaskManagerComponent } from './task-manager.component';
 
 describe('TaskManagerComponent', () => {
   let component: TaskManagerComponent;
   let fixture: ComponentFixture<TaskManagerComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        SharedModule,
-        PopoverModule.forRoot(),
-        HttpClientTestingModule
-      ],
-      declarations: [ TaskManagerComponent ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    imports: [SharedModule, PopoverModule.forRoot(), HttpClientTestingModule],
+    declarations: [TaskManagerComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TaskManagerComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/not-found/not-found.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/not-found/not-found.component.spec.ts
@@ -1,17 +1,15 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../shared/unit-test-helper';
 import { NotFoundComponent } from './not-found.component';
 
 describe('NotFoundComponent', () => {
   let component: NotFoundComponent;
   let fixture: ComponentFixture<NotFoundComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ NotFoundComponent ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    declarations: [NotFoundComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(NotFoundComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -1,14 +1,13 @@
 import { HttpClientModule } from '@angular/common/http';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { CephfsService } from './cephfs.service';
 
 describe('CephfsService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [HttpClientModule],
-      providers: [CephfsService]
-    });
+  configureTestBed({
+    imports: [HttpClientModule],
+    providers: [CephfsService]
   });
 
   it(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
@@ -1,15 +1,14 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { ConfigurationService } from './configuration.service';
 
 describe('ConfigurationService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [ConfigurationService],
-      imports: [HttpClientTestingModule, HttpClientModule]
-    });
+  configureTestBed({
+    providers: [ConfigurationService],
+    imports: [HttpClientTestingModule, HttpClientModule]
   });
 
   it(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/dashboard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/dashboard.service.spec.ts
@@ -1,15 +1,14 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { DashboardService } from './dashboard.service';
 
 describe('DashboardService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [DashboardService],
-      imports: [HttpClientTestingModule, HttpClientModule]
-    });
+  configureTestBed({
+    providers: [DashboardService],
+    imports: [HttpClientTestingModule, HttpClientModule]
   });
 
   it(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/monitor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/monitor.service.spec.ts
@@ -1,15 +1,14 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { MonitorService } from './monitor.service';
 
 describe('MonitorService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [MonitorService],
-      imports: [HttpClientTestingModule, HttpClientModule]
-    });
+  configureTestBed({
+    providers: [MonitorService],
+    imports: [HttpClientTestingModule, HttpClientModule]
   });
 
   it(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
@@ -1,19 +1,19 @@
 import { HttpClientModule } from '@angular/common/http';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { OsdService } from './osd.service';
 
 describe('OsdService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [OsdService],
-      imports: [
-        HttpClientModule,
-      ],
-    });
+  configureTestBed({
+    providers: [OsdService],
+    imports: [HttpClientModule]
   });
 
-  it('should be created', inject([OsdService], (service: OsdService) => {
-    expect(service).toBeTruthy();
-  }));
+  it(
+    'should be created',
+    inject([OsdService], (service: OsdService) => {
+      expect(service).toBeTruthy();
+    })
+  );
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.spec.ts
@@ -1,21 +1,16 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../unit-test-helper';
 import { PerformanceCounterService } from './performance-counter.service';
 
 describe('PerformanceCounterService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [PerformanceCounterService],
-      imports: [
-        HttpClientTestingModule,
-        BsDropdownModule.forRoot(),
-        HttpClientModule
-      ]
-    });
+  configureTestBed({
+    providers: [PerformanceCounterService],
+    imports: [HttpClientTestingModule, BsDropdownModule.forRoot(), HttpClientModule]
   });
 
   it(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
@@ -1,15 +1,14 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { RbdMirroringService } from './rbd-mirroring.service';
 
 describe('RbdMirroringService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [RbdMirroringService],
-      imports: [HttpClientTestingModule, HttpClientModule]
-    });
+  configureTestBed({
+    providers: [RbdMirroringService],
+    imports: [HttpClientTestingModule, HttpClientModule]
   });
 
   it(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
@@ -1,15 +1,14 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { RgwBucketService } from './rgw-bucket.service';
 
 describe('RgwBucketService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [RgwBucketService],
-      imports: [HttpClientTestingModule, HttpClientModule]
-    });
+  configureTestBed({
+    providers: [RgwBucketService],
+    imports: [HttpClientTestingModule, HttpClientModule]
   });
 
   it(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
@@ -1,15 +1,14 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { RgwDaemonService } from './rgw-daemon.service';
 
 describe('RgwDaemonService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [RgwDaemonService],
-      imports: [HttpClientTestingModule, HttpClientModule]
-    });
+  configureTestBed({
+    providers: [RgwDaemonService],
+    imports: [HttpClientTestingModule, HttpClientModule]
   });
 
   it(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
@@ -1,15 +1,14 @@
 import { HttpClientModule } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { inject, TestBed } from '@angular/core/testing';
+import { inject } from '@angular/core/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { RgwUserService } from './rgw-user.service';
 
 describe('RgwUserService', () => {
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [RgwUserService],
-      imports: [HttpClientTestingModule, HttpClientModule]
-    });
+  configureTestBed({
+    providers: [RgwUserService],
+    imports: [HttpClientTestingModule, HttpClientModule]
   });
 
   it(

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.spec.ts
@@ -1,10 +1,11 @@
 import { Component, NgModule, NO_ERRORS_SCHEMA, TemplateRef, ViewChild } from '@angular/core';
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 
 import { BsModalRef, BsModalService, ModalModule } from 'ngx-bootstrap';
 import { Observable, Subscriber, timer as observableTimer } from 'rxjs';
 
+import { configureTestBed } from '../../unit-test-helper';
 import { DeletionModalComponent } from './deletion-modal.component';
 
 @NgModule({
@@ -96,13 +97,11 @@ describe('DeletionModalComponent', () => {
   let mockFixture: ComponentFixture<MockComponent>;
   let fixture: ComponentFixture<DeletionModalComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [MockComponent, DeletionModalComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      imports: [ModalModule.forRoot(), ReactiveFormsModule, MockModule]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [MockComponent, DeletionModalComponent],
+    schemas: [NO_ERRORS_SCHEMA],
+    imports: [ModalModule.forRoot(), ReactiveFormsModule, MockModule]
+  });
 
   beforeEach(() => {
     mockFixture = TestBed.createComponent(MockComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.spec.ts
@@ -1,20 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../unit-test-helper';
 import { ErrorPanelComponent } from './error-panel.component';
 
 describe('ErrorPanelComponent', () => {
   let component: ErrorPanelComponent;
   let fixture: ComponentFixture<ErrorPanelComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ErrorPanelComponent ],
-      imports: [ AlertModule.forRoot() ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    declarations: [ErrorPanelComponent],
+    imports: [AlertModule.forRoot()]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ErrorPanelComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.spec.ts
@@ -1,20 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../unit-test-helper';
 import { HelperComponent } from './helper.component';
 
 describe('HelperComponent', () => {
   let component: HelperComponent;
   let fixture: ComponentFixture<HelperComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [ PopoverModule.forRoot() ],
-      declarations: [ HelperComponent ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    imports: [PopoverModule.forRoot()],
+    declarations: [HelperComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(HelperComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/info-panel/info-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/info-panel/info-panel.component.spec.ts
@@ -1,20 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../unit-test-helper';
 import { InfoPanelComponent } from './info-panel.component';
 
 describe('InfoPanelComponent', () => {
   let component: InfoPanelComponent;
   let fixture: ComponentFixture<InfoPanelComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ InfoPanelComponent ],
-      imports: [ AlertModule.forRoot() ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    declarations: [InfoPanelComponent],
+    imports: [AlertModule.forRoot()]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(InfoPanelComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/loading-panel/loading-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/loading-panel/loading-panel.component.spec.ts
@@ -1,20 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../unit-test-helper';
 import { LoadingPanelComponent } from './loading-panel.component';
 
 describe('LoadingPanelComponent', () => {
   let component: LoadingPanelComponent;
   let fixture: ComponentFixture<LoadingPanelComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ LoadingPanelComponent ],
-      imports: [ AlertModule.forRoot() ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    declarations: [LoadingPanelComponent],
+    imports: [AlertModule.forRoot()]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoadingPanelComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.spec.ts
@@ -1,21 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ModalModule } from 'ngx-bootstrap/modal';
 
+import { configureTestBed } from '../../unit-test-helper';
 import { ModalComponent } from './modal.component';
 
 describe('ModalComponent', () => {
   let component: ModalComponent;
   let fixture: ComponentFixture<ModalComponent>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        imports: [ModalModule.forRoot()],
-        declarations: [ModalComponent]
-      }).compileComponents();
-    })
-  );
+  configureTestBed({
+    imports: [ModalModule.forRoot()],
+    declarations: [ModalComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ModalComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sparkline/sparkline.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sparkline/sparkline.component.spec.ts
@@ -1,19 +1,18 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../unit-test-helper';
 import { SparklineComponent } from './sparkline.component';
 
 describe('SparklineComponent', () => {
   let component: SparklineComponent;
   let fixture: ComponentFixture<SparklineComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [SparklineComponent],
-      schemas: [NO_ERRORS_SCHEMA],
-      imports: []
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [SparklineComponent],
+    schemas: [NO_ERRORS_SCHEMA],
+    imports: []
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SparklineComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.spec.ts
@@ -1,19 +1,16 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormGroup } from '@angular/forms';
 
+import { configureTestBed } from '../../unit-test-helper';
 import { SubmitButtonComponent } from './submit-button.component';
 
 describe('SubmitButtonComponent', () => {
   let component: SubmitButtonComponent;
   let fixture: ComponentFixture<SubmitButtonComponent>;
 
-  beforeEach(
-    async(() => {
-      TestBed.configureTestingModule({
-        declarations: [SubmitButtonComponent]
-      }).compileComponents();
-    })
-  );
+  configureTestBed({
+    declarations: [SubmitButtonComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(SubmitButtonComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.spec.ts
@@ -1,26 +1,20 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TooltipModule } from 'ngx-bootstrap';
 
 import { PipesModule } from '../../pipes/pipes.module';
 import { ServicesModule } from '../../services/services.module';
+import { configureTestBed } from '../../unit-test-helper';
 import { UsageBarComponent } from './usage-bar.component';
 
 describe('UsageBarComponent', () => {
   let component: UsageBarComponent;
   let fixture: ComponentFixture<UsageBarComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      imports: [
-        PipesModule,
-        ServicesModule,
-        TooltipModule.forRoot()
-      ],
-      declarations: [ UsageBarComponent ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    imports: [PipesModule, ServicesModule, TooltipModule.forRoot()],
+    declarations: [UsageBarComponent]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UsageBarComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.spec.ts
@@ -1,20 +1,18 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../unit-test-helper';
 import { ViewCacheComponent } from './view-cache.component';
 
 describe('ViewCacheComponent', () => {
   let component: ViewCacheComponent;
   let fixture: ComponentFixture<ViewCacheComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ ViewCacheComponent ],
-      imports: [AlertModule.forRoot()]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    declarations: [ViewCacheComponent],
+    imports: [AlertModule.forRoot()]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(ViewCacheComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
@@ -1,10 +1,11 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 
 import { ComponentsModule } from '../../components/components.module';
+import { configureTestBed } from '../../unit-test-helper';
 import { TableComponent } from '../table/table.component';
 import { TableKeyValueComponent } from './table-key-value.component';
 
@@ -12,13 +13,10 @@ describe('TableKeyValueComponent', () => {
   let component: TableKeyValueComponent;
   let fixture: ComponentFixture<TableKeyValueComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ TableComponent, TableKeyValueComponent ],
-      imports: [ FormsModule, NgxDatatableModule, ComponentsModule, RouterTestingModule ]
-    })
-    .compileComponents();
-  }));
+  configureTestBed({
+    declarations: [TableComponent, TableKeyValueComponent],
+    imports: [FormsModule, NgxDatatableModule, ComponentsModule, RouterTestingModule]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TableKeyValueComponent);
@@ -35,10 +33,7 @@ describe('TableKeyValueComponent', () => {
   });
 
   it('should make key value object pairs out of arrays with length two', () => {
-    component.data = [
-      ['someKey', 0],
-      [3, 'something'],
-    ];
+    component.data = [['someKey', 0], [3, 'something']];
     component.ngOnInit();
     expect(component.tableData.length).toBe(2);
     expect(component.tableData[0].key).toBe('someKey');
@@ -46,10 +41,7 @@ describe('TableKeyValueComponent', () => {
   });
 
   it('should transform arrays', () => {
-    component.data = [
-      ['someKey', [1, 2, 3]],
-      [3, 'something']
-    ];
+    component.data = [['someKey', [1, 2, 3]], [3, 'something']];
     component.ngOnInit();
     expect(component.tableData.length).toBe(2);
     expect(component.tableData[0].key).toBe('someKey');
@@ -58,10 +50,7 @@ describe('TableKeyValueComponent', () => {
   });
 
   it('should remove pure object values', () => {
-    component.data = [
-      [3, 'something'],
-      ['will be removed', { a: 3, b: 4, c: 5}]
-    ];
+    component.data = [[3, 'something'], ['will be removed', { a: 3, b: 4, c: 5 }]];
     component.ngOnInit();
     expect(component.tableData.length).toBe(1);
     expect(component.tableData[0].value).toBe('something');
@@ -100,40 +89,45 @@ describe('TableKeyValueComponent', () => {
     expect(() => component.ngOnInit()).toThrowError('Wrong data format');
     component.data = [['someKey', 0, 3]];
     expect(() => component.ngOnInit()).toThrowError('Wrong array format: [string, any][]');
-    component.data = [{somekey: 939, somethingElse: 'test'}];
-    expect(() => component.ngOnInit())
-      .toThrowError('Wrong object array format: {key: string, value: any}[]');
+    component.data = [{ somekey: 939, somethingElse: 'test' }];
+    expect(() => component.ngOnInit()).toThrowError(
+      'Wrong object array format: {key: string, value: any}[]'
+    );
   });
 
   it('tests _makePairs', () => {
-    expect(component._makePairs([['dash', 'board']])).toEqual([{key: 'dash', value: 'board'}]);
-    const pair = [{key: 'dash', value: 'board'}, {key: 'ceph', value: 'mimic'}];
+    expect(component._makePairs([['dash', 'board']])).toEqual([{ key: 'dash', value: 'board' }]);
+    const pair = [{ key: 'dash', value: 'board' }, { key: 'ceph', value: 'mimic' }];
     expect(component._makePairs(pair)).toEqual(pair);
-    expect(component._makePairs({dash: 'board'})).toEqual([{key: 'dash', value: 'board'}]);
-    expect(component._makePairs({dash: 'board', ceph: 'mimic'})).toEqual(pair);
+    expect(component._makePairs({ dash: 'board' })).toEqual([{ key: 'dash', value: 'board' }]);
+    expect(component._makePairs({ dash: 'board', ceph: 'mimic' })).toEqual(pair);
   });
 
   it('tests _makePairsFromArray', () => {
-    expect(component._makePairsFromArray([['dash', 'board']]))
-      .toEqual([{key: 'dash', value: 'board'}]);
-    const pair = [{key: 'dash', value: 'board'}, {key: 'ceph', value: 'mimic'}];
+    expect(component._makePairsFromArray([['dash', 'board']])).toEqual([
+      { key: 'dash', value: 'board' }
+    ]);
+    const pair = [{ key: 'dash', value: 'board' }, { key: 'ceph', value: 'mimic' }];
     expect(component._makePairsFromArray(pair)).toEqual(pair);
   });
 
   it('tests _makePairsFromObject', () => {
-    expect(component._makePairsFromObject({dash: 'board'}))
-      .toEqual([{key: 'dash', value: 'board'}]);
-    expect(component._makePairsFromObject({dash: 'board', ceph: 'mimic'}))
-      .toEqual([{key: 'dash', value: 'board'}, {key: 'ceph', value: 'mimic'}]);
+    expect(component._makePairsFromObject({ dash: 'board' })).toEqual([
+      { key: 'dash', value: 'board' }
+    ]);
+    expect(component._makePairsFromObject({ dash: 'board', ceph: 'mimic' })).toEqual([
+      { key: 'dash', value: 'board' },
+      { key: 'ceph', value: 'mimic' }
+    ]);
   });
 
   it('tests _convertValue', () => {
-    const v = value => ({key: 'sth', value: value});
+    const v = (value) => ({ key: 'sth', value: value });
     expect(component._convertValue(v('something'))).toEqual(v('something'));
     expect(component._convertValue(v([1, 2, 3]))).toEqual(v('1, 2, 3'));
-    expect(component._convertValue(v({sth: 'something'}))).toBe(undefined);
+    expect(component._convertValue(v({ sth: 'something' }))).toBe(undefined);
     component.renderObjects = true;
-    expect(component._convertValue(v({sth: 'something'}))).toEqual(v({sth: 'something'}));
+    expect(component._convertValue(v({ sth: 'something' }))).toEqual(v({ sth: 'something' }));
   });
 
   it('tests _insertFlattenObjects', () => {
@@ -155,10 +149,10 @@ describe('TableKeyValueComponent', () => {
       }
     ];
     expect(component._insertFlattenObjects(v)).toEqual([
-      {key: 'no', value: 'change'},
-      {key: 'first second l3_1', value: 33},
-      {key: 'first second l3_2', value: 44},
-      {key: 'first layer', value: 'something'}
+      { key: 'no', value: 'change' },
+      { key: 'first second l3_1', value: 33 },
+      { key: 'first second l3_2', value: 44 },
+      { key: 'first layer', value: 'something' }
     ]);
   });
 
@@ -168,7 +162,7 @@ describe('TableKeyValueComponent', () => {
         options: {
           someSetting1: 38,
           anotherSetting2: 'somethingElse',
-          suboptions : {
+          suboptions: {
             sub1: 12,
             sub2: 34,
             sub3: 56
@@ -182,12 +176,12 @@ describe('TableKeyValueComponent', () => {
     it('with parent key', () => {
       component.ngOnInit();
       expect(component.tableData).toEqual([
-        {key: 'options someSetting1', value: 38},
-        {key: 'options anotherSetting2', value: 'somethingElse'},
-        {key: 'options suboptions sub1', value: 12},
-        {key: 'options suboptions sub2', value: 34},
-        {key: 'options suboptions sub3', value: 56},
-        {key: 'someKey', value: 0}
+        { key: 'options someSetting1', value: 38 },
+        { key: 'options anotherSetting2', value: 'somethingElse' },
+        { key: 'options suboptions sub1', value: 12 },
+        { key: 'options suboptions sub2', value: 34 },
+        { key: 'options suboptions sub3', value: 56 },
+        { key: 'someKey', value: 0 }
       ]);
     });
 
@@ -195,12 +189,12 @@ describe('TableKeyValueComponent', () => {
       component.appendParentKey = false;
       component.ngOnInit();
       expect(component.tableData).toEqual([
-        {key: 'someSetting1', value: 38},
-        {key: 'anotherSetting2', value: 'somethingElse'},
-        {key: 'sub1', value: 12},
-        {key: 'sub2', value: 34},
-        {key: 'sub3', value: 56},
-        {key: 'someKey', value: 0}
+        { key: 'someSetting1', value: 38 },
+        { key: 'anotherSetting2', value: 'somethingElse' },
+        { key: 'sub1', value: 12 },
+        { key: 'sub2', value: 34 },
+        { key: 'sub3', value: 56 },
+        { key: 'someKey', value: 0 }
       ]);
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -1,10 +1,11 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 
 import { ComponentsModule } from '../../components/components.module';
+import { configureTestBed } from '../../unit-test-helper';
 import { TableComponent } from './table.component';
 
 describe('TableComponent', () => {
@@ -28,12 +29,10 @@ describe('TableComponent', () => {
     component.localStorage.clear();
   };
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [TableComponent],
-      imports: [NgxDatatableModule, FormsModule, ComponentsModule, RouterTestingModule]
-    }).compileComponents();
-  }));
+  configureTestBed({
+    declarations: [TableComponent],
+    imports: [NgxDatatableModule, FormsModule, ComponentsModule, RouterTestingModule]
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(TableComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
@@ -3,14 +3,15 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { configureTestBed } from '../unit-test-helper';
 import { AuthGuardService } from './auth-guard.service';
 import { AuthStorageService } from './auth-storage.service';
 
 describe('AuthGuardService', () => {
   let service: AuthGuardService;
 
-  @Component({selector: 'cd-login', template: ''})
-  class LoginComponent { }
+  @Component({ selector: 'cd-login', template: '' })
+  class LoginComponent {}
 
   const routes: Routes = [{ path: 'login', component: LoginComponent }];
 
@@ -18,13 +19,13 @@ describe('AuthGuardService', () => {
     isLoggedIn: () => true
   };
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes(routes)],
-      providers: [AuthGuardService, { provide: AuthStorageService, useValue: fakeService }],
-      declarations: [LoginComponent]
-    });
+  configureTestBed({
+    imports: [RouterTestingModule.withRoutes(routes)],
+    providers: [AuthGuardService, { provide: AuthStorageService, useValue: fakeService }],
+    declarations: [LoginComponent]
+  });
 
+  beforeEach(() => {
     service = TestBed.get(AuthGuardService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
@@ -1,7 +1,6 @@
-import { TestBed } from '@angular/core/testing';
-
 import { DimlessBinaryPipe } from '../pipes/dimless-binary.pipe';
 import { DimlessPipe } from '../pipes/dimless.pipe';
+import { configureTestBed } from '../unit-test-helper';
 import { FormatterService } from './formatter.service';
 
 describe('FormatterService', () => {
@@ -13,10 +12,11 @@ describe('FormatterService', () => {
     expect(dimlessBinaryPipe.transform(service.toBytes(value))).toBe(newValue || value);
   };
 
+  configureTestBed({
+    providers: [FormatterService, DimlessBinaryPipe]
+  });
+
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [FormatterService, DimlessBinaryPipe]
-    });
     service = new FormatterService();
     dimlessBinaryPipe = new DimlessBinaryPipe(service);
     dimlessPipe = new DimlessPipe(service);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { of as observableOf } from 'rxjs';
 
+import { configureTestBed } from '../unit-test-helper';
 import { ModuleStatusGuardService } from './module-status-guard.service';
 
 describe('ModuleStatusGuardService', () => {
@@ -20,13 +21,13 @@ describe('ModuleStatusGuardService', () => {
 
   const routes: Routes = [{ path: '**', component: FooComponent }];
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes(routes)],
-      providers: [ModuleStatusGuardService, { provide: HttpClient, useValue: fakeService }],
-      declarations: [FooComponent]
-    });
+  configureTestBed({
+    imports: [RouterTestingModule.withRoutes(routes)],
+    providers: [ModuleStatusGuardService, { provide: HttpClient, useValue: fakeService }],
+    declarations: [FooComponent]
+  }, true);
 
+  beforeEach(() => {
     service = TestBed.get(ModuleStatusGuardService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
@@ -5,6 +5,7 @@ import { ToastsManager } from 'ng2-toastr';
 
 import { NotificationType } from '../enum/notification-type.enum';
 import { FinishedTask } from '../models/finished-task';
+import { configureTestBed } from '../unit-test-helper';
 import { NotificationService } from './notification.service';
 import { TaskManagerMessageService } from './task-manager-message.service';
 
@@ -21,15 +22,15 @@ describe('NotificationService', () => {
     getSuccessMessage: () => true
   };
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        NotificationService,
-        { provide: TaskManagerMessageService, useValue: fakeService },
-        { provide: ToastsManager, useValue: fakeService }
-      ]
-    });
+  configureTestBed({
+    providers: [
+      NotificationService,
+      { provide: TaskManagerMessageService, useValue: fakeService },
+      { provide: ToastsManager, useValue: fakeService }
+    ]
+  });
 
+  beforeEach(() => {
     notificationService = TestBed.get(NotificationService);
     notificationService.removeAll();
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -3,6 +3,7 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { of as observableOf } from 'rxjs';
 
+import { configureTestBed } from '../unit-test-helper';
 import { AuthStorageService } from './auth-storage.service';
 import { SummaryService } from './summary.service';
 
@@ -24,15 +25,15 @@ describe('SummaryService', () => {
       })
   };
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [
-        SummaryService,
-        AuthStorageService,
-        { provide: HttpClient, useValue: httpClientSpy }
-      ]
-    });
+  configureTestBed({
+    providers: [
+      SummaryService,
+      AuthStorageService,
+      { provide: HttpClient, useValue: httpClientSpy }
+    ]
+  });
 
+  beforeEach(() => {
     summaryService = TestBed.get(SummaryService);
     authStorageService = TestBed.get(AuthStorageService);
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.spec.ts
@@ -3,6 +3,7 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import * as _ from 'lodash';
 import { Subject } from 'rxjs';
 
+import { configureTestBed } from '../unit-test-helper';
 import { SummaryService } from './summary.service';
 import { TaskManagerService } from './task-manager.service';
 
@@ -25,11 +26,11 @@ describe('TaskManagerService', () => {
     filesystems: [{ id: 1, name: 'cephfs_a' }]
   };
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [TaskManagerService, { provide: SummaryService, useValue: fakeService }]
-    });
+  configureTestBed({
+    providers: [TaskManagerService, { provide: SummaryService, useValue: fakeService }]
+  });
 
+  beforeEach(() => {
     taskManagerService = TestBed.get(TaskManagerService);
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/unit-test-helper.ts
@@ -1,0 +1,25 @@
+import { async, TestBed } from '@angular/core/testing';
+
+import { _DEV_ } from '../../unit-test-configuration';
+
+export function configureTestBed(configuration, useOldMethod?) {
+  if (_DEV_ && !useOldMethod) {
+    const resetTestingModule = TestBed.resetTestingModule;
+    beforeAll((done) =>
+      (async () => {
+        TestBed.resetTestingModule();
+        TestBed.configureTestingModule(configuration);
+        // prevent Angular from resetting testing module
+        TestBed.resetTestingModule = () => TestBed;
+      })()
+        .then(done)
+        .catch(done.fail));
+    afterAll(() => {
+      TestBed.resetTestingModule = resetTestingModule;
+    });
+  } else {
+    beforeEach(async(() => {
+      TestBed.configureTestingModule(configuration);
+    }));
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/tsconfig.app.json
+++ b/src/pybind/mgr/dashboard/frontend/src/tsconfig.app.json
@@ -7,6 +7,7 @@
     "types": []
   },
   "exclude": [
+    "app/shared/unit-test-helper.ts",
     "test.ts",
     "**/*.spec.ts"
   ]

--- a/src/pybind/mgr/dashboard/frontend/src/unit-test-configuration.ts.sample
+++ b/src/pybind/mgr/dashboard/frontend/src/unit-test-configuration.ts.sample
@@ -1,0 +1,1 @@
+export const _DEV_ = false;

--- a/src/pybind/mgr/dashboard/run-frontend-unittests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-unittests.sh
@@ -4,10 +4,21 @@ set -e
 
 cd $CEPH_ROOT/src/pybind/mgr/dashboard/frontend
 
+config='src/unit-test-configuration.ts'
+if [ -e $config ]; then
+  mv $config ${config}_old
+fi
+cp ${config}.sample $config
+
 .  $CEPH_ROOT/build/src/pybind/mgr/dashboard/node-env/bin/activate
 
 npm run build -- --prod
 npm run test:ci
 npm run lint
+
+rm $config
+if [ -e ${config}_old ]; then
+  mv ${config}_old $config
+fi
 
 deactivate


### PR DESCRIPTION
With this helper function you can easily resolve the TestBed resetting
performance issue. If more tests exists in a test suite, it makes sense
to configure TestBed only once if you are not doing a lot of TestBed
specific stuff (haven't hit the limitation). It will reduce the test
run time by around $tests * 50 %. In my case it was a test suite with
47 tests with a run time of over 30s after using the static test bed
method it ran in 1.2s. The run time was reduced to 0.04 %! This is
equivalent to a speed increase of 2500% (100/0.04)!

For our own security the normal way will be taken if you not
set the _DEV_ configuration variable to true. It will be false when
"run-frontend-unittests.sh" is run.

Signed-off-by: Stephan Müller <smueller@suse.com>