### PR TITLE
mds,messages: silence -Wclass-memaccess warnings

### DIFF
--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -128,7 +128,6 @@ void KeyRing::encode_plaintext(bufferlist& bl)
 
 void KeyRing::encode_formatted(string label, Formatter *f, bufferlist& bl)
 {
-  std::ostringstream(os);
   f->open_array_section(label.c_str());
   for (map<EntityName, EntityAuth>::iterator p = keys.begin();
        p != keys.end();

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13229,7 +13229,7 @@ int Client::ll_delegation(Fh *fh, unsigned cmd, ceph_deleg_cb_t cb, void *priv)
   default:
     try {
       ret = inode->set_deleg(fh, cmd, cb, priv);
-    } catch (std::bad_alloc) {
+    } catch (std::bad_alloc&) {
       ret = -ENOMEM;
     }
     break;

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -534,7 +534,6 @@ struct inode_t {
   {
     clear_layout();
     memset(&dir_layout, 0, sizeof(dir_layout));
-    memset(&quota, 0, sizeof(quota));
   }
 
   // file type

--- a/src/messages/MClientQuota.h
+++ b/src/messages/MClientQuota.h
@@ -11,10 +11,7 @@ struct MClientQuota : public Message {
   MClientQuota() :
     Message(CEPH_MSG_CLIENT_QUOTA),
     ino(0)
-  {
-    memset(&rstat, 0, sizeof(rstat));
-    memset(&quota, 0, sizeof(quota));
-  }
+  {}
 private:
   ~MClientQuota() override {}
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4707,8 +4707,8 @@ void OSDSuperblock::generate_test_instances(list<OSDSuperblock*>& o)
 {
   OSDSuperblock z;
   o.push_back(new OSDSuperblock(z));
-  memset(&z.cluster_fsid, 1, sizeof(z.cluster_fsid));
-  memset(&z.osd_fsid, 2, sizeof(z.osd_fsid));
+  z.cluster_fsid.parse("01010101-0101-0101-0101-010101010101");
+  z.osd_fsid.parse("02020202-0202-0202-0202-020202020202");
   z.whoami = 3;
   z.current_epoch = 4;
   z.oldest_map = 5;

--- a/src/test/system/systest_runnable.cc
+++ b/src/test/system/systest_runnable.cc
@@ -29,8 +29,9 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
-#include <vector>
 #include <atomic>
+#include <limits>
+#include <vector>
 
 using std::ostringstream;
 using std::string;
@@ -176,7 +177,7 @@ void SysTestRunnable::
 update_id_str(bool started)
 {
   bool use_threads = SysTestSettings::inst().use_threads();
-  char extra[128];
+  char extra[std::numeric_limits<int>::digits10 + 1];
   extra[0] = '\0';
 
   if (started) {


### PR DESCRIPTION
this change silences warnings like:

warning: ‘void* memset(void*, int, size_t)’ writing to an object of
non-trivial type ‘struct uuid_d’; use assignment instead [-Wcla
ss-memaccess]
   memset(&z.cluster_fsid, 1, sizeof(z.cluster_fsid));
                                                    ^

Signed-off-by: Kefu Chai <kchai@redhat.com>