### PR TITLE
Eliminate new warnings in Fedora 28

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -31,7 +31,7 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wtype-limits -Wignored-qualifiers -Winit-self")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Werror=format-security -fno-strict-aliasing -fsigned-char")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-depth-1024 -Wno-invalid-offsetof")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-depth-1024")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-pragmas")

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -1595,7 +1595,6 @@ int SyntheticClient::full_walk(string& basedir)
   list<frag_info_t> statq;
   dirq.push_back(basedir);
   frag_info_t empty;
-  memset(&empty, 0, sizeof(empty));
   statq.push_back(empty);
 
   ceph::unordered_map<inodeno_t, int> nlink;
@@ -3358,7 +3357,6 @@ int SyntheticClient::chunk_file(string &filename)
   dout(0) << "file " << filename << " size is " << size << dendl;
 
   inode_t inode{};
-  memset(&inode, 0, sizeof(inode));
   inode.ino = st.st_ino;
   ret = client->fdescribe_layout(fd, &inode.layout);
   assert(ret == 0); // otherwise fstat did a bad thing

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1618,7 +1618,7 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
   if (olh_key == dest_key) {
     /* this is the current head, need to update! */
     cls_rgw_obj_key next_key;
-    bool found;
+    bool found = false;
     ret = obj.find_next_key(&next_key, &found);
     if (ret < 0) {
       CLS_LOG(0, "ERROR: obj.find_next_key() returned ret=%d", ret);

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -89,7 +89,10 @@ int get_block_device_base(const char *dev, char *out, size_t out_len)
     if (*p == '/')
       *p = '!';
 
-  snprintf(fn, sizeof(fn), "%s/sys/block/%s", sandbox_dir, devname);
+  if (static_cast<size_t>(snprintf(fn, sizeof(fn), "%s/sys/block/%s",
+                                   sandbox_dir, devname))
+      >= sizeof(fn))
+    return -ERANGE;
   if (stat(fn, &st) == 0) {
     if (strlen(devname) + 1 > out_len) {
       return -ERANGE;
@@ -107,8 +110,10 @@ int get_block_device_base(const char *dev, char *out, size_t out_len)
   while ((de = ::readdir(dir))) {
     if (de->d_name[0] == '.')
       continue;
-    snprintf(fn, sizeof(fn), "%s/sys/block/%s/%s", sandbox_dir, de->d_name,
-	     devname);
+    if (static_cast<size_t>(snprintf(fn, sizeof(fn), "%s/sys/block/%s/%s",
+                                     sandbox_dir, de->d_name,
+                                     devname)) >= sizeof(fn))
+      return -ERANGE;
 
     if (stat(fn, &st) == 0) {
       // match!

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -209,45 +209,6 @@ int block_device_model(const char *devname, char *model, size_t max)
   return get_block_device_string_property(devname, "device/model", model, max);
 }
 
-int get_device_by_uuid(uuid_d dev_uuid, const char* label, char* partition,
-	char* device)
-{
-  char uuid_str[UUID_LEN+1];
-  char basename[PATH_MAX];
-  const char* temp_partition_ptr = NULL;
-  blkid_cache cache = NULL;
-  blkid_dev dev = NULL;
-  int rc = 0;
-
-  dev_uuid.print(uuid_str);
-
-  if (blkid_get_cache(&cache, NULL) >= 0)
-    dev = blkid_find_dev_with_tag(cache, label, (const char*)uuid_str);
-  else
-    return -EINVAL;
-
-  if (dev) {
-    temp_partition_ptr = blkid_dev_devname(dev);
-    strncpy(partition, temp_partition_ptr, PATH_MAX);
-    rc = get_block_device_base(partition, basename,
-      sizeof(basename));
-    if (rc >= 0) {
-      strncpy(device, basename, sizeof(basename));
-      rc = 0;
-    } else {
-      rc = -ENODEV;
-    }
-  } else {
-    rc = -EINVAL;
-  }
-
-  /* From what I can tell, blkid_put_cache cleans up dev, which
-   * appears to be a pointer into cache, as well */
-  if (cache)
-    blkid_put_cache(cache);
-  return rc;
-}
-
 int get_device_by_fd(int fd, char *partition, char *device, size_t max)
 {
   struct stat st;
@@ -424,12 +385,6 @@ bool block_device_is_rotational(const char *devname)
   return false;
 }
 
-int get_device_by_uuid(uuid_d dev_uuid, const char* label, char* partition,
-	char* device)
-{
-  return -EOPNOTSUPP;
-}
-
 void get_dm_parents(const std::string& dev, std::set<std::string> *ls)
 {
 }
@@ -475,11 +430,6 @@ bool block_device_is_rotational(const char *devname)
   return false;
 }
 
-int get_device_by_uuid(uuid_d dev_uuid, const char* label, char* partition,
-	char* device)
-{
-  return -EOPNOTSUPP;
-}
 int get_device_by_fd(int fd, char *partition, char *device, size_t max)
 {
   return -EOPNOTSUPP;
@@ -523,12 +473,6 @@ int block_device_discard(int fd, int64_t offset, int64_t len)
 bool block_device_is_rotational(const char *devname)
 {
   return false;
-}
-
-int get_device_by_uuid(uuid_d dev_uuid, const char* label, char* partition,
-	char* device)
-{
-  return -EOPNOTSUPP;
 }
 
 int get_device_by_fd(int fd, char *partition, char *device, size_t max)

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -15,10 +15,6 @@ extern int block_device_discard(int fd, int64_t offset, int64_t len);
 extern int get_block_device_size(int fd, int64_t *psize);
 extern int get_device_by_fd(int fd, char* partition, char* device, size_t max);
 
-// from a uuid
-extern int get_device_by_uuid(uuid_d dev_uuid, const char* label,
-			      char* partition, char* device);
-
 // from a device (e.g., "sdb")
 extern int64_t get_block_device_int_property(
 	const char *devname, const char *property);

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -208,8 +208,6 @@ CDir::CDir(CInode *in, frag_t fg, MDCache *mdcache, bool auth) :
   num_dentries_auth_subtree_nested(0),
   dir_auth(CDIR_AUTH_DEFAULT)
 {
-  memset(&fnode, 0, sizeof(fnode));
-
   // auth
   assert(in->is_dir());
   if (auth) state_set(STATE_AUTH);

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1582,7 +1582,7 @@ bool AuthMonitor::_upgrade_format_to_dumpling()
       bufferlist::iterator it = p->second.caps["mon"].begin();
       decode(mon_caps, it);
     }
-    catch (buffer::error) {
+    catch (const buffer::error&) {
       dout(10) << __func__ << " unable to parse mon cap for "
 	       << p->first << dendl;
       continue;

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -606,7 +606,6 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
           info.standby_for_name);
       if (leaderinfo && (leaderinfo->rank >= 0)) {
         const auto &fscid = pending.mds_roles.at(leaderinfo->global_id);
-        const auto &fs = pending.get_filesystem(fscid);
 
         pending.modify_daemon(gid, [fscid, leaderinfo](
               MDSMap::mds_info_t *info) {

--- a/src/mount/canonicalize.c
+++ b/src/mount/canonicalize.c
@@ -154,7 +154,7 @@ canonicalize_dm_name(const char *ptname)
 {
 	FILE	*f;
 	size_t	sz;
-	char	path[256], name[256], *res = NULL;
+	char	path[268], name[256], *res = NULL;
 
 	snprintf(path, sizeof(path), "/sys/block/%s/dm/name", ptname);
 	if (!(f = fopen(path, "r")))

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -584,7 +584,7 @@ int Infiniband::MemoryManager::Cluster::fill(uint32_t num)
   end = base + bytes;
   assert(base);
   chunk_base = static_cast<Chunk*>(::malloc(sizeof(Chunk) * num));
-  memset(chunk_base, 0, sizeof(Chunk) * num);
+  memset(static_cast<void*>(chunk_base), 0, sizeof(Chunk) * num);
   free_chunks.reserve(num);
   ibv_mr* m = ibv_reg_mr(manager.pd->pd, base, bytes, IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE);
   assert(m);

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -459,7 +459,7 @@ ssize_t RDMAConnectedSocketImpl::submit(bool more)
     unsigned total_copied = 0;
     Chunk *current_chunk = tx_buffers[chunk_idx];
     while (start != end) {
-      const uintptr_t addr = reinterpret_cast<const uintptr_t>(start->c_str());
+      const uintptr_t addr = reinterpret_cast<uintptr_t>(start->c_str());
       unsigned copied = 0;
       while (copied < start->length()) {
         uint32_t r = current_chunk->write((char*)addr+copied, start->length() - copied);

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -320,7 +320,7 @@ static int os_getattr(const char *path, struct stat *stbuf)
       int bits = fs->store->collection_bits(ch);
       if (bits < 0)
 	return -ENOENT;
-      char buf[8];
+      char buf[12];
       snprintf(buf, sizeof(buf), "%d\n", bits);
       stbuf->st_size = strlen(buf);
     }
@@ -630,7 +630,7 @@ static int os_open(const char *path, struct fuse_file_info *fi)
       int r = fs->store->collection_bits(ch);
       if (r < 0)
         return r;
-      char buf[8];
+      char buf[12];
       snprintf(buf, sizeof(buf), "%d\n", r);
       pbl = new bufferlist;
       pbl->append(buf);

--- a/src/perfglue/heap_profiler.cc
+++ b/src/perfglue/heap_profiler.cc
@@ -79,6 +79,12 @@ bool ceph_heap_profiler_running()
 
 static void get_profile_name(char *profile_name, int profile_name_len)
 {
+#if __GNUC__ && __GNUC__ >= 8
+#pragma GCC diagnostic push
+  // Don't care, it doesn't matter, and we can't do anything about it.
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
+
   char path[PATH_MAX];
   snprintf(path, sizeof(path), "%s", g_conf->log_file.c_str());
   char *last_slash = rindex(path, '/');
@@ -92,6 +98,9 @@ static void get_profile_name(char *profile_name, int profile_name_len)
     snprintf(profile_name, profile_name_len, "%s/%s.profile",
 	     path, g_conf->name.to_cstr());
   }
+#if __GNUC__ && __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 }
 
 void ceph_heap_profiler_start()

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -106,7 +106,7 @@ static boost::optional<ACLGrant> referrer_to_grant(std::string url_spec,
 
     grant.set_referer(url_spec, is_negative ? 0 : perm);
     return grant;
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     return boost::none;
   }
 }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2347,7 +2347,7 @@ static int bucket_source_sync_status(RGWRados *store, const RGWZone& zone,
   int num_full = 0;
   int num_inc = 0;
   uint64_t full_complete = 0;
-  const int total_shards = status.size();
+  const size_t total_shards = status.size();
 
   using BucketSyncState = rgw_bucket_shard_sync_info::SyncState;
   for (size_t shard_id = 0; shard_id < total_shards; shard_id++) {

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -552,7 +552,7 @@ RGWHTTPClient::~RGWHTTPClient()
 
 int RGWHTTPHeadersCollector::receive_header(void * const ptr, const size_t len)
 {
-  const boost::string_ref header_line(static_cast<const char * const>(ptr), len);
+  const boost::string_ref header_line(static_cast<const char *>(ptr), len);
 
   /* We're tokening the line that way due to backward compatibility. */
   const size_t sep_loc = header_line.find_first_of(" \t:");

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4310,7 +4310,7 @@ int RGWDeleteObj::handle_slo_manifest(bufferlist& bl)
   try {
     deleter = std::unique_ptr<RGWBulkDelete::Deleter>(\
           new RGWBulkDelete::Deleter(store, s));
-  } catch (std::bad_alloc) {
+  } catch (const std::bad_alloc&) {
     return -ENOMEM;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6549,7 +6549,7 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
   RGWPutObjDataProcessor *filter = nullptr;
   boost::optional<RGWPutObj_Compress> compressor;
 
-  if (size > static_cast<const size_t>(s->cct->_conf->rgw_max_put_size)) {
+  if (size > static_cast<size_t>(s->cct->_conf->rgw_max_put_size)) {
     op_ret = -ERR_TOO_LARGE;
     return op_ret;
   }

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -399,7 +399,7 @@ ExternalTokenEngine::authenticate(const std::string& token,
     } else {
       swift_user = std::move(swift_groups[0]);
     }
-  } catch (std::out_of_range) {
+  } catch (const std::out_of_range&) {
     /* The X-Auth-Groups header isn't present in the response. */
     return result_t::deny(-EPERM);
   }

--- a/src/test/libcephfs/acl.cc
+++ b/src/test/libcephfs/acl.cc
@@ -240,7 +240,7 @@ TEST(ACL, DefaultACL) {
   // set default acl
   ASSERT_EQ(ceph_setxattr(cmount, test_dir1, ACL_EA_DEFAULT, acl1_buf, acl_buf_size, 0), 0);
 
-  char test_dir2[256];
+  char test_dir2[262];
   sprintf(test_dir2, "%s/dir2", test_dir1);
   ASSERT_EQ(ceph_mkdir(cmount, test_dir2, 0755), 0);
 
@@ -258,7 +258,7 @@ TEST(ACL, DefaultACL) {
     ASSERT_EQ(check_acl_and_mode(acl2_buf, acl_buf_size, stx.stx_mode), 0);
   }
 
-  char test_file1[256];
+  char test_file1[262];
   sprintf(test_file1, "%s/file1", test_dir1);
   int fd = ceph_open(cmount, test_file1, O_CREAT|O_RDWR, 0666);
   ASSERT_GT(fd, 0);

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -632,14 +632,14 @@ TEST(LibCephFS, StatDirNlink) {
   ASSERT_EQ(stx.stx_nlink, 2);
 
   {
-    char test_dir2[256];
+    char test_dir2[296];
     sprintf(test_dir2, "%s/.", test_dir1);
     ASSERT_EQ(ceph_statx(cmount, test_dir2, &stx, CEPH_STATX_NLINK, AT_SYMLINK_NOFOLLOW), 0);
     ASSERT_EQ(stx.stx_nlink, 2);
   }
 
   {
-    char test_dir2[256];
+    char test_dir2[296];
     sprintf(test_dir2, "%s/1", test_dir1);
     ASSERT_EQ(ceph_mkdir(cmount, test_dir2, 0700), 0);
     ASSERT_EQ(ceph_statx(cmount, test_dir2, &stx, CEPH_STATX_NLINK, AT_SYMLINK_NOFOLLOW), 0);
@@ -968,7 +968,7 @@ TEST(LibCephFS, LoopSyms) {
   ASSERT_EQ(fd, -ELOOP);
 
   // loop: /a -> /b, /b -> /c, /c -> /a
-  char a[256], b[256], c[256];
+  char a[264], b[264], c[264];
   sprintf(a, "/%s/a", test_dir1);
   sprintf(b, "/%s/b", test_dir1);
   sprintf(c, "/%s/c", test_dir1);
@@ -1565,7 +1565,7 @@ TEST(LibCephFS, SlashDotDot) {
   ASSERT_EQ(ino, stx.stx_ino);
 
   /* Test accessing the parent of an unlinked directory */
-  char dir1[32], dir2[32];
+  char dir1[32], dir2[56];
   sprintf(dir1, "/sldotdot%x", getpid());
   sprintf(dir2, "%s/sub%x", dir1, getpid());
 
@@ -1781,7 +1781,7 @@ TEST(LibCephFS, DirChangeAttr) {
   ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
   ASSERT_EQ(ceph_mount(cmount, "/"), 0);
 
-  char dirname[32], filename[32];
+  char dirname[32], filename[56];
   sprintf(dirname, "/dirchange%x", getpid());
   sprintf(filename, "%s/foo", dirname);
 

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -2398,8 +2398,15 @@ docompareandwrite(unsigned offset, unsigned size)
 
 void clone_filename(char *buf, size_t len, int clones)
 {
+#if __GNUC__ && __GNUC__ >= 8
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-truncation"
+#endif
 	snprintf(buf, len, "%s/fsx-%s-parent%d",
 		 dirpath, iname, clones);
+#if __GNUC__ && __GNUC__ >= 8
+#pragma GCC diagnostic pop
+#endif
 }
 
 void clone_imagename(char *buf, size_t len, int clones)

--- a/src/test/system/systest_runnable.h
+++ b/src/test/system/systest_runnable.h
@@ -44,7 +44,7 @@ std::string get_temp_pool_name(const char* prefix);
 class SysTestRunnable
 {
 public:
-  static const int ID_STR_SZ = 128;
+  static const int ID_STR_SZ = 196;
 
   SysTestRunnable(int argc, const char **argv);
   virtual ~SysTestRunnable();

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -308,7 +308,6 @@ int main(int argc, const char **argv)
       num_osd = -1;
     }
     uuid_d fsid;
-    memset(&fsid, 0, sizeof(uuid_d));
     if (createpool) {
       osdmap.build_simple_with_pool(
 	g_ceph_context, 0, fsid, num_osd, pg_bits, pgp_bits);


### PR DESCRIPTION
At least all those in the main body of the code rather than the submodules.