### PR TITLE
JFW wip command multiplex (RFC, DNM!)

### DIFF
--- a/src/include/util.h
+++ b/src/include/util.h
@@ -99,5 +99,15 @@ bool match_str(const std::string& s, const XS& ...xs)
  return ((s == xs) || ...);
 }
 
+// Sugar for getting a line from a stream as a string, returning the string:
+template <typename IStreamT>
+inline std::string get_line(IStreamT& is)
+{
+ std::string r;
+ std::getline(is, r);
+ return r;
+}
+
 } // namespace ceph::util
+
 #endif /* CEPH_UTIL_H */

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -112,6 +112,8 @@ struct MMonHealth;
 
 #define COMPAT_SET_LOC "feature_set"
 
+struct MonitorProjection;
+
 class C_MonContext final : public FunctionContext {
   const Monitor *mon;
 public:
@@ -122,6 +124,11 @@ public:
 
 class Monitor : public Dispatcher,
                 public md_config_obs_t {
+
+public:
+  // Projection class (capture selected private members externally):
+  class multiplexer_projection;
+
 public:
   // me
   string name;
@@ -853,7 +860,7 @@ public:
     }
   };
 
- private:
+  private:
   class C_RetryMessage : public C_MonOp {
     Monitor *mon;
   public:
@@ -975,6 +982,21 @@ public:
 
   static bool is_keyring_required();
 };
+
+/* Projection class (capture selected private members externally): */
+
+namespace ceph::mon::cmds { struct MonitorProjection; }
+
+class Monitor::multiplexer_projection : public Monitor {
+  friend ceph::mon::cmds::MonitorProjection;
+
+  using C_Command      = Monitor::C_Command;		// already public, but now matches C_RetryMessage
+  using C_RetryMessage = Monitor::C_RetryMessage;
+  
+  multiplexer_projection() = delete;
+};
+
+
 
 #define CEPH_MON_FEATURE_INCOMPAT_BASE CompatSet::Feature (1, "initial feature set (~v.18)")
 #define CEPH_MON_FEATURE_INCOMPAT_GV CompatSet::Feature (2, "global version sequencing (v0.52)")

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -51,6 +51,7 @@
 #include "mon/MonOpRequest.h"
 #include "common/WorkQueue.h"
 
+#include "mon/command_multiplexer.h"
 
 #define CEPH_MON_PROTOCOL     13 /* cluster internal */
 
@@ -985,11 +986,12 @@ public:
 
 /* Projection class (capture selected private members externally): */
 
-namespace ceph::mon::cmds { struct MonitorProjection; }
+namespace ceph::cmds::mon { struct MonitorProjection; }
 
 class Monitor::multiplexer_projection : public Monitor {
-  friend ceph::mon::cmds::MonitorProjection;
+  friend ceph::cmds::mon::MonitorProjection;
 
+  protected:
   using C_Command      = Monitor::C_Command;		// already public, but now matches C_RetryMessage
   using C_RetryMessage = Monitor::C_RetryMessage;
   

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -93,6 +93,37 @@ const uint32_t MAX_POOL_APPLICATION_LENGTH = 128;
 
 } // anonymous namespace
 
+namespace ceph::mon::cmds {
+
+auto multiplex_command(const ceph::operation_type op_type, ceph::mon::cmds::osdmonitor_command_ctx& state, std::string_view prefix) 
+{
+  using status_t = ceph::mon::cmds::osdmonitor_command_registry::op_result;
+
+  auto [status, result] = state.osdmonitor.commands.apply(op_type, prefix, state);
+
+  if (status_t::declined == status) {
+      return make_tuple(status, false);
+  }
+
+  auto& fn_status      = std::get<0>(result); // success/failure
+  auto& fn_result_code = std::get<1>(result); // error code returned by called function
+
+  // JFW: this should match what the reply: label currently does:
+  getline(state.ss, state.rs);
+
+  if (fn_result_code < 0 && state.rs.length() == 0) {
+      state.rs = cpp_strerror(fn_result_code);
+  }
+
+  state.mon.reply_command(state.op, fn_result_code, state.rs, state.rdata, state.osdmonitor.get_last_committed());
+
+  // This should match the role of "ret":
+  return make_tuple(status,
+                    ceph::mon::cmds::osdmonitor_cmd_status::success == fn_status ? true : false);
+}
+
+} // namespace ceph::mon::cmds
+
 void LastEpochClean::Lec::report(ps_t ps, epoch_t last_epoch_clean)
 {
   if (epoch_by_pg.size() <= ps) {
@@ -180,6 +211,12 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon, const OSDMap& osdmap)
 		<< ").osd e" << osdmap.get_epoch() << " ";
 }
 
+namespace ceph::mon::cmds::osdmonitor {
+
+void register_commands(ceph::mon::cmds::osdmonitor_command_registry&);
+
+} // namespace ceph::mon::cmds::osdmonitor
+
 OSDMonitor::OSDMonitor(
   CephContext *cct,
   Monitor *mn,
@@ -187,11 +224,14 @@ OSDMonitor::OSDMonitor(
   const string& service_name)
  : PaxosService(mn, p, service_name),
    cct(cct),
+   commands("OSDMonitor"),
    inc_osd_cache(g_conf->mon_osd_cache_size),
    full_osd_cache(g_conf->mon_osd_cache_size),
    has_osdmap_manifest(false),
    mapper(mn->cct, &mn->cpu_tp)
-{}
+{
+    ceph::mon::cmds::osdmonitor::register_commands(commands);
+}
 
 bool OSDMonitor::_have_pending_crush()
 {
@@ -4256,6 +4296,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   int r = 0;
   bufferlist rdata;
   stringstream ss, ds;
+  string rs;  
 
   cmdmap_t cmdmap;
   if (!cmdmap_from_json(m->cmd, &cmdmap, ss)) {
@@ -4276,6 +4317,17 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   string format;
   cmd_getval(cct, cmdmap, "format", format, string("plain"));
   boost::scoped_ptr<Formatter> f(Formatter::create(format));
+
+/////// JFW: preprocess_command() multiplexer:
+  // Capture the context (state environment) required by commands:
+  ceph::mon::cmds::osdmonitor_command_ctx state(
+    *this, *cct, *mon, *m, op, *paxos, cmdmap, osdmap, f.get(), ss, rdata, rs, prefix);
+
+  if(auto [status, result ] = ceph::mon::cmds::multiplex_command(ceph::operation_type::preprocess, state, prefix);
+     ceph::mon::cmds::osdmonitor_command_registry::op_result::accepted == status) {
+    return result;
+  }
+/////// JFW: END preprocess_command() multiplexer:
 
   if (prefix == "osd stat") {
     osdmap.print_summary(f.get(), ds, "", true);
@@ -5585,7 +5637,6 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   }
 
  reply:
-  string rs;
   getline(ss, rs);
   mon->reply_command(op, r, rs, rdata, get_last_committed());
   return true;
@@ -7970,8 +8021,21 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
   // This should be used as a general guideline for most commands handled
   // in this function.  Adapt as you see fit, but please bear in mind that
   // this is the expected behavior.
-   
- 
+
+  // Multiplex registered commands:   
+  {
+  using namespace ceph::mon::cmds;
+
+  // Capture the context (state environment) required by commands:
+  osdmonitor_command_ctx state(
+    *this, *cct, *mon, *m, op, *paxos, cmdmap, osdmap, f.get(), ss, rdata, rs, prefix);
+
+  if(auto [status, result ] = multiplex_command(ceph::operation_type::prepare, state, prefix);
+     osdmonitor_command_registry::op_result::accepted == status) {
+    return result;
+  }
+  }
+
   if (prefix == "osd setcrushmap" ||
       (prefix == "osd crush set" && !osdid_present)) {
     if (pending_inc.crush.length()) {
@@ -12267,3 +12331,210 @@ void OSDMonitor::_pool_op_reply(MonOpRequestRef op,
 					 ret, epoch, get_last_committed(), blp);
   mon->send_reply(op, reply);
 }
+
+////////// JFW: porting commands:
+
+namespace ceph::mon::cmds::osdmonitor {
+
+using namespace ceph::mon::cmds;
+
+struct osd_new : public osdmonitor_command
+{
+ vector<string> tags() { return { "osd new" }; }
+
+ osdmonitor_command_result at_prepare(const osdmonitor_command_ctx& state, string_view cmd)
+ {
+    auto* mon    = &state.mon;          // ptr, otherwise macro dout() fails
+    auto& osdmap = state.osdmap;        // otherwise macro dout() fails
+
+    auto& m      = state.mmon_command;
+
+    int err = 0; // sometimes used to indicate idempotent, but appears inconsistent...
+
+dout(10) << "JFW: in at_prepare()! HERE I AM!" << dendl;
+    // make sure authmon is writeable.
+    if (!mon->authmon()->is_writeable()) {
+      dout(10) << __func__ << " waiting for auth mon to be writeable for "
+               << "osd new" << dendl;
+      mon->authmon()->wait_for_writeable(state.op, new OSDMonitor::C_RetryMessage(&state.osdmonitor, state.op));
+      return { osdmonitor_cmd_status::failure, err };
+    }
+
+    bufferlist bl = m.get_data();
+    string param_json = bl.to_str();
+    dout(20) << __func__ << " osd new json = " << param_json << dendl;
+
+    map<string,string> param_map; 
+
+    err = get_json_str_map(param_json, state.ss, &param_map);
+    if (err < 0) {
+dout(10) << "JFW: get_json_str_map() failed, return failure" << dendl;
+      return { osdmonitor_cmd_status::failure, err };
+    }
+
+    dout(20) << __func__ << " osd new params " << param_map << dendl;
+
+    state.paxos.plug();
+    err = state.osdmonitor.prepare_command_osd_new(state.op, state.cmdmap, param_map, state.ss, state.f);
+    state.paxos.unplug();
+
+    if (err < 0) {
+dout(10) << "JFW: paxos/prepare_command_osd_new issue, return failure" << dendl;
+        return { osdmonitor_cmd_status::failure, err };
+    }
+
+    if (state.f) {
+      state.f->flush(state.rdata);
+    } else {
+      state.rdata.append(state.ss);
+    }
+
+    if (err == EEXIST) {
+dout(10) << "JFW: err == EEXIST, return ok" << dendl;
+      // idempotent operation
+// JFW: very hard to understand if this should be a success or a failure:
+      return { osdmonitor_cmd_status::success, 0 };
+    }
+
+    state.osdmonitor.wait_for_finished_proposal(state.op,
+        new MonitorProjection::C_Command(mon, state.op, 0, state.rs, state.rdata,
+                                         state.osdmonitor.get_last_committed() + 1));
+    state.osdmonitor.force_immediate_propose();
+
+dout(10) << "JFW: normal exit, return 1" << dendl;
+    return { osdmonitor_cmd_status::success, 1 };
+ }
+};
+
+struct osd_purge : public osdmonitor_command
+{
+ vector<string> tags() { return { "osd destroy", "osd purge" }; }
+
+ osdmonitor_command_result at_prepare(const osdmonitor_command_ctx& state, string_view cmd)
+ {
+    auto* mon    = &state.mon;          // ptr, otherwise macro dout() fails
+    auto& osdmap = state.osdmap;        // otherwise macro dout() fails
+
+    auto& ss     = state.ss;
+
+dout(10) << "JFW: osd_purge at_prepare()" << dendl;
+    /*
+     * Destroying an OSD means that we don't expect to further make use of
+     * the OSDs data (which may even become unreadable after this operation),
+     * and that we are okay with scrubbing all its cephx keys and config-key
+     * data (which may include lockbox keys, thus rendering the osd's data
+     * unreadable).
+     *
+     * The OSD will not be removed. Instead, we will mark it as destroyed,
+     * such that a subsequent call to `create` will not reuse the osd id.
+     * This will play into being able to recreate the OSD, at the same
+     * crush location, with minimal data movement.
+     *
+     * Note: this command requires the target OSD to be marked down. If you're
+     * trying to test this locally, using "osd down" may not work because the 
+     * target OSD may mark itself "up"-- so, kill the OSD process.
+     */
+
+    int err = 0;    // used for result checking 
+
+    // make sure authmon is writeable.
+    if (!mon->authmon()->is_writeable()) {
+      dout(10) << __func__ << " waiting for auth mon to be writeable for "
+               << "osd destroy" << dendl;
+      mon->authmon()->wait_for_writeable(state.op, new MonitorProjection::C_RetryMessage(mon, state.op));
+
+      return { osdmonitor_cmd_status::failure, 0 };
+    }
+
+    int64_t id;
+    if (!cmd_getval(&state.cct, state.cmdmap, "id", id)) {
+      state.ss << "unable to parse osd id value '"
+               << cmd_vartype_stringify(state.cmdmap.at("id")) << "";
+
+      return { osdmonitor_cmd_status::failure, -EINVAL };
+    }
+
+    bool is_destroy = (state.prefix == "osd destroy");
+    if (!is_destroy) {
+      assert("osd purge" == state.prefix);
+    }
+
+    string sure;
+    if (!cmd_getval(&state.cct, state.cmdmap, "sure", sure) ||
+        sure != "--yes-i-really-mean-it") {
+      ss << "Are you SURE? This will mean real, permanent data loss, as well "
+         << "as cephx and lockbox keys. Pass --yes-i-really-mean-it if you "
+         << "really do.";
+
+      return { osdmonitor_cmd_status::failure, -EPERM};
+    } else if (!osdmap.exists(id)) {
+      ss << "osd." << id << " does not exist";
+
+      return { osdmonitor_cmd_status::failure, 0 };
+    } else if (osdmap.is_up(id)) {
+      ss << "osd." << id << " is not `down`.";
+
+dout(10) << "JFW: osd_purge at_prepare() IS NOT DOWN" << dendl;
+      return { osdmonitor_cmd_status::failure, -EBUSY };
+    } else if (is_destroy && osdmap.is_destroyed(id)) {
+      ss << "destroyed osd." << id;
+
+      return { osdmonitor_cmd_status::failure, 0 };
+    }
+
+    bool goto_reply = false;
+
+    state.paxos.plug();
+    if (is_destroy) {
+      err = state.osdmonitor.prepare_command_osd_destroy(id, ss);
+      // we checked above that it should exist.
+      assert(err != -ENOENT);
+    } else {
+      err = state.osdmonitor.prepare_command_osd_purge(id, ss);
+      if (err == -ENOENT) {
+        err = 0;
+        ss << "osd." << id << " does not exist.";
+        goto_reply = true;
+      }
+    }
+    state.paxos.unplug();
+
+    if (err < 0 || goto_reply) {
+
+      return { osdmonitor_cmd_status::failure, err };
+    }
+
+    if (is_destroy) {
+      ss << "destroyed osd." << id;
+    } else {
+      ss << "purged osd." << id;
+    }
+
+    getline(ss, state.rs);
+    state.osdmonitor.wait_for_finished_proposal(state.op,
+        new MonitorProjection::C_Command(&state.mon, state.op, 0, state.rs, state.rdata, state.osdmonitor.get_last_committed() + 1));
+    state.osdmonitor.force_immediate_propose();
+
+    return { osdmonitor_cmd_status::success, 1 };
+ }
+};
+
+} // namespace ceph::mon::cmds::osdmonitor 
+
+/* Command registry:
+    - Add your function types here, watch them grow!  */
+namespace ceph::mon::cmds::osdmonitor {
+
+void register_commands(ceph::mon::cmds::osdmonitor_command_registry& commands)
+{
+ ceph::register_commands<osdmonitor_command_registry, 
+    osd_new,
+    osd_purge
+ >(commands);
+
+ /* If you require a non-default ctor, you can manually initialize and
+    add your types here: */
+}
+
+} // namespace ceph::mon::cmds::osdmonitor
+

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -26,7 +26,9 @@
 
 #include "include/types.h"
 #include "include/encoding.h"
+
 #include "common/simple_cache.hpp"
+
 #include "msg/Messenger.h"
 
 #include "osd/OSDMap.h"
@@ -34,6 +36,8 @@
 
 #include "CreatingPGs.h"
 #include "PaxosService.h"
+
+#include "command_multiplexer.h"
 
 class Monitor;
 class PGMap;
@@ -127,6 +131,79 @@ public:
   epoch_t get_lower_bound(const OSDMap& latest) const;
 };
 
+namespace ceph::mon::cmds {
+
+/* Enviornment that OSDMonitor commands run in:
+	(It would be a good idea to dial in the const-ness and names a bit more...) */
+struct osdmonitor_command_ctx
+{
+ OSDMonitor&                  osdmonitor;
+ CephContext&                 cct;
+ Monitor&                     mon;
+ MMonCommand&                 mmon_command;    // aka "m"
+ mutable MonOpRequestRef      op;
+ Paxos&                       paxos;
+ const cmdmap_t&			  cmdmap;
+ OSDMap&                      osdmap;
+
+ Formatter*                   f;               // JFW: observing ptr
+ std::stringstream&           ss;
+ buffer::list&                rdata;
+ std::string&                 rs;			   // modified by side-effect
+ const std::string&           prefix;          // eg. the command ("osd new")
+
+ osdmonitor_command_ctx(OSDMonitor& osdmonitor_,
+                        CephContext& cct_,
+                        Monitor& mon_,
+                        MMonCommand& mmon_command_,
+                        MonOpRequestRef op_,
+                        Paxos& paxos_,
+                        const cmdmap_t& cmdmap_,
+                        OSDMap& osdmap_,
+                        Formatter* f_,
+                        std::stringstream& ss_,
+                        buffer::list& rdata_,
+                        std::string& rs_,
+                        const std::string& prefix_)
+  : osdmonitor(osdmonitor_),
+    cct(cct_),
+    mon(mon_),
+    mmon_command(mmon_command_),
+    op(op_),
+    paxos(paxos_),
+    cmdmap(cmdmap_),
+    osdmap(osdmap_),
+    f(f_),
+    ss(ss_),
+    rdata(rdata_),
+    rs(rs_),
+    prefix(prefix_)
+  {}
+};
+
+// Did the operation succeed, or did it fail:
+enum class osdmonitor_cmd_status : int { failure = 0, success };
+
+// Select access to private Monitor members (eg. filter out members):
+struct MonitorProjection : private Monitor::multiplexer_projection
+{
+ using C_Command      = Monitor::multiplexer_projection::C_Command;
+ using C_RetryMessage = Monitor::multiplexer_projection::C_RetryMessage;
+ 
+ private:
+ MonitorProjection() = delete;
+};
+
+// The result of the operation, plus a result code):
+using osdmonitor_cmd_result = std::tuple<osdmonitor_cmd_status, int>;
+
+using osdmonitor_command_result   = osdmonitor_cmd_result;
+using osdmonitor_command          = ceph::command<osdmonitor_command_ctx, osdmonitor_command_result>;
+using osdmonitor_command_registry = ceph::command_registry<osdmonitor_command>;
+
+auto multiplex_command(const ceph::operation_type op_type, ceph::mon::cmds::osdmonitor_command_ctx& cmdctx, std::string_view prefix);
+
+} // namespace ceph::mon::cmds
 
 struct osdmap_manifest_t {
   // all the maps we have pinned -- i.e., won't be removed unless
@@ -209,6 +286,10 @@ WRITE_CLASS_ENCODER(osdmap_manifest_t);
 
 class OSDMonitor : public PaxosService {
   CephContext *cct;
+
+  ceph::mon::cmds::osdmonitor_command_registry commands;
+
+  friend auto ceph::mon::cmds::multiplex_command(const ceph::operation_type, ceph::mon::cmds::osdmonitor_command_ctx&, std::string_view);
 
 public:
   OSDMap osdmap;
@@ -680,6 +761,10 @@ public:
       pending_inc.new_flags &= ~flag;
     }
   }
+
+ private:
+ // Allow access to the private types in OSDMonitor: 
+ friend ceph::mon::cmds::osdmonitor_command;
 };
 
 #endif

--- a/src/mon/command_multiplexer.h
+++ b/src/mon/command_multiplexer.h
@@ -1,0 +1,295 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ * @author Jesse Williamson <jwilliamson@suse.de>
+ *
+*/
+
+#ifndef COMMAND_DISPATCHER_HPP
+ #define COMMAND_DISPATCHER_HPP 1
+
+#include <string>
+#include <vector>
+#include <memory>
+#include <algorithm>
+#include <exception>
+#include <string_view>
+
+#include <experimental/iterator>
+
+/*
+This is a mini-framework for mapping commands and their parameters from the command-line (or wherever) to functions.
+
+For example, if you are at the command-line and run "ceph mon add", this command will be forwarded to this framework.
+
+From a high level, this library provides a container, called a command_registry, that holds bindings from strings
+to functions, and manages the details of memory management, standardizing the details of whether or not a command
+was handled, etc.. 
+
+While much of the framework isn't directly specific to mon, there are two major ways involving specific code: we
+have two kinds of operations, preprocess operations and prepare operations. 
+
+Installing a command_registry into a subsystem requires patching the preprocess and prepare pipelines. Additionally,
+the environment a user's function (ie. a command) runs in is centralized into a single state structure.
+
+*/
+
+namespace ceph {
+
+enum class operation_type : int { preprocess, prepare };
+
+template <typename CommandState, typename CommandResult>
+struct command;
+
+template <typename CommandType>
+struct command_registry
+{
+ using command_type = CommandType;
+
+ enum class op_result { accepted, declined };
+
+ // The type returned by an operation:
+ using status_type  = std::tuple<op_result, typename command_type::result_type>;
+
+ private:
+ command_registry(const command_registry&)              = delete;
+ command_registry& operator=(const command_registry&)   = delete;
+
+ public:
+ std::string name;      // eg. the name of the registry 
+
+ std::vector<std::unique_ptr<command_type>> commands;
+
+ public:
+ 
+ command_registry(std::string_view name_)
+  : name(name_)
+ {}
+
+ virtual ~command_registry()    {}
+
+ public:
+ auto find_cmd_for_tag(std::string_view candidate_tag)
+ {
+    using std::end;
+    using std::begin;
+
+    auto tag_match = [candidate_tag](const auto& command) {
+        auto tags = command->tags();
+        return end(tags) != std::find(begin(tags), end(tags), candidate_tag);
+    };
+
+    return std::find_if(begin(commands), end(commands), tag_match); 
+ }
+
+ bool in_registry(std::string_view tag)
+ {
+    return end(commands) != find_cmd_for_tag(tag);
+ }
+
+ template <typename K, typename A, template <typename, typename> typename SeqT = std::vector>
+ bool in_registry(const SeqT<K, A>& tags)
+ {
+    return std::end(tags) != std::find_if(std::begin(tags), std::end(tags), 
+                                         [this](const auto& tag) {
+                                           return this->in_registry(tag);
+                                        });
+ }
+
+ void add_command(std::unique_ptr<CommandType> cmd) 
+ {
+    using namespace std;
+
+    auto tags(cmd->tags());
+
+    if (in_registry(tags)) {
+      ostringstream os;
+      os << "already in registry: ";
+      copy(begin(tags), end(tags), experimental::ostream_joiner(os, ','));
+      throw runtime_error(os.str());
+    }
+
+    commands.push_back(std::move(cmd));
+ }
+
+ // Actually accept a user's function and call it, or decline service:
+ public:
+ status_type apply(const operation_type op_type, 
+                   std::string_view cmd_prefix, 
+                   const typename CommandType::state_type& state)
+ {
+    auto cmd = find_cmd_for_tag(cmd_prefix);
+
+    // Command not found:
+    if (std::end(commands) != cmd) 
+        return { op_result::declined, {} };
+
+    auto& c = *cmd;
+
+    auto [result, tag] = c->accepts(op_type, cmd_prefix, c->tags());
+
+    // Command found, but did not accept:
+    if (!result)
+        return { op_result::declined, {} };
+
+    if (ceph::operation_type::preprocess == op_type)
+     return { op_result::accepted, c->at_preprocess(state, cmd_prefix.substr(tag.size())) };
+
+    if (ceph::operation_type::prepare == op_type)
+     return { op_result::accepted, c->at_prepare(state, cmd_prefix.substr(tag.size())) };
+
+    // If this happens, something's very wrong:
+    std::ostringstream os;
+    os << "invalid op_type " << static_cast<int>(op_type);
+    throw std::invalid_argument(os.str());
+ }
+};
+
+/* 
+This is a base class that provides a customization point for user functions, and is
+what users will indirectly interact with most of the time.
+
+In the context of your multiplexer deployment, there will be a defined type along the lines of:
+
+    using my_command_t = ceph::command<my_command_ctx, my_command_result>;
+
+Given that, to add a new function of your own, follow these steps: 
+
+    * derive your new type from my_command_t;
+    * define the tags (strings) you want to respond to by listing them in your
+    tags() meber function;
+    * override one or both of the prepare() and preprocess() member functions;
+    * register the type of your command with the registry helper
+
+In practice, a minimal function would look something like this:
+
+    struct my_command : public my_command_t
+    {
+        vector<string> tags() { return { "my_command" }; }
+    };
+
+...next, you need to register the type of your command function. The framework deployment will probably
+provide a place for you to do this, most likely a free function called register_commands(). There
+will be a place for you to add your command type. Below, we've added "my_command":
+
+    void register_commands(my_command_registry& commands)
+    {
+     ceph::register_commands<my_command_registry, 
+        my_command
+     >(commands);
+    }
+
+That will automatically register your function, set up the command bindings, set up multiplexing for
+whatever phase (preprocess, prepare) you've defined, and handle interpreting the results of your function,
+leaving you to concentrate on what you want it to do.
+
+Next, you'll probably want to define member functions for only the phases (ie. prepare, preprocess) that you
+wish to respond to. For example, we can extend my_command with a prepare command like so:
+
+    struct my_command : public my_command_t
+    {
+        vector<string> tags() { return { "my_command" }; }
+
+        my_command_result at_prepare(const my_command_ctx& state, string_view cmd);
+    };
+
+...that's it. 
+
+Your function's exact call is in the "cmd" parameter, and any other state is communicated via the
+"state" parameter (which you may call something shorter if you like); the exact content depends on
+what is available in your particular deployment.
+
+Next, let's consider what to return from our functions. This is defined by your local deployment, there 
+is no fixed type. Most of the time, you'll probably see something like this:
+    using my_cmd_result = std::tuple<my_cmd_status, int>;
+
+Where my_cmd_status is something like:
+
+    enum class my_cmd_status : int { failure = 0, success };
+
+...but, once again, nothing in the mini-framework enforces this. Above, the enum is allowed to degrade
+to int because the functions it wraps expects an int <= 0 on failure, > 0 on success back.
+
+Now, our final example:
+
+    struct my_command : public my_command_t
+    {
+        vector<string> tags() { return { "my_command" }; }
+
+        my_command_result at_prepare(const my_command_ctx& state, string_view cmd)
+        {
+            return { my_cmd_status::success, 1 };
+        }
+    };
+
+*/
+template <typename CommandState, typename CommandResult>
+struct command 
+{
+ using state_type   = CommandState;
+ using result_type  = CommandResult;
+
+ public:
+ virtual ~command() {}
+
+ /* The default string-matching acceptance check. Nothing prevents you from 
+ creating a custom version that assumes tags are regular expressions, for 
+ example (this might make a future good default version, for that matter): */
+ public:
+ [[nodiscard]] 
+ virtual auto accepts(const ceph::operation_type op_type, 
+                      std::string_view command, 
+                      const std::vector<std::string>& tags) 
+ -> std::tuple<bool, std::string>
+ {
+    for (const auto& tag : tags) {
+      if (tag.size() > command.size())
+       continue;
+
+      if (tag == command.substr(0, tag.size()))
+       return { true, tag };
+    }
+
+    return { false, "" };
+ }
+
+ public:
+ virtual std::vector<std::string> tags() = 0;
+
+ /* CommandResult must be a DefaultConstructable type. It is expected that returning
+ a default-constructed CommandResult indicates an accepted-but-failed state, however 
+ there is no constraint on this within the framework itself (it is instead determined
+ by the actual local dispatching stub) because it is possible that an implementation 
+ will want to accomplish something by side-effect. 
+
+ Should we need to add more than two categories, I suggest it would be best to 
+ approach this design a bit differently, using an associative array. (In any 
+ case, this is a situation where a little runtime overhead should be 
+ acceptable.) Perhaps something like:
+    auto fn = cmd.functions["preprocess"]; 
+ or auto ff = cmd.functions[tag_types::preprocess];
+ */
+ public:
+ virtual CommandResult at_preprocess(const CommandState& state, std::string_view cmd) { return CommandResult {}; };
+ virtual CommandResult at_prepare(const CommandState& state, std::string_view cmd)    { return CommandResult {}; };
+};
+
+// Helper for adding multiple default-constructed commands:
+template <typename CommandRegistry, typename ...CommandTypes>
+void register_commands(CommandRegistry& registry)
+{
+ (registry.add_command(std::make_unique<CommandTypes>(CommandTypes {})), ...);
+}
+
+} // namespace ceph
+
+#endif

--- a/src/test/common/test_util.cc
+++ b/src/test/common/test_util.cc
@@ -32,3 +32,12 @@ TEST(util, collect_sys_info)
   cct->put();
 }
 #endif
+
+TEST(util, get_line)
+{
+ const auto input = "Hello, World!";
+
+ std::istringstream is(input);
+
+ ASSERT_TRUE(input == ceph::util::get_line(is));
+}


### PR DESCRIPTION
** Request for Comments, please Do Not Merge! **

This branch introduces a mini-framework meant as a step toward unifying and standardizing the way that commands are multiplexed (I'd say dispatched, but that's taken) in Ceph (or at least mon). 

Because this is something that will be an investment to change after it begins to be used, I'd like to ask for comments at this point in the cycle. 

Some goals of this design include:

* compartmentalize commands (rather than having them be in one gigantic function)
* provide clearer semantics (explicit success/failure, reduce magical values, make the required
state explicit; reduce passing bare pointers, etc.)
* make adding new commands "easy"
  - centralize the parameters and naming conventions of variables
* increase visibility to make further improvements possible: 
  - see what parameters are or are not const
  - see the structure of commands in general
  - reduce overall complexity to see new patterns
* provide a generalized way to handle commands
  - core code and approach should be fairly flexible and reusable
* as command multiplexing is expected to be overshadowed by actual processing, I've proceeded under the assumption that some pointer indirection and lookup cost is acceptable

The basic idea:
There is a template or two (in common/command_multiplexer.hpp) that you can instantiate with whatever kind of context structure, etc. you want. Then, you bind commands into it. The normal behavior is for commands to be implemented via an interface, typically a user should just specify a dispatching tag (or tags) and implement the phase(s) they are interested in (eg. preprocess and prepare). 
The environment for commands is provided via a context structure that is automatically passed as a parameter to the command member functions. 

There are several additional things I'd like to draw attention to:
- In OSDMonitor, you can see a single function that handles the multiplexing.
- In MonmapMonitor, you can see what happens when all commands are migrated-- in particular, the context constructor is able to centralize all the details of initialization. The preprocess_command() and prepare_command() member functions become much simpler. (However, notice that in MonmapMonitor they are not currently dispatching into a single function because of a minor (and possibly undesirable) behavior difference, as noted in my code comment.)
- the context structures are meant to provide everything needed by any function, in no small part so we can see exactly what those things are. However, that does mean that there's overhead for constructing possibly unused things. The current assumption is that those are all sufficiently "cheap" as to have no significant effect on overall performance. We may need to look at other approaches, such as having data constructed inside functions that need them, however this may be more clear /after/ we migrate things.
- Another thought I had was to allow free functions, however providing a more traditional class hierarchy here allows us to help the user with a little more magic than we might get otherwise. 
- I realize some of the identifiers and namespaces are pretty verbose. I'm open to suggestions for new names, but I like to start with pretty explicit ideas.

Thank you very much for your time and constructive comments!