### PR TITLE
rgw: fix copy response header etag format not correct

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1436,7 +1436,7 @@ void RGWPutObj_ObjStore_S3::send_response()
       if (strftime(buf, sizeof(buf), "%Y-%m-%dT%T.000Z", &tmp) > 0) {
         s->formatter->dump_string("LastModified", buf);
       }
-      s->formatter->dump_string("ETag", etag);
+      dump_etag(s, etag);
       s->formatter->close_section();
       rgw_flush_formatter_and_reset(s, s->formatter);
       return;
@@ -2192,9 +2192,7 @@ void RGWCopyObj_ObjStore_S3::send_response()
 
   if (op_ret == 0) {
     dump_time(s, "LastModified", &mtime);
-    if (! etag.empty()) {
-      s->formatter->dump_string("ETag", std::move(etag));
-    }
+    dump_etag(s, etag);
     s->formatter->close_section();
     rgw_flush_formatter_and_reset(s, s->formatter);
   }


### PR DESCRIPTION
response header etag should wrapped with quotation marks

fixes: http://tracker.ceph.com/issues/24563

Signed-off-by: Tianshan Qu <tianshan@xsky.com>