### PR TITLE
luminous: spdk: fix ceph-osd crash when activate SPDK

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -928,6 +928,8 @@ void NVMEDevice::close()
 {
   dout(1) << __func__ << dendl;
 
+  delete queue_t;
+  queue_t = nullptr;
   name.clear();
   driver->remove_device(this);
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/24471