### PR TITLE
osd: read object attrs failed at EC recovery

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2341,14 +2341,21 @@ int ECBackend::send_all_remaining_reads(
     rop.to_read.find(hoid)->second.to_read;
   GenContext<pair<RecoveryMessages *, read_result_t& > &> *c =
     rop.to_read.find(hoid)->second.cb;
-
+  // (Note cuixf) If we need to read attrs and we read failed, try to read again.
+  bool want_attrs = 
+    rop.to_read.find(hoid)->second.want_attrs && 
+    (!(rop.complete[hoid].attrs) ||
+    ((rop.complete[hoid].attrs) && !(*(rop.complete[hoid].attrs)).size()));
+  if (want_attrs) {
+    dout(10) << __func__ << " want attrs again=" << want_attrs << " "
+  }
   rop.to_read.erase(hoid);
   rop.to_read.insert(make_pair(
       hoid,
       read_request_t(
 	offsets,
 	shards,
-	false,
+	want_attrs,
 	c)));
   do_read_op(rop);
   return 0;


### PR DESCRIPTION
In EC recovery read, only one shard will read the 'attrs' of object, and we will not try to read it again
when it failed which may be caused by aio failure for example. We need to read the object's 'attrs' again
if we don't have it, when trying to send all remaining reads.

Signed-off-by: xiaofei cui <cuixf@sangfor.com>