### PR TITLE
mon,mgr: add safety check to 'osd destroy'; deprecate 'osd rm'

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,10 @@
+14.0.1
+------
+
+* The 'ceph osd rm' command has been deprecated.  Users should use
+  'ceph osd destroy' or 'ceph osd purge' (but after first confirming it is
+  safe to do so via the 'ceph osd safe-to-destroy' command).
+
 >=13.1.0
 --------
 

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1202,7 +1202,8 @@ bool DaemonServer::handle_command(MCommand *m)
       return true;
     }
   } else if (prefix == "osd safe-to-destroy" ||
-	     prefix == "osd destroy") {
+	     prefix == "osd destroy" ||
+	     prefix == "osd purge") {
     set<int> osds;
     int r = 0;
     if (prefix == "osd safe-to-destroy") {
@@ -1284,11 +1285,12 @@ bool DaemonServer::handle_command(MCommand *m)
       r = -EBUSY;
     }
 
-    if (r && prefix == "osd destroy") {
+    if (r && (prefix == "osd destroy" ||
+	      prefix == "osd purge")) {
       string sure;
       if (!cmd_getval(cct, cmdctx->cmdmap, "sure", sure) ||
 	  sure != "--force") {
-	ss << "\nYou can proceed with OSD removal by passing --force, but be warned that this will likely mean real, permanent data loss.";
+	ss << "\nYou can proceed by passing --force, but be warned that this will likely mean real, permanent data loss.";
       } else {
 	r = 0;
       }
@@ -1297,10 +1299,11 @@ bool DaemonServer::handle_command(MCommand *m)
       cmdctx->reply(r, ss);
       return true;
     }
-    if (prefix == "osd destroy") {
+    if (prefix == "osd destroy" ||
+	prefix == "osd purge") {
       const string cmd =
 	"{"
-	"\"prefix\": \"osd destroy-actual\", "
+	"\"prefix\": \"" + prefix + "-actual\", "
 	"\"id\": " + stringify(osds) + ", "
 	"\"sure\": \"--yes-i-really-mean-it\""
 	"}";

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1289,7 +1289,8 @@ bool DaemonServer::handle_command(MCommand *m)
 	      prefix == "osd purge")) {
       string sure;
       if (!cmd_getval(cct, cmdctx->cmdmap, "sure", sure) ||
-	  sure != "--force") {
+	  (sure != "--force" &&
+	   sure != "--yes-i-really-mean-it" /* for backward compat */)) {
 	ss << "\nYou can proceed by passing --force, but be warned that this will likely mean real, permanent data loss.";
       } else {
 	r = 0;

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -107,6 +107,14 @@ COMMAND("osd test-reweight-by-pg " \
 	"dry run of reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
 	"osd", "r", "cli,rest")
 
+COMMAND("osd destroy "	    \
+        "name=id,type=CephOsdName " \
+        "name=sure,type=CephString,req=False",
+        "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \
+        "but removes cephx keys, config-key data and lockbox keys, "\
+        "rendering data permanently unreadable.", \
+        "osd", "rw", "cli,rest")
+
 COMMAND("osd safe-to-destroy name=ids,type=CephString,n=N",
 	"check whether osd(s) can be safely destroyed without reducing data durability",
 	"osd", "r", "cli,rest")

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -114,6 +114,12 @@ COMMAND("osd destroy "	    \
         "but removes cephx keys, config-key data and lockbox keys, "\
         "rendering data permanently unreadable.", \
         "osd", "rw", "cli,rest")
+COMMAND("osd purge " \
+        "name=id,type=CephOsdName " \
+        "name=sure,type=CephString,req=false",			     \
+        "purge all osd data from the monitors including the OSD id " \
+	"and CRUSH position",					     \
+	"osd", "rw", "cli,rest")
 
 COMMAND("osd safe-to-destroy name=ids,type=CephString,n=N",
 	"check whether osd(s) can be safely destroyed without reducing data durability",

--- a/src/mon/MonCommand.h
+++ b/src/mon/MonCommand.h
@@ -31,6 +31,7 @@ struct MonCommand {
   static const uint64_t FLAG_DEPRECATED = 1 << 2;
   static const uint64_t FLAG_MGR        = 1 << 3;
   static const uint64_t FLAG_POLL       = 1 << 4;
+  static const uint64_t FLAG_HIDDEN     = 1 << 5;
 
   bool has_flag(uint64_t flag) const { return (flags & flag) != 0; }
   void set_flag(uint64_t flag) { flags |= flag; }
@@ -89,6 +90,10 @@ struct MonCommand {
 
   bool is_mgr() const {
     return has_flag(MonCommand::FLAG_MGR);
+  }
+
+  bool is_hidden() const {
+    return has_flag(MonCommand::FLAG_HIDDEN);
   }
 
   static void encode_array(const MonCommand *cmds, int size, bufferlist &bl) {

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -774,11 +774,12 @@ COMMAND("osd in " \
 	"set osd(s) <id> [<id>...] in, "
         "can use <any|all> to automatically set all previously out osds in", \
         "osd", "rw", "cli,rest")
-COMMAND("osd rm " \
+COMMAND_WITH_FLAG("osd rm " \
 	"name=ids,type=CephString,n=N", \
 	"remove osd(s) <id> [<id>...], "
         "or use <any|all> to remove all osds", \
-        "osd", "rw", "cli,rest")
+	"osd", "rw", "cli,rest",
+	FLAG(DEPRECATED))
 COMMAND("osd add-noup " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noup, " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -870,7 +870,7 @@ COMMAND("osd primary-affinity " \
 	"type=CephFloat,name=weight,range=0.0|1.0", \
 	"adjust osd primary-affinity from 0.0 <= <weight> <= 1.0", \
 	"osd", "rw", "cli,rest")
-COMMAND("osd destroy " \
+COMMAND("osd destroy-actual "	    \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
         "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -114,6 +114,7 @@
  *  MGR       - command goes to ceph-mgr (for luminous+)
  *  POLL      - command is intended to be called periodically by the
  *              client (see iostat)
+ *  HIDDEN    - command is hidden (no reported by help etc)
  *
  * A command should always be first considered DEPRECATED before being
  * considered OBSOLETE, giving due consideration to users and conforming

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -871,13 +871,13 @@ COMMAND("osd primary-affinity " \
 	"type=CephFloat,name=weight,range=0.0|1.0", \
 	"adjust osd primary-affinity from 0.0 <= <weight> <= 1.0", \
 	"osd", "rw", "cli,rest")
-COMMAND("osd destroy-actual "	    \
+COMMAND_WITH_FLAG("osd destroy-actual "	    \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
         "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \
         "but removes cephx keys, config-key data and lockbox keys, "\
         "rendering data permanently unreadable.", \
-        "osd", "rw", "cli,rest")
+		  "osd", "rw", "cli,rest", FLAG(HIDDEN))
 COMMAND("osd purge-new " \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -884,12 +884,12 @@ COMMAND("osd purge-new " \
         "purge all traces of an OSD that was partially created but never " \
 	"started", \
         "osd", "rw", "cli,rest")
-COMMAND("osd purge " \
+COMMAND_WITH_FLAG("osd purge-actual " \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
         "purge all osd data from the monitors. Combines `osd destroy`, " \
         "`osd rm`, and `osd crush rm`.", \
-        "osd", "rw", "cli,rest")
+		  "osd", "rw", "cli,rest", FLAG(HIDDEN))
 COMMAND("osd lost " \
 	"name=id,type=CephOsdName " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2977,7 +2977,9 @@ void Monitor::handle_command(MonOpRequestRef op)
         paxos_service[PAXOS_MGR].get())->get_command_descs();
 
     for (auto& c : leader_mon_commands) {
-      commands.push_back(c);
+      if (!c.is_hidden()) {
+	commands.push_back(c);
+      }
     }
 
     format_command_descriptions(commands, f, &rdata);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10680,9 +10680,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     string sure;
     if (!cmd_getval(cct, cmdmap, "sure", sure) ||
         sure != "--yes-i-really-mean-it") {
-      ss << "Are you SURE? This will mean real, permanent data loss, as well "
-         << "as cephx and lockbox keys. Pass --yes-i-really-mean-it if you "
-         << "really do.";
+      ss << "Are you SURE?  Did you verify with 'ceph osd safe-to-destroy'?  "
+	 << "This will mean real, permanent data loss, as well "
+         << "as deletion of cephx and lockbox keys. "
+	 << "Pass --yes-i-really-mean-it if you really do.";
       err = -EPERM;
       goto reply;
     } else if (!osdmap.exists(id)) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10640,7 +10640,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       return true;
     }
 
-  } else if (prefix == "osd destroy" ||
+  } else if (prefix == "osd destroy-actual" ||
 	     prefix == "osd purge" ||
 	     prefix == "osd purge-new") {
     /* Destroying an OSD means that we don't expect to further make use of
@@ -10665,13 +10665,18 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
     int64_t id;
     if (!cmd_getval(cct, cmdmap, "id", id)) {
-      ss << "unable to parse osd id value '"
-         << cmd_vartype_stringify(cmdmap.at("id")) << "";
+      auto p = cmdmap.find("id");
+      if (p == cmdmap.end()) {
+	ss << "no osd id specified";
+      } else {
+	ss << "unable to parse osd id value '"
+	   << cmd_vartype_stringify(cmdmap.at("id")) << "";
+      }
       err = -EINVAL;
       goto reply;
     }
 
-    bool is_destroy = (prefix == "osd destroy");
+    bool is_destroy = (prefix == "osd destroy-actual");
     if (!is_destroy) {
       assert("osd purge" == prefix ||
 	     "osd purge-new" == prefix);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10641,7 +10641,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     }
 
   } else if (prefix == "osd destroy-actual" ||
-	     prefix == "osd purge" ||
+	     prefix == "osd purge-actual" ||
 	     prefix == "osd purge-new") {
     /* Destroying an OSD means that we don't expect to further make use of
      * the OSDs data (which may even become unreadable after this operation),
@@ -10678,7 +10678,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
     bool is_destroy = (prefix == "osd destroy-actual");
     if (!is_destroy) {
-      assert("osd purge" == prefix ||
+      assert("osd purge-actual" == prefix ||
 	     "osd purge-new" == prefix);
     }
 


### PR DESCRIPTION
- osd destroy and osd purge now do the safe-to-destroy safety check.
- if the check fails, --force can be passed to proceed anyway.
- osd rm is deprecated (it has no real purpose at this point)