### PR TITLE
mimic: mgr/dashboard: Fix bug when creating S3 keys

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -9,6 +9,7 @@ import { Observable } from 'rxjs/Observable';
 
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { RgwUserS3Key } from '../models/rgw-user-s3-key';
 import { RgwUserFormComponent } from './rgw-user-form.component';
 
 describe('RgwUserFormComponent', () => {
@@ -47,6 +48,51 @@ describe('RgwUserFormComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('s3 key management', () => {
+    let rgwUserService: RgwUserService;
+
+    beforeEach(() => {
+      rgwUserService = TestBed.get(RgwUserService);
+      spyOn(rgwUserService, 'addS3Key').and.stub();
+    });
+
+    it('should not update key', () => {
+      component.setS3Key(new RgwUserS3Key(), 3);
+      expect(component.s3Keys.length).toBe(0);
+      expect(rgwUserService.addS3Key).not.toHaveBeenCalled();
+    });
+
+    it('should set key', () => {
+      const key = new RgwUserS3Key();
+      key.user = 'test1:subuser2';
+      component.setS3Key(key);
+      expect(component.s3Keys.length).toBe(1);
+      expect(component.s3Keys[0].user).toBe('test1:subuser2');
+      expect(rgwUserService.addS3Key).toHaveBeenCalledWith(
+        'test1',
+        'subuser2',
+        undefined,
+        undefined,
+        undefined
+      );
+    });
+
+    it('should set key w/o subuser', () => {
+      const key = new RgwUserS3Key();
+      key.user = 'test1';
+      component.setS3Key(key);
+      expect(component.s3Keys.length).toBe(1);
+      expect(component.s3Keys[0].user).toBe('test1');
+      expect(rgwUserService.addS3Key).toHaveBeenCalledWith(
+        'test1',
+        '',
+        undefined,
+        undefined,
+        undefined
+      );
+    });
   });
 
   describe('quotaMaxSizeValidator', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.ts
@@ -442,9 +442,11 @@ export class RgwUserFormComponent implements OnInit, OnDestroy {
     if (_.isNumber(index)) { // Modify
       // Nothing to do here at the moment.
     } else { // Add
+      // Split the key's user name into its user and subuser parts.
+      const userMatches = key.user.match(/([^:]+)(:(.+))?/);
       // Create an observable to add the S3 key when the form is submitted.
       this.submitObservables.push(this.rgwUserService.addS3Key(
-        this.userForm.get('user_id').value, key.user, key.access_key,
+        userMatches[1], userMatches[2] ? userMatches[3] : '', key.access_key,
         key.secret_key, key.generate_key));
       // If the access and the secret key are auto-generated, then visualize
       // this to the user by displaying a notification instead of the key.

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
@@ -132,7 +132,9 @@ export class RgwUserService {
       params = params.append('access-key', accessKey);
       params = params.append('secret-key', secretKey);
     }
-    params = params.append('subuser', subuser);
+    if (!_.isEmpty(subuser)) {
+      params = params.append('subuser', subuser);
+    }
     return this.http.put(`${this.url}?key`, null, {params: params});
   }
 


### PR DESCRIPTION
Currently a new subuser is created if a key is created for the main user. That's because the uid is set as subuser parameter, too.
To fix that the key's user name, e.g. test2 or test1:subuser2, must be splitted into its user and subuser parts.

Signed-off-by: Volker Theile <vtheile@suse.com>