### PR TITLE
osd/ReplicatedBackend: fix use-after-free on InProgressOp

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -236,7 +236,8 @@ void ReplicatedBackend::on_change()
 {
   dout(10) << __func__ << dendl;
   for (auto& op : in_progress_ops) {
-    delete op.second.on_commit;
+    delete op.second->on_commit;
+    op.second->on_commit = nullptr;
   }
   in_progress_ops.clear();
   clear_recovery_state();
@@ -264,7 +265,7 @@ void ReplicatedBackend::objects_read_async(
 
 class C_OSD_OnOpCommit : public Context {
   ReplicatedBackend *pg;
-  ReplicatedBackend::InProgressOp *op;
+  ReplicatedBackend::InProgressOpRef op;
 public:
   C_OSD_OnOpCommit(ReplicatedBackend *pg, ReplicatedBackend::InProgressOp *op) 
     : pg(pg), op(op) {}
@@ -453,13 +454,13 @@ void ReplicatedBackend::submit_transaction(
   auto insert_res = in_progress_ops.insert(
     make_pair(
       tid,
-      InProgressOp(
+      new InProgressOp(
 	tid, on_all_commit,
 	orig_op, at_version)
       )
     );
   assert(insert_res.second);
-  InProgressOp &op = insert_res.first->second;
+  InProgressOp &op = *insert_res.first->second;
 
   op.waiting_for_commit.insert(
     parent->get_acting_recovery_backfill_shards().begin(),
@@ -504,8 +505,13 @@ void ReplicatedBackend::submit_transaction(
 }
 
 void ReplicatedBackend::op_commit(
-  InProgressOp *op)
+  InProgressOpRef& op)
 {
+  if (op->on_commit == nullptr) {
+    // aborted
+    return;
+  }
+
   FUNCTRACE(cct);
   OID_EVENT_TRACE_WITH_MSG((op && op->op) ? op->op->get_req() : NULL, "OP_COMMIT_BEGIN", true);
   dout(10) << __func__ << ": " << op->tid << dendl;
@@ -538,7 +544,7 @@ void ReplicatedBackend::do_repop_reply(OpRequestRef op)
 
   auto iter = in_progress_ops.find(rep_tid);
   if (iter != in_progress_ops.end()) {
-    InProgressOp &ip_op = iter->second;
+    InProgressOp &ip_op = *iter->second;
     const MOSDOp *m = NULL;
     if (ip_op.op)
       m = static_cast<const MOSDOp *>(ip_op.op->get_req());


### PR DESCRIPTION
- op in flight to disk...
- on_change() clears the InProgressOp
- C_OSD_OnOpCommit calls op_commit() w/ bare pointer
- crash!

Fix by refcounting InProgressOp and setting a canceled flag if we cancel.

Fixes: http://tracker.ceph.com/issues/24219
Signed-off-by: Sage Weil <sage@redhat.com>