### PR TITLE
osd: fix memory leak at EC read

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1257,6 +1257,13 @@ void ECBackend::complete_read_op(ReadOp &rop, RecoveryMessages *m)
       reqiter->second.cb = nullptr;
     }
   }
+  // if the read op is over. clean all the data of this tid.
+  for (set<pg_shard_t>::iterator iter = rop.in_progress.begin();
+    iter != rop.in_progress.end();
+    iter++) {
+    shard_to_read_map[*iter].erase(rop.tid);
+  }
+  rop.in_progress.clear();
   tid_to_read_map.erase(rop.tid);
 }
 


### PR DESCRIPTION
For EC k+m, we will send k+m read operations when the configuration of
fast read is true. And we think the read is complete after we receive k 
shards. 
Only tid_to_read_map is cleaned after the read complete, there are also
someting left in shard_to_read_map and in_proress.
This happens at normal read too. If the osd of one shard down, we will 
remove the to_read and complete, which makes the next read reply make the
read op complete. But the left shards are still in shard_to_read_map and
in_progess. The primary osd may crash, if another osd in in_progress down.
To prevent all the above happen, we should clean the in_progess and 
tid_to_read_map when we think a read op is complete.

Signed-off-by: xiaofei cui <cuixiaofei@sangfor.com>