### PR TITLE
mgr/dashboard: Add help menu entry

### DIFF
--- a/qa/tasks/mgr/dashboard/test_summary.py
+++ b/qa/tasks/mgr/dashboard/test_summary.py
@@ -17,6 +17,7 @@ class SummaryTest(DashboardTestCase):
         self.assertIn('rbd_mirroring', data)
         self.assertIn('executing_tasks', data)
         self.assertIn('finished_tasks', data)
+        self.assertIn('version', data)
         self.assertIsNotNone(data['health_status'])
         self.assertIsNotNone(data['mgr_id'])
         self.assertIsNotNone(data['have_mon_connection'])

--- a/src/pybind/mgr/dashboard/controllers/summary.py
+++ b/src/pybind/mgr/dashboard/controllers/summary.py
@@ -49,5 +49,6 @@ class Summary(BaseController):
             'mgr_id': mgr.get_mgr_id(),
             'have_mon_connection': mgr.have_mon_connection(),
             'executing_tasks': executing_t,
-            'finished_tasks': finished_t
+            'finished_tasks': finished_t,
+            'version': mgr.version
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.html
@@ -1,0 +1,27 @@
+<div dropdown>
+  <a dropdownToggle
+     class="dropdown-toggle"
+     data-toggle="dropdown">
+    <i class="fa fa-question-circle-o"></i>
+    <span i18n>Help</span>
+    <span class="caret"></span>
+  </a>
+  <ul *dropdownMenu
+      class="dropdown-menu">
+    <li>
+      <a i18n
+         class="dropdown-item"
+         [ngClass]="{'disabled': !docsUrl}"
+         href="{{ docsUrl }}"
+         target="_blank">Documentation
+      </a>
+    </li>
+    <li>
+      <a i18n
+         class="dropdown-item"
+         href="/docs"
+         target="_blank">API
+      </a>
+    </li>
+  </ul>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.spec.ts
@@ -1,0 +1,27 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SharedModule } from '../../../shared/shared.module';
+import { configureTestBed } from '../../../shared/unit-test-helper';
+import { DashboardHelpComponent } from './dashboard-help.component';
+
+describe('DashboardHelpComponent', () => {
+  let component: DashboardHelpComponent;
+  let fixture: ComponentFixture<DashboardHelpComponent>;
+
+  configureTestBed({
+    imports: [HttpClientTestingModule, SharedModule],
+    declarations: [DashboardHelpComponent]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DashboardHelpComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+
+import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
+import { SummaryService } from '../../../shared/services/summary.service';
+
+@Component({
+  selector: 'cd-dashboard-help',
+  templateUrl: './dashboard-help.component.html',
+  styleUrls: ['./dashboard-help.component.scss']
+})
+export class DashboardHelpComponent implements OnInit {
+
+  docsUrl: string;
+
+  constructor(private summaryService: SummaryService,
+              private cephReleaseNamePipe: CephReleaseNamePipe) {}
+
+  ngOnInit() {
+    const subs = this.summaryService.summaryData$.subscribe((summary: any) => {
+      const releaseName = this.cephReleaseNamePipe.transform(summary.version);
+      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/`;
+      subs.unsubscribe();
+    });
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation.module.ts
@@ -7,6 +7,7 @@ import { BsDropdownModule, CollapseModule, PopoverModule } from 'ngx-bootstrap';
 import { AppRoutingModule } from '../../app-routing.module';
 import { SharedModule } from '../../shared/shared.module';
 import { AuthModule } from '../auth/auth.module';
+import { DashboardHelpComponent } from './dashboard-help/dashboard-help.component';
 import { NavigationComponent } from './navigation/navigation.component';
 import { NotificationsComponent } from './notifications/notifications.component';
 import { TaskManagerComponent } from './task-manager/task-manager.component';
@@ -22,7 +23,12 @@ import { TaskManagerComponent } from './task-manager/task-manager.component';
     SharedModule,
     RouterModule
   ],
-  declarations: [NavigationComponent, NotificationsComponent, TaskManagerComponent],
+  declarations: [
+    NavigationComponent,
+    NotificationsComponent,
+    TaskManagerComponent,
+    DashboardHelpComponent
+  ],
   exports: [NavigationComponent]
 })
 export class NavigationModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -204,6 +204,9 @@
       <li>
         <cd-notifications class="oa-navbar"></cd-notifications>
       </li>
+      <li>
+        <cd-dashboard-help class="oa-navbar"></cd-dashboard-help>
+      </li>
       <li class="tc_logout">
         <cd-logout class="oa-navbar"></cd-logout>
       </li>

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
@@ -8,6 +8,7 @@ import { NotificationService } from '../../../shared/services/notification.servi
 import { SharedModule } from '../../../shared/shared.module';
 import { configureTestBed } from '../../../shared/unit-test-helper';
 import { LogoutComponent } from '../../auth/logout/logout.component';
+import { DashboardHelpComponent } from '../dashboard-help/dashboard-help.component';
 import { NotificationsComponent } from '../notifications/notifications.component';
 import { TaskManagerComponent } from '../task-manager/task-manager.component';
 import { NavigationComponent } from './navigation.component';
@@ -30,7 +31,8 @@ describe('NavigationComponent', () => {
       NavigationComponent,
       NotificationsComponent,
       LogoutComponent,
-      TaskManagerComponent
+      TaskManagerComponent,
+      DashboardHelpComponent
     ],
     providers: [{ provide: NotificationService, useValue: fakeService }]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.spec.ts
@@ -1,0 +1,21 @@
+import { CephReleaseNamePipe } from './ceph-release-name.pipe';
+
+describe('CephReleaseNamePipe', () => {
+  const pipe = new CephReleaseNamePipe();
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('transforms with correct version format', () => {
+    const value =
+      'ceph version 13.1.0-534-g23d3751b89 \
+       (23d3751b897b31d2bda57aeaf01acb5ff3c4a9cd) nautilus (dev)';
+    expect(pipe.transform(value)).toBe('nautilus');
+  });
+
+  it('transforms with wrong version format', () => {
+    const value = 'foo';
+    expect(pipe.transform(value)).toBe('foo');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'cephReleaseName'
+})
+export class CephReleaseNamePipe implements PipeTransform {
+  transform(value: any, args?: any): any {
+    // Expect "ceph version 13.1.0-419-g251e2515b5
+    //         (251e2515b563856349498c6caf34e7a282f62937) nautilus (dev)"
+    const result = /ceph version\s+[^ ]+\s+\(.+\)\s+(.+)\s+/.exec(value);
+    if (result) {
+      // Return the "nautilus" part
+      return result[1];
+    } else {
+      // Unexpected format, pass it through
+      return value;
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 
 import { EmptyPipe } from '../empty.pipe';
 import { CdDatePipe } from './cd-date.pipe';
+import { CephReleaseNamePipe } from './ceph-release-name.pipe';
 import { CephShortVersionPipe } from './ceph-short-version.pipe';
 import { DimlessBinaryPipe } from './dimless-binary.pipe';
 import { DimlessPipe } from './dimless.pipe';
@@ -18,6 +19,7 @@ import { RelativeDatePipe } from './relative-date.pipe';
     HealthColorPipe,
     DimlessPipe,
     CephShortVersionPipe,
+    CephReleaseNamePipe,
     RelativeDatePipe,
     ListPipe,
     FilterPipe,
@@ -29,6 +31,7 @@ import { RelativeDatePipe } from './relative-date.pipe';
     HealthColorPipe,
     DimlessPipe,
     CephShortVersionPipe,
+    CephReleaseNamePipe,
     RelativeDatePipe,
     ListPipe,
     FilterPipe,
@@ -38,6 +41,7 @@ import { RelativeDatePipe } from './relative-date.pipe';
   providers: [
     DatePipe,
     CephShortVersionPipe,
+    CephReleaseNamePipe,
     DimlessBinaryPipe,
     DimlessPipe,
     RelativeDatePipe,

--- a/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
@@ -323,8 +323,12 @@ ul.task-queue-pagination {
 .navbar-openattic .navbar-collapse {
   padding: 0;
 }
+.navbar-openattic .navbar-nav>li>.oa-navbar>[dropdown]>ul>li>.dropdown-item {
+  font-size: 12px;
+}
 .navbar-openattic .navbar-nav>li>a,
-.navbar-openattic .navbar-nav>li>.oa-navbar>a {
+.navbar-openattic .navbar-nav>li>.oa-navbar>a,
+.navbar-openattic .navbar-nav>li>.oa-navbar>[dropdown]>a {
   color: #ececec;
   line-height: 1;
   padding: 10px 20px;
@@ -335,11 +339,15 @@ ul.task-queue-pagination {
 .navbar-openattic .navbar-nav>li>a:focus,
 .navbar-openattic .navbar-nav>li>a:hover,
 .navbar-openattic .navbar-nav>li>.oa-navbar>a:focus,
-.navbar-openattic .navbar-nav>li>.oa-navbar>a:hover {
+.navbar-openattic .navbar-nav>li>.oa-navbar>a:hover,
+.navbar-openattic .navbar-nav>li>.oa-navbar>[dropdown]>a:focus,
+.navbar-openattic .navbar-nav>li>.oa-navbar>[dropdown]>a:hover {
   color: #ececec;
 }
 .navbar-openattic .navbar-nav>li>a:hover,
-.navbar-openattic .navbar-nav>li>.oa-navbar>a:hover {
+.navbar-openattic .navbar-nav>li>.oa-navbar>a:hover,
+.navbar-openattic .navbar-nav>li>.oa-navbar>[dropdown]>a:hover,
+.navbar-openattic .navbar-nav>li>.oa-navbar>[dropdown].open>a {
   background-color: #505050;
 }
 .navbar-openattic .navbar-nav>.open>a,
@@ -347,7 +355,10 @@ ul.task-queue-pagination {
 .navbar-openattic .navbar-nav>.open>a:focus,
 .navbar-openattic .navbar-nav>.open>.oa-navbar>a,
 .navbar-openattic .navbar-nav>.open>.oa-navbar>a:hover,
-.navbar-openattic .navbar-nav>.open>.oa-navbar>a:focus {
+.navbar-openattic .navbar-nav>.open>.oa-navbar>a:focus,
+.navbar-openattic .navbar-nav>.open>.oa-navbar>[dropdown]>a,
+.navbar-openattic .navbar-nav>.open>.oa-navbar>[dropdown]>a:hover,
+.navbar-openattic .navbar-nav>.open>.oa-navbar>li>a:focus {
   color: #ececec;
   border-color: transparent;
   background-color: transparent;

--- a/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/tests/test_rbd_mirroring.py
@@ -59,6 +59,9 @@ class RbdMirroringControllerTest(ControllerTestCase):
         mgr.url_prefix = ''
         mgr.get_mgr_id.return_value = 0
         mgr.have_mon_connection.return_value = True
+        mgr.version = 'ceph version 13.1.0-534-g23d3751b89 ' \
+                      '(23d3751b897b31d2bda57aeaf01acb5ff3c4a9cd) ' \
+                      'nautilus (dev)'
 
         RbdMirror._cp_config['tools.authenticate.on'] = False  # pylint: disable=protected-access
 


### PR DESCRIPTION
Should be merged after [PR 22282](https://github.com/ceph/ceph/pull/22282)

----

This PR will add a new `Help` menu entry, on top-right navigation, with two sub-menus:

1. **Documentation**: A link to the dashboard documentation
2. **API**: A link to the `Swagger` REST API documentation

![screenshot from 2018-05-29 15-49-14](https://user-images.githubusercontent.com/14297426/40666544-e6b3b934-6357-11e8-9f25-2d5a2d4ecf1d.png)

Signed-off-by: Ricardo Marques <rimarques@suse.com>