### PR TITLE
jewel:monitor:Change monitor compact command to run asynchronously

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -268,6 +268,9 @@ public:
   /// compact the underlying store
   virtual void compact() {}
 
+  /// compact async the underlying store
+  virtual void compact_async() {}
+
   /// compact db for all keys with a given prefix
   virtual void compact_prefix(const std::string& prefix) {}
   /// compact db for all keys with a given prefix, async

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -334,7 +334,13 @@ void LevelDBStore::compact_thread_entry()
       logger->set(l_leveldb_compact_queue_len, compact_queue.size());
       compact_queue_lock.Unlock();
       logger->inc(l_leveldb_compact_range);
-      compact_range(range.first, range.second);
+      if (range.first.empty() && range.second.empty()){
+        derr << "Begin to compact leveldb store all..." << dendl;
+        compact();
+        derr << "Finished to compact leveldb store all..." << dendl;
+      }else{
+        compact_range(range.first, range.second);
+      }
       compact_queue_lock.Lock();
       continue;
     }

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -94,6 +94,11 @@ public:
   /// compact the underlying leveldb store
   void compact();
 
+  /// compact full the underlying leveldb store
+  void compact_async(){
+    compact_range_async(string(), string());
+  }
+  
   /// compact db for all keys with a given prefix
   void compact_prefix(const string& prefix) {
     compact_range(prefix, past_prefix(prefix));

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2849,7 +2849,7 @@ void Monitor::handle_command(MonOpRequestRef op)
   if (prefix == "compact" || prefix == "mon compact") {
     dout(1) << "triggering manual compaction" << dendl;
     utime_t start = ceph_clock_now(g_ceph_context);
-    store->compact();
+    store->compact_async();
     utime_t end = ceph_clock_now(g_ceph_context);
     end -= start;
     dout(1) << "finished manual compaction in " << end << " seconds" << dendl;

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -613,6 +613,10 @@ class MonitorDBStore
     db->compact();
   }
 
+  void compact_async() {
+    db->compact_async();
+  }
+
   void compact_prefix(const string& prefix) {
     db->compact_prefix(prefix);
   }


### PR DESCRIPTION
I have met a monitor problem with capacity too large in our production environment.
This logical volume for monitor is 100GB, the capacity can grow to 95GB, and then go down. Sometimes, the monitor process can not start ,we have to rebuild the monitor.
Then we set a crontab task, every week we compact the monitor at a assigned point time. The command is "ceph tell mon.xx compact", While the monitor is compacting(it can last for 80 seconds), the monitor is down by lease timeout. When the compact  task complete, the monitors vote again ,the monitor is up and active.
In monitor message dispatch code, while one command is executing , it must have the dispatch lock. So indeed  all command are executing synchronously.  If one command is executing for long time, others command must wait.
So I change the monitor tell compact  command to just add a task(compact range(0,0)) to the monitor compact thread to execute the compact  task, so the monitor tell compact command can execute immediately.

Signed-off-by: brandy <penglaiyxy@gmail.com>