### PR TITLE
mimic: mon: exception for dashboard in config-key warning

### DIFF
--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -238,11 +238,18 @@ bool ConfigKeyService::service_dispatch(MonOpRequestRef op)
     }
 
     std::string mgr_prefix = "mgr/";
-    if (key.size() >= mgr_prefix.size() &&
-        key.substr(0, mgr_prefix.size()) == mgr_prefix) {
+    std::string dashboard_prefix = "mgr/dashboard";
+    if ((key.size() >= mgr_prefix.size() &&
+         key.substr(0, mgr_prefix.size()) == mgr_prefix)
+        &&
+        (key.size() < dashboard_prefix.size() ||
+         key.substr(0, dashboard_prefix.size()) != dashboard_prefix)) {
+
       // In <= mimic, we used config-key for mgr module configuration,
       // and we bring values forward in an upgrade, but subsequent
-      // `set` operations will not be picked up.  Warn user about this.
+      // `set` operations will not be picked up.  Warn user about this,
+      // unless they're addressing the dashboard, which uses config-key
+      // for its certificates in Mimic (but not in Nautilus)
       ss << "WARNING: it looks like you might be trying to set a ceph-mgr "
             "module configuration key.  Since Ceph 13.0.0 (Mimic), mgr module "
             "configuration is done with `config set`, and new values "


### PR DESCRIPTION
This warning went in with the expectation that nobody
would be using config-key commands for modules any more,
but the dashboard does use these in order to get the
"-i" functionality on the CLI for loading certs/keys.

In Nautilus they can switch to using "-i" on real module
commands, but for Mimic let's silence the warning for
the dashboard module.

Fixes: https://tracker.ceph.com/issues/24689
Signed-off-by: John Spray <john.spray@redhat.com>