### PR TITLE
qa/suites: set osd_pg_log_dups_tracked in cfuse_workunit_suites_fsync.yaml

### DIFF
--- a/qa/suites/powercycle/osd/tasks/cfuse_workunit_suites_fsync.yaml
+++ b/qa/suites/powercycle/osd/tasks/cfuse_workunit_suites_fsync.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        osd_pg_log_dups_tracked: 10000
+
 tasks:
 - ceph-fuse:
 - workunit:


### PR DESCRIPTION
Increase `osd_pg_log_dups_tracked` for this test, so that we keep track of dup ops and don't end up treating dup ops as new ops. 

Fixes: https://tracker.ceph.com/issues/23827

Signed-off-by: Neha Ojha <nojha@redhat.com>