### PR TITLE
osd/filestore: Change default filestore_merge_threshold to -10

### DIFF
--- a/doc/rados/configuration/filestore-config-ref.rst
+++ b/doc/rados/configuration/filestore-config-ref.rst
@@ -297,7 +297,7 @@ Misc
               NOTE: A negative value means to disable subdir merging
 :Type: Integer
 :Required: No
-:Default: ``10``
+:Default: ``-10``
 
 
 ``filestore split multiple``

--- a/qa/standalone/mon/osd-pool-create.sh
+++ b/qa/standalone/mon/osd-pool-create.sh
@@ -213,7 +213,6 @@ function TEST_pool_create_rep_expected_num_objects() {
     setup $dir || return 1
 
     # disable pg dir merge
-    CEPH_ARGS+="--filestore-merge-threshold=-10 "
     export CEPH_ARGS
     run_mon $dir a || return 1
     run_mgr $dir x || return 1

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4622,7 +4622,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("filestore_merge_threshold", Option::TYPE_INT, Option::LEVEL_DEV)
-    .set_default(10)
+    .set_default(-10)
     .set_description(""),
 
     Option("filestore_split_multiple", Option::TYPE_INT, Option::LEVEL_DEV)

--- a/src/sample.ceph.conf
+++ b/src/sample.ceph.conf
@@ -397,7 +397,7 @@
     # Type: Integer
     # Required: No
     # Default:  10
-    ;filestore merge threshold    = 10
+    ;filestore merge threshold    = -10
 
     # filestore_split_multiple * abs(filestore_merge_threshold) * 16 is the maximum number of files in a subdirectory before splitting into child directories.
     # Type: Integer


### PR DESCRIPTION
Performance evaluations of medium to large size Ceph clusters have
demonstrated negligible performance impact from unnecessarily deep
directory hierarchies but significant performance impact from filestore
split and merge activity. Disable merges by default.

Fixes: http://tracker.ceph.com/issues/24686
Signed-off-by: Douglas Fuller <dfuller@redhat.com>