### PR TITLE
mon: add 'osd destroy-new' command that only destroys NEW osd slots

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1334,7 +1334,7 @@ function test_mon_osd_create_destroy()
   expect_false ceph auth get-key client.osd-lockbox.$uuid2
   expect_false ceph config-key exists dm-crypt/osd/$uuid2/luks
 
-  ceph osd destroy osd.$id2 --yes-i-really-mean-it
+  ceph osd destroy-new osd.$id2 --yes-i-really-mean-it
   ceph osd destroy $id2 --yes-i-really-mean-it
   ceph osd find $id2
   expect_false ceph auth get-key osd.$id2

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -217,6 +217,7 @@ void MonCapGrant::expand_profile_mon(const EntityName& name) const
     profile_grants.push_back(MonCapGrant("osd", MON_CAP_R));  // read osdmap
     profile_grants.push_back(MonCapGrant("mon getmap"));
     profile_grants.push_back(MonCapGrant("osd new"));
+    profile_grants.push_back(MonCapGrant("osd destroy-new"));
   }
   if (profile == "bootstrap-mds") {
     profile_grants.push_back(MonCapGrant("mon", MON_CAP_R));  // read monmap

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -874,6 +874,13 @@ COMMAND("osd destroy " \
         "but removes cephx keys, config-key data and lockbox keys, "\
         "rendering data permanently unreadable.", \
         "osd", "rw", "cli,rest")
+COMMAND("osd destroy-new " \
+        "name=id,type=CephOsdName " \
+        "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+        "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \
+        "but removes cephx keys, config-key data and lockbox keys, "\
+        "rendering data permanently unreadable.  Only works on new, unbooted osd ids.", \
+        "osd", "rw", "cli,rest")
 COMMAND("osd purge " \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \


### PR DESCRIPTION
http://tracker.ceph.com/issues/24428