### PR TITLE
osd/PG: restrict async_recovery_targets to up osds

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1514,6 +1514,12 @@ void PG::choose_async_recovery_ec(const map<pg_shard_t, pg_info_t> &all_info,
     // do not include strays
     if (stray_set.find(shard_i) != stray_set.end())
       continue;
+    // Do not include an osd that is not up, since choosing it as
+    // an async_recovery_target will move it out of the acting set.
+    // This results in it being identified as a stray during peering,
+    // because it is no longer in the up or acting set.
+    if (!is_up(shard_i))
+      continue;
     auto shard_info = all_info.find(shard_i)->second;
     // for ec pools we rollback all entries past the authoritative
     // last_update *before* activation. This is relatively inexpensive
@@ -1555,6 +1561,12 @@ void PG::choose_async_recovery_replicated(const map<pg_shard_t, pg_info_t> &all_
     pg_shard_t shard_i(osd_num, shard_id_t::NO_SHARD);
     // do not include strays
     if (stray_set.find(shard_i) != stray_set.end())
+      continue;
+    // Do not include an osd that is not up, since choosing it as
+    // an async_recovery_target will move it out of the acting set.
+    // This results in it being identified as a stray during peering,
+    // because it is no longer in the up or acting set.
+    if (!is_up(shard_i))
       continue;
     auto shard_info = all_info.find(shard_i)->second;
     // use the approximate magnitude of the difference in length of


### PR DESCRIPTION
When an osd that is part of the acting set and not the up set, gets chosen
as an async_recovery_target, it gets removed from the acting set. Since this
osd is no longer in the up or acting set, it is classified as a stray in
the next peering cycle. This results in choose_acting() looping between two
proposed acting sets.

To avoid this, we will only choose up osds as async_recovery_targets.

Fixes: https://tracker.ceph.com/issues/24487
Signed-off-by: Neha Ojha <nojha@redhat.com>