### PR TITLE
rgw: rgwgc:process coredump in some special case。

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -313,7 +313,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
           ctx = new IoCtx;
 	  ret = rgw_init_ioctx(store->get_rados_handle(), obj.pool, *ctx);
 	  if (ret < 0) {
-        last_pool = "";
+	    last_pool = "";
 	    dout(0) << "ERROR: failed to create ioctx pool=" << obj.pool << dendl;
 	    continue;
 	  }

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -313,6 +313,7 @@ int RGWGC::process(int index, int max_secs, bool expired_only,
           ctx = new IoCtx;
 	  ret = rgw_init_ioctx(store->get_rados_handle(), obj.pool, *ctx);
 	  if (ret < 0) {
+        last_pool = "";
 	    dout(0) << "ERROR: failed to create ioctx pool=" << obj.pool << dendl;
 	    continue;
 	  }


### PR DESCRIPTION
rgw: rgwgc:process coredump in some special case。 Gc processes obja, objb, objc in order and pool of objb is deleted (obja and objc is in the same pool and pool exits). RGW will coredump as ctx->io_ctx_impl is an empty point during delete objc.
Fixes:http://tracker.ceph.com/issues/23199

Signed-off-by: zhaokun <develop@hikdata.com>