### PR TITLE
test: silence unused variable warning

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -113,7 +113,6 @@ TEST(LibRadosMiscPool, PoolCreationRace) {
   rados_pool_create(cluster_a, poolname);
   rados_ioctx_t a;
   rados_ioctx_create(cluster_a, poolname, &a);
-  int64_t poolid = rados_ioctx_get_id(a);
 
   char pool2name[80];
   snprintf(pool2name, sizeof(pool2name), "poolrace2.%d", rand());


### PR DESCRIPTION
Remove the unused variable 'poolid' in TEST(LibRadosMicsPool,
PoolCreationRace).

Signed-off-by: Mao Zhongyi <maozy.fnst@cn.fujitsu.com>