### PR TITLE
luminous: ceph-disk: write log to /var/log/ceph not to /var/run/ceph

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1528,10 +1528,11 @@ def get_free_partition_index(dev):
 
 
 def check_journal_reqs(args):
+    log_file = "/var/log/ceph/$cluster-osd-check.log"
     _, _, allows_journal = command([
         'ceph-osd', '--check-allows-journal',
         '-i', '0',
-        '--log-file', '$run_dir/$cluster-osd-check.log',
+        '--log-file', log_file,
         '--cluster', args.cluster,
         '--setuser', get_ceph_user(),
         '--setgroup', get_ceph_group(),
@@ -1539,7 +1540,7 @@ def check_journal_reqs(args):
     _, _, wants_journal = command([
         'ceph-osd', '--check-wants-journal',
         '-i', '0',
-        '--log-file', '$run_dir/$cluster-osd-check.log',
+        '--log-file', log_file,
         '--cluster', args.cluster,
         '--setuser', get_ceph_user(),
         '--setgroup', get_ceph_group(),
@@ -1547,7 +1548,7 @@ def check_journal_reqs(args):
     _, _, needs_journal = command([
         'ceph-osd', '--check-needs-journal',
         '-i', '0',
-        '--log-file', '$run_dir/$cluster-osd-check.log',
+        '--log-file', log_file,
         '--cluster', args.cluster,
         '--setuser', get_ceph_user(),
         '--setgroup', get_ceph_group(),


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/24041
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit e0856bd7e78828ea352290bd325aa4f5e06c3029)