### PR TITLE
rgw: Get the user metadata of the user used to sign the request

### DIFF
--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -59,6 +59,15 @@ void RGWOp_Metadata_Get::execute() {
   http_ret = 0;
 }
 
+void RGWOp_Metadata_Get_Myself::execute() {
+  string owner_id;
+
+  owner_id = s->owner.get_id().to_str();
+  s->info.args.append("key", owner_id);
+
+  return RGWOp_Metadata_Get::execute();
+}
+
 void RGWOp_Metadata_List::execute() {
   string marker = s->info.args.get("marker");
   bool max_entries_specified;
@@ -301,6 +310,8 @@ void RGWOp_Metadata_Unlock::execute() {
 }
 
 RGWOp *RGWHandler_Metadata::op_get() {
+  if (s->info.args.exists("myself"))
+    return new RGWOp_Metadata_Get_Myself;
   if (s->info.args.exists("key"))
     return new RGWOp_Metadata_Get;
   else

--- a/src/rgw/rgw_rest_metadata.h
+++ b/src/rgw/rgw_rest_metadata.h
@@ -39,6 +39,14 @@ public:
   const char* name() const override { return "get_metadata"; }
 };
 
+class RGWOp_Metadata_Get_Myself : public RGWOp_Metadata_Get {
+public:
+  RGWOp_Metadata_Get_Myself() {}
+  ~RGWOp_Metadata_Get_Myself() override {}
+
+  void execute() override;
+};
+
 class RGWOp_Metadata_Put : public RGWRESTOp {
   int get_data(bufferlist& bl);
   string update_status;


### PR DESCRIPTION
Add REST endpoint /admin/metadata/user?myself to get the metadata of the user that is used to sign the request.

See feature request https://tracker.ceph.com/issues/24335.

This feature is required by https://tracker.ceph.com/issues/24080 and PR #22276.