### PR TITLE
cmake: Let's be fatal if liboath isn't present

### DIFF
--- a/cmake/modules/Findliboath.cmake
+++ b/cmake/modules/Findliboath.cmake
@@ -14,6 +14,10 @@ find_library(LIBOATH_LIBRARY NAMES oath liboath PATHS
   /usr/local/lib
   /usr/lib)
 
+if (NOT(LIBOATH_INCLUDE_DIR AND LIBOATH_LIBRARY))
+  message(FATAL_ERROR "Could NOT find oath")
+endif ()
+
 # handle the QUIETLY and REQUIRED arguments and set UUID_FOUND to TRUE if
 # all listed variables are TRUE
 include(FindPackageHandleStandardArgs)


### PR DESCRIPTION
cmake can be successful while liboath-devel isn't present leading to the following build error in rgw:

[ 12%] Building CXX object src/rgw/CMakeFiles/rgw_common.dir/rgw_rest_s3.cc.o
/home/erwan/ceph/src/rgw/rgw_rest_s3.cc:17:10: fatal error: liboath/oath.h: Aucun fichier ou dossier de ce type
 #include <liboath/oath.h>

This commit is about triggering a FATAL error when oath is missing.

Signed-off-by: Erwan Velu <erwan@redhat.com>