### PR TITLE
rgw: fix meta and data notify thread miss stop cr manager

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3141,6 +3141,9 @@ class RGWMetaNotifier : public RGWRadosThread {
   uint64_t interval_msec() override {
     return cct->_conf->rgw_md_notify_interval_msec;
   }
+  void stop_process() override {
+    notify_mgr.stop();
+  }
 public:
   RGWMetaNotifier(RGWRados *_store, RGWMetadataLog* log)
     : RGWRadosThread(_store, "meta-notifier"), notify_mgr(_store), log(log) {}
@@ -3172,6 +3175,9 @@ class RGWDataNotifier : public RGWRadosThread {
 
   uint64_t interval_msec() override {
     return cct->_conf->get_val<int64_t>("rgw_data_notify_interval_msec");
+  }
+  void stop_process() override {
+    notify_mgr.stop();
   }
 public:
   RGWDataNotifier(RGWRados *_store) : RGWRadosThread(_store, "data-notifier"), notify_mgr(_store) {}


### PR DESCRIPTION
rgw restrat or reload will stuck in RGWCompletionManager::get_next()

fixes: http://tracker.ceph.com/issues/24589

Signed-off-by: Tianshan Qu <tianshan@xsky.com>