### PR TITLE
messages: print quota info in MClientQuota msg

### DIFF
--- a/src/messages/MClientQuota.h
+++ b/src/messages/MClientQuota.h
@@ -20,7 +20,8 @@ public:
   void print(ostream& out) const override {
     out << "client_quota(";
     out << " [" << ino << "] ";
-    out << rstat;
+    out << rstat << " ";
+    out << quota;
     out << ")";
   }
 


### PR DESCRIPTION
This is a minor change to print quota info in MClientQuota msg.

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>