### PR TITLE
mgr/dashboard: Fix RBD object size dropdown options

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.ts
@@ -53,23 +53,23 @@ export class RbdFormComponent implements OnInit {
   response: RbdFormResponseModel;
   snapName: string;
 
-  defaultObjectSize = '4MiB';
+  defaultObjectSize = '4 MiB';
 
   objectSizes: Array<string> = [
-    '4KiB',
-    '8KiB',
-    '16KiB',
-    '32KiB',
-    '64KiB',
-    '128KiB',
-    '256KiB',
-    '512KiB',
-    '1MiB',
-    '2MiB',
-    '4MiB',
-    '8MiB',
-    '16MiB',
-    '32MiB'
+    '4 KiB',
+    '8 KiB',
+    '16 KiB',
+    '32 KiB',
+    '64 KiB',
+    '128 KiB',
+    '256 KiB',
+    '512 KiB',
+    '1 MiB',
+    '2 MiB',
+    '4 MiB',
+    '8 MiB',
+    '16 MiB',
+    '32 MiB'
   ];
 
   constructor(


### PR DESCRIPTION
RBD object size options should have a blank space between the value and the unit.

Fixes: https://tracker.ceph.com/issues/24756

Signed-off-by: Ricardo Marques <rimarques@suse.com>