### PR TITLE
compressor: use initializer_list for compression_algorithms

### DIFF
--- a/src/compressor/Compressor.cc
+++ b/src/compressor/Compressor.cc
@@ -24,7 +24,7 @@
 #include "common/debug.h"
 #include "common/dout.h"
 
-std::string Compressor::get_comp_alg_name(int a) {
+const char* Compressor::get_comp_alg_name(int a) {
 
   auto p = std::find_if(std::cbegin(compression_algorithms), std::cend(compression_algorithms),
 		   [a](const auto& kv) { return kv.second == a; });
@@ -32,15 +32,17 @@ std::string Compressor::get_comp_alg_name(int a) {
   if (std::cend(compression_algorithms) == p)
    return "???"; // It would be nice to revise this...
 
-  return std::string { p->first };
+  return p->first;
 }
 
 boost::optional<Compressor::CompressionAlgorithm> Compressor::get_comp_alg_type(const std::string &s) {
 
-  if (auto pos = compression_algorithms.find(s.c_str()); std::end(compression_algorithms) != pos)
-   return pos->second;
+  auto p = std::find_if(std::cbegin(compression_algorithms), std::cend(compression_algorithms),
+		   [&s](const auto& kv) { return kv.first == s; });
+  if (std::cend(compression_algorithms) == p)
+    return {};
 
-  return boost::optional<Compressor::CompressionAlgorithm> {};
+  return p->second;
 }
 
 const char *Compressor::get_comp_mode_name(int m) {

--- a/src/compressor/Compressor.h
+++ b/src/compressor/Compressor.h
@@ -15,7 +15,6 @@
 #ifndef CEPH_COMPRESSOR_H
 #define CEPH_COMPRESSOR_H
 
-#include <map>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -44,7 +43,8 @@ public:
     COMP_ALG_LAST   //the last value for range checks
   };
 
-  inline static const std::map<const std::string, const CompressionAlgorithm> compression_algorithms {
+  using pair_type = std::pair<const char*, CompressionAlgorithm>;
+  static constexpr std::initializer_list<pair_type> compression_algorithms {
 	{ "none",	COMP_ALG_NONE },
 	{ "snappy",	COMP_ALG_SNAPPY },
 	{ "zlib",	COMP_ALG_ZLIB },
@@ -65,7 +65,7 @@ public:
     COMP_FORCE                  ///< compress always
   };
 
-  static std::string get_comp_alg_name(int a);
+  static const char* get_comp_alg_name(int a);
   static boost::optional<CompressionAlgorithm> get_comp_alg_type(const std::string &s);
 
   static const char *get_comp_mode_name(int m);


### PR DESCRIPTION
use a compile-type array instead of heap-allocated tree to associate compression types with their names