### PR TITLE
luminous - osd/osd_types: fix object_stat_sum_t decode

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1998,9 +1998,9 @@ void object_stat_sum_t::encode(bufferlist& bl) const
 void object_stat_sum_t::decode(bufferlist::iterator& bl)
 {
   bool decode_finish = false;
-  DECODE_START(17, bl);
+  DECODE_START(17, bl);  // make sure to also update fast decode below
 #if defined(CEPH_LITTLE_ENDIAN)
-  if (struct_v >= 16) {
+  if (struct_v >= 17) {  // this must match newest decode version
     bl.copy(sizeof(object_stat_sum_t), (char*)(&num_bytes));
     decode_finish = true;
   }


### PR DESCRIPTION
Broken by 71bf04775bef90c9291bd825da626bc9de6f9ec1

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 68f38a0544349a09100484c17a0d1d4d348d0146)