### PR TITLE
mon: change monitor compact command to run asynchronously

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -364,6 +364,9 @@ public:
   /// compact the underlying store
   virtual void compact() {}
 
+  /// compact the underlying store in async mode
+  virtual void compact_async() {}
+
   /// compact db for all keys with a given prefix
   virtual void compact_prefix(const std::string& prefix) {}
   /// compact db for all keys with a given prefix, async

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -394,7 +394,11 @@ void LevelDBStore::compact_thread_entry()
       logger->set(l_leveldb_compact_queue_len, compact_queue.size());
       compact_queue_lock.Unlock();
       logger->inc(l_leveldb_compact_range);
-      compact_range(range.first, range.second);
+      if (range.first.empty() && range.second.empty()) {
+        compact();
+      } else {
+        compact_range(range.first, range.second);
+      }
       compact_queue_lock.Lock();
       continue;
     }

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -98,6 +98,10 @@ public:
   /// compact the underlying leveldb store
   void compact() override;
 
+  void compact_async() override {
+    compact_range_async(string(), string());
+  }
+
   /// compact db for all keys with a given prefix
   void compact_prefix(const string& prefix) override {
     compact_range(prefix, past_prefix(prefix));

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1172,7 +1172,11 @@ void RocksDBStore::compact_thread_entry()
       logger->set(l_rocksdb_compact_queue_len, compact_queue.size());
       compact_queue_lock.Unlock();
       logger->inc(l_rocksdb_compact_range);
-      compact_range(range.first, range.second);
+      if (range.first.empty() && range.second.empty()) {
+        compact();
+      } else {
+        compact_range(range.first, range.second);
+      }
       compact_queue_lock.Lock();
       continue;
     }

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -120,6 +120,10 @@ public:
   bool enable_rmrange;
   void compact() override;
 
+  void compact_async() override {
+    compact_range_async(string(), string());
+  }
+
   int tryInterpret(const string& key, const string& val, rocksdb::Options &opt);
   int ParseOptionsFromString(const string& opt_str, rocksdb::Options &opt);
   static int _test_init(const string& dir);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3168,7 +3168,7 @@ void Monitor::handle_command(MonOpRequestRef op)
   if (prefix == "compact" || prefix == "mon compact") {
     dout(1) << "triggering manual compaction" << dendl;
     auto start = ceph::coarse_mono_clock::now();
-    store->compact();
+    store->compact_async();
     auto end = ceph::coarse_mono_clock::now();
     double duration = std::chrono::duration<double>(end-start).count();
     dout(1) << "finished manual compaction in " << duration << " seconds" << dendl;

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -688,6 +688,10 @@ class MonitorDBStore
     db->compact();
   }
 
+  void compact_async() {
+    db->compact_async();
+  }
+
   void compact_prefix(const string& prefix) {
     db->compact_prefix(prefix);
   }


### PR DESCRIPTION
In monitor message dispatch code, while one command is executing , it must have the dispatch lock. So indeed all command are executing synchronously. If one command is executing for long time, others command must wait.So change the monitor compact command to execute asynchronously.

Fixed:  http://tracker.ceph.com/issues/24160
Signed-off-by: brandy penglaiyxy@gmail.com