### PR TITLE
mimic: os/bluestore: don't store/use path_block.{db,wal} from meta

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -162,10 +162,12 @@ def activate_bluestore(lvs, no_systemd=False):
         destination = os.path.join(osd_path, 'block.db')
         process.run(['ln', '-snf', db_device_path, destination])
         system.chown(db_device_path)
+        system.chown(destination)
     if wal_device_path:
         destination = os.path.join(osd_path, 'block.wal')
         process.run(['ln', '-snf', wal_device_path, destination])
         system.chown(wal_device_path)
+        system.chown(destination)
 
     if no_systemd is False:
         # enable the ceph-volume unit for this OSD

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -87,6 +87,7 @@ def chown(path, recursive=True):
     """
     uid, gid = get_ceph_user_ids()
     if os.path.islink(path):
+        process.run(['chown', '-h', 'ceph:ceph', path])
         path = os.path.realpath(path)
     if recursive:
         process.run(['chown', '-R', 'ceph:ceph', path])

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4724,9 +4724,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
     string bfn;
     struct stat st;
 
-    if (read_meta("path_block.db", &bfn) < 0) {
-      bfn = path + "/block.db";
-    }
+    bfn = path + "/block.db";
     if (::stat(bfn.c_str(), &st) == 0) {
       r = bluefs->add_block_device(BlueFS::BDEV_DB, bfn,
 	    create && cct->_conf->bdev_enable_discard);
@@ -4766,10 +4764,8 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
     }
 
     // shared device
-    if (read_meta("path_block", &bfn) < 0) {
-      bfn = path + "/block";
-    }
-     // never trim here
+    bfn = path + "/block";
+    // never trim here
     r = bluefs->add_block_device(bluefs_shared_bdev, bfn, false);
     if (r < 0) {
       derr << __func__ << " add block device(" << bfn << ") returned: " 
@@ -4798,9 +4794,7 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
       bluefs_extents.insert(start, initial);
     }
 
-    if (read_meta("path_block.wal", &bfn) < 0) {
-      bfn = path + "/block.wal";
-    }
+    bfn = path + "/block.wal";
     if (::stat(bfn.c_str(), &st) == 0) {
       r = bluefs->add_block_device(BlueFS::BDEV_WAL, bfn,
 	create && cct->_conf->bdev_enable_discard);
@@ -5427,17 +5421,6 @@ int BlueStore::mkfs()
   r = _open_bdev(true);
   if (r < 0)
     goto out_close_fsid;
-
-  {
-    string wal_path = cct->_conf->get_val<string>("bluestore_block_wal_path");
-    if (wal_path.size()) {
-      write_meta("path_block.wal", wal_path);
-    }
-    string db_path = cct->_conf->get_val<string>("bluestore_block_db_path");
-    if (db_path.size()) {
-      write_meta("path_block.db", db_path);
-    }
-  }
 
   // choose min_alloc_size
   if (cct->_conf->bluestore_min_alloc_size) {


### PR DESCRIPTION
This reverts most of 8d07fa5.

ceph-volume goes to great lengths to ensure that the symlinks in the
osd dir are accurate. Having these values here is an opportunity to
get them out of sync. And that can happen very easily if the initial
mkfs was performed using a /dev/sdX device name (which is unstable
across reboots). Even after ceph-volume corrects the symlink, bluestore
will continue to use the stale device path.

Backport of: https://github.com/ceph/ceph/pull/22462