### PR TITLE
mgr/dashboard: Listen on port 8443 by default and not 8080

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -152,7 +152,7 @@ Host name and port
 Like most web applications, dashboard binds to a TCP/IP address and TCP port.
 
 By default, the ``ceph-mgr`` daemon hosting the dashboard (i.e., the currently
-active manager) will bind to TCP port 8080. If no specific address has been
+active manager) will bind to TCP port 8443. If no specific address has been
 configured, the web app will bind to ``::``, which corresponds to all available
 IPv4 and IPv6 addresses.
 

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -61,7 +61,7 @@ Build the Project
 
 Run ``npm run build`` to build the project. The build artifacts will be
 stored in the ``dist/`` directory. Use the ``-prod`` flag for a
-production build. Navigate to ``https://localhost:8080``.
+production build. Navigate to ``https://localhost:8443``.
 
 Running Unit Tests
 ~~~~~~~~~~~~~~~~~~
@@ -292,12 +292,12 @@ following code:
       return {'msg': "Hello"}
 
 The ``hello`` endpoint of the ``Ping`` controller can be reached by the
-following URL: https://mgr_hostname:8080/ping/hello using HTTP GET requests.
+following URL: https://mgr_hostname:8443/ping/hello using HTTP GET requests.
 As you can see the controller URL path ``/ping`` is concatenated to the
 method name ``hello`` to generate the endpoint's URL.
 
 In the case of the ``ApiPing`` controller, the ``hello`` endpoint can be
-reached by the following URL: https://mgr_hostname:8080/api/ping/hello using a
+reached by the following URL: https://mgr_hostname:8443/api/ping/hello using a
 HTTP GET request.
 The API controller URL path ``/ping`` is prefixed by the ``/api`` path and then
 concatenated to the method name ``hello`` to generate the endpoint's URL.
@@ -307,7 +307,7 @@ decorator by passing an additional decorator parameter called ``base_url``::
   @ApiController('/ping') <=> @Controller('/ping', base_url="/api")
 
 ``UiApiPing`` works in a similar way than the ``ApiPing``, but the URL will be
-prefixed by ``/ui-api``: https://mgr_hostname:8080/ui-api/ping/hello. ``UiApiPing`` is
+prefixed by ``/ui-api``: https://mgr_hostname:8443/ui-api/ping/hello. ``UiApiPing`` is
 also a ``@Controller`` extension::
 
   @UiApiController('/ping') <=> @Controller('/ping', base_url="/ui-api")
@@ -408,7 +408,7 @@ Consider the following example:
 In this example we explicitly declare a path parameter ``{node}`` in the
 controller URL path, and a path parameter ``{date}`` in the ``latency``
 method. The endpoint for the ``latency`` method is then accessible through
-the URL: https://mgr_hostname:8080/ping/{node}/stats/{date}/latency .
+the URL: https://mgr_hostname:8443/ping/{node}/stats/{date}/latency .
 
 For a full set of examples on how to use the ``@Endpoint``
 decorator please check the unit test file: ``tests/test_controllers.py``.

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -540,9 +540,9 @@ class RESTController(BaseController):
     Test with curl:
 
     curl -H "Content-Type: application/json" -X POST \
-         -d '{"username":"xyz","password":"xyz"}'  http://127.0.0.1:8080/foo
-    curl http://127.0.0.1:8080/foo
-    curl http://127.0.0.1:8080/foo/0
+         -d '{"username":"xyz","password":"xyz"}'  https://127.0.0.1:8443/foo
+    curl https://127.0.0.1:8443/foo
+    curl https://127.0.0.1:8443/foo/0
 
     """
 

--- a/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
+++ b/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
@@ -1,11 +1,11 @@
 {
   "/api/": {
-    "target": "https://localhost:8080",
+    "target": "https://localhost:8443",
     "secure": false,
     "logLevel": "debug"
   },
   "/ui-api/": {
-    "target": "https://localhost:8080",
+    "target": "https://localhost:8443",
     "secure": false,
     "logLevel": "debug"
   }

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -114,7 +114,7 @@ class SSLCherryPyConfig(object):
         :returns our URI
         """
         server_addr = self.get_localized_config('server_addr', '::')
-        server_port = self.get_localized_config('server_port', '8080')
+        server_port = self.get_localized_config('server_port', '8443')
         if server_addr is None:
             raise ServerConfigException(
                 'no server_addr configured; '


### PR DESCRIPTION
Port 8080 is a common alternative HTTP port used for web traffic.

The dashboard however uses SSL (which can not be turned off) and for
that purpose we should either use 8443.

Historically the dashboard would run on port 7000 so to keep this backwards
compatibility the dashboard should bind again on TCP 7000.

Signed-off-by: Wido den Hollander <wido@42on.com>