### PR TITLE
mgr: Centralize PG_STATES to MgrModule

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -8,6 +8,37 @@ import threading
 from collections import defaultdict
 import rados
 
+PG_STATES = [
+        "active",
+        "clean",
+        "down",
+        "recovery_unfound",
+        "backfill_unfound",
+        "scrubbing",
+        "degraded",
+        "inconsistent",
+        "peering",
+        "repair",
+        "recovering",
+        "forced_recovery",
+        "backfill_wait",
+        "incomplete",
+        "stale",
+        "remapped",
+        "deep",
+        "backfilling",
+        "forced_backfill",
+        "backfill_toofull",
+        "recovery_wait",
+        "recovery_toofull",
+        "undersized",
+        "activating",
+        "peered",
+        "snaptrim",
+        "snaptrim_wait",
+        "snaptrim_error",
+        "creating",
+        "unknown"]
 
 class CPlusPlusHandler(logging.Handler):
     def __init__(self, module_inst):

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -6,7 +6,7 @@ import os
 import socket
 import threading
 from collections import OrderedDict
-from mgr_module import MgrModule, MgrStandbyModule, CommandResult
+from mgr_module import MgrModule, MgrStandbyModule, CommandResult, PG_STATES
 
 # Defaults for the Prometheus HTTP server.  Can also set in config-key
 # see https://github.com/prometheus/prometheus/wiki/Default-port-allocations
@@ -43,38 +43,6 @@ def health_status_to_number(status):
         return 1
     elif status == 'HEALTH_ERR':
         return 2
-
-PG_STATES = [
-        "active",
-        "clean",
-        "down",
-        "recovery_unfound",
-        "backfill_unfound",
-        "scrubbing",
-        "degraded",
-        "inconsistent",
-        "peering",
-        "repair",
-        "recovering",
-        "forced_recovery",
-        "backfill_wait",
-        "incomplete",
-        "stale",
-        "remapped",
-        "deep",
-        "backfilling",
-        "forced_backfill",
-        "backfill_toofull",
-        "recovery_wait",
-        "recovery_toofull",
-        "undersized",
-        "activating",
-        "peered",
-        "snaptrim",
-        "snaptrim_wait",
-        "snaptrim_error",
-        "creating",
-        "unknown"]
 
 DF_CLUSTER = ['total_bytes', 'total_used_bytes', 'total_objects']
 

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -8,7 +8,7 @@ from threading import Event
 
 from telegraf.basesocket import BaseSocket
 from telegraf.protocol import Line
-from mgr_module import MgrModule
+from mgr_module import MgrModule, PG_STATES
 
 try:
     from urllib.parse import urlparse
@@ -130,18 +130,13 @@ class Module(MgrModule):
                     'num_pgs', 'num_objects', 'num_pools']:
             stats[key] = pg_status[key]
 
-        pg_states = ['active', 'peering', 'clean', 'scrubbing', 'undersized',
-                     'backfilling', 'recovering', 'degraded', 'inconsistent',
-                     'remapped', 'backfill_toofull', 'wait_backfill',
-                     'recovery_wait']
-
-        for state in pg_states:
+        for state in PG_STATES:
             stats['num_pgs_{0}'.format(state)] = 0
 
         stats['num_pgs'] = pg_status['num_pgs']
         for state in pg_status['pgs_by_state']:
             states = state['state_name'].split('+')
-            for s in pg_states:
+            for s in PG_STATES:
                 key = 'num_pgs_{0}'.format(s)
                 if s in states:
                     stats[key] += state['count']


### PR DESCRIPTION
The Prometheus, Telegraf and Influx module can use this list
of states to send information about Placement Groups to their
endpoint.

Signed-off-by: Wido den Hollander <wido@42on.com>