### PR TITLE
mgr/dashboard: Hide progress bar in case of an error

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -12,7 +12,8 @@
                [status]="viewCacheStatus.status"
                [statusFor]="viewCacheStatus.statusFor"></cd-view-cache>
 
-<cd-table [data]="images"
+<cd-table #table
+          [data]="images"
           columnMode="flex"
           [columns]="columns"
           identifier="id"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -6,6 +6,7 @@ import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { ConfirmationModalComponent } from '../../../shared/components/confirmation-modal/confirmation-modal.component';
 import { DeletionModalComponent } from '../../../shared/components/deletion-modal/deletion-modal.component';
+import { TableComponent } from '../../../shared/datatable/table/table.component';
 import { CellTemplate } from '../../../shared/enum/cell-template.enum';
 import { ViewCacheStatus } from '../../../shared/enum/view-cache-status.enum';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
@@ -27,6 +28,7 @@ import { RbdModel } from './rbd-model';
   styleUrls: ['./rbd-list.component.scss']
 })
 export class RbdListComponent implements OnInit, OnDestroy {
+  @ViewChild(TableComponent) table: TableComponent;
   @ViewChild('usageTpl') usageTpl: TemplateRef<any>;
   @ViewChild('parentTpl') parentTpl: TemplateRef<any>;
   @ViewChild('nameTpl') nameTpl: TemplateRef<any>;
@@ -119,6 +121,10 @@ export class RbdListComponent implements OnInit, OnDestroy {
       this.summaryDataSubscription = this.summaryService.summaryData$.subscribe((data: any) => {
         this.loadImages(data.executing_tasks);
       });
+    },
+    () => {
+      this.table.reset(); // Disable loading indicator.
+      this.viewCacheStatusList = [{ status: ViewCacheStatus.ValueException }];
     });
   }
 
@@ -166,6 +172,7 @@ export class RbdListComponent implements OnInit, OnDestroy {
         this.executingTasks = executingTasks;
       },
       () => {
+        this.table.reset(); // Disable loading indicator.
         this.viewCacheStatusList = [{ status: ViewCacheStatus.ValueException }];
       }
     );

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.html
@@ -8,7 +8,7 @@
 <cd-table [data]="filesystems"
           columnMode="flex"
           [columns]="columns"
-          (fetchData)="loadFilesystems()"
+          (fetchData)="loadFilesystems($event)"
           identifier="id"
           forceIdentifier="true"
           selectionType="single"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 
 import { CephfsService } from '../../../shared/api/cephfs.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
+import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 
 @Component({
@@ -36,10 +37,15 @@ export class CephfsListComponent implements OnInit {
     ];
   }
 
-  loadFilesystems() {
-    this.cephfsService.list().subscribe((resp: any[]) => {
-      this.filesystems = resp;
-    });
+  loadFilesystems(context: CdTableFetchDataContext) {
+    this.cephfsService.list().subscribe(
+      (resp: any[]) => {
+        this.filesystems = resp;
+      },
+      () => {
+        context.error();
+      }
+    );
   }
 
   updateSelection(selection: CdTableSelection) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
@@ -6,7 +6,7 @@
   </ol>
 </nav>
 <cd-table [data]="data | filter:filters"
-          (fetchData)="getConfigurationList()"
+          (fetchData)="getConfigurationList($event)"
           [columns]="columns"
           selectionType="single"
           (updateSelection)="updateSelection($event)">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
 import { ConfigurationService } from '../../../shared/api/configuration.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
+import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 
 @Component({
@@ -114,10 +115,15 @@ export class ConfigurationComponent implements OnInit {
     this.selection = selection;
   }
 
-  getConfigurationList() {
-    this.configurationService.getConfigData().subscribe((data: any) => {
-      this.data = data;
-    });
+  getConfigurationList(context: CdTableFetchDataContext) {
+    this.configurationService.getConfigData().subscribe(
+      (data: any) => {
+        this.data = data;
+      },
+      () => {
+        context.error();
+      }
+    );
   }
 
   updateFilter() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -10,7 +10,7 @@
 <cd-table [data]="hosts"
           [columns]="columns"
           columnMode="flex"
-          (fetchData)="getHosts()">
+          (fetchData)="getHosts($event)">
   <ng-template #servicesTpl let-value="value">
     <span *ngFor="let service of value; last as isLast">
       <a [routerLink]="[service.cdLink]"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
 import { HostService } from '../../../shared/api/host.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
+import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
 import { Permissions } from '../../../shared/models/permissions';
 import { CephShortVersionPipe } from '../../../shared/pipes/ceph-short-version.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
@@ -49,7 +50,7 @@ export class HostsComponent implements OnInit {
     ];
   }
 
-  getHosts() {
+  getHosts(context: CdTableFetchDataContext) {
     if (this.isLoadingHosts) {
       return;
     }
@@ -62,23 +63,21 @@ export class HostsComponent implements OnInit {
       mgr: 'manager'
     };
     this.isLoadingHosts = true;
-    this.hostService
-      .list()
-      .then((resp) => {
-        resp.map((host) => {
-          host.services.map((service) => {
-            service.cdLink = `/perf_counters/${service.type}/${service.id}`;
-            const permissionKey = typeToPermissionKey[service.type];
-            service.canRead = this.permissions[permissionKey].read;
-            return service;
-          });
-          return host;
+    this.hostService.list().then((resp) => {
+      resp.map((host) => {
+        host.services.map((service) => {
+          service.cdLink = `/perf_counters/${service.type}/${service.id}`;
+          const permissionKey = typeToPermissionKey[service.type];
+          service.canRead = this.permissions[permissionKey].read;
+          return service;
         });
-        this.hosts = resp;
-        this.isLoadingHosts = false;
-      })
-      .catch(() => {
-        this.isLoadingHosts = false;
+        return host;
       });
+      this.hosts = resp;
+      this.isLoadingHosts = false;
+    }).catch(() => {
+      this.isLoadingHosts = false;
+      context.error();
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
@@ -4,7 +4,7 @@
   </ol>
 </nav>
 <cd-table [data]="pools"
-          (fetchData)="getPoolList()"
+          (fetchData)="getPoolList($event)"
           [columns]="columns"
           selectionType="single"
           (updateSelection)="updateSelection($event)">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 import { PoolService } from '../../../shared/api/pool.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
+import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 
 @Component({
@@ -14,9 +15,7 @@ export class PoolListComponent {
   columns: CdTableColumn[];
   selection = new CdTableSelection();
 
-  constructor(
-    private poolService: PoolService,
-  ) {
+  constructor(private poolService: PoolService) {
     this.columns = [
       {
         prop: 'pool_name',
@@ -68,10 +67,14 @@ export class PoolListComponent {
     this.selection = selection;
   }
 
-  getPoolList() {
-    this.poolService.getList().subscribe((pools: any[]) => {
-      this.pools = pools;
-    });
+  getPoolList(context: CdTableFetchDataContext) {
+    this.poolService.getList().subscribe(
+      (pools: any[]) => {
+        this.pools = pools;
+      },
+      () => {
+        context.error();
+      }
+    );
   }
-
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
@@ -15,7 +15,7 @@
           selectionType="multi"
           (updateSelection)="updateSelection($event)"
           identifier="bucket"
-          (fetchData)="getBucketList()">
+          (fetchData)="getBucketList($event)">
   <div class="table-actions">
     <div class="btn-group"
          dropdown>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
@@ -7,6 +7,7 @@ import { RgwBucketService } from '../../../shared/api/rgw-bucket.service';
 import { DeletionModalComponent } from '../../../shared/components/deletion-modal/deletion-modal.component';
 import { TableComponent } from '../../../shared/datatable/table/table.component';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
+import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permission } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
@@ -44,15 +45,13 @@ export class RgwBucketListComponent {
     ];
   }
 
-  getBucketList() {
+  getBucketList(context: CdTableFetchDataContext) {
     this.rgwBucketService.list().subscribe(
       (resp: object[]) => {
         this.buckets = resp;
       },
       () => {
-        // Force datatable to hide the loading indicator in
-        // case of an error.
-        this.buckets = [];
+        context.error();
       }
     );
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html
@@ -13,7 +13,7 @@
           columnMode="flex"
           selectionType="single"
           (updateSelection)="updateSelection($event)"
-          (fetchData)="getDaemonList()">
+          (fetchData)="getDaemonList($event)">
   <cd-rgw-daemon-details cdTableDetail
                          [selection]="selection">
   </cd-rgw-daemon-details>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.ts
@@ -2,6 +2,7 @@ import { Component } from '@angular/core';
 
 import { RgwDaemonService } from '../../../shared/api/rgw-daemon.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
+import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { CephShortVersionPipe } from '../../../shared/pipes/ceph-short-version.pipe';
 
@@ -39,15 +40,13 @@ export class RgwDaemonListComponent {
     ];
   }
 
-  getDaemonList() {
+  getDaemonList(context: CdTableFetchDataContext) {
     this.rgwDaemonService.list().subscribe(
       (resp: object[]) => {
         this.daemons = resp;
       },
       () => {
-        // Force datatable to hide the loading indicator in
-        // case of an error.
-        this.daemons = [];
+        context.error();
       }
     );
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.html
@@ -15,7 +15,7 @@
           selectionType="multi"
           (updateSelection)="updateSelection($event)"
           identifier="user_id"
-          (fetchData)="getUserList()">
+          (fetchData)="getUserList($event)">
   <div class="table-actions">
     <div class="btn-group" dropdown>
       <button type="button"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
@@ -8,6 +8,7 @@ import { DeletionModalComponent } from '../../../shared/components/deletion-moda
 import { TableComponent } from '../../../shared/datatable/table/table.component';
 import { CellTemplate } from '../../../shared/enum/cell-template.enum';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
+import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permission } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
@@ -61,15 +62,13 @@ export class RgwUserListComponent {
     ];
   }
 
-  getUserList() {
+  getUserList(context: CdTableFetchDataContext) {
     this.rgwUserService.list().subscribe(
       (resp: object[]) => {
         this.users = resp;
       },
       () => {
-        // Force datatable to hide the loading indicator in
-        // case of an error.
-        this.users = [];
+        context.error();
       }
     );
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -17,6 +17,7 @@ import { SparklineComponent } from './sparkline/sparkline.component';
 import { SubmitButtonComponent } from './submit-button/submit-button.component';
 import { UsageBarComponent } from './usage-bar/usage-bar.component';
 import { ViewCacheComponent } from './view-cache/view-cache.component';
+import { WarningPanelComponent } from './warning-panel/warning-panel.component';
 
 @NgModule({
   imports: [
@@ -42,7 +43,8 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     InfoPanelComponent,
     ModalComponent,
     DeletionModalComponent,
-    ConfirmationModalComponent
+    ConfirmationModalComponent,
+    WarningPanelComponent
   ],
   providers: [],
   exports: [
@@ -54,7 +56,8 @@ import { ViewCacheComponent } from './view-cache/view-cache.component';
     LoadingPanelComponent,
     InfoPanelComponent,
     UsageBarComponent,
-    ModalComponent
+    ModalComponent,
+    WarningPanelComponent
   ],
   entryComponents: [ModalComponent, DeletionModalComponent, ConfirmationModalComponent]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.html
@@ -2,7 +2,7 @@
   <table>
     <tr>
       <td rowspan="2" class="error-panel-alert-icon">
-        <i class="fa fa-3x fa-exclamation-triangle alert-danger"
+        <i class="fa fa-3x fa-times-circle alert-danger"
            aria-hidden="true"></i>
       </td>
       <td class="error-panel-alert-title">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.html
@@ -1,17 +1,14 @@
-<alert i18n
-       type="info"
-       *ngIf="status === vcs.ValueNone">
+<cd-info-panel i18n
+               *ngIf="status === vcs.ValueNone">
   Retrieving data<span *ngIf="statusFor"> for <span [innerHtml]="statusFor"></span></span>. Please wait...
-</alert>
+</cd-info-panel>
 
-<alert i18n
-       type="warning"
-       *ngIf="status === vcs.ValueStale">
+<cd-warning-panel i18n
+                  *ngIf="status === vcs.ValueStale">
   Displaying previously cached data<span *ngIf="statusFor"> for <span [innerHtml]="statusFor"></span></span>.
-</alert>
+</cd-warning-panel>
 
-<alert i18n
-       type="danger"
-       *ngIf="status === vcs.ValueException">
+<cd-error-panel i18n
+                *ngIf="status === vcs.ValueException">
   Could not load data<span *ngIf="statusFor"> for <span [innerHtml]="statusFor"></span></span>. Please check the cluster health.
-</alert>
+</cd-error-panel>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.spec.ts
@@ -3,6 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AlertModule } from 'ngx-bootstrap';
 
 import { configureTestBed } from '../../unit-test-helper';
+import { ErrorPanelComponent } from '../error-panel/error-panel.component';
+import { InfoPanelComponent } from '../info-panel/info-panel.component';
+import { WarningPanelComponent } from '../warning-panel/warning-panel.component';
 import { ViewCacheComponent } from './view-cache.component';
 
 describe('ViewCacheComponent', () => {
@@ -10,7 +13,12 @@ describe('ViewCacheComponent', () => {
   let fixture: ComponentFixture<ViewCacheComponent>;
 
   configureTestBed({
-    declarations: [ViewCacheComponent],
+    declarations: [
+      ErrorPanelComponent,
+      InfoPanelComponent,
+      ViewCacheComponent,
+      WarningPanelComponent
+    ],
     imports: [AlertModule.forRoot()]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.html
@@ -1,0 +1,18 @@
+<alert type="warning">
+  <table>
+    <tr>
+      <td rowspan="2" class="warning-panel-alert-icon">
+        <i class="fa fa-3x fa-warning alert-warning"
+           aria-hidden="true"></i>
+      </td>
+      <td class="warning-panel-alert-title">
+        {{ title }}
+      </td>
+    </tr>
+    <tr>
+      <td class="warning-panel-alert-text">
+        <ng-content></ng-content>
+      </td>
+    </tr>
+  </table>
+</alert>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.scss
@@ -1,0 +1,9 @@
+.warning-panel-alert-icon {
+  vertical-align: top;
+  padding-right: 15px; // See @alert-padding in bootstrap/less/variables.less
+}
+.warning-panel-alert-title {
+  font-weight: bold;
+}
+.warning-panel-alert-text {
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.spec.ts
@@ -1,0 +1,26 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AlertModule } from 'ngx-bootstrap';
+
+import { configureTestBed } from '../../unit-test-helper';
+import { WarningPanelComponent } from './warning-panel.component';
+
+describe('WarningPanelComponent', () => {
+  let component: WarningPanelComponent;
+  let fixture: ComponentFixture<WarningPanelComponent>;
+
+  configureTestBed({
+    declarations: [WarningPanelComponent],
+    imports: [AlertModule.forRoot()]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WarningPanelComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'cd-warning-panel',
+  templateUrl: './warning-panel.component.html',
+  styleUrls: ['./warning-panel.component.scss']
+})
+export class WarningPanelComponent {
+  /**
+   * The title to be displayed. Defaults to 'Warning'.
+   * @type {string}
+   */
+  @Input() title = 'Warning';
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -1,3 +1,7 @@
+<cd-error-panel i18n
+                *ngIf="loadingError">
+  Failed to load data.
+</cd-error-panel>
 <div class="dataTables_wrapper">
   <div class="dataTables_header clearfix"
        *ngIf="toolHeader">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -5,6 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 
 import { ComponentsModule } from '../../components/components.module';
+import { CdTableFetchDataContext } from '../../models/cd-table-fetch-data-context';
 import { configureTestBed } from '../../unit-test-helper';
 import { TableComponent } from './table.component';
 
@@ -239,6 +240,51 @@ describe('TableComponent', () => {
       expect(component.userConfig.sorts[0].prop).toBe('b');
       expect(component.tableColumns.length).toBe(4);
       equalStorageConfig();
+    });
+
+    afterEach(() => {
+      clearLocalStorage();
+    });
+  });
+
+  describe('reload data', () => {
+    beforeEach(() => {
+      component.ngOnInit();
+      component.data = [];
+      component.updating = false;
+    });
+
+    it('should call fetchData callback function', () => {
+      component.fetchData.subscribe((context) => {
+        expect(context instanceof CdTableFetchDataContext).toBeTruthy();
+      });
+      component.reloadData();
+    });
+
+    it('should call error function', () => {
+      component.data = createFakeData(5);
+      component.fetchData.subscribe((context) => {
+        context.error();
+        expect(component.loadingError).toBeTruthy();
+        expect(component.data.length).toBe(0);
+        expect(component.loadingIndicator).toBeFalsy();
+        expect(component.updating).toBeFalsy();
+      });
+      component.reloadData();
+    });
+
+    it('should call error function with custom config', () => {
+      component.data = createFakeData(10);
+      component.fetchData.subscribe((context) => {
+        context.errorConfig.resetData = false;
+        context.errorConfig.displayError = false;
+        context.error();
+        expect(component.loadingError).toBeFalsy();
+        expect(component.data.length).toBe(10);
+        expect(component.loadingIndicator).toBeFalsy();
+        expect(component.updating).toBeFalsy();
+      });
+      component.reloadData();
     });
 
     afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-fetch-data-context.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-fetch-data-context.ts
@@ -1,0 +1,17 @@
+export class CdTableFetchDataContext {
+  errorConfig = {
+    resetData: true,   // Force data table to show no data
+    displayError: true // Show an error panel above the data table
+  };
+
+  /**
+   * The function that should be called from within the error handler
+   * of the 'fetchData' function to display the error panel and to
+   * reset the data table to the correct state.
+   */
+  error: Function;
+
+  constructor(error: () => void) {
+    this.error = error;
+  }
+}


### PR DESCRIPTION
Otherwise it looks like in this https://youtu.be/2UwRwJTDF0Q?t=1287 video.

The datatable has been enhanced to be able to display an error message in case of a loading failure. The datatable will still show the 'No data to display', but a error panel is displayed above the datatable. We are using such panels spread accross the UI, so it does not make sense to do it different here.

![fireshot capture 34 - ceph - http___localhost_4200_ _configuration](https://user-images.githubusercontent.com/1897962/41034195-31c07548-6989-11e8-84c6-12db869421d4.png)

Signed-off-by: Volker Theile <vtheile@suse.com>
