### PR TITLE
qa/tests: changed distro symlink to point to new way using supported OSes

### DIFF
--- a/qa/suites/upgrade/luminous-x/parallel/distros
+++ b/qa/suites/upgrade/luminous-x/parallel/distros
@@ -1,1 +1,0 @@
-../../../../distros/supported/

--- a/qa/suites/upgrade/luminous-x/parallel/supported-all-distro
+++ b/qa/suites/upgrade/luminous-x/parallel/supported-all-distro
@@ -1,0 +1,1 @@
+../../../../distros/supported-all-distro/

--- a/qa/suites/upgrade/luminous-x/stress-split-erasure-code/distros
+++ b/qa/suites/upgrade/luminous-x/stress-split-erasure-code/distros
@@ -1,1 +1,0 @@
-../../../../distros/supported/

--- a/qa/suites/upgrade/luminous-x/stress-split-erasure-code/supported-all-distro
+++ b/qa/suites/upgrade/luminous-x/stress-split-erasure-code/supported-all-distro
@@ -1,0 +1,1 @@
+../../../../distros/supported-all-distro/

--- a/qa/suites/upgrade/luminous-x/stress-split/distros
+++ b/qa/suites/upgrade/luminous-x/stress-split/distros
@@ -1,1 +1,0 @@
-../../../../distros/supported/

--- a/qa/suites/upgrade/luminous-x/stress-split/supported-all-distro
+++ b/qa/suites/upgrade/luminous-x/stress-split/supported-all-distro
@@ -1,0 +1,1 @@
+../../../../distros/supported-all-distro/


### PR DESCRIPTION


backport of https://github.com/ceph/ceph/pull/22536

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>
(cherry picked from commit 37ac8df5559a6084091670e6a1f479ab9332c24b)
Signed-off-by: Yuri Weinstein <yweinste@redhat.com>