### PR TITLE
[RFC] mgr/dashboard: Sync pgp_num with pg_num

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -76,6 +76,9 @@ class Pool(RESTController):
             for app in application_metadata.split(','):
                 CephService.send_command('mon', 'osd pool application enable', pool=pool, app=app)
 
+        if 'pg_num' in kwargs:
+            kwargs['pgp_num'] = kwargs['pg_num']
+
         for key, value in kwargs.items():
             CephService.send_command('mon', 'osd pool set', pool=pool, var=key, val=value)
 


### PR DESCRIPTION
Otherwise we will make the cluster unhealthy when updating pg_num without pgp_num.

**Depends on #21881**, as it will extract this code block in a separate method. 

**RFC**: Another way to fix this would be to synchronize pgp_num with pg_num in the frontend. 

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>