### PR TITLE
common: add a generic async Completion for use with boost::asio

### DIFF
--- a/src/common/async/bind_handler.h
+++ b/src/common/async/bind_handler.h
@@ -1,0 +1,111 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#ifndef CEPH_ASYNC_BIND_HANDLER_H
+#define CEPH_ASYNC_BIND_HANDLER_H
+
+#include <tuple>
+#include <boost/asio.hpp>
+
+namespace ceph::async {
+
+/**
+ * A bound completion handler for use with boost::asio.
+ *
+ * A completion handler wrapper that allows a tuple of arguments to be forwarded
+ * to the original Handler. This is intended for use with boost::asio functions
+ * like defer(), dispatch() and post() which expect handlers which are callable
+ * with no arguments.
+ *
+ * The original Handler's associated allocator and executor are maintained.
+ *
+ * @see bind_handler
+ */
+template <typename Handler, typename Tuple>
+struct CompletionHandler {
+  Handler handler;
+  Tuple args;
+
+  CompletionHandler(Handler&& handler, Tuple&& args)
+    : handler(std::move(handler)),
+      args(std::move(args))
+  {}
+
+  void operator()() & {
+    std::apply(handler, args);
+  }
+  void operator()() const & {
+    std::apply(handler, args);
+  }
+  void operator()() && {
+    std::apply(std::move(handler), std::move(args));
+  }
+
+  using allocator_type = boost::asio::associated_allocator_t<Handler>;
+  allocator_type get_allocator() const noexcept {
+    return boost::asio::get_associated_allocator(handler);
+  }
+};
+
+} // namespace ceph::async
+
+namespace boost::asio {
+
+// specialize boost::asio::associated_executor<> for CompletionHandler
+template <typename Handler, typename Tuple, typename Executor>
+struct associated_executor<ceph::async::CompletionHandler<Handler, Tuple>, Executor> {
+  using type = boost::asio::associated_executor_t<Handler, Executor>;
+
+  static type get(const ceph::async::CompletionHandler<Handler, Tuple>& handler,
+                  const Executor& ex = Executor()) noexcept {
+    return boost::asio::get_associated_executor(handler.handler, ex);
+  }
+};
+
+} // namespace boost::asio
+
+namespace ceph::async {
+
+/**
+ * Returns a wrapped completion handler with bound arguments.
+ *
+ * Binds the given arguments to a handler, and returns a CompletionHandler that
+ * is callable with no arguments. This is similar to std::bind(), except that
+ * all arguments must be provided. Move-only argument types are supported as
+ * long as the CompletionHandler's 'operator() &&' overload is used, i.e.
+ * std::move(handler)().
+ *
+ * Example use:
+ *
+ *   // bind the arguments (5, "hello") to a callback lambda:
+ *   auto callback = [] (int a, std::string b) {};
+ *   auto handler = bind_handler(callback, 5, "hello");
+ *
+ *   // execute the bound handler on an io_context:
+ *   boost::asio::io_context context;
+ *   boost::asio::post(context, std::move(handler));
+ *   context.run();
+ *
+ * @see CompletionHandler
+ */
+template <typename Handler, typename ...Args>
+auto bind_handler(Handler&& h, Args&& ...args)
+{
+  return CompletionHandler{std::forward<Handler>(h),
+                           std::make_tuple(std::forward<Args>(args)...)};
+}
+
+} // namespace ceph::async
+
+#endif // CEPH_ASYNC_BIND_HANDLER_H

--- a/src/common/async/completion.h
+++ b/src/common/async/completion.h
@@ -1,0 +1,315 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#ifndef CEPH_ASYNC_COMPLETION_H
+#define CEPH_ASYNC_COMPLETION_H
+
+#include <memory>
+
+#include "bind_handler.h"
+
+namespace ceph::async {
+
+/**
+ * Abstract completion handler interface for use with boost::asio.
+ *
+ * Memory management is performed using the Handler's 'associated allocator',
+ * which carries the additional requirement that its memory be released before
+ * the Handler is invoked. This allows memory allocated for one asynchronous
+ * operation to be reused in its continuation. Because of this requirement, any
+ * calls to invoke the completion must first release ownership of it. To enforce
+ * this, the static functions defer()/dispatch()/post() take the completion by
+ * rvalue-reference to std::unique_ptr<Completion>, i.e. std::move(completion).
+ *
+ * Handlers may also have an 'associated executor', so the calls to defer(),
+ * dispatch(), and post() are forwarded to that executor. If there is no
+ * associated executor (which is generally the case unless one was bound with
+ * boost::asio::bind_executor()), the executor passed to Completion::create()
+ * is used as a default.
+ *
+ * Example use:
+ *
+ *   // declare a Completion type with Signature = void(int, string)
+ *   using MyCompletion = ceph::async::Completion<void(int, string)>;
+ *
+ *   // create a completion with the given callback:
+ *   std::unique_ptr<MyCompletion> c;
+ *   c = MyCompletion::create(ex, [] (int a, const string& b) {});
+ *
+ *   // bind arguments to the callback and post to its associated executor:
+ *   MyCompletion::post(std::move(c), 5, "hello");
+ *
+ *
+ * Additional user data may be stored along with the Completion to take
+ * advantage of the handler allocator optimization. This is accomplished by
+ * specifying its type in the template parameter T. For example, the type
+ * Completion<void(), int> contains a public member variable 'int user_data'.
+ * Any additional arguments to Completion::create() will be forwarded to type
+ * T's constructor.
+ *
+ * If the AsBase<T> type tag is used, as in Completion<void(), AsBase<T>>,
+ * the Completion will inherit from T instead of declaring it as a member
+ * variable.
+ *
+ * When invoking the completion handler via defer(), dispatch(), or post(),
+ * care must be taken when passing arguments that refer to user data, because
+ * its memory is destroyed prior to invocation. In such cases, the user data
+ * should be moved/copied out of the Completion first.
+ */
+template <typename Signature, typename T = void>
+class Completion;
+
+
+/// type tag for UserData
+template <typename T> struct AsBase {};
+
+namespace detail {
+
+/// optional user data to be stored with the Completion
+template <typename T>
+struct UserData {
+  T user_data;
+  template <typename ...Args>
+  UserData(Args&& ...args)
+    : user_data(std::forward<Args>(args)...)
+  {}
+};
+// AsBase specialization inherits from T
+template <typename T>
+struct UserData<AsBase<T>> : public T {
+  template <typename ...Args>
+  UserData(Args&& ...args)
+    : T(std::forward<Args>(args)...)
+  {}
+};
+// void specialization
+template <>
+class UserData<void> {};
+
+} // namespace detail
+
+
+// template specialization to pull the Signature's args apart
+template <typename T, typename ...Args>
+class Completion<void(Args...), T> : public detail::UserData<T> {
+ protected:
+  // internal interfaces for type-erasure on the Handler/Executor. uses
+  // tuple<Args...> to provide perfect forwarding because you can't make
+  // virtual function templates
+  virtual void destroy_defer(std::tuple<Args...>&& args) = 0;
+  virtual void destroy_dispatch(std::tuple<Args...>&& args) = 0;
+  virtual void destroy_post(std::tuple<Args...>&& args) = 0;
+  virtual void destroy() = 0;
+
+  // constructor is protected, use create(). any constructor arguments are
+  // forwarded to UserData
+  template <typename ...TArgs>
+  Completion(TArgs&& ...args)
+    : detail::UserData<T>(std::forward<TArgs>(args)...)
+  {}
+ public:
+  virtual ~Completion() = default;
+
+  // use the virtual destroy() interface on delete. this allows the derived
+  // class to manage its memory using Handler allocators, without having to use
+  // a custom Deleter for std::unique_ptr<>
+  static void operator delete(void *p) {
+    static_cast<Completion*>(p)->destroy();
+  }
+
+  /// completion factory function that uses the handler's associated allocator.
+  /// any additional arguments are forwared to T's constructor
+  template <typename Executor1, typename Handler, typename ...TArgs>
+  static std::unique_ptr<Completion>
+  create(const Executor1& ex1, Handler&& handler, TArgs&& ...args);
+
+  /// take ownership of the completion, bind any arguments to the completion
+  /// handler, then defer() it on its associated executor
+  template <typename ...Args2>
+  static void defer(std::unique_ptr<Completion>&& c, Args2&&...args);
+
+  /// take ownership of the completion, bind any arguments to the completion
+  /// handler, then dispatch() it on its associated executor
+  template <typename ...Args2>
+  static void dispatch(std::unique_ptr<Completion>&& c, Args2&&...args);
+
+  /// take ownership of the completion, bind any arguments to the completion
+  /// handler, then post() it to its associated executor
+  template <typename ...Args2>
+  static void post(std::unique_ptr<Completion>&& c, Args2&&...args);
+};
+
+namespace detail {
+
+// concrete Completion that knows how to invoke the completion handler. this
+// observes all of the 'Requirements on asynchronous operations' specified by
+// the C++ Networking TS
+template <typename Executor1, typename Handler, typename T, typename ...Args>
+class CompletionImpl final : public Completion<void(Args...), T> {
+  // use Handler's associated executor (or Executor1 by default) for callbacks
+  using Executor2 = boost::asio::associated_executor_t<Handler, Executor1>;
+  // maintain work on both executors
+  using Work1 = boost::asio::executor_work_guard<Executor1>;
+  using Work2 = boost::asio::executor_work_guard<Executor2>;
+  std::pair<Work1, Work2> work;
+  Handler handler;
+
+  // use Handler's associated allocator
+  using Alloc2 = boost::asio::associated_allocator_t<Handler>;
+  using Traits2 = std::allocator_traits<Alloc2>;
+  using RebindAlloc2 = typename Traits2::template rebind_alloc<CompletionImpl>;
+  using RebindTraits2 = std::allocator_traits<RebindAlloc2>;
+
+  // placement new for the handler allocator
+  static void* operator new(size_t, RebindAlloc2 alloc2) {
+    return RebindTraits2::allocate(alloc2, 1);
+  }
+  // placement delete for when the constructor throws during placement new
+  static void operator delete(void *p, RebindAlloc2 alloc2) {
+    RebindTraits2::deallocate(alloc2, static_cast<CompletionImpl*>(p), 1);
+  }
+
+  void destroy_defer(std::tuple<Args...>&& args) override {
+    auto w = std::move(work);
+    auto f = CompletionHandler{std::move(handler), std::move(args)};
+    RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);
+    RebindTraits2::destroy(alloc2, this);
+    RebindTraits2::deallocate(alloc2, this, 1);
+    w.second.get_executor().defer(std::move(f), alloc2);
+  }
+  void destroy_dispatch(std::tuple<Args...>&& args) override {
+    auto w = std::move(work);
+    auto f = CompletionHandler{std::move(handler), std::move(args)};
+    RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);
+    RebindTraits2::destroy(alloc2, this);
+    RebindTraits2::deallocate(alloc2, this, 1);
+    w.second.get_executor().dispatch(std::move(f), alloc2);
+  }
+  void destroy_post(std::tuple<Args...>&& args) override {
+    auto w = std::move(work);
+    auto f = CompletionHandler{std::move(handler), std::move(args)};
+    RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);
+    RebindTraits2::destroy(alloc2, this);
+    RebindTraits2::deallocate(alloc2, this, 1);
+    w.second.get_executor().post(std::move(f), alloc2);
+  }
+  void destroy() override {
+    RebindAlloc2 alloc2 = boost::asio::get_associated_allocator(handler);
+    RebindTraits2::destroy(alloc2, this);
+    RebindTraits2::deallocate(alloc2, this, 1);
+  }
+
+  // constructor is private, use create(). extra constructor arguments are
+  // forwarded to UserData
+  template <typename ...TArgs>
+  CompletionImpl(const Executor1& ex1, Handler&& handler, TArgs&& ...args)
+    : Completion<void(Args...), T>(std::forward<TArgs>(args)...),
+      work(ex1, boost::asio::make_work_guard(handler, ex1)),
+      handler(std::move(handler))
+  {}
+
+ public:
+  template <typename ...TArgs>
+  static auto create(const Executor1& ex, Handler&& handler, TArgs&& ...args) {
+    auto alloc2 = boost::asio::get_associated_allocator(handler);
+    using Ptr = std::unique_ptr<CompletionImpl>;
+    return Ptr{new (alloc2) CompletionImpl(ex, std::move(handler),
+                                           std::forward<TArgs>(args)...)};
+  }
+
+  static void operator delete(void *p) {
+    static_cast<CompletionImpl*>(p)->destroy();
+  }
+};
+
+} // namespace detail
+
+
+template <typename T, typename ...Args>
+template <typename Executor1, typename Handler, typename ...TArgs>
+std::unique_ptr<Completion<void(Args...), T>>
+Completion<void(Args...), T>::create(const Executor1& ex,
+                                     Handler&& handler, TArgs&& ...args)
+{
+  using Impl = detail::CompletionImpl<Executor1, Handler, T, Args...>;
+  return Impl::create(ex, std::forward<Handler>(handler),
+                      std::forward<TArgs>(args)...);
+}
+
+template <typename T, typename ...Args>
+template <typename ...Args2>
+void Completion<void(Args...), T>::defer(std::unique_ptr<Completion>&& ptr,
+                                         Args2&& ...args)
+{
+  auto c = ptr.release();
+  c->destroy_defer(std::make_tuple(std::forward<Args2>(args)...));
+}
+
+template <typename T, typename ...Args>
+template <typename ...Args2>
+void Completion<void(Args...), T>::dispatch(std::unique_ptr<Completion>&& ptr,
+                                            Args2&& ...args)
+{
+  auto c = ptr.release();
+  c->destroy_dispatch(std::make_tuple(std::forward<Args2>(args)...));
+}
+
+template <typename T, typename ...Args>
+template <typename ...Args2>
+void Completion<void(Args...), T>::post(std::unique_ptr<Completion>&& ptr,
+                                        Args2&& ...args)
+{
+  auto c = ptr.release();
+  c->destroy_post(std::make_tuple(std::forward<Args2>(args)...));
+}
+
+
+/// completion factory function that uses the handler's associated allocator.
+/// any additional arguments are forwared to T's constructor
+template <typename Signature, typename T, typename Executor1,
+          typename Handler, typename ...TArgs>
+std::unique_ptr<Completion<Signature, T>>
+create_completion(const Executor1& ex, Handler&& handler, TArgs&& ...args)
+{
+  return Completion<Signature, T>::create(ex, std::forward<Handler>(handler),
+                                          std::forward<TArgs>(args)...);
+}
+
+/// take ownership of the completion, bind any arguments to the completion
+/// handler, then defer() it on its associated executor
+template <typename Signature, typename T, typename ...Args>
+void defer(std::unique_ptr<Completion<Signature, T>>&& ptr, Args&& ...args)
+{
+  Completion<Signature, T>::defer(std::move(ptr), std::forward<Args>(args)...);
+}
+
+/// take ownership of the completion, bind any arguments to the completion
+/// handler, then dispatch() it on its associated executor
+template <typename Signature, typename T, typename ...Args>
+void dispatch(std::unique_ptr<Completion<Signature, T>>&& ptr, Args&& ...args)
+{
+  Completion<Signature, T>::dispatch(std::move(ptr), std::forward<Args>(args)...);
+}
+
+/// take ownership of the completion, bind any arguments to the completion
+/// handler, then post() it to its associated executor
+template <typename Signature, typename T, typename ...Args>
+void post(std::unique_ptr<Completion<Signature, T>>&& ptr, Args&& ...args)
+{
+  Completion<Signature, T>::post(std::move(ptr), std::forward<Args>(args)...);
+}
+
+} // namespace ceph::async
+
+#endif // CEPH_ASYNC_COMPLETION_H

--- a/src/common/async/forward_handler.h
+++ b/src/common/async/forward_handler.h
@@ -1,0 +1,103 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#ifndef CEPH_ASYNC_FORWARD_HANDLER_H
+#define CEPH_ASYNC_FORWARD_HANDLER_H
+
+#include <boost/asio.hpp>
+
+namespace ceph::async {
+
+/**
+ * A forwarding completion handler for use with boost::asio.
+ *
+ * A completion handler wrapper that invokes the handler's operator() as an
+ * rvalue, regardless of whether the wrapper is invoked as an lvalue or rvalue.
+ * This operation is potentially destructive to the wrapped handler, so is only
+ * suitable for single-use handlers.
+ *
+ * This is useful when combined with bind_handler() and move-only arguments,
+ * because executors will always call the lvalue overload of operator().
+ *
+ * The original Handler's associated allocator and executor are maintained.
+ *
+ * @see forward_handler
+ */
+template <typename Handler>
+struct ForwardingHandler {
+  Handler handler;
+
+  ForwardingHandler(Handler&& handler)
+    : handler(std::move(handler))
+  {}
+
+  template <typename ...Args>
+  void operator()(Args&& ...args) {
+    std::move(handler)(std::forward<Args>(args)...);
+  }
+
+  using allocator_type = boost::asio::associated_allocator_t<Handler>;
+  allocator_type get_allocator() const noexcept {
+    return boost::asio::get_associated_allocator(handler);
+  }
+};
+
+} // namespace ceph::async
+
+namespace boost::asio {
+
+// specialize boost::asio::associated_executor<> for ForwardingHandler
+template <typename Handler, typename Executor>
+struct associated_executor<ceph::async::ForwardingHandler<Handler>, Executor> {
+  using type = boost::asio::associated_executor_t<Handler, Executor>;
+
+  static type get(const ceph::async::ForwardingHandler<Handler>& handler,
+                  const Executor& ex = Executor()) noexcept {
+    return boost::asio::get_associated_executor(handler.handler, ex);
+  }
+};
+
+} // namespace boost::asio
+
+namespace ceph::async {
+
+/**
+ * Returns a single-use completion handler that always forwards on operator().
+ *
+ * Wraps a completion handler such that it is always invoked as an rvalue. This
+ * is necessary when combining executors and bind_handler() with move-only
+ * argument types.
+ *
+ * Example use:
+ *
+ *   auto callback = [] (std::unique_ptr<int>&& p) {};
+ *   auto bound_handler = bind_handler(callback, std::make_unique<int>(5));
+ *   auro handler = forward_handler(std::move(bound_handler));
+ *
+ *   // execute the forwarding handler on an io_context:
+ *   boost::asio::io_context context;
+ *   boost::asio::post(context, std::move(handler));
+ *   context.run();
+ *
+ * @see ForwardingHandler
+ */
+template <typename Handler>
+auto forward_handler(Handler&& h)
+{
+  return ForwardingHandler{std::forward<Handler>(h)};
+}
+
+} // namespace ceph::async
+
+#endif // CEPH_ASYNC_FORWARD_HANDLER_H

--- a/src/common/async/shared_mutex.h
+++ b/src/common/async/shared_mutex.h
@@ -1,0 +1,428 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#ifndef CEPH_ASYNC_SHARED_MUTEX_H
+#define CEPH_ASYNC_SHARED_MUTEX_H
+
+#include <condition_variable>
+#include <mutex>
+#include <shared_mutex> // for std::shared_lock
+
+#include <boost/intrusive/list.hpp>
+
+#include "common/async/completion.h"
+
+namespace ceph::async {
+
+/**
+ * An asynchronous shared mutex for use with boost::asio.
+ *
+ * A shared mutex class with asynchronous lock operations that complete on a
+ * boost::asio executor. The class also has synchronous interfaces that meet
+ * most of the standard library's requirements for the SharedMutex concept,
+ * which makes it compatible with lock_guard, unique_lock, and shared_lock.
+ *
+ * All lock requests can fail with operation_aborted on cancel() or destruction.
+ * The non-error_code overloads of lock() and lock_shared() will throw this
+ * error as an exception of type boost::system::system_error.
+ *
+ * Exclusive locks are prioritized over shared locks. Locks of the same type
+ * are granted in fifo order. The implementation defines a limit on the number
+ * of shared locks to 65534 at a time.
+ *
+ * Example use:
+ *
+ *   boost::asio::io_context context;
+ *   SharedMutex mutex{context.get_executor()};
+ *
+ *   mutex.async_lock([&] (boost::system::error_code ec, auto lock) {
+ *       if (!ec) {
+ *         // mutate shared state ...
+ *       }
+ *     });
+ *   mutex.async_lock_shared([&] (boost::system::error_code ec, auto lock) {
+ *       if (!ec) {
+ *         // read shared state ...
+ *       }
+ *     });
+ *
+ *   context.run();
+ */
+template <typename Executor>
+class SharedMutex {
+ public:
+  SharedMutex(const Executor& ex1);
+
+  /// on destruction, all pending lock requests are canceled
+  ~SharedMutex();
+
+  using executor_type = Executor;
+  executor_type get_executor() const noexcept { return ex1; }
+
+  /// initiate an asynchronous request for an exclusive lock. when the lock is
+  /// granted, the completion handler is invoked with a successful error code
+  /// and a std::unique_lock that owns this mutex.
+  /// Signature = void(boost::system::error_code, std::unique_lock)
+  template <typename CompletionToken>
+  auto async_lock(CompletionToken&& token);
+
+  /// wait synchronously for an exclusive lock. if an error occurs before the
+  /// lock is granted, that error is thrown as an exception
+  void lock();
+
+  /// wait synchronously for an exclusive lock. if an error occurs before the
+  /// lock is granted, that error is assigned to 'ec'
+  void lock(boost::system::error_code& ec);
+
+  /// try to acquire an exclusive lock. if the lock is not immediately
+  /// available, returns false
+  bool try_lock();
+
+  /// releases an exclusive lock. not required to be called from the same thread
+  /// that initiated the lock
+  void unlock();
+
+  /// initiate an asynchronous request for a shared lock. when the lock is
+  /// granted, the completion handler is invoked with a successful error code
+  /// and a std::shared_lock that owns this mutex.
+  /// Signature = void(boost::system::error_code, std::shared_lock)
+  template <typename CompletionToken>
+  auto async_lock_shared(CompletionToken&& token);
+
+  /// wait synchronously for a shared lock. if an error occurs before the
+  /// lock is granted, that error is thrown as an exception
+  void lock_shared();
+
+  /// wait synchronously for a shared lock. if an error occurs before the lock
+  /// is granted, that error is assigned to 'ec'
+  void lock_shared(boost::system::error_code& ec);
+
+  /// try to acquire a shared lock. if the lock is not immediately available,
+  /// returns false
+  bool try_lock_shared();
+
+  /// releases a shared lock. not required to be called from the same thread
+  /// that initiated the lock
+  void unlock_shared();
+
+  /// cancel any pending requests for exclusive or shared locks with an
+  /// operation_aborted error
+  void cancel();
+
+ private:
+  Executor ex1; //< default callback executor
+
+  struct LockRequest : public boost::intrusive::list_base_hook<> {
+    virtual ~LockRequest() {}
+    virtual void complete(boost::system::error_code ec) = 0;
+    virtual void destroy() = 0;
+  };
+  using RequestList = boost::intrusive::list<LockRequest>;
+
+  RequestList shared_queue; //< requests waiting on a shared lock
+  RequestList exclusive_queue; //< requests waiting on an exclusive lock
+
+  /// lock state encodes the number of shared lockers, or 'max' for exclusive
+  using LockState = uint16_t;
+  static constexpr LockState Unlocked = 0;
+  static constexpr LockState Exclusive = std::numeric_limits<LockState>::max();
+  static constexpr LockState MaxShared = Exclusive - 1;
+  LockState state = Unlocked; //< current lock state
+
+  std::mutex mutex; //< protects lock state and wait queues
+
+  // sync requests live on the stack and wait on a condition variable
+  class SyncRequest;
+
+  // async requests use async::Completion to invoke a handler on its executor
+  template <template <typename Mutex> typename Lock>
+  class AsyncRequest;
+
+  using AsyncExclusiveRequest = AsyncRequest<std::unique_lock>;
+  using AsyncSharedRequest = AsyncRequest<std::shared_lock>;
+
+  void complete(RequestList&& requests, boost::system::error_code ec);
+};
+
+template <typename Executor>
+class SharedMutex<Executor>::SyncRequest : public LockRequest {
+  std::condition_variable cond;
+  std::optional<boost::system::error_code> ec;
+ public:
+  boost::system::error_code wait(std::unique_lock<std::mutex>& lock) {
+    // return the error code once its been set
+    cond.wait(lock, [this] { return ec; });
+    return *ec;
+  }
+  void complete(boost::system::error_code ec) override {
+    this->ec = ec;
+    cond.notify_one();
+  }
+  void destroy() override {
+    // nothing, SyncRequests live on the stack
+  }
+};
+
+template <typename Executor>
+template <template <typename Mutex> typename Lock>
+class SharedMutex<Executor>::AsyncRequest : public LockRequest {
+  SharedMutex& mutex; //< mutex argument for lock guard
+ public:
+  AsyncRequest(SharedMutex& mutex) : mutex(mutex) {}
+
+  using Signature = void(boost::system::error_code, Lock<SharedMutex>);
+  using LockCompletion = Completion<Signature, AsBase<AsyncRequest>>;
+
+  void complete(boost::system::error_code ec) override {
+    auto r = static_cast<LockCompletion*>(this);
+    // pass ownership of ourselves to post(). on error, pass an empty lock
+    post(std::unique_ptr<LockCompletion>{r}, ec,
+         ec ? Lock{mutex, std::defer_lock} : Lock{mutex, std::adopt_lock});
+  }
+  void destroy() override {
+    delete static_cast<LockCompletion*>(this);
+  }
+};
+
+
+template <typename Executor>
+inline SharedMutex<Executor>::SharedMutex(const Executor& ex1)
+  : ex1(ex1)
+{
+}
+
+template <typename Executor>
+inline SharedMutex<Executor>::~SharedMutex()
+{
+  try {
+    cancel();
+  } catch (const std::exception&) {
+    // swallow any exceptions, the destructor can't throw
+  }
+}
+
+template <typename Executor>
+template <typename CompletionToken>
+auto SharedMutex<Executor>::async_lock(CompletionToken&& token)
+{
+  using Signature = typename AsyncExclusiveRequest::Signature;
+  boost::asio::async_completion<CompletionToken, Signature> init(token);
+  auto& handler = init.completion_handler;
+  {
+    std::lock_guard lock{mutex};
+
+    if (state == Unlocked) {
+      state = Exclusive;
+
+      // post the completion
+      auto ex2 = boost::asio::get_associated_executor(handler, ex1);
+      auto alloc2 = boost::asio::get_associated_allocator(handler);
+      auto b = bind_handler(std::move(handler), boost::system::error_code{},
+                            std::unique_lock{*this, std::adopt_lock});
+      ex2.post(forward_handler(std::move(b)), alloc2);
+    } else {
+      // create a request and add it to the exclusive list
+      using LockCompletion = typename AsyncExclusiveRequest::LockCompletion;
+      auto request = LockCompletion::create(ex1, std::move(handler), *this);
+      exclusive_queue.push_back(*request.release());
+    }
+  }
+  return init.result.get();
+}
+
+template <typename Executor>
+inline void SharedMutex<Executor>::lock()
+{
+  boost::system::error_code ec;
+  lock(ec);
+  if (ec) {
+    throw boost::system::system_error(ec);
+  }
+}
+
+template <typename Executor>
+void SharedMutex<Executor>::lock(boost::system::error_code& ec)
+{
+  std::unique_lock lock{mutex};
+
+  if (state == Unlocked) {
+    state = Exclusive;
+    ec.clear();
+  } else {
+    SyncRequest request;
+    exclusive_queue.push_back(request);
+    ec = request.wait(lock);
+  }
+}
+
+template <typename Executor>
+inline bool SharedMutex<Executor>::try_lock()
+{
+  std::lock_guard lock{mutex};
+
+  if (state == Unlocked) {
+    state = Exclusive;
+    return true;
+  }
+  return false;
+}
+
+template <typename Executor>
+void SharedMutex<Executor>::unlock()
+{
+  RequestList granted;
+  {
+    std::lock_guard lock{mutex};
+    assert(state == Exclusive);
+
+    if (!exclusive_queue.empty()) {
+      // grant next exclusive lock
+      auto& request = exclusive_queue.front();
+      exclusive_queue.pop_front();
+      granted.push_back(request);
+    } else {
+      // grant shared locks, if any
+      state = shared_queue.size();
+      if (state > MaxShared) {
+        state = MaxShared;
+        auto end = std::next(shared_queue.begin(), MaxShared);
+        granted.splice(granted.end(), shared_queue,
+                       shared_queue.begin(), end, MaxShared);
+      } else {
+        granted.splice(granted.end(), shared_queue);
+      }
+    }
+  }
+  complete(std::move(granted), boost::system::error_code{});
+}
+
+template <typename Executor>
+template <typename CompletionToken>
+auto SharedMutex<Executor>::async_lock_shared(CompletionToken&& token)
+{
+  using Signature = typename AsyncSharedRequest::Signature;
+  boost::asio::async_completion<CompletionToken, Signature> init(token);
+  auto& handler = init.completion_handler;
+  {
+    std::lock_guard lock{mutex};
+
+    if (exclusive_queue.empty() && state < MaxShared) {
+      state++;
+
+      auto ex2 = boost::asio::get_associated_executor(handler, ex1);
+      auto alloc2 = boost::asio::get_associated_allocator(handler);
+      auto b = bind_handler(std::move(handler), boost::system::error_code{},
+                            std::shared_lock{*this, std::adopt_lock});
+      ex2.post(forward_handler(std::move(b)), alloc2);
+    } else {
+      using LockCompletion = typename AsyncSharedRequest::LockCompletion;
+      auto request = LockCompletion::create(ex1, std::move(handler), *this);
+      shared_queue.push_back(*request.release());
+    }
+  }
+  return init.result.get();
+}
+
+template <typename Executor>
+inline void SharedMutex<Executor>::lock_shared()
+{
+  boost::system::error_code ec;
+  lock_shared(ec);
+  if (ec) {
+    throw boost::system::system_error(ec);
+  }
+}
+
+template <typename Executor>
+void SharedMutex<Executor>::lock_shared(boost::system::error_code& ec)
+{
+  std::unique_lock lock{mutex};
+
+  if (exclusive_queue.empty() && state < MaxShared) {
+    state++;
+    ec.clear();
+  } else {
+    SyncRequest request;
+    shared_queue.push_back(request);
+    ec = request.wait(lock);
+  }
+}
+
+template <typename Executor>
+inline bool SharedMutex<Executor>::try_lock_shared()
+{
+  std::lock_guard lock{mutex};
+
+  if (exclusive_queue.empty() && state < MaxShared) {
+    state++;
+    return true;
+  }
+  return false;
+}
+
+template <typename Executor>
+inline void SharedMutex<Executor>::unlock_shared()
+{
+  std::lock_guard lock{mutex};
+  assert(state != Unlocked && state <= MaxShared);
+
+  if (state == 1 && !exclusive_queue.empty()) {
+    // grant next exclusive lock
+    state = Exclusive;
+    auto& request = exclusive_queue.front();
+    exclusive_queue.pop_front();
+    request.complete(boost::system::error_code{});
+  } else if (state == MaxShared && !shared_queue.empty() &&
+             exclusive_queue.empty()) {
+    // grant next shared lock
+    auto& request = shared_queue.front();
+    shared_queue.pop_front();
+    request.complete(boost::system::error_code{});
+  } else {
+    state--;
+  }
+}
+
+template <typename Executor>
+inline void SharedMutex<Executor>::cancel()
+{
+  RequestList canceled;
+  {
+    std::lock_guard lock{mutex};
+    canceled.splice(canceled.end(), shared_queue);
+    canceled.splice(canceled.end(), exclusive_queue);
+  }
+  complete(std::move(canceled), boost::asio::error::operation_aborted);
+}
+
+template <typename Executor>
+void SharedMutex<Executor>::complete(RequestList&& requests,
+                                     boost::system::error_code ec)
+{
+  while (!requests.empty()) {
+    auto& request = requests.front();
+    requests.pop_front();
+    try {
+      request.complete(ec);
+    } catch (...) {
+      // clean up any remaining completions and rethrow
+      requests.clear_and_dispose([] (LockRequest *r) { r->destroy(); });
+      throw;
+    }
+  }
+}
+
+} // namespace ceph::async
+
+#endif // CEPH_ASYNC_SHARED_MUTEX_H

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -294,3 +294,7 @@ add_ceph_unittest(unittest_hobject)
 add_executable(unittest_async_completion test_async_completion.cc)
 add_ceph_unittest(unittest_async_completion)
 target_link_libraries(unittest_async_completion Boost::system)
+
+add_executable(unittest_async_shared_mutex test_async_shared_mutex.cc)
+add_ceph_unittest(unittest_async_shared_mutex)
+target_link_libraries(unittest_async_shared_mutex Boost::system)

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -290,3 +290,7 @@ add_executable(unittest_hobject test_hobject.cc
   $<TARGET_OBJECTS:unit-main>)
 target_link_libraries(unittest_hobject global ceph-common)
 add_ceph_unittest(unittest_hobject)
+
+add_executable(unittest_async_completion test_async_completion.cc)
+add_ceph_unittest(unittest_async_completion)
+target_link_libraries(unittest_async_completion Boost::system)

--- a/src/test/common/test_async_completion.cc
+++ b/src/test/common/test_async_completion.cc
@@ -1,0 +1,229 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/async/completion.h"
+#include <optional>
+#include <boost/intrusive/list.hpp>
+#include <gtest/gtest.h>
+
+namespace ceph::async {
+
+using boost::system::error_code;
+
+struct move_only {
+  move_only() = default;
+  move_only(move_only&&) = default;
+  move_only& operator=(move_only&&) = default;
+  move_only(const move_only&) = delete;
+  move_only& operator=(const move_only&) = delete;
+};
+
+TEST(AsyncCompletion, BindHandler)
+{
+  auto h1 = [] (int i, char c) {};
+  auto b1 = bind_handler(std::move(h1), 5, 'a');
+  b1();
+  const auto& c1 = b1;
+  c1();
+  std::move(b1)();
+
+  // move-only types can be forwarded with 'operator() &&'
+  auto h2 = [] (move_only&& m) {};
+  auto b2 = bind_handler(std::move(h2), move_only{});
+  std::move(b2)();
+
+  // references bound with std::ref() and passed to all operator() overloads
+  auto h3 = [] (int& c) { c++; };
+  int count = 0;
+  auto b3 = bind_handler(std::move(h3), std::ref(count));
+  EXPECT_EQ(0, count);
+  b3();
+  EXPECT_EQ(1, count);
+  const auto& c3 = b3;
+  c3();
+  EXPECT_EQ(2, count);
+  std::move(b3)();
+  EXPECT_EQ(3, count);
+}
+
+TEST(AsyncCompletion, MoveOnly)
+{
+  boost::asio::io_context context;
+  auto ex1 = context.get_executor();
+
+  std::optional<error_code> ec1, ec2;
+  {
+    // move-only user data
+    using Completion = Completion<void(error_code), move_only>;
+    auto c = Completion::create(ex1, [&ec1] (error_code ec) { ec1 = ec; });
+    Completion::post(std::move(c), boost::asio::error::operation_aborted);
+    EXPECT_FALSE(ec1);
+  }
+  {
+    // move-only handler
+    using Completion = Completion<void(error_code)>;
+    auto c = Completion::create(ex1, [&ec2, m=move_only{}] (error_code ec) { ec2 = ec; });
+    Completion::post(std::move(c), boost::asio::error::operation_aborted);
+    EXPECT_FALSE(ec2);
+  }
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::asio::error::operation_aborted, *ec1);
+  ASSERT_TRUE(ec2);
+  EXPECT_EQ(boost::asio::error::operation_aborted, *ec2);
+}
+
+TEST(AsyncCompletion, VoidCompletion)
+{
+  boost::asio::io_context context;
+  auto ex1 = context.get_executor();
+
+  using Completion = Completion<void(error_code)>;
+  std::optional<error_code> ec1;
+
+  auto c = Completion::create(ex1, [&ec1] (error_code ec) { ec1 = ec; });
+  Completion::post(std::move(c), boost::asio::error::operation_aborted);
+
+  EXPECT_FALSE(ec1);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::asio::error::operation_aborted, *ec1);
+}
+
+TEST(AsyncCompletion, CompletionList)
+{
+  boost::asio::io_context context;
+  auto ex1 = context.get_executor();
+
+  using T = AsBase<boost::intrusive::list_base_hook<>>;
+  using Completion = Completion<void(), T>;
+  boost::intrusive::list<Completion> completions;
+  int completed = 0;
+  for (int i = 0; i < 3; i++) {
+    auto c = Completion::create(ex1, [&] { completed++; });
+    completions.push_back(*c.release());
+  }
+  completions.clear_and_dispose([] (Completion *c) {
+      Completion::post(std::unique_ptr<Completion>{c});
+    });
+
+  EXPECT_EQ(0, completed);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  EXPECT_EQ(3, completed);
+}
+
+TEST(AsyncCompletion, CompletionPair)
+{
+  boost::asio::io_context context;
+  auto ex1 = context.get_executor();
+
+  using T = std::pair<int, std::string>;
+  using Completion = Completion<void(int, std::string), T>;
+
+  std::optional<T> t;
+  auto c = Completion::create(ex1, [&] (int first, std::string second) {
+      t = T{first, std::move(second)};
+    }, 2, "hello");
+
+  auto data = std::move(c->user_data);
+  Completion::post(std::move(c), data.first, std::move(data.second));
+
+  EXPECT_FALSE(t);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  ASSERT_TRUE(t);
+  EXPECT_EQ(2, t->first);
+  EXPECT_EQ("hello", t->second);
+}
+
+TEST(AsyncCompletion, CompletionReference)
+{
+  boost::asio::io_context context;
+  auto ex1 = context.get_executor();
+
+  using Completion = Completion<void(int&)>;
+
+  auto c = Completion::create(ex1, [] (int& i) { ++i; });
+
+  int i = 42;
+  Completion::post(std::move(c), std::ref(i));
+
+  EXPECT_EQ(42, i);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  EXPECT_EQ(43, i);
+}
+
+struct throws_on_move {
+  throws_on_move() = default;
+  throws_on_move(throws_on_move&&) {
+    throw std::runtime_error("oops");
+  }
+  throws_on_move& operator=(throws_on_move&&) {
+    throw std::runtime_error("oops");
+  }
+  throws_on_move(const throws_on_move&) = default;
+  throws_on_move& operator=(const throws_on_move&) = default;
+};
+
+TEST(AsyncCompletion, ThrowOnCtor)
+{
+  boost::asio::io_context context;
+  auto ex1 = context.get_executor();
+  {
+    using Completion = Completion<void(int&)>;
+
+    // throw on Handler move construction
+    EXPECT_THROW(Completion::create(ex1, [t=throws_on_move{}] (int& i) { ++i; }),
+                 std::runtime_error);
+  }
+  {
+    using T = throws_on_move;
+    using Completion = Completion<void(int&), T>;
+
+    // throw on UserData construction
+    EXPECT_THROW(Completion::create(ex1, [] (int& i) { ++i; }, throws_on_move{}),
+                 std::runtime_error);
+  }
+}
+
+TEST(AsyncCompletion, FreeFunctions)
+{
+  boost::asio::io_context context;
+  auto ex1 = context.get_executor();
+
+  auto c1 = create_completion<void(), void>(ex1, [] {});
+  post(std::move(c1));
+
+  auto c2 = create_completion<void(int), int>(ex1, [] (int) {}, 5);
+  defer(std::move(c2), c2->user_data);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+}
+
+} // namespace ceph::async

--- a/src/test/common/test_async_shared_mutex.cc
+++ b/src/test/common/test_async_shared_mutex.cc
@@ -1,0 +1,428 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "common/async/shared_mutex.h"
+#include <optional>
+#include <gtest/gtest.h>
+
+namespace ceph::async {
+
+using executor_type = boost::asio::io_context::executor_type;
+using unique_lock = std::unique_lock<SharedMutex<executor_type>>;
+using shared_lock = std::shared_lock<SharedMutex<executor_type>>;
+
+// return a lambda that captures its error code and lock
+auto capture(std::optional<boost::system::error_code>& ec, unique_lock& lock)
+{
+  return [&] (boost::system::error_code e, unique_lock l) {
+    ec = e;
+    lock = std::move(l);
+  };
+}
+auto capture(std::optional<boost::system::error_code>& ec, shared_lock& lock)
+{
+  return [&] (boost::system::error_code e, shared_lock l) {
+    ec = e;
+    lock = std::move(l);
+  };
+}
+
+TEST(SharedMutex, async_exclusive)
+{
+  boost::asio::io_context context;
+  SharedMutex mutex(context.get_executor());
+
+  std::optional<boost::system::error_code> ec1, ec2, ec3;
+  unique_lock lock1, lock2, lock3;
+
+  // request three exclusive locks
+  mutex.async_lock(capture(ec1, lock1));
+  mutex.async_lock(capture(ec2, lock2));
+  mutex.async_lock(capture(ec3, lock3));
+
+  EXPECT_FALSE(ec1); // no callbacks until poll()
+  EXPECT_FALSE(ec2);
+  EXPECT_FALSE(ec3);
+
+  context.poll();
+  EXPECT_FALSE(context.stopped()); // second lock still pending
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::system::errc::success, *ec1);
+  ASSERT_TRUE(lock1);
+  EXPECT_FALSE(ec2);
+
+  lock1.unlock();
+
+  EXPECT_FALSE(ec2);
+
+  context.poll();
+  EXPECT_FALSE(context.stopped());
+
+  ASSERT_TRUE(ec2);
+  EXPECT_EQ(boost::system::errc::success, *ec2);
+  ASSERT_TRUE(lock2);
+  EXPECT_FALSE(ec3);
+
+  lock2.unlock();
+
+  EXPECT_FALSE(ec3);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  ASSERT_TRUE(ec3);
+  EXPECT_EQ(boost::system::errc::success, *ec3);
+  ASSERT_TRUE(lock3);
+}
+
+TEST(SharedMutex, async_shared)
+{
+  boost::asio::io_context context;
+  SharedMutex mutex(context.get_executor());
+
+  std::optional<boost::system::error_code> ec1, ec2;
+  shared_lock lock1, lock2;
+
+  // request two shared locks
+  mutex.async_lock_shared(capture(ec1, lock1));
+  mutex.async_lock_shared(capture(ec2, lock2));
+
+  EXPECT_FALSE(ec1); // no callbacks until poll()
+  EXPECT_FALSE(ec2);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::system::errc::success, *ec1);
+  ASSERT_TRUE(lock1);
+  ASSERT_TRUE(ec2);
+  EXPECT_EQ(boost::system::errc::success, *ec2);
+  ASSERT_TRUE(lock2);
+}
+
+TEST(SharedMutex, async_exclusive_while_shared)
+{
+  boost::asio::io_context context;
+  SharedMutex mutex(context.get_executor());
+
+  std::optional<boost::system::error_code> ec1, ec2;
+  shared_lock lock1;
+  unique_lock lock2;
+
+  // request a shared and exclusive lock
+  mutex.async_lock_shared(capture(ec1, lock1));
+  mutex.async_lock(capture(ec2, lock2));
+
+  EXPECT_FALSE(ec1); // no callbacks until poll()
+  EXPECT_FALSE(ec2);
+
+  context.poll();
+  EXPECT_FALSE(context.stopped()); // second lock still pending
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::system::errc::success, *ec1);
+  ASSERT_TRUE(lock1);
+  EXPECT_FALSE(ec2);
+
+  lock1.unlock();
+
+  EXPECT_FALSE(ec2);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  ASSERT_TRUE(ec2);
+  EXPECT_EQ(boost::system::errc::success, *ec2);
+  ASSERT_TRUE(lock2);
+}
+
+TEST(SharedMutex, async_shared_while_exclusive)
+{
+  boost::asio::io_context context;
+  SharedMutex mutex(context.get_executor());
+
+  std::optional<boost::system::error_code> ec1, ec2;
+  unique_lock lock1;
+  shared_lock lock2;
+
+  // request an exclusive and shared lock
+  mutex.async_lock(capture(ec1, lock1));
+  mutex.async_lock_shared(capture(ec2, lock2));
+
+  EXPECT_FALSE(ec1); // no callbacks until poll()
+  EXPECT_FALSE(ec2);
+
+  context.poll();
+  EXPECT_FALSE(context.stopped()); // second lock still pending
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::system::errc::success, *ec1);
+  ASSERT_TRUE(lock1);
+  EXPECT_FALSE(ec2);
+
+  lock1.unlock();
+
+  EXPECT_FALSE(ec2);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  ASSERT_TRUE(ec2);
+  EXPECT_EQ(boost::system::errc::success, *ec2);
+  ASSERT_TRUE(lock2);
+}
+
+TEST(SharedMutex, async_prioritize_exclusive)
+{
+  boost::asio::io_context context;
+  SharedMutex mutex(context.get_executor());
+
+  std::optional<boost::system::error_code> ec1, ec2, ec3;
+  shared_lock lock1, lock3;
+  unique_lock lock2;
+
+  // acquire a shared lock, then request an exclusive and another shared lock
+  mutex.async_lock_shared(capture(ec1, lock1));
+  mutex.async_lock(capture(ec2, lock2));
+  mutex.async_lock_shared(capture(ec3, lock3));
+
+  EXPECT_FALSE(ec1); // no callbacks until poll()
+  EXPECT_FALSE(ec2);
+  EXPECT_FALSE(ec3);
+
+  context.poll();
+  EXPECT_FALSE(context.stopped());
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::system::errc::success, *ec1);
+  ASSERT_TRUE(lock1);
+  EXPECT_FALSE(ec2);
+  // exclusive waiter blocks the second shared lock
+  EXPECT_FALSE(ec3);
+
+  lock1.unlock();
+
+  EXPECT_FALSE(ec2);
+  EXPECT_FALSE(ec3);
+
+  context.poll();
+  EXPECT_FALSE(context.stopped());
+
+  ASSERT_TRUE(ec2);
+  EXPECT_EQ(boost::system::errc::success, *ec2);
+  ASSERT_TRUE(lock2);
+  EXPECT_FALSE(ec3);
+}
+
+TEST(SharedMutex, async_cancel)
+{
+  boost::asio::io_context context;
+  SharedMutex mutex(context.get_executor());
+
+  std::optional<boost::system::error_code> ec1, ec2, ec3, ec4;
+  unique_lock lock1, lock2;
+  shared_lock lock3, lock4;
+
+  // request 2 exclusive and shared locks
+  mutex.async_lock(capture(ec1, lock1));
+  mutex.async_lock(capture(ec2, lock2));
+  mutex.async_lock_shared(capture(ec3, lock3));
+  mutex.async_lock_shared(capture(ec4, lock4));
+
+  EXPECT_FALSE(ec1); // no callbacks until poll()
+  EXPECT_FALSE(ec2);
+  EXPECT_FALSE(ec3);
+  EXPECT_FALSE(ec4);
+
+  context.poll();
+  EXPECT_FALSE(context.stopped());
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::system::errc::success, *ec1);
+  ASSERT_TRUE(lock1);
+  EXPECT_FALSE(ec2);
+  EXPECT_FALSE(ec3);
+  EXPECT_FALSE(ec4);
+
+  mutex.cancel();
+
+  EXPECT_FALSE(ec2);
+  EXPECT_FALSE(ec3);
+  EXPECT_FALSE(ec4);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  ASSERT_TRUE(ec2);
+  EXPECT_EQ(boost::asio::error::operation_aborted, *ec2);
+  EXPECT_FALSE(lock2);
+  ASSERT_TRUE(ec3);
+  EXPECT_EQ(boost::asio::error::operation_aborted, *ec3);
+  EXPECT_FALSE(lock3);
+  ASSERT_TRUE(ec4);
+  EXPECT_EQ(boost::asio::error::operation_aborted, *ec4);
+  EXPECT_FALSE(lock4);
+}
+
+TEST(SharedMutex, async_destruct)
+{
+  boost::asio::io_context context;
+
+  std::optional<boost::system::error_code> ec1, ec2, ec3, ec4;
+  unique_lock lock1, lock2;
+  shared_lock lock3, lock4;
+
+  {
+    SharedMutex mutex(context.get_executor());
+
+    // request 2 exclusive and shared locks
+    mutex.async_lock(capture(ec1, lock1));
+    mutex.async_lock(capture(ec2, lock2));
+    mutex.async_lock_shared(capture(ec3, lock3));
+    mutex.async_lock_shared(capture(ec4, lock4));
+  }
+
+  EXPECT_FALSE(ec1); // no callbacks until poll()
+  EXPECT_FALSE(ec2);
+  EXPECT_FALSE(ec3);
+  EXPECT_FALSE(ec4);
+
+  context.poll();
+  EXPECT_TRUE(context.stopped());
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::system::errc::success, *ec1);
+  ASSERT_TRUE(lock1);
+  ASSERT_TRUE(ec2);
+  EXPECT_EQ(boost::asio::error::operation_aborted, *ec2);
+  EXPECT_FALSE(lock2);
+  ASSERT_TRUE(ec3);
+  EXPECT_EQ(boost::asio::error::operation_aborted, *ec3);
+  EXPECT_FALSE(lock3);
+  ASSERT_TRUE(ec4);
+  EXPECT_EQ(boost::asio::error::operation_aborted, *ec4);
+  EXPECT_FALSE(lock4);
+}
+
+// return a capture() lambda that's bound to the given executor
+template <typename Executor, typename ...Args>
+auto capture_ex(const Executor& ex, Args&& ...args)
+{
+  return boost::asio::bind_executor(ex, capture(std::forward<Args>(args)...));
+}
+
+TEST(SharedMutex, cross_executor)
+{
+  boost::asio::io_context mutex_context;
+  SharedMutex mutex(mutex_context.get_executor());
+
+  boost::asio::io_context callback_context;
+  auto ex2 = callback_context.get_executor();
+
+  std::optional<boost::system::error_code> ec1, ec2;
+  unique_lock lock1, lock2;
+
+  // request two exclusive locks
+  mutex.async_lock(capture_ex(ex2, ec1, lock1));
+  mutex.async_lock(capture_ex(ex2, ec2, lock2));
+
+  EXPECT_FALSE(ec1);
+  EXPECT_FALSE(ec2);
+
+  mutex_context.poll();
+  EXPECT_FALSE(mutex_context.stopped()); // maintains work on both executors
+
+  EXPECT_FALSE(ec1); // no callbacks until poll() on callback_context
+  EXPECT_FALSE(ec2);
+
+  callback_context.poll();
+  EXPECT_FALSE(callback_context.stopped()); // second lock still pending
+
+  ASSERT_TRUE(ec1);
+  EXPECT_EQ(boost::system::errc::success, *ec1);
+  ASSERT_TRUE(lock1);
+  EXPECT_FALSE(ec2);
+
+  lock1.unlock();
+
+  mutex_context.poll();
+  EXPECT_TRUE(mutex_context.stopped());
+
+  EXPECT_FALSE(ec2);
+
+  callback_context.poll();
+  EXPECT_TRUE(callback_context.stopped());
+
+  ASSERT_TRUE(ec2);
+  EXPECT_EQ(boost::system::errc::success, *ec2);
+  ASSERT_TRUE(lock2);
+}
+
+TEST(SharedMutex, try_exclusive)
+{
+  boost::asio::io_context context;
+  SharedMutex mutex(context.get_executor());
+  {
+    std::lock_guard lock{mutex};
+    ASSERT_FALSE(mutex.try_lock()); // fail during exclusive
+  }
+  {
+    std::shared_lock lock{mutex};
+    ASSERT_FALSE(mutex.try_lock()); // fail during shared
+  }
+  ASSERT_TRUE(mutex.try_lock());
+  mutex.unlock();
+}
+
+TEST(SharedMutex, try_shared)
+{
+  boost::asio::io_context context;
+  SharedMutex mutex(context.get_executor());
+  {
+    std::lock_guard lock{mutex};
+    ASSERT_FALSE(mutex.try_lock_shared()); // fail during exclusive
+  }
+  {
+    std::shared_lock lock{mutex};
+    ASSERT_TRUE(mutex.try_lock_shared()); // succeed during shared
+    mutex.unlock_shared();
+  }
+  ASSERT_TRUE(mutex.try_lock_shared());
+  mutex.unlock_shared();
+}
+
+TEST(SharedMutex, cancel)
+{
+  boost::asio::io_context context;
+  SharedMutex mutex(context.get_executor());
+
+  std::lock_guard l{mutex}; // exclusive lock blocks others
+
+  // make synchronous lock calls in other threads
+  auto f1 = std::async(std::launch::async, [&] { mutex.lock(); });
+  auto f2 = std::async(std::launch::async, [&] { mutex.lock_shared(); });
+
+  // this will race with spawned threads. just keep canceling until the
+  // futures are ready
+  const auto t = std::chrono::milliseconds(1);
+  do { mutex.cancel(); } while (f1.wait_for(t) != std::future_status::ready);
+  do { mutex.cancel(); } while (f2.wait_for(t) != std::future_status::ready);
+
+  EXPECT_THROW(f1.get(), boost::system::system_error);
+  EXPECT_THROW(f2.get(), boost::system::system_error);
+}
+
+} // namespace ceph::async


### PR DESCRIPTION
(split out from https://github.com/ceph/ceph/pull/21271)

SharedMutex presents a unified interface for sync and async waits. the async waits use a new generic async::Completion primitive

when these Completions are used with a boost::asio::strand executor (as is the case with boost's stackful coroutines), the associated allocator is a 'recycling_allocator' that reuses memory from the previous async operation. so in effect, neither the sync nor async waits in SharedMutex require heap allocation