### PR TITLE
luminous: kceph: umount on evicted client blocks forever

### DIFF
--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -124,7 +124,7 @@ class KernelMount(CephFSMount):
     def cleanup(self):
         pass
 
-    def umount_wait(self, force=False, require_clean=False):
+    def umount_wait(self, force=False, require_clean=False, timeout=900):
         """
         Unlike the fuse client, the kernel client's umount is immediate
         """

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -356,7 +356,8 @@ void Server::handle_client_session(MClientSession *m)
         });
 
     if (blacklisted) {
-      dout(10) << "ignoring blacklisted client " << session->info.inst.addr << dendl;
+      dout(10) << "rejecting blacklisted client " << session->info.inst.addr << dendl;
+      mds->send_message_client(new MClientSession(CEPH_SESSION_REJECT), session);
       m->put();
       return;
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/24188
http://tracker.ceph.com/issues/24189