### PR TITLE
messages/MOSDPGLog: encode epoch for query_epoch for pre-nautilus OSDs

### DIFF
--- a/src/messages/MOSDPGLog.h
+++ b/src/messages/MOSDPGLog.h
@@ -96,7 +96,12 @@ public:
     encode(info, payload);
     encode(log, payload);
     encode(missing, payload);
-    encode(query_epoch, payload);
+    if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
+      // pre-nautilus OSDs do not set last_peering_reset properly
+      encode(epoch, payload);
+    } else {
+      encode(query_epoch, payload);
+    }
     encode(past_intervals, payload);
     encode(to, payload);
     encode(from, payload);


### PR DESCRIPTION
This fix is analogous to d5a3ae6008e4399b336f3a72d8dee328f97a0002.  As of
84a1984b7cb70c74eaf517ffc424228fa954ed37 we set query_epoch to a lower
value reliably, but we need to encode the latest epoch for pre-nautilus
OSDs because they do not set last_peering_epoch reliably and havin a lower
query_epoch will cause them to discard this message.

Signed-off-by: Sage Weil <sage@redhat.com>