### PR TITLE
common: fix typo in rados bench write JSON output

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -606,7 +606,7 @@ int ObjBencher::write_bench(int secondsToRun,
     formatter->dump_format("min_iops", "%d", data.idata.min_iops);
     formatter->dump_format("average_latency", "%f", data.avg_latency);
     formatter->dump_format("stddev_latency", "%f", latency_stddev);
-    formatter->dump_format("max_latency:", "%f", data.max_latency);
+    formatter->dump_format("max_latency", "%f", data.max_latency);
     formatter->dump_format("min_latency", "%f", data.min_latency);
   }
   //write object size/number data for read benchmarks


### PR DESCRIPTION
Fixes typo in `max_latency` key in JSON output from rados bench write.

Fixes: http://tracker.ceph.com/issues/24199
Signed-off-by: Sandor Zeestraten <sandor@zeestrataca.com>