### PR TITLE
mgr/dashboard: Task wrapper service

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -1,17 +1,11 @@
-import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { of as observableOf } from 'rxjs';
+import { ToastModule } from 'ng2-toastr';
 
-import { PoolService } from '../../../shared/api/pool.service';
-import { RbdService } from '../../../shared/api/rbd.service';
-import { DimlessBinaryPipe } from '../../../shared/pipes/dimless-binary.pipe';
-import { FormatterService } from '../../../shared/services/formatter.service';
-import { NotificationService } from '../../../shared/services/notification.service';
-import { TaskManagerMessageService } from '../../../shared/services/task-manager-message.service';
-import { TaskManagerService } from '../../../shared/services/task-manager.service';
+import { SharedModule } from '../../../shared/shared.module';
 import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdFormComponent } from './rbd-form.component';
 
@@ -19,31 +13,15 @@ describe('RbdFormComponent', () => {
   let component: RbdFormComponent;
   let fixture: ComponentFixture<RbdFormComponent>;
 
-  const fakeService = {
-    subscribe: (name, metadata, onTaskFinished: (finishedTask: any) => any) => {
-      return null;
-    },
-    defaultFeatures: () => observableOf([]),
-    list: (attrs = []) => {
-      return new Promise(function(resolve, reject) {
-        return;
-      });
-    }
-  };
-
   configureTestBed({
-    imports: [ReactiveFormsModule, RouterTestingModule],
-    declarations: [RbdFormComponent],
-    schemas: [NO_ERRORS_SCHEMA],
-    providers: [
-      DimlessBinaryPipe,
-      FormatterService,
-      TaskManagerMessageService,
-      { provide: NotificationService, useValue: fakeService },
-      { provide: PoolService, useValue: fakeService },
-      { provide: RbdService, useValue: fakeService },
-      { provide: TaskManagerService, useValue: fakeService }
-    ]
+    imports: [
+      HttpClientTestingModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      ToastModule.forRoot(),
+      SharedModule
+    ],
+    declarations: [RbdFormComponent]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -1,21 +1,17 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ToastModule } from 'ng2-toastr';
 import {
   AlertModule,
   BsDropdownModule,
-  BsModalRef,
   ModalModule,
   TabsModule,
   TooltipModule
 } from 'ngx-bootstrap';
-import { throwError as observableThrowError } from 'rxjs';
 
-import { RbdService } from '../../../shared/api/rbd.service';
 import { ComponentsModule } from '../../../shared/components/components.module';
-import { NotificationService } from '../../../shared/services/notification.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdDetailsComponent } from '../rbd-details/rbd-details.component';
@@ -50,42 +46,5 @@ describe('RbdListComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-  });
-
-  describe('api delete request', () => {
-    let called;
-    let rbdService: RbdService;
-    let notificationService: NotificationService;
-
-    beforeEach(() => {
-      called = false;
-      rbdService = new RbdService(null);
-      notificationService = new NotificationService(null, null);
-      component = new RbdListComponent(
-        rbdService,
-        null,
-        null,
-        null,
-        null,
-        notificationService,
-        null,
-        null
-      );
-      spyOn(rbdService, 'delete').and.returnValue(observableThrowError({ status: 500 }));
-      spyOn(notificationService, 'notifyTask').and.stub();
-      component.modalRef = new BsModalRef();
-      component.modalRef.content = {
-        stopLoadingSpinner: () => (called = true)
-      };
-    });
-
-    it('should make sure that if the deletion fails stopLoadingSpinner is called', <any>fakeAsync(
-      () => {
-        expect(called).toBe(false);
-        component.deleteRbd('sth', 'test');
-        tick(500);
-        expect(called).toBe(true);
-      }
-    ));
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
@@ -3,6 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverModule } from 'ngx-bootstrap';
 
+import { ExecutingTask } from '../../../shared/models/executing-task';
+import { FinishedTask } from '../../../shared/models/finished-task';
 import { SharedModule } from '../../../shared/shared.module';
 import { configureTestBed } from '../../../shared/unit-test-helper';
 import { TaskManagerComponent } from './task-manager.component';
@@ -10,6 +12,10 @@ import { TaskManagerComponent } from './task-manager.component';
 describe('TaskManagerComponent', () => {
   let component: TaskManagerComponent;
   let fixture: ComponentFixture<TaskManagerComponent>;
+  const tasks = {
+    executing: [],
+    finished: []
+  };
 
   configureTestBed({
     imports: [SharedModule, PopoverModule.forRoot(), HttpClientTestingModule],
@@ -20,9 +26,54 @@ describe('TaskManagerComponent', () => {
     fixture = TestBed.createComponent(TaskManagerComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    tasks.executing = [
+      new ExecutingTask('rbd/delete', {
+        pool_name: 'somePool',
+        image_name: 'someImage'
+      })
+    ];
+    tasks.finished = [
+      new FinishedTask('rbd/copy', {
+        dest_pool_name: 'somePool',
+        dest_image_name: 'someImage'
+      }),
+      new FinishedTask('rbd/clone', {
+        child_pool_name: 'somePool',
+        child_image_name: 'someImage'
+      })
+    ];
+    tasks.finished[1].success = false;
+    tasks.finished[1].exception = { code: 17 };
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should get executing message for task', () => {
+    component._handleTasks(tasks.executing, []);
+    expect(component.executingTasks.length).toBe(1);
+    expect(component.executingTasks[0].description).toBe('Deleting RBD \'somePool/someImage\'');
+  });
+
+  it('should get finished message for task', () => {
+    component._handleTasks([], tasks.finished);
+    expect(component.finishedTasks.length).toBe(2);
+    expect(component.finishedTasks[0].description).toBe('Copy RBD \'somePool/someImage\'');
+    expect(component.finishedTasks[0].errorMessage).toBe(undefined);
+    expect(component.finishedTasks[1].description).toBe('Clone RBD \'somePool/someImage\'');
+    expect(component.finishedTasks[1].errorMessage).toBe(
+      'Name \'somePool/someImage\' is already in use.'
+    );
+  });
+
+  it('should get an empty hour glass with only finished tasks', () => {
+    component._setIcon(0);
+    expect(component.icon).toBe('fa-hourglass-o');
+  });
+
+  it('should get a nearly empty hour glass with executing tasks', () => {
+    component._setIcon(10);
+    expect(component.icon).toBe('fa-hourglass-start');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/task.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/task.ts
@@ -1,4 +1,8 @@
 export class Task {
+  constructor(name?, metadata?) {
+    this.name = name;
+    this.metadata = metadata;
+  }
   name: string;
   metadata: object;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.spec.ts
@@ -28,6 +28,25 @@ describe('TaskManagerMessageService', () => {
     expect(message).toBe('Unknown Task');
   });
 
+  it('should get default running message', () => {
+    finishedTask.metadata = {};
+    let message = service.getRunningMessage(finishedTask);
+    expect(message).toBe('Executing unknown task');
+    finishedTask.metadata = { component: 'rbd' };
+    message = service.getRunningMessage(finishedTask);
+    expect(message).toBe('Executing RBD');
+  });
+
+  it('should get custom running message', () => {
+    finishedTask.name = 'rbd/create';
+    finishedTask.metadata = {
+      pool_name: 'somePool',
+      image_name: 'someImage'
+    };
+    const message = service.getRunningMessage(finishedTask);
+    expect(message).toBe('Creating RBD \'somePool/someImage\'');
+  });
+
   it('should getErrorMessage', () => {
     finishedTask.exception = _.assign(new TaskException(), {
       code: 1
@@ -46,6 +65,7 @@ describe('TaskManagerMessageService', () => {
       expect(value.descr({})).toBeTruthy();
       expect(value.success({})).toBeTruthy();
       expect(value.error({})).toBeTruthy();
+      expect(value.running({})).toBeTruthy();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.ts
@@ -7,15 +7,18 @@ import { ServicesModule } from './services.module';
 
 class TaskManagerMessage {
   descr: (metadata) => string;
+  running: (metadata) => string;
   success: (metadata) => string;
   error: (metadata) => object;
 
   constructor(
     descr: (metadata) => string,
+    running: (metadata) => string,
     success: (metadata) => string,
     error: (metadata) => object
   ) {
     this.descr = descr;
+    this.running = running;
     this.success = success;
     this.error = error;
   }
@@ -28,30 +31,31 @@ export class TaskManagerMessageService {
   messages = {
     'rbd/create': new TaskManagerMessage(
       (metadata) => `Create RBD '${metadata.pool_name}/${metadata.image_name}'`,
-      (metadata) => `RBD '${metadata.pool_name}/${metadata.image_name}'
-                     has been created successfully`,
+      (metadata) => `Creating RBD '${metadata.pool_name}/${metadata.image_name}'`,
+      (metadata) =>
+        `RBD '${metadata.pool_name}/${metadata.image_name}' has been created successfully`,
       (metadata) => {
         return {
-          '17': `Name '${metadata.pool_name}/${metadata.image_name}' is already
-                 in use.`
+          '17': `Name '${metadata.pool_name}/${metadata.image_name}' is already in use.`
         };
       }
     ),
     'rbd/edit': new TaskManagerMessage(
       (metadata) => `Update RBD '${metadata.pool_name}/${metadata.image_name}'`,
-      (metadata) => `RBD '${metadata.pool_name}/${metadata.image_name}'
-                     has been updated successfully`,
+      (metadata) => `Updating RBD '${metadata.pool_name}/${metadata.image_name}'`,
+      (metadata) =>
+        `RBD '${metadata.pool_name}/${metadata.image_name}' has been updated successfully`,
       (metadata) => {
         return {
-          '17': `Name '${metadata.pool_name}/${metadata.name}' is already
-                 in use.`
+          '17': `Name '${metadata.pool_name}/${metadata.name}' is already in use.`
         };
       }
     ),
     'rbd/delete': new TaskManagerMessage(
       (metadata) => `Delete RBD '${metadata.pool_name}/${metadata.image_name}'`,
-      (metadata) => `RBD '${metadata.pool_name}/${metadata.image_name}'
-                     has been deleted successfully`,
+      (metadata) => `Deleting RBD '${metadata.pool_name}/${metadata.image_name}'`,
+      (metadata) =>
+        `RBD '${metadata.pool_name}/${metadata.image_name}' has been deleted successfully`,
       (metadata) => {
         return {
           '39': `RBD image contains snapshots.`
@@ -60,31 +64,36 @@ export class TaskManagerMessageService {
     ),
     'rbd/clone': new TaskManagerMessage(
       (metadata) => `Clone RBD '${metadata.child_pool_name}/${metadata.child_image_name}'`,
-      (metadata) => `RBD '${metadata.child_pool_name}/${metadata.child_image_name}'
-                     has been cloned successfully`,
+      (metadata) => `Cloning RBD '${metadata.child_pool_name}/${metadata.child_image_name}'`,
+      (metadata) =>
+        `RBD '${metadata.child_pool_name}/${
+          metadata.child_image_name
+        }' has been cloned successfully`,
       (metadata) => {
         return {
-          '17': `Name '${metadata.child_pool_name}/${metadata.child_image_name}' is already
-                 in use.`,
+          '17': `Name '${metadata.child_pool_name}/${
+            metadata.child_image_name
+          }' is already in use.`,
           '22': `Snapshot must be protected.`
         };
       }
     ),
     'rbd/copy': new TaskManagerMessage(
       (metadata) => `Copy RBD '${metadata.dest_pool_name}/${metadata.dest_image_name}'`,
-      (metadata) => `RBD '${metadata.dest_pool_name}/${metadata.dest_image_name}'
-                     has been copied successfully`,
+      (metadata) => `Copying RBD '${metadata.dest_pool_name}/${metadata.dest_image_name}'`,
+      (metadata) =>
+        `RBD '${metadata.dest_pool_name}/${metadata.dest_image_name}' has been copied successfully`,
       (metadata) => {
         return {
-          '17': `Name '${metadata.dest_pool_name}/${metadata.dest_image_name}' is already
-                 in use.`
+          '17': `Name '${metadata.dest_pool_name}/${metadata.dest_image_name}' is already in use.`
         };
       }
     ),
     'rbd/flatten': new TaskManagerMessage(
       (metadata) => `Flatten RBD '${metadata.pool_name}/${metadata.image_name}'`,
-      (metadata) => `RBD '${metadata.pool_name}/${metadata.image_name}'
-                     has been flattened successfully`,
+      (metadata) => `Flattening RBD '${metadata.pool_name}/${metadata.image_name}'`,
+      (metadata) =>
+        `RBD '${metadata.pool_name}/${metadata.image_name}' has been flattened successfully`,
       () => {
         return {};
       }
@@ -92,6 +101,9 @@ export class TaskManagerMessageService {
     'rbd/snap/create': new TaskManagerMessage(
       (metadata) =>
         `Create snapshot ` +
+        `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}'`,
+      (metadata) =>
+        `Creating snapshot ` +
         `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}'`,
       (metadata) =>
         `Snapshot ` +
@@ -108,6 +120,9 @@ export class TaskManagerMessageService {
         `Update snapshot ` +
         `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}'`,
       (metadata) =>
+        `Updating snapshot ` +
+        `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}'`,
+      (metadata) =>
         `Snapshot ` +
         `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}' ` +
         `has been updated successfully`,
@@ -120,6 +135,9 @@ export class TaskManagerMessageService {
     'rbd/snap/delete': new TaskManagerMessage(
       (metadata) =>
         `Delete snapshot ` +
+        `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}'`,
+      (metadata) =>
+        `Deleting snapshot ` +
         `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}'`,
       (metadata) =>
         `Snapshot ` +
@@ -136,6 +154,9 @@ export class TaskManagerMessageService {
         `Rollback snapshot ` +
         `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}'`,
       (metadata) =>
+        `Rolling back snapshot ` +
+        `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}'`,
+      (metadata) =>
         `Snapshot ` +
         `'${metadata.pool_name}/${metadata.image_name}@${metadata.snapshot_name}' ` +
         `has been rolled back successfully`,
@@ -148,6 +169,11 @@ export class TaskManagerMessageService {
   defaultMessage = new TaskManagerMessage(
     (metadata) => {
       return Components[metadata.component] || metadata.component || 'Unknown Task';
+    },
+    (metadata) => {
+      return (
+        'Executing ' + (Components[metadata.component] || metadata.component || 'unknown task')
+      );
     },
     (metadata) => 'Task executed successfully',
     () => {
@@ -173,5 +199,10 @@ export class TaskManagerMessageService {
   getDescription(task: Task) {
     const taskManagerMessage = this.messages[task.name] || this.defaultMessage;
     return taskManagerMessage.descr(task.metadata);
+  }
+
+  getRunningMessage(task: Task) {
+    const taskManagerMessage = this.messages[task.name] || this.defaultMessage;
+    return taskManagerMessage.running(task.metadata);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
@@ -1,0 +1,92 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { inject, TestBed } from '@angular/core/testing';
+
+import { ToastModule } from 'ng2-toastr';
+import { Observable } from 'rxjs/Observable';
+
+import { ExecutingTask } from '../models/executing-task';
+import { FinishedTask } from '../models/finished-task';
+import { SharedModule } from '../shared.module';
+import { configureTestBed } from '../unit-test-helper';
+import { NotificationService } from './notification.service';
+import { TaskManagerService } from './task-manager.service';
+import { TaskWrapperService } from './task-wrapper.service';
+
+describe('TaskWrapperService', () => {
+  let service: TaskWrapperService;
+
+  configureTestBed({
+    imports: [HttpClientTestingModule, ToastModule.forRoot(), SharedModule],
+    providers: [TaskWrapperService]
+  });
+
+  beforeEach(inject([TaskWrapperService], (wrapper: TaskWrapperService) => {
+    service = wrapper;
+  }));
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('wrapTaskAroundCall', () => {
+    let notify: NotificationService;
+    let tasks: ExecutingTask[];
+    let passed: boolean;
+
+    const fakeCall = (status?) =>
+      new Observable((observer) => {
+        if (!status) {
+          observer.error({ error: 'failed' });
+        }
+        observer.next({ status: status });
+        observer.complete();
+      });
+
+    const callWrapTaskAroundCall = (status, name) => {
+      return service.wrapTaskAroundCall({
+        task: new FinishedTask(name, { sth: 'else' }),
+        call: fakeCall(status),
+        tasks: tasks
+      });
+    };
+
+    beforeEach(() => {
+      passed = false;
+      tasks = [];
+      notify = TestBed.get(NotificationService);
+      spyOn(notify, 'show');
+      spyOn(service, '_handleExecutingTasks').and.callThrough();
+    });
+
+    it('should simulate a synchronous task', () => {
+      callWrapTaskAroundCall(200, 'sync').subscribe(null, null, () => (passed = true));
+      expect(service._handleExecutingTasks).not.toHaveBeenCalled();
+      expect(passed).toBeTruthy();
+      expect(tasks.length).toBe(0);
+    });
+
+    it('should simulate a asynchronous task', () => {
+      callWrapTaskAroundCall(202, 'async').subscribe(null, null, () => (passed = true));
+      expect(service._handleExecutingTasks).toHaveBeenCalled();
+      expect(passed).toBeTruthy();
+      expect(tasks.length).toBe(1);
+    });
+
+    it('should call notifyTask if asynchronous task would have been finished', () => {
+      const taskManager = TestBed.get(TaskManagerService);
+      spyOn(taskManager, 'subscribe').and.callFake((name, metadata, onTaskFinished) => {
+        onTaskFinished();
+      });
+      spyOn(notify, 'notifyTask').and.stub();
+      callWrapTaskAroundCall(202, 'async').subscribe(null, null, () => (passed = true));
+      expect(notify.notifyTask).toHaveBeenCalled();
+    });
+
+    it('should simulate a task failure', () => {
+      callWrapTaskAroundCall(null, 'async').subscribe(null, () => (passed = true), null);
+      expect(service._handleExecutingTasks).not.toHaveBeenCalled();
+      expect(passed).toBeTruthy();
+      expect(tasks.length).toBe(0);
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.ts
@@ -56,7 +56,7 @@ export class TaskWrapperService {
   _handleExecutingTasks(task: FinishedTask, tasks?: ExecutingTask[]) {
     this.notificationService.show(
       NotificationType.info,
-      task.name + ' in progress...',
+      this.taskManagerMessageService.getRunningMessage(task),
       this.taskManagerMessageService.getDescription(task)
     );
     const executingTask = new ExecutingTask(task.name, task.metadata);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from '@angular/core';
+
+import { Observable } from 'rxjs/Observable';
+import { Subscriber } from 'rxjs/Subscriber';
+
+import { NotificationType } from '../enum/notification-type.enum';
+import { ExecutingTask } from '../models/executing-task';
+import { FinishedTask } from '../models/finished-task';
+import { NotificationService } from './notification.service';
+import { ServicesModule } from './services.module';
+import { TaskManagerMessageService } from './task-manager-message.service';
+import { TaskManagerService } from './task-manager.service';
+
+@Injectable({
+  providedIn: ServicesModule
+})
+export class TaskWrapperService {
+  constructor(
+    private notificationService: NotificationService,
+    private taskManagerMessageService: TaskManagerMessageService,
+    private taskManagerService: TaskManagerService
+  ) {}
+
+  wrapTaskAroundCall({
+    task,
+    call,
+    tasks
+  }: {
+    task: FinishedTask;
+    call: Observable<any>;
+    tasks?: ExecutingTask[];
+  }) {
+    return new Observable((observer: Subscriber<any>) => {
+      call.subscribe(
+        (resp) => {
+          if (resp.status === 202) {
+            this._handleExecutingTasks(task, tasks);
+          } else {
+            task.success = true;
+            this.notificationService.notifyTask(task);
+          }
+        },
+        (resp) => {
+          task.success = false;
+          task.exception = resp.error;
+          this.notificationService.notifyTask(task);
+          observer.error();
+        },
+        () => {
+          observer.complete();
+        }
+      );
+    });
+  }
+
+  _handleExecutingTasks(task: FinishedTask, tasks?: ExecutingTask[]) {
+    this.notificationService.show(
+      NotificationType.info,
+      task.name + ' in progress...',
+      this.taskManagerMessageService.getDescription(task)
+    );
+    const executingTask = new ExecutingTask(task.name, task.metadata);
+    if (tasks) {
+      tasks.push(executingTask);
+    }
+    this.taskManagerService.subscribe(
+      executingTask.name,
+      executingTask.metadata,
+      (asyncTask: FinishedTask) => {
+        this.notificationService.notifyTask(asyncTask);
+      }
+    );
+  }
+}


### PR DESCRIPTION
Has a method to wrap an API call into a task.

These changes are also used in the upcoming Pool Management PR https://github.com/ceph/ceph/pull/21614.

Signed-off-by: Stephan Müller <smueller@suse.com>