### PR TITLE
mimic: librbd: deep_copy: resize head object map if needed

### DIFF
--- a/src/librbd/deep_copy/SnapshotCopyRequest.h
+++ b/src/librbd/deep_copy/SnapshotCopyRequest.h
@@ -70,6 +70,9 @@ private:
    * SET_HEAD (skip if not needed)
    *    |
    *    v
+   * RESIZE_OBJECT_MAP (skip if not needed)
+   *    |
+   *    v
    * <finish>
    *
    * @endverbatim
@@ -114,6 +117,9 @@ private:
   void send_set_head();
   void handle_set_head(int r);
 
+  void send_resize_object_map();
+  void handle_resize_object_map(int r);
+
   bool handle_cancellation();
 
   void error(int r);
@@ -121,6 +127,7 @@ private:
   int validate_parent(ImageCtxT *image_ctx, librbd::ParentSpec *spec);
 
   Context *start_lock_op();
+  Context *start_lock_op(RWLock &owner_lock);
 
   void finish(int r);
 };

--- a/src/test/librbd/mock/MockObjectMap.h
+++ b/src/test/librbd/mock/MockObjectMap.h
@@ -13,6 +13,8 @@ namespace librbd {
 struct MockObjectMap {
   MOCK_CONST_METHOD1(enabled, bool(const RWLock &object_map_lock));
 
+  MOCK_CONST_METHOD0(size, uint64_t());
+
   MOCK_METHOD1(open, void(Context *on_finish));
   MOCK_METHOD1(close, void(Context *on_finish));
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/24499