### PR TITLE
librbd: mask 'operations' feature when inheriting features from clone parent

### DIFF
--- a/src/librbd/image/CloneRequest.cc
+++ b/src/librbd/image/CloneRequest.cc
@@ -193,7 +193,7 @@ void CloneRequest<I>::send_create() {
   ldout(m_cct, 20) << this << " " << __func__ << dendl;
 
   if (m_use_p_features) {
-    m_features = m_p_features;
+    m_features = m_p_features & ~RBD_FEATURE_OPERATIONS;
   }
 
   uint64_t order = m_p_imctx->order;


### PR DESCRIPTION
The feature is set on parent for v2 clone request and causes image
create request to fail due to a forbidden feature.

Signed-off-by: Mykola Golub <mgolub@suse.com>