### PR TITLE
mgr/dashboard: Move unit-test-helper into the new testing folder

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.component.spec.ts
@@ -4,9 +4,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { ToastModule } from 'ng2-toastr';
 
+import { configureTestBed } from '../testing/unit-test-helper';
 import { AppComponent } from './app.component';
 import { AuthStorageService } from './shared/services/auth-storage.service';
-import { configureTestBed } from './shared/unit-test-helper';
 
 describe('AppComponent', () => {
   let component: AppComponent;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
@@ -1,13 +1,13 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { TcmuIscsiService } from '../../../shared/api/tcmu-iscsi.service';
 import { CephShortVersionPipe } from '../../../shared/pipes/ceph-short-version.pipe';
 import { DimlessPipe } from '../../../shared/pipes/dimless.pipe';
 import { ListPipe } from '../../../shared/pipes/list.pipe';
 import { RelativeDatePipe } from '../../../shared/pipes/relative-date.pipe';
 import { FormatterService } from '../../../shared/services/formatter.service';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { IscsiComponent } from './iscsi.component';
 
 describe('IscsiComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirroring.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/mirroring/mirroring.component.spec.ts
@@ -4,8 +4,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BsDropdownModule, TabsModule } from 'ngx-bootstrap';
 import { ProgressbarModule } from 'ngx-bootstrap/progressbar';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { MirrorHealthColorPipe } from '../mirror-health-color.pipe';
 import { MirroringComponent } from './mirroring.component';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.spec.ts
@@ -3,8 +3,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { TabsModule, TooltipModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdSnapshotListComponent } from '../rbd-snapshot-list/rbd-snapshot-list.component';
 import { RbdDetailsComponent } from './rbd-details.component';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-form/rbd-form.component.spec.ts
@@ -7,9 +7,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ToastModule } from 'ng2-toastr';
 
 import { ActivatedRouteStub } from '../../../../testing/activated-route-stub';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdFormMode } from './rbd-form-mode.enum';
 import { RbdFormComponent } from './rbd-form.component';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -11,9 +11,9 @@ import {
   TooltipModule
 } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdDetailsComponent } from '../rbd-details/rbd-details.component';
 import { RbdSnapshotListComponent } from '../rbd-snapshot-list/rbd-snapshot-list.component';
 import { RbdListComponent } from './rbd-list.component';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
@@ -5,11 +5,11 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { ToastModule } from 'ng2-toastr';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ApiModule } from '../../../shared/api/api.module';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { ServicesModule } from '../../../shared/services/services.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdSnapshotFormComponent } from './rbd-snapshot-form.component';
 
 describe('RbdSnapshotFormComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.spec.ts
@@ -6,6 +6,7 @@ import { ToastModule } from 'ng2-toastr';
 import { BsModalRef, ModalModule } from 'ngx-bootstrap';
 import { throwError as observableThrowError } from 'rxjs';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ApiModule } from '../../../shared/api/api.module';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { ComponentsModule } from '../../../shared/components/components.module';
@@ -15,7 +16,6 @@ import { PipesModule } from '../../../shared/pipes/pipes.module';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { ServicesModule } from '../../../shared/services/services.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RbdSnapshotListComponent } from './rbd-snapshot-list.component';
 
 describe('RbdSnapshotListComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-chart/cephfs-chart.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-chart/cephfs-chart.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ChartsModule } from 'ng2-charts/ng2-charts';
 
-import { configureTestBed } from '../../../shared/unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { CephfsChartComponent } from './cephfs-chart.component';
 
 describe('CephfsChartComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-clients/cephfs-clients.component.spec.ts
@@ -4,9 +4,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { CephfsService } from '../../../shared/api/cephfs.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { CephfsClientsComponent } from './cephfs-clients.component';
 
 describe('CephfsClientsComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.spec.ts
@@ -6,9 +6,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ChartsModule } from 'ng2-charts/ng2-charts';
 import { BsDropdownModule, ProgressbarModule, TabsModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { CephfsService } from '../../../shared/api/cephfs.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { CephfsDetailComponent } from './cephfs-detail.component';
 
 @Component({ selector: 'cd-cephfs-chart', template: '' })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-list/cephfs-list.component.spec.ts
@@ -2,10 +2,10 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Component, Input } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { CephfsService } from '../../../shared/api/cephfs.service';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { CephfsListComponent } from './cephfs-list.component';
 
 @Component({ selector: 'cd-cephfs-detail', template: '' })

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
@@ -4,9 +4,9 @@ import { FormsModule } from '@angular/forms';
 
 import { TabsModule } from 'ngx-bootstrap/tabs/tabs.module';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ConfigurationService } from '../../../shared/api/configuration.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { ConfigurationComponent } from './configuration.component';
 
 describe('ConfigurationComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -4,11 +4,11 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { Permissions } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { HostsComponent } from './hosts.component';
 
 describe('HostsComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.spec.ts
@@ -1,8 +1,8 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { MonitorService } from '../../../shared/api/monitor.service';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { MonitorComponent } from './monitor.component';
 
 describe('MonitorComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
@@ -3,10 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../../testing/unit-test-helper';
 import { DataTableModule } from '../../../../shared/datatable/datatable.module';
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../../shared/shared.module';
-import { configureTestBed } from '../../../../shared/unit-test-helper';
 import { PerformanceCounterModule } from '../../../performance-counter/performance-counter.module';
 import { OsdPerformanceHistogramComponent } from '../osd-performance-histogram/osd-performance-histogram.component';
 import { OsdDetailsComponent } from './osd-details.component';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.spec.ts
@@ -6,10 +6,10 @@ import * as _ from 'lodash';
 import { ToastModule } from 'ng2-toastr';
 import { BsModalRef, ModalModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../../testing/unit-test-helper';
 import { NotificationType } from '../../../../shared/enum/notification-type.enum';
 import { NotificationService } from '../../../../shared/services/notification.service';
 import { SharedModule } from '../../../../shared/shared.module';
-import { configureTestBed } from '../../../../shared/unit-test-helper';
 import { OsdFlagsModalComponent } from './osd-flags-modal.component';
 
 function getFlagsArray(component: OsdFlagsModalComponent) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -3,6 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
+import { configureTestBed } from '../../../../../testing/unit-test-helper';
 import { ComponentsModule } from '../../../../shared/components/components.module';
 import { DataTableModule } from '../../../../shared/datatable/datatable.module';
 import { Permissions } from '../../../../shared/models/permissions';
@@ -10,7 +11,6 @@ import { DimlessPipe } from '../../../../shared/pipes/dimless.pipe';
 import { AuthStorageService } from '../../../../shared/services/auth-storage.service';
 import { FormatterService } from '../../../../shared/services/formatter.service';
 import { SharedModule } from '../../../../shared/shared.module';
-import { configureTestBed } from '../../../../shared/unit-test-helper';
 import { PerformanceCounterModule } from '../../../performance-counter/performance-counter.module';
 import { OsdDetailsComponent } from '../osd-details/osd-details.component';
 import { OsdPerformanceHistogramComponent } from '../osd-performance-histogram/osd-performance-histogram.component';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-performance-histogram/osd-performance-histogram.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-performance-histogram/osd-performance-histogram.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../../../../shared/unit-test-helper';
+import { configureTestBed } from '../../../../../testing/unit-test-helper';
 import { OsdPerformanceHistogramComponent } from './osd-performance-histogram.component';
 
 describe('OsdPerformanceHistogramComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-scrub-modal/osd-scrub-modal.component.spec.ts
@@ -4,9 +4,9 @@ import { ReactiveFormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../../testing/unit-test-helper';
 import { OsdService } from '../../../../shared/api/osd.service';
 import { NotificationService } from '../../../../shared/services/notification.service';
-import { configureTestBed } from '../../../../shared/unit-test-helper';
 import { OsdScrubModalComponent } from './osd-scrub-modal.component';
 
 describe('OsdScrubModalComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.spec.ts
@@ -1,7 +1,7 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../../../shared/unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { DashboardComponent } from './dashboard.component';
 
 describe('DashboardComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.spec.ts
@@ -1,9 +1,9 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { DimlessBinaryPipe } from '../../../shared/pipes/dimless-binary.pipe';
 import { FormatterService } from '../../../shared/services/formatter.service';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { HealthPieComponent } from './health-pie.component';
 
 describe('HealthPieComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
@@ -2,9 +2,9 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { DashboardService } from '../../../shared/api/dashboard.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { LogColorPipe } from '../log-color.pipe';
 import { MdsSummaryPipe } from '../mds-summary.pipe';
 import { MgrSummaryPipe } from '../mgr-summary.pipe';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.spec.ts
@@ -2,8 +2,8 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { TablePerformanceCounterComponent } from '../table-performance-counter/table-performance-counter.component';
 import { PerformanceCounterComponent } from './performance-counter.component';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { TablePerformanceCounterComponent } from './table-performance-counter.component';
 
 describe('TablePerformanceCounterComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs/tabs.module';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { PoolListComponent } from './pool-list.component';
 
 describe('PoolListComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.spec.ts
@@ -1,8 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { Rgw501Component } from './rgw-501.component';
 
 describe('Rgw501Component', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-details/rgw-bucket-details.component.spec.ts
@@ -2,9 +2,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwBucketDetailsComponent } from './rgw-bucket-details.component';
 
 describe('RgwBucketDetailsComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-form/rgw-bucket-form.component.spec.ts
@@ -5,10 +5,10 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { of as observableOf } from 'rxjs';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { RgwBucketService } from '../../../shared/api/rgw-bucket.service';
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwBucketFormComponent } from './rgw-bucket-form.component';
 
 describe('RgwBucketFormComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.spec.ts
@@ -4,9 +4,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { ModalModule, TabsModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { RgwBucketService } from '../../../shared/api/rgw-bucket.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwBucketDetailsComponent } from '../rgw-bucket-details/rgw-bucket-details.component';
 import { RgwBucketListComponent } from './rgw-bucket-list.component';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.spec.ts
@@ -3,10 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { RgwDaemonService } from '../../../shared/api/rgw-daemon.service';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { PerformanceCounterModule } from '../../performance-counter/performance-counter.module';
 import { RgwDaemonDetailsComponent } from './rgw-daemon-details.component';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { PerformanceCounterModule } from '../../performance-counter/performance-counter.module';
 import { RgwDaemonDetailsComponent } from '../rgw-daemon-details/rgw-daemon-details.component';
 import { RgwDaemonListComponent } from './rgw-daemon-list.component';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-capability-modal/rgw-user-capability-modal.component.spec.ts
@@ -3,8 +3,8 @@ import { ReactiveFormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserCapabilityModalComponent } from './rgw-user-capability-modal.component';
 
 describe('RgwUserCapabilityModalComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-details/rgw-user-details.component.spec.ts
@@ -5,9 +5,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserDetailsComponent } from './rgw-user-details.component';
 
 describe('RgwUserDetailsComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -6,9 +6,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { BsModalService } from 'ngx-bootstrap/modal';
 import { of as observableOf } from 'rxjs';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserS3Key } from '../models/rgw-user-s3-key';
 import { RgwUserFormComponent } from './rgw-user-form.component';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -24,17 +24,9 @@ describe('RgwUserFormComponent', () => {
   }
 
   configureTestBed({
-    declarations: [ RgwUserFormComponent ],
-    imports: [
-      HttpClientTestingModule,
-      ReactiveFormsModule,
-      RouterTestingModule,
-      SharedModule
-    ],
-    providers: [
-      BsModalService,
-      { provide: RgwUserService, useClass: MockRgwUserService }
-    ]
+    declarations: [RgwUserFormComponent],
+    imports: [HttpClientTestingModule, ReactiveFormsModule, RouterTestingModule, SharedModule],
+    providers: [BsModalService, { provide: RgwUserService, useClass: MockRgwUserService }]
   });
 
   beforeEach(() => {
@@ -67,14 +59,12 @@ describe('RgwUserFormComponent', () => {
       component.setS3Key(key);
       expect(component.s3Keys.length).toBe(1);
       expect(component.s3Keys[0].user).toBe('test1:subuser2');
-      expect(rgwUserService.addS3Key).toHaveBeenCalledWith(
-        'test1', {
-          subuser: 'subuser2',
-          generate_key: 'false',
-          access_key: undefined,
-          secret_key: undefined
-        }
-      );
+      expect(rgwUserService.addS3Key).toHaveBeenCalledWith('test1', {
+        subuser: 'subuser2',
+        generate_key: 'false',
+        access_key: undefined,
+        secret_key: undefined
+      });
     });
 
     it('should set key w/o subuser', () => {
@@ -83,14 +73,12 @@ describe('RgwUserFormComponent', () => {
       component.setS3Key(key);
       expect(component.s3Keys.length).toBe(1);
       expect(component.s3Keys[0].user).toBe('test1');
-      expect(rgwUserService.addS3Key).toHaveBeenCalledWith(
-        'test1', {
-          subuser: '',
-          generate_key: 'false',
-          access_key: undefined,
-          secret_key: undefined
-        }
-      );
+      expect(rgwUserService.addS3Key).toHaveBeenCalledWith('test1', {
+        subuser: '',
+        generate_key: 'false',
+        access_key: undefined,
+        secret_key: undefined
+      });
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.spec.ts
@@ -5,9 +5,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { ModalModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { RgwUserService } from '../../../shared/api/rgw-user.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserListComponent } from './rgw-user-list.component';
 
 describe('RgwUserListComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-s3-key-modal/rgw-user-s3-key-modal.component.spec.ts
@@ -3,8 +3,8 @@ import { ReactiveFormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserS3KeyModalComponent } from './rgw-user-s3-key-modal.component';
 
 describe('RgwUserS3KeyModalComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.spec.ts
@@ -12,12 +12,9 @@ describe('RgwUserSubuserModalComponent', () => {
   let fixture: ComponentFixture<RgwUserSubuserModalComponent>;
 
   configureTestBed({
-    declarations: [ RgwUserSubuserModalComponent ],
-    imports: [
-      ReactiveFormsModule,
-      SharedModule
-    ],
-    providers: [ BsModalRef ]
+    declarations: [RgwUserSubuserModalComponent],
+    imports: [ReactiveFormsModule, SharedModule],
+    providers: [BsModalRef]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-subuser-modal/rgw-user-subuser-modal.component.spec.ts
@@ -3,8 +3,8 @@ import { FormControl, ReactiveFormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { RgwUserSubuserModalComponent } from './rgw-user-subuser-modal.component';
 
 describe('RgwUserSubuserModalComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-swift-key-modal/rgw-user-swift-key-modal.component.spec.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 
 import { BsModalRef } from 'ngx-bootstrap/modal';
 
-import { configureTestBed } from '../../../shared/unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { RgwUserSwiftKeyModalComponent } from './rgw-user-swift-key-modal.component';
 
 describe('RgwUserSwiftKeyModalComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
@@ -3,9 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { AuthService } from '../../../shared/api/auth.service';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { LoginComponent } from './login.component';
 
 describe('LoginComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/logout/logout.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/logout/logout.component.spec.ts
@@ -2,7 +2,7 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { configureTestBed } from '../../../shared/unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { AuthModule } from '../auth.module';
 import { LogoutComponent } from './logout.component';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.spec.ts
@@ -5,9 +5,9 @@ import { BsModalRef } from 'ngx-bootstrap';
 import 'rxjs/add/observable/of';
 import { Observable } from 'rxjs/Observable';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { AboutComponent } from './about.component';
 
 class SummaryServiceMock {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.spec.ts
@@ -1,8 +1,8 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { DashboardHelpComponent } from './dashboard-help.component';
 
 describe('DashboardHelpComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.spec.ts
@@ -23,5 +23,4 @@ describe('DashboardHelpComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
-
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { AppModule } from '../../../app.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { NavigationComponent } from './navigation.component';
 
 describe('NavigationComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.spec.ts
@@ -3,9 +3,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ToastModule } from 'ng2-toastr';
 import { PopoverModule } from 'ngx-bootstrap/popover';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { NotificationService } from '../../../shared/services/notification.service';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { NotificationsComponent } from './notifications.component';
 
 describe('NotificationsComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
@@ -3,10 +3,10 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ExecutingTask } from '../../../shared/models/executing-task';
 import { FinishedTask } from '../../../shared/models/finished-task';
 import { SharedModule } from '../../../shared/shared.module';
-import { configureTestBed } from '../../../shared/unit-test-helper';
 import { TaskManagerComponent } from './task-manager.component';
 
 describe('TaskManagerComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
@@ -53,17 +53,17 @@ describe('TaskManagerComponent', () => {
   it('should get executing message for task', () => {
     component._handleTasks(tasks.executing, []);
     expect(component.executingTasks.length).toBe(1);
-    expect(component.executingTasks[0].description).toBe('Deleting RBD \'somePool/someImage\'');
+    expect(component.executingTasks[0].description).toBe(`Deleting RBD 'somePool/someImage'`);
   });
 
   it('should get finished message for task', () => {
     component._handleTasks([], tasks.finished);
     expect(component.finishedTasks.length).toBe(2);
-    expect(component.finishedTasks[0].description).toBe('Copy RBD \'somePool/someImage\'');
+    expect(component.finishedTasks[0].description).toBe(`Copy RBD 'somePool/someImage'`);
     expect(component.finishedTasks[0].errorMessage).toBe(undefined);
-    expect(component.finishedTasks[1].description).toBe('Clone RBD \'somePool/someImage\'');
+    expect(component.finishedTasks[1].description).toBe(`Clone RBD 'somePool/someImage'`);
     expect(component.finishedTasks[1].errorMessage).toBe(
-      'Name \'somePool/someImage\' is already in use.'
+      `Name 'somePool/someImage' is already in use.`
     );
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/not-found/not-found.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/not-found/not-found.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../../shared/unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { NotFoundComponent } from './not-found.component';
 
 describe('NotFoundComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/auth.service.spec.ts
@@ -3,7 +3,7 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { AuthStorageService } from '../services/auth-storage.service';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { AuthService } from './auth.service';
 
 describe('AuthService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/cephfs.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { CephfsService } from './cephfs.service';
 
 describe('CephfsService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { ConfigurationService } from './configuration.service';
 
 describe('ConfigurationService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/dashboard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/dashboard.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { DashboardService } from './dashboard.service';
 
 describe('DashboardService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { HostService } from './host.service';
 
 describe('HostService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/logging.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/logging.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { LoggingService } from './logging.service';
 
 describe('LoggingService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/monitor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/monitor.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { MonitorService } from './monitor.service';
 
 describe('MonitorService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { OsdService } from './osd.service';
 
 describe('OsdService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/performance-counter.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { PerformanceCounterService } from './performance-counter.service';
 
 describe('PerformanceCounterService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { PoolService } from './pool.service';
 
 describe('PoolService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { RbdMirroringService } from './rbd-mirroring.service';
 
 describe('RbdMirroringService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { RbdService } from './rbd.service';
 
 describe('RbdService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-bucket.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { RgwBucketService } from './rgw-bucket.service';
 
 describe('RgwBucketService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-daemon.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { RgwDaemonService } from './rgw-daemon.service';
 
 describe('RgwDaemonService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.spec.ts
@@ -3,7 +3,7 @@ import { TestBed } from '@angular/core/testing';
 
 import { of as observableOf } from 'rxjs';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { RgwUserService } from './rgw-user.service';
 
 describe('RgwUserService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/tcmu-iscsi.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/tcmu-iscsi.service.spec.ts
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { TcmuIscsiService } from './tcmu-iscsi.service';
 
 describe('TcmuIscsiService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.spec.ts
@@ -5,7 +5,7 @@ import { NgForm, ReactiveFormsModule } from '@angular/forms';
 import { BsModalRef, BsModalService, ModalModule } from 'ngx-bootstrap';
 import { Observable, Subscriber, timer as observableTimer } from 'rxjs';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { DeletionModalComponent } from './deletion-modal.component';
 
 @NgModule({

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/error-panel/error-panel.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ErrorPanelComponent } from './error-panel.component';
 
 describe('ErrorPanelComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PopoverModule } from 'ngx-bootstrap';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { HelperComponent } from './helper.component';
 
 describe('HelperComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/info-panel/info-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/info-panel/info-panel.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { InfoPanelComponent } from './info-panel.component';
 
 describe('InfoPanelComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/loading-panel/loading-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/loading-panel/loading-panel.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { LoadingPanelComponent } from './loading-panel.component';
 
 describe('LoadingPanelComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ModalModule } from 'ngx-bootstrap/modal';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ModalComponent } from './modal.component';
 
 describe('ModalComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sparkline/sparkline.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sparkline/sparkline.component.spec.ts
@@ -1,7 +1,7 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SparklineComponent } from './sparkline.component';
 
 describe('SparklineComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormGroup } from '@angular/forms';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SubmitButtonComponent } from './submit-button.component';
 
 describe('SubmitButtonComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.spec.ts
@@ -2,9 +2,9 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { TooltipModule } from 'ngx-bootstrap';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { PipesModule } from '../../pipes/pipes.module';
 import { ServicesModule } from '../../services/services.module';
-import { configureTestBed } from '../../unit-test-helper';
 import { UsageBarComponent } from './usage-bar.component';
 
 describe('UsageBarComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/view-cache/view-cache.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ErrorPanelComponent } from '../error-panel/error-panel.component';
 import { InfoPanelComponent } from '../info-panel/info-panel.component';
 import { WarningPanelComponent } from '../warning-panel/warning-panel.component';

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/warning-panel/warning-panel.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
-import { configureTestBed } from '../../unit-test-helper';
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { WarningPanelComponent } from './warning-panel.component';
 
 describe('WarningPanelComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table-key-value/table-key-value.component.spec.ts
@@ -4,8 +4,8 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ComponentsModule } from '../../components/components.module';
-import { configureTestBed } from '../../unit-test-helper';
 import { TableComponent } from '../table/table.component';
 import { TableKeyValueComponent } from './table-key-value.component';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -4,9 +4,9 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
 
+import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ComponentsModule } from '../../components/components.module';
 import { CdTableFetchDataContext } from '../../models/cd-table-fetch-data-context';
-import { configureTestBed } from '../../unit-test-helper';
 import { TableComponent } from './table.component';
 
 describe('TableComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -19,7 +19,7 @@ describe('TableComponent', () => {
       data.push({
         a: i,
         b: i * i,
-        c: [-(i % 10), 'score' + (i % 16 + 6)],
+        c: [-(i % 10), 'score' + ((i % 16) + 6)],
         d: !(i % 2)
       });
     }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.spec.ts
@@ -3,7 +3,7 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { Router, Routes } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { AuthGuardService } from './auth-guard.service';
 import { AuthStorageService } from './auth-storage.service';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.spec.ts
@@ -1,6 +1,6 @@
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { DimlessBinaryPipe } from '../pipes/dimless-binary.pipe';
 import { DimlessPipe } from '../pipes/dimless.pipe';
-import { configureTestBed } from '../unit-test-helper';
 import { FormatterService } from './formatter.service';
 
 describe('FormatterService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
@@ -36,11 +36,14 @@ describe('ModuleStatusGuardService', () => {
     expect(router.url).toBe(urlResult);
   };
 
-  configureTestBed({
-    imports: [RouterTestingModule.withRoutes(routes)],
-    providers: [ModuleStatusGuardService, { provide: HttpClient, useValue: fakeService }],
-    declarations: [FooComponent]
-  }, true);
+  configureTestBed(
+    {
+      imports: [RouterTestingModule.withRoutes(routes)],
+      providers: [ModuleStatusGuardService, { provide: HttpClient, useValue: fakeService }],
+      declarations: [FooComponent]
+    },
+    true
+  );
 
   beforeEach(() => {
     service = TestBed.get(ModuleStatusGuardService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/module-status-guard.service.spec.ts
@@ -6,7 +6,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { of as observableOf } from 'rxjs';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { ModuleStatusGuardService } from './module-status-guard.service';
 
 describe('ModuleStatusGuardService', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
@@ -3,9 +3,9 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import * as _ from 'lodash';
 import { ToastsManager } from 'ng2-toastr';
 
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { NotificationType } from '../enum/notification-type.enum';
 import { FinishedTask } from '../models/finished-task';
-import { configureTestBed } from '../unit-test-helper';
 import { NotificationService } from './notification.service';
 import { TaskManagerMessageService } from './task-manager-message.service';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -3,7 +3,7 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { of as observableOf } from 'rxjs';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { AuthStorageService } from './auth-storage.service';
 import { SummaryService } from './summary.service';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.spec.ts
@@ -3,7 +3,7 @@ import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import * as _ from 'lodash';
 import { Subject } from 'rxjs';
 
-import { configureTestBed } from '../unit-test-helper';
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { SummaryService } from './summary.service';
 import { TaskManagerService } from './task-manager.service';
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.spec.ts
@@ -27,9 +27,12 @@ describe('TaskManagerService', () => {
     filesystems: [{ id: 1, name: 'cephfs_a' }]
   };
 
-  configureTestBed({
-    providers: [TaskManagerService, { provide: SummaryService, useValue: fakeService }]
-  }, true);
+  configureTestBed(
+    {
+      providers: [TaskManagerService, { provide: SummaryService, useValue: fakeService }]
+    },
+    true
+  );
 
   beforeEach(() => {
     taskManagerService = TestBed.get(TaskManagerService);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
@@ -4,10 +4,10 @@ import { inject, TestBed } from '@angular/core/testing';
 import { ToastModule } from 'ng2-toastr';
 import { Observable } from 'rxjs/Observable';
 
+import { configureTestBed } from '../../../testing/unit-test-helper';
 import { ExecutingTask } from '../models/executing-task';
 import { FinishedTask } from '../models/finished-task';
 import { SharedModule } from '../shared.module';
-import { configureTestBed } from '../unit-test-helper';
 import { NotificationService } from './notification.service';
 import { TaskManagerService } from './task-manager.service';
 import { TaskWrapperService } from './task-wrapper.service';

--- a/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/testing/unit-test-helper.ts
@@ -1,6 +1,6 @@
 import { async, TestBed } from '@angular/core/testing';
 
-import { _DEV_ } from '../../unit-test-configuration';
+import { _DEV_ } from '../unit-test-configuration';
 
 export function configureTestBed(configuration, useOldMethod?) {
   if (_DEV_ && !useOldMethod) {

--- a/src/pybind/mgr/dashboard/frontend/src/tsconfig.app.json
+++ b/src/pybind/mgr/dashboard/frontend/src/tsconfig.app.json
@@ -7,9 +7,8 @@
     "types": []
   },
   "exclude": [
-    "app/shared/unit-test-helper.ts",
+    "**/*.spec.ts",
     "test.ts",
-    "testing/*.ts",
-    "**/*.spec.ts"
+    "testing/*.ts"
   ]
 }


### PR DESCRIPTION
Angular [1] suggest us to create a `src/testing` folder where we can put files that will be used in tests.
I created that folder on #22829 and to keep it consistent I'm now moving `unit-test-helper.ts` to that folder.

[1] https://angular.io/guide/testing#activatedroutestub

