### PR TITLE
qa/suites/rados/verify: remove random-distro$

### DIFF
--- a/qa/suites/rados/verify/supported-random-distro$
+++ b/qa/suites/rados/verify/supported-random-distro$
@@ -1,1 +1,0 @@
-../basic/supported-random-distro$


### PR DESCRIPTION
the distro specified by random-distro$ will be overwrited by the one
specfied by valgrind.yaml. and teuthology-suite will give

KeyError: '16.04 not a centos version or codename'

when scheduling a suite involving the facets above. also, i think it's
of not much value to run valgrind/lockdep with different distros.

Signed-off-by: Kefu Chai <kchai@redhat.com>