### PR TITLE
mgr/dashboard: Get user ID via RGW Admin Ops API

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -25,9 +25,8 @@ class Rgw(BaseController):
             if not instance.is_service_online():
                 status['message'] = 'Failed to connect to the Object Gateway\'s Admin Ops API.'
                 raise RequestException(status['message'])
-            # If the API user ID is configured via 'ceph dashboard set-rgw-api-user-id <user_id>'
-            # (which is not mandatory), then ensure it is known by the RGW.
-            if instance.userid and not instance.is_system_user():
+            # Ensure the API user ID is known by the RGW.
+            if not instance.is_system_user():
                 status['message'] = 'The user "{}" is unknown to the Object Gateway.'.format(
                     instance.userid)
                 raise RequestException(status['message'])


### PR DESCRIPTION
The RGW API user id (set via 'ceph dashboard set-rgw-api-user-id <xxx>') is optional but the user ID is required internally for some situations. Because of that the user ID is requested via a RGW Admin Ops API call if it is not configured via CLI.
