### PR TITLE
dashboard: Return float if rate not available

### DIFF
--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -176,9 +176,9 @@ class CephService(object):
         :rtype: list[tuple[int, float]]"""
         data = mgr.get_counter(svc_type, svc_name, path)[path]
         if not data:
-            return [(0, 0)]
+            return [(0, 0.0)]
         elif len(data) == 1:
-            return [(data[0][0], 0)]
+            return [(data[0][0], 0.0)]
         return [(data2[0], differentiate(data1, data2)) for data1, data2 in pairwise(data)]
 
     @classmethod


### PR DESCRIPTION
This fixes a test case issue when some of the data might not be
available during the test, yet. The test expects the second value to be
JFloat but that fails because get_rates return an int in that case.

Signed-off-by: Boris Ranto <branto@redhat.com>

I was able to hit this while testing  #22010 regularly. The latest patch did help:

http://pulpito.ceph.com/branto-2018-05-30_05:43:19-rados:mgr-wip-branto-distro-basic-smithi/