### PR TITLE
misc: mark functions with 'override' specifier

### DIFF
--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -48,7 +48,7 @@ namespace ceph {
 
     int create_rule(const std::string &name,
 		    CrushWrapper &crush,
-		    std::ostream *ss) const;
+		    std::ostream *ss) const override;
 
     int sanity_check_k(int k, std::ostream *ss);
 
@@ -56,7 +56,7 @@ namespace ceph {
       return get_chunk_count() - get_data_chunk_count();
     }
 
-    virtual int get_sub_chunk_count() {
+    virtual int get_sub_chunk_count() override {
       return 1;
     }
 

--- a/src/kv/KineticStore.h
+++ b/src/kv/KineticStore.h
@@ -56,7 +56,7 @@ public:
   /// Creates underlying db if missing and opens it
   int create_and_open(ostream &out, const std::vector<ColumnFamily>& = {}) override;
 
-  void close();
+  void close() override;
 
   enum KineticOpType {
     KINETIC_OP_WRITE,
@@ -91,15 +91,15 @@ public:
     void rm_range_keys(
         const string &prefix,
         const string &start,
-        const string &end);
+        const string &end) override;
   };
 
-  KeyValueDB::Transaction get_transaction() {
+  KeyValueDB::Transaction get_transaction() override {
     return std::make_shared<KineticTransactionImpl>(this);
   }
 
-  int submit_transaction(KeyValueDB::Transaction t);
-  int submit_transaction_sync(KeyValueDB::Transaction t);
+  int submit_transaction(KeyValueDB::Transaction t) override;
+  int submit_transaction_sync(KeyValueDB::Transaction t) override;
   int get(
     const string &prefix,
     const std::set<string> &key,
@@ -117,22 +117,22 @@ public:
     explicit KineticWholeSpaceIteratorImpl(kinetic::BlockingKineticConnection *conn);
     virtual ~KineticWholeSpaceIteratorImpl() { }
 
-    int seek_to_first() {
+    int seek_to_first() override {
       return seek_to_first("");
     }
     int seek_to_first(const string &prefix);
-    int seek_to_last();
+    int seek_to_last() override;
     int seek_to_last(const string &prefix);
     int upper_bound(const string &prefix, const string &after);
     int lower_bound(const string &prefix, const string &to);
-    bool valid();
-    int next();
-    int prev();
+    bool valid() override;
+    int next() override;
+    int prev() override;
     string key();
     pair<string,string> raw_key();
     bool raw_key_is_prefixed(const string &prefix);
-    bufferlist value();
-    int status();
+    bufferlist value() override;
+    int status() override;
   };
 
   /// Utility

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1405,13 +1405,13 @@ public:
     dbiter->Seek(slice_bound);
     return dbiter->status().ok() ? 0 : -1;
   }
-  int next(bool validate=true) {
+  int next(bool validate=true) override {
     if (valid()) {
       dbiter->Next();
     }
     return dbiter->status().ok() ? 0 : -1;
   }
-  int prev(bool validate=true) {
+  int prev(bool validate=true) override {
     if (valid()) {
       dbiter->Prev();
     }
@@ -1423,7 +1423,7 @@ public:
   string key() override {
     return dbiter->key().ToString();
   }
-  std::pair<std::string, std::string> raw_key() {
+  std::pair<std::string, std::string> raw_key() override {
     return make_pair(prefix, key());
   }
   bufferlist value() override {

--- a/src/librbd/cache/PassthroughImageCache.h
+++ b/src/librbd/cache/PassthroughImageCache.h
@@ -27,7 +27,7 @@ public:
   void aio_write(Extents&& image_extents, ceph::bufferlist&& bl,
                  int fadvise_flags, Context *on_finish) override;
   void aio_discard(uint64_t offset, uint64_t length,
-                   bool skip_partial_discard, Context *on_finish);
+                   bool skip_partial_discard, Context *on_finish) override;
   void aio_flush(Context *on_finish) override;
   void aio_writesame(uint64_t offset, uint64_t length,
                      ceph::bufferlist&& bl,

--- a/src/msg/async/dpdk/EventDPDK.h
+++ b/src/msg/async/dpdk/EventDPDK.h
@@ -34,7 +34,7 @@ class DPDKDriver : public EventDriver {
   int del_event(int fd, int cur_mask, int del_mask) override;
   int resize_events(int newsize) override;
   int event_wait(vector<FiredFileEvent> &fired_events, struct timeval *tp) override;
-  bool need_wakeup() { return false; }
+  bool need_wakeup() override { return false; }
 };
 
 #endif //CEPH_EVENTDPDK_H

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -268,7 +268,7 @@ class RDMAStack : public NetworkStack {
   explicit RDMAStack(CephContext *cct, const string &t);
   virtual ~RDMAStack();
   virtual bool support_zero_copy_read() const override { return false; }
-  virtual bool nonblock_connect_need_writable_event() const { return false; }
+  virtual bool nonblock_connect_need_writable_event() const override { return false; }
 
   virtual void spawn_worker(unsigned i, std::function<void ()> &&func) override;
   virtual void join_worker(unsigned i) override;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -361,7 +361,7 @@ public:
   const PGLog &get_log() const override {
     return pg_log;
   }
-  void add_local_next_event(const pg_log_entry_t& e) {
+  void add_local_next_event(const pg_log_entry_t& e) override {
     pg_log.missing_add_next_entry(e);
   }
   bool pgb_is_primary() const override {
@@ -1095,7 +1095,7 @@ protected:
 				  PGBackend::RecoveryHandle *h,
 				  bool *work_started);
 
-  void finish_degraded_object(const hobject_t& oid);
+  void finish_degraded_object(const hobject_t& oid) override;
 
   // Cancels/resets pulls from peer
   void check_recovery_sources(const OSDMapRef& map) override ;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2240,7 +2240,7 @@ public:
     delete info;
   }
 
-  string get_marker(void *handle) {
+  string get_marker(void *handle) override {
     list_keys_info *info = static_cast<list_keys_info *>(handle);
     return info->store->list_raw_objs_get_cursor(info->ctx);
   }
@@ -2442,7 +2442,7 @@ public:
     delete info;
   }
 
-  string get_marker(void *handle) {
+  string get_marker(void *handle) override {
     list_keys_info *info = static_cast<list_keys_info *>(handle);
     return info->store->list_raw_objs_get_cursor(info->ctx);
   }

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -459,8 +459,8 @@ class RGWRadosRemoveCR : public RGWSimpleCoroutine {
 public:
   RGWRadosRemoveCR(RGWRados *store, const rgw_raw_obj& obj);
 
-  int send_request();
-  int request_complete();
+  int send_request() override;
+  int request_complete() override;
 };
 
 class RGWSimpleRadosLockCR : public RGWSimpleCoroutine {

--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -436,7 +436,7 @@ public:
   int read(bufferlist *data, uint64_t max, bool *need_retry) override; /* reentrant */
   int decode_rest_obj(map<string, string>& headers, bufferlist& extra_data) override;
   bool has_attrs() override;
-  void get_attrs(std::map<string, string> *attrs);
+  void get_attrs(std::map<string, string> *attrs) override;
   bool is_done();
   virtual bool need_extra_data() { return false; }
 
@@ -532,7 +532,7 @@ public:
                     std::shared_ptr<RGWStreamWriteHTTPResourceCRF>& _out_crf);
   ~RGWStreamSpliceCR();
 
-  int operate();
+  int operate() override;
 };
 
 #endif

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -955,7 +955,7 @@ public:
     return true;
   }
 
-  RGWOrderCallCR *allocate_order_control_cr() {
+  RGWOrderCallCR *allocate_order_control_cr() override {
     return new RGWLastCallerWinsCR(sync_env->cct);
   }
 };
@@ -2456,7 +2456,7 @@ public:
                                           attrs);
   }
 
-  RGWOrderCallCR *allocate_order_control_cr() {
+  RGWOrderCallCR *allocate_order_control_cr() override {
     return new RGWLastCallerWinsCR(sync_env->cct);
   }
 };
@@ -2532,7 +2532,7 @@ public:
     return (key_to_marker.find(key) == key_to_marker.end());
   }
 
-  RGWOrderCallCR *allocate_order_control_cr() {
+  RGWOrderCallCR *allocate_order_control_cr() override {
     return new RGWLastCallerWinsCR(sync_env->cct);
   }
 };

--- a/src/rgw/rgw_es_query.cc
+++ b/src/rgw/rgw_es_query.cc
@@ -148,7 +148,7 @@ public:
     delete second;
   }
 
-  void dump(Formatter *f) const {
+  void dump(Formatter *f) const override {
     f->open_object_section("bool");
     const char *section = (op == "and" ? "must" : "should");
     f->open_array_section(section);
@@ -177,7 +177,7 @@ public:
     val = str_val;
     return true;
   }
-  void encode_json(const string& field, Formatter *f) const {
+  void encode_json(const string& field, Formatter *f) const override {
     ::encode_json(field.c_str(), val.c_str(), f);
   }
 };
@@ -195,7 +195,7 @@ public:
     }
     return true;
   }
-  void encode_json(const string& field, Formatter *f) const {
+  void encode_json(const string& field, Formatter *f) const override {
     ::encode_json(field.c_str(), val, f);
   }
 };
@@ -211,7 +211,7 @@ public:
     }
     return true;
   }
-  void encode_json(const string& field, Formatter *f) const {
+  void encode_json(const string& field, Formatter *f) const override {
     string s;
     rgw_to_iso8601(val, &s);
     ::encode_json(field.c_str(), s, f);
@@ -274,7 +274,7 @@ public:
     allow_restricted = allow;
   }
 
-  virtual void dump(Formatter *f) const = 0;
+  virtual void dump(Formatter *f) const override = 0;
 };
 
 class ESQueryNode_Op_Equal : public ESQueryNode_Op {
@@ -293,7 +293,7 @@ public:
     return do_init(pnode, perr);
   }
 
-  virtual void dump(Formatter *f) const {
+  virtual void dump(Formatter *f) const override {
     f->open_object_section("term");
     val->encode_json(field, f);
     f->close_section();
@@ -305,7 +305,7 @@ class ESQueryNode_Op_Range : public ESQueryNode_Op {
 public:
   ESQueryNode_Op_Range(ESQueryCompiler *compiler, const string& rs) : ESQueryNode_Op(compiler), range_str(rs) {}
 
-  virtual void dump(Formatter *f) const {
+  virtual void dump(Formatter *f) const override {
     f->open_object_section("range");
     f->open_object_section(field.c_str());
     val->encode_json(range_str, f);
@@ -332,7 +332,7 @@ public:
     delete next;
   }
 
-  virtual void dump(Formatter *f) const {
+  virtual void dump(Formatter *f) const override {
     f->open_object_section("nested");
     string s = string("meta.custom-") + type_str();
     encode_json("path", s.c_str(), f);
@@ -353,7 +353,7 @@ public:
   }
 
   string type_str() const;
-  string get_custom_leaf_field_name() {
+  string get_custom_leaf_field_name() override {
     return string("meta.custom-") + type_str() + ".value";
   }
 };

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -355,7 +355,7 @@ public:
   BarbicanTokenRequestVer2(CephContext * const _cct)
     : cct(_cct) {
   }
-  void dump(Formatter *f) const;
+  void dump(Formatter *f) const override;
 };
 
 class BarbicanTokenRequestVer3 : public AdminTokenRequest {
@@ -365,7 +365,7 @@ public:
   BarbicanTokenRequestVer3(CephContext * const _cct)
     : cct(_cct) {
   }
-  void dump(Formatter *f) const;
+  void dump(Formatter *f) const override;
 };
 
 

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -172,7 +172,7 @@ public:
   LCMPExpiration_S3() {}
   ~LCMPExpiration_S3() {}
 
-  bool xml_end(const char *el);
+  bool xml_end(const char *el) override;
   void to_xml(ostream& out) {
     out << "<AbortIncompleteMultipartUpload>" << "<DaysAfterInitiation>" << days << "</DaysAfterInitiation>" << "</AbortIncompleteMultipartUpload>";
   }

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -319,7 +319,7 @@ public:
     delete data;
   }
 
-  virtual string get_marker(void *handle) {
+  virtual string get_marker(void *handle) override {
     iter_data *data = static_cast<iter_data *>(handle);
 
     if (data->iter != data->sections.end()) {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -344,14 +344,14 @@ class RGWGetObjTags : public RGWOp {
   bufferlist tags_bl;
   bool has_tags{false};
  public:
-  int verify_permission();
-  void execute();
-  void pre_exec();
+  int verify_permission() override;
+  void execute() override;
+  void pre_exec() override;
 
   virtual void send_response_data(bufferlist& bl) = 0;
   virtual const string name() noexcept override { return "get_obj_tags"; }
-  virtual uint32_t op_mask() { return RGW_OP_TYPE_READ; }
-  RGWOpType get_type() { return RGW_OP_GET_OBJ_TAGGING; }
+  virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
+  RGWOpType get_type() override { return RGW_OP_GET_OBJ_TAGGING; }
 
 };
 
@@ -359,27 +359,27 @@ class RGWPutObjTags : public RGWOp {
  protected:
   bufferlist tags_bl;
  public:
-  int verify_permission();
-  void execute();
+  int verify_permission() override;
+  void execute() override;
 
-  virtual void send_response() = 0;
+  virtual void send_response() override = 0;
   virtual int get_params() = 0;
-  virtual const string name() { return "put_obj_tags"; }
-  virtual uint32_t op_mask() { return RGW_OP_TYPE_WRITE; }
-  RGWOpType get_type() { return RGW_OP_PUT_OBJ_TAGGING; }
+  virtual const string name() override { return "put_obj_tags"; }
+  virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
+  RGWOpType get_type() override { return RGW_OP_PUT_OBJ_TAGGING; }
 
 };
 
 class RGWDeleteObjTags: public RGWOp {
  public:
-  void pre_exec();
-  int verify_permission();
-  void execute();
+  void pre_exec() override;
+  int verify_permission() override;
+  void execute() override;
 
-  virtual void send_response() = 0;
-  virtual const string name() { return "delete_obj_tags"; }
-  virtual uint32_t op_mask() { return RGW_OP_TYPE_DELETE; }
-  RGWOpType get_type() { return RGW_OP_DELETE_OBJ_TAGGING;}
+  virtual void send_response() override = 0;
+  virtual const string name() override { return "delete_obj_tags"; }
+  virtual uint32_t op_mask() override { return RGW_OP_TYPE_DELETE; }
+  RGWOpType get_type() override { return RGW_OP_DELETE_OBJ_TAGGING;}
 };
 
 class RGWBulkDelete : public RGWOp {
@@ -487,7 +487,7 @@ protected:
   class AlignedStreamGetter;
 
   virtual std::unique_ptr<StreamGetter> create_stream() = 0;
-  virtual void send_response() = 0;
+  virtual void send_response() override = 0;
 
   boost::optional<std::pair<std::string, rgw_obj_key>>
   parse_path(const boost::string_ref& path);
@@ -2097,16 +2097,16 @@ public:
   int check_caps(RGWUserCaps& caps) {
     return caps.check_cap("admin", RGW_CAP_READ);
   }
-  int verify_permission() {
+  int verify_permission() override {
     return check_caps(s->user->caps);
   }
-  void pre_exec();
-  void execute();
+  void pre_exec() override;
+  void execute() override;
 
-  virtual void send_response() = 0;
-  virtual const string name() { return "get_obj_layout"; }
-  virtual RGWOpType get_type() { return RGW_OP_GET_OBJ_LAYOUT; }
-  virtual uint32_t op_mask() { return RGW_OP_TYPE_READ; }
+  virtual void send_response() override = 0;
+  virtual const string name() override { return "get_obj_layout"; }
+  virtual RGWOpType get_type() override { return RGW_OP_GET_OBJ_LAYOUT; }
+  virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
 
 class RGWPutBucketPolicy : public RGWOp {
@@ -2177,26 +2177,26 @@ protected:
 public:
   RGWConfigBucketMetaSearch() {}
 
-  int verify_permission();
-  void pre_exec();
-  void execute();
+  int verify_permission() override;
+  void pre_exec() override;
+  void execute() override;
 
   virtual int get_params() = 0;
-  virtual void send_response() = 0;
-  virtual const string name() { return "config_bucket_meta_search"; }
-  virtual RGWOpType get_type() { return RGW_OP_CONFIG_BUCKET_META_SEARCH; }
-  virtual uint32_t op_mask() { return RGW_OP_TYPE_WRITE; }
+  virtual void send_response() override = 0;
+  virtual const string name() override { return "config_bucket_meta_search"; }
+  virtual RGWOpType get_type() override { return RGW_OP_CONFIG_BUCKET_META_SEARCH; }
+  virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
 
 class RGWGetBucketMetaSearch : public RGWOp {
 public:
   RGWGetBucketMetaSearch() {}
 
-  int verify_permission();
-  void pre_exec();
-  void execute() {}
+  int verify_permission() override;
+  void pre_exec() override;
+  void execute() override {}
 
-  virtual void send_response() = 0;
+  virtual void send_response() override = 0;
   virtual const string name() { return "get_bucket_meta_search"; }
   virtual RGWOpType get_type() { return RGW_OP_GET_BUCKET_META_SEARCH; }
   virtual uint32_t op_mask() { return RGW_OP_TYPE_READ; }
@@ -2207,13 +2207,13 @@ public:
   RGWDelBucketMetaSearch() {}
 
   int verify_permission();
-  void pre_exec();
-  void execute();
+  void pre_exec() override;
+  void execute() override;
 
-  virtual void send_response() = 0;
-  virtual const string name() { return "delete_bucket_meta_search"; }
+  virtual void send_response() override = 0;
+  virtual const string name() override { return "delete_bucket_meta_search"; }
   virtual RGWOpType delete_type() { return RGW_OP_DEL_BUCKET_META_SEARCH; }
-  virtual uint32_t op_mask() { return RGW_OP_TYPE_WRITE; }
+  virtual uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };
 
 class RGWGetClusterStat : public RGWOp {
@@ -2226,10 +2226,10 @@ public:
     RGWOp::init(store, s, h);
   }
   int verify_permission() override {return 0;}
-  virtual void send_response() = 0;
+  virtual void send_response() override = 0;
   virtual int get_params() = 0;
   void execute() override;
-  virtual const string name() { return "get_cluster_stat"; }
+  virtual const string name() override { return "get_cluster_stat"; }
 };
 
 

--- a/src/rgw/rgw_otp.cc
+++ b/src/rgw/rgw_otp.cc
@@ -139,7 +139,7 @@ public:
     delete info;
   }
 
-  string get_marker(void *handle) {
+  string get_marker(void *handle) override {
     list_keys_info *info = static_cast<list_keys_info *>(handle);
     return info->store->list_raw_objs_get_cursor(info->ctx);
   }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -969,7 +969,7 @@ public:
 
   int check_bucket_shards(uint64_t max_objs_per_shard, uint64_t num_shards,
 			  const rgw_user& user, const rgw_bucket& bucket, RGWQuotaInfo& bucket_quota,
-			  uint64_t num_objs, bool& need_resharding, uint32_t *suggested_num_shards)
+			  uint64_t num_objs, bool& need_resharding, uint32_t *suggested_num_shards) override
   {
     RGWStorageStats bucket_stats;
     int ret = bucket_stats_cache.get_stats(user, bucket, bucket_stats,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1190,7 +1190,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   RGWZoneParams(const string& id, const string& name, const string& _realm_id)
     : RGWSystemMetaObj(id, name), realm_id(_realm_id) {}
 
-  rgw_pool get_pool(CephContext *cct);
+  rgw_pool get_pool(CephContext *cct) override;
   const string get_default_oid(bool old_format = false) override;
   const string& get_names_oid_prefix() override;
   const string& get_info_oid_prefix(bool old_format = false) override;
@@ -1575,7 +1575,7 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
                string *predirect_zone);
   int remove_zone(const std::string& zone_id);
   int rename_zone(const RGWZoneParams& zone_params);
-  rgw_pool get_pool(CephContext *cct);
+  rgw_pool get_pool(CephContext *cct) override;
   const string get_default_oid(bool old_region_format = false) override;
   const string& get_info_oid_prefix(bool old_region_format = false) override;
   const string& get_names_oid_prefix() override;
@@ -1755,7 +1755,7 @@ public:
 
   int create(bool exclusive = true) override;
   int delete_obj();
-  rgw_pool get_pool(CephContext *cct);
+  rgw_pool get_pool(CephContext *cct) override;
   const string get_default_oid(bool old_format = false) override;
   const string& get_names_oid_prefix() override;
   const string& get_info_oid_prefix(bool old_format = false) override;
@@ -4176,14 +4176,14 @@ class RGWPutObjProcessor_Multipart : public RGWPutObjProcessor_Atomic
   string upload_id;
 
 protected:
-  int prepare(RGWRados *store, string *oid_rand);
+  int prepare(RGWRados *store, string *oid_rand) override;
   int do_complete(size_t accounted_size, const string& etag,
                   ceph::real_time *mtime, ceph::real_time set_mtime,
                   map<string, bufferlist>& attrs, ceph::real_time delete_at,
                   const char *if_match, const char *if_nomatch, const string *user_data,
                   rgw_zone_set *zones_trace) override;
 public:
-  bool immutable_head() { return true; }
+  bool immutable_head() override { return true; }
   RGWPutObjProcessor_Multipart(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info, uint64_t _p, req_state *_s) :
                    RGWPutObjProcessor_Atomic(obj_ctx, bucket_info, _s->bucket, _s->object.name, _p, _s->req_id, false), s(_s) {}
   void get_mp(RGWMPObj** _mp);

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -215,9 +215,9 @@ public:
     return caps.check_cap("buckets", RGW_CAP_WRITE);
   }
 
-  void execute();
+  void execute() override;
 
-  virtual const string name() { return "set_bucket_quota"; }
+  virtual const string name() override { return "set_bucket_quota"; }
 };
 
 #define QUOTA_INPUT_MAX_LEN 1024

--- a/src/rgw/rgw_rest_config.h
+++ b/src/rgw/rgw_rest_config.h
@@ -44,12 +44,12 @@ public:
   int check_caps(RGWUserCaps& caps) {
     return caps.check_cap("admin", RGW_CAP_READ);
   }
-  int verify_permission() {
+  int verify_permission() override {
     return check_caps(s->user->caps);
   }
-  void execute() {} /* store already has the info we need, just need to send response */
-  void send_response();
-  const string name() {
+  void execute() override {} /* store already has the info we need, just need to send response */
+  void send_response() override ;
+  const string name() override {
     return "get_zone_config";
   }
 };

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -242,7 +242,7 @@ public:
   RGWPostObj_ObjStore_S3() {}
   ~RGWPostObj_ObjStore_S3() override {}
 
-  int verify_requester(const rgw::auth::StrategyRegistry& auth_registry) {
+  int verify_requester(const rgw::auth::StrategyRegistry& auth_registry) override {
     auth_registry_ptr = &auth_registry;
     return RGWPostObj_ObjStore::verify_requester(auth_registry);
   }
@@ -437,7 +437,7 @@ public:
   RGWGetObjLayout_ObjStore_S3() {}
   ~RGWGetObjLayout_ObjStore_S3() {}
 
-  void send_response();
+  void send_response() override;
 };
 
 class RGWConfigBucketMetaSearch_ObjStore_S3 : public RGWConfigBucketMetaSearch {

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1216,7 +1216,7 @@ public:
                                                            sync_marker);
   }
 
-  RGWOrderCallCR *allocate_order_control_cr() {
+  RGWOrderCallCR *allocate_order_control_cr() override {
     return new RGWLastCallerWinsCR(sync_env->cct);
   }
 };
@@ -2496,7 +2496,7 @@ class PurgePeriodLogsCR : public RGWCoroutine {
       realm_epoch(realm_epoch), last_trim_epoch(last_trim)
   {}
 
-  int operate();
+  int operate() override;
 };
 
 int PurgePeriodLogsCR::operate()
@@ -2776,7 +2776,7 @@ class MetaMasterTrimCR : public RGWCoroutine {
     : RGWCoroutine(env.store->ctx()), env(env)
   {}
 
-  int operate();
+  int operate() override;
 };
 
 int MetaMasterTrimCR::operate()
@@ -2978,7 +2978,7 @@ class MetaPeerTrimCR : public RGWCoroutine {
  public:
   MetaPeerTrimCR(PeerTrimEnv& env) : RGWCoroutine(env.store->ctx()), env(env) {}
 
-  int operate();
+  int operate() override;
 };
 
 int MetaPeerTrimCR::operate()
@@ -3044,7 +3044,7 @@ class MetaTrimPollCR : public RGWCoroutine {
       cookie(RGWSimpleRadosLockCR::gen_random_cookie(cct))
   {}
 
-  int operate();
+  int operate() override;
 };
 
 int MetaTrimPollCR::operate()

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -311,7 +311,7 @@ public:
 
   int operate() override;
 
-  void call_cr(RGWCoroutine *_cr) {
+  void call_cr(RGWCoroutine *_cr) override {
     if (cr) {
       cr->put();
     }

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -732,7 +732,7 @@ class BucketTrimCR : public RGWCoroutine {
       observer(observer), obj(obj), counter(config.counter_size)
   {}
 
-  int operate();
+  int operate() override;
 };
 
 const std::string BucketTrimCR::section{"bucket.instance"};
@@ -889,7 +889,7 @@ class BucketTrimPollCR : public RGWCoroutine {
       cookie(RGWSimpleRadosLockCR::gen_random_cookie(cct))
   {}
 
-  int operate();
+  int operate() override;
 };
 
 int BucketTrimPollCR::operate()

--- a/src/rgw/rgw_sync_module_aws.cc
+++ b/src/rgw/rgw_sync_module_aws.cc
@@ -801,7 +801,7 @@ public:
                                                      sync_env(_sync_env), src_properties(_src_properties), target(_target), dest_obj(_dest_obj) {
   }
 
-  int init() {
+  int init() override {
     /* init output connection */
     RGWRESTStreamS3PutObj *out_req{nullptr};
 
@@ -1007,7 +1007,7 @@ public:
                                                    dest_obj(_dest_obj),
                                                    src_properties(_src_properties) {}
 
-  int operate() {
+  int operate() override {
     reenter(this) {
       /* init input */
       in_crf.reset(new RGWRESTStreamGetCRF(cct, get_env(), this, sync_env,
@@ -1068,7 +1068,7 @@ public:
                                                    part_info(_part_info),
                                                    petag(_petag) {}
 
-  int operate() {
+  int operate() override {
     reenter(this) {
       /* init input */
       in_crf.reset(new RGWRESTStreamGetCRF(cct, get_env(), this, sync_env,
@@ -1117,7 +1117,7 @@ public:
                                                    dest_obj(_dest_obj),
                                                    upload_id(_upload_id) {}
 
-  int operate() {
+  int operate() override {
     reenter(this) {
 
       yield {
@@ -1177,7 +1177,7 @@ public:
                                                    attrs(_attrs),
                                                    upload_id(_upload_id) {}
 
-  int operate() {
+  int operate() override {
     reenter(this) {
 
       yield {
@@ -1279,7 +1279,7 @@ public:
                                                    upload_id(_upload_id),
                                                    req_enc(_parts) {}
 
-  int operate() {
+  int operate() override {
     reenter(this) {
 
       yield {
@@ -1359,7 +1359,7 @@ public:
                                                             status_obj(_status_obj),
                                                             upload_id(_upload_id) {}
 
-  int operate() {
+  int operate() override {
     reenter(this) {
       yield call(new RGWAWSAbortMultipartCR(sync_env, dest_conn, dest_obj, upload_id));
       if (retcode < 0) {
@@ -1425,7 +1425,7 @@ public:
   }
 
 
-  int operate() {
+  int operate() override {
     reenter(this) {
       yield call(new RGWSimpleRadosReadCR<rgw_sync_aws_multipart_upload_info>(sync_env->async_rados, sync_env->store,
                                                                  status_obj, &status, false));
@@ -1753,7 +1753,7 @@ public:
                   instance(_conf) {
   }
 
-  void init(RGWDataSyncEnv *sync_env, uint64_t instance_id) {
+  void init(RGWDataSyncEnv *sync_env, uint64_t instance_id) override {
     instance.init(sync_env, instance_id);
   }
 

--- a/src/rgw/rgw_sync_module_es_rest.cc
+++ b/src/rgw/rgw_sync_module_es_rest.cc
@@ -135,17 +135,17 @@ public:
     es_module = static_cast<RGWElasticSyncModuleInstance *>(sync_module_ref.get());
   }
 
-  int verify_permission() {
+  int verify_permission() override {
     return 0;
   }
   virtual int get_params() = 0;
-  void pre_exec();
-  void execute();
+  void pre_exec() override;
+  void execute() override;
 
-  virtual void send_response() = 0;
-  virtual const string name() { return "metadata_search"; }
-  virtual RGWOpType get_type() { return RGW_OP_METADATA_SEARCH; }
-  virtual uint32_t op_mask() { return RGW_OP_TYPE_READ; }
+  virtual void send_response() override = 0;
+  virtual const string name() override { return "metadata_search"; }
+  virtual RGWOpType get_type() override { return RGW_OP_METADATA_SEARCH; }
+  virtual uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
 
 void RGWMetadataSearchOp::pre_exec()
@@ -366,7 +366,7 @@ public:
 
 class RGWHandler_REST_MDSearch_S3 : public RGWHandler_REST_S3 {
 protected:
-  RGWOp *op_get() {
+  RGWOp *op_get() override {
     if (s->info.args.exists("query")) {
       return new RGWMetadataSearch_ObjStore_S3(store->get_sync_module());
     }
@@ -376,10 +376,10 @@ protected:
     }
     return nullptr;
   }
-  RGWOp *op_head() {
+  RGWOp *op_head() override {
     return nullptr;
   }
-  RGWOp *op_post() {
+  RGWOp *op_post() override {
     return nullptr;
   }
 public:

--- a/src/rgw/rgw_tag_s3.h
+++ b/src/rgw/rgw_tag_s3.h
@@ -53,7 +53,7 @@ public:
 
 class RGWObjTagsXMLParser : public RGWXMLParser
 {
-  XMLObj *alloc_obj(const char *el);
+  XMLObj *alloc_obj(const char *el) override;
 public:
   RGWObjTagsXMLParser() {}
   ~RGWObjTagsXMLParser() {}

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2814,7 +2814,7 @@ public:
     delete info;
   }
 
-  string get_marker(void *handle) {
+  string get_marker(void *handle) override {
     list_keys_info *info = static_cast<list_keys_info *>(handle);
     return info->store->list_raw_objs_get_cursor(info->ctx);
   }

--- a/src/test/common/test_static_ptr.cc
+++ b/src/test/common/test_static_ptr.cc
@@ -40,7 +40,7 @@ protected:
   int val;
 public:
   explicit grandchild(int val) : val(val) {}
-  virtual int call(int n) { return n * val; }
+  virtual int call(int n) override { return n * val; }
 };
 
 class great_grandchild : public grandchild {


### PR DESCRIPTION
Fix for:

[src/*/*.h:XX] -> [src/*/*.h:XX]: (style) The function 'XYZ' overrides a
 function in a base class but is not marked with a 'override' specifier.

Signed-off-by: Danny Al-Gaaf <danny.al-gaaf@bisect.de>