### PR TITLE
mimic: test: Need to escape parens in log-whitelist for grep

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/cephfs_scrub_tests.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cephfs_scrub_tests.yaml
@@ -6,7 +6,7 @@ overrides:
       - Metadata damage detected
       - bad backtrace on inode
       - overall HEALTH_
-      - (MDS_TRIM)
+      - \(MDS_TRIM\)
     conf:
       mds:
         mds log max segments: 1

--- a/qa/suites/rados/basic/tasks/repair_test.yaml
+++ b/qa/suites/rados/basic/tasks/repair_test.yaml
@@ -18,9 +18,9 @@ overrides:
       - attr name mismatch
       - Regular scrub request, deep-scrub details will be lost
       - overall HEALTH_
-      - (OSDMAP_FLAGS)
-      - (OSD_
-      - (PG_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
     conf:
       osd:
         filestore debug inject read err: true

--- a/qa/suites/rados/basic/tasks/scrub_test.yaml
+++ b/qa/suites/rados/basic/tasks/scrub_test.yaml
@@ -16,11 +16,11 @@ overrides:
     - 'deep-scrub 1 missing, 0 inconsistent objects'
     - 'failed to pick suitable auth object'
     - overall HEALTH_
-    - (OSDMAP_FLAGS)
-    - (OSD_
-    - (PG_
-    - (OSD_SCRUB_ERRORS)
-    - (TOO_FEW_PGS)
+    - \(OSDMAP_FLAGS\)
+    - \(OSD_
+    - \(PG_
+    - \(OSD_SCRUB_ERRORS\)
+    - \(TOO_FEW_PGS\)
     conf:
       osd:
         osd deep scrub update digest min age: 0

--- a/qa/suites/rados/monthrash/ceph.yaml
+++ b/qa/suites/rados/monthrash/ceph.yaml
@@ -14,7 +14,7 @@ overrides:
       - overall HEALTH_
       - \(MGR_DOWN\)
 # slow mons -> slow peering -> PG_AVAILABILITY
-      - \(PG_AVAILABILITY)
+      - \(PG_AVAILABILITY\)
       - \(SLOW_OPS\)
 tasks:
 - install:

--- a/qa/suites/rados/monthrash/workloads/rados_mon_workunits.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_mon_workunits.yaml
@@ -5,6 +5,7 @@ overrides:
     - overall HEALTH_
     - \(PG_
     - \(MON_DOWN\)
+    - \(CACHE_POOL_NO_HIT_SET\)
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/multimon/tasks/mon_clock_no_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_no_skews.yaml
@@ -6,6 +6,6 @@ tasks:
     - .*clock.*skew.*
     - clocks not synchronized
     - overall HEALTH_
-    - (MON_CLOCK_SKEW)
+    - \(MON_CLOCK_SKEW\)
 - mon_clock_skew_check:
     expect-skew: false

--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -26,6 +26,7 @@ tasks:
     - \(OSD_
     - \(PG_
     - \(SMALLER_PG_NUM\)
+    - \(CACHE_POOL_NO_HIT_SET\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -22,10 +22,10 @@ tasks:
     - failsafe engaged, dropping updates
     - failsafe disengaged, no longer dropping updates
     - overall HEALTH_
-    - (OSDMAP_FLAGS)
-    - (OSD_
-    - (PG_
-    - (SMALLER_PG_NUM)
+    - \(OSDMAP_FLAGS\)
+    - \(OSD_
+    - \(PG_
+    - \(SMALLER_PG_NUM\)
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/admin_socket_output.yaml
@@ -10,10 +10,10 @@ overrides:
       - MDS in read-only mode
       - force file system read-only
       - overall HEALTH_
-      - (OSDMAP_FLAGS)
-      - (OSD_FULL)
-      - (MDS_READ_ONLY)
-      - (POOL_FULL)
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_FULL\)
+      - \(MDS_READ_ONLY\)
+      - \(POOL_FULL\)
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
+++ b/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
@@ -16,9 +16,9 @@ tasks:
       - but it is still running
       - slow request
       - overall HEALTH_
-      - (OSDMAP_FLAGS)
-      - (OSD_
-      - (PG_
+      - \(OSDMAP_FLAGS\)
+      - \(OSD_
+      - \(PG_
 - exec:
     client.0:
       - sudo ceph osd pool create foo 128 128

--- a/qa/suites/rados/singleton/all/random-eio.yaml
+++ b/qa/suites/rados/singleton/all/random-eio.yaml
@@ -20,8 +20,8 @@ tasks:
     - objects unfound and apparently lost
     - had a read error
     - overall HEALTH_
-    - (POOL_APP_NOT_ENABLED)
-    - (PG_DEGRADED)
+    - \(POOL_APP_NOT_ENABLED\)
+    - \(PG_DEGRADED\)
 - full_sequential:
   - exec:
       client.0:

--- a/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
+++ b/qa/suites/rados/singleton/all/thrash_cache_writeback_proxy_none.yaml
@@ -19,7 +19,7 @@ tasks:
       - but it is still running
       - slow request
       - overall HEALTH_
-      - (CACHE_POOL_
+      - \(CACHE_POOL_
 - exec:
     client.0:
       - sudo ceph osd pool create base 4

--- a/qa/suites/rbd/openstack/base/install.yaml
+++ b/qa/suites/rbd/openstack/base/install.yaml
@@ -4,4 +4,4 @@ tasks:
 overrides:
   ceph:
     log-whitelist:
-      - (POOL_APP_NOT_ENABLED)
+      - \(POOL_APP_NOT_ENABLED\)

--- a/qa/suites/rbd/thrash/thrashers/cache.yaml
+++ b/qa/suites/rbd/thrash/thrashers/cache.yaml
@@ -4,8 +4,8 @@ overrides:
       - but it is still running
       - objects unfound and apparently lost
       - overall HEALTH_
-      - (CACHE_POOL_NEAR_FULL)
-      - (CACHE_POOL_NO_HIT_SET)
+      - \(CACHE_POOL_NEAR_FULL\)
+      - \(CACHE_POOL_NO_HIT_SET\)
 tasks:
 - exec:
     client.0:

--- a/qa/suites/upgrade/kraken-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/kraken-x/parallel/0-cluster/start.yaml
@@ -24,7 +24,7 @@ overrides:
     - scrub mismatch
     - ScrubResult
     - wrongly marked
-    - (POOL_APP_NOT_ENABLED)
+    - \(POOL_APP_NOT_ENABLED\)
     - overall HEALTH_
     conf:
       global:


### PR DESCRIPTION
Any tests that include these yamls without this change wouldn't detect errors in the logs.