### PR TITLE
ceph-volume describe better the options for migrating away from ceph-disk

### DIFF
--- a/doc/ceph-volume/index.rst
+++ b/doc/ceph-volume/index.rst
@@ -22,7 +22,13 @@ Migrating
 ---------
 Starting on Ceph version 12.2.2, ``ceph-disk`` is deprecated. Deprecation
 warnings will show up that will link to this page. It is strongly suggested
-that users start consuming ``ceph-volume``.
+that users start consuming ``ceph-volume``. There are two paths for migrating:
+
+#. Keep OSDs deployed with ``ceph-disk``: The :ref:`ceph-volume-simple` command
+   provides a way to take over the management while disabling ``ceph-disk``
+   triggers.
+#. Redeploy existing OSDs with ``ceph-volume``: This is covered in depth on
+   :ref:`rados-replacing-an-osd`
 
 New deployments
 ^^^^^^^^^^^^^^^

--- a/doc/ceph-volume/simple/index.rst
+++ b/doc/ceph-volume/simple/index.rst
@@ -17,3 +17,16 @@ Implements the functionality needed to manage OSDs from the ``simple`` subcomman
 By *taking over* management, it disables all ``ceph-disk`` systemd units used
 to trigger devices at startup, relying on basic (customizable) JSON
 configuration and systemd for starting up OSDs.
+
+This process involves two steps:
+
+#. :ref:`Scan <ceph-volume-simple-scan>` Scan the running OSD or the data device
+#. :ref:`Activate <ceph-volume-simple-activate>` the scanned OSD
+
+The scanning will infer everything that ``ceph-volume`` needs to start the OSD,
+so that when activation is needed, the OSD can start normally without getting
+interference from ``ceph-disk``.
+
+As part of the activation process the systemd units for ``ceph-disk`` in charge
+of reacting to ``udev`` events, are linked to ``/dev/null`` so that they are
+fully inactive.

--- a/doc/rados/operations/add-or-rm-osds.rst
+++ b/doc/rados/operations/add-or-rm-osds.rst
@@ -164,6 +164,7 @@ weight).
  Note that this practice will no longer be necessary in Bobtail and
  subsequent releases.
 
+.. _rados-replacing-an-osd:
 
 Replacing an OSD
 ----------------


### PR DESCRIPTION
Documentation was missing some better narrative to explain the steps (and options) that are available for a migration away from ceph-disk.

Fixes: http://tracker.ceph.com/issues/24036