### PR TITLE
ceph-volume initial take on auto sub-command

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/auto/__init__.py
+++ b/src/ceph-volume/ceph_volume/devices/auto/__init__.py
@@ -1,0 +1,1 @@
+from main import Auto # noqa

--- a/src/ceph-volume/ceph_volume/devices/auto/main.py
+++ b/src/ceph-volume/ceph_volume/devices/auto/main.py
@@ -1,0 +1,70 @@
+import argparse
+from textwrap import dedent
+from ceph_volume import terminal, decorators
+from ceph_volume.util import disk
+
+
+device_list_template = """
+  * {path: <25} {size: <10} {state}"""
+
+
+def device_formatter(devices):
+    lines = []
+    for path, details in devices:
+        lines.append(device_list_template.format(
+            path=path, size=details['human_readable_size'],
+            state='solid' if details['rotational'] == '0' else 'rotational')
+        )
+
+    return ''.join(lines)
+
+
+class Auto(object):
+
+    help = 'Auto-detect devices for multi-OSD provisioning with minimal interaction'
+
+    _help = dedent("""
+    Automatically detect devices ready for OSD provisioning based on configurable strategies.
+
+    Detected devices:
+    {detected_devices}
+
+    Current strategy: {strategy_name}
+    Path: {strategy_path}
+
+    """)
+
+    # TODO: add the reporting sub-command here (list?)
+    mapper = {
+    }
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def get_devices(self):
+        all_devices = disk.get_devices()
+        # remove devices with partitions
+        # XXX Should be optional when getting device info
+        for device, detail in all_devices.items():
+            if detail.get('partitions') != {}:
+                del all_devices[device]
+        devices = sorted(all_devices.items(), key=lambda x: (x[0], x[1]['size']))
+        return device_formatter(devices)
+
+    def print_help(self, sub_help):
+        return self._help.format(
+            detected_devices=self.get_devices(),
+            strategy_name='default',
+            strategy_path='/etc/ceph/osd/strategies/default')
+
+    @decorators.needs_root
+    def main(self):
+        terminal.dispatch(self.mapper, self.argv)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume auto',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.print_help(terminal.subhelp(self.mapper)),
+        )
+        parser.parse_args(self.argv)
+        if len(self.argv) <= 1:
+            return parser.print_help()

--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -27,7 +27,12 @@ Ceph Conf: {ceph_path}
     """
 
     def __init__(self, argv=None, parse=True):
-        self.mapper = {'lvm': devices.lvm.LVM, 'simple': devices.simple.Simple}
+        self.mapper = {
+            'lvm': devices.lvm.LVM,
+            'simple': devices.simple.Simple,
+            # XXX Disabled for now - comment out when fully functional
+            #'auto': devices.auto.Auto,
+        }
         self.plugin_help = "No plugins found/loaded"
         if argv is None:
             self.argv = sys.argv

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -132,8 +132,9 @@ def tmpfile(tmpdir):
     Create a temporary file, optionally filling it with contents, returns an
     absolute path to the file when called
     """
-    def generate_file(name='file', contents=''):
-        path = os.path.join(str(tmpdir), name)
+    def generate_file(name='file', contents='', directory=None):
+        directory = directory or str(tmpdir)
+        path = os.path.join(directory, name)
         with open(path, 'w') as fp:
             fp.write(contents)
         return path

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -1,3 +1,4 @@
+import os
 from ceph_volume.util import disk
 
 
@@ -39,3 +40,47 @@ class TestDeviceFamily(object):
         result = disk.device_family('sdaa5')
         for parsed in result:
             assert parsed['NAME'] in names
+
+
+class TestMapDevPaths(object):
+
+    def test_errors_return_empty_mapping(self, tmpdir):
+        bad_dir = os.path.join(str(tmpdir), 'nonexisting')
+        assert disk._map_dev_paths(bad_dir) == {}
+
+    def test_base_name_and_abspath(self, tmpfile):
+        sda_path = tmpfile(name='sda', contents='')
+        directory = os.path.dirname(sda_path)
+        result = disk._map_dev_paths(directory)
+        assert result.keys() == ['sda']
+        assert result['sda'] == sda_path
+
+    def test_abspath_included(self, tmpfile):
+        sda_path = tmpfile(name='sda', contents='')
+        directory = os.path.dirname(sda_path)
+        result = disk._map_dev_paths(directory, include_abspath=True)
+        assert sorted(result.keys()) == sorted(['sda', sda_path])
+        assert result['sda'] == sda_path
+        assert result[sda_path] == 'sda'
+
+    def test_realpath_included(self, tmpfile):
+        sda_path = tmpfile(name='sda', contents='')
+        directory = os.path.dirname(sda_path)
+        dm_path = os.path.join(directory, 'dm-0')
+        os.symlink(sda_path, os.path.join(directory, 'dm-0'))
+        result = disk._map_dev_paths(directory, include_realpath=True)
+        assert sorted(result.keys()) == sorted(['sda', 'dm-0'])
+        assert result['sda'] == dm_path
+        assert result['dm-0'] == dm_path
+
+    def test_absolute_and_realpath_included(self, tmpfile):
+        dm_path = tmpfile(name='dm-0', contents='')
+        directory = os.path.dirname(dm_path)
+        sda_path = os.path.join(directory, 'sda')
+        os.symlink(sda_path, os.path.join(directory, 'sda'))
+        result = disk._map_dev_paths(directory, include_realpath=True, include_abspath=True)
+        assert sorted(result.keys()) == sorted([dm_path, sda_path, 'sda', 'dm-0'])
+        assert result['sda'] == sda_path
+        assert result['dm-0'] == dm_path
+        assert result[sda_path] == sda_path
+        assert result[dm_path] == 'dm-0'

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -97,3 +97,29 @@ class TestGetBlockDevs(object):
         path = os.path.dirname(tmpfile(name='loop0', contents=''))
         result = disk.get_block_devs(sys_block_path=path, skip_loop=False)
         assert result == ['loop0']
+
+
+class TestGetDevDevs(object):
+
+    def test_abspaths_are_included(self, tmpfile):
+        sda_path = tmpfile(name='sda', contents='')
+        directory = os.path.dirname(sda_path)
+        result = disk.get_dev_devs(directory)
+        assert sorted(result.keys()) == sorted(['sda', sda_path])
+        assert result['sda'] == sda_path
+        assert result[sda_path] == 'sda'
+
+
+class TestGetMapperDevs(object):
+
+    def test_abspaths_and_realpaths_are_included(self, tmpfile):
+        dm_path = tmpfile(name='dm-0', contents='')
+        directory = os.path.dirname(dm_path)
+        sda_path = os.path.join(directory, 'sda')
+        os.symlink(sda_path, os.path.join(directory, 'sda'))
+        result = disk.get_mapper_devs(directory)
+        assert sorted(result.keys()) == sorted([dm_path, sda_path, 'sda', 'dm-0'])
+        assert result['sda'] == sda_path
+        assert result['dm-0'] == dm_path
+        assert result[sda_path] == sda_path
+        assert result[dm_path] == 'dm-0'

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -84,3 +84,16 @@ class TestMapDevPaths(object):
         assert result['dm-0'] == dm_path
         assert result[sda_path] == sda_path
         assert result[dm_path] == 'dm-0'
+
+
+class TestGetBlockDevs(object):
+
+    def test_loop_devices_are_missing(self, tmpfile):
+        path = os.path.dirname(tmpfile(name='loop0', contents=''))
+        result = disk.get_block_devs(sys_block_path=path)
+        assert result == []
+
+    def test_loop_devices_are_included(self, tmpfile):
+        path = os.path.dirname(tmpfile(name='loop0', contents=''))
+        result = disk.get_block_devs(sys_block_path=path, skip_loop=False)
+        assert result == ['loop0']

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -123,3 +123,26 @@ class TestGetMapperDevs(object):
         assert result['dm-0'] == dm_path
         assert result[sda_path] == sda_path
         assert result[dm_path] == 'dm-0'
+
+
+class TestHumanReadableSize(object):
+
+    def test_bytes(self):
+        result = disk.human_readable_size(800)
+        assert result == '800.00 B'
+
+    def test_kilobytes(self):
+        result = disk.human_readable_size(800*1024)
+        assert result == '800.00 KB'
+
+    def test_megabytes(self):
+        result = disk.human_readable_size(800*1024*1024)
+        assert result == '800.00 MB'
+
+    def test_gigabytes(self):
+        result = disk.human_readable_size(8.19*1024*1024*1024)
+        assert result == '8.19 GB'
+
+    def test_terabytes(self):
+        result = disk.human_readable_size(81.2*1024*1024*1024*1024)
+        assert result == '81.20 TB'

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -52,7 +52,7 @@ class TestMapDevPaths(object):
         sda_path = tmpfile(name='sda', contents='')
         directory = os.path.dirname(sda_path)
         result = disk._map_dev_paths(directory)
-        assert result.keys() == ['sda']
+        assert len(result.keys()) == 1
         assert result['sda'] == sda_path
 
     def test_abspath_included(self, tmpfile):
@@ -96,6 +96,7 @@ class TestGetBlockDevs(object):
     def test_loop_devices_are_included(self, tmpfile):
         path = os.path.dirname(tmpfile(name='loop0', contents=''))
         result = disk.get_block_devs(sys_block_path=path, skip_loop=False)
+        assert len(result) == 1
         assert result == ['loop0']
 
 
@@ -146,3 +147,144 @@ class TestHumanReadableSize(object):
     def test_terabytes(self):
         result = disk.human_readable_size(81.2*1024*1024*1024*1024)
         assert result == '81.20 TB'
+
+
+class TestGetDevices(object):
+
+    def setup_paths(self, tmpdir):
+        paths = []
+        for directory in ['block', 'dev', 'mapper']:
+            path = os.path.join(str(tmpdir), directory)
+            paths.append(path)
+            os.makedirs(path)
+        return paths
+
+    def test_no_devices_are_found(self, tmpdir):
+        result = disk.get_devices(
+            _sys_block_path=str(tmpdir),
+            _dev_path=str(tmpdir),
+            _mapper_path=str(tmpdir))
+        assert result == {}
+
+    def test_sda_block_is_found(self, tmpfile, tmpdir):
+        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
+        dev_sda_path = os.path.join(dev_path, 'sda')
+        os.makedirs(os.path.join(block_path, 'sda'))
+        os.makedirs(dev_sda_path)
+        result = disk.get_devices(
+            _sys_block_path=block_path,
+            _dev_path=dev_path,
+            _mapper_path=mapper_path)
+        assert len(result.keys()) == 1
+        assert result[dev_sda_path]['human_readable_size'] == '0.00 B'
+        assert result[dev_sda_path]['model'] == ''
+        assert result[dev_sda_path]['partitions'] == {}
+
+    def test_sda_is_removable_gets_skipped(self, tmpfile, tmpdir):
+        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
+        dev_sda_path = os.path.join(dev_path, 'sda')
+        block_sda_path = os.path.join(block_path, 'sda')
+        os.makedirs(block_sda_path)
+        os.makedirs(dev_sda_path)
+
+        tmpfile('removable', contents='1', directory=block_sda_path)
+        result = disk.get_devices(
+            _sys_block_path=block_path,
+            _dev_path=dev_path,
+            _mapper_path=mapper_path)
+        assert result == {}
+
+    def test_dm_device_is_not_used(self, monkeypatch, tmpdir):
+        # the link to the mapper is used instead
+        monkeypatch.setattr(disk.lvm, 'is_lv', lambda: True)
+        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
+        dev_dm_path = os.path.join(dev_path, 'dm-0')
+        ceph_data_path = os.path.join(mapper_path, 'ceph-data')
+        os.symlink(dev_dm_path, ceph_data_path)
+        block_dm_path = os.path.join(block_path, 'dm-0')
+        os.makedirs(block_dm_path)
+
+        result = disk.get_devices(
+            _sys_block_path=block_path,
+            _dev_path=dev_path,
+            _mapper_path=mapper_path)
+        result = list(result.keys())
+        assert len(result) == 1
+        assert result == [ceph_data_path]
+
+    def test_sda_size(self, tmpfile, tmpdir):
+        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
+        block_sda_path = os.path.join(block_path, 'sda')
+        dev_sda_path = os.path.join(dev_path, 'sda')
+        os.makedirs(block_sda_path)
+        os.makedirs(dev_sda_path)
+        tmpfile('size', '1024', directory=block_sda_path)
+        result = disk.get_devices(
+            _sys_block_path=block_path,
+            _dev_path=dev_path,
+            _mapper_path=mapper_path)
+        assert list(result.keys()) == [dev_sda_path]
+        assert result[dev_sda_path]['human_readable_size'] == '512.00 KB'
+
+    def test_sda_sectorsize_fallsback(self, tmpfile, tmpdir):
+        # if no sectorsize, it will use queue/hw_sector_size
+        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
+        block_sda_path = os.path.join(block_path, 'sda')
+        sda_queue_path = os.path.join(block_sda_path, 'queue')
+        dev_sda_path = os.path.join(dev_path, 'sda')
+        os.makedirs(block_sda_path)
+        os.makedirs(sda_queue_path)
+        os.makedirs(dev_sda_path)
+        tmpfile('hw_sector_size', contents='1024', directory=sda_queue_path)
+        result = disk.get_devices(
+            _sys_block_path=block_path,
+            _dev_path=dev_path,
+            _mapper_path=mapper_path)
+        assert list(result.keys()) == [dev_sda_path]
+        assert result[dev_sda_path]['sectorsize'] == '1024'
+
+    def test_sda_sectorsize_from_logical_block(self, tmpfile, tmpdir):
+        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
+        block_sda_path = os.path.join(block_path, 'sda')
+        sda_queue_path = os.path.join(block_sda_path, 'queue')
+        dev_sda_path = os.path.join(dev_path, 'sda')
+        os.makedirs(block_sda_path)
+        os.makedirs(sda_queue_path)
+        os.makedirs(dev_sda_path)
+        tmpfile('logical_block_size', contents='99', directory=sda_queue_path)
+        result = disk.get_devices(
+            _sys_block_path=block_path,
+            _dev_path=dev_path,
+            _mapper_path=mapper_path)
+        assert result[dev_sda_path]['sectorsize'] == '99'
+
+    def test_sda_sectorsize_does_not_fallback(self, tmpfile, tmpdir):
+        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
+        block_sda_path = os.path.join(block_path, 'sda')
+        sda_queue_path = os.path.join(block_sda_path, 'queue')
+        dev_sda_path = os.path.join(dev_path, 'sda')
+        os.makedirs(block_sda_path)
+        os.makedirs(sda_queue_path)
+        os.makedirs(dev_sda_path)
+        tmpfile('logical_block_size', contents='99', directory=sda_queue_path)
+        tmpfile('hw_sector_size', contents='1024', directory=sda_queue_path)
+        result = disk.get_devices(
+            _sys_block_path=block_path,
+            _dev_path=dev_path,
+            _mapper_path=mapper_path)
+        assert result[dev_sda_path]['sectorsize'] == '99'
+
+    def test_is_rotational(self, tmpfile, tmpdir):
+        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
+        block_sda_path = os.path.join(block_path, 'sda')
+        sda_queue_path = os.path.join(block_sda_path, 'queue')
+        dev_sda_path = os.path.join(dev_path, 'sda')
+        os.makedirs(block_sda_path)
+        os.makedirs(sda_queue_path)
+        os.makedirs(dev_sda_path)
+        tmpfile('rotational', contents='1', directory=sda_queue_path)
+        result = disk.get_devices(
+            _sys_block_path=block_path,
+            _dev_path=dev_path,
+            _mapper_path=mapper_path)
+        assert result[dev_sda_path]['rotational'] == '1'

--- a/src/ceph-volume/ceph_volume/tests/util/test_system.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_system.py
@@ -168,6 +168,30 @@ class TestIsBinary(object):
         assert system.is_binary(binary_path) is False
 
 
+class TestGetFileContents(object):
+
+    def test_path_does_not_exist(self, tmpdir):
+        filepath = os.path.join(str(tmpdir), 'doesnotexist')
+        assert system.get_file_contents(filepath, 'default') == 'default'
+
+    def test_path_has_contents(self, tmpfile):
+        interesting_file = tmpfile(contents="1")
+        result = system.get_file_contents(interesting_file)
+        assert result == "1"
+
+    def test_path_has_multiline_contents(self, tmpfile):
+        interesting_file = tmpfile(contents="0\n1")
+        result = system.get_file_contents(interesting_file)
+        assert result == "0\n1"
+
+    def test_exception_returns_default(self, tmpfile):
+        interesting_file = tmpfile(contents="0")
+        # remove read, causes IOError
+        os.chmod(interesting_file, 0o000)
+        result = system.get_file_contents(interesting_file)
+        assert result == ''
+
+
 class TestWhich(object):
 
     def test_executable_exists_but_is_not_file(self, monkeypatch):

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -65,6 +65,19 @@ def get_ceph_user_ids():
     return user[2], user[3]
 
 
+def get_file_contents(path, default=''):
+    contents = default
+    if not os.path.exists(path):
+        return contents
+    try:
+        with open(path, 'r') as open_file:
+            contents = open_file.read().strip()
+    except Exception:
+        logger.exception('Failed to read contents from: %s' % path)
+
+    return contents
+
+
 def mkdir_p(path, chown=True):
     """
     A `mkdir -p` that defaults to chown the path to the ceph user


### PR DESCRIPTION
The following PR adds the smallest sub-set of changes needed to be able to create OSDs from a set of rules (to be defined).

The basic building block is the device discovery, that includes capturing of metadata. The current `get_devices` helper will produce information for a given device like: is it rotational or solid, does it have partitions, sectors, size, human readable size, and vendor.

It currently allows to detect devices that are: raw, with no partitions, that are not part of LVM. Devices like VDO (coming from device mapper) are respected and selected. 

Note that the sub-command is disabled. Some sample output:

On a Xenial host:

    ceph-volume auto
    usage: ceph-volume auto [-h]

    Automatically detect devices ready for OSD provisioning based on configurable strategies.

    Detected devices:

      * /dev/nvme0n2              10.00 GB   solid
      * /dev/sdb                  10.74 GB   rotational
      * /dev/sdc                  10.74 GB   rotational
      * /dev/sdd                  10.74 GB   rotational
      * /dev/sde                  10.74 GB   rotational
      * /dev/sdf                  10.74 GB   rotational
      * /dev/sdg                  10.74 GB   rotational
      * /dev/sdh                  10.74 GB   rotational
      * /dev/sdi                  10.74 GB   rotational

    Current strategy: default
    Path: /etc/ceph/osd/strategies/default

    optional arguments:
      -h, --help  show this help message and exit

On a RHEL host with VDO devices:

    $ ceph-volume auto
    usage: ceph-volume auto [-h]

    Automatically detect devices ready for OSD provisioning based on configurable strategies.

    Detected devices:

      * /dev/mapper/vdo0          2.00 TB    rotational
      * /dev/mapper/vdo1          2.00 TB    rotational

    Current strategy: default
    Path: /etc/ceph/osd/strategies/default

    optional arguments:
      -h, --help  show this help message and exit
