### PR TITLE
qa/suites: Add supported-random-distro$ links.

### DIFF
--- a/qa/suites/fs/32bits/supported-random-distros$
+++ b/qa/suites/fs/32bits/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/fs/basic_functional/supported-random-distros$
+++ b/qa/suites/fs/basic_functional/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/fs/basic_workload/supported-random-distros$
+++ b/qa/suites/fs/basic_workload/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/fs/multifs/supported-random-distros$
+++ b/qa/suites/fs/multifs/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/fs/permission/supported-random-distros$
+++ b/qa/suites/fs/permission/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/fs/snaps/supported-random-distros$
+++ b/qa/suites/fs/snaps/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/fs/thrash/supported-random-distros$
+++ b/qa/suites/fs/thrash/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/fs/traceless/supported-random-distros$
+++ b/qa/suites/fs/traceless/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/fs/upgrade/supported-random-distros$
+++ b/qa/suites/fs/upgrade/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/kcephfs/cephfs/supported-random-distros$
+++ b/qa/suites/kcephfs/cephfs/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/kcephfs/mixed-clients/supported-random-distros$
+++ b/qa/suites/kcephfs/mixed-clients/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/kcephfs/recovery/supported-random-distros$
+++ b/qa/suites/kcephfs/recovery/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/kcephfs/thrash/supported-random-distros$
+++ b/qa/suites/kcephfs/thrash/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/multimds/basic/supported-random-distros$
+++ b/qa/suites/multimds/basic/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/

--- a/qa/suites/multimds/thrash/supported-random-distros$
+++ b/qa/suites/multimds/thrash/supported-random-distros$
@@ -1,0 +1,1 @@
+../../../distros/supported-random-distro$/


### PR DESCRIPTION
Add supported-random-distro$ links for fs, kcephfs, and multimds

@wusui @batrick Maybe this will be faster ?  
Please close https://github.com/ceph/ceph/pull/22532 if this is merged.

Note: needs to be backported to `mimic`

Fixes: http://tracker.ceph.com/issues/24138
Signed off by: Warren Usui <wusui@redhat.com>