### PR TITLE
luminous: rgw: fix 'copy part' without 'x-amz-copy-source-range' when compressi…

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3424,7 +3424,7 @@ void RGWPutObj::execute()
       op_ret = -ENOENT;
       goto done;
     }
-    lst = astate->size - 1;
+    lst = astate->accounted_size - 1;
   } else {
     lst = copy_source_range_lst;
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/24298