### PR TITLE
luminous: MDSMonitor: crash after assigning standby-replay daemon in multifs setup

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2226,6 +2226,7 @@ bool MDSMonitor::maybe_promote_standby(std::shared_ptr<Filesystem> &fs)
 
       // check everyone
       for (const auto &p : pending.filesystems) {
+	bool assigned = false;
         const auto &fs = p.second;
         const MDSMap &mds_map = fs->mds_map;
         for (const auto &mds_i : mds_map.mds_info) {
@@ -2237,12 +2238,15 @@ bool MDSMonitor::maybe_promote_standby(std::shared_ptr<Filesystem> &fs)
             }
 
             if (try_standby_replay(info, *fs, cand_info)) {
-              do_propose = true;
+	      assigned = true;
               break;
             }
-            continue;
           }
         }
+	if (assigned) {
+	  do_propose = true;
+	  break;
+	}
       }
     }
   }

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2226,6 +2226,10 @@ bool MDSMonitor::maybe_promote_standby(std::shared_ptr<Filesystem> &fs)
 
       // check everyone
       for (const auto &p : pending.filesystems) {
+	if (info.standby_for_fscid != FS_CLUSTER_ID_NONE &&
+	    info.standby_for_fscid != p.first)
+	  continue;
+
 	bool assigned = false;
         const auto &fs = p.second;
         const MDSMap &mds_map = fs->mds_map;


### PR DESCRIPTION
http://tracker.ceph.com/issues/23792