### PR TITLE
cls/rgw: ready rgw_usage_log_entry for extraction via ceph-dencoder

### DIFF
--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -578,6 +578,54 @@ void rgw_bucket_dir::dump(Formatter *f) const
   f->close_section();
 }
 
+void rgw_usage_log_entry::dump(Formatter *f) const
+{
+  f->dump_string("owner", owner.to_str());
+  f->dump_string("payer", payer.to_str());
+  f->dump_string("bucket", bucket);
+  f->dump_unsigned("epoch", epoch);
+
+  f->open_object_section("total_usage");
+  f->dump_unsigned("bytes_sent", total_usage.bytes_sent);
+  f->dump_unsigned("bytes_received", total_usage.bytes_received);
+  f->dump_unsigned("ops", total_usage.ops);
+  f->dump_unsigned("successful_ops", total_usage.successful_ops);
+  f->close_section();
+
+  f->open_array_section("categories");
+  if (usage_map.size() > 0) {
+    map<string, rgw_usage_data>::const_iterator it;
+    for (it = usage_map.begin(); it != usage_map.end(); it++) {
+      const rgw_usage_data& total_usage = it->second;
+      f->open_object_section("entry");
+      f->dump_string("category", it->first.c_str());
+      f->dump_unsigned("bytes_sent", total_usage.bytes_sent);
+      f->dump_unsigned("bytes_received", total_usage.bytes_received);
+      f->dump_unsigned("ops", total_usage.ops);
+      f->dump_unsigned("successful_ops", total_usage.successful_ops);
+      f->close_section();
+    }
+  }
+  f->close_section();
+}
+
+void rgw_usage_log_entry::generate_test_instances(list<rgw_usage_log_entry *> &o)
+{
+  rgw_usage_log_entry *entry = new rgw_usage_log_entry;
+  rgw_usage_data usage_data{1024, 2048};
+  entry->owner = rgw_user("owner");
+  entry->payer = rgw_user("payer");
+  entry->bucket = "bucket";
+  entry->epoch = 1234;
+  entry->total_usage.bytes_sent = usage_data.bytes_sent;
+  entry->total_usage.bytes_received = usage_data.bytes_received;
+  entry->total_usage.ops = usage_data.ops;
+  entry->total_usage.successful_ops = usage_data.successful_ops;
+  entry->usage_map["get_obj"] = usage_data;
+  o.push_back(entry);
+  o.push_back(new rgw_usage_log_entry);
+}
+
 void cls_rgw_reshard_entry::generate_key(const string& tenant, const string& bucket_name, string *key)
 {
   *key = tenant + ":" + bucket_name;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -857,6 +857,10 @@ struct rgw_usage_log_entry {
     usage_map[category].aggregate(data);
     total_usage.aggregate(data);
   }
+
+  void dump(Formatter* f) const;
+  static void generate_test_instances(list<rgw_usage_log_entry*>& o);
+
 };
 WRITE_CLASS_ENCODER(rgw_usage_log_entry)
 

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -325,6 +325,7 @@ TYPE(rgw_bucket_dir)
 TYPE(rgw_bucket_entry_ver)
 TYPE(cls_rgw_obj_key)
 TYPE(rgw_bucket_olh_log_entry)
+TYPE(rgw_usage_log_entry)
 
 #include "cls/rgw/cls_rgw_ops.h"
 TYPE(rgw_cls_obj_prepare_op)


### PR DESCRIPTION
This adds in ability for `ceph-dencoder` to be able to parse user/bucket usage entries from usage shards which is useful for debugging in certain situations. The addition to `ceph-dencoder` is for the type *rgw_usage_log_entry*.

r: @cbodley 

Signed-off-by: Vaibhav Bhembre vaibhav@digitalocean.com