### PR TITLE
mon: remove all routed osdmap requests when their request osdmap inc is distributed

### DIFF
--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -79,6 +79,7 @@ struct MonOpRequest : public TrackedOp {
 
 private:
   Message *request;
+  bool could_duplicate;
   utime_t dequeued_time;
   MonSession *session;
   ConnectionRef con;
@@ -93,6 +94,7 @@ private:
     session(NULL),
     con(NULL),
     forwarded_to_leader(false),
+    could_duplicate(false),
     op_type(OP_TYPE_NONE)
   {
     if (req) {
@@ -192,6 +194,14 @@ public:
 
   op_type_t get_op_type() {
     return op_type;
+  }
+
+  void set_could_duplicate(bool cd) {
+    could_duplicate = cd;
+  }
+
+  bool could_duplicate() {
+    return could_duplicate;
   }
 
   bool is_type_service() {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -798,6 +798,7 @@ public:
   };
   uint64_t routed_request_tid;
   map<uint64_t, RoutedRequest*> routed_requests;
+  map<entity_inst_t, set<uint64_t> > src_rr_map;
   
   void forward_request_leader(MonOpRequestRef op);
   void handle_forward(MonOpRequestRef op);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1991,6 +1991,7 @@ bool OSDMonitor::prepare_update(MonOpRequestRef op)
   op->mark_osdmon_event(__func__);
   Message *m = op->get_req();
   dout(7) << "prepare_update " << *m << " from " << m->get_orig_source_inst() << dendl;
+  op->set_could_duplicate(true);
 
   switch (m->get_type()) {
     // damp updates


### PR DESCRIPTION
mon: remove all routed osdmap requests when their request osdmap inc is distributed

Fixes: http://tracker.ceph.com/issues/24342
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>