### PR TITLE
os/bluestore: fix wrong usage for Finisher::queue.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9619,8 +9619,8 @@ int BlueStore::queue_transactions(
   for (auto c : on_applied_sync) {
     c->complete(0);
   }
-  for (auto c : on_applied) {
-    finishers[osr->shard]->queue(c);
+  if (!on_applied.empty()) {
+    finishers[osr->shard]->queue(on_applied);
   }
 
   logger->tinc(l_bluestore_submit_lat, mono_clock::now() - start);


### PR DESCRIPTION
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>