### PR TITLE
rgw: elastic: fixes for supporting Elasticsearch versions >= 5.0

### DIFF
--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -264,6 +264,17 @@ public:
     : RGWSendRESTResourceCR<S, T>(_cct, _conn, _http_manager,
                                   "PUT", _path,
                                   _params, nullptr, _input, _result) {}
+
+  RGWPutRESTResourceCR(CephContext *_cct, RGWRESTConn *_conn,
+                       RGWHTTPManager *_http_manager,
+                       const string& _path,
+                       rgw_http_param_pair *_params,
+                       map <string, string> *_attrs,
+                       S& _input, T *_result)
+    : RGWSendRESTResourceCR<S, T>(_cct, _conn, _http_manager,
+                                  "PUT", _path,
+                                  _params, _attrs, _input, _result) {}
+
 };
 
 class RGWDeleteRESTResourceCR : public RGWSimpleCoroutine {

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -161,12 +161,46 @@ struct ElasticConfig {
 
 using ElasticConfigRef = std::shared_ptr<ElasticConfig>;
 
+std::optional<const char*> es_type_to_str(const ESType& t) {
+  switch (t) {
+  case ESType::String: return "string";
+  case ESType::Text: return "text";
+  case ESType::Keyword: return "keyword";
+  case ESType::Long: return "long";
+  case ESType::Integer: return "integer";
+  case ESType::Short: return "short";
+  case ESType::Byte: return "byte";
+  case ESType::Double: return "double";
+  case ESType::Float: return "float";
+  case ESType::Half_Float: return "half_float";
+  case ESType::Scaled_Float: return "scaled_float";
+  case ESType::Date: return "date";
+  case ESType::Boolean: return "boolean";
+  case ESType::Integer_Range: return "integer_range";
+  case ESType::Float_Range: return "float_range";
+  case ESType::Double_Range: return "date_range";
+  case ESType::Date_Range: return "date_range";
+  case ESType::Geo_Point: return "geo_point";
+  case ESType::Ip: return "ip";
+  default:
+    return std::nullopt;
+  }
+
+}
+
 struct es_dump_type {
   const char *type;
   const char *format;
   bool analyzed;
+  std::string default_type;
 
   es_dump_type(const char *t, const char *f = nullptr, bool a = false) : type(t), format(f), analyzed(a) {}
+
+  es_dump_type(ESType t, const char *f = nullptr, bool a = false,
+               std::string default_type="text"): format(f), analyzed(a),
+                                                 default_type(default_type) {
+    type = es_type_to_str(t).value_or(default_type.c_str());
+  }
 
   void dump(Formatter *f) const {
     encode_json("type", type, f);
@@ -180,37 +214,45 @@ struct es_dump_type {
 };
 
 struct es_index_mappings {
+  ESType string_type {ESType::String};
+
   void dump_custom(Formatter *f, const char *section, const char *type, const char *format) const {
     f->open_object_section(section);
     ::encode_json("type", "nested", f);
     f->open_object_section("properties");
-    encode_json("name", es_dump_type("string"), f);
+    encode_json("name", es_dump_type(string_type), f);
     encode_json("value", es_dump_type(type, format), f);
     f->close_section(); // entry
     f->close_section(); // custom-string
   }
+
+  void dump_custom(Formatter *f, const char* section, ESType t, const char *format) const {
+    const auto s = es_type_to_str(t).value_or("text");
+    dump_custom(f,section,s,format);
+  }
+
   void dump(Formatter *f) const {
     f->open_object_section("object");
     f->open_object_section("properties");
-    encode_json("bucket", es_dump_type("string"), f);
-    encode_json("name", es_dump_type("string"), f);
-    encode_json("instance", es_dump_type("string"), f);
-    encode_json("versioned_epoch", es_dump_type("long"), f);
+    encode_json("bucket", es_dump_type(string_type), f);
+    encode_json("name", es_dump_type(string_type), f);
+    encode_json("instance", es_dump_type(string_type), f);
+    encode_json("versioned_epoch", es_dump_type(ESType::Date), f);
     f->open_object_section("meta");
     f->open_object_section("properties");
-    encode_json("cache_control", es_dump_type("string"), f);
-    encode_json("content_disposition", es_dump_type("string"), f);
-    encode_json("content_encoding", es_dump_type("string"), f);
-    encode_json("content_language", es_dump_type("string"), f);
-    encode_json("content_type", es_dump_type("string"), f);
-    encode_json("etag", es_dump_type("string"), f);
-    encode_json("expires", es_dump_type("string"), f);
+    encode_json("cache_control", es_dump_type(string_type), f);
+    encode_json("content_disposition", es_dump_type(string_type), f);
+    encode_json("content_encoding", es_dump_type(string_type), f);
+    encode_json("content_language", es_dump_type(string_type), f);
+    encode_json("content_type", es_dump_type(string_type), f);
+    encode_json("etag", es_dump_type(string_type), f);
+    encode_json("expires", es_dump_type(string_type), f);
     f->open_object_section("mtime");
     ::encode_json("type", "date", f);
     ::encode_json("format", "strict_date_optional_time||epoch_millis", f);
     f->close_section(); // mtime
-    encode_json("size", es_dump_type("long"), f);
-    dump_custom(f, "custom-string", "string", nullptr);
+    encode_json("size", es_dump_type(ESType::Long), f);
+    dump_custom(f, "custom-string", string_type, nullptr);
     dump_custom(f, "custom-int", "long", nullptr);
     dump_custom(f, "custom-date", "date", "strict_date_optional_time||epoch_millis");
     f->close_section(); // properties

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -103,6 +103,55 @@ public:
 #define ES_NUM_SHARDS_DEFAULT 16
 #define ES_NUM_REPLICAS_DEFAULT 1
 
+struct ESVersion {
+  int major_ver;
+  int minor_ver;
+
+  ESVersion(int _major, int _minor): major_ver(_major), minor_ver(_minor) {}
+  ESVersion(): major_ver(0), minor_ver(0) {}
+
+  void from_str(const char* s) {
+    sscanf(s, "%d.%d", &major_ver, &minor_ver);
+  }
+
+  std::string to_str() const {
+    return std::to_string(major_ver) + "." + std::to_string(minor_ver);
+  }
+
+  void decode_json(JSONObj *obj);
+};
+
+bool operator >= (const ESVersion& v1, const ESVersion& v2)
+{
+  if (v1.major_ver == v2.major_ver)
+    return v1.minor_ver >= v2.minor_ver;
+
+  return v1.major_ver > v2.major_ver;
+}
+
+struct ESInfo {
+  std::string name;
+  std::string cluster_name;
+  std::string cluster_uuid;
+  ESVersion version;
+
+  void decode_json(JSONObj *obj);
+};
+
+void ESInfo::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("name", name, obj);
+  JSONDecoder::decode_json("cluster_name", cluster_name, obj);
+  JSONDecoder::decode_json("cluster_uuid", cluster_uuid, obj);
+  JSONDecoder::decode_json("version", version, obj);
+}
+
+void ESVersion::decode_json(JSONObj *obj)
+{
+  std::string s;
+  JSONDecoder::decode_json("number", s, obj);
+  this->from_str(s.c_str());
+}
 
 struct ElasticConfig {
   uint64_t sync_instance{0};

--- a/src/rgw/rgw_sync_module_es.h
+++ b/src/rgw/rgw_sync_module_es.h
@@ -3,6 +3,33 @@
 
 #include "rgw_sync_module.h"
 
+enum ESType {
+  /* string datatypes */
+  String, /* Deprecated Since 5.X+ */
+  Text,
+  Keyword,
+
+  /* Numeric Types */
+  Long, Integer, Short, Byte, Double, Float, Half_Float, Scaled_Float,
+
+  /* Date Type */
+  Date,
+
+  /* Boolean */
+  Boolean,
+
+  /* Binary; Must Be Base64 Encoded */
+  Binary,
+
+  /* Range Types */
+  Integer_Range, Float_Range, Long_Range, Double_Range, Date_Range,
+
+  /* A Few Specialized Types */
+  Geo_Point,
+  Ip
+};
+
+
 class RGWElasticSyncModule : public RGWSyncModule {
 public:
   RGWElasticSyncModule() {}


### PR DESCRIPTION
This series of commits introduces support for ES clusters>= 5.0 where the string type is deprecated and 6.0 clusters where the type is invalid. We determine the ESversion and then decide on the string type to use, using text type for ES version >= 5.0.  

An enum called ESType is introduced having mappings to various ESTypes and this is later used in dump_type. Also introduces structures for ES version info and cluster name info which we parse from ES endpoint, while only the version info is used to determine the string type, there might be use for storing away the es cluster name and uuid for future use. 

Fixes: http://tracker.ceph.com/issues/22877