### PR TITLE
mds: broadcast quota to relevant clients when quota is explicitly set

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2001,7 +2001,7 @@ void MDCache::project_rstat_frag_to_inode(nest_info_t& rstat, nest_info_t& accou
   }
 }
 
-void MDCache::broadcast_quota_to_client(CInode *in)
+void MDCache::broadcast_quota_to_client(CInode *in, client_t exclude_ct)
 {
   if (!(mds->is_active() || mds->is_stopping()))
     return;
@@ -2026,6 +2026,10 @@ void MDCache::broadcast_quota_to_client(CInode *in)
       continue;
 
     Capability *cap = it->second;
+
+    if (exclude_ct >= 0 && exclude_ct != it->first)
+      goto update;
+
     if (cap->last_rbytes == i->rstat.rbytes &&
         cap->last_rsize == i->rstat.rsize())
       continue;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -404,7 +404,7 @@ public:
   void project_rstat_frag_to_inode(nest_info_t& rstat, nest_info_t& accounted_rstat,
 				   snapid_t ofirst, snapid_t last, 
 				   CInode *pin, bool cow_head);
-  void broadcast_quota_to_client(CInode *in);
+  void broadcast_quota_to_client(CInode *in, client_t exclude_ct = -1);
   void predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
 				CInode *in, CDir *parent,
 				int flags, int linkunlink=0,

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4850,6 +4850,9 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur,
     }
     mdr->no_early_reply = true;
     pip = &pi.inode;
+
+    client_t exclude_ct = mdr->get_client();
+    mdcache->broadcast_quota_to_client(cur, exclude_ct);
   } else if (name.find("ceph.dir.pin") == 0) {
     if (!cur->is_dir() || cur->is_root()) {
       respond_to_request(mdr, -EINVAL);


### PR DESCRIPTION
Try to broadcast quota to relevant clients proactively if quota is explicitly
set by someone, in case that client won't get quota update for a long
time.

Fixes: http://tracker.ceph.com/issues/24133

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>