### PR TITLE
qa: For teuthology copy logs to teuthology expected location

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -170,7 +170,13 @@ function teardown() {
         fi
     fi
     if [ "$cores" = "yes" -o "$dumplogs" = "1" ]; then
-        display_logs $dir
+	if [ -n "$LOCALRUN" ]; then
+	    display_logs $dir
+        else
+	    # Move logs to where Teuthology will archive it
+	    sudo mkdir -p $TESTDIR/archive/log
+	    sudo mv $dir/*.log $TESTDIR/archive/log
+	fi
     fi
     rm -fr $dir
     rm -rf $(get_asok_dir)


### PR DESCRIPTION

While trying to diagnose wip-23492 I needed to get logs saved to the archive after a teuthology run of standalone tests.  This change does that.