### PR TITLE
rgw: add local auth engine before externals

### DIFF
--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -135,7 +135,6 @@ public:
     }
 
     /* The external auth. */
-    Control local_engine_mode;
     if (! external_engines.is_empty()) {
       add_engine(Control::SUFFICIENT, external_engines);
     }

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -129,20 +129,17 @@ public:
       add_engine(Control::SUFFICIENT, anonymous_engine);
     }
 
+    /* The local auth. */
+    if (cct->_conf->rgw_s3_auth_use_rados) {
+      add_engine(Control::SUFFICIENT, local_engine);
+    }
+
     /* The external auth. */
     Control local_engine_mode;
     if (! external_engines.is_empty()) {
       add_engine(Control::SUFFICIENT, external_engines);
-
-      local_engine_mode = Control::FALLBACK;
-    } else {
-      local_engine_mode = Control::SUFFICIENT;
     }
 
-    /* The local auth. */
-    if (cct->_conf->rgw_s3_auth_use_rados) {
-      add_engine(local_engine_mode, local_engine);
-    }
   }
 
   const char* get_name() const noexcept override {


### PR DESCRIPTION
Change the order of auth engine so that local users are checked
before querying external engines (e.g. keystone, ldap).

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>