### PR TITLE
test/librados: fix LibRadosList.ListObjectsNS

### DIFF
--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -185,7 +185,7 @@ TEST_F(LibRadosList, ListObjectsNS) {
 
   char nspace[4];
   ASSERT_EQ(-ERANGE, rados_ioctx_get_namespace(ioctx, nspace, 3));
-  ASSERT_EQ(0, rados_ioctx_get_namespace(ioctx, nspace, sizeof(nspace)));
+  ASSERT_EQ(strlen("ns2"), rados_ioctx_get_namespace(ioctx, nspace, sizeof(nspace)));
   ASSERT_EQ(0, strcmp("ns2", nspace));
 
   std::set<std::string> def, ns1, ns2, all;


### PR DESCRIPTION
rados_ioctx_get_namespace() returns the length of namespace string on
success, not 0.

Signed-off-by: Kefu Chai <kchai@redhat.com>