### PR TITLE
qa/workunits/suites/pjd: tolerate other pjd* dirs

### DIFF
--- a/qa/workunits/suites/pjd.sh
+++ b/qa/workunits/suites/pjd.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+test ! -d pjd.$$
+mkdir pjd.$$
+cd $$
 wget http://download.ceph.com/qa/pjd-fstest-20090130-RC-aclfixes.tgz
 tar zxvf pjd*.tgz
 cd pjd*
@@ -14,4 +17,5 @@ cd tmp
 sudo prove -r -v --exec 'bash -x' ../pjd*/tests
 cd ..
 rm -rf tmp pjd*
-
+cd ..
+rmdir pjd.$$


### PR DESCRIPTION
Avoid errors like

2018-05-24T20:11:06.269 INFO:tasks.workunit.client.0.smithi136.stderr:/home/ubuntu/cephtest/clone.client.0/qa/workunits/suites/pjd.sh: line 7: cd: too many arguments

Fixes: http://tracker.ceph.com/issues/24307
Signed-off-by: Sage Weil <sage@redhat.com>