### PR TITLE
mgr/dashboard: proxy.conf.json.sample TLS update

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
+++ b/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
@@ -1,6 +1,6 @@
 {
   "/api/": {
-    "target": "http://localhost:8080",
+    "target": "https://localhost:8080",
     "secure": false,
     "logLevel": "debug"
   }


### PR DESCRIPTION
Since https://github.com/ceph/ceph/pull/21627 has been merged the dashboard uses TLS. It needs to be added here as well because otherwise you will receive the following error message when using the frontend development server: "The client sent a plain HTTP request, but this server only speaks HTTPS on this port."

Signed-off-by: Tatjana Dehler <tdehler@suse.com>