### PR TITLE
test/pybind/test_rados.py: collect output in stdout for "bench" cmd

### DIFF
--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -1070,8 +1070,8 @@ class TestCommand(object):
         ret, buf, err = self.rados.osd_command(0, json.dumps(cmd), b'',
                                                timeout=30)
         eq(ret, 0)
-        assert len(err) > 0
-        out = json.loads(err)
+        assert len(buf) > 0
+        out = json.loads(buf.decode('utf-8'))
         eq(out['blocksize'], cmd['size'])
         eq(out['bytes_written'], cmd['count'])
 


### PR DESCRIPTION
it was changed from stderr to stdout in 23583ccc

Signed-off-by: Kefu Chai <kchai@redhat.com>