### PR TITLE
cmake: update fio version from 3.5 to 540e235dcd276e63c57.

### DIFF
--- a/cmake/modules/BuildFIO.cmake
+++ b/cmake/modules/BuildFIO.cmake
@@ -6,7 +6,7 @@ function(build_fio)
     DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/src/
     UPDATE_COMMAND "" # this disables rebuild on each run
     GIT_REPOSITORY "https://github.com/axboe/fio.git"
-    GIT_TAG "fio-3.5"
+    GIT_TAG "540e235dcd276e63c57ca4bd35f70a0651e2d00e"
     SOURCE_DIR ${CMAKE_BINARY_DIR}/src/fio
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND <SOURCE_DIR>/configure

--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -538,7 +538,7 @@ class UnitComplete : public Context {
   }
 };
 
-int fio_ceph_os_queue(thread_data* td, io_u* u)
+enum fio_q_status fio_ceph_os_queue(thread_data* td, io_u* u)
 {
   fio_ro_check(td, u);
 


### PR DESCRIPTION
Fio commit(d04f1d5b342e7733) make external ioengine work.
This need when build libfio_ceph_objectstore.so.

Meanwhile fix a comiler error:
/home/ceph/src/test/fio/fio_ceph_objectstore.cc: In constructor ‘{anonymous}::ceph_ioengine::ceph_ioengine()’:
/home/ceph/src/test/fio/fio_ceph_objectstore.cc:733:19: error: invalid conversion from ‘int (*)(thread_data*, io_u*)’ to ‘fio_q_status (*)(thread_data*, io_u*)’ [-fpermissive]
     queue       = fio_ceph_os_queue;
                   ^~~~~~~~~~~~~~~~~
src/test/fio/CMakeFiles/fio_ceph_objectstore.dir/build.make:62: recipe for target 'src/test/fio/CMakeFiles/fio_ceph_objectstore.dir/fio_ceph_objectstore.cc.o' failed

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>