### PR TITLE
mimic: doc: update experimental features - snapshots

### DIFF
--- a/doc/cephfs/experimental-features.rst
+++ b/doc/cephfs/experimental-features.rst
@@ -44,12 +44,10 @@ some cases. Specifically, if you share a pool for multiple FSes and delete
 a snapshot in one FS, expect to lose snapshotted file data in any other FS using
 snapshots. See the :doc:`/dev/cephfs-snapshots` page for more information.
 
-Snapshots are known not to work with multi-MDS filesystems.
-
 For somewhat obscure implementation reasons, the kernel client only supports up
 to 400 snapshots (http://tracker.ceph.com/issues/21420).
 
-Snapshotting was blocked off with the ``allow_new_snaps`` flag prior to Firefly.
+Snapshotting was blocked off with the ``allow_new_snaps`` flag prior to Mimic.
 
 Multiple filesystems within a Ceph cluster
 ------------------------------------------
@@ -70,7 +68,7 @@ Note that snapshots and multiple filesystems are *not* tested in combination
 and may not work together; see above.
 
 Multiple filesystems were available starting in the Jewel release candidates
-but were protected behind the ``enable_multiple`` flag before the final release.
+but must be turned on via the ``enable_multiple`` flag until declared stable.
 
 
 Previously experimental features

--- a/doc/cephfs/experimental-features.rst
+++ b/doc/cephfs/experimental-features.rst
@@ -21,7 +21,7 @@ load on the MDS. It is not sufficiently tested to support at this time, although
 failures within it are unlikely to make non-inlined data inaccessible
 
 Inline data has always been off by default and requires setting
-the "inline_data" flag.
+the ``inline_data`` flag.
 
 Mantle: Programmable Metadata Load Balancer
 -------------------------------------------
@@ -49,7 +49,7 @@ Snapshots are known not to work with multi-MDS filesystems.
 For somewhat obscure implementation reasons, the kernel client only supports up
 to 400 snapshots (http://tracker.ceph.com/issues/21420).
 
-Snapshotting was blocked off with the "allow_new_snaps" flag prior to Firefly.
+Snapshotting was blocked off with the ``allow_new_snaps`` flag prior to Firefly.
 
 Multiple filesystems within a Ceph cluster
 ------------------------------------------
@@ -70,7 +70,7 @@ Note that snapshots and multiple filesystems are *not* tested in combination
 and may not work together; see above.
 
 Multiple filesystems were available starting in the Jewel release candidates
-but were protected behind the "enable_multiple" flag before the final release.
+but were protected behind the ``enable_multiple`` flag before the final release.
 
 
 Previously experimental features


### PR DESCRIPTION
https://tracker.ceph.com/issues/24746

---

* drop the experimental warning of multi-MDS
* update snapshotting blocked off version
* update Multiple filesystems availability in Jewel