### PR TITLE
ceph-volume: provide a nice errror message when missing ceph.conf

### DIFF
--- a/src/ceph-volume/ceph_volume/__init__.py
+++ b/src/ceph-volume/ceph_volume/__init__.py
@@ -1,5 +1,16 @@
 from collections import namedtuple
 
+
+class UnloadedConfig(object):
+    """
+    This class is used as the default value for conf.ceph so that if
+    a configuration file is not successfully loaded then it will give
+    a nice error message when values from the config are used.
+    """
+    def __getattr__(self, *a):
+        raise RuntimeError("No valid ceph configuration file was loaded.")
+
 conf = namedtuple('config', ['ceph', 'cluster', 'verbosity', 'path', 'log_path'])
+conf.ceph = UnloadedConfig()
 
 __version__ = "1.0.0"

--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -10,12 +10,6 @@ from ceph_volume.decorators import catches
 from ceph_volume import log, devices, configuration, conf, exceptions, terminal
 
 
-IGNORE_CEPH_CONFIG_COMMANDS = [
-    "lvm list",
-    "lvm zap",
-]
-
-
 class Volume(object):
     _help = """
 ceph-volume: Deploy Ceph OSDs using different device technologies like lvm or
@@ -155,16 +149,11 @@ Ceph Conf: {ceph_path}
         try:
             conf.ceph = configuration.load(conf.path)
         except exceptions.ConfigurationError as error:
-            is_help = "-h" in subcommand_args or "--help" in subcommand_args
-            if " ".join(subcommand_args[:2]) in IGNORE_CEPH_CONFIG_COMMANDS or is_help:
-                # we warn only here, because it is possible that the configuration
-                # file is not needed, or that it will be loaded by some other means
-                # (like reading from lvm tags)
-                logger.exception('ignoring inability to load ceph.conf')
-                terminal.red(error)
-            else:
-                terminal.red(error)
-                raise
+            # we warn only here, because it is possible that the configuration
+            # file is not needed, or that it will be loaded by some other means
+            # (like reading from lvm tags)
+            logger.exception('ignoring inability to load ceph.conf')
+            terminal.red(error)
         # dispatch to sub-commands
         terminal.dispatch(self.mapper, subcommand_args)
 


### PR DESCRIPTION
Instead of maintaining a list of commands that do not require ceph.conf we should always ignore a missing ceph.conf but provide a nice error message if a subcommand fails when trying to use it.

Our first approach here broke the ``simple trigger`` subcommand when we backported #22724 to luminous because it should have been added to ``IGNORE_CEPH_CONFIG_COMMANDS``. In this way we don't have the maintenance burden of that list of commands and provides a friendly error message if the ceph.conf is missing but needed.