### PR TITLE
luminous: osd: Don't evict even when preemption has restarted with smaller chunk

### DIFF
--- a/qa/standalone/scrub/osd-recovery-scrub.sh
+++ b/qa/standalone/scrub/osd-recovery-scrub.sh
@@ -127,3 +127,4 @@ main osd-recovery-scrub "$@"
 # Local Variables:
 # compile-command: "cd build ; make -j4 && \
 #    ../qa/run-standalone.sh osd-recovery-scrub.sh"
+# End:

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -56,6 +56,7 @@ function run() {
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
+    CEPH_ARGS+="--osd-skip-data-digest=false "
 
     local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do
@@ -2771,8 +2772,7 @@ function corrupt_scrub_erasure() {
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -2846,8 +2846,7 @@ function corrupt_scrub_erasure() {
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -2953,8 +2952,7 @@ function corrupt_scrub_erasure() {
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -3063,8 +3061,7 @@ function corrupt_scrub_erasure() {
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -3430,8 +3427,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -3510,8 +3506,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -3623,8 +3618,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -3739,8 +3733,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -4093,8 +4086,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -4174,8 +4166,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -4250,8 +4241,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -4363,8 +4353,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -4478,8 +4467,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -3368,8 +3368,7 @@ EOF
             "lost": 0,
             "flags": [
               "dirty",
-              "data_digest",
-              "omap_digest"
+              "data_digest"
             ],
             "truncate_seq": 0,
             "truncate_size": 0,
@@ -3675,8 +3674,7 @@ EOF
             "lost": 0,
             "flags": [
               "dirty",
-              "data_digest",
-              "omap_digest"
+              "data_digest"
             ],
             "truncate_seq": 0,
             "truncate_size": 0,
@@ -3792,8 +3790,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -3889,8 +3886,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -4027,8 +4023,7 @@ EOF
             "lost": 0,
             "flags": [
               "dirty",
-              "data_digest",
-              "omap_digest"
+              "data_digest"
             ],
             "truncate_seq": 0,
             "truncate_size": 0,
@@ -4408,8 +4403,7 @@ EOF
             "lost": 0,
             "flags": [
               "dirty",
-              "data_digest",
-              "omap_digest"
+              "data_digest"
             ],
             "truncate_seq": 0,
             "truncate_size": 0,
@@ -4527,8 +4521,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -4626,8 +4619,7 @@ EOF
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -5122,6 +5122,6 @@ EOF
 main osd-scrub-repair "$@"
 
 # Local Variables:
-# compile-command: "cd ../.. ; make -j4 && \
-#    test/osd/osd-scrub-repair.sh # TEST_corrupt_and_repair_replicated"
+# compile-command: "cd build ; make -j4 && \
+#    ../qa/run-standalone.sh osd-scrub-repair.sh"
 # End:

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -2720,8 +2720,7 @@ function corrupt_scrub_erasure() {
             "lost": 0,
             "flags": [
               "dirty",
-              "data_digest",
-              "omap_digest"
+              "data_digest"
             ],
             "truncate_seq": 0,
             "truncate_size": 0,
@@ -3009,8 +3008,7 @@ function corrupt_scrub_erasure() {
             "lost": 0,
             "flags": [
               "dirty",
-              "data_digest",
-              "omap_digest"
+              "data_digest"
             ],
             "truncate_seq": 0,
             "truncate_size": 0,
@@ -3119,8 +3117,7 @@ function corrupt_scrub_erasure() {
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,
@@ -3215,8 +3212,7 @@ function corrupt_scrub_erasure() {
         "lost": 0,
         "flags": [
           "dirty",
-          "data_digest",
-          "omap_digest"
+          "data_digest"
         ],
         "truncate_seq": 0,
         "truncate_size": 0,

--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -833,7 +833,7 @@ function _scrub_snaps_multi() {
     # Since all of the snapshots on the primary is consistent there are no errors here
     if [ $which = "replica" ];
     then
-        scruberrors="20"
+        scruberrors="21"
         jq "$jqfilter" << EOF | python -c "$sortkeys" > $dir/checkcsjson
 {
     "epoch": 23,
@@ -842,7 +842,7 @@ function _scrub_snaps_multi() {
 EOF
 
 else
-        scruberrors="30"
+        scruberrors="33"
         jq "$jqfilter" << EOF | python -c "$sortkeys" > $dir/checkcsjson
 {
     "epoch": 23,
@@ -917,6 +917,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
+                "head_exists": 1,
                 "snap_context": {
                     "seq": 1,
                     "snaps": [
@@ -942,6 +943,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
+                "head_exists": 1,
                 "snap_context": {
                     "seq": 1,
                     "snaps": [
@@ -958,11 +960,40 @@ else
             ]
         },
         {
+           "errors": [
+             "head_mismatch"
+           ],
+           "locator": "",
+           "name": "obj12",
+           "nspace": "",
+           "snap": "head",
+           "snapset": {
+             "clones": [
+               {
+                 "overlap": "[]",
+                 "size": 1032,
+                 "snap": 1,
+                 "snaps": [
+                   1
+                 ]
+               }
+             ],
+             "head_exists": 0,
+              "snap_context": {
+              "seq": 1,
+              "snaps": [
+                1
+              ]
+            }
+          }
+        },
+        {
             "name": "obj14",
             "nspace": "",
             "locator": "",
             "snap": "head",
             "snapset": {
+                "head_exists": 1,
                 "snap_context": {
                     "seq": 1,
                     "snaps": [
@@ -988,6 +1019,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
+                "head_exists": 1,
                 "snap_context": {
                     "seq": 6,
                     "snaps": [
@@ -1049,6 +1081,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
+                "head_exists": 1,
                 "snap_context": {
                     "seq": 1,
                     "snaps": [
@@ -1070,6 +1103,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
+                "head_exists": 0,
                 "snap_context": {
                     "seq": 0,
                     "snaps": []
@@ -1077,6 +1111,7 @@ else
                 "clones": []
             },
             "errors": [
+                "head_mismatch",
                 "extra_clones"
             ],
             "extra clones": [
@@ -1089,6 +1124,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
+                "head_exists": 1,
                 "snap_context": {
                     "seq": 0,
                     "snaps": [
@@ -1116,6 +1152,7 @@ else
             "locator": "",
             "snap": "head",
             "snapset": {
+                "head_exists": 1,
                 "snap_context": {
                     "seq": 1,
                     "snaps": [

--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -775,5 +775,6 @@ EOF
 main osd-scrub-snaps "$@"
 
 # Local Variables:
-# compile-command: "cd ../.. ; make -j4 && \
-#    test/osd/osd-scrub-snaps.sh"
+# compile-command: "cd build ; make -j4 && \
+#    ../qa/run-standalone.sh osd-scrub-snaps.sh"
+# End:

--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -772,6 +772,465 @@ EOF
     return 0
 }
 
+function _scrub_snaps_multi() {
+    local dir=$1
+    local poolname=test
+    local OBJS=15
+    local OSDS=2
+    local which=$2
+
+    TESTDATA="testdata.$$"
+
+    run_mon $dir a --osd_pool_default_size=$OSDS || return 1
+    run_mgr $dir x || return 1
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd || return 1
+    done
+
+    # Create a pool with a single pg
+    create_pool $poolname 1 1
+    wait_for_clean || return 1
+    poolid=$(ceph osd dump | grep "^pool.*[']test[']" | awk '{ print $2 }')
+
+    dd if=/dev/urandom of=$TESTDATA bs=1032 count=1
+    for i in `seq 1 $OBJS`
+    do
+        rados -p $poolname put obj${i} $TESTDATA
+    done
+
+    local primary=$(get_primary $poolname obj1)
+    local replica=$(get_not_primary $poolname obj1)
+
+    eval create_scenario $dir $poolname $TESTDATA \$$which
+
+    rm -f $TESTDATA
+
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd || return 1
+    done
+
+    local pgid="${poolid}.0"
+    if ! pg_scrub "$pgid" ; then
+        cat $dir/osd.0.log
+        return 1
+    fi
+
+    test "$(grep "_scan_snaps start" $dir/osd.${primary}.log | wc -l)" -gt "3" || return 1
+    test "$(grep "_scan_snaps start" $dir/osd.${replica}.log | wc -l)" -gt "3" || return 1
+
+    rados list-inconsistent-pg $poolname > $dir/json || return 1
+    # Check pg count
+    test $(jq '. | length' $dir/json) = "1" || return 1
+    # Check pgid
+    test $(jq -r '.[0]' $dir/json) = $pgid || return 1
+
+    rados list-inconsistent-obj $pgid --format=json-pretty
+
+    rados list-inconsistent-snapset $pgid > $dir/json || return 1
+
+    # Since all of the snapshots on the primary is consistent there are no errors here
+    if [ $which = "replica" ];
+    then
+        scruberrors="20"
+        jq "$jqfilter" << EOF | python -c "$sortkeys" > $dir/checkcsjson
+{
+    "epoch": 23,
+    "inconsistents": []
+}
+EOF
+
+else
+        scruberrors="30"
+        jq "$jqfilter" << EOF | python -c "$sortkeys" > $dir/checkcsjson
+{
+    "epoch": 23,
+    "inconsistents": [
+        {
+            "name": "obj10",
+            "nspace": "",
+            "locator": "",
+            "snap": 1,
+            "errors": [
+                "size_mismatch"
+            ]
+        },
+        {
+            "name": "obj11",
+            "nspace": "",
+            "locator": "",
+            "snap": 1,
+            "errors": [
+                "headless"
+            ]
+        },
+        {
+            "name": "obj14",
+            "nspace": "",
+            "locator": "",
+            "snap": 1,
+            "errors": [
+                "size_mismatch"
+            ]
+        },
+        {
+            "name": "obj6",
+            "nspace": "",
+            "locator": "",
+            "snap": 1,
+            "errors": [
+                "headless"
+            ]
+        },
+        {
+            "name": "obj7",
+            "nspace": "",
+            "locator": "",
+            "snap": 1,
+            "errors": [
+                "headless"
+            ]
+        },
+        {
+            "name": "obj9",
+            "nspace": "",
+            "locator": "",
+            "snap": 1,
+            "errors": [
+                "size_mismatch"
+            ]
+        },
+        {
+            "name": "obj5",
+            "nspace": "",
+            "locator": "",
+            "snap": 7,
+            "errors": [
+                "info_missing",
+                "headless"
+            ]
+        },
+        {
+            "name": "obj10",
+            "nspace": "",
+            "locator": "",
+            "snap": "head",
+            "snapset": {
+                "snap_context": {
+                    "seq": 1,
+                    "snaps": [
+                        1
+                    ]
+                },
+                "clones": [
+                    {
+                        "snap": 1,
+                        "size": 1032,
+                        "overlap": "????",
+                        "snaps": [
+                            1
+                        ]
+                    }
+                ]
+            },
+            "errors": []
+        },
+        {
+            "name": "obj11",
+            "nspace": "",
+            "locator": "",
+            "snap": "head",
+            "snapset": {
+                "snap_context": {
+                    "seq": 1,
+                    "snaps": [
+                        1
+                    ]
+                },
+                "clones": []
+            },
+            "errors": [
+                "extra_clones"
+            ],
+            "extra clones": [
+                1
+            ]
+        },
+        {
+            "name": "obj14",
+            "nspace": "",
+            "locator": "",
+            "snap": "head",
+            "snapset": {
+                "snap_context": {
+                    "seq": 1,
+                    "snaps": [
+                        1
+                    ]
+                },
+                "clones": [
+                    {
+                        "snap": 1,
+                        "size": 1033,
+                        "overlap": "[]",
+                        "snaps": [
+                            1
+                        ]
+                    }
+                ]
+            },
+            "errors": []
+        },
+        {
+            "name": "obj5",
+            "nspace": "",
+            "locator": "",
+            "snap": "head",
+            "snapset": {
+                "snap_context": {
+                    "seq": 6,
+                    "snaps": [
+                        6,
+                        5,
+                        4,
+                        3,
+                        2,
+                        1
+                    ]
+                },
+                "clones": [
+                    {
+                        "snap": 1,
+                        "size": 1032,
+                        "overlap": "[]",
+                        "snaps": [
+                            1
+                        ]
+                    },
+                    {
+                        "snap": 2,
+                        "size": 256,
+                        "overlap": "[]",
+                        "snaps": [
+                            2
+                        ]
+                    },
+                    {
+                        "snap": 4,
+                        "size": 512,
+                        "overlap": "[]",
+                        "snaps": [
+                            4,
+                            3
+                        ]
+                    },
+                    {
+                        "snap": 6,
+                        "size": 1024,
+                        "overlap": "[]",
+                        "snaps": [
+                            6,
+                            5
+                        ]
+                    }
+                ]
+            },
+            "errors": [
+                "extra_clones"
+            ],
+            "extra clones": [
+                7
+            ]
+        },
+        {
+            "name": "obj6",
+            "nspace": "",
+            "locator": "",
+            "snap": "head",
+            "snapset": {
+                "snap_context": {
+                    "seq": 1,
+                    "snaps": [
+                        1
+                    ]
+                },
+                "clones": []
+            },
+            "errors": [
+                "extra_clones"
+            ],
+            "extra clones": [
+                1
+            ]
+        },
+        {
+            "name": "obj7",
+            "nspace": "",
+            "locator": "",
+            "snap": "head",
+            "snapset": {
+                "snap_context": {
+                    "seq": 0,
+                    "snaps": []
+                },
+                "clones": []
+            },
+            "errors": [
+                "extra_clones"
+            ],
+            "extra clones": [
+                1
+            ]
+        },
+        {
+            "name": "obj8",
+            "nspace": "",
+            "locator": "",
+            "snap": "head",
+            "snapset": {
+                "snap_context": {
+                    "seq": 0,
+                    "snaps": [
+                        1
+                    ]
+                },
+                "clones": [
+                    {
+                        "snap": 1,
+                        "size": 1032,
+                        "overlap": "[]",
+                        "snaps": [
+                            1
+                        ]
+                    }
+                ]
+            },
+            "errors": [
+                "snapset_error"
+            ]
+        },
+        {
+            "name": "obj9",
+            "nspace": "",
+            "locator": "",
+            "snap": "head",
+            "snapset": {
+                "snap_context": {
+                    "seq": 1,
+                    "snaps": [
+                        1
+                    ]
+                },
+                "clones": [
+                    {
+                        "snap": 1,
+                        "size": "????",
+                        "overlap": "[]",
+                        "snaps": [
+                            1
+                        ]
+                    }
+                ]
+            },
+            "errors": []
+        }
+    ]
+}
+EOF
+fi
+
+    jq "$jqfilter" $dir/json | python -c "$sortkeys" > $dir/csjson
+    diff ${DIFFCOLOPTS} $dir/checkcsjson $dir/csjson || test $getjson = "yes" || return 1
+    if test $getjson = "yes"
+    then
+        jq '.' $dir/json > save1.json
+    fi
+
+    if test "$LOCALRUN" = "yes" && which jsonschema > /dev/null;
+    then
+      jsonschema -i $dir/json $CEPH_ROOT/doc/rados/command/list-inconsistent-snap.json || return 1
+    fi
+
+    pidfiles=$(find $dir 2>/dev/null | grep 'osd[^/]*\.pid')
+    pids=""
+    for pidfile in ${pidfiles}
+    do
+        pids+="$(cat $pidfile) "
+    done
+
+    # When removing snapshots with a corrupt replica, it crashes.
+    # See http://tracker.ceph.com/issues/23875
+    if [ $which = "primary" ];
+    then
+        for i in `seq 1 7`
+        do
+            rados -p $poolname rmsnap snap$i
+        done
+    fi
+
+    ERRORS=0
+
+    for pid in $pids
+    do
+        if ! kill -0 $pid
+        then
+            echo "OSD Crash occurred"
+            ERRORS=$(expr $ERRORS + 1)
+        fi
+    done
+
+    kill_daemons $dir || return 1
+
+    declare -a err_strings
+    err_strings[0]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 shard [0-1] missing .*:::obj4:7"
+    err_strings[1]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 shard [0-1]: soid .*:::obj3:head size 3840 != size 768 from auth oi"
+    err_strings[2]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 shard [0-1] missing .*:::obj5:1"
+    err_strings[3]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 shard [0-1] missing .*:::obj5:2"
+    err_strings[4]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 shard [0-1]: soid .*:::obj5:4 size 4608 != size 512 from auth oi"
+    err_strings[5]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 soid .*:::obj5:7: failed to pick suitable object info"
+    err_strings[6]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 shard [0-1] missing .*:::obj1:head"
+    err_strings[7]="log_channel[(]cluster[)] log [[]ERR[]] : [0-9]*[.]0 scrub ${scruberrors} errors"
+
+    for err_string in "${err_strings[@]}"
+    do
+        if ! grep "$err_string" $dir/osd.${primary}.log > /dev/null;
+        then
+            echo "Missing log message '$err_string'"
+            ERRORS=$(expr $ERRORS + 1)
+        fi
+    done
+
+    if [ $ERRORS != "0" ];
+    then
+        echo "TEST FAILED WITH $ERRORS ERRORS"
+        return 1
+    fi
+
+    echo "TEST PASSED"
+    return 0
+}
+
+function TEST_scrub_snaps_replica() {
+    local dir=$1
+    ORIG_ARGS=$CEPH_ARGS
+    CEPH_ARGS+=" --osd_scrub_chunk_min=3 --osd_scrub_chunk_max=3"
+    _scrub_snaps_multi $dir replica
+    err=$?
+    CEPH_ARGS=$ORIG_ARGS
+    return $err
+}
+
+function TEST_scrub_snaps_primary() {
+    local dir=$1
+    ORIG_ARGS=$CEPH_ARGS
+    CEPH_ARGS+=" --osd_scrub_chunk_min=3 --osd_scrub_chunk_max=3"
+    _scrub_snaps_multi $dir primary
+    err=$?
+    CEPH_ARGS=$ORIG_ARGS
+    return $err
+}
+
 main osd-scrub-snaps "$@"
 
 # Local Variables:

--- a/qa/standalone/scrub/osd-scrub-snaps.sh
+++ b/qa/standalone/scrub/osd-scrub-snaps.sh
@@ -20,6 +20,9 @@ source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
 # Set to "yes" in order to ignore diff errors and save results to update test
 getjson="no"
 
+jqfilter='.inconsistents'
+sortkeys='import json; import sys ; JSON=sys.stdin.read() ; ud = json.loads(JSON) ; print json.dumps(ud, sort_keys=True, indent=2)'
+
 function run() {
     local dir=$1
     shift
@@ -37,33 +40,12 @@ function run() {
     done
 }
 
-function TEST_scrub_snaps() {
+function create_scenario() {
     local dir=$1
-    local poolname=test
-    local OBJS=15
-    local OSDS=1
+    local poolname=$2
+    local TESTDATA=$3
+    local osd=$4
 
-    TESTDATA="testdata.$$"
-
-    run_mon $dir a --osd_pool_default_size=$OSDS || return 1
-    run_mgr $dir x || return 1
-    for osd in $(seq 0 $(expr $OSDS - 1))
-    do
-      run_osd $dir $osd || return 1
-    done
-
-    # Create a pool with a single pg
-    create_pool $poolname 1 1
-    wait_for_clean || return 1
-    poolid=$(ceph osd dump | grep "^pool.*[']test[']" | awk '{ print $2 }')
-
-    dd if=/dev/urandom of=$TESTDATA bs=1032 count=1
-    for i in `seq 1 $OBJS`
-    do
-        rados -p $poolname put obj${i} $TESTDATA
-    done
-
-    local primary=$(get_primary $poolname obj1)
     SNAP=1
     rados -p $poolname mksnap snap${SNAP}
     dd if=/dev/urandom of=$TESTDATA bs=256 count=${SNAP}
@@ -107,60 +89,91 @@ function TEST_scrub_snaps() {
 
     # Don't need to use ceph_objectstore_tool() function because osd stopped
 
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj1)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" --force remove
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj1)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" --force remove
 
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --op list obj5 | grep \"snapid\":2)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" remove
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --op list obj5 | grep \"snapid\":2)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" remove
 
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --op list obj5 | grep \"snapid\":1)"
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --op list obj5 | grep \"snapid\":1)"
     OBJ5SAVE="$JSON"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" remove
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" remove
 
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --op list obj5 | grep \"snapid\":4)"
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --op list obj5 | grep \"snapid\":4)"
     dd if=/dev/urandom of=$TESTDATA bs=256 count=18
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" set-bytes $TESTDATA
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" set-bytes $TESTDATA
 
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj3)"
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj3)"
     dd if=/dev/urandom of=$TESTDATA bs=256 count=15
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" set-bytes $TESTDATA
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" set-bytes $TESTDATA
 
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --op list obj4 | grep \"snapid\":7)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" remove
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --op list obj4 | grep \"snapid\":7)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" remove
 
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj2)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" rm-attr snapset
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj2)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" rm-attr snapset
 
     # Create a clone which isn't in snapset and doesn't have object info
     JSON="$(echo "$OBJ5SAVE" | sed s/snapid\":1/snapid\":7/)"
     dd if=/dev/urandom of=$TESTDATA bs=256 count=7
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" set-bytes $TESTDATA
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" set-bytes $TESTDATA
 
-    rm -f $TESTDATA
-
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj6)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" clear-snapset
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj7)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" clear-snapset corrupt
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj8)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" clear-snapset seq
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj9)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" clear-snapset clone_size
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj10)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" clear-snapset clone_overlap
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj11)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" clear-snapset clones
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj12)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" clear-snapset head
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj13)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" clear-snapset snaps
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj14)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" clear-snapset size
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj6)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj7)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset corrupt
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj8)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset seq
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj9)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset clone_size
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj10)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset clone_overlap
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj11)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset clones
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj12)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset head
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj13)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset snaps
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj14)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" clear-snapset size
 
     echo "garbage" > $dir/bad
-    JSON="$(ceph-objectstore-tool --data-path $dir/${primary} --head --op list obj15)"
-    ceph-objectstore-tool --data-path $dir/${primary} "$JSON" set-attr snapset $dir/bad
+    JSON="$(ceph-objectstore-tool --data-path $dir/${osd} --head --op list obj15)"
+    ceph-objectstore-tool --data-path $dir/${osd} "$JSON" set-attr snapset $dir/bad
     rm -f $dir/bad
+}
+
+function TEST_scrub_snaps() {
+    local dir=$1
+    local poolname=test
+    local OBJS=15
+    local OSDS=1
+
+    TESTDATA="testdata.$$"
+
+    run_mon $dir a --osd_pool_default_size=$OSDS || return 1
+    run_mgr $dir x || return 1
+    for osd in $(seq 0 $(expr $OSDS - 1))
+    do
+      run_osd $dir $osd || return 1
+    done
+
+    # Create a pool with a single pg
+    create_pool $poolname 1 1
+    wait_for_clean || return 1
+    poolid=$(ceph osd dump | grep "^pool.*[']test[']" | awk '{ print $2 }')
+
+    dd if=/dev/urandom of=$TESTDATA bs=1032 count=1
+    for i in `seq 1 $OBJS`
+    do
+        rados -p $poolname put obj${i} $TESTDATA
+    done
+
+    local primary=$(get_primary $poolname obj1)
+
+    create_scenario $dir $poolname $TESTDATA $primary
+
+    rm -f $TESTDATA
 
     for osd in $(seq 0 $(expr $OSDS - 1))
     do
@@ -172,7 +185,8 @@ function TEST_scrub_snaps() {
         cat $dir/osd.0.log
         return 1
     fi
-    grep 'log_channel' $dir/osd.0.log
+
+    test "$(grep "_scan_snaps start" $dir/osd.${primary}.log | wc -l)" = "2" || return 1
 
     rados list-inconsistent-pg $poolname > $dir/json || return 1
     # Check pg count
@@ -180,10 +194,22 @@ function TEST_scrub_snaps() {
     # Check pgid
     test $(jq -r '.[0]' $dir/json) = $pgid || return 1
 
-    rados list-inconsistent-snapset $pgid > $dir/json || return 1
+    rados list-inconsistent-obj $pgid > $dir/json || return 1
 
-    local jqfilter='.inconsistents'
-    local sortkeys='import json; import sys ; JSON=sys.stdin.read() ; ud = json.loads(JSON) ; print json.dumps(ud, sort_keys=True, indent=2)'
+    # The injected snapshot errors with a single copy pool doesn't
+    # see object errors because all the issues are detected by
+    # comparing copies.
+    jq "$jqfilter" << EOF | python -c "$sortkeys" > $dir/checkcsjson
+{
+    "epoch": 17,
+    "inconsistents": []
+}
+EOF
+
+    jq "$jqfilter" $dir/json | python -c "$sortkeys" > $dir/csjson
+    diff ${DIFFCOLOPTS} $dir/checkcsjson $dir/csjson || test $getjson = "yes" || return 1
+
+    rados list-inconsistent-snapset $pgid > $dir/json || return 1
 
     jq "$jqfilter" << EOF | python -c "$sortkeys" > $dir/checkcsjson
 {
@@ -676,6 +702,13 @@ EOF
       jsonschema -i $dir/json $CEPH_ROOT/doc/rados/command/list-inconsistent-snap.json || return 1
     fi
 
+    pidfiles=$(find $dir 2>/dev/null | grep 'osd[^/]*\.pid')
+    pids=""
+    for pidfile in ${pidfiles}
+    do
+        pids+="$(cat $pidfile) "
+    done
+
     for i in `seq 1 7`
     do
         rados -p $poolname rmsnap snap$i
@@ -683,14 +716,14 @@ EOF
 
     ERRORS=0
 
-    pidfile=$(find $dir 2>/dev/null | grep $name_prefix'[^/]*\.pid')
-    pid=$(cat $pidfile)
-    if ! kill -0 $pid
-    then
-        echo "OSD crash occurred"
-        tail -100 $dir/osd.0.log
-        ERRORS=$(expr $ERRORS + 1)
-    fi
+    for pid in $pids
+    do
+        if ! kill -0 $pid
+        then
+            echo "OSD Crash occurred"
+            ERRORS=$(expr $ERRORS + 1)
+        fi
+    done
 
     kill_daemons $dir || return 1
 

--- a/qa/standalone/scrub/osd-scrub-test.sh
+++ b/qa/standalone/scrub/osd-scrub-test.sh
@@ -109,5 +109,6 @@ function TEST_scrub_test() {
 main osd-scrub-test "$@"
 
 # Local Variables:
-# compile-command: "cd ../.. ; make -j4 && \
-#    qa/standalone/scrub/osd-scrub-test.sh"
+# compile-command: "cd build ; make -j4 && \
+#    ../qa/run-standalone.sh osd-scrub-test.sh"
+# End:

--- a/qa/suites/fs/basic_functional/tasks/cephfs_scrub_tests.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cephfs_scrub_tests.yaml
@@ -6,7 +6,7 @@ overrides:
       - Metadata damage detected
       - bad backtrace on inode
       - overall HEALTH_
-      - (MDS_TRIM)
+      - \(MDS_TRIM\)
     conf:
       mds:
         mds log max segments: 1

--- a/qa/suites/rados/basic-luminous/scrub_test.yaml
+++ b/qa/suites/rados/basic-luminous/scrub_test.yaml
@@ -16,11 +16,11 @@ overrides:
     - 'deep-scrub 1 missing, 0 inconsistent objects'
     - 'failed to pick suitable auth object'
     - overall HEALTH_
-    - (OSDMAP_FLAGS)
-    - (OSD_
-    - (PG_
-    - (OSD_SCRUB_ERRORS)
-    - (TOO_FEW_PGS)
+    - \(OSDMAP_FLAGS\)
+    - \(OSD_
+    - \(PG_
+    - \(OSD_SCRUB_ERRORS\)
+    - \(TOO_FEW_PGS\)
     conf:
       osd:
         osd deep scrub update digest min age: 0

--- a/qa/suites/rados/basic-luminous/scrub_test.yaml
+++ b/qa/suites/rados/basic-luminous/scrub_test.yaml
@@ -24,5 +24,6 @@ overrides:
     conf:
       osd:
         osd deep scrub update digest min age: 0
+        osd skip data digest: false
 tasks:
 - scrub_test:

--- a/qa/suites/rados/basic/tasks/repair_test.yaml
+++ b/qa/suites/rados/basic/tasks/repair_test.yaml
@@ -18,9 +18,9 @@ overrides:
       - attr name mismatch
       - Regular scrub request, deep-scrub details will be lost
       - overall HEALTH_
-      - (OSDMAP_FLAGS)
-      - (OSD_
-      - (PG_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
     conf:
       osd:
         filestore debug inject read err: true

--- a/qa/suites/rados/multimon/tasks/mon_clock_no_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_no_skews.yaml
@@ -6,6 +6,6 @@ tasks:
     - .*clock.*skew.*
     - clocks not synchronized
     - overall HEALTH_
-    - (MON_CLOCK_SKEW)
+    - \(MON_CLOCK_SKEW\)
 - mon_clock_skew_check:
     expect-skew: false

--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -22,10 +22,10 @@ tasks:
     - failsafe engaged, dropping updates
     - failsafe disengaged, no longer dropping updates
     - overall HEALTH_
-    - (OSDMAP_FLAGS)
-    - (OSD_
-    - (PG_
-    - (SMALLER_PG_NUM)
+    - \(OSDMAP_FLAGS\)
+    - \(OSD_
+    - \(PG_
+    - \(SMALLER_PG_NUM\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
@@ -6,10 +6,10 @@ overrides:
       - MDS in read-only mode
       - force file system read-only
       - overall HEALTH_
-      - (OSDMAP_FLAGS)
-      - (OSD_FULL)
-      - (MDS_READ_ONLY)
-      - (POOL_FULL)
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_FULL\)
+      - \(MDS_READ_ONLY\)
+      - \(POOL_FULL\)
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton/all/divergent_priors.yaml
+++ b/qa/suites/rados/singleton/all/divergent_priors.yaml
@@ -19,9 +19,6 @@ overrides:
       - \(PG_
       - \(OBJECT_
       - \(POOL_APP_NOT_ENABLED\)
-    conf:
-      osd:
-        debug osd: 5
 
 tasks:
 - install:

--- a/qa/suites/rados/singleton/all/divergent_priors2.yaml
+++ b/qa/suites/rados/singleton/all/divergent_priors2.yaml
@@ -19,9 +19,6 @@ overrides:
       - \(PG_
       - \(OBJECT_
       - \(POOL_APP_NOT_ENABLED\)
-    conf:
-      osd:
-        debug osd: 5
 
 tasks:
 - install:

--- a/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
+++ b/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
@@ -16,9 +16,9 @@ tasks:
       - but it is still running
       - slow request
       - overall HEALTH_
-      - (OSDMAP_FLAGS)
-      - (OSD_
-      - (PG_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
 - exec:
     client.0:
       - sudo ceph osd pool create foo 128 128

--- a/qa/suites/rados/singleton/all/random-eio.yaml
+++ b/qa/suites/rados/singleton/all/random-eio.yaml
@@ -19,8 +19,8 @@ tasks:
     - missing primary copy of
     - objects unfound and apparently lost
     - overall HEALTH_
-    - (POOL_APP_NOT_ENABLED)
-    - (PG_DEGRADED)
+    - \(POOL_APP_NOT_ENABLED\)
+    - \(PG_DEGRADED\)
 - full_sequential:
   - exec:
       client.0:

--- a/qa/suites/rados/singleton/all/thrash-eio.yaml
+++ b/qa/suites/rados/singleton/all/thrash-eio.yaml
@@ -25,11 +25,11 @@ tasks:
     - missing primary copy of
     - objects unfound and apparently lost
     - overall HEALTH_
-    - (OSDMAP_FLAGS)
-    - (REQUEST_SLOW)
-    - (PG_
+    - \(OSDMAP_FLAGS\)
+    - \(REQUEST_SLOW\)
+    - \(PG_
     - \(OBJECT_MISPLACED\)
-    - (OSD_
+    - \(OSD_
 - thrashosds:
     op_delay: 30
     clean_interval: 120

--- a/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
+++ b/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
@@ -19,7 +19,7 @@ tasks:
       - but it is still running
       - slow request
       - overall HEALTH_
-      - (CACHE_POOL_
+      - \(CACHE_POOL_
 - exec:
     client.0:
       - sudo ceph osd pool create base 4

--- a/qa/suites/rbd/openstack/base/install.yaml
+++ b/qa/suites/rbd/openstack/base/install.yaml
@@ -4,4 +4,4 @@ tasks:
 overrides:
   ceph:
     log-whitelist:
-      - (POOL_APP_NOT_ENABLED)
+      - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/thrash/thrashers/cache.yaml
+++ b/qa/suites/rbd/thrash/thrashers/cache.yaml
@@ -4,8 +4,8 @@ overrides:
       - but it is still running
       - objects unfound and apparently lost
       - overall HEALTH_
-      - (CACHE_POOL_NEAR_FULL)
-      - (CACHE_POOL_NO_HIT_SET)
+      - \(CACHE_POOL_NEAR_FULL\)
+      - \(CACHE_POOL_NO_HIT_SET\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/smoke/basic/tasks/rados_api_tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_api_tests.yaml
@@ -6,7 +6,7 @@ tasks:
     - reached quota
     - but it is still running
     - objects unfound and apparently lost
-    - (POOL_APP_NOT_ENABLED)
+    - \(POOL_APP_NOT_ENABLED\)
 - thrashosds:
     chance_pgnum_grow: 2
     chance_pgpnum_fix: 1

--- a/qa/suites/upgrade/kraken-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/kraken-x/parallel/0-cluster/start.yaml
@@ -25,7 +25,7 @@ overrides:
     - scrub mismatch
     - ScrubResult
     - wrongly marked
-    - (POOL_APP_NOT_ENABLED)
+    - \(POOL_APP_NOT_ENABLED\)
     - overall HEALTH_
     conf:
       global:

--- a/qa/suites/upgrade/luminous-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/luminous-x/parallel/0-cluster/start.yaml
@@ -25,7 +25,7 @@ overrides:
     - scrub mismatch
     - ScrubResult
     - wrongly marked
-    - (POOL_APP_NOT_ENABLED)
+    - \(POOL_APP_NOT_ENABLED\)
     - overall HEALTH_
     conf:
       global:

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1059,6 +1059,8 @@ def osd_scrub_pgs(ctx, config):
         # allow this to fail; in certain cases the OSD might not be up
         # at this point.  we will catch all pgs below.
         try:
+            manager.raw_cluster_cmd('tell', 'osd.' + id_, 'config', 'set',
+                                    'osd_debug_deep_scrub_sleep', '0');
             manager.raw_cluster_cmd('osd', 'deep-scrub', id_)
         except run.CommandFailedError:
             pass

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -830,6 +830,7 @@ OPTION(osd_debug_misdirected_ops, OPT_BOOL)
 OPTION(osd_debug_skip_full_check_in_recovery, OPT_BOOL)
 OPTION(osd_debug_random_push_read_error, OPT_DOUBLE)
 OPTION(osd_debug_verify_cached_snaps, OPT_BOOL)
+OPTION(osd_debug_deep_scrub_sleep, OPT_FLOAT)
 OPTION(osd_enable_op_tracker, OPT_BOOL) // enable/disable OSD op tracking
 OPTION(osd_num_op_tracker_shard, OPT_U32) // The number of shards for holding the ops
 OPTION(osd_op_history_size, OPT_U32)    // Max number of completed ops to track

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -769,6 +769,8 @@ OPTION(osd_max_scrubs, OPT_INT)
 OPTION(osd_scrub_during_recovery, OPT_BOOL) // Allow new scrubs to start while recovery is active on the OSD
 OPTION(osd_scrub_begin_hour, OPT_INT)
 OPTION(osd_scrub_end_hour, OPT_INT)
+OPTION(osd_scrub_begin_week_day, OPT_INT)
+OPTION(osd_scrub_end_week_day, OPT_INT)
 OPTION(osd_scrub_load_threshold, OPT_FLOAT)
 OPTION(osd_scrub_min_interval, OPT_FLOAT)    // if load is low
 OPTION(osd_scrub_max_interval, OPT_FLOAT)  // regardless of load

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -787,6 +787,8 @@ OPTION(osd_deep_scrub_stride, OPT_INT)
 OPTION(osd_deep_scrub_keys, OPT_INT)
 OPTION(osd_deep_scrub_update_digest_min_age, OPT_INT)   // objects must be this old (seconds) before we update the whole-object digest on scrub
 OPTION(osd_skip_data_digest, OPT_BOOL)
+OPTION(osd_deep_scrub_large_omap_object_key_threshold, OPT_U64)
+OPTION(osd_deep_scrub_large_omap_object_value_sum_threshold, OPT_U64)
 OPTION(osd_class_dir, OPT_STR) // where rados plugins are stored
 OPTION(osd_open_classes_on_start, OPT_BOOL)
 OPTION(osd_class_load_list, OPT_STR) // list of object classes allowed to be loaded (allow all: *)

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -785,6 +785,7 @@ OPTION(osd_deep_scrub_interval, OPT_FLOAT) // once a week
 OPTION(osd_deep_scrub_randomize_ratio, OPT_FLOAT) // scrubs will randomly become deep scrubs at this rate (0.15 -> 15% of scrubs are deep)
 OPTION(osd_deep_scrub_stride, OPT_INT)
 OPTION(osd_deep_scrub_update_digest_min_age, OPT_INT)   // objects must be this old (seconds) before we update the whole-object digest on scrub
+OPTION(osd_skip_data_digest, OPT_BOOL)
 OPTION(osd_class_dir, OPT_STR) // where rados plugins are stored
 OPTION(osd_open_classes_on_start, OPT_BOOL)
 OPTION(osd_class_load_list, OPT_STR) // list of object classes allowed to be loaded (allow all: *)

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -784,6 +784,7 @@ OPTION(osd_scrub_auto_repair_num_errors, OPT_U32)   // only auto-repair when num
 OPTION(osd_deep_scrub_interval, OPT_FLOAT) // once a week
 OPTION(osd_deep_scrub_randomize_ratio, OPT_FLOAT) // scrubs will randomly become deep scrubs at this rate (0.15 -> 15% of scrubs are deep)
 OPTION(osd_deep_scrub_stride, OPT_INT)
+OPTION(osd_deep_scrub_keys, OPT_INT)
 OPTION(osd_deep_scrub_update_digest_min_age, OPT_INT)   // objects must be this old (seconds) before we update the whole-object digest on scrub
 OPTION(osd_skip_data_digest, OPT_BOOL)
 OPTION(osd_class_dir, OPT_STR) // where rados plugins are stored

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2563,6 +2563,10 @@ std::vector<Option> get_global_options() {
     .set_default(524288)
     .set_description(""),
 
+    Option("osd_deep_scrub_keys", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(1024)
+    .set_description(""),
+
     Option("osd_deep_scrub_update_digest_min_age", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(2_hr)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2551,6 +2551,10 @@ std::vector<Option> get_global_options() {
     .set_default(5)
     .set_description(""),
 
+    Option("osd_scrub_max_preemptions", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(5)
+    .set_description("Set the maximum number of times we will preempt a deep scrub due to a client operation before blocking client IO to complete the scrub"),
+
     Option("osd_deep_scrub_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(7_day)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2499,6 +2499,14 @@ std::vector<Option> get_global_options() {
     .set_default(24)
     .set_description(""),
 
+    Option("osd_scrub_begin_week_day", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("The begin week day permits to scrub, include this day, 0 Sunday,1 Monday, .., 6 Saturday"),
+
+    Option("osd_scrub_end_week_day", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(7)
+    .set_description("The end week day permits to scrub, not include this day, 0 Sunday,1 Monday, .., 6 Saturday"),
+
     Option("osd_scrub_load_threshold", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0.5)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1973,6 +1973,10 @@ std::vector<Option> get_global_options() {
     .set_default(8)
     .set_description(""),
 
+    Option("osd_skip_data_digest", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description(""),
+
     Option("osd_op_queue", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("wpq")
     .set_enum_allowed( { "wpq", "prioritized", "mclock_opclass", "mclock_client", "debug_random" } )

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2489,67 +2489,80 @@ std::vector<Option> get_global_options() {
 
     Option("osd_max_scrubs", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1)
-    .set_description(""),
+    .set_description("Maximum concurrent scrubs on a single OSD"),
 
     Option("osd_scrub_during_recovery", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
-    .set_description(""),
+    .set_description("Allow scrubbing when PGs on the OSD are undergoing recovery"),
 
     Option("osd_scrub_begin_hour", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(0)
-    .set_description(""),
+    .set_description("Restrict scrubbing to this hour of the day or later")
+    .add_see_also("osd_scrub_end_hour"),
 
     Option("osd_scrub_end_hour", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(24)
-    .set_description(""),
+    .set_description("Restrict scrubbing to hours of the day earlier than this")
+    .add_see_also("osd_scrub_begin_hour"),
 
     Option("osd_scrub_begin_week_day", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(0)
-    .set_description("The begin week day permits to scrub, include this day, 0 Sunday,1 Monday, .., 6 Saturday"),
+    .set_description("Restrict scrubbing to this day of the week or later")
+    .set_long_description("0 or 7 = Sunday, 1 = Monday, etc.")
+    .add_see_also("osd_scrub_end_week_day"),
 
     Option("osd_scrub_end_week_day", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(7)
-    .set_description("The end week day permits to scrub, not include this day, 0 Sunday,1 Monday, .., 6 Saturday"),
+    .set_description("Restrict scrubbing to days of the week earlier than this")
+    .set_long_description("0 or 7 = Sunday, 1 = Monday, etc.")
+    .add_see_also("osd_scrub_begin_week_day"),
 
     Option("osd_scrub_load_threshold", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0.5)
-    .set_description(""),
+    .set_description("Allow scrubbing when system load divided by number of CPUs is below this value"),
 
     Option("osd_scrub_min_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(1_day)
-    .set_description(""),
+    .set_description("Scrub each PG no more often than this interval")
+    .add_see_also("osd_scrub_max_interval"),
 
     Option("osd_scrub_max_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(7_day)
-    .set_description(""),
+    .set_description("Scrub each PG no less often than this interval")
+    .add_see_also("osd_scrub_min_interval"),
 
     Option("osd_scrub_interval_randomize_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0.5)
-    .set_description(""),
+    .set_description("Ratio of scrub interval to randomly vary")
+    .set_long_description("This prevents a scrub 'stampede' by randomly varying the scrub intervals so that they are soon uniformly distributed over the week")
+    .add_see_also("osd_scrub_min_interval"),
 
-    Option("osd_scrub_backoff_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    Option("osd_scrub_backoff_ratio", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(.66)
-    .set_description(""),
+    .set_description("Backoff ratio after a failed scrub scheduling attempt"),
 
     Option("osd_scrub_chunk_min", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(5)
-    .set_description(""),
+    .set_description("Minimum number of objects to scrub in a single chunk")
+    .add_see_also("osd_scrub_chunk_max"),
 
     Option("osd_scrub_chunk_max", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(25)
-    .set_description(""),
+    .set_description("Maximum number of object to scrub in a single chunk")
+    .add_see_also("osd_scrub_chunk_min"),
 
     Option("osd_scrub_sleep", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
-    .set_description(""),
+    .set_description("Duration to inject a delay during scrubbing"),
 
     Option("osd_scrub_auto_repair", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
-    .set_description(""),
+    .set_description("Automatically repair damaged objects detected during scrub"),
 
     Option("osd_scrub_auto_repair_num_errors", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
-    .set_description(""),
+    .set_description("Maximum number of detected errors to automatically repair")
+    .add_see_also("osd_scrub_auto_repair"),
 
     Option("osd_scrub_max_preemptions", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
@@ -2557,33 +2570,35 @@ std::vector<Option> get_global_options() {
 
     Option("osd_deep_scrub_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(7_day)
-    .set_description(""),
+    .set_description("Deep scrub each PG (i.e., verify data checksums) at least this often"),
 
     Option("osd_deep_scrub_randomize_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0.15)
-    .set_description(""),
+    .set_description("Ratio of deep scrub interval to randomly vary")
+    .set_long_description("This prevents a deep scrub 'stampede' by randomly varying the scrub intervals so that they are soon uniformly distributed over the week")
+    .add_see_also("osd_deep_scrub_interval"),
 
     Option("osd_deep_scrub_stride", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(524288)
-    .set_description(""),
+    .set_description("Number of bytes to read from an object at a time during deep scrub"),
 
     Option("osd_deep_scrub_keys", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1024)
-    .set_description(""),
+    .set_description("Number of keys to read from an object at a time during deep scrub"),
 
     Option("osd_deep_scrub_update_digest_min_age", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(2_hr)
-    .set_description(""),
+    .set_description("Update overall object digest only if object was last modified longer ago than this"),
 
     Option("osd_deep_scrub_large_omap_object_key_threshold", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(2000000)
-    .set_description("threshold for number of keys to determine a large omap object")
+    .set_description("Warn when we encounter an object with more omap keys than this")
     .add_service("osd")
     .add_see_also("osd_deep_scrub_large_omap_object_value_sum_threshold"),
 
     Option("osd_deep_scrub_large_omap_object_value_sum_threshold", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(1_G)
-    .set_description("threshold for summed size (bytes) of all key values to determine a large omap object")
+    .set_description("Warn when we encounter an object with more omap key bytes than this")
     .add_service("osd")
     .add_see_also("osd_deep_scrub_large_omap_object_key_threshold"),
 
@@ -2779,7 +2794,8 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_debug_deep_scrub_sleep", Option::TYPE_FLOAT, Option::LEVEL_DEV)
-    .set_default(0),
+    .set_default(0)
+    .set_description("Inject an expensive sleep during deep scrub IO to make it easier to induce preemption"),
 
     Option("osd_enable_op_tracker", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
@@ -3018,11 +3034,11 @@ std::vector<Option> get_global_options() {
 
     Option("osd_scrub_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
-    .set_description(""),
+    .set_description("Priority for scrub operations in work queue"),
 
     Option("osd_scrub_cost", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(50<<20)
-    .set_description(""),
+    .set_description("Cost for scrub operations in work queue"),
 
     Option("osd_requested_scrub_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(120)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2770,6 +2770,9 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("osd_debug_deep_scrub_sleep", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(0),
+
     Option("osd_enable_op_tracker", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),

--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -24,7 +24,7 @@
 
 struct MOSDRepScrub : public MOSDFastDispatchOp {
 
-  static const int HEAD_VERSION = 7;
+  static const int HEAD_VERSION = 8;
   static const int COMPAT_VERSION = 6;
 
   spg_t pgid;             // PG to scrub
@@ -36,6 +36,7 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
   hobject_t end;         // upper bound of scrub, exclusive
   bool deep;             // true if scrub should be deep
   uint32_t seed;         // seed value for digest calculation
+  bool allow_preemption = false;
 
   epoch_t get_map_epoch() const override {
     return map_epoch;
@@ -54,7 +55,8 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
       seed(0) { }
 
   MOSDRepScrub(spg_t pgid, eversion_t scrub_to, epoch_t map_epoch, epoch_t min_epoch,
-               hobject_t start, hobject_t end, bool deep, uint32_t seed)
+               hobject_t start, hobject_t end, bool deep, uint32_t seed,
+	       bool preemption)
     : MOSDFastDispatchOp(MSG_OSD_REP_SCRUB, HEAD_VERSION, COMPAT_VERSION),
       pgid(pgid),
       scrub_to(scrub_to),
@@ -64,7 +66,8 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
       start(start),
       end(end),
       deep(deep),
-      seed(seed) { }
+      seed(seed),
+      allow_preemption(preemption) { }
 
 
 private:
@@ -73,15 +76,17 @@ private:
 public:
   const char *get_type_name() const override { return "replica scrub"; }
   void print(ostream& out) const override {
-    out << "replica scrub(pg: ";
-    out << pgid << ",from:" << scrub_from << ",to:" << scrub_to
+    out << "replica_scrub(pg: "	<< pgid
+	<< ",from:" << scrub_from
+	<< ",to:" << scrub_to
         << ",epoch:" << map_epoch << "/" << min_epoch
 	<< ",start:" << start << ",end:" << end
         << ",chunky:" << chunky
         << ",deep:" << deep
 	<< ",seed:" << seed
-        << ",version:" << header.version;
-    out << ")";
+        << ",version:" << header.version
+	<< ",allow_preemption:" << (int)allow_preemption
+	<< ")";
   }
 
   void encode_payload(uint64_t features) override {
@@ -96,6 +101,7 @@ public:
     ::encode(pgid.shard, payload);
     ::encode(seed, payload);
     ::encode(min_epoch, payload);
+    ::encode(allow_preemption, payload);
   }
   void decode_payload() override {
     bufferlist::iterator p = payload.begin();
@@ -113,6 +119,9 @@ public:
       ::decode(min_epoch, p);
     } else {
       min_epoch = map_epoch;
+    }
+    if (header.version >= 8) {
+      ::decode(allow_preemption, p);
     }
   }
 };

--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -35,7 +35,6 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
   hobject_t start;       // lower bound of scrub, inclusive
   hobject_t end;         // upper bound of scrub, exclusive
   bool deep;             // true if scrub should be deep
-  uint32_t seed;         // seed value for digest calculation
   bool allow_preemption = false;
 
   epoch_t get_map_epoch() const override {
@@ -51,11 +50,10 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
   MOSDRepScrub()
     : MOSDFastDispatchOp(MSG_OSD_REP_SCRUB, HEAD_VERSION, COMPAT_VERSION),
       chunky(false),
-      deep(false),
-      seed(0) { }
+      deep(false) { }
 
   MOSDRepScrub(spg_t pgid, eversion_t scrub_to, epoch_t map_epoch, epoch_t min_epoch,
-               hobject_t start, hobject_t end, bool deep, uint32_t seed,
+               hobject_t start, hobject_t end, bool deep,
 	       bool preemption)
     : MOSDFastDispatchOp(MSG_OSD_REP_SCRUB, HEAD_VERSION, COMPAT_VERSION),
       pgid(pgid),
@@ -66,7 +64,6 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
       start(start),
       end(end),
       deep(deep),
-      seed(seed),
       allow_preemption(preemption) { }
 
 
@@ -83,7 +80,6 @@ public:
 	<< ",start:" << start << ",end:" << end
         << ",chunky:" << chunky
         << ",deep:" << deep
-	<< ",seed:" << seed
         << ",version:" << header.version
 	<< ",allow_preemption:" << (int)allow_preemption
 	<< ")";
@@ -99,7 +95,7 @@ public:
     ::encode(end, payload);
     ::encode(deep, payload);
     ::encode(pgid.shard, payload);
-    ::encode(seed, payload);
+    ::encode((uint32_t)-1, payload); // seed
     ::encode(min_epoch, payload);
     ::encode(allow_preemption, payload);
   }
@@ -114,7 +110,10 @@ public:
     ::decode(end, p);
     ::decode(deep, p);
     ::decode(pgid.shard, p);
-    ::decode(seed, p);
+    {
+      uint32_t seed;
+      ::decode(seed, p);
+    }
     if (header.version >= 7) {
       ::decode(min_epoch, p);
     } else {

--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -24,7 +24,7 @@
 
 struct MOSDRepScrub : public MOSDFastDispatchOp {
 
-  static const int HEAD_VERSION = 8;
+  static const int HEAD_VERSION = 9;
   static const int COMPAT_VERSION = 6;
 
   spg_t pgid;             // PG to scrub
@@ -36,6 +36,8 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
   hobject_t end;         // upper bound of scrub, exclusive
   bool deep;             // true if scrub should be deep
   bool allow_preemption = false;
+  int32_t priority = 0;
+  bool high_priority = false;
 
   epoch_t get_map_epoch() const override {
     return map_epoch;
@@ -54,7 +56,7 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
 
   MOSDRepScrub(spg_t pgid, eversion_t scrub_to, epoch_t map_epoch, epoch_t min_epoch,
                hobject_t start, hobject_t end, bool deep,
-	       bool preemption)
+	       bool preemption, int prio, bool highprio)
     : MOSDFastDispatchOp(MSG_OSD_REP_SCRUB, HEAD_VERSION, COMPAT_VERSION),
       pgid(pgid),
       scrub_to(scrub_to),
@@ -64,7 +66,9 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
       start(start),
       end(end),
       deep(deep),
-      allow_preemption(preemption) { }
+      allow_preemption(preemption),
+      priority(prio),
+      high_priority(highprio) { }
 
 
 private:
@@ -82,6 +86,8 @@ public:
         << ",deep:" << deep
         << ",version:" << header.version
 	<< ",allow_preemption:" << (int)allow_preemption
+	<< ",priority=" << priority
+	<< (high_priority ? " (high)":"")
 	<< ")";
   }
 
@@ -98,6 +104,8 @@ public:
     ::encode((uint32_t)-1, payload); // seed
     ::encode(min_epoch, payload);
     ::encode(allow_preemption, payload);
+    ::encode(priority, payload);
+    ::encode(high_priority, payload);
   }
   void decode_payload() override {
     bufferlist::iterator p = payload.begin();
@@ -121,6 +129,10 @@ public:
     }
     if (header.version >= 8) {
       ::decode(allow_preemption, p);
+    }
+    if (header.version >= 9) {
+      ::decode(priority, p);
+      ::decode(high_priority, p);
     }
   }
 };

--- a/src/messages/MOSDRepScrubMap.h
+++ b/src/messages/MOSDRepScrubMap.h
@@ -23,13 +23,14 @@
 
 struct MOSDRepScrubMap : public MOSDFastDispatchOp {
 
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
   spg_t pgid;            // primary spg_t
   epoch_t map_epoch = 0;
   pg_shard_t from;   // whose scrubmap this is
   bufferlist scrub_map_bl;
+  bool preempted = false;
 
   epoch_t get_map_epoch() const override {
     return map_epoch;
@@ -54,19 +55,24 @@ public:
   const char *get_type_name() const { return "rep_scrubmap"; }
   void print(ostream& out) const {
     out << "rep_scrubmap(" << pgid << " e" << map_epoch
-	<< " from shard " << from << ")";
+	<< " from shard " << from
+	<< (preempted ? " PREEMPTED":"") << ")";
   }
 
   void encode_payload(uint64_t features) {
     ::encode(pgid, payload);
     ::encode(map_epoch, payload);
     ::encode(from, payload);
+    ::encode(preempted, payload);
   }
   void decode_payload() {
     bufferlist::iterator p = payload.begin();
     ::decode(pgid, p);
     ::decode(map_epoch, p);
     ::decode(from, p);
+    if (header.version >= 2) {
+      ::decode(preempted, p);
+    }
   }
 };
 

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -2049,6 +2049,9 @@ public:
   virtual void inject_mdata_error(const ghobject_t &oid) {}
 
   virtual void compact() {}
+  virtual bool has_builtin_csum() const {
+    return false;
+  }
 };
 WRITE_CLASS_ENCODER(ObjectStore::Transaction)
 WRITE_CLASS_ENCODER(ObjectStore::Transaction::TransactionData)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2417,7 +2417,10 @@ public:
     assert(db);
     db->compact();
   }
-  
+  bool has_builtin_csum() const override {
+    return true;
+  }
+
 private:
   bool _debug_data_eio(const ghobject_t& o) {
     if (!cct->_conf->bluestore_debug_inject_read_err) {

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -647,6 +647,10 @@ public:
     object_map->compact();
   }
 
+  bool has_builtin_csum() const override {
+    return false;
+  }
+
   void debug_obj_on_delete(const ghobject_t &oid);
   bool debug_data_eio(const ghobject_t &oid);
   bool debug_mdata_eio(const ghobject_t &oid);

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2482,7 +2482,10 @@ int ECBackend::be_deep_scrub(
     if (!get_parent()->get_pool().allows_ecoverwrites()) {
       assert(hinfo->has_chunk_hash());
       if (hinfo->get_total_chunk_size() != (unsigned)pos.data_pos) {
-	dout(0) << "_scan_list  " << poid << " got incorrect size on read" << dendl;
+	dout(0) << "_scan_list  " << poid << " got incorrect size on read 0x"
+		<< std::hex << pos
+		<< " expected 0x" << hinfo->get_total_chunk_size() << std::dec
+		<< dendl;
 	o.ec_size_mismatch = true;
 	return 0;
       }
@@ -2490,7 +2493,10 @@ int ECBackend::be_deep_scrub(
       if (!skip_data_digest &&
           hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) !=
 	  pos.data_hash.digest()) {
-	dout(0) << "_scan_list  " << poid << " got incorrect hash on read" << dendl;
+	dout(0) << "_scan_list  " << poid << " got incorrect hash on read 0x"
+		<< std::hex << pos.data_hash.digest() << " !=  expected 0x"
+		<< hinfo->get_chunk_hash(get_parent()->whoami_shard().shard)
+		<< std::dec << dendl;
 	o.ec_hash_mismatch = true;
 	return 0;
       }

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2432,7 +2432,7 @@ void ECBackend::be_deep_scrub(
   sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
   uint64_t pos = 0;
   bool skip_data_digest = store->has_builtin_csum() &&
-    g_conf->get_val<bool>("osd_skip_data_digest");
+    g_conf->osd_skip_data_digest;
 
   uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
                            CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2436,7 +2436,7 @@ int ECBackend::be_deep_scrub(
   sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
 
   if (pos.data_pos == 0) {
-    pos.data_hash = bufferhash(pos.seed);
+    pos.data_hash = bufferhash(-1);
   }
 
   uint64_t stride = cct->_conf->osd_deep_scrub_stride;
@@ -2518,7 +2518,7 @@ int ECBackend::be_deep_scrub(
     }
   }
 
-  o.omap_digest = pos.seed;
+  o.omap_digest = -1;
   o.omap_digest_present = true;
   return 0;
 }

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -763,6 +763,7 @@ bool ECBackend::_handle_message(
     // not conflict with ECSubWrite's operator<<.
     MOSDECSubOpWrite *op = static_cast<MOSDECSubOpWrite*>(
       _op->get_nonconst_req());
+    parent->maybe_preempt_replica_scrub(op->op.soid);
     handle_sub_write(op->op.from, _op, op->op, _op->pg_trace);
     return true;
   }

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2434,6 +2434,10 @@ int ECBackend::be_deep_scrub(
 
   utime_t sleeptime;
   sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
+  if (sleeptime != utime_t()) {
+    lgeneric_derr(cct) << __func__ << " sleeping for " << sleeptime << dendl;
+    sleeptime.sleep();
+  }
 
   if (pos.data_pos == 0) {
     pos.data_hash = bufferhash(-1);

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2429,8 +2429,11 @@ void ECBackend::be_deep_scrub(
   if (stride % sinfo.get_chunk_size())
     stride += sinfo.get_chunk_size() - (stride % sinfo.get_chunk_size());
   uint64_t pos = 0;
+  bool skip_data_digest = store->has_builtin_csum() &&
+    g_conf->get_val<bool>("osd_skip_data_digest");
 
-  uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL | CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
+  uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
+                           CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
 
   while (true) {
     bufferlist bl;
@@ -2449,7 +2452,9 @@ void ECBackend::be_deep_scrub(
       break;
     }
     pos += r;
-    h << bl;
+    if (!skip_data_digest) {
+      h << bl;
+    }
     if ((unsigned)r < stride)
       break;
   }
@@ -2476,7 +2481,8 @@ void ECBackend::be_deep_scrub(
 	return;
       }
 
-      if (hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) != h.digest()) {
+      if (!skip_data_digest &&
+          hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) != h.digest()) {
 	dout(0) << "_scan_list  " << poid << " got incorrect hash on read" << dendl;
 	o.ec_hash_mismatch = true;
 	return;

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -677,12 +677,11 @@ public:
   bool scrub_supported() override { return true; }
   bool auto_repair_supported() const override { return true; }
 
-  void be_deep_scrub(
-    const hobject_t &obj,
-    uint32_t seed,
-    ScrubMap::object &o,
-    ThreadPool::TPHandle &handle,
-    ScrubMap* const map = nullptr) override;
+  int be_deep_scrub(
+    const hobject_t &poid,
+    ScrubMap &map,
+    ScrubMapBuilder &pos,
+    ScrubMap::object &o) override;
   uint64_t be_get_ondisk_size(uint64_t logical_size) override {
     return sinfo.logical_to_next_chunk_offset(logical_size);
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1273,10 +1273,12 @@ bool OSDService::can_inc_scrubs_pending()
 
   if (scrubs_pending + scrubs_active < cct->_conf->osd_max_scrubs) {
     dout(20) << __func__ << " " << scrubs_pending << " -> " << (scrubs_pending+1)
-	     << " (max " << cct->_conf->osd_max_scrubs << ", active " << scrubs_active << ")" << dendl;
+	     << " (max " << cct->_conf->osd_max_scrubs << ", active " << scrubs_active
+	     << ")" << dendl;
     can_inc = true;
   } else {
-    dout(20) << __func__ << scrubs_pending << " + " << scrubs_active << " active >= max " << cct->_conf->osd_max_scrubs << dendl;
+    dout(20) << __func__ << " " << scrubs_pending << " + " << scrubs_active
+	     << " active >= max " << cct->_conf->osd_max_scrubs << dendl;
   }
 
   return can_inc;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7523,6 +7523,25 @@ bool OSD::scrub_time_permit(utime_t now)
   struct tm bdt;
   time_t tt = now.sec();
   localtime_r(&tt, &bdt);
+
+  bool day_permit = false;
+  if (cct->_conf->osd_scrub_begin_week_day < cct->_conf->osd_scrub_end_week_day) {
+    if (bdt.tm_wday >= cct->_conf->osd_scrub_begin_week_day && bdt.tm_wday < cct->_conf->osd_scrub_end_week_day) {
+      day_permit = true;
+    }
+  } else {
+    if (bdt.tm_wday >= cct->_conf->osd_scrub_begin_week_day || bdt.tm_wday < cct->_conf->osd_scrub_end_week_day) {
+      day_permit = true;
+    }
+  }
+
+  if (!day_permit) {
+    dout(20) << __func__ << " should run between week day " << cct->_conf->osd_scrub_begin_week_day
+            << " - " << cct->_conf->osd_scrub_end_week_day
+            << " now " << bdt.tm_wday << " = no" << dendl;
+    return false;
+  }
+
   bool time_permit = false;
   if (cct->_conf->osd_scrub_begin_hour < cct->_conf->osd_scrub_end_hour) {
     if (bdt.tm_hour >= cct->_conf->osd_scrub_begin_hour && bdt.tm_hour < cct->_conf->osd_scrub_end_hour) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4231,45 +4231,62 @@ void PG::_repair_oinfo_oid(ScrubMap &smap)
     }
   }
 }
-
-/*
- * build a scrub map over a chunk without releasing the lock
- * only used by chunky scrub
- */
 int PG::build_scrub_map_chunk(
   ScrubMap &map,
-  hobject_t start, hobject_t end, bool deep, uint32_t seed,
+  ScrubMapBuilder &pos,
+  hobject_t start,
+  hobject_t end,
+  bool deep,
+  uint32_t seed,
   ThreadPool::TPHandle &handle)
 {
   dout(10) << __func__ << " [" << start << "," << end << ") "
-	   << " seed " << seed << dendl;
+	   << " pos " << pos
+	   << dendl;
 
-  map.valid_through = info.last_update;
+  // start
+  while (pos.empty()) {
+    pos.deep = deep;
+    pos.seed = seed;
+    map.valid_through = info.last_update;
+    osr->flush();
 
-  osr->flush();
-
-  // objects
-  vector<hobject_t> ls;
-  vector<ghobject_t> rollback_obs;
-  osr->flush();
-  int ret = get_pgbackend()->objects_list_range(
-    start,
-    end,
-    0,
-    &ls,
-    &rollback_obs);
-  if (ret < 0) {
-    dout(5) << "objects_list_range error: " << ret << dendl;
-    return ret;
+    // objects
+    vector<ghobject_t> rollback_obs;
+    pos.ret = get_pgbackend()->objects_list_range(
+      start,
+      end,
+      0,
+      &pos.ls,
+      &rollback_obs);
+    if (pos.ret < 0) {
+      dout(5) << "objects_list_range error: " << pos.ret << dendl;
+      return pos.ret;
+    }
+    if (pos.ls.empty()) {
+      break;
+    }
+    _scan_rollback_obs(rollback_obs, handle);
+    pos.pos = 0;
+    return -EINPROGRESS;
   }
 
+  // scan objects
+  while (!pos.done()) {
+    int r = get_pgbackend()->be_scan_list(map, pos);
+    if (r == -EINPROGRESS) {
+      return r;
+    }
+  }
 
-  get_pgbackend()->be_scan_list(map, ls, deep, seed, handle);
-  _scan_rollback_obs(rollback_obs, handle);
+  // finish
+  dout(20) << __func__ << " finishing" << dendl;
+  assert(pos.done());
   _scan_snaps(map);
   _repair_oinfo_oid(map);
 
-  dout(20) << __func__ << " done" << dendl;
+  dout(20) << __func__ << " done, got " << map.objects.size() << " items"
+	   << dendl;
   return 0;
 }
 
@@ -4355,8 +4372,6 @@ void PG::replica_scrub(
     return;
   }
 
-  ScrubMap map;
-
   assert(msg->chunky);
   if (last_update_applied < msg->scrub_to) {
     dout(10) << "waiting for last_update_applied to catch up" << dendl;
@@ -4370,45 +4385,16 @@ void PG::replica_scrub(
     return;
   }
 
-  // compensate for hobject_t's with wrong pool from sloppy hammer OSDs
-  hobject_t start = msg->start;
-  hobject_t end = msg->end;
-  if (!start.is_max())
-    start.pool = info.pgid.pool();
-  if (!end.is_max())
-    end.pool = info.pgid.pool();
+  scrubber.state = Scrubber::BUILD_MAP_REPLICA;
+  scrubber.replica_scrub_start = msg->min_epoch;
+  scrubber.start = msg->start;
+  scrubber.end = msg->end;
+  scrubber.deep = msg->deep;
+  scrubber.epoch_start = info.history.same_interval_since;
 
-  build_scrub_map_chunk(
-    map, start, end, msg->deep, msg->seed,
-    handle);
+  scrubber.replica_scrubmap_pos.reset();
 
-  if (HAVE_FEATURE(acting_features, SERVER_LUMINOUS)) {
-    MOSDRepScrubMap *reply = new MOSDRepScrubMap(
-      spg_t(info.pgid.pgid, get_primary().shard),
-      msg->map_epoch,
-      pg_whoami);
-    ::encode(map, reply->get_data());
-    osd->send_message_osd_cluster(reply, msg->get_connection());
-  } else {
-    // for jewel compatibility
-    vector<OSDOp> scrub(1);
-    scrub[0].op.op = CEPH_OSD_OP_SCRUB_MAP;
-    hobject_t poid;
-    eversion_t v;
-    osd_reqid_t reqid;
-    MOSDSubOp *subop = new MOSDSubOp(
-      reqid,
-      pg_whoami,
-      spg_t(info.pgid.pgid, get_primary().shard),
-      poid,
-      0,
-      msg->map_epoch,
-      osd->get_tid(),
-      v);
-    ::encode(map, subop->get_data());
-    subop->ops = scrub;
-    osd->send_message_osd_cluster(subop, msg->get_connection());
-  }
+  requeue_scrub(false);
 }
 
 /* Scrub:
@@ -4464,6 +4450,13 @@ void PG::scrub(epoch_t queued, ThreadPool::TPHandle &handle)
   assert(scrub_queued);
   scrub_queued = false;
   scrubber.needs_sleep = true;
+
+  // for the replica
+  if (!is_primary() &&
+      scrubber.state == PG::Scrubber::BUILD_MAP_REPLICA) {
+    chunky_scrub(handle);
+    return;
+  }
 
   if (!is_primary() || !is_active() || !is_clean() || !is_scrubbing()) {
     dout(10) << "scrub -- not primary or active or not clean" << dendl;
@@ -4585,6 +4578,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
     switch (scrubber.state) {
       case PG::Scrubber::INACTIVE:
         dout(10) << "scrub start" << dendl;
+	assert(is_primary());
 
         publish_stats_to_osd();
         scrubber.epoch_start = info.history.same_interval_since;
@@ -4642,7 +4636,9 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	   * left end of the range if we are a tier because they may legitimately
 	   * not exist (see _scrub).
 	   */
-	  int min = MAX(3, cct->_conf->osd_scrub_chunk_min);
+	  int min = std::max<int64_t>(3, cct->_conf->osd_scrub_chunk_min /
+				      scrubber.preempt_divisor);
+	  int max = std::max<int64_t>(min, cct->_conf->osd_scrub_chunk_max);
           hobject_t start = scrubber.start;
 	  hobject_t candidate_end;
 	  vector<hobject_t> objects;
@@ -4650,7 +4646,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  ret = get_pgbackend()->objects_list_partial(
 	    start,
 	    min,
-	    MAX(min, cct->_conf->osd_scrub_chunk_max),
+	    max,
 	    &objects,
 	    &candidate_end);
 	  assert(ret >= 0);
@@ -4742,30 +4738,43 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
         break;
 
       case PG::Scrubber::WAIT_LAST_UPDATE:
-        if (last_update_applied >= scrubber.subset_last_update) {
-          scrubber.state = PG::Scrubber::BUILD_MAP;
-        } else {
+        if (last_update_applied < scrubber.subset_last_update) {
           // will be requeued by op_applied
           dout(15) << "wait for writes to flush" << dendl;
           done = true;
-        }
+	  break;
+	}
+
+	scrubber.state = PG::Scrubber::BUILD_MAP;
+	scrubber.primary_scrubmap_pos.reset();
         break;
 
       case PG::Scrubber::BUILD_MAP:
         assert(last_update_applied >= scrubber.subset_last_update);
 
         // build my own scrub map
-        ret = build_scrub_map_chunk(scrubber.primary_scrubmap,
-                                    scrubber.start, scrubber.end,
-                                    scrubber.deep, scrubber.seed,
-				    handle);
-        if (ret < 0) {
-          dout(5) << "error building scrub map: " << ret << ", aborting" << dendl;
+	ret = build_scrub_map_chunk(
+	  scrubber.primary_scrubmap,
+	  scrubber.primary_scrubmap_pos,
+	  scrubber.start, scrubber.end,
+	  scrubber.deep, scrubber.seed,
+	  handle);
+	if (ret == -EINPROGRESS) {
+	  requeue_scrub();
+	  done = true;
+	  break;
+	}
+	scrubber.state = PG::Scrubber::BUILD_MAP_DONE;
+	break;
+
+      case PG::Scrubber::BUILD_MAP_DONE:
+	if (scrubber.primary_scrubmap_pos.ret < 0) {
+	  dout(5) << "error: " << scrubber.primary_scrubmap_pos.ret
+		  << ", aborting" << dendl;
           scrub_clear_state();
           scrub_unreserve_replicas();
           return;
         }
-
 	dout(10) << __func__ << " waiting_on_whom was "
 		 << scrubber.waiting_on_whom << dendl;
 	assert(scrubber.waiting_on_whom.count(pg_whoami));
@@ -4829,6 +4838,59 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	}
 
         break;
+
+      case PG::Scrubber::BUILD_MAP_REPLICA:
+        // build my own scrub map
+	  ret = build_scrub_map_chunk(
+	    scrubber.replica_scrubmap,
+	    scrubber.replica_scrubmap_pos,
+	    scrubber.start, scrubber.end,
+	    scrubber.deep, scrubber.seed,
+	    handle);
+	if (ret == -EINPROGRESS) {
+	  requeue_scrub();
+	  done = true;
+	  break;
+	}
+	// reply
+	if (HAVE_FEATURE(acting_features, SERVER_LUMINOUS)) {
+	  MOSDRepScrubMap *reply = new MOSDRepScrubMap(
+	    spg_t(info.pgid.pgid, get_primary().shard),
+	    scrubber.replica_scrub_start,
+	    pg_whoami);
+	  ::encode(scrubber.replica_scrubmap, reply->get_data());
+	  osd->send_message_osd_cluster(
+	    get_primary().osd, reply,
+	    scrubber.replica_scrub_start);
+	} else {
+	  // for jewel compatibility
+	  vector<OSDOp> scrub(1);
+	  scrub[0].op.op = CEPH_OSD_OP_SCRUB_MAP;
+	  hobject_t poid;
+	  eversion_t v;
+	  osd_reqid_t reqid;
+	  MOSDSubOp *subop = new MOSDSubOp(
+	    reqid,
+	    pg_whoami,
+	    spg_t(info.pgid.pgid, get_primary().shard),
+	    poid,
+	    0,
+	    scrubber.replica_scrub_start,
+	    osd->get_tid(),
+	    v);
+	  ::encode(scrubber.replica_scrubmap, subop->get_data());
+	  subop->ops = scrub;
+	  osd->send_message_osd_cluster(
+	    get_primary().osd, subop,
+	    scrubber.replica_scrub_start);
+	}
+	scrubber.state = PG::Scrubber::INACTIVE;
+	scrubber.replica_scrubmap = ScrubMap();
+	scrubber.replica_scrubmap_pos = ScrubMapBuilder();
+	scrubber.start = hobject_t();
+	scrubber.end = hobject_t();
+	done = true;
+	break;
 
       default:
         ceph_abort();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4297,6 +4297,8 @@ int PG::build_scrub_map_chunk(
   _repair_oinfo_oid(map);
   if (!is_primary()) {
     ScrubMap for_meta_scrub;
+    // In case we restarted smaller chunk, clear old data
+    scrubber.cleaned_meta_map.clear_from(scrubber.start);
     scrubber.cleaned_meta_map.insert(map);
     scrubber.clean_meta_map(for_meta_scrub);
     _scan_snaps(for_meta_scrub);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4080,11 +4080,18 @@ void PG::_scan_snaps(ScrubMap &smap)
 {
   hobject_t head;
   SnapSet snapset;
+
+  // Test qa/standalone/scrub/osd-scrub-snaps.sh uses this message to verify 
+  // caller using clean_meta_map(), and it works properly.
+  dout(20) << __func__ << " start" << dendl;
+
   for (map<hobject_t, ScrubMap::object>::reverse_iterator i = smap.objects.rbegin();
        i != smap.objects.rend();
        ++i) {
     const hobject_t &hoid = i->first;
     ScrubMap::object &o = i->second;
+
+    dout(20) << __func__ << " " << hoid << dendl;
 
     if (hoid.is_head() || hoid.is_snapdir()) {
       // parse the SnapSet
@@ -4287,8 +4294,13 @@ int PG::build_scrub_map_chunk(
   // finish
   dout(20) << __func__ << " finishing" << dendl;
   assert(pos.done());
-  _scan_snaps(map);
   _repair_oinfo_oid(map);
+  if (!is_primary()) {
+    ScrubMap for_meta_scrub;
+    scrubber.cleaned_meta_map.insert(map);
+    scrubber.clean_meta_map(for_meta_scrub);
+    _scan_snaps(for_meta_scrub);
+  }
 
   dout(20) << __func__ << " done, got " << map.objects.size() << " items"
 	   << dendl;
@@ -5076,26 +5088,12 @@ void PG::scrub_compare_maps()
   }
 
   ScrubMap for_meta_scrub;
-  if (scrubber.end.is_max() ||
-      scrubber.cleaned_meta_map.objects.empty()) {
-    scrubber.cleaned_meta_map.swap(for_meta_scrub);
-  } else {
-    auto iter = scrubber.cleaned_meta_map.objects.end();
-    --iter; // not empty, see if clause
-    auto begin = scrubber.cleaned_meta_map.objects.begin();
-    while (iter != begin) {
-      auto next = iter--;
-      if (next->first.get_head() != iter->first.get_head()) {
-	++iter;
-	break;
-      }
-    }
-    for_meta_scrub.objects.insert(begin, iter);
-    scrubber.cleaned_meta_map.objects.erase(begin, iter);
-  }
+  scrubber.clean_meta_map(for_meta_scrub);
 
   // ok, do the pg-type specific scrubbing
   scrub_snapshot_metadata(for_meta_scrub, missing_digest);
+  // Called here on the primary can use an authoritative map if it isn't the primary
+  _scan_snaps(for_meta_scrub);
   if (!scrubber.store->empty()) {
     if (state_test(PG_STATE_REPAIR)) {
       dout(10) << __func__ << ": discarding scrub results" << dendl;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1016,8 +1016,7 @@ PG::Scrubber::Scrubber()
    auto_repair(false),
    num_digest_updates_pending(0),
    state(INACTIVE),
-   deep(false),
-   seed(0)
+   deep(false)
 {}
 
 PG::Scrubber::~Scrubber() {}
@@ -3848,17 +3847,17 @@ void PG::sub_op_scrub_map(OpRequestRef op)
 void PG::_request_scrub_map(
   pg_shard_t replica, eversion_t version,
   hobject_t start, hobject_t end,
-  bool deep, uint32_t seed,
+  bool deep,
   bool allow_preemption)
 {
   assert(replica != pg_whoami);
   dout(10) << "scrub  requesting scrubmap from osd." << replica
-	   << " deep " << (int)deep << " seed " << seed << dendl;
+	   << " deep " << (int)deep << dendl;
   MOSDRepScrub *repscrubop = new MOSDRepScrub(
     spg_t(info.pgid.pgid, replica.shard), version,
     get_osdmap()->get_epoch(),
     get_last_peering_reset(),
-    start, end, deep, seed,
+    start, end, deep,
     allow_preemption);
   // default priority, we want the rep scrub processed prior to any recovery
   // or client io messages (we are holding a lock!)
@@ -4243,7 +4242,6 @@ int PG::build_scrub_map_chunk(
   hobject_t start,
   hobject_t end,
   bool deep,
-  uint32_t seed,
   ThreadPool::TPHandle &handle)
 {
   dout(10) << __func__ << " [" << start << "," << end << ") "
@@ -4253,7 +4251,6 @@ int PG::build_scrub_map_chunk(
   // start
   while (pos.empty()) {
     pos.deep = deep;
-    pos.seed = seed;
     map.valid_through = info.last_update;
     osr->flush();
 
@@ -4619,7 +4616,6 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  osd->clog->debug(oss);
 	}
 
-	scrubber.seed = -1;
 	scrubber.preempt_left = cct->_conf->get_val<uint64_t>(
 	  "osd_scrub_max_preemptions");
 	scrubber.preempt_divisor = 1;
@@ -4739,7 +4735,6 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  if (*i == pg_whoami) continue;
           _request_scrub_map(*i, scrubber.subset_last_update,
                              scrubber.start, scrubber.end, scrubber.deep,
-			     scrubber.seed,
 			     scrubber.preempt_left > 0);
           scrubber.waiting_on_whom.insert(*i);
         }
@@ -4783,7 +4778,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  scrubber.primary_scrubmap,
 	  scrubber.primary_scrubmap_pos,
 	  scrubber.start, scrubber.end,
-	  scrubber.deep, scrubber.seed,
+	  scrubber.deep,
 	  handle);
 	if (ret == -EINPROGRESS) {
 	  requeue_scrub();
@@ -4886,7 +4881,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	    scrubber.replica_scrubmap,
 	    scrubber.replica_scrubmap_pos,
 	    scrubber.start, scrubber.end,
-	    scrubber.deep, scrubber.seed,
+	    scrubber.deep,
 	    handle);
 	}
 	if (ret == -EINPROGRESS) {
@@ -7640,7 +7635,6 @@ boost::statechart::result PG::RecoveryState::Active::react(const QueryState& q)
     q.f->dump_stream("scrubber.end") << pg->scrubber.end;
     q.f->dump_stream("scrubber.subset_last_update") << pg->scrubber.subset_last_update;
     q.f->dump_bool("scrubber.deep", pg->scrubber.deep);
-    q.f->dump_unsigned("scrubber.seed", pg->scrubber.seed);
     {
       q.f->open_array_section("scrubber.waiting_on_whom");
       for (set<pg_shard_t>::iterator p = pg->scrubber.waiting_on_whom.begin();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4245,6 +4245,8 @@ int PG::build_scrub_map_chunk(
 
   map.valid_through = info.last_update;
 
+  osr->flush();
+
   // objects
   vector<hobject_t> ls;
   vector<ghobject_t> rollback_obs;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4638,9 +4638,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  scrubber.preempt_divisor *= 2;
 	  dout(10) << __func__ << " preempted, " << scrubber.preempt_left
 		   << " left" << dendl;
-	  scrubber.state = PG::Scrubber::NEW_CHUNK;
+	  scrub_preempted = false;
 	}
-	scrub_preempted = false;
 	scrub_can_preempt = scrubber.preempt_left > 0;
 
         {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4406,6 +4406,7 @@ void PG::replica_scrub(
   scrubber.replica_scrub_start = msg->min_epoch;
   scrubber.start = msg->start;
   scrubber.end = msg->end;
+  scrubber.max_end = msg->end;
   scrubber.deep = msg->deep;
   scrubber.epoch_start = info.history.same_interval_since;
   if (msg->priority) {
@@ -4597,7 +4598,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 
   while (!done) {
     dout(20) << "scrub state " << Scrubber::state_string(scrubber.state)
-	     << " [" << scrubber.start << "," << scrubber.end << ")" << dendl;
+	     << " [" << scrubber.start << "," << scrubber.end << ")"
+	     << " max_end " << scrubber.max_end << dendl;
 
     switch (scrubber.state) {
       case PG::Scrubber::INACTIVE:
@@ -4717,6 +4719,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	    break;
 	  }
 	  scrubber.end = candidate_end;
+	  if (scrubber.end > scrubber.max_end)
+	    scrubber.max_end = scrubber.end;
         }
 
         // walk the log to find the latest update that affects our chunk
@@ -4948,6 +4952,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	scrubber.replica_scrubmap_pos = ScrubMapBuilder();
 	scrubber.start = hobject_t();
 	scrubber.end = hobject_t();
+	scrubber.max_end = hobject_t();
 	done = true;
 	break;
 
@@ -4956,7 +4961,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
     }
   }
   dout(20) << "scrub final state " << Scrubber::state_string(scrubber.state)
-	   << " [" << scrubber.start << "," << scrubber.end << ")" << dendl;
+	   << " [" << scrubber.start << "," << scrubber.end << ")"
+	   << " max_end " << scrubber.max_end << dendl;
 }
 
 bool PG::write_blocked_by_scrub(const hobject_t& soid)
@@ -4978,8 +4984,8 @@ bool PG::write_blocked_by_scrub(const hobject_t& soid)
 
 bool PG::range_intersects_scrub(const hobject_t &start, const hobject_t& end)
 {
-  // does [start, end] intersect [scrubber.start, scrubber.end)
-  return (start < scrubber.end &&
+  // does [start, end] intersect [scrubber.start, scrubber.max_end)
+  return (start < scrubber.max_end &&
 	  end >= scrubber.start);
 }
 
@@ -7645,6 +7651,7 @@ boost::statechart::result PG::RecoveryState::Active::react(const QueryState& q)
     q.f->dump_string("scrubber.state", Scrubber::state_string(pg->scrubber.state));
     q.f->dump_stream("scrubber.start") << pg->scrubber.start;
     q.f->dump_stream("scrubber.end") << pg->scrubber.end;
+    q.f->dump_stream("scrubber.max_end") << pg->scrubber.max_end;
     q.f->dump_stream("scrubber.subset_last_update") << pg->scrubber.subset_last_update;
     q.f->dump_bool("scrubber.deep", pg->scrubber.deep);
     {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1011,7 +1011,7 @@ PG::Scrubber::Scrubber()
  : reserved(false), reserve_failed(false),
    epoch_start(0),
    active(false),
-   waiting_on(0), shallow_errors(0), deep_errors(0), fixed(0),
+   shallow_errors(0), deep_errors(0), fixed(0),
    must_scrub(false), must_deep_scrub(false), must_repair(false),
    auto_repair(false),
    num_digest_updates_pending(0),
@@ -3788,9 +3788,11 @@ void PG::do_replica_scrub_map(OpRequestRef op)
 	   << scrubber.received_maps[m->from].valid_through
 	   << dendl;
 
-  --scrubber.waiting_on;
+  dout(10) << __func__ << " waiting_on_whom was " << scrubber.waiting_on_whom
+	   << dendl;
+  assert(scrubber.waiting_on_whom.count(m->from));
   scrubber.waiting_on_whom.erase(m->from);
-  if (scrubber.waiting_on == 0) {
+  if (scrubber.waiting_on_whom.empty()) {
     if (ops_blocked_by_scrub()) {
       requeue_scrub(true);
     } else {
@@ -3827,10 +3829,9 @@ void PG::sub_op_scrub_map(OpRequestRef op)
 	     << scrubber.received_maps[m->from].valid_through
 	     << dendl;
 
-  --scrubber.waiting_on;
   scrubber.waiting_on_whom.erase(m->from);
 
-  if (scrubber.waiting_on == 0) {
+  if (scrubber.waiting_on_whom.empty()) {
     if (ops_blocked_by_scrub()) {
       requeue_scrub(true);
     } else {
@@ -4711,7 +4712,6 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
         // ask replicas to wait until
         // last_update_applied >= scrubber.subset_last_update and then scan
         scrubber.waiting_on_whom.insert(pg_whoami);
-        ++scrubber.waiting_on;
 
         // request maps from replicas
 	for (set<pg_shard_t>::iterator i = actingbackfill.begin();
@@ -4722,8 +4722,9 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
                              scrubber.start, scrubber.end, scrubber.deep,
 			     scrubber.seed);
           scrubber.waiting_on_whom.insert(*i);
-          ++scrubber.waiting_on;
         }
+	dout(10) << __func__ << " waiting_on_whom " << scrubber.waiting_on_whom
+		 << dendl;
 
         scrubber.state = PG::Scrubber::WAIT_PUSHES;
 
@@ -4763,14 +4764,16 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           return;
         }
 
-        --scrubber.waiting_on;
+	dout(10) << __func__ << " waiting_on_whom was "
+		 << scrubber.waiting_on_whom << dendl;
+	assert(scrubber.waiting_on_whom.count(pg_whoami));
         scrubber.waiting_on_whom.erase(pg_whoami);
 
         scrubber.state = PG::Scrubber::WAIT_REPLICAS;
         break;
 
       case PG::Scrubber::WAIT_REPLICAS:
-        if (scrubber.waiting_on > 0) {
+        if (!scrubber.waiting_on_whom.empty()) {
           // will be requeued by sub_op_scrub_map
           dout(10) << "wait for replicas to build scrub map" << dendl;
           done = true;
@@ -4781,7 +4784,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 
       case PG::Scrubber::COMPARE_MAPS:
         assert(last_update_applied >= scrubber.subset_last_update);
-        assert(scrubber.waiting_on == 0);
+        assert(scrubber.waiting_on_whom.empty());
 
         scrub_compare_maps();
 	scrubber.start = scrubber.end;
@@ -7512,7 +7515,6 @@ boost::statechart::result PG::RecoveryState::Active::react(const QueryState& q)
     q.f->dump_stream("scrubber.subset_last_update") << pg->scrubber.subset_last_update;
     q.f->dump_bool("scrubber.deep", pg->scrubber.deep);
     q.f->dump_unsigned("scrubber.seed", pg->scrubber.seed);
-    q.f->dump_int("scrubber.waiting_on", pg->scrubber.waiting_on);
     {
       q.f->open_array_section("scrubber.waiting_on_whom");
       for (set<pg_shard_t>::iterator p = pg->scrubber.waiting_on_whom.begin();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4662,7 +4662,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	   */
 	  int min = std::max<int64_t>(3, cct->_conf->osd_scrub_chunk_min /
 				      scrubber.preempt_divisor);
-	  int max = std::max<int64_t>(min, cct->_conf->osd_scrub_chunk_max);
+	  int max = std::max<int64_t>(min, cct->_conf->osd_scrub_chunk_max /
+                                      scrubber.preempt_divisor);
           hobject_t start = scrubber.start;
 	  hobject_t candidate_end;
 	  vector<hobject_t> objects;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3792,6 +3792,10 @@ void PG::do_replica_scrub_map(OpRequestRef op)
 	   << dendl;
   assert(scrubber.waiting_on_whom.count(m->from));
   scrubber.waiting_on_whom.erase(m->from);
+  if (m->preempted) {
+    dout(10) << __func__ << " replica was preempted, setting flag" << dendl;
+    scrub_preempted = true;
+  }
   if (scrubber.waiting_on_whom.empty()) {
     if (ops_blocked_by_scrub()) {
       requeue_scrub(true);
@@ -3844,7 +3848,8 @@ void PG::sub_op_scrub_map(OpRequestRef op)
 void PG::_request_scrub_map(
   pg_shard_t replica, eversion_t version,
   hobject_t start, hobject_t end,
-  bool deep, uint32_t seed)
+  bool deep, uint32_t seed,
+  bool allow_preemption)
 {
   assert(replica != pg_whoami);
   dout(10) << "scrub  requesting scrubmap from osd." << replica
@@ -3853,7 +3858,8 @@ void PG::_request_scrub_map(
     spg_t(info.pgid.pgid, replica.shard), version,
     get_osdmap()->get_epoch(),
     get_last_peering_reset(),
-    start, end, deep, seed);
+    start, end, deep, seed,
+    allow_preemption);
   // default priority, we want the rep scrub processed prior to any recovery
   // or client io messages (we are holding a lock!)
   osd->send_message_osd_cluster(
@@ -4392,6 +4398,8 @@ void PG::replica_scrub(
   scrubber.deep = msg->deep;
   scrubber.epoch_start = info.history.same_interval_since;
 
+  scrub_can_preempt = msg->allow_preemption;
+  scrub_preempted = false;
   scrubber.replica_scrubmap_pos.reset();
 
   requeue_scrub(false);
@@ -4612,12 +4620,25 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	}
 
 	scrubber.seed = -1;
-
+	scrubber.preempt_left = cct->_conf->get_val<uint64_t>(
+	  "osd_scrub_max_preemptions");
+	scrubber.preempt_divisor = 1;
         break;
 
       case PG::Scrubber::NEW_CHUNK:
         scrubber.primary_scrubmap = ScrubMap();
         scrubber.received_maps.clear();
+
+	// begin (possible) preemption window
+	if (scrub_preempted) {
+	  scrubber.preempt_left--;
+	  scrubber.preempt_divisor *= 2;
+	  dout(10) << __func__ << " preempted, " << scrubber.preempt_left
+		   << " left" << dendl;
+	  scrubber.state = PG::Scrubber::NEW_CHUNK;
+	}
+	scrub_preempted = false;
+	scrub_can_preempt = scrubber.preempt_left > 0;
 
         {
           /* get the start and end of our scrub chunk
@@ -4718,14 +4739,14 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  if (*i == pg_whoami) continue;
           _request_scrub_map(*i, scrubber.subset_last_update,
                              scrubber.start, scrubber.end, scrubber.deep,
-			     scrubber.seed);
+			     scrubber.seed,
+			     scrubber.preempt_left > 0);
           scrubber.waiting_on_whom.insert(*i);
         }
 	dout(10) << __func__ << " waiting_on_whom " << scrubber.waiting_on_whom
 		 << dendl;
 
         scrubber.state = PG::Scrubber::WAIT_PUSHES;
-
         break;
 
       case PG::Scrubber::WAIT_PUSHES:
@@ -4753,6 +4774,11 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
         assert(last_update_applied >= scrubber.subset_last_update);
 
         // build my own scrub map
+	if (scrub_preempted) {
+	  dout(10) << __func__ << " preempted" << dendl;
+	  scrubber.state = PG::Scrubber::BUILD_MAP_DONE;
+	  break;
+	}
 	ret = build_scrub_map_chunk(
 	  scrubber.primary_scrubmap,
 	  scrubber.primary_scrubmap_pos,
@@ -4788,7 +4814,14 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           // will be requeued by sub_op_scrub_map
           dout(10) << "wait for replicas to build scrub map" << dendl;
           done = true;
-        } else {
+	  break;
+	}
+	// end (possible) preemption window
+	scrub_can_preempt = false;
+	if (scrub_preempted) {
+	  dout(10) << __func__ << " preempted, restarting chunk" << dendl;
+	  scrubber.state = PG::Scrubber::NEW_CHUNK;
+	} else {
           scrubber.state = PG::Scrubber::COMPARE_MAPS;
         }
         break;
@@ -4817,8 +4850,12 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	  break;
 	}
 
+	scrubber.preempt_left = cct->_conf->get_val<uint64_t>(
+	  "osd_scrub_max_preemptions");
+	scrubber.preempt_divisor = 1;
+
 	if (!(scrubber.end.is_max())) {
-          scrubber.state = PG::Scrubber::NEW_CHUNK;
+	  scrubber.state = PG::Scrubber::NEW_CHUNK;
 	  requeue_scrub();
           done = true;
         } else {
@@ -4841,12 +4878,17 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 
       case PG::Scrubber::BUILD_MAP_REPLICA:
         // build my own scrub map
+	if (scrub_preempted) {
+	  dout(10) << __func__ << " preempted" << dendl;
+	  ret = 0;
+	} else {
 	  ret = build_scrub_map_chunk(
 	    scrubber.replica_scrubmap,
 	    scrubber.replica_scrubmap_pos,
 	    scrubber.start, scrubber.end,
 	    scrubber.deep, scrubber.seed,
 	    handle);
+	}
 	if (ret == -EINPROGRESS) {
 	  requeue_scrub();
 	  done = true;
@@ -4858,6 +4900,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	    spg_t(info.pgid.pgid, get_primary().shard),
 	    scrubber.replica_scrub_start,
 	    pg_whoami);
+	  reply->preempted = scrub_preempted;
 	  ::encode(scrubber.replica_scrubmap, reply->get_data());
 	  osd->send_message_osd_cluster(
 	    get_primary().osd, reply,
@@ -4884,6 +4927,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	    get_primary().osd, subop,
 	    scrubber.replica_scrub_start);
 	}
+	scrub_preempted = false;
+	scrub_can_preempt = false;
 	scrubber.state = PG::Scrubber::INACTIVE;
 	scrubber.replica_scrubmap = ScrubMap();
 	scrubber.replica_scrubmap_pos = ScrubMapBuilder();
@@ -4898,6 +4943,23 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
   }
   dout(20) << "scrub final state " << Scrubber::state_string(scrubber.state)
 	   << " [" << scrubber.start << "," << scrubber.end << ")" << dendl;
+}
+
+bool PG::write_blocked_by_scrub(const hobject_t& soid)
+{
+  if (soid < scrubber.start || soid >= scrubber.end) {
+    return false;
+  }
+  if (scrub_can_preempt) {
+    if (!scrub_preempted) {
+      dout(10) << __func__ << " " << soid << " preempted" << dendl;
+      scrub_preempted = true;
+    } else {
+      dout(10) << __func__ << " " << soid << " already preempted" << dendl;
+    }
+    return false;
+  }
+  return true;
 }
 
 void PG::scrub_clear_state()

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4251,6 +4251,7 @@ int PG::build_scrub_map_chunk(
   // objects
   vector<hobject_t> ls;
   vector<ghobject_t> rollback_obs;
+  osr->flush();
   int ret = get_pgbackend()->objects_list_range(
     start,
     end,
@@ -4645,6 +4646,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           hobject_t start = scrubber.start;
 	  hobject_t candidate_end;
 	  vector<hobject_t> objects;
+	  osr->flush();
 	  ret = get_pgbackend()->objects_list_partial(
 	    start,
 	    min,

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3858,7 +3858,9 @@ void PG::_request_scrub_map(
     get_osdmap()->get_epoch(),
     get_last_peering_reset(),
     start, end, deep,
-    allow_preemption);
+    allow_preemption,
+    scrubber.priority,
+    ops_blocked_by_scrub());
   // default priority, we want the rep scrub processed prior to any recovery
   // or client io messages (we are holding a lock!)
   osd->send_message_osd_cluster(
@@ -4394,12 +4396,17 @@ void PG::replica_scrub(
   scrubber.end = msg->end;
   scrubber.deep = msg->deep;
   scrubber.epoch_start = info.history.same_interval_since;
+  if (msg->priority) {
+    scrubber.priority = msg->priority;
+  } else {
+    scrubber.priority = get_scrub_priority();
+  }
 
   scrub_can_preempt = msg->allow_preemption;
   scrub_preempted = false;
   scrubber.replica_scrubmap_pos.reset();
 
-  requeue_scrub(false);
+  requeue_scrub(msg->high_priority);
 }
 
 /* Scrub:

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4976,6 +4976,13 @@ bool PG::write_blocked_by_scrub(const hobject_t& soid)
   return true;
 }
 
+bool PG::range_intersects_scrub(const hobject_t &start, const hobject_t& end)
+{
+  // does [start, end] intersect [scrubber.start, scrubber.end)
+  return (start < scrubber.end &&
+	  end >= scrubber.start);
+}
+
 void PG::scrub_clear_state()
 {
   assert(is_locked());

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1257,11 +1257,15 @@ public:
         auto iter = cleaned_meta_map.objects.end();
         --iter; // not empty, see if clause
         auto begin = cleaned_meta_map.objects.begin();
-        while (iter != begin) {
-          auto next = iter--;
-          if (next->first.get_head() != iter->first.get_head()) {
-	    ++iter;
-	    break;
+        if (iter->first.has_snapset()) {
+          ++iter;
+        } else {
+          while (iter != begin) {
+            auto next = iter--;
+            if (next->first.get_head() != iter->first.get_head()) {
+	      ++iter;
+	      break;
+            }
           }
         }
         for_meta_scrub.objects.insert(begin, iter);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1390,6 +1390,9 @@ public:
   // not stop until the scrub range is completed.
   bool write_blocked_by_scrub(const hobject_t &soid);
 
+  /// true if the given range intersects the scrub interval in any way
+  bool range_intersects_scrub(const hobject_t &start, const hobject_t& end);
+
   void repair_object(
     const hobject_t& soid, list<pair<ScrubMap::object, pg_shard_t> > *ok_peers,
     pg_shard_t bad_peer);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1211,7 +1211,6 @@ public:
 
     // common to both scrubs
     bool active;
-    int waiting_on;
     set<pg_shard_t> waiting_on_whom;
     int shallow_errors;
     int deep_errors;
@@ -1313,7 +1312,6 @@ public:
     // clear all state
     void reset() {
       active = false;
-      waiting_on = 0;
       waiting_on_whom.clear();
       if (active_rep_scrub) {
         active_rep_scrub = OpRequestRef();

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1277,7 +1277,8 @@ public:
     int num_digest_updates_pending;
 
     // chunky scrub
-    hobject_t start, end;
+    hobject_t start, end;    // [start,end)
+    hobject_t max_end;       // Largest end that may have been sent to replicas
     eversion_t subset_last_update;
 
     // chunky scrub state
@@ -1353,6 +1354,7 @@ public:
       state = PG::Scrubber::INACTIVE;
       start = hobject_t();
       end = hobject_t();
+      max_end = hobject_t();
       subset_last_update = eversion_t();
       shallow_errors = 0;
       deep_errors = 0;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1275,6 +1275,8 @@ public:
     // deep scrub
     bool deep;
     uint32_t seed;
+    int preempt_left;
+    int preempt_divisor;
 
     list<Context*> callbacks;
     void add_callback(Context *context) {
@@ -1310,12 +1312,6 @@ public:
     }
 
     bool is_chunky_scrub_active() const { return state != INACTIVE; }
-
-    // classic (non chunk) scrubs block all writes
-    // chunky scrubs only block writes to a range
-    bool write_blocked_by_scrub(const hobject_t &soid) {
-      return (soid >= start && soid < end);
-    }
 
     // clear all state
     void reset() {
@@ -1364,6 +1360,14 @@ public:
 
   int active_pushes;
 
+  bool scrub_can_preempt = false;
+  bool scrub_preempted = false;
+
+  // we allow some number of preemptions of the scrub, which mean we do
+  // not block.  then we start to block.  once we start blocking, we do
+  // not stop until the scrub range is completed.
+  bool write_blocked_by_scrub(const hobject_t &soid);
+
   void repair_object(
     const hobject_t& soid, list<pair<ScrubMap::object, pg_shard_t> > *ok_peers,
     pg_shard_t bad_peer);
@@ -1385,7 +1389,7 @@ public:
     ThreadPool::TPHandle &handle);
   void _request_scrub_map(pg_shard_t replica, eversion_t version,
                           hobject_t start, hobject_t end, bool deep,
-			  uint32_t seed);
+			  uint32_t seed, bool allow_preemption);
   int build_scrub_map_chunk(
     ScrubMap &map,
     ScrubMapBuilder &pos,

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1217,6 +1217,10 @@ public:
     int large_omap_objects = 0;
     int fixed;
     ScrubMap primary_scrubmap;
+    ScrubMapBuilder primary_scrubmap_pos;
+    epoch_t replica_scrub_start = 0;
+    ScrubMap replica_scrubmap;
+    ScrubMapBuilder replica_scrubmap_pos;
     map<pg_shard_t, ScrubMap> received_maps;
     OpRequestRef active_rep_scrub;
     utime_t scrub_reg_stamp;  // stamp we registered for
@@ -1259,10 +1263,12 @@ public:
       WAIT_PUSHES,
       WAIT_LAST_UPDATE,
       BUILD_MAP,
+      BUILD_MAP_DONE,
       WAIT_REPLICAS,
       COMPARE_MAPS,
       WAIT_DIGEST_UPDATES,
       FINISH,
+      BUILD_MAP_REPLICA,
     } state;
 
     std::unique_ptr<Scrub::Store> store;
@@ -1293,10 +1299,12 @@ public:
         case WAIT_PUSHES: ret = "WAIT_PUSHES"; break;
         case WAIT_LAST_UPDATE: ret = "WAIT_LAST_UPDATE"; break;
         case BUILD_MAP: ret = "BUILD_MAP"; break;
+        case BUILD_MAP_DONE: ret = "BUILD_MAP_DONE"; break;
         case WAIT_REPLICAS: ret = "WAIT_REPLICAS"; break;
         case COMPARE_MAPS: ret = "COMPARE_MAPS"; break;
         case WAIT_DIGEST_UPDATES: ret = "WAIT_DIGEST_UPDATES"; break;
         case FINISH: ret = "FINISH"; break;
+        case BUILD_MAP_REPLICA: ret = "BUILD_MAP_REPLICA"; break;
       }
       return ret;
     }
@@ -1338,6 +1346,10 @@ public:
       missing.clear();
       authoritative.clear();
       num_digest_updates_pending = 0;
+      primary_scrubmap = ScrubMap();
+      primary_scrubmap_pos.reset();
+      replica_scrubmap = ScrubMap();
+      replica_scrubmap_pos.reset();
       cleaned_meta_map = ScrubMap();
       sleeping = false;
       needs_sleep = true;
@@ -1376,6 +1388,7 @@ public:
 			  uint32_t seed);
   int build_scrub_map_chunk(
     ScrubMap &map,
+    ScrubMapBuilder &pos,
     hobject_t start, hobject_t end, bool deep, uint32_t seed,
     ThreadPool::TPHandle &handle);
   /**

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1274,7 +1274,6 @@ public:
     std::unique_ptr<Scrub::Store> store;
     // deep scrub
     bool deep;
-    uint32_t seed;
     int preempt_left;
     int preempt_divisor;
 
@@ -1336,7 +1335,6 @@ public:
       large_omap_objects = 0;
       fixed = 0;
       deep = false;
-      seed = 0;
       run_callbacks();
       inconsistent.clear();
       missing.clear();
@@ -1389,11 +1387,11 @@ public:
     ThreadPool::TPHandle &handle);
   void _request_scrub_map(pg_shard_t replica, eversion_t version,
                           hobject_t start, hobject_t end, bool deep,
-			  uint32_t seed, bool allow_preemption);
+			  bool allow_preemption);
   int build_scrub_map_chunk(
     ScrubMap &map,
     ScrubMapBuilder &pos,
-    hobject_t start, hobject_t end, bool deep, uint32_t seed,
+    hobject_t start, hobject_t end, bool deep,
     ThreadPool::TPHandle &handle);
   /**
    * returns true if [begin, end) is good to scrub at this time

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1249,6 +1249,26 @@ public:
     // Cleaned map pending snap metadata scrub
     ScrubMap cleaned_meta_map;
 
+    void clean_meta_map(ScrubMap &for_meta_scrub) {
+      if (end.is_max() ||
+          cleaned_meta_map.objects.empty()) {
+         cleaned_meta_map.swap(for_meta_scrub);
+      } else {
+        auto iter = cleaned_meta_map.objects.end();
+        --iter; // not empty, see if clause
+        auto begin = cleaned_meta_map.objects.begin();
+        while (iter != begin) {
+          auto next = iter--;
+          if (next->first.get_head() != iter->first.get_head()) {
+	    ++iter;
+	    break;
+          }
+        }
+        for_meta_scrub.objects.insert(begin, iter);
+        cleaned_meta_map.objects.erase(begin, iter);
+      }
+    }
+
     // digest updates which we are waiting on
     int num_digest_updates_pending;
 

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -289,6 +289,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual bool check_osdmap_full(const set<pg_shard_t> &missing_on) = 0;
 
+     virtual bool maybe_preempt_replica_scrub(const hobject_t& oid) = 0;
      virtual ~Listener() {}
    };
    Listener *parent;

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -132,6 +132,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 					eversion_t v,
 					Context *on_complete) = 0;
 
+
      /**
       * Bless a context
       *
@@ -558,9 +559,9 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 
    virtual bool scrub_supported() = 0;
    virtual bool auto_repair_supported() const = 0;
-   void be_scan_list(
-     ScrubMap &map, const vector<hobject_t> &ls, bool deep, uint32_t seed,
-     ThreadPool::TPHandle &handle);
+   int be_scan_list(
+     ScrubMap &map,
+     ScrubMapBuilder &pos);
    bool be_compare_scrub_objects(
      pg_shard_t auth_shard,
      const ScrubMap::object &auth,
@@ -590,12 +591,11 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      ostream &errorstream);
    virtual uint64_t be_get_ondisk_size(
      uint64_t logical_size) = 0;
-   virtual void be_deep_scrub(
-     const hobject_t &poid,
-     uint32_t seed,
-     ScrubMap::object &o,
-     ThreadPool::TPHandle &handle,
-     ScrubMap* const map = nullptr) = 0;
+   virtual int be_deep_scrub(
+     const hobject_t &oid,
+     ScrubMap &map,
+     ScrubMapBuilder &pos,
+     ScrubMap::object &o) = 0;
    void be_large_omap_check(
      const map<pg_shard_t,ScrubMap*> &maps,
      const set<hobject_t> &master_set,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2060,7 +2060,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   }
 
   if (write_ordered && scrubber.is_chunky_scrub_active() &&
-      scrubber.write_blocked_by_scrub(head)) {
+      write_blocked_by_scrub(head)) {
     dout(20) << __func__ << ": waiting for scrub" << dendl;
     waiting_for_scrub.push_back(op);
     op->mark_delayed("waiting for scrub");
@@ -3127,7 +3127,7 @@ void PrimaryLogPG::promote_object(ObjectContextRef obc,
 {
   hobject_t hoid = obc ? obc->obs.oi.soid : missing_oid;
   assert(hoid != hobject_t());
-  if (scrubber.write_blocked_by_scrub(hoid)) {
+  if (write_blocked_by_scrub(hoid)) {
     dout(10) << __func__ << " " << hoid
 	     << " blocked by scrub" << dendl;
     if (op) {
@@ -9052,7 +9052,7 @@ int PrimaryLogPG::try_flush_mark_clean(FlushOpRef fop)
   }
 
   if (!fop->blocking &&
-      scrubber.write_blocked_by_scrub(oid)) {
+      write_blocked_by_scrub(oid)) {
     if (fop->op) {
       dout(10) << __func__ << " blocked by scrub" << dendl;
       requeue_op(fop->op);
@@ -9794,7 +9794,7 @@ void PrimaryLogPG::handle_watch_timeout(WatchRef watch)
     return;
   }
 
-  if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid)) {
+  if (write_blocked_by_scrub(obc->obs.oi.soid)) {
     dout(10) << "handle_watch_timeout waiting for scrub on obj "
 	     << obc->obs.oi.soid
 	     << dendl;
@@ -12681,7 +12681,7 @@ void PrimaryLogPG::hit_set_remove_all()
     // Once we hit a degraded object just skip
     if (is_degraded_or_backfilling_object(aoid))
       return;
-    if (scrubber.write_blocked_by_scrub(aoid))
+    if (write_blocked_by_scrub(aoid))
       return;
   }
 
@@ -12800,7 +12800,7 @@ void PrimaryLogPG::hit_set_persist()
     // Once we hit a degraded object just skip further trim
     if (is_degraded_or_backfilling_object(aoid))
       return;
-    if (scrubber.write_blocked_by_scrub(aoid))
+    if (write_blocked_by_scrub(aoid))
       return;
   }
 
@@ -12834,7 +12834,7 @@ void PrimaryLogPG::hit_set_persist()
     new_hset.using_gmt);
 
   // If the current object is degraded we skip this persist request
-  if (scrubber.write_blocked_by_scrub(oid))
+  if (write_blocked_by_scrub(oid))
     return;
 
   hit_set->seal();
@@ -13078,7 +13078,7 @@ bool PrimaryLogPG::agent_work(int start_max, int agent_flush_quota)
       osd->logger->inc(l_osd_agent_skip);
       continue;
     }
-    if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid)) {
+    if (write_blocked_by_scrub(obc->obs.oi.soid)) {
       dout(20) << __func__ << " skip (scrubbing) " << obc->obs.oi << dendl;
       osd->logger->inc(l_osd_agent_skip);
       continue;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -13078,7 +13078,8 @@ bool PrimaryLogPG::agent_work(int start_max, int agent_flush_quota)
       osd->logger->inc(l_osd_agent_skip);
       continue;
     }
-    if (write_blocked_by_scrub(obc->obs.oi.soid)) {
+    if (range_intersects_scrub(obc->obs.oi.soid,
+			       obc->obs.oi.soid.get_head())) {
       dout(20) << __func__ << " skip (scrubbing) " << obc->obs.oi << dendl;
       osd->logger->inc(l_osd_agent_skip);
       continue;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5045,6 +5045,8 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   ObjectState& obs = ctx->new_obs;
   object_info_t& oi = obs.oi;
   const hobject_t& soid = oi.soid;
+  bool skip_data_digest = osd->store->has_builtin_csum() &&
+    g_conf->get_val<bool>("osd_skip_data_digest");
 
   PGTransaction* t = ctx->op_t.get();
 
@@ -5857,12 +5859,18 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	    soid, op.extent.offset, op.extent.length, osd_op.indata, op.flags);
 	}
 
-	if (op.extent.offset == 0 && op.extent.length >= oi.size)
+	if (op.extent.offset == 0 && op.extent.length >= oi.size
+            && !skip_data_digest) {
 	  obs.oi.set_data_digest(osd_op.indata.crc32c(-1));
-	else if (op.extent.offset == oi.size && obs.oi.is_data_digest())
-	  obs.oi.set_data_digest(osd_op.indata.crc32c(obs.oi.data_digest));
-	else
+	} else if (op.extent.offset == oi.size && obs.oi.is_data_digest()) {
+          if (skip_data_digest) {
+            obs.oi.clear_data_digest();
+          } else {
+	    obs.oi.set_data_digest(osd_op.indata.crc32c(obs.oi.data_digest));
+          }
+	} else {
 	  obs.oi.clear_data_digest();
+        }
 	write_update_size_and_usage(ctx->delta_stats, oi, ctx->modified_ranges,
 				    op.extent.offset, op.extent.length);
 
@@ -5894,7 +5902,9 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	if (op.extent.length) {
 	  t->write(soid, 0, op.extent.length, osd_op.indata, op.flags);
 	}
-	obs.oi.set_data_digest(osd_op.indata.crc32c(-1));
+        if (!skip_data_digest) {
+	  obs.oi.set_data_digest(osd_op.indata.crc32c(-1));
+        }
 
 	write_update_size_and_usage(ctx->delta_stats, oi, ctx->modified_ranges,
 	    0, op.extent.length, true);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -12458,10 +12458,10 @@ void PrimaryLogPG::update_range(
   if (bi->version < info.log_tail) {
     dout(10) << __func__<< ": bi is old, rescanning local backfill_info"
 	     << dendl;
+    osr->flush();
     if (last_update_applied >= info.log_tail) {
       bi->version = last_update_applied;
     } else {
-      osr->flush();
       bi->version = info.last_update;
     }
     scan_range(local_min, local_max, bi, handle);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2059,7 +2059,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     return;
   }
 
-  if (write_ordered &&
+  if (write_ordered && scrubber.is_chunky_scrub_active() &&
       scrubber.write_blocked_by_scrub(head)) {
     dout(20) << __func__ << ": waiting for scrub" << dendl;
     waiting_for_scrub.push_back(op);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -829,7 +829,10 @@ protected:
     if (!to_req.empty()) {
       // requeue at front of scrub blocking queue if we are blocked by scrub
       for (auto &&p: to_req) {
-	if (scrubber.write_blocked_by_scrub(p.first.get_head())) {
+	if (write_blocked_by_scrub(p.first.get_head())) {
+          for (auto& op : p.second) {
+            op->mark_delayed("waiting for scrub");
+          }
 	  waiting_for_scrub.splice(
 	    waiting_for_scrub.begin(),
 	    p.second,
@@ -1785,6 +1788,9 @@ public:
   void on_shutdown() override;
   bool check_failsafe_full(ostream &ss) override;
   bool check_osdmap_full(const set<pg_shard_t> &missing_on) override;
+  bool maybe_preempt_replica_scrub(const hobject_t& oid) override {
+    return write_blocked_by_scrub(oid);
+  }
   int rep_repair_primary_object(const hobject_t& soid, OpRequestRef op);
 
   // attr cache handling

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -715,7 +715,7 @@ int ReplicatedBackend::be_deep_scrub(
                            CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
 
   bool skip_data_digest = store->has_builtin_csum() &&
-    g_conf->get_val<bool>("osd_skip_data_digest");
+    g_conf->osd_skip_data_digest;
 
   utime_t sleeptime;
   sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -801,7 +801,7 @@ int ReplicatedBackend::be_deep_scrub(
   while (iter->status() == 0 && iter->valid()) {
     pos.omap_bytes += iter->value().length();
     ++pos.omap_keys;
-
+    --max;
     // fixme: we can do this more efficiently.
     bufferlist bl;
     ::encode(iter->key(), bl);

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -703,135 +703,145 @@ void ReplicatedBackend::do_repop_reply(OpRequestRef op)
   }
 }
 
-void ReplicatedBackend::be_deep_scrub(
+int ReplicatedBackend::be_deep_scrub(
   const hobject_t &poid,
-  uint32_t seed,
-  ScrubMap::object &o,
-  ThreadPool::TPHandle &handle,
-  ScrubMap* const map)
+  ScrubMap &map,
+  ScrubMapBuilder &pos,
+  ScrubMap::object &o)
 {
-  dout(10) << __func__ << " " << poid << " seed " 
-	   << std::hex << seed << std::dec << dendl;
-  bufferhash h(seed), oh(seed);
-  bufferlist bl, hdrbl;
+  dout(10) << __func__ << " " << poid << " pos " << pos << dendl;
   int r;
-  __u64 pos = 0;
-  bool skip_data_digest = store->has_builtin_csum() &&
-    g_conf->get_val<bool>("osd_skip_data_digest");
-  utime_t sleeptime;
-  sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
-
   uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
                            CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
 
-  while (true) {
-    if (sleeptime != utime_t()) {
-      lgeneric_derr(cct) << __func__ << " sleeping for " << sleeptime << dendl;
-      sleeptime.sleep();
+  bool skip_data_digest = store->has_builtin_csum() &&
+    g_conf->get_val<bool>("osd_skip_data_digest");
+
+  utime_t sleeptime;
+  sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
+  if (sleeptime != utime_t()) {
+    lgeneric_derr(cct) << __func__ << " sleeping for " << sleeptime << dendl;
+    sleeptime.sleep();
+  }
+
+  assert(poid == pos.ls[pos.pos]);
+  if (!pos.data_done()) {
+    if (pos.data_pos == 0) {
+      pos.data_hash = bufferhash(pos.seed);
     }
-    handle.reset_tp_timeout();
+
+    bufferlist bl;
     r = store->read(
-	  ch,
-	  ghobject_t(
-	    poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
-	  pos,
-	  cct->_conf->osd_deep_scrub_stride, bl,
-	  fadvise_flags);
-    if (r <= 0)
-      break;
-
+      ch,
+      ghobject_t(
+	poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
+      pos.data_pos,
+      cct->_conf->osd_deep_scrub_stride, bl,
+      fadvise_flags);
+    if (r < 0) {
+      dout(20) << __func__ << "  " << poid << " got "
+	       << r << " on read, read_error" << dendl;
+      o.read_error = true;
+      return 0;
+    }
+    if (r > 0 && !skip_data_digest) {
+      pos.data_hash << bl;
+    }
+    pos.data_pos += r;
+    if (r == cct->_conf->osd_deep_scrub_stride) {
+      dout(20) << __func__ << "  " << poid << " more data, digest so far 0x"
+	       << std::hex << pos.data_hash.digest() << std::dec << dendl;
+      return -EINPROGRESS;
+    }
+    // done with bytes
+    pos.data_pos = -1;
     if (!skip_data_digest) {
-      h << bl;
+      o.digest = pos.data_hash.digest();
+      o.digest_present = true;
     }
-    pos += bl.length();
-    bl.clear();
-  }
-  if (r == -EIO) {
-    dout(25) << __func__ << "  " << poid << " got "
-	     << r << " on read, read_error" << dendl;
-    o.read_error = true;
-    return;
-  }
-  if (!skip_data_digest) {
-    o.digest = h.digest();
-    o.digest_present = true;
+    dout(20) << __func__ << "  " << poid << " done with data, digest 0x"
+	     << std::hex << o.digest << std::dec << dendl;
   }
 
-  bl.clear();
-  r = store->omap_get_header(
-    coll,
-    ghobject_t(
-      poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
-    &hdrbl, true);
-  // NOTE: bobtail to giant, we would crc the head as (len, head).
-  // that changes at the same time we start using a non-zero seed.
-  if (r == 0 && hdrbl.length()) {
-    dout(25) << "CRC header " << string(hdrbl.c_str(), hdrbl.length())
-             << dendl;
-    if (seed == 0) {
-      // legacy
-      bufferlist bl;
-      ::encode(hdrbl, bl);
-      oh << bl;
-    } else {
-      oh << hdrbl;
+  // omap header
+  if (pos.omap_pos.empty()) {
+    pos.omap_hash = bufferhash(pos.seed);
+
+    bufferlist hdrbl;
+    r = store->omap_get_header(
+      coll,
+      ghobject_t(
+	poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
+      &hdrbl, true);
+    if (r == -EIO) {
+      dout(20) << __func__ << "  " << poid << " got "
+	       << r << " on omap header read, read_error" << dendl;
+      o.read_error = true;
+      return 0;
     }
-  } else if (r == -EIO) {
-    dout(25) << __func__ << "  " << poid << " got "
-	     << r << " on omap header read, read_error" << dendl;
-    o.read_error = true;
-    return;
+    if (r == 0 && hdrbl.length()) {
+      dout(25) << "CRC header " << string(hdrbl.c_str(), hdrbl.length())
+	       << dendl;
+      pos.omap_hash << hdrbl;
+    }
   }
 
+  // omap
   ObjectMap::ObjectMapIterator iter = store->get_omap_iterator(
     coll,
     ghobject_t(
       poid, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard));
   assert(iter);
-  uint64_t keys_scanned = 0;
-  uint64_t value_sum = 0;
-  for (iter->seek_to_first(); iter->status() == 0 && iter->valid();
-    iter->next(false)) {
-    ++keys_scanned;
-    handle.reset_tp_timeout();
+  if (pos.omap_pos.length()) {
+    iter->lower_bound(pos.omap_pos);
+  } else {
+    iter->seek_to_first();
+  }
+  int max = g_conf->osd_deep_scrub_keys;
+  while (iter->status() == 0 && iter->valid()) {
+    pos.omap_bytes += iter->value().length();
+    ++pos.omap_keys;
 
-    dout(25) << "CRC key " << iter->key() << " value:\n";
-    iter->value().hexdump(*_dout);
-    *_dout << dendl;
-
-    value_sum += iter->value().length();
-
+    // fixme: we can do this more efficiently.
+    bufferlist bl;
     ::encode(iter->key(), bl);
     ::encode(iter->value(), bl);
-    oh << bl;
-    bl.clear();
+    pos.omap_hash << bl;
+
+    iter->next();
+
+    if (iter->valid() && max == 0) {
+      pos.omap_pos = iter->key();
+      return -EINPROGRESS;
+    }
+    if (iter->status() < 0) {
+      dout(25) << __func__ << "  " << poid
+	       << " on omap scan, db status error" << dendl;
+      o.read_error = true;
+      return 0;
+    }
   }
 
-  if (keys_scanned > cct->_conf->get_val<uint64_t>(
-                         "osd_deep_scrub_large_omap_object_key_threshold") ||
-      value_sum > cct->_conf->get_val<uint64_t>(
-                      "osd_deep_scrub_large_omap_object_value_sum_threshold")) {
+  if (pos.omap_keys > cct->_conf->get_val<uint64_t>(
+	"osd_deep_scrub_large_omap_object_key_threshold") ||
+      pos.omap_bytes > cct->_conf->get_val<uint64_t>(
+	"osd_deep_scrub_large_omap_object_value_sum_threshold")) {
     dout(25) << __func__ << " " << poid
-             << " large omap object detected. Object has " << keys_scanned
-             << " keys and size " << value_sum << " bytes" << dendl;
+	     << " large omap object detected. Object has " << pos.omap_keys
+	     << " keys and size " << pos.omap_bytes << " bytes" << dendl;
     o.large_omap_object_found = true;
-    o.large_omap_object_key_count = keys_scanned;
-    o.large_omap_object_value_size = value_sum;
-    map->has_large_omap_object_errors = true;
+    o.large_omap_object_key_count = pos.omap_keys;
+    o.large_omap_object_value_size = pos.omap_bytes;
+    map.has_large_omap_object_errors = true;
   }
 
-  if (iter->status() < 0) {
-    dout(25) << __func__ << "  " << poid
-             << " on omap scan, db status error" << dendl;
-    o.read_error = true;
-    return;
-  }
-
-  //Store final calculated CRC32 of omap header & key/values
-  o.omap_digest = oh.digest();
+  o.omap_digest = pos.omap_hash.digest();
   o.omap_digest_present = true;
-  dout(20) << __func__ << "  " << poid << " omap_digest "
+  dout(20) << __func__ << " done with " << poid << " omap_digest "
 	   << std::hex << o.omap_digest << std::dec << dendl;
+
+  // done!
+  return 0;
 }
 
 void ReplicatedBackend::_do_push(OpRequestRef op)

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -727,7 +727,7 @@ int ReplicatedBackend::be_deep_scrub(
   assert(poid == pos.ls[pos.pos]);
   if (!pos.data_done()) {
     if (pos.data_pos == 0) {
-      pos.data_hash = bufferhash(pos.seed);
+      pos.data_hash = bufferhash(-1);
     }
 
     bufferlist bl;
@@ -765,7 +765,7 @@ int ReplicatedBackend::be_deep_scrub(
 
   // omap header
   if (pos.omap_pos.empty()) {
-    pos.omap_hash = bufferhash(pos.seed);
+    pos.omap_hash = bufferhash(-1);
 
     bufferlist hdrbl;
     r = store->omap_get_header(

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1136,6 +1136,8 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   // we better not be missing this.
   assert(!parent->get_log().get_missing().is_missing(soid));
 
+  parent->maybe_preempt_replica_scrub(soid);
+
   int ackerosd = m->get_source().num();
 
   op->mark_started();

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -822,10 +822,10 @@ int ReplicatedBackend::be_deep_scrub(
     }
   }
 
-  if (pos.omap_keys > cct->_conf->get_val<uint64_t>(
-	"osd_deep_scrub_large_omap_object_key_threshold") ||
-      pos.omap_bytes > cct->_conf->get_val<uint64_t>(
-	"osd_deep_scrub_large_omap_object_value_sum_threshold")) {
+  if (pos.omap_keys > cct->_conf->
+	osd_deep_scrub_large_omap_object_key_threshold ||
+      pos.omap_bytes > cct->_conf->
+	osd_deep_scrub_large_omap_object_value_sum_threshold) {
     dout(25) << __func__ << " " << poid
 	     << " large omap object detected. Object has " << pos.omap_keys
 	     << " keys and size " << pos.omap_bytes << " bytes" << dendl;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -718,11 +718,17 @@ void ReplicatedBackend::be_deep_scrub(
   __u64 pos = 0;
   bool skip_data_digest = store->has_builtin_csum() &&
     g_conf->get_val<bool>("osd_skip_data_digest");
+  utime_t sleeptime;
+  sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
 
   uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
                            CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
 
   while (true) {
+    if (sleeptime != utime_t()) {
+      lgeneric_derr(cct) << __func__ << " sleeping for " << sleeptime << dendl;
+      sleeptime.sleep();
+    }
     handle.reset_tp_timeout();
     r = store->read(
 	  ch,

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -430,12 +430,11 @@ private:
   bool auto_repair_supported() const override { return false; }
 
 
-  void be_deep_scrub(
-    const hobject_t &obj,
-    uint32_t seed,
-    ScrubMap::object &o,
-    ThreadPool::TPHandle &handle,
-    ScrubMap* const map = nullptr) override;
+  int be_deep_scrub(
+    const hobject_t &poid,
+    ScrubMap &map,
+    ScrubMapBuilder &pos,
+    ScrubMap::object &o) override;
   uint64_t be_get_ondisk_size(uint64_t logical_size) override { return logical_size; }
 };
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4782,8 +4782,8 @@ struct object_info_t {
     omap_digest = -1;
   }
   void new_object() {
-    set_data_digest(-1);
-    set_omap_digest(-1);
+    clear_data_digest();
+    clear_omap_digest();
   }
 
   void encode(bufferlist& bl, uint64_t features) const;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4968,6 +4968,9 @@ struct ScrubMap {
   bool has_large_omap_object_errors:1;
 
   void merge_incr(const ScrubMap &l);
+  void clear_from(const hobject_t& start) {
+    objects.erase(objects.lower_bound(start), objects.end());
+  }
   void insert(const ScrubMap &r) {
     objects.insert(r.objects.begin(), r.objects.end());
   }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4988,7 +4988,6 @@ WRITE_CLASS_ENCODER(ScrubMap)
 
 struct ScrubMapBuilder {
   bool deep = false;
-  uint32_t seed = 0;
   vector<hobject_t> ls;
   size_t pos = 0;
   int64_t data_pos = 0;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4986,6 +4986,61 @@ struct ScrubMap {
 WRITE_CLASS_ENCODER(ScrubMap::object)
 WRITE_CLASS_ENCODER(ScrubMap)
 
+struct ScrubMapBuilder {
+  bool deep = false;
+  uint32_t seed = 0;
+  vector<hobject_t> ls;
+  size_t pos = 0;
+  int64_t data_pos = 0;
+  string omap_pos;
+  int ret = 0;
+  bufferhash data_hash, omap_hash;  ///< accumulatinng hash value
+  uint64_t omap_keys = 0;
+  uint64_t omap_bytes = 0;
+
+  bool empty() {
+    return ls.empty();
+  }
+  bool done() {
+    return pos >= ls.size();
+  }
+  void reset() {
+    *this = ScrubMapBuilder();
+  }
+
+  bool data_done() {
+    return data_pos < 0;
+  }
+
+  void next_object() {
+    ++pos;
+    data_pos = 0;
+    omap_pos.clear();
+    omap_keys = 0;
+    omap_bytes = 0;
+  }
+
+  friend ostream& operator<<(ostream& out, const ScrubMapBuilder& pos) {
+    out << "(" << pos.pos << "/" << pos.ls.size();
+    if (pos.pos < pos.ls.size()) {
+      out << " " << pos.ls[pos.pos];
+    }
+    if (pos.data_pos < 0) {
+      out << " byte " << pos.data_pos;
+    }
+    if (!pos.omap_pos.empty()) {
+      out << " key " << pos.omap_pos;
+    }
+    if (pos.deep) {
+      out << " deep";
+    }
+    if (pos.ret) {
+      out << " ret " << pos.ret;
+    }
+    return out << ")";
+  }
+};
+
 struct OSDOp {
   ceph_osd_op op;
   sobject_t soid;


### PR DESCRIPTION
backport trackers:
* https://tracker.ceph.com/issues/22769
* https://tracker.ceph.com/issues/23863
* https://tracker.ceph.com/issues/24153

These commits are on top of ceph/ceph#20033

Pull requests included:
ceph/ceph#21546 osd: process _scan_snaps() with all snapshots with head
ceph/ceph#21628 osd/PrimaryLogPG: defer evict if head *or* object intersect scrub interval
ceph/ceph#21892 osd: Don't evict even when preemption has restarted with smaller chunk
ceph/ceph#22074 test: Need to escape parens in log-whitelist for grep