### PR TITLE
[DNM] rgw: use rgw_swift_need_stats to mean "need real stats"

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3859,6 +3859,14 @@ AWSGeneralAbstractor::get_auth_data_v4(const req_state* const s,
    * aws4_auth_needs_complete and aws4_auth_streaming_mode are set to false
    * by default. We don't need to change that. */
   if (is_v4_payload_unsigned(exp_payload_hash) || is_v4_payload_empty(s)) {
+    if (s->cct->_conf->subsys.should_gather<ceph_subsys_rgw, 17>()) {
+      ldout(s->cct, 17)
+	<< " payload_unsigned="
+	<< std::to_string(is_v4_payload_unsigned(exp_payload_hash))
+	<< " payload_empty="
+	<< std::to_string(is_v4_payload_empty(s))
+	<< dendl;
+    }
     return {
       access_key_id,
       client_signature,

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -36,7 +36,8 @@ public:
 };
 
 class RGWListBuckets_ObjStore_SWIFT : public RGWListBuckets_ObjStore {
-  bool need_stats;
+  bool need_stats; // fetch bucket stats, override via rgw_swift_needs_stats
+  bool wants_stats; // api request expects stats values
   bool wants_reversed;
   std::string prefix;
   std::vector<RGWUserBuckets> reverse_buffer;
@@ -48,6 +49,7 @@ class RGWListBuckets_ObjStore_SWIFT : public RGWListBuckets_ObjStore {
 public:
   RGWListBuckets_ObjStore_SWIFT()
     : need_stats(true),
+      wants_stats(false),
       wants_reversed(false) {
   }
   ~RGWListBuckets_ObjStore_SWIFT() override {}


### PR DESCRIPTION
When stats requested but rgw_swift_need_stats has been overridden
to be false, then send 0 values for the ListBuckets stats.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>