### PR TITLE
librados: Revert "librados: return ENOENT if pool_id invalid"

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -188,12 +188,11 @@ int librados::RadosClient::pool_get_auid(uint64_t pool_id,
   return r;
 }
 
-int librados::RadosClient::pool_get_name(uint64_t pool_id, std::string *s, bool wait_latest_map)
+int librados::RadosClient::pool_get_name(uint64_t pool_id, std::string *s)
 {
   int r = wait_for_osdmap();
   if (r < 0)
     return r;
-  retry:
   objecter->with_osdmap([&](const OSDMap& o) {
       if (!o.have_pg_pool(pool_id)) {
 	r = -ENOENT;
@@ -202,14 +201,6 @@ int librados::RadosClient::pool_get_name(uint64_t pool_id, std::string *s, bool 
 	*s = o.get_pool_name(pool_id);
       }
     });
-  if (r == -ENOENT && wait_latest_map) {
-    r = wait_for_latest_osdmap();
-    if (r < 0)
-      return r;
-    wait_latest_map = false;
-    goto retry;
-  }
-
   return r;
 }
 

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -500,10 +500,6 @@ int librados::RadosClient::create_ioctx(const char *name, IoCtxImpl **io)
 
 int librados::RadosClient::create_ioctx(int64_t pool_id, IoCtxImpl **io)
 {
-  std::string pool_name;
-  int r = pool_get_name(pool_id, &pool_name, true);
-  if (r < 0)
-    return r;
   *io = new librados::IoCtxImpl(this, objecter, pool_id, CEPH_NOSNAP);
   return 0;
 }

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -114,7 +114,7 @@ public:
   uint64_t pool_required_alignment(int64_t pool_id);
   int pool_required_alignment2(int64_t pool_id, uint64_t *alignment);
   int pool_get_auid(uint64_t pool_id, unsigned long long *auid);
-  int pool_get_name(uint64_t pool_id, std::string *auid, bool wait_latest_map = false);
+  int pool_get_name(uint64_t pool_id, std::string *auid);
 
   int pool_list(std::list<std::pair<int64_t, string> >& ls);
   int get_pool_stats(std::list<string>& ls, map<string,::pool_stat_t>& result);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/24076

this reverts #21609