### PR TITLE
 mds/Mantle: Fixed obsolete Lua C++ API

### DIFF
--- a/src/mds/Mantle.cc
+++ b/src/mds/Mantle.cc
@@ -119,7 +119,21 @@ Mantle::Mantle (void)
   }
 
   /* balancer policies can use basic Lua functions */
-  luaL_openlibs(L);
+  static const luaL_Reg loadedlibs[] = {
+    {"_G", luaopen_base},
+    {LUA_COLIBNAME, luaopen_coroutine},
+    {LUA_STRLIBNAME, luaopen_string},
+    {LUA_MATHLIBNAME, luaopen_math},
+    {LUA_TABLIBNAME, luaopen_table},
+    {LUA_UTF8LIBNAME, luaopen_utf8},
+    {NULL, NULL}
+  };
+
+  const luaL_Reg *lib;
+  for (lib = loadedlibs; lib->func; lib++) {
+      luaL_requiref(L, lib->name, lib->func, 1);
+      lua_pop(L, 1);  /* remove lib */
+  }
 
   /* setup debugging */
   lua_register(L, "BAL_LOG", dout_wrapper);

--- a/src/mds/Mantle.cc
+++ b/src/mds/Mantle.cc
@@ -119,12 +119,7 @@ Mantle::Mantle (void)
   }
 
   /* balancer policies can use basic Lua functions */
-  luaopen_base(L);
-  luaopen_coroutine(L);
-  luaopen_string(L);
-  luaopen_math(L);
-  luaopen_table(L);
-  luaopen_utf8(L);
+  luaL_openlibs(L);
 
   /* setup debugging */
   lua_register(L, "BAL_LOG", dout_wrapper);


### PR DESCRIPTION
Rationale: Currently Mantle's Lua C++ API uses 6 `luaopen_*(L)` calls to provide balancers with Lua libraries. This method has been deprecated since Lua 5.1 in favor of one single `luaL_openlibs(L)` call (ASAIK Ceph uses Lua 5.3), and wasn't able to actually support Lua library functions to the balancers. This patch fixes the aforementioned issue.  

Signed-off-by: Tsung-Ju (Andy) Lii, <usefulalgorithm@gmail.com>