### PR TITLE
mon/OSDMonitor: Respect paxos_propose_interval

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -190,7 +190,6 @@ OSDMonitor::OSDMonitor(
    inc_osd_cache(g_conf->mon_osd_cache_size),
    full_osd_cache(g_conf->mon_osd_cache_size),
    has_osdmap_manifest(false),
-   last_attempted_minwait_time(utime_t()),
    mapper(mn->cct, &mn->cpu_tp)
 {}
 
@@ -2036,22 +2035,6 @@ bool OSDMonitor::should_propose(double& delay)
     delay = 0.0;
     osd_weight.clear();
     return true;
-  }
-
-  // propose as fast as possible if updating up_thru or pg_temp
-  // want to merge OSDMap changes as much as possible
-  if ((pending_inc.new_primary_temp.size() == 1
-      || pending_inc.new_up_thru.size() == 1)
-      && pending_inc.new_state.size() < 2) {
-    dout(15) << " propose as fast as possible for up_thru/pg_temp" << dendl;
-
-    utime_t now = ceph_clock_now();
-    if (now - last_attempted_minwait_time > g_conf->paxos_propose_interval
-	&& now - paxos->get_last_commit_time() > g_conf->paxos_min_wait) {
-      delay = g_conf->paxos_min_wait;
-      last_attempted_minwait_time = now;
-      return true;
-    }
   }
 
   return PaxosService::should_propose(delay);

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -237,9 +237,6 @@ public:
   bool check_failure(utime_t now, int target_osd, failure_info_t& fi);
   void force_failure(int target_osd, int by);
 
-  // the time of last msg(MSG_ALIVE and MSG_PGTEMP) proposed without delay
-  utime_t last_attempted_minwait_time;
-
   bool _have_pending_crush();
   CrushWrapper &_get_stable_crush();
   void _get_pending_crush(CrushWrapper& newcrush);

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -1231,14 +1231,6 @@ public:
    * @return the first committed version
    */
   version_t get_first_committed() { return first_committed; }
-  /** 
-   * Get the last commit time
-   *
-   * @returns Our last commit time
-  */
-  utime_t get_last_commit_time() const{
-    return last_commit_time;
-  }
   /**
    * Check if a given version is readable.
    *


### PR DESCRIPTION
This change doesn't looks right and causing twice as much proposal as we targeted to (limited by paxos_propose_interval).

Imaging we have a sequence of pg_temp/up_thru during a large recovery.

now =T
The 1st up_thru/pg_temp will go through fast path and trigger propose at T + paxos_min_wait, last_attempted_minwait_time = T.

now = T+ paxos_min_wait
The [2, K] up_thru will failed by (now - last_attempted_minwait_time > g_conf->paxos_propose_interval)
and go through PaxosService::should_propose, which will schedule the propose at) T+paxos_propose_interval

now= T+ paxos_propose_interval + paxos_min_wait
The K+1 up_thru/pg_temp comes, both
 (now - last_attempted_minwait_time > g_conf->paxos_propose_interval)
and
(now - paxos->get_last_commit_time() > g_conf->paxos_min_wait)
satisfied, so we trigger another propose at now+ paxos_min_wait = T+ paxos_propose_interval +paxos_min_wait.

clearly we made TWO proposal in each paxos_propose_interval.

This reverts commit ca652104fe91ac41c7c1788a2907178c36fbe6ef.

Signed-off-by: Xiaoxi CHEN <xiaoxchen@ebay.com>