### PR TITLE
mimic: cmake: fix cython target in test/CMakeFile.txt

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -545,7 +545,7 @@ add_dependencies(tests
   ceph_erasure_code_non_regression
   ceph_erasure_code
   ceph-disk
-  cython_modules)
+  cython${PY_BINDING_INFIX}_modules)
 if(WITH_RBD)
   add_dependencies(tests unittest_librbd rbd)
   if(FREEBSD)


### PR DESCRIPTION
Backport of #22295. Fixes ceph-test builds in python3 only environments.