### PR TITLE
client: proactively open sessions for potential export targets

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2654,8 +2654,14 @@ void Client::handle_mds_map(MMDSMap* m)
       // in its dcache/icache. Hopefully, the kernel will release some unused
       // inodes before the new MDS enters reconnect state.
       trim_cache_for_reconnect(session);
-    } else if (oldstate == newstate)
+    } else if (oldstate == newstate) {
+      if (newstate >= MDSMap::STATE_ACTIVE &&
+	  oldmap->get_mds_info(mds).export_targets !=
+	  mdsmap->get_mds_info(mds).export_targets) {
+	connect_mds_targets(mds);
+      }
       continue;  // no change
+    }
     
     session->mds_state = newstate;
     if (newstate == MDSMap::STATE_RECONNECT) {


### PR DESCRIPTION
For the case that mds exports non-auth caps to auth mds, the exporter
mds may not send cap export message. So client should not rely on cap
export message to open session for export target.

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>
Fixes: http://tracker.ceph.com/issues/24052