### PR TITLE
osd/PG: create new PGs from activate in last_peering_reset epoch

### DIFF
--- a/src/messages/MOSDPGLog.h
+++ b/src/messages/MOSDPGLog.h
@@ -60,7 +60,7 @@ public:
       true,
       new PGCreateInfo(
 	get_spg(),
-	epoch,
+	query_epoch,
 	info.history,
 	past_intervals,
 	false));

--- a/src/messages/MOSDPGScan.h
+++ b/src/messages/MOSDPGScan.h
@@ -74,7 +74,12 @@ public:
     using ceph::encode;
     encode(op, payload);
     encode(map_epoch, payload);
-    encode(query_epoch, payload);
+    if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
+      // pre-nautilus OSDs do not set last_peering_reset properly
+      encode(map_epoch, payload);
+    } else {
+      encode(query_epoch, payload);
+    }
     encode(pgid.pgid, payload);
     encode(begin, payload);
     encode(end, payload);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1948,7 +1948,8 @@ void PG::activate(ObjectStore::Transaction& t,
 
 	m = new MOSDPGLog(
 	  i->shard, pg_whoami.shard,
-	  get_osdmap()->get_epoch(), pi);
+	  get_osdmap()->get_epoch(), pi,
+	  last_peering_reset /* epoch to create pg at */);
 
 	// send some recent log, so that op dup detection works well.
 	m->log.copy_up_to(pg_log.get_log(), cct->_conf->osd_min_pg_log_entries);
@@ -1961,7 +1962,8 @@ void PG::activate(ObjectStore::Transaction& t,
 	assert(pg_log.get_tail() <= pi.last_update);
 	m = new MOSDPGLog(
 	  i->shard, pg_whoami.shard,
-	  get_osdmap()->get_epoch(), info);
+	  get_osdmap()->get_epoch(), info,
+	  last_peering_reset /* epoch to create pg at */);
 	// send new stuff to append to replicas log
 	m->log.copy_after(pg_log.get_log(), pi.last_update);
       }


### PR DESCRIPTION
If we create a new PG (e.g., a backfill target) in the current epoch, it
might be > last_peering_reset.  That can lead to last_peering_reset on
the replica having a higher last_peering_reset than the primary's, which
can then lead to future messages, like pg_scan during backfill, being
ignored.

Fixes: http://tracker.ceph.com/issues/24452
Signed-off-by: Sage Weil <sage@redhat.com>