### PR TITLE
[DNM] rgw: Implementation of STS AssumeRole.

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1541,5 +1541,7 @@ OPTION(rgw_max_objs_per_shard, OPT_INT)
 OPTION(rgw_reshard_thread_interval, OPT_U32) // maximum time between rounds of reshard thread processing
 
 OPTION(rgw_acl_grants_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html), An ACL can have up to 100 grants.
+
 OPTION(rgw_cors_rules_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html), An cors can have up to 100 rules.
 OPTION(rgw_sts_entry, OPT_STR)
+OPTION(rgw_sts_key, OPT_STR)

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1542,3 +1542,4 @@ OPTION(rgw_reshard_thread_interval, OPT_U32) // maximum time between rounds of r
 
 OPTION(rgw_acl_grants_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html), An ACL can have up to 100 grants.
 OPTION(rgw_cors_rules_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html), An cors can have up to 100 rules.
+OPTION(rgw_sts_entry, OPT_STR)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5091,7 +5091,7 @@ std::vector<Option> get_rgw_options() {
         "will be located in the path that is specified here. "),
 
     Option("rgw_enable_apis", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("s3, s3website, swift, swift_auth, admin")
+    .set_default("s3, s3website, swift, swift_auth, admin, sts")
     .set_description("A list of set of RESTful APIs that rgw handles."),
 
     Option("rgw_cache_enabled", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -6345,6 +6345,12 @@ std::vector<Option> get_rgw_options() {
 			  "increasing this value may cause some operations to "
 			  "take longer in exceptional cases and thus may, "
 			  "rarely, cause clients to time out."),
+
+    Option("rgw_sts_entry", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("sts")
+    .set_description("STS URL prefix")
+    .set_long_description("URL path prefix for internal STS requests.")
+
   });
 }
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6349,7 +6349,12 @@ std::vector<Option> get_rgw_options() {
     Option("rgw_sts_entry", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("sts")
     .set_description("STS URL prefix")
-    .set_long_description("URL path prefix for internal STS requests.")
+    .set_long_description("URL path prefix for internal STS requests."),
+
+    Option("rgw_sts_key", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("sts")
+    .set_description("STS Key")
+    .set_long_description("Key used for encrypting/ decrypting session token.")
 
   });
 }

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -142,7 +142,8 @@ set(rgw_a_srcs
   rgw_swift_auth.cc
   rgw_usage.cc
   rgw_opa.cc
-  sts-assume-role.cc)
+  sts-assume-role.cc
+  rgw_rest_sts.cc)
 
 gperf_generate(${CMAKE_SOURCE_DIR}/src/rgw/rgw_iam_policy_keywords.gperf
   rgw_iam_policy_keywords.frag.cc)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -141,7 +141,8 @@ set(rgw_a_srcs
   rgw_rest_user.cc
   rgw_swift_auth.cc
   rgw_usage.cc
-  rgw_opa.cc)
+  rgw_opa.cc
+  sts-assume-role.cc)
 
 gperf_generate(${CMAKE_SOURCE_DIR}/src/rgw/rgw_iam_policy_keywords.gperf
   rgw_iam_policy_keywords.frag.cc)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -109,7 +109,9 @@ set(librgw_common_srcs
   rgw_crypt.cc
   rgw_crypt_sanitize.cc
   rgw_iam_policy.cc
-)
+  rgw_sts.cc
+  rgw_rest_sts.cc)
+
 add_library(rgw_common OBJECT ${librgw_common_srcs})
 
 if(WITH_LTTNG)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -142,7 +142,7 @@ set(rgw_a_srcs
   rgw_swift_auth.cc
   rgw_usage.cc
   rgw_opa.cc
-  sts-assume-role.cc
+  rgw_sts.cc
   rgw_rest_sts.cc)
 
 gperf_generate(${CMAKE_SOURCE_DIR}/src/rgw/rgw_iam_policy_keywords.gperf

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5021,21 +5021,14 @@ int main(int argc, const char **argv)
         cerr << "ERROR: assume role policy document is empty" << std::endl;
         return -EINVAL;
       }
-      /* The following two calls will be replaced by read_decode_json or something
-         similar when the code for AWS Policies is in places */
-      bufferlist bl;
-      int ret = read_input(assume_role_doc, bl);
-      if (ret < 0) {
-        cerr << "ERROR: failed to read input: " << cpp_strerror(-ret) << std::endl;
-        return ret;
-      }
-      JSONParser p;
-      if (!p.parse(bl.c_str(), bl.length())) {
-        cout << "ERROR: failed to parse JSON: " << assume_role_doc << std::endl;
+      bufferlist bl = bufferlist::static_from_string(assume_role_doc);
+      try {
+        const rgw::IAM::Policy p(g_ceph_context, tenant, bl);
+      } catch (rgw::IAM::PolicyParseException& e) {
+        cerr << "failed to parse policy: " << e.what() << std::endl;
         return -EINVAL;
       }
-      string trust_policy = bl.to_str();
-      RGWRole role(g_ceph_context, store, role_name, path, trust_policy, tenant);
+      RGWRole role(g_ceph_context, store, role_name, path, assume_role_doc, tenant);
       ret = role.create(true);
       if (ret < 0) {
         return -ret;
@@ -5137,28 +5130,20 @@ int main(int argc, const char **argv)
         return -EINVAL;
       }
 
-      /* The following two calls will be replaced by read_decode_json or something
-         similar, when code for AWS Policies is in place.*/
-      bufferlist bl;
-      int ret = read_input(perm_policy_doc, bl);
-      if (ret < 0) {
-        cerr << "ERROR: failed to read input: " << cpp_strerror(-ret) << std::endl;
-        return ret;
-      }
-      JSONParser p;
-      if (!p.parse(bl.c_str(), bl.length())) {
-        cout << "ERROR: failed to parse JSON: " << std::endl;
+      bufferlist bl = bufferlist::static_from_string(perm_policy_doc);
+      try {
+        const rgw::IAM::Policy p(g_ceph_context, tenant, bl);
+      } catch (rgw::IAM::PolicyParseException& e) {
+        cerr << "failed to parse perm policy: " << e.what() << std::endl;
         return -EINVAL;
       }
-      string perm_policy;
-      perm_policy = bl.c_str();
 
       RGWRole role(g_ceph_context, store, role_name, tenant);
       ret = role.get();
       if (ret < 0) {
         return -ret;
       }
-      role.set_perm_policy(policy_name, perm_policy);
+      role.set_perm_policy(policy_name, perm_policy_doc);
       ret = role.update();
       if (ret < 0) {
         return -ret;

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -33,15 +33,18 @@ transform_old_authinfo(const req_state* const s)
     const rgw_user id;
     const int perm_mask;
     const bool is_admin;
+    const uint32_t type;
   public:
     DummyIdentityApplier(CephContext* const cct,
                          const rgw_user& auth_id,
                          const int perm_mask,
-                         const bool is_admin)
+                         const bool is_admin,
+                         const uint32_t type)
       : cct(cct),
         id(auth_id),
         perm_mask(perm_mask),
-        is_admin(is_admin) {
+        is_admin(is_admin),
+        type(type) {
     }
 
     uint32_t get_perms_from_aclspec(const aclspec_t& aclspec) const override {
@@ -75,6 +78,14 @@ transform_old_authinfo(const req_state* const s)
       return perm_mask;
     }
 
+    uint32_t get_identity_type() const override {
+      return type;
+    }
+
+    string get_acct_name() const override {
+      return {};
+    }
+
     void to_str(std::ostream& out) const override {
       out << "RGWDummyIdentityApplier(auth_id=" << id
           << ", perm_mask=" << perm_mask
@@ -88,7 +99,8 @@ transform_old_authinfo(const req_state* const s)
                                  s->perm_mask,
   /* System user has admin permissions by default - it's supposed to pass
    * through any security check. */
-                                 s->system_request));
+                                 s->system_request,
+                                 s->user->type));
 }
 
 } /* namespace auth */
@@ -449,7 +461,6 @@ void rgw::auth::RemoteApplier::load_acct_info(RGWUserInfo& user_info) const     
   /* Succeeded if we are here (create_account() hasn't throwed). */
 }
 
-
 /* rgw::auth::LocalApplier */
 /* static declaration */
 const std::string rgw::auth::LocalApplier::NO_SUBUSER;
@@ -517,7 +528,6 @@ void rgw::auth::LocalApplier::load_acct_info(RGWUserInfo& user_info) const /* ou
    * to RADOS may be safely skipped in this case. */
   user_info = this->user_info;
 }
-
 
 rgw::auth::Engine::result_t
 rgw::auth::AnonymousEngine::authenticate(const req_state* const s) const

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -68,6 +68,12 @@ public:
   /* Verify whether a given identity corresponds to an identity in the
      provided set */
   virtual bool is_identity(const idset_t& ids) const = 0;
+
+  /* Identity Type: RGW/ LDAP/ Keystone */
+  virtual uint32_t get_identity_type() const = 0;
+
+  /* Name of Account */
+  virtual string get_acct_name() const = 0;
 };
 
 inline std::ostream& operator<<(std::ostream& out,
@@ -422,6 +428,8 @@ public:
   uint32_t get_perm_mask() const override { return info.perm_mask; }
   void to_str(std::ostream& out) const override;
   void load_acct_info(RGWUserInfo& user_info) const override; /* out */
+  uint32_t get_identity_type() const override { return info.acct_type; }
+  string get_acct_name() const override { return info.acct_name; }
 
   struct Factory {
     virtual ~Factory() {}
@@ -470,6 +478,8 @@ public:
   }
   void to_str(std::ostream& out) const override;
   void load_acct_info(RGWUserInfo& user_info) const override; /* out */
+  uint32_t get_identity_type() const override { return TYPE_RGW; }
+  string get_acct_name() const override { return {}; }
 
   struct Factory {
     virtual ~Factory() {}

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -80,6 +80,14 @@ public:
     return get_decoratee().get_perm_mask();
   }
 
+  uint32_t get_identity_type() const override {
+    return get_decoratee().get_identity_type();
+  }
+
+  string get_acct_name() const override {
+    return get_decoratee().get_acct_name();
+  }
+
   bool is_identity(
     const boost::container::flat_set<Principal>& ids) const override {
     return get_decoratee().is_identity(ids);

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -97,6 +97,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_NO_ROLE_FOUND, {404, "NoSuchEntity"}},
     { ERR_NO_CORS_FOUND, {404, "NoSuchCORSConfiguration"}},
     { ERR_NO_SUCH_SUBUSER, {404, "NoSuchSubUser"}},
+    { ERR_NO_SUCH_ENTITY, {404, "NoSuchEntity"}},
     { ERR_METHOD_NOT_ALLOWED, {405, "MethodNotAllowed" }},
     { ETIMEDOUT, {408, "RequestTimeout" }},
     { EEXIST, {409, "BucketAlreadyExists" }},

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -138,6 +138,10 @@ rgw_http_errors rgw_http_swift_errors({
     { ERR_ZERO_IN_URL, {412, "Invalid UTF8 or contains NULL"}},
 });
 
+rgw_http_errors rgw_http_sts_errors({
+    { ERR_PACKED_POLICY_TOO_LARGE, {400, "PackedPolicyTooLarge" }},
+});
+
 int rgw_perf_start(CephContext *cct)
 {
   PerfCountersBuilder plb(cct, "rgw", l_rgw_first, l_rgw_last);
@@ -323,6 +327,11 @@ void set_req_state_err(struct rgw_err& err,	/* out */
 
   if (prot_flags & RGW_REST_SWIFT) {
     if (search_err(rgw_http_swift_errors, err_no, err.http_ret, err.err_code))
+      return;
+  }
+
+  if (prot_flags & RGW_REST_STS) {
+    if (search_err(rgw_http_sts_errors, err_no, err.http_ret, err.err_code))
       return;
   }
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -133,6 +133,7 @@ using ceph::crypto::MD5;
 #define RGW_REST_SWIFT_AUTH     0x2
 #define RGW_REST_S3             0x4
 #define RGW_REST_WEBSITE     0x8
+#define RGW_REST_STS            0x10
 
 #define RGW_SUSPENDED_USER_AUID (uint64_t)-2
 
@@ -221,6 +222,8 @@ using ceph::crypto::MD5;
 #define ERR_NO_CORS_FOUND        2216
 
 #define ERR_BUSY_RESHARDING      2300
+// STS Errors
+#define ERR_PACKED_POLICY_TOO_LARGE 2400
 
 #ifndef UINT32_MAX
 #define UINT32_MAX (0xffffffffu)
@@ -511,6 +514,8 @@ enum RGWOpType {
   RGW_OP_CONFIG_BUCKET_META_SEARCH,
   RGW_OP_GET_BUCKET_META_SEARCH,
   RGW_OP_DEL_BUCKET_META_SEARCH,
+  /* sts specific*/
+  RGW_STS_ASSUME_ROLE,
 };
 
 class RGWAccessControlPolicy;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -107,6 +107,7 @@ using ceph::crypto::MD5;
 /* IAM Policy */
 #define RGW_ATTR_IAM_POLICY	RGW_ATTR_PREFIX "iam-policy"
 
+#define RGW_ATTR_USER_POLICY    RGW_ATTR_PREFIX "user-policy"
 
 /* RGW File Attributes */
 #define RGW_ATTR_UNIX_KEY1      RGW_ATTR_PREFIX "unix-key1"
@@ -222,6 +223,8 @@ using ceph::crypto::MD5;
 #define ERR_NO_CORS_FOUND        2216
 
 #define ERR_BUSY_RESHARDING      2300
+#define ERR_NO_SUCH_ENTITY       2301
+
 // STS Errors
 #define ERR_PACKED_POLICY_TOO_LARGE 2400
 
@@ -646,6 +649,7 @@ struct RGWUserInfo
   RGWQuotaInfo user_quota;
   uint32_t type;
   set<string> mfa_ids;
+  string assumed_role_arn;
 
   RGWUserInfo()
     : suspended(0),
@@ -664,7 +668,7 @@ struct RGWUserInfo
   }
 
   void encode(bufferlist& bl) const {
-     ENCODE_START(20, 9, bl);
+     ENCODE_START(21, 9, bl);
      encode((uint64_t)0, bl); // old auid
      string access_key;
      string secret_key;
@@ -706,6 +710,7 @@ struct RGWUserInfo
      encode(admin, bl);
      encode(type, bl);
      encode(mfa_ids, bl);
+     encode(assumed_role_arn, bl);
      ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator& bl) {
@@ -786,6 +791,9 @@ struct RGWUserInfo
     }
     if (struct_v >= 20) {
       decode(mfa_ids, bl);
+    }
+    if (struct_v >= 21) {
+      decode(assumed_role_arn, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -12,6 +12,8 @@ extern rgw_http_errors rgw_http_s3_errors;
 
 extern rgw_http_errors rgw_http_swift_errors;
 
+extern rgw_http_errors rgw_http_sts_errors;
+
 static inline int rgw_http_error_to_errno(int http_err)
 {
   if (http_err >= 200 && http_err <= 299)

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -98,6 +98,8 @@ static constexpr std::uint64_t s3DeleteObjectVersionTagging = 1ULL << 53;
 static constexpr std::uint64_t s3Count = 54;
 static constexpr std::uint64_t s3All = (1ULL << s3Count) - 1;
 
+static constexpr std::uint64_t stsAssumeRole = 1ULL << 55;
+
 namespace {
 inline int op_to_perm(std::uint64_t op) {
   switch (op) {
@@ -431,6 +433,9 @@ struct Statement {
   Effect eval(const Environment& e,
 	      boost::optional<const rgw::auth::Identity&> ida,
 	      std::uint64_t action, const ARN& resource) const;
+
+  Effect eval_principal(const Environment& e,
+		       boost::optional<const rgw::auth::Identity&> ida) const;
 };
 
 std::ostream& operator <<(ostream& m, const Statement& s);
@@ -458,6 +463,9 @@ struct Policy {
   Effect eval(const Environment& e,
 	      boost::optional<const rgw::auth::Identity&> ida,
 	      std::uint64_t action, const ARN& resource) const;
+
+  Effect eval_principal(const Environment& e,
+	      boost::optional<const rgw::auth::Identity&> ida) const;
 
   template <typename F>
   bool has_conditional(const string& conditional, F p) const {

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -342,12 +342,13 @@ int main(int argc, const char **argv)
 
   // S3 website mode is a specialization of S3
   const bool s3website_enabled = apis_map.count("s3website") > 0;
+  const bool sts_enabled = apis_map.count("sts") > 0;
   // Swift API entrypoint could placed in the root instead of S3
   const bool swift_at_root = g_conf()->rgw_swift_url_prefix == "/";
   if (apis_map.count("s3") > 0 || s3website_enabled) {
     if (! swift_at_root) {
       rest.register_default_mgr(set_logging(rest_filter(store, RGW_REST_S3,
-                                                        new RGWRESTMgr_S3(s3website_enabled))));
+                                                        new RGWRESTMgr_S3(s3website_enabled, sts_enabled))));
     } else {
       derr << "Cannot have the S3 or S3 Website enabled together with "
            << "Swift API placed in the root of hierarchy" << dendl;
@@ -402,11 +403,6 @@ int main(int argc, const char **argv)
     admin_resource->register_resource("config", new RGWRESTMgr_Config);
     admin_resource->register_resource("realm", new RGWRESTMgr_Realm);
     rest.register_resource(g_conf()->rgw_admin_entry, admin_resource);
-  }
-
-  if (apis_map.count("sts") > 0) {
-    auto *sts = new RGWRESTMgr_STS;
-    rest.register_resource(g_conf->rgw_sts_entry, set_logging(sts));
   }
 
   /* Initialize the registry of auth strategies which will coordinate

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -28,6 +28,7 @@
 #include "rgw_rest_opstate.h"
 #include "rgw_rest_config.h"
 #include "rgw_rest_realm.h"
+#include "rgw_rest_sts.h"
 #include "rgw_swift_auth.h"
 #include "rgw_log.h"
 #include "rgw_tools.h"
@@ -401,6 +402,11 @@ int main(int argc, const char **argv)
     admin_resource->register_resource("config", new RGWRESTMgr_Config);
     admin_resource->register_resource("realm", new RGWRESTMgr_Realm);
     rest.register_resource(g_conf()->rgw_admin_entry, admin_resource);
+  }
+
+  if (apis_map.count("sts") > 0) {
+    auto *sts = new RGWRESTMgr_STS;
+    rest.register_resource(g_conf->rgw_sts_entry, set_logging(sts));
   }
 
   /* Initialize the registry of auth strategies which will coordinate

--- a/src/rgw/rgw_rest_role.h
+++ b/src/rgw/rgw_rest_role.h
@@ -11,6 +11,7 @@ protected:
   string policy_name;
   string perm_policy;
   string path_prefix;
+  string max_session_duration;
 
 public:
   int verify_permission() override;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -44,6 +44,9 @@
 #include "rgw_crypt_sanitize.h"
 
 #include "include/assert.h"
+#include "rgw_role.h"
+#include "rgw_rest_sts.h"
+#include "rgw_sts.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -3006,6 +3009,11 @@ RGWOp *RGWHandler_REST_Service_S3::op_post()
     if (action.compare("DeleteRolePolicy") == 0)
       return new RGWDeleteRolePolicy;
   }
+  if (this->isSTSenabled) {
+    RGWHandler_REST_STS sts_handler(auth_registry);
+    sts_handler.init(store, s, s->cio);
+    return sts_handler.get_op(store);
+  }
   return NULL;
 }
 
@@ -3502,7 +3510,7 @@ RGWHandler_REST* RGWRESTMgr_S3::get_handler(struct req_state* const s,
     }
   } else {
     if (s->init_state.url_bucket.empty()) {
-      handler = new RGWHandler_REST_Service_S3(auth_registry);
+      handler = new RGWHandler_REST_Service_S3(auth_registry, enable_sts);
     } else if (s->object.empty()) {
       handler = new RGWHandler_REST_Bucket_S3(auth_registry);
     } else {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -498,7 +498,7 @@ public:
 
 class RGWHandler_REST_S3 : public RGWHandler_REST {
   friend class RGWRESTMgr_S3;
-
+protected:
   const rgw::auth::StrategyRegistry& auth_registry;
 public:
   static int init_from_header(struct req_state *s, int default_formatter, bool configurable_format);
@@ -520,6 +520,7 @@ public:
 
 class RGWHandler_REST_Service_S3 : public RGWHandler_REST_S3 {
 protected:
+    bool isSTSenabled;
     bool is_usage_op() {
     return s->info.args.exists("usage");
   }
@@ -527,7 +528,9 @@ protected:
   RGWOp *op_head() override;
   RGWOp *op_post() override;
 public:
-  using RGWHandler_REST_S3::RGWHandler_REST_S3;
+   RGWHandler_REST_Service_S3(const rgw::auth::StrategyRegistry& auth_registry,
+                              bool isSTSenabled) :
+      RGWHandler_REST_S3(auth_registry), isSTSenabled(isSTSenabled) {}
   ~RGWHandler_REST_Service_S3() override = default;
 };
 
@@ -591,9 +594,11 @@ public:
 class RGWRESTMgr_S3 : public RGWRESTMgr {
 private:
   bool enable_s3website;
+  bool enable_sts;
 public:
-  explicit RGWRESTMgr_S3(bool enable_s3website = false)
-    : enable_s3website(enable_s3website) {
+  explicit RGWRESTMgr_S3(bool enable_s3website = false, bool enable_sts = false)
+    : enable_s3website(enable_s3website),
+      enable_sts(enable_sts) {
   }
 
   ~RGWRESTMgr_S3() override = default;

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -35,7 +35,7 @@
 
 int RGWREST_STS::verify_permission()
 {
-  STS::STSService _sts(s->cct, store, s->user->user_id);
+  STS::STSService _sts(s->cct, store, s->user->user_id, s->auth.identity.get());
   sts = std::move(_sts);
 
   string rArn = s->info.args.get("RoleArn");

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -22,7 +22,7 @@
 #include "rgw_iam_policy.h"
 #include "rgw_iam_policy_keywords.h"
 
-#include "sts-assume-role.h"
+#include "rgw_sts.h"
 
 #include <array>
 #include <sstream>

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -35,7 +35,7 @@
 
 int RGWREST_STS::verify_permission()
 {
-  STS::STSService _sts(s->cct, store);
+  STS::STSService _sts(s->cct, store, s->user->user_id);
   sts = std::move(_sts);
 
   string rArn = s->info.args.get("RoleArn");

--- a/src/rgw/rgw_rest_sts.cc
+++ b/src/rgw/rgw_rest_sts.cc
@@ -1,0 +1,161 @@
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/format.hpp>
+#include <boost/optional.hpp>
+#include <boost/utility/in_place_factory.hpp>
+
+#include "include/assert.h"
+#include "ceph_ver.h"
+
+#include "common/Formatter.h"
+#include "common/utf8.h"
+#include "common/ceph_json.h"
+
+#include "rgw_rest.h"
+#include "rgw_auth.h"
+#include "rgw_auth_s3.h"
+#include "rgw_rest_sts.h"
+#include "rgw_formats.h"
+#include "rgw_client_io.h"
+
+#include "rgw_request.h"
+#include "rgw_process.h"
+
+#include "sts-assume-role.h"
+
+#include <array>
+#include <sstream>
+#include <memory>
+
+#include <boost/utility/string_ref.hpp>
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rgw
+
+int RGWREST_STS::verify_permission()
+{
+  return 0;
+}
+
+void RGWREST_STS::send_response()
+{
+  if (op_ret) {
+    set_req_state_err(s, op_ret);
+  }
+  dump_errno(s);
+  end_header(s);
+}
+
+int RGWSTSAssumeRole::get_params()
+{
+  duration = s->info.args.get("DurationSeconds");
+  externalId = s->info.args.get("ExternalId");
+  policy = s->info.args.get("Policy");
+  roleArn = s->info.args.get("RoleArn");
+  roleSessionName = s->info.args.get("RoleSessionName");
+  serialNumber = s->info.args.get("SerialNumber");
+  tokenCode = s->info.args.get("TokenCode");
+
+  if (roleArn.empty() || roleSessionName.empty()) {
+    ldout(s->cct, 20) << "ERROR: one of role arn or role session name is empty" << dendl;
+    return -EINVAL;
+  }
+
+  JSONParser p;
+  if (!p.parse(policy.c_str(), policy.length())) {
+    ldout(s->cct, 20) << "ERROR: failed to parse policy doc" << dendl;
+    return -ERR_MALFORMED_DOC;
+  }
+
+  return 0;
+}
+
+void RGWSTSAssumeRole::execute()
+{
+  STS::AssumeRoleRequest req(duration, externalId, policy, roleArn,
+                        roleSessionName, serialNumber, tokenCode);
+  STS::STSService sts(s->cct, store);
+  const auto& [op_ret, assumedRoleUser, creds, packedPolicySize] = sts.assumeRole(req);
+
+  //Dump the output
+  if (op_ret == 0) {
+    s->formatter->open_object_section("AssumeRole");
+    assumedRoleUser.dump(s->formatter);
+    creds.dump(s->formatter);
+    encode_json("PackedPolicySize", packedPolicySize , s->formatter);
+    s->formatter->close_section();
+  }
+}
+
+RGWOp *RGWHandler_REST_STS::op_post()
+{
+  if (s->info.args.exists("Action"))    {
+    if (string action = s->info.args.get("Action"); action == "AssumeRole") {
+      return new RGWSTSAssumeRole;
+    }
+  }
+  return nullptr;
+}
+
+int RGWHandler_REST_STS::init(RGWRados *store,
+                              struct req_state *s,
+                              rgw::io::BasicClient *cio)
+{
+  s->dialect = "sts";
+
+  if (int ret = RGWHandler_REST_STS::init_from_header(s, RGW_FORMAT_JSON, true); ret < 0) {
+    ldout(s->cct, 10) << "init_from_header returned err=" << ret <<  dendl;
+    return ret;
+  }
+
+  return RGWHandler_REST::init(store, s, cio);
+}
+
+int RGWHandler_REST_STS::init_from_header(struct req_state* s,
+                                          int default_formatter,
+                                          bool configurable_format)
+{
+  string req;
+  string first;
+
+  s->prot_flags |= RGW_REST_STS;
+
+  const char *p, *req_name;
+  if (req_name = s->relative_uri.c_str(); *req_name == '?') {
+    p = req_name;
+  } else {
+    p = s->info.request_params.c_str();
+  }
+
+  s->info.args.set(p);
+  s->info.args.parse();
+
+  /* must be called after the args parsing */
+  if (int ret = allocate_formatter(s, default_formatter, configurable_format); ret < 0)
+    return ret;
+
+  if (*req_name != '/')
+    return 0;
+
+  req_name++;
+
+  if (!*req_name)
+    return 0;
+
+  req = req_name;
+  int pos = req.find('/');
+  if (pos >= 0) {
+    first = req.substr(0, pos);
+  } else {
+    first = req;
+  }
+
+  return 0;
+}
+
+RGWHandler_REST*
+RGWRESTMgr_STS::get_handler(struct req_state* const s,
+                              const rgw::auth::StrategyRegistry& auth_registry,
+                              const std::string& frontend_prefix)
+{
+  return new RGWHandler_REST_STS(auth_registry);
+}

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -1,8 +1,13 @@
 #ifndef CEPH_RGW_REST_STS_H
 #define CEPH_RGW_REST_STS_H
 
+#include "sts-assume-role.h"
+
 class RGWREST_STS : public RGWRESTOp {
+protected:
+  STS::STSService sts;
 public:
+  RGWREST_STS() = default;
   int verify_permission() override;
   void send_response() override;
 };

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -1,0 +1,64 @@
+#ifndef CEPH_RGW_REST_STS_H
+#define CEPH_RGW_REST_STS_H
+
+class RGWREST_STS : public RGWRESTOp {
+public:
+  int verify_permission() override;
+  void send_response() override;
+};
+
+class RGWSTSAssumeRole : public RGWREST_STS {
+protected:
+  string duration;
+  string externalId;
+  string policy;
+  string roleArn;
+  string roleSessionName;
+  string serialNumber;
+  string tokenCode;
+public:
+  RGWSTSAssumeRole() = default;
+  void execute() override;
+  int get_params();
+  const string name() override { return "assume_role"; }
+  RGWOpType get_type() override { return RGW_STS_ASSUME_ROLE; }
+};
+
+class RGWHandler_REST_STS : public RGWHandler_REST {
+  const rgw::auth::StrategyRegistry& auth_registry;
+  RGWOp *op_post() override;
+public:
+  static int init_from_header(struct req_state *s, int default_formatter, bool configurable_format);
+
+  RGWHandler_REST_STS(const rgw::auth::StrategyRegistry& auth_registry)
+    : RGWHandler_REST(),
+      auth_registry(auth_registry) {}
+  ~RGWHandler_REST_STS() override = default;
+
+  int init(RGWRados *store,
+           struct req_state *s,
+           rgw::io::BasicClient *cio) override;
+  int authorize() override {
+    return RGW_Auth_S3::authorize(store, auth_registry, s);
+  }
+  int postauth_init() override { return 0; }
+};
+
+class RGWRESTMgr_STS : public RGWRESTMgr {
+public:
+  RGWRESTMgr_STS() = default;
+  ~RGWRESTMgr_STS() override = default;
+  
+  RGWRESTMgr *get_resource_mgr(struct req_state* const s,
+                               const std::string& uri,
+                               std::string* const out_uri) override {
+    return this;
+  }
+
+  RGWHandler_REST* get_handler(struct req_state*,
+                               const rgw::auth::StrategyRegistry&,
+                               const std::string&) override;
+};
+
+#endif /* CEPH_RGW_REST_STS_H */
+

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -25,7 +25,7 @@ public:
   RGWSTSAssumeRole() = default;
   void execute() override;
   int get_params();
-  const string name() override { return "assume_role"; }
+  const char* name() const override { return "assume_role"; }
   RGWOpType get_type() override { return RGW_STS_ASSUME_ROLE; }
 };
 

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -1,7 +1,7 @@
 #ifndef CEPH_RGW_REST_STS_H
 #define CEPH_RGW_REST_STS_H
 
-#include "sts-assume-role.h"
+#include "rgw_sts.h"
 
 class RGWREST_STS : public RGWRESTOp {
 protected:

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -276,6 +276,7 @@ void RGWRole::dump(Formatter *f) const
   encode_json("path", path, f);
   encode_json("arn", arn, f);
   encode_json("create_date", creation_date, f);
+  encode_json("max_session_duration", max_session_duration, f);
   encode_json("assume_role_policy_document", trust_policy, f);
 }
 
@@ -286,6 +287,7 @@ void RGWRole::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("path", path, obj);
   JSONDecoder::decode_json("arn", arn, obj);
   JSONDecoder::decode_json("create_date", creation_date, obj);
+  JSONDecoder::decode_json("max_session_duration", max_session_duration, obj);
   JSONDecoder::decode_json("assume_role_policy_document", trust_policy, obj);
 }
 
@@ -394,6 +396,11 @@ bool RGWRole::validate_input()
     return false;
   }
 
+  if (max_session_duration < SESSION_DURATION_MIN ||
+          max_session_duration > SESSION_DURATION_MAX) {
+    ldout(cct, 0) << "ERROR: Invalid session duration, should be between 3600 and 43200 seconds " << dendl;
+    return false;
+  }
   return true;
 }
 

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -58,7 +58,7 @@ public:
     if (this->path.empty())
       this->path = "/";
     extract_name_tenant(this->name);
-    if (! max_session_duration_str.empty()) {
+    if (max_session_duration_str.empty()) {
       max_session_duration = SESSION_DURATION_MIN;
     } else {
       max_session_duration = std::stoull(max_session_duration_str);

--- a/src/rgw/rgw_role.h
+++ b/src/rgw/rgw_role.h
@@ -16,6 +16,8 @@ class RGWRole
   static const string role_arn_prefix;
   static constexpr int MAX_ROLE_NAME_LEN = 64;
   static constexpr int MAX_PATH_NAME_LEN = 512;
+  static constexpr uint64_t SESSION_DURATION_MIN = 3600; // in seconds
+  static constexpr uint64_t SESSION_DURATION_MAX = 43200; // in seconds
 
   CephContext *cct;
   RGWRados *store;
@@ -27,6 +29,7 @@ class RGWRole
   string trust_policy;
   map<string, string> perm_policy_map;
   string tenant;
+  uint64_t max_session_duration;
 
   int store_info(bool exclusive);
   int store_name(bool exclusive);
@@ -44,7 +47,8 @@ public:
           string name,
           string path,
           string trust_policy,
-          string tenant)
+          string tenant,
+          string max_session_duration_str="")
   : cct(cct),
     store(store),
     name(std::move(name)),
@@ -54,6 +58,11 @@ public:
     if (this->path.empty())
       this->path = "/";
     extract_name_tenant(this->name);
+    if (! max_session_duration_str.empty()) {
+      max_session_duration = SESSION_DURATION_MIN;
+    } else {
+      max_session_duration = std::stoull(max_session_duration_str);
+    }
   }
 
   RGWRole(CephContext *cct,
@@ -84,7 +93,7 @@ public:
   ~RGWRole() = default;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     encode(id, bl);
     encode(name, bl);
     encode(path, bl);
@@ -93,6 +102,7 @@ public:
     encode(trust_policy, bl);
     encode(perm_policy_map, bl);
     encode(tenant, bl);
+    encode(max_session_duration, bl);
     ENCODE_FINISH(bl);
   }
 
@@ -108,6 +118,9 @@ public:
     if (struct_v >= 2) {
       decode(tenant, bl);
     }
+    if (struct_v >= 3) {
+      decode(max_session_duration, bl);
+    }
     DECODE_FINISH(bl);
   }
 
@@ -116,6 +129,7 @@ public:
   const string& get_path() const { return path; }
   const string& get_create_date() const { return creation_date; }
   const string& get_assume_role_policy() const { return trust_policy;}
+  const uint64_t& get_max_session_duration() const { return max_session_duration; }
 
   int create(bool exclusive);
   int delete_obj();

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -20,7 +20,7 @@
 #include "rgw_role.h"
 #include "rgw_user.h"
 #include "rgw_iam_policy.h"
-#include "sts-assume-role.h"
+#include "rgw_sts.h"
 
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -64,11 +64,8 @@ int Credentials::generateCredentials(CephContext* cct,
   if (! cryptohandler) {
     return -EINVAL;
   }
-  char secret_s[] = {
-    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
-  };
-  buffer::ptr secret(secret_s, sizeof(secret_s));
+  string secret_s = cct->_conf->rgw_sts_key;
+  buffer::ptr secret(secret_s.c_str(), secret_s.length());
   int ret = 0;
   if (ret = cryptohandler->validate_secret(secret); ret < 0) {
     ldout(cct, 0) << "ERROR: Invalid secret key" << dendl;

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -2,6 +2,7 @@
 #define CEPH_RGW_STS_H
 
 #include "rgw_role.h"
+#include "rgw_auth.h"
 
 namespace STS {
 
@@ -59,6 +60,52 @@ public:
   void dump(Formatter *f) const;
 };
 
+struct SessionToken {
+  string access_key_id;
+  string secret_access_key;
+  string expiration;
+  string policy;
+  string roleId;
+  rgw_user user;
+  string acct_name;
+  uint32_t perm_mask;
+  bool is_admin;
+  uint32_t acct_type;
+
+  SessionToken() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(access_key_id, bl);
+    encode(secret_access_key, bl);
+    encode(expiration, bl);
+    encode(policy, bl);
+    encode(roleId, bl);
+    encode(user, bl);
+    encode(acct_name, bl);
+    encode(perm_mask, bl);
+    encode(is_admin, bl);
+    encode(acct_type, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(access_key_id, bl);
+    decode(secret_access_key, bl);
+    decode(expiration, bl);
+    decode(policy, bl);
+    decode(roleId, bl);
+    decode(user, bl);
+    decode(acct_name, bl);
+    decode(perm_mask, bl);
+    decode(is_admin, bl);
+    decode(acct_type, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(SessionToken)
+
 class Credentials {
   static constexpr int MAX_ACCESS_KEY_LEN = 20;
   static constexpr int MAX_SECRET_KEY_LEN = 40;
@@ -69,8 +116,10 @@ class Credentials {
 public:
   int generateCredentials(CephContext* cct,
                           const uint64_t& duration,
-                          const string& policy,
-                          const string& roleId);
+                          const boost::optional<string>& policy,
+                          const boost::optional<string>& roleId,
+                          boost::optional<rgw_user> user,
+                          rgw::auth::Identity* identity);
   const string& getAccessKeyId() const { return accessKeyId; }
   const string& getExpiration() const { return expiration; }
   const string& getSecretAccessKey() const { return secretAccessKey; }
@@ -86,10 +135,11 @@ class STSService {
   RGWRados *store;
   rgw_user user_id;
   RGWRole role;
+  rgw::auth::Identity* identity;
   int storeARN(string& arn);
 public:
   STSService() = default;
-  STSService(CephContext* _cct, RGWRados *_store, rgw_user _user_id) : cct(_cct), store(_store), user_id(_user_id) {}
+  STSService(CephContext* cct, RGWRados *store, rgw_user user_id, rgw::auth::Identity* identity) : cct(cct), store(store), user_id(user_id), identity(identity) {}
   std::tuple<int, RGWRole> getRoleInfo(const string& arn);
   AssumeRoleResponse assumeRole(AssumeRoleRequest& req);
 };

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -1,5 +1,5 @@
-#ifndef CEPH_STS_ASSUME_ROLE_H
-#define CEPH_STS_ASSUME_ROLE_H
+#ifndef CEPH_RGW_STS_H
+#define CEPH_RGW_STS_H
 
 #include "rgw_role.h"
 
@@ -90,5 +90,5 @@ public:
   AssumeRoleResponse assumeRole(AssumeRoleRequest& req);
 };
 }
-#endif /* CEPH_STS_ASSUME_ROLE_H */
+#endif /* CEPH_RGW_STS_H */
 

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -60,13 +60,17 @@ public:
 };
 
 class Credentials {
-  static constexpr int MAX_ACCESS_KEY_LEN = 64;
+  static constexpr int MAX_ACCESS_KEY_LEN = 20;
+  static constexpr int MAX_SECRET_KEY_LEN = 40;
   string accessKeyId;
   string expiration;
   string secretAccessKey;
   string sessionToken;
 public:
-  int generateCredentials(CephContext* cct, const uint64_t& duration);
+  int generateCredentials(CephContext* cct,
+                          const uint64_t& duration,
+                          const string& policy,
+                          const string& roleId);
   const string& getAccessKeyId() const { return accessKeyId; }
   const string& getExpiration() const { return expiration; }
   const string& getSecretAccessKey() const { return secretAccessKey; }
@@ -82,7 +86,7 @@ class STSService {
   RGWRados *store;
   rgw_user user_id;
   RGWRole role;
-  int _storeARNandPolicy(string& policy, string& arn);
+  int storeARN(string& arn);
 public:
   STSService() = default;
   STSService(CephContext* _cct, RGWRados *_store, rgw_user _user_id) : cct(_cct), store(_store), user_id(_user_id) {}

--- a/src/rgw/sts-assume-role.cc
+++ b/src/rgw/sts-assume-role.cc
@@ -1,0 +1,145 @@
+#include <errno.h>
+#include <ctime>
+#include <regex>
+#include <boost/format.hpp>
+#include <boost/algorithm/string/replace.hpp>
+
+#include "common/errno.h"
+#include "common/Formatter.h"
+#include "common/ceph_json.h"
+#include "common/ceph_time.h"
+#include "rgw_rados.h"
+#include "auth/Crypto.h"
+#include "include/ceph_fs.h"
+
+#include "include/types.h"
+#include "rgw_string.h"
+
+#include "rgw_common.h"
+#include "rgw_tools.h"
+#include "rgw_role.h"
+#include "sts-assume-role.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+namespace STS {
+  
+int Credentials::generateCredentials(CephContext* cct)
+{
+  uuid_d accessKey, secretKey;
+  char accessKeyId_str[MAX_ACCESS_KEY_LEN], secretAccessKey_str[MAX_ACCESS_KEY_LEN];
+
+  //AccessKeyId
+  accessKey.generate_random();
+  accessKey.print(accessKeyId_str);
+  accessKeyId = accessKeyId_str;
+
+  //SecretAccessKey
+  secretKey.generate_random();
+  secretKey.print(secretAccessKey_str);
+  secretAccessKey = secretAccessKey_str;
+
+  //Expiration
+  real_clock::time_point t = real_clock::now();
+
+  struct timeval tv;
+  real_clock::to_timeval(t, tv);
+  tv.tv_sec += EXPIRATION_TIME_IN_SECS;
+
+  struct tm result;
+  gmtime_r(&tv.tv_sec, &result);
+  int usec = (int)tv.tv_usec/1000;
+  expiration = boost::str(boost::format("%s-%s-%sT%s:%s:%s.%sZ")
+                                         % (result.tm_year + 1900)
+                                         % (result.tm_mon + 1)
+                                         % result.tm_mday
+                                         % result.tm_hour
+                                         % result.tm_min
+                                         % result.tm_sec
+                                         % usec);
+
+  //Session Token - Encrypt using AES & base64 encode the result
+  auto* cryptohandler = cct->get_crypto_handler(CEPH_CRYPTO_AES);
+  if (! cryptohandler) {
+    return -EINVAL;
+  }
+  char secret_s[] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+  };
+  bufferptr secret(secret_s, sizeof(secret_s));
+  int ret = 0;
+  if (ret = cryptohandler->validate_secret(secret); ret < 0) {
+    ldout(cct, 0) << "ERROR: Invalid secret key" << dendl;
+    return ret;
+  }
+  string error;
+  auto* keyhandler = cryptohandler->get_key_handler(secret, error);
+  if (! keyhandler) {
+    return -EINVAL;
+  }
+  error.clear();
+  string encrypted_str, input_str = "acess_key_id=" + accessKeyId + "&" +
+                     "secret_access_key=" + secretAccessKey + "&" +
+                     "expiration=" + expiration;
+  bufferlist input, enc_output;
+  input.append(input_str);
+  if (ret = keyhandler->encrypt(input, enc_output, &error); ret < 0) {
+    return ret;
+  }
+
+  enc_output.append('\0');
+  encrypted_str = enc_output.c_str();
+
+  std::string decoded_str;
+  bufferlist enc_bp, encoded_op;
+  enc_bp.append(encrypted_str);
+  encoded_op.encode_base64(enc_bp);
+  encoded_op.append('\0');
+  sessionToken = encoded_op.c_str();
+
+  return ret;
+}
+
+int AssumedRoleUser::generateAssumedRoleUser(CephContext* cct,
+                                              RGWRados *store,
+                                              const string& roleArn,
+                                              const string& roleSessionName)
+{
+  auto r_arn = rgw::IAM::ARN::parse(roleArn);
+  string resource = r_arn->resource;
+  boost::replace_first(resource, "role", "assumed-role");
+  resource.append("/");
+  resource.append(roleSessionName);
+  
+  rgw::IAM::ARN assumed_role_arn(rgw::IAM::Partition::aws,
+                                  rgw::IAM::Service::sts,
+                                  "", r_arn->account, resource);
+  arn = assumed_role_arn.to_string();
+
+  //Assumeroleid = roleid:rolesessionname
+  auto pos = r_arn->resource.find_last_of('/');
+  string roleName = r_arn->resource.substr(pos + 1);
+  RGWRole role(cct, store, roleName, r_arn->account);
+  if (int ret = role.get(); ret < 0) {
+    return ret;
+  }
+  assumeRoleId = role.get_id() + ":" + roleSessionName;
+
+  return 0;
+}
+
+AssumeRoleResponse STSService::assumeRole(const AssumeRoleRequest& req)
+{
+  AssumedRoleUser user;
+  user.generateAssumedRoleUser(cct, store, req.getRoleARN(), req.getRoleSessionName());
+
+  Credentials cred;
+  cred.generateCredentials(cct);
+
+  string policy = req.getPolicy();
+  uint64_t packedPolicySize = (policy.size() / req.getMaxPolicySize()) * 100;
+  return make_tuple(user, cred, packedPolicySize);
+}
+
+}

--- a/src/rgw/sts-assume-role.h
+++ b/src/rgw/sts-assume-role.h
@@ -52,7 +52,7 @@ public:
   int generateAssumedRoleUser( CephContext* cct,
                                 RGWRados *store,
                                 const string& roleId,
-                                const boost::optional<rgw::IAM::ARN>& roleArn,
+                                const rgw::IAM::ARN& roleArn,
                                 const string& roleSessionName);
   const string& getARN() const { return arn; }
   const string& getAssumeRoleId() const { return assumeRoleId; }
@@ -80,9 +80,11 @@ using AssumeRoleResponse = std::tuple<int, AssumedRoleUser, Credentials, uint64_
 class STSService {
   CephContext* cct;
   RGWRados *store;
-  std::tuple<int, boost::optional<rgw::IAM::ARN>, RGWRole> _getRoleInfo(const string& arn);
+  RGWRole role;
 public:
+  STSService() = default;
   STSService(CephContext* _cct, RGWRados *_store) : cct(_cct), store(_store) {}
+  std::tuple<int, RGWRole> getRoleInfo(const string& arn);
   AssumeRoleResponse assumeRole(AssumeRoleRequest& req);
 };
 }

--- a/src/rgw/sts-assume-role.h
+++ b/src/rgw/sts-assume-role.h
@@ -1,0 +1,67 @@
+#ifndef CEPH_STS_ASSUME_ROLE_H
+#define CEPH_STS_ASSUME_ROLE_H
+
+namespace STS {
+
+class AssumeRoleRequest {
+  static constexpr int MAX_POLICY_SIZE = 2048;
+  uint64_t duration;
+  string externalId;
+  string iamPolicy;
+  string roleArn;
+  string roleSessionName;
+  string serialNumber;
+  string tokenCode;
+public:
+  AssumeRoleRequest(uint64_t _duration, string _externalId, string _iamPolicy,
+                    string _roleArn, string _roleSessionName, string _serialNumber,
+                    string _tokenCode)
+                    : duration(_duration), externalId(_externalId), iamPolicy(_iamPolicy),
+                      roleArn(_roleArn), roleSessionName(_roleSessionName),
+                      serialNumber(_serialNumber), tokenCode(_tokenCode) {}
+  string getRoleARN() const { return roleArn; }
+  string getRoleSessionName() const { return roleSessionName; }
+  string getPolicy() const {return iamPolicy; }
+  int getMaxPolicySize() const { return MAX_POLICY_SIZE; }
+};
+
+
+class AssumedRoleUser {
+  string arn;
+  string assumeRoleId;
+public:
+  int generateAssumedRoleUser( CephContext* cct,
+                                RGWRados *store,
+                                const string& roleArn,
+                                const string& roleSessionName);
+  string getARN() const { return arn; }
+  string getAssumeRoleId() const { return assumeRoleId; }
+};
+
+class Credentials {
+  static constexpr int MAX_ACCESS_KEY_LEN = 64;
+  static constexpr int EXPIRATION_TIME_IN_SECS = 86400; // 1 day
+  string accessKeyId;
+  string expiration;
+  string secretAccessKey;
+  string sessionToken;
+public:
+  int generateCredentials(CephContext* cct);
+  string getAccessKeyId() const { return accessKeyId; }
+  string getExpiration() const { return expiration; }
+  string getSecretAccessKey() const { return secretAccessKey; }
+  string getSessionToken() const { return sessionToken; }
+};
+
+using AssumeRoleResponse = std::tuple<AssumedRoleUser, Credentials, uint64_t> ;
+
+class STSService {
+  CephContext* cct;
+  RGWRados *store;
+public:
+  STSService(CephContext* _cct, RGWRados *_store) : cct(_cct), store(_store) {}
+  AssumeRoleResponse assumeRole(const AssumeRoleRequest& req);
+};
+}
+#endif /* CEPH_STS_ASSUME_ROLE_H */
+

--- a/src/rgw/sts-assume-role.h
+++ b/src/rgw/sts-assume-role.h
@@ -80,10 +80,12 @@ using AssumeRoleResponse = std::tuple<int, AssumedRoleUser, Credentials, uint64_
 class STSService {
   CephContext* cct;
   RGWRados *store;
+  rgw_user user_id;
   RGWRole role;
+  int _storeARNandPolicy(string& policy, string& arn);
 public:
   STSService() = default;
-  STSService(CephContext* _cct, RGWRados *_store) : cct(_cct), store(_store) {}
+  STSService(CephContext* _cct, RGWRados *_store, rgw_user _user_id) : cct(_cct), store(_store), user_id(_user_id) {}
   std::tuple<int, RGWRole> getRoleInfo(const string& arn);
   AssumeRoleResponse assumeRole(AssumeRoleRequest& req);
 };

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -105,6 +105,16 @@ public:
     return 0;
   }
 
+  uint32_t get_identity_type() const override {
+    abort();
+    return 0;
+  }
+
+  string get_acct_name() const override {
+    abort();
+    return 0;
+  }
+
   void to_str(std::ostream& out) const override {
     out << id;
   }


### PR DESCRIPTION
1. This is a basic implementation of AssumeRole and is not in the best shape right now, but is tested and we get back security credentials for an assumed role.
2. The secret key used to encrypt the session token is hardcoded right now, and has to be changed to be read from the conf file.
3. The permission evaluation for AssumeRole API call only verifies if the caller is in the trust policy of the role. There is another step to verify whether the caller has a policy which allows it to assume a role - this hasn't been done and will be done once User Policies are in place.
4. This is only the implementation of AssumeRole, in order to use these credentials to authenticate a user, we need to have another piece of code in place.