### PR TITLE
mgr/dashboard: Deletion dialog falsely executes deletion when pressing 'Cancel'

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.html
@@ -7,7 +7,6 @@
   <ng-container class="modal-content">
     <form name="deletionForm"
           #formDir="ngForm"
-          (submit)="delete($event)"
           [formGroup]="deletionForm"
           novalidate>
       <div class="modal-body">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.ts
@@ -74,10 +74,6 @@ export class DeletionModalComponent implements OnInit {
     this.confirmation.updateValueAndValidity();
   }
 
-  delete ($event) {
-    this.submitButton.submit($event);
-  }
-
   deletionCall() {
     if (this.deletionObserver) {
       this.deletionObserver().subscribe(


### PR DESCRIPTION
This is a backport of PR #22003.

If a deletion fails and the 'Cancel' button is pressed to close the dialog, then the deletion process is triggered again.

Signed-off-by: Volker Theile <vtheile@suse.com>
(cherry picked from commit 0473b02872f9dbc1993ec5d6686484c24986e85c)