### PR TITLE
 rgw: es: support username and password for ES 

### DIFF
--- a/src/rgw/rgw_cr_rest.h
+++ b/src/rgw/rgw_cr_rest.h
@@ -267,6 +267,17 @@ public:
     : RGWSendRESTResourceCR<S, T>(_cct, _conn, _http_manager,
                                   "PUT", _path,
                                   _params, nullptr, _input, _result) {}
+
+  RGWPutRESTResourceCR(CephContext *_cct, RGWRESTConn *_conn,
+                       RGWHTTPManager *_http_manager,
+                       const string& _path,
+                       rgw_http_param_pair *_params,
+                       map <string, string> *_attrs,
+                       S& _input, T *_result)
+    : RGWSendRESTResourceCR<S, T>(_cct, _conn, _http_manager,
+                                  "PUT", _path,
+                                  _params, _attrs, _input, _result) {}
+
 };
 
 class RGWDeleteRESTResourceCR : public RGWSimpleCoroutine {

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -109,6 +109,55 @@ public:
 #define ES_NUM_SHARDS_DEFAULT 16
 #define ES_NUM_REPLICAS_DEFAULT 1
 
+struct ESVersion {
+  int major_ver;
+  int minor_ver;
+
+  ESVersion(int _major, int _minor): major_ver(_major), minor_ver(_minor) {}
+  ESVersion(): major_ver(0), minor_ver(0) {}
+
+  void from_str(const char* s) {
+    sscanf(s, "%d.%d", &major_ver, &minor_ver);
+  }
+
+  std::string to_str() const {
+    return std::to_string(major_ver) + "." + std::to_string(minor_ver);
+  }
+
+  void decode_json(JSONObj *obj);
+};
+
+bool operator >= (const ESVersion& v1, const ESVersion& v2)
+{
+  if (v1.major_ver == v2.major_ver)
+    return v1.minor_ver >= v2.minor_ver;
+
+  return v1.major_ver > v2.major_ver;
+}
+
+struct ESInfo {
+  std::string name;
+  std::string cluster_name;
+  std::string cluster_uuid;
+  ESVersion version;
+
+  void decode_json(JSONObj *obj);
+};
+
+void ESInfo::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("name", name, obj);
+  JSONDecoder::decode_json("cluster_name", cluster_name, obj);
+  JSONDecoder::decode_json("cluster_uuid", cluster_uuid, obj);
+  JSONDecoder::decode_json("version", version, obj);
+}
+
+void ESVersion::decode_json(JSONObj *obj)
+{
+  std::string s;
+  JSONDecoder::decode_json("number", s, obj);
+  this->from_str(s.c_str());
+}
 
 struct ElasticConfig {
   uint64_t sync_instance{0};

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -556,6 +556,7 @@ struct es_obj_metadata {
 class RGWElasticInitConfigCBCR : public RGWCoroutine {
   RGWDataSyncEnv *sync_env;
   ElasticConfigRef conf;
+  ESInfo es_info;
 public:
   RGWElasticInitConfigCBCR(RGWDataSyncEnv *_sync_env,
                           ElasticConfigRef _conf) : RGWCoroutine(_sync_env->cct),
@@ -564,18 +565,33 @@ public:
   int operate() override {
     reenter(this) {
       ldout(sync_env->cct, 0) << ": init elasticsearch config zone=" << sync_env->source_zone << dendl;
+      yield call(new RGWReadRESTResourceCR<ESInfo> (sync_env->cct,
+                                                    conf->conn.get(),
+                                                    sync_env->http_manager,
+                                                    "/", nullptr, &es_info));
+      if (retcode < 0) {
+        return set_cr_error(retcode);
+      }
+
       yield {
         string path = conf->get_index_path();
+        ldout(sync_env->cct, 5) << "got elastic version=" << es_info.version.to_str() << dendl;
 
         es_index_settings settings(conf->num_replicas, conf->num_shards);
         es_index_mappings mappings;
+        if (es_info.version >= ESVersion(5,0)) {
+          ldout(sync_env->cct, 0) << "elasticsearch: using text type for string index mappings " << dendl;
+          mappings.string_type = ESType::Text;
+        }
 
         es_index_config index_conf(settings, mappings);
-
-        call(new RGWPutRESTResourceCR<es_index_config, int>(sync_env->cct, conf->conn.get(),
-                                                              sync_env->http_manager,
-                                                              path, nullptr /* params */,
-                                                              index_conf, nullptr /* result */));
+        std::map <string, string> hdrs = {{ "Content-Type", "application/json" }};
+        call(new RGWPutRESTResourceCR<es_index_config, int> (sync_env->cct,
+                                                             conf->conn.get(),
+                                                             sync_env->http_manager,
+                                                             path, nullptr /*params*/,
+                                                             &hdrs,
+                                                             index_conf, nullptr));
       }
       if (retcode < 0) {
         return set_cr_error(retcode);
@@ -605,9 +621,11 @@ public:
         string path = conf->get_obj_path(bucket_info, key);
         es_obj_metadata doc(sync_env->cct, conf, bucket_info, key, mtime, size, attrs, versioned_epoch);
 
+        std::map <string, string> hdrs = {{ "Content-Type", "application/json" }};
         call(new RGWPutRESTResourceCR<es_obj_metadata, int>(sync_env->cct, conf->conn.get(),
                                                             sync_env->http_manager,
                                                             path, nullptr /* params */,
+                                                            &hdrs,
                                                             doc, nullptr /* result */));
 
       }

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -110,31 +110,8 @@ public:
 #define ES_NUM_SHARDS_DEFAULT 16
 #define ES_NUM_REPLICAS_DEFAULT 1
 
-struct ESVersion {
-  int major_ver;
-  int minor_ver;
-
-  ESVersion(int _major, int _minor): major_ver(_major), minor_ver(_minor) {}
-  ESVersion(): major_ver(0), minor_ver(0) {}
-
-  void from_str(const char* s) {
-    sscanf(s, "%d.%d", &major_ver, &minor_ver);
-  }
-
-  std::string to_str() const {
-    return std::to_string(major_ver) + "." + std::to_string(minor_ver);
-  }
-
-  void decode_json(JSONObj *obj);
-};
-
-bool operator >= (const ESVersion& v1, const ESVersion& v2)
-{
-  if (v1.major_ver == v2.major_ver)
-    return v1.minor_ver >= v2.minor_ver;
-
-  return v1.major_ver > v2.major_ver;
-}
+using ESVersion = std::pair<int,int>;
+static constexpr ESVersion ES_V5{5,0};
 
 struct ESInfo {
   std::string name;
@@ -143,21 +120,43 @@ struct ESInfo {
   ESVersion version;
 
   void decode_json(JSONObj *obj);
+
+  std::string get_version_str(){
+    return std::to_string(version.first) + "." + std::to_string(version.second);
+  }
 };
+
+// simple wrapper structure to wrap the es version nested type
+struct es_version_decoder {
+  ESVersion version;
+
+  int parse_version(const std::string& s) {
+    int major, minor;
+    int ret = sscanf(s.c_str(), "%d.%d", &major, &minor);
+    if (ret < 0) {
+      return ret;
+    }
+    version = std::make_pair(major,minor);
+    return 0;
+  }
+
+  void decode_json(JSONObj *obj) {
+    std::string s;
+    JSONDecoder::decode_json("number",s,obj);
+    if (parse_version(s) < 0)
+      throw JSONDecoder::err("Failed to parse ElasticVersion");
+  }
+};
+
 
 void ESInfo::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("name", name, obj);
   JSONDecoder::decode_json("cluster_name", cluster_name, obj);
   JSONDecoder::decode_json("cluster_uuid", cluster_uuid, obj);
-  JSONDecoder::decode_json("version", version, obj);
-}
-
-void ESVersion::decode_json(JSONObj *obj)
-{
-  std::string s;
-  JSONDecoder::decode_json("number", s, obj);
-  this->from_str(s.c_str());
+  es_version_decoder esv;
+  JSONDecoder::decode_json("version", esv, obj);
+  version = std::move(esv.version);
 }
 
 struct ElasticConfig {
@@ -585,11 +584,11 @@ public:
 
       yield {
         string path = conf->get_index_path();
-        ldout(sync_env->cct, 5) << "got elastic version=" << es_info.version.to_str() << dendl;
+        ldout(sync_env->cct, 5) << "got elastic version=" << es_info.get_version_str() << dendl;
 
         es_index_settings settings(conf->num_replicas, conf->num_shards);
         es_index_mappings mappings;
-        if (es_info.version >= ESVersion(5,0)) {
+        if (es_info.version >= ES_V5) {
           ldout(sync_env->cct, 0) << "elasticsearch: using text type for string index mappings " << dendl;
           mappings.string_type = ESType::Text;
         }

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -565,10 +565,15 @@ public:
   int operate() override {
     reenter(this) {
       ldout(sync_env->cct, 0) << ": init elasticsearch config zone=" << sync_env->source_zone << dendl;
-      yield call(new RGWReadRESTResourceCR<ESInfo> (sync_env->cct,
-                                                    conf->conn.get(),
-                                                    sync_env->http_manager,
-                                                    "/", nullptr, &es_info));
+      yield {
+        auto hdrs = make_param_list(&conf->default_headers);
+        call(new RGWReadRESTResourceCR<ESInfo> (sync_env->cct,
+                                                conf->conn.get(),
+                                                sync_env->http_manager,
+                                                "/", nullptr /*params*/,
+                                                &hdrs,
+                                                &es_info));
+      }
       if (retcode < 0) {
         return set_cr_error(retcode);
       }

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "rgw_b64.h"
 #include "rgw_common.h"
 #include "rgw_coroutine.h"
 #include "rgw_sync_module.h"
@@ -170,6 +171,7 @@ struct ElasticConfig {
   ItemList allow_owners;
   uint32_t num_shards{0};
   uint32_t num_replicas{0};
+  std::map <string,string> default_headers = {{ "Content-Type", "application/json" }};
 
   void init(CephContext *cct, const JSONFormattable& config) {
     string elastic_endpoint = config["endpoint"];
@@ -184,6 +186,12 @@ struct ElasticConfig {
       num_shards = ES_NUM_SHARDS_MIN;
     }
     num_replicas = config["num_replicas"](ES_NUM_REPLICAS_DEFAULT);
+    if (string user = config["username"], pw = config["password"];
+        !user.empty() && !pw.empty()) {
+      auto auth_string = user + ":" + pw;
+      default_headers.emplace("AUTHORIZATION", "Basic " + rgw::to_base64(auth_string));
+    }
+
   }
 
   void init_instance(const RGWRealm& realm, uint64_t instance_id) {
@@ -565,15 +573,12 @@ public:
   int operate() override {
     reenter(this) {
       ldout(sync_env->cct, 0) << ": init elasticsearch config zone=" << sync_env->source_zone << dendl;
-      yield {
-        auto hdrs = make_param_list(&conf->default_headers);
-        call(new RGWReadRESTResourceCR<ESInfo> (sync_env->cct,
-                                                conf->conn.get(),
-                                                sync_env->http_manager,
-                                                "/", nullptr /*params*/,
-                                                &hdrs,
-                                                &es_info));
-      }
+      yield call(new RGWReadRESTResourceCR<ESInfo> (sync_env->cct,
+                                                    conf->conn.get(),
+                                                    sync_env->http_manager,
+                                                    "/", nullptr /*params*/,
+                                                    &(conf->default_headers),
+                                                    &es_info));
       if (retcode < 0) {
         return set_cr_error(retcode);
       }
@@ -590,12 +595,11 @@ public:
         }
 
         es_index_config index_conf(settings, mappings);
-        std::map <string, string> hdrs = {{ "Content-Type", "application/json" }};
         call(new RGWPutRESTResourceCR<es_index_config, int> (sync_env->cct,
                                                              conf->conn.get(),
                                                              sync_env->http_manager,
                                                              path, nullptr /*params*/,
-                                                             &hdrs,
+                                                             &(conf->default_headers),
                                                              index_conf, nullptr));
       }
       if (retcode < 0) {
@@ -626,11 +630,10 @@ public:
         string path = conf->get_obj_path(bucket_info, key);
         es_obj_metadata doc(sync_env->cct, conf, bucket_info, key, mtime, size, attrs, versioned_epoch);
 
-        std::map <string, string> hdrs = {{ "Content-Type", "application/json" }};
         call(new RGWPutRESTResourceCR<es_obj_metadata, int>(sync_env->cct, conf->conn.get(),
                                                             sync_env->http_manager,
                                                             path, nullptr /* params */,
-                                                            &hdrs,
+                                                            &(conf->default_headers),
                                                             doc, nullptr /* result */));
 
       }

--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -167,12 +167,46 @@ struct ElasticConfig {
 
 using ElasticConfigRef = std::shared_ptr<ElasticConfig>;
 
+std::optional<const char*> es_type_to_str(const ESType& t) {
+  switch (t) {
+  case ESType::String: return "string";
+  case ESType::Text: return "text";
+  case ESType::Keyword: return "keyword";
+  case ESType::Long: return "long";
+  case ESType::Integer: return "integer";
+  case ESType::Short: return "short";
+  case ESType::Byte: return "byte";
+  case ESType::Double: return "double";
+  case ESType::Float: return "float";
+  case ESType::Half_Float: return "half_float";
+  case ESType::Scaled_Float: return "scaled_float";
+  case ESType::Date: return "date";
+  case ESType::Boolean: return "boolean";
+  case ESType::Integer_Range: return "integer_range";
+  case ESType::Float_Range: return "float_range";
+  case ESType::Double_Range: return "date_range";
+  case ESType::Date_Range: return "date_range";
+  case ESType::Geo_Point: return "geo_point";
+  case ESType::Ip: return "ip";
+  default:
+    return std::nullopt;
+  }
+
+}
+
 struct es_dump_type {
   const char *type;
   const char *format;
   bool analyzed;
+  std::string default_type;
 
   es_dump_type(const char *t, const char *f = nullptr, bool a = false) : type(t), format(f), analyzed(a) {}
+
+  es_dump_type(ESType t, const char *f = nullptr, bool a = false,
+               std::string default_type="text"): format(f), analyzed(a),
+                                                 default_type(default_type) {
+    type = es_type_to_str(t).value_or(default_type.c_str());
+  }
 
   void dump(Formatter *f) const {
     encode_json("type", type, f);
@@ -186,37 +220,45 @@ struct es_dump_type {
 };
 
 struct es_index_mappings {
+  ESType string_type {ESType::String};
+
   void dump_custom(Formatter *f, const char *section, const char *type, const char *format) const {
     f->open_object_section(section);
     ::encode_json("type", "nested", f);
     f->open_object_section("properties");
-    encode_json("name", es_dump_type("string"), f);
+    encode_json("name", es_dump_type(string_type), f);
     encode_json("value", es_dump_type(type, format), f);
     f->close_section(); // entry
     f->close_section(); // custom-string
   }
+
+  void dump_custom(Formatter *f, const char* section, ESType t, const char *format) const {
+    const auto s = es_type_to_str(t).value_or("text");
+    dump_custom(f,section,s,format);
+  }
+
   void dump(Formatter *f) const {
     f->open_object_section("object");
     f->open_object_section("properties");
-    encode_json("bucket", es_dump_type("string"), f);
-    encode_json("name", es_dump_type("string"), f);
-    encode_json("instance", es_dump_type("string"), f);
-    encode_json("versioned_epoch", es_dump_type("long"), f);
+    encode_json("bucket", es_dump_type(string_type), f);
+    encode_json("name", es_dump_type(string_type), f);
+    encode_json("instance", es_dump_type(string_type), f);
+    encode_json("versioned_epoch", es_dump_type(ESType::Date), f);
     f->open_object_section("meta");
     f->open_object_section("properties");
-    encode_json("cache_control", es_dump_type("string"), f);
-    encode_json("content_disposition", es_dump_type("string"), f);
-    encode_json("content_encoding", es_dump_type("string"), f);
-    encode_json("content_language", es_dump_type("string"), f);
-    encode_json("content_type", es_dump_type("string"), f);
-    encode_json("etag", es_dump_type("string"), f);
-    encode_json("expires", es_dump_type("string"), f);
+    encode_json("cache_control", es_dump_type(string_type), f);
+    encode_json("content_disposition", es_dump_type(string_type), f);
+    encode_json("content_encoding", es_dump_type(string_type), f);
+    encode_json("content_language", es_dump_type(string_type), f);
+    encode_json("content_type", es_dump_type(string_type), f);
+    encode_json("etag", es_dump_type(string_type), f);
+    encode_json("expires", es_dump_type(string_type), f);
     f->open_object_section("mtime");
     ::encode_json("type", "date", f);
     ::encode_json("format", "strict_date_optional_time||epoch_millis", f);
     f->close_section(); // mtime
-    encode_json("size", es_dump_type("long"), f);
-    dump_custom(f, "custom-string", "string", nullptr);
+    encode_json("size", es_dump_type(ESType::Long), f);
+    dump_custom(f, "custom-string", string_type, nullptr);
     dump_custom(f, "custom-int", "long", nullptr);
     dump_custom(f, "custom-date", "date", "strict_date_optional_time||epoch_millis");
     f->close_section(); // properties

--- a/src/rgw/rgw_sync_module_es.h
+++ b/src/rgw/rgw_sync_module_es.h
@@ -6,6 +6,33 @@
 
 #include "rgw_sync_module.h"
 
+enum class ESType {
+  /* string datatypes */
+  String, /* Deprecated Since 5.X+ */
+  Text,
+  Keyword,
+
+  /* Numeric Types */
+  Long, Integer, Short, Byte, Double, Float, Half_Float, Scaled_Float,
+
+  /* Date Type */
+  Date,
+
+  /* Boolean */
+  Boolean,
+
+  /* Binary; Must Be Base64 Encoded */
+  Binary,
+
+  /* Range Types */
+  Integer_Range, Float_Range, Long_Range, Double_Range, Date_Range,
+
+  /* A Few Specialized Types */
+  Geo_Point,
+  Ip
+};
+
+
 class RGWElasticSyncModule : public RGWSyncModule {
 public:
   RGWElasticSyncModule() {}


### PR DESCRIPTION
For ES endpoints terminated with a username and password, either via xpack or
fronted by another webserver with http basic auth, we now support "username" and
"password" configurable which should be capable of doing HTTP basic
authentication

Fixes: https://tracker.ceph.com/issues/23655

This is built atop of https://github.com/ceph/ceph/pull/21852 and basically first adds support for headers in get http crs, and then adds these headers as a part of all the ES requests 