### PR TITLE
mgr/dashboard: Add ability to list,set and unset cluster-wide OSD flags to the backend

### DIFF
--- a/qa/suites/rados/mgr/tasks/dashboard.yaml
+++ b/qa/suites/rados/mgr/tasks/dashboard.yaml
@@ -18,6 +18,7 @@ tasks:
         - \(MDS_DAMAGE\)
         - \(MDS_ALL_DOWN\)
         - \(MDS_UP_LESS_THAN_MAX\)
+        - pauserd,pausewr flag\(s\) set
   - rgw: [client.0]
   - cephfs_test_runner:
       fail_on_skip: false

--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -2,6 +2,8 @@
 
 from __future__ import absolute_import
 
+import json
+
 from .helper import DashboardTestCase, authenticate, JObj, JAny, JList, JLeaf, JTuple
 
 
@@ -42,3 +44,42 @@ class OsdTest(DashboardTestCase):
 
         self._post('/api/osd/0/scrub?deep=True')
         self.assertStatus(200)
+
+
+class OsdFlagsTest(DashboardTestCase):
+    def __init__(self, *args, **kwargs):
+        super(OsdFlagsTest, self).__init__(*args, **kwargs)
+        self._initial_flags = sorted(  # These flags cannot be unset
+            ['sortbitwise', 'recovery_deletes', 'purged_snapdirs'])
+
+    @classmethod
+    def _get_cluster_osd_flags(cls):
+        return sorted(
+            json.loads(cls._ceph_cmd(['osd', 'dump',
+                                      '--format=json']))['flags_set'])
+
+    @classmethod
+    def _put_flags(cls, flags):
+        cls._put('/api/osd/flags', data={'flags': flags})
+        return sorted(cls._resp.json())
+
+    @authenticate
+    def test_list_osd_flags(self):
+        flags = self._get('/api/osd/flags')
+        self.assertStatus(200)
+        self.assertEqual(len(flags), 3)
+        self.assertEqual(sorted(flags), self._initial_flags)
+
+    @authenticate
+    def test_add_osd_flag(self):
+        flags = self._put_flags([
+            'sortbitwise', 'recovery_deletes', 'purged_snapdirs', 'noout',
+            'pause'
+        ])
+        self.assertEqual(flags, sorted([
+            'sortbitwise', 'recovery_deletes', 'purged_snapdirs', 'noout',
+            'pause'
+        ]))
+
+        # Restore flags
+        self._put_flags(self._initial_flags)

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -70,6 +70,10 @@ class UiApiController(Controller):
 
 
 def AuthRequired(enabled=True):
+    if not isinstance(enabled, bool):
+        raise TypeError('AuthRequired used incorrectly. '
+                        'You are likely missing parentheses!')
+
     def decorate(cls):
         if not hasattr(cls, '_cp_config'):
             cls._cp_config = {

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -2,8 +2,7 @@
 from __future__ import absolute_import
 
 from . import ApiController, AuthRequired, RESTController
-from .. import mgr
-
+from .. import mgr, logger
 from ..services.ceph_service import CephService
 from ..services.exception import handle_send_command_error
 from ..tools import str_to_bool
@@ -63,3 +62,41 @@ class Osd(RESTController):
     def scrub(self, svc_id, deep=False):
         api_scrub = "osd deep-scrub" if str_to_bool(deep) else "osd scrub"
         CephService.send_command("mon", api_scrub, who=svc_id)
+
+
+@ApiController('/osd/flags')
+class OsdFlagsController(RESTController):
+    @staticmethod
+    def _osd_flags():
+        enabled_flags = mgr.get('osd_map')['flags_set']
+        if 'pauserd' in enabled_flags and 'pausewr' in enabled_flags:
+            # 'pause' is set by calling `ceph osd set pause` and unset by
+            # calling `set osd unset pause`, but `ceph osd dump | jq '.flags'`
+            # will contain 'pauserd,pausewr' if pause is set.
+            # Let's pretend to the API that 'pause' is in fact a proper flag.
+            enabled_flags = list(
+                set(enabled_flags) - {'pauserd', 'pausewr'} | {'pause'})
+        return sorted(enabled_flags)
+
+    def list(self):
+        return self._osd_flags()
+
+    def bulk_set(self, flags):
+        """
+        The `recovery_deletes` and `sortbitwise` flags cannot be unset.
+        `purged_snapshots` cannot even be set. It is therefore required to at
+        least include those three flags for a successful operation.
+        """
+        assert isinstance(flags, list)
+
+        enabled_flags = set(self._osd_flags())
+        data = set(flags)
+        added = data - enabled_flags
+        removed = enabled_flags - data
+        for flag in added:
+            CephService.send_command('mon', 'osd set', '', key=flag)
+        for flag in removed:
+            CephService.send_command('mon', 'osd unset', '', key=flag)
+        logger.info('Changed OSD flags: added=%s removed=%s', added, removed)
+
+        return sorted(enabled_flags - removed | added)

--- a/src/pybind/mgr/dashboard/run-backend-api-request.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-request.sh
@@ -3,13 +3,16 @@
 CURR_DIR=`pwd`
 cd ../../../../build
 API_URL=`./bin/ceph mgr services 2>/dev/null | jq .dashboard | sed -e 's/"//g' -e 's!/$!!g'`
+if [ "$API_URL" = "null" ]; then
+	echo "Couldn't retrieve API URL, exiting..." >&2
+	exit 1
+fi
 cd $CURR_DIR
 
 curl --insecure  -s -c /tmp/cd-cookie.txt -H "Content-Type: application/json" -X POST -d '{"username":"admin","password":"admin"}'  $API_URL/api/auth > /dev/null
 
-echo "API_ENDPOINT: $API_URL"
 echo "METHOD: $1"
-echo "PATH: $2"
+echo "URL: ${API_URL}${2}"
 echo "DATA: $3"
 echo ""
 

--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 
+if [[ "$1" = "-h" || "$1" = "--help" ]]; then
+	echo "Usage (run from ./):"
+	echo -e "\t./run-backend-api-tests.sh"
+	echo -e "\t./run-backend-api-tests.sh [tests]..."
+	echo
+	echo "Example:"
+	echo -e "\t./run-backend-api-tests.sh tasks.mgr.dashboard.test_pool.DashboardTest"
+	echo
+	echo "Or source this script. This allows to re-run tests faster:"
+	echo -e "\tsource run-backend-api-tests.sh"
+	echo -e "\trun_teuthology_tests [tests]..."
+	echo -e "\tcleanup_teuthology"
+	echo
 
-
-# Usage (run from ./):
-# ./run-backend-api-tests.sh
-# ./run-backend-api-tests.sh [tests]...
-#
-# Example:
-# ./run-backend-api-tests.sh tasks.mgr.dashboard.test_pool.DashboardTest
-#
-# Or source this script. Allows to re-run tests faster:
-# $ source run-backend-api-tests.sh
-# $ run_teuthology_tests [tests]...
-# $ cleanup_teuthology
+	exit 0
+fi
 
 # creating temp directory to store virtualenv and teuthology
 

--- a/src/pybind/mgr/dashboard/tests/test_controllers.py
+++ b/src/pybind/mgr/dashboard/tests/test_controllers.py
@@ -157,6 +157,15 @@ class ControllersTest(ControllerTestCase):
         self.assertStatus(200)
         self.assertJsonBody({'key': '300', 'data1': 20, 'data2': True})
 
+        self._put('/test/api/rtest/{}'.format(400),
+                  {'data1': 20, 'data2': ['one', 'two', 'three']})
+        self.assertStatus(200)
+        self.assertJsonBody({
+            'key': '400',
+            'data1': 20,
+            'data2': ['one', 'two', 'three'],
+        })
+
     def test_rest_bulk_delete(self):
         self._delete('/test/api/rtest/{}?opt=2'.format(300))
         self.assertStatus(204)


### PR DESCRIPTION
This PR will add an API resource `/api/osd/flags` to list, set and unset cluster-wide OSD flags.

Also: 

- Make  noise when AuthRequired is used incorrectly (without parentheses). Without this commit, it'll silently fail and the whole Controller isn't used at all.
- Extends dev scripts for manual API testing/development.