### PR TITLE
mgr/dashboard: Disable package-lock.json creation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/.npmrc
+++ b/src/pybind/mgr/dashboard/frontend/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Since we are not keeping track of this file, it is better to not generate it.
Otherwise we might face some package version conflicts,
which break the dashboard build.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`