### PR TITLE
paxos: avoid too many paxos in store.db

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1751,6 +1751,10 @@ std::vector<Option> get_global_options() {
     .set_default(500)
     .set_description(""),
 
+    Option("paxos_max", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(1000)
+    .set_description(""),
+
     Option("paxos_trim_min", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(250)
     .set_description(""),

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -1230,6 +1230,8 @@ void Paxos::trim()
 
   if (first_committed >= end)
     return;
+  if (get_version() > g_conf->paxos_max)
+    end = std::max(end, get_version() - g_conf->paxos_max);
 
   dout(10) << "trim to " << end << " (was " << first_committed << ")" << dendl;
 


### PR DESCRIPTION
in one ceph cluster, mon warn that
> mon.node-1 store is getting too big 23262 MB >=20480 

after `ceph tell mon.node-1 compact`, two days latter the warn comes again.
with ceph-kvstore-tool, i find that there are 82134 paxos in store.db:
>paxos:142244714
>...
>paxos:142845516

i find Paxos::trim() only considerates paxos_min, but not care it's max, so i write this.
and i am not sure if this is right, push it for discuss. 

Signed-off-by: kungf <yang.wang@easystack.cn>