### PR TITLE
luminous: lvm: when osd creation fails log the exception

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/create.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/create.py
@@ -31,7 +31,7 @@ class Create(object):
             # activate, which would never need to be rolled back.
             Activate([]).activate(args)
         except Exception:
-            logger.error('lvm activate was unable to complete, while creating the OSD')
+            logger.exception('lvm activate was unable to complete, while creating the OSD')
             logger.info('will rollback OSD ID creation')
             rollback_osd(args, osd_id)
             raise

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -215,7 +215,7 @@ class Prepare(object):
         try:
             self.prepare(args)
         except Exception:
-            logger.error('lvm prepare was unable to complete')
+            logger.exception('lvm prepare was unable to complete')
             logger.info('will rollback OSD ID creation')
             rollback_osd(args, self.osd_id)
             raise


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/24456

Signed-off-by: Andrew Schoen <aschoen@redhat.com>
(cherry picked from commit d622dadef09a53d24c6a7b9119051594f8da1cae)

Backport of #22627