### PR TITLE
cmake: move crypto_plugins target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -920,9 +920,7 @@ if(WITH_TESTS AND WITH_DMCLOCK_TESTS)
   add_subdirectory(dmclock/support/test)
 endif(WITH_TESTS AND WITH_DMCLOCK_TESTS)
 
-if(HAVE_INTEL AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))
-  add_subdirectory(crypto/isa-l)
-endif()
+add_subdirectory(crypto)
 
 if(WITH_TESTS)
   configure_file(${CMAKE_SOURCE_DIR}/src/ceph-coverage.in

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_custom_target(crypto_plugins)
+
+if(HAVE_INTEL AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))
+  add_subdirectory(isa-l)
+endif()

--- a/src/crypto/isa-l/CMakeLists.txt
+++ b/src/crypto/isa-l/CMakeLists.txt
@@ -26,7 +26,6 @@ add_library(isal_crypto_plugin_objs OBJECT ${isal_crypto_plugin_srcs})
 target_include_directories(isal_crypto_plugin_objs PRIVATE ${isal_dir}/include)
 set(isal_crypto_plugin_dir ${CMAKE_INSTALL_PKGLIBDIR}/crypto)
 
-add_custom_target(crypto_plugins)
 if(HAVE_GOOD_YASM_ELF64)
 add_dependencies(crypto_plugins ceph_crypto_isal)
 endif(HAVE_GOOD_YASM_ELF64)


### PR DESCRIPTION
the crypto_plugins target was defined in src/crypto/isa-l/CMakeLists.txt, but this is only included
if(HAVE_INTEL AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))

moving it out of the if() block allows the os target to depend on it even if no plugins are built