### PR TITLE
jewel: rgw: fix index update in dir_suggest_changes

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1927,7 +1927,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx, bufferlist *in, bufferlis
     string cur_change_key;
     encode_obj_index_key(cur_change.key, &cur_change_key);
     int ret = cls_cxx_map_get_val(hctx, cur_change_key, &cur_disk_bl);
-    if (ret < 0 && ret != -ENOENT)
+    if (ret < 0)
       return -EINVAL;
 
     if (cur_disk_bl.length()) {
@@ -1983,18 +1983,6 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx, bufferlist *in, bufferlis
         }
         break;
       case CEPH_RGW_UPDATE:
-	if (!cur_disk.exists) {
-	  // this update would only have been sent by the rgw client
-	  // if the rgw_bucket_dir_entry existed, however between that
-	  // check and now the entry has diappeared, so we were likely
-	  // in the midst of a delete op, and we will not recreate the
-	  // entry
-	  CLS_LOG(10,
-		  "CEPH_RGW_UPDATE not applied because rgw_bucket_dir_entry"
-		  " no longer exists\n");
-	  break;
-	}
-
         CLS_LOG(10, "CEPH_RGW_UPDATE name=%s instance=%s total_entries: %" PRId64 " -> %" PRId64 "\n",
                 cur_change.key.name.c_str(), cur_change.key.instance.c_str(), stats.num_entries, stats.num_entries + 1);
         stats.num_entries++;


### PR DESCRIPTION
1. do nothing if the index is no longer exists in cls rgw_dir_suggest_changes,
   whatever the pending state we got in check_disk_state, to avoid recreate
   index when list race with delete. the situations:
   * if dir_suggest_changes is done before complete op in Delete, the index
     will be deleted finally.
   * if dir_suggest_changes is done after complete op in Delete, the index
     will no exists and do nothing.
2. stale pending write op's index is existent but exists field is false,
   so remove cur_disk.exists check in op CEPH_RGW_UPDATE, make it recover the
   situation again.

fixes: http://tracker.ceph.com/issues/24627

jewel backport of: https://github.com/ceph/ceph/pull/22217

(cherry picked from commit 8304c3e934d667fb89dbe0a79b252a5610b5eb62)