### PR TITLE
mgr/dashboard: Fix Jest conflict with coverage files

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -23,13 +23,9 @@
       "^.+\\.(ts|html)$": "<rootDir>/node_modules/jest-preset-angular/preprocessor.js",
       "^.+\\.js$": "babel-jest"
     },
-    "setupFiles": [
-      "jest-canvas-mock"
-    ],
-    "coverageReporters": [
-      "text",
-      "cobertura"
-    ]
+    "setupFiles": ["jest-canvas-mock"],
+    "coverageReporters": ["text", "cobertura"],
+    "modulePathIgnorePatterns": ["<rootDir>/coverage/"]
   },
   "dependencies": {
     "@angular/animations": "^5.0.0",


### PR DESCRIPTION
It seems 'jest --watch' is trying to determine the modules that are imported
inside the coverage folder.
Since this folder is not always up to date, when there are references to
nonexistent files, Jest will simply break and hang still.

I added an explicit rule for Jest to ignore this folder.

Signed-off-by: Tiago Melo <tmelo@suse.com>