### PR TITLE
osd: clear past_intervals if merged older last_epoch_clean

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5657,7 +5657,10 @@ void PG::update_history(const pg_history_t& new_history)
   if (info.history.merge(new_history)) {
     dout(20) << __func__ << " advanced history from " << new_history << dendl;
     dirty_info = true;
-    if (info.history.last_epoch_clean >= info.history.same_interval_since) {
+
+    auto apib = past_intervals.get_bounds();
+    if (info.history.last_epoch_clean >= info.history.same_interval_since || 
+        info.history.last_epoch_clean < apib.first) {
       dout(20) << __func__ << " clearing past_intervals" << dendl;
       past_intervals.clear();
       dirty_big_info = true;


### PR DESCRIPTION
the past_interval valid bound is from last_epoch_clean to same_interval_since,
So if we change our last_epoch_clean to older value in `update_history()`, the
intervals must rebuild.

http://tracker.ceph.com/issues/21142

Signed-off-by: Zengran Zhang <zhzr@sangfor.com>