### PR TITLE
mgr/dashboard: Change font-family of checkbox

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
@@ -1142,3 +1142,10 @@ hr.oa-hr-small {
   padding-left: 4px;
   vertical-align: text-top;
 }
+
+// awesome-bootstrap-checkbox + ForkAwesome
+input[type="checkbox"].styled:checked + label:after,
+input[type="radio"].styled:checked + label:after,
+.checkbox input[type=checkbox]:checked + label:after {
+    font-family: 'ForkAwesome';
+}


### PR DESCRIPTION
awesome-bootstrap-checkbox was still trying to use Font Awesome,
this will force it to use Fork Awesome.

**before:**
![image](https://user-images.githubusercontent.com/399326/39539715-5658d678-4e38-11e8-89ff-4f3960675d74.png)

**after:**
![image](https://user-images.githubusercontent.com/399326/39539685-45583bac-4e38-11e8-88dc-f2fec8031a94.png)

`Signed-off-by: Tiago Melo <tmelo@suse.com>`