### PR TITLE
rgw: fix RGWSyncTraceNode crash in reload

### DIFF
--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -130,6 +130,8 @@ RGWSyncTraceManager::~RGWSyncTraceManager()
   cct->get_admin_socket()->unregister_commands(this);
   service_map_thread->stop();
   delete service_map_thread;
+
+  nodes.clear();
 }
 
 int RGWSyncTraceManager::hook_to_admin_command()


### PR DESCRIPTION
reload or restart will finalize RGWSyncTraceManager and destroy
complete_nodes, which will trigger RGWSyncTraceNode release twice.

A situation is sync more than 4096 objects and get full complete_nodes, complete_nodes
have a member A who's parent is P which is not finished and A is the last child of P.
In destroy complete_nodes, nodes will be released one by one. Release A will trigger
release P, and call finish_node(P). there is trap that circular_buffer
won't change size until destroy all items, so circular_buffer is still
full and pop the first item which is A, and released A again.

fixes: http://tracker.ceph.com/issues/24432

Signed-off-by: Tianshan Qu <tianshan@xsky.com>