### PR TITLE
mimic: doc: rgw: fix tagging support status

### DIFF
--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -122,6 +122,8 @@ For all requests, condition keys we support are:
 
 We support certain s3 condition keys for bucket and object requests.
 
+.. versionadded:: Mimic
+
 Bucket Related Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -145,6 +147,7 @@ Bucket Related Operations
 |                       | s3:x-amz-grant-<perm>|                |
 +-----------------------+----------------------+----------------+
 
+.. _tag_policy:
 
 Object Related Operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -194,7 +197,7 @@ Object Related Operations
 |s3:GetObjectVersionTagging   |                                               |                   |
 +-----------------------------+-----------------------------------------------+-------------------+
 |s3:DeleteObjectTagging &     |s3:ExistingOBjectTag/<tag-key>                 |                   |
-|s3:DeleteOBjectVersionTagging|                                               |                   |
+|s3:DeleteObjectVersionTagging|                                               |                   |
 +-----------------------------+-----------------------------------------------+-------------------+
 
 

--- a/doc/radosgw/s3.rst
+++ b/doc/radosgw/s3.rst
@@ -72,7 +72,7 @@ The following table describes the support status for current Amazon S3 functiona
 +---------------------------------+-----------------+----------------------------------------+
 | **Multipart Uploads**           | Supported       |                                        |
 +---------------------------------+-----------------+----------------------------------------+
-| **Object Tagging**              | Supported       | Not supported in bucket policy/LC rules|
+| **Object Tagging**              | Supported       | See :ref:`tag_policy` for Policy verbs |
 +---------------------------------+-----------------+----------------------------------------+
 
 


### PR DESCRIPTION
As of mimic, policy and LC conditionals for tagging are merged, so let's drop
the unsupported status.

Fixes: http://tracker.ceph.com/issues/24164
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>
(cherry picked from commit 17dab9b3f24c1454a12f42184fd262119eb97e3e)