### PR TITLE
mgr/dashboard: Login failure should return HTTP 400

### DIFF
--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -47,8 +47,12 @@ class AuthTest(DashboardTestCase):
 
     def test_login_invalid(self):
         self._post("/api/auth", {'username': 'admin', 'password': 'inval'})
-        self.assertStatus(403)
-        self.assertJsonBody({"detail": "Invalid credentials"})
+        self.assertStatus(400)
+        self.assertJsonBody({
+            "component": "auth",
+            "code": "invalid_credentials",
+            "detail": "Invalid credentials"
+        })
 
     def test_logout(self):
         self._post("/api/auth", {'username': 'admin', 'password': 'admin'})

--- a/src/pybind/mgr/dashboard/controllers/auth.py
+++ b/src/pybind/mgr/dashboard/controllers/auth.py
@@ -8,6 +8,7 @@ import cherrypy
 
 from . import ApiController, RESTController
 from .. import logger, mgr
+from ..exceptions import DashboardException
 from ..tools import Session
 
 
@@ -40,13 +41,14 @@ class Auth(RESTController):
             logger.debug('Login successful')
             return {'username': username}
 
-        cherrypy.response.status = 403
         if config_username is None:
             logger.warning('No Credentials configured. Need to call `ceph dashboard '
                            'set-login-credentials <username> <password>` first.')
         else:
             logger.debug('Login failed')
-        return {'detail': 'Invalid credentials'}
+        raise DashboardException(msg='Invalid credentials',
+                                 code='invalid_credentials',
+                                 component='auth')
 
     def bulk_delete(self):
         logger.debug('Logout successful')

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/components.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/components.enum.ts
@@ -1,4 +1,5 @@
 export enum Components {
+  auth = 'Login',
   cephfs = 'CephFS',
   rbd = 'RBD',
   pool = 'Pool',


### PR DESCRIPTION
A login failure should return HTTP code `400`, instead of `403 - Forbidden`, so we can distinguish between `Login failure` and `Forbidden`.

Signed-off-by: Ricardo Marques <rimarques@suse.com>