### PR TITLE
luminous: common: partially revert 95fc248 to make get_process_name work

### DIFF
--- a/src/common/code_environment.cc
+++ b/src/common/code_environment.cc
@@ -16,9 +16,13 @@
 
 #include <iostream>
 
+#include "acconfig.h"
+
 #ifdef HAVE_SYS_PRCTL_H
 #include <sys/prctl.h>
 #endif
+
+#include <string.h>
 
 code_environment_t g_code_env = CODE_ENVIRONMENT_UTILITY;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/24216