### PR TITLE
ceph-volume tests destroy osds on monitor hosts

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
@@ -1,4 +1,3 @@
-
 - hosts: osds
   become: yes
   tasks:
@@ -8,9 +7,26 @@
         name: ceph-osd@2
         state: stopped
 
+    - name: stop ceph-osd@0 daemon
+      service:
+        name: ceph-osd@0
+        state: stopped
+
+- hosts: mons
+  become: yes
+  tasks:
+
     - name: destroy osd.2
       command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
 
+    - name: destroy osd.0
+      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+
+- hosts: osds
+  become: yes
+  tasks:
+
+    # osd.2 device
     - name: zap /dev/sdd1
       command: "ceph-volume lvm zap /dev/sdd1 --destroy"
       environment:
@@ -21,14 +37,7 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
-    - name: stop ceph-osd@0 daemon
-      service:
-        name: ceph-osd@0
-        state: stopped
-
-    - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
-
+    # osd.0 lv
     - name: zap test_group/data-lv1
       command: "ceph-volume lvm zap test_group/data-lv1"
       environment:
@@ -44,8 +53,19 @@
         name: ceph-osd@0
         state: stopped
 
+
+- hosts: mons
+  become: yes
+  tasks:
+
     - name: destroy osd.0
       command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+
+
+- hosts: osds
+  become: yes
+  tasks:
+
 
     - name: zap test_group/data-lv1
       command: "ceph-volume lvm zap test_group/data-lv1"

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
@@ -8,9 +8,28 @@
         name: ceph-osd@2
         state: stopped
 
+    - name: stop ceph-osd@0 daemon
+      service:
+        name: ceph-osd@0
+        state: stopped
+
+
+- hosts: mons
+  become: yes
+  tasks:
+
     - name: destroy osd.2
       command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
 
+    - name: destroy osd.0
+      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+
+
+- hosts: osds
+  become: yes
+  tasks:
+
+    # osd.2 device
     - name: zap /dev/sdd1
       command: "ceph-volume lvm zap /dev/sdd1 --destroy"
       environment:
@@ -26,14 +45,7 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
-    - name: stop ceph-osd@0 daemon
-      service:
-        name: ceph-osd@0
-        state: stopped
-
-    - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
-
+    # osd.0 lv
     - name: zap test_group/data-lv1
       command: "ceph-volume lvm zap test_group/data-lv1"
       environment:

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
@@ -8,9 +8,28 @@
         name: ceph-osd@2
         state: stopped
 
+    - name: stop ceph-osd@0 daemon
+      service:
+        name: ceph-osd@0
+        state: stopped
+
+
+- hosts: mons
+  become: yes
+  tasks:
+
     - name: destroy osd.2
       command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
 
+    - name: destroy osd.0
+      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+
+
+- hosts: osds
+  become: yes
+  tasks:
+
+    # osd.2 device
     - name: zap /dev/sdd1
       command: "ceph-volume lvm zap /dev/sdd1 --destroy"
       environment:
@@ -21,14 +40,7 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
-    - name: stop ceph-osd@0 daemon
-      service:
-        name: ceph-osd@0
-        state: stopped
-
-    - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
-
+    # osd.0 device
     - name: zap test_group/data-lv1
       command: "ceph-volume lvm zap test_group/data-lv1"
       environment:

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
@@ -8,14 +8,34 @@
         name: ceph-osd@2
         state: stopped
 
+    - name: stop ceph-osd@0 daemon
+      service:
+        name: ceph-osd@0
+        state: stopped
+
+
+- hosts: mons
+  become: yes
+  tasks:
+
     - name: destroy osd.2
       command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
 
+    - name: destroy osd.0
+      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+
+
+- hosts: osds
+  become: yes
+  tasks:
+
+    # osd.2 device
     - name: zap /dev/sdd1
       command: "ceph-volume lvm zap /dev/sdd1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
+    # osd.2 journal
     - name: zap /dev/sdd2
       command: "ceph-volume lvm zap /dev/sdd2 --destroy"
       environment:
@@ -26,19 +46,13 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
-    - name: stop ceph-osd@0 daemon
-      service:
-        name: ceph-osd@0
-        state: stopped
-
-    - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
-
+    # osd.0 data lv
     - name: zap test_group/data-lv1
       command: "ceph-volume lvm zap test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
+    # osd.0 journal device
     - name: zap /dev/sdc1
       command: "ceph-volume lvm zap /dev/sdc1 --destroy"
       environment:

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
@@ -1,4 +1,3 @@
-
 - hosts: osds
   become: yes
   tasks:
@@ -8,33 +7,44 @@
         name: ceph-osd@2
         state: stopped
 
-    - name: destroy osd.2 
-      command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
-
-    - name: zap /dev/sdd1 
-      command: "ceph-volume lvm zap /dev/sdd1 --destroy"
-      environment:
-        CEPH_VOLUME_DEBUG: 1
-
-    - name: redeploy osd.2 using /dev/sdd1 
-      command: "ceph-volume lvm create --bluestore --data /dev/sdd1 --osd-id 2"
-      environment:
-        CEPH_VOLUME_DEBUG: 1
-
     - name: stop ceph-osd@0 daemon
       service:
         name: ceph-osd@0
         state: stopped
 
-    - name: destroy osd.0 
+- hosts: mons
+  become: yes
+  tasks:
+
+    - name: destroy osd.2
+      command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
+
+    - name: destroy osd.0
       command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
 
-    - name: zap test_group/data-lv1 
+
+- hosts: osds
+  become: yes
+  tasks:
+
+    # osd.2 device
+    - name: zap /dev/sdd1
+      command: "ceph-volume lvm zap /dev/sdd1 --destroy"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
+    - name: redeploy osd.2 using /dev/sdd1
+      command: "ceph-volume lvm create --bluestore --data /dev/sdd1 --osd-id 2"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
+    # osd.0 lv
+    - name: zap test_group/data-lv1
       command: "ceph-volume lvm zap test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
-    - name: redeploy osd.0 using test_group/data-lv1 
+    - name: redeploy osd.0 using test_group/data-lv1
       command: "ceph-volume lvm create --bluestore --data test_group/data-lv1 --osd-id 0"
       environment:
         CEPH_VOLUME_DEBUG: 1
@@ -44,8 +54,18 @@
         name: ceph-osd@0
         state: stopped
 
+
+- hosts: mons
+  become: yes
+  tasks:
+
     - name: destroy osd.0
       command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+
+
+- hosts: osds
+  become: yes
+  tasks:
 
     - name: zap test_group/data-lv1
       command: "ceph-volume lvm zap test_group/data-lv1"

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
@@ -8,9 +8,28 @@
         name: ceph-osd@2
         state: stopped
 
+    - name: stop ceph-osd@0 daemon
+      service:
+        name: ceph-osd@0
+        state: stopped
+
+
+- hosts: mons
+  become: yes
+  tasks:
+
     - name: destroy osd.2
       command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
 
+    - name: destroy osd.0
+      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+
+
+- hosts: osds
+  become: yes
+  tasks:
+
+    # osd.2 device
     - name: zap /dev/sdd1
       command: "ceph-volume lvm zap /dev/sdd1 --destroy"
       environment:
@@ -26,14 +45,7 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
-    - name: stop ceph-osd@0 daemon
-      service:
-        name: ceph-osd@0
-        state: stopped
-
-    - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
-
+    # osd.0 lv
     - name: zap test_group/data-lv1
       command: "ceph-volume lvm zap test_group/data-lv1"
       environment:


### PR DESCRIPTION
This will prevent permission issues that will show up now that we are not copying the admin keyring to OSD nodes.

Instead, we now stop the OSDs on the osd nodes, then destroy them in the mon nodes, and finally continue the re-deployment process on the osd nodes. 

In the end nothing changes except that the `destroy` happens only on the monitors, everything else on the osds.