### PR TITLE
mgr/dashboard: controller infrastructure refactor and new features

### DIFF
--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -72,5 +72,3 @@ class AuthTest(DashboardTestCase):
     def test_unauthorized(self):
         self._get("/api/host")
         self.assertStatus(401)
-        self._get("/api")
-        self.assertStatus(401)

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -245,48 +245,191 @@ Or, ``source`` the script and run the tests manually::
 How to add a new controller?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to add a new endpoint to the backend, you just need to add a
-class derived from ``BaseController`` decorated with ``ApiController`` in a
-Python file located under the ``controllers`` directory. The Dashboard module
-will automatically load your new controller upon start.
+A controller is a Python class that extends from the ``BaseController`` class
+and is decorated with either the ``@Controller`` or ``@ApiController``
+decorators. The Python class must be stored inside a Python file located under
+the ``controllers`` directory. The Dashboard module will automatically load
+your new controller upon start.
 
-For example create a file ``ping2.py`` under ``controllers`` directory with the
-following code::
+The ``@ApiController`` decorator is a specialization of the ``@Controller``
+decorator, and should be used for controllers that provide an API-like REST
+interface. For any other kinds of controllers the ``@Controller`` decorator
+should be used.
 
-  import cherrypy
-  from ..tools import ApiController, BaseController
+A controller has a URL prefix path associated that is specified in the
+controller decorator, and all endpoints exposed by the controller will share
+the same URL prefix path.
 
-  @ApiController('ping2')
-  class Ping2(BaseController):
-    @cherrypy.expose
-    def default(self, *args):
-      return "Hello"
+A controller's endpoint is exposed by implementing a method on the controller
+class decorated with the ``@Endpoint`` decorator.
 
-Every path given in the ``ApiController`` decorator will automatically be
-prefixed with ``api``. After reloading the Dashboard module you can access the
-above mentioned controller by pointing your browser to
-https://mgr_hostname:8080/api/ping2.
+For example create a file ``ping.py`` under ``controllers`` directory with the
+following code:
 
-It is also possible to have nested controllers. The ``RgwController`` uses
-this technique to make the daemons available through the URL
-https://mgr_hostname:8080/api/rgw/daemon::
+.. code-block:: python
 
-  @ApiController('rgw')
-  @AuthRequired()
-  class Rgw(RESTController):
-    pass
+  from ..tools import Controller, ApiController, BaseController, Endpoint
 
+  @Controller('/ping')
+  class Ping(BaseController):
+    @Endpoint()
+    def hello(self):
+      return {msg: "Hello"}
 
-  @ApiController('rgw/daemon')
-  @AuthRequired()
-  class RgwDaemon(RESTController):
-
-    def list(self):
-      pass
+  @ApiController('/ping')
+  class ApiPing(BaseController):
+    @Endpoint()
+    def hello(self):
+      return {msg: "Hello"}
 
 
-Note that paths must be unique and that a path like ``rgw/daemon`` has to have
-a parent ``rgw``. Otherwise it won't work.
+The ``hello`` endpoint of the ``Ping`` controller can be reached by the
+following URL: https://mgr_hostname:8080/ping/hello using HTTP GET requests.
+As you can see the controller URL path ``/ping`` is concatenated to the
+method name ``hello`` to generate the endpoint's URL.
+
+In the case of the ``ApiPing`` controller, the ``hello`` endpoint can be
+reached by the following URL: https://mgr_hostname:8080/api/ping/hello using
+HTTP GET request.
+The API controller URL path ``/ping`` is prefixed by the ``/api`` path and then
+concatenated to the method name ``hello`` to generate the endpoint's URL.
+Internally, the ``@ApiController`` is actually calling the ``@Controller``
+decorator by passing an additional decorator parameter called ``base_url``::
+
+  @ApiController('/ping') <=> @Controller('/ping', base_url="/api")
+
+The ``@Endpoint`` decorator also supports many parameters to customize the
+endpoint:
+
+* ``method="GET"``: the HTTP method allowed to access this endpoint.
+* ``path="/<method_name>"``: the URL path of the endpoint, excluding the
+  controller URL path prefix.
+* ``path_params=[]``: list of method parameter names that correspond to URL
+  path parameters. Can only be used when ``method in ['POST', 'PUT']``.
+* ``query_params=[]``: list of method parameter names that correspond to URL
+  query parameters.
+* ``json_response=True``: indicates if the endpoint response should be
+  serialized in JSON format.
+* ``proxy=False``: indicates if the endpoint should be used as a proxy.
+
+An endpoint method may have parameters declared. Depending on the HTTP method
+defined for the endpoint the method parameters might be considered either
+path parameters, query parameters, or body parameters.
+
+For ``GET`` and ``DELETE`` methods, the method non-optional parameters are
+considered path parameters by default. Optional parameters are considered
+query parameters. By specifing the ``query_parameters`` in the endpoint
+decorator it is possible to make a non-optional parameter to be a query
+parameter.
+
+For ``POST`` and ``PUT`` methods, all method parameters are considered
+body parameters by default. To override this default, one can use the
+``path_params`` and ``query_params`` to specify which method parameters are
+path and query parameters respectivelly.
+Body parameters are decoded from the request body, either from a form format, or
+from a dictionary in JSON format.
+
+Let's use an example to better understand the possible ways to custumize an
+endpoint:
+
+.. code-block:: python
+
+  from ..tools import Controller, BaseController, Endpoint
+
+  @Controller('/ping')
+  class Ping(BaseController):
+
+    # URL: /ping/{key}?opt1=...&opt2=...
+    @Endpoint(path="/", query_params=['opt1'])
+    def index(self, key, opt1, opt2=None):
+      # ...
+
+    # URL: /ping/{key}?opt1=...&opt2=...
+    @Endpoint(query_params=['opt1'])
+    def __call__(self, key, opt1, opt2=None):
+      # ...
+
+    # URL: /ping/post/{key1}/{key2}
+    @Endpoint('POST', path_params=['key1', 'key2'])
+    def post(self, key1, key2, data1, data2=None):
+      # ...
+
+From the above example you can see that the path parameters are collected from
+the URL by parsing the list of values separated by slashes ``/`` that come
+after the URL path ``/ping`` for ``index`` method case, and ``/ping/post`` for
+the ``post`` method case.
+
+In the above example we also see how the ``path`` option can be used to
+override the generated endpoint URL in order to not use the method name in the
+URL. In the ``index`` method we set the ``path`` to ``"/"`` to generate an
+endpoint that is accessible by the root URL of the controller.
+
+An alternative approach to generate an endpoint that is accessible through just
+the controller's path URL is by using the ``__call__`` method, as we show in
+the above example.
+
+Defining path parameters in endpoints's URLs using python methods's parameters
+is very easy but it is still a bit strict with respect to the position of these
+parameters in the URL structure.
+Sometimes we may want to explictly define a URL scheme that
+contains path parameters mixed with static parts of the URL.
+Our controller infrastructure also supports the declaration of URL paths with
+explicit path parameters at both the controller level and method level.
+
+Consider the following example:
+
+.. code-block:: python
+
+  from ..tools import Controller, BaseController, Endpoint
+
+  @Controller('/ping/{node}/stats')
+  class Ping(BaseController):
+
+    # URL: /ping/{node}/stats/{date}/latency?unit=...
+    @Endpoint(path="/{date}/latency")
+    def latency(self, node, date, unit="ms"):
+      # ...
+
+In this example we explicitly declare a path parameter ``{node}`` in the
+controller URL path, and a path parameter ``{date}`` in the ``latency``
+method. The endpoint for the ``latency`` method is then accessible through
+the URL: https://mgr_hostname:8080/ping/{node}/stats/{date}/latency .
+
+For a full set of examples on how to use the ``@Endpoint``
+decorator please check the unit test file: ``tests/test_controllers.py``.
+There you will find many examples of how to customize endpoint methods.
+
+
+Implementing Proxy Controller
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Sometimes you might need to relay some requests from the Dashboard frontend
+directly to an external service.
+For that purpose we provide a decorator called ``@Proxy``.
+(As a concrete example, check the ``controllers/rgw.py`` file where we
+implemented an RGW Admin Ops proxy.)
+
+
+The ``@Proxy`` decorator is a wrapper of the ``@Endpoint`` decorator that
+already customizes the endpoint for working as a proxy.
+A proxy endpoint works by capturing the URL path that follows the controller
+URL prefix path, and does not do any decoding of the request body.
+
+Example:
+
+.. code-block:: python
+
+  from ..tools import Controller, BaseController, Proxy
+
+  @Controller('/foo/proxy')
+  class FooServiceProxy(BaseController):
+
+    @Proxy()
+    def proxy(self, path, **params):
+      # if requested URL is "/foo/proxy/access/service?opt=1"
+      # then path is "access/service" and params is {'opt': '1'}
+      # ...
+
 
 How does the RESTController work?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -443,13 +443,15 @@ and unifies the work with collections. A collection is just an array of objects
 with a specific type. ``RESTController`` enables some default mappings of
 request types and given parameters to specific method names. This may sound
 complicated at first, but it's fairly easy. Lets have look at the following
-example::
+example:
+
+.. code-block:: python
 
   import cherrypy
   from ..tools import ApiController, RESTController
 
-  @ApiController('ping2')
-  class Ping2(RESTController):
+  @ApiController('ping')
+  class Ping(RESTController):
     def list(self):
       return {"msg": "Hello"}
 
@@ -457,7 +459,7 @@ example::
       return self.objects[id]
 
 In this case, the ``list`` method is automatically used for all requests to
-``api/ping2`` where no additional argument is given and where the request type
+``api/ping`` where no additional argument is given and where the request type
 is ``GET``. If the request is given an additional argument, the ID in our
 case, it won't map to ``list`` anymore but to ``get`` and return the element
 with the given ID (assuming that ``self.objects`` has been filled before). The
@@ -470,8 +472,6 @@ same applies to other request types:
 +--------------+------------+----------------+-------------+
 | PUT          | No         | bulk_set       | 200         |
 +--------------+------------+----------------+-------------+
-| PATCH        | No         | bulk_set       | 200         |
-+--------------+------------+----------------+-------------+
 | POST         | No         | create         | 201         |
 +--------------+------------+----------------+-------------+
 | DELETE       | No         | bulk_delete    | 204         |
@@ -479,8 +479,6 @@ same applies to other request types:
 | GET          | Yes        | get            | 200         |
 +--------------+------------+----------------+-------------+
 | PUT          | Yes        | set            | 200         |
-+--------------+------------+----------------+-------------+
-| PATCH        | Yes        | set            | 200         |
 +--------------+------------+----------------+-------------+
 | DELETE       | Yes        | delete         | 204         |
 +--------------+------------+----------------+-------------+
@@ -512,7 +510,9 @@ How to access the manager module instance from a controller?
 We provide the manager module instance as a global variable that can be
 imported in any module. We also provide a logger instance in the same way.
 
-Example::
+Example:
+
+.. code-block:: python
 
   import cherrypy
   from .. import logger, mgr
@@ -532,29 +532,31 @@ How to write a unit test for a controller?
 We provide a test helper class called ``ControllerTestCase`` to easily create
 unit tests for your controller.
 
-If we want to write a unit test for the above ``Ping2`` controller, create a
-``test_ping2.py`` file under the ``tests`` directory with the following code::
+If we want to write a unit test for the above ``Ping`` controller, create a
+``test_ping.py`` file under the ``tests`` directory with the following code:
+
+.. code-block:: python
 
   from .helper import ControllerTestCase
-  from .controllers.ping2 import Ping2
+  from .controllers.ping import Ping
 
 
-  class Ping2Test(ControllerTestCase):
+  class PingTest(ControllerTestCase):
       @classmethod
       def setup_test(cls):
-          Ping2._cp_config['tools.authentica.on'] = False
+          Ping._cp_config['tools.authentication.on'] = False
+          cls.setup_controllers([Ping])
 
-      def test_ping2(self):
-          self._get("/api/ping2")
+      def test_ping(self):
+          self._get("/api/ping")
           self.assertStatus(200)
           self.assertJsonBody({'msg': 'Hello'})
 
-The ``ControllerTestCase`` class will call the dashboard module code that loads
-the controllers and initializes the CherryPy webserver. Then it will call the
-``setup_test()`` class method to execute additional instructions that each test
-case needs to add to the test.
-In the example above we use the ``setup_test()`` method to disable the
-authentication handler for the ``Ping2`` controller.
+The ``ControllerTestCase`` class starts by initializing a CherryPy webserver.
+Then it will call the ``setup_test()`` class method where we can explicitly
+load the controllers that we want to test. In the above example we are only
+loading the ``Ping`` controller. We can also disable authentication of a
+controller at this stage, as depicted in the example.
 
 
 How to listen for manager notifications in a controller?
@@ -570,7 +572,9 @@ For this reason we provide a notification queue that controllers can register
 themselves with to receive cluster notifications.
 
 The example below represents a controller that implements a very simple live
-log viewer page::
+log viewer page:
+
+.. code-block:: python
 
   from __future__ import absolute_import
 
@@ -626,7 +630,9 @@ How to write a unit test when a controller accesses a Ceph module?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Consider the following example that implements a controller that retrieves the
-list of RBD images of the ``rbd`` pool::
+list of RBD images of the ``rbd`` pool:
+
+.. code-block:: python
 
   import rbd
   from .. import mgr
@@ -645,7 +651,9 @@ list of RBD images of the ``rbd`` pool::
 In the example above, we want to mock the return value of the ``rbd.list``
 function, so that we can test the JSON response of the controller.
 
-The unit test code will look like the following::
+The unit test code will look like the following:
+
+.. code-block:: python
 
   import mock
   from .helper import ControllerTestCase
@@ -688,7 +696,9 @@ get and set that setting::
 
 To access, or modify the config setting value from your Python code, either
 inside a controller or anywhere else, you just need to import the ``Settings``
-class and access it like this::
+class and access it like this:
+
+.. code-block:: python
 
   from settings import Settings
 

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -409,6 +409,21 @@ class BaseController(object):
 
     @classmethod
     def endpoints(cls):
+        """
+        The endpoints method returns a list of endpoints. Each endpoint
+        consists of a tuple with methods, URL suffix, an action and its
+        arguments.
+
+        By default, endpoints will be methods of the BaseController class,
+        which have been decorated by the @cherrpy.expose decorator. A method
+        will also be considered an endpoint if the `exposed` attribute has been
+        set on the method to a value which evaluates to True, which is
+        basically what @cherrpy.expose does, too.
+
+        :return: A tuple of methods, url_suffix, action and arguments of the
+                 function
+        :rtype: list[tuple]
+        """
         result = []
 
         for name, func in inspect.getmembers(cls, predicate=callable):

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -3,17 +3,12 @@
 from __future__ import absolute_import
 
 import collections
-from datetime import datetime, timedelta
-import fnmatch
 import importlib
 import inspect
 import json
 import os
 import pkgutil
 import sys
-import time
-import threading
-import types  # pylint: disable=import-error
 
 import cherrypy
 from six import add_metaclass

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -11,7 +11,7 @@ from .. import logger, mgr
 from ..tools import Session
 
 
-@ApiController('auth')
+@ApiController('/auth')
 class Auth(RESTController):
     """
     Provide login and logout actions.

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -6,13 +6,13 @@ from collections import defaultdict
 import cherrypy
 
 from ..exceptions import DashboardException
-from . import ApiController, AuthRequired, BaseController
+from . import ApiController, AuthRequired, Endpoint, BaseController
 from .. import mgr
 from ..services.ceph_service import CephService
 from ..tools import ViewCache
 
 
-@ApiController('cephfs')
+@ApiController('/cephfs')
 @AuthRequired()
 class CephFS(BaseController):
     def __init__(self):
@@ -22,22 +22,19 @@ class CephFS(BaseController):
         # dict is FSCID
         self.cephfs_clients = {}
 
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
+    @Endpoint()
     def clients(self, fs_id):
         fs_id = self.fs_id_to_int(fs_id)
 
         return self._clients(fs_id)
 
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
+    @Endpoint()
     def data(self, fs_id):
         fs_id = self.fs_id_to_int(fs_id)
 
         return self.fs_status(fs_id)
 
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
+    @Endpoint()
     def mds_counters(self, fs_id):
         """
         Result format: map of daemon name to map of counter to list of datapoints

--- a/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
@@ -7,7 +7,7 @@ from .. import mgr
 from . import ApiController, RESTController, AuthRequired
 
 
-@ApiController('cluster_conf')
+@ApiController('/cluster_conf')
 @AuthRequired()
 class ClusterConfiguration(RESTController):
     def list(self):

--- a/src/pybind/mgr/dashboard/controllers/dashboard.py
+++ b/src/pybind/mgr/dashboard/controllers/dashboard.py
@@ -4,9 +4,7 @@ from __future__ import absolute_import
 import collections
 import json
 
-import cherrypy
-
-from . import ApiController, AuthRequired, BaseController
+from . import ApiController, AuthRequired, Endpoint, BaseController
 from .. import mgr
 from ..services.ceph_service import CephService
 from ..tools import NotificationQueue
@@ -15,7 +13,7 @@ from ..tools import NotificationQueue
 LOG_BUFFER_SIZE = 30
 
 
-@ApiController('dashboard')
+@ApiController('/dashboard')
 @AuthRequired()
 class Dashboard(BaseController):
     def __init__(self):
@@ -38,8 +36,7 @@ class Dashboard(BaseController):
         for l in lines:
             buf.appendleft(l)
 
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
+    @Endpoint()
     def health(self):
         if not self._log_initialized:
             self._log_initialized = True

--- a/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
+++ b/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
@@ -15,7 +15,7 @@ def _serialize_ecp(name, ecp):
     return ecp
 
 
-@ApiController('erasure_code_profile')
+@ApiController('/erasure_code_profile')
 @AuthRequired()
 class ErasureCodeProfile(RESTController):
     """

--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -5,7 +5,7 @@ from . import ApiController, AuthRequired, RESTController
 from .. import mgr
 
 
-@ApiController('host')
+@ApiController('/host')
 @AuthRequired()
 class Host(RESTController):
     def list(self):

--- a/src/pybind/mgr/dashboard/controllers/monitor.py
+++ b/src/pybind/mgr/dashboard/controllers/monitor.py
@@ -3,17 +3,14 @@ from __future__ import absolute_import
 
 import json
 
-import cherrypy
-
-from . import ApiController, AuthRequired, BaseController
+from . import ApiController, AuthRequired, Endpoint, BaseController
 from .. import mgr
 
 
-@ApiController('monitor')
+@ApiController('/monitor')
 @AuthRequired()
 class Monitor(BaseController):
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
+    @Endpoint()
     def __call__(self):
         in_quorum, out_quorum = [], []
 

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -7,7 +7,7 @@ from ..services.ceph_service import CephService
 from ..services.exception import handle_send_command_error
 
 
-@ApiController('osd')
+@ApiController('/osd')
 @AuthRequired()
 class Osd(RESTController):
     def list(self):

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -3,13 +3,13 @@ from __future__ import absolute_import
 
 import cherrypy
 
-from . import ApiController, RESTController, AuthRequired
+from . import ApiController, RESTController, Endpoint, AuthRequired
 from .. import mgr
 from ..services.ceph_service import CephService
 from ..services.exception import handle_send_command_error
 
 
-@ApiController('pool')
+@ApiController('/pool')
 @AuthRequired()
 class Pool(RESTController):
 
@@ -88,8 +88,7 @@ class Pool(RESTController):
         for key, value in kwargs.items():
             CephService.send_command('mon', 'osd pool set', pool=pool, var=key, val=value)
 
-    @cherrypy.tools.json_out()
-    @cherrypy.expose
+    @Endpoint()
     def _info(self):
         """Used by the create-pool dialog"""
         def rules(pool_type):

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -43,7 +43,7 @@ class Pool(RESTController):
             return var
         return var.lower() in ("true", "yes", "1", 1)
 
-    def list(self, attrs=None, stats=False):
+    def _pool_list(self, attrs=None, stats=False):
         if attrs:
             attrs = attrs.split(',')
 
@@ -54,8 +54,11 @@ class Pool(RESTController):
 
         return [self._serialize_pool(pool, attrs) for pool in pools]
 
+    def list(self, attrs=None, stats=False):
+        return self._pool_list(attrs, stats)
+
     def get(self, pool_name, attrs=None, stats=False):
-        pools = self.list(attrs, stats)
+        pools = self._pool_list(attrs, stats)
         pool = [pool for pool in pools if pool['pool_name'] == pool_name]
         if not pool:
             return cherrypy.NotFound('No such pool')
@@ -103,7 +106,7 @@ class Pool(RESTController):
                     if o['name'] == conf_name][0]
 
         return {
-            "pool_names": [p['pool_name'] for p in self.list()],
+            "pool_names": [p['pool_name'] for p in self._pool_list()],
             "crush_rules_replicated": rules(1),
             "crush_rules_erasure": rules(3),
             "is_all_bluestore": all_bluestore(),

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -112,7 +112,7 @@ def _sort_features(features, enable=True):
     features.sort(key=key_func, reverse=not enable)
 
 
-@ApiController('block/image')
+@ApiController('/block/image')
 @AuthRequired()
 class Rbd(RESTController):
 
@@ -334,7 +334,7 @@ class Rbd(RESTController):
               'src_image_name': '{image_name}',
               'dest_pool_name': '{dest_pool_name}',
               'dest_image_name': '{dest_image_name}'}, 2.0)
-    @RESTController.resource(['POST'])
+    @RESTController.Resource('POST')
     def copy(self, pool_name, image_name, dest_pool_name, dest_image_name,
              snapshot_name=None, obj_size=None, features=None, stripe_unit=None,
              stripe_count=None, data_pool=None):
@@ -360,7 +360,7 @@ class Rbd(RESTController):
         return _rbd_image_call(pool_name, image_name, _src_copy)
 
     @RbdTask('flatten', ['{pool_name}', '{image_name}'], 2.0)
-    @RESTController.resource(['POST'])
+    @RESTController.Resource('POST')
     def flatten(self, pool_name, image_name):
 
         def _flatten(ioctx, image):
@@ -368,13 +368,13 @@ class Rbd(RESTController):
 
         return _rbd_image_call(pool_name, image_name, _flatten)
 
-    @RESTController.collection(['GET'])
+    @RESTController.Collection('GET')
     def default_features(self):
         rbd_default_features = mgr.get('config')['rbd_default_features']
         return _format_bitmask(int(rbd_default_features))
 
 
-@ApiController('block/image/:pool_name/:image_name/snap')
+@ApiController('/block/image/:pool_name/:image_name/snap')
 @AuthRequired()
 class RbdSnapshot(RESTController):
 
@@ -417,7 +417,7 @@ class RbdSnapshot(RESTController):
 
     @RbdTask('snap/rollback',
              ['{pool_name}', '{image_name}', '{snapshot_name}'], 5.0)
-    @RESTController.resource(['POST'])
+    @RESTController.Resource('POST')
     def rollback(self, pool_name, image_name, snapshot_name):
         def _rollback(ioctx, img, snapshot_name):
             img.rollback_to_snap(snapshot_name)
@@ -429,7 +429,7 @@ class RbdSnapshot(RESTController):
               'parent_snap_name': '{snapshot_name}',
               'child_pool_name': '{child_pool_name}',
               'child_image_name': '{child_image_name}'}, 2.0)
-    @RESTController.resource(['POST'])
+    @RESTController.Resource('POST')
     def clone(self, pool_name, image_name, snapshot_name, child_pool_name,
               child_image_name, obj_size=None, features=None,
               stripe_unit=None, stripe_count=None, data_pool=None):

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -6,10 +6,9 @@ import re
 
 from functools import partial
 
-import cherrypy
 import rbd
 
-from . import ApiController, AuthRequired, BaseController
+from . import ApiController, AuthRequired, Endpoint, BaseController
 from .. import logger, mgr
 from ..services.ceph_service import CephService
 from ..tools import ViewCache
@@ -155,7 +154,7 @@ def get_daemons_and_pools():  # pylint: disable=R0915
     }
 
 
-@ApiController('rbdmirror')
+@ApiController('/rbdmirror')
 @AuthRequired()
 class RbdMirror(BaseController):
 
@@ -163,8 +162,7 @@ class RbdMirror(BaseController):
         super(RbdMirror, self).__init__()
         self.pool_data = {}
 
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
+    @Endpoint()
     @handle_rbd_error()
     def __call__(self):
         status, content_data = self._get_content_data()

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -4,19 +4,19 @@ from __future__ import absolute_import
 import json
 import cherrypy
 
-from . import ApiController, BaseController, RESTController, AuthRequired
+from . import ApiController, BaseController, RESTController, AuthRequired, \
+              Endpoint, Proxy
 from .. import logger
 from ..services.ceph_service import CephService
 from ..services.rgw_client import RgwClient
 from ..rest_client import RequestException
 
 
-@ApiController('rgw')
+@ApiController('/rgw')
 @AuthRequired()
-class Rgw(RESTController):
+class Rgw(BaseController):
 
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
+    @Endpoint()
     def status(self):
         status = {'available': False, 'message': None}
         try:
@@ -37,7 +37,7 @@ class Rgw(RESTController):
         return status
 
 
-@ApiController('rgw/daemon')
+@ApiController('/rgw/daemon')
 @AuthRequired()
 class RgwDaemon(RESTController):
 
@@ -84,11 +84,11 @@ class RgwDaemon(RESTController):
         return daemon
 
 
-@ApiController('rgw/proxy/{path:.*}')
+@ApiController('/rgw/proxy')
 @AuthRequired()
 class RgwProxy(BaseController):
 
-    @cherrypy.expose
+    @Proxy()
     def __call__(self, path, **params):
         try:
             rgw_client = RgwClient.admin_instance()
@@ -109,7 +109,7 @@ class RgwProxy(BaseController):
             return json.dumps({'detail': str(e)}).encode('utf-8')
 
 
-@ApiController('rgw/bucket')
+@ApiController('/rgw/bucket')
 @AuthRequired()
 class RgwBucket(RESTController):
 

--- a/src/pybind/mgr/dashboard/controllers/summary.py
+++ b/src/pybind/mgr/dashboard/controllers/summary.py
@@ -3,17 +3,15 @@ from __future__ import absolute_import
 
 import json
 
-import cherrypy
-
 from .. import mgr
-from . import AuthRequired, ApiController, BaseController
+from . import AuthRequired, ApiController, Endpoint, BaseController
 from ..controllers.rbd_mirroring import get_daemons_and_pools
 from ..tools import ViewCacheNoDataException
 from ..services.ceph_service import CephService
 from ..tools import TaskManager
 
 
-@ApiController('summary')
+@ApiController('/summary')
 @AuthRequired()
 class Summary(BaseController):
     def _rbd_pool_data(self):
@@ -57,8 +55,7 @@ class Summary(BaseController):
                 warnings += 1
         return {'warnings': warnings, 'errors': errors}
 
-    @cherrypy.expose
-    @cherrypy.tools.json_out()
+    @Endpoint()
     def __call__(self):
         executing_t, finished_t = TaskManager.list_serializable()
         return {

--- a/src/pybind/mgr/dashboard/controllers/task.py
+++ b/src/pybind/mgr/dashboard/controllers/task.py
@@ -5,7 +5,7 @@ from . import ApiController, AuthRequired, RESTController
 from ..tools import TaskManager
 
 
-@ApiController('task')
+@ApiController('/task')
 @AuthRequired()
 class Task(RESTController):
     def list(self, name=None):

--- a/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
@@ -8,7 +8,7 @@ from ..services.ceph_service import CephService
 SERVICE_TYPE = 'tcmu-runner'
 
 
-@ApiController('tcmuiscsi')
+@ApiController('/tcmuiscsi')
 @AuthRequired()
 class TcmuIscsi(RESTController):
     # pylint: disable=too-many-nested-blocks

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -286,7 +286,7 @@ class Module(MgrModule, SSLCherryPyConfig):
             }
         }
         for purl in parent_urls:
-            config['{}/{}'.format(self.url_prefix, purl)] = {
+            config[purl] = {
                 'request.dispatch': mapper
             }
         cherrypy.tree.mount(None, config=config)

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -276,16 +276,19 @@ class Module(MgrModule, SSLCherryPyConfig):
         # about to start serving
         self.set_uri(uri)
 
-        mapper = generate_routes(self.url_prefix)
+        mapper, parent_urls = generate_routes(self.url_prefix)
 
         config = {
             '{}/'.format(self.url_prefix): {
                 'tools.staticdir.on': True,
                 'tools.staticdir.dir': self.get_frontend_path(),
                 'tools.staticdir.index': 'index.html'
-            },
-            '{}/api'.format(self.url_prefix): {'request.dispatch': mapper}
+            }
         }
+        for purl in parent_urls:
+            config['{}/{}'.format(self.url_prefix, purl)] = {
+                'request.dispatch': mapper
+            }
         cherrypy.tree.mount(None, config=config)
 
         cherrypy.engine.start()

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -91,7 +91,7 @@ class ControllerTestCase(helper.CPWebCase):
                     logger.info("task (%s, %s) is still executing", self.task_name,
                                 self.task_metadata)
                     time.sleep(1)
-                    self.tc._get('/task?name={}'.format(self.task_name))
+                    self.tc._get('/api/task?name={}'.format(self.task_name))
                     res = self.tc.jsonBody()
                     for task in res['finished_tasks']:
                         if task['metadata'] == self.task_metadata:

--- a/src/pybind/mgr/dashboard/tests/test_controllers.py
+++ b/src/pybind/mgr/dashboard/tests/test_controllers.py
@@ -1,0 +1,183 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+from .helper import ControllerTestCase
+from ..controllers import BaseController, RESTController, Controller, \
+                          ApiController, Endpoint
+
+
+@Controller("/btest/{key}", base_url="/ui")
+class BTest(BaseController):
+    @Endpoint()
+    def test1(self, key, opt=1):
+        return {'key': key, 'opt': opt}
+
+    @Endpoint()
+    def test2(self, key, skey, opt=1):
+        return {'key': key, 'skey': skey, 'opt': opt}
+
+    @Endpoint(path="/foo/{skey}/test-3")
+    def test3(self, key, skey, opt=1):
+        return {'key': key, 'skey': skey, 'opt': opt}
+
+    @Endpoint('POST', path="/foo/{skey}/test-3", query_params=['opt'])
+    def test4(self, key, skey, data, opt=1):
+        return {'key': key, 'skey': skey, 'data': data, 'opt': opt}
+
+    @Endpoint('PUT', path_params=['skey'], query_params=['opt'])
+    def test5(self, key, skey, data1, data2=None, opt=1):
+        return {'key': key, 'skey': skey, 'data1': data1, 'data2': data2,
+                'opt': opt}
+
+    @Endpoint('GET', json_response=False)
+    def test6(self, key, opt=1):
+        return "My Formatted string key={} opt={}".format(key, opt)
+
+    @Endpoint()
+    def __call__(self, key, opt=1):
+        return {'key': key, 'opt': opt}
+
+
+@ApiController("/rtest/{key}")
+class RTest(RESTController):
+    RESOURCE_ID = 'skey/ekey'
+
+    def list(self, key, opt=1):
+        return {'key': key, 'opt': opt}
+
+    def create(self, key, data1, data2=None):
+        return {'key': key, 'data1': data1, 'data2': data2}
+
+    def get(self, key, skey, ekey, opt=1):
+        return {'key': key, 'skey': skey, 'ekey': ekey, 'opt': opt}
+
+    def set(self, key, skey, ekey, data):
+        return {'key': key, 'skey': skey, 'ekey': ekey, 'data': data}
+
+    def delete(self, key, skey, ekey, opt=1):
+        pass
+
+    def bulk_set(self, key, data1, data2=None):
+        return {'key': key, 'data1': data1, 'data2': data2}
+
+    def bulk_delete(self, key, opt=1):
+        pass
+
+    @RESTController.Collection('POST')
+    def cmethod(self, key, data):
+        return {'key': key, 'data': data}
+
+    @RESTController.Resource('GET')
+    def rmethod(self, key, skey, ekey, opt=1):
+        return {'key': key, 'skey': skey, 'ekey': ekey, 'opt': opt}
+
+
+@Controller("/")
+class Root(BaseController):
+    @Endpoint(json_response=False)
+    def __call__(self):
+        return "<html></html>"
+
+
+class ControllersTest(ControllerTestCase):
+    @classmethod
+    def setup_server(cls):
+        cls.setup_controllers([BTest, RTest], "/test")
+
+    def test_1(self):
+        self._get('/test/ui/btest/{}/test1?opt=3'.format(100))
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '100', 'opt': '3'})
+
+    def test_2(self):
+        self._get('/test/ui/btest/{}/test2/{}?opt=3'.format(100, 200))
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '100', 'skey': '200', 'opt': '3'})
+
+    def test_3(self):
+        self._get('/test/ui/btest/{}/foo/{}/test-3?opt=3'.format(100, 200))
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '100', 'skey': '200', 'opt': '3'})
+
+    def test_4(self):
+        self._post('/test/ui/btest/{}/foo/{}/test-3?opt=3'.format(100, 200),
+                   {'data': 30})
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '100', 'skey': '200', 'data': 30,
+                             'opt': '3'})
+
+    def test_5(self):
+        self._put('/test/ui/btest/{}/test5/{}?opt=3'.format(100, 200),
+                  {'data1': 40, 'data2': "hello"})
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '100', 'skey': '200', 'data1': 40,
+                             'data2': "hello", 'opt': '3'})
+
+    def test_6(self):
+        self._get('/test/ui/btest/{}/test6'.format(100))
+        self.assertStatus(200)
+        self.assertBody("My Formatted string key=100 opt=1")
+
+    def test_7(self):
+        self._get('/test/ui/btest/{}?opt=3'.format(100))
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '100', 'opt': '3'})
+
+    def test_rest_list(self):
+        self._get('/test/api/rtest/{}?opt=2'.format(300))
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '300', 'opt': '2'})
+
+    def test_rest_create(self):
+        self._post('/test/api/rtest/{}'.format(300),
+                   {'data1': 20, 'data2': True})
+        self.assertStatus(201)
+        self.assertJsonBody({'key': '300', 'data1': 20, 'data2': True})
+
+    def test_rest_get(self):
+        self._get('/test/api/rtest/{}/{}/{}?opt=3'.format(300, 1, 2))
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '300', 'skey': '1', 'ekey': '2',
+                             'opt': '3'})
+
+    def test_rest_set(self):
+        self._put('/test/api/rtest/{}/{}/{}'.format(300, 1, 2),
+                  {'data': 40})
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '300', 'skey': '1', 'ekey': '2',
+                             'data': 40})
+
+    def test_rest_delete(self):
+        self._delete('/test/api/rtest/{}/{}/{}?opt=3'.format(300, 1, 2))
+        self.assertStatus(204)
+
+    def test_rest_bulk_set(self):
+        self._put('/test/api/rtest/{}'.format(300),
+                  {'data1': 20, 'data2': True})
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '300', 'data1': 20, 'data2': True})
+
+    def test_rest_bulk_delete(self):
+        self._delete('/test/api/rtest/{}?opt=2'.format(300))
+        self.assertStatus(204)
+
+    def test_rest_collection(self):
+        self._post('/test/api/rtest/{}/cmethod'.format(300), {'data': 30})
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '300', 'data': 30})
+
+    def test_rest_resourse(self):
+        self._get('/test/api/rtest/{}/{}/{}/rmethod?opt=4'.format(300, 2, 3))
+        self.assertStatus(200)
+        self.assertJsonBody({'key': '300', 'skey': '2', 'ekey': '3',
+                             'opt': '4'})
+
+
+class RootControllerTest(ControllerTestCase):
+    @classmethod
+    def setup_server(cls):
+        cls.setup_controllers([Root])
+
+    def test_index(self):
+        self._get("/")
+        self.assertBody("<html></html>")

--- a/src/pybind/mgr/dashboard/tests/test_exceptions.py
+++ b/src/pybind/mgr/dashboard/tests/test_exceptions.py
@@ -126,11 +126,6 @@ class RESTControllerTest(ControllerTestCase):
             {'detail': '[errno -42] list', 'code': "42", 'component': 'foo'}
         )
 
-    def test_error_send_command_bowsable_api(self):
-        self.getPage('/foo/error_send_command', headers=[('Accept', 'text/html')])
-        for err in ["'detail': '[errno -42] hi'", "'component': 'foo'"]:
-            self.assertIn(err.replace("'", "\'").encode('utf-8'), self.body)
-
     def test_error_foo_generic(self):
         self._get('/foo/error_generic')
         self.assertJsonBody({'detail': 'hi', 'code': 'Error', 'component': None})

--- a/src/pybind/mgr/dashboard/tests/test_exceptions.py
+++ b/src/pybind/mgr/dashboard/tests/test_exceptions.py
@@ -7,7 +7,7 @@ import cherrypy
 
 import rados
 from ..services.ceph_service import SendCommandError
-from ..controllers import RESTController, ApiController, Task
+from ..controllers import RESTController, Controller, Task
 from .helper import ControllerTestCase
 from ..services.exception import handle_rados_error, handle_send_command_error, \
     serialize_dashboard_exception
@@ -15,7 +15,7 @@ from ..tools import ViewCache, TaskManager, NotificationQueue
 
 
 # pylint: disable=W0613
-@ApiController('foo')
+@Controller('foo')
 class FooResource(RESTController):
 
     @cherrypy.expose

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -64,11 +64,11 @@ class RbdMirroringControllerTest(ControllerTestCase):
 
         Summary._cp_config['tools.authenticate.on'] = False  # pylint: disable=protected-access
 
-        cls.setup_controllers([RbdMirror, Summary], '/api/test')
+        cls.setup_controllers([RbdMirror, Summary], '/test')
 
     @mock.patch('dashboard.controllers.rbd_mirroring.rbd')
     def test_default(self, rbd_mock):  # pylint: disable=W0613
-        self._get('/api/test/rbdmirror')
+        self._get('/test/api/rbdmirror')
         result = self.jsonBody()
         self.assertStatus(200)
         self.assertEqual(result['status'], 0)
@@ -78,7 +78,7 @@ class RbdMirroringControllerTest(ControllerTestCase):
     @mock.patch('dashboard.controllers.rbd_mirroring.rbd')
     def test_summary(self, rbd_mock):  # pylint: disable=W0613
         """We're also testing `summary`, as it also uses code from `rbd_mirroring.py`"""
-        self._get('/api/test/summary')
+        self._get('/test/api/summary')
         self.assertStatus(200)
 
         summary = self.jsonBody()['rbd_mirroring']

--- a/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
+++ b/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
@@ -29,12 +29,12 @@ class TaskTest(RESTController):
         time.sleep(TaskTest.sleep_time)
 
     @Task('task/foo', ['{param}'])
-    @RESTController.collection(['POST'])
+    @RESTController.Collection('POST')
     def foo(self, param):
         return {'my_param': param}
 
     @Task('task/bar', ['{key}', '{param}'])
-    @RESTController.resource(['PUT'])
+    @RESTController.Resource('PUT')
     def bar(self, key, param=None):
         return {'my_param': param, 'key': key}
 

--- a/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
+++ b/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
@@ -4,12 +4,12 @@
 import time
 
 from .helper import ControllerTestCase
-from ..controllers import ApiController, RESTController, Task
+from ..controllers import Controller, RESTController, Task
 from ..controllers.task import Task as TaskController
 from ..tools import NotificationQueue, TaskManager
 
 
-@ApiController('test/task')
+@Controller('test/task')
 class TaskTest(RESTController):
     sleep_time = 0.0
 
@@ -45,6 +45,7 @@ class TaskControllerTest(ControllerTestCase):
         # pylint: disable=protected-access
         NotificationQueue.start_queue()
         TaskManager.init()
+        TaskTest._cp_config['tools.authenticate.on'] = False
         TaskController._cp_config['tools.authenticate.on'] = False
         cls.setup_controllers([TaskTest, TaskController])
 

--- a/src/pybind/mgr/dashboard/tests/test_tcmu_iscsi.py
+++ b/src/pybind/mgr/dashboard/tests/test_tcmu_iscsi.py
@@ -71,10 +71,10 @@ class TcmuIscsiControllerTest(ControllerTestCase):
         mgr.url_prefix = ''
         TcmuIscsi._cp_config['tools.authenticate.on'] = False  # pylint: disable=protected-access
 
-        cls.setup_controllers(TcmuIscsi, "/api/test")
+        cls.setup_controllers(TcmuIscsi, "/test")
 
     def test_list(self):
-        self._get('/api/test/tcmuiscsi')
+        self._get('/test/api/tcmuiscsi')
         self.assertStatus(200)
         self.assertJsonBody({
             'daemons': [

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -137,24 +137,6 @@ class RESTControllerTest(ControllerTestCase):
         self._post('/foo/1/detail', 'post-data')
         self.assertStatus(404)
 
-    # def test_developer_page(self):
-    #     self.getPage('/foo', headers=[('Accept', 'text/html')])
-    #     self.assertIn('<p>GET', self.body.decode('utf-8'))
-    #     self.assertIn('Content-Type: text/html', self.body.decode('utf-8'))
-    #     self.assertIn('<form action="/api/foo/" method="post">', self.body.decode('utf-8'))
-    #     self.assertIn('<input type="hidden" name="_method" value="post" />',
-    #                   self.body.decode('utf-8'))
-
-    # def test_developer_exception_page(self):
-    #     self.getPage('/foo',
-    #                  headers=[('Accept', 'text/html'), ('Content-Length', '0')],
-    #                  method='put')
-    #     self.assertStatus(404)
-
-    def test_create_form(self):
-        self.getPage('/fooargs', headers=[('Accept', 'text/html')])
-        self.assertIn('my_arg_name', self.body.decode('utf-8'))
-
     def test_generate_controller_routes(self):
         # We just need to add this controller in setup_server():
         # noinspection PyStatementEffect

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -10,12 +10,12 @@ from mock import patch
 from ..services.exception import handle_rados_error
 from .helper import ControllerTestCase
 from ..controllers import RESTController, ApiController, Controller, \
-                          BaseController
+                          BaseController, Proxy
 from ..tools import is_valid_ipv6_address, dict_contains_path
 
 
 # pylint: disable=W0613
-@Controller('foo')
+@Controller('/foo')
 class FooResource(RESTController):
     elems = []
 
@@ -40,20 +40,20 @@ class FooResource(RESTController):
         return dict(key=key, newdata=newdata)
 
 
-@Controller('foo/:key/:method')
+@Controller('/foo/:key/:method')
 class FooResourceDetail(RESTController):
     def list(self, key, method):
         return {'detail': (key, [method])}
 
 
-@ApiController('rgw/proxy/{path:.*}')
+@ApiController('/rgw/proxy')
 class GenerateControllerRoutesController(BaseController):
-    @cherrypy.expose
+    @Proxy()
     def __call__(self, path, **params):
         pass
 
 
-@ApiController('fooargs')
+@ApiController('/fooargs')
 class FooArgs(RESTController):
     def set(self, code, name=None, opt1=None, opt2=None):
         return {'code': code, 'name': name, 'opt1': opt1, 'opt2': opt2}

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -137,19 +137,19 @@ class RESTControllerTest(ControllerTestCase):
         self._post('/foo/1/detail', 'post-data')
         self.assertStatus(404)
 
-    def test_developer_page(self):
-        self.getPage('/foo', headers=[('Accept', 'text/html')])
-        self.assertIn('<p>GET', self.body.decode('utf-8'))
-        self.assertIn('Content-Type: text/html', self.body.decode('utf-8'))
-        self.assertIn('<form action="/api/foo/" method="post">', self.body.decode('utf-8'))
-        self.assertIn('<input type="hidden" name="_method" value="post" />',
-                      self.body.decode('utf-8'))
+    # def test_developer_page(self):
+    #     self.getPage('/foo', headers=[('Accept', 'text/html')])
+    #     self.assertIn('<p>GET', self.body.decode('utf-8'))
+    #     self.assertIn('Content-Type: text/html', self.body.decode('utf-8'))
+    #     self.assertIn('<form action="/api/foo/" method="post">', self.body.decode('utf-8'))
+    #     self.assertIn('<input type="hidden" name="_method" value="post" />',
+    #                   self.body.decode('utf-8'))
 
-    def test_developer_exception_page(self):
-        self.getPage('/foo',
-                     headers=[('Accept', 'text/html'), ('Content-Length', '0')],
-                     method='put')
-        self.assertStatus(404)
+    # def test_developer_exception_page(self):
+    #     self.getPage('/foo',
+    #                  headers=[('Accept', 'text/html'), ('Content-Length', '0')],
+    #                  method='put')
+    #     self.assertStatus(404)
 
     def test_create_form(self):
         self.getPage('/fooargs', headers=[('Accept', 'text/html')])

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -9,11 +9,13 @@ from mock import patch
 
 from ..services.exception import handle_rados_error
 from .helper import ControllerTestCase
-from ..controllers import RESTController, ApiController, BaseController
+from ..controllers import RESTController, ApiController, Controller, \
+                          BaseController
 from ..tools import is_valid_ipv6_address, dict_contains_path
 
 
-@ApiController('foo')
+# pylint: disable=W0613
+@Controller('foo')
 class FooResource(RESTController):
     elems = []
 
@@ -38,7 +40,7 @@ class FooResource(RESTController):
         return dict(key=key, newdata=newdata)
 
 
-@ApiController('foo/:key/:method')
+@Controller('foo/:key/:method')
 class FooResourceDetail(RESTController):
     def list(self, key, method):
         return {'detail': (key, [method])}
@@ -115,13 +117,13 @@ class RESTControllerTest(ControllerTestCase):
         assert 'traceback' in body
 
     def test_args_from_json(self):
-        self._put("/fooargs/hello", {'name': 'world'})
+        self._put("/api/fooargs/hello", {'name': 'world'})
         self.assertJsonBody({'code': 'hello', 'name': 'world', 'opt1': None, 'opt2': None})
 
-        self._put("/fooargs/hello", {'name': 'world', 'opt1': 'opt1'})
+        self._put("/api/fooargs/hello", {'name': 'world', 'opt1': 'opt1'})
         self.assertJsonBody({'code': 'hello', 'name': 'world', 'opt1': 'opt1', 'opt2': None})
 
-        self._put("/fooargs/hello", {'name': 'world', 'opt2': 'opt2'})
+        self._put("/api/fooargs/hello", {'name': 'world', 'opt2': 'opt2'})
         self.assertJsonBody({'code': 'hello', 'name': 'world', 'opt1': None, 'opt2': 'opt2'})
 
     def test_detail_route(self):

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -579,7 +579,7 @@ class Task(object):
         return hash((self.name, tuple(sorted(self.metadata.items()))))
 
     def __eq__(self, other):
-        return self.name == self.name and self.metadata == self.metadata
+        return self.name == other.name and self.metadata == other.metadata
 
     def __str__(self):
         return "Task(ns={}, md={})" \

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -23,4 +23,4 @@ commands=
     cov: coverage report
     cov: coverage xml
     lint: pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests services
-    lint: pycodestyle --max-line-length=100 --exclude=.tox,venv,frontend --ignore=E402,E121,E123,E126,E226,E24,E704,W503,E741 .
+    lint: pycodestyle --max-line-length=100 --exclude=.tox,venv,frontend,.vscode --ignore=E402,E121,E123,E126,E226,E24,E704,W503,E741 .


### PR DESCRIPTION
This PR introduces several changes to the internal implementation of the dashboard controller infrastructure.
The main novelty is that the `RESTController` class is now a real specialization of the  `BaseController` implementation, because the `BaseController` class now provide the new decorator `@Endpoint` that allows to expose controller methods as endpoints instead of using the `@cherrypy.expose` decorator.

This PR also removes the browsable API feature from the controller infrastructure, with the intention of re-adding a new "browsable API" feature based on [Swagger UI](https://swagger.io/swagger-ui/) in a future PR.

This PR also adds support for differentiate controllers that are part of an API, and endpoints that might only serve the purpose of the dashboard frontend. We now have two kinds of controller decorators: the `@Controller` and `@ApiController`. The latter one can also be parameterized with a version number so that in the future we can support versioning of the dashboard REST API.

A good example of the new way of defining endpoints can be seen in the `tests/test_controlllers.py` unit test file. There you can find the several different ways one can declare and endpoint method.

