### PR TITLE
mimic: mgr/dashboard: Fixes documentation link- to open in new tab

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.html
@@ -7,6 +7,6 @@
 <cd-info-panel>
   {{ message }}
   <ng-container i18n>
-    Please consult the <a href="http://docs.ceph.com/docs/mimic/mgr/dashboard/#enabling-the-object-gateway-management-frontend">documentation</a> on how to configure and enable the Object Gateway management functionality.
+    Please consult the <a href="http://docs.ceph.com/docs/mimic/mgr/dashboard/#enabling-the-object-gateway-management-frontend" target="_blank">documentation</a> on how to configure and enable the Object Gateway management functionality.
   </ng-container>
 </cd-info-panel>


### PR DESCRIPTION
Adds 'target' attribute to open link in new tab.
Fixes : https://tracker.ceph.com/issues/24288

Signed-off-by: Kanika Murarka <murarkakanika@gmail.com>
(cherry picked from commit 3677a11fff46bc63cc996e3cb0025b373f74b45f )