### PR TITLE
rgw: fix content-length-range condition in RGWPolicy

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3957,7 +3957,7 @@ void RGWPostObj::execute()
       op_ret = put_data_and_throttle(filter, flush, ofs, false);
     }
 
-    if (len < min_len) {
+    if (ofs < min_len) {
       op_ret = -ERR_TOO_SMALL;
       return;
     }


### PR DESCRIPTION
```diff
     bool again;
     do {
       ceph::bufferlist data;
       len = get_data(data, again);
 
       if (len < 0) {
         op_ret = len;
         return;
       }
 
       if (!len) {
         break;
       }
 
       hash.Update((const unsigned char *)data.c_str(), data.length());
       op_ret = put_data_and_throttle(filter, data, ofs, false);
 
       ofs += len;
 
       if (ofs > max_len) {                                 <---- we use "ofs" here
         op_ret = -ERR_TOO_LARGE;
         return;
       }
     } while (again);
 
     {
       bufferlist flush;
       op_ret = put_data_and_throttle(filter, flush, ofs, false);
     }
 
-    if (len < min_len) {
+    if (ofs < min_len) {
       op_ret = -ERR_TOO_SMALL;
       return;
     }
```

Signed-off-by: Chang Liu <liuchang0812@gmail.com>