### PR TITLE
cmake: module boost_test does not exist on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -590,7 +590,7 @@ option(WITH_SYSTEM_BOOST "require and build with system Boost" OFF)
 # Boost::thread depends on Boost::atomic, so list it explicitly.
 set(BOOST_COMPONENTS
   atomic chrono filesystem thread system regex random program_options date_time
-  iostreams unit_test_framework)
+  iostreams unit_test_framework timer)
 set(BOOST_HEADER_COMPONENTS container)
 
 if(WITH_MGR)
@@ -599,7 +599,9 @@ endif()
 if(WITH_BOOST_CONTEXT)
   list(APPEND BOOST_COMPONENTS context coroutine)
 endif()
-list(APPEND BOOST_COMPONENTS test timer)
+if(NOT FREEBSD)
+  list(APPEND BOOST_COMPONENTS test)
+endif()
 
 set(Boost_USE_MULTITHREADED ON)
 # require minimally the bundled version


### PR DESCRIPTION
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>