### PR TITLE
mon: deprecate 'osd rm'

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,10 @@
+14.0.1
+------
+
+* The 'ceph osd rm' command has been deprecated.  Users should use
+  'ceph osd destroy' or 'ceph osd purge' (but after first confirming it is
+  safe to do so via the 'ceph osd safe-to-destroy' command).
+
 >=13.1.0
 --------
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -772,11 +772,12 @@ COMMAND("osd in " \
 	"set osd(s) <id> [<id>...] in, "
         "can use <any|all> to automatically set all previously out osds in", \
         "osd", "rw", "cli,rest")
-COMMAND("osd rm " \
+COMMAND_WITH_FLAG("osd rm " \
 	"name=ids,type=CephString,n=N", \
 	"remove osd(s) <id> [<id>...], "
         "or use <any|all> to remove all osds", \
-        "osd", "rw", "cli,rest")
+	"osd", "rw", "cli,rest",
+	FLAG(DEPRECATED))
 COMMAND("osd add-noup " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noup, " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10536,9 +10536,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     string sure;
     if (!cmd_getval(cct, cmdmap, "sure", sure) ||
         sure != "--yes-i-really-mean-it") {
-      ss << "Are you SURE? This will mean real, permanent data loss, as well "
-         << "as cephx and lockbox keys. Pass --yes-i-really-mean-it if you "
-         << "really do.";
+      ss << "Are you SURE?  Did you verify with 'ceph osd safe-to-destroy'?  "
+	 << "This will mean real, permanent data loss, as well "
+         << "as deletion of cephx and lockbox keys. "
+	 << "Pass --yes-i-really-mean-it if you really do.";
       err = -EPERM;
       goto reply;
     } else if (!osdmap.exists(id)) {


### PR DESCRIPTION
I'm also wondering if we should combine osd destroy|purge with safe-to-destroy too, so that you can't issue those commands without doing the safety check.  Destroy already includes a force flag, but we would it make sense to fail if the safety check fails, but proceed (without the force flag) if the safety check says it's safe?  Then the force flag would be for the determined user who insists on removing an osd even though the cluster isn't sure if it has data.