### PR TITLE
ceph-fuse: print error for double dash

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -94,7 +94,8 @@ int main(int argc, const char **argv, const char *envp[]) {
 
   for (auto i = args.begin(); i != args.end();) {
     if (ceph_argparse_double_dash(args, i)) {
-      break;
+      cerr << "-- not allowed with ceph-fuse" << std::endl;
+      exit(0);
     } else if (ceph_argparse_flag(args, i, "--localize-reads", (char*)nullptr)) {
       cerr << "setting CEPH_OSD_FLAG_LOCALIZE_READS" << std::endl;
       filer_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;


### PR DESCRIPTION
Do not allow double dash because:
   * In ceph-fuse we don't have a requirement to change the meaning of the next parameter.
   * The double dash cannot be the end of all options. For instance, the check for '-m' is somewhere outside the loop.

Fixes: https://tracker.ceph.com/issues/24030
Signed-off-by: Jos Collin <jcollin@redhat.com>