### PR TITLE
luminous: Deleting a pool with active notify linger ops can result in seg fault

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -138,7 +138,7 @@ struct C_aio_notify_Complete : public C_aio_linger_Complete {
   }
 
   void complete(int r) override {
-    // invoked by C_notify_Finish (or C_aio_notify_Ack on failure)
+    // invoked by C_notify_Finish
     lock.Lock();
     finished = true;
     complete_unlock(r);
@@ -175,10 +175,6 @@ struct C_aio_notify_Ack : public Context {
     ldout(cct, 10) << __func__ << " linger op " << oncomplete->linger_op << " "
                    << "acked (" << r << ")" << dendl;
     oncomplete->handle_ack(r);
-    if (r < 0) {
-      // on failure, we won't expect to see a notify_finish callback
-      onfinish->complete(r);
-    }
   }
 };
 
@@ -1832,6 +1828,7 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
   Context *notify_finish = new C_notify_Finish(client->cct, &notify_finish_cond,
                                                objecter, linger_op, preply_bl,
                                                preply_buf, preply_buf_len);
+  (void) notify_finish;
 
   uint32_t timeout = notify_timeout;
   if (timeout_ms)
@@ -1863,7 +1860,6 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
   } else {
     ldout(client->cct, 10) << __func__ << " failed to initiate notify, r = "
 			   << r << dendl;
-    notify_finish->complete(r);
   }
 
   objecter->linger_cancel(linger_op);

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1860,6 +1860,7 @@ int librados::IoCtxImpl::notify(const object_t& oid, bufferlist& bl,
   } else {
     ldout(client->cct, 10) << __func__ << " failed to initiate notify, r = "
 			   << r << dendl;
+    notify_finish_cond.wait();
   }
 
   objecter->linger_cancel(linger_op);

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1643,6 +1643,7 @@ void Objecter::_check_linger_pool_dne(LingerOp *op, bool *need_unregister)
   }
   if (op->map_dne_bound > 0) {
     if (osdmap->get_epoch() >= op->map_dne_bound) {
+      LingerOp::unique_lock wl{op->watch_lock};
       if (op->on_reg_commit) {
 	op->on_reg_commit->complete(-ENOENT);
 	op->on_reg_commit = nullptr;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -594,6 +594,10 @@ void Objecter::_linger_commit(LingerOp *info, int r, bufferlist& outbl)
     info->on_reg_commit->complete(r);
     info->on_reg_commit = NULL;
   }
+  if (r < 0 && info->on_notify_finish) {
+    info->on_notify_finish->complete(r);
+    info->on_notify_finish = nullptr;
+  }
 
   // only tell the user the first time we do this
   info->registered = true;
@@ -1642,6 +1646,10 @@ void Objecter::_check_linger_pool_dne(LingerOp *op, bool *need_unregister)
       if (op->on_reg_commit) {
 	op->on_reg_commit->complete(-ENOENT);
 	op->on_reg_commit = nullptr;
+      }
+      if (op->on_notify_finish) {
+        op->on_notify_finish->complete(-ENOENT);
+        op->on_notify_finish = nullptr;
       }
       *need_unregister = true;
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/24059