### PR TITLE
rgw: fix throttle_data size not correct

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1862,14 +1862,14 @@ static inline int put_data_and_throttle(RGWPutObjDataProcessor *processor,
     void *handle = nullptr;
     rgw_raw_obj obj;
 
-    uint64_t size = data.length();
-
     int ret = processor->handle_data(data, ofs, &handle, &obj, &again);
     if (ret < 0)
       return ret;
+
+    int write_size = ret; // get processor actual write size
     if (handle != nullptr)
     {
-      ret = processor->throttle_data(handle, obj, size, need_to_wait);
+      ret = processor->throttle_data(handle, obj, write_size, need_to_wait);
       if (ret < 0)
         return ret;
     }


### PR DESCRIPTION
If handle_data get not enough for one write, we will put in pending_data_bl,
so the throttle_data will only throttle the last bl. This will affect put
and data sync, big object's throttle will useless.

make RGWPutObjProcessor_Atomic::handle_data return the actual write_size,
throttle_data will get the return size to throttle.

Fixes: http://tracker.ceph.com/issues/24594

Signed-off-by: Tianshan Qu <tianshan@xsky.com>