### PR TITLE
mgr/dashboard: Improve 'no pool' message on rbd form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -81,7 +81,7 @@
                       [ngValue]="null">Loading...
               </option>
               <option *ngIf="pools !== null && pools.length === 0"
-                      [ngValue]="null">-- No pools available --
+                      [ngValue]="null">-- No rbd pools available --
               </option>
               <option *ngIf="pools !== null && pools.length > 0"
                       [ngValue]="null">-- Select a pool --


### PR DESCRIPTION
The pools dropdown from the RBD form only displays rbd pools, so we can improve the usability by changing the message from `-- No pools available --` to `-- No rbd pools available --`, to make it more clear that other pools will not be listed.

Signed-off-by: Ricardo Marques <rimarques@suse.com>