### PR TITLE
luminous: os/bluestore: fix the demotion in StupidAllocator::init_rm_free

### DIFF
--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -517,8 +517,8 @@ class interval_set {
     erase(val, 1);
   }
 
-  void erase(T start, T len,
-    std::function<bool(T, T)> post_process = {}) {
+  void erase(T start, T len, 
+    std::function<bool(T, T)> claim = {}) {
     typename Map::iterator p = find_inc_m(start);
 
     _size -= len;
@@ -530,13 +530,22 @@ class interval_set {
     T before = start - p->first;
     assert(p->second >= before+len);
     T after = p->second - before - len;
-    if (before && (post_process ? post_process(p->first, before) : true)) {
-      p->second = before;        // shorten bit before
+    if (before) {
+      if (claim && claim(p->first, before)) {
+	_size -= before;
+	m.erase(p);
+      } else {
+	p->second = before;        // shorten bit before
+      }
     } else {
       m.erase(p);
     }
-    if (after && (post_process ? post_process(start + len, after) : true)) {
-      m[start + len] = after;
+    if (after) {
+      if (claim && claim(start + len, after)) {
+	_size -= after;
+      } else {
+	m[start + len] = after;
+      }
     }
   }
 

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -306,9 +306,9 @@ void StupidAllocator::init_rm_free(uint64_t offset, uint64_t length)
               ldout(cct, 30) << __func__ << " demoting1 0x" << std::hex << off << "~" << len
                              << std::dec << " to bin " << newbin << dendl;
               _insert_free(off, len);
-              return false;
+              return true;
             }
-            return true;
+            return false;
           });
         ++it;
       }


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/24132

* we should update the _size field when demotion kicks in, otherwise the
  interval_set::m and interval_set::_size won't be consistent.
* also rename post_process to claim, as it "steals" the leftover(s) of
chopped segment.

Fixes: https://tracker.ceph.com/issues/24051
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit d43c8da83329dd743c635869b1443366d03839fd)