### PR TITLE
mgr: fix Clangs/FreeBSD missing vector

### DIFF
--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -16,6 +16,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 #include <boost/optional.hpp>
 #include "common/Mutex.h"
 #include "Python.h"


### PR DESCRIPTION
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>