### PR TITLE
prometheus: Fix order of occupation values

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -530,8 +530,8 @@ class Module(MgrModule):
                     id_, osd_hostname, osd_dev_node))
                 self.metrics.set('disk_occupation', 1, (
                     "osd.{0}".format(id_),
-                    osd_hostname,
-                    osd_dev_node
+                    osd_dev_node,
+                    osd_hostname
                 ))
             else:
                 self.log.info("Missing dev node metadata for osd {0}, skipping "


### PR DESCRIPTION
When we merged the PR to unify the metadata labels, we forgot to switch
the order of hostname and disk in ceph_disk_occupation metric.

Signed-off-by: Boris Ranto <branto@redhat.com>