### PR TITLE
luminous: cmake: disable FAIL_ON_WARNINGS for rocksdb

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -824,10 +824,7 @@ if (NOT WITH_SYSTEM_ROCKSDB)
   # rocksdb/util/crc32c.cc.
   list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_AR=${CMAKE_AR})
   list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
-
-  if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-    list(APPEND ROCKSDB_CMAKE_ARGS -DFAIL_ON_WARNINGS=OFF)
-  endif()
+  list(APPEND ROCKSDB_CMAKE_ARGS -DFAIL_ON_WARNINGS=OFF)
 
   # we use an external project and copy the sources to bin directory to ensure
   # that object files are built outside of the source tree.


### PR DESCRIPTION
otherwise -Werror=implicit-fallthrough will fail the build with GCC-7

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 6559a850512ddefef384d2733823ac2cb8027e3a)

Conflicts:
	cmake/modules/BuildRocksDB.cmake: we have not extract the
BuildRocksDB to this cmake module yet in luminous. so update
src/CMakeLists.txt instead.