### PR TITLE
mds: add reference when setting Connection::priv to existing session

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1339,7 +1339,7 @@ bool MDSDaemon::ms_verify_authorizer(Connection *con, int peer_type,
     } else {
       dout(10) << " existing session " << s << " for " << s->info.inst << " existing con " << s->connection
 	       << ", new/authorizing con " << con << dendl;
-      con->set_priv(RefCountedPtr{s, false});
+      con->set_priv(RefCountedPtr{s});
 
 
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1017,7 +1017,7 @@ void MDSRank::send_message_client_counted(Message *m, client_t client)
 void MDSRank::send_message_client_counted(Message *m, Connection *connection)
 {
   // do not carry ref
-  auto session = static_cast<Session *>(m->get_connection()->get_priv().get());
+  auto session = static_cast<Session *>(connection->get_priv().get());
   if (session) {
     send_message_client_counted(m, session);
   } else {


### PR DESCRIPTION
the bug was introduced by commit 72883956c26 "use intrusive_ptr for
holding Connection::priv"

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>