### PR TITLE
install-deps.sh: Support openSUSE Leap 15

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -259,7 +259,7 @@ else
 	fi
         ! grep -q -i error: $DIR/yum-builddep.out || exit 1
         ;;
-    opensuse|suse|sles|opensuse-tumbleweed)
+    opensuse|suse|sles|opensuse-leap|opensuse-tumbleweed)
         echo "Using zypper to install dependencies"
         zypp_install="zypper --gpg-auto-import-keys --non-interactive install --no-recommends"
         $SUDO $zypp_install lsb-release systemd-rpm-macros


### PR DESCRIPTION
openSUSE Leap 15 identifies itself as 'opensuse-leap' instead of
'opensuse'. Add this new string to the instal-deps.sh script's zypper
install section.

Signed-off-by: Blaine Gardner <blaine.gardner@suse.com>