### PR TITLE
osd: remove useless condition.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9740,15 +9740,6 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
     osd->service.maybe_inject_dispatch_delay();
     sdata->shard_lock.Lock();
 
-    auto q = sdata->pg_slots.find(token);
-    if (q == sdata->pg_slots.end()) {
-      // this can happen if we race with pg removal.
-      dout(20) << __func__ << " slot " << token << " no longer there" << dendl;
-      pg->unlock();
-      sdata->shard_lock.Unlock();
-      return;
-    }
-    slot = q->second.get();
     --slot->num_running;
 
     if (slot->to_process.empty()) {


### PR DESCRIPTION
If slot already do num_rnning++ and release the lock. There is no
chance to erase this slot. This because:
a)only slot->num_running is zero, we can erase slot.
b)__process the only path can do num_running--.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>