### PR TITLE
os/bluestore: silence warning from -Wsign-compare

### DIFF
--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -113,7 +113,7 @@ int64_t BitMapAllocator::allocate(
   auto res = allocate_dis(want_size, alloc_unit / m_block_size,
                       max_alloc_size, hint / m_block_size, extents);
 
-  if (res < want_size) {
+  if (res > 0 && res < static_cast<int64_t>(want_size)) {
     auto unused = want_size - res;
     int nblks = unused / m_block_size;
     assert(!(unused % m_block_size));


### PR DESCRIPTION
```
/home/jenkins-build/build/workspace/ceph-pull-requests/src/os/bluestore/BitMapAllocator.cc: In member function 'virtual int64_t BitMapAllocator::allocate(uint64_t, uint64_t, uint64_t, int64_t, PExtentVector*)':
/home/jenkins-build/build/workspace/ceph-pull-requests/src/os/bluestore/BitMapAllocator.cc:116:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (res < want_size) {
       ~~~~^~~~~~~~~~~
```

Signed-off-by: Igor Fedotov <ifedotov@suse.com>