### PR TITLE
mon: simplify timecheck map keys

### DIFF
--- a/src/messages/MTimeCheck2.h
+++ b/src/messages/MTimeCheck2.h
@@ -1,0 +1,86 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2012 Inktank, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+struct MTimeCheck2 : public Message
+{
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+
+  enum {
+    OP_PING = 1,
+    OP_PONG = 2,
+    OP_REPORT = 3,
+  };
+
+  int op = 0;
+  version_t epoch = 0;
+  version_t round = 0;
+
+  utime_t timestamp;
+  map<int, double> skews;
+  map<int, double> latencies;
+
+  MTimeCheck2() : Message(MSG_TIMECHECK2, HEAD_VERSION, COMPAT_VERSION) { }
+  MTimeCheck2(int op) :
+    Message(MSG_TIMECHECK2, HEAD_VERSION, COMPAT_VERSION),
+    op(op)
+  { }
+
+private:
+  ~MTimeCheck2() override { }
+
+public:
+  const char *get_type_name() const override { return "time_check2"; }
+  const char *get_op_name() const {
+    switch (op) {
+    case OP_PING: return "ping";
+    case OP_PONG: return "pong";
+    case OP_REPORT: return "report";
+    }
+    return "???";
+  }
+  void print(ostream &o) const override {
+    o << "time_check( " << get_op_name()
+      << " e " << epoch << " r " << round;
+    if (op == OP_PONG) {
+      o << " ts " << timestamp;
+    } else if (op == OP_REPORT) {
+      o << " #skews " << skews.size()
+        << " #latencies " << latencies.size();
+    }
+    o << " )";
+  }
+
+  void decode_payload() override {
+    auto p = payload.cbegin();
+    decode(op, p);
+    decode(epoch, p);
+    decode(round, p);
+    decode(timestamp, p);
+    decode(skews, p);
+    decode(latencies, p);
+  }
+
+  void encode_payload(uint64_t features) override {
+    using ceph::encode;
+    encode(op, payload);
+    encode(epoch, payload);
+    encode(round, payload);
+    encode(timestamp, payload);
+    encode(skews, payload, features);
+    encode(latencies, payload, features);
+  }
+};

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -540,7 +540,7 @@ bool AuthMonitor::prep_auth(MonOpRequestRef op, bool paxos_writable)
 	int leader = mon->get_leader();
 	MMonGlobalID *req = new MMonGlobalID();
 	req->old_max_id = max_global_id;
-	mon->messenger->send_message(req, mon->monmap->get_inst(leader));
+	mon->send_mon_message(req, leader);
 	wait_for_finished_proposal(op, new C_RetryMessage(this, op));
 	return true;
       }

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -105,7 +105,7 @@ void Elector::start()
     MMonElection *m =
       new MMonElection(MMonElection::OP_PROPOSE, epoch, mon->monmap);
     m->mon_features = ceph::features::mon::get_supported();
-    mon->messenger->send_message(m, mon->monmap->get_inst(i));
+    mon->send_mon_message(m, i);
   }
   
   reset_timer();
@@ -127,7 +127,7 @@ void Elector::defer(int who)
   m->mon_features = ceph::features::mon::get_supported();
   mon->collect_metadata(&m->metadata);
 
-  mon->messenger->send_message(m, mon->monmap->get_inst(who));
+  mon->send_mon_message(m, who);
   
   // set a timer
   reset_timer(1.0);  // give the leader some extra time to declare victory
@@ -220,7 +220,7 @@ void Elector::victory()
     m->quorum_features = cluster_features;
     m->mon_features = mon_features;
     m->sharing_bl = mon->get_local_commands_bl(mon_features);
-    mon->messenger->send_message(m, mon->monmap->get_inst(*p));
+    mon->send_mon_message(m, *p);
   }
 
   // tell monitor

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -285,8 +285,7 @@ bool HealthMonitor::check_member_health()
     changed = true;
   } else {
     // tell the leader
-    mon->messenger->send_message(new MMonHealthChecks(next),
-                                 mon->monmap->get_inst(mon->get_leader()));
+    mon->send_mon_message(new MMonHealthChecks(next), mon->get_leader());
   }
 
   return changed;
@@ -348,8 +347,7 @@ bool HealthMonitor::check_leader_health()
       if (tcstatus != HEALTH_OK) {
 	warns.push_back(name);
 	ostringstream tmp_ss;
-	tmp_ss << "mon." << name
-	       << " " << tcss.str()
+	tmp_ss << "mon." << name << " " << tcss.str()
 	       << " (latency " << latency << "s)";
 	details.push_back(tmp_ss.str());
       }

--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -339,19 +339,17 @@ bool HealthMonitor::check_leader_health()
   if (!mon->timecheck_skews.empty()) {
     list<string> warns;
     list<string> details;
-    for (map<entity_inst_t,double>::iterator i = mon->timecheck_skews.begin();
-	 i != mon->timecheck_skews.end(); ++i) {
-      entity_inst_t inst = i->first;
-      double skew = i->second;
-      double latency = mon->timecheck_latencies[inst];
-      string name = mon->monmap->get_name(inst.addr);
+    for (auto& i : mon->timecheck_skews) {
+      double skew = i.second;
+      double latency = mon->timecheck_latencies[i.first];
+      string name = mon->monmap->get_name(i.first);
       ostringstream tcss;
       health_status_t tcstatus = mon->timecheck_status(tcss, skew, latency);
       if (tcstatus != HEALTH_OK) {
 	warns.push_back(name);
 	ostringstream tmp_ss;
 	tmp_ss << "mon." << name
-	       << " addr " << inst.addr << " " << tcss.str()
+	       << " " << tcss.str()
 	       << " (latency " << latency << "s)";
 	details.push_back(tmp_ss.str());
       }

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -271,9 +271,8 @@ bool MonClient::ms_dispatch(Message *m)
   Mutex::Locker lock(monc_lock);
 
   if (_hunting()) {
-    auto pending_con = pending_cons.find(m->get_source_addr());
-    if (pending_con == pending_cons.end() ||
-	pending_con->second.get_con() != m->get_connection()) {
+    auto p = _find_pending_con(m->get_connection());
+    if (p == pending_cons.end()) {
       // ignore any messages outside hunting sessions
       ldout(cct, 10) << "discarding stray monitor message " << *m << dendl;
       m->put();
@@ -541,7 +540,7 @@ void MonClient::handle_auth(MAuthReply *m)
   }
 
   // hunting
-  auto found = pending_cons.find(m->get_source_addr());
+  auto found = _find_pending_con(m->get_connection());
   assert(found != pending_cons.end());
   int auth_err = found->second.handle_auth(m, entity_name, want_keys,
 					   rotating_secrets.get());

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -216,6 +216,16 @@ private:
   void _add_conns(uint64_t global_id);
   void _send_mon_message(Message *m);
 
+  std::map<entity_addr_t, MonConnection>::iterator _find_pending_con(
+    const ConnectionRef& con) {
+    for (auto i = pending_cons.begin(); i != pending_cons.end(); ++i) {
+      if (i->second.get_con() == con) {
+	return i;
+      }
+    }
+    return pending_cons.end();
+  }
+
 public:
   void set_entity_name(EntityName name) { entity_name = name; }
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -107,7 +107,7 @@ class MMonProbe;
 struct MMonSubscribe;
 struct MRoute;
 struct MForward;
-struct MTimeCheck;
+struct MTimeCheck2;
 struct MMonHealth;
 
 #define COMPAT_SET_LOC "feature_set"
@@ -485,9 +485,9 @@ private:
    *  - Once all the quorum members have pong'ed, the leader will share the
    *    clock skew and latency maps with all the monitors in the quorum.
    */
-  map<entity_inst_t, utime_t> timecheck_waiting;
-  map<entity_inst_t, double> timecheck_skews;
-  map<entity_inst_t, double> timecheck_latencies;
+  map<int, utime_t> timecheck_waiting;
+  map<int, double> timecheck_skews;
+  map<int, double> timecheck_latencies;
   // odd value means we are mid-round; even value means the round has
   // finished.
   version_t timecheck_round;

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -812,6 +812,8 @@ public:
   void send_command(const entity_inst_t& inst,
 		    const vector<string>& com);
 
+  void send_mon_message(Message *m, int rank);
+
 public:
   struct C_Command : public C_MonOp {
     Monitor *mon;

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -196,7 +196,7 @@ void Paxos::collect(version_t oldpn)
     collect->last_committed = last_committed;
     collect->first_committed = first_committed;
     collect->pn = accepted_pn;
-    mon->messenger->send_message(collect, mon->monmap->get_inst(*p));
+    mon->send_mon_message(collect, *p);
   }
 
   // set timeout event
@@ -516,7 +516,7 @@ void Paxos::handle_last(MonOpRequestRef op)
 					MMonPaxos::OP_COMMIT,
 					ceph_clock_now());
       share_state(commit, peer_first_committed[p->first], p->second);
-      mon->messenger->send_message(commit, mon->monmap->get_inst(p->first));
+      mon->send_mon_message(commit, p->first);
     }
   }
 
@@ -688,7 +688,7 @@ void Paxos::begin(bufferlist& v)
     begin->last_committed = last_committed;
     begin->pn = accepted_pn;
     
-    mon->messenger->send_message(begin, mon->monmap->get_inst(*p));
+    mon->send_mon_message(begin, *p);
   }
 
   // set timeout event
@@ -914,7 +914,7 @@ void Paxos::commit_finish()
     commit->pn = accepted_pn;
     commit->last_committed = last_committed;
 
-    mon->messenger->send_message(commit, mon->monmap->get_inst(*p));
+    mon->send_mon_message(commit, *p);
   }
 
   assert(g_conf->paxos_kill_at != 9);
@@ -987,7 +987,7 @@ void Paxos::extend_lease()
     lease->last_committed = last_committed;
     lease->lease_timestamp = lease_expire;
     lease->first_committed = first_committed;
-    mon->messenger->send_message(lease, mon->monmap->get_inst(*p));
+    mon->send_mon_message(lease, *p);
   }
 
   // set timeout event.

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -182,6 +182,7 @@
 
 #include "messages/MWatchNotify.h"
 #include "messages/MTimeCheck.h"
+#include "messages/MTimeCheck2.h"
 
 #include "common/config.h"
 
@@ -808,6 +809,9 @@ Message *decode_message(CephContext *cct, int crcflags,
 
   case MSG_TIMECHECK:
     m = new MTimeCheck();
+    break;
+  case MSG_TIMECHECK2:
+    m = new MTimeCheck2();
     break;
 
   case MSG_MON_HEALTH:

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -194,6 +194,7 @@
 #define MSG_NOP                   0x607
 
 #define MSG_MON_HEALTH_CHECKS     0x608
+#define MSG_TIMECHECK2            0x609
 
 // *** ceph-mgr <-> OSD/MDS daemons ***
 #define MSG_MGR_OPEN              0x700


### PR DESCRIPTION
These were using entity_inst_t, which is problematic for addrvec, and also overkill, since
we're only considering mons in quorum.

Added the send_mon_message helper at the end (which is what i was trying to do when I collided with the entity_inst_t usage).