### PR TITLE
mimic: Fix ceph-mgr restarts

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -243,6 +243,7 @@ class Module(MgrModule, SSLCherryPyConfig):
         mgr.init(self)
 
         self._stopping = threading.Event()
+        self.shutdown_event = threading.Event()
 
     @classmethod
     def can_run(cls):
@@ -287,22 +288,22 @@ class Module(MgrModule, SSLCherryPyConfig):
         cherrypy.engine.start()
         NotificationQueue.start_queue()
         TaskManager.init()
-        logger.info('Waiting for engine...')
-        cherrypy.engine.block()
+        logger.info('Engine started.')
+        # wait for the shutdown event
+        self.shutdown_event.wait()
+        self.shutdown_event.clear()
+        NotificationQueue.stop()
+        cherrypy.engine.stop()
         if 'COVERAGE_ENABLED' in os.environ:
             _cov.stop()
             _cov.save()
-        logger.info('Engine done')
+        logger.info('Engine stopped')
 
     def shutdown(self):
         super(Module, self).shutdown()
-
         SSLCherryPyConfig.shutdown(self)
-
-        logger.info('Stopping server...')
-        NotificationQueue.stop()
-        cherrypy.engine.exit()
-        logger.info('Stopped server')
+        logger.info('Stopping engine...')
+        self.shutdown_event.set()
 
     def handle_command(self, cmd):
         res = handle_option_command(cmd)
@@ -351,6 +352,7 @@ class StandbyModule(MgrStandbyModule, SSLCherryPyConfig):
     def __init__(self, *args, **kwargs):
         super(StandbyModule, self).__init__(*args, **kwargs)
         SSLCherryPyConfig.__init__(self)
+        self.shutdown_event = threading.Event()
 
         # We can set the global mgr instance to ourselves even though
         # we're just a standby, because it's enough for logging.
@@ -393,14 +395,16 @@ class StandbyModule(MgrStandbyModule, SSLCherryPyConfig):
         cherrypy.tree.mount(Root(), "{}/".format(self.url_prefix), {})
         self.log.info("Starting engine...")
         cherrypy.engine.start()
-        self.log.info("Waiting for engine...")
-        cherrypy.engine.wait(state=cherrypy.engine.states.STOPPED)
-        self.log.info("Engine done.")
+        self.log.info("Engine started...")
+        # Wait for shutdown event
+        self.shutdown_event.wait()
+        self.shutdown_event.clear()
+        cherrypy.engine.stop()
+        self.log.info("Engine stopped.")
 
     def shutdown(self):
         SSLCherryPyConfig.shutdown(self)
 
-        self.log.info("Stopping server...")
-        cherrypy.engine.wait(state=cherrypy.engine.states.STARTED)
-        cherrypy.engine.stop()
-        self.log.info("Stopped server")
+        self.log.info("Stopping engine...")
+        self.shutdown_event.set()
+        self.log.info("Stopped engine...")

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -4,6 +4,7 @@ import errno
 import math
 import os
 import socket
+import threading
 from collections import OrderedDict
 from mgr_module import MgrModule, MgrStandbyModule, CommandResult
 
@@ -352,6 +353,7 @@ class Module(MgrModule):
         super(Module, self).__init__(*args, **kwargs)
         self.metrics = Metrics()
         self.schema = OrderedDict()
+        self.shutdown_event = threading.Event()
         _global_instance['plugin'] = self
 
     def get_health(self):
@@ -680,16 +682,22 @@ class Module(MgrModule):
         self.log.info('Starting engine...')
         cherrypy.engine.start()
         self.log.info('Engine started.')
-        cherrypy.engine.block()
+        # wait for the shutdown event
+        self.shutdown_event.wait()
+        self.shutdown_event.clear()
+        cherrypy.engine.stop()
+        self.log.info('Engine stopped.')
 
     def shutdown(self):
         self.log.info('Stopping engine...')
-        cherrypy.engine.wait(state=cherrypy.engine.states.STARTED)
-        cherrypy.engine.exit()
-        self.log.info('Stopped engine')
+        self.shutdown_event.set()
 
 
 class StandbyModule(MgrStandbyModule):
+    def __init__(self, *args, **kwargs):
+        super(StandbyModule, self).__init__(*args, **kwargs)
+        self.shutdown_event = threading.Event()
+
     def serve(self):
         server_addr = self.get_localized_config('server_addr', '::')
         server_port = self.get_localized_config('server_port', DEFAULT_PORT)
@@ -724,12 +732,14 @@ class StandbyModule(MgrStandbyModule):
         cherrypy.tree.mount(Root(), '/', {})
         self.log.info('Starting engine...')
         cherrypy.engine.start()
-        self.log.info("Waiting for engine...")
-        cherrypy.engine.wait(state=cherrypy.engine.states.STOPPED)
         self.log.info('Engine started.')
+        # Wait for shutdown event
+        self.shutdown_event.wait()
+        self.shutdown_event.clear()
+        cherrypy.engine.stop()
+        self.log.info('Engine stopped.')
 
     def shutdown(self):
         self.log.info("Stopping engine...")
-        cherrypy.engine.wait(state=cherrypy.engine.states.STARTED)
-        cherrypy.engine.stop()
+        self.shutdown_event.set()
         self.log.info("Stopped engine")


### PR DESCRIPTION
This PR contains a mimic back-port for shutdown/restart fix for prometheus module and a patch to fix the shutdown/restart with dashboard module enabled in the similar way.