### PR TITLE
test/fio: fix compiler error.

### DIFF
--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -145,7 +145,7 @@ struct Collection {
   ObjectStore::CollectionHandle ch;
   // Can't use mutex directly in vectors hence dynamic allocation
 
-  ceph::unique_ptr<std::mutex> lock;
+  std::unique_ptr<std::mutex> lock;
   uint64_t pglog_ver_head = 1;
   uint64_t pglog_ver_tail = 1;
   uint64_t pglog_dup_ver_tail = 1;


### PR DESCRIPTION
Compile  with -DWITH_FIO=ON, met the following bug.
/home/ceph/src/test/fio/fio_ceph_objectstore.cc:148:9: error: ‘unique_ptr’ in namespace ‘ceph’ does not name a template type
   ceph::unique_ptr<std::mutex> lock;
         ^~~~~~~~~~
/home/ceph/src/test/fio/fio_ceph_objectstore.cc: In constructor ‘{anonymous}::Collection::Collection(const spg_t&, ObjectStore::CollectionHandle)’:
/home/ceph/src/test/fio/fio_ceph_objectstore.cc:158:9: error: class ‘{anonymous}::Collection’ does not have any field named ‘lock’
         lock(new std::mutex) {
         ^~~~
/home/ceph/src/test/fio/fio_ceph_objectstore.cc: In function ‘fio_q_status {anonymous}::fio_ceph_os_queue(thread_data*, io_u*)’:
/home/ceph/src/test/fio/fio_ceph_objectstore.cc:604:38: error: ‘struct {anonymous}::Collection’ has no member named ‘lock’
  std::lock_guard<std::mutex> l(*coll.lock);

This bug introduct by commit da5d156b6bdffdd31e4edbadc1cdfc69197bef49.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>