### PR TITLE
rbd: don't load config overrides from monitor initially

### DIFF
--- a/src/stop.sh
+++ b/src/stop.sh
@@ -80,8 +80,8 @@ while [ $# -ge 1 ]; do
 done
 
 if [ $stop_all -eq 1 ]; then
-    if "${CEPH_BIN}"/rbd device list -c $conf_fn --no-mon-config >/dev/null 2>&1; then
-        "${CEPH_BIN}"/rbd device list -c $conf_fn --no-mon-config | tail -n +2 |
+    if "${CEPH_BIN}"/rbd device list -c $conf_fn >/dev/null 2>&1; then
+        "${CEPH_BIN}"/rbd device list -c $conf_fn | tail -n +2 |
         while read DEV; do
             # While it is currently possible to create an rbd image with
             # whitespace chars in its name, krbd will refuse mapping such
@@ -89,10 +89,10 @@ if [ $stop_all -eq 1 ]; then
             # same goes for whitespace chars in names of the pools that
             # contain rbd images).
             DEV="$(echo "${DEV}" | tr -s '[:space:]' | awk '{ print $5 }')"
-            sudo "${CEPH_BIN}"/rbd device unmap "${DEV}" -c $conf_fn --no-mon-config
+            sudo "${CEPH_BIN}"/rbd device unmap "${DEV}" -c $conf_fn
         done
 
-	if [ -n "$("${CEPH_BIN}"/rbd device list -c $conf_fn --no-mon-config)" ]; then
+        if [ -n "$("${CEPH_BIN}"/rbd device list -c $conf_fn)" ]; then
             echo "WARNING: Some rbd images are still mapped!" >&2
         fi
     fi

--- a/src/tools/rbd/Shell.cc
+++ b/src/tools/rbd/Shell.cc
@@ -32,7 +32,8 @@ boost::intrusive_ptr<CephContext> global_init(
   argv_to_vec(argc, argv, cmd_args);
   std::vector<const char*> args(cmd_args);
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
-                         CODE_ENVIRONMENT_UTILITY, 0);
+                         CODE_ENVIRONMENT_UTILITY,
+                         CINIT_FLAG_NO_MON_CONFIG);
 
   *command_args = {args.begin(), args.end()};
 


### PR DESCRIPTION
The overrides will be loaded when we connect to the cluster via librados
and the current approach prevents running 'rbd help' without a running
cluster.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>