### PR TITLE
common: FreeBSD does not have /etc/os-release

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -93,6 +93,7 @@ static void file_values_parse(const map<string, string>& kvm, FILE *fp, map<stri
 
 static bool os_release_parse(map<string, string> *m, CephContext *cct)
 {
+#if defined(__linux__)
   static const map<string, string> kvm = {
     { "distro", "ID=" },
     { "distro_description", "PRETTY_NAME=" },
@@ -109,6 +110,15 @@ static bool os_release_parse(map<string, string> *m, CephContext *cct)
   file_values_parse(kvm, fp, m, cct);
 
   fclose(fp);
+#elif defined(__FreeBSD__)
+  struct utsname u;
+  int r = uname(&u);
+  if (!r) {
+     m->insert(std::make_pair("distro", u.sysname));
+     m->insert(std::make_pair("distro_description", u.version));
+     m->insert(std::make_pair("distro_version", u.release));
+  }
+#endif
 
   return true;
 }

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -207,8 +207,8 @@ static void handle_fatal_signal(int signum)
 	  jf.dump_string("utsname_version", u.version);
 	  jf.dump_string("utsname_machine", u.machine);
 	}
-
-	// os-releaes
+#if defined(__linux__)
+	// os-release
 	int in = ::open("/etc/os-release", O_RDONLY);
 	if (in >= 0) {
 	  char buf[4096];
@@ -231,6 +231,7 @@ static void handle_fatal_signal(int signum)
 	  }
 	  ::close(in);
 	}
+#endif
 
 	// assert?
 	if (g_assert_condition) {


### PR DESCRIPTION
But it does have uname() with lots of information.
So use that instead.

It will decrease the number of unneeded lines in the log
telling us that the file does not exisit.
Especially ceph-mgr suffers from repeated calls.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>