### PR TITLE
luminous: qa/suites/rbd/basic/msgr-failures: remove many.yaml

### DIFF
--- a/qa/suites/rbd/basic/msgr-failures/many.yaml
+++ b/qa/suites/rbd/basic/msgr-failures/many.yaml
@@ -1,5 +1,0 @@
-overrides:
-  ceph:
-    conf:
-      global:
-        ms inject socket failures: 500


### PR DESCRIPTION
Overkill, and triggers some failures, see
http://tracker.ceph.com/issues/23789

Removed in master by 4046f46d0e6a70d860d74945dfb95c2511394640

Fixes: http://tracker.ceph.com/issues/23789
Signed-off-by: Sage Weil <sage@redhat.com>