### PR TITLE
librbd: fix crash when opening nonexistent snapshot

### DIFF
--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -515,8 +515,9 @@ Context *OpenRequest<I>::send_set_snap(int *result) {
                                        m_image_ctx->snap_name);
   }
   if (snap_id == CEPH_NOSNAP) {
-    *result = -ENOENT;
-    return m_on_finish;
+    lderr(cct) << "failed to find snapshot " << m_image_ctx->snap_name << dendl;
+    send_close_image(-ENOENT);
+    return nullptr;
   }
 
   using klass = OpenRequest<I>;

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -142,6 +142,14 @@ TEST_F(TestInternal, OpenByID) {
    close_image(ictx);
 }
 
+TEST_F(TestInternal, OpenSnapDNE) {
+   librbd::ImageCtx *ictx;
+   ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+   ictx = new librbd::ImageCtx(m_image_name, "", "unknown_snap", m_ioctx, true);
+   ASSERT_EQ(-ENOENT, ictx->state->open(true));
+}
+
 TEST_F(TestInternal, IsExclusiveLockOwner) {
   REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/24637
Signed-off-by: Mykola Golub <mgolub@suse.com>