### PR TITLE
mgr/dashboard: Log frontend errors + @UiController

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -246,15 +246,18 @@ How to add a new controller?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 A controller is a Python class that extends from the ``BaseController`` class
-and is decorated with either the ``@Controller`` or ``@ApiController``
-decorators. The Python class must be stored inside a Python file located under
-the ``controllers`` directory. The Dashboard module will automatically load
-your new controller upon start.
+and is decorated with either the ``@Controller``, ``@ApiController`` or
+``@UiApiController`` decorators. The Python class must be stored inside a Python
+file located under the ``controllers`` directory. The Dashboard module will
+automatically load your new controller upon start.
 
-The ``@ApiController`` decorator is a specialization of the ``@Controller``
-decorator, and should be used for controllers that provide an API-like REST
-interface. For any other kinds of controllers the ``@Controller`` decorator
-should be used.
+``@ApiController`` and ``@UiApiController`` are both specializations of the
+``@Controller`` decorator.
+
+The ``@ApiController`` should be used for controllers that provide an API-like
+REST interface and the ``@UiApiController`` should be used for endpoints consumed
+by the UI but that are not part of the 'public' API. For any other kinds of
+controllers the ``@Controller`` decorator should be used.
 
 A controller has a URL prefix path associated that is specified in the
 controller decorator, and all endpoints exposed by the controller will share
@@ -268,7 +271,7 @@ following code:
 
 .. code-block:: python
 
-  from ..tools import Controller, ApiController, BaseController, Endpoint
+  from ..tools import Controller, ApiController, UiApiController, BaseController, Endpoint
 
   @Controller('/ping')
   class Ping(BaseController):
@@ -282,6 +285,11 @@ following code:
     def hello(self):
       return {'msg': "Hello"}
 
+  @UiApiController('/ping')
+  class UiApiPing(BaseController):
+    @Endpoint()
+    def hello(self):
+      return {'msg': "Hello"}
 
 The ``hello`` endpoint of the ``Ping`` controller can be reached by the
 following URL: https://mgr_hostname:8080/ping/hello using HTTP GET requests.
@@ -297,6 +305,12 @@ Internally, the ``@ApiController`` is actually calling the ``@Controller``
 decorator by passing an additional decorator parameter called ``base_url``::
 
   @ApiController('/ping') <=> @Controller('/ping', base_url="/api")
+
+``UiApiPing`` works in a similar way than the ``ApiPing``, but the URL will be
+prefixed by ``/ui-api``: https://mgr_hostname:8080/ui-api/ping/hello. ``UiApiPing`` is
+also a ``@Controller`` extension::
+
+  @UiApiController('/ping') <=> @Controller('/ping', base_url="/ui-api")
 
 The ``@Endpoint`` decorator also supports many parameters to customize the
 endpoint:

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -64,6 +64,11 @@ class ApiController(Controller):
         return cls
 
 
+class UiApiController(Controller):
+    def __init__(self, path):
+        super(UiApiController, self).__init__(path, base_url="/ui-api")
+
+
 def AuthRequired(enabled=True):
     def decorate(cls):
         if not hasattr(cls, '_cp_config'):

--- a/src/pybind/mgr/dashboard/controllers/logging.py
+++ b/src/pybind/mgr/dashboard/controllers/logging.py
@@ -1,0 +1,10 @@
+from . import UiApiController, BaseController, Endpoint
+from .. import logger
+
+
+@UiApiController('/logging')
+class Logging(BaseController):
+
+    @Endpoint('POST', path='js-error')
+    def jsError(self, url, message, stack):
+        logger.error('frontend error (%s): %s\n %s\n', url, message, stack)

--- a/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
+++ b/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
@@ -3,5 +3,10 @@
     "target": "https://localhost:8080",
     "secure": false,
     "logLevel": "debug"
+  },
+  "/ui-api/": {
+    "target": "https://localhost:8080",
+    "secure": false,
+    "logLevel": "debug"
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
-import { NgModule } from '@angular/core';
+import { ErrorHandler, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -11,6 +11,7 @@ import { AppComponent } from './app.component';
 import { CephModule } from './ceph/ceph.module';
 import { CoreModule } from './core/core.module';
 import { ApiInterceptorService } from './shared/services/api-interceptor.service';
+import { JsErrorHandler } from './shared/services/js-error-handler.service';
 import { SharedModule } from './shared/shared.module';
 
 export class CustomOption extends ToastOptions {
@@ -39,6 +40,10 @@ export class CustomOption extends ToastOptions {
   ],
   exports: [SharedModule],
   providers: [
+    {
+      provide: ErrorHandler,
+      useClass: JsErrorHandler,
+    },
     {
       provide: HTTP_INTERCEPTORS,
       useClass: ApiInterceptorService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/api.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/api.module.ts
@@ -6,6 +6,7 @@ import { CephfsService } from './cephfs.service';
 import { ConfigurationService } from './configuration.service';
 import { DashboardService } from './dashboard.service';
 import { HostService } from './host.service';
+import { LoggingService } from './logging.service';
 import { MonitorService } from './monitor.service';
 import { OsdService } from './osd.service';
 import { PerformanceCounterService } from './performance-counter.service';
@@ -35,6 +36,7 @@ import { TcmuIscsiService } from './tcmu-iscsi.service';
     RgwDaemonService,
     RgwUserService,
     PerformanceCounterService,
+    LoggingService,
     TcmuIscsiService
   ]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/logging.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/logging.service.ts
@@ -1,0 +1,19 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class LoggingService {
+
+  constructor(private http: HttpClient) {
+  }
+
+  jsError(url, message, stack) {
+    const request = {
+      url: url,
+      message: message,
+      stack: stack
+    };
+    return this.http.post('ui-api/logging/js-error', request);
+  }
+
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/js-error-handler.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/js-error-handler.service.ts
@@ -1,0 +1,18 @@
+import { ErrorHandler, Injectable, Injector } from '@angular/core';
+import { LoggingService } from '../api/logging.service';
+
+@Injectable()
+export class JsErrorHandler implements ErrorHandler {
+
+  constructor(private injector: Injector) { }
+
+  handleError(error) {
+    const loggingService = this.injector.get(LoggingService);
+    const url = window.location.href;
+    const message = error && error.message;
+    const stack = error && error.stack;
+    loggingService.jsError(url, message, stack).subscribe();
+    throw error;
+  }
+
+}


### PR DESCRIPTION
This PR adds a frontend error handler that will log all javascript exceptions on server log.

Additionally this PR adds a new backend decorator `@UiController` that should be used as an alternative to `@ApiController`, for cases where we want to create UI specific endpoints that should not be considered part of the `public`API.
