### PR TITLE
test: Add CACHE_POOL_NO_HIT_SET to whitelist for mon/pool_ops.sh

### DIFF
--- a/qa/suites/rados/monthrash/workloads/rados_mon_workunits.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_mon_workunits.yaml
@@ -5,6 +5,7 @@ overrides:
     - overall HEALTH_
     - \(PG_
     - \(MON_DOWN\)
+    - \(CACHE_POOL_NO_HIT_SET\)
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
+++ b/qa/suites/rados/singleton-bluestore/all/cephtool.yaml
@@ -26,6 +26,7 @@ tasks:
     - \(OSD_
     - \(PG_
     - \(SMALLER_PG_NUM\)
+    - \(CACHE_POOL_NO_HIT_SET\)
 - workunit:
     clients:
       all:


### PR DESCRIPTION
After re-doing some of the commits I missed cherry picking this commit from ceph/ceph#22074