### PR TITLE
os/bluestore: firstly delete db then delete bluefs if open db met error.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4966,13 +4966,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
   }
   if (r) {
     derr << __func__ << " erroring opening db: " << err.str() << dendl;
-    if (bluefs) {
-      bluefs->umount();
-      delete bluefs;
-      bluefs = NULL;
-    }
-    delete db;
-    db = NULL;
+    _close_db();
     return -EIO;
   }
   dout(1) << __func__ << " opened " << kv_backend


### PR DESCRIPTION
When create Rocksdb but failed, met the followong error messages:

2018-05-31 22:30:15.017 7facd3f4f240 -1 rocksdb: do_open Failed to create rocksdb column family: L
2018-05-31 22:30:15.017 7facd3f4f240 -1 bluestore(/home/jianpeng/ceph/build/dev/osd0) _open_db erroring opening db:
*** Caught signal (Segmentation fault) **
 in thread 7facd3f4f240 thread_name:ceph-osd
 ceph version 14.0.0-109-g9d317e5d23 (9d317e5d23eb78deec1a048aff5c2a31997c8345) nautilus (dev)
 1: (()+0x910ee0) [0x555727d3aee0]
 2: (()+0x12890) [0x7facc9a8d890]
 3: (pthread_mutex_lock()+0) [0x7facc9a84fa0]
 4: (BlockDevice::queue_reap_ioc(IOContext*)+0x28) [0x555727ce4fa8]
 5: (BlueFS::_close_writer(BlueFS::FileWriter*)+0x62) [0x555727ce9d52]
 6: (BlueRocksWritableFile::~BlueRocksWritableFile()+0x49) [0x555727d0e659]
 7: (rocksdb::WritableFileWriter::Close()+0x1e7) [0x555727ef0c77]
 8: (rocksdb::log::Writer::~Writer()+0x4d) [0x555727dfbb1d]
 9: (rocksdb::DBImpl::CloseHelper()+0x342) [0x555727d6d632]
 10: (rocksdb::DBImpl::~DBImpl()+0x4dd) [0x555727d7cb6d]
 11: (rocksdb::DBImpl::~DBImpl()+0x11) [0x555727d7cc11]
 12: (RocksDBStore::~RocksDBStore()+0xc1) [0x555727c8a6f1]
 13: (RocksDBStore::~RocksDBStore()+0x9) [0x555727c8aa29]
 14: (BlueStore::_open_db(bool, bool)+0x2416) [0x555727c204b6]
 15: (BlueStore::mkfs()+0x805) [0x555727c50105]
 16: (OSD::mkfs(CephContext*, ObjectStore*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, uuid_d, int)+0x1b0) [0x5557277ffa70]
 17: (main()+0x4222) [0x5557276ebb92]
 18: (__libc_start_main()+0xe7) [0x7facc8948b97]
 19: (_start()+0x2a) [0x5557277b0a9a]
2018-05-31 22:30:15.789 7facd3f4f240 -1 *** Caught signal (Segmentation fault) **
 in thread 7facd3f4f240 thread_name:ceph-osd

This because the error handle for this case firstly delete bluefs then
db. Like close path, it should firstly delete db than delete bluefs.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>