### PR TITLE
qa/tasks/mgr: fix test_pool.py

### DIFF
--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -97,9 +97,10 @@ class PoolTest(DashboardTestCase):
                                          data['application_metadata'].split(','))
                     elif k == 'pool':
                         self.assertEqual(pool['pool_name'], v)
-                    elif k in ['compression_mode', 'compression_algorithm',
-                               'compression_max_blob_size']:
+                    elif k in ['compression_mode', 'compression_algorithm']:
                         self.assertEqual(pool['options'][k], data[k])
+                    elif k == 'compression_max_blob_size':
+                        self.assertEqual(pool['options'][k], int(data[k]))
                     elif k == 'compression_required_ratio':
                         self.assertEqual(pool['options'][k], float(data[k]))
                     else:
@@ -136,7 +137,7 @@ class PoolTest(DashboardTestCase):
             'pool_type': 'replicated',
             'compression_algorithm': 'zstd',
             'compression_mode': 'aggressive',
-            'compression_max_blob_size': 10000000,
+            'compression_max_blob_size': "10000000",
             'compression_required_ratio': '0.8',
         }]
         for data in pools:
@@ -150,7 +151,7 @@ class PoolTest(DashboardTestCase):
         self.assertJsonBody({
             'component': 'pool',
             'code': "2",
-            'detail': "specified rule dnf doesn't exist"
+            'detail': "[errno -2] specified rule dnf doesn't exist"
         })
 
     @authenticate


### PR DESCRIPTION
per command desc of "osd pool set", "val" parameter should be a "string"
not a number. so update the test_pool.py accordingly.

Fixes: http://tracker.ceph.com/issues/24077
Signed-off-by: Kefu Chai <kchai@redhat.com>