### PR TITLE
mimic: mon/LogMonitor: call no_reply() on ignored log message

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -313,6 +313,7 @@ bool LogMonitor::preprocess_log(MonOpRequestRef op)
   return false;
 
  done:
+  mon->no_reply(op);
   return true;
 }
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/24195