### PR TITLE
mon/MgrMonitor: change 'unresponsive' message to info level

### DIFF
--- a/qa/suites/rados/monthrash/ceph.yaml
+++ b/qa/suites/rados/monthrash/ceph.yaml
@@ -10,7 +10,6 @@ overrides:
         mon osdmap full prune txsize: 2
 # thrashing monitors may make mgr have trouble w/ its keepalive
     log-whitelist:
-      - daemon x is unresponsive
       - overall HEALTH_
       - \(MGR_DOWN\)
 # slow mons -> slow peering -> PG_AVAILABILITY

--- a/qa/suites/upgrade/jewel-x/parallel/1-jewel-install/jewel.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/1-jewel-install/jewel.yaml
@@ -23,7 +23,6 @@ tasks:
       - \(PG_
       - Monitor daemon marked osd
       - Behind on trimming
-      - is unresponsive
     conf:
       global:
         mon warn on pool no app: false

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -577,7 +577,7 @@ void MgrMonitor::tick()
                         << " daemon " << pending_map.active_name;
     } else {
       dout(4) << "Active is laggy but have no standbys to replace it" << dendl;
-      mon->clog->warn() << "Manager daemon " << old_active_name
+      mon->clog->info() << "Manager daemon " << old_active_name
                         << " is unresponsive.  No standby daemons available.";
     }
   } else if (pending_map.active_gid == 0) {


### PR DESCRIPTION
We generate a MGR_DOWN health warning at the appropriate points; having
this at WRN level just triggers failed teuthology runs but doesn't much
value for the user.

Clear out teuthology whitelisting for this message.

Fixes: http://tracker.ceph.com/issues/24222
Signed-off-by: Sage Weil <sage@redhat.com>