### PR TITLE
 doc: Mention PURGED_SNAPDIRS and RECOVERY_DELETES in Mimic release notes

### DIFF
--- a/doc/releases/mimic.rst
+++ b/doc/releases/mimic.rst
@@ -27,10 +27,10 @@ Major Changes from Luminous
 
   * RGW can now replicate a zone (or a subset of buckets) to an
     external cloud storage service like S3.
-  * RGW now supports the S3 multi-factor authentication api on
+  * RGW now supports the S3 multi-factor authentication API on
     versioned buckets.
-  * The Beast frontend is no long expermiental and is considered stable
-    and ready for use.
+  * The Beast frontend is no longer experimental, and is considered
+    stable and ready for use.
 
 - *CephFS*:
 
@@ -100,7 +100,7 @@ Instructions
    possibly have a negative impact on your Ceph clients' performance.
 
 #. Make sure your cluster is stable and healthy (no down or
-   recoverying OSDs).  (Optional, but recommended.)
+   recovering OSDs).  (Optional, but recommended.)
 
 #. Set the ``noout`` flag for the duration of the upgrade. (Optional,
    but recommended.)::
@@ -112,9 +112,9 @@ Instructions
 
      # systemctl restart ceph-mon.target
 
-   Verify the monitor upgrade is complete once all monitors are up by
-   looking for the ``mimic`` feature string in the mon map.  For
-   example::
+   Once all monitors are up, verify that the monitor upgrade is
+   complete by looking for the ``mimic`` feature string in the mon
+   map.  For example::
 
      # ceph mon feature ls
 
@@ -129,7 +129,8 @@ Instructions
 
      # systemctl restart ceph-mgr.target
 
-   Verify the ceph-mgr daemons are running by checking ``ceph -s``::
+   Verify the ``ceph-mgr`` daemons are running by checking ``ceph
+   -s``::
 
      # ceph -s
 
@@ -192,7 +193,7 @@ Instructions
 
      # systemctl restart radosgw.target
 
-#. Complete the upgrade by disallowing pre-mimic OSDs and enabling
+#. Complete the upgrade by disallowing pre-Mimic OSDs and enabling
    all new Mimic-only functionality::
 
      # ceph osd require-osd-release mimic

--- a/doc/releases/mimic.rst
+++ b/doc/releases/mimic.rst
@@ -69,6 +69,36 @@ Notes
 Instructions
 ~~~~~~~~~~~~
 
+#. If your cluster was originally installed with a version prior to
+   Luminous, ensure that it has completed at least one full scrub of
+   all PGs while running Luminous.  Failure to do so will cause your
+   monitor daemons to refuse to join the quorum on start, leaving them
+   non-functional.
+
+   If you are unsure whether or not your Luminous cluster has
+   completed a full scrub of all PGs, you can check your cluster's
+   state by running::
+
+     # ceph osd dump | grep ^flags
+
+   In order to be able to proceed to Mimic, your OSD map must include
+   the ``recovery_deletes`` and ``purged_snapdirs`` flags.
+
+   If your OSD map does not contain both these flags, you can simply
+   wait for approximately 24-48 hours, which in a standard cluster
+   configuration should be ample time for all your placement groups to
+   be scrubbed at least once, and then repeat the above process to
+   recheck.
+
+   However, if you have just completed an upgrade to Luminous and want
+   to proceed to Mimic in short order, you can force a scrub on all
+   placement groups with a one-line shell command, like::
+
+     # ceph pg dump pgs_brief | cut -d " " -f 1 | xargs -n1 ceph pg scrub
+
+   You should take into consideration that this forced scrub may
+   possibly have a negative impact on your Ceph clients' performance.
+
 #. Make sure your cluster is stable and healthy (no down or
    recoverying OSDs).  (Optional, but recommended.)
 
@@ -177,7 +207,9 @@ Upgrading from pre-Luminous releases (like Jewel)
 -------------------------------------------------
 
 You *must* first upgrade to Luminous (12.2.z) before attempting an
-upgrade to Mimic.
+upgrade to Mimic.  In addition, your cluster must have completed at
+least one scrub of all PGs while running Luminous, setting the
+``recovery_deletes`` and ``purged_snapdirs`` flags in the OSD map.
 
 Upgrade compatibility notes
 ---------------------------


### PR DESCRIPTION
71d1dcb (in the Mimic cycle, included in 13.0.1) started enforcing the `PURGED_SNAPDIRS` osdmap flag before am upgraded mon could join the quorum. 9b80b14 (also in 13.0.1) then extended that check to also include `RECOVERY_DELETES`. The Mimic release notes do not mention these flags as prerequisites for an upgrade beyond Luminous. 

That creates an obvious issue for users who skipped Luminous in production, and now want to upgrade from Jewel to Mimic in, say, a weekend: if they attempt an upgrade before a scrub on all PGs has completed, then `PURGED_SNAPDIRS` will not be set, and their mons won't join the quorum. If they make the mistake of attempting to update two mons at once, then they will not only have a brief cluster outage like they "normally" would when they did that, but rather a prolonged one with no trivial way to fix. (The fix would involve downgrading at least one mon, bringing it back online, running the scrub, and then proceeding with the upgrade. Factoring in the time it takes to _find out_ what the real issue is, we might easily talk about several hours' downtime.)

This PR updates the release notes to include those flags as prerequisites for a Luminous to Mimic upgrade, explain how users can make sure that they are set, and also give users a one-liner to fix up their PGs in a pinch, if they need to.

It also fixes a handful of minor grammar, spelling, and style issues in the release notes.