### PR TITLE
common/PriorityCache: First Step toward priority based caching

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -540,6 +540,7 @@ set(libcommon_files
   common/dns_resolve.cc
   common/hostname.cc
   common/util.cc
+  common/PriorityCache.cc
   librbd/Features.cc
   arch/probe.cc
   ${auth_files}

--- a/src/common/PriorityCache.cc
+++ b/src/common/PriorityCache.cc
@@ -1,0 +1,29 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "PriorityCache.h"
+
+namespace PriorityCache {
+  int64_t get_chunk(uint64_t usage, uint64_t chunk_bytes) {
+    // Add a chunk of headroom and round up to the near chunk
+    uint64_t val = usage + chunk_bytes;
+    uint64_t r = (val) % chunk_bytes;
+    if (r > 0)
+      val = val + chunk_bytes - r;
+    return val;
+  }
+
+  PriCache::~PriCache() {
+  }
+}

--- a/src/common/PriorityCache.h
+++ b/src/common/PriorityCache.h
@@ -1,0 +1,69 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_PRIORITY_CACHE_H
+#define CEPH_PRIORITY_CACHE_H
+
+#include <stdint.h>
+#include <string>
+
+namespace PriorityCache {
+  enum Priority {
+    PRI0,  // Reserved for special items
+    PRI1,  // High priority cache items
+    PRI2,  // Medium priority cache items
+    PRI3,  // Low priority cache items
+    LAST = PRI3,
+  };
+
+  int64_t get_chunk(uint64_t usage, uint64_t chunk_bytes);
+
+  struct PriCache {
+    virtual ~PriCache();
+
+    /* Ask the cache to request memory for the given priority rounded up to
+     * the nearst chunk_bytes.  This for example, may return the size of all
+     * items associated with this priority plus some additional space for
+     * future growth.  Note that the cache may ultimately be allocated less 
+     * memory than it requests here.
+     */
+    virtual int64_t request_cache_bytes(PriorityCache::Priority pri, uint64_t chunk_bytes) const = 0;
+
+    // Get the number of bytes currently allocated to the given priority.
+    virtual int64_t get_cache_bytes(PriorityCache::Priority pri) const = 0;
+
+    // Get the number of bytes currently allocated to all priorities.
+    virtual int64_t get_cache_bytes() const = 0;
+
+    // Allocate bytes for a given priority.
+    virtual void set_cache_bytes(PriorityCache::Priority pri, int64_t bytes) = 0;
+
+    // Allocate additional bytes for a given priority.
+    virtual void add_cache_bytes(PriorityCache::Priority pri, int64_t bytes) = 0;
+
+    // Commit the current number of bytes allocated to the cache.
+    virtual int64_t commit_cache_size() = 0;
+
+    // Get the ratio of available memory this cache should target.
+    virtual double get_cache_ratio() const = 0;
+
+    // Set the ratio of available memory this cache should target.
+    virtual void set_cache_ratio(double ratio) = 0;
+
+    // Get the name of this cache.
+    virtual std::string get_cache_name() const = 0;
+  };
+}
+
+#endif

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1024,7 +1024,6 @@ OPTION(bluestore_cache_size_hdd, OPT_U64)
 OPTION(bluestore_cache_size_ssd, OPT_U64)
 OPTION(bluestore_cache_meta_ratio, OPT_DOUBLE)
 OPTION(bluestore_cache_kv_ratio, OPT_DOUBLE)
-OPTION(bluestore_cache_kv_min, OPT_INT)
 OPTION(bluestore_kvbackend, OPT_STR)
 OPTION(bluestore_allocator, OPT_STR)     // stupid | bitmap
 OPTION(bluestore_freelist_blocks_per_key, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4050,15 +4050,21 @@ std::vector<Option> get_global_options() {
     .add_see_also("bluestore_cache_size")
     .set_description("Ratio of bluestore cache to devote to kv database (rocksdb)"),
 
-    Option("bluestore_cache_kv_min", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(512_M)
-    .set_description("Minimum memory (bytes) of bluestore_cache_size to devote to kv database (rocksdb)")
+    Option("bluestore_cache_autotune", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
     .add_see_also("bluestore_cache_size")
-    .set_long_description("A negative value means using bluestore_cache_meta_ratio "
-      "and bluestore_cache_kv_ratio instead of calculating these ratios using "
-      "bluestore_cache_size_* and bluestore_cache_kv_min.  If "
-      "bluestore_cache_size is below bluestore_cache_kv_min "
-      "then this option has no effect."),
+    .add_see_also("bluestore_cache_meta_ratio")
+    .set_description("Automatically tune the ratio of caches while respecting min values."),
+
+    Option("bluestore_cache_autotune_chunk_size", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(33554432)
+    .add_see_also("bluestore_cache_autotune")
+    .set_description("The chunk size in bytes to allocate to caches when cache autotune is enabled."),
+
+    Option("bluestore_cache_autotune_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(5)
+    .add_see_also("bluestore_cache_autotune")
+    .set_description("The number of seconds to wait between rebalances when cache autotune is enabled."),
 
     Option("bluestore_kvbackend", Option::TYPE_STR, Option::LEVEL_DEV)
     .set_default("rocksdb")

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -21,6 +21,7 @@
 using std::string;
 #include "common/perf_counters.h"
 #include "common/debug.h"
+#include "common/PriorityCache.h"
 #include "include/str_list.h"
 #include "include/stringify.h"
 #include "include/str_map.h"
@@ -388,25 +389,18 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
   uint64_t row_cache_size = cache_size * g_conf->rocksdb_cache_row_ratio;
   uint64_t block_cache_size = cache_size - row_cache_size;
 
-  if (block_cache_size == 0) {
-    // disable block cache
-    dout(10) << __func__ << " block_cache_size " << block_cache_size
-             << ", setting no_block_cache " << dendl;
-    bbt_opts.no_block_cache = true;
+  if (g_conf->rocksdb_cache_type == "lru") {
+    bbt_opts.block_cache = rocksdb::NewLRUCache(
+      block_cache_size,
+      g_conf->rocksdb_cache_shard_bits);
+  } else if (g_conf->rocksdb_cache_type == "clock") {
+    bbt_opts.block_cache = rocksdb::NewClockCache(
+      block_cache_size,
+      g_conf->rocksdb_cache_shard_bits);
   } else {
-    if (g_conf->rocksdb_cache_type == "lru") {
-      bbt_opts.block_cache = rocksdb::NewLRUCache(
-        block_cache_size,
-        g_conf->rocksdb_cache_shard_bits);
-    } else if (g_conf->rocksdb_cache_type == "clock") {
-      bbt_opts.block_cache = rocksdb::NewClockCache(
-        block_cache_size,
-        g_conf->rocksdb_cache_shard_bits);
-    } else {
-      derr << "unrecognized rocksdb_cache_type '" << g_conf->rocksdb_cache_type
-        << "'" << dendl;
-      return -EINVAL;
-    }
+    derr << "unrecognized rocksdb_cache_type '" << g_conf->rocksdb_cache_type
+      << "'" << dendl;
+    return -EINVAL;
   }
   bbt_opts.block_size = g_conf->rocksdb_block_size;
 
@@ -1236,6 +1230,85 @@ void RocksDBStore::compact_range(const string& start, const string& end)
   rocksdb::Slice cstart(start);
   rocksdb::Slice cend(end);
   db->CompactRange(options, &cstart, &cend);
+}
+
+int64_t RocksDBStore::request_cache_bytes(PriorityCache::Priority pri, uint64_t chunk_bytes) const
+{
+  auto cache = bbt_opts.block_cache;
+  int64_t assigned = get_cache_bytes(pri);
+
+  switch (pri) {
+  // PRI0 is for rocksdb's high priority items (indexes/filters)
+  case PriorityCache::Priority::PRI0:
+    {
+      int64_t usage = cache->GetHighPriPoolUsage();
+
+      // RocksDB sometimes flushes the high pri cache when the low priority
+      // cache exceeds the soft cap, so in that case use a "watermark" for 
+      // the usage instead.
+      if (high_pri_watermark > usage) {
+        usage = high_pri_watermark;
+      }
+      dout(10) << __func__ << " high pri pool usage: " << usage << dendl;
+      int64_t request = PriorityCache::get_chunk(usage, chunk_bytes);
+      return (request > assigned) ? request - assigned : 0;
+    }
+  // All other cache items are currently shoved into the LAST priority. 
+  case PriorityCache::Priority::LAST:
+    { 
+      uint64_t usage = cache->GetUsage() - cache->GetHighPriPoolUsage();
+      dout(10) << __func__ << " low pri pool usage: " << usage << dendl;
+      int64_t request = PriorityCache::get_chunk(usage, chunk_bytes);
+      return (request > assigned) ? request - assigned : 0;
+    }
+  default:
+    break;
+  }
+  return -EOPNOTSUPP;
+}
+
+int64_t RocksDBStore::get_cache_usage() const
+{
+  return static_cast<int64_t>(bbt_opts.block_cache->GetUsage());
+}
+
+int64_t RocksDBStore::commit_cache_size()
+{
+  int64_t high_pri_bytes = get_cache_bytes(PriorityCache::Priority::PRI0);
+  int64_t total_bytes = get_cache_bytes();
+
+  double ratio = (double) high_pri_bytes / total_bytes;
+  size_t old_bytes = bbt_opts.block_cache->GetCapacity();
+  dout(10) << __func__ << " old: " << old_bytes
+           << ", new: " << total_bytes << dendl;
+  bbt_opts.block_cache->SetCapacity((size_t) total_bytes);
+  set_cache_high_pri_pool_ratio(ratio);
+
+  // After setting the cache sizes, updated the high pri watermark. 
+  int64_t high_pri_pool_usage = bbt_opts.block_cache->GetHighPriPoolUsage();
+  if (high_pri_watermark < high_pri_pool_usage) {
+    high_pri_watermark = high_pri_pool_usage;
+  } else {
+    high_pri_watermark = static_cast<int64_t>(0.90 * high_pri_watermark);
+  }
+
+  return total_bytes;
+}
+
+int RocksDBStore::set_cache_high_pri_pool_ratio(double ratio)
+{
+  if (g_conf->rocksdb_cache_type != "lru") {
+    return -EOPNOTSUPP;
+  }
+  dout(10) << __func__ << " old ratio: " 
+          << bbt_opts.block_cache->GetHighPriPoolRatio() << " new ratio: "
+          << ratio << dendl;
+  bbt_opts.block_cache->SetHighPriPoolRatio(ratio);
+  return 0;
+}
+
+int64_t RocksDBStore::get_cache_capacity() {
+  return bbt_opts.block_cache->GetCapacity();
 }
 
 RocksDBStore::RocksDBWholeSpaceIteratorImpl::~RocksDBWholeSpaceIteratorImpl()

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -828,9 +828,10 @@ void BlueStore::LRUCache::_trim(uint64_t onode_max, uint64_t buffer_max)
   }
 
   // onodes
-  int num = onode_lru.size() - onode_max;
-  if (num <= 0)
+  if (onode_max >= onode_lru.size()) {
     return; // don't even try
+  }
+  uint64_t num = onode_lru.size() - onode_max;
 
   auto p = onode_lru.end();
   assert(p != onode_lru.begin());
@@ -1124,9 +1125,10 @@ void BlueStore::TwoQCache::_trim(uint64_t onode_max, uint64_t buffer_max)
   }
 
   // onodes
-  int num = onode_lru.size() - onode_max;
-  if (num <= 0)
+  if (onode_max >= onode_lru.size()) {
     return; // don't even try
+  }
+  uint64_t num = onode_lru.size() - onode_max;
 
   auto p = onode_lru.end();
   assert(p != onode_lru.begin());

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -28,6 +28,7 @@
 #include "include/str_map.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
+#include "common/PriorityCache.h"
 #include "Allocator.h"
 #include "FreelistManager.h"
 #include "BlueFS.h"
@@ -781,77 +782,17 @@ BlueStore::Cache *BlueStore::Cache::create(CephContext* cct, string type,
   return c;
 }
 
+void BlueStore::Cache::trim(uint64_t onode_max, uint64_t buffer_max)
+{
+  std::lock_guard<std::recursive_mutex> l(lock);
+  _trim(onode_max, buffer_max);
+}
+
 void BlueStore::Cache::trim_all()
 {
   std::lock_guard<std::recursive_mutex> l(lock);
   _trim(0, 0);
 }
-
-void BlueStore::Cache::trim(
-  uint64_t target_bytes,
-  float target_meta_ratio,
-  float target_data_ratio,
-  float bytes_per_onode)
-{
-  std::lock_guard<std::recursive_mutex> l(lock);
-  uint64_t current_meta = _get_num_onodes() * bytes_per_onode;
-  uint64_t current_buffer = _get_buffer_bytes();
-  uint64_t current = current_meta + current_buffer;
-
-  uint64_t target_meta = target_bytes * target_meta_ratio;
-  uint64_t target_buffer = target_bytes * target_data_ratio;
-
-  // correct for overflow or float imprecision
-  target_meta = min(target_bytes, target_meta);
-  target_buffer = min(target_bytes - target_meta, target_buffer);
-
-  if (current <= target_bytes) {
-    dout(30) << __func__
-	     << " shard target " << byte_u_t(target_bytes)
-	     << " meta/data ratios " << target_meta_ratio
-	     << " + " << target_data_ratio << " ("
-	     << byte_u_t(target_meta) << " + "
-	     << byte_u_t(target_buffer) << "), "
-	     << " current " << byte_u_t(current) << " ("
-	     << byte_u_t(current_meta) << " + "
-	     << byte_u_t(current_buffer) << ")"
-	     << dendl;
-    return;
-  }
-
-  uint64_t need_to_free = current - target_bytes;
-  uint64_t free_buffer = 0;
-  uint64_t free_meta = 0;
-  if (current_buffer > target_buffer) {
-    free_buffer = current_buffer - target_buffer;
-    if (free_buffer > need_to_free) {
-      free_buffer = need_to_free;
-    }
-  }
-  free_meta = need_to_free - free_buffer;
-
-  // start bounds at what we have now
-  uint64_t max_buffer = current_buffer - free_buffer;
-  uint64_t max_meta = current_meta - free_meta;
-  uint64_t max_onodes = max_meta / bytes_per_onode;
-
-  dout(20) << __func__
-	   << " shard target " << byte_u_t(target_bytes)
-	   << " ratio " << target_meta_ratio << " ("
-	   << byte_u_t(target_meta) << " + "
-	   << byte_u_t(target_buffer) << "), "
-	   << " current " << byte_u_t(current) << " ("
-	   << byte_u_t(current_meta) << " + "
-	   << byte_u_t(current_buffer) << "),"
-	   << " need_to_free " << byte_u_t(need_to_free) << " ("
-	   << byte_u_t(free_meta) << " + "
-	   << byte_u_t(free_buffer) << ")"
-	   << " -> max " << max_onodes << " onodes + "
-	   << max_buffer << " buffer"
-	   << dendl;
-  _trim(max_onodes, max_buffer);
-}
-
 
 // LRUCache
 #undef dout_prefix
@@ -3457,33 +3398,37 @@ void BlueStore::Collection::split_cache(
 
 // =======================================================
 
+// MempoolThread
+
+#undef dout_prefix
+#define dout_prefix *_dout << "bluestore.MempoolThread(" << this << ") "
+
 void *BlueStore::MempoolThread::entry()
 {
   Mutex::Locker l(lock);
+
+  std::list<PriorityCache::PriCache *> caches;
+  caches.push_back(store->db);
+  caches.push_back(&meta_cache);
+  caches.push_back(&data_cache);
+
+  utime_t next_balance = ceph_clock_now();
   while (!stop) {
-    uint64_t meta_bytes =
-      mempool::bluestore_cache_other::allocated_bytes() +
-      mempool::bluestore_cache_onode::allocated_bytes();
-    uint64_t onode_num =
-      mempool::bluestore_cache_onode::allocated_items();
+    _adjust_cache_settings();
 
-    if (onode_num < 2) {
-      onode_num = 2;
+    // Before we trim, check and see if it's time to rebalance
+    bool log_stats = false;
+    double autotune_interval = store->cache_autotune_interval;
+    if (autotune_interval > 0 && next_balance < ceph_clock_now()) {
+      if (store->cache_autotune) {
+        _balance_cache(caches);
+      }
+      next_balance = ceph_clock_now();
+      next_balance += autotune_interval;
+      log_stats = true;
     }
 
-    float bytes_per_onode = (float)meta_bytes / (float)onode_num;
-    size_t num_shards = store->cache_shards.size();
-    float target_ratio = store->cache_meta_ratio + store->cache_data_ratio;
-    // A little sloppy but should be close enough
-    uint64_t shard_target = target_ratio * (store->cache_size / num_shards);
-
-    for (auto i : store->cache_shards) {
-      i->trim(shard_target,
-	      store->cache_meta_ratio,
-	      store->cache_data_ratio,
-	      bytes_per_onode);
-    }
-
+    _trim_shards(log_stats);
     store->_update_cache_logger();
 
     utime_t wait;
@@ -3492,6 +3437,161 @@ void *BlueStore::MempoolThread::entry()
   }
   stop = false;
   return NULL;
+}
+
+void BlueStore::MempoolThread::_adjust_cache_settings()
+{
+  store->db->set_cache_ratio(store->cache_kv_ratio);
+  meta_cache.set_cache_ratio(store->cache_meta_ratio);
+  data_cache.set_cache_ratio(store->cache_data_ratio);
+}
+
+void BlueStore::MempoolThread::_trim_shards(bool log_stats)
+{
+  uint64_t cache_size = store->cache_size;
+  size_t num_shards = store->cache_shards.size();
+  int64_t kv_alloc_bytes = 0;
+  int64_t meta_alloc_bytes = 0;
+  int64_t data_alloc_bytes = 0;
+
+  if (store->cache_autotune) {
+    kv_alloc_bytes = store->db->get_cache_bytes();
+    meta_alloc_bytes = meta_cache.get_cache_bytes();
+    data_alloc_bytes = data_cache.get_cache_bytes();
+  } else {
+    kv_alloc_bytes = static_cast<int64_t>(
+        store->db->get_cache_ratio() * cache_size);
+    meta_alloc_bytes = static_cast<int64_t>(
+        meta_cache.get_cache_ratio() * cache_size);
+    data_alloc_bytes = static_cast<int64_t>(
+        data_cache.get_cache_ratio() * cache_size);
+  }
+  if (log_stats) {
+    double kv_alloc_ratio = (double) kv_alloc_bytes / cache_size;
+    double meta_alloc_ratio = (double) meta_alloc_bytes / cache_size;
+    double data_alloc_ratio = (double) data_alloc_bytes / cache_size;
+    double kv_used_ratio = (double) store->db->get_cache_usage() / cache_size;
+    double meta_used_ratio = (double) meta_cache._get_used_bytes() / cache_size;
+    double data_used_ratio = (double) data_cache._get_used_bytes() / cache_size;
+
+    ldout(store->cct, 5) << __func__ << " ratios -" << std::fixed << std::setprecision(1)
+                         << " kv_alloc: " << 100*kv_alloc_ratio << "%"
+                         << " kv_used: " << 100*kv_used_ratio << "%"
+                         << " meta_alloc: " << 100*meta_alloc_ratio << "%"
+                         << " meta_used: " << 100*meta_used_ratio << "%"
+                         << " data_alloc: " << 100*data_alloc_ratio << "%"
+                         << " data_used: " << 100*data_used_ratio << "%" << dendl;
+  }
+
+  uint64_t max_shard_onodes = static_cast<uint64_t>(
+      (meta_alloc_bytes / (double) num_shards) / meta_cache.get_bytes_per_onode());
+  uint64_t max_shard_buffer = static_cast<uint64_t>(
+      data_alloc_bytes / num_shards);
+  ldout(store->cct, 30) << __func__ << " max_shard_onodes: " << max_shard_onodes
+                        << " max_shard_buffer: " << max_shard_buffer << dendl;
+
+  for (auto i : store->cache_shards) {
+    i->trim(max_shard_onodes, max_shard_buffer);
+  }
+}
+
+void BlueStore::MempoolThread::_balance_cache(
+    const std::list<PriorityCache::PriCache *>& caches)
+{
+  int64_t mem_avail = store->cache_size;
+
+  // Assign memory for each priority level
+  for (int i = 0; i < PriorityCache::Priority::LAST + 1; i++) {
+    ldout(store->cct, 10) << __func__ << " assigning cache bytes for PRI: " << i << dendl;
+    PriorityCache::Priority pri = static_cast<PriorityCache::Priority>(i);
+    _balance_cache_pri(&mem_avail, caches, pri);
+  }
+  // Assign any leftover memory based on the default ratios.
+  if (mem_avail > 0) {
+    for (auto it = caches.begin(); it != caches.end(); it++) {
+      int64_t fair_share =
+          static_cast<int64_t>((*it)->get_cache_ratio() * mem_avail);
+      if (fair_share > 0) {
+        (*it)->add_cache_bytes(PriorityCache::Priority::LAST, fair_share);
+      }
+    }
+  }
+  // assert if we assigned more memory than is available.
+  assert(mem_avail >= 0);
+
+  // Finally commit the new cache sizes
+  for (auto it = caches.begin(); it != caches.end(); it++) {
+    (*it)->commit_cache_size();
+  }
+}
+
+void BlueStore::MempoolThread::_balance_cache_pri(int64_t *mem_avail,
+    const std::list<PriorityCache::PriCache *>& caches, PriorityCache::Priority pri) 
+{
+  std::list<PriorityCache::PriCache *> tmp_caches = caches;
+  double cur_ratios = 0;
+  double new_ratios = 0;
+
+  // Zero this priority's bytes, sum the initial ratios.
+  for (auto it = tmp_caches.begin(); it != tmp_caches.end(); it++) {
+    (*it)->set_cache_bytes(pri, 0);
+    cur_ratios += (*it)->get_cache_ratio();
+  }
+
+  // For this priority, loop until caches are satisified or we run out of memory.
+  // Since we can't allocate fractional bytes, stop if we have fewer bytes left
+  // than the number of participating caches.
+  while (!tmp_caches.empty() && *mem_avail > static_cast<int64_t>(tmp_caches.size())) {
+    uint64_t total_assigned = 0;
+
+    for (auto it = tmp_caches.begin(); it != tmp_caches.end(); ) {
+      int64_t cache_wants = (*it)->request_cache_bytes(pri, store->cache_autotune_chunk_size);
+
+      // Usually the ratio should be set to the fraction of the current caches'
+      // assigned ratio compared to the total ratio of all caches that still
+      // want memory.  There is a special case where the only caches left are
+      // all assigned 0% ratios but still want memory.  In that case, give 
+      // them an equal shot at the remaining memory for this priority.
+      double ratio = 1.0 / tmp_caches.size();
+      if (cur_ratios > 0) {
+        ratio = (*it)->get_cache_ratio() / cur_ratios;
+      }
+      int64_t fair_share = static_cast<int64_t>(*mem_avail * ratio);
+
+      if (cache_wants > fair_share) {
+        // If we want too much, take what we can get but stick around for more
+        (*it)->add_cache_bytes(pri, fair_share);
+        total_assigned += fair_share;
+
+        new_ratios += (*it)->get_cache_ratio();
+        ldout(store->cct, 20) << __func__ << " " << (*it)->get_cache_name() 
+                              << " wanted: " << cache_wants << " fair_share: " << fair_share
+                              << " mem_avail: " << *mem_avail
+                              << " staying in list.  Size: " << tmp_caches.size()
+                              << dendl;
+        ++it;
+      } else {
+        // Otherwise assign only what we want
+        if (cache_wants > 0) { 
+          (*it)->add_cache_bytes(pri, cache_wants);
+          total_assigned += cache_wants;
+
+          ldout(store->cct, 20) << __func__ << " " << (*it)->get_cache_name()
+                                << " wanted: " << cache_wants << " fair_share: " << fair_share
+                                << " mem_avail: " << *mem_avail
+                                << " removing from list.  New size: " << tmp_caches.size() - 1
+                                << dendl;
+
+        }
+        // Either the cache didn't want anything or got what it wanted, so remove it from the tmp list. 
+        it = tmp_caches.erase(it);
+      }
+    }
+    // Reset the ratios 
+    *mem_avail -= total_assigned;
+    cur_ratios = new_ratios;
+    new_ratios = 0;
+  }
 }
 
 // =======================================================
@@ -3872,6 +3972,12 @@ void BlueStore::_set_blob_size()
 int BlueStore::_set_cache_sizes()
 {
   assert(bdev);
+  cache_autotune = cct->_conf->get_val<bool>("bluestore_cache_autotune");
+  cache_autotune_chunk_size = 
+      cct->_conf->get_val<uint64_t>("bluestore_cache_autotune_chunk_size");
+  cache_autotune_interval =
+      cct->_conf->get_val<double>("bluestore_cache_autotune_interval");
+
   if (cct->_conf->bluestore_cache_size) {
     cache_size = cct->_conf->bluestore_cache_size;
   } else {
@@ -3882,50 +3988,36 @@ int BlueStore::_set_cache_sizes()
       cache_size = cct->_conf->bluestore_cache_size_ssd;
     }
   }
-  cache_meta_ratio = cct->_conf->bluestore_cache_meta_ratio;
-  cache_kv_ratio = cct->_conf->bluestore_cache_kv_ratio;
 
+  cache_meta_ratio = cct->_conf->bluestore_cache_meta_ratio;
   if (cache_meta_ratio < 0 || cache_meta_ratio > 1.0) {
     derr << __func__ << " bluestore_cache_meta_ratio (" << cache_meta_ratio
-	 << ") must be in range [0,1.0]" << dendl;
+         << ") must be in range [0,1.0]" << dendl;
     return -EINVAL;
   }
+
+  cache_kv_ratio = cct->_conf->bluestore_cache_kv_ratio;
   if (cache_kv_ratio < 0 || cache_kv_ratio > 1.0) {
     derr << __func__ << " bluestore_cache_kv_ratio (" << cache_kv_ratio
-	 << ") must be in range [0,1.0]" << dendl;
+         << ") must be in range [0,1.0]" << dendl;
     return -EINVAL;
   }
+
   if (cache_meta_ratio + cache_kv_ratio > 1.0) {
     derr << __func__ << " bluestore_cache_meta_ratio (" << cache_meta_ratio
-	 << ") + bluestore_cache_kv_ratio (" << cache_kv_ratio
-	 << ") = " << cache_meta_ratio + cache_kv_ratio << "; must be <= 1.0"
-	 << dendl;
+         << ") + bluestore_cache_kv_ratio (" << cache_kv_ratio
+         << ") = " << cache_meta_ratio + cache_kv_ratio << "; must be <= 1.0"
+         << dendl;
     return -EINVAL;
-  }
-
-  double cache_kv_min = cct->_conf->bluestore_cache_kv_min;
-  double cache_kv_min_ratio = 0;
-
-  // if cache_kv_min is negative, disable it
-  if (cache_size > 0 && cache_kv_min >= 0) {
-    cache_kv_min_ratio = std::min((double)cache_kv_min / (double)cache_size,
-				  (double)1.0);
-    if (cache_kv_min_ratio > cache_kv_ratio) {
-      dout(1) << __func__ << " kv_min_ratio " << cache_kv_min_ratio
-            << " > kv_ratio " << cache_kv_ratio << dendl;
-      cache_kv_ratio = cache_kv_min_ratio;
-      cache_meta_ratio = std::min((double)cache_meta_ratio,
-				  (double)1.0 - cache_kv_ratio);
-    }
   }
 
   cache_data_ratio =
     (double)1.0 - (double)cache_meta_ratio - (double)cache_kv_ratio;
-
   if (cache_data_ratio < 0) {
     // deal with floating point imprecision
     cache_data_ratio = 0;
   }
+    
   dout(1) << __func__ << " cache_size " << cache_size
           << " meta " << cache_meta_ratio
 	  << " kv " << cache_kv_ratio
@@ -4912,6 +5004,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
     }
   }
 
+
   db = KeyValueDB::create(cct,
 			  kv_backend,
 			  fn,
@@ -4933,8 +5026,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
 
   FreelistManager::setup_merge_operators(db);
   db->set_merge_operator(PREFIX_STAT, merge_op);
-
-  db->set_cache_size(cache_size * cache_kv_ratio);
+  db->set_cache_size(cache_kv_ratio * cache_size);
 
   if (kv_backend == "rocksdb") {
     options = cct->_conf->bluestore_rocksdb_options;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -36,6 +36,7 @@
 #include "common/bloom_filter.hpp"
 #include "common/Finisher.h"
 #include "common/perf_counters.h"
+#include "common/PriorityCache.h"
 #include "compressor/Compressor.h"
 #include "os/ObjectStore.h"
 
@@ -1097,10 +1098,7 @@ public:
       --num_blobs;
     }
 
-    void trim(uint64_t target_bytes,
-	      float target_meta_ratio,
-	      float target_data_ratio,
-	      float bytes_per_onode);
+    void trim(uint64_t onode_max, uint64_t buffer_max);
 
     void trim_all();
 
@@ -1925,22 +1923,129 @@ private:
 
   // cache trim control
   uint64_t cache_size = 0;      ///< total cache size
-  float cache_meta_ratio = 0;   ///< cache ratio dedicated to metadata
-  float cache_kv_ratio = 0;     ///< cache ratio dedicated to kv (e.g., rocksdb)
-  float cache_data_ratio = 0;   ///< cache ratio dedicated to object data
+  double cache_meta_ratio = 0;   ///< cache ratio dedicated to metadata
+  double cache_kv_ratio = 0;     ///< cache ratio dedicated to kv (e.g., rocksdb)
+  double cache_data_ratio = 0;   ///< cache ratio dedicated to object data
+  uint64_t cache_meta_min = 0;   ///< cache min dedicated to metadata
+  uint64_t cache_kv_min = 0;     ///< cache min dedicated to kv (e.g., rocksdb)
+  uint64_t cache_data_min = 0;   ///< cache min dedicated to object data
+  bool cache_autotune = false;   ///< cache autotune setting
+  uint64_t cache_autotune_chunk_size = 0; ///< cache autotune chunk size
+  double cache_autotune_interval = 0; ///< time to wait between cache rebalancing
 
   std::mutex vstatfs_lock;
   volatile_statfs vstatfs;
 
   struct MempoolThread : public Thread {
+  public:
     BlueStore *store;
+
     Cond cond;
     Mutex lock;
     bool stop = false;
+
+    struct MempoolCache : public PriorityCache::PriCache {
+      BlueStore *store;
+      int64_t cache_bytes[PriorityCache::Priority::LAST+1];
+      double cache_ratio = 0;
+
+      MempoolCache(BlueStore *s) : store(s) {};
+
+      virtual uint64_t _get_used_bytes() const = 0;
+
+      virtual int64_t request_cache_bytes(
+          PriorityCache::Priority pri, uint64_t chunk_bytes) const {
+        int64_t assigned = get_cache_bytes(pri);
+
+        switch (pri) {
+        // All cache items are currently shoved into the LAST priority 
+        case PriorityCache::Priority::LAST:
+          {
+            uint64_t usage = _get_used_bytes();
+            int64_t request = PriorityCache::get_chunk(usage, chunk_bytes);
+            return(request > assigned) ? request - assigned : 0;
+          }
+        default:
+          break;
+        }
+        return -EOPNOTSUPP;
+      }
+ 
+      virtual int64_t get_cache_bytes(PriorityCache::Priority pri) const {
+        return cache_bytes[pri];
+      }
+      virtual int64_t get_cache_bytes() const { 
+        int64_t total = 0;
+
+        for (int i = 0; i < PriorityCache::Priority::LAST + 1; i++) {
+          PriorityCache::Priority pri = static_cast<PriorityCache::Priority>(i);
+          total += get_cache_bytes(pri);
+        }
+        return total;
+      }
+      virtual void set_cache_bytes(PriorityCache::Priority pri, int64_t bytes) {
+        cache_bytes[pri] = bytes;
+      }
+      virtual void add_cache_bytes(PriorityCache::Priority pri, int64_t bytes) {
+        cache_bytes[pri] += bytes;
+      }
+      virtual int64_t commit_cache_size() {
+        return get_cache_bytes(); 
+      }
+      virtual double get_cache_ratio() const {
+        return cache_ratio;
+      }
+      virtual void set_cache_ratio(double ratio) {
+        cache_ratio = ratio;
+      }
+      virtual string get_cache_name() const = 0;
+    };
+
+    struct MetaCache : public MempoolCache {
+      MetaCache(BlueStore *s) : MempoolCache(s) {};
+
+      virtual uint64_t _get_used_bytes() const {
+        return mempool::bluestore_cache_other::allocated_bytes() +
+            mempool::bluestore_cache_onode::allocated_bytes();
+      }
+
+      virtual string get_cache_name() const {
+        return "BlueStore Meta Cache";
+      }
+
+      uint64_t _get_num_onodes() const {
+        uint64_t onode_num =
+            mempool::bluestore_cache_onode::allocated_items();
+        return (2 > onode_num) ? 2 : onode_num;
+      }
+
+      double get_bytes_per_onode() const {
+        return (double)_get_used_bytes() / (double)_get_num_onodes();
+      }
+    } meta_cache;
+
+    struct DataCache : public MempoolCache {
+      DataCache(BlueStore *s) : MempoolCache(s) {};
+
+      virtual uint64_t _get_used_bytes() const {
+        uint64_t bytes = 0;
+        for (auto i : store->cache_shards) {
+          bytes += i->_get_buffer_bytes();
+        }
+        return bytes; 
+      }
+      virtual string get_cache_name() const {
+        return "BlueStore Data Cache";
+      }
+    } data_cache;
+
   public:
     explicit MempoolThread(BlueStore *s)
       : store(s),
-	lock("BlueStore::MempoolThread::lock") {}
+	lock("BlueStore::MempoolThread::lock"),
+        meta_cache(MetaCache(s)),
+        data_cache(DataCache(s)) {}
+
     void *entry() override;
     void init() {
       assert(stop == false);
@@ -1953,6 +2058,14 @@ private:
       lock.Unlock();
       join();
     }
+
+  private:
+    void _adjust_cache_settings();
+    void _trim_shards(bool log_stats);
+    void _balance_cache(const std::list<PriorityCache::PriCache *>& caches);
+    void _balance_cache_pri(int64_t *mem_avail, 
+                            const std::list<PriorityCache::PriCache *>& caches, 
+                            PriorityCache::Priority pri);
   } mempool_thread;
 
   // --------------------------------------------------------


### PR DESCRIPTION
This PR depends on either the upstream rocksdb PR here:

https://github.com/facebook/rocksdb/pull/3732

or a PR against our fork here:

https://github.com/ceph/rocksdb/pull/39

# Problem:

The way that we currently cache data in bluestore is suboptimal.  Bluestore relies heavily on 3 different kinds of cache:

1) metadata cache
2) data cache
3) rocksdb block cache

Currently, we implement a scheme where the user specifies a total amount of cache in bytes that bluestore should allocate and specifies ratios that should be allocated to each cache.  Uunfortunately there are corner cases where this scheme doesn't work well.  One example is during heavy RGW workloads where the total DB size becomes very large, and it's important to give rocksdb enough memory to cache all of the indexes and bloom filters.  Users are required to change the ratios assigned to each cache as the number of objects in RGW grows.  To help alleviate this, we implemented a "minimum" KV cache setting so that in most cases the users could just leave the default ratios while still making sure a minimum amount of memory was assigned to the KV store, however this meant that users were confused when different ratios were set than they specified.

Another issue is that during RBD workloads, you may need more or less memory than is assigned to the metadata cache to fully cache all bluestore onode metadata, and the amount of cache needed changes based on how much RBD data is present.  In master, bluestore can change the amount of memory allocated to data and metadata depending on how much is used.  This helps, but does not necessarily avoid the scenario where there is not enough cache to avoid caching all onodes and onodes end up double cached in rocksdb's cache and bluestore's cache.  It also further confuses the users, especially since even under memory pressure bluestore's caches tend to over-allocate memory to the metadata cache beyond what the user specified.

![master_behavior](https://user-images.githubusercontent.com/1286295/40058491-e37ef3f6-5816-11e8-8e24-813edfe97915.png)

Ultimately, for optimal behavior, the ratios of caches must change to match the current workload, and so it's impossible for both us as developers and for users to specify static ratios that work well under all scenarios.  The result of all of this is that users have a hard time understanding how these different options and behaviors interact, how their settings ultimately affect the amount of memory assigned to different caches, and how they should configure these settings on their cluster.

# What this PR Does

This PR introduces the concept of cache autotuning in Ceph, along with laying the foundation for a concept called priority based caching.  

# Autotuning Disabled

When autotuning is disabled, we should make bluestore's behavior as transparent to the user as possible.  IE given a certain cache size and certain ratios, set the cache sizes accordingly and don't mess with them beyond that.  This may result in less (or more) optimal behavior than current master, but does exactly what the user requests (and leaves it up to them to find the right ratios).

# Autotuning Enabled

When autotuning is enabled, bluestore will periodically query each cache for how much memory it would like for a given priority (typically how much memory is currently being used plus some extra space for expansion).  It will either allocate this amount or the user-defined fair ratio of remaining memory depending on which is larger.  If any caches don't get as much memory for this priority as they want and there is still memory available, that cache may get additional memory assigned to it to fulfill it's current priority needs before moving on to lower priorities.  Currently the only high priority items are rocksdb's index and filter blocks in rocksdb's high priority cache pool.  This PR lays the ground work for supporting an arbitrary number of generic priorities however.  A future PR for example may implement the concept of binned LRUs where each cache segments their LRU into different priority bins based on age.  If for example, the KV cache generally has older items than bluestore's onode cache, it would get a lower proportion of the available memory.

# RBD Behavior - Autotuning Disabled

![wip-bs-cache-autotune-40-40-20-false](https://user-images.githubusercontent.com/1286295/40060902-42ab50b2-581d-11e8-9981-d296e82317f5.png)

The behavior in the example above is similar to that of master, except that there are no longer any minimums for the user to set and the ratios assigned to each cache exactly match what the user specified.  In this example, 40% of the memory is devoted to bluestore metadata, 40% to RocksDB's block cache, and 20% to bluestore data.  There is not enough memory devoted to bluestore's metadata cache to cache all onode related metadata.  Once random writes start, rocksdb's block cache begins to fill with onode metadata due to cache misses at both the bluestore meta cache and rocksdb block cache levels.  In fact rocksdb is caching much of the same onode data that bluestore is caching.

![wip-bs-cache-autotune-10-85-5-false](https://user-images.githubusercontent.com/1286295/40061409-7b49cf92-581e-11e8-90c2-ddf38fd1782f.png)

Setting a larger onode ratio (85%) that is able to cache all onodes results in no double caching in rocksdb, but now we've assigned significantly more memory to bluestore's onode cache than is necessary to cache all onodes.  A significant portion of the available memory is underutilized when it could have been assigned to data cache.

# RBD Behavior -Autotuning Enabled

![wip-bs-cache-autotune-40-40-20-true](https://user-images.githubusercontent.com/1286295/40062311-8d03af30-5820-11e8-85f4-4620907965a9.png)
![wip-bs-cache-autotune-10-85-5-true](https://user-images.githubusercontent.com/1286295/40062508-ff64390a-5820-11e8-9ba9-4f0448335f26.png)

When autotuning is enabled, no matter what default ratios are specified, the autotuner converges on the same ratios.  The bluestore metadata cache is given roughly 51% of the available cache.  Because all onodes are cached in bluestore's onode cache, the KV cache is seldom utilized and remains small (~4%).  Any remaining memory is assigned to bluestore's data cache which receives a significantly larger chunk of the memory than was specified.

# RBD Performance

![wip-bs-cache-autotune-performance](https://user-images.githubusercontent.com/1286295/40069518-377b893c-5831-11e8-96e7-a68230c74aef.png)
![wip-bs-cache-autotune-99th_latency](https://user-images.githubusercontent.com/1286295/40070757-96cafb2c-5834-11e8-9bfd-6848a9eea1de.png)

The most important performance consideration for the RBD workload is avoiding bluestore meta cache misses.  The autotuner does this implicitly though it can also be accomplished by setting a high enough meta cache ratio to ensure all onodes are cached (but this is difficult for users to do!).  the Autotuner is also able to do this while setting aside a large proportion of the memory for data cache.  While this doesn't appear to dramatically help the random read results here, it may have a more  profound affect in benchmarks that stress hotspot distributions like zipf.  One notable point to make is how much keeping onodes cached improves the 99th percentile latency for reads.  Presumably as latency in the read and write path is reduced via other methods, the importance of avoiding onode cache misses is going to become more pronounced.

# RGW Behavior - Autotuning Disabled

![wip-bs-cache-autotune-40-40-20-false-rgw](https://user-images.githubusercontent.com/1286295/40067374-a42d6632-582b-11e8-9369-5726f67a0029.png)
![wip-bs-cache-autotune-10-85-5-false-rgw](https://user-images.githubusercontent.com/1286295/40067383-a888195c-582b-11e8-8419-46cc3e1a986d.png)

Due to the large amount of onode and omap data during small object RGW workloads, all caches end up filling relatively quickly.  There is still likely a large amount of onode double caching going on, competing with OMAP data in rocksdb's block cache.

# RGW Behavior - Autotuning Enabled

![wip-bs-cache-autotune-40-40-20-true-rgw](https://user-images.githubusercontent.com/1286295/40067404-afa26fe4-582b-11e8-9922-8495f3dca6fa.png)
![wip-bs-cache-autotune-10-85-5-true-rgw](https://user-images.githubusercontent.com/1286295/40067416-b32de800-582b-11e8-9edb-4b832799c739.png)

The autotuned results look much closer to the non-autotuned results for this RGW workload vs the previous RBD workload.  Because all caches end up competing for resources, the autotuner tends to converge toward the default specified ratios with one exception.  Because the autotuner prioritizes rocksdb index and filter blocks at a higher priority than typical cache items, the amount of memory devoted to rocksdb's block cache tends to increase over time.

# RGW Performance

![wip-bs-cache-autotune-performance-rgw](https://user-images.githubusercontent.com/1286295/40072207-a669025a-5838-11e8-9749-3377610f8459.png)
![wip-bs-cache-autotune-avg_latency-rgw](https://user-images.githubusercontent.com/1286295/40072212-a9dc0a04-5838-11e8-8208-a045d4ec0e0f.png)

Neither the cache ratios nor the autotuner appeared to have significant affect on the performance or latency of the RGW put workload.  A small effect may be present when memory is significantly skewed toward onode cache (to the point where indexes/filters are not cached), though it's also possible that there are other bottlenecks in the RGW path resulting in caching having minimal affect one way or the other.


# Caveats

The idea behind the cache autotuner is that it adjusts the caches relatively slowly.  By default it waits 5 seconds between rebalances and asks for memory requests in 32MB chunks (with an extra chunk of headroom if a cache is at or above capacity before trim).  This plays relatively well with bluestore's caches but rocksdb's block cache behavior is less straightforward.  Compaction may drive rocksdb to exceed it's cache ratio for a short period of time, and it's unclear how the cache balancer should handle this.  More importantly, when rocksdb exceeds the block cache size (due to compaction), all indexes and filters in the high priority pool appear to be evicted and then rapidly re-added.  It's not yet clear why this only appears to happen only when the block_cache size is exceeded and not in other scenarios.  Both of these behaviors potentially can make the autotuner thrash in undesirable ways if encountered.  To help mitigate this, a high watermark is set and memory is requested as normal at the elevated level.  If the data in the pool (high priority pool or otherwise) rapidly shrinks, the memory request size degrades slowly over time in case the cache is quickly repopulated faster than the autotuner can adapt.

# Future Work

Imagine a scenario in which a cluster receives heavy RGW writes to a large data set, then a series of small random RBD writes/reads.  Currently the autotuning mostly gives bluestore's metadata cache, data cache, and RocksDB's block cache equal priority at a single level (with the exception of RocksDB's indexes and filters).  After heavy RGW writes, each cache will likely request more memory than is available.  The autotuner will ultimately revert to the default ratios specified by the user as it has no knowledge of the relative importance of data in bluestore's onode cache and rocksdb's block cache.  A future PR may introduce the concept of binned LRU caches.  The idea being that the relative age of items in each cache should determine how much total memory each cache is assigned.  Onodes that are less than 60s old should for example be cached with a higher priority than OMAP data that is older than 60s, even if that might skew the ratios toward bluestore meta cache.  If an OSD is spending most of it's time serving RGW bucket index data, the rocksdb block cache may have significantly more recent data in it than bluestore's onode cache, in which case the ratios may skew the other direction.

Another direction for future work might be to move the cache balancer out of bluestore and make it general to the OSD itself.  Ultimately the user doesn't care what bluestore's cache size is.  They care about how much memory the OSD process uses overall.  Currently the amount of memory the OSD uses is extremely difficult to determine and is dependent on many additional factors beyond bluestore's cache size.  Future work may involve incorporating other buffers and caches into the autotuner (Pinned at PRI0) to determine how much memory each cache can be assigned.

Finally, in the RGW scenario, all 3 caches tend to fill rapidly to the point where all are competing for resources.  This results in double caching of onodes in the bluestore meta cache and rocksdb block cache.  Specifically in the block cache, recently accessed onodes and OMAP data compete for resources despite the fact that those onodes are also likely cached in bluestore's cache.  It's possible that in addition to age-binned LRU caches, we may wish to create multiple LRU caches in rocksdb for different column families of data.  IE recent OMAP data and bluestore metadata may be cached at a higher priority than recent onodes cached in rocksdb's block cache that may also be cached in the bluestore metadata cache.

Signed-off-by: Mark Nelson <mnelson@redhat.com>