### PR TITLE
rgw: change default rgw_thread_pool_size to 512

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5326,7 +5326,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_thread_pool_size", Option::TYPE_INT, Option::LEVEL_BASIC)
-    .set_default(100)
+    .set_default(512)
     .set_description("RGW requests handling thread pool size.")
     .set_long_description(
         "This parameter determines the number of concurrent requests RGW can process "


### PR DESCRIPTION
This value is commonly tuned up and demonstrates better performance on
large systems.

Fixes: http://tracker.ceph.com/issues/24544
Signed-off-by: Douglas Fuller <dfuller@redhat.com>