### PR TITLE
jewel: mon/LogMonitor: call no_reply() on ignored log message

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -341,6 +341,7 @@ bool LogMonitor::preprocess_log(MonOpRequestRef op)
   return false;
 
  done:
+  mon->no_reply(op);
   return true;
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/24293