### PR TITLE
mgr/dashboard: Replaced "Pool" with "Pools" in navigation bar

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -84,7 +84,7 @@
       <li routerLinkActive="active"
           class="tc_menuitem tc_menuitem_pool">
         <a i18n
-           routerLink="/pool">Pool
+           routerLink="/pool">Pools
         </a>
       </li>
 


### PR DESCRIPTION
Replaced the string "Pool" with "Pools" in the navigation component.

Fixes: https://tracker.ceph.com/issues/24623
Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>

![screenshot-2018-6-26 ceph](https://user-images.githubusercontent.com/263427/41909053-5237c782-7946-11e8-80e1-56d0a7696a60.png)
