### PR TITLE
install-deps.sh: fix installing gcc on ubuntu when no old compiler

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -67,9 +67,11 @@ EOF
 	 --install /usr/bin/gcc gcc /usr/bin/gcc-${new} 20 \
 	 --slave   /usr/bin/g++ g++ /usr/bin/g++-${new}
 
-    $SUDO update-alternatives \
-	 --install /usr/bin/gcc gcc /usr/bin/gcc-${old} 10 \
-	 --slave   /usr/bin/g++ g++ /usr/bin/g++-${old}
+    if [ -f /usr/bin/g++-${old} ]; then
+      $SUDO update-alternatives \
+  	 --install /usr/bin/gcc gcc /usr/bin/gcc-${old} 10 \
+  	 --slave   /usr/bin/g++ g++ /usr/bin/g++-${old}
+    fi
 
     $SUDO update-alternatives --auto gcc
 


### PR DESCRIPTION
Running `./install-deps.sh` on clean ubuntu xenial will fail with following error:
```
update-alternatives: error: alternative path /usr/bin/gcc-5 doesn't exist
```
This is because script installing gcc-7 later assumes that there is also gcc-5 in the system and tries to change its priority with `update-alternatives`. 

This PR fixes it by checking if there is gcc-5 in the system.
