### PR TITLE
rgw: feature: storage class

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -528,7 +528,7 @@ static int check_index(cls_method_context_t hctx, struct rgw_bucket_dir_header *
       stats.total_size += entry.meta.accounted_size;
       stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
       stats.actual_size += entry.meta.size;
-      if (entry.meta.placement_type.compare("STANDARD_IA")==0)
+      if (entry.meta.placement_storage_class.compare("STANDARD_IA")==0)
         stats.total_size_storage_class_ia += entry.meta.accounted_size;
 
       start_obj = kiter->first;
@@ -735,7 +735,7 @@ static void unaccount_entry(struct rgw_bucket_dir_header& header, struct rgw_buc
   stats.total_size -= entry.meta.accounted_size;
   stats.total_size_rounded -= cls_rgw_get_rounded_size(entry.meta.accounted_size);
   stats.actual_size -= entry.meta.size;
-  if (entry.meta.placement_type.compare("STANDARD_IA")==0)
+  if (entry.meta.placement_storage_class.compare("STANDARD_IA")==0)
     stats.total_size_storage_class_ia -= entry.meta.accounted_size;
 }
 
@@ -928,7 +928,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
       stats.total_size += meta.accounted_size;
       stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
       stats.actual_size += meta.size;
-      if (entry.meta.placement_type.compare("STANDARD_IA")==0)
+      if (entry.meta.placement_storage_class.compare("STANDARD_IA")==0)
         stats.total_size_storage_class_ia += meta.accounted_size;
       bufferlist new_key_bl;
       encode(entry, new_key_bl);
@@ -1953,7 +1953,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         old_stats.total_size -= cur_disk.meta.accounted_size;
         old_stats.total_size_rounded -= cls_rgw_get_rounded_size(cur_disk.meta.accounted_size);
         old_stats.actual_size -= cur_disk.meta.size;
-        if (cur_disk.meta.placement_type.compare("STANDARD_IA")==0)
+        if (cur_disk.meta.placement_storage_class.compare("STANDARD_IA")==0)
           old_stats.total_size_storage_class_ia -= cur_disk.meta.accounted_size;
         header_changed = true;
       }
@@ -1984,7 +1984,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         stats.total_size += cur_change.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
         stats.actual_size += cur_change.meta.size;
-        if (cur_change.meta.placement_type.compare("STANDARD_IA")==0)
+        if (cur_change.meta.placement_storage_class.compare("STANDARD_IA")==0)
           stats.total_size_storage_class_ia += cur_change.meta.accounted_size;
         header_changed = true;
         cur_change.index_ver = header.ver;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -528,6 +528,8 @@ static int check_index(cls_method_context_t hctx, struct rgw_bucket_dir_header *
       stats.total_size += entry.meta.accounted_size;
       stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
       stats.actual_size += entry.meta.size;
+      if (entry.meta.placement_type.compare("STANDARD_IA")==0)
+        stats.total_size_storage_class_ia += entry.meta.accounted_size;
 
       start_obj = kiter->first;
     }
@@ -733,6 +735,8 @@ static void unaccount_entry(struct rgw_bucket_dir_header& header, struct rgw_buc
   stats.total_size -= entry.meta.accounted_size;
   stats.total_size_rounded -= cls_rgw_get_rounded_size(entry.meta.accounted_size);
   stats.actual_size -= entry.meta.size;
+  if (entry.meta.placement_type.compare("STANDARD_IA")==0)
+    stats.total_size_storage_class_ia -= entry.meta.accounted_size;
 }
 
 static void log_entry(const char *func, const char *str, struct rgw_bucket_dir_entry *entry)
@@ -924,6 +928,8 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
       stats.total_size += meta.accounted_size;
       stats.total_size_rounded += cls_rgw_get_rounded_size(meta.accounted_size);
       stats.actual_size += meta.size;
+      if (entry.meta.placement_type.compare("STANDARD_IA")==0)
+        stats.total_size_storage_class_ia += meta.accounted_size;
       bufferlist new_key_bl;
       encode(entry, new_key_bl);
       int ret = cls_cxx_map_set_val(hctx, idx, &new_key_bl);
@@ -1947,6 +1953,8 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         old_stats.total_size -= cur_disk.meta.accounted_size;
         old_stats.total_size_rounded -= cls_rgw_get_rounded_size(cur_disk.meta.accounted_size);
         old_stats.actual_size -= cur_disk.meta.size;
+        if (cur_disk.meta.placement_type.compare("STANDARD_IA")==0)
+          old_stats.total_size_storage_class_ia -= cur_disk.meta.accounted_size;
         header_changed = true;
       }
       struct rgw_bucket_category_stats& stats =
@@ -1976,6 +1984,8 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         stats.total_size += cur_change.meta.accounted_size;
         stats.total_size_rounded += cls_rgw_get_rounded_size(cur_change.meta.accounted_size);
         stats.actual_size += cur_change.meta.size;
+        if (cur_change.meta.placement_type.compare("STANDARD_IA")==0)
+          stats.total_size_storage_class_ia += cur_change.meta.accounted_size;
         header_changed = true;
         cur_change.index_ver = header.ver;
         bufferlist cur_state_bl;

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -356,6 +356,9 @@ void rgw_cls_bucket_update_stats_op::generate_test_instances(list<rgw_cls_bucket
   s.total_size = 1;
   s.total_size_rounded = 4096;
   s.num_entries = 1;
+  s.total_size_ia = 1;
+  s.total_size_rounded_ia = 4096;
+  s.num_entries_ia = 1;
   o.push_back(r);
 
   o.push_back(new rgw_cls_bucket_update_stats_op);

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -61,7 +61,7 @@ void rgw_bucket_dir_entry_meta::dump(Formatter *f) const
   encode_json("content_type", content_type, f);
   encode_json("accounted_size", accounted_size, f);
   encode_json("user_data", user_data, f);
-  encode_json("placement_type", placement_type, f);
+  encode_json("placement_storage_class", placement_storage_class, f);
 }
 
 void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
@@ -78,7 +78,7 @@ void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("content_type", content_type, obj);
   JSONDecoder::decode_json("accounted_size", accounted_size, obj);
   JSONDecoder::decode_json("user_data", user_data, obj);
-  JSONDecoder::decode_json("placement_type", placement_type, obj);
+  JSONDecoder::decode_json("placement_storage_class", placement_storage_class, obj);
 }
 
 void rgw_bucket_dir_entry::generate_test_instances(list<rgw_bucket_dir_entry*>& o)

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -497,6 +497,7 @@ void rgw_bucket_category_stats::dump(Formatter *f) const
   f->dump_unsigned("total_size_rounded", total_size_rounded);
   f->dump_unsigned("num_entries", num_entries);
   f->dump_unsigned("actual_size", actual_size);
+  f->dump_unsigned("total_size_ia", total_size_storage_class_ia);
 }
 
 void rgw_bucket_dir_header::generate_test_instances(list<rgw_bucket_dir_header*>& o)

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -255,9 +255,18 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key, uint8_t *category, rgw_buc
         decode(entry, iter);
         *key = entry.key;
         *category = entry.meta.category;
-        accounted_stats->num_entries++;
-        accounted_stats->total_size += entry.meta.accounted_size;
-        accounted_stats->total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
+        if(entry.meta.placement_storage_class.compare("STANDARD_IA")==0) {
+          accounted_stats->num_entries_ia++;
+          if (entry.meta.accounted_size < entry.meta.storage_class_standard_ia_min_size)
+            accounted_stats->total_size_ia += entry.meta.storage_class_standard_ia_min_size;
+          else
+            accounted_stats->total_size_ia += entry.meta.accounted_size;
+          accounted_stats->total_size_rounded_ia += cls_rgw_get_rounded_size(entry.meta.accounted_size);
+        } else {
+          accounted_stats->num_entries++;
+          accounted_stats->total_size += entry.meta.accounted_size;
+          accounted_stats->total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
+        }
         account = true;
       }
       break;
@@ -487,6 +496,10 @@ void rgw_bucket_category_stats::generate_test_instances(list<rgw_bucket_category
   s->total_size_rounded = 4096;
   s->num_entries = 2;
   s->actual_size = 1024;
+  s->total_size_ia = 1024;
+  s->total_size_rounded_ia = 4096;
+  s->num_entries_ia = 2;
+  s->actual_size_ia = 1024;
   o.push_back(s);
   o.push_back(new rgw_bucket_category_stats);
 }
@@ -497,7 +510,10 @@ void rgw_bucket_category_stats::dump(Formatter *f) const
   f->dump_unsigned("total_size_rounded", total_size_rounded);
   f->dump_unsigned("num_entries", num_entries);
   f->dump_unsigned("actual_size", actual_size);
-  f->dump_unsigned("total_size_ia", total_size_storage_class_ia);
+  f->dump_unsigned("total_size_ia", total_size_ia);
+  f->dump_unsigned("total_size_rounded_ia", total_size_rounded_ia);
+  f->dump_unsigned("num_entries_ia", num_entries_ia);
+  f->dump_unsigned("actual_size_ia", actual_size_ia);
 }
 
 void rgw_bucket_dir_header::generate_test_instances(list<rgw_bucket_dir_header*>& o)

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -61,6 +61,7 @@ void rgw_bucket_dir_entry_meta::dump(Formatter *f) const
   encode_json("content_type", content_type, f);
   encode_json("accounted_size", accounted_size, f);
   encode_json("user_data", user_data, f);
+  encode_json("placement_type", placement_type, f);
 }
 
 void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
@@ -77,6 +78,7 @@ void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("content_type", content_type, obj);
   JSONDecoder::decode_json("accounted_size", accounted_size, obj);
   JSONDecoder::decode_json("user_data", user_data, obj);
+  JSONDecoder::decode_json("placement_type", placement_type, obj);
 }
 
 void rgw_bucket_dir_entry::generate_test_instances(list<rgw_bucket_dir_entry*>& o)

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -98,7 +98,7 @@ struct rgw_bucket_dir_entry_meta {
   string content_type;
   uint64_t accounted_size;
   string user_data;
-  std::string placement_type;
+  std::string placement_storage_class;
 
   rgw_bucket_dir_entry_meta() :
   category(0), size(0), accounted_size(0) { }
@@ -114,7 +114,7 @@ struct rgw_bucket_dir_entry_meta {
     encode(content_type, bl);
     encode(accounted_size, bl);
     encode(user_data, bl);
-    encode(placement_type, bl);
+    encode(placement_storage_class, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
@@ -133,8 +133,10 @@ struct rgw_bucket_dir_entry_meta {
       accounted_size = size;
     if (struct_v >= 5)
       decode(user_data, bl);
-    if (struct_v >= 6)
-      decode(placement_type, bl);
+    if (struct_v >= 6) 
+      decode(placement_storage_class, bl);
+    else
+      placement_storage_class = "STANDARD";
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -98,12 +98,13 @@ struct rgw_bucket_dir_entry_meta {
   string content_type;
   uint64_t accounted_size;
   string user_data;
+  std::string placement_type;
 
   rgw_bucket_dir_entry_meta() :
   category(0), size(0), accounted_size(0) { }
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(5, 3, bl);
+    ENCODE_START(6, 3, bl);
     encode(category, bl);
     encode(size, bl);
     encode(mtime, bl);
@@ -113,10 +114,11 @@ struct rgw_bucket_dir_entry_meta {
     encode(content_type, bl);
     encode(accounted_size, bl);
     encode(user_data, bl);
+    encode(placement_type, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::const_iterator &bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(5, 3, 3, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(6, 3, 3, bl);
     decode(category, bl);
     decode(size, bl);
     decode(mtime, bl);
@@ -131,6 +133,8 @@ struct rgw_bucket_dir_entry_meta {
       accounted_size = size;
     if (struct_v >= 5)
       decode(user_data, bl);
+    if (struct_v >= 6)
+      decode(placement_type, bl);
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;

--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -92,6 +92,9 @@ static void add_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry
   stats->total_entries += entry.count;
   stats->total_bytes += entry.size;
   stats->total_bytes_rounded += entry.size_rounded;
+  stats->total_entries_ia += entry.count_ia;
+  stats->total_bytes_ia += entry.size_ia;
+  stats->total_bytes_rounded_ia += entry.size_rounded_ia;
 }
 
 static void dec_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry)
@@ -99,6 +102,9 @@ static void dec_header_stats(cls_user_stats *stats, cls_user_bucket_entry& entry
   stats->total_bytes -= entry.size;
   stats->total_bytes_rounded -= entry.size_rounded;
   stats->total_entries -= entry.count;
+  stats->total_bytes_ia -= entry.size_ia;
+  stats->total_bytes_rounded_ia -= entry.size_rounded_ia;
+  stats->total_entries_ia -= entry.count_ia;
 }
 
 static void apply_entry_stats(const cls_user_bucket_entry& src_entry, cls_user_bucket_entry *target_entry)
@@ -106,6 +112,9 @@ static void apply_entry_stats(const cls_user_bucket_entry& src_entry, cls_user_b
   target_entry->size = src_entry.size;
   target_entry->size_rounded = src_entry.size_rounded;
   target_entry->count = src_entry.count;
+  target_entry->size_ia = src_entry.size_ia;
+  target_entry->size_rounded_ia = src_entry.size_rounded_ia;
+  target_entry->count_ia = src_entry.count_ia;
 }
 
 static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, bufferlist *out)

--- a/src/cls/user/cls_user_types.cc
+++ b/src/cls/user/cls_user_types.cc
@@ -5,6 +5,7 @@
 #include "common/Formatter.h"
 #include "common/ceph_json.h"
 #include "include/utime.h"
+#include "cls_user_types.h"
 
 void cls_user_gen_test_bucket(cls_user_bucket *bucket, int i)
 {
@@ -38,6 +39,9 @@ void cls_user_bucket_entry::dump(Formatter *f) const
   encode_json("size_rounded", size_rounded, f);
   encode_json("creation_time", utime_t(creation_time), f);
   encode_json("count", count, f);
+  encode_json("size_ia", size_ia, f);
+  encode_json("size_rounded_ia", size_rounded_ia, f);
+  encode_json("count_ia", count_ia, f);
   encode_json("user_stats_sync", user_stats_sync, f);
 }
 
@@ -64,6 +68,9 @@ void cls_user_gen_test_stats(cls_user_stats *s)
   s->total_entries = 1;
   s->total_bytes = 2;
   s->total_bytes_rounded = 3;
+  s->total_entries_ia = 1;
+  s->total_bytes_ia = 2;
+  s->total_bytes_rounded_ia = 3;
 }
 
 void cls_user_stats::dump(Formatter *f) const
@@ -71,6 +78,9 @@ void cls_user_stats::dump(Formatter *f) const
   f->dump_int("total_entries", total_entries);
   f->dump_int("total_bytes", total_bytes);
   f->dump_int("total_bytes_rounded", total_bytes_rounded);
+  f->dump_int("total_entries_ia", total_entries_ia);
+  f->dump_int("total_bytes_ia", total_bytes_ia);
+  f->dump_int("total_bytes_rounded_ia", total_bytes_rounded_ia);
 }
 
 void cls_user_stats::generate_test_instances(list<cls_user_stats*>& ls)

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1534,6 +1534,9 @@ OPTION(rgw_swift_custom_header, OPT_STR) // option to enable swift custom header
 
 OPTION(rgw_swift_need_stats, OPT_BOOL) // option to enable stats on bucket listing for swift
 
+/* rgw storage class */
+OPTION(rgw_storage_class_standard_ia_min_size, OPT_INT) // min size for STANDARD_IA storage class object
+
 /* resharding tunables */
 OPTION(rgw_reshard_num_logs, OPT_INT)
 OPTION(rgw_reshard_bucket_lock_duration, OPT_INT) // duration of lock on bucket obj during resharding

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6156,6 +6156,10 @@ std::vector<Option> get_rgw_options() {
     .set_default(true)
     .set_description("Enable stats on bucket listing in Swift"),
 
+    Option("rgw_storage_class_standard_ia_min_size", Option::TYPE_INT, Option::LEVEL_DEV)
+    .set_default(65536)
+    .set_description(""),
+
     Option("rgw_reshard_num_logs", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(16)
     .set_description(""),

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -266,7 +266,7 @@ void usage()
   cout << "   --read-only               set zone as read-only (when adding to zonegroup)\n";
   cout << "   --redirect-zone           specify zone id to redirect when response is 404 (not found)\n";
   cout << "   --placement-id            placement id for zonegroup placement commands\n";
-  cout << "   --placement-type          placement type for zonegroup placement commands\n";
+  cout << "   --placement-storage-class placement storage class for zonegroup placement commands\n";
   cout << "   --tags=<list>             list of tags for zonegroup placement add and modify commands\n";
   cout << "   --tags-add=<list>         list of tags to add for zonegroup placement modify command\n";
   cout << "   --tags-rm=<list>          list of tags to remove for zonegroup placement modify command\n";
@@ -2704,7 +2704,7 @@ int main(int argc, const char **argv)
   string quota_scope;
   string object_version;
   string placement_id;
-  string placement_type;
+  string placement_storage_class;
   list<string> tags;
   list<string> tags_add;
   list<string> tags_rm;
@@ -3018,8 +3018,8 @@ int main(int argc, const char **argv)
       zonegroup_new_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-id", (char*)NULL)) {
       placement_id = val;
-    } else if (ceph_argparse_witharg(args, i, &val, "--placement-type", (char*)NULL)) {
-      placement_type = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--placement-storage-class", (char*)NULL)) {
+      placement_storage_class = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--tags", (char*)NULL)) {
       get_str_list(val, tags);
     } else if (ceph_argparse_witharg(args, i, &val, "--tags-add", (char*)NULL)) {
@@ -4193,13 +4193,13 @@ int main(int argc, const char **argv)
 	}
 
         if (opt_cmd == OPT_ZONEGROUP_PLACEMENT_ADD) {
-          if (placement_type.empty()) {
-            cerr << "ERROR: --placement-type not specified" << std::endl;
+          if (placement_storage_class.empty()) {
+            cerr << "ERROR: --placement-storage-class not specified" << std::endl;
             return EINVAL;
           }
           RGWZoneGroupPlacementTarget target;
           target.name = placement_id;
-          target.type = placement_type;
+          target.type = placement_storage_class;
           for (auto& t : tags) {
             target.tags.insert(t);
           }
@@ -4213,8 +4213,8 @@ int main(int argc, const char **argv)
             }
           }
           target.name = placement_id;
-          if (!placement_type.empty())
-            target.type = placement_type;
+          if (!placement_storage_class.empty())
+            target.type = placement_storage_class;
           for (auto& t : tags_rm) {
             target.tags.erase(t);
           }

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -60,6 +60,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_INVALID_DIGEST, {400, "InvalidDigest" }},
     { ERR_BAD_DIGEST, {400, "BadDigest" }},
     { ERR_INVALID_LOCATION_CONSTRAINT, {400, "InvalidLocationConstraint" }},
+    { ERR_INVALID_STORAGE_CLASS, {400, "InvalidStorageClass" }},
     { ERR_ZONEGROUP_DEFAULT_PLACEMENT_MISCONFIGURATION, {400, "ZonegroupDefaultPlacementMisconfiguration" }},
     { ERR_INVALID_BUCKET_NAME, {400, "InvalidBucketName" }},
     { ERR_INVALID_OBJECT_NAME, {400, "InvalidObjectName" }},

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1832,7 +1832,8 @@ struct req_state : DoutPrefixProvider {
   bool has_bad_meta{false};
 
   RGWUserInfo *user;
-  std::string placement_id;
+  string placement_id;
+  bool storage_class_restore{false};
 
   struct {
     /* TODO(rzarzynski): switch out to the static_ptr for both members. */

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -107,7 +107,7 @@ using ceph::crypto::MD5;
 /* IAM Policy */
 #define RGW_ATTR_IAM_POLICY	RGW_ATTR_PREFIX "iam-policy"
 
-#define RGW_ATTR_PLACEMENT_TYPE    RGW_ATTR_PREFIX "placement-type"
+#define RGW_ATTR_PLACEMENT_STORAGE_CLASS    RGW_ATTR_PREFIX "placement-storage-class"
 
 /* RGW File Attributes */
 #define RGW_ATTR_UNIX_KEY1      RGW_ATTR_PREFIX "unix-key1"

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1435,13 +1435,18 @@ struct RGWStorageStats
   uint64_t size_utilized{0}; //< size after compression, encryption
   uint64_t num_objects;
   uint64_t size_ia{0}; // storage class ia size
+  uint64_t size_rounded_ia{0};
+  uint64_t size_utilized_ia{0}; //< size after compression, encryption
+  uint64_t num_objects_ia{0};
 
   RGWStorageStats()
     : category(RGW_OBJ_CATEGORY_NONE),
       size(0),
       size_rounded(0),
       num_objects(0),
-      size_ia(0) {}
+      size_ia(0),
+      size_rounded_ia(0),
+      num_objects_ia(0) {}
 
   void dump(Formatter *f) const;
 };

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -107,6 +107,7 @@ using ceph::crypto::MD5;
 /* IAM Policy */
 #define RGW_ATTR_IAM_POLICY	RGW_ATTR_PREFIX "iam-policy"
 
+#define RGW_ATTR_PLACEMENT_TYPE    RGW_ATTR_PREFIX "placement-type"
 
 /* RGW File Attributes */
 #define RGW_ATTR_UNIX_KEY1      RGW_ATTR_PREFIX "unix-key1"
@@ -217,6 +218,7 @@ using ceph::crypto::MD5;
 #define ERR_MALFORMED_ACL_ERROR  2212
 #define ERR_ZONEGROUP_DEFAULT_PLACEMENT_MISCONFIGURATION 2213
 #define ERR_INVALID_ENCRYPTION_ALGORITHM                 2214
+#define ERR_INVALID_STORAGE_CLASS 2215
 
 #define ERR_BUSY_RESHARDING      2300
 
@@ -1823,6 +1825,7 @@ struct req_state : DoutPrefixProvider {
   bool has_bad_meta{false};
 
   RGWUserInfo *user;
+  std::string placement_id;
 
   struct {
     /* TODO(rzarzynski): switch out to the static_ptr for both members. */

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1434,12 +1434,14 @@ struct RGWStorageStats
   uint64_t size_rounded;
   uint64_t size_utilized{0}; //< size after compression, encryption
   uint64_t num_objects;
+  uint64_t size_ia{0}; // storage class ia size
 
   RGWStorageStats()
     : category(RGW_OBJ_CATEGORY_NONE),
       size(0),
       size_rounded(0),
-      num_objects(0) {}
+      num_objects(0),
+      size_ia(0) {}
 
   void dump(Formatter *f) const;
 };

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -176,6 +176,7 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
   if (!cur_part_id) {
     if (ofs < max_head_size) {
       location->set_placement_rule(head_placement_rule);
+      location->using_tail_data_pool = false;
       *location = obj;
       return;
     } else {
@@ -208,6 +209,8 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
   loc.key.set_instance(tail_instance);
 
   location->set_placement_rule(tail_placement.placement_rule);
+  location->using_tail_data_pool = true;
+  using_tail_data_pool = true;
   *location = loc;
 }
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -2352,10 +2352,11 @@ public:
                                        bool *is_multipart) override {
     struct req_state* s = get_state();
     uint64_t part_size = s->cct->_conf->rgw_obj_stripe_size;
+    const std::string& pid = s->placement_id.empty() ? s->bucket_info.placement_rule : s->placement_id;
     RGWPutObjProcessor_Atomic *processor =
       new RGWPutObjProcessor_Atomic(obj_ctx, s->bucket_info, s->bucket,
 				    s->object.name, part_size, s->req_id,
-				    s->bucket_info.versioning_enabled());
+				    s->bucket_info.versioning_enabled(), pid);
     processor->set_olh_epoch(olh_epoch);
     processor->set_version_id(version_id);
     return processor;

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -954,6 +954,7 @@ void RGWZonePlacementInfo::dump(Formatter *f) const
 {
   encode_json("index_pool", index_pool, f);
   encode_json("data_pool", data_pool, f);
+  encode_json("tail_data_pool", tail_data_pool, f);
   encode_json("data_extra_pool", data_extra_pool, f);
   encode_json("index_type", (uint32_t)index_type, f);
   encode_json("compression", compression_type, f);
@@ -963,6 +964,7 @@ void RGWZonePlacementInfo::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("index_pool", index_pool, obj);
   JSONDecoder::decode_json("data_pool", data_pool, obj);
+  JSONDecoder::decode_json("tail_data_pool", tail_data_pool, obj);
   JSONDecoder::decode_json("data_extra_pool", data_extra_pool, obj);
   uint32_t it;
   JSONDecoder::decode_json("index_type", it, obj);
@@ -1031,12 +1033,14 @@ void RGWZoneGroupPlacementTarget::dump(Formatter *f) const
 {
   encode_json("name", name, f);
   encode_json("tags", tags, f);
+  encode_json("type", type, f);
 }
 
 void RGWZoneGroupPlacementTarget::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("name", name, obj);
   JSONDecoder::decode_json("tags", tags, obj);
+  JSONDecoder::decode_json("type", type, obj);
 }
 
 void RGWZoneGroup::dump(Formatter *f) const

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -665,9 +665,14 @@ void RGWStorageStats::dump(Formatter *f) const
   encode_json("size_kb", rgw_rounded_kb(size), f);
   encode_json("size_kb_actual", rgw_rounded_kb(size_rounded), f);
   encode_json("size_kb_utilized", rgw_rounded_kb(size_utilized), f);
-  encode_json("size_ia", size_ia, f);
-  encode_json("size_ia_kb", rgw_rounded_kb(size_ia), f);
   encode_json("num_objects", num_objects, f);
+  encode_json("size_ia", size_ia, f);
+  encode_json("size_actual_ia", size_rounded_ia, f);
+  encode_json("size_utilized_ia", size_utilized_ia, f);
+  encode_json("size_kb_ia", rgw_rounded_kb(size_ia), f);
+  encode_json("size_kb_actual_ia", rgw_rounded_kb(size_rounded_ia), f);
+  encode_json("size_kb_utilized_ia", rgw_rounded_kb(size_utilized_ia), f);
+  encode_json("num_objects_ia", num_objects_ia, f);
 }
 
 void RGWRedirectInfo::dump(Formatter *f) const

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -665,6 +665,8 @@ void RGWStorageStats::dump(Formatter *f) const
   encode_json("size_kb", rgw_rounded_kb(size), f);
   encode_json("size_kb_actual", rgw_rounded_kb(size_rounded), f);
   encode_json("size_kb_utilized", rgw_rounded_kb(size_utilized), f);
+  encode_json("size_ia", size_ia, f);
+  encode_json("size_ia_kb", rgw_rounded_kb(size_ia), f);
   encode_json("num_objects", num_objects, f);
 }
 

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -27,7 +27,6 @@ const char* LC_STATUS[] = {
       "COMPLETE"
 };
 
-static string STANDARD_IA = "STANDARD_IA";
 
 using namespace librados;
 
@@ -440,7 +439,7 @@ int RGWLC::handle_transition(RGWRados::Bucket *target, const map<string, lc_op>&
           if (!key.ns.empty()) {
             continue;
           }
-          if (obj_iter->meta.placement_type != src_type) {
+          if (obj_iter->meta.placement_storage_class != src_type) {
             continue;
           }
           if (dst_iter->second.date != boost::none) {

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -98,14 +98,14 @@ bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
       action.date = ceph::from_iso_8601(elem.second.get_date());
     }
     action.storage_class = elem.first;
-    op.transitions.emplace(action.storage_class, std::move(action));
+    op.transitions.emplace(elem.first, std::move(action));
   }
   for (const auto &elem : rule->get_noncur_transitions()) {
     transition_action action;
     action.days = elem.second.get_days();
     action.date = ceph::from_iso_8601(elem.second.get_date());
     action.storage_class = elem.first;
-    op.noncur_transitions.emplace(action.storage_class, std::move(action));
+    op.noncur_transitions.emplace(elem.first, std::move(action));
   }
   std::string prefix;
   if (rule->get_filter().has_prefix()){

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -35,6 +35,13 @@ typedef enum {
   lc_complete,
 }LC_BUCKET_STATUS;
 
+typedef enum {
+  standard_ia = 0,
+  onezone_ia,
+  glacier,
+  undefined,
+} STORAGE_CLASS;
+
 class LCExpiration
 {
 protected:
@@ -89,7 +96,80 @@ public:
     return true;
   }
 };
-WRITE_CLASS_ENCODER(LCExpiration)
+WRITE_CLASS_ENCODER(LCExpiration);
+
+class LCTransition
+{
+protected:
+  string days;
+  string date;
+  string storage_class;
+
+public:
+  int get_days() const {
+    return atoi(days.c_str());
+  }
+
+  string get_date() const {
+    return date;
+  }
+
+  string get_storage_class_str() const {
+    return storage_class;
+  }
+
+  STORAGE_CLASS get_storage_class() const {
+    if (storage_class.compare("STANDARD_IA") == 0) {
+      return standard_ia;
+    } else if (storage_class.compare("ONEZONE_IA") == 0) {
+      return onezone_ia;
+    } else if (storage_class.compare("GLACIER") == 0) {
+      return glacier;
+    } else {
+      return undefined;
+    }
+  }
+
+  bool has_days() const {
+    return !days.empty();
+  }
+
+  bool has_date() const {
+    return !date.empty();
+  }
+
+  bool empty() const {
+    return days.empty() && date.empty();
+  }
+
+  bool valid() const {
+    if (!days.empty() && !date.empty()) {
+      return false;
+    } else if (!days.empty() && get_days() <=0) {
+      return false;
+    }
+    //We've checked date in xml parsing
+    return true;
+  }
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(days, bl);
+    encode(date, bl);
+    encode(storage_class, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(days, bl);
+    decode(date, bl);
+    decode(storage_class, bl);
+    DECODE_FINISH(bl);
+  }
+  void dump(Formatter *f) const;
+};
+WRITE_CLASS_ENCODER(LCTransition);
 
 class LCFilter
 {
@@ -159,6 +239,8 @@ protected:
   LCExpiration noncur_expiration;
   LCExpiration mp_expiration;
   LCFilter filter;
+  map<int, LCTransition> transitions;
+  map<int, LCTransition> noncur_transitions;
   bool dm_expiration = false;
 
 public:
@@ -199,6 +281,14 @@ public:
     return dm_expiration;
   }
 
+  map<int, LCTransition>& get_transitions() {
+    return transitions;
+  }
+
+  map<int, LCTransition>& get_noncur_transitions() {
+    return noncur_transitions;
+  }
+
   void set_id(string*_id) {
     id = *_id;
   }
@@ -227,10 +317,20 @@ public:
     dm_expiration = _dm_expiration;
   }
 
+  bool add_transition(LCTransition* _transition) {
+    auto ret = transitions.emplace(_transition->get_storage_class(), *_transition);
+    return ret.second;
+  }
+
+  bool add_noncur_transition(LCTransition* _noncur_transition) {
+    auto ret = noncur_transitions.emplace(_noncur_transition->get_storage_class(), *_noncur_transition);
+    return ret.second;
+  }
+
   bool valid();
   
   void encode(bufferlist& bl) const {
-     ENCODE_START(5, 1, bl);
+     ENCODE_START(6, 1, bl);
      encode(id, bl);
      encode(prefix, bl);
      encode(status, bl);
@@ -239,10 +339,12 @@ public:
      encode(mp_expiration, bl);
      encode(dm_expiration, bl);
      encode(filter, bl);
+     encode(transitions, bl);
+     encode(noncur_transitions, bl);
      ENCODE_FINISH(bl);
    }
    void decode(bufferlist::const_iterator& bl) {
-     DECODE_START_LEGACY_COMPAT_LEN(5, 1, 1, bl);
+     DECODE_START_LEGACY_COMPAT_LEN(6, 1, 1, bl);
      decode(id, bl);
      decode(prefix, bl);
      decode(status, bl);
@@ -259,12 +361,24 @@ public:
      if (struct_v >= 5) {
        decode(filter, bl);
      }
+     if (struct_v >= 6) {
+       decode(transitions, bl);
+       decode(noncur_transitions, bl);
+     }
      DECODE_FINISH(bl);
    }
   void dump(Formatter *f) const;
 
 };
 WRITE_CLASS_ENCODER(LCRule)
+
+struct transition_action
+{
+  int days;
+  boost::optional<ceph::real_time> date;
+  int storage_class;
+  transition_action() : days(0), storage_class(standard_ia) {}
+};
 
 struct lc_op
 {
@@ -275,6 +389,8 @@ struct lc_op
   int mp_expiration;
   boost::optional<ceph::real_time> expiration_date;
   boost::optional<RGWObjTags> obj_tags;
+  map<int, transition_action> transitions;
+  map<int, transition_action> noncur_transitions;
   lc_op() : status(false), dm_expiration(false), expiration(0), noncur_expiration(0), mp_expiration(0) {}
   
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -35,13 +35,6 @@ typedef enum {
   lc_complete,
 }LC_BUCKET_STATUS;
 
-typedef enum {
-  standard_ia = 0,
-  onezone_ia,
-  glacier,
-  undefined,
-} STORAGE_CLASS;
-
 class LCExpiration
 {
 protected:
@@ -114,20 +107,8 @@ public:
     return date;
   }
 
-  string get_storage_class_str() const {
+  string get_storage_class() const {
     return storage_class;
-  }
-
-  STORAGE_CLASS get_storage_class() const {
-    if (storage_class.compare("STANDARD_IA") == 0) {
-      return standard_ia;
-    } else if (storage_class.compare("ONEZONE_IA") == 0) {
-      return onezone_ia;
-    } else if (storage_class.compare("GLACIER") == 0) {
-      return glacier;
-    } else {
-      return undefined;
-    }
   }
 
   bool has_days() const {
@@ -239,8 +220,8 @@ protected:
   LCExpiration noncur_expiration;
   LCExpiration mp_expiration;
   LCFilter filter;
-  map<int, LCTransition> transitions;
-  map<int, LCTransition> noncur_transitions;
+  map<string, LCTransition> transitions;
+  map<string, LCTransition> noncur_transitions;
   bool dm_expiration = false;
 
 public:
@@ -281,11 +262,11 @@ public:
     return dm_expiration;
   }
 
-  map<int, LCTransition>& get_transitions() {
+  map<string, LCTransition>& get_transitions() {
     return transitions;
   }
 
-  map<int, LCTransition>& get_noncur_transitions() {
+  map<string, LCTransition>& get_noncur_transitions() {
     return noncur_transitions;
   }
 
@@ -376,8 +357,8 @@ struct transition_action
 {
   int days;
   boost::optional<ceph::real_time> date;
-  int storage_class;
-  transition_action() : days(0), storage_class(standard_ia) {}
+  string storage_class;
+  transition_action() : days(0) {}
 };
 
 struct lc_op
@@ -389,8 +370,8 @@ struct lc_op
   int mp_expiration;
   boost::optional<ceph::real_time> expiration_date;
   boost::optional<RGWObjTags> obj_tags;
-  map<int, transition_action> transitions;
-  map<int, transition_action> noncur_transitions;
+  map<string, transition_action> transitions;
+  map<string, transition_action> noncur_transitions;
   lc_op() : status(false), dm_expiration(false), expiration(0), noncur_expiration(0), mp_expiration(0) {}
   
   void dump(Formatter *f) const;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -481,6 +481,7 @@ class RGWLC {
   int remove_expired_obj(RGWBucketInfo& bucket_info, rgw_obj_key obj_key, const string& owner, const string& owner_display_name, bool remove_indeed = true);
   bool obj_has_expired(ceph::real_time mtime, int days);
   int handle_multipart_expiration(RGWRados::Bucket *target, const map<string, lc_op>& prefix_map);
+  int handle_transition(RGWRados::Bucket *target, const map<string, lc_op>& prefix_map, const string& src_type, const string& dst_type);
 };
 
 

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -355,7 +355,7 @@ XMLObj *RGWLCXMLParser_S3::alloc_obj(const char *el)
   return obj;
 }
 
-bool check_date(const string& _date)
+static bool check_date(const string& _date)
 {
   boost::optional<ceph::real_time> date = ceph::from_iso_8601(_date);
   if (boost::none == date) {

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -11,6 +11,18 @@
 
 #define dout_subsys ceph_subsys_rgw
 
+static bool check_date(const string& _date)
+{
+  boost::optional<ceph::real_time> date = ceph::from_iso_8601(_date);
+  if (boost::none == date) {
+    return false;
+  }
+  struct timespec time = ceph::real_clock::to_timespec(*date);
+  if (time.tv_sec % (24*60*60) || time.tv_nsec) {
+    return false;
+  }
+  return true;
+}
 
 bool LCExpiration_S3::xml_end(const char * el) {
   LCDays_S3 *lc_days = static_cast<LCDays_S3 *>(find_first("Days"));
@@ -355,15 +367,4 @@ XMLObj *RGWLCXMLParser_S3::alloc_obj(const char *el)
   return obj;
 }
 
-static bool check_date(const string& _date)
-{
-  boost::optional<ceph::real_time> date = ceph::from_iso_8601(_date);
-  if (boost::none == date) {
-    return false;
-  }
-  struct timespec time = ceph::real_clock::to_timespec(*date);
-  if (time.tv_sec % (24*60*60) || time.tv_nsec) {
-    return false;
-  }
-  return true;
-}
+

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -327,5 +327,4 @@ public:
   void dump_xml(Formatter *f) const;
 };
 
-bool check_date(const string& _date);
 #endif

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -255,8 +255,6 @@ static void log_usage(RGWRados *store, struct req_state *s, const string& op_nam
       storage_class = "STANDARD";
       ldout(s->cct, 0) << "log_usage: get_obj_attrs failed, set storage_class to STANDARD" << dendl;
     }
-  } else {
-    storage_class = "STANDARD";
   }
 
   if(storage_class.compare("STANDARD_IA") == 0) {
@@ -271,7 +269,11 @@ static void log_usage(RGWRados *store, struct req_state *s, const string& op_nam
                       << bytes_received << ", success_ia=" << data.successful_ops_ia << dendl;
   } else {
     data.bytes_sent = bytes_sent;
-    data.bytes_received = bytes_received;
+    if (s->storage_class_restore) {
+      data.bytes_received = s->obj_size;
+    } else {
+      data.bytes_received = bytes_received;
+    }
     data.ops = 1;
     if (!s->is_err())
       data.successful_ops = 1;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3563,9 +3563,8 @@ void RGWPutObj::execute()
   }
 
   if (!placement_type.empty()) {
-    buffer::list tmp;
-    tmp.append(placement_type.c_str());
-    tmp.append('\0');
+    bufferlist tmp;
+    tmp.append(placement_type.c_str(), placement_type.length());
     emplace_attr(RGW_ATTR_PLACEMENT_TYPE, std::move(tmp));
   }
 
@@ -3842,9 +3841,8 @@ void RGWPutObj::execute()
                                  (placement_type.empty() ? nullptr : &placement_type));
   } else {
     if (!processor->get_placement_type().empty()) {
-      buffer::list tmp;
-      tmp.append(processor->get_placement_type().c_str());
-      tmp.append('\0');
+      bufferlist tmp;
+      tmp.append(processor->get_placement_type().c_str(), processor->get_placement_type().length());
       emplace_attr(RGW_ATTR_PLACEMENT_TYPE, std::move(tmp));
     }
     op_ret = processor->complete(s->obj_size, etag, &mtime, real_time(), attrs,
@@ -4061,9 +4059,8 @@ void RGWPostObj::execute()
     emplace_attr(RGW_ATTR_ETAG, std::move(bl));
 
     if (!placement_type.empty()) {
-      buffer::list tmp;
-      tmp.append(placement_type.c_str());
-      tmp.append('\0');
+      bufferlist tmp;
+      tmp.append(placement_type.c_str(), placement_type.length());
       emplace_attr(RGW_ATTR_PLACEMENT_TYPE, std::move(tmp));
     }
 
@@ -4811,9 +4808,8 @@ void RGWCopyObj::execute()
   /* Store the placement type */
   if (!placement_type.empty()) {
     attrs.erase(RGW_ATTR_PLACEMENT_TYPE);
-    buffer::list tmp;
-    tmp.append(placement_type.c_str());
-    tmp.append('\0');
+    bufferlist tmp;
+    tmp.append(placement_type.c_str(), placement_type.length());
     emplace_attr(RGW_ATTR_PLACEMENT_TYPE, std::move(tmp));
   }
 
@@ -5486,9 +5482,8 @@ void RGWInitMultipart::execute()
   }
 
   if (!placement_type.empty()) {
-    buffer::list tmp;
-    tmp.append(placement_type.c_str());
-    tmp.append('\0');
+    bufferlist tmp;
+    tmp.append(placement_type.c_str(), placement_type.length());
     attrs[RGW_ATTR_PLACEMENT_TYPE] = tmp;
   }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3278,15 +3278,12 @@ int RGWPutObjProcessor_Multipart::do_complete(size_t accounted_size,
   head_obj_op.meta.mtime = mtime;
   head_obj_op.meta.owner = s->owner.get_id();
   head_obj_op.meta.delete_at = delete_at;
-  bool using_tail_data_pool = false;
 
   if (placement_id && placement_id->compare("default-placement") == 0) {
     head_obj_op.meta.storage_class = static_cast<const std::string*>(&standard_storage_class);
-    using_tail_data_pool = false;
   }
   else {
     head_obj_op.meta.storage_class = static_cast<const std::string*>(&standard_ia_storage_class);
-    using_tail_data_pool = true;
   }
 
   head_obj_op.meta.zones_trace = zones_trace;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1022,7 +1022,7 @@ protected:
   string user_data;
 
   boost::optional<ceph::real_time> delete_at;
-  string placement_type;
+  string placement_storage_class;
 
 public:
   RGWPutObj() : ofs(0),
@@ -1110,7 +1110,7 @@ protected:
   RGWAccessControlPolicy policy;
   map<string, bufferlist> attrs;
   boost::optional<ceph::real_time> delete_at;
-  string placement_type;
+  string placement_storage_class;
 
   /* Must be called after get_data() or the result is undefined. */
   virtual std::string get_current_filename() const = 0;
@@ -1323,7 +1323,7 @@ protected:
   uint64_t olh_epoch;
 
   boost::optional<ceph::real_time> delete_at;
-  string placement_type;
+  string placement_storage_class;
   bool copy_if_newer;
 
   int init_common();
@@ -1602,7 +1602,7 @@ class RGWInitMultipart : public RGWOp {
 protected:
   string upload_id;
   RGWAccessControlPolicy policy;
-  string placement_type;
+  string placement_storage_class;
 
 public:
   RGWInitMultipart() {}
@@ -1630,7 +1630,7 @@ protected:
   string version_id;
   char *data;
   int len;
-  string placement_type;
+  string placement_storage_class;
 
   struct MPSerializer {
     librados::IoCtx ioctx;
@@ -1696,7 +1696,7 @@ protected:
   int marker;
   RGWAccessControlPolicy policy;
   bool truncated;
-  string placement_type;
+  string placement_storage_class;
 
 public:
   RGWListMultipart() {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1022,7 +1022,7 @@ protected:
   string user_data;
 
   boost::optional<ceph::real_time> delete_at;
-  std::string placement_type;
+  string placement_type;
 
 public:
   RGWPutObj() : ofs(0),
@@ -1110,7 +1110,7 @@ protected:
   RGWAccessControlPolicy policy;
   map<string, bufferlist> attrs;
   boost::optional<ceph::real_time> delete_at;
-  std::string placement_type;
+  string placement_type;
 
   /* Must be called after get_data() or the result is undefined. */
   virtual std::string get_current_filename() const = 0;
@@ -1323,7 +1323,7 @@ protected:
   uint64_t olh_epoch;
 
   boost::optional<ceph::real_time> delete_at;
-  std::string placement_type;
+  string placement_type;
   bool copy_if_newer;
 
   int init_common();
@@ -1602,7 +1602,7 @@ class RGWInitMultipart : public RGWOp {
 protected:
   string upload_id;
   RGWAccessControlPolicy policy;
-  std::string placement_type;
+  string placement_type;
 
 public:
   RGWInitMultipart() {}
@@ -1630,6 +1630,7 @@ protected:
   string version_id;
   char *data;
   int len;
+  string placement_type;
 
   struct MPSerializer {
     librados::IoCtx ioctx;
@@ -1695,7 +1696,7 @@ protected:
   int marker;
   RGWAccessControlPolicy policy;
   bool truncated;
-  std::string placement_type;
+  string placement_type;
 
 public:
   RGWListMultipart() {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1022,6 +1022,7 @@ protected:
   string user_data;
 
   boost::optional<ceph::real_time> delete_at;
+  std::string placement_type;
 
 public:
   RGWPutObj() : ofs(0),
@@ -1109,6 +1110,7 @@ protected:
   RGWAccessControlPolicy policy;
   map<string, bufferlist> attrs;
   boost::optional<ceph::real_time> delete_at;
+  std::string placement_type;
 
   /* Must be called after get_data() or the result is undefined. */
   virtual std::string get_current_filename() const = 0;
@@ -1321,6 +1323,7 @@ protected:
   uint64_t olh_epoch;
 
   boost::optional<ceph::real_time> delete_at;
+  std::string placement_type;
   bool copy_if_newer;
 
   int init_common();
@@ -1599,6 +1602,7 @@ class RGWInitMultipart : public RGWOp {
 protected:
   string upload_id;
   RGWAccessControlPolicy policy;
+  std::string placement_type;
 
 public:
   RGWInitMultipart() {}
@@ -1691,6 +1695,7 @@ protected:
   int marker;
   RGWAccessControlPolicy policy;
   bool truncated;
+  std::string placement_type;
 
 public:
   RGWListMultipart() {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1324,6 +1324,7 @@ protected:
 
   boost::optional<ceph::real_time> delete_at;
   string placement_storage_class;
+  bool storage_class_restore{false};
   bool copy_if_newer;
 
   int init_common();
@@ -1366,7 +1367,12 @@ public:
   virtual int get_params() = 0;
   virtual void send_partial_response(off_t ofs) {}
   void send_response() override = 0;
-  const char* name() const override { return "copy_obj"; }
+  const char* name() const override {
+    if (storage_class_restore)
+      return "restore_obj";
+    else
+      return "copy_obj";
+  }
   RGWOpType get_type() override { return RGW_OP_COPY_OBJ; }
   uint32_t op_mask() override { return RGW_OP_TYPE_WRITE; }
 };

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -235,7 +235,7 @@ struct RGWCompressionInfo {
 WRITE_CLASS_ENCODER(RGWCompressionInfo)
 
 int rgw_compression_info_from_attrset(map<string, bufferlist>& attrs, bool& need_decompress, RGWCompressionInfo& cs_info);
-
+int rgw_placement_id_from_attrset(map<string, bufferlist>& attrs, RGWRados *store, req_state *s);
 struct RGWOLHInfo {
   rgw_obj target;
   bool removed;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -83,6 +83,9 @@ public:
       target.num_entries += entry_stats.num_entries;
       target.total_size += entry_stats.total_size;
       target.total_size_rounded += entry_stats.total_size_rounded;
+      target.num_entries_ia += entry_stats.num_entries_ia;
+      target.total_size_ia += entry_stats.total_size_ia;
+      target.total_size_rounded_ia += entry_stats.total_size_rounded_ia;
     }
     if (entries.size() >= RESHARD_SHARD_WINDOW) {
       int ret = flush();

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -642,10 +642,12 @@ void RGWGetUsage_ObjStore_S3::send_response()
        formatter->open_object_section("Total");
        formatter->dump_int("BytesSent", total_usage.bytes_sent);
        formatter->dump_int("BytesReceived", total_usage.bytes_received);
-       formatter->dump_int("BytesSent_IA", total_usage.bytes_sent_ia);
-       formatter->dump_int("BytesReceived_IA", total_usage.bytes_received_ia);
        formatter->dump_int("Ops", total_usage.ops);
        formatter->dump_int("SuccessfulOps", total_usage.successful_ops);
+       formatter->dump_int("BytesSent_IA", total_usage.bytes_sent_ia);
+       formatter->dump_int("BytesReceived_IA", total_usage.bytes_received_ia);
+       formatter->dump_int("Ops_IA", total_usage.ops_ia);
+       formatter->dump_int("SuccessfulOps_IA", total_usage.successful_ops_ia);
        formatter->close_section(); // total
        formatter->close_section(); // user
      }
@@ -657,6 +659,9 @@ void RGWGetUsage_ObjStore_S3::send_response()
      formatter->dump_int("TotalBytes", header.stats.total_bytes);
      formatter->dump_int("TotalBytesRounded", header.stats.total_bytes_rounded);
      formatter->dump_int("TotalEntries", header.stats.total_entries);
+     formatter->dump_int("TotalBytes_IA", header.stats.total_bytes_ia);
+     formatter->dump_int("TotalBytesRounded_IA", header.stats.total_bytes_rounded_ia);
+     formatter->dump_int("TotalEntries_IA", header.stats.total_entries_ia);
 
      if (s->cct->_conf->rgw_rest_getusage_op_compat) {
        formatter->close_section(); //Stats

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -518,6 +518,8 @@ static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log
     formatter->dump_string("Category", uiter->first);
     formatter->dump_int("BytesSent", usage.bytes_sent);
     formatter->dump_int("BytesReceived", usage.bytes_received);
+    formatter->dump_int("BytesSent_IA", usage.bytes_sent_ia);
+    formatter->dump_int("BytesReceived_IA", usage.bytes_received_ia);
     formatter->dump_int("Ops", usage.ops);
     formatter->dump_int("SuccessfulOps", usage.successful_ops);
     formatter->close_section(); // Entry
@@ -603,6 +605,8 @@ void RGWGetUsage_ObjStore_S3::send_response()
        formatter->open_object_section("Total");
        formatter->dump_int("BytesSent", total_usage.bytes_sent);
        formatter->dump_int("BytesReceived", total_usage.bytes_received);
+       formatter->dump_int("BytesSent_IA", total_usage.bytes_sent_ia);
+       formatter->dump_int("BytesReceived_IA", total_usage.bytes_received_ia);
        formatter->dump_int("Ops", total_usage.ops);
        formatter->dump_int("SuccessfulOps", total_usage.successful_ops);
        formatter->close_section(); // total
@@ -1286,9 +1290,9 @@ int RGWPutObj_ObjStore_S3::get_params()
 
   policy = s3policy;
 
-  placement_type = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS", "");
+  placement_type = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS", "STANDARD");
   if (!placement_type.empty()) {
-    std::string placement_id;
+    string placement_id;
     bool is_exist = false;
     const auto& zonegroup = store->get_zonegroup();
     for (const auto& target : zonegroup.placement_targets) {
@@ -1668,10 +1672,9 @@ int RGWPostObj_ObjStore_S3::get_params()
     string part_str(part.data.c_str(), part.data.length());
     env.add_var(part.name, part_str);
     if (stringcasecmp(part.name, "x-amz-storage-class") == 0) {
-      //  placement_type = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS", "");
       placement_type = part_str;
       if (!placement_type.empty()) {
-        std::string placement_id;
+        string placement_id;
         bool is_exist = false;
         const auto& zonegroup = store->get_zonegroup();
         for (const auto& target : zonegroup.placement_targets) {
@@ -2244,9 +2247,9 @@ int RGWCopyObj_ObjStore_S3::get_params()
     ldout(s->cct, 0) << s->err.message << dendl;
     return -ERR_INVALID_REQUEST;
   }
-  placement_type = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS", "");
+  placement_type = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS", "STANDARD");
   if (!placement_type.empty()) {
-    std::string placement_id;
+    string placement_id;
     bool is_exist = false;
     const auto& zonegroup = store->get_zonegroup();
     for (const auto& target : zonegroup.placement_targets) {
@@ -2648,9 +2651,9 @@ int RGWInitMultipart_ObjStore_S3::get_params()
     return op_ret;
 
   policy = s3policy;
-  placement_type = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS", "");
+  placement_type = s->info.env->get("HTTP_X_AMZ_STORAGE_CLASS", "STANDARD");
   if (!placement_type.empty()) {
-    std::string placement_id;
+    string placement_id;
     bool is_exist = false;
     const auto& zonegroup = store->get_zonegroup();
     for (const auto& target : zonegroup.placement_targets) {

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -26,6 +26,8 @@ static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log
     formatter->dump_int("bytes_received_ia", usage.bytes_received_ia);
     formatter->dump_int("ops", usage.ops);
     formatter->dump_int("successful_ops", usage.successful_ops);
+    formatter->dump_int("ops_ia", usage.ops_ia);
+    formatter->dump_int("successful_ops_ia", usage.successful_ops_ia);
     formatter->close_section(); // entry
   }
   formatter->close_section(); // categories
@@ -128,6 +130,8 @@ int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
       formatter->dump_int("bytes_received_ia", total_usage.bytes_received_ia);
       formatter->dump_int("ops", total_usage.ops);
       formatter->dump_int("successful_ops", total_usage.successful_ops);
+      formatter->dump_int("ops_ia", total_usage.ops_ia);
+      formatter->dump_int("successful_ops_ia", total_usage.successful_ops_ia);
       formatter->close_section(); // total
 
       formatter->close_section(); // user

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -22,6 +22,8 @@ static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log
     formatter->dump_string("category", uiter->first);
     formatter->dump_int("bytes_sent", usage.bytes_sent);
     formatter->dump_int("bytes_received", usage.bytes_received);
+    formatter->dump_int("bytes_sent_ia", usage.bytes_sent_ia);
+    formatter->dump_int("bytes_received_ia", usage.bytes_received_ia);
     formatter->dump_int("ops", usage.ops);
     formatter->dump_int("successful_ops", usage.successful_ops);
     formatter->close_section(); // entry
@@ -122,6 +124,8 @@ int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
       formatter->open_object_section("total");
       formatter->dump_int("bytes_sent", total_usage.bytes_sent);
       formatter->dump_int("bytes_received", total_usage.bytes_received);
+      formatter->dump_int("bytes_sent_ia", total_usage.bytes_sent_ia);
+      formatter->dump_int("bytes_received_ia", total_usage.bytes_received_ia);
       formatter->dump_int("ops", total_usage.ops);
       formatter->dump_int("successful_ops", total_usage.successful_ops);
       formatter->close_section(); // total


### PR DESCRIPTION
step to setup:
```
#create realm
./bin/radosgw-admin realm  create --rgw-realm=default
#modify zonegroup use realm created 
./bin/radosgw-admin zonegroup modify --rgw-zonegroup=default  --rgw-realm=default  --master
#modify zone use realm created
./bin/radosgw-admin zone  modify  --rgw-zone=default --rgw-zonegroup=default  --rgw-realm=default  --master
#create pool for rgw obj tail (STANDARD_IA storage class)
./bin/ceph osd pool create default.rgw.buckets.data-ia 8 8
#modify STANDARD storage class placement 
./bin/radosgw-admin zone placement modify --rgw-zone=default --placement-id=default-placement  --index-pool default.rgw.buckets.index  --data-pool default.rgw.buckets.data  --data-extra-pool=default.rgw.buckets.non-ec  --tail-data-pool=default.rgw.buckets.data --placement-storage-class=STANDARD
#add STANDARD_IA storage class placement 
./bin/radosgw-admin zone placement add --rgw-zone=default --placement-id=default-placement-ia  --index-pool default.rgw.buckets.index  --data-pool default.rgw.buckets.data  --data-extra-pool=default.rgw.buckets.non-ec  --tail-data-pool=default.rgw.buckets.data-ia --placement-storage-class=STANDARD_IA
#add to zonegroup
./bin/radosgw-admin zonegroup placement add --placement-id=default-placement --placement-storage-class=STANDARD --rgw-zonegroup=default
#add to zonegroup 
./bin/radosgw-admin zonegroup placement add --placement-id=default-placement-ia --placement-storage-class=STANDARD_IA --rgw-zonegroup=default
#update period
./bin/radosgw-admin period update --commit

add

rgw_realm = default
rgw_zonegroup = default
rgw_zone = default

to ceph.conf  and restart radosgw

```

upload with STANDARD_IA storage class
```
s3cmd put 5M_random  s3://test1/m1  --storage-class=STANDARD_IA  --multipart-chunk-size-mb=5
```
upload with STANDARD storage class
```
s3cmd put 6M_random  s3://test1/6M_ST  --storage-class=STANDARD  --multipart-chunk-size-mb=5
```

head obj
```
< HEAD /test1/m1 HTTP/1.1
< Host: 127.0.0.1:80
< Connection: keep-alive
< Accept-Encoding: gzip, deflate
< Accept: */*
< User-Agent: python-requests/2.18.4
< date: Wed, 20 Jun 2018 00:43:35 GMT
< Authorization: AWS yly:REaZAJiyz4SJxodtsJJKOB4Iom4=
<

> HTTP/1.1 200 OK
> Content-Length: 5242880
> Accept-Ranges: bytes
> Last-Modified: Tue, 19 Jun 2018 11:12:01 GMT
> ETag: "81485c0e873d222199469076b60f30e9-1"
> x-amz-storage-class: STANDARD_IA
> x-amz-request-id: tx000000000000000000004-005b29a337-51917-default
> Content-Type: binary/octet-stream
> Date: Wed, 20 Jun 2018 00:43:35 GMT
> Connection: Keep-Alive
>
```
list bucket
```
< GET /test1 HTTP/1.1
< Host: 127.0.0.1:80
< Connection: keep-alive
< Accept-Encoding: gzip, deflate
< Accept: */*
< User-Agent: python-requests/2.18.4
< date: Wed, 20 Jun 2018 00:44:07 GMT
< Authorization: AWS yly:036rWlrx0+umIExkfPkZTSp0sMk=
<

> HTTP/1.1 200 OK
> x-amz-request-id: tx000000000000000000005-005b29a357-51917-default
> Content-Type: application/xml
> Content-Length: 493
> Date: Wed, 20 Jun 2018 00:44:07 GMT
> Connection: Keep-Alive
>
<?xml version="1.0" encoding="UTF-8"?>
<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
  <Name>test1</Name>
  <Prefix/>
  <Marker/>
  <MaxKeys>1000</MaxKeys>
  <IsTruncated>false</IsTruncated>
  <Contents>
    <Key>6M_ST</Key>
    <LastModified>2018-06-20T00:45:41.779Z</LastModified>
    <ETag>"b85b671783f71782e00fa82f81a87fa9-2"</ETag>
    <Size>6291456</Size>
    <StorageClass>STANDARD</StorageClass>
    <Owner>
      <ID>yly</ID>
      <DisplayName>yly</DisplayName>
    </Owner>
  </Contents>
  <Contents>
    <Key>m1</Key>
    <LastModified>2018-06-19T11:12:01.432Z</LastModified>
    <ETag>"81485c0e873d222199469076b60f30e9-1"</ETag>
    <Size>5242880</Size>
    <StorageClass>STANDARD_IA</StorageClass>
    <Owner>
      <ID>yly</ID>
      <DisplayName>yly</DisplayName>
    </Owner>
  </Contents>
</ListBucketResult>

```
and ceph df

```
GLOBAL:
    SIZE       AVAIL      RAW USED     %RAW USED
    80 GiB     50 GiB       29 GiB         36.89
POOLS:
    NAME                            ID     USED        %USED     MAX AVAIL     OBJECTS
    .rgw.root                       9      6.6 KiB         0        50 GiB          18
    default.rgw.control             10         0 B         0        50 GiB           8
    default.rgw.meta                11     3.1 KiB         0        50 GiB          21
    default.rgw.log                 12        63 B         0        50 GiB         179
    default.rgw.buckets.data-ia     13       5 MiB         0        50 GiB           2
    default.rgw.buckets.index       14         0 B         0        50 GiB           3
    default.rgw.buckets.data        15       6 MiB      0.01        50 GiB           5
    data                            16         0 B         0        50 GiB           0
    default.rgw.buckets.non-ec      21         0 B         0        50 GiB           0

```

5 MiB for m1 obj (STANDARD_IA storage)
6 MiB for  6M_ST obj (STANDARD storage)

