### PR TITLE
mimic: rbd: Prevent the use of internal feature bits from outside cls/rbd

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -360,6 +360,12 @@ int create(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   omap_vals["snap_seq"] = snap_seqbl;
   omap_vals["create_timestamp"] = create_timestampbl;
 
+  if ((features & RBD_FEATURES_INTERNAL) != 0ULL) {
+    CLS_ERR("Attempting to set internal feature: %" PRIu64,
+            static_cast<uint64_t>(features & RBD_FEATURES_INTERNAL));
+    return -EINVAL;
+  }
+
   if (features & RBD_FEATURE_DATA_POOL) {
     if (data_pool_id == -1) {
       CLS_ERR("data pool not provided with feature enabled");

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -174,7 +174,7 @@ int Image<I>::deep_copy(I *src, librados::IoCtx& dest_md_ctx,
   uint64_t src_size;
   {
     RWLock::RLocker snap_locker(src->snap_lock);
-    features = src->features;
+    features = (src->features & ~RBD_FEATURES_IMPLICIT_ENABLE);
     src_size = src->get_image_size(src->snap_id);
   }
   uint64_t format = 2;

--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -36,6 +36,10 @@ int validate_features(CephContext *cct, uint64_t features,
     lderr(cct) << "librbd does not support requested features." << dendl;
     return -ENOSYS;
   }
+  if ((features & RBD_FEATURES_INTERNAL) != 0) {
+    lderr(cct) << "cannot use internally controlled features" << dendl;
+    return -EINVAL;
+  }
   if ((features & RBD_FEATURE_FAST_DIFF) != 0 &&
       (features & RBD_FEATURE_OBJECT_MAP) == 0) {
     lderr(cct) << "cannot use fast diff without object map" << dendl;

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -372,6 +372,8 @@ TEST_F(TestClsRbd, create)
                             object_prefix, 123));
   ASSERT_EQ(0, ioctx.remove(oid));
   ASSERT_EQ(-EINVAL, create_image(&ioctx, oid, size, order,
+                                  RBD_FEATURE_OPERATIONS, object_prefix, -1));
+  ASSERT_EQ(-EINVAL, create_image(&ioctx, oid, size, order,
                                   RBD_FEATURE_DATA_POOL, object_prefix, -1));
   ASSERT_EQ(-EINVAL, create_image(&ioctx, oid, size, order, 0, object_prefix,
                                   123));

--- a/src/test/librbd/test_DeepCopy.cc
+++ b/src/test/librbd/test_DeepCopy.cc
@@ -336,6 +336,8 @@ struct TestDeepCopy : public TestFixture {
         int order = m_src_ictx->order;
         uint64_t features;
         ASSERT_EQ(0, librbd::get_features(m_src_ictx, &features));
+        features &= ~RBD_FEATURES_IMPLICIT_ENABLE;
+
         std::cout << "clone " << m_src_ictx->name << " -> " << clone_name
                   << std::endl;
         ASSERT_EQ(0, librbd::clone(m_ioctx, m_src_ictx->name.c_str(),

--- a/src/test/rbd_mirror/test_ImageDeleter.cc
+++ b/src/test/rbd_mirror/test_ImageDeleter.cc
@@ -66,7 +66,8 @@ public:
 
     m_local_image_id = librbd::util::generate_image_id(m_local_io_ctx);
     librbd::ImageOptions image_opts;
-    image_opts.set(RBD_IMAGE_OPTION_FEATURES, RBD_FEATURES_ALL);
+    image_opts.set(RBD_IMAGE_OPTION_FEATURES,
+                   (RBD_FEATURES_ALL & ~RBD_FEATURES_IMPLICIT_ENABLE));
     EXPECT_EQ(0, librbd::create(m_local_io_ctx, m_image_name, m_local_image_id,
                                 1 << 20, image_opts, GLOBAL_IMAGE_ID,
                                 m_remote_mirror_uuid, true));

--- a/src/test/rbd_mirror/test_fixture.cc
+++ b/src/test/rbd_mirror/test_fixture.cc
@@ -89,7 +89,9 @@ void TestFixture::TearDown() {
 int TestFixture::create_image(librbd::RBD &rbd, librados::IoCtx &ioctx,
                               const std::string &name, uint64_t size) {
   int order = 18;
-  return rbd.create2(ioctx, name.c_str(), size, RBD_FEATURES_ALL, &order);
+  return rbd.create2(ioctx, name.c_str(), size,
+                     (RBD_FEATURES_ALL & ~RBD_FEATURES_IMPLICIT_ENABLE),
+                     &order);
 }
 
 int TestFixture::open_image(librados::IoCtx &io_ctx,

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
@@ -69,35 +69,7 @@ void CreateImageRequest<I>::create_image() {
   RWLock::RLocker snap_locker(m_remote_image_ctx->snap_lock);
 
   librbd::ImageOptions image_options;
-  image_options.set(RBD_IMAGE_OPTION_FEATURES, m_remote_image_ctx->features);
-  image_options.set(RBD_IMAGE_OPTION_ORDER, m_remote_image_ctx->order);
-  image_options.set(RBD_IMAGE_OPTION_STRIPE_UNIT,
-                    m_remote_image_ctx->stripe_unit);
-  image_options.set(RBD_IMAGE_OPTION_STRIPE_COUNT,
-                    m_remote_image_ctx->stripe_count);
-
-  // Determine the data pool for the local image as follows:
-  // 1. If the local pool has a default data pool, use it.
-  // 2. If the remote image has a data pool different from its metadata pool and
-  //    a pool with the same name exists locally, use it.
-  // 3. Don't set the data pool explicitly.
-  std::string data_pool;
-  librados::Rados local_rados(m_local_io_ctx);
-  auto default_data_pool = g_ceph_context->_conf->get_val<std::string>("rbd_default_data_pool");
-  auto remote_md_pool = m_remote_image_ctx->md_ctx.get_pool_name();
-  auto remote_data_pool = m_remote_image_ctx->data_ctx.get_pool_name();
-
-  if (default_data_pool != "") {
-    data_pool = default_data_pool;
-  } else if (remote_data_pool != remote_md_pool) {
-    if (local_rados.pool_lookup(remote_data_pool.c_str()) >= 0) {
-      data_pool = remote_data_pool;
-    }
-  }
-
-  if (data_pool != "") {
-    image_options.set(RBD_IMAGE_OPTION_DATA_POOL, data_pool);
-  }
+  populate_image_options(&image_options);
 
   librbd::image::CreateRequest<I> *req = librbd::image::CreateRequest<I>::create(
     m_local_io_ctx, m_local_image_name, m_local_image_id,
@@ -325,10 +297,7 @@ void CreateImageRequest<I>::clone_image() {
   dout(20) << dendl;
 
   librbd::ImageOptions opts;
-  opts.set(RBD_IMAGE_OPTION_FEATURES, m_remote_image_ctx->features);
-  opts.set(RBD_IMAGE_OPTION_ORDER, m_remote_image_ctx->order);
-  opts.set(RBD_IMAGE_OPTION_STRIPE_UNIT, m_remote_image_ctx->stripe_unit);
-  opts.set(RBD_IMAGE_OPTION_STRIPE_COUNT, m_remote_image_ctx->stripe_count);
+  populate_image_options(&opts);
 
   using klass = CreateImageRequest<I>;
   Context *ctx = create_context_callback<klass, &klass::handle_clone_image>(this);
@@ -461,6 +430,40 @@ int CreateImageRequest<I>::validate_parent() {
   }
 
   return 0;
+}
+
+template <typename I>
+void CreateImageRequest<I>::populate_image_options(
+    librbd::ImageOptions* image_options) {
+  image_options->set(RBD_IMAGE_OPTION_FEATURES, m_remote_image_ctx->features);
+  image_options->set(RBD_IMAGE_OPTION_ORDER, m_remote_image_ctx->order);
+  image_options->set(RBD_IMAGE_OPTION_STRIPE_UNIT,
+                     m_remote_image_ctx->stripe_unit);
+  image_options->set(RBD_IMAGE_OPTION_STRIPE_COUNT,
+                     m_remote_image_ctx->stripe_count);
+
+  // Determine the data pool for the local image as follows:
+  // 1. If the local pool has a default data pool, use it.
+  // 2. If the remote image has a data pool different from its metadata pool and
+  //    a pool with the same name exists locally, use it.
+  // 3. Don't set the data pool explicitly.
+  std::string data_pool;
+  librados::Rados local_rados(m_local_io_ctx);
+  auto default_data_pool = g_ceph_context->_conf->get_val<std::string>("rbd_default_data_pool");
+  auto remote_md_pool = m_remote_image_ctx->md_ctx.get_pool_name();
+  auto remote_data_pool = m_remote_image_ctx->data_ctx.get_pool_name();
+
+  if (default_data_pool != "") {
+    data_pool = default_data_pool;
+  } else if (remote_data_pool != remote_md_pool) {
+    if (local_rados.pool_lookup(remote_data_pool.c_str()) >= 0) {
+      data_pool = remote_data_pool;
+    }
+  }
+
+  if (data_pool != "") {
+    image_options->set(RBD_IMAGE_OPTION_DATA_POOL, data_pool);
+  }
 }
 
 } // namespace image_replayer

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
@@ -435,7 +435,9 @@ int CreateImageRequest<I>::validate_parent() {
 template <typename I>
 void CreateImageRequest<I>::populate_image_options(
     librbd::ImageOptions* image_options) {
-  image_options->set(RBD_IMAGE_OPTION_FEATURES, m_remote_image_ctx->features);
+  image_options->set(RBD_IMAGE_OPTION_FEATURES,
+                     (m_remote_image_ctx->features &
+                        ~RBD_FEATURES_IMPLICIT_ENABLE));
   image_options->set(RBD_IMAGE_OPTION_ORDER, m_remote_image_ctx->order);
   image_options->set(RBD_IMAGE_OPTION_STRIPE_UNIT,
                      m_remote_image_ctx->stripe_unit);

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
@@ -13,6 +13,7 @@
 class Context;
 class ContextWQ;
 namespace librbd { class ImageCtx; }
+namespace librbd { class ImageOptions; }
 
 namespace rbd {
 namespace mirror {
@@ -134,6 +135,8 @@ private:
   void finish(int r);
 
   int validate_parent();
+
+  void populate_image_options(librbd::ImageOptions* image_options);
 
 };
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/24203