### PR TITLE
ceph-volume: sort and align `lvm list` output

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -17,7 +17,7 @@ osd_list_header_template = """\n
 
 osd_device_header_template = """
 
-  [{type: >4}]    {path}
+  {type: <13} {path}
 """
 
 device_metadata_item_template = """
@@ -31,18 +31,18 @@ def readable_tag(tag):
 
 def pretty_report(report):
     output = []
-    for _id, devices in report.items():
+    for _id, devices in sorted(report.items()):
         output.append(
             osd_list_header_template.format(osd_id=" osd.%s " % _id)
         )
         for device in devices:
             output.append(
                 osd_device_header_template.format(
-                    type=device['type'],
+                    type='[%s]' % device['type'],
                     path=device['path']
                 )
             )
-            for tag_name, value in device.get('tags', {}).items():
+            for tag_name, value in sorted(device.get('tags', {}).items()):
                 output.append(
                     device_metadata_item_template.format(
                         tag_name=readable_tag(tag_name),
@@ -179,7 +179,6 @@ class List(object):
                 return self.full_report(lvs=lvs)
 
         if lv:
-
             try:
                 _id = lv.tags['ceph.osd_id']
             except KeyError:

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
@@ -26,7 +26,7 @@ class TestPrettyReport(object):
             {'type': 'data', 'path': '/dev/sda1', 'devices': ['/dev/sda']}
         ]})
         stdout, stderr = capsys.readouterr()
-        assert '[data]    /dev/sda1' in stdout
+        assert '[data]        /dev/sda1' in stdout
 
     def test_osd_id_header_is_reported(self, capsys):
         lvm.listing.pretty_report({0: [


### PR DESCRIPTION
This commit targets the `ceph-volume lvm list` command.
The output is sorted by the osd id, so ceph operators
can find relevant information easier. Also the listing
of the physical devices can help operators find the
underlying malfunctioned device of a failed osd.

Signed-off-by: Theofilos Mouratidis <t.mour@cern.ch>