### PR TITLE
luminous: rgw: trim all spaces inside a metadata value

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -17,6 +17,7 @@
 
 #include <boost/container/small_vector.hpp>
 #include <boost/utility/string_view.hpp>
+#include <boost/algorithm/string/trim_all.hpp>
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -620,7 +621,8 @@ get_v4_canonical_headers(const req_info& info,
   std::string canonical_hdrs;
   for (const auto& header : canonical_hdrs_map) {
     const boost::string_view& name = header.first;
-    const std::string& value = header.second;
+    std::string value = header.second;
+    boost::trim_all<std::string>(value);
 
     canonical_hdrs.append(name.data(), name.length())
                   .append(":", std::strlen(":"))


### PR DESCRIPTION
http://tracker.ceph.com/issues/24120