### PR TITLE
kv/RocksDBStore: Don't use sync mode when disableWAL is set.

### DIFF
--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -823,7 +823,8 @@ int RocksDBStore::submit_transaction_sync(KeyValueDB::Transaction t)
 {
   utime_t start = ceph_clock_now();
   rocksdb::WriteOptions woptions;
-  woptions.sync = true;
+  // if disableWAL, sync can't set
+  woptions.sync = !disableWAL;
   
   int result = submit_common(woptions, t);
   


### PR DESCRIPTION
If disableWAL is set, it will met those error:
>> rocksdb: submit_common error: Invalid argument: Sync writes has to enable WAL. code = 4 Rocksdb transaction:

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>