### PR TITLE
tools/rbd/action: align column headers left

### DIFF
--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -637,7 +637,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
     <name>quuy</name>
   </images>
   $ rbd list -l
-  NAME         SIZE PARENT FMT PROT LOCK 
+  NAME      SIZE    PARENT FMT PROT LOCK 
   foo         1 GiB          1           
   foo@snap    1 GiB          1           
   quux        1 MiB          1      excl 
@@ -762,7 +762,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
     <name>deep-flatten-child</name>
   </images>
   $ rbd list rbd_other -l
-  NAME                       SIZE PARENT       FMT PROT LOCK 
+  NAME                    SIZE    PARENT       FMT PROT LOCK 
   child                   512 MiB                2           
   child@snap              512 MiB rbd/bar@snap   2           
   deep-flatten-child      512 MiB                2           
@@ -900,7 +900,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
     </lock>
   </locks>
   $ rbd snap list foo
-  SNAPID NAME  SIZE TIMESTAMP 
+  SNAPID NAME*SIZE*TIMESTAMP 
   *snap*1 GiB* (glob)
   $ rbd snap list foo --format json | python -mjson.tool | sed 's/,$/, /'
   [
@@ -960,7 +960,7 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
   $ rbd snap list baz --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
   <snapshots></snapshots>
   $ rbd snap list rbd_other/child
-  SNAPID NAME    SIZE TIMESTAMP                
+  SNAPID NAME*SIZE*TIMESTAMP                
   *snap*512 MiB* (glob)
   $ rbd snap list rbd_other/child --format json | python -mjson.tool | sed 's/,$/, /'
   [

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -102,8 +102,8 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
     f->open_array_section("images");
   } else {
     tbl.define_column("NAME", TextTable::LEFT, TextTable::LEFT);
-    tbl.define_column("PROVISIONED", TextTable::RIGHT, TextTable::RIGHT);
-    tbl.define_column("USED", TextTable::RIGHT, TextTable::RIGHT);
+    tbl.define_column("PROVISIONED", TextTable::LEFT, TextTable::RIGHT);
+    tbl.define_column("USED", TextTable::LEFT, TextTable::RIGHT);
   }
 
   uint32_t count = 0;

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -559,7 +559,7 @@ int execute_group_snap_list(const po::variables_map &vm,
     f->open_array_section("group_snaps");
   } else {
     t.define_column("NAME", TextTable::LEFT, TextTable::LEFT);
-    t.define_column("STATUS", TextTable::RIGHT, TextTable::RIGHT);
+    t.define_column("STATUS", TextTable::LEFT, TextTable::RIGHT);
   }
 
   for (auto i : snaps) {

--- a/src/tools/rbd/action/List.cc
+++ b/src/tools/rbd/action/List.cc
@@ -192,9 +192,9 @@ int do_list(std::string &pool_name, bool lflag, int threads, Formatter *f) {
     f->open_array_section("images");
   } else {
     tbl.define_column("NAME", TextTable::LEFT, TextTable::LEFT);
-    tbl.define_column("SIZE", TextTable::RIGHT, TextTable::RIGHT);
+    tbl.define_column("SIZE", TextTable::LEFT, TextTable::RIGHT);
     tbl.define_column("PARENT", TextTable::LEFT, TextTable::LEFT);
-    tbl.define_column("FMT", TextTable::RIGHT, TextTable::RIGHT);
+    tbl.define_column("FMT", TextTable::LEFT, TextTable::RIGHT);
     tbl.define_column("PROT", TextTable::LEFT, TextTable::LEFT);
     tbl.define_column("LOCK", TextTable::LEFT, TextTable::LEFT);
   }

--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -44,9 +44,9 @@ int do_list_snaps(librbd::Image& image, Formatter *f, bool all_snaps, librados::
   if (f) {
     f->open_array_section("snapshots");
   } else {
-    t.define_column("SNAPID", TextTable::RIGHT, TextTable::RIGHT);
+    t.define_column("SNAPID", TextTable::LEFT, TextTable::RIGHT);
     t.define_column("NAME", TextTable::LEFT, TextTable::LEFT);
-    t.define_column("SIZE", TextTable::RIGHT, TextTable::RIGHT);
+    t.define_column("SIZE", TextTable::LEFT, TextTable::RIGHT);
     t.define_column("TIMESTAMP", TextTable::LEFT, TextTable::LEFT);
     if (all_snaps) {
       t.define_column("NAMESPACE", TextTable::LEFT, TextTable::LEFT);


### PR DESCRIPTION
Even if the column content is right-aligned, we should align the column
header left.  That way intead of

```
  SNAPID NAME  SIZE TIMESTAMP                NAMESPACE
       4 snap 1 GiB Mon Jun  4 16:27:17 2018 user
```

which has makes it hard to visually parse what that 1 belongs to (NAME or
SIZE?), we get

```
  SNAPID NAME SIZE  TIMESTAMP                NAMESPACE
       4 snap 1 GiB Mon Jun  4 16:27:17 2018 user
```