### PR TITLE
os/bluefs/BlueFS: cleanup code.

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2165,8 +2165,6 @@ BlueFS::FileWriter *BlueFS::_create_writer(FileRef f)
   for (unsigned i = 0; i < MAX_BDEV; ++i) {
     if (bdev[i]) {
       w->iocv[i] = new IOContext(cct, NULL);
-    } else {
-      w->iocv[i] = NULL;
     }
   }
   return w;


### PR DESCRIPTION
In constructor of FileWriter, it already filled nullptr.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>