### PR TITLE
spdk: update to latest spdk-18.05 branch

### DIFF
--- a/cmake/modules/BuildSPDK.cmake
+++ b/cmake/modules/BuildSPDK.cmake
@@ -30,10 +30,10 @@ macro(build_spdk)
   endforeach()
   set_target_properties(spdk::env_dpdk PROPERTIES
     INTERFACE_LINK_LIBRARIES "${DPDK_LIBRARIES};rt")
-  if(LINUX)
-    set_target_properties(spdk::lvol PROPERTIES
-      INTERFACE_LINK_LIBRARIES ${UUID_LIBRARIES})
-  endif()
+  set_target_properties(spdk::lvol PROPERTIES
+    INTERFACE_LINK_LIBRARIES spdk::util)
+  set_target_properties(spdk::util PROPERTIES
+    INTERFACE_LINK_LIBRARIES ${UUID_LIBRARIES})
   set(SPDK_INCLUDE_DIR "${source_dir}/include")
   unset(source_dir)
 endmacro()


### PR DESCRIPTION
also bump dpdk to to spdk-18.05 branch. this should fix the build
failure on Fedora 28

Signed-off-by: Kefu Chai <kchai@redhat.com>