### PR TITLE
mgr/status: output to stdout, not stderr

### DIFF
--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -249,7 +249,7 @@ class Module(MgrModule):
                 ])
             output += version_table.get_string() + "\n"
 
-        return 0, "", output
+        return 0, output, ""
 
     def handle_osd_status(self, cmd):
         osd_table = PrettyTable(['id', 'host', 'used', 'avail', 'wr ops', 'wr data', 'rd ops', 'rd data', 'state'])
@@ -301,7 +301,7 @@ class Module(MgrModule):
                                ','.join(osd['state']),
                                ])
 
-        return 0, "", osd_table.get_string()
+        return 0, osd_table.get_string(), ""
 
     def handle_command(self, cmd):
         self.log.error("handle_command")


### PR DESCRIPTION
I think this was just me forgetting the order
of the arguments when writing the return statements.

Fixes: http://tracker.ceph.com/issues/24175
Signed-off-by: John Spray <john.spray@redhat.com>