### PR TITLE
osdc: Fix the wrong BufferHead offset

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1728,7 +1728,7 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace,
       ldout(cct, 10) << "writex writing " << f_it->first << "~"
 		     << f_it->second << " into " << *bh << " at " << opos
 		     << dendl;
-      uint64_t bhoff = bh->start() - opos;
+      uint64_t bhoff = opos - bh->start();
       assert(f_it->second <= bh->length() - bhoff);
 
       // get the frag we're mapping in


### PR DESCRIPTION
the BufferHead offset should be "opos - bh->start()"

issue: https://tracker.ceph.com/issues/24484
Signed-off-by: dongdong tao <tdd21151186@gmail.com>