### PR TITLE
mgr/influx: Only split string on first occurence of dot (.)

### DIFF
--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -189,7 +189,7 @@ class Module(MgrModule):
         now = datetime.utcnow().isoformat() + 'Z'
 
         for daemon, counters in self.get_all_perf_counters().iteritems():
-            svc_type, svc_id = daemon.split(".")
+            svc_type, svc_id = daemon.split(".", 1)
             metadata = self.get_metadata(svc_type, svc_id)
 
             for path, counter_info in counters.items():


### PR DESCRIPTION
Service names are not always osd.X or mon.X, they might be
rgw.radosgw.rgw1

This would lead to:

  Unhandled exception from module 'influx' while running on mgr.mon01: too many values to unpack

Only split on the first dot as the rest is the service name

Signed-off-by: Wido den Hollander <wido@42on.com>