### PR TITLE
qa: krbd_exclusive_option.sh: bump lock_timeout to 60 seconds

### DIFF
--- a/qa/workunits/rbd/krbd_exclusive_option.sh
+++ b/qa/workunits/rbd/krbd_exclusive_option.sh
@@ -135,7 +135,7 @@ assert_unlocked
 
 DEV=$(sudo rbd map -o exclusive $IMAGE_NAME)
 assert_locked $DEV
-OTHER_DEV=$(sudo rbd map -o noshare,lock_timeout=30 $IMAGE_NAME)
+OTHER_DEV=$(sudo rbd map -o noshare,lock_timeout=60 $IMAGE_NAME)
 dd if=/dev/urandom of=$OTHER_DEV bs=4k count=10 oflag=direct &
 PID=$!
 sleep 20


### PR DESCRIPTION
Avoid sporadic failures in combination with msgr-failures/many.yaml,
where assert_locked() might take over 10 seconds.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>