### PR TITLE
qa/rgw: reorganize verify tasks

### DIFF
--- a/qa/suites/rgw/verify/tasks/0-install.yaml
+++ b/qa/suites/rgw/verify/tasks/0-install.yaml
@@ -9,18 +9,7 @@ tasks:
 - rgw:
     client.0:
       valgrind: [--tool=memcheck]
-- s3tests:
-    client.0:
-      force-branch: ceph-master
-      rgw_server: client.0
-- swift:
-    client.0:
-      rgw_server: client.0
-- ragweed:
-    client.0:
-      force-branch: ceph-master
-      rgw_server: client.0
-      stages: prepare,check
+
 overrides:
   ceph:
     conf:

--- a/qa/suites/rgw/verify/tasks/ragweed.yaml
+++ b/qa/suites/rgw/verify/tasks/ragweed.yaml
@@ -1,0 +1,6 @@
+tasks:
+- ragweed:
+    client.0:
+      force-branch: ceph-master
+      rgw_server: client.0
+      stages: prepare,check

--- a/qa/suites/rgw/verify/tasks/s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/s3tests.yaml
@@ -1,0 +1,5 @@
+tasks:
+- s3tests:
+    client.0:
+      force-branch: ceph-master
+      rgw_server: client.0

--- a/qa/suites/rgw/verify/tasks/swift.yaml
+++ b/qa/suites/rgw/verify/tasks/swift.yaml
@@ -1,0 +1,4 @@
+tasks:
+- swift:
+    client.0:
+      rgw_server: client.0


### PR DESCRIPTION
split the verify suite tasks back into separate yaml files, using + to combine them into a single job