### PR TITLE
mgr/dashboard: Fix building under FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -634,6 +634,13 @@ set(Boost_USE_MULTITHREADED ON)
 
 # dashboard angular2 frontend
 option(WITH_MGR_DASHBOARD_FRONTEND "Build the mgr/dashboard frontend using `npm`" ON)
+option(WITH_SYSTEM_NPM "Assume that dashboard build tools already installed through packages" OFF)
+if(WITH_SYSTEM_NPM)
+  find_program(NPM npm)
+  if(NOT NPM)
+    message(FATAL_ERROR "Can't find npm.")
+  endif()
+endif()
 
 include_directories(SYSTEM ${PROJECT_BINARY_DIR}/include)
 

--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -14,14 +14,27 @@ fi
 #   To test with a new release Clang, use with cmake:
 #	-D CMAKE_CXX_COMPILER="/usr/local/bin/clang++-devel" \
 #	-D CMAKE_C_COMPILER="/usr/local/bin/clang-devel" \
+#
+#   On FreeBSD we need to preinstall all the tools that are required for building
+#   dashboard, because versions fetched are not working on FreeBSD.
+ 
 
-rm -rf build && ./do_cmake.sh "$*" \
+if [ -d build ]; then
+    mv build build.remove
+    rm -f build.remove &
+fi
+
+./do_cmake.sh "$*" \
+	-D WITH_CCACHE=ON \
 	-D CMAKE_BUILD_TYPE=Debug \
 	-D CMAKE_CXX_FLAGS_DEBUG="$CXX_FLAGS_DEBUG -O0 -g" \
 	-D CMAKE_C_FLAGS_DEBUG="$C_FLAGS_DEBUG -O0 -g" \
 	-D ENABLE_GIT_VERSION=OFF \
 	-D WITH_SYSTEM_BOOST=ON \
+	-D WITH_SYSTEM_NPM=ON \
 	-D WITH_LTTNG=OFF \
+	-D WITH_BABELTRACE=OFF \
+	-D WITH_SEASTAR=OFF \
 	-D WITH_BLKID=OFF \
 	-D WITH_BLUESTORE=OFF \
 	-D WITH_FUSE=ON \
@@ -42,5 +55,7 @@ date
 
 echo start testing 
 date
+# And remove cores leftover from previous runs
+sudo rm -rf /tmp/cores.*
 (cd build; ctest -j$NPROC || ctest --rerun-failed --output-on-failure)
 

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -176,6 +176,8 @@ if [ x$(uname)x = xFreeBSDx ]; then
         devel/py-prettytable \
 	www/py-routes \
         www/py-flask \
+	www/node \
+	www/npm \
         www/fcgi \
 	security/oath-toolkit \
         sysutils/flock \

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -15,7 +15,7 @@ function(add_npm_command)
   cmake_parse_arguments(NC "${options}" "${single_kw}" "${multi_kw}" ${ARGN})
   string(REPLACE ";" " " command "${NC_COMMAND}")
   if(NC_NODEENV)
-    string(REGEX REPLACE "^(npm .*)$" ". ${mgr-dashboard-nodeenv}/bin/activate && \\1 && deactivate" command ${command})
+    string(REGEX REPLACE "^(npm .*)$" ". ${mgr-dashboard-nodeenv-dir}/bin/activate && \\1 && deactivate" command ${command})
   endif()
   string(REPLACE " " ";" command "${command}")
   add_custom_command(
@@ -28,20 +28,34 @@ endfunction(add_npm_command)
 
 if(WITH_MGR_DASHBOARD_FRONTEND AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64|arm|ARM")
 
-set(mgr-dashboard-nodeenv ${CMAKE_CURRENT_BINARY_DIR}/node-env)
+if(WITH_SYSTEM_NPM)
+  set(mgr-dashboard-nodeenv-dir )
+  set(nodeenv "")
+  add_custom_target(mgr-dashboard-frontend-deps
+    DEPENDS frontend/node_modules 
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
+  )
+else()
+  set(mgr-dashboard-nodeenv-dir ${CMAKE_CURRENT_BINARY_DIR}/node-env)
+  set(nodeenv NODEENV)
 
-add_custom_command(
-  OUTPUT "${mgr-dashboard-nodeenv}/bin/npm"
-  COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${MGR_PYTHON_EXECUTABLE} ${mgr-dashboard-nodeenv}
-  COMMAND ${mgr-dashboard-nodeenv}/bin/pip install nodeenv
-  COMMAND ${mgr-dashboard-nodeenv}/bin/nodeenv -p --node=8.11.3
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-  COMMENT "dashboard nodeenv is being installed"
-)
-add_custom_target(mgr-dashboard-nodeenv
-  DEPENDS ${mgr-dashboard-nodeenv}/bin/npm
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-)
+  add_custom_command(
+    OUTPUT "${mgr-dashboard-nodeenv-dir}/bin/npm"
+    COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${MGR_PYTHON_EXECUTABLE} ${mgr-dashboard-nodeenv-dir}
+    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/pip install nodeenv
+    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv -p --node=8.11.3
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    COMMENT "dashboard nodeenv is being installed"
+  )
+  add_custom_target(mgr-dashboard-nodeenv
+    DEPENDS ${mgr-dashboard-nodeenv-dir}/bin/npm
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+  )
+  add_custom_target(mgr-dashboard-frontend-deps
+    DEPENDS frontend/node_modules mgr-dashboard-nodeenv
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
+  )
+endif()
 
 add_npm_command(
   OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/node_modules"
@@ -49,12 +63,7 @@ add_npm_command(
   DEPENDS frontend/package.json
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
   COMMENT "dashboard frontend dependencies are being installed"
-  NODEENV
-)
-
-add_custom_target(mgr-dashboard-frontend-deps
-  DEPENDS frontend/node_modules mgr-dashboard-nodeenv
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
+  ${nodeenv}
 )
 
 # Glob some frontend files. With CMake 3.6, this can be simplified
@@ -87,7 +96,7 @@ add_npm_command(
   DEPENDS ${frontend_src} frontend/node_modules
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
   COMMENT "dashboard frontend is being created"
-  NODEENV
+  ${nodeenv}
 )
 add_custom_target(mgr-dashboard-frontend-build
   ALL

--- a/src/pybind/mgr/dashboard/run-frontend-unittests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-unittests.sh
@@ -2,7 +2,9 @@
 
 failed=false
 cd $CEPH_ROOT/src/pybind/mgr/dashboard/frontend
-.  $CEPH_ROOT/build/src/pybind/mgr/dashboard/node-env/bin/activate
+if [ `uname` != "FreeBSD" ]; then
+  .  $CEPH_ROOT/build/src/pybind/mgr/dashboard/node-env/bin/activate
+fi
 
 # Build
 npm run build -- --prod --progress=false || failed=true
@@ -34,7 +36,9 @@ if [ $? -gt 0 ]; then
   echo -e "\nTry running 'npm run prettier' to fix linting errors."
 fi
 
-deactivate
+if [ `uname` != "FreeBSD" ]; then
+  deactivate
+fi 
 
 if [ "$failed" = "true" ]; then
   exit 1


### PR DESCRIPTION
The nodeenv version fetched is not working on FreeBSD. And further packaged
fetched are not available. So install without going through nodeenv

On FreeBSD we will need to preinstall all the tools that are required for
building dashboard, because online downloading does not work during package
building. It is only allowed in the fetch-phase, so that will require an
extra script. Which will be added in a future commit.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>