### PR TITLE
jewel:mon:modify choose moncmd method in Monitor::_get_moncommand.

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2524,17 +2524,63 @@ void Monitor::_generate_command_map(map<string,cmd_vartype>& cmdmap,
 }
 
 const MonCommand *Monitor::_get_moncommand(const string &cmd_prefix,
-                                           MonCommand *cmds, int cmds_size)
+											MonCommand *cmds, int cmds_size,map<string,cmd_vartype> cmdmap)
 {
   MonCommand *this_cmd = NULL;
   for (MonCommand *cp = cmds;
        cp < &cmds[cmds_size]; cp++) {
     if (cp->cmdstring.compare(0, cmd_prefix.size(), cmd_prefix) == 0) {
+		bool allfind = true;
+		vector<string> moncmd_name = _get_moncmd_name(cp->cmdstring);	
+		for(map<string,cmd_vartype>::iterator i = cmdmap.begin(); i!= cmdmap.end();i++)
+		{
+			if(i->first == "prefix" || i->first == "format")
+				continue;
+			bool found = false;
+			for(int j = 0 ; j < moncmd_name.size(); j++)
+			{
+				if(moncmd_name[j] == i->first)
+				{
+					found = true;
+					break;
+				}
+			}
+			if(found == false)
+			{
+				allfind = false;
+				break;
+			}
+				
+		}
+		if(!allfind)
+			continue;
       this_cmd = cp;
       break;
     }
   }
   return this_cmd;
+}
+vector<string> Monitor::_get_moncmd_name(string cmdstring)
+{
+	vector<string> res;
+	vector<string> tmpres;
+	int pos = 0;   
+	while(pos >= 0) 
+	{                 
+		pos = cmdstring.find("name",pos+1);
+		if(pos > 0)
+		{             
+			int nextpos = cmdstring.find("name",pos+1);
+			tmpres.push_back(cmdstring.substr(pos,(nextpos>0?nextpos:cmdstring.size()) - pos));
+		}             
+	}                 
+	for(int i = 0 ; i < tmpres.size() ; i++)
+	{                 
+		int start = tmpres[i].find('=',0);
+		int end = tmpres[i].find(',',0);
+		res.push_back(tmpres[i].substr(start+1,(end>0?end-1:tmpres[i].size()) - start));
+	}                 
+	return res;
 }
 
 bool Monitor::_allowed_command(MonSession *s, string &module, string &prefix,
@@ -2701,14 +2747,14 @@ void Monitor::handle_command(MonOpRequestRef op)
   leader_cmd = _get_moncommand(prefix,
                                // the boost underlying this isn't const for some reason
                                const_cast<MonCommand*>(leader_supported_mon_commands),
-                               leader_supported_mon_commands_size);
+                               leader_supported_mon_commands_size,cmdmap);
   if (!leader_cmd) {
     reply_command(op, -EINVAL, "command not known", 0);
     return;
   }
   // validate command is in our map & matches, or forward if it is allowed
   const MonCommand *mon_cmd = _get_moncommand(prefix, mon_commands,
-                                              ARRAY_SIZE(mon_commands));
+                                              ARRAY_SIZE(mon_commands),cmdmap);
   if (!is_leader()) {
     if (!mon_cmd) {
       if (leader_cmd->is_noforward()) {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -669,7 +669,8 @@ public:
   static void _generate_command_map(map<string,cmd_vartype>& cmdmap,
                                     map<string,string> &param_str_map);
   static const MonCommand *_get_moncommand(const string &cmd_prefix,
-                                           MonCommand *cmds, int cmds_size);
+                                           MonCommand *cmds, int cmds_size,map<string,cmd_vartype> cmdmap);
+  static vector<string> _get_moncmd_name(string cmdstring);
   bool _allowed_command(MonSession *s, string &module, string &prefix,
                         const map<string,cmd_vartype>& cmdmap,
                         const map<string,string>& param_str_map,


### PR DESCRIPTION
Modify Monitor::_get_moncommand.Just use prefix to locate the cmd is not appropriate.

Because some cmds have the same prefix buf not the same authority like "osd blacklist ls" and "osd blacklist add".
So I add cmdmap to locate the certain cmd.
Signed-off-by: Guang Yang Developer <pyrl247@gmail.com>