### PR TITLE
rgw: remove the useless is_cors_op in RGWHandler_REST_Obj_S3.

### DIFF
--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -569,9 +569,6 @@ protected:
   bool is_acl_op() {
     return s->info.args.exists("acl");
   }
-  bool is_cors_op() {
-      return s->info.args.exists("cors");
-  }
   bool is_tagging_op() {
     return s->info.args.exists("tagging");
   }


### PR DESCRIPTION
Cors is modified on buckets，so the “is_cors_op” is useless in RGWHandler_REST_Obj_S3.

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>