### PR TITLE
doc/dashboard: fix formatting on Grafana instructions-2

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -238,7 +238,7 @@ Enabling the Embedding of Grafana Dashboards
 Grafana and Prometheus are likely going to be bundled and installed by some
 orchestration tools along Ceph in the near future, but currently, you will have
 to install and configure both manually. After you have installed Prometheus and
-Grafana on your preferred hosts, proceed with the following steps:
+Grafana on your preferred hosts, proceed with the following steps.
 
 #. Enable the Ceph Exporter which comes as Ceph Manager module by running::
 


### PR DESCRIPTION
It's better drop that colon. See the difference now:
http://docs.ceph.com/docs/master/mgr/dashboard/
http://docs.ceph.com/ceph-prs/22706/mgr/dashboard/

Referring: 
https://github.com/ceph/ceph/pull/22657
https://github.com/ceph/ceph/pull/22658

Signed-off-by: Jos Collin <jcollin@redhat.com>