### PR TITLE
mgr/dashboard: Stacktrace is optional on 'js-error' endpoint

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/logging.py
+++ b/src/pybind/mgr/dashboard/controllers/logging.py
@@ -6,5 +6,5 @@ from .. import logger
 class Logging(BaseController):
 
     @Endpoint('POST', path='js-error')
-    def jsError(self, url, message, stack):
+    def jsError(self, url, message, stack=None):
         logger.error('frontend error (%s): %s\n %s\n', url, message, stack)


### PR DESCRIPTION
Stacktrace should be optional because a javascript error can have no stacktrace.

Signed-off-by: Ricardo Marques <rimarques@suse.com>