### PR TITLE
cmake: use javac -h for creating JNI native headers

### DIFF
--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -22,18 +22,21 @@ set(java_srcs
 # as per
 #   https://blogs.oracle.com/darcy/entry/bootclasspath_older_source
 set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.7" "-target" "1.7" "-Xlint:-options")
-add_jar(libcephfs ${java_srcs})
-install_jar(libcephfs share/java)
+set(jni_header_dir "${CMAKE_CURRENT_BINARY_DIR}/native")
+if(CMAKE_VERSION VERSION_LESS 3.11)
+  set(CMAKE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} "-h" ${jni_header_dir})
+  add_jar(libcephfs ${java_srcs})
+  add_custom_target(
+    jni-header
+    DEPENDS libcephfs)
+  add_dependencies(jni-header libcephfs)
+else()
+  add_jar(libcephfs ${java_srcs}
+    GENERATE_NATIVE_HEADERS jni-header
+    DESTINATION ${jni_header_dir})
+endif()
 get_property(libcephfs_jar TARGET libcephfs PROPERTY JAR_FILE)
-
-set(java_h native/com_ceph_fs_CephMount.h)
-add_custom_command(
-  OUTPUT ${java_h}
-  COMMAND ${Java_JAVAH_EXECUTABLE} -classpath ${libcephfs_jar} -jni -o ${CMAKE_CURRENT_BINARY_DIR}/${java_h} com.ceph.fs.CephMount)
-add_custom_target(
-  jni-header
-  DEPENDS ${java_h})
-add_dependencies(jni-header libcephfs)
+install_jar(libcephfs share/java)
 
 find_jar(JUNIT_JAR
   NAMES junit4 junit

--- a/src/java/CMakeLists.txt
+++ b/src/java/CMakeLists.txt
@@ -21,7 +21,7 @@ set(java_srcs
 #   warning: [options] bootstrap class path not set in conjunction with -source 1.7
 # as per
 #   https://blogs.oracle.com/darcy/entry/bootclasspath_older_source
-set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.7" "-target" "1.7" "-Xlint:-options")
+set(CMAKE_JAVA_COMPILE_FLAGS "-source" "1.8" "-target" "1.8" "-Xlint:-options")
 set(jni_header_dir "${CMAKE_CURRENT_BINARY_DIR}/native")
 if(CMAKE_VERSION VERSION_LESS 3.11)
   set(CMAKE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} "-h" ${jni_header_dir})


### PR DESCRIPTION
JDK 1.10 does not offer javah anymore, so we need to use "javac -h" or
add_jar(... GENERATE_NATIVE_HEADERS) instead.

Fixes: http://tracker.ceph.com/issues/24012
Signed-off-by: Kefu Chai <kchai@redhat.com>