### PR TITLE
osd/PG: do not choose stray osds as async_recovery_targets

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1510,6 +1510,9 @@ void PG::choose_async_recovery_ec(const map<pg_shard_t, pg_info_t> &all_info,
     // now. We could use minimum_to_decode_with_cost() later if
     // necessary.
     pg_shard_t shard_i((*want)[i], shard_id_t(i));
+    // do not include strays
+    if (stray_set.find(shard_i) != stray_set.end())
+      continue;
     auto shard_info = all_info.find(shard_i)->second;
     // for ec pools we rollback all entries past the authoritative
     // last_update *before* activation. This is relatively inexpensive
@@ -1549,6 +1552,9 @@ void PG::choose_async_recovery_replicated(const map<pg_shard_t, pg_info_t> &all_
   set<pair<int, pg_shard_t> > candidates_by_cost;
   for (auto osd_num : *want) {
     pg_shard_t shard_i(osd_num, shard_id_t::NO_SHARD);
+    // do not include strays
+    if (stray_set.find(shard_i) != stray_set.end())
+      continue;
     auto shard_info = all_info.find(shard_i)->second;
     // use the approximate magnitude of the difference in length of
     // logs as the cost of recovery


### PR DESCRIPTION
Without this change, we might accept stray osds as async_recovery_targets,
and need to ensure that they get a chance to become part of the acting set
after recovery is over.

However, when choose_acting() is called in the Recovered state, we set
restrict_to_up_acting=true, which does not allow them to get back to the
acting set.

Therefore, similar to backfill, do not allow stray osds to become
async_recovery_targets.

Fixes: https://tracker.ceph.com/issues/24349
Signed-off-by: Neha Ojha <nojha@redhat.com>