### PR TITLE
luminous: test: fix CLI unit formatting tests

### DIFF
--- a/qa/workunits/rbd/import_export.sh
+++ b/qa/workunits/rbd/import_export.sh
@@ -136,7 +136,7 @@ if rbd help export | grep -q export-format; then
     rbd import --stripe-count 1000 --stripe-unit 4096 ${TMPDIR}/img testimg
     rbd export --export-format 2 testimg ${TMPDIR}/img_v2
     rbd import --export-format 2 ${TMPDIR}/img_v2 testimg_import
-    rbd info testimg_import|grep "stripe unit"|awk '{print $3}'|grep -Ei '(4K|4096)'
+    rbd info testimg_import|grep "stripe unit"|grep -Ei '(4K|4 KiB|4096)'
     rbd info testimg_import|grep "stripe count"|awk '{print $3}'|grep 1000
 
     rm ${TMPDIR}/img_v2


### PR DESCRIPTION
cherry-picking form https://github.com/ceph/ceph/pull/22230 which doesn't have an issue. There were conflicts in the tests due to MB->MiB transition, not sure whether this holds in luminous. Also cli generic changeset has been dropped as thick provisioning isn't a part of Luminous (?)