### PR TITLE
luminous: client: use common interp of st_nlink for dirs

### DIFF
--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -48,6 +48,7 @@ ostream& operator<<(ostream &out, const Inode &in)
       << " open=" << in.open_by_mode
       << " mode=" << oct << in.mode << dec
       << " size=" << in.size << "/" << in.max_size
+      << " nlink=" << in.nlink
       << " mtime=" << in.mtime
       << " caps=" << ccap_string(in.caps_issued());
   if (!in.caps.empty()) {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/23987