### PR TITLE
dout: declare dpp using `decltype(auto)` instead of `auto`

### DIFF
--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -97,7 +97,7 @@ struct is_dynamic<dynamic_marker_t<T>> : public std::true_type {};
 #define lderr(cct) dout_impl(cct, ceph_subsys_, -1) dout_prefix
 
 #define ldpp_dout(dpp, v) 						\
-  if (auto pdpp = (dpp); pdpp) /* workaround -Wnonnull-compare for 'this' */ \
+  if (decltype(auto) pdpp = (dpp); pdpp) /* workaround -Wnonnull-compare for 'this' */ \
     dout_impl(pdpp->get_cct(), ceph::dout::need_dynamic(pdpp->get_subsys()), v) \
       pdpp->gen_prefix(*_dout)
 


### PR DESCRIPTION
this makes `pdpp` an alias of `dpp`, guess this ensures GCC that the
returned `sub` is a constant.
```
In file included from /home/kefu/dev/ceph/src/kv/LevelDBStore.h:25,
                 from /home/kefu/dev/ceph/src/kv/KeyValueDB.cc:6:
/home/kefu/dev/ceph/src/osd/osd_types.h: In lambda function:
/home/kefu/dev/ceph/src/common/dout.h:101:75: error: the value of ‘pdpp’ is not usable in a constant expression
     dout_impl(pdpp->get_cct(),
ceph::dout::need_dynamic(pdpp->get_subsys()), v) \
                                                                           ^
/home/kefu/dev/ceph/src/common/dout.h:81:58: note: in definition of macro ‘dout_impl’
       return (cctX->_conf->subsys.template should_gather<sub, v>()); \
                                                          ^~~
/home/kefu/dev/ceph/src/osd/osd_types.h:2992:3: note: in expansion of macro ‘ldpp_dout’
   ldpp_dout(dpp, 10) << "build_prior all_probe " << all_probe << dendl;
   ^~~~~~~~~
/home/kefu/dev/ceph/src/common/dout.h:100:12: note: ‘pdpp’ was not declared ‘constexpr’
   if (auto pdpp = (dpp); pdpp) /* workaround -Wnonnull-compare for 'this' */ \
            ^~~~
/home/kefu/dev/ceph/src/common/dout.h:100:12: note: in definition of macro ‘ldpp_dout’
   if (auto pdpp = (dpp); pdpp) /* workaround -Wnonnull-compare for 'this' */ \
            ^~~~
```
Signed-off-by: Kefu Chai <kchai@redhat.com>