### PR TITLE
PG: release reservations after backfill completes

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7005,11 +7005,10 @@ PG::RecoveryState::Backfilling::Backfilling(my_context ctx)
   pg->publish_stats_to_osd();
 }
 
-void PG::RecoveryState::Backfilling::cancel_backfill()
+void PG::RecoveryState::Backfilling::backfill_release_reservations()
 {
   PG *pg = context< RecoveryMachine >().pg;
   pg->osd->local_reserver.cancel_reservation(pg->info.pgid);
-
   for (set<pg_shard_t>::iterator it = pg->backfill_targets.begin();
        it != pg->backfill_targets.end();
        ++it) {
@@ -7025,11 +7024,23 @@ void PG::RecoveryState::Backfilling::cancel_backfill()
 	con.get());
     }
   }
+}
 
+void PG::RecoveryState::Backfilling::cancel_backfill()
+{
+  PG *pg = context< RecoveryMachine >().pg;
+  backfill_release_reservations();
   if (!pg->waiting_on_backfill.empty()) {
     pg->waiting_on_backfill.clear();
     pg->finish_recovery_op(hobject_t::get_max());
   }
+}
+
+boost::statechart::result
+PG::RecoveryState::Backfilling::react(const Backfilled &c)
+{
+  backfill_release_reservations();
+  return transit<Recovered>();
 }
 
 boost::statechart::result

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2278,7 +2278,7 @@ protected:
 
     struct Backfilling : boost::statechart::state< Backfilling, Active >, NamedState {
       typedef boost::mpl::list<
-	boost::statechart::transition< Backfilled, Recovered >,
+        boost::statechart::custom_reaction< Backfilled >,
 	boost::statechart::custom_reaction< DeferBackfill >,
 	boost::statechart::custom_reaction< UnfoundBackfill >,
 	boost::statechart::custom_reaction< RemoteReservationRejected >,
@@ -2291,6 +2291,8 @@ protected:
 	post_event(RemoteReservationRevokedTooFull());
 	return discard_event();
       }
+      void backfill_release_reservations();
+      boost::statechart::result react(const Backfilled& evt);
       boost::statechart::result react(const RemoteReservationRevokedTooFull& evt);
       boost::statechart::result react(const RemoteReservationRevoked& evt);
       boost::statechart::result react(const DeferBackfill& evt);


### PR DESCRIPTION
The cause for this issue is that after backfill completes, we directly go to the `Recovered` state without releasing reservations. 

A test case has been generated with 1 pg per osd in a single pool setup and an additional check has been added to see if there are any existing reservations after backfill completes.

The following failure indicates outstanding reservations are backfill is over:
http://pulpito.ceph.com/nojha-2018-05-25_05:26:56-rados-wip-test-reservation-release2-distro-basic-smithi/

The same test with this fix, passes:
http://pulpito.ceph.com/nojha-2018-05-24_02:03:15-rados-wip-double-reservation-2018-05-23-distro-basic-smithi/

Fixes: http://tracker.ceph.com/issues/23614
Signed-off-by: Neha Ojha <nojha@redhat.com>
