### PR TITLE
src: balance std::hex and std::dec manipulators

### DIFF
--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -72,7 +72,7 @@ int CephxClientHandler::build_request(bufferlist& bl) const
     encode(req, bl);
 
     ldout(cct, 10) << "get auth session key: client_challenge "
-		   << hex << req.client_challenge << dendl;
+		   << std::hex << req.client_challenge << std::dec << dendl;
     return 0;
   }
 
@@ -120,7 +120,7 @@ int CephxClientHandler::handle_response(int ret, bufferlist::const_iterator& ind
     decode(ch, indata);
     server_challenge = ch.server_challenge;
     ldout(cct, 10) << " got initial server challenge "
-		   << hex << server_challenge << dendl;
+		   << std::hex << server_challenge << std::dec << dendl;
     starting = false;
 
     tickets.invalidate_ticket(CEPH_ENTITY_TYPE_AUTH);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -664,7 +664,8 @@ void Client::trim_cache_for_reconnect(MetaSession *s)
 void Client::trim_dentry(Dentry *dn)
 {
   ldout(cct, 15) << "trim_dentry unlinking dn " << dn->name 
-		 << " in dir " << hex << dn->dir->parent_inode->ino 
+		 << " in dir "
+		 << std::hex << dn->dir->parent_inode->ino << std::dec
 		 << dendl;
   if (dn->inode) {
     Inode *diri = dn->dir->parent_inode;

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2659,7 +2659,7 @@ void Locker::handle_client_caps(MClientCaps *m)
 	  << " on " << m->get_ino()
 	  << " tid " << m->get_client_tid() << " follows " << follows
 	  << " op " << ceph_cap_op_name(m->get_op())
-	  << " flags 0x" << hex << m->flags << dendl;
+	  << " flags 0x" << std::hex << m->flags << std::dec << dendl;
 
   Session *session = mds->get_session(m);
   if (!mds->is_clientreplay() && !mds->is_active() && !mds->is_stopping()) {

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1837,7 +1837,8 @@ void DaemonServer::send_report()
           if (!collector) {
             derr << __func__ << " " << key.first << "." << key.second
 		 << " sent me an unknown health metric: "
-		 << hex << static_cast<uint8_t>(metric.get_type()) << dendl;
+		 << std::hex << static_cast<uint8_t>(metric.get_type())
+		 << std::dec << dendl;
             continue;
           }
 	  dout(20) << " + " << state->key << " "

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3362,7 +3362,8 @@ MOSDMap *OSDMonitor::build_latest_full(uint64_t features)
 
 MOSDMap *OSDMonitor::build_incremental(epoch_t from, epoch_t to, uint64_t features)
 {
-  dout(10) << "build_incremental [" << from << ".." << to << "] with features " << std::hex << features << dendl;
+  dout(10) << "build_incremental [" << from << ".." << to << "] with features "
+	   << std::hex << features << std::dec << dendl;
   MOSDMap *m = new MOSDMap(mon->monmap->fsid, features);
   m->oldest_map = get_first_committed();
   m->newest_map = osdmap.get_epoch();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6119,7 +6119,7 @@ int BlueStore::_fsck(bool deep, bool repair)
 	if (i.second & blob.unused) {
 	  derr << "fsck error: " << oid << " blob claims unused 0x"
 	       << std::hex << blob.unused
-	       << " but extents reference 0x" << i.second
+	       << " but extents reference 0x" << i.second << std::dec
 	       << " on blob " << *i.first << dendl;
 	  ++errors;
 	}
@@ -6603,7 +6603,7 @@ int BlueStore::_fsck(bool deep, bool repair)
 	      // since we will never allocate this region below min_alloc_size.
 	      dout(10) << __func__ << " ignoring free extent between SUPER_RESERVED"
 		       << " and min_alloc_size, 0x" << std::hex << offset << "~"
-		       << length << dendl;
+		       << length << std::dec << dendl;
 	    } else {
               intersects = true;
 	      if (repair) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1300,7 +1300,8 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	  }
 
           dout(10) << " pgnls candidate 0x" << std::hex << candidate.get_hash()
-            << " vs lower bound 0x" << lower_bound.get_hash() << dendl;
+		   << " vs lower bound 0x" << lower_bound.get_hash()
+		   << std::dec << dendl;
 
 	  if (candidate >= next) {
 	    break;

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -453,7 +453,7 @@ std::ostream &operator<<(std::ostream &os, const NBDServer::IOContext &ctx) {
   }
 
   os << ctx.request.from << "~" << ctx.request.len << " "
-     << ntohl(ctx.reply.error) << "]";
+     << std::dec << ntohl(ctx.reply.error) << "]";
 
   return os;
 }


### PR DESCRIPTION
we're caching the "t_os.streambuf", so the fmtflags persist across
log entries. to avoid this side effects, we should do the cleanup
before finishing each log entry.

Signed-off-by: Kefu Chai <kchai@redhat.com>