### PR TITLE
include/types: space between number and units

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1785,8 +1785,8 @@ function test_mon_osd_pool_quota()
   #
   # get quotas
   #
-  ceph osd pool get-quota tmp-quota-pool | grep 'max bytes.*10B'
-  ceph osd pool get-quota tmp-quota-pool | grep 'max objects.*10M objects'
+  ceph osd pool get-quota tmp-quota-pool | grep 'max bytes.*10 B'
+  ceph osd pool get-quota tmp-quota-pool | grep 'max objects.*10 M objects'
   #
   # set valid quotas with unit prefix
   #
@@ -1794,7 +1794,7 @@ function test_mon_osd_pool_quota()
   #
   # get quotas
   #
-  ceph osd pool get-quota tmp-quota-pool | grep 'max bytes.*10Ki'
+  ceph osd pool get-quota tmp-quota-pool | grep 'max bytes.*10 Ki'
   #
   # set valid quotas with unit prefix
   #
@@ -1802,7 +1802,7 @@ function test_mon_osd_pool_quota()
   #
   # get quotas
   #
-  ceph osd pool get-quota tmp-quota-pool | grep 'max bytes.*10Ki'
+  ceph osd pool get-quota tmp-quota-pool | grep 'max bytes.*10 Ki'
   #
   #
   # reset pool quotas

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -44,8 +44,8 @@ test_others() {
     rbd export testimg1 /tmp/img3
 
     # info
-    rbd info testimg1 | grep 'size 128MiB'
-    rbd info --snap=snap1 testimg1 | grep 'size 256MiB'
+    rbd info testimg1 | grep 'size 128 MiB'
+    rbd info --snap=snap1 testimg1 | grep 'size 256 MiB'
 
     # export-diff
     rm -rf /tmp/diff-testimg1-1 /tmp/diff-testimg1-2
@@ -58,10 +58,10 @@ test_others() {
     rbd import-diff --sparse-size 8K /tmp/diff-testimg1-2 testimg-diff1
 
     # info
-    rbd info testimg1 | grep 'size 128MiB'
-    rbd info --snap=snap1 testimg1 | grep 'size 256MiB'
-    rbd info testimg-diff1 | grep 'size 128MiB'
-    rbd info --snap=snap1 testimg-diff1 | grep 'size 256MiB'
+    rbd info testimg1 | grep 'size 128 MiB'
+    rbd info --snap=snap1 testimg1 | grep 'size 256 MiB'
+    rbd info testimg-diff1 | grep 'size 128 MiB'
+    rbd info --snap=snap1 testimg-diff1 | grep 'size 256 MiB'
 
     # make copies
     rbd copy testimg1 --snap=snap1 testimg2
@@ -70,16 +70,16 @@ test_others() {
     rbd copy testimg-diff1 --sparse-size 768K testimg-diff3
 
     # verify the result
-    rbd info testimg2 | grep 'size 256MiB'
-    rbd info testimg3 | grep 'size 128MiB'
-    rbd info testimg-diff2 | grep 'size 256MiB'
-    rbd info testimg-diff3 | grep 'size 128MiB'
+    rbd info testimg2 | grep 'size 256 MiB'
+    rbd info testimg3 | grep 'size 128 MiB'
+    rbd info testimg-diff2 | grep 'size 256 MiB'
+    rbd info testimg-diff3 | grep 'size 128 MiB'
 
     # deep copies
     rbd deep copy testimg1 testimg4
     rbd deep copy testimg1 --snap=snap1 testimg5
-    rbd info testimg4 | grep 'size 128MiB'
-    rbd info testimg5 | grep 'size 256MiB'
+    rbd info testimg4 | grep 'size 128 MiB'
+    rbd info testimg5 | grep 'size 256 MiB'
     rbd snap ls testimg4 | grep -v 'SNAPID' | wc -l | grep 1
     rbd snap ls testimg4 | grep '.*snap1.*'
 
@@ -98,8 +98,8 @@ test_others() {
     # rollback
     rbd snap rollback --snap=snap1 testimg1
     rbd snap rollback --snap=snap1 testimg-diff1
-    rbd info testimg1 | grep 'size 256MiB'
-    rbd info testimg-diff1 | grep 'size 256MiB'
+    rbd info testimg1 | grep 'size 256 MiB'
+    rbd info testimg-diff1 | grep 'size 256 MiB'
     rbd export testimg1 /tmp/img1.snap1
     rbd export testimg-diff1 /tmp/img-diff1.snap1
     cmp /tmp/img2 /tmp/img1.snap1
@@ -158,8 +158,8 @@ test_ls() {
     rbd ls | grep test2
     rbd ls | wc -l | grep 2
     # look for fields in output of ls -l without worrying about space
-    rbd ls -l | grep 'test1.*1MiB.*1'
-    rbd ls -l | grep 'test2.*1MiB.*1'
+    rbd ls -l | grep 'test1.*1 MiB.*1'
+    rbd ls -l | grep 'test2.*1 MiB.*1'
 
     rbd rm test1
     rbd rm test2
@@ -169,8 +169,8 @@ test_ls() {
     rbd ls | grep test1
     rbd ls | grep test2
     rbd ls | wc -l | grep 2
-    rbd ls -l | grep 'test1.*1MiB.*2'
-    rbd ls -l | grep 'test2.*1MiB.*2'
+    rbd ls -l | grep 'test1.*1 MiB.*2'
+    rbd ls -l | grep 'test2.*1 MiB.*2'
 
     rbd rm test1
     rbd rm test2
@@ -180,8 +180,8 @@ test_ls() {
     rbd ls | grep test1
     rbd ls | grep test2
     rbd ls | wc -l | grep 2
-    rbd ls -l | grep 'test1.*1MiB.*2'
-    rbd ls -l | grep 'test2.*1MiB.*1'
+    rbd ls -l | grep 'test1.*1 MiB.*2'
+    rbd ls -l | grep 'test2.*1 MiB.*1'
     remove_images
 
     # test that many images can be shown by ls
@@ -495,7 +495,7 @@ test_deep_copy_clone() {
     rbd clone testimg1@snap1 testimg2
     rbd snap create testimg2@snap2
     rbd deep copy testimg2 testimg3
-    rbd info testimg3 | grep 'size 256MiB'
+    rbd info testimg3 | grep 'size 256 MiB'
     rbd info testimg3 | grep 'parent: rbd/testimg1@snap1'
     rbd snap ls testimg3 | grep -v 'SNAPID' | wc -l | grep 1
     rbd snap ls testimg3 | grep '.*snap2.*'
@@ -513,7 +513,7 @@ test_deep_copy_clone() {
     rbd clone testimg1@snap1 testimg2
     rbd snap create testimg2@snap2
     rbd deep copy --flatten testimg2 testimg3
-    rbd info testimg3 | grep 'size 256MiB'
+    rbd info testimg3 | grep 'size 256 MiB'
     rbd info testimg3 | grep -v 'parent:'
     rbd snap ls testimg3 | grep -v 'SNAPID' | wc -l | grep 1
     rbd snap ls testimg3 | grep '.*snap2.*'
@@ -572,7 +572,7 @@ test_thick_provision() {
     ret=""
     while [ $count -lt 10 ]
     do
-        rbd du|grep test1|tr -s " "|cut -d " " -f 3|grep '^64MiB' && ret=$?
+        rbd du|grep test1|tr -s " "|cut -d " " -f 3|grep '^64 MiB' && ret=$?
         if [ "$ret" = "0" ]
         then
             break;
@@ -594,7 +594,7 @@ test_thick_provision() {
     ret=""
     while [ $count -lt 10 ]
     do
-        rbd du|grep test1|tr -s " "|cut -d " " -f 3|grep '^4GiB' && ret=$?
+        rbd du|grep test1|tr -s " "|cut -d " " -f 3|grep '^4 GiB' && ret=$?
         if [ "$ret" = "0" ]
         then
             break;

--- a/qa/workunits/rbd/import_export.sh
+++ b/qa/workunits/rbd/import_export.sh
@@ -139,7 +139,7 @@ if rbd help export | grep -q export-format; then
     rbd import --stripe-count 1000 --stripe-unit 4096 ${TMPDIR}/img testimg
     rbd export --export-format 2 testimg ${TMPDIR}/img_v2
     rbd import --export-format 2 ${TMPDIR}/img_v2 testimg_import
-    rbd info testimg_import|grep "stripe unit"|awk '{print $3}'|grep -Ei '(4KiB|4096)'
+    rbd info testimg_import|grep "stripe unit"|awk '{print $3}'|grep -Ei '(4 KiB|4096)'
     rbd info testimg_import|grep "stripe count"|awk '{print $3}'|grep 1000
 
     rm ${TMPDIR}/img_v2
@@ -184,7 +184,7 @@ dd if=/dev/urandom bs=1M count=1 of=${TMPDIR}/sparse2; truncate ${TMPDIR}/sparse
 # 1M sparse, 1M data
 rbd rm sparse1 || true
 rbd import $RBD_CREATE_ARGS --order 20 ${TMPDIR}/sparse1
-rbd ls -l | grep sparse1 | grep -Ei '(2MiB|2048k)'
+rbd ls -l | grep sparse1 | grep -Ei '(2 MiB|2048k)'
 [ $tiered -eq 1 -o "$(objects sparse1)" = '1' ]
 
 # export, compare contents and on-disk size
@@ -196,7 +196,7 @@ rbd rm sparse1
 # 1M data, 1M sparse
 rbd rm sparse2 || true
 rbd import $RBD_CREATE_ARGS --order 20 ${TMPDIR}/sparse2
-rbd ls -l | grep sparse2 | grep -Ei '(2MiB|2048k)'
+rbd ls -l | grep sparse2 | grep -Ei '(2 MiB|2048k)'
 [ $tiered -eq 1 -o "$(objects sparse2)" = '0' ]
 rbd export sparse2 ${TMPDIR}/sparse2.out
 compare_files_and_ondisk_sizes ${TMPDIR}/sparse2 ${TMPDIR}/sparse2.out
@@ -207,7 +207,7 @@ rbd rm sparse2
 truncate ${TMPDIR}/sparse1 -s 10M
 # import from stdin just for fun, verify still sparse
 rbd import $RBD_CREATE_ARGS --order 20 - sparse1 < ${TMPDIR}/sparse1
-rbd ls -l | grep sparse1 | grep -Ei '(10MiB|10240k)'
+rbd ls -l | grep sparse1 | grep -Ei '(10 MiB|10240k)'
 [ $tiered -eq 1 -o "$(objects sparse1)" = '1' ]
 rbd export sparse1 ${TMPDIR}/sparse1.out
 compare_files_and_ondisk_sizes ${TMPDIR}/sparse1 ${TMPDIR}/sparse1.out
@@ -218,7 +218,7 @@ rbd rm sparse1
 dd if=/dev/urandom bs=2M count=1 of=${TMPDIR}/sparse2 oflag=append conv=notrunc
 # again from stding
 rbd import $RBD_CREATE_ARGS --order 20 - sparse2 < ${TMPDIR}/sparse2
-rbd ls -l | grep sparse2 | grep -Ei '(4MiB|4096k)'
+rbd ls -l | grep sparse2 | grep -Ei '(4 MiB|4096k)'
 [ $tiered -eq 1 -o "$(objects sparse2)" = '0 2 3' ]
 rbd export sparse2 ${TMPDIR}/sparse2.out
 compare_files_and_ondisk_sizes ${TMPDIR}/sparse2 ${TMPDIR}/sparse2.out

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -363,11 +363,11 @@ namespace {
     char buffer[32];
 
     if (index == 0) {
-      (void) snprintf(buffer, sizeof(buffer), "%" PRId64 "%s", n, u);
+      (void) snprintf(buffer, sizeof(buffer), "%" PRId64 " %s", n, u);
     } else if ((v % mult) == 0) {
       // If this is an even multiple of the base, always display
       // without any decimal fraction.
-      (void) snprintf(buffer, sizeof(buffer), "%" PRId64 "%s", n, u);
+      (void) snprintf(buffer, sizeof(buffer), "%" PRId64 " %s", n, u);
     } else {
       // We want to choose a precision that reflects the best choice
       // for fitting in 5 characters.  This can get rather tricky when
@@ -378,7 +378,7 @@ namespace {
       // easier just to try each combination in turn.
       int i;
       for (i = 2; i >= 0; i--) {
-        if (snprintf(buffer, sizeof(buffer), "%.*f%s", i,
+        if (snprintf(buffer, sizeof(buffer), "%.*f %s", i,
           static_cast<double>(v) / mult, u) <= 7)
           break;
       }

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -56,8 +56,8 @@ TODO: figure out why .* does not match the block_name_prefix line in rbd info.
 For now, use a more inclusive regex.
   $ rbd info foo
   rbd image 'foo':
-  \tsize 1GiB in 256 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 1 GiB in 256 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 1 (esc)
   [^^]+ (re)
   \tformat: 1 (esc)
@@ -89,8 +89,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info foo@snap
   rbd image 'foo':
-  \tsize 1GiB in 256 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 1 GiB in 256 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 1 (esc)
   [^^]+ (re)
   \tformat: 1 (esc)
@@ -123,8 +123,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info bar
   rbd image 'bar':
-  \tsize 1GiB in 256 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 1 GiB in 256 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 2 (esc)
   \tid:* (glob)
   [^^]+ (re)
@@ -179,8 +179,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info bar@snap
   rbd image 'bar':
-  \tsize 512MiB in 128 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 512 MiB in 128 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 2 (esc)
   \tid:* (glob)
   [^^]+ (re)
@@ -238,8 +238,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info bar@snap2
   rbd image 'bar':
-  \tsize 1GiB in 256 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 1 GiB in 256 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 2 (esc)
   \tid:* (glob)
   [^^]+ (re)
@@ -297,8 +297,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info baz
   rbd image 'baz':
-  \tsize 2GiB in 512 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 2 GiB in 512 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 0 (esc)
   \tid:* (glob)
   [^^]+ (re)
@@ -345,8 +345,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info quux
   rbd image 'quux':
-  \tsize 1MiB in 1 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 1 MiB in 1 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 0 (esc)
   [^^]+ (re)
   \tformat: 1 (esc)
@@ -376,8 +376,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info rbd_other/child
   rbd image 'child':
-  \tsize 512MiB in 128 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 512 MiB in 128 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 1 (esc)
   \tid:* (glob)
   [^^]+ (re)
@@ -430,8 +430,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info rbd_other/child@snap
   rbd image 'child':
-  \tsize 512MiB in 128 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 512 MiB in 128 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 1 (esc)
   \tid:* (glob)
   [^^]+ (re)
@@ -442,7 +442,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   \tcreate_timestamp:* (glob)
   \tprotected: False (esc)
   \tparent: rbd/bar@snap (esc)
-  \toverlap: 512MiB (esc)
+  \toverlap: 512 MiB (esc)
   $ rbd info rbd_other/child@snap --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "block_name_prefix": "rbd_data.*",  (glob)
@@ -501,8 +501,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info rbd_other/deep-flatten-child
   rbd image 'deep-flatten-child':
-  \tsize 512MiB in 128 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 512 MiB in 128 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 1 (esc)
   \tid:* (glob)
   [^^]+ (re)
@@ -557,8 +557,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </image>
   $ rbd info rbd_other/deep-flatten-child@snap
   rbd image 'deep-flatten-child':
-  \tsize 512MiB in 128 objects (esc)
-  \torder 22 (4MiB objects) (esc)
+  \tsize 512 MiB in 128 objects (esc)
+  \torder 22 (4 MiB objects) (esc)
   \tsnapshot_count: 1 (esc)
   \tid:* (glob)
   [^^]+ (re)
@@ -638,14 +638,14 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </images>
   $ rbd list -l
   NAME        SIZE PARENT FMT PROT LOCK 
-  foo         1GiB          1           
-  foo@snap    1GiB          1           
-  quux        1MiB          1      excl 
-  bar         1GiB          2           
-  bar@snap  512MiB          2 yes       
-  bar@snap2   1GiB          2           
-  baz         2GiB          2      shr  
-  quuy        2GiB          2           
+  foo         1 GiB          1
+  foo@snap    1 GiB          1
+  quux        1 MiB          1      excl
+  bar         1 GiB          2
+  bar@snap  512 MiB          2 yes
+  bar@snap2   1 GiB          2
+  baz         2 GiB          2      shr
+  quuy        2 GiB          2
   $ rbd list -l --format json | python -mjson.tool | sed 's/,$/, /'
   [
       {
@@ -763,10 +763,10 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </images>
   $ rbd list rbd_other -l
   NAME                      SIZE PARENT       FMT PROT LOCK 
-  child                   512MiB                2           
-  child@snap              512MiB rbd/bar@snap   2           
-  deep-flatten-child      512MiB                2           
-  deep-flatten-child@snap 512MiB                2           
+  child                   512 MiB                2
+  child@snap              512 MiB rbd/bar@snap   2
+  deep-flatten-child      512 MiB                2
+  deep-flatten-child@snap 512 MiB                2
   $ rbd list rbd_other -l --format json | python -mjson.tool | sed 's/,$/, /'
   [
       {
@@ -901,7 +901,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </locks>
   $ rbd snap list foo
   SNAPID NAME SIZE TIMESTAMP 
-      *snap*1GiB* (glob)
+      *snap*1 GiB* (glob)
   $ rbd snap list foo --format json | python -mjson.tool | sed 's/,$/, /'
   [
       {
@@ -922,8 +922,8 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </snapshots>
   $ rbd snap list bar
   SNAPID NAME    SIZE TIMESTAMP                
-      *snap*512MiB* (glob)
-      *snap2*1GiB* (glob)
+      *snap*512 MiB* (glob)
+      *snap2*1 GiB* (glob)
   $ rbd snap list bar --format json | python -mjson.tool | sed 's/,$/, /'
   [
       {
@@ -961,7 +961,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   <snapshots></snapshots>
   $ rbd snap list rbd_other/child
   SNAPID NAME   SIZE TIMESTAMP                
-      *snap*512MiB* (glob)
+      *snap*512 MiB* (glob)
   $ rbd snap list rbd_other/child --format json | python -mjson.tool | sed 's/,$/, /'
   [
       {
@@ -982,11 +982,11 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   </snapshots>
   $ rbd disk-usage --pool rbd_other 2>/dev/null
   NAME                    PROVISIONED USED 
-  child@snap                   512MiB   0B 
-  child                        512MiB 4MiB 
-  deep-flatten-child@snap      512MiB   0B 
-  deep-flatten-child           512MiB   0B 
-  <TOTAL>                        1GiB 4MiB 
+  child@snap                   512 MiB   0 B
+  child                        512 MiB 4 MiB
+  deep-flatten-child@snap      512 MiB   0 B
+  deep-flatten-child           512 MiB   0 B
+  <TOTAL>                        1 GiB 4 MiB
   $ rbd disk-usage --pool rbd_other --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "images": [


### PR DESCRIPTION
not

    client:   504B/s rd, 10.6MiB/s wr, 0op/s rd, 30op/s wr

but

    client:   504 B/s rd, 10.6 MiB/s wr, 0 op/s rd, 30 op/s wr

This was changed as part of d3cecebacdcebcf475808a6204de22dfa94d729d.

Signed-off-by: Sage Weil <sage@redhat.com>