### PR TITLE
mon: destroy-new -> purge-new

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1334,7 +1334,7 @@ function test_mon_osd_create_destroy()
   expect_false ceph auth get-key client.osd-lockbox.$uuid2
   expect_false ceph config-key exists dm-crypt/osd/$uuid2/luks
 
-  ceph osd destroy-new osd.$id2 --yes-i-really-mean-it
+  ceph osd destroy osd.$id2 --yes-i-really-mean-it
   ceph osd destroy $id2 --yes-i-really-mean-it
   ceph osd find $id2
   expect_false ceph auth get-key osd.$id2
@@ -1348,13 +1348,13 @@ function test_mon_osd_create_destroy()
   ceph auth get-key osd.$id3
   ceph config-key exists dm-crypt/osd/$uuid3/luks
 
-  ceph osd purge osd.$id3 --yes-i-really-mean-it
+  ceph osd purge-new osd.$id3 --yes-i-really-mean-it
   expect_false ceph osd find $id2
   expect_false ceph auth get-key osd.$id2
   expect_false ceph auth get-key client.osd-lockbox.$uuid3
   expect_false ceph config-key exists dm-crypt/osd/$uuid3/luks
   ceph osd purge osd.$id3 --yes-i-really-mean-it
-  ceph osd purge osd.$id3 --yes-i-really-mean-it # idempotent
+  ceph osd purge-new osd.$id3 --yes-i-really-mean-it # idempotent
 
   ceph osd purge osd.$id --yes-i-really-mean-it
   ceph osd purge 123456 --yes-i-really-mean-it

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -217,7 +217,7 @@ void MonCapGrant::expand_profile_mon(const EntityName& name) const
     profile_grants.push_back(MonCapGrant("osd", MON_CAP_R));  // read osdmap
     profile_grants.push_back(MonCapGrant("mon getmap"));
     profile_grants.push_back(MonCapGrant("osd new"));
-    profile_grants.push_back(MonCapGrant("osd destroy-new"));
+    profile_grants.push_back(MonCapGrant("osd purge-new"));
   }
   if (profile == "bootstrap-mds") {
     profile_grants.push_back(MonCapGrant("mon", MON_CAP_R));  // read monmap

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -874,12 +874,11 @@ COMMAND("osd destroy " \
         "but removes cephx keys, config-key data and lockbox keys, "\
         "rendering data permanently unreadable.", \
         "osd", "rw", "cli,rest")
-COMMAND("osd destroy-new " \
+COMMAND("osd purge-new " \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
-        "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \
-        "but removes cephx keys, config-key data and lockbox keys, "\
-        "rendering data permanently unreadable.  Only works on new, unbooted osd ids.", \
+        "purge all traces of an OSD that was partially created but never " \
+	"started", \
         "osd", "rw", "cli,rest")
 COMMAND("osd purge " \
         "name=id,type=CephOsdName " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7682,7 +7682,10 @@ int OSDMonitor::prepare_command_osd_new(
     assert(id >= 0);
     assert(osdmap.is_destroyed(id));
     pending_inc.new_weight[id] = CEPH_OSD_OUT;
-    pending_inc.new_state[id] |= CEPH_OSD_DESTROYED | CEPH_OSD_NEW;
+    pending_inc.new_state[id] |= CEPH_OSD_DESTROYED;
+    if ((osdmap.get_state(id) & CEPH_OSD_NEW) == 0) {
+      pending_inc.new_state[id] |= CEPH_OSD_NEW;
+    }
     if (osdmap.get_state(id) & CEPH_OSD_UP) {
       // due to http://tracker.ceph.com/issues/20751 some clusters may
       // have UP set for non-existent OSDs; make sure it is cleared

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10501,7 +10501,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
   } else if (prefix == "osd destroy" ||
 	     prefix == "osd purge" ||
-	     prefix == "osd destroy-new") {
+	     prefix == "osd purge-new") {
     /* Destroying an OSD means that we don't expect to further make use of
      * the OSDs data (which may even become unreadable after this operation),
      * and that we are okay with scrubbing all its cephx keys and config-key
@@ -10530,10 +10530,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       goto reply;
     }
 
-    bool is_destroy = (prefix == "osd destroy" ||
-		       prefix == "osd destroy-new");
+    bool is_destroy = (prefix == "osd destroy");
     if (!is_destroy) {
-      assert("osd purge" == prefix);
+      assert("osd purge" == prefix ||
+	     "osd purge-new" == prefix);
     }
 
     string sure;
@@ -10558,7 +10558,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       goto reply;
     }
 
-    if (prefix == "osd destroy-new" &&
+    if (prefix == "osd purge-new" &&
 	(osdmap.get_state(id) & CEPH_OSD_NEW) == 0) {
       ss << "osd." << id << " is not new";
       err = -EPERM;


### PR DESCRIPTION
What we actually want is a purge, not a destroy.  Destroy leaves the OSD ID in place and allows it to be recreated.  What ceph-volume wants is to purge all trace of the failed OSD setup.