### PR TITLE
cmake: disable -Werror-stringop-truncation for rocksdb

### DIFF
--- a/cmake/modules/BuildRocksDB.cmake
+++ b/cmake/modules/BuildRocksDB.cmake
@@ -21,7 +21,10 @@ function(do_build_rocksdb)
   list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
   list(APPEND ROCKSDB_CMAKE_ARGS -DFAIL_ON_WARNINGS=OFF)
   list(APPEND ROCKSDB_CMAKE_ARGS -DUSE_RTTI=1)
-
+  CHECK_C_COMPILER_FLAG("-Wno-stringop-truncation" HAS_WARNING_STRINGOP_TRUNCATION)
+  if(HAS_WARNING_STRINGOP_TRUNCATION)
+    list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_C_FLAGS="-Wno-stringop-truncation")
+  endif()
   # we use an external project and copy the sources to bin directory to ensure
   # that object files are built outside of the source tree.
   include(ExternalProject)


### PR DESCRIPTION
this option was introduced in GCC-8.1, and is enabled by default.
otherwise we will have:

src/rocksdb/util/status.cc:28:15: error: ‘char* strncpy(char*, const
char*, size_t)’ output truncated before terminating nul copying as many
bytes from a string as its length [-Werror=string
op-truncation]
   std::strncpy(result, state, cch - 1);
   ~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
/var/ssd/ceph/src/rocksdb/util/status.cc:19:18: note: length computed
here
       std::strlen(state) + 1; // +1 for the null terminator
       ~~~~~~~~~~~^~~~~~~
cc1plus: all warnings being treated as errors

Signed-off-by: Kefu Chai <kchai@redhat.com>