### PR TITLE
osd: write "bench" output to stdout

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6124,9 +6124,9 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       f->dump_int("blocksize", bsize);
       f->dump_unsigned("bytes_per_sec", rate);
       f->close_section();
-      f->flush(ss);
+      f->flush(ds);
     } else {
-      ss << "bench: wrote " << byte_u_t(count)
+      ds << "bench: wrote " << byte_u_t(count)
 	 << " in blocks of " << byte_u_t(bsize) << " in "
 	 << (end-start) << " sec at " << byte_u_t(rate) << "/sec";
     }


### PR DESCRIPTION
...not stderr.  Seems more reasonable as this
command is essentially feeding back a measurement result,
rather than just commenting on its status

Fixes: http://tracker.ceph.com/issues/24022
Signed-off-by: John Spray <john.spray@redhat.com>