### PR TITLE
relicense LGPL-2.1 code as LGPL-2.1 or LGPL-3.0

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -41,6 +41,12 @@ Copyright:
     Copyright 2012-2013 Intel Corporation All Rights Reserved.
 License: BSD 3-clause
 
+Files: src/common/deleter.h
+Copyright:
+    Copyright (C) 2014 Cloudius Systems, Ltd.
+License:
+    Apache-2.0
+
 Files: src/common/sctp_crc32.c: 
 Copyright:
     Copyright (c) 2001-2007, by Cisco Systems, Inc. All rights reserved.
@@ -71,6 +77,18 @@ License:
   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
   THE POSSIBILITY OF SUCH DAMAGE.
+
+Files: src/common/sstring.hh
+Copyright:
+    Copyright 2014 Cloudius Systems
+License:
+    Apache-2.0
+
+Files: src/include/cpp-btree
+Copyright:
+    Copyright 2013 Google Inc. All Rights Reserved.
+License:
+    Apache-2.0
 
 Files: src/json_spirit
 Copyright:

--- a/COPYING
+++ b/COPYING
@@ -5,7 +5,7 @@ Source: http://ceph.com/
 
 Files: *
 Copyright: (c) 2004-2010 by Sage Weil <sage@newdream.net>
-License: LGPL2.1 (see COPYING-LGPL2.1)
+License: LGPL-2.1 (see COPYING-LGPL2.1)
 
 Files: cmake/modules/FindLTTngUST.cmake
 Copyright:
@@ -22,7 +22,7 @@ License: GPL3
 
 Files: src/mount/canonicalize.c
 Copyright: Copyright (C) 1993 Rick Sladkey <jrs@world.std.com>
-License: LGPL2 or later
+License: LGPL-2 or later
 
 Files: src/os/btrfs_ioctl.h
 Copyright: Copyright (C) 2007 Oracle.  All rights reserved.
@@ -103,7 +103,7 @@ License:
 
 Files: src/test/common/Throttle.cc src/test/filestore/chain_xattr.cc
 Copyright: Copyright (C) 2013 Cloudwatt <libre.licensing@cloudwatt.com>
-License: LGPL2.1 or later
+License: LGPL-2.1 or later
 
 Files: src/osd/ErasureCodePluginJerasure/*.{c,h}
 Copyright: Copyright (c) 2011, James S. Plank <plank@cs.utk.edu>

--- a/COPYING
+++ b/COPYING
@@ -7,6 +7,12 @@ Files: *
 Copyright: (c) 2004-2010 by Sage Weil <sage@newdream.net>
 License: LGPL2.1 (see COPYING-LGPL2.1)
 
+Files: cmake/modules/FindLTTngUST.cmake
+Copyright:
+    Copyright 2016 Kitware, Inc.
+    Copyright 2016 Philippe Proulx <pproulx@efficios.com>
+License: BSD 3-clause
+
 Files: doc/*
 Copyright: (c) 2010-2012 New Dream Network and contributors
 License: Creative Commons Attribution Share Alike 3.0 (CC-BY-SA-3.0)
@@ -95,6 +101,10 @@ License:
   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
   OTHER DEALINGS IN THE SOFTWARE.
 
+Files: src/test/common/Throttle.cc src/test/filestore/chain_xattr.cc
+Copyright: Copyright (C) 2013 Cloudwatt <libre.licensing@cloudwatt.com>
+License: LGPL2.1 or later
+
 Files: src/osd/ErasureCodePluginJerasure/*.{c,h}
 Copyright: Copyright (c) 2011, James S. Plank <plank@cs.utk.edu>
 License:
@@ -131,6 +141,13 @@ Packaging:
     Copyright (C) 2004-2009 by Sage Weil <sage@newdream.net>
     Copyright (C) 2010 Canonical, Ltd.
     Licensed under LGPL-2.1
+
+Files: src/test/perf_local.cc
+Copyright:
+  (c) 2011-2014 Stanford University
+  (c) 2011 Facebook
+License:
+  The MIT License
 
 File: qa/workunits/erasure-code/jquery.js
   Copyright 2012 jQuery Foundation and other contributors

--- a/COPYING
+++ b/COPYING
@@ -5,7 +5,7 @@ Source: http://ceph.com/
 
 Files: *
 Copyright: (c) 2004-2010 by Sage Weil <sage@newdream.net>
-License: LGPL-2.1 (see COPYING-LGPL2.1)
+License: LGPL-2.1 or LGPL-3 (see COPYING-LGPL2.1 and COPYING-LGPL3)
 
 Files: cmake/modules/FindLTTngUST.cmake
 Copyright:
@@ -158,7 +158,7 @@ License:
 Packaging:
     Copyright (C) 2004-2009 by Sage Weil <sage@newdream.net>
     Copyright (C) 2010 Canonical, Ltd.
-    Licensed under LGPL-2.1
+    Licensed under LGPL-2.1 or LGPL-3.0
 
 Files: src/test/perf_local.cc
 Copyright:

--- a/COPYING-LGPL3
+++ b/COPYING-LGPL3
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/CodingStyle
+++ b/CodingStyle
@@ -71,7 +71,7 @@ by section.
 * Comments > File Comments:
 
    Don't sweat it, unless the license varies from that of the project
-   (LGPL2.1) or the code origin isn't reflected by the git history.
+   (LGPL2.1 or LGPL3.0) or the code origin isn't reflected by the git history.
 
 * Formatting > Tabs:
   Indent width is two spaces.  When runs of 8 spaces can be compressed

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Please see http://ceph.com/ for current info.
 
 ## Contributing Code
 
-Most of Ceph is licensed under the LGPL version 2.1.  Some
+Most of Ceph is dual licensed under the LGPL version 2.1 or 3.0.  Some
 miscellaneous code is under BSD-style license or is public domain.
 The documentation is licensed under Creative Commons
 Attribution Share Alike 3.0 (CC-BY-SA-3.0).  There are a handful of headers

--- a/alpine/APKBUILD.in
+++ b/alpine/APKBUILD.in
@@ -8,7 +8,7 @@ pkgusers="ceph"
 pkggroups="ceph"
 url="http://ceph.com"
 arch="x86_64"
-license="LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and \
+license="LGPL-2.1 and LGPL-3.0 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and \
 GPL-2.0-with-autoconf-exception and BSD-3-Clause and MIT"
 depends="ceph-osd ceph-mds ceph-mgr	ceph-mon"
 # grep --quiet option required

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -114,7 +114,7 @@ Epoch:		2
 %global _epoch_prefix %{?epoch:%{epoch}:}
 
 Summary:	User space components of the Ceph file system
-License:	LGPL-2.1 and CC-BY-SA-3.0 and GPL-2.0 and BSL-1.0 and BSD-3-Clause and MIT
+License:	LGPL-2.1 and LGPL-3.0 and CC-BY-SA-3.0 and GPL-2.0 and BSL-1.0 and BSD-3-Clause and MIT
 %if 0%{?suse_version}
 Group:		System/Filesystems
 %endif

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,7 +5,7 @@ Source: http://ceph.com/
 
 Files: *
 Copyright: (c) 2004-2010 by Sage Weil <sage@newdream.net>
-License: LGPL-2.1 (see COPYING-LGPL2.1)
+License: LGPL-2.1 or LGPL-3 (see COPYING-LGPL2.1 and COPYING-LGPL3)
 
 Files: cmake/modules/FindLTTngUST.cmake
 Copyright:
@@ -158,7 +158,7 @@ License:
 Packaging:
     Copyright (C) 2004-2009 by Sage Weil <sage@newdream.net>
     Copyright (C) 2010 Canonical, Ltd.
-    Licensed under LGPL-2.1
+    Licensed under LGPL-2.1 or LGPL-3.0
 
 Files: src/test/perf_local.cc
 Copyright:

--- a/debian/copyright
+++ b/debian/copyright
@@ -41,6 +41,12 @@ Copyright:
     Copyright 2012-2013 Intel Corporation All Rights Reserved.
 License: BSD 3-clause
 
+Files: src/common/deleter.h
+Copyright:
+    Copyright (C) 2014 Cloudius Systems, Ltd.
+License:
+    Apache-2.0
+
 Files: src/common/sctp_crc32.c:
 Copyright:
     Copyright (c) 2001-2007, by Cisco Systems, Inc. All rights reserved.
@@ -71,6 +77,18 @@ License:
   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
   THE POSSIBILITY OF SUCH DAMAGE.
+
+Files: src/common/sstring.hh
+Copyright:
+    Copyright 2014 Cloudius Systems
+License:
+    Apache-2.0
+
+Files: src/include/cpp-btree
+Copyright:
+    Copyright 2013 Google Inc. All Rights Reserved.
+License:
+    Apache-2.0
 
 Files: src/json_spirit
 Copyright:

--- a/debian/copyright
+++ b/debian/copyright
@@ -5,7 +5,7 @@ Source: http://ceph.com/
 
 Files: *
 Copyright: (c) 2004-2010 by Sage Weil <sage@newdream.net>
-License: LGPL2.1 (see COPYING-LGPL2.1)
+License: LGPL-2.1 (see COPYING-LGPL2.1)
 
 Files: cmake/modules/FindLTTngUST.cmake
 Copyright:
@@ -17,9 +17,12 @@ Files: doc/*
 Copyright: (c) 2010-2012 New Dream Network and contributors
 License: Creative Commons Attribution Share Alike 3.0 (CC-BY-SA-3.0)
 
+Files: bin/git-archive-all.sh
+License: GPL3
+
 Files: src/mount/canonicalize.c
 Copyright: Copyright (C) 1993 Rick Sladkey <jrs@world.std.com>
-License: LGPL2 or later (see COPYING-GPL2)
+License: LGPL-2 or later
 
 Files: src/os/btrfs_ioctl.h
 Copyright: Copyright (C) 2007 Oracle.  All rights reserved.
@@ -30,7 +33,7 @@ Copyright: None
 License: Public domain
 
 Files: src/common/bloom_filter.hpp
-Copyright: Copyright (C) 2000 Arash Partow
+Copyright: Copyright (C) 2000 Arash Partow <arash@partow.net>
 License: Boost Software License, Version 1.0
 
 Files: src/common/crc32c_intel*:
@@ -98,11 +101,9 @@ License:
   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
   OTHER DEALINGS IN THE SOFTWARE.
 
-
-
 Files: src/test/common/Throttle.cc src/test/filestore/chain_xattr.cc
 Copyright: Copyright (C) 2013 Cloudwatt <libre.licensing@cloudwatt.com>
-License: LGPL2.1 or later
+License: LGPL-2.1 or later
 
 Files: src/osd/ErasureCodePluginJerasure/*.{c,h}
 Copyright: Copyright (c) 2011, James S. Plank <plank@cs.utk.edu>
@@ -147,3 +148,17 @@ Copyright:
   (c) 2011 Facebook
 License:
   The MIT License
+
+File: qa/workunits/erasure-code/jquery.js
+  Copyright 2012 jQuery Foundation and other contributors
+  Released under the MIT license
+  http://jquery.org/license
+
+Files: qa/workunits/erasure-code/jquery.{flot.categories,flot}.js
+  Copyright (c) 2007-2014 IOLA and Ole Laursen.
+  Licensed under the MIT license.
+
+Files: src/include/timegm.h
+  Copyright (C) Copyright Howard Hinnant
+  Copyright (C) Copyright 2010-2011 Vicente J. Botet Escriba
+  License: Boost Software License, Version 1.0

--- a/doc/dev/developer_guide/index.rst
+++ b/doc/dev/developer_guide/index.rst
@@ -78,9 +78,9 @@ Licensing
 
 Ceph is free software.
 
-Unless stated otherwise, the Ceph source code is distributed under the terms of
-the LGPL2.1. For full details, see the file `COPYING`_ in the top-level
-directory of the source-code tree.
+Unless stated otherwise, the Ceph source code is distributed under the
+terms of the LGPL2.1 or LGPL3.0. For full details, see the file
+`COPYING`_ in the top-level directory of the source-code tree.
 
 .. _`COPYING`:
   https://github.com/ceph/ceph/blob/master/COPYING

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -17,7 +17,7 @@
  *
  *     http://www.ssrc.ucsc.edu/Papers/weil-sc06.pdf
  *
- * LGPL2.1
+ * LGPL-2.1 or LGPL-3.0
  */
 
 

--- a/src/crush/mapper.h
+++ b/src/crush/mapper.h
@@ -5,7 +5,7 @@
  * CRUSH functions for find rules and then mapping an input to an
  * output set.
  *
- * LGPL2.1
+ * LGPL-2.1 or LGPL-3.0
  */
 
 #include "crush.h"

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -6,7 +6,7 @@
  * primarily intended to describe data structures that pass over the
  * wire or that are stored on disk.
  *
- * LGPL2.1
+ * LGPL-2.1 or LGPL-3.0
  */
 
 #ifndef CEPH_FS_H

--- a/src/ocf/rbd.in
+++ b/src/ocf/rbd.in
@@ -3,7 +3,7 @@
 #   OCF resource agent for mapping and unmapping
 #   RADOS Block Devices (RBDs)
 #
-#   License:      GNU Lesser General Public License (LGPL) 2.1
+#   License:      GNU Lesser General Public License (LGPL) 2.1 or 3.0
 #   (c) 2012 Florian Haas, hastexo
 #
 

--- a/src/powerdns/pdns-backend-rgw.py
+++ b/src/powerdns/pdns-backend-rgw.py
@@ -47,7 +47,7 @@ Should return something like:
 '''
 
 # Copyright: Wido den Hollander <wido@42on.com> 2014
-# License:   LGPL2.1
+# License:   LGPL-2.1 or LGPL-3.0
 
 from ConfigParser import SafeConfigParser, NoSectionError
 from flask import abort, Flask, request, Response

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -7,7 +7,7 @@ daemon.
 
 Copyright (C) 2013 Inktank Storage, Inc.
 
-LGPL2.1.  See file COPYING.
+LGPL-2.1 or LGPL-3.0.  See file COPYING.
 """
 from __future__ import print_function
 import copy

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -1,7 +1,7 @@
 """
 Copyright (C) 2015 Red Hat, Inc.
 
-LGPL2.1.  See file COPYING.
+LGPL-2.1 or LGPL-3.0.  See file COPYING.
 """
 
 from contextlib import contextmanager

--- a/src/test/common/histogram.cc
+++ b/src/test/common/histogram.cc
@@ -5,7 +5,7 @@
  *
  * Copyright (C) 2014 Inktank <info@inktank.com>
  *
- * LGPL2.1 (see COPYING-LGPL2.1) or later
+ * LGPL-2.1 (see COPYING-LGPL2.1) or later
  */
 
 #include <iostream>

--- a/src/test/common/test_bit_vector.cc
+++ b/src/test/common/test_bit_vector.cc
@@ -5,7 +5,7 @@
  *
  * Copyright (C) 2014 Red Hat <contact@redhat.com>
  *
- * LGPL2.1 (see COPYING-LGPL2.1) or later
+ * LGPL-2.1 (see COPYING-LGPL2.1) or later
  */
 
 #include <gtest/gtest.h>

--- a/src/test/common/test_bloom_filter.cc
+++ b/src/test/common/test_bloom_filter.cc
@@ -5,7 +5,7 @@
  *
  * Copyright (C) 2013 Inktank <info@inktank.com>
  *
- * LGPL2.1 (see COPYING-LGPL2.1) or later
+ * LGPL-2.1 (see COPYING-LGPL2.1) or later
  */
 
 #include <iostream>

--- a/src/test/common/test_iso_8601.cc
+++ b/src/test/common/test_iso_8601.cc
@@ -5,7 +5,7 @@
  *
  * Copyright (C) 2017 Red Hat <contact@redhat.com>
  *
- * LGPL2.1 (see COPYING-LGPL2.1) or later
+ * LGPL-2.1 (see COPYING-LGPL2.1) or later
  */
 
 #include <chrono>

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -5,7 +5,7 @@
  *
  * Copyright (C) 2013 Inktank <info@inktank.com>
  *
- * LGPL2.1 (see COPYING-LGPL2.1) or later
+ * LGPL-2.1 (see COPYING-LGPL2.1) or later
  */
 
 #include <iostream>


### PR DESCRIPTION
The primary motivation to relicense is a desire to integrate with projects that are licensed under the Apache License version 2.0.  Although opinions vary, there are some who argue the the LGPL-2.1 and Apache-2.0 licenses are not fully compatible.  We would like to avoid the ambiguity and potential for controversy.

Projects we would like to consume that are Apache-2.0 licensed include RocksDB, Seastar, OpenSSL (which is in the process of relicensing to Apache-2.0), and Swagger (swagger.io).Note that some of these are (or could be) dynamically linked or are consumed via a high-level language, and may or may not require a change to LGPL-3.0, but providing the option for LGPL-3.0 certainly avoids any uncertainty.

A few other source files are already incorporated into Ceph that claim an Apache-2.0 license:

       src/common/deleter.h
       src/common/sstring.h
       src/include/cpp-btree

The Ceph developers would further like to provide a license option that is more modern than the current LGPL-2.1.  LGPL-3.0 includes updated, clarified language around several issues and is widely considered more modern, superior license.