### PR TITLE
qa/workunits/suites/pjd.sh: use correct dir name

### DIFF
--- a/qa/workunits/suites/pjd.sh
+++ b/qa/workunits/suites/pjd.sh
@@ -4,7 +4,7 @@ set -e
 
 wget http://download.ceph.com/qa/pjd-fstest-20090130-RC-aclfixes.tgz
 tar zxvf pjd*.tgz
-cd pjd*
+cd pjd-fstest-20090130-RC
 make clean
 make
 cd ..


### PR DESCRIPTION
Fixes 
`2018-05-24T17:32:15.682 INFO:tasks.workunit.client.0.smithi124.stderr:/home/ubuntu/cephtest/clone.client.0/qa/workunits/suites/pjd.sh: line 7: cd: too many arguments`

http://pulpito.ceph.com/yuriw-2018-05-24_17:07:20-powercycle-master-distro-basic-smithi/2580436/

Fixes: https://tracker.ceph.com/issues/24307
Signed-off-by: Neha Ojha <nojha@redhat.com>