### PR TITLE
mgr: Ignore daemon if no metadata was returned

### DIFF
--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -151,6 +151,9 @@ class Module(MgrModule):
         data = []
         for osd_id, stats in osd_sum.iteritems():
             metadata = self.get_metadata('osd', "%s" % osd_id)
+            if not metadata:
+                continue
+
             for stat in stats:
                 point_1 = {
                     "measurement": "ceph_pg_summary_osd",

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -105,6 +105,8 @@ class Module(MgrModule):
         for daemon, counters in self.get_all_perf_counters().iteritems():
             svc_type, svc_id = daemon.split('.', 1)
             metadata = self.get_metadata(svc_type, svc_id)
+            if not metadata:
+                continue
 
             for path, counter_info in counters.items():
                 if counter_info['type'] & self.PERFCOUNTER_HISTOGRAM:


### PR DESCRIPTION
It can happen that the Mgr does not return any metadata for a given
daemon as it might not be available at that moment.

None is returned by the get_metadata() method at that moment and both
the Influx and Telegraf module should then ignore the daemon in their
statistics and continue on to the next daemon.

Signed-off-by: Wido den Hollander <wido@42on.com>