### PR TITLE
librados: Add a librbd command to cancel all aio operations.

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1074,6 +1074,7 @@ namespace librados
      * @returns 0 on success, negative error code on failure
      */
     int aio_cancel(AioCompletion *c);
+    int aio_cancel_all();
 
     int aio_exec(const std::string& oid, AioCompletion *c, const char *cls, const char *method,
 	         bufferlist& inbl, bufferlist *outbl);

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1239,6 +1239,15 @@ int librados::IoCtxImpl::aio_cancel(AioCompletionImpl *c)
   return objecter->op_cancel(c->tid, -ECANCELED);
 }
 
+int librados::IoCtxImpl::aio_cancel_all()
+{
+  objecter->op_cancel_all(-EIO);
+  objecter->command_op_cancel_all(-EIO);
+  objecter->pool_op_cancel_all(-EIO);
+  objecter->pool_stat_op_cancel_all(-EIO);
+  objecter->statfs_op_cancel_all(-EIO);
+}
+
 
 int librados::IoCtxImpl::hit_set_list(uint32_t hash, AioCompletionImpl *c,
 			      std::list< std::pair<time_t, time_t> > *pls)

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -225,6 +225,7 @@ struct librados::IoCtxImpl {
   int aio_rmxattr(const object_t& oid, AioCompletionImpl *c,
 		  const char *name);
   int aio_cancel(AioCompletionImpl *c);
+  int aio_cancel_all();
 
   int pool_change_auid(unsigned long long auid);
   int pool_change_auid_async(unsigned long long auid, PoolAsyncCompletionImpl *c);

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2053,6 +2053,10 @@ int librados::IoCtx::aio_cancel(librados::AioCompletion *c)
   return io_ctx_impl->aio_cancel(c->pc);
 }
 
+int librados::IoCtx::aio_cancel_all() {
+  return io_ctx_impl->aio_cancel_all();
+}
+
 int librados::IoCtx::watch(const string& oid, uint64_t ver, uint64_t *cookie,
 			   librados::WatchCtx *ctx)
 {

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1659,6 +1659,7 @@ public:
   void _assign_command_session(CommandOp *c, shunique_lock &sul);
   void _send_command(CommandOp *c);
   int command_op_cancel(OSDSession *s, ceph_tid_t tid, int r);
+  int command_op_cancel_all(int r);
   void _finish_command(CommandOp *c, int r, string rs);
   void handle_command_reply(MCommandReply *m);
 
@@ -2200,10 +2201,13 @@ public:
   /// cancel an in-progress request with the given return code
 private:
   int op_cancel(OSDSession *s, ceph_tid_t tid, int r);
+  int op_cancel(OSDSession *s, int r, int64_t pool, bool writes_only);
   int _op_cancel(ceph_tid_t tid, int r);
+  int command_op_cancel(OSDSession *s, int r);
 public:
   int op_cancel(ceph_tid_t tid, int r);
   int op_cancel(const vector<ceph_tid_t>& tidls, int r);
+  epoch_t op_cancel_all(int r, int64_t pool=-1, bool writes_only=false);
 
   /**
    * Any write op which is in progress at the start of this call shall no
@@ -2936,6 +2940,7 @@ public:
 
   void handle_pool_op_reply(MPoolOpReply *m);
   int pool_op_cancel(ceph_tid_t tid, int r);
+  int pool_op_cancel_all(int r);
 
   // --------------------------
   // pool stats
@@ -2946,6 +2951,7 @@ public:
   void get_pool_stats(list<string>& pools, map<string,pool_stat_t> *result,
 		      Context *onfinish);
   int pool_stat_op_cancel(ceph_tid_t tid, int r);
+  int pool_stat_op_cancel_all(int r);
   void _finish_pool_stat_op(PoolStatOp *op, int r);
 
   // ---------------------------
@@ -2957,6 +2963,7 @@ public:
   void get_fs_stats(struct ceph_statfs& result, boost::optional<int64_t> poolid,
 		    Context *onfinish);
   int statfs_op_cancel(ceph_tid_t tid, int r);
+  int statfs_op_cancel_all(int r);
   void _finish_statfs_op(StatfsOp *op, int r);
 
   // ---------------------------


### PR DESCRIPTION
This is useful when ceph can not be put up permanently, and we want
to make sure the client side's state is clean without restarting.