### PR TITLE
mgr/dashboard: Return task also if run synchronously

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -323,7 +323,11 @@ class Task(object):
             if status == TaskManager.VALUE_EXECUTING:
                 cherrypy.response.status = 202
                 return {'name': self.name, 'metadata': md}
-            return value
+            return {
+                'name': task.name,
+                'metadata': task.metadata,
+                'ret_value': value,
+            }
         wrapper.__wrapped__ = func
         return wrapper
 

--- a/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
+++ b/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
@@ -57,7 +57,8 @@ class TaskControllerTest(ControllerTestCase):
 
     def test_create_task(self):
         self._task_post('/test/task', {'param': 'hello'})
-        self.assertJsonBody({'my_param': 'hello'})
+        self.assertJsonBody({'name': 'task/create', 'metadata': {'param': 'hello'},
+                             'ret_value': {'my_param': 'hello'}})
 
     def test_long_set_task(self):
         TaskTest.sleep_time = 2.0
@@ -69,8 +70,10 @@ class TaskControllerTest(ControllerTestCase):
 
     def test_foo_task(self):
         self._task_post('/test/task/foo', {'param': 'hello'})
-        self.assertJsonBody({'my_param': 'hello'})
+        self.assertJsonBody({'name': 'task/foo', 'metadata': {'param': 'hello'},
+                             'ret_value': {'my_param': 'hello'}})
 
     def test_bar_task(self):
         self._task_put('/test/task/3/bar', {'param': 'hello'})
-        self.assertJsonBody({'my_param': 'hello', 'key': '3'})
+        self.assertJsonBody({'name': 'task/bar', 'metadata': {'key': '3', 'param': 'hello'},
+                             'ret_value': {'my_param': 'hello', 'key': '3'}})


### PR DESCRIPTION
Returned JSON is a subset for finished tasks of
`mgr.dashboard.tools.TaskManager#list_serializable`

**It only makes sense to merge this PR, if it actually helps the frontend!**

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>