### PR TITLE
mimic: mds: crash when using `config set` on tracked configs

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -374,8 +374,10 @@ void MonClient::handle_monmap(MMonMap *m)
 void MonClient::handle_config(MConfig *m)
 {
   ldout(cct,10) << __func__ << " " << *m << dendl;
-  cct->_conf->set_mon_vals(cct, m->config, config_cb);
-  m->put();
+  finisher.queue(new FunctionContext([this, m](int r) {
+	cct->_conf->set_mon_vals(cct, m->config, config_cb);
+	m->put();
+      }));
   got_config = true;
   map_cond.Signal();
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/24157