### PR TITLE
luminous: ceph-volume tests do not include admin keyring in OSD nodes

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/group_vars/all
@@ -10,7 +10,7 @@ osd_objectstore: "bluestore"
 osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/group_vars/all
@@ -11,7 +11,7 @@ osd_objectstore: "bluestore"
 osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/group_vars/all
@@ -10,7 +10,7 @@ osd_objectstore: "filestore"
 osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
   - data: data-lv1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/group_vars/all
@@ -11,7 +11,7 @@ osd_objectstore: "filestore"
 osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
   - data: data-lv1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/group_vars/all
@@ -10,7 +10,7 @@ osd_objectstore: "bluestore"
 osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/group_vars/all
@@ -11,7 +11,7 @@ osd_objectstore: "bluestore"
 osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 lvm_volumes:
   - data: data-lv1
     data_vg: test_group

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/group_vars/all
@@ -10,7 +10,7 @@ osd_objectstore: "filestore"
 osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
   - data: data-lv1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/group_vars/all
@@ -11,7 +11,7 @@ osd_objectstore: "filestore"
 osd_scenario: lvm
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
   - data: data-lv1

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/activate/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/activate/group_vars/all
@@ -9,7 +9,7 @@ journal_size: 100
 osd_objectstore: "bluestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-luks/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-luks/group_vars/all
@@ -10,7 +10,7 @@ journal_size: 100
 osd_objectstore: "bluestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-plain/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/bluestore/dmcrypt-plain/group_vars/all
@@ -10,7 +10,7 @@ journal_size: 100
 osd_objectstore: "bluestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/activate/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/activate/group_vars/all
@@ -9,7 +9,7 @@ journal_size: 100
 osd_objectstore: "filestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/dmcrypt-luks/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/dmcrypt-luks/group_vars/all
@@ -10,7 +10,7 @@ journal_size: 100
 osd_objectstore: "filestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/dmcrypt-plain/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/centos7/filestore/dmcrypt-plain/group_vars/all
@@ -10,7 +10,7 @@ journal_size: 100
 osd_objectstore: "filestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/activate/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/activate/group_vars/all
@@ -9,7 +9,7 @@ journal_size: 100
 osd_objectstore: "bluestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/dmcrypt-luks/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/dmcrypt-luks/group_vars/all
@@ -10,7 +10,7 @@ journal_size: 100
 osd_objectstore: "bluestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/dmcrypt-plain/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/bluestore/dmcrypt-plain/group_vars/all
@@ -10,7 +10,7 @@ journal_size: 100
 osd_objectstore: "bluestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/activate/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/activate/group_vars/all
@@ -9,7 +9,7 @@ journal_size: 100
 osd_objectstore: "filestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/dmcrypt-luks/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/dmcrypt-luks/group_vars/all
@@ -10,7 +10,7 @@ journal_size: 100
 osd_objectstore: "filestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/dmcrypt-plain/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/xenial/filestore/dmcrypt-plain/group_vars/all
@@ -10,7 +10,7 @@ journal_size: 100
 osd_objectstore: "filestore"
 ceph_origin: 'repository'
 ceph_repository: 'dev'
-copy_admin_key: true
+copy_admin_key: false
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }


### PR DESCRIPTION
backport of #22399