### PR TITLE
deb,rpm: package librgw_admin_user.{h,so.*}

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1655,6 +1655,7 @@ fi
 
 %files -n librgw2
 %{_libdir}/librgw.so.*
+%{_libdir}/librgw_admin_user.so.*
 %if %{with lttng}
 %{_libdir}/librgw_op_tp.so*
 %{_libdir}/librgw_rados_tp.so*
@@ -1667,8 +1668,10 @@ fi
 %files -n librgw-devel
 %dir %{_includedir}/rados
 %{_includedir}/rados/librgw.h
+%{_includedir}/rados/librgw_admin_user.h
 %{_includedir}/rados/rgw_file.h
 %{_libdir}/librgw.so
+%{_libdir}/librgw_admin_user.so
 
 %if 0%{with python2}
 %files -n python-rgw

--- a/debian/librgw-dev.install
+++ b/debian/librgw-dev.install
@@ -1,3 +1,5 @@
 usr/include/rados/librgw.h
+usr/include/rados/librgw_admin_user.h
 usr/include/rados/rgw_file.h
 usr/lib/librgw.so
+usr/lib/librgw_admin_user.so

--- a/debian/librgw2.install
+++ b/debian/librgw2.install
@@ -1,1 +1,2 @@
 usr/lib/librgw.so.*
+usr/lib/librgw_admin_user.so.*

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -27,5 +27,6 @@ if(WITH_RADOSGW)
   install(FILES
     rados/librgw.h
     rados/rgw_file.h
+    rgw/librgw_admin_user.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rados)
 endif()


### PR DESCRIPTION
* install and package librgw_admin_user.h, so developers can use it to
  create rgw user.
* package librgw_admin_user, so user can use it to create rgw user.

Signed-off-by: Kefu Chai <kchai@redhat.com>