### PR TITLE
os/bluestore: introduce new BlueFS perf counter to track the amount of

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -35,6 +35,7 @@ enum {
   l_bluefs_files_written_sst,
   l_bluefs_bytes_written_wal,
   l_bluefs_bytes_written_sst,
+  l_bluefs_bytes_written_slow,
   l_bluefs_last,
 };
 


### PR DESCRIPTION
data written to slow device.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>