### PR TITLE
 osd: write "debug dump_missing" output to stdout

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6157,7 +6157,7 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       f->close_section();
     }
     f->close_section();
-    f->flush(ss);
+    f->flush(ds);
   }
   else if (prefix == "debug kick_recovery_wq") {
     int64_t delay;


### PR DESCRIPTION
Output was sent to stderr by a mistake. Now it goes to stdout.
