### PR TITLE
mgr/dashboard: Improve max-line-length tslint rule

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-short-version.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-short-version.pipe.spec.ts
@@ -9,7 +9,8 @@ describe('CephShortVersionPipe', () => {
 
   it('transforms with correct version format', () => {
     const value =
-      'ceph version 13.1.0-534-g23d3751b89 (23d3751b897b31d2bda57aeaf01acb5ff3c4a9cd) nautilus (dev)';
+      'ceph version 13.1.0-534-g23d3751b89 \
+       (23d3751b897b31d2bda57aeaf01acb5ff3c4a9cd) nautilus (dev)';
     expect(pipe.transform(value)).toBe('13.1.0-534-g23d3751b89');
   });
 

--- a/src/pybind/mgr/dashboard/frontend/tslint.json
+++ b/src/pybind/mgr/dashboard/frontend/tslint.json
@@ -15,6 +15,7 @@
     "indent": [true, "spaces"],
     "interface-over-type-literal": true,
     "label-position": true,
+    "max-line-length": [true, {"limit": 100, "ignore-pattern": "^import |^export {(.*?)}"}],
     "member-access": false,
     "member-ordering": [
       true,


### PR DESCRIPTION
Prettier is not breaking strings if they are bigger
then the defined max line length.

With this rule we can make sure lines are not exceeding it,
with the exception of import/export lines.

Signed-off-by: Tiago Melo <tmelo@suse.com>