### PR TITLE
systemd: only restart 3 times in 30 minutes, as fast as possible

### DIFF
--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -18,8 +18,7 @@ PrivateTmp=true
 TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
-StartLimitBurst=30
-RestartSec=20s
+StartLimitBurst=3
 
 [Install]
 WantedBy=ceph-osd.target


### PR DESCRIPTION
Once upon a time, we configured our init systems to only restart an OSD 3 times
in a 30 minute period. This made sure a permanently-slow OSD would stay dead,
and that an OSD which was dying on boot (but only after a long boot process)
would not insist on rejoining the cluster for *too* long.

In 62084375fa8370ca3884327b4a4ad28e0281747e, Boris applied these same rules to
systemd in a great bid for init system consistency. Hurray!

Sadly, Loic discovered that the great dragons udev and ceph-disk were
susceptible to races under systemd (that we apparently didn't see with
the other init systems?), and our 3x start limit was preventing the
system from sorting them out. In b3887379d6dde3b5a44f2e84cf917f4f0a0cb120
he configured the system to allow *30* restarts in 30 minutes, but no more
frequently than every 20 seconds.

So that resolved the race issue, which was far more immediately annoying
than any concern about OSDs sometimes taking too long to die. But I've started
hearing in-person reports about OSDs not failing hard and fast when they go bad,
and I attribute some of those reports to these init system differences.

Happily, we no longer rely on udev and ceph-disk, and ceph-volume shouldn't
be susceptible to the same race, so I think we can just go back to the old way.

Partly-reverts: b3887379d6dde3b5a44f2e84cf917f4f0a0cb120
Partly-fixes: http://tracker.ceph.com/issues/24368

Signed-off-by: Greg Farnum <gfarnum@redhat.com>