### PR TITLE
mgr/dashboard: role based authentication/authorization system

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -40,7 +40,8 @@ information and statistics about the Ceph cluster using a web server hosted by
 The dashboard currently provides the following features to monitor and manage
 various aspects of your Ceph cluster:
 
-* **Username/password protection**: The dashboard can only be accessed by
+* **Multi-User and Role Management**: The dashboard supports the management of
+  multiple user accounts, and the management of permission roles.
   providing a configurable username and password.
 * **SSL/TLS support**: All HTTP communication between the web browser and the
   dashboard is secured via SSL. A self-signed certificate can be created with
@@ -181,13 +182,16 @@ app.
 Username and password
 ^^^^^^^^^^^^^^^^^^^^^
 
-In order to be able to log in, you need to define a username and password, which
-will be stored in the MON's configuration database::
+In order to be able to log in, you need to create a user account and associate
+it with at least one role. We provide a set of predefined *system roles* that
+you can use. For more details please refer to the `User and Role Management`_
+section.
 
-  $ ceph dashboard set-login-credentials <username> <password>
+To create a user with the administrator role you can use the following
+commands::
 
-The password will be stored in the configuration database in encrypted form
-using ``bcrypt``. This is a global setting that applies to all dashboard instances.
+  $ ceph dashboard ac-user-create <username> <password> administrator
+
 
 Enabling the Object Gateway management frontend
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -316,6 +320,173 @@ previously defined username and password. Select the **Keep me logged in**
 checkbox if you want to skip the username/password request when accessing the
 dashboard in the future.
 
+
+User and Role Management
+------------------------
+
+User Accounts
+^^^^^^^^^^^^^
+
+Ceph Dashboard supports managing multiple user accounts. Each user account
+consists of a username, a password (stored in encrypted form using ``bcrypt``),
+an optional name, and an optional email address.
+
+User accounts are stored in MON's configuration database, and are globally
+shared across all ceph-mgr instances.
+
+We provide a set of CLI commands to manage user accounts:
+
+- *Show User(s)*::
+
+  $ ceph dashboard ac-user-show [<username>]
+
+- *Create User*::
+
+  $ ceph dashboard ac-user-create <username> <password> [<rolename>] [<name>] [<email>]
+
+- *Delete User*::
+
+  $ ceph dashboard ac-user-delete <username>
+
+- *Change Password*::
+
+  $ ceph dashboard ac-user-set-password <username> <password>
+
+- *Modify User (name, and email)*::
+
+  $ ceph dashboard ac-user-set-info <username> <name> <email>
+
+
+User Roles and Permissions
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+User accounts are also associated with a set of roles that define which
+dashboard fuctionality can be accessed by the user.
+
+Dashboard functionality/modules are grouped within a *security scope*.
+Security scopes are predefined and static. The current avaliable security
+scopes are:
+
+- **hosts**: includes all features related to the ``Hosts`` menu
+  entry.
+- **config-opt**: includes all features related to management of Ceph
+  configuration options.
+- **pool**: includes all features related to pool management.
+- **osd**: includes all features related to OSD management.
+- **monitor**: includes all features related to Monitor management.
+- **rbd-image**: includes all features related to RBD image
+  management.
+- **rbd-mirroring**: includes all features related to RBD-Mirroring
+  management.
+- **iscsi**: includes all features related to iSCSI management.
+- **rgw**: includes all features related to Rados Gateway management.
+- **cephfs**: includes all features related to CephFS management.
+- **manager**: include all features related to Ceph Manager
+  management.
+- **log**: include all features related to Ceph logs management.
+- **grafana**: include all features related to Grafana proxy.
+
+A *role* specifies a set of mappings between a *security scope* and a set of
+*permissions*. There are four types of permissions:
+
+- **read**
+- **create**
+- **update**
+- **delete**
+
+See below for an example of a role specification based on a Python dictionary::
+
+  # example of a role
+  {
+    'role': 'my_new_role',
+    'description': 'My new role',
+    'scopes_permissions': {
+      'pool': ['read', 'create'],
+      'rbd-image': ['read', 'create', 'update', 'delete']
+    }
+  }
+
+The above role dictates that a user has *read* and *create* permissions for
+features related to pool management, and has full permissions for
+features related to RBD image management.
+
+The Dashboard already provides a set of predefined roles that we call
+*system roles*, and can be used right away in a fresh Ceph Dashboard
+installation.
+
+The list of system roles are:
+
+- **administrator**: provides full permissions for all security scopes.
+- **read-only**: provides *read* permission for all security scopes.
+- **block-manager**: provides full permissions for *rbd-image*,
+  *rbd-mirroring*, and *iscsi* scopes.
+- **rgw-manager**: provides full permissions for the *rgw* scope
+- **cluster-manager**: provides full permissions for the *hosts*, *osd*,
+  *monitor*, *manager*, and *config-opt* scopes.
+- **pool-manager**: provides full permissions for the *pool* scope.
+- **cephfs-manager**: provides full permissions for the *cephfs* scope.
+
+The list of currently available roles can be retrieved by the following
+command::
+
+  $ ceph dashboard ac-role-show [<rolename>]
+
+It is also possible to create new roles using CLI commands. The available
+commands to manage roles are the following:
+
+- *Create Role*::
+
+  $ ceph dashboard ac-role-create <rolename> [<description>]
+
+- *Delete Role*::
+
+  $ ceph dashboard ac-role-delete <rolename>
+
+- *Add Scope Permissions to Role*::
+
+  $ ceph dashboard ac-role-add-scope-perms <rolename> <scopename> <permission> [<permission>...]
+
+- *Delete Scope Permission from Role*::
+
+  $ ceph dashboard ac-role-del-perms <rolename> <scopename>
+
+To associate roles to users, the following CLI commands are available:
+
+- *Set User Roles*::
+
+  $ ceph dashboard ac-user-set-roles <username> <rolename> [<rolename>...]
+
+- *Add Roles To User*::
+
+  $ ceph dashboard ac-user-add-roles <username> <rolename> [<rolename>...]
+
+- *Delete Roles from User*::
+
+  $ ceph dashboard ac-user-del-roles <username> <rolename> [<rolename>...]
+
+
+Example of user and custom role creation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In this section we show a full example of the commands that need to be used
+in order to create a user account, that should be able to manage RBD images,
+view and create Ceph pools, and have read-only access to any other scopes.
+
+1. *Create the user*::
+
+   $ ceph dashboard ac-user-create bob mypassword
+
+2. *Create role and specify scope permissions*::
+
+   $ ceph dashboard ac-role-create rbd/pool-manager
+   $ ceph dashboard ac-role-add-scope-perms rbd/pool-manager rbd-image read create update delete
+   $ ceph dashboard ac-role-add-scope-perms rbd/pool-manager pool read create
+
+3. *Associate roles to user*::
+
+   $ ceph dashboard ac-user-set-roles bob rbd/pool-manager read-only
+
+
 Reverse proxies
 ---------------
 
@@ -329,3 +500,4 @@ to use hyperlinks that include your prefix, you can set the
   ceph config set mgr mgr/dashboard/url_prefix $PREFIX
 
 so you can access the dashboard at ``http://$IP:$PORT/$PREFIX/``.
+

--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -8,15 +8,18 @@ from .helper import DashboardTestCase
 
 
 class AuthTest(DashboardTestCase):
+
+    AUTO_AUTHENTICATE = False
+
     def setUp(self):
         self.reset_session()
-        self._ceph_cmd(['dashboard', 'set-login-credentials', 'admin', 'admin'])
 
     def test_a_set_login_credentials(self):
-        self._ceph_cmd(['dashboard', 'set-login-credentials', 'admin2', 'admin2'])
+        self.create_user('admin2', 'admin2', ['administrator'])
         self._post("/api/auth", {'username': 'admin2', 'password': 'admin2'})
         self.assertStatus(201)
         self.assertJsonBody({"username": "admin2"})
+        self.delete_user('admin2')
 
     def test_login_valid(self):
         self._post("/api/auth", {'username': 'admin', 'password': 'admin'})

--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -18,13 +18,32 @@ class AuthTest(DashboardTestCase):
         self.create_user('admin2', 'admin2', ['administrator'])
         self._post("/api/auth", {'username': 'admin2', 'password': 'admin2'})
         self.assertStatus(201)
-        self.assertJsonBody({"username": "admin2"})
+        # self.assertJsonBody({"username": "admin2"})
+        data = self.jsonBody()
+        self.assertIn('username', data)
+        self.assertEqual(data['username'], "admin2")
+        self.assertIn('permissions', data)
+        for scope, perms in data['permissions'].items():
+            self.assertIsNotNone(scope)
+            self.assertIn('read', perms)
+            self.assertIn('update', perms)
+            self.assertIn('create', perms)
+            self.assertIn('delete', perms)
         self.delete_user('admin2')
 
     def test_login_valid(self):
         self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
         self.assertStatus(201)
-        self.assertJsonBody({"username": "admin"})
+        data = self.jsonBody()
+        self.assertIn('username', data)
+        self.assertEqual(data['username'], "admin")
+        self.assertIn('permissions', data)
+        for scope, perms in data['permissions'].items():
+            self.assertIsNotNone(scope)
+            self.assertIn('read', perms)
+            self.assertIn('update', perms)
+            self.assertIn('create', perms)
+            self.assertIn('delete', perms)
 
     def test_login_stay_signed_in(self):
         self._post("/api/auth", {

--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -2,11 +2,11 @@ from __future__ import absolute_import
 
 import time
 
-from .helper import DashboardTestCase, authenticate
+from .helper import DashboardTestCase
 
 
 class ClusterConfigurationTest(DashboardTestCase):
-    @authenticate
+
     def test_list(self):
         data = self._get('/api/cluster_conf')
         self.assertStatus(200)
@@ -15,7 +15,6 @@ class ClusterConfigurationTest(DashboardTestCase):
         for conf in data:
             self._validate_single(conf)
 
-    @authenticate
     def test_get(self):
         data = self._get('/api/cluster_conf/admin_socket')
         self.assertStatus(200)
@@ -25,7 +24,6 @@ class ClusterConfigurationTest(DashboardTestCase):
         data = self._get('/api/cluster_conf/fantasy_name')
         self.assertStatus(404)
 
-    @authenticate
     def test_get_specific_db_config_option(self):
         def _get_mon_allow_pool_delete_config():
             data = self._get('/api/cluster_conf/mon_allow_pool_delete')

--- a/qa/tasks/mgr/dashboard/test_dashboard.py
+++ b/qa/tasks/mgr/dashboard/test_dashboard.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from .helper import DashboardTestCase, authenticate
+from .helper import DashboardTestCase
 
 
 class DashboardTest(DashboardTestCase):
     CEPHFS = True
 
-    @authenticate
     def test_health(self):
         data = self._get("/api/dashboard/health")
         self.assertStatus(200)
@@ -35,4 +34,29 @@ class DashboardTest(DashboardTestCase):
             self.assertIn(pool['pool_name'], cluster_pools)
 
         self.assertIsNotNone(data['mgr_map'])
+        self.assertIsNotNone(data['df'])
+
+
+    @DashboardTestCase.RunAs('test', 'test', ['pool-manager'])
+    def test_health_permissions(self):
+        data = self._get("/api/dashboard/health")
+        self.assertStatus(200)
+
+        self.assertIn('health', data)
+        self.assertNotIn('mon_status', data)
+        self.assertNotIn('fs_map', data)
+        self.assertNotIn('osd_map', data)
+        self.assertNotIn('clog', data)
+        self.assertNotIn('audit_log', data)
+        self.assertIn('pools', data)
+        self.assertNotIn('mgr_map', data)
+        self.assertIn('df', data)
+        self.assertIsNotNone(data['health'])
+        self.assertIsNotNone(data['pools'])
+
+        cluster_pools = self.ceph_cluster.mon_manager.list_pools()
+        self.assertEqual(len(cluster_pools), len(data['pools']))
+        for pool in data['pools']:
+            self.assertIn(pool['pool_name'], cluster_pools)
+
         self.assertIsNotNone(data['df'])

--- a/qa/tasks/mgr/dashboard/test_host.py
+++ b/qa/tasks/mgr/dashboard/test_host.py
@@ -1,12 +1,18 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from .helper import DashboardTestCase, authenticate
+from .helper import DashboardTestCase
 
 
 class HostControllerTest(DashboardTestCase):
 
-    @authenticate
+    AUTH_ROLES = ['read-only']
+
+    @DashboardTestCase.RunAs('test', 'test', ['block-manager'])
+    def test_access_permissions(self):
+        self._get('/api/host')
+        self.assertStatus(403)
+
     def test_host_list(self):
         data = self._get('/api/host')
         self.assertStatus(200)

--- a/qa/tasks/mgr/dashboard/test_monitor.py
+++ b/qa/tasks/mgr/dashboard/test_monitor.py
@@ -1,11 +1,18 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from .helper import DashboardTestCase, authenticate
+from .helper import DashboardTestCase
 
 
 class MonitorTest(DashboardTestCase):
-    @authenticate
+    AUTH_ROLES = ['cluster-manager']
+
+    @DashboardTestCase.RunAs('test', 'test', ['block-manager'])
+    def test_access_permissions(self):
+        self._get('/api/monitor')
+        self.assertStatus(403)
+
+
     def test_monitor_default(self):
         data = self._get("/api/monitor")
         self.assertStatus(200)

--- a/qa/tasks/mgr/dashboard/test_perf_counters.py
+++ b/qa/tasks/mgr/dashboard/test_perf_counters.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from .helper import DashboardTestCase, authenticate
+from .helper import DashboardTestCase
 
 
 class PerfCountersControllerTest(DashboardTestCase):
 
-    @authenticate
     def test_perf_counters_list(self):
         data = self._get('/api/perf_counters')
         self.assertStatus(200)
@@ -34,28 +33,24 @@ class PerfCountersControllerTest(DashboardTestCase):
             self.assertIn('value', counter)
 
 
-    @authenticate
     def test_perf_counters_mon_get(self):
         mon = self.mons()[0]
         data = self._get('/api/perf_counters/mon/{}'.format(mon))
         self.assertStatus(200)
         self._validate_perf(mon, 'mon', data, allow_empty=False)
 
-    @authenticate
     def test_perf_counters_mgr_get(self):
         mgr = self.mgr_cluster.mgr_ids[0]
         data = self._get('/api/perf_counters/mgr/{}'.format(mgr))
         self.assertStatus(200)
         self._validate_perf(mgr, 'mgr', data, allow_empty=False)
 
-    @authenticate
     def test_perf_counters_mds_get(self):
         for mds in self.mds_cluster.mds_ids:
             data = self._get('/api/perf_counters/mds/{}'.format(mds))
             self.assertStatus(200)
             self._validate_perf(mds, 'mds', data, allow_empty=True)
 
-    @authenticate
     def test_perf_counters_osd_get(self):
         for osd in self.ceph_cluster.mon_manager.get_osd_dump():
             osd = osd['osd']

--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -5,12 +5,14 @@ import logging
 
 import six
 
-from .helper import DashboardTestCase, authenticate
+from .helper import DashboardTestCase
 
 log = logging.getLogger(__name__)
 
 
 class PoolTest(DashboardTestCase):
+    AUTH_ROLES = ['pool-manager']
+
     @classmethod
     def tearDownClass(cls):
         super(PoolTest, cls).tearDownClass()
@@ -18,7 +20,23 @@ class PoolTest(DashboardTestCase):
             cls._ceph_cmd(['osd', 'pool', 'delete', name, name, '--yes-i-really-really-mean-it'])
         cls._ceph_cmd(['osd', 'erasure-code-profile', 'rm', 'ecprofile'])
 
-    @authenticate
+    @DashboardTestCase.RunAs('test', 'test', [{'pool': ['create', 'update', 'delete']}])
+    def test_read_access_permissions(self):
+        self._get('/api/pool')
+        self.assertStatus(403)
+        self._get('/api/pool/bla')
+        self.assertStatus(403)
+
+    @DashboardTestCase.RunAs('test', 'test', [{'pool': ['read', 'update', 'delete']}])
+    def test_create_access_permissions(self):
+        self._post('/api/pool/', {})
+        self.assertStatus(403)
+
+    @DashboardTestCase.RunAs('test', 'test', [{'pool': ['read', 'create', 'update']}])
+    def test_delete_access_permissions(self):
+        self._delete('/api/pool/ddd')
+        self.assertStatus(403)
+
     def test_pool_list(self):
         data = self._get("/api/pool")
         self.assertStatus(200)
@@ -35,7 +53,6 @@ class PoolTest(DashboardTestCase):
             self.assertNotIn('stats', pool)
             self.assertIn(pool['pool_name'], cluster_pools)
 
-    @authenticate
     def test_pool_list_attrs(self):
         data = self._get("/api/pool?attrs=type,flags")
         self.assertStatus(200)
@@ -50,7 +67,6 @@ class PoolTest(DashboardTestCase):
             self.assertNotIn('stats', pool)
             self.assertIn(pool['pool_name'], cluster_pools)
 
-    @authenticate
     def test_pool_list_stats(self):
         data = self._get("/api/pool?stats=true")
         self.assertStatus(200)
@@ -66,7 +82,6 @@ class PoolTest(DashboardTestCase):
             self.assertIn('flags_names', pool)
             self.assertIn(pool['pool_name'], cluster_pools)
 
-    @authenticate
     def test_pool_get(self):
         cluster_pools = self.ceph_cluster.mon_manager.list_pools()
         pool = self._get("/api/pool/{}?stats=true&attrs=type,flags,stats"
@@ -77,7 +92,6 @@ class PoolTest(DashboardTestCase):
         self.assertIn('stats', pool)
         self.assertNotIn('flags_names', pool)
 
-    @authenticate
     def _pool_create(self, data):
         try:
             self._post('/api/pool/', data)
@@ -143,7 +157,6 @@ class PoolTest(DashboardTestCase):
         for data in pools:
             self._pool_create(data)
 
-    @authenticate
     def test_pool_create_fail(self):
         data = {'pool_type': u'replicated', 'rule_name': u'dnf', 'pg_num': u'8', 'pool': u'sadfs'}
         self._post('/api/pool/', data)
@@ -154,7 +167,6 @@ class PoolTest(DashboardTestCase):
             'detail': "[errno -2] specified rule dnf doesn't exist"
         })
 
-    @authenticate
     def test_pool_info(self):
         info_data = self._get("/api/pool/_info")
         self.assertEqual(set(info_data),
@@ -172,5 +184,3 @@ class PoolTest(DashboardTestCase):
             all(isinstance(n, six.string_types) for n in info_data['compression_algorithms']))
         self.assertTrue(
             all(isinstance(n, six.string_types) for n in info_data['compression_modes']))
-
-

--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -7,11 +7,7 @@ from .helper import DashboardTestCase, JObj, JLeaf, JList
 
 
 class RbdTest(DashboardTestCase):
-
-    @classmethod
-    def authenticate(cls):
-        cls._ceph_cmd(['dashboard', 'set-login-credentials', 'admin', 'admin'])
-        cls._post('/api/auth', {'username': 'admin', 'password': 'admin'})
+    AUTH_ROLES = ['pool-manager', 'block-manager']
 
     @classmethod
     def create_pool(cls, name, pg_num, pool_type, application='rbd'):
@@ -24,6 +20,42 @@ class RbdTest(DashboardTestCase):
         if pool_type == 'erasure':
             data['flags'] = ['ec_overwrites']
         cls._post("/api/pool", data)
+
+    @DashboardTestCase.RunAs('test', 'test', [{'rbd-image': ['create', 'update', 'delete']}])
+    def test_read_access_permissions(self):
+        self._get('/api/block/image')
+        self.assertStatus(403)
+        self._get('/api/block/image/pool/image')
+        self.assertStatus(403)
+
+    @DashboardTestCase.RunAs('test', 'test', [{'rbd-image': ['read', 'update', 'delete']}])
+    def test_create_access_permissions(self):
+        self.create_image('pool', 'name', 0)
+        self.assertStatus(403)
+        self.create_snapshot('pool', 'image', 'snapshot')
+        self.assertStatus(403)
+        self.copy_image('src_pool', 'src_image', 'dest_pool', 'dest_image')
+        self.assertStatus(403)
+        self.clone_image('parent_pool', 'parent_image', 'parent_snap', 'pool', 'name')
+        self.assertStatus(403)
+
+    @DashboardTestCase.RunAs('test', 'test', [{'rbd-image': ['read', 'create', 'delete']}])
+    def test_update_access_permissions(self):
+        self.edit_image('pool', 'image')
+        self.assertStatus(403)
+        self.update_snapshot('pool', 'image', 'snapshot', None, None)
+        self.assertStatus(403)
+        self._task_post('/api/block/image/rbd/rollback_img/snap/snap1/rollback')
+        self.assertStatus(403)
+        self.flatten_image('pool', 'image')
+        self.assertStatus(403)
+
+    @DashboardTestCase.RunAs('test', 'test', [{'rbd-image': ['read', 'create', 'update']}])
+    def test_delete_access_permissions(self):
+        self.remove_image('pool', 'image')
+        self.assertStatus(403)
+        self.remove_snapshot('pool', 'image', 'snapshot')
+        self.assertStatus(403)
 
     @classmethod
     def create_image(cls, pool, name, size, **kwargs):
@@ -80,7 +112,6 @@ class RbdTest(DashboardTestCase):
     @classmethod
     def setUpClass(cls):
         super(RbdTest, cls).setUpClass()
-        cls.authenticate()
         cls.create_pool('rbd', 10, 'replicated')
         cls.create_pool('rbd_iscsi', 10, 'replicated')
 

--- a/qa/tasks/mgr/dashboard/test_rgw.py
+++ b/qa/tasks/mgr/dashboard/test_rgw.py
@@ -1,16 +1,19 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import urllib
 import logging
-logger = logging.getLogger(__name__)
 
-from .helper import DashboardTestCase, authenticate
+from .helper import DashboardTestCase
+
+
+logger = logging.getLogger(__name__)
 
 
 class RgwTestCase(DashboardTestCase):
 
     maxDiff = None
     create_test_user = False
+
+    AUTH_ROLES = ['rgw-manager']
 
     @classmethod
     def setUpClass(cls):
@@ -49,7 +52,10 @@ class RgwTestCase(DashboardTestCase):
     def tearDownClass(cls):
         if cls.create_test_user:
             cls._radosgw_admin_cmd(['user', 'rm', '--uid=teuth-test-user'])
-        super(DashboardTestCase, cls).tearDownClass()
+        super(RgwTestCase, cls).tearDownClass()
+
+    def setUp(self):
+        super(RgwTestCase, self).setUp()
 
     def get_rgw_user(self, uid):
         return self._get('/api/rgw/user/{}'.format(uid))
@@ -68,17 +74,20 @@ class RgwTestCase(DashboardTestCase):
 
 class RgwApiCredentialsTest(RgwTestCase):
 
+    AUTH_ROLES = ['rgw-manager']
+
     def setUp(self):
         # Restart the Dashboard module to ensure that the connection to the
         # RGW Admin Ops API is re-established with the new credentials.
+        self.logout()
         self._ceph_cmd(['mgr', 'module', 'disable', 'dashboard'])
         self._ceph_cmd(['mgr', 'module', 'enable', 'dashboard', '--force'])
         # Set the default credentials.
         self._ceph_cmd(['dashboard', 'set-rgw-api-user-id', ''])
         self._ceph_cmd(['dashboard', 'set-rgw-api-secret-key', 'admin'])
         self._ceph_cmd(['dashboard', 'set-rgw-api-access-key', 'admin'])
+        super(RgwApiCredentialsTest, self).setUp()
 
-    @authenticate
     def test_no_access_secret_key(self):
         self._ceph_cmd(['dashboard', 'set-rgw-api-secret-key', ''])
         self._ceph_cmd(['dashboard', 'set-rgw-api-access-key', ''])
@@ -87,9 +96,8 @@ class RgwApiCredentialsTest(RgwTestCase):
         self.assertIn('detail', resp)
         self.assertIn('component', resp)
         self.assertIn('No RGW credentials found', resp['detail'])
-        self.assertEquals(resp['component'], 'rgw')
+        self.assertEqual(resp['component'], 'rgw')
 
-    @authenticate
     def test_success(self):
         data = self._get('/api/rgw/status')
         self.assertStatus(200)
@@ -97,7 +105,6 @@ class RgwApiCredentialsTest(RgwTestCase):
         self.assertIn('message', data)
         self.assertTrue(data['available'])
 
-    @authenticate
     def test_invalid_user_id(self):
         self._ceph_cmd(['dashboard', 'set-rgw-api-user-id', 'xyz'])
         data = self._get('/api/rgw/status')
@@ -111,12 +118,13 @@ class RgwApiCredentialsTest(RgwTestCase):
 
 class RgwBucketTest(RgwTestCase):
 
+    AUTH_ROLES = ['rgw-manager']
+
     @classmethod
     def setUpClass(cls):
         cls.create_test_user = True
         super(RgwBucketTest, cls).setUpClass()
 
-    @authenticate
     def test_all(self):
         # Create a new bucket.
         self._post(
@@ -134,7 +142,7 @@ class RgwBucketTest(RgwTestCase):
         self.assertIn('creation_time', data)
         self.assertIn('name', data['bucket'])
         self.assertIn('bucket_id', data['bucket'])
-        self.assertEquals(data['bucket']['name'], 'teuth-test-bucket')
+        self.assertEqual(data['bucket']['name'], 'teuth-test-bucket')
 
         # List all buckets.
         data = self._get('/api/rgw/bucket')
@@ -149,8 +157,8 @@ class RgwBucketTest(RgwTestCase):
         self.assertIn('bucket', data)
         self.assertIn('bucket_quota', data)
         self.assertIn('owner', data)
-        self.assertEquals(data['bucket'], 'teuth-test-bucket')
-        self.assertEquals(data['owner'], 'admin')
+        self.assertEqual(data['bucket'], 'teuth-test-bucket')
+        self.assertEqual(data['owner'], 'admin')
 
         # Update the bucket.
         self._put(
@@ -162,7 +170,7 @@ class RgwBucketTest(RgwTestCase):
         self.assertStatus(200)
         data = self._get('/api/rgw/bucket/teuth-test-bucket')
         self.assertStatus(200)
-        self.assertEquals(data['owner'], 'teuth-test-user')
+        self.assertEqual(data['owner'], 'teuth-test-user')
 
         # Delete the bucket.
         self._delete('/api/rgw/bucket/teuth-test-bucket')
@@ -174,7 +182,16 @@ class RgwBucketTest(RgwTestCase):
 
 class RgwDaemonTest(DashboardTestCase):
 
-    @authenticate
+    AUTH_ROLES = ['rgw-manager']
+
+
+    @DashboardTestCase.RunAs('test', 'test', [{'rgw': ['create', 'update', 'delete']}])
+    def test_read_access_permissions(self):
+        self._get('/api/rgw/daemon')
+        self.assertStatus(403)
+        self._get('/api/rgw/daemon/id')
+        self.assertStatus(403)
+
     def test_list(self):
         data = self._get('/api/rgw/daemon')
         self.assertStatus(200)
@@ -184,7 +201,6 @@ class RgwDaemonTest(DashboardTestCase):
         self.assertIn('version', data)
         self.assertIn('server_hostname', data)
 
-    @authenticate
     def test_get(self):
         data = self._get('/api/rgw/daemon')
         self.assertStatus(200)
@@ -196,7 +212,6 @@ class RgwDaemonTest(DashboardTestCase):
         self.assertIn('rgw_status', data)
         self.assertTrue(data['rgw_metadata'])
 
-    @authenticate
     def test_status(self):
         self._radosgw_admin_cmd([
             'user', 'create', '--uid=admin', '--display-name=admin',
@@ -215,6 +230,8 @@ class RgwDaemonTest(DashboardTestCase):
 
 class RgwUserTest(RgwTestCase):
 
+    AUTH_ROLES = ['rgw-manager']
+
     @classmethod
     def setUpClass(cls):
         super(RgwUserTest, cls).setUpClass()
@@ -232,21 +249,18 @@ class RgwUserTest(RgwTestCase):
         self.assertIn('tenant', data)
         self.assertIn('user_id', data)
 
-    @authenticate
     def test_get(self):
         data = self.get_rgw_user('admin')
         self.assertStatus(200)
         self._assert_user_data(data)
-        self.assertEquals(data['user_id'], 'admin')
+        self.assertEqual(data['user_id'], 'admin')
 
-    @authenticate
     def test_list(self):
         data = self._get('/api/rgw/user')
         self.assertStatus(200)
         self.assertGreaterEqual(len(data), 1)
         self.assertIn('admin', data)
 
-    @authenticate
     def test_create_update_delete(self):
         # Create a new user.
         self._post('/api/rgw/user', params={
@@ -256,14 +270,14 @@ class RgwUserTest(RgwTestCase):
         self.assertStatus(201)
         data = self.jsonBody()
         self._assert_user_data(data)
-        self.assertEquals(data['user_id'], 'teuth-test-user')
-        self.assertEquals(data['display_name'], 'display name')
+        self.assertEqual(data['user_id'], 'teuth-test-user')
+        self.assertEqual(data['display_name'], 'display name')
 
         # Get the user.
         data = self.get_rgw_user('teuth-test-user')
         self.assertStatus(200)
         self._assert_user_data(data)
-        self.assertEquals(data['user_id'], 'teuth-test-user')
+        self.assertEqual(data['user_id'], 'teuth-test-user')
 
         # Update the user.
         self._put(
@@ -291,12 +305,13 @@ class RgwUserTest(RgwTestCase):
 
 class RgwUserCapabilityTest(RgwTestCase):
 
+    AUTH_ROLES = ['rgw-manager']
+
     @classmethod
     def setUpClass(cls):
         cls.create_test_user = True
         super(RgwUserCapabilityTest, cls).setUpClass()
 
-    @authenticate
     def test_set(self):
         self._post(
             '/api/rgw/user/teuth-test-user/capability',
@@ -318,7 +333,6 @@ class RgwUserCapabilityTest(RgwTestCase):
         self.assertEqual(data['caps'][0]['type'], 'usage')
         self.assertEqual(data['caps'][0]['perm'], 'read')
 
-    @authenticate
     def test_delete(self):
         self._delete(
             '/api/rgw/user/teuth-test-user/capability',
@@ -336,12 +350,13 @@ class RgwUserCapabilityTest(RgwTestCase):
 
 class RgwUserKeyTest(RgwTestCase):
 
+    AUTH_ROLES = ['rgw-manager']
+
     @classmethod
     def setUpClass(cls):
         cls.create_test_user = True
         super(RgwUserKeyTest, cls).setUpClass()
 
-    @authenticate
     def test_create_s3(self):
         self._post(
             '/api/rgw/user/teuth-test-user/key',
@@ -358,7 +373,6 @@ class RgwUserKeyTest(RgwTestCase):
         self.assertIsInstance(key, object)
         self.assertEqual(key['secret_key'], 'aaabbbccc')
 
-    @authenticate
     def test_create_swift(self):
         self._post(
             '/api/rgw/user/teuth-test-user/key',
@@ -374,7 +388,6 @@ class RgwUserKeyTest(RgwTestCase):
         key = self.find_in_list('secret_key', 'xxxyyyzzz', data)
         self.assertIsInstance(key, object)
 
-    @authenticate
     def test_delete_s3(self):
         self._delete(
             '/api/rgw/user/teuth-test-user/key',
@@ -384,7 +397,6 @@ class RgwUserKeyTest(RgwTestCase):
             })
         self.assertStatus(204)
 
-    @authenticate
     def test_delete_swift(self):
         self._delete(
             '/api/rgw/user/teuth-test-user/key',
@@ -396,6 +408,8 @@ class RgwUserKeyTest(RgwTestCase):
 
 
 class RgwUserQuotaTest(RgwTestCase):
+
+    AUTH_ROLES = ['rgw-manager']
 
     @classmethod
     def setUpClass(cls):
@@ -414,13 +428,11 @@ class RgwUserQuotaTest(RgwTestCase):
         self.assertIn('max_size_kb', data['bucket_quota'])
         self.assertIn('max_size', data['bucket_quota'])
 
-    @authenticate
     def test_get_quota(self):
         data = self._get('/api/rgw/user/teuth-test-user/quota')
         self.assertStatus(200)
         self._assert_quota(data)
 
-    @authenticate
     def test_set_user_quota(self):
         self._put(
             '/api/rgw/user/teuth-test-user/quota',
@@ -439,7 +451,6 @@ class RgwUserQuotaTest(RgwTestCase):
         self.assertTrue(data['user_quota']['enabled'])
         self.assertEqual(data['user_quota']['max_size_kb'], 2048)
 
-    @authenticate
     def test_set_bucket_quota(self):
         self._put(
             '/api/rgw/user/teuth-test-user/quota',
@@ -461,12 +472,13 @@ class RgwUserQuotaTest(RgwTestCase):
 
 class RgwUserSubuserTest(RgwTestCase):
 
+    AUTH_ROLES = ['rgw-manager']
+
     @classmethod
     def setUpClass(cls):
         cls.create_test_user = True
         super(RgwUserSubuserTest, cls).setUpClass()
 
-    @authenticate
     def test_create_swift(self):
         self._post(
             '/api/rgw/user/teuth-test-user/subuser',
@@ -487,7 +499,6 @@ class RgwUserSubuserTest(RgwTestCase):
         key = self.find_in_list('user', 'teuth-test-user:tux', data['swift_keys'])
         self.assertIsInstance(key, object)
 
-    @authenticate
     def test_create_s3(self):
         self._post(
             '/api/rgw/user/teuth-test-user/subuser',
@@ -511,7 +522,6 @@ class RgwUserSubuserTest(RgwTestCase):
         self.assertIsInstance(key, object)
         self.assertEqual(key['secret_key'], 'xxx')
 
-    @authenticate
     def test_delete_w_purge(self):
         self._delete(
             '/api/rgw/user/teuth-test-user/subuser/teuth-test-subuser2')
@@ -524,7 +534,6 @@ class RgwUserSubuserTest(RgwTestCase):
                                 data['swift_keys'])
         self.assertIsNone(key)
 
-    @authenticate
     def test_delete_wo_purge(self):
         self._delete(
             '/api/rgw/user/teuth-test-user/subuser/teuth-test-subuser',

--- a/qa/tasks/mgr/dashboard/test_summary.py
+++ b/qa/tasks/mgr/dashboard/test_summary.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import
 
-from .helper import DashboardTestCase, authenticate
+from .helper import DashboardTestCase
 
 
 class SummaryTest(DashboardTestCase):
     CEPHFS = True
 
-    @authenticate
     def test_summary(self):
         data = self._get("/api/summary")
         self.assertStatus(200)
@@ -22,3 +21,20 @@ class SummaryTest(DashboardTestCase):
         self.assertIsNotNone(data['mgr_id'])
         self.assertIsNotNone(data['have_mon_connection'])
         self.assertEqual(data['rbd_mirroring'], {'errors': 0, 'warnings': 0})
+
+    @DashboardTestCase.RunAs('test', 'test', ['pool-manager'])
+    def test_summary_permissions(self):
+        data = self._get("/api/summary")
+        self.assertStatus(200)
+
+        self.assertIn('health_status', data)
+        self.assertIn('mgr_id', data)
+        self.assertIn('have_mon_connection', data)
+        self.assertNotIn('rbd_mirroring', data)
+        self.assertIn('executing_tasks', data)
+        self.assertIn('finished_tasks', data)
+        self.assertIn('version', data)
+        self.assertIsNotNone(data['health_status'])
+        self.assertIsNotNone(data['mgr_id'])
+        self.assertIsNotNone(data['have_mon_connection'])
+

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -505,22 +505,22 @@ same applies to other request types:
 How to restrict access to a controller?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you require that only authenticated users can access you controller, just
-add the ``AuthRequired`` decorator to your controller class.
+All controllers require authentication by default.
+If you require that the controller can be accessed without authentication,
+then you can add the parameter ``secure=False`` to the controller decorator.
 
-Example::
+Example:
+
+.. code-block:: python
 
   import cherrypy
-  from ..tools import ApiController, AuthRequired, RESTController
+  from . import ApiController, RESTController
 
 
-  @ApiController('ping2')
-  @AuthRequired()
-  class Ping2(RESTController):
+  @ApiController('ping', secure=False)
+  class Ping(RESTController):
     def list(self):
       return {"msg": "Hello"}
-
-Now only authenticated users will be able to "ping" your controller.
 
 
 How to access the manager module instance from a controller?

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -542,6 +542,8 @@ class BaseController(object):
                     kwargs.update(data.items())
                     ret = func(*args, **kwargs)
 
+            if isinstance(ret, bytes):
+                ret = ret.decode('utf-8')
             if json_response:
                 cherrypy.response.headers['Content-Type'] = 'application/json'
                 ret = json.dumps(ret).encode('utf8')

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -12,7 +12,7 @@ from ..services.auth import AuthManager
 from ..tools import Session
 
 
-@ApiController('/auth')
+@ApiController('/auth', secure=False)
 class Auth(RESTController):
     """
     Provide login and logout actions.

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -27,13 +27,17 @@ class Auth(RESTController):
 
     def create(self, username, password, stay_signed_in=False):
         now = time.time()
-        if AuthManager.authenticate(username, password):
+        user_perms = AuthManager.authenticate(username, password)
+        if user_perms is not None:
             cherrypy.session.regenerate()
             cherrypy.session[Session.USERNAME] = username
             cherrypy.session[Session.TS] = now
             cherrypy.session[Session.EXPIRE_AT_BROWSER_CLOSE] = not stay_signed_in
             logger.debug('Login successful')
-            return {'username': username}
+            return {
+                'username': username,
+                'permissions': user_perms
+            }
 
         logger.debug('Login failed')
         raise DashboardException(msg='Invalid credentials',

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -8,11 +8,12 @@ import cherrypy
 from . import ApiController, RESTController
 from .. import mgr
 from ..exceptions import DashboardException
+from ..security import Scope
 from ..services.ceph_service import CephService
 from ..tools import ViewCache
 
 
-@ApiController('/cephfs')
+@ApiController('/cephfs', Scope.CEPHFS)
 class CephFS(RESTController):
     def __init__(self):
         super(CephFS, self).__init__()

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -5,15 +5,14 @@ from collections import defaultdict
 
 import cherrypy
 
-from ..exceptions import DashboardException
-from . import ApiController, AuthRequired, RESTController
+from . import ApiController, RESTController
 from .. import mgr
+from ..exceptions import DashboardException
 from ..services.ceph_service import CephService
 from ..tools import ViewCache
 
 
 @ApiController('/cephfs')
-@AuthRequired()
 class CephFS(RESTController):
     def __init__(self):
         super(CephFS, self).__init__()

--- a/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
+++ b/src/pybind/mgr/dashboard/controllers/cluster_configuration.py
@@ -3,13 +3,12 @@ from __future__ import absolute_import
 
 import cherrypy
 
+from . import ApiController, RESTController
 from .. import mgr
 from ..services.ceph_service import CephService
-from . import ApiController, RESTController, AuthRequired
 
 
 @ApiController('/cluster_conf')
-@AuthRequired()
 class ClusterConfiguration(RESTController):
 
     def _append_config_option_values(self, options):

--- a/src/pybind/mgr/dashboard/controllers/dashboard.py
+++ b/src/pybind/mgr/dashboard/controllers/dashboard.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import collections
 import json
 
-from . import ApiController, AuthRequired, Endpoint, BaseController
+from . import ApiController, Endpoint, BaseController
 from .. import mgr
 from ..services.ceph_service import CephService
 from ..tools import NotificationQueue
@@ -14,7 +14,6 @@ LOG_BUFFER_SIZE = 30
 
 
 @ApiController('/dashboard')
-@AuthRequired()
 class Dashboard(BaseController):
     def __init__(self):
         super(Dashboard, self).__init__()

--- a/src/pybind/mgr/dashboard/controllers/docs.py
+++ b/src/pybind/mgr/dashboard/controllers/docs.py
@@ -3,12 +3,11 @@ from __future__ import absolute_import
 
 import cherrypy
 
-from . import Controller, BaseController, AuthRequired, Endpoint, ENDPOINT_MAP
+from . import Controller, BaseController, Endpoint, ENDPOINT_MAP
 from .. import logger
 
 
 @Controller('/docs')
-@AuthRequired()
 class Docs(BaseController):
 
     @classmethod

--- a/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
+++ b/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 from cherrypy import NotFound
 
-from . import ApiController, AuthRequired, RESTController
+from . import ApiController, RESTController
 from ..services.ceph_service import CephService
 from .. import mgr
 
@@ -16,7 +16,6 @@ def _serialize_ecp(name, ecp):
 
 
 @ApiController('/erasure_code_profile')
-@AuthRequired()
 class ErasureCodeProfile(RESTController):
     """
     create() supports additional key-value arguments that are passed to the

--- a/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
+++ b/src/pybind/mgr/dashboard/controllers/erasure_code_profile.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 from cherrypy import NotFound
 
 from . import ApiController, RESTController
+from ..security import Scope
 from ..services.ceph_service import CephService
 from .. import mgr
 
@@ -15,7 +16,7 @@ def _serialize_ecp(name, ecp):
     return ecp
 
 
-@ApiController('/erasure_code_profile')
+@ApiController('/erasure_code_profile', Scope.POOL)
 class ErasureCodeProfile(RESTController):
     """
     create() supports additional key-value arguments that are passed to the

--- a/src/pybind/mgr/dashboard/controllers/grafana.py
+++ b/src/pybind/mgr/dashboard/controllers/grafana.py
@@ -5,7 +5,7 @@ import cherrypy
 import requests
 from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
 
-from . import ApiController, BaseController, AuthRequired, Proxy, Endpoint
+from . import ApiController, BaseController, Proxy, Endpoint
 from .. import logger
 from ..settings import Settings
 
@@ -102,7 +102,6 @@ class GrafanaRestClient(object):
 
 
 @ApiController('/grafana')
-@AuthRequired()
 class Grafana(BaseController):
 
     @Endpoint()
@@ -117,7 +116,6 @@ class Grafana(BaseController):
 
 
 @ApiController('/grafana/proxy')
-@AuthRequired()
 class GrafanaProxy(BaseController):
     @Proxy()
     def __call__(self, path, **params):

--- a/src/pybind/mgr/dashboard/controllers/grafana.py
+++ b/src/pybind/mgr/dashboard/controllers/grafana.py
@@ -5,8 +5,9 @@ import cherrypy
 import requests
 from six.moves.urllib.parse import urlparse  # pylint: disable=import-error
 
-from . import ApiController, BaseController, Proxy, Endpoint
+from . import ApiController, BaseController, Proxy, Endpoint, ReadPermission
 from .. import logger
+from ..security import Scope
 from ..settings import Settings
 
 
@@ -101,10 +102,11 @@ class GrafanaRestClient(object):
         return True, ''
 
 
-@ApiController('/grafana')
+@ApiController('/grafana', Scope.GRAFANA)
 class Grafana(BaseController):
 
     @Endpoint()
+    @ReadPermission
     def status(self):
         grafana = GrafanaRestClient.instance()
         available, msg = grafana.is_service_online()
@@ -115,9 +117,10 @@ class Grafana(BaseController):
         return response
 
 
-@ApiController('/grafana/proxy')
+@ApiController('/grafana/proxy', Scope.GRAFANA)
 class GrafanaProxy(BaseController):
     @Proxy()
+    @ReadPermission
     def __call__(self, path, **params):
         grafana = GrafanaRestClient.instance()
         method = cherrypy.request.method

--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import ApiController, AuthRequired, RESTController
+from . import ApiController, RESTController
 from .. import mgr
 
 
 @ApiController('/host')
-@AuthRequired()
 class Host(RESTController):
     def list(self):
         return mgr.list_servers()

--- a/src/pybind/mgr/dashboard/controllers/host.py
+++ b/src/pybind/mgr/dashboard/controllers/host.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import
 
 from . import ApiController, RESTController
 from .. import mgr
+from ..security import Scope
 
 
-@ApiController('/host')
+@ApiController('/host', Scope.HOSTS)
 class Host(RESTController):
     def list(self):
         return mgr.list_servers()

--- a/src/pybind/mgr/dashboard/controllers/logging.py
+++ b/src/pybind/mgr/dashboard/controllers/logging.py
@@ -2,7 +2,7 @@ from . import UiApiController, BaseController, Endpoint
 from .. import logger
 
 
-@UiApiController('/logging')
+@UiApiController('/logging', secure=False)
 class Logging(BaseController):
 
     @Endpoint('POST', path='js-error')

--- a/src/pybind/mgr/dashboard/controllers/monitor.py
+++ b/src/pybind/mgr/dashboard/controllers/monitor.py
@@ -3,13 +3,15 @@ from __future__ import absolute_import
 
 import json
 
-from . import ApiController, Endpoint, BaseController
+from . import ApiController, Endpoint, BaseController, ReadPermission
 from .. import mgr
+from ..security import Scope
 
 
-@ApiController('/monitor')
+@ApiController('/monitor', Scope.MONITOR)
 class Monitor(BaseController):
     @Endpoint()
+    @ReadPermission
     def __call__(self):
         in_quorum, out_quorum = [], []
 

--- a/src/pybind/mgr/dashboard/controllers/monitor.py
+++ b/src/pybind/mgr/dashboard/controllers/monitor.py
@@ -3,12 +3,11 @@ from __future__ import absolute_import
 
 import json
 
-from . import ApiController, AuthRequired, Endpoint, BaseController
+from . import ApiController, Endpoint, BaseController
 from .. import mgr
 
 
 @ApiController('/monitor')
-@AuthRequired()
 class Monitor(BaseController):
     @Endpoint()
     def __call__(self):

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import ApiController, AuthRequired, RESTController
+from . import ApiController, RESTController
 from .. import mgr, logger
 from ..services.ceph_service import CephService
 from ..services.exception import handle_send_command_error
@@ -9,7 +9,6 @@ from ..tools import str_to_bool
 
 
 @ApiController('/osd')
-@AuthRequired()
 class Osd(RESTController):
     def list(self):
         osds = self.get_osd_map()

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import ApiController, RESTController
+from . import ApiController, RESTController, UpdatePermission
 from .. import mgr, logger
+from ..security import Scope
 from ..services.ceph_service import CephService
 from ..services.exception import handle_send_command_error
 from ..tools import str_to_bool
 
 
-@ApiController('/osd')
+@ApiController('/osd', Scope.OSD)
 class Osd(RESTController):
     def list(self):
         osds = self.get_osd_map()
@@ -58,12 +59,13 @@ class Osd(RESTController):
         }
 
     @RESTController.Resource('POST', query_params=['deep'])
+    @UpdatePermission
     def scrub(self, svc_id, deep=False):
         api_scrub = "osd deep-scrub" if str_to_bool(deep) else "osd scrub"
         CephService.send_command("mon", api_scrub, who=svc_id)
 
 
-@ApiController('/osd/flags')
+@ApiController('/osd/flags', Scope.OSD)
 class OsdFlagsController(RESTController):
     @staticmethod
     def _osd_flags():

--- a/src/pybind/mgr/dashboard/controllers/perf_counters.py
+++ b/src/pybind/mgr/dashboard/controllers/perf_counters.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import ApiController, AuthRequired, RESTController
+from . import ApiController, RESTController
 from .. import mgr
 from ..services.ceph_service import CephService
 
@@ -39,43 +39,36 @@ class PerfCounter(RESTController):
 
 
 @ApiController('perf_counters/mds')
-@AuthRequired()
 class MdsPerfCounter(PerfCounter):
     service_type = 'mds'
 
 
 @ApiController('perf_counters/mon')
-@AuthRequired()
 class MonPerfCounter(PerfCounter):
     service_type = 'mon'
 
 
 @ApiController('perf_counters/osd')
-@AuthRequired()
 class OsdPerfCounter(PerfCounter):
     service_type = 'osd'
 
 
 @ApiController('perf_counters/rgw')
-@AuthRequired()
 class RgwPerfCounter(PerfCounter):
     service_type = 'rgw'
 
 
 @ApiController('perf_counters/rbd-mirror')
-@AuthRequired()
 class RbdMirrorPerfCounter(PerfCounter):
     service_type = 'rbd-mirror'
 
 
 @ApiController('perf_counters/mgr')
-@AuthRequired()
 class MgrPerfCounter(PerfCounter):
     service_type = 'mgr'
 
 
 @ApiController('perf_counters')
-@AuthRequired()
 class PerfCounters(RESTController):
     def list(self):
         return mgr.get_all_perf_counters()

--- a/src/pybind/mgr/dashboard/controllers/perf_counters.py
+++ b/src/pybind/mgr/dashboard/controllers/perf_counters.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 
 from . import ApiController, RESTController
 from .. import mgr
+from ..security import Scope
 from ..services.ceph_service import CephService
 
 
@@ -38,32 +39,32 @@ class PerfCounter(RESTController):
         }
 
 
-@ApiController('perf_counters/mds')
+@ApiController('perf_counters/mds', Scope.CEPHFS)
 class MdsPerfCounter(PerfCounter):
     service_type = 'mds'
 
 
-@ApiController('perf_counters/mon')
+@ApiController('perf_counters/mon', Scope.MONITOR)
 class MonPerfCounter(PerfCounter):
     service_type = 'mon'
 
 
-@ApiController('perf_counters/osd')
+@ApiController('perf_counters/osd', Scope.OSD)
 class OsdPerfCounter(PerfCounter):
     service_type = 'osd'
 
 
-@ApiController('perf_counters/rgw')
+@ApiController('perf_counters/rgw', Scope.RGW)
 class RgwPerfCounter(PerfCounter):
     service_type = 'rgw'
 
 
-@ApiController('perf_counters/rbd-mirror')
+@ApiController('perf_counters/rbd-mirror', Scope.RBD_MIRRORING)
 class RbdMirrorPerfCounter(PerfCounter):
     service_type = 'rbd-mirror'
 
 
-@ApiController('perf_counters/mgr')
+@ApiController('perf_counters/mgr', Scope.MANAGER)
 class MgrPerfCounter(PerfCounter):
     service_type = 'mgr'
 

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 import cherrypy
 
-from . import ApiController, RESTController, Endpoint, AuthRequired
+from . import ApiController, RESTController, Endpoint
 from .. import mgr
 from ..services.ceph_service import CephService
 from ..services.exception import handle_send_command_error
@@ -11,7 +11,6 @@ from ..tools import str_to_bool
 
 
 @ApiController('/pool')
-@AuthRequired()
 class Pool(RESTController):
 
     @classmethod

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -3,14 +3,15 @@ from __future__ import absolute_import
 
 import cherrypy
 
-from . import ApiController, RESTController, Endpoint
+from . import ApiController, RESTController, Endpoint, ReadPermission
 from .. import mgr
+from ..security import Scope
 from ..services.ceph_service import CephService
 from ..services.exception import handle_send_command_error
 from ..tools import str_to_bool
 
 
-@ApiController('/pool')
+@ApiController('/pool', Scope.POOL)
 class Pool(RESTController):
 
     @classmethod
@@ -83,6 +84,7 @@ class Pool(RESTController):
             CephService.send_command('mon', 'osd pool set', pool=pool, var=key, val=value)
 
     @Endpoint()
+    @ReadPermission
     def _info(self):
         """Used by the create-pool dialog"""
         def rules(pool_type):

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -11,7 +11,7 @@ import six
 
 import rbd
 
-from . import ApiController, AuthRequired, RESTController, Task
+from . import ApiController, RESTController, Task
 from .. import mgr
 from ..services.ceph_service import CephService
 from ..tools import ViewCache
@@ -113,7 +113,6 @@ def _sort_features(features, enable=True):
 
 
 @ApiController('/block/image')
-@AuthRequired()
 class Rbd(RESTController):
 
     RESOURCE_ID = "pool_name/image_name"
@@ -375,7 +374,6 @@ class Rbd(RESTController):
 
 
 @ApiController('/block/image/:pool_name/:image_name/snap')
-@AuthRequired()
 class RbdSnapshot(RESTController):
 
     RESOURCE_ID = "snapshot_name"

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -11,8 +11,9 @@ import six
 
 import rbd
 
-from . import ApiController, RESTController, Task
+from . import ApiController, RESTController, Task, UpdatePermission
 from .. import mgr
+from ..security import Scope
 from ..services.ceph_service import CephService
 from ..tools import ViewCache
 from ..services.exception import handle_rados_error, handle_rbd_error, \
@@ -112,7 +113,7 @@ def _sort_features(features, enable=True):
     features.sort(key=key_func, reverse=not enable)
 
 
-@ApiController('/block/image')
+@ApiController('/block/image', Scope.RBD_IMAGE)
 class Rbd(RESTController):
 
     RESOURCE_ID = "pool_name/image_name"
@@ -360,6 +361,7 @@ class Rbd(RESTController):
 
     @RbdTask('flatten', ['{pool_name}', '{image_name}'], 2.0)
     @RESTController.Resource('POST')
+    @UpdatePermission
     def flatten(self, pool_name, image_name):
 
         def _flatten(ioctx, image):
@@ -373,7 +375,7 @@ class Rbd(RESTController):
         return _format_bitmask(int(rbd_default_features))
 
 
-@ApiController('/block/image/:pool_name/:image_name/snap')
+@ApiController('/block/image/{pool_name}/{image_name}/snap', Scope.RBD_IMAGE)
 class RbdSnapshot(RESTController):
 
     RESOURCE_ID = "snapshot_name"
@@ -416,6 +418,7 @@ class RbdSnapshot(RESTController):
     @RbdTask('snap/rollback',
              ['{pool_name}', '{image_name}', '{snapshot_name}'], 5.0)
     @RESTController.Resource('POST')
+    @UpdatePermission
     def rollback(self, pool_name, image_name, snapshot_name):
         def _rollback(ioctx, img, snapshot_name):
             img.rollback_to_snap(snapshot_name)

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -8,7 +8,7 @@ from functools import partial
 
 import rbd
 
-from . import ApiController, AuthRequired, Endpoint, BaseController
+from . import ApiController, Endpoint, BaseController
 from .. import logger, mgr
 from ..services.ceph_service import CephService
 from ..tools import ViewCache
@@ -155,7 +155,6 @@ def get_daemons_and_pools():  # pylint: disable=R0915
 
 
 @ApiController('/rbdmirror')
-@AuthRequired()
 class RbdMirror(BaseController):
 
     def __init__(self):

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -8,8 +8,9 @@ from functools import partial
 
 import rbd
 
-from . import ApiController, Endpoint, BaseController
+from . import ApiController, Endpoint, BaseController, ReadPermission
 from .. import logger, mgr
+from ..security import Scope
 from ..services.ceph_service import CephService
 from ..tools import ViewCache
 from ..services.exception import handle_rbd_error
@@ -154,7 +155,7 @@ def get_daemons_and_pools():  # pylint: disable=R0915
     }
 
 
-@ApiController('/rbdmirror')
+@ApiController('/rbdmirror', Scope.RBD_MIRRORING)
 class RbdMirror(BaseController):
 
     def __init__(self):
@@ -163,6 +164,7 @@ class RbdMirror(BaseController):
 
     @Endpoint()
     @handle_rbd_error()
+    @ReadPermission
     def __call__(self):
         status, content_data = self._get_content_data()
         return {'status': status, 'content_data': content_data}

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -4,7 +4,7 @@ from __future__ import absolute_import
 import json
 import cherrypy
 
-from . import ApiController, BaseController, RESTController, AuthRequired, Endpoint
+from . import ApiController, BaseController, RESTController, Endpoint
 from .. import logger
 from ..services.ceph_service import CephService
 from ..services.rgw_client import RgwClient
@@ -13,7 +13,6 @@ from ..exceptions import DashboardException
 
 
 @ApiController('/rgw')
-@AuthRequired()
 class Rgw(BaseController):
 
     @Endpoint()
@@ -37,7 +36,6 @@ class Rgw(BaseController):
 
 
 @ApiController('/rgw/daemon')
-@AuthRequired()
 class RgwDaemon(RESTController):
 
     def list(self):
@@ -97,7 +95,6 @@ class RgwRESTController(RESTController):
 
 
 @ApiController('/rgw/bucket')
-@AuthRequired()
 class RgwBucket(RgwRESTController):
 
     def list(self):
@@ -128,7 +125,6 @@ class RgwBucket(RgwRESTController):
 
 
 @ApiController('/rgw/user')
-@AuthRequired()
 class RgwUser(RgwRESTController):
 
     def list(self):

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -4,18 +4,21 @@ from __future__ import absolute_import
 import json
 import cherrypy
 
-from . import ApiController, BaseController, RESTController, Endpoint
+from . import ApiController, BaseController, RESTController, Endpoint, \
+              ReadPermission
 from .. import logger
+from ..security import Scope
 from ..services.ceph_service import CephService
 from ..services.rgw_client import RgwClient
 from ..rest_client import RequestException
 from ..exceptions import DashboardException
 
 
-@ApiController('/rgw')
+@ApiController('/rgw', Scope.RGW)
 class Rgw(BaseController):
 
     @Endpoint()
+    @ReadPermission
     def status(self):
         status = {'available': False, 'message': None}
         try:
@@ -35,7 +38,7 @@ class Rgw(BaseController):
         return status
 
 
-@ApiController('/rgw/daemon')
+@ApiController('/rgw/daemon', Scope.RGW)
 class RgwDaemon(RESTController):
 
     def list(self):
@@ -94,7 +97,7 @@ class RgwRESTController(RESTController):
             raise DashboardException(e, http_status_code=500, component='rgw')
 
 
-@ApiController('/rgw/bucket')
+@ApiController('/rgw/bucket', Scope.RGW)
 class RgwBucket(RgwRESTController):
 
     def list(self):
@@ -124,7 +127,7 @@ class RgwBucket(RgwRESTController):
         }, json_response=False)
 
 
-@ApiController('/rgw/user')
+@ApiController('/rgw/user', Scope.RGW)
 class RgwUser(RgwRESTController):
 
     def list(self):

--- a/src/pybind/mgr/dashboard/controllers/summary.py
+++ b/src/pybind/mgr/dashboard/controllers/summary.py
@@ -6,8 +6,9 @@ import json
 
 from . import ApiController, Endpoint, BaseController
 from .. import mgr
+from ..security import Permission, Scope
 from ..controllers.rbd_mirroring import get_daemons_and_pools
-from ..tools import ViewCacheNoDataException
+from ..exceptions import ViewCacheNoDataException
 from ..tools import TaskManager
 
 
@@ -43,12 +44,14 @@ class Summary(BaseController):
     @Endpoint()
     def __call__(self):
         executing_t, finished_t = TaskManager.list_serializable()
-        return {
+        result = {
             'health_status': self._health_status(),
-            'rbd_mirroring': self._rbd_mirroring(),
             'mgr_id': mgr.get_mgr_id(),
             'have_mon_connection': mgr.have_mon_connection(),
             'executing_tasks': executing_t,
             'finished_tasks': finished_t,
             'version': mgr.version
         }
+        if self._has_permissions(Permission.READ, Scope.RBD_MIRRORING):
+            result['rbd_mirroring'] = self._rbd_mirroring()
+        return result

--- a/src/pybind/mgr/dashboard/controllers/summary.py
+++ b/src/pybind/mgr/dashboard/controllers/summary.py
@@ -3,15 +3,15 @@ from __future__ import absolute_import
 
 import json
 
+
+from . import ApiController, Endpoint, BaseController
 from .. import mgr
-from . import AuthRequired, ApiController, Endpoint, BaseController
 from ..controllers.rbd_mirroring import get_daemons_and_pools
 from ..tools import ViewCacheNoDataException
 from ..tools import TaskManager
 
 
 @ApiController('/summary')
-@AuthRequired()
 class Summary(BaseController):
     def _health_status(self):
         health_data = mgr.get("health")

--- a/src/pybind/mgr/dashboard/controllers/task.py
+++ b/src/pybind/mgr/dashboard/controllers/task.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import ApiController, AuthRequired, RESTController
+from . import ApiController, RESTController
 from ..tools import TaskManager
 
 
 @ApiController('/task')
-@AuthRequired()
 class Task(RESTController):
     def list(self, name=None):
         executing_t, finished_t = TaskManager.list_serializable(name)

--- a/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from . import ApiController, AuthRequired, RESTController
+from . import ApiController, RESTController
 from .. import mgr
 from ..services.ceph_service import CephService
 
@@ -9,7 +9,6 @@ SERVICE_TYPE = 'tcmu-runner'
 
 
 @ApiController('/tcmuiscsi')
-@AuthRequired()
 class TcmuIscsi(RESTController):
     # pylint: disable=too-many-nested-blocks
     def list(self):  # pylint: disable=unused-argument

--- a/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
@@ -3,12 +3,13 @@ from __future__ import absolute_import
 
 from . import ApiController, RESTController
 from .. import mgr
+from ..security import Scope
 from ..services.ceph_service import CephService
 
 SERVICE_TYPE = 'tcmu-runner'
 
 
-@ApiController('/tcmuiscsi')
+@ApiController('/tcmuiscsi', Scope.ISCSI)
 class TcmuIscsi(RESTController):
     # pylint: disable=too-many-nested-blocks
     def list(self):  # pylint: disable=unused-argument

--- a/src/pybind/mgr/dashboard/exceptions.py
+++ b/src/pybind/mgr/dashboard/exceptions.py
@@ -43,3 +43,61 @@ class DashboardException(Exception):
         if self._code:
             return str(self._code)
         return str(abs(self.errno))
+
+
+# access control module exceptions
+class RoleAlreadyExists(Exception):
+    def __init__(self, name):
+        super(RoleAlreadyExists, self).__init__(
+            "Role '{}' already exists".format(name))
+
+
+class RoleDoesNotExist(Exception):
+    def __init__(self, name):
+        super(RoleDoesNotExist, self).__init__(
+            "Role '{}' does not exist".format(name))
+
+
+class ScopeNotValid(Exception):
+    def __init__(self, name):
+        super(ScopeNotValid, self).__init__(
+            "Scope '{}' is not valid".format(name))
+
+
+class PermissionNotValid(Exception):
+    def __init__(self, name):
+        super(PermissionNotValid, self).__init__(
+            "Permission '{}' is not valid".format(name))
+
+
+class RoleIsAssociatedWithUser(Exception):
+    def __init__(self, rolename, username):
+        super(RoleIsAssociatedWithUser, self).__init__(
+            "Role '{}' is still associated with user '{}'"
+            .format(rolename, username))
+
+
+class UserAlreadyExists(Exception):
+    def __init__(self, name):
+        super(UserAlreadyExists, self).__init__(
+            "User '{}' already exists".format(name))
+
+
+class UserDoesNotExist(Exception):
+    def __init__(self, name):
+        super(UserDoesNotExist, self).__init__(
+            "User '{}' does not exist".format(name))
+
+
+class ScopeNotInRole(Exception):
+    def __init__(self, scopename, rolename):
+        super(ScopeNotInRole, self).__init__(
+            "There are no permissions for scope '{}' in role '{}'"
+            .format(scopename, rolename))
+
+
+class RoleNotInUser(Exception):
+    def __init__(self, rolename, username):
+        super(RoleNotInUser, self).__init__(
+            "Role '{}' is not associated with user '{}'"
+            .format(rolename, username))

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -20,6 +20,7 @@ import { RgwDaemonListComponent } from './ceph/rgw/rgw-daemon-list/rgw-daemon-li
 import { RgwUserFormComponent } from './ceph/rgw/rgw-user-form/rgw-user-form.component';
 import { RgwUserListComponent } from './ceph/rgw/rgw-user-list/rgw-user-list.component';
 import { LoginComponent } from './core/auth/login/login.component';
+import { ForbiddenComponent } from './core/forbidden/forbidden.component';
 import { NotFoundComponent } from './core/not-found/not-found.component';
 import { AuthGuardService } from './shared/services/auth-guard.service';
 import { ModuleStatusGuardService } from './shared/services/module-status-guard.service';
@@ -107,6 +108,7 @@ const routes: Routes = [
   { path: 'cephfs', component: CephfsListComponent, canActivate: [AuthGuardService] },
   { path: 'configuration', component: ConfigurationComponent, canActivate: [AuthGuardService] },
   { path: 'mirroring', component: MirroringComponent, canActivate: [AuthGuardService] },
+  { path: '403', component: ForbiddenComponent },
   { path: '404', component: NotFoundComponent },
   { path: 'osd', component: OsdListComponent, canActivate: [AuthGuardService] },
   { path: '**', redirectTo: '/404' }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -76,15 +76,16 @@
           <div class="col-sm-9">
             <input class="form-control"
                    type="text"
+                   placeholder="Pool name..."
                    id="pool"
                    name="pool"
                    formControlName="pool"
-                   *ngIf="mode === 'editing'">
+                   *ngIf="mode === 'editing' || !poolPermission.read">
             <select id="pool"
                     name="pool"
                     class="form-control"
                     formControlName="pool"
-                    *ngIf="mode !== 'editing'">
+                    *ngIf="mode !== 'editing' && poolPermission.read">
               <option *ngIf="pools === null"
                       [ngValue]="null">Loading...
               </option>
@@ -136,16 +137,17 @@
           <div class="col-sm-9">
             <input class="form-control"
                    type="text"
+                   placeholder="Data pool name..."
                    id="dataPool"
                    name="dataPool"
                    formControlName="dataPool"
-                   *ngIf="mode === 'editing'">
+                   *ngIf="mode === 'editing' || !poolPermission.read">
             <select id="dataPool"
                     name="dataPool"
                     class="form-control"
                     formControlName="dataPool"
                     (change)="onDataPoolChange($event.target.value)"
-                    *ngIf="mode !== 'editing'">
+                    *ngIf="mode !== 'editing' && poolPermission.read">
               <option *ngIf="dataPools === null"
                       [ngValue]="null">Loading...
               </option>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -8,7 +8,9 @@ import { Observable } from 'rxjs/Observable';
 import { PoolService } from '../../../shared/api/pool.service';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { FinishedTask } from '../../../shared/models/finished-task';
+import { Permission } from '../../../shared/models/permissions';
 import { DimlessBinaryPipe } from '../../../shared/pipes/dimless-binary.pipe';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { FormatterService } from '../../../shared/services/formatter.service';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
 import { RbdFormCloneRequestModel } from './rbd-form-clone-request.model';
@@ -25,6 +27,7 @@ import { RbdFormResponseModel } from './rbd-form-response.model';
 })
 export class RbdFormComponent implements OnInit {
 
+  poolPermission: Permission;
   rbdForm: FormGroup;
   featuresFormGroups: FormGroup;
   deepFlattenFormControl: FormControl;
@@ -71,6 +74,7 @@ export class RbdFormComponent implements OnInit {
   ];
 
   constructor(
+    private authStorageService: AuthStorageService,
     private route: ActivatedRoute,
     private router: Router,
     private poolService: PoolService,
@@ -79,6 +83,7 @@ export class RbdFormComponent implements OnInit {
     private taskWrapper: TaskWrapperService,
     private dimlessBinaryPipe: DimlessBinaryPipe
   ) {
+    this.poolPermission = this.authStorageService.getPermissions().pool;
     this.features = {
       'deep-flatten': {
         desc: 'Deep flatten',
@@ -217,7 +222,7 @@ export class RbdFormComponent implements OnInit {
           this.setFeatures(defaultFeatures);
         });
     }
-    if (this.mode !== this.rbdFormMode.editing) {
+    if (this.mode !== this.rbdFormMode.editing && this.poolPermission.read) {
       this.poolService.list(['pool_name', 'type', 'flags_names', 'application_metadata']).then(
         resp => {
           const pools = [];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -24,29 +24,36 @@
          dropdown>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="!selection.hasSingleSelection"
+              *ngIf="permission.create && (!permission.update || !selection.hasSingleSelection)"
               routerLink="/rbd/add">
-        <i class="fa fa-fw fa-plus"></i>
-        <span i18n>Add</span>
+        <i class="fa fa-fw fa-plus"></i><span i18n>Add</span>
       </button>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="selection.hasSingleSelection"
-              [ngClass]="{'disabled': selection.first().executing}"
+              *ngIf="permission.update && (!permission.create || permission.create && selection.hasSingleSelection)"
+              [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}"
               routerLink="/rbd/edit/{{ selection.first()?.pool_name }}/{{ selection.first()?.name }}">
-        <i class="fa fa-fw fa-pencil"></i>
-        <span i18n>Edit</span>
+        <i class="fa fa-fw fa-pencil"></i><span i18n>Edit</span>
+      </button>
+      <button type="button"
+              class="btn btn-sm btn-primary"
+              *ngIf="permission.delete && !permission.update && !permission.create"
+              [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}"
+              (click)="deleteRbdModal()">
+        <i class="fa fa-fw fa-trash-o"></i><span i18n>Delete</span>
       </button>
       <button type="button"
               dropdownToggle
-              class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split">
+              class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split"
+              *ngIf="permission.create || permission.update">
         <span class="caret"></span>
         <span class="sr-only"></span>
       </button>
       <ul *dropdownMenu
           class="dropdown-menu"
           role="menu">
-        <li role="menuitem">
+        <li role="menuitem"
+            *ngIf="permission.create">
           <a class="dropdown-item"
              routerLink="/rbd/add">
             <i class="fa fa-fw fa-plus"></i>
@@ -54,6 +61,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.update"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
           <a class="dropdown-item"
              routerLink="/rbd/edit/{{ selection.first()?.pool_name }}/{{ selection.first()?.name }}">
@@ -62,6 +70,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.create"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
           <a class="dropdown-item"
              routerLink="/rbd/copy/{{ selection.first()?.pool_name }}/{{ selection.first()?.name }}">
@@ -70,6 +79,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.update"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing || !selection.first().parent}">
           <a class="dropdown-item"
              (click)="flattenRbdModal()">
@@ -78,6 +88,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.delete"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
           <a class="dropdown-item"
              (click)="deleteRbdModal()">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -12,8 +12,10 @@ import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { ExecutingTask } from '../../../shared/models/executing-task';
 import { FinishedTask } from '../../../shared/models/finished-task';
+import { Permission } from '../../../shared/models/permissions';
 import { DimlessBinaryPipe } from '../../../shared/pipes/dimless-binary.pipe';
 import { DimlessPipe } from '../../../shared/pipes/dimless.pipe';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { TaskWrapperService } from '../../../shared/services/task-wrapper.service';
 import { RbdParentModel } from '../rbd-form/rbd-parent.model';
@@ -28,9 +30,9 @@ export class RbdListComponent implements OnInit, OnDestroy {
   @ViewChild('usageTpl') usageTpl: TemplateRef<any>;
   @ViewChild('parentTpl') parentTpl: TemplateRef<any>;
   @ViewChild('nameTpl') nameTpl: TemplateRef<any>;
-
   @ViewChild('flattenTpl') flattenTpl: TemplateRef<any>;
 
+  permission: Permission;
   images: any;
   executingTasks: ExecutingTask[] = [];
   columns: CdTableColumn[];
@@ -43,13 +45,15 @@ export class RbdListComponent implements OnInit, OnDestroy {
   modalRef: BsModalRef;
 
   constructor(
+    private authStorageService: AuthStorageService,
     private rbdService: RbdService,
     private dimlessBinaryPipe: DimlessBinaryPipe,
     private dimlessPipe: DimlessPipe,
     private summaryService: SummaryService,
     private modalService: BsModalService,
-    private taskWrapper: TaskWrapperService
-  ) {}
+    private taskWrapper: TaskWrapperService) {
+    this.permission = this.authStorageService.getPermissions().rbdImage;
+  }
 
   ngOnInit() {
     this.columns = [

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.html
@@ -8,29 +8,39 @@
          dropdown>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="!selection.hasSingleSelection"
+              *ngIf="permission.create && (!permission.update || !selection.hasSingleSelection)"
               (click)="openCreateSnapshotModal()">
         <i class="fa fa-fw fa-plus"></i>
         <span i18n>Create</span>
       </button>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="selection.hasSingleSelection"
-              [ngClass]="{'disabled': selection.first().executing}"
+              *ngIf="permission.update && (!permission.create || permission.create && selection.hasSingleSelection)"
+              [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}"
               (click)="openEditSnapshotModal()">
         <i class="fa fa-fw fa-pencil"></i>
         <span i18n>Rename</span>
       </button>
       <button type="button"
+              class="btn btn-sm btn-primary"
+              *ngIf="permission.delete && !permission.update && !permission.create"
+              [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}"
+              (click)="deleteSnapshotModal()">
+        <i class="fa fa-fw fa-trash-o"></i>
+        <span i18n>Delete</span>
+      </button>
+      <button type="button"
               dropdownToggle
-              class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split">
+              class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split"
+              *ngIf="permission.create || permission.update">
         <span class="caret"></span>
         <span class="sr-only"></span>
       </button>
       <ul *dropdownMenu
           class="dropdown-menu"
           role="menu">
-        <li role="menuitem">
+        <li role="menuitem"
+            *ngIf="permission.create">
           <a class="dropdown-item"
              (click)="openCreateSnapshotModal()">
             <i class="fa fa-fw fa-plus"></i>
@@ -38,17 +48,17 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.update"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
-          <a class="dropdown-item"
-             (click)="openEditSnapshotModal()">
+          <a class="dropdown-item" (click)="openEditSnapshotModal()">
             <i class="fa fa-fw fa-pencil"></i>
             <span i18n>Rename</span>
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.update"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
-          <a class="dropdown-item"
-             (click)="toggleProtection()">
+          <a class="dropdown-item" (click)="toggleProtection()">
             <span *ngIf="!selection.first()?.is_protected">
               <i class="fa fa-fw fa-lock"></i>
               <span i18n>Protect</span>
@@ -60,6 +70,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.create"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
           <a class="dropdown-item"
              routerLink="/rbd/clone/{{ poolName }}/{{ rbdName }}/{{ selection.first()?.name }}">
@@ -68,14 +79,14 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.create"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
-          <a class="dropdown-item"
-             routerLink="/rbd/copy/{{ poolName }}/{{ rbdName }}/{{ selection.first()?.name }}">
-            <i class="fa fa-fw fa-copy"></i>
-            <span i18n>Copy</span>
+          <a class="dropdown-item" routerLink="/rbd/copy/{{ poolName }}/{{ rbdName }}/{{ selection.first()?.name }}">
+            <i class="fa fa-fw fa-copy"></i><span i18n>Copy</span>
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.update"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
           <a class="dropdown-item"
              (click)="rollbackModal()">
@@ -84,6 +95,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.delete"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing || selection.first().is_protected}">
           <a class="dropdown-item"
              (click)="deleteSnapshotModal()">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -10,6 +10,7 @@ import { ApiModule } from '../../../shared/api/api.module';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { DataTableModule } from '../../../shared/datatable/datatable.module';
+import { Permissions } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { ServicesModule } from '../../../shared/services/services.module';
@@ -19,6 +20,15 @@ import { RbdSnapshotListComponent } from './rbd-snapshot-list.component';
 describe('RbdSnapshotListComponent', () => {
   let component: RbdSnapshotListComponent;
   let fixture: ComponentFixture<RbdSnapshotListComponent>;
+
+  const fakeAuthStorageService = {
+    isLoggedIn: () => {
+      return true;
+    },
+    getPermissions: () => {
+      return new Permissions({ 'rbd-image': ['read', 'update', 'create', 'delete'] });
+    }
+  };
 
   configureTestBed({
     declarations: [RbdSnapshotListComponent],
@@ -32,7 +42,7 @@ describe('RbdSnapshotListComponent', () => {
       HttpClientTestingModule,
       RouterTestingModule
     ],
-    providers: [AuthStorageService]
+    providers: [{ provide: AuthStorageService, useValue: fakeAuthStorageService }]
   });
 
   beforeEach(() => {
@@ -49,12 +59,16 @@ describe('RbdSnapshotListComponent', () => {
     let called;
     let rbdService: RbdService;
     let notificationService: NotificationService;
+    let authStorageService: AuthStorageService;
 
     beforeEach(() => {
       called = false;
       rbdService = new RbdService(null);
       notificationService = new NotificationService(null, null);
+      authStorageService = new AuthStorageService();
+      authStorageService.set('user', { 'rbd-image': ['create', 'read', 'update', 'delete'] });
       component = new RbdSnapshotListComponent(
+        authStorageService,
         null,
         null,
         null,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -11,8 +11,10 @@ import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { ExecutingTask } from '../../../shared/models/executing-task';
 import { FinishedTask } from '../../../shared/models/finished-task';
+import { Permission } from '../../../shared/models/permissions';
 import { CdDatePipe } from '../../../shared/pipes/cd-date.pipe';
 import { DimlessBinaryPipe } from '../../../shared/pipes/dimless-binary.pipe';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { TaskManagerService } from '../../../shared/services/task-manager.service';
 import { RbdSnapshotFormComponent } from '../rbd-snapshot-form/rbd-snapshot-form.component';
@@ -33,6 +35,8 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
   @ViewChild('protectTpl') protectTpl: TemplateRef<any>;
   @ViewChild('rollbackTpl') rollbackTpl: TemplateRef<any>;
 
+  permission: Permission;
+
   data: RbdSnapshotModel[];
 
   columns: CdTableColumn[];
@@ -42,13 +46,16 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
   selection = new CdTableSelection();
 
   constructor(
+    private authStorageService: AuthStorageService,
     private modalService: BsModalService,
     private dimlessBinaryPipe: DimlessBinaryPipe,
     private cdDatePipe: CdDatePipe,
     private rbdService: RbdService,
     private taskManagerService: TaskManagerService,
     private notificationService: NotificationService
-  ) {}
+  ) {
+    this.permission = this.authStorageService.getPermissions().rbdImage;
+  }
 
   ngOnInit() {
     this.columns = [

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -13,7 +13,10 @@
           (fetchData)="getHosts()">
   <ng-template #servicesTpl let-value="value">
     <span *ngFor="let service of value; last as isLast">
-      <a [routerLink]="[service.cdLink]">{{ service.type }}.{{ service.id }}</a>{{ !isLast ? ", " : "" }}
+      <a [routerLink]="[service.cdLink]"
+         *ngIf="service.canRead">{{ service.type }}.{{ service.id }}</a>
+      <span *ngIf="!service.canRead">{{ service.type }}.{{ service.id }}</span>
+      {{ !isLast ? ", " : "" }}
     </span>
   </ng-template>
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -5,6 +5,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BsDropdownModule } from 'ngx-bootstrap';
 
 import { ComponentsModule } from '../../../shared/components/components.module';
+import { Permissions } from '../../../shared/models/permissions';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { configureTestBed } from '../../../shared/unit-test-helper';
 import { HostsComponent } from './hosts.component';
@@ -12,6 +14,12 @@ import { HostsComponent } from './hosts.component';
 describe('HostsComponent', () => {
   let component: HostsComponent;
   let fixture: ComponentFixture<HostsComponent>;
+
+  const fakeAuthStorageService = {
+    getPermissions: () => {
+      return new Permissions({ hosts: ['read', 'update', 'create', 'delete'] });
+    }
+  };
 
   configureTestBed({
     imports: [
@@ -21,6 +29,7 @@ describe('HostsComponent', () => {
       BsDropdownModule.forRoot(),
       RouterTestingModule
     ],
+    providers: [{ provide: AuthStorageService, useValue: fakeAuthStorageService }],
     declarations: [HostsComponent]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -10,7 +10,8 @@
           selectionType="single"
           (updateSelection)="updateSelection($event)"
           [updateSelectionOnRefresh]="false">
-  <div class="table-actions">
+  <div class="table-actions"
+       *ngIf="permission.update">
     <div class="btn-group"
          dropdown>
       <button dropdownToggle

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -5,7 +5,9 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { ComponentsModule } from '../../../../shared/components/components.module';
 import { DataTableModule } from '../../../../shared/datatable/datatable.module';
+import { Permissions } from '../../../../shared/models/permissions';
 import { DimlessPipe } from '../../../../shared/pipes/dimless.pipe';
+import { AuthStorageService } from '../../../../shared/services/auth-storage.service';
 import { FormatterService } from '../../../../shared/services/formatter.service';
 import { SharedModule } from '../../../../shared/shared.module';
 import { configureTestBed } from '../../../../shared/unit-test-helper';
@@ -18,6 +20,12 @@ describe('OsdListComponent', () => {
   let component: OsdListComponent;
   let fixture: ComponentFixture<OsdListComponent>;
 
+  const fakeAuthStorageService = {
+    getPermissions: () => {
+      return new Permissions({ osd: ['read', 'update', 'create', 'delete'] });
+    }
+  };
+
   configureTestBed({
     imports: [
       HttpClientModule,
@@ -28,7 +36,11 @@ describe('OsdListComponent', () => {
       SharedModule
     ],
     declarations: [OsdListComponent, OsdDetailsComponent, OsdPerformanceHistogramComponent],
-    providers: [DimlessPipe, FormatterService]
+    providers: [
+      DimlessPipe,
+      FormatterService,
+      { provide: AuthStorageService, useValue: fakeAuthStorageService }
+    ]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -7,7 +7,9 @@ import { TableComponent } from '../../../../shared/datatable/table/table.compone
 import { CellTemplate } from '../../../../shared/enum/cell-template.enum';
 import { CdTableColumn } from '../../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
+import { Permission } from '../../../../shared/models/permissions';
 import { DimlessBinaryPipe } from '../../../../shared/pipes/dimless-binary.pipe';
+import { AuthStorageService } from '../../../../shared/services/auth-storage.service';
 import { OsdScrubModalComponent } from '../osd-scrub-modal/osd-scrub-modal.component';
 
 @Component({
@@ -20,16 +22,20 @@ export class OsdListComponent implements OnInit {
   @ViewChild('osdUsageTpl') osdUsageTpl: TemplateRef<any>;
   @ViewChild(TableComponent) tableComponent: TableComponent;
 
+  permission: Permission;
   bsModalRef: BsModalRef;
   osds = [];
   columns: CdTableColumn[];
   selection = new CdTableSelection();
 
   constructor(
+    private authStorageService: AuthStorageService,
     private osdService: OsdService,
     private dimlessBinaryPipe: DimlessBinaryPipe,
     private modalService: BsModalService
-  ) {}
+  ) {
+    this.permission = this.authStorageService.getPermissions().osd;
+  }
 
   ngOnInit() {
     this.columns = [

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.html
@@ -20,7 +20,8 @@
       <!--STATS -->
       <div class="row">
         <div class="col-md-6">
-          <div class="well">
+          <div class="well"
+               *ngIf="contentData.mon_status">
             <div class="media">
               <div class="media-left">
                 <i class="fa fa-database fa-fw"></i>
@@ -36,7 +37,8 @@
           </div>
         </div>
         <div class="col-md-6">
-          <div class="well">
+          <div class="well"
+               *ngIf="contentData.osd_map">
             <div class="media">
               <div class="media-left">
                 <i class="fa fa-hdd-o fa-fw"></i>
@@ -54,7 +56,8 @@
       </div>
       <div class="row">
         <div class="col-md-6">
-          <div class="well">
+          <div class="well"
+               *ngIf="contentData.fs_map">
             <div class="media">
               <div class="media-left">
                 <i class="fa fa-folder fa-fw"></i>
@@ -68,7 +71,8 @@
           </div>
         </div>
         <div class="col-md-6">
-          <div class="well">
+          <div class="well"
+               *ngIf="contentData.mgr_map">
             <div class="media">
               <div class="media-left">
                 <i class="fa fa-cog fa-fw"></i>
@@ -88,7 +92,8 @@
   <div class="row">
     <!-- USAGE -->
     <div class="col-md-6">
-      <div class="well">
+      <div class="well"
+           *ngIf="contentData.df?.stats?.total_objects">
         <fieldset class="usage">
           <legend i18n>Usage</legend>
 
@@ -125,7 +130,8 @@
     </div>
 
     <div class="col-md-6">
-      <div class="well">
+      <div class="well"
+           *ngIf="contentData.pools">
         <fieldset>
           <legend i18n>Pools</legend>
           <table class="table table-condensed">
@@ -172,13 +178,15 @@
   <div class="row">
     <div class="col-md-12">
       <!-- LOGS -->
-      <div class="well">
+      <div class="well"
+           *ngIf="contentData.clog || contentData.audit_log">
         <fieldset>
           <legend i18n>Logs</legend>
 
           <tabset>
             <tab heading="Cluster log"
                  class="text-monospace"
+                 *ngIf="contentData.clog"
                  i18n-heading>
               <span *ngFor="let line of contentData.clog">
                 {{ line.stamp }}&nbsp;{{ line.priority }}&nbsp;
@@ -190,6 +198,7 @@
             </tab>
             <tab heading="Audit log"
                  class="text-monospace"
+                 *ngIf="contentData.audit_log"
                  i18n-heading>
               <span *ngFor="let line of contentData.audit_log">
                 {{ line.stamp }}&nbsp;{{ line.priority }}&nbsp;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
@@ -20,27 +20,34 @@
     <div class="btn-group" dropdown>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="!selection.hasSelection"
+              *ngIf="permission.create && (
+                       permission.update && permission.delete && !selection.hasSelection ||
+                       !permission.update && !permission.delete ||
+                       !permission.update && permission.delete && !selection.hasMultiSelection ||
+                       permission.update && !selection.hasSingleSelection && !permission.delete)"
               routerLink="/rgw/bucket/add">
         <i class="fa fa-fw fa-plus"></i>
         <ng-container i18n>Add</ng-container>
       </button>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="selection.hasSingleSelection"
+              [ngClass]="{'disabled': !selection.hasSelection}"
+              *ngIf="permission.update && (!permission.create && !selection.hasMultiSelection || selection.hasSingleSelection)"
               routerLink="/rgw/bucket/edit/{{ selection.first()?.bucket }}">
         <i class="fa fa-fw fa-pencil"></i>
         <ng-container i18n>Edit</ng-container>
       </button>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="selection.hasMultiSelection"
+              [ngClass]="{'disabled': !selection.hasSelection}"
+              *ngIf="permission.delete && (!permission.update && !permission.create || selection.hasMultiSelection)"
               (click)="deleteAction()">
         <i class="fa fa-fw fa-trash-o"></i>
         <ng-container i18n>Delete</ng-container>
       </button>
       <button type="button"
               class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split"
+              *ngIf="((permission.create?1:0) + (permission.update?1:0) + (permission.delete?1:0)) > 1"
               dropdownToggle>
         <span class="caret"></span>
         <span class="sr-only"></span>
@@ -48,7 +55,8 @@
       <ul class="dropdown-menu"
           *dropdownMenu
           role="menu">
-        <li role="menuitem">
+        <li role="menuitem"
+            *ngIf="permission.create">
           <a class="dropdown-item"
              routerLink="/rgw/bucket/add"
              i18n>
@@ -57,6 +65,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.update"
             [ngClass]="{'disabled': !selection.hasSingleSelection}">
           <a class="dropdown-item"
              routerLink="/rgw/bucket/edit/{{ selection.first()?.bucket }}"
@@ -66,6 +75,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.delete"
             [ngClass]="{'disabled': !selection.hasSelection}">
           <a class="dropdown-item"
              (click)="deleteAction()"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
@@ -8,6 +8,8 @@ import { DeletionModalComponent } from '../../../shared/components/deletion-moda
 import { TableComponent } from '../../../shared/datatable/table/table.component';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
+import { Permission } from '../../../shared/models/permissions';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 
 @Component({
   selector: 'cd-rgw-bucket-list',
@@ -17,11 +19,17 @@ import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 export class RgwBucketListComponent {
   @ViewChild(TableComponent) table: TableComponent;
 
+  permission: Permission;
   columns: CdTableColumn[] = [];
   buckets: object[] = [];
   selection: CdTableSelection = new CdTableSelection();
 
-  constructor(private rgwBucketService: RgwBucketService, private bsModalService: BsModalService) {
+  constructor(
+    private authStorageService: AuthStorageService,
+    private rgwBucketService: RgwBucketService,
+    private bsModalService: BsModalService
+  ) {
+    this.permission = this.authStorageService.getPermissions().rgw;
     this.columns = [
       {
         name: 'Name',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.html
@@ -20,27 +20,34 @@
     <div class="btn-group" dropdown>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="!selection.hasSelection"
+              *ngIf="permission.create && (
+                       permission.update && permission.delete && !selection.hasSelection ||
+                       !permission.update && !permission.delete ||
+                       !permission.update && permission.delete && !selection.hasMultiSelection ||
+                       permission.update && !selection.hasSingleSelection && !permission.delete)"
               routerLink="/rgw/user/add">
         <i class="fa fa-fw fa-plus"></i>
         <ng-container i18n>Add</ng-container>
       </button>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="selection.hasSingleSelection"
+              [ngClass]="{'disabled': !selection.hasSelection}"
+              *ngIf="permission.update && (!permission.create && !selection.hasMultiSelection || selection.hasSingleSelection)"
               routerLink="/rgw/user/edit/{{ selection.first()?.user_id }}">
         <i class="fa fa-fw fa-pencil"></i>
         <ng-container i18n>Edit</ng-container>
       </button>
       <button type="button"
               class="btn btn-sm btn-primary"
-              *ngIf="selection.hasMultiSelection"
+              [ngClass]="{'disabled': !selection.hasSelection}"
+              *ngIf="permission.delete && (!permission.update && !permission.create || selection.hasMultiSelection)"
               (click)="deleteAction()">
         <i class="fa fa-fw fa-trash-o"></i>
         <ng-container i18n>Delete</ng-container>
       </button>
       <button type="button"
               class="btn btn-sm btn-primary dropdown-toggle dropdown-toggle-split"
+              *ngIf="((permission.create?1:0) + (permission.update?1:0) + (permission.delete?1:0)) > 1"
               dropdownToggle>
         <span class="caret"></span>
         <span class="sr-only"></span>
@@ -48,7 +55,8 @@
       <ul class="dropdown-menu"
           *dropdownMenu
           role="menu">
-        <li role="menuitem">
+        <li role="menuitem"
+            *ngIf="permission.create">
           <a class="dropdown-item"
              routerLink="/rgw/user/add"
              i18n>
@@ -57,6 +65,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.update"
             [ngClass]="{'disabled': !selection.hasSingleSelection}">
           <a class="dropdown-item"
              routerLink="/rgw/user/edit/{{ selection.first()?.user_id }}"
@@ -66,6 +75,7 @@
           </a>
         </li>
         <li role="menuitem"
+            *ngIf="permission.delete"
             [ngClass]="{'disabled': !selection.hasSelection}">
           <a class="dropdown-item"
              (click)="deleteAction()"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.spec.ts
@@ -6,6 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ModalModule } from 'ngx-bootstrap';
 
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
+import { SharedModule } from '../../../shared/shared.module';
 import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserListComponent } from './rgw-user-list.component';
 
@@ -15,7 +16,7 @@ describe('RgwUserListComponent', () => {
 
   configureTestBed({
     declarations: [RgwUserListComponent],
-    imports: [RouterTestingModule, HttpClientTestingModule, ModalModule.forRoot()],
+    imports: [RouterTestingModule, HttpClientTestingModule, ModalModule.forRoot(), SharedModule],
     providers: [RgwUserService],
     schemas: [NO_ERRORS_SCHEMA]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
@@ -9,6 +9,8 @@ import { TableComponent } from '../../../shared/datatable/table/table.component'
 import { CellTemplate } from '../../../shared/enum/cell-template.enum';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
+import { Permission } from '../../../shared/models/permissions';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 
 @Component({
   selector: 'cd-rgw-user-list',
@@ -18,11 +20,17 @@ import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 export class RgwUserListComponent {
   @ViewChild(TableComponent) table: TableComponent;
 
+  permission: Permission;
   columns: CdTableColumn[] = [];
   users: object[] = [];
   selection: CdTableSelection = new CdTableSelection();
 
-  constructor(private rgwUserService: RgwUserService, private bsModalService: BsModalService) {
+  constructor(
+    private authStorageService: AuthStorageService,
+    private rgwUserService: RgwUserService,
+    private bsModalService: BsModalService
+  ) {
+    this.permission = this.authStorageService.getPermissions().rgw;
     this.columns = [
       {
         name: 'Username',

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/core.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/core.module.ts
@@ -2,16 +2,13 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { AuthModule } from './auth/auth.module';
+import { ForbiddenComponent } from './forbidden/forbidden.component';
 import { NavigationModule } from './navigation/navigation.module';
 import { NotFoundComponent } from './not-found/not-found.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    NavigationModule,
-    AuthModule
-  ],
+  imports: [CommonModule, NavigationModule, AuthModule],
   exports: [NavigationModule],
-  declarations: [NotFoundComponent]
+  declarations: [NotFoundComponent, ForbiddenComponent]
 })
-export class CoreModule { }
+export class CoreModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.html
@@ -1,0 +1,10 @@
+<div class="row">
+  <div class="col-md-12 text-center">
+    <h1 i18n>Forbidden</h1>
+
+    <i class="fa fa-lock text-danger"></i>
+
+    <h2 i18n>Sorry, you are not allowed to see what you were looking for.</h2>
+
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.scss
@@ -1,0 +1,13 @@
+h1 {
+  font-size: -webkit-xxx-large;
+  font-family: monospace;
+}
+
+h2 {
+  font-size: xx-large;
+  font-family: monospace;
+}
+
+i {
+  font-size: 200px;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ForbiddenComponent } from './forbidden.component';
+
+describe('ForbiddenComponent', () => {
+  let component: ForbiddenComponent;
+  let fixture: ComponentFixture<ForbiddenComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ForbiddenComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ForbiddenComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/forbidden/forbidden.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'cd-forbidden',
+  templateUrl: './forbidden.component.html',
+  styleUrls: ['./forbidden.component.scss']
+})
+export class ForbiddenComponent {
+  constructor() {}
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -40,7 +40,8 @@
       <!-- Cluster -->
       <li dropdown
           routerLinkActive="active"
-          class="dropdown tc_menuitem tc_menuitem_cluster">
+          class="dropdown tc_menuitem tc_menuitem_cluster"
+          *ngIf="permissions.hosts.read || permissions.monitor.read || permissions.osd.read || permissions.configOpt.read">
         <a dropdownToggle
            class="dropdown-toggle"
            data-toggle="dropdown">
@@ -50,28 +51,32 @@
         <ul *dropdownMenu
             class="dropdown-menu">
           <li routerLinkActive="active"
-              class="tc_submenuitem tc_submenuitem_hosts">
+              class="tc_submenuitem tc_submenuitem_hosts"
+              *ngIf="permissions.hosts.read">
             <a i18n
                class="dropdown-item"
                routerLink="/hosts">Hosts
             </a>
           </li>
           <li routerLinkActive="active"
-              class="tc_submenuitem tc_submenuitem_cluster_monitor">
+              class="tc_submenuitem tc_submenuitem_cluster_monitor"
+              *ngIf="permissions.monitor.read">
             <a i18n
                class="dropdown-item"
                routerLink="/monitor/"> Monitors
             </a>
           </li>
           <li routerLinkActive="active"
-              class="tc_submenuitem tc_submenuitem_hosts">
+              class="tc_submenuitem tc_submenuitem_hosts"
+              *ngIf="permissions.osd.read">
             <a i18n
                class="dropdown-item"
                routerLink="/osd">OSDs
             </a>
           </li>
           <li routerLinkActive="active"
-              class="tc_submenuitem tc_submenuitem_configuration">
+              class="tc_submenuitem tc_submenuitem_configuration"
+              *ngIf="permissions.configOpt.read">
             <a i18n
                class="dropdown-item"
                routerLink="/configuration">Configuration Doc.
@@ -82,7 +87,8 @@
 
       <!-- Pools -->
       <li routerLinkActive="active"
-          class="tc_menuitem tc_menuitem_pool">
+          class="tc_menuitem tc_menuitem_pool"
+          *ngIf="permissions.pool.read">
         <a i18n
            routerLink="/pool">Pool
         </a>
@@ -91,7 +97,8 @@
       <!-- Block -->
       <li dropdown
           routerLinkActive="active"
-          class="dropdown tc_menuitem tc_menuitem_block">
+          class="dropdown tc_menuitem tc_menuitem_block"
+          *ngIf="permissions.rbdImage.read || permissions.rbdMirroring.read || permissions.iscsi.read">
         <a dropdownToggle
            class="dropdown-toggle"
            data-toggle="dropdown"
@@ -101,14 +108,16 @@
         </a>
 
         <ul class="dropdown-menu">
-          <li routerLinkActive="active">
+          <li routerLinkActive="active"
+              *ngIf="permissions.rbdImage.read">
             <a i18n
                class="dropdown-item"
                routerLink="/block/rbd">Images</a>
           </li>
 
           <li routerLinkActive="active"
-              class="tc_submenuitem tc_submenuitem_block_mirroring">
+              class="tc_submenuitem tc_submenuitem_block_mirroring"
+              *ngIf="permissions.rbdMirroring.read">
             <a i18n
                class="dropdown-item"
                routerLink="/mirroring/"> Mirroring
@@ -119,7 +128,8 @@
             </a>
           </li>
 
-          <li routerLinkActive="active">
+          <li routerLinkActive="active"
+              *ngIf="permissions.iscsi.read">
             <a i18n
                class="dropdown-item"
                routerLink="/block/iscsi">iSCSI</a>
@@ -130,7 +140,8 @@
 
       <!-- Filesystem -->
       <li routerLinkActive="active"
-          class="tc_menuitem tc_menuitem_cephs">
+          class="tc_menuitem tc_menuitem_cephs"
+          *ngIf="permissions.cephfs.read">
         <a i18n
            routerLink="/cephfs">Filesystems
         </a>
@@ -153,7 +164,8 @@
       <!-- Object Gateway -->
       <li dropdown
           routerLinkActive="active"
-          class="dropdown tc_menuitem tc_menuitem_rgw">
+          class="dropdown tc_menuitem tc_menuitem_rgw"
+          *ngIf="permissions.rgw.read">
         <a dropdownToggle
            class="dropdown-toggle"
            data-toggle="dropdown">

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+
+import { Permissions } from '../../../shared/models/permissions';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { SummaryService } from '../../../shared/services/summary.service';
 
 @Component({
@@ -7,10 +10,16 @@ import { SummaryService } from '../../../shared/services/summary.service';
   styleUrls: ['./navigation.component.scss']
 })
 export class NavigationComponent implements OnInit {
+  permissions: Permissions;
   summaryData: any;
   isCollapsed = true;
 
-  constructor(private summaryService: SummaryService) {}
+  constructor(
+    private authStorageService: AuthStorageService,
+    private summaryService: SummaryService
+  ) {
+    this.permissions = this.authStorageService.getPermissions();
+  }
 
   ngOnInit() {
     this.summaryService.summaryData$.subscribe((data: any) => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.ts
@@ -16,7 +16,7 @@ export class AuthService {
       .post('api/auth', credentials)
       .toPromise()
       .then((resp: Credentials) => {
-        this.authStorageService.set(resp.username);
+        this.authStorageService.set(resp.username, resp.permissions);
       });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/credentials.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/credentials.ts
@@ -1,5 +1,6 @@
 export class Credentials {
   username: string;
   password: string;
+  permissions: any;
   stay_signed_in = false;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/permissions.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/permissions.ts
@@ -1,0 +1,43 @@
+export class Permission {
+  read: boolean;
+  create: boolean;
+  update: boolean;
+  delete: boolean;
+
+  constructor(serverPermission: Array<string> = []) {
+    this.read = serverPermission.indexOf('read') !== -1;
+    this.create = serverPermission.indexOf('create') !== -1;
+    this.update = serverPermission.indexOf('update') !== -1;
+    this.delete = serverPermission.indexOf('delete') !== -1;
+  }
+}
+
+export class Permissions {
+  hosts: Permission;
+  configOpt: Permission;
+  pool: Permission;
+  osd: Permission;
+  monitor: Permission;
+  rbdImage: Permission;
+  iscsi: Permission;
+  rbdMirroring: Permission;
+  rgw: Permission;
+  cephfs: Permission;
+  manager: Permission;
+  log: Permission;
+
+  constructor(serverPermissions: any) {
+    this.hosts = new Permission(serverPermissions['hosts']);
+    this.configOpt = new Permission(serverPermissions['config-opt']);
+    this.pool = new Permission(serverPermissions['pool']);
+    this.osd = new Permission(serverPermissions['osd']);
+    this.monitor = new Permission(serverPermissions['monitor']);
+    this.rbdImage = new Permission(serverPermissions['rbd-image']);
+    this.iscsi = new Permission(serverPermissions['iscsi']);
+    this.rbdMirroring = new Permission(serverPermissions['rbd-mirroring']);
+    this.rgw = new Permission(serverPermissions['rgw']);
+    this.cephfs = new Permission(serverPermissions['cephfs']);
+    this.manager = new Permission(serverPermissions['manager']);
+    this.log = new Permission(serverPermissions['log']);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
@@ -56,6 +56,9 @@ export class ApiInterceptorService implements HttpInterceptor {
               this.authStorageService.remove();
               this.router.navigate(['/login']);
               break;
+            case 403:
+              this.router.navigate(['/403']);
+              break;
             case 404:
               this.router.navigate(['/404']);
               break;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-storage.service.ts
@@ -1,17 +1,17 @@
 import { Injectable } from '@angular/core';
 
+import { Permissions } from '../models/permissions';
 import { ServicesModule } from './services.module';
 
 @Injectable({
   providedIn: ServicesModule
 })
 export class AuthStorageService {
+  constructor() {}
 
-  constructor() {
-  }
-
-  set(username: string) {
+  set(username: string, permissions: any = {}) {
     localStorage.setItem('dashboard_username', username);
+    localStorage.setItem('dashboard_permissions', JSON.stringify(new Permissions(permissions)));
   }
 
   remove() {
@@ -22,4 +22,9 @@ export class AuthStorageService {
     return localStorage.getItem('dashboard_username') !== null;
   }
 
+  getPermissions(): Permissions {
+    return JSON.parse(
+      localStorage.getItem('dashboard_permissions') || JSON.stringify(new Permissions({}))
+    );
+  }
 }

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -58,10 +58,9 @@ if 'COVERAGE_ENABLED' in os.environ:
 # pylint: disable=wrong-import-position
 from . import logger, mgr
 from .controllers import generate_routes, json_error_page
-from .controllers.auth import Auth
 from .tools import SessionExpireAtBrowserCloseTool, NotificationQueue, \
                    RequestLoggingTool, TaskManager
-from .services.auth import AuthManager
+from .services.auth import AuthManager, AuthManagerTool
 from .services.access_control import ACCESS_CONTROL_COMMANDS, \
                                      handle_access_control_command
 from .services.exception import dashboard_exception_handler
@@ -127,7 +126,7 @@ class SSLCherryPyConfig(object):
                       server_port)
 
         # Initialize custom handlers.
-        cherrypy.tools.authenticate = cherrypy.Tool('before_handler', Auth.check_auth)
+        cherrypy.tools.authenticate = AuthManagerTool()
         cherrypy.tools.session_expire_at_browser_close = SessionExpireAtBrowserCloseTool()
         cherrypy.tools.request_logging = RequestLoggingTool()
         cherrypy.tools.dashboard_exception_handler = HandlerWrapperTool(dashboard_exception_handler,
@@ -210,13 +209,6 @@ class Module(MgrModule, SSLCherryPyConfig):
     """
 
     COMMANDS = [
-        {
-            'cmd': 'dashboard set-login-credentials '
-                   'name=username,type=CephString '
-                   'name=password,type=CephString',
-            'desc': 'Set the login credentials',
-            'perm': 'w'
-        },
         {
             'cmd': 'dashboard set-session-expire '
                    'name=seconds,type=CephInt',
@@ -325,9 +317,6 @@ class Module(MgrModule, SSLCherryPyConfig):
         res = handle_access_control_command(cmd)
         if res[0] != -errno.ENOSYS:
             return res
-        if cmd['prefix'] == 'dashboard set-login-credentials':
-            Auth.set_login_credentials(cmd['username'], cmd['password'])
-            return 0, 'Username and password updated', ''
         elif cmd['prefix'] == 'dashboard set-session-expire':
             self.set_config('session-expire', str(cmd['seconds']))
             return 0, 'Session expiration timeout updated', ''

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -61,6 +61,9 @@ from .controllers import generate_routes, json_error_page
 from .controllers.auth import Auth
 from .tools import SessionExpireAtBrowserCloseTool, NotificationQueue, \
                    RequestLoggingTool, TaskManager
+from .services.auth import AuthManager
+from .services.access_control import ACCESS_CONTROL_COMMANDS, \
+                                     handle_access_control_command
 from .services.exception import dashboard_exception_handler
 from .settings import options_command_list, options_schema_list, \
                       handle_option_command
@@ -227,6 +230,7 @@ class Module(MgrModule, SSLCherryPyConfig):
         },
     ]
     COMMANDS.extend(options_command_list())
+    COMMANDS.extend(ACCESS_CONTROL_COMMANDS)
 
     OPTIONS = [
         {'name': 'server_addr'},
@@ -267,6 +271,8 @@ class Module(MgrModule, SSLCherryPyConfig):
     def serve(self):
         if 'COVERAGE_ENABLED' in os.environ:
             _cov.start()
+
+        AuthManager.initialize()
 
         uri = self.await_configuration()
         if uri is None:
@@ -314,6 +320,9 @@ class Module(MgrModule, SSLCherryPyConfig):
 
     def handle_command(self, inbuf, cmd):
         res = handle_option_command(cmd)
+        if res[0] != -errno.ENOSYS:
+            return res
+        res = handle_access_control_command(cmd)
         if res[0] != -errno.ENOSYS:
             return res
         if cmd['prefix'] == 'dashboard set-login-credentials':

--- a/src/pybind/mgr/dashboard/security.py
+++ b/src/pybind/mgr/dashboard/security.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import inspect
+
+
+class Scope(object):
+    """
+    List of Dashboard Security Scopes.
+    If you need another security scope, please add it here.
+    """
+
+    HOSTS = "hosts"
+    CONFIG_OPT = "config-opt"
+    POOL = "pool"
+    OSD = "osd"
+    MONITOR = "monitor"
+    RBD_IMAGE = "rbd-image"
+    ISCSI = "iscsi"
+    RBD_MIRRORING = "rbd-mirroring"
+    RGW = "rgw"
+    CEPHFS = "cephfs"
+    MANAGER = "manager"
+    LOG = "log"
+    GRAFANA = "grafana"
+
+    @classmethod
+    def all_scopes(cls):
+        return [val for scope, val in
+                inspect.getmembers(cls,
+                                   lambda memb: not inspect.isroutine(memb))
+                if not scope.startswith('_')]
+
+    @classmethod
+    def valid_scope(cls, scope_name):
+        return scope_name in cls.all_scopes()
+
+
+class Permission(object):
+    """
+    Scope permissions types
+    """
+    READ = "read"
+    CREATE = "create"
+    UPDATE = "update"
+    DELETE = "delete"
+
+    @classmethod
+    def all_permissions(cls):
+        return [val for perm, val in
+                inspect.getmembers(cls,
+                                   lambda memb: not inspect.isroutine(memb))
+                if not perm.startswith('_')]
+
+    @classmethod
+    def valid_permission(cls, perm_name):
+        return perm_name in cls.all_permissions()

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -1,0 +1,664 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=too-many-arguments,too-many-return-statements
+# pylint: disable=too-many-branches, too-many-locals, too-many-statements
+from __future__ import absolute_import
+
+import errno
+import json
+import threading
+
+import bcrypt
+
+from .. import mgr, logger
+from ..security import Scope, Permission
+from ..exceptions import RoleAlreadyExists, RoleDoesNotExist, ScopeNotValid, \
+                         PermissionNotValid, RoleIsAssociatedWithUser, \
+                         UserAlreadyExists, UserDoesNotExist, ScopeNotInRole, \
+                         RoleNotInUser
+
+
+# password hashing algorithm
+def password_hash(password, salt_password=None):
+    if not salt_password:
+        salt_password = bcrypt.gensalt()
+    else:
+        salt_password = salt_password.encode('utf8')
+    return bcrypt.hashpw(password.encode('utf8'), salt_password).decode('utf8')
+
+
+_P = Permission  # short alias
+
+
+class Role(object):
+    def __init__(self, name, description=None, scope_permissions=None):
+        self.name = name
+        self.description = description
+        if scope_permissions is None:
+            self.scopes_permissions = {}
+        else:
+            self.scopes_permissions = scope_permissions
+
+    def __hash__(self):
+        return hash(self.name)
+
+    def __eq__(self, other):
+        return self.name == other.name
+
+    def set_scope_permissions(self, scope, permissions):
+        if not Scope.valid_scope(scope):
+            raise ScopeNotValid(scope)
+        for perm in permissions:
+            if not Permission.valid_permission(perm):
+                raise PermissionNotValid(perm)
+
+        permissions.sort()
+        self.scopes_permissions[scope] = permissions
+
+    def del_scope_permissions(self, scope):
+        if scope not in self.scopes_permissions:
+            raise ScopeNotInRole(scope, self.name)
+        del self.scopes_permissions[scope]
+
+    def authorize(self, scope, permissions):
+        if scope in self.scopes_permissions:
+            role_perms = self.scopes_permissions[scope]
+            for perm in permissions:
+                if perm not in role_perms:
+                    return False
+            return True
+        return False
+
+    def to_dict(self):
+        return {
+            'name': self.name,
+            'description': self.description,
+            'scopes_permissions': self.scopes_permissions
+        }
+
+    @classmethod
+    def from_dict(cls, r_dict):
+        return Role(r_dict['name'], r_dict['description'],
+                    r_dict['scopes_permissions'])
+
+
+# static pre-defined system roles
+# this roles cannot be deleted nor updated
+
+# admin role provides all permissions for all scopes
+ADMIN_ROLE = Role('administrator', 'Administrator', dict([
+    (scope_name, Permission.all_permissions())
+    for scope_name in Scope.all_scopes()
+]))
+
+
+# read-only role provides read-only permission for all scopes
+READ_ONLY_ROLE = Role('read-only', 'Read-Only', dict([
+    (scope_name, [_P.READ]) for scope_name in Scope.all_scopes()
+]))
+
+
+# block manager role provides all permission for block related scopes
+BLOCK_MGR_ROLE = Role('block-manager', 'Block Manager', {
+    Scope.RBD_IMAGE: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+    Scope.ISCSI: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+    Scope.RBD_MIRRORING: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+})
+
+
+# RadosGW manager role provides all permissions for block related scopes
+RGW_MGR_ROLE = Role('rgw-manager', 'RGW Manager', {
+    Scope.RGW: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+})
+
+
+# Cluster manager role provides all permission for OSDs, Monitors, and
+# Config options
+CLUSTER_MGR_ROLE = Role('cluster-manager', 'Cluster Manager', {
+    Scope.HOSTS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+    Scope.OSD: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+    Scope.MONITOR: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+    Scope.MANAGER: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+    Scope.CONFIG_OPT: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+    Scope.LOG: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+})
+
+
+# Pool manager role provides all permissions for pool related scopes
+POOL_MGR_ROLE = Role('pool-manager', 'Pool Manager', {
+    Scope.POOL: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+})
+
+# Pool manager role provides all permissions for CephFS related scopes
+CEPHFS_MGR_ROLE = Role('cephfs-manager', 'CephFS Manager', {
+    Scope.CEPHFS: [_P.READ, _P.CREATE, _P.UPDATE, _P.DELETE],
+})
+
+
+SYSTEM_ROLES = {
+    ADMIN_ROLE.name: ADMIN_ROLE,
+    READ_ONLY_ROLE.name: READ_ONLY_ROLE,
+    BLOCK_MGR_ROLE.name: BLOCK_MGR_ROLE,
+    RGW_MGR_ROLE.name: RGW_MGR_ROLE,
+    CLUSTER_MGR_ROLE.name: CLUSTER_MGR_ROLE,
+    POOL_MGR_ROLE.name: POOL_MGR_ROLE,
+    CEPHFS_MGR_ROLE.name: CEPHFS_MGR_ROLE,
+}
+
+
+class User(object):
+    def __init__(self, username, password, name=None, email=None, roles=None):
+        self.username = username
+        self.password = password
+        self.name = name
+        self.email = email
+        if roles is None:
+            self.roles = set()
+        else:
+            self.roles = roles
+
+    def set_password(self, password):
+        self.password = password_hash(password)
+
+    def set_roles(self, roles):
+        self.roles = set(roles)
+
+    def add_roles(self, roles):
+        self.roles = self.roles.union(set(roles))
+
+    def del_roles(self, roles):
+        for role in roles:
+            if role not in self.roles:
+                raise RoleNotInUser(role.name, self.username)
+        self.roles.difference_update(set(roles))
+
+    def authorize(self, scope, permissions):
+        for role in self.roles:
+            if role.authorize(scope, permissions):
+                return True
+        return False
+
+    def to_dict(self):
+        return {
+            'username': self.username,
+            'password': self.password,
+            'roles': sorted([r.name for r in self.roles]),
+            'name': self.name,
+            'email': self.email
+        }
+
+    @classmethod
+    def from_dict(cls, u_dict, roles):
+        return User(u_dict['username'], u_dict['password'], u_dict['name'],
+                    u_dict['email'], set([roles[r] for r in u_dict['roles']]))
+
+
+class AccessControlDB(object):
+    VERSION = 1
+    ACDB_CONFIG_KEY = "accessdb_v"
+
+    def __init__(self, version, users, roles):
+        self.users = users
+        self.version = version
+        self.roles = roles
+        self.lock = threading.RLock()
+
+    def create_role(self, name, description=None):
+        with self.lock:
+            if name in SYSTEM_ROLES or name in self.roles:
+                raise RoleAlreadyExists(name)
+            role = Role(name, description)
+            self.roles[name] = role
+            return role
+
+    def get_role(self, name):
+        with self.lock:
+            if name not in self.roles:
+                raise RoleDoesNotExist(name)
+            return self.roles[name]
+
+    def delete_role(self, name):
+        with self.lock:
+            if name not in self.roles:
+                raise RoleDoesNotExist(name)
+            role = self.roles[name]
+
+            # check if role is not associated with a user
+            for username, user in self.users.items():
+                if role in user.roles:
+                    raise RoleIsAssociatedWithUser(name, username)
+
+            del self.roles[name]
+
+    def create_user(self, username, password, name, email):
+        logger.debug("AC: creating user: username=%s", username)
+        with self.lock:
+            if username in self.users:
+                raise UserAlreadyExists(username)
+            user = User(username, password_hash(password), name, email)
+            self.users[username] = user
+            return user
+
+    def get_user(self, username):
+        with self.lock:
+            if username not in self.users:
+                raise UserDoesNotExist(username)
+            return self.users[username]
+
+    def delete_user(self, username):
+        with self.lock:
+            if username not in self.users:
+                raise UserDoesNotExist(username)
+            del self.users[username]
+
+    def save(self):
+        with self.lock:
+            db = {
+                'users': dict([(un, u.to_dict()) for un, u in self.users.items()]),
+                'roles': dict([(rn, r.to_dict()) for rn, r in self.roles.items()]),
+                'version': self.version
+            }
+            mgr.set_store(self.accessdb_config_key(), json.dumps(db))
+
+    @classmethod
+    def accessdb_config_key(cls, version=None):
+        if version is None:
+            version = cls.VERSION
+        return "{}{}".format(cls.ACDB_CONFIG_KEY, version)
+
+    def check_and_update_db(self):
+        logger.debug("AC: Checking for previews DB versions")
+        if self.VERSION == 1:  # current version
+            # check if there is username/password from previous version
+            username = mgr.get_config('username', None)
+            password = mgr.get_config('password', None)
+            if username and password:
+                logger.debug("AC: Found single user credentials: user=%s",
+                             username)
+                # found user credentials
+                user = self.create_user(username, "", None, None)
+                # password is already hashed, so setting manually
+                user.password = password
+                user.add_roles([ADMIN_ROLE])
+                self.save()
+        else:
+            raise NotImplementedError()
+
+    @classmethod
+    def load(cls):
+        logger.info("AC: Loading user roles DB version=%s", cls.VERSION)
+
+        json_db = mgr.get_store(cls.accessdb_config_key(), None)
+        if json_db is None:
+            logger.debug("AC: No DB v%s found, creating new...", cls.VERSION)
+            db = cls(cls.VERSION, {}, {})
+            # check if we can update from a previous version database
+            db.check_and_update_db()
+            return db
+
+        db = json.loads(json_db)
+        roles = dict([(rn, Role.from_dict(r))
+                      for rn, r in db.get('roles', {}).items()])
+        users = dict([(un, User.from_dict(u, dict(roles, **SYSTEM_ROLES)))
+                      for un, u in db.get('users', {}).items()])
+        return cls(db['version'], users, roles)
+
+
+ACCESS_CTRL_DB = None
+
+
+def load_access_control_db():
+    # pylint: disable=W0603
+    global ACCESS_CTRL_DB
+    ACCESS_CTRL_DB = AccessControlDB.load()
+
+
+# CLI dashboard access controll scope commands
+ACCESS_CONTROL_COMMANDS = [
+    # for backwards compatibility
+    {
+        'cmd': 'dashboard set-login-credentials '
+               'name=username,type=CephString '
+               'name=password,type=CephString',
+        'desc': 'Set the login credentials',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-role-show '
+               'name=rolename,type=CephString,req=false',
+        'desc': 'Show role info',
+        'perm': 'r'
+    },
+    {
+        'cmd': 'dashboard ac-role-create '
+               'name=rolename,type=CephString '
+               'name=description,type=CephString,req=false',
+        'desc': 'Create a new access control role',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-role-delete '
+               'name=rolename,type=CephString',
+        'desc': 'Delete an access control role',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-role-add-scope-perms '
+               'name=rolename,type=CephString '
+               'name=scopename,type=CephString '
+               'name=permissions,type=CephString,n=N',
+        'desc': 'Add the scope permissions for a role',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-role-del-scope-perms '
+               'name=rolename,type=CephString '
+               'name=scopename,type=CephString',
+        'desc': 'Delete the scope permissions for a role',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-user-show '
+               'name=username,type=CephString,req=false',
+        'desc': 'Show user info',
+        'perm': 'r'
+    },
+    {
+        'cmd': 'dashboard ac-user-create '
+               'name=username,type=CephString '
+               'name=password,type=CephString '
+               'name=rolename,type=CephString,req=false '
+               'name=name,type=CephString,req=false '
+               'name=email,type=CephString,req=false',
+        'desc': 'Create a user',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-user-delete '
+               'name=username,type=CephString',
+        'desc': 'Delete user',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-user-set-roles '
+               'name=username,type=CephString '
+               'name=roles,type=CephString,n=N',
+        'desc': 'Set user roles',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-user-add-roles '
+               'name=username,type=CephString '
+               'name=roles,type=CephString,n=N',
+        'desc': 'Add roles to user',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-user-del-roles '
+               'name=username,type=CephString '
+               'name=roles,type=CephString,n=N',
+        'desc': 'Delete roles from user',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-user-set-password '
+               'name=username,type=CephString '
+               'name=password,type=CephString',
+        'desc': 'Set user password',
+        'perm': 'w'
+    },
+    {
+        'cmd': 'dashboard ac-user-set-info '
+               'name=username,type=CephString '
+               'name=name,type=CephString '
+               'name=email,type=CephString',
+        'desc': 'Set user info',
+        'perm': 'w'
+    }
+]
+
+
+def handle_access_control_command(cmd):
+    if cmd['prefix'] == 'dashboard set-login-credentials':
+        username = cmd['username']
+        password = cmd['password']
+        try:
+            user = ACCESS_CTRL_DB.get_user(username)
+            user.set_password(password)
+        except UserDoesNotExist:
+            user = ACCESS_CTRL_DB.create_user(username, password, None, None)
+            user.set_roles([ADMIN_ROLE])
+
+        ACCESS_CTRL_DB.save()
+
+        return 0, '''\
+******************************************************************
+***          WARNING: this command is deprecated.              ***
+*** Please use the ac-user-* related commands to manage users. ***
+******************************************************************
+Username and password updated''', ''
+
+    if cmd['prefix'] == 'dashboard ac-role-show':
+        rolename = cmd['rolename'] if 'rolename' in cmd else None
+        if not rolename:
+            roles = dict(ACCESS_CTRL_DB.roles)
+            roles.update(SYSTEM_ROLES)
+            roles_list = [name for name, _ in roles.items()]
+            return 0, json.dumps(roles_list), ''
+        try:
+            role = ACCESS_CTRL_DB.get_role(rolename)
+        except RoleDoesNotExist as ex:
+            if rolename not in SYSTEM_ROLES:
+                return -errno.ENOENT, '', str(ex)
+            role = SYSTEM_ROLES[rolename]
+        return 0, json.dumps(role.to_dict()), ''
+
+    elif cmd['prefix'] == 'dashboard ac-role-create':
+        rolename = cmd['rolename']
+        description = cmd['description'] if 'description' in cmd else None
+        try:
+            role = ACCESS_CTRL_DB.create_role(rolename, description)
+            ACCESS_CTRL_DB.save()
+            return 0, json.dumps(role.to_dict()), ''
+        except RoleAlreadyExists as ex:
+            return -errno.EEXIST, '', str(ex)
+
+    elif cmd['prefix'] == 'dashboard ac-role-delete':
+        rolename = cmd['rolename']
+        try:
+            ACCESS_CTRL_DB.delete_role(rolename)
+            ACCESS_CTRL_DB.save()
+            return 0, "Role '{}' deleted".format(rolename), ""
+        except RoleDoesNotExist as ex:
+            if rolename in SYSTEM_ROLES:
+                return -errno.EPERM, '', "Cannot delete system role '{}'" \
+                                         .format(rolename)
+            return -errno.ENOENT, '', str(ex)
+        except RoleIsAssociatedWithUser as ex:
+            return -errno.EPERM, '', str(ex)
+
+    elif cmd['prefix'] == 'dashboard ac-role-add-scope-perms':
+        rolename = cmd['rolename']
+        scopename = cmd['scopename']
+        permissions = cmd['permissions']
+        try:
+            role = ACCESS_CTRL_DB.get_role(rolename)
+            perms_array = [perm.strip() for perm in permissions]
+            role.set_scope_permissions(scopename, perms_array)
+            ACCESS_CTRL_DB.save()
+            return 0, json.dumps(role.to_dict()), ''
+        except RoleDoesNotExist as ex:
+            if rolename in SYSTEM_ROLES:
+                return -errno.EPERM, '', "Cannot update system role '{}'" \
+                                         .format(rolename)
+            return -errno.ENOENT, '', str(ex)
+        except ScopeNotValid as ex:
+            return -errno.EINVAL, '', str(ex) + "\n Possible values: {}" \
+                                                .format(Scope.all_scopes())
+        except PermissionNotValid as ex:
+            return -errno.EINVAL, '', str(ex) + \
+                                      "\n Possible values: {}" \
+                                      .format(Permission.all_permissions())
+
+    elif cmd['prefix'] == 'dashboard ac-role-del-scope-perms':
+        rolename = cmd['rolename']
+        scopename = cmd['scopename']
+        try:
+            role = ACCESS_CTRL_DB.get_role(rolename)
+            role.del_scope_permissions(scopename)
+            ACCESS_CTRL_DB.save()
+            return 0, json.dumps(role.to_dict()), ''
+        except RoleDoesNotExist as ex:
+            if rolename in SYSTEM_ROLES:
+                return -errno.EPERM, '', "Cannot update system role '{}'" \
+                                         .format(rolename)
+            return -errno.ENOENT, '', str(ex)
+        except ScopeNotInRole as ex:
+            return -errno.ENOENT, '', str(ex)
+
+    elif cmd['prefix'] == 'dashboard ac-user-show':
+        username = cmd['username'] if 'username' in cmd else None
+        if not username:
+            users = ACCESS_CTRL_DB.users
+            users_list = [name for name, _ in users.items()]
+            return 0, json.dumps(users_list), ''
+        try:
+            user = ACCESS_CTRL_DB.get_user(username)
+            return 0, json.dumps(user.to_dict()), ''
+        except UserDoesNotExist as ex:
+            return -errno.ENOENT, '', str(ex)
+
+    elif cmd['prefix'] == 'dashboard ac-user-create':
+        username = cmd['username']
+        password = cmd['password']
+        rolename = cmd['rolename'] if 'rolename' in cmd else None
+        name = cmd['name'] if 'name' in cmd else None
+        email = cmd['email'] if 'email' in cmd else None
+        try:
+            user = ACCESS_CTRL_DB.create_user(username, password, name, email)
+            role = ACCESS_CTRL_DB.get_role(rolename) if rolename else None
+        except UserAlreadyExists as ex:
+            return -errno.EEXIST, '', str(ex)
+        except RoleDoesNotExist as ex:
+            if rolename not in SYSTEM_ROLES:
+                return -errno.ENOENT, '', str(ex)
+            role = SYSTEM_ROLES[rolename]
+
+        if role:
+            user.set_roles([role])
+        ACCESS_CTRL_DB.save()
+        return 0, json.dumps(user.to_dict()), ''
+
+    elif cmd['prefix'] == 'dashboard ac-user-delete':
+        username = cmd['username']
+        try:
+            ACCESS_CTRL_DB.delete_user(username)
+            ACCESS_CTRL_DB.save()
+            return 0, "User '{}' deleted".format(username), ""
+        except UserDoesNotExist as ex:
+            return -errno.ENOENT, '', str(ex)
+
+    elif cmd['prefix'] == 'dashboard ac-user-set-roles':
+        username = cmd['username']
+        rolesname = cmd['roles']
+        roles = []
+        for rolename in rolesname:
+            try:
+                roles.append(ACCESS_CTRL_DB.get_role(rolename))
+            except RoleDoesNotExist as ex:
+                if rolename not in SYSTEM_ROLES:
+                    return -errno.ENOENT, '', str(ex)
+                roles.append(SYSTEM_ROLES[rolename])
+        try:
+            user = ACCESS_CTRL_DB.get_user(username)
+            user.set_roles(roles)
+            ACCESS_CTRL_DB.save()
+            return 0, json.dumps(user.to_dict()), ''
+        except UserDoesNotExist as ex:
+            return -errno.ENOENT, '', str(ex)
+
+    elif cmd['prefix'] == 'dashboard ac-user-add-roles':
+        username = cmd['username']
+        rolesname = cmd['roles']
+        roles = []
+        for rolename in rolesname:
+            try:
+                roles.append(ACCESS_CTRL_DB.get_role(rolename))
+            except RoleDoesNotExist as ex:
+                if rolename not in SYSTEM_ROLES:
+                    return -errno.ENOENT, '', str(ex)
+                roles.append(SYSTEM_ROLES[rolename])
+        try:
+            user = ACCESS_CTRL_DB.get_user(username)
+            user.add_roles(roles)
+            ACCESS_CTRL_DB.save()
+            return 0, json.dumps(user.to_dict()), ''
+        except UserDoesNotExist as ex:
+            return -errno.ENOENT, '', str(ex)
+
+    elif cmd['prefix'] == 'dashboard ac-user-del-roles':
+        username = cmd['username']
+        rolesname = cmd['roles']
+        roles = []
+        for rolename in rolesname:
+            try:
+                roles.append(ACCESS_CTRL_DB.get_role(rolename))
+            except RoleDoesNotExist as ex:
+                if rolename not in SYSTEM_ROLES:
+                    return -errno.ENOENT, '', str(ex)
+                roles.append(SYSTEM_ROLES[rolename])
+        try:
+            user = ACCESS_CTRL_DB.get_user(username)
+            user.del_roles(roles)
+            ACCESS_CTRL_DB.save()
+            return 0, json.dumps(user.to_dict()), ''
+        except UserDoesNotExist as ex:
+            return -errno.ENOENT, '', str(ex)
+        except RoleNotInUser as ex:
+            return -errno.ENOENT, '', str(ex)
+
+    elif cmd['prefix'] == 'dashboard ac-user-set-password':
+        username = cmd['username']
+        password = cmd['password']
+        try:
+            user = ACCESS_CTRL_DB.get_user(username)
+            user.set_password(password)
+
+            ACCESS_CTRL_DB.save()
+            return 0, json.dumps(user.to_dict()), ''
+        except UserDoesNotExist as ex:
+            return -errno.ENOENT, '', str(ex)
+
+    elif cmd['prefix'] == 'dashboard ac-user-set-info':
+        username = cmd['username']
+        name = cmd['name']
+        email = cmd['email']
+        try:
+            user = ACCESS_CTRL_DB.get_user(username)
+            if name:
+                user.name = name
+            if email:
+                user.email = email
+            ACCESS_CTRL_DB.save()
+            return 0, json.dumps(user.to_dict()), ''
+        except UserDoesNotExist as ex:
+            return -errno.ENOENT, '', str(ex)
+
+    return -errno.ENOSYS, '', ''
+
+
+class LocalAuthenticator(object):
+    def __init__(self):
+        load_access_control_db()
+
+    def authenticate(self, username, password):
+        try:
+            user = ACCESS_CTRL_DB.get_user(username)
+            pass_hash = password_hash(password, user.password)
+            return pass_hash == user.password
+        except UserDoesNotExist:
+            logger.debug("User '%s' does not exist", username)
+            return False
+
+    def authorize(self, username, scope, permissions):
+        user = ACCESS_CTRL_DB.get_user(username)
+        return user.authorize(scope, permissions)

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import time
+
+import cherrypy
+
+from .access_control import LocalAuthenticator
+from .. import mgr, logger
+from ..tools import Session
+
+
+class AuthManager(object):
+    AUTH_PROVIDER = None
+
+    @classmethod
+    def initialize(cls):
+        cls.AUTH_PROVIDER = LocalAuthenticator()
+
+    @classmethod
+    def authenticate(cls, username, password):
+        return cls.AUTH_PROVIDER.authenticate(username, password)
+
+    @classmethod
+    def authorize(cls, username, scope, permissions):
+        return cls.AUTH_PROVIDER.authorize(username, scope, permissions)
+
+
+class AuthManagerTool(cherrypy.Tool):
+    def __init__(self):
+        super(AuthManagerTool, self).__init__(
+            'before_handler', self._check_authentication, priority=20)
+
+    def _check_authentication(self):
+        username = cherrypy.session.get(Session.USERNAME)
+        if not username:
+            logger.debug('Unauthorized access to %s',
+                         cherrypy.url(relative='server'))
+            raise cherrypy.HTTPError(401, 'You are not authorized to access '
+                                          'that resource')
+        now = time.time()
+        expires = float(mgr.get_config(
+            'session-expire', Session.DEFAULT_EXPIRE))
+        if expires > 0:
+            username_ts = cherrypy.session.get(Session.TS, None)
+            if username_ts and float(username_ts) < (now - expires):
+                cherrypy.session[Session.USERNAME] = None
+                cherrypy.session[Session.TS] = None
+                logger.debug('Session expired')
+                raise cherrypy.HTTPError(401,
+                                         'Session expired. You are not '
+                                         'authorized to access that resource')
+        cherrypy.session[Session.TS] = now
+
+        self._check_authorization(username)
+
+    def _check_authorization(self, username):
+        logger.debug("AMT: checking authorization...")
+        handler = cherrypy.request.handler.callable
+        controller = handler.__self__
+        sec_scope = getattr(controller, '_security_scope', None)
+        sec_perms = getattr(handler, '_security_permissions', None)
+        logger.debug("AMT: checking %s access to '%s' scope", sec_perms,
+                     sec_scope)
+
+        if not sec_scope:
+            # controller does not define any authorization restrictions
+            return
+
+        if not sec_perms:
+            logger.debug("Fail to check permission on: %s:%s", controller,
+                         handler)
+            raise cherrypy.HTTPError(403, "You don't have permissions to "
+                                          "access that resource")
+
+        if not AuthManager.authorize(username, sec_scope, sec_perms):
+            raise cherrypy.HTTPError(403, "You don't have permissions to "
+                                          "access that resource")

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -12,7 +12,7 @@ from cherrypy.test import helper
 
 from .. import logger
 from ..controllers import json_error_page, generate_controller_routes
-from ..controllers.auth import Auth
+from ..services.auth import AuthManagerTool
 from ..services.exception import dashboard_exception_handler
 from ..tools import SessionExpireAtBrowserCloseTool
 
@@ -31,7 +31,7 @@ class ControllerTestCase(helper.CPWebCase):
             base_url: {'request.dispatch': mapper}})
 
     def __init__(self, *args, **kwargs):
-        cherrypy.tools.authenticate = cherrypy.Tool('before_handler', Auth.check_auth)
+        cherrypy.tools.authenticate = AuthManagerTool()
         cherrypy.tools.session_expire_at_browser_close = SessionExpireAtBrowserCloseTool()
         cherrypy.tools.dashboard_exception_handler = HandlerWrapperTool(dashboard_exception_handler,
                                                                         priority=31)

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -11,8 +11,8 @@ from cherrypy._cptools import HandlerWrapperTool
 from cherrypy.test import helper
 
 from .. import logger
-from ..controllers.auth import Auth
 from ..controllers import json_error_page, generate_controller_routes
+from ..controllers.auth import Auth
 from ..services.exception import dashboard_exception_handler
 from ..tools import SessionExpireAtBrowserCloseTool
 

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -23,8 +23,15 @@ class ControllerTestCase(helper.CPWebCase):
         if not isinstance(ctrl_classes, list):
             ctrl_classes = [ctrl_classes]
         mapper = cherrypy.dispatch.RoutesDispatcher()
+        endpoint_list = []
         for ctrl in ctrl_classes:
-            generate_controller_routes(ctrl, mapper, base_url)
+            inst = ctrl()
+            for endpoint in ctrl.endpoints():
+                endpoint.inst = inst
+                endpoint_list.append(endpoint)
+        endpoint_list = sorted(endpoint_list, key=lambda e: e.url)
+        for endpoint in endpoint_list:
+            generate_controller_routes(endpoint, mapper, base_url)
         if base_url == '':
             base_url = '/'
         cherrypy.tree.mount(None, config={

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -1,0 +1,612 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=dangerous-default-value,too-many-public-methods
+from __future__ import absolute_import
+
+import errno
+import json
+import unittest
+
+from .. import mgr
+from ..security import Scope, Permission
+from ..services.access_control import handle_access_control_command, \
+                                      load_access_control_db, \
+                                      password_hash, AccessControlDB, \
+                                      SYSTEM_ROLES
+
+
+class CmdException(Exception):
+    def __init__(self, retcode, message):
+        super(CmdException, self).__init__(message)
+        self.retcode = retcode
+
+
+class AccessControlTest(unittest.TestCase):
+    CONFIG_KEY_DICT = {}
+
+    @classmethod
+    def mock_set_config(cls, attr, val):
+        cls.CONFIG_KEY_DICT[attr] = val
+
+    @classmethod
+    def mock_get_config(cls, attr, default):
+        return cls.CONFIG_KEY_DICT.get(attr, default)
+
+    @classmethod
+    def setUpClass(cls):
+        mgr.set_config.side_effect = cls.mock_set_config
+        mgr.get_config.side_effect = cls.mock_get_config
+        mgr.set_store.side_effect = cls.mock_set_config
+        mgr.get_store.side_effect = cls.mock_get_config
+
+    def setUp(self):
+        self.CONFIG_KEY_DICT.clear()
+        load_access_control_db()
+
+    @classmethod
+    def exec_cmd(cls, cmd, **kwargs):
+        cmd_dict = {'prefix': 'dashboard {}'.format(cmd)}
+        cmd_dict.update(kwargs)
+        ret, out, err = handle_access_control_command(cmd_dict)
+        if ret < 0:
+            raise CmdException(ret, err)
+        try:
+            return json.loads(out)
+        except ValueError:
+            return out
+
+    def load_persistent_db(self):
+        config_key = AccessControlDB.accessdb_config_key()
+        self.assertIn(config_key, self.CONFIG_KEY_DICT)
+        db_json = self.CONFIG_KEY_DICT[config_key]
+        db = json.loads(db_json)
+        return db
+
+    def validate_persistent_role(self, rolename, scopes_permissions,
+                                 description=None):
+        db = self.load_persistent_db()
+        self.assertIn('roles', db)
+        self.assertIn(rolename, db['roles'])
+        self.assertEqual(db['roles'][rolename]['name'], rolename)
+        self.assertEqual(db['roles'][rolename]['description'], description)
+        self.assertDictEqual(db['roles'][rolename]['scopes_permissions'],
+                             scopes_permissions)
+
+    def validate_persistent_no_role(self, rolename):
+        db = self.load_persistent_db()
+        self.assertIn('roles', db)
+        self.assertNotIn(rolename, db['roles'])
+
+    def validate_persistent_user(self, username, roles, password=None,
+                                 name=None, email=None):
+        db = self.load_persistent_db()
+        self.assertIn('users', db)
+        self.assertIn(username, db['users'])
+        self.assertEqual(db['users'][username]['username'], username)
+        self.assertListEqual(db['users'][username]['roles'], roles)
+        if password:
+            self.assertEqual(db['users'][username]['password'], password)
+        if name:
+            self.assertEqual(db['users'][username]['name'], name)
+        if email:
+            self.assertEqual(db['users'][username]['email'], email)
+
+    def validate_persistent_no_user(self, username):
+        db = self.load_persistent_db()
+        self.assertIn('users', db)
+        self.assertNotIn(username, db['users'])
+
+    def test_create_role(self):
+        role = self.exec_cmd('ac-role-create', rolename='test_role')
+        self.assertDictEqual(role, {'name': 'test_role', 'description': None,
+                                    'scopes_permissions': {}})
+        self.validate_persistent_role('test_role', {})
+
+    def test_create_role_with_desc(self):
+        role = self.exec_cmd('ac-role-create', rolename='test_role',
+                             description='Test Role')
+        self.assertDictEqual(role, {'name': 'test_role',
+                                    'description': 'Test Role',
+                                    'scopes_permissions': {}})
+        self.validate_persistent_role('test_role', {}, 'Test Role')
+
+    def test_create_duplicate_role(self):
+        self.test_create_role()
+
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-create', rolename='test_role')
+
+        self.assertEqual(ctx.exception.retcode, -errno.EEXIST)
+        self.assertEqual(str(ctx.exception), "Role 'test_role' already exists")
+
+    def test_delete_role(self):
+        self.test_create_role()
+        out = self.exec_cmd('ac-role-delete', rolename='test_role')
+        self.assertEqual(out, "Role 'test_role' deleted")
+        self.validate_persistent_no_role('test_role')
+
+    def test_delete_nonexistent_role(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-delete', rolename='test_role')
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "Role 'test_role' does not exist")
+
+    def test_show_single_role(self):
+        self.test_create_role()
+        role = self.exec_cmd('ac-role-show', rolename='test_role')
+        self.assertDictEqual(role, {'name': 'test_role', 'description': None,
+                                    'scopes_permissions': {}})
+
+    def test_show_nonexistent_role(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-show', rolename='test_role')
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "Role 'test_role' does not exist")
+
+    def test_show_system_roles(self):
+        roles = self.exec_cmd('ac-role-show')
+        self.assertEqual(len(roles), len(SYSTEM_ROLES))
+        for role in roles:
+            self.assertIn(role, SYSTEM_ROLES)
+
+    def test_show_system_role(self):
+        role = self.exec_cmd('ac-role-show', rolename="read-only")
+        self.assertEqual(role['name'], 'read-only')
+        self.assertEqual(role['description'], 'Read-Only')
+
+    def test_delete_system_role(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-delete', rolename='administrator')
+
+        self.assertEqual(ctx.exception.retcode, -errno.EPERM)
+        self.assertEqual(str(ctx.exception),
+                         "Cannot delete system role 'administrator'")
+
+    def test_add_role_scope_perms(self):
+        self.test_create_role()
+        self.exec_cmd('ac-role-add-scope-perms', rolename='test_role',
+                      scopename=Scope.POOL,
+                      permissions=[Permission.READ, Permission.DELETE])
+        role = self.exec_cmd('ac-role-show', rolename='test_role')
+        self.assertDictEqual(role, {'name': 'test_role',
+                                    'description': None,
+                                    'scopes_permissions': {
+                                        Scope.POOL: [Permission.DELETE,
+                                                     Permission.READ]
+                                    }})
+        self.validate_persistent_role('test_role', {
+            Scope.POOL: [Permission.DELETE, Permission.READ]
+        })
+
+    def test_del_role_scope_perms(self):
+        self.test_add_role_scope_perms()
+        self.exec_cmd('ac-role-add-scope-perms', rolename='test_role',
+                      scopename=Scope.MONITOR,
+                      permissions=[Permission.READ, Permission.CREATE])
+        self.validate_persistent_role('test_role', {
+            Scope.POOL: [Permission.DELETE, Permission.READ],
+            Scope.MONITOR: [Permission.CREATE, Permission.READ]
+        })
+        self.exec_cmd('ac-role-del-scope-perms', rolename='test_role',
+                      scopename=Scope.POOL)
+        role = self.exec_cmd('ac-role-show', rolename='test_role')
+        self.assertDictEqual(role, {'name': 'test_role',
+                                    'description': None,
+                                    'scopes_permissions': {
+                                        Scope.MONITOR: [Permission.CREATE,
+                                                        Permission.READ]
+                                    }})
+        self.validate_persistent_role('test_role', {
+            Scope.MONITOR: [Permission.CREATE, Permission.READ]
+        })
+
+    def test_add_role_scope_perms_nonexistent_role(self):
+
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-add-scope-perms', rolename='test_role',
+                          scopename='pool',
+                          permissions=['read', 'delete'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "Role 'test_role' does not exist")
+
+    def test_add_role_invalid_scope_perms(self):
+        self.test_create_role()
+
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-add-scope-perms', rolename='test_role',
+                          scopename='invalidscope',
+                          permissions=['read', 'delete'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.EINVAL)
+        self.assertEqual(str(ctx.exception),
+                         "Scope 'invalidscope' is not valid\n Possible values: "
+                         "{}".format(Scope.all_scopes()))
+
+    def test_add_role_scope_invalid_perms(self):
+        self.test_create_role()
+
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-add-scope-perms', rolename='test_role',
+                          scopename='pool', permissions=['invalidperm'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.EINVAL)
+        self.assertEqual(str(ctx.exception),
+                         "Permission 'invalidperm' is not valid\n Possible "
+                         "values: {}".format(Permission.all_permissions()))
+
+    def test_del_role_scope_perms_nonexistent_role(self):
+
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-del-scope-perms', rolename='test_role',
+                          scopename='pool')
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "Role 'test_role' does not exist")
+
+    def test_del_role_nonexistent_scope_perms(self):
+        self.test_add_role_scope_perms()
+
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-del-scope-perms', rolename='test_role',
+                          scopename='nonexistentscope')
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception),
+                         "There are no permissions for scope 'nonexistentscope' "
+                         "in role 'test_role'")
+
+    def test_not_permitted_add_role_scope_perms(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-add-scope-perms', rolename='read-only',
+                          scopename='pool', permissions=['read', 'delete'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.EPERM)
+        self.assertEqual(str(ctx.exception),
+                         "Cannot update system role 'read-only'")
+
+    def test_not_permitted_del_role_scope_perms(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-del-scope-perms', rolename='read-only',
+                          scopename='pool')
+
+        self.assertEqual(ctx.exception.retcode, -errno.EPERM)
+        self.assertEqual(str(ctx.exception),
+                         "Cannot update system role 'read-only'")
+
+    def test_create_user(self, username='admin', rolename=None):
+        user = self.exec_cmd('ac-user-create', username=username,
+                             rolename=rolename, password='admin',
+                             name='{} User'.format(username),
+                             email='{}@user.com'.format(username))
+
+        pass_hash = password_hash('admin', user['password'])
+        self.assertDictEqual(user, {
+            'username': username,
+            'password': pass_hash,
+            'name': '{} User'.format(username),
+            'email': '{}@user.com'.format(username),
+            'roles': [rolename] if rolename else []
+        })
+        self.validate_persistent_user(username, [rolename] if rolename else [],
+                                      pass_hash, '{} User'.format(username),
+                                      '{}@user.com'.format(username))
+
+    def test_create_user_with_role(self):
+        self.test_add_role_scope_perms()
+        self.test_create_user(rolename='test_role')
+
+    def test_create_user_with_system_role(self):
+        self.test_create_user(rolename='administrator')
+
+    def test_delete_user(self):
+        self.test_create_user()
+        out = self.exec_cmd('ac-user-delete', username='admin')
+        self.assertEqual(out, "User 'admin' deleted")
+        users = self.exec_cmd('ac-user-show')
+        self.assertEqual(len(users), 0)
+        self.validate_persistent_no_user('admin')
+
+    def test_create_duplicate_user(self):
+        self.test_create_user()
+
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-create', username='admin', password='admin')
+
+        self.assertEqual(ctx.exception.retcode, -errno.EEXIST)
+        self.assertEqual(str(ctx.exception), "User 'admin' already exists")
+
+    def test_delete_nonexistent_user(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-delete', username='admin')
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "User 'admin' does not exist")
+
+    def test_add_user_roles(self, username='admin',
+                            roles=['pool-manager', 'block-manager']):
+        self.test_create_user(username)
+        uroles = []
+        for role in roles:
+            uroles.append(role)
+            uroles.sort()
+            user = self.exec_cmd('ac-user-add-roles', username=username,
+                                 roles=[role])
+            self.assertDictContainsSubset({'roles': uroles}, user)
+        self.validate_persistent_user(username, uroles)
+
+    def test_add_user_roles2(self):
+        self.test_create_user()
+        user = self.exec_cmd('ac-user-add-roles', username="admin",
+                             roles=['pool-manager', 'block-manager'])
+        self.assertDictContainsSubset(
+            {'roles': ['block-manager', 'pool-manager']}, user)
+        self.validate_persistent_user('admin', ['block-manager',
+                                                'pool-manager'])
+
+    def test_add_user_roles_not_existent_user(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-add-roles', username="admin",
+                          roles=['pool-manager', 'block-manager'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "User 'admin' does not exist")
+
+    def test_add_user_roles_not_existent_role(self):
+        self.test_create_user()
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-add-roles', username="admin",
+                          roles=['Invalid Role'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception),
+                         "Role 'Invalid Role' does not exist")
+
+    def test_set_user_roles(self):
+        self.test_create_user()
+        user = self.exec_cmd('ac-user-add-roles', username="admin",
+                             roles=['pool-manager'])
+        self.assertDictContainsSubset(
+            {'roles': ['pool-manager']}, user)
+        self.validate_persistent_user('admin', ['pool-manager'])
+        user = self.exec_cmd('ac-user-set-roles', username="admin",
+                             roles=['rgw-manager', 'block-manager'])
+        self.assertDictContainsSubset(
+            {'roles': ['block-manager', 'rgw-manager']}, user)
+        self.validate_persistent_user('admin', ['block-manager',
+                                                'rgw-manager'])
+
+    def test_set_user_roles_not_existent_user(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-set-roles', username="admin",
+                          roles=['pool-manager', 'block-manager'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "User 'admin' does not exist")
+
+    def test_set_user_roles_not_existent_role(self):
+        self.test_create_user()
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-set-roles', username="admin",
+                          roles=['Invalid Role'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception),
+                         "Role 'Invalid Role' does not exist")
+
+    def test_del_user_roles(self):
+        self.test_add_user_roles()
+        user = self.exec_cmd('ac-user-del-roles', username="admin",
+                             roles=['pool-manager'])
+        self.assertDictContainsSubset(
+            {'roles': ['block-manager']}, user)
+        self.validate_persistent_user('admin', ['block-manager'])
+
+    def test_del_user_roles_not_existent_user(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-del-roles', username="admin",
+                          roles=['pool-manager', 'block-manager'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "User 'admin' does not exist")
+
+    def test_del_user_roles_not_existent_role(self):
+        self.test_create_user()
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-del-roles', username="admin",
+                          roles=['Invalid Role'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception),
+                         "Role 'Invalid Role' does not exist")
+
+    def test_del_user_roles_not_associated_role(self):
+        self.test_create_user()
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-del-roles', username="admin",
+                          roles=['rgw-manager'])
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception),
+                         "Role 'rgw-manager' is not associated with user "
+                         "'admin'")
+
+    def test_show_user(self):
+        self.test_add_user_roles()
+        user = self.exec_cmd('ac-user-show', username='admin')
+        pass_hash = password_hash('admin', user['password'])
+        self.assertDictEqual(user, {
+            'username': 'admin',
+            'password': pass_hash,
+            'name': 'admin User',
+            'email': 'admin@user.com',
+            'roles': ['block-manager', 'pool-manager']
+        })
+
+    def test_show_nonexistent_user(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-show', username='admin')
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "User 'admin' does not exist")
+
+    def test_show_all_users(self):
+        self.test_add_user_roles('admin', ['administrator'])
+        self.test_add_user_roles('guest', ['read-only'])
+        users = self.exec_cmd('ac-user-show')
+        self.assertEqual(len(users), 2)
+        for user in users:
+            self.assertIn(user, ['admin', 'guest'])
+
+    def test_del_role_associated_with_user(self):
+        self.test_create_role()
+        self.test_add_user_roles('guest', ['test_role'])
+
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-role-delete', rolename='test_role')
+
+        self.assertEqual(ctx.exception.retcode, -errno.EPERM)
+        self.assertEqual(str(ctx.exception),
+                         "Role 'test_role' is still associated with user "
+                         "'guest'")
+
+    def test_set_user_info(self):
+        self.test_create_user()
+        user = self.exec_cmd('ac-user-set-info', username='admin',
+                             name='Admin Name', email='admin@admin.com')
+        pass_hash = password_hash('admin', user['password'])
+        self.assertDictEqual(user, {
+            'username': 'admin',
+            'password': pass_hash,
+            'name': 'Admin Name',
+            'email': 'admin@admin.com',
+            'roles': []
+        })
+        self.validate_persistent_user('admin', [], pass_hash, 'Admin Name',
+                                      'admin@admin.com')
+
+    def test_set_user_info_nonexistent_user(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-set-info', username='admin',
+                          name='Admin Name', email='admin@admin.com')
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "User 'admin' does not exist")
+
+    def test_set_user_password(self):
+        self.test_create_user()
+        user = self.exec_cmd('ac-user-set-password', username='admin',
+                             password='newpass')
+        pass_hash = password_hash('newpass', user['password'])
+        self.assertDictEqual(user, {
+            'username': 'admin',
+            'password': pass_hash,
+            'name': 'admin User',
+            'email': 'admin@user.com',
+            'roles': []
+        })
+        self.validate_persistent_user('admin', [], pass_hash, 'admin User',
+                                      'admin@user.com')
+
+    def test_set_user_password_nonexistent_user(self):
+        with self.assertRaises(CmdException) as ctx:
+            self.exec_cmd('ac-user-set-password', username='admin',
+                          password='newpass')
+
+        self.assertEqual(ctx.exception.retcode, -errno.ENOENT)
+        self.assertEqual(str(ctx.exception), "User 'admin' does not exist")
+
+    def test_set_login_credentials(self):
+        self.exec_cmd('set-login-credentials', username='admin',
+                      password='admin')
+        user = self.exec_cmd('ac-user-show', username='admin')
+        pass_hash = password_hash('admin', user['password'])
+        self.assertDictEqual(user, {
+            'username': 'admin',
+            'password': pass_hash,
+            'name': None,
+            'email': None,
+            'roles': ['administrator']
+        })
+        self.validate_persistent_user('admin', ['administrator'], pass_hash,
+                                      None, None)
+
+    def test_set_login_credentials_for_existing_user(self):
+        self.test_add_user_roles('admin', ['read-only'])
+        self.exec_cmd('set-login-credentials', username='admin',
+                      password='admin2')
+        user = self.exec_cmd('ac-user-show', username='admin')
+        pass_hash = password_hash('admin2', user['password'])
+        self.assertDictEqual(user, {
+            'username': 'admin',
+            'password': pass_hash,
+            'name': 'admin User',
+            'email': 'admin@user.com',
+            'roles': ['read-only']
+        })
+        self.validate_persistent_user('admin', ['read-only'], pass_hash,
+                                      'admin User', 'admin@user.com')
+
+    def test_load_v1(self):
+        self.CONFIG_KEY_DICT['accessdb_v1'] = '''
+            {{
+                "users": {{
+                    "admin": {{
+                        "username": "admin",
+                        "password":
+                "$2b$12$sd0Az7mm3FaJl8kN3b/xwOuztaN0sWUwC1SJqjM4wcDw/s5cmGbLK",
+                        "roles": ["block-manager", "test_role"],
+                        "name": "admin User",
+                        "email": "admin@user.com"
+                    }}
+                }},
+                "roles": {{
+                    "test_role": {{
+                        "name": "test_role",
+                        "description": "Test Role",
+                        "scopes_permissions": {{
+                            "{}": ["{}", "{}"],
+                            "{}": ["{}"]
+                        }}
+                    }}
+                }},
+                "version": 1
+            }}
+        '''.format(Scope.ISCSI, Permission.READ, Permission.UPDATE,
+                   Scope.POOL, Permission.CREATE)
+
+        load_access_control_db()
+        role = self.exec_cmd('ac-role-show', rolename="test_role")
+        self.assertDictEqual(role, {
+            'name': 'test_role',
+            'description': "Test Role",
+            'scopes_permissions': {
+                Scope.ISCSI: [Permission.READ, Permission.UPDATE],
+                Scope.POOL: [Permission.CREATE]
+            }
+        })
+        user = self.exec_cmd('ac-user-show', username="admin")
+        self.assertDictEqual(user, {
+            'username': 'admin',
+            'password':
+                "$2b$12$sd0Az7mm3FaJl8kN3b/xwOuztaN0sWUwC1SJqjM4wcDw/s5cmGbLK",
+            'name': 'admin User',
+            'email': 'admin@user.com',
+            'roles': ['block-manager', 'test_role']
+        })
+
+    def test_update_from_previous_version_v1(self):
+        self.CONFIG_KEY_DICT['username'] = 'admin'
+        self.CONFIG_KEY_DICT['password'] = \
+            '$2b$12$sd0Az7mm3FaJl8kN3b/xwOuztaN0sWUwC1SJqjM4wcDw/s5cmGbLK'
+        load_access_control_db()
+        user = self.exec_cmd('ac-user-show', username="admin")
+        self.assertDictEqual(user, {
+            'username': 'admin',
+            'password':
+                "$2b$12$sd0Az7mm3FaJl8kN3b/xwOuztaN0sWUwC1SJqjM4wcDw/s5cmGbLK",
+            'name': None,
+            'email': None,
+            'roles': ['administrator']
+        })

--- a/src/pybind/mgr/dashboard/tests/test_controllers.py
+++ b/src/pybind/mgr/dashboard/tests/test_controllers.py
@@ -6,7 +6,7 @@ from ..controllers import BaseController, RESTController, Controller, \
                           ApiController, Endpoint
 
 
-@Controller("/btest/{key}", base_url="/ui")
+@Controller("/btest/{key}", base_url="/ui", secure=False)
 class BTest(BaseController):
     @Endpoint()
     def test1(self, key, opt=1):
@@ -38,7 +38,7 @@ class BTest(BaseController):
         return {'key': key, 'opt': opt}
 
 
-@ApiController("/rtest/{key}")
+@ApiController("/rtest/{key}", secure=False)
 class RTest(RESTController):
     RESOURCE_ID = 'skey/ekey'
 
@@ -72,7 +72,7 @@ class RTest(RESTController):
         return {'key': key, 'skey': skey, 'ekey': ekey, 'opt': opt}
 
 
-@Controller("/")
+@Controller("/", secure=False)
 class Root(BaseController):
     @Endpoint(json_response=False)
     def __call__(self):

--- a/src/pybind/mgr/dashboard/tests/test_exceptions.py
+++ b/src/pybind/mgr/dashboard/tests/test_exceptions.py
@@ -13,7 +13,7 @@ from ..tools import ViewCache, TaskManager, NotificationQueue
 
 
 # pylint: disable=W0613
-@Controller('foo')
+@Controller('foo', secure=False)
 class FooResource(RESTController):
 
     @Endpoint()

--- a/src/pybind/mgr/dashboard/tests/test_grafana.py
+++ b/src/pybind/mgr/dashboard/tests/test_grafana.py
@@ -25,7 +25,7 @@ class Grafana(TestCase):
                 url='//localhost:3000', username='admin', password='admin')
 
 
-@Controller('grafana/mocked')
+@Controller('/grafana/mocked', secure=False)
 class GrafanaMockInstance(BaseController):
     @Proxy()
     def __call__(self, path, **params):

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -78,9 +78,11 @@ class RbdMirroringControllerTest(ControllerTestCase):
         for k in ['daemons', 'pools', 'image_error', 'image_syncing', 'image_ready']:
             self.assertIn(k, result['content_data'])
 
+    @mock.patch('dashboard.controllers.BaseController._has_permissions')
     @mock.patch('dashboard.controllers.rbd_mirroring.rbd')
-    def test_summary(self, rbd_mock):  # pylint: disable=W0613
+    def test_summary(self, rbd_mock, has_perms_mock):  # pylint: disable=W0613
         """We're also testing `summary`, as it also uses code from `rbd_mirroring.py`"""
+        has_perms_mock.return_value = True
         self._get('/test/api/summary')
         self.assertStatus(200)
 

--- a/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
+++ b/src/pybind/mgr/dashboard/tests/test_rest_tasks.py
@@ -9,7 +9,7 @@ from ..controllers.task import Task as TaskController
 from ..tools import NotificationQueue, TaskManager
 
 
-@Controller('test/task')
+@Controller('/test/task', secure=False)
 class TaskTest(RESTController):
     sleep_time = 0.0
 

--- a/src/pybind/mgr/dashboard/tests/test_tools.py
+++ b/src/pybind/mgr/dashboard/tests/test_tools.py
@@ -15,7 +15,7 @@ from ..tools import is_valid_ipv6_address, dict_contains_path
 
 
 # pylint: disable=W0613
-@Controller('/foo')
+@Controller('/foo', secure=False)
 class FooResource(RESTController):
     elems = []
 
@@ -40,20 +40,20 @@ class FooResource(RESTController):
         return dict(key=key, newdata=newdata)
 
 
-@Controller('/foo/:key/:method')
+@Controller('/foo/:key/:method', secure=False)
 class FooResourceDetail(RESTController):
     def list(self, key, method):
         return {'detail': (key, [method])}
 
 
-@ApiController('/rgw/proxy')
+@ApiController('/rgw/proxy', secure=False)
 class GenerateControllerRoutesController(BaseController):
     @Proxy()
     def __call__(self, path, **params):
         pass
 
 
-@ApiController('/fooargs')
+@ApiController('/fooargs', secure=False)
 class FooArgs(RESTController):
     def set(self, code, name=None, opt1=None, opt2=None):
         return {'code': code, 'name': name, 'opt1': opt1, 'opt2': opt2}

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -21,7 +21,7 @@ from .exceptions import ViewCacheNoDataException
 class RequestLoggingTool(cherrypy.Tool):
     def __init__(self):
         cherrypy.Tool.__init__(self, 'before_handler', self.request_begin,
-                               priority=95)
+                               priority=10)
 
     def _setup(self):
         cherrypy.Tool._setup(self)

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -22,5 +22,5 @@ commands=
     cov: coverage combine {toxinidir}/{env:COVERAGE_FILE}
     cov: coverage report
     cov: coverage xml
-    lint: pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests services
+    lint: pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests services exceptions.py
     lint: pycodestyle --max-line-length=100 --exclude=.tox,venv,frontend,.vscode --ignore=E402,E121,E123,E126,E226,E24,E704,W503,E741 .

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -712,7 +712,7 @@ EOF
 
     # setting login credentials for dashboard
     if $with_mgr_dashboard; then
-        ceph_adm tell mgr dashboard set-login-credentials admin admin
+        ceph_adm tell mgr dashboard ac-user-create admin admin administrator
         if ! ceph_adm tell mgr dashboard create-self-signed-cert;  then
             echo dashboard module not working correctly!
         fi


### PR DESCRIPTION
This PR adds multi-user and role-based authentication, and also makes controllers to require authentication by default.

The authorization scheme is based on static security scopes and permissions, and dynamic roles.
Each controller belongs to a predefined security scope. Currently the list of security scopes are:
* hosts
* config-opt
* pool
* osd
* monitor
* rbd-image
* iscsi
* rbd-mirroring
* rgw
* cephfs
* manager

Each endpoint defined inside a controller is annotated with the kind(s) of permissions is required to access the endpoint. The list of possible permission kinds is the following:
* READ
* CREATE
* UPDATE
* DELETE

Each user can have a set of roles associated. Each role is a set of pairs where the first element is a security scope, and the second element is a set of permissions.

This PR adds CLI commands to manage both users and roles. We also provide a set of predefined roles (aka system roles) that cannot be deleted nor changed, and are the following:
* Administrator: has all kinds of permissions for all security scopes
* Read-only: has READ permission for all security scopes
* Block Manager: has all kinds of permissions for rbd-image, rbd-mirroring, and iscsi scopes
* RGW Manager: has all kinds of permissions for rgw scope
* Cluster Manager: has all kinds of permissions for the hosts, osd, monitor, manager, and config_opt scopes
* Pool Manager: has all kinds of permissions for the pool scope
* CephFS Manager: has all kinds of permissions for the cephfs scope.

