### PR TITLE
luminous: ceph-volume: error on commands that need ceph.conf to operate

### DIFF
--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -10,6 +10,12 @@ from ceph_volume.decorators import catches
 from ceph_volume import log, devices, configuration, conf, exceptions, terminal
 
 
+IGNORE_CEPH_CONFIG_COMMANDS = [
+    "lvm list",
+    "lvm zap",
+]
+
+
 class Volume(object):
     _help = """
 ceph-volume: Deploy Ceph OSDs using different device technologies like lvm or
@@ -144,11 +150,16 @@ Ceph Conf: {ceph_path}
         try:
             conf.ceph = configuration.load(conf.path)
         except exceptions.ConfigurationError as error:
-            # we warn only here, because it is possible that the configuration
-            # file is not needed, or that it will be loaded by some other means
-            # (like reading from lvm tags)
-            logger.exception('ignoring inability to load ceph.conf')
-            terminal.red(error)
+            is_help = "-h" in subcommand_args or "--help" in subcommand_args
+            if " ".join(subcommand_args[:2]) in IGNORE_CEPH_CONFIG_COMMANDS or is_help:
+                # we warn only here, because it is possible that the configuration
+                # file is not needed, or that it will be loaded by some other means
+                # (like reading from lvm tags)
+                logger.exception('ignoring inability to load ceph.conf')
+                terminal.red(error)
+            else:
+                terminal.red(error)
+                raise
         # dispatch to sub-commands
         terminal.dispatch(self.mapper, subcommand_args)
 


### PR DESCRIPTION
We had been ignoring the failure to load ceph.conf for all subcommands
but most of them require that a ceph.conf be present. This changes that
so only commands that do not need ceph.conf ignore the failure to find
it.

Fixes: http://tracker.ceph.com/issues/23941

Signed-off-by: Andrew Schoen <aschoen@redhat.com>
(cherry picked from commit de8b301ac20ae07f59a19bc1b3a083e9c010667d)

backport of #22724