### PR TITLE
build: link ceph-osd with common statically. Enforce initial-exec TLS model.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -907,7 +907,7 @@ set(ceph_osd_srcs
   ceph_osd.cc)
 add_executable(ceph-osd ${ceph_osd_srcs})
 add_dependencies(ceph-osd erasure_code_plugins)
-target_link_libraries(ceph-osd osd os global-static ceph-common
+target_link_libraries(ceph-osd osd os global-static common
   ${BLKID_LIBRARIES})
 if(WITH_FUSE)
   target_link_libraries(ceph-osd ${FUSE_LIBRARIES})


### PR DESCRIPTION
Summary
=======
Our building process currently fabricates `ceph-common` in two variants:
1) dynamic, interposable, position independent `libceph-common.so.0`,
2) statical `libcommon.a`.

The change instructs CMake to switch linking of `ceph-osd` to the former one. This is actually a trade-off between executable size and the run-time overhead of `-fPIC` which consists:

* conveying all symbols lookups through extra indirection layers  (GOT for data accesses; PLT+GOT for calls) for the sake of symbol interposition (overwriteability with e.g. `LD_PRELOAD`, `/etc/ld.so.preload`). That is, all references, even across the same translation unit, have to traverse up to 2 memory indirections. Additionally, code inlineability can be affected.
* Imposing the `global-dynamic` thread-local-storage model in which an access to `thread_local` variable is resolved by a call to `__tls_get_addr()` . The overhead varies and can become unpleasant when [the `unlikely`-hinted path](https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/dl-tls.c;h=c87caf13d6a97ba4981c5ddaba2ecec21f4753b0;hb=05598a0907cad1350962e89b781215209a785d92#l828), with `update_get_addr()` and `_dl_update_slotinfo()`, is being taken over and over. This happens when `_dl_update_slotinfo()` can't bump up the generation counter of DTV (a per-thread vector of pointers to TLSes of loaded ELF modules) high enough to match the global `dl_tls_generation` (increased on e.g. `dlopen()`, `dlclose()`) [due to synchronization-related restrictions](https://sourceware.org/git/?p=glibc.git;a=blob;f=elf/dl-tls.c;h=c87caf13d6a97ba4981c5ddaba2ecec21f4753b0;hb=05598a0907cad1350962e89b781215209a785d92#l632). Although this hasn't been observed on current `master`, I was hit by the case while working on per-thread `PerfCounters` (extensive usage  of TLS).

Performance comparison
======================
All tests have been conducted on the `incerta07` node in 5 rounds. The result for each round is sum of bandwidth 4 separated FIO-librbd clients get from a cluster consisted of 3 OSDs . CBT has been used for deployment and orchestration. Values are in KBps.

On average for 4 KiB randreads:
```
>>> (377789 + 386926 + 379479 + 380018 + 381411)/(363013. + 361890 + 356313 + 368839 + 366750)
1.0488869196198822
```

The reference point: 3d34add1e2083957dce223aa17ff9a0ce50d2c94.
-------------------------------------------------------------
```
randread,  4 KiB:  363013,  361890,  356313,  368839,  366750
randread, 64 KiB: 3450393, 3527752, 3468953, 3454142, 3487138

```

After the change: 9b093b41ad3b9ab7e29a698352dd5b79f4f11601.
-----------------------------------------------------------
```
randread,  4 KiB:  377789,  386926,  379479,  380018,  381411
randread, 64 KiB: 3595865, 3639222, 3569413, 3585917, 3682473

```

Drawbacks
========
The main drawback is increment in size of `ceph-osd`.

The reference point: 3d34add1e2083957dce223aa17ff9a0ce50d2c94.
-------------------------------------------------------------
```
[root@incerta07 build]# ldd bin/ceph-osd | grep ceph-common
        libceph-common.so.0 => /home/perf/src/ceph-rzarzynski2/build/lib/libceph-common.so.0 (0x00007fad52102000)
[root@incerta07 build]# strip bin/ceph-osd
[root@incerta07 build]# ls -alh bin/ceph-osd
-rwxrwxr-x. 1 perf perf 14M 06-25 14:39 bin/ceph-osd
```

After the change: 9b093b41ad3b9ab7e29a698352dd5b79f4f11601.
-----------------------------------------------------------
```
[root@incerta07 build]# ldd bin/ceph-osd | grep ceph-common
[root@incerta07 build]# strip bin/ceph-osd
[root@incerta07 build]# ls -alh bin/ceph-osd
-rwxr-xr-x. 1 root root 20M 06-25 14:43 bin/ceph-osd
```

Alternatives
=========
*  `-fvisibility=hidden`