### PR TITLE
doc: fixed restful mgr module SSL configuration commands

### DIFF
--- a/doc/mgr/restful.rst
+++ b/doc/mgr/restful.rst
@@ -40,15 +40,15 @@ can be generated with a command similar to::
 The ``restful.crt`` should then be signed by your organization's CA
 (certificate authority).  Once that is done, you can set it with::
 
-  ceph config set mgr mgr/restful/$name/crt -i restful.crt
-  ceph config set mgr mgr/restful/$name/key -i restful.key
+  ceph config-key set mgr/restful/$name/crt -i restful.crt
+  ceph config-key set mgr/restful/$name/key -i restful.key
 
 where ``$name`` is the name of the ``ceph-mgr`` instance (usually the
 hostname). If all manager instances are to share the same certificate,
 you can leave off the ``$name`` portion::
 
-  ceph config set mgr mgr/restful/crt -i restful.crt
-  ceph config set mgr mgr/restful/key -i restful.key
+  ceph config-key set mgr/restful/crt -i restful.crt
+  ceph config-key set mgr/restful/key -i restful.key
 
 
 Configuring IP and port

--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -127,7 +127,7 @@ For rpm based instructions execute the following commands:
           # api_port = 5001
           # trusted_ip_list = 192.168.0.10,192.168.0.11
 
-      ..note::
+      .. note::
         trusted_ip_list is a list of IP addresses on each iscsi gateway that
         will be used for management operations like target creation, lun
         exporting, etc. The IP can be the same that will be used for iSCSI


### PR DESCRIPTION
Fixed restful mgr module SSL configuration commands

Fixed typo in a reStructuredText note entity of the iSCSI config chapter

Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>
