### PR TITLE
mgr/dashboard: ng serve bind to 0.0.0.0

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve --delete-output-path false --proxy-config proxy.conf.json",
+    "start": "ng serve --delete-output-path false --proxy-config proxy.conf.json --host 0.0.0.0",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
By default `ng serve` is only accessible from localhost, this change will allow access from remote machines.

Signed-off-by: Ricardo Marques <rimarques@suse.com>