### PR TITLE
client: cleanup Cap init

### DIFF
--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -545,7 +545,7 @@ void Inode::dump(Formatter *f) const
 void Cap::dump(Formatter *f) const
 {
   f->dump_int("mds", session->mds_num);
-  f->dump_stream("ino") << inode->ino;
+  f->dump_stream("ino") << inode.ino;
   f->dump_unsigned("cap_id", cap_id);
   f->dump_stream("issued") << ccap_string(issued);
   if (implemented != issued)

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -32,10 +32,11 @@ class Fh;
 class Cap {
 public:
   Cap() = delete;
-  Cap(Inode *i, MetaSession *s) :
-      session(s), inode(i), cap_id(0), issued(0),
-      implemented(0), wanted(0), seq(0), issue_seq(0), mseq(0), gen(s->cap_gen),
-      latest_perms(), cap_item(this) {
+  Cap(Inode &i, MetaSession *s) : inode(i),
+                                  session(s),
+                                  gen(s->cap_gen),
+                                  cap_item(this)
+  {
     s->caps.push_back(&cap_item);
   }
   ~Cap() {
@@ -49,14 +50,15 @@ public:
 
   void dump(Formatter *f) const;
 
+  Inode &inode;
   MetaSession *session;
-  Inode *inode;
-  uint64_t cap_id;
-  unsigned issued;
-  unsigned implemented;
-  unsigned wanted;   // as known to mds.
-  uint64_t seq, issue_seq;
-  __u32 mseq;  // migration seq
+  uint64_t cap_id = 0;
+  unsigned issued = 0;
+  unsigned implemented = 0;
+  unsigned wanted = 0;   // as known to mds.
+  uint64_t seq = 0;
+  uint64_t issue_seq = 0;
+  __u32 mseq = 0;  // migration seq
   __u32 gen;
   UserPerm latest_perms;
 


### PR DESCRIPTION
Use reference for inode so it's write-once and must be valid.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>