### PR TITLE
cmake: always turn off bjam debugging output

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -78,11 +78,8 @@ function(do_build_boost version)
     message(STATUS "BUILDING Boost Libraries at j ${BOOST_J}")
     list(APPEND b2 -j${BOOST_J})
   endif()
-  if(CMAKE_VERBOSE_MAKEFILE)
-    list(APPEND b2 -d1)
-  else()
-    list(APPEND b2 -d0)
-  endif()
+  # suppress all debugging levels for b2
+  list(APPEND b2 -d0)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
     set(toolset gcc)


### PR DESCRIPTION
we have 'DH_VERBOSE=1' in debian/rules, which instructs debhelper to
pass -DCMAKE_VERBOSE_MAKEFILE=ON to cmake. but the verbose output for
building boost does not really help if something goes wrong while
building the deb packages. if we do want to enable the verbose output,
we can always enable it by passing `-d <N>' to it. see
https://boostorg.github.io/build/manual/develop/index.html#bbv2.overview.invocation.options
.

Signed-off-by: Kefu Chai <kchai@redhat.com>