### PR TITLE
Improving smoke.sh reliability

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1442,8 +1442,7 @@ function test_wait_for_clean() {
 #######################################################################
 
 ##
-# Wait until the cluster becomes HEALTH_OK again or if it does not make progress
-# for $TIMEOUT seconds.
+# Wait until the cluster becomes HEALTH_OK again for $TIMEOUT seconds.
 #
 # @return 0 if the cluster is HEALTHY, 1 otherwise
 #

--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -18,6 +18,7 @@
 # GNU Library Public License for more details.
 #
 TIMEOUT=300
+WAIT_FOR_CLEAN_TIMEOUT=90
 PG_NUM=4
 CEPH_BUILD_VIRTUALENV=${TMPDIR:-/tmp}
 
@@ -1387,7 +1388,7 @@ function test_get_timeout_delays() {
 
 ##
 # Wait until the cluster becomes clean or if it does not make progress
-# for $TIMEOUT seconds.
+# for $WAIT_FOR_CLEAN_TIMEOUT seconds.
 # Progress is measured either via the **get_is_making_recovery_progress**
 # predicate or if the number of clean PGs changes (as returned by get_num_active_clean)
 #
@@ -1396,7 +1397,7 @@ function test_get_timeout_delays() {
 function wait_for_clean() {
     local num_active_clean=-1
     local cur_active_clean
-    local -a delays=($(get_timeout_delays $TIMEOUT .1))
+    local -a delays=($(get_timeout_delays $WAIT_FOR_CLEAN_TIMEOUT .1))
     local -i loop=0
 
     flush_pg_stats || return 1
@@ -1432,7 +1433,7 @@ function test_wait_for_clean() {
     run_mon $dir a --osd_pool_default_size=1 || return 1
     run_mgr $dir x || return 1
     create_rbd_pool || return 1
-    ! TIMEOUT=1 wait_for_clean || return 1
+    ! WAIT_FOR_CLEAN_TIMEOUT=1 wait_for_clean || return 1
     run_osd $dir 0 || return 1
     wait_for_clean || return 1
     teardown $dir || return 1

--- a/qa/standalone/osd/osd-dup.sh
+++ b/qa/standalone/osd/osd-dup.sh
@@ -43,7 +43,7 @@ function TEST_filestore_to_bluestore() {
     create_pool foo 16
 
     # write some objects
-    rados bench -p foo 10 write -b 4096 --no-cleanup || return 1
+    timeout 20 rados bench -p foo 10 write -b 4096 --no-cleanup || return 1
 
     # kill
     while kill $osd_pid; do sleep 1 ; done

--- a/qa/standalone/osd/osd-fast-mark-down.sh
+++ b/qa/standalone/osd/osd-fast-mark-down.sh
@@ -61,7 +61,7 @@ function test_fast_kill() {
    create_rbd_pool || return 1
 
    # make some objects so osds to ensure connectivity between osds
-   rados -p rbd bench 10 write -b 4096 --max-objects 128 --no-cleanup
+   timeout 20 rados -p rbd bench 10 write -b 4096 --max-objects 128 --no-cleanup || return 1
    sleep 1
 
    killid=0

--- a/src/test/smoke.sh
+++ b/src/test/smoke.sh
@@ -52,7 +52,7 @@ function TEST_multimon() {
     ceph osd out 0
     wait_for_clean
 
-    rados -p foo bench 4 write -b 4096 --no-cleanup
+    timeout 8 rados -p foo bench 4 write -b 4096 --no-cleanup || return 1
     wait_for_clean
 
     ceph osd in 0


### PR DESCRIPTION
On my local test setup I found that smoke.sh was reach the global timeout which is 3600sec = 1hour.
I tried to understand why and PR #22553 fix the root cause of it.

That second PR is about trying to prevent the the endless loop when such failure occurs.