### PR TITLE
rgw: Copying object data should generate new tail tag for the new object.

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8429,6 +8429,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   }
 
   if (copy_data) { /* refcounting tail wouldn't work here, just copy the data */
+    attrs.erase(RGW_ATTR_TAIL_TAG);
     return copy_obj_data(obj_ctx, dest_bucket_info, read_op, obj_size - 1, dest_obj,
                          mtime, real_time(), attrs, olh_epoch, delete_at,
                          version_id, petag);


### PR DESCRIPTION


Fixes: http://tracker.ceph.com/issues/24562

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>