### PR TITLE
msg/async/Event: clear time_events on shutdown

### DIFF
--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -171,7 +171,8 @@ EventCenter::~EventCenter()
       external_events.pop_front();
     }
   }
-  assert(time_events.empty());
+  time_events.clear();
+  //assert(time_events.empty());
 
   if (notify_receive_fd >= 0)
     ::close(notify_receive_fd);


### PR DESCRIPTION
Works around crash from http://tracker.ceph.com/issues/24162

Signed-off-by: Sage Weil <sage@redhat.com>