### PR TITLE
doc: updated documentation for installing google-perftools on Debian systems

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -119,10 +119,6 @@ release::
 
 	echo deb https://download.ceph.com/debian-{release-name}/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
-Ceph on ARM processors requires Google's memory profiling tools (``google-perftools``). ::
-
-	sudo apt-get install google-perftools libgoogle-perftools-dev	
-
 For development release packages, add our package repository to your system's
 list of APT sources.  See `the testing Debian repository`_ for a complete list
 of Debian and Ubuntu releases supported. ::

--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -119,12 +119,9 @@ release::
 
 	echo deb https://download.ceph.com/debian-{release-name}/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
-Ceph on ARM processors requires Google's memory profiling tools (``google-perftools``).
-The Ceph repository should have a copy at
-https://download.ceph.com/packages/google-perftools/debian. ::
+Ceph on ARM processors requires Google's memory profiling tools (``google-perftools``). ::
 
-	echo deb https://download.ceph.com/packages/google-perftools/debian  $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/google-perftools.list
-
+	sudo apt-get install google-perftools libgoogle-perftools-dev	
 
 For development release packages, add our package repository to your system's
 list of APT sources.  See `the testing Debian repository`_ for a complete list


### PR DESCRIPTION
The link for installing google-perftools on ARM-based Debian systems is broken (404 error). I tried tracing back the package on https://download.ceph.com but couldn't find a packages directory. I took the link out of the doc/install/get-packages.rst file and added a simple apt-get command. The package google-perftools should be in the Debian/Ubuntu sources for ARM systems. If anyone finds an error in this, please let me know and I'll correct.

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>