### PR TITLE
doc/dashboard: don't advise mgr_initial_modules

### DIFF
--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -109,6 +109,18 @@ Here is an example of enabling the :term:`Dashboard` module:
 	}
 
 
+The first time the cluster starts, it uses the ``mgr_initial_modules``
+setting to override which modules to enable.  However, this setting
+is ignored through the rest of the lifetime of the cluster: only
+use it for bootstrapping.  For example, before starting your
+monitor daemons for the first time, you might add a section like
+this to your ``ceph.conf``:
+
+::
+
+    [mon]
+        mgr initial modules = dashboard balancer
+
 Calling module commands
 -----------------------
 

--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -79,18 +79,6 @@ Within a running Ceph cluster, the Ceph Manager Dashboard is enabled with::
 
   $ ceph mgr module enable dashboard
 
-This can be automated (e.g. during deployment) by adding the following to
-``ceph.conf``::
-
-  [mon]
-          mgr initial modules = dashboard
-
-Note that ``mgr initial modules`` takes a space-separated list of modules, so
-if you wanted to include other modules in addition to dashboard, just make it
-a list like so::
-
-          mgr initial modules = balancer dashboard
-
 Configuration
 -------------
 


### PR DESCRIPTION
This setting tends to confuse people, as it's only respected
on the very first startup of the cluster.  Instead, mention
it (with appropriate caveats) on the general mgr admin
page.

Signed-off-by: John Spray <john.spray@redhat.com>