### PR TITLE
qa: use $TESTDIR for testing mkfs

### DIFF
--- a/qa/workunits/cephtool/test_kvstore_tool.sh
+++ b/qa/workunits/cephtool/test_kvstore_tool.sh
@@ -18,7 +18,8 @@ expect_false()
     if "$@"; then return 1; else return 0; fi
 }
 
-TEMP_DIR=$(mktemp -d ${TMPDIR-/tmp}/cephtool.XXX)
+TMPDIR=${TMPDIR:-${TESTDIR}}
+TEMP_DIR=$(mktemp -d ${TMPDIR:-/tmp}/cephtool.XXX)
 trap "rm -fr $TEMP_DIR" 0
 
 TEMP_FILE=$(mktemp $TEMP_DIR/test_invalid.XXX)


### PR DESCRIPTION
as tmpfs does not support O_DIRECT, but bluefs use this flag for
accessing the underlying file.

Signed-off-by: Kefu Chai <kchai@redhat.com>