### PR TITLE
qa/suites/rados/objecstore: preserve data dir for ceph_test_objecstore

### DIFF
--- a/qa/suites/rados/objectstore/backends/objectstore.yaml
+++ b/qa/suites/rados/objectstore/backends/objectstore.yaml
@@ -8,5 +8,5 @@ tasks:
 - install:
 - exec:
     client.0:
-      - mkdir $TESTDIR/ostest && cd $TESTDIR/ostest && ulimit -c 0 && ulimit -Sn 16384 && CEPH_ARGS="--no-log-to-stderr --log-file $TESTDIR/archive/ceph_test_objectstore.log --debug-filestore 20 --debug-bluestore 20" ceph_test_objectstore --gtest_filter=-*/3
-      - rm -rf $TESTDIR/ostest
+      - mkdir $TESTDIR/archive/ostest && cd $TESTDIR/archive/ostest && ulimit -c 0 && ulimit -Sn 16384 && CEPH_ARGS="--no-log-to-stderr --log-file $TESTDIR/archive/ceph_test_objectstore.log --debug-filestore 20 --debug-bluestore 20" ceph_test_objectstore --gtest_filter=-*/3
+      - rm -rf $TESTDIR/archive/ostest

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1672,7 +1672,7 @@ void BlueStore::SharedBlob::put()
 			     << " removing self from set " << get_parent()
 			     << dendl;
     if (get_parent()) {
-      get_parent()->remove(this);
+      get_parent()->remove_last(this);
     }
     delete this;
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1672,9 +1672,16 @@ void BlueStore::SharedBlob::put()
 			     << " removing self from set " << get_parent()
 			     << dendl;
     if (get_parent()) {
-      get_parent()->remove_last(this);
+      if (get_parent()->try_remove(this)) {
+	delete this;
+      } else {
+	ldout(coll->store->cct, 20)
+	  << __func__ << " " << this << " lost race to remove myself from set"
+	  << dendl;
+      }
+    } else {
+      delete this;
     }
-    delete this;
   }
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5212,7 +5212,8 @@ int BlueStore::_open_collections(int *errors)
              << pretty_binary_string(it->key()) << dendl;
         return -EIO;
       }   
-      dout(20) << __func__ << " opened " << cid << " " << c << dendl;
+      dout(20) << __func__ << " opened " << cid << " " << c
+	       << " " << c->cnode << dendl;
       coll_map[cid] = c;
     } else {
       derr << __func__ << " unrecognized collection " << it->key() << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5191,6 +5191,7 @@ void BlueStore::_commit_bluefs_freespace(
 
 int BlueStore::_open_collections(int *errors)
 {
+  dout(10) << __func__ << dendl;
   assert(coll_map.empty());
   KeyValueDB::Iterator it = db->get_iterator(PREFIX_COLL);
   for (it->upper_bound(string());

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5989,7 +5989,8 @@ int BlueStore::_fsck(bool deep, bool repair)
 	  continue;
 	}
 	c->cid.is_pg(&pgid);
-	dout(20) << __func__ << "  collection " << c->cid << dendl;
+	dout(20) << __func__ << "  collection " << c->cid << " " << c->cnode
+		 << dendl;
       }
 
       if (!expecting_shards.empty()) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -450,15 +450,17 @@ public:
       sb->coll = coll;
     }
 
+    void remove_last(SharedBlob *sb) {
+      std::lock_guard<std::mutex> l(lock);
+      assert(sb->nref == 0);
+      assert(sb->get_parent() == this);
+      sb_map.erase(sb->get_sbid());
+    }
+
     void remove(SharedBlob *sb) {
       std::lock_guard<std::mutex> l(lock);
       assert(sb->get_parent() == this);
-      // only remove if it still points to us
-      auto p = sb_map.find(sb->get_sbid());
-      if (p != sb_map.end() &&
-	  p->second == sb) {
-	sb_map.erase(p);
-      }
+      sb_map.erase(sb->get_sbid());
     }
 
     bool empty() {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -437,8 +437,7 @@ public:
     SharedBlobRef lookup(uint64_t sbid) {
       std::lock_guard<std::mutex> l(lock);
       auto p = sb_map.find(sbid);
-      if (p == sb_map.end() ||
-	  p->second->nref == 0) {
+      if (p == sb_map.end()) {
         return nullptr;
       }
       return p->second;
@@ -450,11 +449,14 @@ public:
       sb->coll = coll;
     }
 
-    void remove_last(SharedBlob *sb) {
+    bool try_remove(SharedBlob *sb) {
       std::lock_guard<std::mutex> l(lock);
-      assert(sb->nref == 0);
-      assert(sb->get_parent() == this);
-      sb_map.erase(sb->get_sbid());
+      if (sb->nref == 0) {
+	assert(sb->get_parent() == this);
+	sb_map.erase(sb->get_sbid());
+	return true;
+      }
+      return false;
     }
 
     void remove(SharedBlob *sb) {

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -94,6 +94,11 @@ void bluestore_cnode_t::generate_test_instances(list<bluestore_cnode_t*>& o)
   o.push_back(new bluestore_cnode_t(123));
 }
 
+ostream& operator<<(ostream& out, const bluestore_cnode_t& l)
+{
+  return out << "cnode(bits " << l.bits << ")";
+}
+
 // bluestore_extent_ref_map_t
 
 void bluestore_extent_ref_map_t::_check() const

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -64,6 +64,8 @@ struct bluestore_cnode_t {
 };
 WRITE_CLASS_DENC(bluestore_cnode_t)
 
+ostream& operator<<(ostream& out, const bluestore_cnode_t& l);
+
 /// pextent: physical extent
 struct bluestore_pextent_t {
   static const uint64_t INVALID_OFFSET = ~0ull;


### PR DESCRIPTION
If we fail, preserve the data directory.

Signed-off-by: Sage Weil <sage@redhat.com>