### PR TITLE
rbd-ggate: tag "level" with need_dynamic

### DIFF
--- a/src/tools/rbd_ggate/debug.cc
+++ b/src/tools/rbd_ggate/debug.cc
@@ -17,7 +17,7 @@ extern "C" void debugv(int level, const char *fmt, va_list ap) {
 
     vasprintf(&msg, fmt, ap);
 
-    dout(level) << msg << dendl;
+    dout(ceph::dout::need_dynamic(level)) << msg << dendl;
 
     free(msg);
     errno = saved_errno;


### PR DESCRIPTION
otherwise compiler will fail to figure out the right should_gather()
variant to use.
see also 1a3e9357

Signed-off-by: Kefu Chai <kchai@redhat.com>