### PR TITLE
rgw: fix index update in dir_suggest_changes

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1898,7 +1898,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
     string cur_change_key;
     encode_obj_index_key(cur_change.key, &cur_change_key);
     int ret = cls_cxx_map_get_val(hctx, cur_change_key, &cur_disk_bl);
-    if (ret < 0 && ret != -ENOENT)
+    if (ret < 0)
       return -EINVAL;
 
     if (cur_disk_bl.length()) {
@@ -1955,18 +1955,6 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         }
         break;
       case CEPH_RGW_UPDATE:
-	if (!cur_disk.exists) {
-	  // this update would only have been sent by the rgw client
-	  // if the rgw_bucket_dir_entry existed, however between that
-	  // check and now the entry has diappeared, so we were likely
-	  // in the midst of a delete op, and we will not recreate the
-	  // entry
-	  CLS_LOG(10,
-		  "CEPH_RGW_UPDATE not applied because rgw_bucket_dir_entry"
-		  " no longer exists\n");
-	  break;
-	}
-
         CLS_LOG(10, "CEPH_RGW_UPDATE name=%s instance=%s total_entries: %" PRId64 " -> %" PRId64 "\n",
                 cur_change.key.name.c_str(), cur_change.key.instance.c_str(), stats.num_entries, stats.num_entries + 1);
 


### PR DESCRIPTION
try to address problems of recover index after rgw crash and
not recreate index in del op race with list op.

1. do nothing if the index is no longer exists in cls rgw_dir_suggest_changes,
whatever the pending state we got in check_disk_state, to avoid recreate
index when list race with delete. the situations:
* if dir_suggest_changes is done before complete op in Delete, the index
will be deleted finally.
* if dir_suggest_changes is done after complete op in Delete, the index
will no exists and do nothing.

2. stale pending write op's index is existent but exists field is false,
so remove cur_disk.exists check in op CEPH_RGW_UPDATE, make it recover the
situation again.

fixes: http://tracker.ceph.com/issues/24280

Signed-off-by: Tianshan Qu <tianshan@xsky.com>