### PR TITLE
mimic: osd/PrimaryLogPG: fix try_flush_mark_clean write contention case

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10013,7 +10013,6 @@ int PrimaryLogPG::try_flush_mark_clean(FlushOpRef fop)
   } else if (fop->op) {
     dout(10) << __func__ << " waiting on write lock " << fop->op << " "
 	     << fop->dup_ops << dendl;
-    close_op_ctx(ctx.release());
     // fop->op is now waiting on the lock; get fop->dup_ops to wait too.
     for (auto op : fop->dup_ops) {
       bool locked = ctx->lock_manager.get_lock_type(
@@ -10023,6 +10022,7 @@ int PrimaryLogPG::try_flush_mark_clean(FlushOpRef fop)
 	op);
       assert(!locked);
     }
+    close_op_ctx(ctx.release());
     return -EAGAIN;    // will retry
   } else {
     dout(10) << __func__ << " failed write lock, no op; failing" << dendl;


### PR DESCRIPTION
Release ctx *after* we dereference it to queue up the other flush waiters.
This was a dumb mistake in the recent fix from 41609ba1b24e5384494c7959494e19302b5a2429

Fixes: http://tracker.ceph.com/issues/24174
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 6d6cf388b245e21cc78be00d838e8b214b1e9497)