### PR TITLE
ceph-volume use purge-new to avoid requiring admin key

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -1,19 +1,18 @@
 from ceph_volume.util import arg_validators
-from ceph_volume import process
+from ceph_volume import process, conf
 from ceph_volume import terminal
 import argparse
 
 
 def rollback_osd(args, osd_id=None):
     """
-    When the process of creating or preparing fails, the OSD needs to be either
-    purged (ID fully removed) or destroyed (ID persists). This is important
-    because otherwise it would leave the ID around, which can cause confusion
-    if relying on the automatic (OSD.N + 1) behavior.
+    When the process of creating or preparing fails, the OSD needs to be
+    destroyed so that the ID cane be reused.  This is prevents leaving the ID
+    around as "used" on the monitor, which can cause confusion if expecting
+    sequential OSD IDs.
 
-    When the OSD id is specified in the command line explicitly (with
-    ``--osd-id``) , the the ID is then preserved with a soft removal (``ceph
-    osd destroy``), otherwise it is fully removed with ``purge``.
+    The usage of `destroy-new` allows this to be done without requiring the
+    admin keyring (otherwise needed for destroy and purge commands)
     """
     if not osd_id:
         # it means that it wasn't generated, so there is nothing to rollback here
@@ -22,20 +21,17 @@ def rollback_osd(args, osd_id=None):
     # once here, this is an error condition that needs to be rolled back
     terminal.error('Was unable to complete a new OSD, will rollback changes')
     osd_name = 'osd.%s'
-    if args.osd_id is None:
-        terminal.error('OSD will be fully purged from the cluster, because the ID was generated')
-        # the ID wasn't passed in explicitly, so make sure it is fully removed
-        process.run([
-            'ceph', 'osd', 'purge',
-            osd_name % osd_id,
-            '--yes-i-really-mean-it'])
-    else:
-        terminal.error('OSD will be destroyed, keeping the ID because it was provided with --osd-id')
-        # the ID was passed explicitly, so allow to re-use by using `destroy`
-        process.run([
-            'ceph', 'osd', 'destroy',
-            osd_name % args.osd_id,
-            '--yes-i-really-mean-it'])
+    bootstrap_keyring = '/var/lib/ceph/bootstrap-osd/%s.keyring' % conf.cluster
+    cmd = [
+        'ceph',
+        '--cluster', conf.cluster,
+        '--name', 'client.bootstrap-osd',
+        '--keyring', bootstrap_keyring,
+        'osd', 'purge-new', osd_name % osd_id,
+        '--yes-i-really-mean-it',
+    ]
+
+    process.run(cmd)
 
 
 def common_parser(prog, description):


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/24427

Although the ticket mentions better wording, we are opting to just use `purge-new` and avoid all/any requirements of the admin key.

