### PR TITLE
osd/PG: fix uninit read in Incomplete::react(AdvMap&)

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -8959,7 +8959,8 @@ boost::statechart::result PG::RecoveryState::Incomplete::react(const AdvMap &adv
   int64_t poolnum = pg->info.pgid.pool();
 
   // Reset if min_size turn smaller than previous value, pg might now be able to go active
-  if (advmap.lastmap->get_pools().find(poolnum)->second.min_size >
+  if (!advmap.osdmap->have_pg_pool(poolnum) ||
+      advmap.lastmap->get_pools().find(poolnum)->second.min_size >
       advmap.osdmap->get_pools().find(poolnum)->second.min_size) {
     post_event(advmap);
     return transit< Reset >();


### PR DESCRIPTION
If a PG is incomplete when the pool is deleted we'll dereference invalid
iterators here.

Fixes: http://tracker.ceph.com/issues/23980
Signed-off-by: Sage Weil <sage@redhat.com>