### PR TITLE
ceph-volume lvm.activate Do not search for a MON configuration

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -151,7 +151,7 @@ def activate_bluestore(lvs, no_systemd=False):
     process.run([
         'ceph-bluestore-tool', '--cluster=%s' % conf.cluster,
         'prime-osd-dir', '--dev', osd_lv_path,
-        '--path', osd_path])
+        '--path', osd_path, '--no-mon-config'])
     # always re-do the symlink regardless if it exists, so that the block,
     # block.wal, and block.db devices that may have changed can be mapped
     # correctly every time


### PR DESCRIPTION
This system might not have one nor can we be sure that we have
a client.admin keyring on the system.

Just prime the directory and have the OSD then use it's own cephx
key to communicate with the MONs.

Signed-off-by: Wido den Hollander <wido@42on.com>