### PR TITLE
osd,mon: enable level_compaction_dynamic_level_bytes for rocksdb

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3494,7 +3494,9 @@ std::vector<Option> get_global_options() {
     .set_description("The block size for index partitions. (0 = rocksdb default)"),
 
     Option("mon_rocksdb_options", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("write_buffer_size=33554432,compression=kNoCompression")
+    .set_default("write_buffer_size=33554432,"
+		 "compression=kNoCompression,"
+		 "level_compaction_dynamic_level_bytes=true")
     .set_description(""),
 
     Option("osd_client_op_priority", Option::TYPE_UINT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/24361
Signed-off-by: Kefu Chai <kchai@redhat.com>