### PR TITLE
mgr/dashboard: Fix more layout issues in UI

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -205,6 +205,10 @@
     }
     .datatable-pager .pager {
       margin-right: 5px !important;
+      & li:not(:first-child) {
+        /** Add space between buttons */
+        margin-left: 3px;
+      }
       & li > a, & li > span {
         border-radius: 3px;
       }

--- a/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/openattic-theme.scss
@@ -545,8 +545,8 @@ ul.task-queue-pagination {
 .panel .panel-toolbar>.dropdown>a {
   padding-left: 5px;
 }
-.panel .panel-footer > .button-group button.btn {
-  margin-left: 3px;
+.panel .panel-footer > .button-group button.btn:not(:first-child) {
+  margin-left: 5px;
 }
 .panel-dashboard {
   height: 100%;
@@ -1132,8 +1132,8 @@ hr.oa-hr-small {
 }
 
 /* Modal dialog */
-.modal-footer button.btn {
-  margin-left: 3px;
+.modal-footer button.btn:not(:first-child) {
+  margin-left: 5px;
 }
 
 // awesome-bootstrap-checkbox + ForkAwesome


### PR DESCRIPTION
Improve the CSS3 selectors and use the margin-left values from the 'btn-toolbar' Bootstrap class.

Add space between data table pager.
![auswahl_004](https://user-images.githubusercontent.com/1897962/41585647-f638b694-73aa-11e8-9e07-4e7c52f6b4f6.png)

Signed-off-by: Volker Theile <vtheile@suse.com>