### PR TITLE
mgr/devicehealth: devicehealth module base

### DIFF
--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -51,6 +51,9 @@ class TestModuleSelftest(MgrTestCase):
     def test_iostat(self):
         self._selftest_plugin("iostat")
 
+    def test_devicehealth(self):
+        self._selftest_plugin("devicehealth")
+
     def test_selftest_run(self):
         self._load_module("selftest")
         self.mgr_cluster.mon_manager.raw_cluster_cmd("mgr", "self-test", "run")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4771,7 +4771,7 @@ std::vector<Option> get_global_options() {
     .set_description("Filesystem path to manager modules."),
 
     Option("mgr_initial_modules", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("restful status balancer iostat")
+    .set_default("restful status balancer iostat devicehealth")
     .set_flag(Option::FLAG_NO_MON_UPDATE)
     .set_flag(Option::FLAG_CLUSTER_CREATE)
     .add_service("mon")

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -281,10 +281,10 @@ PyObject *ActivePyModules::get_python(const std::string &what)
     return f.get();
   } else if (what == "pg_dump") {
     PyFormatter f;
-        cluster_state.with_pgmap(
-        [&f](const PGMap &pg_map) {
-	  pg_map.dump(&f);
-        }
+    cluster_state.with_pgmap(
+      [&f](const PGMap &pg_map) {
+	pg_map.dump(&f);
+      }
     );
     return f.get();
   } else if (what == "devices") {
@@ -294,6 +294,14 @@ PyObject *ActivePyModules::get_python(const std::string &what)
 	f.dump_object("device", dev);
       });
     f.close_section();
+    return f.get();
+  } else if (what.size() > 7 &&
+	     what.substr(0, 7) == "device ") {
+    string devid = what.substr(7);
+    PyFormatter f;
+    daemon_state.with_device(devid, [&f] (const DeviceState& dev) {
+	f.dump_object("device", dev);
+      });
     return f.get();
   } else if (what == "io_rate") {
     PyFormatter f;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2243,7 +2243,9 @@ will start to track new ops received afterwards.";
     }
     f->close_section();
   } else if (admin_command == "smart") {
-    probe_smart(ss);
+    string devid;
+    cmd_getval(cct, cmdmap, "devid", devid);
+    probe_smart(devid, ss);
   } else if (admin_command == "list_devices") {
     set<string> devnames;
     store->get_devices(&devnames);
@@ -2813,7 +2815,7 @@ void OSD::final_init()
 
   assert(r == 0);
 
-  r = admin_socket->register_command("smart", "smart",
+  r = admin_socket->register_command("smart", "smart name=devid,type=CephString,req=False",
                                      asok_hook,
                                      "probe OSD devices for SMART data.");
 
@@ -5733,7 +5735,7 @@ COMMAND("compact",
         "compact object store's omap. "
         "WARNING: Compaction probably slows your requests",
         "osd", "rw", "cli,rest")
-COMMAND("smart",
+COMMAND("smart name=devid,type=CephString,req=False",
         "runs smartctl on this osd devices.  ",
         "osd", "rw", "cli,rest")
 };
@@ -6171,7 +6173,9 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
   }
 
   else if (prefix == "smart") {
-    probe_smart(ds);
+    string devid;
+    cmd_getval(cct, cmdmap, "devid", devid);
+    probe_smart(devid, ds);
   }
 
   else {
@@ -6192,13 +6196,12 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
   }
 }
 
-void OSD::probe_smart(ostream& ss)
+void OSD::probe_smart(const string& only_devid, ostream& ss)
 {
   set<string> devnames;
   store->get_devices(&devnames);
   uint64_t smart_timeout = cct->_conf->get_val<uint64_t>(
     "osd_smart_report_timeout");
-  std::string result;
 
   // == typedef std::map<std::string, mValue> mObject;
   json_spirit::mObject json_map;
@@ -6216,9 +6219,15 @@ void OSD::probe_smart(ostream& ss)
 	       << dendl;
       continue;
     }
+    if (only_devid.size() && devid != only_devid) {
+      continue;
+    }
+
+    std::string result;
     if (probe_smart_device(("/dev/" + dev).c_str(), smart_timeout, &result)) {
       dout(10) << "probe_smart_device failed for /dev/" << dev << dendl;
-      continue;
+      //continue;
+      result = "{\"error\": \"smartctl failed\", \"dev\": \"" + dev + "\"}";
     }
 
     // TODO: change to read_or_throw?

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2208,7 +2208,7 @@ private:
 
   float get_osd_recovery_sleep();
 
-  void probe_smart(ostream& ss);
+  void probe_smart(const string& devid, ostream& ss);
   int probe_smart_device(const char *device, int timeout, std::string *result);
 
 public:

--- a/src/pybind/mgr/devicehealth/__init__.py
+++ b/src/pybind/mgr/devicehealth/__init__.py
@@ -1,0 +1,2 @@
+
+from .module import Module

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -1,0 +1,37 @@
+
+"""
+Device health monitoring
+"""
+
+import json
+from mgr_module import MgrModule, CommandResult
+import rados
+from threading import Event
+from datetime import datetime, timedelta, date, time
+
+class Module(MgrModule):
+    COMMANDS = [
+        {
+            "cmd": "device query-daemon-health-metrics "
+                   "name=osd_id,type=CephOsdName,req=true",
+            "desc": "Get device health metrics for a given daemon (OSD)",
+            "perm": "r"
+        },
+    ]
+
+    def handle_command(self, inbuf, cmd):
+        self.log.error("handle_command")
+
+        if cmd['prefix'] == 'device query-daemon-health-metrics':
+            result = CommandResult('')
+            self.send_command(result, 'osd', str(cmd['osd_id']), json.dumps({
+                'prefix': 'smart',
+                'format': 'json',
+            }), '')
+            r, outb, outs = result.wait()
+            return (r, outb, outs)
+
+        else:
+            # mgr should respect our self.COMMANDS and not call us for
+            # any prefix we don't advertise
+            raise NotImplementedError(cmd['prefix'])

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -3,35 +3,275 @@
 Device health monitoring
 """
 
+import errno
 import json
 from mgr_module import MgrModule, CommandResult
 import rados
 from threading import Event
 from datetime import datetime, timedelta, date, time
 
+TIME_FORMAT = '%Y%m%d-%H%M%S'
+
 class Module(MgrModule):
+    OPTIONS = [
+        { 'name': 'active' },
+        { 'name': 'scrape_frequency' },
+        { 'name': 'pool_name' },
+        { 'name': 'retention_period' },
+    ]
+    DEFAULTS = {
+        'active': True,
+        'scrape_frequency': str(86400),
+        'retention_period': str(86400*14),
+        'pool_name': 'device_health_metrics',
+    }
+    active = DEFAULTS['active']
+    scrape_frequency = DEFAULTS['scrape_frequency']
+    retention_period = DEFAULTS['retention_period']
+    pool_name = DEFAULTS['pool_name']
+
     COMMANDS = [
         {
             "cmd": "device query-daemon-health-metrics "
-                   "name=osd_id,type=CephOsdName,req=true",
+                   "name=who,type=CephString",
             "desc": "Get device health metrics for a given daemon (OSD)",
             "perm": "r"
         },
+        {
+            "cmd": "device scrape-daemon-health-metrics "
+                   "name=who,type=CephString",
+            "desc": "Scrape and store device health metrics for a given daemon",
+            "perm": "r"
+        },
+        {
+            "cmd": "device scrape-health-metrics name=devid,type=CephString,req=False",
+            "desc": "Scrape and store health metrics",
+            "perm": "r"
+        },
+        {
+            "cmd": "device show-health-metrics name=devid,type=CephString name=sample,type=CephString,req=False",
+            "desc": "Show stored device metrics for the device",
+            "perm": "r"
+        },
     ]
+
+    run = True
+    event = Event()
+    last_scrape_time = ""
 
     def handle_command(self, inbuf, cmd):
         self.log.error("handle_command")
 
         if cmd['prefix'] == 'device query-daemon-health-metrics':
+            who = cmd.get('who', '')
+            if who[0:4] != 'osd.':
+                return (-errno.EINVAL, '', 'not a valid <osd.NNN> id')
+            osd_id = who[4:]
             result = CommandResult('')
-            self.send_command(result, 'osd', str(cmd['osd_id']), json.dumps({
+            self.send_command(result, 'osd', osd_id, json.dumps({
                 'prefix': 'smart',
                 'format': 'json',
             }), '')
             r, outb, outs = result.wait()
             return (r, outb, outs)
+        elif cmd['prefix'] == 'device scrape-daemon-health-metrics':
+            who = cmd.get('who', '')
+            if who[0:4] != 'osd.':
+                return (-errno.EINVAL, '', 'not a valid <osd.NNN> id')
+            id = int(who[4:])
+            return self.scrape_osd(id)
+        elif cmd['prefix'] == 'device scrape-health-metrics':
+            if 'devid' in cmd:
+                return self.scrape_device(cmd['devid'])
+            return self.scrape_all();
+        elif cmd['prefix'] == 'device show-health-metrics':
+            return self.show_device_metrics(cmd['devid'], cmd.get('sample'))
 
         else:
             # mgr should respect our self.COMMANDS and not call us for
             # any prefix we don't advertise
             raise NotImplementedError(cmd['prefix'])
+
+    def refresh_config(self):
+        self.active = self.get_config('active', '') is not '' or 'false'
+        for opt, value in self.DEFAULTS.iteritems():
+            setattr(self, opt, self.get_config(opt) or value)
+
+    def serve(self):
+        self.log.info("Starting")
+        while self.run:
+            self.refresh_config()
+
+            # TODO normalize/align sleep interval
+            sleep_interval = int(self.scrape_frequency)
+
+            self.log.debug('Sleeping for %d seconds', sleep_interval)
+            ret = self.event.wait(sleep_interval)
+            self.event.clear()
+
+            # in case 'wait' was interrupted, it could mean config was changed
+            # by the user; go back and read config vars
+            if ret:
+                continue
+
+            self.log.debug('Waking up [%s]',
+                           "active" if self.active else "inactive")
+            if not self.active:
+                continue
+            self.log.debug('Running')
+
+            # WRITE ME
+
+    def shutdown(self):
+        self.log.info('Stopping')
+        self.run = False
+        self.event.set()
+
+    def open_connection(self):
+        pools = self.rados.list_pools()
+        is_pool = False
+        for pool in pools:
+            if pool == self.pool_name:
+                is_pool = True
+                break
+        if not is_pool:
+            self.log.debug('create %s pool' % self.pool_name)
+            # create pool
+            result = CommandResult('')
+            self.send_command(result, 'mon', '', json.dumps({
+                'prefix': 'osd pool create',
+                'format': 'json',
+                'pool': self.pool_name,
+                'pg_num': 1,
+            }), '')
+            r, outb, outs = result.wait()
+            assert r == 0
+
+            # set pool application
+            result = CommandResult('')
+            self.send_command(result, 'mon', '', json.dumps({
+                'prefix': 'osd pool application enable',
+                'format': 'json',
+                'pool': self.pool_name,
+                'app': 'mgr_devicehealth',
+            }), '')
+            r, outb, outs = result.wait()
+            assert r == 0
+
+        ioctx = self.rados.open_ioctx(self.pool_name)
+        return (ioctx)
+
+    def scrape_osd(self, osd_id):
+        ioctx = self.open_connection()
+        raw_smart_data = self.do_scrape_osd(osd_id, ioctx)
+        if raw_smart_data:
+            for device, raw_data in raw_smart_data.items():
+                data = self.extract_smart_features(raw_data)
+                self.put_device_metrics(ioctx, device, data)
+        ioctx.close()
+        return (0, "", "")
+
+    def scrape_all(self):
+        osdmap = self.get("osd_map")
+        assert osdmap is not None
+        ioctx = self.open_connection()
+        did_device = {}
+        for osd in osdmap['osds']:
+            osd_id = osd['osd']
+            raw_smart_data = self.do_scrape_osd(osd_id, ioctx)
+            if not raw_smart_data:
+                continue
+            for device, raw_data in raw_smart_data.items():
+                if device in did_device:
+                    self.log.debug('skipping duplicate %s' % device)
+                    continue
+                did_device[device] = 1
+                data = self.extract_smart_features(raw_data)
+                self.put_device_metrics(ioctx, device, data)
+
+        ioctx.close()
+        return (0, "", "")
+
+    def scrape_device(self, devid):
+        r = self.get("device " + devid)
+        if not r or 'device' not in r.keys():
+            return (-errno.ENOENT, '', 'device ' + devid + ' not found')
+        daemons = r['device'].get('daemons', [])
+        osds = [int(r[4:]) for r in daemons if r.startswith('osd.')]
+        if not osds:
+            return (-errno.EAGAIN, '',
+                    'device ' + devid + ' not claimed by any active OSD daemons')
+        osd_id = osds[0]
+        ioctx = self.open_connection()
+        raw_smart_data = self.do_scrape_osd(osd_id, ioctx, devid=devid)
+        if raw_smart_data:
+            for device, raw_data in raw_smart_data.items():
+                data = self.extract_smart_features(raw_data)
+                self.put_device_metrics(ioctx, device, data)
+        ioctx.close()
+        return (0, "", "")
+
+    def do_scrape_osd(self, osd_id, ioctx, devid=''):
+        self.log.debug('do_scrape_osd osd.%d' % osd_id)
+
+        # scrape from osd
+        result = CommandResult('')
+        self.send_command(result, 'osd', str(osd_id), json.dumps({
+            'prefix': 'smart',
+            'format': 'json',
+            'devid': devid,
+        }), '')
+        r, outb, outs = result.wait()
+
+        try:
+            return json.loads(outb)
+        except:
+            self.log.debug('Fail to parse JSON result from "%s"' % outb)
+
+    def put_device_metrics(self, ioctx, devid, data):
+        old_key = datetime.now() - timedelta(
+            seconds=int(self.retention_period))
+        prune = old_key.strftime(TIME_FORMAT)
+        self.log.debug('put_device_metrics device %s prune %s' %
+                       (devid, prune))
+        erase = []
+        with rados.ReadOpCtx() as op:
+            iter, ret = ioctx.get_omap_keys(op, "", 500) # fixme
+            assert ret == 0
+            ioctx.operate_read_op(op, devid)
+            for key, _ in list(iter):
+                if key >= prune:
+                    break
+                erase.append(key)
+        key = datetime.now().strftime(TIME_FORMAT)
+        self.log.debug('put_device_metrics device %s key %s = %s, erase %s' %
+                       (devid, key, data, erase))
+        with rados.WriteOpCtx() as op:
+            ioctx.set_omap(op, (key,), (str(json.dumps(data)),))
+            if len(erase):
+                ioctx.remove_omap_keys(op, tuple(erase))
+            ioctx.operate_write_op(op, devid)
+
+    def show_device_metrics(self, devid, sample):
+        ioctx = self.open_connection()
+        res = {}
+        with rados.ReadOpCtx() as op:
+            iter, ret = ioctx.get_omap_vals(op, "", sample or '', 500) # fixme
+            assert ret == 0
+            ioctx.operate_read_op(op, devid)
+            for key, value in list(iter):
+                if sample and key != sample:
+                    break
+                try:
+                    v = json.loads(value)
+                except:
+                    self.log.debug('unable to parse value for %s: "%s"' %
+                                   (key, value))
+                    pass
+                res[key] = v
+        return (0, json.dumps(res, indent=4), '')
+
+    def extract_smart_features(self, raw):
+        # FIXME: extract and normalize raw smartctl --json output and
+        # generate a dict of the fields we care about.
+        return raw

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -12,6 +12,13 @@ from datetime import datetime, timedelta, date, time
 
 TIME_FORMAT = '%Y%m%d-%H%M%S'
 
+DEFAULTS = {
+    'enable_monitoring': True,
+    'scrape_frequency': str(86400),
+    'retention_period': str(86400*14),
+    'pool_name': 'device_health_metrics',
+}
+
 class Module(MgrModule):
     OPTIONS = [
         { 'name': 'enable_monitoring' },
@@ -19,16 +26,6 @@ class Module(MgrModule):
         { 'name': 'pool_name' },
         { 'name': 'retention_period' },
     ]
-    DEFAULTS = {
-        'enable_monitoring': True,
-        'scrape_frequency': str(86400),
-        'retention_period': str(86400*14),
-        'pool_name': 'device_health_metrics',
-    }
-    enable_monitoring = DEFAULTS['enable_monitoring']
-    scrape_frequency = DEFAULTS['scrape_frequency']
-    retention_period = DEFAULTS['retention_period']
-    pool_name = DEFAULTS['pool_name']
 
     COMMANDS = [
         {
@@ -55,9 +52,18 @@ class Module(MgrModule):
         },
     ]
 
-    run = True
-    event = Event()
-    last_scrape_time = ""
+    def __init__(self, *args, **kwargs):
+        super(Module, self).__init__(*args, **kwargs)
+
+        # options
+        self.enable_monitoring = DEFAULTS['enable_monitoring']
+        self.scrape_frequency = DEFAULTS['scrape_frequency']
+        self.retention_period = DEFAULTS['retention_period']
+        self.pool_name = DEFAULTS['pool_name']
+
+        # other
+        self.run = True
+        self.event = Event()
 
     def handle_command(self, inbuf, cmd):
         self.log.error("handle_command")
@@ -94,7 +100,7 @@ class Module(MgrModule):
 
     def refresh_config(self):
         self.enable_monitoring = self.get_config('enable_monitoring', '') is not '' or 'false'
-        for opt, value in self.DEFAULTS.iteritems():
+        for opt, value in DEFAULTS.iteritems():
             setattr(self, opt, self.get_config(opt) or value)
 
     def serve(self):

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -235,14 +235,17 @@ class Module(MgrModule):
         self.log.debug('put_device_metrics device %s prune %s' %
                        (devid, prune))
         erase = []
-        with rados.ReadOpCtx() as op:
-            iter, ret = ioctx.get_omap_keys(op, "", 500) # fixme
-            assert ret == 0
-            ioctx.operate_read_op(op, devid)
-            for key, _ in list(iter):
-                if key >= prune:
-                    break
-                erase.append(key)
+        try:
+            with rados.ReadOpCtx() as op:
+                iter, ret = ioctx.get_omap_keys(op, "", 500) # fixme
+                assert ret == 0
+                ioctx.operate_read_op(op, devid)
+                for key, _ in list(iter):
+                    if key >= prune:
+                        break
+                    erase.append(key)
+        except:
+            pass
         key = datetime.now().strftime(TIME_FORMAT)
         self.log.debug('put_device_metrics device %s key %s = %s, erase %s' %
                        (devid, key, data, erase))
@@ -253,22 +256,30 @@ class Module(MgrModule):
             ioctx.operate_write_op(op, devid)
 
     def show_device_metrics(self, devid, sample):
+        # verify device exists
+        r = self.get("device " + devid)
+        if not r or 'device' not in r.keys():
+            return (-errno.ENOENT, '', 'device ' + devid + ' not found')
+        # fetch metrics
         ioctx = self.open_connection()
         res = {}
         with rados.ReadOpCtx() as op:
             iter, ret = ioctx.get_omap_vals(op, "", sample or '', 500) # fixme
             assert ret == 0
-            ioctx.operate_read_op(op, devid)
-            for key, value in list(iter):
-                if sample and key != sample:
-                    break
-                try:
-                    v = json.loads(value)
-                except:
-                    self.log.debug('unable to parse value for %s: "%s"' %
-                                   (key, value))
-                    pass
-                res[key] = v
+            try:
+                ioctx.operate_read_op(op, devid)
+                for key, value in list(iter):
+                    if sample and key != sample:
+                        break
+                    try:
+                        v = json.loads(value)
+                    except:
+                        self.log.debug('unable to parse value for %s: "%s"' %
+                                       (key, value))
+                        pass
+                    res[key] = v
+            except:
+                pass
         return (0, json.dumps(res, indent=4), '')
 
     def extract_smart_features(self, raw):

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -14,18 +14,18 @@ TIME_FORMAT = '%Y%m%d-%H%M%S'
 
 class Module(MgrModule):
     OPTIONS = [
-        { 'name': 'active' },
+        { 'name': 'enable_monitoring' },
         { 'name': 'scrape_frequency' },
         { 'name': 'pool_name' },
         { 'name': 'retention_period' },
     ]
     DEFAULTS = {
-        'active': True,
+        'enable_monitoring': True,
         'scrape_frequency': str(86400),
         'retention_period': str(86400*14),
         'pool_name': 'device_health_metrics',
     }
-    active = DEFAULTS['active']
+    enable_monitoring = DEFAULTS['enable_monitoring']
     scrape_frequency = DEFAULTS['scrape_frequency']
     retention_period = DEFAULTS['retention_period']
     pool_name = DEFAULTS['pool_name']
@@ -93,7 +93,7 @@ class Module(MgrModule):
             raise NotImplementedError(cmd['prefix'])
 
     def refresh_config(self):
-        self.active = self.get_config('active', '') is not '' or 'false'
+        self.enable_monitoring = self.get_config('enable_monitoring', '') is not '' or 'false'
         for opt, value in self.DEFAULTS.iteritems():
             setattr(self, opt, self.get_config(opt) or value)
 
@@ -115,8 +115,8 @@ class Module(MgrModule):
                 continue
 
             self.log.debug('Waking up [%s]',
-                           "active" if self.active else "inactive")
-            if not self.active:
+                           "active" if self.enable_monitoring else "inactive")
+            if not self.enable_monitoring:
                 continue
             self.log.debug('Running')
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -312,7 +312,8 @@ class MgrModule(ceph_module.BaseMgrModule):
 
         :param str data_name: Valid things to fetch are osd_crush_map_text, 
                 osd_map, osd_map_tree, osd_map_crush, config, mon_map, fs_map,
-                osd_metadata, pg_summary, io_rate, pg_dump, df, osd_stats, health, mon_status.
+                osd_metadata, pg_summary, io_rate, pg_dump, df, osd_stats,
+                health, mon_status, devices, device <devid>.
 
         Note:
             All these structures have their own JSON representations: experiment

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -434,7 +434,7 @@ prepare_conf() {
         heartbeat file = $CEPH_OUT_DIR/\$name.heartbeat
 "
 
-    local mgr_modules="restful status balancer iostat"
+    local mgr_modules="restful status balancer iostat devicehealth"
     if $with_mgr_dashboard; then
       mgr_modules="dashboard $mgr_modules"
     fi


### PR DESCRIPTION
- rename 'smart' module 'devicehealth'
- port parts of @yaarith's #21301 over to scrape and store metrics in a rados pool
- empty serve() method to do whatever background work makes sense going forward
  - checking stored device life expectancies and reacting (preemptively marking devices out, raising health alerts, etc.)
  - scraping at regular intervals and either (1) storing locally and generating a prediction or (2) quering an external API to get a prediction