### PR TITLE
src/test: Using gtest-parallel to speedup unittests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,3 +55,6 @@
 [submodule "src/seastar"]
 	path = src/seastar
 	url = https://github.com/ceph/seastar.git
+[submodule "src/test/gtest-parallel"]
+	path = src/test/gtest-parallel
+	url = https://github.com/google/gtest-parallel.git

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -25,8 +25,12 @@ endfunction()
 
 #sets uniform compiler flags and link libraries
 function(add_ceph_unittest unittest_name)
-  add_ceph_test(${unittest_name} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${unittest_name})
+  set(UNITTEST "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${unittest_name}")
+  # If the second argument is "parallel", it means we want a parallel run
+  if("${ARGV1}" STREQUAL "parallel")
+    set(UNITTEST ${CMAKE_SOURCE_DIR}/src/test/gtest-parallel/gtest-parallel ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${unittest_name})
+  endif()
+  add_ceph_test(${unittest_name} "${UNITTEST}")
   target_link_libraries(${unittest_name} ${UNITTEST_LIBS})
   set_target_properties(${unittest_name} PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 endfunction()
-

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -113,7 +113,7 @@ add_executable(unittest_throttle
   Throttle.cc
   $<TARGET_OBJECTS:unit-main>
   )
-add_ceph_unittest(unittest_throttle)
+add_ceph_unittest(unittest_throttle parallel)
 target_link_libraries(unittest_throttle global) 
 
 # unittest_lru

--- a/src/test/crush/CMakeLists.txt
+++ b/src/test/crush/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(unittest_crush
   crush.cc
   $<TARGET_OBJECTS:unit-main>
   )
-add_ceph_unittest(unittest_crush)
+add_ceph_unittest(unittest_crush parallel)
 target_link_libraries(unittest_crush global m ${BLKID_LIBRARIES})
 
 add_ceph_test(crush_weights.sh ${CMAKE_CURRENT_SOURCE_DIR}/crush_weights.sh)

--- a/src/test/erasure-code/CMakeLists.txt
+++ b/src/test/erasure-code/CMakeLists.txt
@@ -202,7 +202,7 @@ target_link_libraries(unittest_erasure_code_shec
 add_executable(unittest_erasure_code_shec_all
   TestErasureCodeShec_all.cc
   )
-add_ceph_unittest(unittest_erasure_code_shec_all)
+add_ceph_unittest(unittest_erasure_code_shec_all parallel)
 target_link_libraries(unittest_erasure_code_shec_all
   global
   ${CMAKE_DL_LIBS}

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -39,7 +39,7 @@ add_executable(unittest_rbd_mirror
   image_sync/test_mock_SyncPointPruneRequest.cc
   pool_watcher/test_mock_RefreshImagesRequest.cc
   )
-add_ceph_unittest(unittest_rbd_mirror)
+add_ceph_unittest(unittest_rbd_mirror parallel)
 set_target_properties(unittest_rbd_mirror PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 add_dependencies(unittest_rbd_mirror


### PR DESCRIPTION
Unittests are run sequentially and could take a long while to run.

This commit is about using gtest-parallel on some of them which are
known to be very slow due to this sequentiality.

To enable the parallel features, the 'parallel' argument just have to be
added to the add_ceph_unittest() call like in :
    -add_ceph_unittest(unittest_throttle)
    +add_ceph_unittest(unittest_throttle parallel)

This commit impact the following tests :

Test name                          Before   After (in seconds)
unittest_erasure_code_shec_all:       212      43
unittest_throttle                      15       5
unittest_crush                          9       6
unittest_rbd_mirror                    79      21

Total                                 315      75

This commit saves 240 seconds (4 minutes) per build.

Note it exist several other long tests but can't be parallelized since
there is explicit dependencies in the order to run the subtests.
Those stay sequential.

Signed-off-by: Erwan Velu <erwan@redhat.com>