### PR TITLE
mds: remove useless dout_subsys macro

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -41,7 +41,6 @@ using std::chrono::duration_cast;
 #include "common/errno.h"
 
 #define dout_context g_ceph_context
-#define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << ".bal "
 #undef dout

--- a/src/mds/Mantle.cc
+++ b/src/mds/Mantle.cc
@@ -22,7 +22,6 @@
 #include <fstream>
 
 #define dout_context g_ceph_context
-#define dout_subsys ceph_subsys_mds_balancer
 #undef dout_prefix
 #define dout_prefix *_dout << "mds.mantle "
 #define mantle_dout(lvl) \


### PR DESCRIPTION
Both dout_subsys macros are useless since there is new definition of dout(lvl), so remove those dout_subsys macros. 

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>