### PR TITLE
wip: qa: test rgw with various dns calling formats

### DIFF
--- a/qa/suites/rgw/verify/tasks/s3tests_absolute.yml
+++ b/qa/suites/rgw/verify/tasks/s3tests_absolute.yml
@@ -1,0 +1,14 @@
+# see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
+- s3tests:
+    client.0:
+      git_remote: git://github.com/theanalyst/
+      force-branch: abs-urls
+      calling_format: absolute
+      rgw_server: client.0
+      extra_attrs: ['!fails_with_subdomain']
+
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw dns name: client.0

--- a/qa/suites/rgw/verify/tasks/s3tests_subdomain.yml
+++ b/qa/suites/rgw/verify/tasks/s3tests_subdomain.yml
@@ -1,0 +1,13 @@
+- s3tests:
+    client.0:
+      git_remote: git://github.com/theanalyst/
+      force-branch: abs-urls
+      calling_format: subdomain
+      rgw_server: client.0
+      extra_attrs: ['!fails_with_subdomain']
+
+overrides:
+  ceph:
+    conf:
+      client:
+        rgw dns name: client.0

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -105,7 +105,8 @@ def create_users(ctx, config):
     for client in config['clients']:
         s3tests_conf = config['s3tests_conf'][client]
         s3tests_conf.setdefault('fixtures', {})
-        s3tests_conf['fixtures'].setdefault('bucket prefix', 'test-' + client + '-{random}-')
+        # Dropping the trailing dash as it would create invalid dns names
+        s3tests_conf['fixtures'].setdefault('bucket prefix', 'test-' + client + '-{random}')
         for section, user in users.iteritems():
             _config_user(s3tests_conf, section, '{user}.{client}'.format(user=user, client=client))
             log.debug('Creating user {user} on {host}'.format(user=s3tests_conf[section]['user_id'], host=client))
@@ -263,6 +264,7 @@ def run_tests(ctx, config):
             args += ['REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt']
         else:
             args += ['REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt']
+        attrs.extend(client_config.get("extra_attrs",[]))
         args += [
             '{tdir}/s3-tests/virtualenv/bin/nosetests'.format(tdir=testdir),
             '-w',


### PR DESCRIPTION
Adding qa suites to test rgw with subdomain and absolute style url requests

Depends on https://github.com/ceph/s3-tests/pull/162
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>