### PR TITLE
mimic: mon/OSDMonitor: no_reply on MOSDFailure messages

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2561,6 +2561,7 @@ void OSDMonitor::process_failures()
           o->mark_event(__func__);
           MOSDFailure *m = o->get_req<MOSDFailure>();
           send_latest(o, m->get_epoch());
+	  mon->no_reply(o);
         }
 	ls.pop_front();
       }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2176,6 +2176,7 @@ bool OSDMonitor::preprocess_failure(MonOpRequestRef op)
   return false;
 
  didit:
+  mon->no_reply(op);
   return true;
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/24350