### PR TITLE
jewel: rgw: objects in cache never refresh after rgw_cache_expiry_interval

### DIFF
--- a/src/rgw/rgw_cache.cc
+++ b/src/rgw/rgw_cache.cc
@@ -122,15 +122,15 @@ void ObjectCache::put(string& name, ObjectCacheInfo& info, rgw_cache_entry_info 
     return;
   }
 
-  ldout(cct, 10) << "cache put: name=" << name << " info.flags=" << info.flags << dendl;
-  map<string, ObjectCacheEntry>::iterator iter = cache_map.find(name);
-  if (iter == cache_map.end()) {
-    ObjectCacheEntry entry;
-    entry.lru_iter = lru.end();
-    cache_map.insert(pair<string, ObjectCacheEntry>(name, entry));
-    iter = cache_map.find(name);
-  }
+  ldout(cct, 10) << "cache put: name=" << name << " info.flags=0x"
+                 << std::hex << info.flags << std::dec << dendl;
+
+  auto [iter, inserted] = cache_map.emplace(name, ObjectCacheEntry{});
   ObjectCacheEntry& entry = iter->second;
+  entry.info.time_added = ceph::coarse_mono_clock::now();
+  if (inserted) {
+    entry.lru_iter = lru.end();
+  }
   ObjectCacheInfo& target = entry.info;
 
   invalidate_lru(entry);

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -57,7 +57,7 @@ struct ObjectCacheInfo {
   map<string, bufferlist> rm_xattrs;
   ObjectMetaInfo meta;
   obj_version version = {};
-  ceph::mono_time time_added = ceph::mono_clock::now();
+  ceph::coarse_mono_time time_added;
 
   ObjectCacheInfo() = default;
 


### PR DESCRIPTION
rgw: update ObjectCacheInfo::time_added on overwrite
(cherry picked from commit 7fe9143a4fa1dd3856dcdee3145616bbc40de7bf)

Fixes: https://tracker.ceph.com/issues/24386
Signed-off-by: Pavan Rallabhandi <PRallabhandi@walmartlabs.com>