### PR TITLE
luminous: mgr/influx: Only split string on first occurence of dot (.)

### DIFF
--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -72,7 +72,7 @@ class Module(MgrModule):
         data = []
 
         for daemon, counters in self.get_all_perf_counters().iteritems():
-            svc_type, svc_id = daemon.split(".")
+            svc_type, svc_id = daemon.split(".", 1)
             metadata = self.get_metadata(svc_type, svc_id)
 
             for path, counter_info in counters.items():


### PR DESCRIPTION
http://tracker.ceph.com/issues/24014