### PR TITLE
cmake: add "add_npm_command()" command

### DIFF
--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -7,6 +7,25 @@ add_custom_target(mgr-dashboard-test-venv
   COMMENT "dashboard tests virtualenv is being created")
 add_dependencies(tests mgr-dashboard-test-venv)
 
+include(CMakeParseArguments)
+function(add_npm_command)
+  set(options NODEENV)
+  set(single_kw OUTPUT COMMENT WORKING_DIRECTORY)
+  set(multi_kw COMMAND DEPENDS)
+  cmake_parse_arguments(NC "${options}" "${single_kw}" "${multi_kw}" ${ARGN})
+  string(REPLACE ";" " " command "${NC_COMMAND}")
+  if(NC_NODEENV)
+    string(REGEX REPLACE "^(npm .*)$" ". ${mgr-dashboard-nodeenv}/bin/activate && \\1 && deactivate" command ${command})
+  endif()
+  string(REPLACE " " ";" command "${command}")
+  add_custom_command(
+    OUTPUT "${NC_OUTPUT}"
+    COMMAND ${command}
+    DEPENDS ${NC_DEPENDS}
+    WORKING_DIRECTORY "${NC_WORKING_DIRECTORY}"
+    COMMENT ${NC_COMMENT})
+endfunction(add_npm_command)
+
 if(WITH_MGR_DASHBOARD_FRONTEND AND NOT CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64|arm|ARM")
 
 set(mgr-dashboard-nodeenv ${CMAKE_CURRENT_BINARY_DIR}/node-env)
@@ -19,18 +38,18 @@ add_custom_command(
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
   COMMENT "dashboard nodeenv is being installed"
 )
-
 add_custom_target(mgr-dashboard-nodeenv
   DEPENDS ${mgr-dashboard-nodeenv}/bin/npm
   WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
-add_custom_command(
+add_npm_command(
   OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/node_modules"
-  COMMAND . ${mgr-dashboard-nodeenv}/bin/activate && npm install && deactivate
+  COMMAND npm install
   DEPENDS frontend/package.json
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
   COMMENT "dashboard frontend dependencies are being installed"
+  NODEENV
 )
 
 add_custom_target(mgr-dashboard-frontend-deps
@@ -62,12 +81,13 @@ else()
   set(npm_command npm run build)
 endif()
 
-add_custom_command(
+add_npm_command(
   OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/dist"
-  COMMAND . ${mgr-dashboard-nodeenv}/bin/activate && ${npm_command} && deactivate
+  COMMAND ${npm_command}
   DEPENDS ${frontend_src} frontend/node_modules
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
   COMMENT "dashboard frontend is being created"
+  NODEENV
 )
 add_custom_target(mgr-dashboard-frontend-build
   ALL


### PR DESCRIPTION
so we can use the npm installed otherwhere to preparing the node
asserts in an easier way.

Signed-off-by: Kefu Chai <kchai@redhat.com>