### PR TITLE
luminous: common/DecayCounter: set last_decay to current time when decoding decay counter

### DIFF
--- a/src/common/DecayCounter.cc
+++ b/src/common/DecayCounter.cc
@@ -38,6 +38,7 @@ void DecayCounter::decode(const utime_t &t, bufferlist::iterator &p)
   ::decode(val, p);
   ::decode(delta, p);
   ::decode(vel, p);
+  last_decay = t;
   DECODE_FINISH(p);
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/24538