### PR TITLE
mgr/dashboard: Stringify object[] in KV-table

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
@@ -25,11 +25,6 @@ describe('TableKeyValueComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
-    expect(component._convertValue).toBeTruthy();
-    expect(component._makePairs).toBeTruthy();
-    expect(component._makePairsFromObject).toBeTruthy();
-    expect(component._makePairsFromArray).toBeTruthy();
-    expect(component._insertFlattenObjects).toBeTruthy();
   });
 
   it('should make key value object pairs out of arrays with length two', () => {
@@ -127,17 +122,17 @@ describe('TableKeyValueComponent', () => {
       expect(component._convertValue(v(value)).value).toBe(result);
 
     it('should leave a string as it is', () => {
-      testConvertValue('something', 'something')
+      testConvertValue('something', 'something');
     });
 
     it('should leave an int as it is', () => {
-      testConvertValue(29, 29)
+      testConvertValue(29, 29);
     });
 
     it('should convert arrays with any type to string', () => {
-      testConvertValue([1, 2, 3], '1, 2, 3')
-      testConvertValue([{ sth: 'something' }], '{"sth":"something"}')
-      testConvertValue([1, 'two', { 3: 'three' }], '1, two, {"3":"three"}')
+      testConvertValue([1, 2, 3], '1, 2, 3');
+      testConvertValue([{ sth: 'something' }], '{"sth":"something"}');
+      testConvertValue([1, 'two', { 3: 'three' }], '1, two, {"3":"three"}');
     });
 
     it('should convert only allow objects if renderObjects is set to true', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
@@ -121,13 +121,30 @@ describe('TableKeyValueComponent', () => {
     ]);
   });
 
-  it('tests _convertValue', () => {
+  describe('tests _convertValue', () => {
     const v = (value) => ({ key: 'sth', value: value });
-    expect(component._convertValue(v('something'))).toEqual(v('something'));
-    expect(component._convertValue(v([1, 2, 3]))).toEqual(v('1, 2, 3'));
-    expect(component._convertValue(v({ sth: 'something' }))).toBe(undefined);
-    component.renderObjects = true;
-    expect(component._convertValue(v({ sth: 'something' }))).toEqual(v({ sth: 'something' }));
+    const testConvertValue = (value, result) =>
+      expect(component._convertValue(v(value)).value).toBe(result);
+
+    it('should leave a string as it is', () => {
+      testConvertValue('something', 'something')
+    });
+
+    it('should leave an int as it is', () => {
+      testConvertValue(29, 29)
+    });
+
+    it('should convert arrays with any type to string', () => {
+      testConvertValue([1, 2, 3], '1, 2, 3')
+      testConvertValue([{ sth: 'something' }], '{"sth":"something"}')
+      testConvertValue([1, 'two', { 3: 'three' }], '1, two, {"3":"three"}')
+    });
+
+    it('should convert only allow objects if renderObjects is set to true', () => {
+      expect(component._convertValue(v({ sth: 'something' }))).toBe(undefined);
+      component.renderObjects = true;
+      expect(component._convertValue(v({ sth: 'something' }))).toEqual(v({ sth: 'something' }));
+    });
   });
 
   it('tests _insertFlattenObjects', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.ts
@@ -19,7 +19,6 @@ import { CdTableColumn } from '../../models/cd-table-column';
   styleUrls: ['./table-key-value.component.scss']
 })
 export class TableKeyValueComponent implements OnInit, OnChanges {
-
   columns: Array<CdTableColumn> = [];
 
   @Input() data: any;
@@ -30,8 +29,8 @@ export class TableKeyValueComponent implements OnInit, OnChanges {
   @Input() appendParentKey = true;
 
   tableData: {
-    key: string,
-    value: any
+    key: string;
+    value: any;
   }[];
 
   /**
@@ -39,7 +38,7 @@ export class TableKeyValueComponent implements OnInit, OnChanges {
    */
   @Output() fetchData = new EventEmitter();
 
-  constructor() { }
+  constructor() {}
 
   ngOnInit() {
     this.columns = [
@@ -78,7 +77,7 @@ export class TableKeyValueComponent implements OnInit, OnChanges {
     } else {
       throw new Error('Wrong data format');
     }
-    temp = temp.map((v) => this._convertValue(v)).filter(o => o); // Filters out undefined
+    temp = temp.map((v) => this._convertValue(v)).filter((o) => o); // Filters out undefined
     return this.renderObjects ? this._insertFlattenObjects(temp) : temp;
   }
 
@@ -94,7 +93,7 @@ export class TableKeyValueComponent implements OnInit, OnChanges {
     } else {
       if (_.isArray(first)) {
         if (first.length === 2) {
-          temp = data.map(a => ({
+          temp = data.map((a) => ({
             key: a[0],
             value: a[1]
           }));
@@ -107,7 +106,7 @@ export class TableKeyValueComponent implements OnInit, OnChanges {
   }
 
   _makePairsFromObject(data: object) {
-    return Object.keys(data).map(k => ({
+    return Object.keys(data).map((k) => ({
       key: k,
       value: data[k]
     }));
@@ -117,7 +116,7 @@ export class TableKeyValueComponent implements OnInit, OnChanges {
     temp.forEach((v, i) => {
       if (_.isPlainObject(v.value)) {
         temp.splice(i, 1);
-        this._makePairs(v.value).forEach(item => {
+        this._makePairs(v.value).forEach((item) => {
           if (this.appendParentKey) {
             item.key = v.key + ' ' + item.key;
           }
@@ -131,7 +130,9 @@ export class TableKeyValueComponent implements OnInit, OnChanges {
 
   _convertValue(v: any) {
     if (_.isArray(v.value)) {
-      v.value = v.value.map((v) => (_.isPlainObject(v) ? JSON.stringify(v) : v)).join(', ');
+      v.value = v.value
+        .map((item) => (_.isPlainObject(item) ? JSON.stringify(item) : item))
+        .join(', ');
     } else if (_.isPlainObject(v.value) && !this.renderObjects) {
       return;
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.ts
@@ -131,7 +131,7 @@ export class TableKeyValueComponent implements OnInit, OnChanges {
 
   _convertValue(v: any) {
     if (_.isArray(v.value)) {
-      v.value = v.value.join(', ');
+      v.value = v.value.map((v) => (_.isPlainObject(v) ? JSON.stringify(v) : v)).join(', ');
     } else if (_.isPlainObject(v.value) && !this.renderObjects) {
       return;
     }


### PR DESCRIPTION
The problem was that object[] weren't handled in the key value table
before. Now they will be stringified to prevent an output like
'[Object object]'.