### PR TITLE
os/bluestore: remove useless condtion.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2929,7 +2929,7 @@ int BlueStore::ExtentMap::compress_extent_map(
       }
     }
   }
-  if (removed && onode) {
+  if (removed) {
     onode->c->store->logger->inc(l_bluestore_extent_compress, removed);
   }
   return removed;


### PR DESCRIPTION
onode must not be null in this func.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>