### PR TITLE
mgr/dashboard: Add Pool update endpoint 

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -312,6 +312,9 @@ class DashboardTestCase(MgrTestCase):
         except _ValError as e:
             self.assertEqual(data, str(e))
 
+    def assertSchemaBody(self, schema):
+        self.assertSchema(self.jsonBody(), schema)
+
     def assertBody(self, body):
         self.assertEqual(self._resp.text, body)
 
@@ -391,7 +394,7 @@ class _ValError(Exception):
 def _validate_json(val, schema, path=[]):
     """
     >>> d = {'a': 1, 'b': 'x', 'c': range(10)}
-    ... ds = JObj({'a': JLeaf(int), 'b': JLeaf(str), 'c': JList(JLeaf(int))})
+    ... ds = JObj({'a': int, 'b': str, 'c': JList(int)})
     ... _validate_json(d, ds)
     True
     """
@@ -406,6 +409,8 @@ def _validate_json(val, schema, path=[]):
             raise _ValError('val not of type {}'.format(schema.typ), path)
         return True
     if isinstance(schema, JList):
+        if not isinstance(val, list):
+            raise _ValError('val="{}" is not a list'.format(val), path)
         return all(_validate_json(e, schema.elem_typ, path + [i]) for i, e in enumerate(val))
     if isinstance(schema, JTuple):
         return all(_validate_json(val[i], typ, path + [i])
@@ -415,6 +420,8 @@ def _validate_json(val, schema, path=[]):
             return True
         elif val is None:
             raise _ValError('val is None', path)
+        if not hasattr(val, 'keys'):
+            raise _ValError('val="{}" is not a dict'.format(val), path)
         missing_keys = set(schema.sub_elems.keys()).difference(set(val.keys()))
         if missing_keys:
             raise _ValError('missing keys: {}'.format(missing_keys), path)
@@ -425,5 +432,7 @@ def _validate_json(val, schema, path=[]):
             _validate_json(val[sub_elem_name], sub_elem, path + [sub_elem_name])
             for sub_elem_name, sub_elem in schema.sub_elems.items()
         )
+    if schema in [str, int, float, bool, six.string_types]:
+        return _validate_json(val, JLeaf(schema), path)
 
     assert False, str(path)

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -97,12 +97,12 @@ class PoolTest(DashboardTestCase):
 
     def _pool_create(self, data):
         try:
-            self._post('/api/pool/', data)
+            self._task_post('/api/pool/', data)
             self.assertStatus(201)
 
             self._check_pool_properties(data)
 
-            self._delete("/api/pool/" + data['pool'])
+            self._task_delete("/api/pool/" + data['pool'])
             self.assertStatus(204)
         except Exception:
             log.exception("test_pool_create: data=%s", data)
@@ -190,16 +190,16 @@ class PoolTest(DashboardTestCase):
             }
 
         ]
-        self._post('/api/pool/', pool[0])
+        self._task_post('/api/pool/', pool[0])
         self.assertStatus(201)
 
         self._check_pool_properties(pool[0])
 
         for data in pool[1:]:
-            self._put('/api/pool/' + pool[0]['pool'], data)
+            self._task_put('/api/pool/' + pool[0]['pool'], data)
             self._check_pool_properties(data, pool_name=pool[0]['pool'])
 
-        self._delete("/api/pool/" + pool[0]['pool'])
+        self._task_delete("/api/pool/" + pool[0]['pool'])
         self.assertStatus(204)
 
     def test_pool_create_fail(self):

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -141,6 +141,9 @@ class PoolTest(DashboardTestCase):
             log.exception("test_pool_create: pool=%s", pool)
             raise
 
+        health = self._get('/api/dashboard/health')['health']
+        self.assertEqual(health['status'], 'HEALTH_OK', msg='health={}'.format(health))
+
     def test_pool_create(self):
         self._ceph_cmd(['osd', 'crush', 'rule', 'create-erasure', 'ecrule'])
         self._ceph_cmd(
@@ -178,9 +181,9 @@ class PoolTest(DashboardTestCase):
             {
                 'application_metadata': ['rbd', 'sth'],
             },
-            {
-                'pg_num': '12',
-            },
+            # {
+            #     'pg_num': '12',
+            # },
             {
                 'application_metadata': ['rgw'],
             },

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -37,7 +37,7 @@ class PoolTest(DashboardTestCase):
 
     @DashboardTestCase.RunAs('test', 'test', [{'pool': ['read', 'update', 'delete']}])
     def test_create_access_permissions(self):
-        self._post('/api/pool/', {})
+        self._task_post('/api/pool/', {})
         self.assertStatus(403)
 
     @DashboardTestCase.RunAs('test', 'test', [{'pool': ['read', 'create', 'update']}])
@@ -206,7 +206,7 @@ class PoolTest(DashboardTestCase):
 
     def test_pool_create_fail(self):
         data = {'pool_type': u'replicated', 'rule_name': u'dnf', 'pg_num': u'8', 'pool': u'sadfs'}
-        self._post('/api/pool/', data)
+        self._task_post('/api/pool/', data)
         self.assertStatus(400)
         self.assertJsonBody({
             'component': 'pool',

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -120,6 +120,8 @@ class PoolTest(DashboardTestCase):
                     self.assertEqual(pool['type'], data['pool_type'])
                 elif k == 'pg_num':
                     self.assertEqual(pool[k], int(v), '{}: {} != {}'.format(k, pool[k], v))
+                    k = 'pg_placement_num' # Should have the same value as pg_num
+                    self.assertEqual(pool[k], int(v), '{}: {} != {}'.format(k, pool[k], v))
                 elif k == 'application_metadata':
                     self.assertIsInstance(pool[k], list)
                     self.assertEqual(pool[k],

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -5,7 +5,7 @@ import logging
 
 import six
 
-from .helper import DashboardTestCase
+from .helper import DashboardTestCase, JObj, JList
 
 log = logging.getLogger(__name__)
 
@@ -16,9 +16,17 @@ class PoolTest(DashboardTestCase):
     @classmethod
     def tearDownClass(cls):
         super(PoolTest, cls).tearDownClass()
-        for name in ['dashboard_pool1', 'dashboard_pool2', 'dashboard_pool3']:
+        for name in ['dashboard_pool1', 'dashboard_pool2', 'dashboard_pool3', 'dashboard_pool_update1']:
             cls._ceph_cmd(['osd', 'pool', 'delete', name, name, '--yes-i-really-really-mean-it'])
         cls._ceph_cmd(['osd', 'erasure-code-profile', 'rm', 'ecprofile'])
+
+    pool_schema = JObj(sub_elems={
+        'pool_name': str,
+        'type': str,
+        'application_metadata': JList(str),
+        'flags': int,
+        'flags_names': str,
+    }, allow_unknown=True)
 
     @DashboardTestCase.RunAs('test', 'test', [{'pool': ['create', 'update', 'delete']}])
     def test_read_access_permissions(self):
@@ -43,13 +51,8 @@ class PoolTest(DashboardTestCase):
 
         cluster_pools = self.ceph_cluster.mon_manager.list_pools()
         self.assertEqual(len(cluster_pools), len(data))
+        self.assertSchemaBody(JList(self.pool_schema))
         for pool in data:
-            self.assertIn('pool_name', pool)
-            self.assertIn('type', pool)
-            self.assertIn('application_metadata', pool)
-            self.assertIsInstance(pool['application_metadata'], list)
-            self.assertIn('flags', pool)
-            self.assertIn('flags_names', pool)
             self.assertNotIn('stats', pool)
             self.assertIn(pool['pool_name'], cluster_pools)
 
@@ -97,37 +100,43 @@ class PoolTest(DashboardTestCase):
             self._post('/api/pool/', data)
             self.assertStatus(201)
 
-            pool = self._get("/api/pool/" + data['pool'])
-            self.assertStatus(200)
-            try:
-                for k, v in data.items():
-                    if k == 'pool_type':
-                        self.assertEqual(pool['type'], data['pool_type'])
-                    elif k == 'pg_num':
-                        self.assertEqual(pool[k], int(v), '{}: {} != {}'.format(k, pool[k], v))
-                    elif k == 'application_metadata':
-                        self.assertIsInstance(pool[k], list)
-                        self.assertEqual(pool[k],
-                                         data['application_metadata'])
-                    elif k == 'pool':
-                        self.assertEqual(pool['pool_name'], v)
-                    elif k in ['compression_mode', 'compression_algorithm']:
-                        self.assertEqual(pool['options'][k], data[k])
-                    elif k == 'compression_max_blob_size':
-                        self.assertEqual(pool['options'][k], int(data[k]))
-                    elif k == 'compression_required_ratio':
-                        self.assertEqual(pool['options'][k], float(data[k]))
-                    else:
-                        self.assertEqual(pool[k], v, '{}: {} != {}'.format(k, pool[k], v))
-
-            except Exception:
-                log.exception("test_pool_create: pool=%s", pool)
-                raise
+            self._check_pool_properties(data)
 
             self._delete("/api/pool/" + data['pool'])
             self.assertStatus(204)
         except Exception:
             log.exception("test_pool_create: data=%s", data)
+            raise
+
+    def _check_pool_properties(self, data, pool_name=None):
+        if not pool_name:
+            pool_name = data['pool']
+        pool = self._get("/api/pool/" + pool_name)
+        self.assertStatus(200)
+        self.assertSchemaBody(self.pool_schema)
+        try:
+            for k, v in data.items():
+                if k == 'pool_type':
+                    self.assertEqual(pool['type'], data['pool_type'])
+                elif k == 'pg_num':
+                    self.assertEqual(pool[k], int(v), '{}: {} != {}'.format(k, pool[k], v))
+                elif k == 'application_metadata':
+                    self.assertIsInstance(pool[k], list)
+                    self.assertEqual(pool[k],
+                                     data['application_metadata'])
+                elif k == 'pool':
+                    self.assertEqual(pool['pool_name'], v)
+                elif k in ['compression_mode', 'compression_algorithm']:
+                    self.assertEqual(pool['options'][k], data[k])
+                elif k == 'compression_max_blob_size':
+                    self.assertEqual(pool['options'][k], int(data[k]))
+                elif k == 'compression_required_ratio':
+                    self.assertEqual(pool['options'][k], float(data[k]))
+                else:
+                    self.assertEqual(pool[k], v, '{}: {} != {}'.format(k, pool[k], v))
+
+        except Exception:
+            log.exception("test_pool_create: pool=%s", pool)
             raise
 
     def test_pool_create(self):
@@ -157,6 +166,42 @@ class PoolTest(DashboardTestCase):
         for data in pools:
             self._pool_create(data)
 
+    def test_update(self):
+        pool = [
+            {
+                'pool': 'dashboard_pool_update1',
+                'pg_num': '10',
+                'pool_type': 'replicated',
+            },
+            {
+                'application_metadata': ['rbd', 'sth'],
+            },
+            {
+                'pg_num': '12',
+            },
+            {
+                'application_metadata': ['rgw'],
+            },
+            {
+                'compression_algorithm': 'zstd',
+                'compression_mode': 'aggressive',
+                'compression_max_blob_size': '10000000',
+                'compression_required_ratio': '0.8',
+            }
+
+        ]
+        self._post('/api/pool/', pool[0])
+        self.assertStatus(201)
+
+        self._check_pool_properties(pool[0])
+
+        for data in pool[1:]:
+            self._put('/api/pool/' + pool[0]['pool'], data)
+            self._check_pool_properties(data, pool_name=pool[0]['pool'])
+
+        self._delete("/api/pool/" + pool[0]['pool'])
+        self.assertStatus(204)
+
     def test_pool_create_fail(self):
         data = {'pool_type': u'replicated', 'rule_name': u'dnf', 'pg_num': u'8', 'pool': u'sadfs'}
         self._post('/api/pool/', data)
@@ -168,19 +213,13 @@ class PoolTest(DashboardTestCase):
         })
 
     def test_pool_info(self):
-        info_data = self._get("/api/pool/_info")
-        self.assertEqual(set(info_data),
-                         {'pool_names', 'crush_rules_replicated', 'crush_rules_erasure',
-                          'is_all_bluestore', 'compression_algorithms', 'compression_modes',
-                          'osd_count'})
-        self.assertTrue(all(isinstance(n, six.string_types) for n in info_data['pool_names']))
-        self.assertTrue(
-            all(isinstance(n, dict) for n in info_data['crush_rules_replicated']))
-        self.assertTrue(
-            all(isinstance(n, dict) for n in info_data['crush_rules_erasure']))
-        self.assertIsInstance(info_data['is_all_bluestore'], bool)
-        self.assertIsInstance(info_data['osd_count'], int)
-        self.assertTrue(
-            all(isinstance(n, six.string_types) for n in info_data['compression_algorithms']))
-        self.assertTrue(
-            all(isinstance(n, six.string_types) for n in info_data['compression_modes']))
+        self._get("/api/pool/_info")
+        self.assertSchemaBody(JObj({
+            'pool_names': JList(six.string_types),
+            'compression_algorithms': JList(six.string_types),
+            'compression_modes': JList(six.string_types),
+            'is_all_bluestore': bool,
+            'osd_count': int,
+            'crush_rules_replicated': JList(JObj({}, allow_unknown=True)),
+            'crush_rules_erasure': JList(JObj({}, allow_unknown=True)),
+        }))

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -151,7 +151,7 @@ class PoolTest(DashboardTestCase):
             'pool_type': 'replicated',
             'compression_algorithm': 'zstd',
             'compression_mode': 'aggressive',
-            'compression_max_blob_size': "10000000",
+            'compression_max_blob_size': '10000000',
             'compression_required_ratio': '0.8',
         }]
         for data in pools:

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -108,7 +108,7 @@ class PoolTest(DashboardTestCase):
                     elif k == 'application_metadata':
                         self.assertIsInstance(pool[k], list)
                         self.assertEqual(pool[k],
-                                         data['application_metadata'].split(','))
+                                         data['application_metadata'])
                     elif k == 'pool':
                         self.assertEqual(pool['pool_name'], v)
                     elif k in ['compression_mode', 'compression_algorithm']:
@@ -138,7 +138,7 @@ class PoolTest(DashboardTestCase):
             'pool': 'dashboard_pool1',
             'pg_num': '10',
             'pool_type': 'replicated',
-            'application_metadata': 'rbd',
+            'application_metadata': ['rbd', 'sth'],
         }, {
             'pool': 'dashboard_pool2',
             'pg_num': '10',

--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -15,11 +15,11 @@ class RbdTest(DashboardTestCase):
             'pool': name,
             'pg_num': pg_num,
             'pool_type': pool_type,
-            'application_metadata': application
+            'application_metadata': [application]
         }
         if pool_type == 'erasure':
             data['flags'] = ['ec_overwrites']
-        cls._post("/api/pool", data)
+        cls._task_post("/api/pool", data)
 
     @DashboardTestCase.RunAs('test', 'test', [{'rbd-image': ['create', 'update', 'delete']}])
     def test_read_access_permissions(self):

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -77,8 +77,9 @@ class Pool(RESTController):
                                      val='true')
 
         if application_metadata:
-            for app in application_metadata.split(','):
-                CephService.send_command('mon', 'osd pool application enable', pool=pool, app=app)
+            for app in application_metadata:
+                CephService.send_command('mon', 'osd pool application enable', pool=pool, app=app,
+                                         force='--yes-i-really-mean-it')
 
         for key, value in kwargs.items():
             CephService.send_command('mon', 'osd pool set', pool=pool, var=key, val=value)

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -90,7 +90,7 @@ class Pool(RESTController):
         if flags and 'ec_overwrites' in flags:
             CephService.send_command('mon', 'osd pool set', pool=pool, var='allow_ec_overwrites',
                                      val='true')
-        if application_metadata:
+        if application_metadata is not None:
             def set_app(what, app):
                 CephService.send_command('mon', 'osd pool application ' + what, pool=pool, app=app,
                                          force='--yes-i-really-mean-it')
@@ -107,7 +107,12 @@ class Pool(RESTController):
                 set_app('enable', app)
 
         for key, value in kwargs.items():
-            CephService.send_command('mon', 'osd pool set', pool=pool, var=key, val=value)
+            def set_key(key):
+                CephService.send_command('mon', 'osd pool set', pool=pool, var=key, val=str(value))
+
+            set_key(key)
+            if key == 'pg_num':
+                set_key('pgp_num')
 
     @Endpoint()
     @ReadPermission


### PR DESCRIPTION
This adds `PUT` requests to `/api/pool/<pool_name>` allowing to change existing pools. 


* Copied the fix for `qa/tasks/mgr/dashboard/helper.py` from #21066 
* Added minor tweak to `_validate_json()` to allow skipping `JLeaf()`
* Made use of `_validate_json()` in the Pool test. 