### PR TITLE
luminous: mon/HealthMonitor: do not send MMonHealthChecks to pre-luminous mon

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -298,9 +298,12 @@ bool HealthMonitor::check_member_health()
     quorum_checks[mon->rank] = next;
     changed = true;
   } else {
-    // tell the leader
-    mon->messenger->send_message(new MMonHealthChecks(next),
-                                 mon->monmap->get_inst(mon->get_leader()));
+    // tell the leader, but only if the quorum is luminous
+    if (mon->quorum_mon_features.contains_all(
+	  ceph::features::mon::FEATURE_LUMINOUS)) {
+      mon->messenger->send_message(new MMonHealthChecks(next),
+				   mon->monmap->get_inst(mon->get_leader()));
+    }
   }
 
   return changed;


### PR DESCRIPTION
During upgrade, we start doing the new health check code, but if we are
not the leader we can't send the new MMonHealthChecks message to the leader
or else it will crash.

Fixes: http://tracker.ceph.com/issues/24481
Signed-off-by: Sage Weil <sage@redhat.com>