### PR TITLE
[DNM] luminous: osd: make build_past_intervals_parallel() optional, and off by default

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2721,6 +2721,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("osd_build_past_intervals_parallel", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("Attempt to efficiently build past intervals on startup"),
+
     Option("osd_debug_shutdown", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description("Turn up debug levels during shutdown"),

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4123,7 +4123,9 @@ void OSD::load_pgs()
     }
   }
 
-  build_past_intervals_parallel();
+  if (g_conf->get_val<bool>("osd_build_past_intervals_parallel")) {
+    build_past_intervals_parallel();
+  }
 }
 
 


### PR DESCRIPTION
The implementation is not very tolerant and can cause problems.  For
example, with bug http://tracker.ceph.com/issues/21142 the pg epoch_created
was off, leading to an attempt to rebuild intevals prior to the PG's.
Allow it to be skipped entirely.  (Note that this method is removed
entirely in mimic, see ac9e2f76093ef00238a1a8a0266a95c5ca2468b2).

Signed-off-by: Sage Weil <sage@redhat.com>