### PR TITLE
mimic: qa: wait longer for osd to flush pg stats

### DIFF
--- a/qa/tasks/osd_max_pg_per_osd.py
+++ b/qa/tasks/osd_max_pg_per_osd.py
@@ -81,8 +81,9 @@ def test_create_from_peer(ctx, config):
     manager = ctx.managers['ceph']
     log.info('1. creating pool.a')
     pool_a = manager.create_pool_with_unique_name(pg_num)
-    manager.wait_for_clean()
-    assert manager.get_num_active_clean() == pg_num
+    pg_states = manager.wait_till_pg_convergence(300)
+    pg_created = pg_num_in_all_states(pg_states, 'active', 'clean')
+    assert pg_created == pg_num
 
     log.info('2. creating pool.b')
     while True:


### PR DESCRIPTION
pg sends pg-stats to mgr every 5 seconds, so we cannot check for the
number of pgs right after creating the pool, at that moment, the number
of pgs could be 0, that's why manger.wait_for_clean() returns right
away, and leaves us with 0 pgs: the pgs serving the pool are still being
created. that's why `manager.get_num_active_clean()` returns `0`
sometimes. so, we should force osd to flush their stats to mgr, and wait
until the pg stats converages.

Fixes: http://tracker.ceph.com/issues/24321
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 380747268a1e4a3e8db618d66006c104091fafd5)