### PR TITLE
mgr/DaemonServer: avoid dereferencing end() iterator

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1237,8 +1237,7 @@ bool DaemonServer::handle_command(MCommand *m)
 		auto p = pg_map.osd_stat.find(osd);
 		if (p == pg_map.osd_stat.end()) {
 		  missing_stats.insert(osd);
-		}
-		if (p->second.num_pgs > 0) {
+		} else if (p->second.num_pgs > 0) {
 		  stored_pgs.insert(osd);
 		}
 	      }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/23249
Signed-off-by: Sage Weil <sage@redhat.com>