### PR TITLE
ceph-fuse: Delete inode's bufferhead was in Tx state would lead a assert fail

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3735,7 +3735,7 @@ void Client::_invalidate_inode_cache(Inode *in, int64_t off, int64_t len)
   if (cct->_conf->client_oc) {
     vector<ObjectExtent> ls;
     Striper::file_to_extents(cct, in->ino, &in->layout, off, len, in->truncate_size, ls);
-    objectcacher->discard_set(&in->oset, ls);
+    objectcacher->discard_writeback(&in->oset, ls, nullptr);
   }
 
   _schedule_invalidate_callback(in, off, len);

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -602,6 +602,7 @@ void ObjectCacher::Object::discard(loff_t off, loff_t len,
     if (bh->is_tx() && commit_gather != nullptr) {
       // wait for the writeback to commit
       waitfor_commit[bh->last_write_tid].emplace_back(commit_gather->new_sub());
+      be_discarded = true;
     } else if (bh->is_rx()) {
       // cannot remove bh with in-flight read, but we can ensure the
       // read won't overwrite the discard
@@ -609,7 +610,8 @@ void ObjectCacher::Object::discard(loff_t off, loff_t len,
       bh->bl.clear();
       bh->set_nocache(true);
       oc->mark_zero(bh);
-      return;
+      // we should mark all Rx bh to zero
+      continue;
     } else {
       assert(bh->waitfor_read.empty());
     }
@@ -1229,7 +1231,15 @@ void ObjectCacher::bh_write_commit(int64_t poolid, sobject_t oid,
   if (flush_set_callback &&
       was_dirty_or_tx > 0 &&
       oset->dirty_or_tx == 0) {        // nothing dirty/tx
-    flush_set_callback(flush_set_callback_arg, oset);
+
+    /* if we did discard the obect before, 
+    /* just skip flush_set_callback because 
+    /* _discard_finish will call it
+    */
+    if (ob->be_discarded)
+      ob->be_discarded = false;
+    else
+      flush_set_callback(flush_set_callback_arg, oset);
   }
 
   if (!ls.empty())

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -243,6 +243,7 @@ class ObjectCacher {
 
     bool complete;
     bool exists;
+    bool be_discarded;
 
     map<loff_t, BufferHead*>     data;
 
@@ -263,7 +264,7 @@ class ObjectCacher {
       oc(_oc),
       oid(o), object_no(ono), oset(os), set_item(this), oloc(l),
       truncate_size(ts), truncate_seq(tq),
-      complete(false), exists(true),
+      complete(false), exists(true), be_discarded(false),
       last_write_tid(0), last_commit_tid(0),
       dirty_or_tx(0) {
       // add to set


### PR DESCRIPTION
Prematurely delted the bh which was in Tx state may lead the object can't
be closed before its writer of this bh callback. Thus if inode's ref call
put_inode decrease ref to zero and release inode's oset.An assert fail occur
beacuse the oset can't be emptied.

If we did discard an object, when write callback of one bh belong to the
object and found the oset->dirty_or_tx become to 0, we need skip it in
case of double dropping of caps.

Fixes:http://tracker.ceph.com/issues/23837
Signed-off-by: Guan yunfei <yunfei.guan@xtaotech.com>