### PR TITLE
common/DecayCounter: set last_decay to current time when decoding decay counter

### DIFF
--- a/src/common/DecayCounter.cc
+++ b/src/common/DecayCounter.cc
@@ -38,6 +38,7 @@ void DecayCounter::decode(const utime_t &t, bufferlist::const_iterator &p)
   decode(val, p);
   decode(delta, p);
   decode(vel, p);
+  last_decay = t;
   DECODE_FINISH(p);
 }
 


### PR DESCRIPTION
Recently we found mds load might become zero on another MDS under multi-MDSes scenario. The ceph version is Luminous.

From below log, MDS.1 got its load and would send it to MDS.0.
```
2018-05-13 17:20:31.252804 7ffa471d7700  0 mds.1.bal mds.1 epoch 17 load mdsload<[0,6245.74 12491.5]/[0,33581.5 67163], req 13440, hr 0, qlen 18, cpu 0.04>
``` 

When MDS.0 handled the heartbeat and got MDS.1's load from message, the load became zero.
```
2018-05-13 17:20:30.988828 7f65d8b45700  0 mds.0.bal mds.0 epoch 17 load mdsload<[5580.31,18907.2 43394.8]/[33213.8,109221 251656], req 42543, hr 0, qlen 36, cpu 0.75>
2018-05-13 17:20:31.280096 7f65db34a700  0 mds.0.bal   mds.0 mdsload<[5580.31,18907.2 43394.8]/[33213.8,109221 251656], req 42543, hr 0, qlen 36, cpu 0.75> = 127950 ~ 43394.8
2018-05-13 17:20:31.280113 7f65db34a700  0 mds.0.bal   mds.1 mdsload<[0,0 0]/[0,0 0], req 13440, hr 0, qlen 18, cpu 0.04> = 37045.8 ~ 12564.2
```

We found the last_decay in this message is 0 (utime_t()), so the eclipse time is very large and the original value would be decayed to 0. I think we should not decay any value if last_decay is utime_t().

Fixes: http://tracker.ceph.com/issues/24440

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>