### PR TITLE
doc: Fix typo in ceph-fuse(8)

### DIFF
--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -39,7 +39,7 @@ Any options not recognized by ceph-fuse will be passed on to libfuse.
 
 .. option:: -d
 
-   Run in foreground, send all log otuput to stderr and enable FUSE debugging (-o debug).
+   Run in foreground, send all log output to stderr and enable FUSE debugging (-o debug).
 
 .. option:: -c ceph.conf, --conf=ceph.conf
 


### PR DESCRIPTION
Fixes: https://github.com/ceph/ceph/pull/21616#pullrequestreview-122923127
Signed-off-by: Jos Collin <jcollin@redhat.com>