### PR TITLE
rgw: fix CreateBucket with BucketLocation parameter failed under default zonegroup

### DIFF
--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -396,6 +396,7 @@ def task(ctx, config):
                     {
                     'port'      : endpoint.port,
                     'is_secure' : 'yes' if endpoint.cert else 'no',
+                    'api_name'  : 'default',
                     },
                 'fixtures' : {},
                 's3 main'  : {},

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -266,6 +266,7 @@ rgw_pool RGWZoneGroup::get_pool(CephContext *cct_)
 int RGWZoneGroup::create_default(bool old_format)
 {
   name = default_zonegroup_name;
+  api_name = default_zonegroup_name;
   is_master = true;
 
   RGWZoneGroupPlacementTarget placement_target;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2525,6 +2525,8 @@ public:
       const auto& zonegroups_by_api = current_period.get_map().zonegroups_by_api;
       if (zonegroups_by_api.find(api) != zonegroups_by_api.end())
         return true;
+    } else if (zonegroup.api_name == api) {
+        return true;
     }
     return false;
   }


### PR DESCRIPTION
When we want to specify the bucket's placement rule during CreateBucket, we should fill the "BucketLocation" parameter with {API_NAME:PLACEMENT_RULE}.

Currently, there are two issues in default zonegroup which impact the processing of CreateBucket with BucketLocation parameter.

1. The api_name in default zonegroup is empty ("")

2. Because there is not a default realm, the has_zonegroup_api always returns false
when create bucket with the BucketLocation parameter under default zonegroup,
which always leads to the CreateBucket request failed.

This PR fixes the above two issues.