### PR TITLE
luminous: qa/workunits/rbd/import_export: update unit formatting

### DIFF
--- a/qa/workunits/rbd/import_export.sh
+++ b/qa/workunits/rbd/import_export.sh
@@ -132,7 +132,7 @@ if rbd help export | grep -q export-format; then
     rbd import --stripe-count 1000 --stripe-unit 4096 ${TMPDIR}/img testimg
     rbd export --export-format 2 testimg ${TMPDIR}/img_v2
     rbd import --export-format 2 ${TMPDIR}/img_v2 testimg_import
-    rbd info testimg_import|grep "stripe unit"|awk '{print $3}'|grep 4096
+    rbd info testimg_import|grep "stripe unit"|awk '{print $3}'|grep -Ei '(4K|4096)'
     rbd info testimg_import|grep "stripe count"|awk '{print $3}'|grep 1000
 
     rm ${TMPDIR}/img_v2


### PR DESCRIPTION
Mimic changed the unit formating output for rbd CLI commands, so
for upgrade tests we need to support both Luminous and Mimic style.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>