### PR TITLE
spdk: fix ceph-osd crash when activate SPDK

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -795,6 +795,8 @@ void NVMEDevice::close()
 {
   dout(1) << __func__ << dendl;
 
+  delete queue_t;
+  queue_t = nullptr;
   name.clear();
   driver->remove_device(this);
 


### PR DESCRIPTION
When activate SPDK in Ceph, observe a Ceph crash.

It happened in the case 1) there is a pending IOContext in
NVMEDevice and 2) the lower block device has been recreated and
queue_t then points to an NVMEDevice that no longer exists.

This patch addresses the problem by deleting and zeroing queue_t
when NVMEDevice is closed.

Fixes: http://tracker.ceph.com/issues/24371

Signed-off-by: tone-zhang <tone.zhang@arm.com>