### PR TITLE
luminous: mon/LogMonitor: call no_reply() on ignored log message

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -314,6 +314,7 @@ bool LogMonitor::preprocess_log(MonOpRequestRef op)
   return false;
 
  done:
+  mon->no_reply(op);
   return true;
 }
 


### PR DESCRIPTION
backport tracker: https://tracker.ceph.com/issues/24198

If we're dropping it on the floor, we need to tell the mon that, so that
it can tell the forwarding mon to discard its state.

Fixes: https://tracker.ceph.com/issues/24180
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 9661fa08ccc500587d35d7af8a905916167d8314)