### PR TITLE
mon/PGMap: fix PGMapDigest decode

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -78,6 +78,7 @@ void PGMapDigest::decode(bufferlist::iterator& p)
   } else {
     map<int32_t, int32_t> nps;
     decode(nps, p);
+    num_pg_by_state.clear();
     for (auto i : nps) {
       num_pg_by_state[i.first] = i.second;
     }


### PR DESCRIPTION
The compat path wasn't clearing the map before filling in new entries.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 42bdb066bb0397dbb84a2ca60ec4640cdd0afdef)