### PR TITLE
rgw: use coarse_real_clock for req_state::time

### DIFF
--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -468,6 +468,20 @@ inline timespan to_timespan(signedspan z) {
   ceph_assert(z >= signedspan::zero());
   return std::chrono::duration_cast<timespan>(z);
 }
+
+// detects presence of Clock::to_timespec() and from_timespec()
+template <typename Clock, typename = std::void_t<>>
+struct converts_to_timespec : std::false_type {};
+
+template <typename Clock>
+struct converts_to_timespec<Clock, std::void_t<decltype(
+    Clock::from_timespec(Clock::to_timespec(
+        std::declval<typename Clock::time_point>()))
+  )>> : std::true_type {};
+
+template <typename Clock>
+constexpr bool converts_to_timespec_v = converts_to_timespec<Clock>::value;
+
 } // namespace ceph
 
 #endif // COMMON_CEPH_TIME_H

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -307,6 +307,28 @@ void decode(std::chrono::time_point<Clock, Duration>& t,
   t = Clock::from_timespec(ts);
 }
 
+template<typename Rep, typename Period,
+         typename std::enable_if_t<std::is_integral_v<Rep>>* = nullptr>
+void encode(const std::chrono::duration<Rep, Period>& d,
+	    ceph::bufferlist &bl) {
+  using namespace std::chrono;
+  uint32_t s = duration_cast<seconds>(d).count();
+  uint32_t ns = (duration_cast<nanoseconds>(d) % seconds(1)).count();
+  encode(s, bl);
+  encode(ns, bl);
+}
+
+template<typename Rep, typename Period,
+         typename std::enable_if_t<std::is_integral_v<Rep>>* = nullptr>
+void decode(std::chrono::duration<Rep, Period>& d,
+	    bufferlist::iterator& p) {
+  uint32_t s;
+  uint32_t ns;
+  decode(s, p);
+  decode(ns, p);
+  d = std::chrono::seconds(s) + std::chrono::nanoseconds(ns);
+}
+
 // -----------------------------
 // STL container types
 

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -280,7 +280,8 @@ inline void decode_nohead(int len, bufferlist& s, bufferlist::iterator& p)
 
 // Time, since the templates are defined in std::chrono
 
-template<typename Clock, typename Duration>
+template<typename Clock, typename Duration,
+         typename std::enable_if_t<converts_to_timespec_v<Clock>>* = nullptr>
 void encode(const std::chrono::time_point<Clock, Duration>& t,
 	    ceph::bufferlist &bl) {
   auto ts = Clock::to_timespec(t);
@@ -291,7 +292,8 @@ void encode(const std::chrono::time_point<Clock, Duration>& t,
   encode(ns, bl);
 }
 
-template<typename Clock, typename Duration>
+template<typename Clock, typename Duration,
+         typename std::enable_if_t<converts_to_timespec_v<Clock>>* = nullptr>
 void decode(std::chrono::time_point<Clock, Duration>& t,
 	    bufferlist::iterator& p) {
   uint32_t s;

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -71,10 +71,12 @@ public:
     tv.tv_sec = v.tv_sec;
     tv.tv_nsec = v.tv_nsec;
   }
-  explicit utime_t(const ceph::real_time& rt) {
-    ceph_timespec ts = real_clock::to_ceph_timespec(rt);
-    decode_timeval(&ts);
-  }
+  // conversion from ceph::real_time/coarse_real_time
+  template <typename Clock, typename std::enable_if_t<
+            ceph::converts_to_timespec_v<Clock>>* = nullptr>
+  explicit utime_t(const std::chrono::time_point<Clock>& t)
+    : utime_t(Clock::to_timespec(t)) {} // forward to timespec ctor
+
   utime_t(const struct timeval &v) {
     set_from_timeval(&v);
   }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5343,7 +5343,8 @@ int main(int argc, const char **argv)
         formatter->open_array_section("log_entries");
 
       do {
-	uint64_t total_time =  entry.total_time.to_msec();
+        using namespace std::chrono;
+        uint64_t total_time = duration_cast<milliseconds>(entry.total_time).count();
 
         agg_time += total_time;
         agg_bytes_sent += entry.bytes_sent;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -284,7 +284,7 @@ req_state::req_state(CephContext* _cct, RGWEnv* e, RGWUserInfo* u)
   enable_usage_log = e->get_enable_usage_log();
   defer_to_bucket_acls = e->get_defer_to_bucket_acls();
 
-  time = ceph_clock_now();
+  time = Clock::now();
 }
 
 req_state::~req_state() {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1886,7 +1886,11 @@ struct req_state {
   req_info info;
   req_init_state init_state;
 
-  utime_t time;
+  using Clock = ceph::coarse_real_clock;
+  Clock::time_point time;
+
+  Clock::duration time_elapsed() const { return Clock::now() - time; }
+
   void *obj_ctx{nullptr};
   string dialect;
   string req_id;

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1511,8 +1511,7 @@ namespace rgw {
 
   done:
     dispose_processor(processor);
-    perfcounter->tinc(l_rgw_put_lat,
-		      (ceph_clock_now() - s->time));
+    perfcounter->tinc(l_rgw_put_lat, s->time_elapsed());
     return op_ret;
   } /* exec_finish */
 

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -5,7 +5,6 @@
 #define CEPH_RGW_LOG_H
 #include <boost/container/flat_map.hpp>
 #include "rgw_common.h"
-#include "include/utime.h"
 #include "common/Formatter.h"
 #include "common/OutputDataSocket.h"
 
@@ -14,11 +13,12 @@ class RGWRados;
 struct rgw_log_entry {
 
   using headers_map = boost::container::flat_map<std::string, std::string>;
+  using Clock = req_state::Clock;
 
   rgw_user object_owner;
   rgw_user bucket_owner;
   string bucket;
-  utime_t time;
+  Clock::time_point time;
   string remote_addr;
   string user;
   rgw_obj_key obj;
@@ -29,7 +29,7 @@ struct rgw_log_entry {
   uint64_t bytes_sent;
   uint64_t bytes_received;
   uint64_t obj_size;
-  utime_t total_time;
+  Clock::duration total_time;
   string user_agent;
   string referrer;
   string bucket_id;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1710,7 +1710,6 @@ static bool object_is_expired(map<string, bufferlist>& attrs) {
 
 void RGWGetObj::execute()
 {
-  utime_t start_time = s->time;
   bufferlist bl;
   gc_invalidate_time = ceph_clock_now();
   gc_invalidate_time += (s->cct->_conf->rgw_gc_obj_min_wait / 2);
@@ -1867,8 +1866,7 @@ void RGWGetObj::execute()
   if (op_ret >= 0)
     op_ret = filter->flush();
 
-  perfcounter->tinc(l_rgw_get_lat,
-		    (ceph_clock_now() - start_time));
+  perfcounter->tinc(l_rgw_get_lat, s->time_elapsed());
   if (op_ret < 0) {
     goto done_err;
   }
@@ -3803,8 +3801,7 @@ void RGWPutObj::execute()
 
 done:
   dispose_processor(processor);
-  perfcounter->tinc(l_rgw_put_lat,
-		    (ceph_clock_now() - s->time));
+  perfcounter->tinc(l_rgw_put_lat, s->time_elapsed());
 }
 
 int RGWPostObj::verify_permission()

--- a/src/rgw/rgw_request.cc
+++ b/src/rgw/rgw_request.cc
@@ -22,7 +22,6 @@ void RGWRequest::log_format(struct req_state *s, const char *fmt, ...)
 } /* RGWRequest::log_format */
 
 void RGWRequest::log_init() {
-  ts = ceph_clock_now();
 }
 
 void RGWRequest::log(struct req_state *s, const char *msg) {
@@ -31,7 +30,7 @@ void RGWRequest::log(struct req_state *s, const char *msg) {
     req_str.append(" ");
     req_str.append(s->info.request_uri);
   }
-  utime_t t = ceph_clock_now() - ts;
+  auto t = s->time_elapsed();
   dout(2) << "req " << id << ":" << t << ":" << s->dialect << ":"
 	  << req_str << ":" << (op ? op->name() : "") << ":" << msg
 	  << dendl;

--- a/src/rgw/rgw_request.h
+++ b/src/rgw/rgw_request.h
@@ -23,7 +23,6 @@ struct RGWRequest
   struct req_state *s;
   string req_str;
   RGWOp *op;
-  utime_t ts;
 
   explicit RGWRequest(uint64_t id) : id(id), s(NULL), op(NULL) {}
 

--- a/src/test/encoding/test_ceph_time.h
+++ b/src/test/encoding/test_ceph_time.h
@@ -33,4 +33,29 @@ class real_time_wrapper {
 };
 WRITE_CLASS_ENCODER(real_time_wrapper)
 
+// wrapper for ceph::timespan that implements the dencoder interface
+class timespan_wrapper {
+  ceph::timespan d;
+ public:
+  timespan_wrapper() = default;
+  explicit timespan_wrapper(const ceph::timespan& d) : d(d) {}
+
+  void encode(bufferlist& bl) const {
+    using ceph::encode;
+    encode(d, bl);
+  }
+  void decode(bufferlist::iterator &p) {
+    using ceph::decode;
+    decode(d, p);
+  }
+  void dump(Formatter* f) {
+    f->dump_int("timespan", d.count());
+  }
+  static void generate_test_instances(std::list<timespan_wrapper*>& ls) {
+    constexpr std::chrono::seconds d{7377}; // marathon world record (2:02:57)
+    ls.push_back(new timespan_wrapper(d));
+  }
+};
+WRITE_CLASS_ENCODER(timespan_wrapper)
+
 #endif

--- a/src/test/encoding/test_ceph_time.h
+++ b/src/test/encoding/test_ceph_time.h
@@ -8,11 +8,13 @@
 #include "common/Formatter.h"
 
 // wrapper for ceph::real_time that implements the dencoder interface
-class real_time_wrapper {
-  ceph::real_time t;
+template <typename Clock>
+class time_point_wrapper {
+  using time_point = typename Clock::time_point;
+  time_point t;
  public:
-  real_time_wrapper() = default;
-  explicit real_time_wrapper(const ceph::real_time& t) : t(t) {}
+  time_point_wrapper() = default;
+  explicit time_point_wrapper(const time_point& t) : t(t) {}
 
   void encode(bufferlist& bl) const {
     using ceph::encode;
@@ -23,15 +25,20 @@ class real_time_wrapper {
     decode(t, p);
   }
   void dump(Formatter* f) {
-    auto epoch_time = ceph::real_clock::to_time_t(t);
+    auto epoch_time = Clock::to_time_t(t);
     f->dump_string("time", std::ctime(&epoch_time));
   }
-  static void generate_test_instances(std::list<real_time_wrapper*>& ls) {
+  static void generate_test_instances(std::list<time_point_wrapper*>& ls) {
     constexpr time_t t{455500800}; // Ghostbusters release date
-    ls.push_back(new real_time_wrapper(ceph::real_clock::from_time_t(t)));
+    ls.push_back(new time_point_wrapper(Clock::from_time_t(t)));
   }
 };
+
+using real_time_wrapper = time_point_wrapper<ceph::real_clock>;
 WRITE_CLASS_ENCODER(real_time_wrapper)
+
+using coarse_real_time_wrapper = time_point_wrapper<ceph::coarse_real_clock>;
+WRITE_CLASS_ENCODER(coarse_real_time_wrapper)
 
 // wrapper for ceph::timespan that implements the dencoder interface
 class timespan_wrapper {

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -16,6 +16,7 @@ TYPE(compressible_bloom_filter)
 
 #include "test_ceph_time.h"
 TYPE(real_time_wrapper)
+TYPE(coarse_real_time_wrapper)
 TYPE(timespan_wrapper)
 
 #include "test_sstring.h"

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -16,6 +16,7 @@ TYPE(compressible_bloom_filter)
 
 #include "test_ceph_time.h"
 TYPE(real_time_wrapper)
+TYPE(timespan_wrapper)
 
 #include "test_sstring.h"
 TYPE(sstring_wrapper)


### PR DESCRIPTION
use the cheaper coarse_real_clock when tracking request start time and calculating elapsed time

requires some tweaks to utime_t and encode/decode