### PR TITLE
osd/Session: fix invalid iterator dereference in Session::have_backoff()

### DIFF
--- a/src/osd/Session.h
+++ b/src/osd/Session.h
@@ -177,7 +177,7 @@ struct Session : public RefCountedObject {
     }
     auto p = i->second.lower_bound(oid);
     if (p != i->second.begin() &&
-	p->first > oid) {
+	(p == i->second.end() || p->first > oid)) {
       --p;
     }
     if (p != i->second.end()) {


### PR DESCRIPTION
If p is i->second.end(), we do want to back up a position, but we
shouldn't dereference p for p->first.

Fixes: http://tracker.ceph.com/issues/24486
Signed-off-by: Sage Weil <sage@redhat.com>