### PR TITLE
prometheus: Expose number of degraded/misplaced/unfound objects

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -265,6 +265,9 @@ PyObject *ActivePyModules::get_python(const std::string &what)
             f.dump_int(i.first.c_str(), i.second);
           }
           f.close_section();
+          f.open_object_section("pg_stats_sum");
+          pg_map.pg_sum.dump(&f);
+          f.close_section();
         }
     );
     return f.get();


### PR DESCRIPTION
These come from the pg dump by polling the pg_stas_sum.

Signed-off-by: Boris Ranto <branto@redhat.com>