### PR TITLE
mgr/dashboard: Fix RBD task metadata

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -299,7 +299,7 @@ class Rbd(RESTController):
         rbd_inst = rbd.RBD()
         return _rbd_call(pool_name, rbd_inst.remove, image_name)
 
-    @RbdTask('edit', ['{pool_name}', '{image_name}'], 4.0)
+    @RbdTask('edit', ['{pool_name}', '{image_name}', '{name}'], 4.0)
     def set(self, pool_name, image_name, name=None, size=None, features=None):
         def _edit(ioctx, image):
             rbd_inst = rbd.RBD()

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.ts
@@ -39,7 +39,7 @@ export class TaskManagerMessageService {
                      has been updated successfully`,
       (metadata) => {
         return {
-          '17': `Name '${metadata.pool_name}/${metadata.image_name}' is already
+          '17': `Name '${metadata.pool_name}/${metadata.name}' is already
                  in use.`
         };
       }
@@ -72,7 +72,7 @@ export class TaskManagerMessageService {
                      has been copied successfully`,
       (metadata) => {
         return {
-          '17': `Name '${metadata.child_pool_name}/${metadata.child_image_name}' is already
+          '17': `Name '${metadata.dest_pool_name}/${metadata.dest_image_name}' is already
                  in use.`
         };
       }


### PR DESCRIPTION
Error message template for RBD copy was trying to read
an unexistent property of the returned metada.

Metadata for RBD edit was missing the new image name.
The new name should be displayed, instead of the old one,
when the user tries to use an existent image name.

Fixes: https://tracker.ceph.com/issues/24171

`Signed-off-by: Tiago Melo <tmelo@suse.com>`