### PR TITLE
Fix wrong zpool create command

### DIFF
--- a/doc/install/manual-freebsd-deployment.rst
+++ b/doc/install/manual-freebsd-deployment.rst
@@ -54,7 +54,8 @@ Current implementation works on ZFS pools
 
     gpart create -s GPT ada1
     gpart add -t freebsd-zfs -l osd1 ada1
-    zpool create -o mountpoint=/var/lib/ceph/osd/osd.1 osd
+    zpool create zpool gpt/osd1
+    zfs create -o mountpoint=/var/lib/ceph/osd/osd.1 zpool/osd
 
 * Some cache and log (ZIL) can be attached.
   Please note that this is different from the Ceph journals. Cache and log are


### PR DESCRIPTION
doc: Fix wrong zpool create command

Hi,

The follow command does not work, because the ZFS Pool does not have an attribute for mountpoint.
"zpool create -o mountpoint=/var/lib/ceph/osd/osd.1 osd"
I fixed in the documentation.

Signed-off-by: CD <bofh@scd-systems.net>