### PR TITLE
osd: always set query_epoch explicitly for MOSDPGLog

### DIFF
--- a/src/messages/MOSDPGLog.h
+++ b/src/messages/MOSDPGLog.h
@@ -69,13 +69,6 @@ public:
   MOSDPGLog() : MOSDPeeringOp(MSG_OSD_PG_LOG, HEAD_VERSION, COMPAT_VERSION) {
     set_priority(CEPH_MSG_PRIO_HIGH); 
   }
-  MOSDPGLog(shard_id_t to, shard_id_t from, version_t mv, pg_info_t& i)
-    : MOSDPeeringOp(MSG_OSD_PG_LOG, HEAD_VERSION, COMPAT_VERSION),
-      epoch(mv), query_epoch(mv),
-      to(to), from(from),
-      info(i)  {
-    set_priority(CEPH_MSG_PRIO_HIGH); 
-  }
   MOSDPGLog(shard_id_t to, shard_id_t from,
 	    version_t mv, pg_info_t& i, epoch_t query_epoch)
     : MOSDPeeringOp(MSG_OSD_PG_LOG, HEAD_VERSION, COMPAT_VERSION),

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1914,7 +1914,8 @@ void PG::activate(ObjectStore::Transaction& t,
 	  dout(10) << "activate peer osd." << peer << " is up to date, but sending pg_log anyway" << dendl;
 	  m = new MOSDPGLog(
 	    i->shard, pg_whoami.shard,
-	    get_osdmap()->get_epoch(), info);
+	    get_osdmap()->get_epoch(), info,
+	    last_peering_reset);
 	}
       } else if (
 	pg_log.get_tail() > pi.last_update ||

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10564,7 +10564,7 @@ void PrimaryLogPG::submit_log_entries(
 	  MOSDPGLog *m = new MOSDPGLog(
 	    peer.shard, pg_whoami.shard,
 	    info.last_update.epoch,
-	    info);
+	    info, last_peering_reset);
 	  m->log.log = entries;
 	  m->log.tail = old_last_update;
 	  m->log.head = info.last_update;


### PR DESCRIPTION
it's a follow-up change of 339ae18b. also remove the MOSDPGLog
contructor where query_epoch is optional. it's less error-prone if we
make this parameter mandatory.

Signed-off-by: Kefu Chai <kchai@redhat.com>