### PR TITLE
osd/PrimaryLogPG: rebuild attrs from clients

### DIFF
--- a/src/osd/PGTransaction.h
+++ b/src/osd/PGTransaction.h
@@ -363,7 +363,9 @@ public:
     ) {
     auto &op = get_object_op_for_modify(hoid);
     for (auto &&i: attrs) {
-      op.attr_updates[i.first] = i.second;
+      auto& d = op.attr_updates[i.first];
+      d = i.second;
+      d->rebuild();
     }
   }
   void setattr(
@@ -372,7 +374,9 @@ public:
     bufferlist &bl                 ///< [in] val to write, may be claimed
     ) {
     auto &op = get_object_op_for_modify(hoid);
-    op.attr_updates[attrname] = bl;
+    auto& d = op.attr_updates[attrname];
+    d = bl;
+    d->rebuild();
   }
   void rmattr(
     const hobject_t &hoid,         ///< [in] object to write


### PR DESCRIPTION
Ensure that buffers coming in via client ops are rebuilt before populating
the PGTransaction.  This ensures that we don't pin the raw buffers for
the entire incoming message in memory.

In the past we've addressed this issue at the ObjectStore layer, but we
did not consider the attr_cache in ObjectContext.  Rebuilding the buffers
at this point will sanitize any incoming attribute before it reaches
either PGBackend or ObjectContext object_cache or the ObjectStore
implementation.

Fixes: http://tracker.ceph.com/issues/24768
Signed-off-by: Sage Weil <sage@redhat.com>