### PR TITLE
mgr/dashboard: Add error handling on the frontend

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -462,9 +462,6 @@ export class RbdFormComponent implements OnInit {
       this.router.navigate(['/block/rbd']);
     }, (resp) => {
       this.rbdForm.setErrors({'cdSubmitButton': true});
-      finishedTask.success = false;
-      finishedTask.exception = resp.error;
-      this.notificationService.notifyTask(finishedTask);
     });
   }
 
@@ -521,9 +518,6 @@ export class RbdFormComponent implements OnInit {
         this.router.navigate(['/block/rbd']);
       }).catch((resp) => {
         this.rbdForm.setErrors({'cdSubmitButton': true});
-        finishedTask.success = false;
-        finishedTask.exception = resp.error;
-        this.notificationService.notifyTask(finishedTask);
       });
   }
 
@@ -556,9 +550,6 @@ export class RbdFormComponent implements OnInit {
         this.router.navigate(['/block/rbd']);
       }, (resp) => {
         this.rbdForm.setErrors({'cdSubmitButton': true});
-        finishedTask.success = false;
-        finishedTask.exception = resp.error;
-        this.notificationService.notifyTask(finishedTask);
       });
   }
 
@@ -608,9 +599,6 @@ export class RbdFormComponent implements OnInit {
         this.router.navigate(['/block/rbd']);
       }).catch((resp) => {
         this.rbdForm.setErrors({'cdSubmitButton': true});
-        finishedTask.success = false;
-        finishedTask.exception = resp.error;
-        this.notificationService.notifyTask(finishedTask);
       });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -258,9 +258,6 @@ export class RbdListComponent implements OnInit, OnDestroy {
         this.loadImages(null);
       }).catch((resp) => {
         this.modalRef.content.stopLoadingSpinner();
-        finishedTask.success = false;
-        finishedTask.exception = resp.error;
-        this.notificationService.notifyTask(finishedTask);
       });
   }
 
@@ -300,10 +297,6 @@ export class RbdListComponent implements OnInit, OnDestroy {
         }
         this.modalRef.hide();
         this.loadImages(null);
-      }).catch((resp) => {
-        finishedTask.success = false;
-        finishedTask.exception = resp.error;
-        this.notificationService.notifyTask(finishedTask);
       });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
@@ -74,9 +74,6 @@ export class RbdSnapshotFormComponent implements OnInit {
         this.onSubmit.next(this.snapName);
       }).catch((resp) => {
         this.snapshotForm.setErrors({'cdSubmitButton': true});
-        finishedTask.success = false;
-        finishedTask.exception = resp.error;
-        this.notificationService.notifyTask(finishedTask);
       });
   }
 
@@ -99,9 +96,6 @@ export class RbdSnapshotFormComponent implements OnInit {
         this.onSubmit.next(snapshotName);
       }).catch((resp) => {
         this.snapshotForm.setErrors({'cdSubmitButton': true});
-        finishedTask.success = false;
-        finishedTask.exception = resp.error;
-        this.notificationService.notifyTask(finishedTask);
       });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -178,10 +178,6 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
           (asyncFinishedTask: FinishedTask) => {
             this.notificationService.notifyTask(asyncFinishedTask);
           });
-      }).catch((resp) => {
-        finishedTask.success = false;
-        finishedTask.exception = resp.error;
-        this.notificationService.notifyTask(finishedTask);
       });
   }
 
@@ -208,9 +204,6 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
       })
       .catch((resp) => {
         this.modalRef.content.stopLoadingSpinner();
-        finishedTask.success = false;
-        finishedTask.exception = resp.error;
-        this.notificationService.notifyTask(finishedTask);
       });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/components.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/components.enum.ts
@@ -1,0 +1,6 @@
+export enum Components {
+  cephfs = 'CephFS',
+  rbd = 'RBD',
+  pool = 'Pool',
+  osd = 'OSD'
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/task-exception.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/task-exception.ts
@@ -1,6 +1,9 @@
+import { Task } from './task';
+
 export class TaskException {
   status: number;
-  errno: number;
+  code: number;
   component: string;
   detail: string;
+  task: Task;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@angular/core';
+
+import { Components } from '../enum/components.enum';
 import { FinishedTask } from '../models/finished-task';
 import { Task } from '../models/task';
 
@@ -130,11 +132,13 @@ export class TaskManagerMessageService {
         return {
         };
       }
-    ),
+    )
   };
 
   defaultMessage = new TaskManagerMessage(
-    (metadata) => 'Unknown Task',
+    (metadata) => {
+      return Components[metadata.component] || metadata.component || 'Unknown Task';
+    },
     (metadata) => 'Task executed successfully',
     () => {
       return {
@@ -151,7 +155,7 @@ export class TaskManagerMessageService {
 
   getErrorMessage(finishedTask: FinishedTask) {
     const taskManagerMessage = this.messages[finishedTask.name] || this.defaultMessage;
-    return taskManagerMessage.error(finishedTask.metadata)[finishedTask.exception.errno] ||
+    return taskManagerMessage.error(finishedTask.metadata)[finishedTask.exception.code] ||
       finishedTask.exception.detail;
   }
 


### PR DESCRIPTION
Now all error notifications are processed on the api-interceptor-service,
removing the need to handle them on every api request.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`

This PR depends on #21066.