### PR TITLE
mgr/dashboard: Add support for URI encode

### DIFF
--- a/qa/tasks/mgr/dashboard/test_rbd.py
+++ b/qa/tasks/mgr/dashboard/test_rbd.py
@@ -580,3 +580,22 @@ class RbdTest(DashboardTestCase):
         self.assertEqual(default_features, ['deep-flatten', 'exclusive-lock',
                                              'fast-diff', 'layering',
                                              'object-map'])
+
+    def test_image_with_special_name(self):
+        rbd_name = 'test/rbd'
+        rbd_name_encoded = 'test%2Frbd'
+
+        self.create_image('rbd', rbd_name, 10240)
+        self.assertStatus(201)
+
+        img = self._get("/api/block/image/rbd/" + rbd_name_encoded)
+        self.assertStatus(200)
+
+        self._validate_image(img, name=rbd_name, size=10240,
+                             num_objs=1, obj_size=4194304,
+                             features_name=['deep-flatten',
+                                            'exclusive-lock',
+                                            'fast-diff', 'layering',
+                                            'object-map'])
+
+        self.remove_image('rbd', rbd_name_encoded)

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -9,9 +9,15 @@ import json
 import os
 import pkgutil
 import sys
-
-import cherrypy
 from six import add_metaclass
+
+if sys.version_info >= (3, 0):
+    from urllib.parse import unquote  # pylint: disable=no-name-in-module,import-error
+else:
+    from urllib import unquote  # pylint: disable=no-name-in-module
+
+# pylint: disable=wrong-import-position
+import cherrypy
 
 from .. import logger
 from ..security import Scope, Permission
@@ -521,6 +527,12 @@ class BaseController(object):
     def _request_wrapper(func, method, json_response):
         @wraps(func)
         def inner(*args, **kwargs):
+            for key, value in kwargs.items():
+                # pylint: disable=undefined-variable
+                if (sys.version_info < (3, 0) and isinstance(value, unicode)) \
+                        or isinstance(value, str):
+                    kwargs[key] = unquote(value)
+
             if method in ['GET', 'DELETE']:
                 ret = func(*args, **kwargs)
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -206,9 +206,9 @@ export class RbdFormComponent implements OnInit {
       this.mode === this.rbdFormMode.copying
     ) {
       this.route.params.subscribe((params: { pool: string; name: string; snap: string }) => {
-        const poolName = params.pool;
-        const rbdName = params.name;
-        this.snapName = params.snap;
+        const poolName = decodeURIComponent(params.pool);
+        const rbdName = decodeURIComponent(params.name);
+        this.snapName = decodeURIComponent(params.snap);
         this.rbdService.get(poolName, rbdName).subscribe((resp: RbdFormResponseModel) => {
           this.setResponse(resp, this.snapName);
         });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -26,7 +26,6 @@ import { RbdFormResponseModel } from './rbd-form-response.model';
   styleUrls: ['./rbd-form.component.scss']
 })
 export class RbdFormComponent implements OnInit {
-
   poolPermission: Permission;
   rbdForm: FormGroup;
   featuresFormGroups: FormGroup;
@@ -91,7 +90,7 @@ export class RbdFormComponent implements OnInit {
         allowEnable: false,
         allowDisable: true
       },
-      'layering': {
+      layering: {
         desc: 'Layering',
         requires: null,
         allowEnable: false,
@@ -109,7 +108,7 @@ export class RbdFormComponent implements OnInit {
         allowEnable: true,
         allowDisable: true
       },
-      'journaling': {
+      journaling: {
         desc: 'Journaling (requires exclusive-lock)',
         requires: 'exclusive-lock',
         allowEnable: true,
@@ -134,41 +133,40 @@ export class RbdFormComponent implements OnInit {
     this.deepFlattenFormControl = new FormControl(false);
     this.layeringFormControl = new FormControl(false);
     this.exclusiveLockFormControl = new FormControl(false);
-    this.objectMapFormControl = new FormControl({value: false, disabled: true});
-    this.journalingFormControl = new FormControl({value: false, disabled: true});
-    this.fastDiffFormControl = new FormControl({value: false, disabled: true});
+    this.objectMapFormControl = new FormControl({ value: false, disabled: true });
+    this.journalingFormControl = new FormControl({ value: false, disabled: true });
+    this.fastDiffFormControl = new FormControl({ value: false, disabled: true });
     this.featuresFormGroups = new FormGroup({
       'deep-flatten': this.deepFlattenFormControl,
-      'layering': this.layeringFormControl,
+      layering: this.layeringFormControl,
       'exclusive-lock': this.exclusiveLockFormControl,
       'object-map': this.objectMapFormControl,
-      'journaling': this.journalingFormControl,
-      'fast-diff': this.fastDiffFormControl,
+      journaling: this.journalingFormControl,
+      'fast-diff': this.fastDiffFormControl
     });
-    this.rbdForm = new FormGroup({
-      parent: new FormControl(''),
-      name: new FormControl('', {
-        validators: [
-          Validators.required
-        ]
-      }),
-      pool: new FormControl(null, {
-        validators: [
-          Validators.required
-        ]
-      }),
-      useDataPool: new FormControl(false),
-      dataPool: new FormControl(null),
-      size: new FormControl(null, {
-        updateOn: 'blur'
-      }),
-      obj_size: new FormControl(this.defaultObjectSize),
-      features: this.featuresFormGroups,
-      stripingUnit: new FormControl(null),
-      stripingCount: new FormControl(null, {
-        updateOn: 'blur'
-      })
-    }, this.validateRbdForm(this.formatter));
+    this.rbdForm = new FormGroup(
+      {
+        parent: new FormControl(''),
+        name: new FormControl('', {
+          validators: [Validators.required]
+        }),
+        pool: new FormControl(null, {
+          validators: [Validators.required]
+        }),
+        useDataPool: new FormControl(false),
+        dataPool: new FormControl(null),
+        size: new FormControl(null, {
+          updateOn: 'blur'
+        }),
+        obj_size: new FormControl(this.defaultObjectSize),
+        features: this.featuresFormGroups,
+        stripingUnit: new FormControl(null),
+        stripingCount: new FormControl(null, {
+          updateOn: 'blur'
+        })
+      },
+      this.validateRbdForm(this.formatter)
+    );
   }
 
   disableForEdit() {
@@ -202,29 +200,28 @@ export class RbdFormComponent implements OnInit {
       this.mode = this.rbdFormMode.copying;
       this.disableForCopy();
     }
-    if (this.mode === this.rbdFormMode.editing ||
-        this.mode === this.rbdFormMode.cloning ||
-        this.mode === this.rbdFormMode.copying) {
-      this.route.params.subscribe(
-        (params: { pool: string, name: string, snap: string }) => {
-          const poolName = params.pool;
-          const rbdName = params.name;
-          this.snapName = params.snap;
-          this.rbdService.get(poolName, rbdName)
-            .subscribe((resp: RbdFormResponseModel) => {
-              this.setResponse(resp, this.snapName);
-            });
-        }
-      );
-    } else {
-      this.rbdService.defaultFeatures()
-        .subscribe((defaultFeatures: Array<string>) => {
-          this.setFeatures(defaultFeatures);
+    if (
+      this.mode === this.rbdFormMode.editing ||
+      this.mode === this.rbdFormMode.cloning ||
+      this.mode === this.rbdFormMode.copying
+    ) {
+      this.route.params.subscribe((params: { pool: string; name: string; snap: string }) => {
+        const poolName = params.pool;
+        const rbdName = params.name;
+        this.snapName = params.snap;
+        this.rbdService.get(poolName, rbdName).subscribe((resp: RbdFormResponseModel) => {
+          this.setResponse(resp, this.snapName);
         });
+      });
+    } else {
+      this.rbdService.defaultFeatures().subscribe((defaultFeatures: Array<string>) => {
+        this.setFeatures(defaultFeatures);
+      });
     }
     if (this.mode !== this.rbdFormMode.editing && this.poolPermission.read) {
-      this.poolService.list(['pool_name', 'type', 'flags_names', 'application_metadata']).then(
-        resp => {
+      this.poolService
+        .list(['pool_name', 'type', 'flags_names', 'application_metadata'])
+        .then((resp) => {
           const pools = [];
           const dataPools = [];
           for (const pool of resp) {
@@ -232,8 +229,10 @@ export class RbdFormComponent implements OnInit {
               if (pool.type === 'replicated') {
                 pools.push(pool);
                 dataPools.push(pool);
-              } else if (pool.type === 'erasure' &&
-                pool.flags_names.indexOf('ec_overwrites') !== -1) {
+              } else if (
+                pool.type === 'erasure' &&
+                pool.flags_names.indexOf('ec_overwrites') !== -1
+              ) {
                 dataPools.push(pool);
               }
             }
@@ -247,8 +246,7 @@ export class RbdFormComponent implements OnInit {
             this.rbdForm.get('pool').setValue(poolName);
             this.onPoolChange(poolName);
           }
-        }
-      );
+        });
     }
     this.deepFlattenFormControl.valueChanges.subscribe((value) => {
       this.watchDataFeatures('deep-flatten', value);
@@ -280,7 +278,7 @@ export class RbdFormComponent implements OnInit {
     this.dataPools = newDataPools;
   }
 
-  onUseDataPoolChange () {
+  onUseDataPoolChange() {
     if (!this.rbdForm.get('useDataPool').value) {
       this.rbdForm.get('dataPool').setValue(null);
       this.onDataPoolChange(null);
@@ -304,23 +302,24 @@ export class RbdFormComponent implements OnInit {
       const dataPoolControl = formGroup.get('dataPool');
       let dataPoolControlErrors = null;
       if (useDataPoolControl.value && dataPoolControl.value == null) {
-        dataPoolControlErrors = {'required': true};
+        dataPoolControlErrors = { required: true };
       }
       dataPoolControl.setErrors(dataPoolControlErrors);
       // Size
       const sizeControl = formGroup.get('size');
       const objectSizeControl = formGroup.get('obj_size');
       const objectSizeInBytes = formatter.toBytes(
-        objectSizeControl.value != null ? objectSizeControl.value : this.defaultObjectSize);
+        objectSizeControl.value != null ? objectSizeControl.value : this.defaultObjectSize
+      );
       const stripingCountControl = formGroup.get('stripingCount');
       const stripingCount = stripingCountControl.value != null ? stripingCountControl.value : 1;
       let sizeControlErrors = null;
       if (sizeControl.value === null) {
-        sizeControlErrors = {'required': true};
+        sizeControlErrors = { required: true };
       } else {
         const sizeInBytes = formatter.toBytes(sizeControl.value);
         if (stripingCount * objectSizeInBytes > sizeInBytes) {
-          sizeControlErrors = {'invalidSizeObject': true};
+          sizeControlErrors = { invalidSizeObject: true };
         }
       }
       sizeControl.setErrors(sizeControlErrors);
@@ -328,20 +327,20 @@ export class RbdFormComponent implements OnInit {
       const stripingUnitControl = formGroup.get('stripingUnit');
       let stripingUnitControlErrors = null;
       if (stripingUnitControl.value === null && stripingCountControl.value !== null) {
-        stripingUnitControlErrors = {'required': true};
+        stripingUnitControlErrors = { required: true };
       } else if (stripingUnitControl.value !== null) {
         const stripingUnitInBytes = formatter.toBytes(stripingUnitControl.value);
         if (stripingUnitInBytes > objectSizeInBytes) {
-          stripingUnitControlErrors = {'invalidStripingUnit': true};
+          stripingUnitControlErrors = { invalidStripingUnit: true };
         }
       }
       stripingUnitControl.setErrors(stripingUnitControlErrors);
       // Striping Count
       let stripingCountControlErrors = null;
       if (stripingCountControl.value === null && stripingUnitControl.value !== null) {
-        stripingCountControlErrors = {'required': true};
+        stripingCountControlErrors = { required: true };
       } else if (stripingCount < 1) {
-        stripingCountControlErrors = {'min': true};
+        stripingCountControlErrors = { min: true };
       }
       stripingCountControl.setErrors(stripingCountControlErrors);
       return null;
@@ -361,10 +360,8 @@ export class RbdFormComponent implements OnInit {
         }
       }
       if (this.mode === this.rbdFormMode.editing && this.featuresFormGroups.get(feature).enabled) {
-
         if (this.response.features_name.indexOf(feature) !== -1 && !details.allowDisable) {
           this.featuresFormGroups.get(feature).disable();
-
         } else if (this.response.features_name.indexOf(feature) === -1 && !details.allowEnable) {
           this.featuresFormGroups.get(feature).disable();
         }
@@ -409,7 +406,8 @@ export class RbdFormComponent implements OnInit {
       }
     } else if (response.parent) {
       const parent = response.parent;
-      this.rbdForm.get('parent')
+      this.rbdForm
+        .get('parent')
         .setValue(`${parent.pool_name}/${parent.image_name}@${parent.snap_name}`);
     }
     if (this.mode === this.rbdFormMode.editing) {
@@ -423,8 +421,9 @@ export class RbdFormComponent implements OnInit {
     this.rbdForm.get('size').setValue(this.dimlessBinaryPipe.transform(response.size));
     this.rbdForm.get('obj_size').setValue(this.dimlessBinaryPipe.transform(response.obj_size));
     this.setFeatures(response.features_name);
-    this.rbdForm.get('stripingUnit').setValue(
-      this.dimlessBinaryPipe.transform(response.stripe_unit));
+    this.rbdForm
+      .get('stripingUnit')
+      .setValue(this.dimlessBinaryPipe.transform(response.stripe_unit));
     this.rbdForm.get('stripingCount').setValue(response.stripe_count);
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.html
@@ -32,8 +32,9 @@
               class="btn btn-sm btn-primary"
               *ngIf="permission.update && (!permission.create || permission.create && selection.hasSingleSelection)"
               [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}"
-              routerLink="/rbd/edit/{{ selection.first()?.pool_name }}/{{ selection.first()?.name }}">
-        <i class="fa fa-fw fa-pencil"></i><span i18n>Edit</span>
+              routerLink="/rbd/edit/{{ selection.first()?.pool_name | encodeUri }}/{{ selection.first()?.name | encodeUri }}">
+        <i class="fa fa-fw fa-pencil"></i>
+        <span i18n>Edit</span>
       </button>
       <button type="button"
               class="btn btn-sm btn-primary"
@@ -64,7 +65,7 @@
             *ngIf="permission.update"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
           <a class="dropdown-item"
-             routerLink="/rbd/edit/{{ selection.first()?.pool_name }}/{{ selection.first()?.name }}">
+             routerLink="/rbd/edit/{{ selection.first()?.pool_name | encodeUri }}/{{ selection.first()?.name | encodeUri }}">
             <i class="fa fa-fw fa-pencil"></i>
             <span i18n>Edit</span>
           </a>
@@ -73,7 +74,7 @@
             *ngIf="permission.create"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
           <a class="dropdown-item"
-             routerLink="/rbd/copy/{{ selection.first()?.pool_name }}/{{ selection.first()?.name }}">
+             routerLink="/rbd/copy/{{ selection.first()?.pool_name | encodeUri }}/{{ selection.first()?.name | encodeUri }}">
             <i class="fa fa-fw fa-copy"></i>
             <span i18n>Copy</span>
           </a>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.html
@@ -73,7 +73,7 @@
             *ngIf="permission.create"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
           <a class="dropdown-item"
-             routerLink="/rbd/clone/{{ poolName }}/{{ rbdName }}/{{ selection.first()?.name }}">
+             routerLink="/rbd/clone/{{ poolName | encodeUri }}/{{ rbdName | encodeUri }}/{{ selection.first()?.name | encodeUri }}">
             <i class="fa fa-fw fa-clone"></i>
             <span i18n>Clone</span>
           </a>
@@ -81,8 +81,10 @@
         <li role="menuitem"
             *ngIf="permission.create"
             [ngClass]="{'disabled': !selection.hasSingleSelection || selection.first().executing}">
-          <a class="dropdown-item" routerLink="/rbd/copy/{{ poolName }}/{{ rbdName }}/{{ selection.first()?.name }}">
-            <i class="fa fa-fw fa-copy"></i><span i18n>Copy</span>
+          <a class="dropdown-item"
+             routerLink="/rbd/copy/{{ poolName | encodeUri }}/{{ rbdName | encodeUri }}/{{ selection.first()?.name | encodeUri }}">
+            <i class="fa fa-fw fa-copy"></i>
+            <span i18n>Copy</span>
           </a>
         </li>
         <li role="menuitem"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -11,6 +11,7 @@ import { RbdService } from '../../../shared/api/rbd.service';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { DataTableModule } from '../../../shared/datatable/datatable.module';
 import { Permissions } from '../../../shared/models/permissions';
+import { PipesModule } from '../../../shared/pipes/pipes.module';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { ServicesModule } from '../../../shared/services/services.module';
@@ -40,7 +41,8 @@ describe('RbdSnapshotListComponent', () => {
       ServicesModule,
       ApiModule,
       HttpClientTestingModule,
-      RouterTestingModule
+      RouterTestingModule,
+      PipesModule
     ],
     providers: [{ provide: AuthStorageService, useValue: fakeAuthStorageService }]
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.ts
@@ -56,6 +56,7 @@ export class RgwBucketFormComponent implements OnInit {
         if (!params.hasOwnProperty('bucket')) {
           return;
         }
+        params.bucket = decodeURIComponent(params.bucket);
         this.loading = true;
         // Load the bucket data in 'edit' mode.
         this.editing = true;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
@@ -17,7 +17,8 @@
           identifier="bucket"
           (fetchData)="getBucketList()">
   <div class="table-actions">
-    <div class="btn-group" dropdown>
+    <div class="btn-group"
+         dropdown>
       <button type="button"
               class="btn btn-sm btn-primary"
               *ngIf="permission.create && (

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.html
@@ -34,7 +34,7 @@
               class="btn btn-sm btn-primary"
               [ngClass]="{'disabled': !selection.hasSelection}"
               *ngIf="permission.update && (!permission.create && !selection.hasMultiSelection || selection.hasSingleSelection)"
-              routerLink="/rgw/bucket/edit/{{ selection.first()?.bucket }}">
+              routerLink="/rgw/bucket/edit/{{ selection.first()?.bucket | encodeUri }}">
         <i class="fa fa-fw fa-pencil"></i>
         <ng-container i18n>Edit</ng-container>
       </button>
@@ -69,7 +69,7 @@
             *ngIf="permission.update"
             [ngClass]="{'disabled': !selection.hasSingleSelection}">
           <a class="dropdown-item"
-             routerLink="/rgw/bucket/edit/{{ selection.first()?.bucket }}"
+             routerLink="/rgw/bucket/edit/{{ selection.first()?.bucket | encodeUri }}"
              i18n>
             <i class="fa fa-fw fa-pencil"></i>
             Edit

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.ts
@@ -7,18 +7,19 @@ import { ApiModule } from './api.module';
   providedIn: ApiModule
 })
 export class PoolService {
+  constructor(private http: HttpClient) {}
 
-  constructor(private http: HttpClient) {
-  }
-
-  getList () {
+  getList() {
     return this.http.get('api/pool');
   }
 
   list(attrs = []) {
     const attrsStr = attrs.join(',');
-    return this.http.get(`api/pool?attrs=${attrsStr}`).toPromise().then((resp: any) => {
-      return resp;
-    });
+    return this.http
+      .get(`api/pool?attrs=${attrsStr}`)
+      .toPromise()
+      .then((resp: any) => {
+        return resp;
+      });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.ts
@@ -1,8 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
+import { cdEncode } from '../decorators/cd-encode';
 import { ApiModule } from './api.module';
 
+@cdEncode
 @Injectable({
   providedIn: ApiModule
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
@@ -126,4 +126,12 @@ describe('RbdService', () => {
     const req = httpTesting.expectOne('api/block/image/poolName/rbdName/snap/snapshotName');
     expect(req.request.method).toBe('DELETE');
   });
+
+  describe('Encode decorator', () => {
+    it('should encode the imageName', () => {
+      service.get('poolName', 'rbd/name').subscribe();
+      const req = httpTesting.expectOne('api/block/image/poolName/rbd%2Fname');
+      expect(req.request.method).toBe('GET');
+    });
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.ts
@@ -7,9 +7,7 @@ import { ApiModule } from './api.module';
   providedIn: ApiModule
 })
 export class RbdService {
-
-  constructor(private http: HttpClient) {
-  }
+  constructor(private http: HttpClient) {}
 
   create(rbd) {
     return this.http.post('api/block/image', rbd, { observe: 'response' });
@@ -32,13 +30,15 @@ export class RbdService {
   }
 
   copy(poolName, rbdName, rbd) {
-    return this.http.post(`api/block/image/${poolName}/${rbdName}/copy`, rbd,
-      { observe: 'response' });
+    return this.http.post(`api/block/image/${poolName}/${rbdName}/copy`, rbd, {
+      observe: 'response'
+    });
   }
 
   flatten(poolName, rbdName) {
-    return this.http.post(`api/block/image/${poolName}/${rbdName}/flatten`, null,
-      { observe: 'response' });
+    return this.http.post(`api/block/image/${poolName}/${rbdName}/flatten`, null, {
+      observe: 'response'
+    });
   }
 
   defaultFeatures() {
@@ -49,43 +49,48 @@ export class RbdService {
     const request = {
       snapshot_name: snapshotName
     };
-    return this.http.post(`api/block/image/${poolName}/${rbdName}/snap`, request,
-      { observe: 'response' });
+    return this.http.post(`api/block/image/${poolName}/${rbdName}/snap`, request, {
+      observe: 'response'
+    });
   }
 
   renameSnapshot(poolName, rbdName, snapshotName, newSnapshotName) {
     const request = {
       new_snap_name: newSnapshotName
     };
-    return this.http.put(
-      `api/block/image/${poolName}/${rbdName}/snap/${snapshotName}`, request,
-        { observe: 'response' });
+    return this.http.put(`api/block/image/${poolName}/${rbdName}/snap/${snapshotName}`, request, {
+      observe: 'response'
+    });
   }
 
   protectSnapshot(poolName, rbdName, snapshotName, isProtected) {
     const request = {
       is_protected: isProtected
     };
-    return this.http.put(
-      `api/block/image/${poolName}/${rbdName}/snap/${snapshotName}`, request,
-      { observe: 'response' });
+    return this.http.put(`api/block/image/${poolName}/${rbdName}/snap/${snapshotName}`, request, {
+      observe: 'response'
+    });
   }
 
   rollbackSnapshot(poolName, rbdName, snapshotName) {
     return this.http.post(
-      `api/block/image/${poolName}/${rbdName}/snap/${snapshotName}/rollback`, null,
-      { observe: 'response' });
+      `api/block/image/${poolName}/${rbdName}/snap/${snapshotName}/rollback`,
+      null,
+      { observe: 'response' }
+    );
   }
 
   cloneSnapshot(poolName, rbdName, snapshotName, request) {
     return this.http.post(
-      `api/block/image/${poolName}/${rbdName}/snap/${snapshotName}/clone`, request,
-      { observe: 'response' });
+      `api/block/image/${poolName}/${rbdName}/snap/${snapshotName}/clone`,
+      request,
+      { observe: 'response' }
+    );
   }
 
   deleteSnapshot(poolName, rbdName, snapshotName) {
-    return this.http.delete(
-      `api/block/image/${poolName}/${rbdName}/snap/${snapshotName}`,
-      { observe: 'response' });
+    return this.http.delete(`api/block/image/${poolName}/${rbdName}/snap/${snapshotName}`, {
+      observe: 'response'
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.ts
@@ -1,8 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
+import { cdEncode } from '../decorators/cd-encode';
 import { ApiModule } from './api.module';
 
+@cdEncode
 @Injectable({
   providedIn: ApiModule
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -57,7 +57,7 @@ export class RgwBucketService {
     let params = new HttpParams();
     params = params.append('bucket_id', bucketId);
     params = params.append('uid', uid);
-    return this.http.put(`${this.url}/${bucket}`, null, { params: params});
+    return this.http.put(`${this.url}/${bucket}`, null, { params: params });
   }
 
   delete(bucket: string, purgeObjects = true) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.ts
@@ -5,8 +5,10 @@ import * as _ from 'lodash';
 import { forkJoin as observableForkJoin, of as observableOf } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 
+import { cdEncode } from '../decorators/cd-encode';
 import { ApiModule } from './api.module';
 
+@cdEncode
 @Injectable({
   providedIn: ApiModule
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.ts
@@ -1,8 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
+import { cdEncode } from '../decorators/cd-encode';
 import { ApiModule } from './api.module';
 
+@cdEncode
 @Injectable({
   providedIn: ApiModule
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
@@ -5,8 +5,10 @@ import * as _ from 'lodash';
 import { forkJoin as observableForkJoin, of as observableOf } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 
+import { cdEncode } from '../decorators/cd-encode';
 import { ApiModule } from './api.module';
 
+@cdEncode
 @Injectable({
   providedIn: ApiModule
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/decorators/cd-encode.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/decorators/cd-encode.ts
@@ -1,0 +1,66 @@
+import * as _ from 'lodash';
+
+/**
+ * This decorator can be used in a class or method.
+ * It will encode all the string parameters of all the methods of a class
+ * or, if applied on a method, the specified method.
+ *
+ * @export
+ * @param {Function} [target=null]
+ * @returns {*}
+ */
+export function cdEncode(target: Function = null): any {
+  if (target) {
+    encodeClass(target);
+  } else {
+    return encodeMethod();
+  }
+}
+
+function encodeClass(target: Function) {
+  for (const propertyName of Object.keys(target.prototype)) {
+    const descriptor = Object.getOwnPropertyDescriptor(target.prototype, propertyName);
+    const isMethod = descriptor.value instanceof Function;
+    if (!isMethod) {
+      continue;
+    }
+
+    const originalMethod = descriptor.value;
+    descriptor.value = function(...args: any[]) {
+      args.forEach((arg, i, argsArray) => {
+        if (_.isString(arg)) {
+          argsArray[i] = encodeURIComponent(arg);
+        }
+      });
+
+      const result = originalMethod.apply(this, args);
+      return result;
+    };
+
+    Object.defineProperty(target.prototype, propertyName, descriptor);
+  }
+}
+
+function encodeMethod() {
+  return function(target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    if (descriptor === undefined) {
+      descriptor = Object.getOwnPropertyDescriptor(target, propertyKey);
+    }
+    const originalMethod = descriptor.value;
+
+    descriptor.value = function() {
+      const args = [];
+
+      for (let i = 0; i < arguments.length; i++) {
+        if (_.isString(arguments[i])) {
+          args[i] = encodeURIComponent(arguments[i]);
+        } else {
+          args[i] = arguments[i];
+        }
+      }
+
+      const result = originalMethod.apply(this, args);
+      return result;
+    };
+  };
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/encode-uri.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/encode-uri.pipe.spec.ts
@@ -1,0 +1,13 @@
+import { EncodeUriPipe } from './encode-uri.pipe';
+
+describe('EncodeUriPipe', () => {
+  it('create an instance', () => {
+    const pipe = new EncodeUriPipe();
+    expect(pipe).toBeTruthy();
+  });
+
+  it('should transforms the value', () => {
+    const pipe = new EncodeUriPipe();
+    expect(pipe.transform('rbd/name')).toBe('rbd%2Fname');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/encode-uri.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/encode-uri.pipe.ts
@@ -1,0 +1,10 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'encodeUri'
+})
+export class EncodeUriPipe implements PipeTransform {
+  transform(value: any): any {
+    return encodeURIComponent(value);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/pipes.module.ts
@@ -7,6 +7,7 @@ import { CephReleaseNamePipe } from './ceph-release-name.pipe';
 import { CephShortVersionPipe } from './ceph-short-version.pipe';
 import { DimlessBinaryPipe } from './dimless-binary.pipe';
 import { DimlessPipe } from './dimless.pipe';
+import { EncodeUriPipe } from './encode-uri.pipe';
 import { FilterPipe } from './filter.pipe';
 import { HealthColorPipe } from './health-color.pipe';
 import { ListPipe } from './list.pipe';
@@ -24,7 +25,8 @@ import { RelativeDatePipe } from './relative-date.pipe';
     ListPipe,
     FilterPipe,
     CdDatePipe,
-    EmptyPipe
+    EmptyPipe,
+    EncodeUriPipe
   ],
   exports: [
     DimlessBinaryPipe,
@@ -36,7 +38,8 @@ import { RelativeDatePipe } from './relative-date.pipe';
     ListPipe,
     FilterPipe,
     CdDatePipe,
-    EmptyPipe
+    EmptyPipe,
+    EncodeUriPipe
   ],
   providers: [
     DatePipe,
@@ -47,7 +50,8 @@ import { RelativeDatePipe } from './relative-date.pipe';
     RelativeDatePipe,
     ListPipe,
     CdDatePipe,
-    EmptyPipe
+    EmptyPipe,
+    EncodeUriPipe
   ]
 })
 export class PipesModule {}


### PR DESCRIPTION
Created a decorator and pipe to help encode special URI components in the
frontend.

Modified the backend request handler to decode all the string args.

fixes: http://tracker.ceph.com/issues/24621

Signed-off-by: Tiago Melo <tmelo@suse.com>