### PR TITLE
client: fix bug #24491 _ll_drop_pins may access invalid iterator

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10455,6 +10455,7 @@ int Client::_ll_put(Inode *in, int num)
 void Client::_ll_drop_pins()
 {
   ldout(cct, 10) << __func__ << dendl;
+  std::set<InodeRef> to_be_put; //this set will be deconstructed item by item when exit
   ceph::unordered_map<vinodeno_t, Inode*>::iterator next;
   for (ceph::unordered_map<vinodeno_t, Inode*>::iterator it = inode_map.begin();
        it != inode_map.end();
@@ -10462,8 +10463,10 @@ void Client::_ll_drop_pins()
     Inode *in = it->second;
     next = it;
     ++next;
-    if (in->ll_ref)
+    if (in->ll_ref){
+      to_be_put.insert(in);
       _ll_put(in, in->ll_ref);
+    }
   }
 }
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/24491
If root inode, and it will be delete, then set 'next' to begin iterator, this can avoid access an inode in root_parent that has been delete after _ll_put. 