### PR TITLE
script: build-integration-branch: avoid Unicode error

### DIFF
--- a/src/script/build-integration-branch
+++ b/src/script/build-integration-branch
@@ -61,5 +61,5 @@ for pr in prs:
               pr['head']['ref']])
     assert not r
 print('--- done. these PRs were included:')
-print('\n'.join(prtext))
+print('\n'.join(prtext).encode('ascii', errors='ignore').decode())
 print('--- perhaps you want to: make && ctest -j12 && git push ci %s' % branch)


### PR DESCRIPTION
When run on PRs that have non-ASCII characters in their titles, the script
fails like this when run in a non UTF-8 environment:

UnicodeEncodeError: 'latin-1' codec can't encode character u'\u2026' in
position 651: ordinal not in range(256)

Since failing like that is not useful, avoid the error by forcing ASCII
encoding and filtering out any non-ASCII characters.

Fixes: http://tracker.ceph.com/issues/24003
Signed-off-by: Nathan Cutler <ncutler@suse.com>