### PR TITLE
qa/rgw: disable testing on ec-cache pools

### DIFF
--- a/qa/rgw_pool_type/ec-cache.yaml
+++ b/qa/rgw_pool_type/ec-cache.yaml
@@ -1,6 +1,0 @@
-overrides:
-  rgw:
-    ec-data-pool: true
-    cache-pools: true
-  s3tests:
-    slow_backend: true


### PR DESCRIPTION
https://github.com/ceph/ceph/pull/21630 identified an issue with create_pools() in qa/tasks/rgw.py, which had been using the wrong pool names. because of this, we weren't getting test coverage for non-replicated pool types. after that fix merged, we started seeing several failures in the rgw suite against ec-cache pools that had previously been masked

while these failures are probably valuable to the rados team as a reproducer, they aren't helpful to the rgw team so i'm proposing to remove ec-cache pools from the rgw suite. i'm happy to add it back somewhere under the rados suite, if that's desired

Fixes: http://tracker.ceph.com/issues/23965