### PR TITLE
luminous: qa/workunits/suites/blogbench.sh: use correct dir name

### DIFF
--- a/qa/workunits/suites/blogbench.sh
+++ b/qa/workunits/suites/blogbench.sh
@@ -5,7 +5,7 @@ echo "getting blogbench"
 wget http://download.ceph.com/qa/blogbench-1.0.tar.bz2
 #cp /home/gregf/src/blogbench-1.0.tar.bz2 .
 tar -xvf blogbench-1.0.tar.bz2
-cd blogbench*
+cd blogbench-1.0/
 echo "making blogbench"
 ./configure
 make


### PR DESCRIPTION
https://tracker.ceph.com/issues/24717