### PR TITLE
cmake: allow setting of the CTest timeout during building.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -560,6 +560,8 @@ option(ENABLE_COVERAGE "Coverage is enabled" OFF)
 option(PG_DEBUG_REFS "PG Ref debugging is enabled" OFF)
 
 option(WITH_TESTS "enable the build of ceph-test package scripts/binaries" ON)
+set(CEPH_TEST_TIMEOUT 3600 CACHE STRING 
+  "Maximum time before a CTest gets killed" )
 
 # fio
 option(WITH_FIO "build with fio plugin enabled" OFF)

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -20,7 +20,7 @@ function(add_ceph_test test_name test_path)
   # none of the tests should take more than 1 hour to complete
   set_property(TEST
     ${test_name}
-    PROPERTY TIMEOUT 3600)
+    PROPERTY TIMEOUT ${CEPH_TEST_TIMEOUT})
 endfunction()
 
 option(WITH_GTEST_PARALLEL "Enable running gtest based tests in parallel" OFF)


### PR DESCRIPTION
It is rather had to overide a once set timeout during CTesting. This is the
best next compromise. Disadvantage is that a rebuild is required. But it
helps in my Jenkins testing timely catching run-away programs.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>