### PR TITLE
mgr/dashboard: Do not fetch pool list on RBD edit

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -73,10 +73,17 @@
             <span class="required"></span>
           </label>
           <div class="col-sm-9">
+            <input class="form-control"
+                   type="text"
+                   id="pool"
+                   name="pool"
+                   formControlName="pool"
+                   *ngIf="mode === 'editing'">
             <select id="pool"
                     name="pool"
                     class="form-control"
-                    formControlName="pool">
+                    formControlName="pool"
+                    *ngIf="mode !== 'editing'">
               <option *ngIf="pools === null"
                       [ngValue]="null">Loading...
               </option>
@@ -125,11 +132,18 @@
             </cd-helper>
           </label>
           <div class="col-sm-9">
+            <input class="form-control"
+                   type="text"
+                   id="dataPool"
+                   name="dataPool"
+                   formControlName="dataPool"
+                   *ngIf="mode === 'editing'">
             <select id="dataPool"
                     name="dataPool"
                     class="form-control"
                     formControlName="dataPool"
-                    (change)="onDataPoolChange($event.target.value)">
+                    (change)="onDataPoolChange($event.target.value)"
+                    *ngIf="mode !== 'editing'">
               <option *ngIf="dataPools === null"
                       [ngValue]="null">Loading...
               </option>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.html
@@ -70,7 +70,8 @@
           <label class="control-label col-sm-3"
                  for="pool">
             Pool
-            <span class="required"></span>
+            <span class="required"
+                  *ngIf="mode !== 'editing'"></span>
           </label>
           <div class="col-sm-9">
             <input class="form-control"
@@ -126,7 +127,8 @@
           <label class="control-label col-sm-3"
                  for="dataPool">
             Data pool
-            <span class="required"></span>
+            <span class="required"
+                  *ngIf="mode !== 'editing'"></span>
             <cd-helper i18n-html
                        html="Dedicated pool that stores the object-data of the RBD.">
             </cd-helper>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -219,32 +219,34 @@ export class RbdFormComponent implements OnInit {
           this.setFeatures(defaultFeatures);
         });
     }
-    this.poolService.list(['pool_name', 'type', 'flags_names', 'application_metadata']).then(
-      resp => {
-        const pools = [];
-        const dataPools = [];
-        for (const pool of resp) {
-          if (_.indexOf(pool.application_metadata, 'rbd') !== -1) {
-            if (pool.type === 'replicated') {
-              pools.push(pool);
-              dataPools.push(pool);
-            } else if (pool.type === 'erasure' &&
-              pool.flags_names.indexOf('ec_overwrites') !== -1) {
-              dataPools.push(pool);
+    if (this.mode !== this.rbdFormMode.editing) {
+      this.poolService.list(['pool_name', 'type', 'flags_names', 'application_metadata']).then(
+        resp => {
+          const pools = [];
+          const dataPools = [];
+          for (const pool of resp) {
+            if (_.indexOf(pool.application_metadata, 'rbd') !== -1) {
+              if (pool.type === 'replicated') {
+                pools.push(pool);
+                dataPools.push(pool);
+              } else if (pool.type === 'erasure' &&
+                pool.flags_names.indexOf('ec_overwrites') !== -1) {
+                dataPools.push(pool);
+              }
             }
           }
+          this.pools = pools;
+          this.allPools = pools;
+          this.dataPools = dataPools;
+          this.allDataPools = dataPools;
+          if (this.pools.length === 1) {
+            const poolName = this.pools[0]['pool_name'];
+            this.rbdForm.get('pool').setValue(poolName);
+            this.onPoolChange(poolName);
+          }
         }
-        this.pools = pools;
-        this.allPools = pools;
-        this.dataPools = dataPools;
-        this.allDataPools = dataPools;
-        if (this.pools.length === 1) {
-          const poolName = this.pools[0]['pool_name'];
-          this.rbdForm.get('pool').setValue(poolName);
-          this.onPoolChange(poolName);
-        }
-      }
-    );
+      );
+    }
     this.deepFlattenFormControl.valueChanges.subscribe((value) => {
       this.watchDataFeatures('deep-flatten', value);
     });


### PR DESCRIPTION
When editing an RBD, `Pool` and `Data Pool` are both `read-only` fields so we should not fetch the pool list to populate dropdowns that cannot be edited, instead, we should simply use a `read-only` text input and avoid an useless request to the server which results in better performance.

Signed-off-by: Ricardo Marques <rimarques@suse.com>