### PR TITLE
mds: set could_consume to false when no purge queue item actually executed

### DIFF
--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -350,7 +350,6 @@ bool PurgeQueue::_consume()
 
   bool could_consume = false;
   while(can_consume()) {
-    could_consume = true;
 
     if (delayed_flush) {
       // We are now going to read from the journal, so any proactive
@@ -376,6 +375,7 @@ bool PurgeQueue::_consume()
       return could_consume;
     }
 
+    could_consume = true;
     // The journaler is readable: consume an entry
     bufferlist bl;
     bool readable = journaler.try_read_entry(bl);


### PR DESCRIPTION
In our online clusters, we encountered the bug [#19593](http://tracker.ceph.com/issues/19593). Although we cherry-pick the fixing commits, the purge queue's journal is already damaged. When trying to repair the journal, we found that the journal's head has not been updated for a long time, which is caused by PurgeQueue::_consume() method always returning true while no purge queue item was executed. So we think it might be necessary for this method to return false when there were actually no purge queue item executed, even if the bug [#19593](http://tracker.ceph.com/issues/19593) is fixed. After all, there could be other bugs that could damage the journal.

Fixes: http://tracker.ceph.com/issues/24073
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>