### PR TITLE
mimic: client: avoid freeing inode when it contains TX buffer heads

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3739,7 +3739,7 @@ void Client::_invalidate_inode_cache(Inode *in, int64_t off, int64_t len)
   if (cct->_conf->client_oc) {
     vector<ObjectExtent> ls;
     Striper::file_to_extents(cct, in->ino, &in->layout, off, len, in->truncate_size, ls);
-    objectcacher->discard_set(&in->oset, ls);
+    objectcacher->discard_writeback(&in->oset, ls, nullptr);
   }
 
   _schedule_invalidate_callback(in, off, len);


### PR DESCRIPTION
http://tracker.ceph.com/issues/24209