### PR TITLE
mon/LogMonitor: call no_reply() on ignored log message

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -313,6 +313,7 @@ bool LogMonitor::preprocess_log(MonOpRequestRef op)
   return false;
 
  done:
+  mon->no_reply(op);
   return true;
 }
 


### PR DESCRIPTION
If we're dropping it on the floor, we need to tell the mon that, so that
it can tell the forwarding mon to discard its state.

Fixes: https://tracker.ceph.com/issues/24180
Signed-off-by: Sage Weil <sage@redhat.com>