### PR TITLE
test/objectstore/CMakefiles: fix unittest_alloc_bench build

### DIFF
--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -108,7 +108,8 @@ if(WITH_BLUESTORE)
     Allocator_bench.cc
     $<TARGET_OBJECTS:unit-main>
     )
-  target_link_libraries(unittest_alloc_bench os global)
+  set_target_properties(unittest_alloc_bench PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
+  target_link_libraries(unittest_alloc_bench ${UNITTEST_LIBS} os global)
 
   add_executable(unittest_fastbmap_allocator
     fastbmap_allocator_test.cc


### PR DESCRIPTION
Broken by 434589a3206aafe94de5a3b95b67eddb2cfc3bdb.  The add_ceph_unittest
helper does more than just add this to the list of tests--it also adjusts
linking and build options.

Signed-off-by: Sage Weil <sage@redhat.com>