### PR TITLE
common: use include/types.h early on, otherwise Clang will error.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -18,6 +18,7 @@
 
 #include <sys/uio.h>
 
+#include "include/types.h"
 #include "include/buffer_raw.h"
 #include "include/compat.h"
 #include "include/mempool.h"
@@ -30,7 +31,6 @@
 #include "common/valgrind.h"
 #include "common/deleter.h"
 #include "common/RWLock.h"
-#include "include/types.h"
 #include "include/spinlock.h"
 #include "include/scope_guard.h"
 


### PR DESCRIPTION
In file included from /home/wjw/wip/src/common/buffer.cc:21:
/home/wjw/wip/src/include/buffer_raw.h:92:41: error: unknown type name 'loff_t'; did you mean 'off_t'?
    virtual int zero_copy_to_fd(int fd, loff_t *offset) {
                                        ^~~~~~
                                        off_t
/usr/include/sys/uio.h:49:17: note: 'off_t' declared here
typedef __off_t off_t;
                ^
1 error generated.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>