### PR TITLE
mgr/dashboard: Add OSD device health prediction state

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-
 from datetime import datetime
-
 from . import ApiController, RESTController, UpdatePermission
 from .. import mgr, logger
 from ..security import Scope

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -3,6 +3,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 
+import { TooltipModule } from 'ngx-bootstrap/';
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { ModalModule } from 'ngx-bootstrap/modal';
 import { TabsModule } from 'ngx-bootstrap/tabs';
@@ -29,6 +30,7 @@ import { OsdScrubModalComponent } from './osd/osd-scrub-modal/osd-scrub-modal.co
     FormsModule,
     ReactiveFormsModule,
     BsDropdownModule.forRoot(),
+    TooltipModule.forRoot(),
     ModalModule.forRoot()
   ],
   declarations: [

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -60,6 +60,16 @@
   </span>
 </ng-template>
 
+<ng-template #statusLight
+             let-value="value">
+      <svg width="20" height="20">
+        <circle *ngIf="value==='green'" cx="10" cy="10" r="8" stroke="green" stroke-width="1" fill="green" />
+        <circle *ngIf="value==='yellow'" cx="10" cy="10" r="8" stroke="yellow" stroke-width="1" fill="yellow" />
+        <circle *ngIf="value==='red'" cx="10" cy="10" r="8" stroke="red" stroke-width="1" fill="red" />
+        <circle *ngIf="value==='unknown'" cx="10" cy="10" r="8" stroke="gray" stroke-width="1" fill="gray" />
+      </svg>
+</ng-template>
+
 <ng-template #osdUsageTpl
              let-row="row">
   <cd-usage-bar [totalBytes]="row.stats.stat_bytes"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -59,15 +59,39 @@
     <!-- Has to be on the same line to prevent a space between state and comma. -->
   </span>
 </ng-template>
+<!--
+<ng-template #lifeExpectancyStateGreenTooltipTpl>
+  <div [innerHtml]="'Predicted device life expectancy weeks over 6 weeks'"></div>
+</ng-template>
 
+<ng-template #lifeExpectancyStateYellowTooltipTpl>
+  <div [innerHtml]="'Predicted device life expectancy weeks during 4 - 6 weeks'"></div>
+</ng-template>
+
+<ng-template #lifeExpectancyStateRedTooltipTpl>
+  <div [innerHtml]="'Predicted device life expectancy weeks less 4 weeks'"></div>
+</ng-template>
+
+<ng-template #lifeExpectancyStateGrayTooltipTpl>
+  <div [innerHtml]="'Predicted device life expectancy none configured'"></div>
+</ng-template>
+-->
 <ng-template #statusLight
              let-value="value">
-      <svg width="20" height="20">
-        <circle *ngIf="value==='green'" cx="10" cy="10" r="8" stroke="green" stroke-width="1" fill="green" />
-        <circle *ngIf="value==='yellow'" cx="10" cy="10" r="8" stroke="yellow" stroke-width="1" fill="yellow" />
-        <circle *ngIf="value==='red'" cx="10" cy="10" r="8" stroke="red" stroke-width="1" fill="red" />
-        <circle *ngIf="value==='unknown'" cx="10" cy="10" r="8" stroke="gray" stroke-width="1" fill="gray" />
-      </svg>
+             <ng-template #lifeExpectancyStateTooltipTpl>
+              <div *ngIf="value==='green'" [innerHtml]="'Predicted device life expectancy weeks over 6 weeks'"></div>
+              <div *ngIf="value==='yellow'" [innerHtml]="'Predicted device life expectancy weeks during 4 - 6 weeks'"></div>
+              <div *ngIf="value==='red'" [innerHtml]="'Predicted device life expectancy weeks less 4 weeks'"></div>
+              <div *ngIf="value==='unknown'" [innerHtml]="'Predicted device life expectancy none configured'"></div>
+             </ng-template>
+  <span class="text-muted" [tooltip]="lifeExpectancyStateTooltipTpl" placement="left">
+    <svg width="20" height="20">
+      <circle *ngIf="value==='green'" cx="10" cy="10" r="8" stroke="green" stroke-width="1" fill="green" />
+      <circle *ngIf="value==='yellow'" cx="10" cy="10" r="8" stroke="yellow" stroke-width="1" fill="yellow" />
+      <circle *ngIf="value==='red'" cx="10" cy="10" r="8" stroke="red" stroke-width="1" fill="red" />
+      <circle *ngIf="value==='unknown'" cx="10" cy="10" r="8" stroke="gray" stroke-width="1" fill="gray" />
+    </svg>
+  </span>
 </ng-template>
 
 <ng-template #osdUsageTpl

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { TooltipModule } from 'ngx-bootstrap/';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { configureTestBed } from '../../../../../testing/unit-test-helper';
@@ -33,6 +34,7 @@ describe('OsdListComponent', () => {
       TabsModule.forRoot(),
       DataTableModule,
       ComponentsModule,
+      TooltipModule.forRoot(),
       SharedModule
     ],
     declarations: [OsdListComponent, OsdDetailsComponent, OsdPerformanceHistogramComponent],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -21,6 +21,8 @@ import { OsdScrubModalComponent } from '../osd-scrub-modal/osd-scrub-modal.compo
 export class OsdListComponent implements OnInit {
   @ViewChild('statusColor')
   statusColor: TemplateRef<any>;
+  @ViewChild('statusLight')
+  statusLight: TemplateRef<any>;
   @ViewChild('osdUsageTpl')
   osdUsageTpl: TemplateRef<any>;
   @ViewChild(TableComponent)
@@ -60,7 +62,8 @@ export class OsdListComponent implements OnInit {
         cellTransformation: CellTemplate.sparkline
       },
       { prop: 'stats.op_r', name: 'Read ops', cellTransformation: CellTemplate.perSecond },
-      { prop: 'stats.op_w', name: 'Write ops', cellTransformation: CellTemplate.perSecond }
+      { prop: 'stats.op_w', name: 'Write ops', cellTransformation: CellTemplate.perSecond },
+      { prop: 'stats.lf_s', name: 'Expectancy state', cellTemplate: this.statusLight }
     ];
   }
 


### PR DESCRIPTION
Add ODS device health prediction state in the osd list.
Green: 6+ weeks
Yellow: 4-6 weeks
Red: 0-4 weeks
Gray: unknown
The state relied on the ceph device info.(#22423, #22479, #22239)

![osd_life_expectancy_state](https://user-images.githubusercontent.com/263427/42640796-5e25b8f6-85f3-11e8-8842-186c0705750b.png)

Signed-off-by: Rick Chen rick.chen@prophetstor.com