### PR TITLE
luminous: rbd-mirror: ensure remote demotion is replayed locally

### DIFF
--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
@@ -8,6 +8,7 @@
 #include "include/rados/librados.hpp"
 #include "common/Mutex.h"
 #include "cls/journal/cls_journal_types.h"
+#include "librbd/journal/Types.h"
 #include "librbd/journal/TypeTraits.h"
 #include "tools/rbd_mirror/BaseRequest.h"
 #include "tools/rbd_mirror/types.h"
@@ -173,6 +174,9 @@ private:
   bool m_primary = false;
   int m_ret_val = 0;
   ImageSync<ImageCtxT> *m_image_sync = nullptr;
+
+  uint64_t m_local_tag_tid = 0;
+  librbd::journal::TagData m_local_tag_data;
 
   bufferlist m_out_bl;
 

--- a/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.cc
@@ -63,7 +63,7 @@ void IsPrimaryRequest<I>::handle_get_mirror_state(int r) {
         return;
       } else if (mirror_image.state == cls::rbd::MIRROR_IMAGE_STATE_DISABLING) {
         dout(5) << ": image mirroring is being disabled" << dendl;
-        *m_primary = false;
+        r = -ENOENT;
       } else {
         derr << ": image mirroring is disabled" << dendl;
         r = -EINVAL;
@@ -72,6 +72,8 @@ void IsPrimaryRequest<I>::handle_get_mirror_state(int r) {
       derr << ": failed to decode image mirror state: " << cpp_strerror(r)
            << dendl;
     }
+  } else if (r == -ENOENT) {
+    dout(5) << ": image is not mirrored" << dendl;
   } else {
     derr << ": failed to retrieve image mirror state: " << cpp_strerror(r)
          << dendl;

--- a/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
@@ -152,7 +152,11 @@ template <typename I>
 void OpenLocalImageRequest<I>::handle_is_primary(int r) {
   dout(20) << ": r=" << r << dendl;
 
-  if (r < 0) {
+  if (r == -ENOENT) {
+    dout(5) << ": local image is not mirrored" << dendl;
+    send_close_image(r);
+    return;
+  } else if (r < 0) {
     derr << ": error querying local image primary status: " << cpp_strerror(r)
          << dendl;
     send_close_image(r);


### PR DESCRIPTION
http://tracker.ceph.com/issues/24084