### PR TITLE
mgr: add device id tracking

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -641,8 +641,10 @@ set(ceph_common_deps
   ${BLKIN_LIBRARIES}
   ${CRYPTO_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
-  ${CMAKE_DL_LIBS}
-  ${UDEV_LIBRARIES})
+  ${CMAKE_DL_LIBS})
+if(HAVE_UDEV)
+  list(APPEND ceph_common_deps ${UDEV_LIBRARIES})
+endif()
 if(HAVE_RDMA)
   list(APPEND ceph_common_deps ${RDMA_LIBRARY})
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -641,7 +641,8 @@ set(ceph_common_deps
   ${BLKIN_LIBRARIES}
   ${CRYPTO_LIBS}
   ${CMAKE_THREAD_LIBS_INIT}
-  ${CMAKE_DL_LIBS})
+  ${CMAKE_DL_LIBS}
+  ${UDEV_LIBRARIES})
 if(HAVE_RDMA)
   list(APPEND ceph_common_deps ${RDMA_LIBRARY})
 endif()
@@ -1043,7 +1044,7 @@ if(WITH_RBD)
   if(WITH_KRBD)
     add_library(krbd STATIC krbd.cc
       $<TARGET_OBJECTS:parse_secret_objs>)
-    target_link_libraries(krbd ${KEYUTILS_LIBRARIES} ${UDEV_LIBRARIES})
+    target_link_libraries(krbd ${KEYUTILS_LIBRARIES})
   endif()
   add_subdirectory(librbd)
   if(WITH_FUSE)

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -19,12 +19,12 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <dirent.h>
-#include <libudev.h>
 //#include "common/debug.h"
 #include "include/uuid.h"
 #include "blkdev.h"
 
 #ifdef __linux__
+#include <libudev.h>
 #include <linux/fs.h>
 #include <blkid/blkid.h>
 
@@ -543,6 +543,12 @@ bool get_vdo_utilization(int fd, uint64_t *total, uint64_t *avail)
   return false;
 }
 
+std::string get_device_id(const std::string& devname)
+{
+  // FIXME: implement me for freebsd
+  return std::string();
+}
+
 #else
 int get_block_device_size(int fd, int64_t *psize)
 {
@@ -586,4 +592,11 @@ bool get_vdo_utilization(int fd, uint64_t *total, uint64_t *avail)
 {
   return false;
 }
+
+std::string get_device_id(const std::string& devname)
+{
+  // not implemented
+  return std::string();
+}
+
 #endif

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
  *

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -410,20 +410,19 @@ std::string get_device_id(const std::string& devname)
     return device_id;
   }
 
-  // either udev_device_get_property_value() failed, or succeeded but returned nothing;
-  // trying to read from files.
+  // either udev_device_get_property_value() failed, or succeeded but
+  // returned nothing; trying to read from files.  note that the 'vendor'
+  // file rarely contains the actual vendor; it's usually 'ATA'.
   //derr << "udev could not retrieve serial number of " << devname << dendl;
-
-  std::string vendor, model, serial;
-  vendor = get_block_device_string_property_wrap(devname, "device/vendor");
+  std::string model, serial;
   model = get_block_device_string_property_wrap(devname, "device/model");
   serial = get_block_device_string_property_wrap(devname, "device/serial");
 
-  // "none" is here for indication reasons only, for a start.
-  device_id = (vendor.empty() ? "none" : vendor) + "_"
-    + (model.empty() ? "none" : model) + "_"
-    + (serial.empty() ? "none" : serial);
+  if (!model.size() || serial.size()) {
+    return {};
+  }
 
+  device_id = model + "_" + serial;
   std::replace(device_id.begin(), device_id.end(), ' ', '_');
   return device_id;
 }

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -17,6 +17,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <dirent.h>
+#include <libudev.h>
+//#include "common/debug.h"
 #include "include/uuid.h"
 #include "blkdev.h"
 
@@ -30,6 +32,8 @@
 #define UUID_LEN 36
 
 static const char *sandbox_dir = "";
+
+static std::string get_block_device_string_property_wrap(const std::string &devname, const std::string &property); 
 
 void set_block_device_sandbox_dir(const char *dir)
 {
@@ -209,9 +213,19 @@ bool block_device_is_rotational(const char *devname)
   return get_block_device_int_property(devname, "queue/rotational") > 0;
 }
 
+int block_device_vendor(const char *devname, char *vendor, size_t max)
+{
+  return get_block_device_string_property(devname, "device/vendor", vendor, max);
+}
+
 int block_device_model(const char *devname, char *model, size_t max)
 {
   return get_block_device_string_property(devname, "device/model", model, max);
+}
+
+int block_device_serial(const char *devname, char *serial, size_t max)
+{
+  return get_block_device_string_property(devname, "device/serial", serial, max);
 }
 
 int get_device_by_fd(int fd, char *partition, char *device, size_t max)
@@ -355,6 +369,75 @@ bool get_vdo_utilization(int fd, uint64_t *total, uint64_t *avail)
   *total = block_size * physical_blocks;
   *avail = block_size * avail_blocks;
   return true;
+}
+
+// trying to use udev first, and if it doesn't work, we fall back to 
+// reading /sys/block/$devname/device/(vendor/model/serial).
+std::string get_device_id(const std::string& devname)
+{
+  struct udev_device *dev;
+  static struct udev *udev;
+  const char *data;
+  std::string device_id;
+
+  udev = udev_new();
+  if (!udev) {
+    //derr << "failed to run udev_new(), when calling for device " << devname << dendl;
+    return {};
+  }
+  dev = udev_device_new_from_subsystem_sysname(udev, "block", devname.c_str());
+  if (!dev) {
+    //derr << "failed to run udev_device_new_from_subsystem_sysname() for " << devname << dendl;
+    udev_unref(udev);
+    return {};
+  }
+
+  // "ID_SERIAL_SHORT" returns only the serial number;
+  // "ID_SERIAL" returns vendor model_serial.
+  data = udev_device_get_property_value(dev, "ID_SERIAL");
+  if (data) {
+    device_id = data;
+  }
+
+  udev_device_unref(dev);
+  udev_unref(udev);
+
+  if (!device_id.empty()) {
+    //dout << devname << " serial number: " << data << dendl;
+    std::replace(device_id.begin(), device_id.end(), ' ', '_');
+    return device_id;
+  }
+
+  // either udev_device_get_property_value() failed, or succeeded but returned nothing;
+  // trying to read from files.
+  //derr << "udev could not retrieve serial number of " << devname << dendl;
+
+  std::string vendor, model, serial;
+  vendor = get_block_device_string_property_wrap(devname, "device/vendor");
+  model = get_block_device_string_property_wrap(devname, "device/model");
+  serial = get_block_device_string_property_wrap(devname, "device/serial");
+
+  // "none" is here for indication reasons only, for a start.
+  device_id = (vendor.empty() ? "none" : vendor) + "_"
+    + (model.empty() ? "none" : model) + "_"
+    + (serial.empty() ? "none" : serial);
+
+  std::replace(device_id.begin(), device_id.end(), ' ', '_');
+  return device_id;
+}
+
+std::string get_block_device_string_property_wrap(const std::string &devname,
+						  const std::string &property)
+{
+  char buff[1024] = {0};
+  std::string prop_val;
+  int ret = get_block_device_string_property(devname.c_str(), property.c_str(), buff, sizeof(buff));
+  if (ret < 0) {
+    //derr << "Could not retrieve content of " << property << " file of " << devname << dendl;
+    return {};
+  }
+  prop_val = buff;
+  return prop_val;
 }
 
 #elif defined(__APPLE__)

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -23,9 +23,12 @@ extern int64_t get_block_device_string_property(
 	char *val, size_t maxlen);
 extern bool block_device_support_discard(const char *devname);
 extern bool block_device_is_rotational(const char *devname);
+extern int block_device_vendor(const char *devname, char *vendor, size_t max);
 extern int block_device_model(const char *devname, char *model, size_t max);
+extern int block_device_serial(const char *devname, char *serial, size_t max);
 
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
+extern std::string get_device_id(const std::string& devname);
 
 // for VDO
 

--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -21,6 +21,8 @@
 #include <mach/mach.h>
 #include <mach/mach_time.h>
 
+#include <ostringstream>
+
 #ifndef NSEC_PER_SEC
 #define NSEC_PER_SEC 1000000000ULL
 #endif
@@ -134,4 +136,49 @@ namespace ceph {
   operator<< <coarse_mono_clock>(std::ostream& m, const coarse_mono_time& t);
   template std::ostream&
   operator<< <coarse_real_clock>(std::ostream& m, const coarse_real_time& t);
+
+  std::string timespan_str(timespan t)
+  {
+    // FIXME: somebody pretty please make a version of this function
+    // that isn't as lame as this one!
+    uint64_t nsec = std::chrono::nanoseconds(t).count();
+    ostringstream ss;
+    if (nsec < 2000000000) {
+      ss << ((float)nsec / 1000000000) << "s";
+      return ss.str();
+    }
+    uint64_t sec = nsec / 1000000000;
+    if (sec < 120) {
+      ss << sec << "s";
+      return ss.str();
+    }
+    uint64_t min = sec / 60;
+    if (min < 120) {
+      ss << min << "m";
+      return ss.str();
+    }
+    uint64_t hr = min / 60;
+    if (hr < 48) {
+      ss << hr << "h";
+      return ss.str();
+    }
+    uint64_t day = hr / 24;
+    if (day < 14) {
+      ss << day << "d";
+      return ss.str();
+    }
+    uint64_t wk = day / 7;
+    if (wk < 12) {
+      ss << wk << "w";
+      return ss.str();
+    }
+    uint64_t mn = day / 30;
+    if (mn < 24) {
+      ss << mn << "M";
+      return ss.str();
+    }
+    uint64_t yr = day / 365;
+    ss << yr << "y";
+    return ss.str();
+  }
 }

--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -17,6 +17,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <string>
 #include <sys/time.h>
 
 #include "include/assert.h"
@@ -468,6 +469,8 @@ inline timespan to_timespan(signedspan z) {
   ceph_assert(z >= signedspan::zero());
   return std::chrono::duration_cast<timespan>(z);
 }
+
+std::string timespan_str(timespan t);
 
 // detects presence of Clock::to_timespec() and from_timespec()
 template <typename Clock, typename = std::void_t<>>

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -435,6 +435,16 @@ public:
 
     return 0;
   }
+
+  bool parse(const string& s) {
+    uint64_t epoch, nsec;
+    int r = parse_date(s, &epoch, &nsec);
+    if (r < 0) {
+      return false;
+    }
+    *this = utime_t(epoch, nsec);
+    return true;
+  }
 };
 WRITE_CLASS_ENCODER(utime_t)
 WRITE_CLASS_DENC(utime_t)

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -287,6 +287,14 @@ PyObject *ActivePyModules::get_python(const std::string &what)
         }
     );
     return f.get();
+  } else if (what == "devices") {
+    PyFormatter f;
+    f.open_array_section("devices");
+    daemon_state.with_devices([&f] (const DeviceState& dev) {
+	f.dump_object("device", dev);
+      });
+    f.close_section();
+    return f.get();
   } else if (what == "io_rate") {
     PyFormatter f;
     cluster_state.with_pgmap(

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1686,15 +1686,15 @@ bool DaemonServer::handle_command(MCommand *m)
       if (dm) {
 	if (f) {
 	  f->open_array_section("devices");
-	  for (auto& i : dm->devids) {
-	    f->dump_string("device", i);
+	  for (auto& i : dm->devices) {
+	    f->dump_string("device", i.first);
 	  }
 	  f->close_section();
 	  f->flush(cmdctx->odata);
 	} else {
 	  ostringstream rs;
-	  for (auto& i : dm->devids) {
-	    rs << i << "\n";
+	  for (auto& i : dm->devices) {
+	    rs << i.first << "\n";
 	  }
 	  cmdctx->odata.append(rs.str());
 	}

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1733,32 +1733,9 @@ bool DaemonServer::handle_command(MCommand *m)
     if (!daemon_state.with_device(devid,
 				  [&f, &rs] (const DeviceState& dev) {
 	  if (f) {
-	    f->open_object_section("device");
-	    f->dump_string("devid", dev.devid);
-	    f->dump_string("host", dev.server);
-	    f->open_array_section("daemons");
-	    for (auto& i : dev.daemons) {
-	      f->dump_string("daemon", to_string(i));
-	    }
-	    f->close_section();
-	    if (dev.expected_failure != utime_t()) {
-	      f->dump_stream("expected_failure") << dev.expected_failure;
-	      f->dump_stream("expected_failure_stamp")
-		<< dev.expected_failure_stamp;
-	    }
-	    f->close_section();
+	    f->dump_object("device", dev);
 	  } else {
-	    rs << "device " << dev.devid << "\n";
-	    rs << "host " << dev.server << "\n";
-	    set<string> d;
-	    for (auto& j : dev.daemons) {
-	      d.insert(to_string(j));
-	    }
-	    rs << "daemons " << d << "\n";
-	    if (dev.expected_failure != utime_t()) {
-	      rs << "expected_failure " << dev.expected_failure
-		 << " (as of " << dev.expected_failure_stamp << ")\n";
-	    }
+	    dev.print(rs);
 	  }
 	})) {
       ss << "device " << devid << " not found";

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1671,7 +1671,8 @@ bool DaemonServer::handle_command(MCommand *m)
       tbl.define_column("HOST:DEV", TextTable::LEFT, TextTable::LEFT);
       tbl.define_column("DAEMONS", TextTable::LEFT, TextTable::LEFT);
       tbl.define_column("LIFE EXPECTANCY", TextTable::LEFT, TextTable::LEFT);
-      daemon_state.with_devices([&tbl](const DeviceState& dev) {
+      auto now = ceph_clock_now();
+      daemon_state.with_devices([&tbl, now](const DeviceState& dev) {
 	  string h;
 	  for (auto& i : dev.devnames) {
 	    if (h.size()) {
@@ -1689,7 +1690,7 @@ bool DaemonServer::handle_command(MCommand *m)
 	  tbl << dev.devid
 	      << h
 	      << d
-	      << dev.get_life_expectancy_str()
+	      << dev.get_life_expectancy_str(now)
 	      << TextTable::endrow;
 	});
       cmdctx->odata.append(stringify(tbl));
@@ -1721,8 +1722,10 @@ bool DaemonServer::handle_command(MCommand *m)
 	  tbl.define_column("HOST:DEV", TextTable::LEFT, TextTable::LEFT);
 	  tbl.define_column("EXPECTED FAILURE", TextTable::LEFT,
 			    TextTable::LEFT);
+	  auto now = ceph_clock_now();
 	  for (auto& i : dm->devices) {
-	    daemon_state.with_device(i.first, [&tbl] (const DeviceState& dev) {
+	    daemon_state.with_device(
+	      i.first, [&tbl, now] (const DeviceState& dev) {
 		string h;
 		for (auto& i : dev.devnames) {
 		  if (h.size()) {
@@ -1732,7 +1735,7 @@ bool DaemonServer::handle_command(MCommand *m)
 		}
 		tbl << dev.devid
 		    << h
-		    << dev.get_life_expectancy_str()
+		    << dev.get_life_expectancy_str(now)
 		    << TextTable::endrow;
 	      });
 	  }
@@ -1765,9 +1768,10 @@ bool DaemonServer::handle_command(MCommand *m)
       tbl.define_column("DEV", TextTable::LEFT, TextTable::LEFT);
       tbl.define_column("DAEMONS", TextTable::LEFT, TextTable::LEFT);
       tbl.define_column("EXPECTED FAILURE", TextTable::LEFT, TextTable::LEFT);
+      auto now = ceph_clock_now();
       for (auto& devid : devids) {
 	daemon_state.with_device(
-	  devid, [&tbl, &host] (const DeviceState& dev) {
+	  devid, [&tbl, &host, now] (const DeviceState& dev) {
 	    string n;
 	    for (auto& j : dev.devnames) {
 	      if (j.first == host) {
@@ -1787,7 +1791,7 @@ bool DaemonServer::handle_command(MCommand *m)
 	    tbl << dev.devid
 		<< n
 		<< d
-		<< dev.get_life_expectancy_str()
+		<< dev.get_life_expectancy_str(now)
 		<< TextTable::endrow;
 	  });
       }

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1834,7 +1834,7 @@ bool DaemonServer::handle_command(MCommand *m)
       ss << "unable to parse datetime '" << from_str << "'";
       r = -EINVAL;
       cmdctx->reply(r, ss);
-    } else if (!to.parse(to_str)) {
+    } else if (to_str.size() && !to.parse(to_str)) {
       ss << "unable to parse datetime '" << to_str << "'";
       r = -EINVAL;
       cmdctx->reply(r, ss);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -351,6 +351,19 @@ static DaemonKey key_from_service(
   }
 }
 
+static bool key_from_string(
+  const std::string& name,
+  DaemonKey *out)
+{
+  auto p = name.find('.');
+  if (p == std::string::npos) {
+    return false;
+  }
+  out->first = name.substr(0, p);
+  out->second = name.substr(p + 1);
+  return true;
+}
+
 bool DaemonServer::handle_open(MMgrOpen *m)
 {
   Mutex::Locker l(lock);
@@ -1639,6 +1652,108 @@ bool DaemonServer::handle_command(MCommand *m)
 	f->flush(cmdctx->odata);
       } else {
 	cmdctx->odata.append(stringify(tbl));
+      }
+    }
+    cmdctx->reply(r, ss);
+    return true;
+  } else if (prefix == "device ls") {
+    set<string> devids;
+    if (f) {
+      f->open_array_section("devices");
+      daemon_state.with_devices([&f](const DeviceState& dev) {
+	  f->dump_string("device", dev.devid);
+	});
+      f->close_section();
+      f->flush(cmdctx->odata);
+    } else {
+      ostringstream rs;
+      daemon_state.with_devices([&rs](const DeviceState& dev) {
+	  rs << dev.devid << "\n";
+	});
+      cmdctx->odata.append(rs.str());
+    }
+    cmdctx->reply(0, ss);
+    return true;
+  } else if (prefix == "device ls-by-daemon") {
+    string who;
+    cmd_getval(g_ceph_context, cmdctx->cmdmap, "who", who);
+    DaemonKey k;
+    if (!key_from_string(who, &k)) {
+      ss << who << " is not a valid daemon name";
+      r = -EINVAL;
+    } else {
+      auto dm = daemon_state.get(k);
+      if (dm) {
+	if (f) {
+	  f->open_array_section("devices");
+	  for (auto& i : dm->devids) {
+	    f->dump_string("device", i);
+	  }
+	  f->close_section();
+	  f->flush(cmdctx->odata);
+	} else {
+	  ostringstream rs;
+	  for (auto& i : dm->devids) {
+	    rs << i << "\n";
+	  }
+	  cmdctx->odata.append(rs.str());
+	}
+      } else {
+	r = -ENOENT;
+	ss << "daemon " << who << " not found";
+      }
+      cmdctx->reply(r, ss);
+    }
+  } else if (prefix == "device ls-by-host") {
+    string host;
+    cmd_getval(g_ceph_context, cmdctx->cmdmap, "host", host);
+    set<string> devids;
+    daemon_state.list_devids_by_server(host, &devids);
+    if (f) {
+      f->open_array_section("devices");
+      for (auto& i : devids) {
+	f->dump_string("device", i);
+      }
+      f->close_section();
+      f->flush(cmdctx->odata);
+    } else {
+      ostringstream rs;
+      for (auto& i : devids) {
+	rs << i << "\n";
+      }
+      cmdctx->odata.append(rs.str());
+    }
+    cmdctx->reply(0, ss);
+    return true;
+  } else if (prefix == "device info") {
+    string devid;
+    cmd_getval(g_ceph_context, cmdctx->cmdmap, "devid", devid);
+    int r = 0;
+    ostringstream rs;
+    if (!daemon_state.with_device(devid, [&f, &rs] (const DeviceState& dev) {
+	  if (f) {
+	    f->open_object_section("device");
+	    f->dump_string("devid", dev.devid);
+	    f->dump_string("host", dev.server);
+	    f->open_array_section("daemons");
+	    for (auto& i : dev.daemons) {
+	      f->dump_string("daemon", to_string(i));
+	    }
+	    f->close_section();
+	    f->close_section();
+	  } else {
+	    rs << "device " << dev.devid << "\n";
+	    rs << "host " << dev.server << "\n";
+	    rs << "daemons " << dev.daemons << "\n";
+	  }
+	})) {
+      ss << "device " << devid << " not found";
+      r = -ENOENT;
+    } else {
+      if (f) {
+	f->flush(cmdctx->odata);
+      } else {
+	cmdctx->odata.append(rs.str());
       }
     }
     cmdctx->reply(r, ss);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -383,7 +383,7 @@ bool DaemonServer::handle_open(MMgrOpen *m)
     daemon->perf_counters.clear();
 
     if (m->service_daemon) {
-      daemon->metadata = m->daemon_metadata;
+      daemon->set_metadata(m->daemon_metadata);
       daemon->service_status = m->daemon_status;
 
       utime_t now = ceph_clock_now();
@@ -1885,7 +1885,7 @@ void DaemonServer::got_service_map()
       if (!daemon_state.exists(key)) {
 	auto daemon = std::make_shared<DaemonState>(daemon_state.types);
 	daemon->key = key;
-	daemon->metadata = q.second.metadata;
+	daemon->set_metadata(q.second.metadata);
         if (q.second.metadata.count("hostname")) {
           daemon->hostname = q.second.metadata["hostname"];
         }

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -57,13 +57,25 @@ void DeviceState::rm_life_expectancy()
   metadata.erase("life_expectancy_stamp");
 }
 
-string DeviceState::get_life_expectancy_str() const
+string DeviceState::get_life_expectancy_str(utime_t now) const
 {
   if (life_expectancy.first == utime_t()) {
     return string();
   }
-  return stringify(life_expectancy.first) + " to " +
-    stringify(life_expectancy.second);
+  if (now >= life_expectancy.first) {
+    return "now";
+  }
+  utime_t min = life_expectancy.first - now;
+  utime_t max = life_expectancy.second - now;
+  if (life_expectancy.second == utime_t()) {
+    return string(">") + timespan_str(make_timespan(min));
+  }
+  string a = timespan_str(make_timespan(min));
+  string b = timespan_str(make_timespan(max));
+  if (a == b) {
+    return a;
+  }
+  return a + " to " + b;
 }
 
 void DeviceState::dump(Formatter *f) const

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -15,6 +15,7 @@
 
 #include "MgrSession.h"
 #include "include/stringify.h"
+#include "common/Formatter.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
@@ -48,6 +49,37 @@ void DeviceState::rm_expected_failure()
   expected_failure_stamp = utime_t();
   metadata.erase("expected_failure");
   metadata.erase("expected_failure_stamp");
+}
+
+void DeviceState::dump(Formatter *f) const
+{
+  f->dump_string("devid", devid);
+  f->dump_string("host", server);
+  f->open_array_section("daemons");
+  for (auto& i : daemons) {
+    f->dump_string("daemon", to_string(i));
+  }
+  f->close_section();
+  if (expected_failure != utime_t()) {
+    f->dump_stream("expected_failure") << expected_failure;
+    f->dump_stream("expected_failure_stamp")
+      << expected_failure_stamp;
+  }
+}
+
+void DeviceState::print(ostream& out) const
+{
+  out << "device " << devid << "\n";
+  out << "host " << server << "\n";
+  set<string> d;
+  for (auto& j : daemons) {
+    d.insert(to_string(j));
+  }
+  out << "daemons " << d << "\n";
+  if (expected_failure != utime_t()) {
+    out << "expected_failure " << expected_failure
+	<< " (as of " << expected_failure_stamp << ")\n";
+  }
 }
 
 void DaemonStateIndex::insert(DaemonStatePtr dm)

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -50,7 +50,7 @@ void DaemonStateIndex::_erase(const DaemonKey& dmk)
     auto d = _get_or_create_device(devid);
     assert(d->daemons.count(dmk));
     d->daemons.erase(dmk);
-    if (d->daemons.empty()) {
+    if (d->empty()) {
       _erase_device(d);
     }
   }

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -166,7 +166,9 @@ class DaemonState
       map<std::string,std::string> devs;
       get_str_map(p->second, &devs, ",; ");
       for (auto& i : devs) {
-	devices[i.second] = i.first;
+	if (i.second.size()) {  // skip blank ids
+	  devices[i.second] = i.first;
+	}
       }
     }
   }

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -208,7 +208,7 @@ struct DeviceState : public RefCountedObject
   void set_life_expectancy(utime_t from, utime_t to, utime_t now);
   void rm_life_expectancy();
 
-  string get_life_expectancy_str() const;
+  string get_life_expectancy_str(utime_t now) const;
 
   /// true of we can be safely forgotten/removed from memory
   bool empty() const {

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -191,7 +191,16 @@ struct DeviceState : public RefCountedObject
   std::string server;
   std::set<DaemonKey> daemons;
 
+  std::map<string,string> metadata;  ///< persistent metadata
+
   DeviceState(const std::string& n) : devid(n) {}
+
+  void set_metadata(map<string,string>&& m);
+
+  /// true of we can be safely forgotten/removed from memory
+  bool empty() const {
+    return daemons.empty() && metadata.empty();
+  }
 };
 
 typedef boost::intrusive_ptr<DeviceState> DeviceStateRef;

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -28,6 +28,9 @@
 // For PerfCounterType
 #include "messages/MMgrReport.h"
 
+namespace ceph {
+  class Formatter;
+}
 
 // Unique reference to a daemon within a cluster
 typedef std::pair<std::string, std::string> DaemonKey;
@@ -207,6 +210,9 @@ struct DeviceState : public RefCountedObject
   bool empty() const {
     return daemons.empty() && metadata.empty();
   }
+
+  void dump(Formatter *f) const;
+  void print(ostream& out) const;
 };
 
 typedef boost::intrusive_ptr<DeviceState> DeviceStateRef;

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -198,15 +198,17 @@ struct DeviceState : public RefCountedObject
 
   std::map<string,string> metadata;  ///< persistent metadata
 
-  utime_t expected_failure;       ///< when device failure is expected
-  utime_t expected_failure_stamp; ///< when expected_failure was recorded
+  pair<utime_t,utime_t> life_expectancy;  ///< when device failure is expected
+  utime_t life_expectancy_stamp;          ///< when life expectency was recorded
 
   DeviceState(const std::string& n) : devid(n) {}
 
   void set_metadata(map<string,string>&& m);
 
-  void set_expected_failure(utime_t when, utime_t now);
-  void rm_expected_failure();
+  void set_life_expectancy(utime_t from, utime_t to, utime_t now);
+  void rm_life_expectancy();
+
+  string get_life_expectancy_str() const;
 
   /// true of we can be safely forgotten/removed from memory
   bool empty() const {

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -21,6 +21,7 @@
 #include <boost/circular_buffer.hpp>
 
 #include "common/RWLock.h"
+#include "include/str_map.h"
 
 #include "msg/msg_types.h"
 
@@ -30,6 +31,10 @@
 
 // Unique reference to a daemon within a cluster
 typedef std::pair<std::string, std::string> DaemonKey;
+
+static inline std::string to_string(const DaemonKey& dk) {
+  return dk.first + "." + dk.second;
+}
 
 // An instance of a performance counter type, within
 // a particular daemon.
@@ -121,6 +126,9 @@ class DaemonState
   // The metadata (hostname, version, etc) sent from the daemon
   std::map<std::string, std::string> metadata;
 
+  /// device ids, derived from metadata[device_ids]
+  std::set<std::string> devids;
+
   // TODO: this can be generalized to other daemons
   std::vector<DaemonHealthMetric> daemon_health_metrics;
 
@@ -146,6 +154,18 @@ class DaemonState
   explicit DaemonState(PerfCounterTypes &types_)
     : perf_counters(types_)
   {
+  }
+
+  void set_metadata(const std::map<std::string,std::string>& m) {
+    metadata = m;
+    auto p = m.find("device_ids");
+    if (p != m.end()) {
+      map<std::string,std::string> devs;
+      get_str_map(p->second, &devs, ",; ");
+      for (auto& i : devs) {
+	devids.insert(i.second);
+      }
+    }
   }
 
   const std::map<std::string,std::string>& get_config_defaults() {

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -104,9 +104,11 @@ void MetadataUpdate::finish(int r)
         }
         daemon_meta.erase("hostname");
         state->metadata.clear();
+	map<string,string> m;
         for (const auto &i : daemon_meta) {
-          state->metadata[i.first] = i.second.get_str();
-        }
+          m[i.first] = i.second.get_str();
+	}
+	state->set_metadata(m);
       } else {
         state = std::make_shared<DaemonState>(daemon_state.types);
         state->key = key;
@@ -119,9 +121,11 @@ void MetadataUpdate::finish(int r)
         }
         daemon_meta.erase("hostname");
 
+	map<string,string> m;
         for (const auto &i : daemon_meta) {
-          state->metadata[i.first] = i.second.get_str();
+          m[i.first] = i.second.get_str();
         }
+	state->set_metadata(m);
 
         daemon_state.insert(state);
       }
@@ -349,9 +353,11 @@ void Mgr::load_all_metadata()
     osd_metadata.erase("id");
     osd_metadata.erase("hostname");
 
+    map<string,string> m;
     for (const auto &i : osd_metadata) {
-      dm->metadata[i.first] = i.second.get_str();
+      m[i.first] = i.second.get_str();
     }
+    dm->set_metadata(m);
 
     daemon_state.insert(dm);
   }

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -184,8 +184,9 @@ std::map<std::string, std::string> Mgr::load_store()
       lock.Unlock();
       get_cmd.wait();
       lock.Lock();
-      assert(get_cmd.r == 0);
-      loaded[key] = get_cmd.outbl.to_str();
+      if (get_cmd.r == 0) { // tolerate racing config-key change
+	loaded[key] = get_cmd.outbl.to_str();
+      }
     }
   }
 

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -155,7 +155,7 @@ COMMAND("device ls-by-host name=host,type=CephString",
 	"mgr", "r", "cli,rest")
 COMMAND("device set-life-expectancy name=devid,type=CephString "\
 	"name=from,type=CephString "\
-	"name=to,type=CephString",
+	"name=to,type=CephString,req=False",
 	"Set predicted device life expectancy",
 	"mgr", "rw", "cli,rest")
 COMMAND("device rm-life-expectancy name=devid,type=CephString",

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -153,9 +153,11 @@ COMMAND("device ls-by-daemon name=who,type=CephString",
 COMMAND("device ls-by-host name=host,type=CephString",
 	"Show devices on a host",
 	"mgr", "r", "cli,rest")
-COMMAND("device set-predicted-failure name=devid,type=CephString name=when,type=CephString",
-	"Set predicted device failure time",
+COMMAND("device set-life-expectancy name=devid,type=CephString "\
+	"name=from,type=CephString "\
+	"name=to,type=CephString",
+	"Set predicted device life expectancy",
 	"mgr", "rw", "cli,rest")
-COMMAND("device rm-predicted-failure name=devid,type=CephString",
-	"Clear predicted device failure time",
+COMMAND("device rm-life-expectancy name=devid,type=CephString",
+	"Clear predicted device life expectancy",
 	"mgr", "rw", "cli,rest")

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -140,3 +140,16 @@ COMMAND("config show-with-defaults " \
 	"name=who,type=CephString",
 	"Show running configuration (including compiled-in defaults)",
 	"mgr", "r", "cli,rest")
+
+COMMAND("device ls",
+	"Show devices",
+	"mgr", "r", "cli,rest")
+COMMAND("device info name=devid,type=CephString",
+	"Show information about a device",
+	"mgr", "r", "cli,rest")
+COMMAND("device ls-by-daemon name=who,type=CephString",
+	"Show devices associated with a daemon",
+	"mgr", "r", "cli,rest")
+COMMAND("device ls-by-host name=host,type=CephString",
+	"Show devices on a host",
+	"mgr", "r", "cli,rest")

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -153,3 +153,9 @@ COMMAND("device ls-by-daemon name=who,type=CephString",
 COMMAND("device ls-by-host name=host,type=CephString",
 	"Show devices on a host",
 	"mgr", "r", "cli,rest")
+COMMAND("device set-predicted-failure name=devid,type=CephString name=when,type=CephString",
+	"Set predicted device failure time",
+	"mgr", "rw", "cli,rest")
+COMMAND("device rm-predicted-failure name=devid,type=CephString",
+	"Clear predicted device failure time",
+	"mgr", "rw", "cli,rest")

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -412,7 +412,7 @@ void PyModuleRegistry::upgrade_config(
     dout(1) << "Upgrading module configuration for Mimic" << dendl;
     // Upgrade luminous->mimic: migrate config-key configuration
     // into main configuration store
-    for(auto &i : old_config) {
+    for (auto &i : old_config) {
       auto last_slash = i.first.rfind('/');
       const std::string module_name = i.first.substr(4, i.first.substr(4).find('/'));
       const std::string key = i.first.substr(last_slash + 1);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5422,7 +5422,12 @@ void OSD::_collect_metadata(map<string,string> *pm)
     if (!devids.empty()) {
       devids += ",";
     }
-    devids += dev + "=" + get_device_id(dev);
+    string id = get_device_id(dev);
+    if (id.size()) {
+      devids += dev + "=" + id;
+    } else {
+      dout(10) << __func__ << " no unique device id for " << dev << dendl;
+    }
   }
   (*pm)["device_ids"] = devids;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -48,6 +48,7 @@
 #include "common/version.h"
 #include "common/pick_address.h"
 #include "common/SubProcess.h"
+#include "common/blkdev.h"
 
 #include "os/ObjectStore.h"
 #ifdef HAVE_LIBFUSE
@@ -5416,6 +5417,14 @@ void OSD::_collect_metadata(map<string,string> *pm)
   set<string> devnames;
   store->get_devices(&devnames);
   (*pm)["devices"] = stringify(devnames);
+  string devids;
+  for (auto& dev : devnames) {
+    if (!devids.empty()) {
+      devids += ",";
+    }
+    devids += dev + "=" + get_device_id(dev);
+  }
+  (*pm)["device_ids"] = devids;
 
   dout(10) << __func__ << " " << *pm << dendl;
 }


### PR DESCRIPTION
- osds generate unique per-device device_ids or devids ($vendor_$model_$serial)
- 'ceph device ...' commands to query
- records (and persists) predicted failure timestamp
