### PR TITLE
rgw: support admin rest api get user info through user's access-key

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -30,16 +30,17 @@ void RGWOp_User_Info::execute()
 {
   RGWUserAdminOpState op_state;
 
-  std::string uid_str;
+  std::string uid_str, access_key_str;
   bool fetch_stats;
   bool sync_stats;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
+  RESTArgs::get_string(s, "access-key", access_key_str, &access_key_str);
 
   // if uid was not supplied in rest argument, error out now, otherwise we'll
   // end up initializing anonymous user, for which keys.init will eventually
   // return -EACESS
-  if (uid_str.empty()){
+  if (uid_str.empty() && access_key_str.empty()){
     http_ret=-EINVAL;
     return;
   }
@@ -51,6 +52,7 @@ void RGWOp_User_Info::execute()
   RESTArgs::get_bool(s, "sync", false, &sync_stats);
 
   op_state.set_user_id(uid);
+  op_state.set_access_key(access_key_str);
   op_state.set_fetch_stats(fetch_stats);
   op_state.set_sync_stats(sync_stats);
 


### PR DESCRIPTION
hi, 
   we can get user info with radosgw-admin user info --uid=user-id-wrong   --access-key=some-exist-access-key  

will return the user info correctly that user own the access-key even we --uid= id not exist , it's usefull in some scenes,
for example:
 when our api server(which use rgw admin rest api) recieve a request 

```
rtmp://testyuliyang.oss-cn-shanghai.aliyuncs.com/live
test-channel3?AccessKeyId=xxxxxxxxxxx&Expires=1513858333&Signature=yyyyyyy
```
and we want to verify the request, so we need to get user info through user's AccessKeyId

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>