### PR TITLE
compressor: building error for QAT decompress

### DIFF
--- a/src/compressor/QatAccel.cc
+++ b/src/compressor/QatAccel.cc
@@ -76,11 +76,11 @@ int QatAccel::compress(const bufferlist &in, bufferlist &out) {
 }
 
 int QatAccel::decompress(const bufferlist &in, bufferlist &out) {
-  bufferlist::iterator i = const_cast<bufferlist&>(in).begin();
+  auto i = in.begin();
   return decompress(i, in.length(), out);
 }
 
-int QatAccel::decompress(bufferlist::iterator &p,
+int QatAccel::decompress(bufferlist::const_iterator &p,
 		 size_t compressed_len,
 		 bufferlist &dst) {
   unsigned int ratio_idx = 0;

--- a/src/compressor/QatAccel.h
+++ b/src/compressor/QatAccel.h
@@ -29,7 +29,7 @@ class QatAccel {
 
   int compress(const bufferlist &in, bufferlist &out);
   int decompress(const bufferlist &in, bufferlist &out);
-  int decompress(bufferlist::iterator &p, size_t compressed_len, bufferlist &dst);
+  int decompress(bufferlist::const_iterator &p, size_t compressed_len, bufferlist &dst);
 };
 
 #endif


### PR DESCRIPTION
The parameter of decompress changes from 'bufferlist::iterator' to
'bufferlist::const_iterator', but chis change miss class QatAccel,
and so the building could not be successful for QAT environment.

This patch fix this error with '-DWITH_QATZIP=ON'.

Signed-off-by: Qiaowei Ren <qiaowei.ren@intel.com>