### PR TITLE
osd/PG: unset history_les_bound if local-les is used

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1140,6 +1140,7 @@ map<pg_shard_t, pg_info_t>::const_iterator PG::find_best_info(
     }
     if (!i->second.is_incomplete() &&
 	max_last_epoch_started_found < i->second.last_epoch_started) {
+      *history_les_bound = false;
       max_last_epoch_started_found = i->second.last_epoch_started;
     }
   }


### PR DESCRIPTION
reset history_les_bound if we set max_last_epoch_started_found with
shard's local-les. otherwise it'd be misleading to show
"peering_blocked_by_history_les_bound" in the output of "pg query" if a
pg is stuck in incomplete and/or peering, and the best shard is not
chosen based on the history.les .

Signed-off-by: Kefu Chai <kchai@redhat.com>