### PR TITLE
doc: s/doc/ref for dashboard urls

### DIFF
--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -127,7 +127,7 @@ reflect either technical terms or legacy ways of referring to Ceph systems.
 	Dashboard Plugin
 	Dashboard
                 A built-in web based monitoring and administration application to
-                Ceph Manager. Refer :doc:`/mgr/dashboard` for more details.
+                Ceph Manager. Refer :ref:`mgr-dashboard` for more details.
 
 	Ceph Metadata Server
 	MDS

--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -1,7 +1,7 @@
+.. _mgr-dashboard:
+
 Ceph Manager Dashboard
 ======================
-
-.. _mgr-dashboard-overview:
 
 Overview
 --------

--- a/doc/releases/mimic.rst
+++ b/doc/releases/mimic.rst
@@ -12,7 +12,7 @@ Major Changes from Luminous
     replaced with a new implementation inspired by and derived from the
     `openATTIC <https://openattic.org>`_ Ceph management tool, providing a
     drop-in replacement offering a :ref:`number of additional management
-    features <mgr-dashboard-overview>`.
+    features <mgr-dashboard>`.
 
 - *RADOS*:
 
@@ -419,8 +419,8 @@ These changes occurred between the Luminous and Mimic releases.
     replaced with a new implementation, providing a drop-in replacement offering
     a number of additional management features. To access the new dashboard, you
     first need to define a username and password and create an SSL certificate.
-    See the :ref:`dashboard documentation <mgr-dashboard-overview>` for a feature
-    overview and installation instructions.
+    See the :ref:`mgr-dashboard` for a feature overview and installation
+    instructions.
 
   - The ``ceph-rest-api`` command-line tool (obsoleted by the MGR
     `restful` module and deprecated since v12.2.5) has been dropped.

--- a/doc/start/intro.rst
+++ b/doc/start/intro.rst
@@ -28,7 +28,7 @@ required when running Ceph Filesystem clients.
   state of the Ceph cluster, including storage utilization, current
   performance metrics, and system load.  The Ceph Manager daemons also
   host python-based plugins to manage and expose Ceph cluster
-  information, including a web-based :doc:`/mgr/dashboard` and
+  information, including a web-based :ref:`mgr-dashboard` and
   `REST API`_.  At least two managers are normally required for high
   availability.
 


### PR DESCRIPTION
Replaced `:doc:` with `:ref:` as per the comment https://github.com/ceph/ceph/pull/22750#discussion_r198895040.

Signed-off-by: Jos Collin <jcollin@redhat.com>