### PR TITLE
qa/standalone/scrub/osd-unexpected-clone: make test more resilient

### DIFF
--- a/qa/standalone/scrub/osd-unexpected-clone.sh
+++ b/qa/standalone/scrub/osd-unexpected-clone.sh
@@ -66,7 +66,10 @@ function TEST_recover_unexpected() {
     objectstore_tool $dir $osd "$JSON" set-bytes data
     objectstore_tool $dir $osd "$JSON" set-attr _ _
 
-    sleep 5
+    wait_for_osd up 0 || return 1
+    wait_for_osd up 1 || return 1
+    wait_for_osd up 2 || return 1
+    wait_for_clean || return 1
 
     ceph pg repair 1.0
 
@@ -75,9 +78,9 @@ function TEST_recover_unexpected() {
     ceph log last
 
     # make sure osds are still up
-    timeout 60 ceph tell osd.0 version || return 1
-    timeout 60 ceph tell osd.1 version || return 1
-    timeout 60 ceph tell osd.2 version || return 1
+    ceph osd dump | grep 'osd.0 up' || return 1
+    ceph osd dump | grep 'osd.1 up' || return 1
+    ceph osd dump | grep 'osd.2 up' || return 1
 }
 
 


### PR DESCRIPTION
Avoid getting a spurious ENXIO due to a down OSD during this

Signed-off-by: Sage Weil <sage@redhat.com>