### PR TITLE
luminous: rgw: fix index update in dir_suggest_changes

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1899,7 +1899,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx, bufferlist *in, bufferlis
     string cur_change_key;
     encode_obj_index_key(cur_change.key, &cur_change_key);
     int ret = cls_cxx_map_get_val(hctx, cur_change_key, &cur_disk_bl);
-    if (ret < 0 && ret != -ENOENT)
+    if (ret < 0)
       return -EINVAL;
 
     if (cur_disk_bl.length()) {


### PR DESCRIPTION
https://tracker.ceph.com/issues/24628

---

1. do nothing if the index is no longer exists in cls rgw_dir_suggest_changes, whatever the pending state we got in check_disk_state, to avoid recreate index when list race with delete. the situations:
   * if dir_suggest_changes is done before complete op in Delete, the index will be deleted finally.
   * if dir_suggest_changes is done after complete op in Delete, the index will no exists and do nothing.
2. stale pending write op's index is existent but exists field is false, so remove cur_disk.exists check in op CEPH_RGW_UPDATE, make it recover the situation again.

fixes: http://tracker.ceph.com/issues/24628

luminous backport of: https://github.com/ceph/ceph/pull/22217

(cherry picked from commit 8304c3e934d667fb89dbe0a79b252a5610b5eb62)