### PR TITLE
rbd: add snap validation to get_pool_group_names

### DIFF
--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -347,7 +347,9 @@ int get_pool_group_names(const po::variables_map &vm,
 			 size_t *spec_arg_index,
 			 std::string *pool_name,
 			 std::string *group_name,
-                         std::string *snap_name) {
+                         std::string *snap_name,
+                         SnapshotPresence snapshot_presence,
+                         SpecValidation spec_validation) {
   std::string pool_key = (mod == at::ARGUMENT_MODIFIER_DEST ?
     at::DEST_POOL_NAME : at::POOL_NAME);
   std::string group_key = (mod == at::ARGUMENT_MODIFIER_DEST ?
@@ -388,9 +390,12 @@ int get_pool_group_names(const po::variables_map &vm,
     return -EINVAL;
   }
 
-  if (snap_name != nullptr && snap_name->empty()) {
-    std::cerr << "rbd: snapshot name was not specified" << std::endl;
-    return -EINVAL;
+  if (snap_name != nullptr) {
+    r = validate_snapshot_name(mod, *snap_name, snapshot_presence,
+			       spec_validation);
+    if (r < 0 ) {
+      return r;
+    }
   }
 
   return 0;

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -143,7 +143,9 @@ int get_pool_group_names(const boost::program_options::variables_map &vm,
 			 size_t *spec_arg_index,
 			 std::string *pool_name,
 			 std::string *group_name,
-                         std::string *snap_name);
+                         std::string *snap_name,
+                         SnapshotPresence snapshot_presence,
+                         SpecValidation spec_validation);
 
 int get_pool_journal_names(
     const boost::program_options::variables_map &vm,

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -28,7 +28,8 @@ int execute_create(const po::variables_map &vm,
 
   int r = utils::get_pool_group_names(vm, at::ARGUMENT_MODIFIER_NONE,
                                       &arg_index, &pool_name, &group_name,
-                                      nullptr);
+                                      nullptr, utils::SNAPSHOT_PRESENCE_NONE,
+                                      utils::SPEC_VALIDATION_NONE);     
   if (r < 0) {
     return r;
   }
@@ -101,7 +102,9 @@ int execute_remove(const po::variables_map &vm,
 
   int r = utils::get_pool_group_names(vm, at::ARGUMENT_MODIFIER_NONE,
                                       &arg_index, &pool_name, &group_name,
-                                      nullptr);
+                                      nullptr,
+                                      utils::SNAPSHOT_PRESENCE_NONE,
+                                      utils::SPEC_VALIDATION_NONE);
   if (r < 0) {
     return r;
   }
@@ -133,7 +136,9 @@ int execute_rename(const po::variables_map &vm,
 
   int r = utils::get_pool_group_names(vm, at::ARGUMENT_MODIFIER_NONE,
                                       &arg_index, &pool_name, &group_name,
-                                      nullptr);
+                                      nullptr,
+                                      utils::SNAPSHOT_PRESENCE_NONE,
+                                      utils::SPEC_VALIDATION_NONE);
   if (r < 0) {
     return r;
   }
@@ -143,7 +148,9 @@ int execute_rename(const po::variables_map &vm,
 
   r = utils::get_pool_group_names(vm, at::ARGUMENT_MODIFIER_NONE,
                                   &arg_index, &dest_pool_name,
-                                  &dest_group_name, nullptr);
+                                  &dest_group_name, nullptr,
+                                  utils::SNAPSHOT_PRESENCE_NONE,
+                                  utils::SPEC_VALIDATION_NONE);
   if (r < 0) {
     return r;
   }
@@ -309,7 +316,9 @@ int execute_list_images(const po::variables_map &vm,
 
   int r = utils::get_pool_group_names(vm, at::ARGUMENT_MODIFIER_NONE,
                                       &arg_index, &pool_name, &group_name,
-                                      nullptr);
+                                      nullptr,
+                                      utils::SNAPSHOT_PRESENCE_NONE,
+                                      utils::SPEC_VALIDATION_NONE);
   if (r < 0) {
     return r;
   }
@@ -396,7 +405,9 @@ int execute_group_snap_create(const po::variables_map &vm,
 
   int r = utils::get_pool_group_names(vm, at::ARGUMENT_MODIFIER_NONE,
                                       &arg_index, &pool_name, &group_name,
-                                      &snap_name);
+                                      &snap_name,
+                                      utils::SNAPSHOT_PRESENCE_REQUIRED,
+                                      utils::SPEC_VALIDATION_SNAP);
   if (r < 0) {
     return r;
   }
@@ -418,7 +429,7 @@ int execute_group_snap_create(const po::variables_map &vm,
   return 0;
 }
 
-  int execute_group_snap_remove(const po::variables_map &vm,
+int execute_group_snap_remove(const po::variables_map &vm,
                                 const std::vector<std::string> &global_args) {
   size_t arg_index = 0;
 
@@ -428,7 +439,9 @@ int execute_group_snap_create(const po::variables_map &vm,
 
   int r = utils::get_pool_group_names(vm, at::ARGUMENT_MODIFIER_NONE,
                                       &arg_index, &pool_name, &group_name,
-                                      &snap_name);
+                                      &snap_name,
+                                      utils::SNAPSHOT_PRESENCE_REQUIRED,
+                                      utils::SPEC_VALIDATION_SNAP);
   if (r < 0) {
     return r;
   }
@@ -462,7 +475,9 @@ int execute_group_snap_rename(const po::variables_map &vm,
 
   int r = utils::get_pool_group_names(vm, at::ARGUMENT_MODIFIER_NONE,
                                       &arg_index, &pool_name, &group_name,
-                                      &source_snap_name);
+                                      &source_snap_name,
+                                      utils::SNAPSHOT_PRESENCE_REQUIRED,
+                                      utils::SPEC_VALIDATION_SNAP);
   if (r < 0) {
     return r;
   }
@@ -516,7 +531,9 @@ int execute_group_snap_list(const po::variables_map &vm,
 
   int r = utils::get_pool_group_names(vm, at::ARGUMENT_MODIFIER_NONE,
                                       &arg_index, &pool_name, &group_name,
-                                      nullptr);
+                                      nullptr,
+                                      utils::SNAPSHOT_PRESENCE_NONE,
+                                      utils::SPEC_VALIDATION_NONE);
   if (r < 0) {
     return r;
   }


### PR DESCRIPTION
Add snapshot validation to `get_pool_group_names`
Also fixed indent problem of `execute_group_snap_remove`
Signed-off-by: Zeqing Tyler Qi <qizeqing048@pingan.com.cn>