### PR TITLE
luminous: order rbdmap.service before remote-fs-pre.target

### DIFF
--- a/systemd/rbdmap.service
+++ b/systemd/rbdmap.service
@@ -2,7 +2,8 @@
 Description=Map RBD devices
 
 After=network-online.target
-Wants=network-online.target
+Before=remote-fs-pre.target
+Wants=network-online.target remote-fs-pre.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph

--- a/systemd/rbdmap.service
+++ b/systemd/rbdmap.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=Map RBD devices
 
-After=network-online.target local-fs.target
-Wants=network-online.target local-fs.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph


### PR DESCRIPTION
http://tracker.ceph.com/issues/24735