### PR TITLE
mimic: ceph-volume tests.functional install new ceph-ansible dependencies

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -20,6 +20,7 @@ deps=
   ansible==2.4.1
   testinfra==1.7.1
   pytest-xdist
+  notario>=0.0.13
 changedir=
   # plain/unencrypted
   centos7-filestore-create: {toxinidir}/centos7/filestore/create
@@ -39,6 +40,9 @@ changedir=
   centos7-bluestore-prepare_activate: {toxinidir}/xenial/bluestore/prepare_activate
 commands=
   git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  # XXX Ideally we should be able to consume the requirements for ceph-ansible directly,
+  # but the master branch doesn't pin dependencies so we can't guarantee to work correctly
+  #pip install -r {envdir}/tmp/ceph-ansible/requirements.txt
 
   vagrant up {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -21,6 +21,7 @@ deps=
   ansible==2.4.1
   testinfra==1.7.1
   pytest-xdist
+  notario>=0.0.13
 changedir=
   centos7-filestore-activate: {toxinidir}/centos7/filestore/activate
   centos7-bluestore-activate: {toxinidir}/centos7/bluestore/activate
@@ -36,6 +37,9 @@ changedir=
   centos7-filestore-dmcrypt_luks: {toxinidir}/centos7/filestore/dmcrypt-luks
 commands=
   git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  # XXX Ideally we should be able to consume the requirements for ceph-ansible directly,
+  # but the master branch doesn't pin dependencies so we can't guarantee to work correctly
+  #pip install -r {envdir}/tmp/ceph-ansible/requirements.txt
 
   vagrant up {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/22116

Make note that ceph-ansible's requirements.txt can't be used just yet

Signed-off-by: Alfredo Deza <adeza@redhat.com>
(cherry picked from commit 22310f43165e474e8e12732be57217b26e2b5424)