### PR TITLE
mgr/dashboard: add supported flag information to config options documentation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
@@ -35,4 +35,13 @@
       </span>
     </span>
   </ng-template>
+  <ng-template #confFlagTpl let-value="value">
+    <span *ngIf="value !== ''">
+      <span *ngFor="let flag of value; last as isLast">
+        <span title="{{ flags[flag] }}">
+          {{ flag | uppercase }}{{ !isLast ? "," : "" }}<br/>
+        </span>
+      </span>
+    </span>
+  </ng-template>
 </cd-table>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
@@ -62,8 +62,19 @@ export class ConfigurationComponent implements OnInit {
       }
     }
   ];
+  flags = {
+    runtime: 'The value can be updated at runtime.',
+    no_mon_update:
+      'Daemons/clients do not pull this value from the monitor config database. ' +
+      'We disallow setting this option via \'ceph config set ...\'. This option should be ' +
+      'configured via ceph.conf or via the command line.',
+    startup: 'Option takes effect only during daemon startup.',
+    cluster_create: 'Option only affects cluster creation.',
+    create: 'Option only affects daemon creation.'
+  };
 
   @ViewChild('confValTpl') public confValTpl: TemplateRef<any>;
+  @ViewChild('confFlagTpl') public confFlagTpl: TemplateRef<any>;
 
   constructor(private configurationService: ConfigurationService) {}
 
@@ -80,6 +91,13 @@ export class ConfigurationComponent implements OnInit {
       { flexGrow: 1, prop: 'source' },
       { flexGrow: 2, prop: 'desc', name: 'Description', cellClass: 'wrap' },
       { flexGrow: 2, prop: 'long_desc', name: 'Long description', cellClass: 'wrap' },
+      {
+        flexGrow: 2,
+        prop: 'flags',
+        name: 'Flags',
+        cellClass: 'wrap',
+        cellTemplate: this.confFlagTpl
+      },
       { flexGrow: 1, prop: 'type' },
       { flexGrow: 1, prop: 'level' },
       { flexGrow: 1, prop: 'default', cellClass: 'wrap' },


### PR DESCRIPTION
Add the information about the supported flags (introduced by https://github.com/ceph/ceph/pull/22595) to the config options documentation page.

![screenshot_2018-06-28_16-18-03](https://user-images.githubusercontent.com/8761082/42040025-05d0b688-7aef-11e8-8e55-b14b322fa9e0.png)

Fixes: https://tracker.ceph.com/issues/24605

Signed-off-by: Tatjana Dehler <tdehler@suse.com>