### PR TITLE
mgr/devicehealth: respond to imminent device failures

### DIFF
--- a/doc/mgr/devicehealth.rst
+++ b/doc/mgr/devicehealth.rst
@@ -1,0 +1,52 @@
+Devicehealth plugin
+===================
+
+The *devicehealth* plugin includes code to manage physical devices
+that back Ceph daemons (e.g., OSDs).  This includes scraping health
+metrics (e.g., SMART) and responding to health metrics by migrating
+data away from failing devices.
+
+Enabling
+--------
+
+The *devicehealth* module is enabled with::
+
+  ceph mgr module enable devicehealth
+
+(It is enabled by default.)
+
+Scraping
+--------
+
+Health metrics can be scraped from all devices with::
+
+  ceph device scrape-health-metrics
+
+A single device can be scraped with::
+
+  ceph device scrape-health-metrics <device-id>
+
+Or a single daemon's devices can be scraped with::
+
+  ceph device scrape-daemon-health-metrics <who>
+
+
+Health monitoring
+-----------------
+
+By default, the devicehealth module wakes up periodically and checks
+the health of all devices in the system.  This will raise health
+alerts if devices are expected to fail soon.  This can be disabled by
+turning off the ``mgr/devicehealth/enable_monitoring`` option.
+
+The ``mgr/devicehealth/warn_threshold`` controls how soon an expected
+device failure must be before we generate a health warning.
+
+If the ``mgr/devicehealth/self_heal`` option is enabled (it is by
+default), then for devices that are expected to fail soon the module
+will automatically migrate data away from them by marking the devices
+"out".
+
+The ``mgr/devicehealth/mark_out_threshold`` controls how soon an
+expected device failure must be before we automatically mark an osd
+"out".

--- a/doc/mgr/index.rst
+++ b/doc/mgr/index.rst
@@ -39,3 +39,4 @@ sensible.
     Telemetry plugin <telemetry>
     Iostat plugin <iostat>
     Crash plugin <crash>
+    Devicehealth plugin <devicehealth>

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -251,6 +251,72 @@ You can either raise the pool quota with::
 or delete some existing data to reduce utilization.
 
 
+Device health
+-------------
+
+DEVICE_HEALTH
+_____________
+
+One or more devices is expected to fail soon, where the warning
+threshold is controlled by the ``mgr/devicehealth/warn_threshold``
+config option.
+
+This warning only applies to OSDs that are currently marked "in", so
+the expected response to this failure is to mark the device "out" so
+that data is migrated off of the device, and then to remove the
+hardware from the system.  Note that the marking out is normally done
+automatically if ``mgr/devicehealth/self_heal`` is enabled based on
+the ``mgr/devicehealth/mark_out_threshold``.
+
+Device health can be checked with::
+
+  ceph device info <device-id>
+
+Device life expectancy is set by a prediction model run by
+the mgr or an by external tool via the command::
+
+  ceph device set-life-expectancy <device-id> <from> <to>
+
+You can change the stored life expectancy manually, but that usually
+doesn't accomplish anything as whatever tool originally set it will
+probably set it again, and changing the stored value does not affect
+the actual health of the hardware device.
+
+DEVICE_HEALTH_IN_USE
+____________________
+
+One or more devices is expected to fail soon and has been marked "out"
+of the cluster based on ``mgr/devicehalth/mark_out_threshold``, but it
+is still participating in one more PGs.  This may be because it was
+only recently marked "out" and data is still migrating, or because data
+cannot be migrated off for some reason (e.g., the cluster is nearly
+full, or the CRUSH hierarchy is such that there isn't another suitable
+OSD to migrate the data too).
+
+This message can be silenced by disabling the self heal behavior
+(setting ``mgr/devicehealth/self_heal`` to false), by adjusting the
+``mgr/devicehealth/mark_out_threshold``, or by addressing what is
+preventing data from being migrated off of the ailing device.
+
+DEVICE_HEALTH_TOOMANY
+_____________________
+
+Too many devices is expected to fail soon and the
+``mgr/devicehealth/self_heal`` behavior is enabled, such that marking
+out all of the ailing devices would exceed the clusters
+``mon_osd_min_in_ratio`` ratio that prevents too many OSDs from being
+automatically marked "out".
+
+This generally indicates that too many devices in your cluster are
+expected to fail soon and you should take action to add newer
+(healthier) devices before too many devices fail and data is lost.
+
+The health message can also be silenced by adjusting parameters like
+``mon_osd_min_in_ratio`` or ``mgr/devicehealth/mark_out_threshold``,
+but be warned that this will increase the likelihood of unrecoverable
+data loss in the cluster.
+
+
 Data health (pools & placement groups)
 --------------------------------------
 

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -384,12 +384,10 @@ std::string get_device_id(const std::string& devname)
 
   udev = udev_new();
   if (!udev) {
-    //derr << "failed to run udev_new(), when calling for device " << devname << dendl;
     return {};
   }
   dev = udev_device_new_from_subsystem_sysname(udev, "block", devname.c_str());
   if (!dev) {
-    //derr << "failed to run udev_device_new_from_subsystem_sysname() for " << devname << dendl;
     udev_unref(udev);
     return {};
   }
@@ -405,7 +403,6 @@ std::string get_device_id(const std::string& devname)
   udev_unref(udev);
 
   if (!device_id.empty()) {
-    //dout << devname << " serial number: " << data << dendl;
     std::replace(device_id.begin(), device_id.end(), ' ', '_');
     return device_id;
   }
@@ -413,7 +410,6 @@ std::string get_device_id(const std::string& devname)
   // either udev_device_get_property_value() failed, or succeeded but
   // returned nothing; trying to read from files.  note that the 'vendor'
   // file rarely contains the actual vendor; it's usually 'ATA'.
-  //derr << "udev could not retrieve serial number of " << devname << dendl;
   std::string model, serial;
   model = get_block_device_string_property_wrap(devname, "device/model");
   serial = get_block_device_string_property_wrap(devname, "device/serial");
@@ -434,7 +430,6 @@ std::string get_block_device_string_property_wrap(const std::string &devname,
   std::string prop_val;
   int ret = get_block_device_string_property(devname.c_str(), property.c_str(), buff, sizeof(buff));
   if (ret < 0) {
-    //derr << "Could not retrieve content of " << property << " file of " << devname << dendl;
     return {};
   }
   prop_val = buff;

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -328,6 +328,9 @@ class Module(MgrModule):
             'DEVICE_HEALTH_IN_USE': [],
             }
         devs = self.get("devices")
+        now = datetime.now()
+        osdmap = self.get("osd_map")
+        assert osdmap is not None
         for dev in devs['devices']:
             devid = dev['devid']
             if 'life_expectancy_min' not in dev:
@@ -340,7 +343,6 @@ class Module(MgrModule):
                 '%Y-%m-%d %H:%M:%S.%f')
             self.log.debug('device %s expectancy min %s', dev,
                            life_expectancy_min)
-            now = datetime.now()
 
             if life_expectancy_min - now <= mark_out_threshold_td:
                 if self.self_heal:
@@ -352,7 +354,7 @@ class Module(MgrModule):
                         osds_in = []
                         osds_out = []
                         for _id in osd_ids:
-                            if self.is_osd_in(_id):
+                            if self.is_osd_in(osdmap, _id):
                                 osds_in.append(_id)
                             else:
                                 osds_out.append(_id)
@@ -397,9 +399,7 @@ class Module(MgrModule):
         self.set_health_checks(checks)
         return (0,"","")
 
-    def is_osd_in(self, osd_id):
-        osdmap = self.get("osd_map")
-        assert osdmap is not None
+    def is_osd_in(self, osdmap, osd_id):
         for osd in osdmap['osds']:
             if str(osd_id) == str(osd['osd']):
                 return bool(osd['in'])

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -211,7 +211,7 @@ class Module(MgrModule):
                 data = self.extract_smart_features(raw_data)
                 self.put_device_metrics(ioctx, device, data)
         ioctx.close()
-        return (0, "", "")
+        return 0, "", ""
 
     def scrape_all(self):
         osdmap = self.get("osd_map")
@@ -232,7 +232,7 @@ class Module(MgrModule):
                 self.put_device_metrics(ioctx, device, data)
 
         ioctx.close()
-        return (0, "", "")
+        return 0, "", ""
 
     def scrape_device(self, devid):
         r = self.get("device " + devid)
@@ -251,7 +251,7 @@ class Module(MgrModule):
                 data = self.extract_smart_features(raw_data)
                 self.put_device_metrics(ioctx, device, data)
         ioctx.close()
-        return (0, "", "")
+        return 0, "", ""
 
     def do_scrape_osd(self, osd_id, ioctx, devid=''):
         self.log.debug('do_scrape_osd osd.%d' % osd_id)
@@ -322,7 +322,7 @@ class Module(MgrModule):
                     res[key] = v
             except:
                 pass
-        return (0, json.dumps(res, indent=4), '')
+        return 0, json.dumps(res, indent=4), ''
 
     def check_health(self):
         self.log.info('Check health')
@@ -427,7 +427,7 @@ class Module(MgrModule):
                     'detail': ls,
                 }
         self.set_health_checks(checks)
-        return (0,"","")
+        return 0, "", ""
 
     def is_osd_in(self, osdmap, osd_id):
         for osd in osdmap['osds']:

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -14,13 +14,13 @@ from six import iteritems
 TIME_FORMAT = '%Y%m%d-%H%M%S'
 
 DEFAULTS = {
-    'enable_monitoring': True,
+    'enable_monitoring': str(True),
     'scrape_frequency': str(86400),
     'retention_period': str(86400*14),
     'pool_name': 'device_health_metrics',
     'mark_out_threshold': str(86400*14),
     'warn_threshold': str(86400*14*2),
-    'self_heal': True,
+    'self_heal': str(True),
 }
 
 health_messages = {

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -57,6 +57,11 @@ class Module(MgrModule):
             "desc": "Show stored device metrics for the device",
             "perm": "r"
         },
+        {
+            "cmd": "device check-health",
+            "desc": "Check life expectancy of devices",
+            "perm": "rw",
+        },
     ]
 
     def __init__(self, *args, **kwargs):
@@ -97,6 +102,8 @@ class Module(MgrModule):
             return self.scrape_all();
         elif cmd['prefix'] == 'device show-health-metrics':
             return self.show_device_metrics(cmd['devid'], cmd.get('sample'))
+        elif cmd['prefix'] == 'device check-health':
+            return self.check_health()
         else:
             # mgr should respect our self.COMMANDS and not call us for
             # any prefix we don't advertise
@@ -145,8 +152,7 @@ class Module(MgrModule):
             if not self.enable_monitoring:
                 continue
             self.log.debug('Running')
-
-            # WRITE ME
+            self.check_health()
 
     def shutdown(self):
         self.log.info('Stopping')
@@ -308,7 +314,8 @@ class Module(MgrModule):
                 pass
         return (0, json.dumps(res, indent=4), '')
 
-    def life_expectancy_response(self):
+    def check_health(self):
+        self.log.info('Check health')
         mark_out_threshold_td = timedelta(seconds=int(self.mark_out_threshold))
         warn_threshold_td = timedelta(seconds=int(self.warn_threshold))
         health_warnings = []

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -29,6 +29,9 @@ class Module(MgrModule):
         { 'name': 'scrape_frequency' },
         { 'name': 'pool_name' },
         { 'name': 'retention_period' },
+        { 'name': 'mark_out_threshold' },
+        { 'name': 'warn_threshold' },
+        { 'name': 'self_heal' },
     ]
 
     COMMANDS = [

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -57,10 +57,8 @@ class Module(MgrModule):
         super(Module, self).__init__(*args, **kwargs)
 
         # options
-        self.enable_monitoring = DEFAULTS['enable_monitoring']
-        self.scrape_frequency = DEFAULTS['scrape_frequency']
-        self.retention_period = DEFAULTS['retention_period']
-        self.pool_name = DEFAULTS['pool_name']
+        for k, v in DEFAULTS.iteritems():
+            setattr(self, k, v)
 
         # other
         self.run = True

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -24,10 +24,13 @@ DEFAULTS = {
     'self_heal': str(True),
 }
 
-health_messages = {
-    'DEVICE_HEALTH': '%d device(s) expected to fail soon',
-    'DEVICE_HEALTH_IN_USE': '%d daemons(s) expected to fail soon and still contain data',
-    'DEVICE_HEALTH_TOOMANY': 'Too many daemons are expected to fail soon',
+DEVICE_HEALTH = 'DEVICE_HEALTH'
+DEVICE_HEALTH_IN_USE = 'DEVICE_HEALTH_IN_USE'
+DEVICE_HEALTH_TOOMANY = 'DEVICE_HEALTH_TOOMANY'
+HEALTH_MESSAGES = {
+    DEVICE_HEALTH: '%d device(s) expected to fail soon',
+    DEVICE_HEALTH_IN_USE: '%d daemons(s) expected to fail soon and still contain data',
+    DEVICE_HEALTH_TOOMANY: 'Too many daemons are expected to fail soon',
 }
 
 class Module(MgrModule):
@@ -329,8 +332,8 @@ class Module(MgrModule):
         warn_threshold_td = timedelta(seconds=int(self.warn_threshold))
         checks = {}
         health_warnings = {
-            'DEVICE_HEALTH': [],
-            'DEVICE_HEALTH_IN_USE': [],
+            DEVICE_HEALTH: [],
+            DEVICE_HEALTH_IN_USE: [],
             }
         devs = self.get("devices")
         osds_in = {}
@@ -369,7 +372,7 @@ class Module(MgrModule):
                 # of SCSI multipath
                 device_locations = map(lambda x: x['host'] + ':' + x['dev'],
                                        dev['location'])
-                health_warnings['DEVICE_HEALTH'].append(
+                health_warnings[DEVICE_HEALTH].append(
                     '%s (%s); daemons %s; life expectancy between %s and %s'
                     % (dev['devid'],
                        ','.join(device_locations),
@@ -385,7 +388,7 @@ class Module(MgrModule):
         for _id in osds_out.iterkeys():
             num_pgs = self.get_osd_num_pgs(_id)
             if num_pgs > 0:
-                health_warnings['DEVICE_HEALTH_IN_USE'].append(
+                health_warnings[DEVICE_HEALTH_IN_USE].append(
                     'osd.%s is marked out '
                     'but still has %s PG(s)' %
                     (_id, num_pgs))
@@ -403,9 +406,9 @@ class Module(MgrModule):
                 ratio = float(num_in - did - 1) / float(num_osds)
                 if ratio < min_in_ratio:
                     final_ratio = float(num_in - num_bad) / float(num_osds)
-                    checks['DEVICE_HEALTH_TOOMANY'] = {
+                    checks[DEVICE_HEALTH_TOOMANY] = {
                         'severity': 'warning',
-                        'summary': health_messages['DEVICE_HEALTH_TOOMANY'],
+                        'summary': HEALTH_MESSAGES[DEVICE_HEALTH_TOOMANY],
                         'detail': [
                             '%d OSDs with failing device(s) would bring "in" ratio to %f < mon_osd_min_in_ratio %f' % (num_bad - did, final_ratio, min_in_ratio)
                         ]
@@ -420,7 +423,7 @@ class Module(MgrModule):
             if n:
                 checks[warning] = {
                     'severity': 'warning',
-                    'summary': health_messages[warning] % n,
+                    'summary': HEALTH_MESSAGES[warning] % n,
                     'detail': ls,
                 }
         self.set_health_checks(checks)


### PR DESCRIPTION
- raise health warning for imminent device failures
- raise health warning for imminent device failures that still have PGs
- mark osds out that depend on devices that are about to fail