### PR TITLE
Prevent duplicated rows during async tasks

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -208,24 +208,33 @@ export class RbdListComponent implements OnInit, OnDestroy {
         rbdModel.name = executingTask.metadata['image_name'];
         rbdModel.pool_name = executingTask.metadata['pool_name'];
         rbdModel.cdExecuting = 'creating';
-        resultRBDs.push(rbdModel);
+        this.pushIfNotExists(resultRBDs, rbdModel);
 
       } else if (executingTask.name === 'rbd/clone') {
         const rbdModel = new RbdModel();
         rbdModel.name = executingTask.metadata['child_image_name'];
         rbdModel.pool_name = executingTask.metadata['child_pool_name'];
         rbdModel.cdExecuting = 'cloning';
-        resultRBDs.push(rbdModel);
+        this.pushIfNotExists(resultRBDs, rbdModel);
 
       } else if (executingTask.name === 'rbd/copy') {
         const rbdModel = new RbdModel();
         rbdModel.name = executingTask.metadata['dest_image_name'];
         rbdModel.pool_name = executingTask.metadata['dest_pool_name'];
         rbdModel.cdExecuting = 'copying';
-        resultRBDs.push(rbdModel);
+        this.pushIfNotExists(resultRBDs, rbdModel);
       }
     });
     return resultRBDs;
+  }
+
+  private pushIfNotExists(resultRBDs: RbdModel[], rbdModel: RbdModel) {
+    const exists = resultRBDs.some((resultRBD) => {
+      return resultRBD.name === rbdModel.name && resultRBD.pool_name === rbdModel.pool_name;
+    });
+    if (!exists) {
+      resultRBDs.push(rbdModel);
+    }
   }
 
   updateSelection(selection: CdTableSelection) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -127,10 +127,19 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
         const rbdSnapshotModel = new RbdSnapshotModel();
         rbdSnapshotModel.name = executingTask.metadata['snapshot_name'];
         rbdSnapshotModel.cdExecuting = 'creating';
-        resultSnapshots.push(rbdSnapshotModel);
+        this.pushIfNotExists(resultSnapshots, rbdSnapshotModel);
       }
     });
     return resultSnapshots;
+  }
+
+  private pushIfNotExists(resultSnapshots: RbdSnapshotModel[], rbdSnapshotModel: RbdSnapshotModel) {
+    const exists = resultSnapshots.some((resultSnapshot) => {
+      return resultSnapshot.name === rbdSnapshotModel.name;
+    });
+    if (!exists) {
+      resultSnapshots.push(rbdSnapshotModel);
+    }
   }
 
   private openSnapshotModal(taskName: string, oldSnapshotName: string = null) {


### PR DESCRIPTION
During the execution of an RBD / snapshot async task (e.g. async creation), it may happen that sometimes the user will see two rows for the same RBD / snapshot, one with the `<name>` and other with `<name> (creating...)`.

This PR prevents this behavior by ignoring the `<name> (creating...)` row if the RBD /snapshot is already created.

Signed-off-by: Ricardo Marques <rimarques@suse.com>