### PR TITLE
mgr/dashboard: Changed default value of decimal point to 1

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
@@ -26,26 +26,6 @@ describe('FormatterService', () => {
     expect(service).toBeTruthy();
   });
 
-  describe('truncate', () => {
-    it('should do test integer values', () => {
-      expect(service.truncate('1234', 8)).toBe('1234');
-      expect(service.truncate(1234, 8)).toBe('1234');
-    });
-
-    it('should do test floating values', () => {
-      const value = '1234.567899000';
-      expect(service.truncate(value, 0)).toBe('1235');
-      expect(service.truncate(value, 1)).toBe('1234.6');
-      expect(service.truncate(value, 3)).toBe('1234.568');
-      expect(service.truncate(value, 4)).toBe('1234.5679');
-      expect(service.truncate(value, 5)).toBe('1234.5679');
-      expect(service.truncate(value, 6)).toBe('1234.567899');
-      expect(service.truncate(value, 7)).toBe('1234.567899');
-      expect(service.truncate(value, 10)).toBe('1234.567899');
-      expect(service.truncate(100.0, 4)).toBe('100');
-    });
-  });
-
   describe('format_number', () => {
     const formats = ['B', 'KiB', 'MiB', 'GiB', 'TiB', 'PiB', 'EiB', 'ZiB', 'YiB'];
 
@@ -61,7 +41,7 @@ describe('FormatterService', () => {
       expect(service.format_number('1.2', 1024, formats)).toBe('1.2B');
       expect(service.format_number('1', 1024, formats)).toBe('1B');
       expect(service.format_number('1024', 1024, formats)).toBe('1KiB');
-      expect(service.format_number(23.45678 * Math.pow(1024, 3), 1024, formats)).toBe('23.4568GiB');
+      expect(service.format_number(23.45678 * Math.pow(1024, 3), 1024, formats)).toBe('23.5GiB');
       expect(service.format_number(23.45678 * Math.pow(1024, 3), 1024, formats, 2)).toBe(
         '23.46GiB'
       );
@@ -69,7 +49,7 @@ describe('FormatterService', () => {
 
     it('should test some dimless values', () => {
       expect(dimlessPipe.transform(0.6)).toBe('0.6');
-      expect(dimlessPipe.transform(1000.608)).toBe('1.0006k');
+      expect(dimlessPipe.transform(1000.608)).toBe('1k');
       expect(dimlessPipe.transform(1e10)).toBe('10G');
       expect(dimlessPipe.transform(2.37e16)).toBe('23.7P');
     });
@@ -100,7 +80,7 @@ describe('FormatterService', () => {
       convertToBytesAndBack('1.1MiB');
       convertToBytesAndBack('1.0MiB', '1MiB');
       convertToBytesAndBack('8.9GiB');
-      convertToBytesAndBack('123.456EiB');
+      convertToBytesAndBack('123.5EiB');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
@@ -6,20 +6,7 @@ import * as _ from 'lodash';
 export class FormatterService {
   constructor() {}
 
-  truncate(n: number | string, decimals: number): string {
-    const value = n.toString();
-    const parts = value.split('.');
-    if (parts.length === 1) {
-      return value; // integer
-    } else {
-      return Number.parseFloat(value)
-        .toPrecision(decimals + parts[0].length)
-        .toString()
-        .replace(/0+$/, '');
-    }
-  }
-
-  format_number(n: any, divisor: number, units: string[], decimals: number = 4): string {
+  format_number(n: any, divisor: number, units: string[], decimals: number = 1): string {
     if (_.isString(n)) {
       n = Number(n);
     }
@@ -27,7 +14,7 @@ export class FormatterService {
       return '-';
     }
     const unit = n < 1 ? 0 : Math.floor(Math.log(n) / Math.log(divisor));
-    const truncatedFloat = this.truncate(n / Math.pow(divisor, unit), decimals);
+    const truncatedFloat = _.round(n / Math.pow(divisor, unit), decimals).toString();
     return truncatedFloat === '' ? '-' : truncatedFloat + units[unit];
   }
 


### PR DESCRIPTION
Changed the default decimals point to 1 in 'formater_number' method, this
is used in the 'dimlessPipe' and 'dimlessBinaryPipe'.
This value can still be changed when needed, using one of the parameters.

I have also removed the removal of trailing 0 and switched from 'toPrecision'
to 'toFixed'.

Fixes: https://tracker.ceph.com/issues/24281

Signed-off-by: Tiago Melo <tmelo@suse.com>