### PR TITLE
os/bluestore: fix flush_commit locking

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8452,8 +8452,11 @@ void BlueStore::_txc_state_proc(TransContext *txc)
       return;
     case TransContext::STATE_KV_SUBMITTED:
       txc->log_state_latency(logger, l_bluestore_state_kv_committing_lat);
-      txc->state = TransContext::STATE_KV_DONE;
-      _txc_committed_kv(txc);
+      {
+	std::lock_guard<std::mutex> l(txc->osr->qlock);
+	txc->state = TransContext::STATE_KV_DONE;
+	_txc_committed_kv(txc);
+      }
       // ** fall-thru **
 
     case TransContext::STATE_KV_DONE:


### PR DESCRIPTION
We were updating the txc state to KV_DONE and queuing the oncommits
waiters without holding any locks.  This was mostly fine, *except* that
Collection|OpSequencer::flush_commit(Context *) was looking at the state
(under qlock) and also adding items to oncommits.

The flush_commit() method is only used in 2 places: osd bench, and the
PG reset_interval_flush outgoing message blocking machinery (which is
a bit ick). The first we could get rid of, but the second is hard to
remove (despite its ick factor).

The simple fix is to take qlock while updating the state value and
working with oncommits.

Fixes: http://tracker.ceph.com/issues/21480
Signed-off-by: Sage Weil <sage@redhat.com>