### PR TITLE
doc: update description of mount options for cephfs

### DIFF
--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -46,15 +46,14 @@ Options
 =======
 
 :command:`wsize`
-  int (bytes), max write size. Default: none (writeback uses smaller of wsize
+  int (bytes), max write size. Default: 16777216 (16*1024*1024) (writeback uses smaller of wsize
   and stripe unit)
 
 :command:`rsize`
-  int (bytes), max read size. Default: none
+  int (bytes), max read size. Default: 16777216 (16*1024*1024)
 
 :command:`rasize`
-  int (bytes), max readahead, multiple of 1024, Default: 8388608
-  (8192*1024)
+  int (bytes), max readahead. Default: 8388608 (8192*1024)
 
 :command:`osdtimeout`
   int (seconds), Default: 60


### PR DESCRIPTION
Based on kernel client code, wsize/rsize have default
value 16777216 (16\*1024\*1024) and rasize actually aligns
to PAGE_SIZE.

Signed-off-by: Chengguang Xu <cgxu519@gmx.com>