### PR TITLE
qa/workunits/rados/test_envlibrados_for_rocksdb: install g++ not g++-4.7

### DIFF
--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -14,7 +14,7 @@ function install() {
 function install_one() {
     case $(lsb_release -si) in
         Ubuntu|Debian|Devuan)
-            sudo apt-get install -y --force-yes "$@"
+            sudo env DEBIAN_FRONTEND=noninteractive apt-get install -y "$@"
             ;;
         CentOS|Fedora|RedHatEnterpriseServer)
             sudo yum install -y "$@"
@@ -31,7 +31,7 @@ function install_one() {
 #			Install required tools
 ############################################
 echo "Install required tools"
-install git automake
+install git cmake
 
 CURRENT_PATH=`pwd`
 
@@ -42,10 +42,10 @@ CURRENT_PATH=`pwd`
 # for rocksdb
 case $(lsb_release -si) in
 	Ubuntu|Debian|Devuan)
-		install g++ libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev librados-dev
+		install g++ libsnappy-dev zlib1g-dev libbz2-dev librados-dev
 		;;
 	CentOS|Fedora|RedHatEnterpriseServer)
-		install gcc-c++.x86_64 gflags-devel snappy-devel zlib zlib-devel bzip2 bzip2-devel librados2-devel.x86_64
+		install gcc-c++.x86_64 snappy-devel zlib zlib-devel bzip2 bzip2-devel librados2-devel.x86_64
 		;;
 	*)
         echo "$(lsb_release -si) is unknown, $@ will have to be installed manually."
@@ -73,7 +73,8 @@ git clone https://github.com/facebook/rocksdb.git --depth 1
 
 # compile code
 cd rocksdb
-make env_librados_test ROCKSDB_USE_LIBRADOS=1 DISABLE_WARNING_AS_ERROR=1 -j8
+mkdir build && cd build && cmake -DWITH_LIBRADOS=ON -DWITH_SNAPPY=ON -DWITH_GFLAGS=OFF -DFAIL_ON_WARNINGS=OFF ..
+make rocksdb_env_librados_test -j8
 
 echo "Copy ceph.conf"
 # prepare ceph.conf

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -42,7 +42,7 @@ CURRENT_PATH=`pwd`
 # for rocksdb
 case $(lsb_release -si) in
 	Ubuntu|Debian|Devuan)
-		install g++-4.7 libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev librados-dev
+		install g++ libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev librados-dev
 		;;
 	CentOS|Fedora|RedHatEnterpriseServer)
 		install gcc-c++.x86_64 gflags-devel snappy-devel zlib zlib-devel bzip2 bzip2-devel librados2-devel.x86_64

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -189,7 +189,7 @@ namespace buffer CEPH_BUFFER_API {
       const char *end_ptr;   ///< pointer to bp->end_c_str()
       const bool deep;   ///< if true, do not allow shallow ptr copies
 
-      iterator_impl(std::conditional_t<is_const, const ptr*, ptr*> p,
+      iterator_impl(typename std::conditional<is_const, const ptr*, ptr*>::type p,
 		    size_t offset, bool d)
 	: bp(p),
 	  start(p->c_str() + offset),
@@ -201,7 +201,7 @@ namespace buffer CEPH_BUFFER_API {
       friend class ptr;
 
     public:
-      using pointer = std::conditional_t<is_const, const char*, char *>;
+      using pointer = typename std::conditional<is_const, const char*, char *>::type;
       pointer get_pos_add(size_t n) {
 	auto r = pos;
 	advance(n);


### PR DESCRIPTION
since fog now deploys ubuntu 18.04 where g++-4.7 is not available
anymore, so g++ is good enough.

Signed-off-by: Kefu Chai <kchai@redhat.com>