### PR TITLE
mon: add "osd setall" and "osd unsetall" commands

### DIFF
--- a/src/include/util.h
+++ b/src/include/util.h
@@ -99,5 +99,30 @@ bool match_str(const std::string& s, const XS& ...xs)
  return ((s == xs) || ...);
 }
 
+/* Modifies "haystack": erases any entries matching needle found in the
+haystack (notice that this may convert to the container's value type--
+this is to handle cases like const char* being passed variadically to
+a container of std::string): */
+template <typename SeqT>
+void erase_match(SeqT& haystack, const typename SeqT::value_type& needle)
+{
+ haystack.erase(
+     std::remove(std::begin(haystack), std::end(haystack), needle),
+     std::end(haystack));
+}
+
+/* Modifies "haystack": erases any matching needles found in the 
+haystack; returns the number of entries removed: */
+template <typename SeqT, typename ...ValsT>
+auto count_erase_matches(SeqT& haystack, const ValsT& ...needles)
+{
+ auto original_size = haystack.size();
+
+ (..., erase_match(haystack, needles));
+
+ return original_size - haystack.size();
+}
+
 } // namespace ceph::util
+
 #endif /* CEPH_UTIL_H */

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -758,12 +758,13 @@ COMMAND("osd erasure-code-profile ls", \
 	"list all erasure code profiles", \
 	"osd", "r")
 COMMAND("osd set " \
-	"name=key,type=CephChoices,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim|sortbitwise|recovery_deletes|require_jewel_osds|require_kraken_osds|pglog_hardlimit " \
-        "name=yes_i_really_mean_it,type=CephBool,req=false", \
-	"set <key>", "osd", "rw")
+	"name=key,type=CephChoices,n=N,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim|sortbitwise|recovery_deletes|require_jewel_osds|require_kraken_osds|pglog_hardlimit|--yes-i-really-mean-it ", \
+	"set flag <key>", 
+    "osd", "rw")
 COMMAND("osd unset " \
-	"name=key,type=CephChoices,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim", \
-	"unset <key>", "osd", "rw")
+	"name=key,type=CephChoices,n=N,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim", \
+	"unset flag <key>", 
+    "osd", "rw")
 COMMAND("osd require-osd-release "\
 	"name=release,type=CephChoices,strings=luminous|mimic|nautilus " \
         "name=yes_i_really_mean_it,type=CephBool,req=false", \

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -40,6 +40,19 @@ class PGMap;
 class MonSession;
 class MOSDMap;
 
+namespace ceph::handle_flags {
+
+int set(vector<string> flags, const bool sure,
+        OSDMonitor& osdmon, MonOpRequestRef op, std::ostream& os);
+
+int unset(vector<string> flags, 
+          OSDMonitor& osdmon, MonOpRequestRef op, std::ostream& os);
+
+int set_special(ostream& os, const std::string& flag_name,
+                OSDMonitor& osdmon, OSDMap& osdmap, MonOpRequestRef op, const bool sure);
+
+} // namespace ceph::handle_flags
+
 #include "erasure-code/ErasureCodeInterface.h"
 #include "mon/MonOpRequest.h"
 #include <boost/functional/hash.hpp>
@@ -481,6 +494,10 @@ private:
   int lookup_pruned_snap(int64_t pool, snapid_t snap,
 			 snapid_t *begin, snapid_t *end);
 
+
+  void set_pending_flags(MonOpRequestRef op, const int flag);
+  void unset_pending_flags(MonOpRequestRef op, const int flag);
+  void wait_for_finished_command_proposal(MonOpRequestRef op, const std::string&& msg);
   bool prepare_set_flag(MonOpRequestRef op, int flag);
   bool prepare_unset_flag(MonOpRequestRef op, int flag);
 
@@ -701,6 +718,16 @@ public:
       pending_inc.new_flags &= ~flag;
     }
   }
+
+ private:
+ friend int ceph::handle_flags::set(vector<string> flags, const bool sure,
+                                    OSDMonitor& osdmon, MonOpRequestRef op, std::ostream& os);
+
+ friend int ceph::handle_flags::unset(vector<string> flags, 
+                                      OSDMonitor& osdmon, MonOpRequestRef op, std::ostream& os);
+
+ friend int ceph::handle_flags::set_special(ostream& os, const std::string& flag_name,
+                                OSDMonitor& osdmon, OSDMap& osdmap, MonOpRequestRef op, const bool sure);
 };
 
 #endif


### PR DESCRIPTION
Adds a feature to set or unset multiple flags at once.

As-implemented, flags requiring "--yes-i-am-sure" may not be set using the batch feature. (But may be unset, as the current behavior does not use that flag for un-setting.)

Implements:
http://tracker.ceph.com/issues/22147

Signed-off-by: Jesse Williamson <jwilliamson@suse.de>