### PR TITLE
mimic: osd: fix getting osd maps on initial osd startup

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7358,7 +7358,11 @@ void OSD::handle_osd_map(MOSDMap *m)
   OSDMapRef lastmap;
   for (auto& i : added_maps) {
     if (!lastmap) {
-      lastmap = get_map(i.first - 1);
+      if (!(lastmap = service.try_get_map(i.first - 1))) {
+        dout(10) << __func__ << " can't get previous map " << i.first - 1
+                 << " probably first start of this osd" << dendl;
+        continue;
+      }
     }
     assert(lastmap->get_epoch() + 1 == i.second->get_epoch());
     for (auto& j : lastmap->get_pools()) {


### PR DESCRIPTION
Backport issue: https://tracker.ceph.com/issues/24599

---

Commit 89d0c357964ff28b83ac541c4d946f712a7bee47 introduced a check for
deleted pools that relies on getting an older osd map that might not be
available in some situations on OSDs starting up for the very first
time.

fixes https://tracker.ceph.com/issues/24423

Signed-off-by: Paul Emmerich <paul.emmerich@croit.io>
(cherry picked from commit 02180f644094d520d5763afa0e76403591a90b9b)