### PR TITLE
os/bluestore: provide a rough fragmentation estimate for bitmap allocator

### DIFF
--- a/src/os/bluestore/BitmapAllocator.h
+++ b/src/os/bluestore/BitmapAllocator.h
@@ -38,6 +38,10 @@ public:
   void dump() override
   {
   }
+  double get_fragmentation(uint64_t) override
+  {
+    return _get_fragmentation();
+  }
 
   void init_add_free(uint64_t offset, uint64_t length) override;
   void init_rm_free(uint64_t offset, uint64_t length) override;

--- a/src/os/bluestore/fastbmap_allocator_impl.h
+++ b/src/os/bluestore/fastbmap_allocator_impl.h
@@ -96,6 +96,18 @@ protected:
   uint64_t l0_granularity = 0; // space per entry
   uint64_t l1_granularity = 0; // space per entry
 
+  size_t partial_l1_count = 0;
+  size_t unalloc_l1_count = 0;
+
+  double get_fragmentation() const {
+    double res = 0.0;
+    auto total = unalloc_l1_count + partial_l1_count;
+    if (total) {
+      res = double(partial_l1_count) / double(total);
+    }
+    return res;
+  }
+
   uint64_t _level_granularity() const override
   {
     return l1_granularity;
@@ -122,6 +134,7 @@ class AllocatorLevel01Loose : public AllocatorLevel01
     L1_ENTRY_MASK = (1 << L1_ENTRY_WIDTH) - 1,
     L1_ENTRY_FULL = 0x00,
     L1_ENTRY_PARTIAL = 0x01,
+    L1_ENTRY_NOT_USED = 0x02,
     L1_ENTRY_FREE = 0x03,
     CHILD_PER_SLOT = bits_per_slot / L1_ENTRY_WIDTH, // 32
     CHILD_PER_SLOT_L0 = bits_per_slot, // 64
@@ -265,11 +278,13 @@ protected:
     l1.resize(slot_count, mark_as_free ? all_slot_set : all_slot_clear);
 
     // l0 slot count
-    slot_count = aligned_capacity / _alloc_unit / bits_per_slot;
+    size_t slot_count_l0 = aligned_capacity / _alloc_unit / bits_per_slot;
     // we use set bit(s) as a marker for (partially) free entry
-    l0.resize(slot_count, mark_as_free ? all_slot_set : all_slot_clear);
+    l0.resize(slot_count_l0, mark_as_free ? all_slot_set : all_slot_clear);
 
+    partial_l1_count = unalloc_l1_count = 0;
     if (mark_as_free) {
+      unalloc_l1_count = slot_count * _children_per_slot();
       auto l0_pos_no_use = p2roundup((int64_t)capacity, (int64_t)l0_granularity) / l0_granularity;
       _mark_alloc_l1_l0(l0_pos_no_use, aligned_capacity / l0_granularity);
     }
@@ -728,6 +743,10 @@ protected:
   void _shutdown()
   {
     last_pos = 0;
+  }
+  double _get_fragmentation() {
+    std::lock_guard<std::mutex> l(lock);
+    return l1.get_fragmentation();
   }
 };
 


### PR DESCRIPTION
The approach is counting 'partial' and 'free' slots at L1 on the fly and
use partial / (partial+free) value as rough fragmentation estimate.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>