### PR TITLE
common: optimize/kill Throttle's critical sections

### DIFF
--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -187,8 +187,14 @@ bool Throttle::get_or_fail(int64_t c)
   }
 
   assert (c >= 0);
-  auto l = uniquely_lock(lock);
-  if (_should_wait(c) || !conds.empty()) {
+
+  bool should_wait = _should_wait(c);
+  if (!should_wait) {
+    auto l = uniquely_lock(lock);
+    should_wait = !conds.empty();
+  }
+
+  if (should_wait) {
     ldout(cct, 10) << "get_or_fail " << c << " failed" << dendl;
     if (logger) {
       logger->inc(l_throttle_get_or_fail_fail);


### PR DESCRIPTION
Sending for early review. Final patches might be pushed rather as a part of the `create_request` work (will see).
Profiling results for a scenario with an request flood (100% cache hit, huge IO queues, 10 fio jobs): https://gist.github.com/rzarzynski/014b138108840b8b7ffa670b9b73f324.

Performance comparison
==================
All tests have been conducted on the `incerta07` node in 5 rounds. The result for each round is sum of bandwidth 4 separated FIO-librbd clients get from a cluster consisted of 3 OSDs . CBT has been used for deployment and orchestration. Values are in KBps.

On average for 4 KiB randreads:
```
>>> (367822 + 366273 + 367470 + 367186 + 367414.) / (363013 + 361890 + 356313 + 368839 + 366750)
1.0106560693084838
```

The reference point: 3d34add1e2083957dce223aa17ff9a0ce50d2c94
--------------------
```
randread,  4 KiB:  363013,  361890,  356313,  368839,  366750
randread, 64 KiB: 3450393, 3527752, 3468953, 3454142, 3487138
```

After the changes: 466715e5e2308dc6b0048ce7900e8cb5d3a2c1d4
------------------
```
randread,  4 KiB:  367822,  366273,  367470,  367186,  367414
randread, 64 KiB: 3560073, 3546009, 3458303, 3368952, 3621617

```
