### PR TITLE
doc/dashboard: fix formatting on Grafana instructions

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -238,7 +238,7 @@ Enabling the Embedding of Grafana Dashboards
 Grafana and Prometheus are likely going to be bundled and installed by some
 orchestration tools along Ceph in the near future, but currently, you will have
 to install and configure both manually. After you have installed Prometheus and
-Grafana on your preferred hosts, proceed with the following steps::
+Grafana on your preferred hosts, proceed with the following steps:
 
  1. Enable the Ceph Exporter which comes as Ceph Manager module by running::
 


### PR DESCRIPTION
The whole list was in a code block, instead of just the snippets.

Signed-off-by: John Spray <john.spray@redhat.com>