### PR TITLE
cls/rgw: fix return is missing in rgw_obj_check_mtime

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2158,6 +2158,7 @@ static int rgw_obj_check_mtime(cls_method_context_t hctx, bufferlist *in, buffer
   }
   if (ret == -ENOENT) {
     CLS_LOG(10, "object does not exist, skipping check");
+    return 0;
   }
 
   ceph_timespec obj_ts = ceph::real_clock::to_ceph_timespec(obj_ut);


### PR DESCRIPTION
Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>