### PR TITLE
mgr/dashboard: Upgrade Swimlane's data-table

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -44,7 +44,7 @@
     "@angular/platform-browser": "^5.0.0",
     "@angular/platform-browser-dynamic": "^5.0.0",
     "@angular/router": "^5.0.0",
-    "@swimlane/ngx-datatable": "^11.1.7",
+    "@swimlane/ngx-datatable": "^13.0.1",
     "@types/lodash": "^4.14.95",
     "awesome-bootstrap-checkbox": "0.3.7",
     "bootstrap": "^3.3.7",


### PR DESCRIPTION
Upgrade to latest version 13.0.1. which is ready for Angular 6. Check https://github.com/swimlane/ngx-datatable/blob/13.0.1/docs/changelog.md for more information.

Signed-off-by: Volker Theile <vtheile@suse.com>
