### PR TITLE
osd: do not include Messenger.h if not necessary

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -16,6 +16,7 @@
 #include "include/str_map.h"
 #include "messages/MLog.h"
 #include "messages/MLogAck.h"
+#include "msg/Messenger.h"
 #include "mon/MonMap.h"
 #include "common/Graylog.h"
 

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -15,6 +15,7 @@
 #include "librbd/io/Utils.h"
 #include "librbd/journal/Types.h"
 #include "include/rados/librados.hpp"
+#include "common/perf_counters.h"
 #include "common/WorkQueue.h"
 #include "osdc/Striper.h"
 

--- a/src/mds/JournalPointer.cc
+++ b/src/mds/JournalPointer.cc
@@ -18,6 +18,7 @@
 #include "common/Cond.h"
 #include "osdc/Objecter.h"
 #include "mds/mdstypes.h"
+#include "msg/Messenger.h"
 
 #include "mds/JournalPointer.h"
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -893,6 +893,10 @@ pair<ConnectionRef,ConnectionRef> OSDService::get_con_osd_hb(int peer, epoch_t f
   return ret;
 }
 
+entity_name_t OSDService::get_cluster_msgr_name() const
+{
+  return cluster_messenger->get_myname();
+}
 
 void OSDService::queue_want_pg_temp(pg_t pgid,
 				    const vector<int>& want,

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -433,9 +433,7 @@ public:
   void send_message_osd_client(Message *m, const ConnectionRef& con) {
     con->send_message(m);
   }
-  entity_name_t get_cluster_msgr_name() {
-    return cluster_messenger->get_myname();
-  }
+  entity_name_t get_cluster_msgr_name() const;
 
 private:
   // -- scrub scheduling --

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -18,13 +18,15 @@
 #define CEPH_REPLICATEDPG_H
 
 #include <boost/tuple/tuple.hpp>
-#include "include/assert.h" 
+#include "include/assert.h"
+#include "OSD.h"
 #include "PG.h"
 #include "Watch.h"
 #include "TierAgentState.h"
 #include "messages/MOSDOpReply.h"
 #include "common/Checksummer.h"
 #include "common/sharedptr_registry.hpp"
+#include "common/shared_cache.hpp"
 #include "ReplicatedBackend.h"
 #include "PGTransaction.h"
 #include "cls/refcount/cls_refcount_ops.h"

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -21,6 +21,7 @@
 #include "messages/MOSDPGPushReply.h"
 #include "common/EventTrace.h"
 #include "include/random.h"
+#include "OSD.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -15,7 +15,6 @@
 #ifndef REPBACKEND_H
 #define REPBACKEND_H
 
-#include "OSD.h"
 #include "PGBackend.h"
 #include "include/memory.h"
 

--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -16,8 +16,7 @@
 
 #include "include/memory.h"
 #include <set>
-
-#include "msg/Messenger.h"
+#include "msg/Connection.h"
 #include "include/Context.h"
 
 enum WatcherState {

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -38,6 +38,7 @@
 #include "common/zipkin_trace.h"
 
 #include "messages/MOSDOp.h"
+#include "msg/Dispatcher.h"
 #include "osd/OSDMap.h"
 
 

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -5,6 +5,7 @@
 
 #include "include/Context.h"
 #include "include/types.h"
+#include "common/zipkin_trace.h"
 #include "osd/osd_types.h"
 
 class WritebackHandler {


### PR DESCRIPTION
to speed up the compilation, do not include Messenger.h, and use forward
declaration instead.

Signed-off-by: Kefu Chai <kchai@redhat.com>