### PR TITLE
qa: wait longer for osd to flush pg stats

### DIFF
--- a/qa/tasks/osd_max_pg_per_osd.py
+++ b/qa/tasks/osd_max_pg_per_osd.py
@@ -34,8 +34,9 @@ def test_create_from_mon(ctx, config):
     manager = ctx.managers['ceph']
     log.info('1. creating pool.a')
     pool_a = manager.create_pool_with_unique_name(pg_num)
-    manager.wait_for_clean()
-    assert manager.get_num_active_clean() == pg_num
+    pg_states = manager.wait_till_pg_convergence(300)
+    pg_created = pg_num_in_all_states(pg_states, 'active', 'clean')
+    assert pg_created == pg_num
 
     log.info('2. creating pool.b')
     pool_b = manager.create_pool_with_unique_name(pg_num)


### PR DESCRIPTION
it's the test_create_from_mon()'s counterpart of 38074726.

Fixes: http://tracker.ceph.com/issues/24321
Signed-off-by: Kefu Chai <kchai@redhat.com>