### PR TITLE
[DNM] tracing: use LTTng for logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,8 @@ endif(WITH_MANPAGE)
 
 include_directories(
   ${PROJECT_BINARY_DIR}/src/include
-  ${PROJECT_SOURCE_DIR}/src)
+  ${PROJECT_SOURCE_DIR}/src
+  ${PROJECT_SOURCE_DIR}/build)
 
 if(OFED_PREFIX)
   include_directories(SYSTEM ${OFED_PREFIX}/include)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -174,6 +174,8 @@ BuildRequires:	liboath-devel
 BuildRequires:	libtool
 BuildRequires:	libxml2-devel
 BuildRequires:	libuuid-devel
+BuildRequires:	lttng-tools-devel
+BuildRequires:	lttng-ust-devel
 BuildRequires:	make
 BuildRequires:	ncurses-devel
 BuildRequires:	parted
@@ -1175,6 +1177,7 @@ ${CMAKE} .. \
     -DWITH_MANPAGE=ON \
     -DWITH_PYTHON3=%{python3_version} \
     -DWITH_MGR_DASHBOARD_FRONTEND=OFF \
+    -DWITH_LTTNG_LOGGING=ON \
 %if %{with python2}
     -DWITH_PYTHON2=ON \
 %else
@@ -1330,6 +1333,8 @@ rm -rf %{buildroot}
 %{_libdir}/libos_tp.so*
 %{_libdir}/libosd_tp.so*
 %endif
+%{_libdir}/liblogging_tp.so*
+%{_libdir}/libceph_logging_tp.so*
 %config(noreplace) %{_sysconfdir}/logrotate.d/ceph
 %if 0%{?fedora} || 0%{?rhel}
 %config(noreplace) %{_sysconfdir}/sysconfig/ceph

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,6 +290,7 @@ add_subdirectory(json_spirit)
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/xxHash")
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rapidjson/include")
 
+add_subdirectory(fmt)
 if(WITH_SEASTAR)
   find_package(fmt 5.2.1 QUIET)
   if(NOT fmt_FOUND)
@@ -404,6 +405,8 @@ endif()
 
 add_library(common STATIC ${ceph_common_objs})
 target_link_libraries(common ${ceph_common_deps})
+
+#target_link_libraries(common dispatchqueue_tp)
 
 add_library(ceph-common SHARED ${ceph_common_objs})
 target_link_libraries(ceph-common ${ceph_common_deps})

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -55,6 +55,8 @@
 
 namespace {
 
+TracepointProvider::Traits dispatchqueue_tracepoint_traits("libdispatchqueue_tp.so", "dispatchqueue_tracing");
+
 TracepointProvider::Traits osd_tracepoint_traits("libosd_tp.so",
                                                  "osd_tracing");
 TracepointProvider::Traits os_tracepoint_traits("libos_tp.so",
@@ -653,6 +655,7 @@ flushjournal_out:
   init_async_signal_handler();
   register_async_signal_handler(SIGHUP, sighup_handler);
 
+  TracepointProvider::initialize<dispatchqueue_tracepoint_traits>(g_ceph_context);
   TracepointProvider::initialize<osd_tracepoint_traits>(g_ceph_context);
   TracepointProvider::initialize<os_tracepoint_traits>(g_ceph_context);
 #ifdef WITH_OSD_INSTRUMENT_FUNCTIONS

--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -355,7 +355,11 @@ int cmp(const hobject_t& l, const hobject_t& r)
   return 0;
 }
 
-
+ghobject_t::operator std::string() const {
+  std::stringstream out;
+  out << *this;
+  return out.str();
+}
 
 // This is compatible with decode for hobject_t prior to
 // version 5.

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -464,6 +464,7 @@ public:
     (*this) = temp;
   }
 
+  operator std::string() const;
   void encode(ceph::buffer::list& bl) const;
   void decode(ceph::buffer::list::const_iterator& bl);
   void decode(json_spirit::Value& v);

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -603,6 +603,10 @@ std::vector<Option> get_global_options() {
                    "log_graylog_host",
                    "log_graylog_port"}),
 
+    Option("dispatchqueue_tracing", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description(""),
+
     Option("err_to_graylog", Option::TYPE_BOOL, Option::LEVEL_BASIC)
     .set_default(false)
     .set_description("send critical error log lines to remote graylog server")

--- a/src/common/types.cc
+++ b/src/common/types.cc
@@ -29,4 +29,10 @@ ostream &operator<<(ostream &lhs, const shard_id_t &rhs)
   return lhs << (unsigned)(uint8_t)rhs.id;
 }
 
+byte_u_t::operator std::string() {
+  stringstream out;
+  out << *this;
+  return out.str();
+}
+
 #endif

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -178,6 +178,9 @@
 /* Define if you want to use LTTng */
 #cmakedefine WITH_LTTNG
 
+/* Define if you want to use LTTng for logging instead of dout */
+#cmakedefine WITH_LTTNG_LOGGING
+
 /* Define if you want to OSD function instrumentation */
 #cmakedefine WITH_OSD_INSTRUMENT_FUNCTIONS
 

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -724,6 +724,13 @@ class interval_set {
     other = std::move(m);
   }
 
+public:
+  operator std::string() const {
+    std::stringstream out;
+    out << *this;
+    return out.str();
+  }
+
 private:
   // data
   uint64_t _size;

--- a/src/include/tracing/ceph_logging_impl.h
+++ b/src/include/tracing/ceph_logging_impl.h
@@ -1,0 +1,36 @@
+#ifndef CEPH_LOGGING_IMPL_H
+#define CEPH_LOGGING_IMPL_H
+
+#include <string>
+#include <stdarg.h>
+#include <fmt/include/fmt/format.h>
+#include <fmt/include/fmt/ostream.h>
+
+#include "tracing/ceph_logging.h"
+
+using fmt::format;
+
+#define trace(ll, ss, fmt, ...) __trace(ll, ss, format(fmt, __VA_ARGS__))
+#define trace_error(ss, fmt, ...) __trace(-1, ss, format(fmt, __VA_ARGS__))
+
+//static inline void trace(int loglevel, string subsys, const char *fmt, void *arg, ...)
+static inline void __trace(int loglevel, string subsys, string str)
+{
+  str = subsys + ": " + str;
+  if (loglevel <= -1) {
+    str = "Error: " + str;
+    tracepoint(ceph_logging, log_error, (char*)str.c_str());
+  } else if (loglevel <= 1) {
+    tracepoint(ceph_logging, log_critical, (char*)str.c_str());
+  } else if (loglevel <= 5) {
+    tracepoint(ceph_logging, log_warning, (char*)str.c_str());
+  } else if (loglevel <= 10) {
+    tracepoint(ceph_logging, log_info, (char*)str.c_str());
+  } else if (loglevel <= 15) {
+    tracepoint(ceph_logging, log_debug, (char*)str.c_str());
+  } else {
+    tracepoint(ceph_logging, log_verbose, (char*)str.c_str());
+  }
+}
+
+#endif // CEPH_LOGGING_IMPL_H

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -469,6 +469,7 @@ inline std::ostream& operator<<(std::ostream& out, const si_u_t& b)
 struct byte_u_t {
   uint64_t v;
   explicit byte_u_t(uint64_t _v) : v(_v) {};
+  operator std::string();
 };
 
 inline std::ostream& operator<<(std::ostream& out, const byte_u_t& b)

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -225,6 +225,12 @@ public:
     return ts;
   }
 
+  operator std::string() {
+    stringstream out;
+    localtime(out);
+    return out.str();
+  }
+
   void sleep() const {
     struct timespec ts;
     to_timespec(&ts);

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -68,6 +68,9 @@ struct uuid_d {
 
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<uuid_d*>& o);
+  operator std::string() {
+    return to_string();
+  }
 };
 WRITE_CLASS_ENCODER(uuid_d)
 

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -22,6 +22,25 @@
 
 #include <iostream>
 
+#ifdef WITH_LTTNG_LOGGING
+#define TRACEPOINT_DEFINE
+#define TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#include "tracing/bluestore.h"
+#include "tracing/bluestore_blob.h"
+#include "tracing/bluestore_gc.h"
+#include "tracing/bluestore_lru_cache.h"
+#include "tracing/bluestore_twoqcache.h"
+#include "tracing/bitmapallocator.h"
+#include "tracing/bmap_freelist_manager.h"
+#include "tracing/ceph_logging.h"
+#include "tracing/asyncconnection.h"
+#include "tracing/dispatchqueue.h"
+#undef TRACEPOINT_PROBE_DYNAMIC_LINKAGE
+#undef TRACEPOINT_DEFINE
+#else
+#define tracepoint(...)
+#endif
+
 #define MAX_LOG_BUF 65536
 
 namespace ceph {

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -44,12 +44,12 @@ void DeviceState::set_life_expectancy(utime_t from, utime_t to, utime_t now)
   life_expectancy = make_pair(from, to);
   life_expectancy_stamp = now;
   if (from != utime_t()) {
-    metadata["life_expectancy_min"] = from;
+    metadata["life_expectancy_min"] = stringify(from);
   } else {
     metadata["life_expectancy_min"] = "";
   }
   if (to != utime_t()) {
-    metadata["life_expectancy_max"] = to;
+    metadata["life_expectancy_max"] = stringify(to);
   } else {
     metadata["life_expectancy_max"] = "";
   }

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -285,6 +285,12 @@ void Message::dump(Formatter *f) const
   f->dump_string("summary", ss.str());
 }
 
+Message::operator std::string() const {
+  std::stringstream out;
+  out << *this;
+  return out.str();
+}
+
 Message *decode_message(CephContext *cct, int crcflags,
 			ceph_msg_header& header,
 			ceph_msg_footer& footer,

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -501,6 +501,7 @@ public:
   virtual void dump(ceph::Formatter *f) const;
 
   void encode(uint64_t features, int crcflags, bool skip_header_crc = false);
+  operator std::string() const;
 };
 
 extern Message *decode_message(CephContext *cct, int crcflags,

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -47,6 +47,13 @@ ostream& AsyncConnection::_conn_prefix(std::ostream *_dout) {
                 << ").";
 }
 
+#ifdef WITH_LTTNG_LOGGING
+#include "include/tracing/asyncconnection_impl.h"
+#else
+#define trace(...)
+#define trace_error(...)
+#endif
+
 // Notes:
 // 1. Don't dispatch any event when closed! It may cause AsyncConnection alive even if AsyncMessenger dead
 
@@ -517,12 +524,20 @@ void AsyncConnection::accept(ConnectedSocket socket,
 int AsyncConnection::send_message(Message *m)
 {
   FUNCTRACE(async_msgr->cct);
-  lgeneric_subdout(async_msgr->cct, ms,
-		   1) << "-- " << async_msgr->get_myaddrs() << " --> "
-		      << get_peer_addrs() << " -- "
-		      << *m << " -- " << m << " con "
-		      << this
-		      << dendl;
+//  lgeneric_subdout(async_msgr->cct, ms,
+//		   1) << "-- " << async_msgr->get_myaddrs() << " --> "
+//		      << get_peer_addrs() << " -- "
+//		      << *m << " -- " << m << " con "
+//		      << this
+//		      << dendl;
+  trace_send_message(1, asyncconnection,
+    void*, cct, async_msgr->cct,
+    string, myaddrs, async_msgr->get_myaddrs(),
+    string, peer_addrs, get_peer_addrs(),
+    string, message, *m,
+    void*, m, m,
+    void*, this_, this,
+    "{} {} -- {} --> {} -- {} -- {} con {}");
 
   // optimistic think it's ok to encode(actually may broken now)
   if (!m->get_priority())

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -701,6 +701,12 @@ struct entity_addrvec_t {
     }
   }
 
+  operator std::string() const {
+    std::stringstream out;
+    out << *this;
+    return out.str();
+  }
+
   friend bool operator==(const entity_addrvec_t& l, const entity_addrvec_t& r) {
     return l.v == r.v;
   }
@@ -737,6 +743,11 @@ struct entity_inst_t {
   // cppcheck-suppress noExplicitConstructor
   entity_inst_t(const ceph_entity_inst& i) : name(i.name), addr(i.addr) { }
   entity_inst_t(const ceph_entity_name& n, const ceph_entity_addr &a) : name(n), addr(a) {}
+  operator std::string() {
+    stringstream out;
+    out << this;
+    return out.str();
+  }
   operator ceph_entity_inst() {
     ceph_entity_inst i = {name, addr};
     return i;

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -116,7 +116,7 @@ if(WITH_BLUESTORE)
   add_executable(ceph-bluestore-tool
     bluestore/bluestore_tool.cc)
   target_link_libraries(ceph-bluestore-tool
-    os global)
+    os global fmt::fmt)
   install(TARGETS ceph-bluestore-tool
     DESTINATION bin)
 endif()

--- a/src/os/bluestore/BitmapAllocator.cc
+++ b/src/os/bluestore/BitmapAllocator.cc
@@ -8,6 +8,13 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "fbmap_alloc " << this << " "
 
+#ifdef WITH_LTTNG_LOGGING
+#include "include/tracing/bitmapallocator_impl.h"
+#else
+#define trace(...)
+#define trace_error(...)
+#endif
+
 BitmapAllocator::BitmapAllocator(CephContext* _cct,
 					 int64_t capacity,
 					 int64_t alloc_unit) :
@@ -27,7 +34,12 @@ int64_t BitmapAllocator::allocate(
   ldout(cct, 10) << __func__ << std::hex << " 0x" << want_size
 		 << "/" << alloc_unit << "," << max_alloc_size << "," << hint
 		 << std::dec << dendl;
-    
+  trace_allocate_info(10, bitmapallocator,
+    uint64_t, want_size, want_size,
+    uint64_t, alloc_unit, alloc_unit,
+    uint64_t, max_alloc_size, max_alloc_size,
+    int64_t, hint, hint,
+    "0x{0:x}/{1:x},{2:x},{3:x}");
     
   _allocate_l2(want_size, alloc_unit, max_alloc_size, hint,
     &allocated, extents);
@@ -40,6 +52,13 @@ int64_t BitmapAllocator::allocate(
                    << " extent: 0x" << std::hex << e.offset << "~" << e.length
 		   << "/" << alloc_unit << "," << max_alloc_size << "," << hint
 		   << std::dec << dendl;
+    trace_allocate_extents(10, bitmapallocator,
+      uint64_t, offset, e.offset,
+      uint64_t, length, e.length,
+      uint64_t, alloc_unit, alloc_unit,
+      uint64_t, max_alloc_size, max_alloc_size,
+      int, hint, hint,
+      "0x{0:x}/{1:x},{2:x},{3:x},{4:x}");
   }
   return int64_t(allocated);
 }
@@ -48,11 +67,16 @@ void BitmapAllocator::release(
   const interval_set<uint64_t>& release_set)
 {
   for (auto r : release_set) {
-    ldout(cct, 10) << __func__ << " 0x" << std::hex << r.first << "~" << r.second
-		  << std::dec << dendl;
+//    ldout(cct, 10) << __func__ << " 0x" << std::hex << r.first << "~" << r.second
+//		  << std::dec << dendl;
+    trace_release_info(10, bitmapallocator,
+      uint64_t, first, r.first,
+      uint64_t, second, r.second,
+      "0x{0:x}~{1:x}");
   }
   _free_l2(release_set);
-  ldout(cct, 10) << __func__ << " done" << dendl;
+//  ldout(cct, 10) << __func__ << " done" << dendl;
+  trace_release_done(10, bitmapallocator, "done");
 }
 
 

--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -12,6 +12,13 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "freelist "
 
+#ifdef WITH_LTTNG_LOGGING
+#include "include/tracing/bmap_freelist_manager_impl.h"
+#else
+#define trace(...)
+#define trace_error(...)
+#endif
+
 void make_offset_key(uint64_t offset, std::string *key)
 {
   key->reserve(10);
@@ -505,8 +512,12 @@ void BitmapFreelistManager::allocate(
   uint64_t offset, uint64_t length,
   KeyValueDB::Transaction txn)
 {
-  dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
-	   << std::dec << dendl;
+//  dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
+//	   << std::dec << dendl;
+  trace_allocate_info(10, bmap_freelist_manager,
+    uint64_t, offset, offset,
+    uint64_t, length, length,
+    "0x{0:x}~{1:x}");
   _xor(offset, length, txn);
 }
 
@@ -514,8 +525,12 @@ void BitmapFreelistManager::release(
   uint64_t offset, uint64_t length,
   KeyValueDB::Transaction txn)
 {
-  dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
-	   << std::dec << dendl;
+//  dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
+//	   << std::dec << dendl;
+  trace_release_info(10, bmap_freelist_manager,
+    uint64_t, offset, offset,
+    uint64_t, length, length,
+    "0x{0:x}~{1:x}");
   _xor(offset, length, txn);
 }
 
@@ -529,8 +544,12 @@ void BitmapFreelistManager::_xor(
 
   uint64_t first_key = offset & key_mask;
   uint64_t last_key = (offset + length - 1) & key_mask;
-  dout(20) << __func__ << " first_key 0x" << std::hex << first_key
-	   << " last_key 0x" << last_key << std::dec << dendl;
+//  dout(20) << __func__ << " first_key 0x" << std::hex << first_key
+//	   << " last_key 0x" << last_key << std::dec << dendl;
+  trace_xor_info(20, bmap_freelist_manager,
+    uint64_t, first_key, first_key,
+    uint64_t, last_key, last_key,
+    "first_key 0x{0:x} last_key 0x{1:x}");
 
   if (first_key == last_key) {
     bufferptr p(blocks_per_key >> 3);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -413,6 +413,7 @@ public:
 
     void dump(Formatter* f) const;
     friend ostream& operator<<(ostream& out, const SharedBlob& sb);
+    operator std::string() const;
 
     void get() {
       ++nref;
@@ -514,6 +515,11 @@ public:
 
   public:
 
+    operator std::string() {
+      stringstream out;
+      out << *this;
+      return out.str();
+    }
     friend void intrusive_ptr_add_ref(Blob *b) { b->get(); }
     friend void intrusive_ptr_release(Blob *b) { b->put(); }
 
@@ -730,6 +736,12 @@ public:
     // the given range [o, o + l].
     bool blob_escapes_range(uint32_t o, uint32_t l) const {
       return blob_start() < o || blob_end() > o + l;
+    }
+
+    operator std::string() {
+      std::stringstream out;
+      out << *this;
+      return out.str();
     }
   };
   typedef boost::intrusive::set<Extent> extent_map_t;
@@ -1070,6 +1082,7 @@ public:
     }
 
     void dump(Formatter* f) const;
+    operator std::string() const;
 
     void flush();
     void get() {
@@ -1738,6 +1751,16 @@ public:
     q_list_t q;  ///< transactions
 
     boost::intrusive::list_member_hook<> deferred_osr_queue_item;
+
+    friend ostream& operator<<(ostream& out, const OpSequencer& s) {
+      return out << "osr(" << s.cid << ")";
+    }
+
+    operator std::string() const {
+      std::stringstream out;
+      out << *this;
+      return out.str();
+    }
 
     DeferredBatch *deferred_running = nullptr;
     DeferredBatch *deferred_pending = nullptr;

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -70,6 +70,12 @@ void bluestore_bdev_label_t::generate_test_instances(
   o.back()->meta["foo"] = "bar";
 }
 
+bluestore_bdev_label_t::operator std::string() {
+  std::stringstream out;
+  out << *this;
+  return out.str();
+}
+
 ostream& operator<<(ostream& out, const bluestore_bdev_label_t& l)
 {
   return out << "bdev(osd_uuid " << l.osd_uuid
@@ -92,6 +98,12 @@ void bluestore_cnode_t::generate_test_instances(list<bluestore_cnode_t*>& o)
   o.push_back(new bluestore_cnode_t());
   o.push_back(new bluestore_cnode_t(0));
   o.push_back(new bluestore_cnode_t(123));
+}
+
+bluestore_cnode_t::operator std::string() const {
+  std::stringstream out;
+  out << *this;
+  return out.str();
 }
 
 ostream& operator<<(ostream& out, const bluestore_cnode_t& l)
@@ -583,6 +595,12 @@ void bluestore_pextent_t::generate_test_instances(list<bluestore_pextent_t*>& ls
   ls.push_back(new bluestore_pextent_t(1, 2));
 }
 
+bluestore_pextent_t::operator std::string() {
+  std::stringstream out;
+  out << *this;
+  return out.str();
+}
+
 // bluestore_blob_t
 
 string bluestore_blob_t::get_flags_string(unsigned flags)
@@ -652,6 +670,12 @@ void bluestore_blob_t::generate_test_instances(list<bluestore_blob_t*>& ls)
   ls.back()->allocated_test(
     bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x1000));
   ls.back()->allocated_test(bluestore_pextent_t(0x40120000, 0x10000));
+}
+
+bluestore_blob_t::operator std::string() const {
+  std::stringstream out;
+  out << *this;
+  return out.str();
 }
 
 ostream& operator<<(ostream& out, const bluestore_blob_t& o)
@@ -1011,6 +1035,12 @@ void bluestore_shared_blob_t::generate_test_instances(
   list<bluestore_shared_blob_t*>& ls)
 {
   ls.push_back(new bluestore_shared_blob_t(1));
+}
+
+bluestore_shared_blob_t::operator std::string() const {
+  stringstream out;
+  out << *this;
+  return out.str();
 }
 
 ostream& operator<<(ostream& out, const bluestore_shared_blob_t& sb)

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -43,6 +43,7 @@ struct bluestore_bdev_label_t {
   void decode(bufferlist::const_iterator& p);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<bluestore_bdev_label_t*>& o);
+  operator std::string();
 };
 WRITE_CLASS_ENCODER(bluestore_bdev_label_t)
 
@@ -61,6 +62,7 @@ struct bluestore_cnode_t {
   }
   void dump(Formatter *f) const;
   static void generate_test_instances(list<bluestore_cnode_t*>& o);
+  operator std::string() const;
 };
 WRITE_CLASS_DENC(bluestore_cnode_t)
 
@@ -103,6 +105,7 @@ struct bluestore_pextent_t : public bluestore_interval_t<uint64_t, uint32_t>
     denc_varint_lowz(v.length, p);
   }
 
+  operator std::string();
   void dump(Formatter *f) const;
   static void generate_test_instances(list<bluestore_pextent_t*>& ls);
 };
@@ -457,6 +460,8 @@ public:
   PExtentVector& dirty_extents() {
     return extents;
   }
+
+  operator std::string() const;
 
   DENC_HELPERS;
   void bound_encode(size_t& p, uint64_t struct_v) const {
@@ -882,6 +887,8 @@ struct bluestore_shared_blob_t {
   bool empty() const {
     return ref_map.empty();
   }
+
+  operator std::string() const;
 };
 WRITE_CLASS_DENC(bluestore_shared_blob_t)
 

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -51,6 +51,13 @@ add_library(osd STATIC ${osd_srcs}
 target_link_libraries(osd
   PUBLIC dmclock::dmclock
   PRIVATE os heap_profiler cpu_profiler ${CMAKE_DL_LIBS})
+if(WITH_LTTNG_LOGGING)
+  target_link_libraries(osd PRIVATE logging_tp)
+  target_link_libraries(osd PRIVATE ceph_logging_tp)
+  target_link_libraries(osd PRIVATE lttng-ust-fork)
+
+  target_link_libraries(osd PUBLIC fmt::fmt)
+endif()
 if(WITH_LTTNG)
   add_dependencies(osd osd-tp pg-tp)
 endif()

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -217,6 +217,12 @@ void dump(Formatter* f, const osd_alerts_t& alerts)
   }
 }
 
+pg_shard_t::operator std::string() {
+  stringstream out;
+  out << *this;
+  return out.str();
+}
+
 // -- osd_reqid_t --
 void osd_reqid_t::dump(Formatter *f) const
 {
@@ -935,6 +941,12 @@ void coll_t::generate_test_instances(list<coll_t*>& o)
   o.push_back(new coll_t(spg_t(pg_t(3, 2), shard_id_t(12))));
   o.push_back(new coll_t(o.back()->get_temp()));
   o.push_back(new coll_t());
+}
+
+coll_t::operator std::string() const {
+  std::stringstream out;
+  out << *this;
+  return out.str();
 }
 
 // ---
@@ -3011,6 +3023,12 @@ void store_statfs_t::generate_test_instances(list<store_statfs_t*>& o)
   o.push_back(new store_statfs_t(a));
 }
 
+store_statfs_t::operator std::string() const {
+  stringstream out;
+  out << *this;
+  return out.str();
+}
+
 // -- pool_stat_t --
 
 void pool_stat_t::dump(Formatter *f) const
@@ -3349,6 +3367,12 @@ void pg_info_t::generate_test_instances(list<pg_info_t*>& o)
     pg_hit_set_history_t::generate_test_instances(s);
     o.back()->hit_set = *s.back();
   }
+}
+
+pg_info_t::operator std::string() {
+  stringstream out;
+  out << *this;
+  return out.str();
 }
 
 // -- pg_notify_t --
@@ -4771,6 +4795,17 @@ void pg_log_t::dump(Formatter *f) const
     f->close_section();
   }
   f->close_section();
+}
+
+pg_log_t::operator std::string() {
+  stringstream out;
+  out << *this;
+  return out.str();
+}
+pg_log_t::operator std::string() const {
+  stringstream out;
+  out << *this;
+  return out.str();
 }
 
 void pg_log_t::generate_test_instances(list<pg_log_t*>& o)

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -187,6 +187,7 @@ struct pg_shard_t {
       f->dump_unsigned("shard", shard);
     }
   }
+  operator std::string();
 };
 WRITE_CLASS_ENCODER(pg_shard_t)
 WRITE_EQ_OPERATORS_2(pg_shard_t, osd, shard)
@@ -781,6 +782,7 @@ public:
     return 0;  // whatever.
   }
 
+  operator std::string() const;
   void dump(ceph::Formatter *f) const;
   static void generate_test_instances(std::list<coll_t*>& o);
 };
@@ -2340,6 +2342,7 @@ struct store_statfs_t
     DENC_FINISH(p);
   }
   static void generate_test_instances(std::list<store_statfs_t*>& o);
+  operator std::string() const;
 };
 WRITE_CLASS_DENC(store_statfs_t)
 
@@ -2784,6 +2787,8 @@ struct pg_info_t {
       l.history == r.history &&
       l.hit_set == r.hit_set;
   }
+
+  operator std::string();
 
   pg_info_t()
     : last_epoch_started(0),
@@ -4042,6 +4047,8 @@ public:
     }
   }
 
+  operator std::string();
+  operator std::string() const;
   void clear() {
     eversion_t z;
     rollback_info_trimmed_to = can_rollback_to = head = tail = z;
@@ -4365,6 +4372,12 @@ class pg_missing_set : public pg_missing_const_i {
 
 public:
   pg_missing_set() = default;
+
+  virtual operator std::string() {
+    stringstream out;
+    out << *this;
+    return out.str();
+  }
 
   template <typename missing_type>
   pg_missing_set(const missing_type &m) {

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -35,7 +35,7 @@ install(PROGRAMS
 endif(WITH_TESTS)
 
 add_executable(ceph-osdomap-tool ceph_osdomap_tool.cc)
-target_link_libraries(ceph-osdomap-tool os global Boost::program_options)
+target_link_libraries(ceph-osdomap-tool os ceph_logging_tp global Boost::program_options)
 install(TARGETS ceph-osdomap-tool DESTINATION bin)
 
 add_executable(ceph-monstore-tool
@@ -65,7 +65,7 @@ endif(WITH_LIBCEPHFS)
 add_executable(ceph-kvstore-tool
   kvstore_tool.cc
   ceph_kvstore_tool.cc)
-target_link_libraries(ceph-kvstore-tool os global)
+target_link_libraries(ceph-kvstore-tool os ceph_logging_tp fmt::fmt global)
 install(TARGETS ceph-kvstore-tool DESTINATION bin)
 
 set(ceph_conf_srcs ceph_conf.cc)

--- a/src/tracing/CMakeLists.txt
+++ b/src/tracing/CMakeLists.txt
@@ -4,14 +4,68 @@
 # ${PROJECT_BINARY_DIR}/include, where acconfig.h is also located
 set(working_dir ${CMAKE_BINARY_DIR}/include)
 set(header_dir ${working_dir}/tracing)
+set(tracing_build_dir ${CMAKE_BINARY_DIR}/tracing)
 file(MAKE_DIRECTORY ${header_dir})
+file(MAKE_DIRECTORY ${tracing_build_dir})
 
 add_custom_target(tracepoint_libraries)
 
+# TODO this should be done on all source code automatically instead of
+# indivudal files
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BlueStore.cc -t tp --outdir ${CMAKE_BINARY_DIR})
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BitmapAllocator.cc -t tp --outdir ${CMAKE_BINARY_DIR})
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BitmapFreelistManager.cc -t tp --outdir ${CMAKE_BINARY_DIR})
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/msg/async/AsyncConnection.cc -t tp --outdir ${CMAKE_BINARY_DIR})
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/msg/DispatchQueue.cc -t tp --outdir ${CMAKE_BINARY_DIR})
+if(WITH_LTTNG_LOGGING)
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BlueStore.cc -t h --outdir ${CMAKE_BINARY_DIR})
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BitmapAllocator.cc -t h --outdir ${CMAKE_BINARY_DIR})
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BitmapFreelistManager.cc -t h --outdir ${CMAKE_BINARY_DIR})
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/msg/async/AsyncConnection.cc -t h --outdir ${CMAKE_BINARY_DIR})
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/msg/DispatchQueue.cc -t h --outdir ${CMAKE_BINARY_DIR})
+else()
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BlueStore.cc -t h --outdir ${CMAKE_BINARY_DIR} --disabled)
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BitmapAllocator.cc -t h --outdir ${CMAKE_BINARY_DIR} --disabled)
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BitmapFreelistManager.cc -t h --outdir ${CMAKE_BINARY_DIR} --disabled)
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/msg/async/AsyncConnection.cc -t h --outdir ${CMAKE_BINARY_DIR} --disabled)
+  execute_process(
+    COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/msg/DispatchQueue.cc -t h --outdir ${CMAKE_BINARY_DIR} --disabled)
+endif()
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BlueStore.cc -t c --outdir ${CMAKE_BINARY_DIR})
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BitmapAllocator.cc -t c --outdir ${CMAKE_BINARY_DIR})
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BitmapFreelistManager.cc -t c --outdir ${CMAKE_BINARY_DIR})
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/msg/async/AsyncConnection.cc -t c --outdir ${CMAKE_BINARY_DIR})
+execute_process(
+  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/msg/DispatchQueue.cc -t c --outdir ${CMAKE_BINARY_DIR})
+
+file(GLOB all_files "${tracing_build_dir}/*")
+file(GLOB generated_tps "${tracing_build_dir}/*.tp")
 file(GLOB tps "*.tp")
-foreach(tp ${tps})
+
+#set(generated_tps ${working_dir}/tracing/bluestore_gc.tp;${working_dir}/tracing/bluestore_lru_cache.tp;${working_dir}/tracing/bluestore_twoqcache.tp;${working_dir}/tracing/bluestore.tp;${working_dir}/tracing/bluestore_blob.tp;${working_dir}/tracing/bitmapallocator.tp;${working_dir}/tracing/bmap_freelist_manager.tp;${working_dir}/tracing/asyncconnection.tp)
+
+foreach(tp ${tps} ${generated_tps})
   get_filename_component(name ${tp} NAME_WE)
   set(header ${header_dir}/${name}.h)
+  execute_process(COMMAND ${LTTNG_GEN_TP} ${tp} -o tracing/${name}.h)
   add_custom_command(
     OUTPUT ${header}
     COMMAND ${LTTNG_GEN_TP} ${tp} -o tracing/${name}.h
@@ -23,12 +77,26 @@ foreach(tp ${tps})
     DEPENDS ${header})
 endforeach()
 
+#add_custom_command(
+#  OUTPUT ${CMAKE_BINARY_DIR}/include/tracing/bluestore_impl.h
+#  COMMAND python ${CMAKE_CURRENT_SOURCE_DIR}/tracetool/parsetool.py -f ${CMAKE_SOURCE_DIR}/src/os/bluestore/BlueStore.cc -t h --outdir ${CMAKE_BINARY_DIR}
+#  DEPENDS ${CMAKE_SOURCE_DIR}/src/os/bluestore/BlueStore.cc
+#  COMMENT "Running parsetool.py")
+#add_custom_target(
+#  bluestore-parsetool
+#  DEPENDS ${CMAKE_BINARY_DIR}/include/tracing/bluestore_impl.h)
+
 function(add_tracing_library name tracings version)
   foreach(tp_file ${tracings})
     get_filename_component(tp ${tp_file} NAME_WE)
     list(APPEND hdrs
       ${header_dir}/${tp}.h)
-    list(APPEND tpfiles ${tp}.c)
+    # TODO: remove this condition when we move to tracetool for existing tracepoints
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${tp}.c")
+      list(APPEND tpfiles ${tp}.c)
+    else()
+      list(APPEND tpfiles ${tracing_build_dir}/${tp}.c)
+    endif()
   endforeach()
   add_library(${name} SHARED ${hdrs} ${tpfiles})
   target_link_libraries(${name} ${LTTNGUST_LIBRARIES} ${CMAKE_DL_LIBS})
@@ -41,14 +109,30 @@ function(add_tracing_library name tracings version)
   add_dependencies(tracepoint_libraries ${name})
 endfunction()
 
-set(osd_traces oprequest.tp osd.tp pg.tp)
+set(osd_traces oprequest.tp osd.tp)
 add_tracing_library(osd_tp "${osd_traces}" 1.0.0)
-add_tracing_library(rados_tp librados.tp 2.0.0)
+add_tracing_library(rados_tp librados.tp 3.0.0)
 add_tracing_library(os_tp objectstore.tp 1.0.0)
 add_tracing_library(rgw_op_tp rgw_op.tp 1.0.0)
 add_tracing_library(rgw_rados_tp rgw_rados.tp 1.0.0)
 
-install(TARGETS rados_tp osd_tp os_tp rgw_rados_tp rgw_op_tp DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if(WITH_LTTNG_LOGGING)
+  add_tracing_library(ceph_logging_tp ceph_logging.tp 1.0.0)
+#  Uncommenting this line makes it so that build/include/tracing/ceph_logging.h
+#  isn't generated anymore..
+#  target_link_libraries(ceph_logging_tp fmt::fmt)
+
+  foreach(tp ${generated_tps})
+    get_filename_component(name ${tp} NAME)
+    set(logging_tps "${name};${logging_tps}")
+  endforeach()
+
+  add_tracing_library(logging_tp "${logging_tps}" 1.0.0)
+  install(TARGETS rados_tp osd_tp logging_tp ceph_logging_tp os_tp rgw_rados_tp rgw_op_tp DESTINATION ${CMAKE_INSTALL_LIBDIR})
+else()
+  install(TARGETS rados_tp osd_tp os_tp rgw_rados_tp rgw_op_tp DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
 if(WITH_RBD)
   add_tracing_library(rbd_tp librbd.tp 1.0.0)
   install(TARGETS rbd_tp DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/tracing/ceph_logging.c
+++ b/src/tracing/ceph_logging.c
@@ -1,0 +1,6 @@
+
+#define TRACEPOINT_CREATE_PROBES
+/*
+ * The header containing our TRACEPOINT_EVENTs.
+ */
+#include "tracing/ceph_logging.h"

--- a/src/tracing/ceph_logging.tp
+++ b/src/tracing/ceph_logging.tp
@@ -1,0 +1,55 @@
+#include "include/int_types.h"
+
+TRACEPOINT_EVENT(ceph_logging, log_critical,
+    TP_ARGS(
+        char *, text),
+    TP_FIELDS(
+        ctf_string(message, text)
+    )
+)
+TRACEPOINT_LOGLEVEL(ceph_logging, log_cirtical, TRACE_CRIT)
+
+TRACEPOINT_EVENT(ceph_logging, log_error,
+    TP_ARGS(
+        char *, text),
+    TP_FIELDS(
+        ctf_string(message, text)
+    )
+)
+TRACEPOINT_LOGLEVEL(ceph_logging, log_error, TRACE_ERR)
+
+TRACEPOINT_EVENT(ceph_logging, log_warning,
+    TP_ARGS(
+        char *, text),
+    TP_FIELDS(
+        ctf_string(message, text)
+    )
+)
+TRACEPOINT_LOGLEVEL(ceph_logging, log_warning, TRACE_WARNING)
+
+TRACEPOINT_EVENT(ceph_logging, log_info,
+    TP_ARGS(
+        char *, text),
+    TP_FIELDS(
+        ctf_string(message, text)
+    )
+)
+TRACEPOINT_LOGLEVEL(ceph_logging, log_info, TRACE_INFO)
+
+TRACEPOINT_EVENT(ceph_logging, log_debug,
+    TP_ARGS(
+        char *, text),
+    TP_FIELDS(
+        ctf_string(message, text)
+    )
+)
+TRACEPOINT_LOGLEVEL(ceph_logging, log_debug, TRACE_DEBUG_PROGRAM)
+
+TRACEPOINT_EVENT(ceph_logging, log_verbose,
+    TP_ARGS(
+        char *, text),
+    TP_FIELDS(
+        ctf_string(message, text)
+    )
+)
+TRACEPOINT_LOGLEVEL(ceph_logging, log_verbose, TRACE_DEBUG)

--- a/src/tracing/ceph_logging_impl.h
+++ b/src/tracing/ceph_logging_impl.h
@@ -1,0 +1,36 @@
+#ifndef CEPH_LOGGING_IMPL_H
+#define CEPH_LOGGING_IMPL_H
+
+#include <string>
+#include <stdarg.h>
+#include "fmt/fmt/format.h"
+#include "fmt/fmt/ostream.h"
+
+#include "tracing/ceph_logging.h"
+
+using fmt::format;
+
+#define trace(ll, ss, fmt, ...) __trace(ll, ss, format(fmt, __VA_ARGS__))
+#define trace_error(ss, fmt, ...) __trace(-1, ss, format(fmt, __VA_ARGS__))
+
+//static inline void trace(int loglevel, string subsys, const char *fmt, void *arg, ...)
+static inline void __trace(int loglevel, string subsys, string str)
+{
+  str = subsys + ": " + str;
+  if (loglevel <= -1) {
+    str = "Error: " + str;
+    tracepoint(ceph_logging, log_error, (char*)str.c_str());
+  } else if (loglevel <= 1) {
+    tracepoint(ceph_logging, log_critical, (char*)str.c_str());
+  } else if (loglevel <= 5) {
+    tracepoint(ceph_logging, log_warning, (char*)str.c_str());
+  } else if (loglevel <= 10) {
+    tracepoint(ceph_logging, log_info, (char*)str.c_str());
+  } else if (loglevel <= 15) {
+    tracepoint(ceph_logging, log_debug, (char*)str.c_str());
+  } else {
+    tracepoint(ceph_logging, log_verbose, (char*)str.c_str());
+  }
+}
+
+#endif // CEPH_LOGGING_IMPL_H

--- a/src/tracing/gen-tps.bash
+++ b/src/tracing/gen-tps.bash
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+python tracetool/parsetool.py -f /var/data/ceph/src/os/bluestore/BlueStore.cc -t c --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/os/bluestore/BlueStore.cc -t tp --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/os/bluestore/BlueStore.cc -t h --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/os/bluestore/BitmapAllocator.cc -t c --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/os/bluestore/BitmapAllocator.cc -t tp --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/os/bluestore/BitmapAllocator.cc -t h --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/os/bluestore/BitmapFreelistManager.cc -t c --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/os/bluestore/BitmapFreelistManager.cc -t tp --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/os/bluestore/BitmapFreelistManager.cc -t h --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/msg/async/AsyncConnection.cc -t h --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/msg/async/AsyncConnection.cc -t tp --outdir ../../build/
+python tracetool/parsetool.py -f /var/data/ceph/src/msg/async/AsyncConnection.cc -t c --outdir ../../build/
+touch CMakeLists.txt
+

--- a/src/tracing/tracetool/README.md
+++ b/src/tracing/tracetool/README.md
@@ -1,0 +1,68 @@
+# Tracetool
+
+#### Disclaimer
+This approach and some of its code are taken from the QEMU project.
+
+## Tracepoints and subsystems
+
+All events are declared directly and used in the source code. For now, only ``src/os/bluestore/BlueStore.cc`` can be instrumented, as such:
+
+```
+[disable] <name>(<type1> <arg1>[, <type2> <arg2>] ...) "<format-string>" <log level>
+trace_<tracepoint name>(<loglevel>, <subsystem>, [<type1>, <name arg1>, <value arg1>[, <type2>, <name arg2>, <value arg2>, ...], "<format-string>");
+```
+For example:
+```
+  trace_write(10, bluestore,
+              ghobject_t, oid, o->oid,
+              uint64_t, offset, getOffset(),
+              size_t, length, l,
+              "Do write on ojbect %s, at offset = %llu with and a length of %d");
+```
+Where ``write`` is the tracepoint name, ``oid``, ``offset`` and ``length`` are the payload fields and ``o->oid``, ``getOffset()`` and ``l`` are their respective values. ``"Do write on ojbect %s, at offset = %llu with and a length of %d"`` is how it will be formatted (for certain backends only), ``10`` is its loglevel, and ``bluestore`` is its subsystem. The difference
+
+#### Types
+You can use objects of any class in the events files on the condition that the class implements the ``operator std::string()`` method. For example, you can have:
+```
+trace_read(1, bluestore, byte_u_t length, "Reading length %s")
+```
+As long as the ``byte_u_t`` class implements ``operator std::string()``.
+
+#### How do I use the tracepoints?
+- You need to ``#include <your subsys name>_impl.h`` in the source file where you want to invoke its tracepoints
+- You need to ``#include <your subsys name>.h`` in ``src/log/Log.cc``.
+
+## Parsetool
+
+The parsetool first parses the source code to find tracepoints and generate code that can be built with Ceph. The parseetool is invoked as follows:
+```
+python src/tracing/tracetool/parsetool.py -b <backend> -t <type> --outdir <Ceph build directory>
+```
+Where ``backend`` is either ``dout`` or ``lttng``, and ``type`` is either ``tp`` (tracepoint file), ``c`` (C source file) or ``h`` (header file).
+
+### How do I run this?
+You don't have to, just run ``do_cmake`` with ``-DWITH_LTTNG_LOGGING=ON`` to use the ``LTTng`` backend, otherwise leave it unset to use the ``dout`` backend.
+
+### What are the generated files?
+Three files are generated for the ``lttng`` backend, and one file is generated for the ``dout`` backend. Below are some details:
+
+## Tracing
+
+- Have LTTng installed. Make sure that:
+    - packages `lttng-tools`, `lttng-ust`, `lttng-modules` (), `babeltrace`, as well as their `-devel` counterparts when available, are installed
+    - the `lttng-sessiond` daemon is running (`$> sudo lttng-sessiond -d` otherwise)
+    - you belong to the `tracing` group, otherwise you'll have to run the following commands with `sudo`
+- Start LTTng tracing:
+    - If you have Ceph (or fio with the objectstore backend) already running, you can list the tracepoints using ``$> lttng list -u``
+    - Create a tracing session: ``$> lttng create -o .``. The trace will be written in the local directory and will be called ``ust/``
+    - Enable tracepoints: ``$> lttng enable-event -u -a`` to enable all userspace tracepoints. If you wish to enable only some subsystems, use ``$> lttng enable-event -u bluestore:*``. Replace ``bluestore`` with the subsystem you want to enable. You can run this command multiple times for each subsystem.
+    - Start tracing: ``$> lttng start``
+    - Do something with Ceph (or with fio using the objectstore backend)
+    - Stop tracing: ``$> lttng stop``
+    - Read the trace: ``$> lttng view`` or ``$> babeltrace <path to trace>`` (eg ``babeltrace ust/``)
+    - Destroy the tracing session: ``$> lttng destroy``
+
+## Misc
+### Babeltrace
+You can use Babeltrace's python bindings to parse a trace. This can be useful to write scripts that analyze a trace and extract metrics out of it.
+

--- a/src/tracing/tracetool/parsetool.py
+++ b/src/tracing/tracetool/parsetool.py
@@ -1,0 +1,490 @@
+import re
+import sys
+import argparse
+
+# TODO: make this script compatible with python3
+
+ALLOWED_TYPES = [
+    "int",
+    "long",
+    "short",
+    "char",
+    "bool",
+    "unsigned",
+    "signed",
+    "float",
+    "double",
+    "int8_t",
+    "uint8_t",
+    "int16_t",
+    "uint16_t",
+    "int32_t",
+    "uint32_t",
+    "int64_t",
+    "uint64_t",
+    "void",
+    "size_t",
+    "ssize_t",
+]
+
+LTTNG_LOGLEVEL_MAPPING = [
+    "TRACE_EMERG",
+    "TRACE_ALERT",
+    "TRACE_CRIT",
+    "TRACE_ERR",
+    "TRACE_WARNING",
+    "TRACE_NOTICE",
+    "TRACE_INFO",
+    "TRACE_DEBUG_SYSTEM",
+    "TRACE_DEBUG_PROGRAM",
+    "TRACE_DEBUG_PROCESS",
+    "TRACE_DEBUG_MODULE",
+    "TRACE_DEBUG_UNIT",
+    "TRACE_DEBUG_FUNCTION",
+    "TRACE_DEBUG_LINE",
+    "TRACE_DEBUG"
+]
+
+
+"""
+Notes: same tracepoint can be called from more than one callsite, we should
+    account for duplicates.
+
+TODO: add protection for number of given arguments. make sure the type, name, val
+format is respected
+"""
+
+# trace_do_write(30, bluestore, Blob *, b, int, r, "This is the format: %s %d")
+_CEPH_RE =  re.compile(r"\s*trace_"
+            r"(?P<event_name>[^(]*)"
+            r"\s*"
+            r"\("
+            r"(?P<loglevel>\b\d+\b)\s*,\s*"
+            r"(?P<subsys>\b\w+\b)\s*,\s*"
+            r"((?P<args>[^\"]*)\s*,\s*)?"
+            r"(?P<fmt>\".+)?\s*"
+            r"\)")
+
+
+def is_valid_type(name):
+    bits = name.split(" ")
+    for bit in bits:
+        bit = re.sub("\*", "", bit)
+        if bit == "":
+            continue
+        if bit == "const":
+            continue
+        if bit not in ALLOWED_TYPES:
+            return False
+    return True
+
+
+def out(fout, *lines, **kwargs):
+    """Write a set of output lines.
+
+    You can use kwargs as a shorthand for mapping variables when formating all
+    the strings in lines.
+    """
+    lines = [ l % kwargs for l in lines ]
+    fout.writelines("\n".join(lines) + "\n")
+
+
+class Wrapper(object):
+    def __init__(self):
+        pass
+
+
+class LTTngWrapper(Wrapper):
+    def generate_tp_file(self, events, outdir):
+        fhandles = {}
+        for e in events:
+            if e.subsys not in fhandles:
+                fhandles[e.subsys] = open(outdir + "/tracing/" + e.subsys + ".tp", "w")
+                out(fhandles[e.subsys], '#include "include/int_types.h"\n')
+
+            fobj = fhandles[e.subsys]
+            if len(e.args) > 0:
+                # known bug: if the type is a pointer to a class, it should be a void*
+                out(fobj,
+                    'TRACEPOINT_EVENT(',
+                    '   %(subsys)s,',
+                    '   %(name)s,',
+                    '   TP_ARGS(%(args)s),',
+                    '   TP_FIELDS(',
+                    subsys=e.subsys,
+                    name=e.name,
+                    args=",\n      ".join([', '.join([type_, name]) if is_valid_type(type_) else ', '.join(('char *', name)) for (type_, name, _) in e.args]))
+
+                types = e.args.types()
+                names = e.args.names()
+                fmts = e.formats()
+                for t,n,f in zip(types, names, fmts):
+                    if ('char *' in t) or ('char*' in t) or ('string' in t):
+                        out(fobj, '       ctf_string(' + n + ', ' + n + ')')
+                    elif ("%p" in f) or ("x" in f) or ("PRIx" in f):
+                        out(fobj, '       ctf_integer_hex('+ t + ', ' + n + ', ' + n + ')')
+                    elif ("ptr" in t) or ("*" in t):
+                        out(fobj, '       ctf_integer_hex('+ t + ', ' + n + ', ' + n + ')')
+                    # Bug: if "int" in t is not good enough of a check. There's a bug if
+                    # if t is 'interval_set', this script sees it as an int.
+                    elif ('int' in t) or ('long' in t) or ('unsigned' in t) \
+                            or ('size_t' in t) or ('bool' in t):
+                        out(fobj, '       ctf_integer(' + t + ', ' + n + ', ' + n + ')')
+                    elif ('double' in t) or ('float' in t):
+                        out(fobj, '       ctf_float(' + t + ', ' + n + ', ' + n + ')')
+                    elif ('void *' in t) or ('void*' in t):
+                        out(fobj, '       ctf_integer_hex(unsigned long, ' + n + ', ' + n + ')')
+                    else:
+                        # Make non-basic types strings and implement a method operator std::string()
+                        out(fobj, '       ctf_string(' + n + ', ' + n + ')')
+
+                out(fobj, '   )',
+                    ')',)
+
+            else:
+                out(fobj, 'TRACEPOINT_EVENT(',
+                    '   %(subsys)s,',
+                    '   %(name)s,',
+                    '   TP_ARGS(void),',
+                    '   TP_FIELDS()',
+                    ')',
+                    subsys=e.subsys,
+                    name=e.name)
+
+            out(fobj, 'TRACEPOINT_LOGLEVEL(%(subsys)s, %(name)s, %(loglevel)s)',
+                '',
+                subsys=e.subsys,
+                name=e.name,
+                loglevel=LTTNG_LOGLEVEL_MAPPING[0 if e.level < 0 else min(int(e.level), len(LTTNG_LOGLEVEL_MAPPING) - 1)])
+
+        for v in fhandles.values():
+            v.close()
+
+
+    def generate_c(self, events, outdir):
+        fhandles = {}
+        for e in events:
+            if e.subsys not in fhandles:
+                fhandles[e.subsys] = open(outdir + "/tracing/" + e.subsys + ".c", "w")
+                out(fhandles[e.subsys],
+                    '/* This file was generated automatically by the tracetool script.',
+                    '   Do not edit it manually. Refer to the documentation to add logging. */',
+                    '')
+                out(fhandles[e.subsys],
+                    '#define TRACEPOINT_CREATE_PROBES',
+                    ''
+                    '/*',
+                    ' * The header containing our TRACEPOINT_EVENTs.',
+                    ' */',
+                    '#include "tracing/%(subsys)s.h"',
+                    subsys=e.subsys)
+
+        for v in fhandles.values():
+            v.close()
+
+
+    def generate_header(self, events, outdir, disabled):
+        fhandles = {}
+        for e in events:
+            if e.subsys not in fhandles:
+                fhandles[e.subsys] = open(outdir + "/include/tracing/" + e.subsys + "_impl.h", "w")
+                fobj = fhandles[e.subsys]
+                out(fobj,
+                    '/* This file was generated automatically by the tracetool script.',
+                    '   Do not edit it manually. Refer to the documentation to add logging. */',
+                    '')
+                if not disabled:
+                    out(fobj,
+                        '#ifndef %(usubsys)s_IMPL',
+                        '#define %(usubsys)s_IMPL',
+                        '',
+                        '#include "tracing/%(subsys)s.h"',
+                        usubsys=e.subsys.upper(),
+                        subsys=e.subsys)
+                else:
+                    out(fobj,
+                        '#ifndef %(usubsys)s_IMPL',
+                        '#define %(usubsys)s_IMPL',
+                        usubsys=e.subsys.upper(),
+                        subsys=e.subsys)
+
+
+            fobj = fhandles[e.subsys]
+
+            if not disabled:
+                # Write the event's function
+                out(fobj, '',
+                    'static inline void __%(api)s(%(args)s)',
+                    '{',
+                    api=e.api(e.CEPH_TRACE),
+                    args=", ".join([' '.join(arg[:2]) if is_valid_type(arg[0]) else ' '.join(('string', arg[1])) for arg in e.args]))
+
+                # the c_str() is a temporary hack. we can use operator std::string()
+                argnames = ", ".join(['(char*){}.c_str()'.format(arg[1]) if not is_valid_type(arg[0]) else arg[1] for arg in e.args])
+                if len(e.args) > 0:
+                    argnames = ", " + argnames
+
+                out(fobj, '    tracepoint(%(subsys)s, %(name)s%(tp_args)s);',
+                    subsys=e.subsys,
+                    name=e.name,
+                    tp_args=argnames)
+
+                out(fobj, '}', '')
+
+                # Write the event's #define
+                define_str = '__loglevel, __subsys, '
+                if len(e.args) > 0:
+                    define_str += ', '.join( ['_type{0}, _name{0}, _value{0}'.format(i) for i in range(len(e.args))] )
+                    define_str += ', '
+                define_str += '__format'
+
+                out(fobj,
+                    '#define %(api)s(%(defstr)s) __%(api)s(%(args)s)',
+                    api=e.api(e.CEPH_TRACE),
+                    defstr=define_str,
+                    args=', '.join( ['_value{0}'.format(i) for i in range(len(e.args))] )
+                    )
+            else: # if disabled
+                # Write the event's #define
+                out(fobj, '',
+                    '#define %(api)s(...)',
+                    api=e.api(e.CEPH_TRACE))
+
+        for v in fhandles.values():
+            out(v, '', '#endif')
+            v.close()
+
+
+class Arguments:
+    """Event arguments description."""
+
+    def __init__(self, args):
+        """
+        Parameters
+        ----------
+        args :
+            List of (type, name) tuples or Arguments objects.
+        """
+        self._args = []
+        for arg in args:
+            if isinstance(arg, Arguments):
+                self._args.extend(arg._args)
+            else:
+                self._args.append(arg)
+
+    def copy(self):
+        """Create a new copy."""
+        return Arguments(list(self._args))
+
+    @staticmethod
+    def build(arg_str):
+        """Build and Arguments instance from an argument string.
+
+        Parameters
+        ----------
+        arg_str : str
+            String describing the event arguments.
+        """
+        args_array = [i.strip() for i in arg_str.split(',')]
+        args = zip(*[args_array[i::3] for i in range(3)])
+
+        return Arguments(args)
+
+
+    @staticmethod
+    def old_build(arg_str):
+        """Build and Arguments instance from an argument string.
+
+        Parameters
+        ----------
+        arg_str : str
+            String describing the event arguments.
+        """
+        print('arg_str:')
+        print(arg_str)
+        res = []
+        for arg in arg_str.split(","):
+            arg = arg.strip()
+            if not arg:
+                raise ValueError("Empty argument (did you forget to use 'void'?)")
+            if arg == 'void':
+                continue
+
+            if '*' in arg:
+                arg_type, identifier = arg.rsplit('*', 1)
+                arg_type += '*'
+                identifier = identifier.strip()
+            else:
+                print(arg)
+                arg_type, identifier = arg.rsplit(None, 1)
+
+            res.append((arg_type, identifier))
+        return Arguments(res)
+
+    def __getitem__(self, index):
+        if isinstance(index, slice):
+            return Arguments(self._args[index])
+        else:
+            return self._args[index]
+
+    def __iter__(self):
+        """Iterate over the (type, name, value) tuples."""
+        return iter(self._args)
+
+    def __len__(self):
+        """Number of arguments."""
+        return len(self._args)
+
+    def __str__(self):
+        """String suitable for declaring function arguments."""
+        if len(self._args) == 0:
+            return "void"
+        else:
+            return ", ".join([ " ".join([vartype, varname, varvalue]) for vartype, varname, varvalue in self._args ])
+
+    def __repr__(self):
+        """Evaluable string representation for this object."""
+        return "Arguments(\"%s\")" % str(self)
+
+    def names(self):
+        """List of argument names."""
+        return [ name for _, name, __ in self._args ]
+
+    def types(self):
+        """List of argument types."""
+        return [ type_ for type_, _, __ in self._args ]
+
+    def values(self):
+        """List of argument values."""
+        return [ value for _, __, value in self._args ]
+    
+    def signature(self):
+        """List of (type, name) of argument values"""
+        return [ (type_, name) for type_, name, value in self._args ]
+
+    def casted(self):
+        """List of argument names casted to their type."""
+        return ["(%s)%s" % (type_, name) for type_, name in self._args]
+
+    def transform(self, *trans):
+        """Return a new Arguments instance with transformed types.
+
+        The types in the resulting Arguments instance are transformed according
+        to tracetool.transform.transform_type.
+        """
+        res = []
+        for type_, name in self._args:
+            res.append((tracetool.transform.transform_type(type_, *trans),
+                        name))
+        return Arguments(res)
+
+
+class Event(object):
+    def __init__(self, name, level, fmt, args, subsys):
+        """
+        Parameters
+        ----------
+        name : string
+            Event name.
+        level: number
+            Log level
+        fmt : str, list of str
+            Event printing format string(s).
+        args : Arguments
+            Event arguments.
+        """
+        self.name = name
+        self.level = level
+        self.subsys = subsys
+        self.fmt = fmt
+        self.args = args
+        if len(args._args) > 10:
+            raise ValueError("Event '%s' has more than maximum permitted "
+                             "argument count" % name)
+
+    @staticmethod
+    def build(groups):
+        """Build an Event"""
+        name = groups["event_name"]
+        level = groups["loglevel"]
+        fmt = groups["fmt"]
+        subsys = groups["subsys"]
+        args = Arguments.build(groups["args"])
+
+        event = Event(name, level, fmt, args, subsys)
+
+        return event
+
+
+    # Star matching on PRI is dangerous as one might have multiple
+    # arguments with that format, hence the non-greedy version of it.
+    _FMT = re.compile("(%[\d\.]*\w+|%.*?PRI\S+|{.*?})")
+
+    def formats(self):
+        """List conversion specifiers in the argument print format string."""
+        assert not isinstance(self.fmt, list)
+        return self._FMT.findall(self.fmt)
+
+    CEPH_TRACE               = "trace_%(name)s"
+    CEPH_TRACE_NOCHECK       = "_nocheck__" + CEPH_TRACE
+    CEPH_TRACE_TCG           = CEPH_TRACE + "_tcg"
+    CEPH_DSTATE              = "_TRACE_%(NAME)s_DSTATE"
+    CEPH_BACKEND_DSTATE      = "TRACE_%(NAME)s_BACKEND_DSTATE"
+    CEPH_EVENT               = "_TRACE_%(NAME)s_EVENT"
+
+    def api(self, fmt=None):
+        if fmt is None:
+            fmt = Event.CEPH_TRACE
+        return fmt % {"name": self.name, "NAME": self.name.upper()}
+
+
+def test_re():
+    """ A couple of unit tests """
+    m = _CEPH_RE.match('trace_do_write(30, bluestore, Blob *, the_blob, b, int, ret, ret, "This is the string");')
+    assert m is not None
+    m = _CEPH_RE.match('trace_do_write(1, bluefs, Blob *, blob, (b->it).getBlog(), int, ret, ret, "This is the string %s %d %x" - (should work));')
+    assert m is not None
+    print('Passed unit tests\n')
+
+
+def get_events_from_source(fname):
+    events = []
+    with open(fname, "r") as fobj:
+        src = fobj.read()
+        for match in _CEPH_RE.finditer(src):
+            groups = match.groupdict('')
+            event = Event.build(groups)
+            events.append(event)
+
+            # TODO: account for commented lines
+    return events
+
+
+def main(args):
+    parser = argparse.ArgumentParser(description='Generate trace infrastructure.')
+    parser.add_argument('-f', help='Source file', required=True)
+    parser.add_argument('-t', help='Available types: tp, h, c', required=True)
+    parser.add_argument('--outdir', help='Ceph build directory', required=True)
+    parser.add_argument('--disabled', help='Generate headers for LTTng disabled', action='store_true')
+    parser.add_argument('--test', help='Run unit tests', action='store_true')
+    parsed_args = parser.parse_args(args[1:])
+
+    events = get_events_from_source(parsed_args.f)
+
+    wrapper = LTTngWrapper()
+
+
+    if parsed_args.test:
+        test_re()
+        return
+
+    if parsed_args.t == 'tp':
+        wrapper.generate_tp_file(events, parsed_args.outdir)
+    elif parsed_args.t == 'h':
+        wrapper.generate_header(events, parsed_args.outdir, parsed_args.disabled)
+    elif parsed_args.t == 'c':
+        wrapper.generate_c(events, parsed_args.outdir)
+
+
+if __name__ == "__main__":
+    main(sys.argv)


### PR DESCRIPTION
See ``src/tracing/tracetool/README`` for details. Use ``-DWITH_LTTNG_LOGGING=ON`` with cmake to use LTTng for logging.
Using fio's objectstore backend, with the following job:
```
runtime=120
rw=randwrite
bs=4m
numjobs=16
iodepth=16
```
I get the following results:
- with dout and debug bluestore = 10/0:
```
Average throughput = 119 MiB/s
Average IOPS = 13.68
Disk usage: 48M
```

- with LTTng:
```
Average throughput = 125 MiB/s
Average IOPS = 14.09
Disk usage: 23M
```

fio is writing to Bluestore on an SSD and the log is being written to an HDD for both dout and LTTng. The throughput difference varies. I've seen LTTng up to 10% faster with more iodepth and numjobs (more contention on dout's internal structures), and I've seen it pretty much the same as dout (with lower iodepth and lower numjobs). However, the size on disk of the log is consistently 50%-60% smaller with LTTng (as expected).