### PR TITLE
mimic: mgr/dashboard: Listen on port 8443 by default and not 8080

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -150,7 +150,7 @@ Host name and port
 Like most web applications, dashboard binds to a TCP/IP address and TCP port.
 
 By default, the ``ceph-mgr`` daemon hosting the dashboard (i.e., the currently
-active manager) will bind to TCP port 8080. If no specific address has been
+active manager) will bind to TCP port 8443. If no specific address has been
 configured, the web app will bind to ``::``, which corresponds to all available
 IPv4 and IPv6 addresses.
 

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -61,7 +61,7 @@ Build the Project
 
 Run ``npm run build`` to build the project. The build artifacts will be
 stored in the ``dist/`` directory. Use the ``-prod`` flag for a
-production build. Navigate to ``http://localhost:8080``.
+production build. Navigate to ``https://localhost:8443``.
 
 Running Unit Tests
 ~~~~~~~~~~~~~~~~~~
@@ -265,11 +265,11 @@ following code::
 Every path given in the ``ApiController`` decorator will automatically be
 prefixed with ``api``. After reloading the Dashboard module you can access the
 above mentioned controller by pointing your browser to
-http://mgr_hostname:8080/api/ping2.
+https://mgr_hostname:8443/api/ping2.
 
 It is also possible to have nested controllers. The ``RgwController`` uses
 this technique to make the daemons available through the URL
-http://mgr_hostname:8080/api/rgw/daemon::
+https://mgr_hostname:8443/api/rgw/daemon::
 
   @ApiController('rgw')
   @AuthRequired()

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -415,9 +415,9 @@ class RESTController(BaseController):
     Test with curl:
 
     curl -H "Content-Type: application/json" -X POST \
-         -d '{"username":"xyz","password":"xyz"}'  http://127.0.0.1:8080/foo
-    curl http://127.0.0.1:8080/foo
-    curl http://127.0.0.1:8080/foo/0
+         -d '{"username":"xyz","password":"xyz"}'  https://127.0.0.1:8443/foo
+    curl https://127.0.0.1:8443/foo
+    curl https://127.0.0.1:8443/foo/0
 
     """
 

--- a/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
+++ b/src/pybind/mgr/dashboard/frontend/proxy.conf.json.sample
@@ -1,6 +1,6 @@
 {
   "/api/": {
-    "target": "http://localhost:8080",
+    "target": "https://localhost:8443",
     "secure": false,
     "logLevel": "debug"
   }

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -112,7 +112,7 @@ class SSLCherryPyConfig(object):
         :returns our URI
         """
         server_addr = self.get_localized_config('server_addr', '::')
-        server_port = self.get_localized_config('server_port', '8080')
+        server_port = self.get_localized_config('server_port', '8443')
         if server_addr is None:
             raise ServerConfigException(
                 'no server_addr configured; '


### PR DESCRIPTION
Port 8080 is a common alternative HTTP port used for web traffic.

The dashboard however uses SSL (which can not be turned off) and for
that purpose we should use 8443.

Signed-off-by: Wido den Hollander <wido@42on.com>
(cherry picked from commit b7cc66e809e9f15b211adef5bac369c32a4bacaa)
Signed-off-by: Wido den Hollander <wido@42on.com>