### PR TITLE
common: partially revert 95fc248 to make get_process_name work

### DIFF
--- a/src/common/code_environment.cc
+++ b/src/common/code_environment.cc
@@ -16,9 +16,13 @@
 
 #include <iostream>
 
+#include "acconfig.h"
+
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #endif
+
+#include <string.h>
 
 code_environment_t g_code_env = CODE_ENVIRONMENT_UTILITY;
 


### PR DESCRIPTION
"acconfig.h" is needed for HAVE_SYS_PRCTL_H and <string.h> for memset.

Fixes: http://tracker.ceph.com/issues/24123
Signed-off-by: Mykola Golub <mgolub@suse.com>