### PR TITLE
mgr/dashboard: Reset settings to their default values

### DIFF
--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -46,6 +46,10 @@ class SettingsMeta(type):
         else:
             setattr(SettingsMeta, attr, value)
 
+    def __delattr__(self, attr):
+        if not attr.startswith('_') and hasattr(Options, attr):
+            mgr.set_config(attr, None)
+
 
 # pylint: disable=no-init
 @add_metaclass(SettingsMeta)
@@ -63,8 +67,10 @@ def _options_command_map():
             continue
         key_get = 'dashboard get-{}'.format(option.lower().replace('_', '-'))
         key_set = 'dashboard set-{}'.format(option.lower().replace('_', '-'))
+        key_reset = 'dashboard reset-{}'.format(option.lower().replace('_', '-'))
         cmd_map[key_get] = {'name': option, 'type': None}
         cmd_map[key_set] = {'name': option, 'type': value[1]}
+        cmd_map[key_reset] = {'name': option, 'type': None}
     return cmd_map
 
 
@@ -85,17 +91,25 @@ def options_command_list():
 
     cmd_list = []
     for cmd, opt in _OPTIONS_COMMAND_MAP.items():
-        if not opt['type']:
+        if cmd.startswith('dashboard get'):
             cmd_list.append({
                 'cmd': '{}'.format(cmd),
                 'desc': 'Get the {} option value'.format(opt['name']),
                 'perm': 'r'
             })
-        else:
+        elif cmd.startswith('dashboard set'):
             cmd_list.append({
                 'cmd': '{} name=value,type={}'
                        .format(cmd, py2ceph(opt['type'])),
                 'desc': 'Set the {} option value'.format(opt['name']),
+                'perm': 'w'
+            })
+        elif cmd.startswith('dashboard reset'):
+            desc = 'Reset the {} option to its default value'.format(
+                opt['name'])
+            cmd_list.append({
+                'cmd': '{}'.format(cmd),
+                'desc': desc,
                 'perm': 'w'
             })
 
@@ -118,12 +132,14 @@ def options_schema_list():
 def handle_option_command(cmd):
     if cmd['prefix'] not in _OPTIONS_COMMAND_MAP:
         return (-errno.ENOSYS, '', "Command not found '{}'".format(cmd['prefix']))
-
     opt = _OPTIONS_COMMAND_MAP[cmd['prefix']]
-    if not opt['type']:
-        # get option
-        return 0, str(getattr(Settings, opt['name'])), ''
 
-    # set option
-    setattr(Settings, opt['name'], opt['type'](cmd['value']))
-    return 0, 'Option {} updated'.format(opt['name']), ''
+    if cmd['prefix'].startswith('dashboard reset'):
+        delattr(Settings, opt['name'])
+        return 0, 'Option {} reset to default value "{}"'.format(
+            opt['name'], getattr(Settings, opt['name'])), ''
+    elif cmd['prefix'].startswith('dashboard get'):
+        return 0, str(getattr(Settings, opt['name'])), ''
+    elif cmd['prefix'].startswith('dashboard set'):
+        setattr(Settings, opt['name'], opt['type'](cmd['value']))
+        return 0, 'Option {} updated'.format(opt['name']), ''

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -38,7 +38,12 @@ class Options(object):
 class SettingsMeta(type):
     def __getattr__(cls, attr):
         default, stype = getattr(Options, attr)
-        return stype(mgr.get_config(attr, default))
+        if stype == bool and str(mgr.get_config(attr,
+                                                default)).lower() == 'false':
+            value = False
+        else:
+            value = stype(mgr.get_config(attr, default))
+        return value
 
     def __setattr__(cls, attr, value):
         if not attr.startswith('_') and hasattr(Options, attr):
@@ -141,5 +146,8 @@ def handle_option_command(cmd):
     elif cmd['prefix'].startswith('dashboard get'):
         return 0, str(getattr(Settings, opt['name'])), ''
     elif cmd['prefix'].startswith('dashboard set'):
-        setattr(Settings, opt['name'], opt['type'](cmd['value']))
+        value = opt['type'](cmd['value'])
+        if opt['type'] == bool and cmd['value'].lower() == 'false':
+            value = False
+        setattr(Settings, opt['name'], value)
         return 0, 'Option {} updated'.format(opt['name']), ''

--- a/src/pybind/mgr/dashboard/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard/tests/test_settings.py
@@ -17,6 +17,7 @@ class SettingsTest(unittest.TestCase):
         # pylint: disable=protected-access
         settings.Options.GRAFANA_API_HOST = ('localhost', str)
         settings.Options.GRAFANA_API_PORT = (3000, int)
+        settings.Options.GRAFANA_ENABLED = (False, bool)
         settings._OPTIONS_COMMAND_MAP = settings._options_command_map()
 
     @classmethod
@@ -38,10 +39,18 @@ class SettingsTest(unittest.TestCase):
 
     def test_get_setting(self):
         self.assertEqual(Settings.GRAFANA_API_HOST, 'localhost')
+        self.assertEqual(Settings.GRAFANA_API_PORT, 3000)
+        self.assertEqual(Settings.GRAFANA_ENABLED, False)
 
     def test_set_setting(self):
         Settings.GRAFANA_API_HOST = 'grafanahost'
         self.assertEqual(Settings.GRAFANA_API_HOST, 'grafanahost')
+
+        Settings.GRAFANA_API_PORT = 50
+        self.assertEqual(Settings.GRAFANA_API_PORT, 50)
+
+        Settings.GRAFANA_ENABLED = True
+        self.assertEqual(Settings.GRAFANA_ENABLED, True)
 
     def test_get_cmd(self):
         r, out, err = handle_option_command(

--- a/src/pybind/mgr/dashboard/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard/tests/test_settings.py
@@ -58,6 +58,15 @@ class SettingsTest(unittest.TestCase):
         self.assertEqual(out, 'Option GRAFANA_API_PORT updated')
         self.assertEqual(err, '')
 
+    def test_reset_cmd(self):
+        r, out, err = handle_option_command(
+            {'prefix': 'dashboard reset-grafana-enabled'}
+        )
+        self.assertEqual(r, 0)
+        self.assertEqual(out, 'Option {} reset to default value "{}"'.format(
+            'GRAFANA_ENABLED', Settings.GRAFANA_ENABLED))
+        self.assertEqual(err, '')
+
     def test_inv_cmd(self):
         r, out, err = handle_option_command(
             {'prefix': 'dashboard get-non-existent-option'})


### PR DESCRIPTION
Also: Fixes a bug with setting and reading boolean values in the settings module.

ceph dashboard reset-<setting_name>

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>