### PR TITLE
common: dump crash metadata to /var/lib/ceph/crash

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -999,6 +999,7 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mds
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mgr
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd
+mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/crash
 
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents

--- a/debian/ceph-base.dirs
+++ b/debian/ceph-base.dirs
@@ -4,3 +4,4 @@ var/lib/ceph/bootstrap-osd
 var/lib/ceph/bootstrap-rgw
 var/lib/ceph/bootstrap-rbd
 var/lib/ceph/tmp
+var/lib/ceph/crash

--- a/src/common/BackTrace.cc
+++ b/src/common/BackTrace.cc
@@ -1,9 +1,13 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #include <ostream>
 #include <cxxabi.h>
 #include <string.h>
 
 #include "BackTrace.h"
 #include "common/version.h"
+#include "common/Formatter.h"
 
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
@@ -68,6 +72,68 @@ void BackTrace::print(std::ostream& out) const
     }
     free(function);
   }
+}
+
+void BackTrace::dump(Formatter *f) const
+{
+  f->open_array_section("backtrace");
+  for (size_t i = skip; i < size; i++) {
+    //      out << " " << (i-skip+1) << ": " << strings[i] << std::endl;
+
+    size_t sz = 1024; // just a guess, template names will go much wider
+    char *function = (char *)malloc(sz);
+    if (!function)
+      return;
+    char *begin = 0, *end = 0;
+
+    // find the parentheses and address offset surrounding the mangled name
+#ifdef __FreeBSD__
+    static constexpr char OPEN = '<';
+#else
+    static constexpr char OPEN = '(';
+#endif
+    for (char *j = strings[i]; *j; ++j) {
+      if (*j == OPEN)
+	begin = j+1;
+      else if (*j == '+')
+	end = j;
+    }
+    if (begin && end) {
+      int len = end - begin;
+      char *foo = (char *)malloc(len+1);
+      if (!foo) {
+	free(function);
+	return;
+      }
+      memcpy(foo, begin, len);
+      foo[len] = 0;
+
+      int status;
+      char *ret = nullptr;
+      // only demangle a C++ mangled name
+      if (foo[0] == '_' && foo[1] == 'Z')
+	ret = abi::__cxa_demangle(foo, function, &sz, &status);
+      if (ret) {
+	// return value may be a realloc() of the input
+	function = ret;
+      }
+      else {
+	// demangling failed, just pretend it's a C function with no args
+	strncpy(function, foo, sz);
+	strncat(function, "()", sz);
+	function[sz-1] = 0;
+      }
+      f->dump_stream("frame") << OPEN << function << end;
+      //fprintf(out, "    %s:%s\n", stack.strings[i], function);
+      free(foo);
+    } else {
+      // didn't find the mangled name, just print the whole line
+      //out << " " << (i-skip+1) << ": " << strings[i] << std::endl;
+      f->dump_string("frame", strings[i]);
+    }
+    free(function);
+  }
+  f->close_section();
 }
 
 }

--- a/src/common/BackTrace.h
+++ b/src/common/BackTrace.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef CEPH_BACKTRACE_H
 #define CEPH_BACKTRACE_H
 
@@ -9,6 +12,8 @@
 #include <stdlib.h>
 
 namespace ceph {
+
+class Formatter;
 
 struct BackTrace {
   const static int max = 100;
@@ -36,6 +41,7 @@ struct BackTrace {
   const BackTrace& operator=(const BackTrace& other);
 
   void print(std::ostream& out) const;
+  void dump(Formatter *f) const;
 };
 
 inline std::ostream& operator<<(std::ostream& out, const BackTrace& bt) {

--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -51,16 +51,14 @@ namespace ceph {
     oss << BackTrace(1);
     dout_emergency(oss.str());
 
-    dout_emergency(" NOTE: a copy of the executable, or `objdump -rdS <executable>` "
-		   "is needed to interpret this.\n");
-
     if (g_assert_context) {
       lderr(g_assert_context) << buf << std::endl;
-      *_dout << oss.str();
-      *_dout << " NOTE: a copy of the executable, or `objdump -rdS <executable>` "
-	     << "is needed to interpret this.\n" << dendl;
+      *_dout << oss.str() << dendl;
 
-      g_assert_context->_log->dump_recent();
+      // dump recent only if the abort signal handler won't do it for us
+      if (!g_assert_context->_conf->fatal_signal_handlers) {
+	g_assert_context->_log->dump_recent();
+      }
     }
 
     abort();
@@ -126,16 +124,14 @@ namespace ceph {
     oss << *bt;
     dout_emergency(oss.str());
 
-    dout_emergency(" NOTE: a copy of the executable, or `objdump -rdS <executable>` "
-		   "is needed to interpret this.\n");
-
     if (g_assert_context) {
       lderr(g_assert_context) << buf << std::endl;
-      *_dout << oss.str();
-      *_dout << " NOTE: a copy of the executable, or `objdump -rdS <executable>` "
-	     << "is needed to interpret this.\n" << dendl;
+      *_dout << oss.str() << dendl;
 
-      g_assert_context->_log->dump_recent();
+      // dump recent only if the abort signal handler won't do it for us
+      if (!g_assert_context->_conf->fatal_signal_handlers) {
+	g_assert_context->_log->dump_recent();
+      }
     }
 
     abort();

--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -35,6 +35,14 @@ namespace ceph {
   void __ceph_assert_fail(const char *assertion, const char *file, int line,
 			  const char *func)
   {
+    g_assert_condition = assertion;
+    g_assert_file = file;
+    g_assert_line = line;
+    g_assert_func = func;
+    g_assert_thread = (unsigned long long)pthread_self();
+    pthread_getname_np(pthread_self(), g_assert_thread_name,
+		       sizeof(g_assert_thread_name));
+
     ostringstream tss;
     tss << ceph_clock_now();
 
@@ -74,6 +82,14 @@ namespace ceph {
   {
     ostringstream tss;
     tss << ceph_clock_now();
+
+    g_assert_condition = assertion;
+    g_assert_file = file;
+    g_assert_line = line;
+    g_assert_func = func;
+    g_assert_thread = (unsigned long long)pthread_self();
+    pthread_getname_np(pthread_self(), g_assert_thread_name,
+		       sizeof(g_assert_thread_name));
 
     class BufAppender {
     public:

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -391,6 +391,12 @@ void CephContext::do_command(std::string_view command, const cmdmap_t& cmdmap,
   }
   lgeneric_dout(this, 1) << "do_command '" << command << "' '"
 			 << ss.str() << dendl;
+  if (command == "assert" && _conf->debug_asok_assert_abort) {
+    assert(0 == "assert");
+  }
+  if (command == "abort" && _conf->debug_asok_assert_abort) {
+    abort();
+  }
   if (command == "perfcounters_dump" || command == "1" ||
       command == "perf dump") {
     std::string logger;
@@ -582,6 +588,8 @@ CephContext::CephContext(uint32_t module_type_,
   _plugin_registry = new PluginRegistry(this);
 
   _admin_hook = new CephContextHook(this);
+  _admin_socket->register_command("assert", "assert", _admin_hook, "");
+  _admin_socket->register_command("abort", "abort", _admin_hook, "");
   _admin_socket->register_command("perfcounters_dump", "perfcounters_dump", _admin_hook, "");
   _admin_socket->register_command("1", "1", _admin_hook, "");
   _admin_socket->register_command("perf dump", "perf dump name=logger,type=CephString,req=false name=counter,type=CephString,req=false", _admin_hook, "dump perfcounters value");

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -34,6 +34,7 @@ OPTION(chdir, OPT_STR)
 OPTION(restapi_log_level, OPT_STR) 	// default set by Python code
 OPTION(restapi_base_url, OPT_STR)	// "
 OPTION(fatal_signal_handlers, OPT_BOOL)
+OPTION(crash_dir, OPT_STR)
 SAFE_OPTION(erasure_code_dir, OPT_STR) // default location for erasure-code plugins
 
 OPTION(log_file, OPT_STR) // default changed by common_preinit()

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1516,6 +1516,7 @@ OPTION(rgw_torrent_sha_unit, OPT_INT)    // torrent field piece length 512K
 OPTION(event_tracing, OPT_BOOL) // true if LTTng-UST tracepoints should be enabled
 
 OPTION(debug_deliberately_leak_memory, OPT_BOOL)
+OPTION(debug_asok_assert_abort, OPT_BOOL)
 
 OPTION(rgw_swift_custom_header, OPT_STR) // option to enable swift custom headers
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -537,6 +537,10 @@ std::vector<Option> get_global_options() {
     .add_service({"mon", "mgr", "osd", "mds"})
     .add_tag("service"),
 
+    Option("crash_dir", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("/var/lib/ceph/crash")
+    .set_description("Directory where crash reports are archived"),
+
     // restapi
     Option("restapi_log_level", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_description("default set by python code"),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4880,6 +4880,10 @@ std::vector<Option> get_global_options() {
     Option("debug_asserts_on_shutdown", Option::TYPE_BOOL,Option::LEVEL_DEV)
     .set_default(false)
     .set_description("Enable certain asserts to check for refcounting bugs on shutdown; see http://tracker.ceph.com/issues/21738"),
+
+    Option("debug_asok_assert_abort", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("allow commands 'assert' and 'abort' via asok for testing crash dumps etc"),
   });
 }
 

--- a/src/global/global_context.cc
+++ b/src/global/global_context.cc
@@ -20,3 +20,10 @@
  */
 CephContext *g_ceph_context = NULL;
 md_config_t *g_conf = NULL;
+
+const char *g_assert_file = 0;
+int g_assert_line = 0;
+const char *g_assert_func = 0;
+const char *g_assert_condition = 0;
+unsigned long long g_assert_thread = 0;
+char g_assert_thread_name[4096];

--- a/src/global/global_context.h
+++ b/src/global/global_context.h
@@ -21,4 +21,11 @@ struct md_config_t;
 extern CephContext *g_ceph_context;
 extern md_config_t *g_conf;
 
+extern const char *g_assert_file;
+extern int g_assert_line;
+extern const char *g_assert_func;
+extern const char *g_assert_condition;
+extern unsigned long long g_assert_thread;
+extern char g_assert_thread_name[4096];
+
 #endif

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -191,8 +191,10 @@ global_init(const std::map<std::string,std::string> *defaults,
   int siglist[] = { SIGPIPE, 0 };
   block_signals(siglist, NULL);
 
-  if (g_conf->fatal_signal_handlers)
+  if (g_conf->fatal_signal_handlers) {
     install_standard_sighandlers();
+  }
+  register_assert_context(g_ceph_context);
 
   if (g_conf->log_flush_on_exit)
     g_ceph_context->_log->set_flush_on_exit();
@@ -314,8 +316,6 @@ global_init(const std::map<std::string,std::string> *defaults,
       cerr << "warning: unable to create " << g_conf->run_dir << ": " << cpp_strerror(errno) << std::endl;
     }
   }
-
-  register_assert_context(g_ceph_context);
 
   // call all observers now.  this has the side-effect of configuring
   // and opening the log file immediately.

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -12,11 +12,17 @@
  *
  */
 
+#include <sys/utsname.h>
+
 #include "include/compat.h"
 #include "pthread.h"
 
 #include "common/BackTrace.h"
 #include "common/debug.h"
+#include "common/safe_io.h"
+#include "common/version.h"
+
+#include "include/uuid.h"
 #include "global/pidfile.h"
 #include "global/signal_handler.h"
 
@@ -88,6 +94,49 @@ static void reraise_fatal(int signum)
   exit(1);
 }
 
+
+// /etc/os-release looks like
+//
+//   NAME=Fedora
+//   VERSION="28 (Server Edition)"
+//   ID=fedora
+//   VERSION_ID=28
+//
+// or
+//
+//   NAME="Ubuntu"
+//   VERSION="16.04.3 LTS (Xenial Xerus)"
+//   ID=ubuntu
+//   ID_LIKE=debian
+//
+// get_from_os_release("FOO=bar\nTHIS=\"that\"\n", "FOO=", ...) will
+// write "bar\0" to out buffer, which is assumed to be as large as the input
+// file.
+static int parse_from_os_release(
+  const char *file, const char *key,
+  char *out)
+{
+  const char *p = strstr(file, key);
+  if (!p) {
+    return -1;
+  }
+  const char *start = p + strlen(key);
+  const char *end = strchr(start, '\n');
+  if (!end) {
+    return -1;
+  }
+  if (*start == '"' && *(end - 1) == '"') {
+    ++start;
+    --end;
+  }
+  if (start >= end) {
+    return -1;
+  }
+  memcpy(out, start, end - start);
+  out[end - start] = 0;
+  return 0;
+}
+
 static void handle_fatal_signal(int signum)
 {
   // This code may itself trigger a SIGSEGV if the heap is corrupt. In that
@@ -119,6 +168,101 @@ static void handle_fatal_signal(int signum)
   bt.print(oss);
   dout_emergency(oss.str());
 
+  char base[PATH_MAX] = { 0 };
+  if (g_ceph_context &&
+      g_ceph_context->_conf->crash_dir.size()) {
+    // -- crash dump --
+    // id
+    ostringstream idss;
+    utime_t now = ceph_clock_now();
+    now.gmtime(idss);
+    uuid_d uuid;
+    uuid.generate_random();
+    idss << "_" << uuid;
+    string id = idss.str();
+    std::replace(id.begin(), id.end(), ' ', '_');
+
+    snprintf(base, sizeof(base), "%s/%s",
+	     g_ceph_context->_conf->crash_dir.c_str(),
+	     id.c_str());
+    int r = ::mkdir(base, 0700);
+    if (r >= 0) {
+      char fn[PATH_MAX*2];
+      snprintf(fn, sizeof(fn)-1, "%s/meta", base);
+      int fd = ::open(fn, O_CREAT|O_WRONLY, 0600);
+      if (fd >= 0) {
+	JSONFormatter jf(true);
+	jf.open_object_section("crash");
+	jf.dump_string("crash_id", id);
+	now.gmtime(jf.dump_stream("timestamp"));
+	jf.dump_string("entity_name", g_ceph_context->_conf->name.to_str());
+	jf.dump_string("ceph_version", ceph_version_to_str());
+
+	struct utsname u;
+	r = uname(&u);
+	if (r >= 0) {
+	  jf.dump_string("utsname_hostname", u.nodename);
+	  jf.dump_string("utsname_sysname", u.sysname);
+	  jf.dump_string("utsname_release", u.release);
+	  jf.dump_string("utsname_version", u.version);
+	  jf.dump_string("utsname_machine", u.machine);
+	}
+
+	// os-releaes
+	int in = ::open("/etc/os-release", O_RDONLY);
+	if (in >= 0) {
+	  char buf[4096];
+	  r = safe_read(in, buf, sizeof(buf)-1);
+	  if (r >= 0) {
+	    buf[r] = 0;
+	    char v[4096];
+	    if (parse_from_os_release(buf, "NAME=", v) >= 0) {
+	      jf.dump_string("os_name", v);
+	    }
+	    if (parse_from_os_release(buf, "ID=", v) >= 0) {
+	      jf.dump_string("os_id", v);
+	    }
+	    if (parse_from_os_release(buf, "VERSION_ID=", v) >= 0) {
+	      jf.dump_string("os_version_id", v);
+	    }
+	    if (parse_from_os_release(buf, "VERSION=", v) >= 0) {
+	      jf.dump_string("os_version", v);
+	    }
+	  }
+	  ::close(in);
+	}
+
+	// assert?
+	if (g_assert_condition) {
+	  jf.dump_string("assert_condition", g_assert_condition);
+	}
+	if (g_assert_func) {
+	  jf.dump_string("assert_func", g_assert_func);
+	}
+	if (g_assert_file) {
+	  jf.dump_string("assert_file", g_assert_file);
+	}
+	if (g_assert_line) {
+	  jf.dump_unsigned("assert_file", g_assert_line);
+	}
+	if (g_assert_thread_name[0]) {
+	  jf.dump_string("assert_thread_name", g_assert_thread_name);
+	}
+
+	// backtrace
+	bt.dump(&jf);
+
+	jf.close_section();
+	ostringstream oss;
+	jf.flush(oss);
+	string s = oss.str();
+	r = safe_write(fd, s.c_str(), s.size());
+	(void)r;
+	::close(fd);
+      }
+    }
+  }
+
   // avoid recursion back into logging code if that is where
   // we got the SEGV.
   if (g_ceph_context &&
@@ -133,6 +277,14 @@ static void handle_fatal_signal(int signum)
 	   << dendl;
 
     g_ceph_context->_log->dump_recent();
+
+    if (base[0]) {
+      char fn[PATH_MAX*2];
+      snprintf(fn, sizeof(fn)-1, "%s/log", base);
+      g_ceph_context->_log->set_log_file(fn);
+      g_ceph_context->_log->reopen_log_file();
+      g_ceph_context->_log->dump_recent();
+    }
   }
 
   reraise_fatal(signum);

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -163,7 +163,7 @@ static void handle_fatal_signal(int signum)
   // TODO: don't use an ostringstream here. It could call malloc(), which we
   // don't want inside a signal handler.
   // Also fix the backtrace code not to allocate memory.
-  BackTrace bt(0);
+  BackTrace bt(1);
   ostringstream oss;
   bt.print(oss);
   dout_emergency(oss.str());

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -458,6 +458,7 @@ prepare_conf() {
         plugin dir = $CEPH_LIB
         filestore fd cache size = 32
         run dir = $CEPH_OUT_DIR
+	crash dir = $CEPH_OUT_DIR
         enable experimental unrecoverable data corrupting features = *
 	osd_crush_chooseleaf_type = 0
 $extra_conf

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -461,6 +461,7 @@ prepare_conf() {
 	crash dir = $CEPH_OUT_DIR
         enable experimental unrecoverable data corrupting features = *
 	osd_crush_chooseleaf_type = 0
+	debug asok assert abort = true
 $extra_conf
 EOF
 	if [ "$lockdep" -eq 1 ] ; then


### PR DESCRIPTION
Initial piece of https://pad.ceph.com/p/crash_reports

- various small changes to backtrace, loggin
- new code in the signal handler to dump a blob of json and recent log entries to a crash directory

Updated the pad with some follow-up notes from the CDM discussion.  breakpad looks pretty cool, but orthogonal: it'd take a bunch of build toolchain pieces and, in the end, only get us a bit more than the current stack trace does (it'd provide a line number of a segv).  If/when we do that, we can include the breakpad dump in the same crash directory in addition to or instead of the current json blob.