### PR TITLE
Improve table pagination style

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -204,6 +204,9 @@
     }
     .datatable-pager .pager {
       margin-right: 5px;
+      & li > a, & li > span {
+        border-radius: 3px;
+      }
       .pages {
         & > a, & > span {
           display: inline-block;


### PR DESCRIPTION
Table pagination buttons style was not consistent with the rest of the application, since we do not use "rounded" buttons anywhere else.

BEFORE
![screenshot_20180517_155659](https://user-images.githubusercontent.com/14297426/40186501-2b41a788-59ed-11e8-9cd7-40505119e38c.png)

AFTER
![screenshot_20180517_160921](https://user-images.githubusercontent.com/14297426/40186504-2d5c4956-59ed-11e8-925c-4a88caace040.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>