### PR TITLE
mgr/iostat: column_width should be int not float

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -364,7 +364,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         :param width: the width of the terminal
         """
         n = len(elems)
-        column_width = width / n
+        column_width = int(width / n)
 
         ret = '|'
         for elem in elems:
@@ -380,7 +380,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         :param width: the width of the terminal
         """
         n = len(elems)
-        column_width = width / n
+        column_width = int(width / n)
 
         # dash line
         ret = '+'


### PR DESCRIPTION
in python3, 3/2 is a float not intger

Signed-off-by: Kefu Chai <kchai@redhat.com>