### PR TITLE
doc: remove CZ mirror

### DIFF
--- a/doc/install/mirrors.rst
+++ b/doc/install/mirrors.rst
@@ -16,7 +16,6 @@ These mirrors are available on the following locations:
 
 - **EU: Netherlands**: http://eu.ceph.com/
 - **AU: Australia**: http://au.ceph.com/
-- **CZ: Czech Republic**: http://cz.ceph.com/
 - **SE: Sweden**: http://se.ceph.com/
 - **DE: Germany**: http://de.ceph.com/
 - **HK: Hong Kong**: http://hk.ceph.com/

--- a/mirroring/MIRRORS
+++ b/mirroring/MIRRORS
@@ -3,7 +3,6 @@ eu.ceph.com: Wido den Hollander <wido@42on.com>
 au.ceph.com: Matthew Taylor <matthew.taylor@digitalpacific.com.au>
 de.ceph.com: Oliver Dzombic <info@ip-interactive.de>
 se.ceph.com: Josef Johansson <se-ceph-com@oderland.se>
-cz.ceph.com: Tomáš Kukrál <kukratom@fit.cvut.cz>
 us-east.ceph.com: Tyler Bishop <tyler.bishop@beyondhosting.net>
 hk.ceph.com: Mart van Santen <mart@greenhost.nl>
 fr.ceph.com: Adrien Gillard <gillard.adrien@gmail.com>

--- a/mirroring/mirror-ceph.sh
+++ b/mirroring/mirror-ceph.sh
@@ -13,7 +13,6 @@ declare -A SOURCES
 SOURCES[eu]="eu.ceph.com"
 SOURCES[de]="de.ceph.com"
 SOURCES[se]="se.ceph.com"
-SOURCES[cz]="cz.ceph.com"
 SOURCES[au]="au.ceph.com"
 SOURCES[us]="download.ceph.com"
 SOURCES[hk]="hk.ceph.com"


### PR DESCRIPTION
CZ mirror is no longer running.

I'm not working for CVUT FIT (which was sponsor for the mirror) and they aren't able to run this mirror anymore.