### PR TITLE
mgr/dashboard: Fix regression on rbd form component

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -1,17 +1,22 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { ToastModule } from 'ng2-toastr';
 
+import { ActivatedRouteStub } from '../../../../testing/activated-route-stub';
+import { RbdService } from '../../../shared/api/rbd.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { configureTestBed } from '../../../shared/unit-test-helper';
+import { RbdFormMode } from './rbd-form-mode.enum';
 import { RbdFormComponent } from './rbd-form.component';
 
 describe('RbdFormComponent', () => {
   let component: RbdFormComponent;
   let fixture: ComponentFixture<RbdFormComponent>;
+  let activatedRoute: ActivatedRouteStub;
 
   configureTestBed({
     imports: [
@@ -21,16 +26,47 @@ describe('RbdFormComponent', () => {
       ToastModule.forRoot(),
       SharedModule
     ],
-    declarations: [RbdFormComponent]
+    declarations: [RbdFormComponent],
+    providers: [
+      {
+        provide: ActivatedRoute,
+        useValue: new ActivatedRouteStub({ pool: 'foo', name: 'bar', snap: undefined })
+      }
+    ]
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdFormComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    activatedRoute = TestBed.get(ActivatedRoute);
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('should test decodeURIComponent of params', () => {
+    let rbdService: RbdService;
+
+    beforeEach(() => {
+      rbdService = TestBed.get(RbdService);
+      component.mode = RbdFormMode.editing;
+      fixture.detectChanges();
+      spyOn(rbdService, 'get').and.callThrough();
+    });
+
+    it('without snapName', () => {
+      activatedRoute.setParams({ pool: 'foo%2Ffoo', name: 'bar%2Fbar', snap: undefined });
+
+      expect(rbdService.get).toHaveBeenCalledWith('foo/foo', 'bar/bar');
+      expect(component.snapName).toBeUndefined();
+    });
+
+    it('with snapName', () => {
+      activatedRoute.setParams({ pool: 'foo%2Ffoo', name: 'bar%2Fbar', snap: 'baz%2Fbaz' });
+
+      expect(rbdService.get).toHaveBeenCalledWith('foo/foo', 'bar/bar');
+      expect(component.snapName).toBe('baz/baz');
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -209,7 +209,9 @@ export class RbdFormComponent implements OnInit {
       this.route.params.subscribe((params: { pool: string; name: string; snap: string }) => {
         const poolName = decodeURIComponent(params.pool);
         const rbdName = decodeURIComponent(params.name);
-        this.snapName = decodeURIComponent(params.snap);
+        if (params.snap) {
+          this.snapName = decodeURIComponent(params.snap);
+        }
         this.rbdService.get(poolName, rbdName).subscribe((resp: RbdFormResponseModel) => {
           this.setResponse(resp, this.snapName);
         });

--- a/src/pybind/mgr/dashboard/frontend/src/testing/activated-route-stub.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/activated-route-stub.ts
@@ -1,0 +1,23 @@
+import { ReplaySubject } from 'rxjs';
+
+/**
+ * An ActivateRoute test double with a `params` observable.
+ * Use the `setParams()` method to add the next `params` value.
+ */
+export class ActivatedRouteStub {
+  // Use a ReplaySubject to share previous values with subscribers
+  // and pump new values into the `params` observable
+  private subject = new ReplaySubject<object>();
+
+  constructor(initialParams?: object) {
+    this.setParams(initialParams);
+  }
+
+  /** The mock params observable */
+  readonly params = this.subject.asObservable();
+
+  /** Set the params observables's next value */
+  setParams(params?: object) {
+    this.subject.next(params);
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/tsconfig.app.json
+++ b/src/pybind/mgr/dashboard/frontend/src/tsconfig.app.json
@@ -9,6 +9,7 @@
   "exclude": [
     "app/shared/unit-test-helper.ts",
     "test.ts",
+    "testing/*.ts",
     "**/*.spec.ts"
   ]
 }

--- a/src/pybind/mgr/dashboard/frontend/src/tsconfig.spec.json
+++ b/src/pybind/mgr/dashboard/frontend/src/tsconfig.spec.json
@@ -16,6 +16,7 @@
   ],
   "include": [
     "**/*.spec.ts",
-    "**/*.d.ts"
+    "**/*.d.ts",
+    "testing/*.ts"
   ]
 }


### PR DESCRIPTION
'decodeURIComponent' method was decoding an undefined variable to the string
'undefined', which would later cause problems.

This regression was introduced in 057d6025894800c1b4a422b081fe02ab82b044fe.

Fixes: http://tracker.ceph.com/issues/24757

`Signed-off-by: Tiago Melo <tmelo@suse.com>`