### PR TITLE
qa/suites/rados/thrash-old-clients: only centos and 16.04

### DIFF
--- a/qa/suites/rados/thrash-old-clients/distro$/centos_latest.yaml
+++ b/qa/suites/rados/thrash-old-clients/distro$/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../distros/supported/centos_latest.yaml

--- a/qa/suites/rados/thrash-old-clients/distro$/ubuntu_16.04.yaml
+++ b/qa/suites/rados/thrash-old-clients/distro$/ubuntu_16.04.yaml
@@ -1,0 +1,1 @@
+../../../../distros/all/ubuntu_16.04.yaml

--- a/qa/suites/rados/thrash-old-clients/supported-random-distro$
+++ b/qa/suites/rados/thrash-old-clients/supported-random-distro$
@@ -1,1 +1,0 @@
-../basic/supported-random-distro$


### PR DESCRIPTION
We don't have old client builds for the newer distros.

Signed-off-by: Sage Weil <sage@redhat.com>