### PR TITLE
qa: Don't use sudo when moving logs

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -174,8 +174,8 @@ function teardown() {
 	    display_logs $dir
         else
 	    # Move logs to where Teuthology will archive it
-	    sudo mkdir -p $TESTDIR/archive/log
-	    sudo mv $dir/*.log $TESTDIR/archive/log
+	    mkdir -p $TESTDIR/archive/log
+	    mv $dir/*.log $TESTDIR/archive/log
 	fi
     fi
     rm -fr $dir


### PR DESCRIPTION

I shouldn't have used sudo.  But I hope it doesn't matter because machines are re-imaged?

```
2018-06-28T09:22:18.479 INFO:teuthology.task.internal:Removing archive directory...
2018-06-28T09:22:18.480 INFO:teuthology.orchestra.run.smithi092:Running: 'rm -rf -- /home/ubuntu/cephtest/archive'
2018-06-28T09:22:18.555 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.4.log’: Permission denied
2018-06-28T09:22:18.555 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/mgr.x.log’: Permission denied
2018-06-28T09:22:18.555 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/client.bootstrap-osd.log’: Permission denied
2018-06-28T09:22:18.555 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.0.log’: Permission denied
2018-06-28T09:22:18.556 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.9.log’: Permission denied
2018-06-28T09:22:18.556 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.5.log’: Permission denied
2018-06-28T09:22:18.556 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.2.log’: Permission denied
2018-06-28T09:22:18.556 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/mon.a.log’: Permission denied
2018-06-28T09:22:18.556 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/client.admin.log’: Permission denied
2018-06-28T09:22:18.557 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.8.log’: Permission denied
2018-06-28T09:22:18.557 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.1.log’: Permission denied
2018-06-28T09:22:18.557 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.6.log’: Permission denied
2018-06-28T09:22:18.557 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.3.log’: Permission denied
2018-06-28T09:22:18.558 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.7.log’: Permission denied
2018-06-28T09:22:18.558 INFO:teuthology.orchestra.run.smithi092.stderr:rm: cannot remove ‘/home/ubuntu/cephtest/archive/log/osd.10.log’: Permission denied
2018-06-28T09:22:18.558 ERROR:teuthology.run_tasks:Manager failed: internal.archive
```