### PR TITLE
rgw: set cr state if aio_read err return in RGWCloneMetaLogCoroutine

### DIFF
--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -2371,7 +2371,7 @@ int RGWCloneMetaLogCoroutine::state_send_rest_request()
     log_error() << "failed to send http operation: " << http_op->to_str() << " ret=" << ret << std::endl;
     http_op->put();
     http_op = NULL;
-    return ret;
+    return set_cr_error(ret);
   }
 
   return io_block(0);


### PR DESCRIPTION
fixes: http://tracker.ceph.com/issues/24566

Signed-off-by: Tianshan Qu <tianshan@xsky.com>