### PR TITLE
mon: allow mon cap to be limited to a CIDR network

### DIFF
--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -130,3 +130,19 @@ in the ``bar`` directory of filesystem ``cephfs_a``.
 
 
 .. _User Management - Add a User to a Keyring: ../../rados/operations/user-management/#add-a-user-to-a-keyring
+
+Network restriction
+===================
+
+::
+
+ client.foo
+   key: *key*
+   caps: [mds] allow r network 10.0.0.0/8, allow rw path=/bar network 10.0.0.0/8
+   caps: [mon] allow r network 10.0.0.0/8
+   caps: [osd] allow rw tag cephfs data=cephfs_a network 10.0.0.0/8
+
+The optional ``{network/prefix}`` is a standard network name and
+prefix length in CIDR notation (e.g., ``10.3.0.0/16``).  If present,
+the use of this capability is restricted to clients connecting from
+this network.

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -104,7 +104,7 @@ Capability syntax follows the form::
 - **Monitor Caps:** Monitor capabilities include ``r``, ``w``, ``x`` access
   settings or ``profile {name}``. For example::
 
-	mon 'allow {access-spec}'
+	mon 'allow {access-spec} [network {network/prefix}]'
 
 	mon 'profile {name}'
 
@@ -112,13 +112,18 @@ Capability syntax follows the form::
 
         * | all | [r][w][x]
 
+  The optional ``{network/prefix}`` is a standard network name and
+  prefix length in CIDR notation (e.g., ``10.3.0.0/16``).  If present,
+  the use of this capability is restricted to clients connecting from
+  this network.
+
 - **OSD Caps:** OSD capabilities include ``r``, ``w``, ``x``, ``class-read``,
   ``class-write`` access settings or ``profile {name}``. Additionally, OSD
   capabilities also allow for pool and namespace settings. ::
 
-	osd 'allow {access-spec} [{match-spec}]'
+	osd 'allow {access-spec} [{match-spec}] [network {network/prefix}]'
 
-	osd 'profile {name} [pool={pool-name} [namespace={namespace-name}]]'
+	osd 'profile {name} [pool={pool-name} [namespace={namespace-name}]] [network {network/prefix}]'
 
   The ``{access-spec}`` syntax is either of the following: ::
 
@@ -131,6 +136,11 @@ Capability syntax follows the form::
         pool={pool-name} [namespace={namespace-name}] [object_prefix {prefix}]
 
         [namespace={namespace-name}] tag {application} {key}={value}
+
+  The optional ``{network/prefix}`` is a standard network name and
+  prefix length in CIDR notation (e.g., ``10.3.0.0/16``).  If present,
+  the use of this capability is restricted to clients connecting from
+  this network.
 
 - **Metadata Server Caps:** For administrators, use ``allow *``.  For all
   other users, such as CephFS clients, consult :doc:`/cephfs/client-auth`

--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -10,6 +10,7 @@
 #endif
 
 #include "include/ipaddr.h"
+#include "msg/msg_types.h"
 
 void netmask_ipv4(const struct in_addr *addr,
 			 unsigned int prefix_len,
@@ -163,4 +164,17 @@ bool parse_network(const char *s, struct sockaddr_storage *network, unsigned int
   }
 
   return false;
+}
+
+bool parse_network(const char *s,
+		   entity_addr_t *network,
+		   unsigned int *prefix_len)
+{
+  sockaddr_storage ss;
+  bool ret = parse_network(s, &ss, prefix_len);
+  if (ret) {
+    network->set_type(entity_addr_t::TYPE_LEGACY);
+    network->set_sockaddr((sockaddr *)&ss);
+  }
+  return ret;
 }

--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -178,3 +178,40 @@ bool parse_network(const char *s,
   }
   return ret;
 }
+
+bool network_contains(
+  const struct entity_addr_t& network,
+  unsigned int prefix_len,
+  const struct entity_addr_t& addr)
+{
+  if (addr.get_family() != network.get_family()) {
+    return false;
+  }
+  switch (network.get_family()) {
+  case AF_INET:
+    {
+      struct in_addr a, b;
+      netmask_ipv4(
+	&((const sockaddr_in*)network.get_sockaddr())->sin_addr, prefix_len, &a);
+      netmask_ipv4(
+	&((const sockaddr_in*)addr.get_sockaddr())->sin_addr, prefix_len, &b);
+      if (memcmp(&a, &b, sizeof(a)) == 0) {
+	return true;
+      }
+    }
+    break;
+  case AF_INET6:
+    {
+      struct in6_addr a, b;
+      netmask_ipv6(
+	&((const sockaddr_in6*)network.get_sockaddr())->sin6_addr, prefix_len, &a);
+      netmask_ipv6(
+	&((const sockaddr_in6*)addr.get_sockaddr())->sin6_addr, prefix_len, &b);
+      if (memcmp(&a, &b, sizeof(a)) == 0) {
+	return true;
+      }
+    }
+    break;
+  }
+  return false;
+}

--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -11,7 +11,7 @@
 
 #include "include/ipaddr.h"
 
-static void netmask_ipv4(const struct in_addr *addr,
+void netmask_ipv4(const struct in_addr *addr,
 			 unsigned int prefix_len,
 			 struct in_addr *out) {
   uint32_t mask;
@@ -57,9 +57,9 @@ const struct ifaddrs *find_ipv4_in_subnet(const struct ifaddrs *addrs,
 }
 
 
-static void netmask_ipv6(const struct in6_addr *addr,
-			 unsigned int prefix_len,
-			 struct in6_addr *out) {
+void netmask_ipv6(const struct in6_addr *addr,
+		  unsigned int prefix_len,
+		  struct in6_addr *out) {
   if (prefix_len > 128)
     prefix_len = 128;
 

--- a/src/include/ipaddr.h
+++ b/src/include/ipaddr.h
@@ -1,6 +1,8 @@
 #ifndef CEPH_IPADDR_H
 #define CEPH_IPADDR_H
 
+class entity_addr_t;
+
 /*
  * Find an IP address that is in the wanted subnet.
  *
@@ -22,7 +24,12 @@ const struct ifaddrs *find_ip_in_subnet(const struct ifaddrs *addrs,
  *
  * if the network string is invalid, return false.
  */
-bool parse_network(const char *s, struct sockaddr_storage *network, unsigned int *prefix_len);
+bool parse_network(const char *s,
+		   struct sockaddr_storage *network,
+		   unsigned int *prefix_len);
+bool parse_network(const char *s,
+		   entity_addr_t *network,
+		   unsigned int *prefix_len);
 
 void netmask_ipv6(const struct in6_addr *addr,
 		  unsigned int prefix_len,

--- a/src/include/ipaddr.h
+++ b/src/include/ipaddr.h
@@ -24,4 +24,11 @@ const struct ifaddrs *find_ip_in_subnet(const struct ifaddrs *addrs,
  */
 bool parse_network(const char *s, struct sockaddr_storage *network, unsigned int *prefix_len);
 
+void netmask_ipv6(const struct in6_addr *addr,
+		  unsigned int prefix_len,
+		  struct in6_addr *out);
+
+void netmask_ipv4(const struct in_addr *addr,
+		  unsigned int prefix_len,
+		  struct in_addr *out);
 #endif

--- a/src/include/ipaddr.h
+++ b/src/include/ipaddr.h
@@ -38,4 +38,10 @@ void netmask_ipv6(const struct in6_addr *addr,
 void netmask_ipv4(const struct in_addr *addr,
 		  unsigned int prefix_len,
 		  struct in_addr *out);
+
+bool network_contains(
+	const struct entity_addr_t& network,
+	unsigned int prefix_len,
+	const struct entity_addr_t& addr);
+
 #endif

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3209,9 +3209,11 @@ int CInode::get_caps_allowed_for_client(Session *session, mempool_inode *file_i)
 
   if (!is_dir()) {
     if ((file_i->inline_data.version != CEPH_INLINE_NONE &&
-	 !session->connection->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)) ||
+	 !session->get_connection()->has_feature(
+	   CEPH_FEATURE_MDS_INLINE_DATA)) ||
 	(!file_i->layout.pool_ns.empty() &&
-	 !session->connection->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)))
+	 !session->get_connection()->has_feature(
+	   CEPH_FEATURE_FS_FILE_LAYOUT_V2)))
       allowed &= ~(CEPH_CAP_FILE_RD | CEPH_CAP_FILE_WR);
   }
   return allowed;
@@ -3622,7 +3624,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     ENCODE_FINISH(bl);
   }
   else {
-    assert(session->connection);
+    assert(session->get_connection());
 
     encode(oi->ino, bl);
     encode(snapid, bl);
@@ -3655,22 +3657,22 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     encode(file_i->rstat.rctime, bl);
     dirfragtree.encode(bl);
     encode(symlink, bl);
-    if (session->connection->has_feature(CEPH_FEATURE_DIRLAYOUTHASH)) {
+    if (session->get_connection()->has_feature(CEPH_FEATURE_DIRLAYOUTHASH)) {
       encode(file_i->dir_layout, bl);
     }
     encode(xbl, bl);
-    if (session->connection->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)) {
+    if (session->get_connection()->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)) {
       encode(inline_version, bl);
       encode(inline_data, bl);
     }
-    if (session->connection->has_feature(CEPH_FEATURE_MDS_QUOTA)) {
+    if (session->get_connection()->has_feature(CEPH_FEATURE_MDS_QUOTA)) {
       mempool_inode *policy_i = ppolicy ? pi : oi;
       encode(policy_i->quota, bl);
     }
-    if (session->connection->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
+    if (session->get_connection()->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
       encode(layout.pool_ns, bl);
     }
-    if (session->connection->has_feature(CEPH_FEATURE_FS_BTIME)) {
+    if (session->get_connection()->has_feature(CEPH_FEATURE_FS_BTIME)) {
       encode(any_i->btime, bl);
       encode(any_i->change_attr, bl);
     }

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2027,8 +2027,9 @@ bool Locker::issue_caps(CInode *in, Capability *only_cap)
 
     Session *session = mds->get_session(it->first);
     if (in->inode.inline_data.version != CEPH_INLINE_NONE &&
-	!(session && session->connection &&
-	  session->connection->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)))
+	!(session &&
+	  session->get_connection() &&
+	  session->get_connection()->has_feature(CEPH_FEATURE_MDS_INLINE_DATA)))
       allowed &= ~(CEPH_CAP_FILE_RD | CEPH_CAP_FILE_WR);
 
     int pending = cap->pending();

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2038,8 +2038,9 @@ void MDCache::broadcast_quota_to_client(CInode *in, client_t exclude_ct)
 
   for (auto &p : in->client_caps) {
     Session *session = mds->get_session(p.first);
-    if (!session || !session->connection ||
-        !session->connection->has_feature(CEPH_FEATURE_MDS_QUOTA))
+    if (!session ||
+	!session->get_connection() ||
+        !session->get_connection()->has_feature(CEPH_FEATURE_MDS_QUOTA))
       continue;
 
     Capability *cap = &p.second;
@@ -2079,7 +2080,7 @@ update:
     msg->ino = in->ino();
     msg->rstat = i->rstat;
     msg->quota = i->quota;
-    mds->send_message_client_counted(msg, session->connection);
+    mds->send_message_client_counted(msg, session->get_connection());
   }
   for (const auto &it : in->get_replicas()) {
     MGatherCaps *msg = new MGatherCaps;

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -191,7 +191,8 @@ bool MDSAuthCaps::is_capable(std::string_view inode_path,
 			     uid_t caller_uid, gid_t caller_gid,
 			     const vector<uint64_t> *caller_gid_list,
 			     unsigned mask,
-			     uid_t new_uid, gid_t new_gid) const
+			     uid_t new_uid, gid_t new_gid,
+			     const entity_addr_t& addr) const
 {
   if (cct)
     ldout(cct, 10) << __func__ << " inode(path /" << inode_path

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -23,6 +23,7 @@
 
 #include "common/debug.h"
 #include "MDSAuthCaps.h"
+#include "include/ipaddr.h"
 
 #define dout_subsys ceph_subsys_mds
 
@@ -58,6 +59,7 @@ struct MDSCapParser : qi::grammar<Iterator, MDSAuthCaps()>
       lexeme[lit("\"") >> *(char_ - '"') >> '"'] | 
       lexeme[lit("'") >> *(char_ - '\'') >> '\''];
     unquoted_path %= +char_("a-zA-Z0-9_./-");
+    network_str %= +char_("/.:a-fA-F0-9][");
 
     // match := [path=<path>] [uid=<uid> [gids=<gid>[,<gid>...]]
     path %= (spaces >> lit("path") >> lit('=') >> (quoted_path | unquoted_path));
@@ -86,12 +88,14 @@ struct MDSCapParser : qi::grammar<Iterator, MDSAuthCaps()>
         (lit("r"))[_val = MDSCapSpec(MDSCapSpec::READ)]
         );
 
-    grant = lit("allow") >> (capspec >> match)[_val = phoenix::construct<MDSCapGrant>(_1, _2)];
+    grant = lit("allow") >> (capspec >> match >>
+			     -(spaces >> lit("network") >> spaces >> network_str))
+      [_val = phoenix::construct<MDSCapGrant>(_1, _2, _3)];
     grants %= (grant % (*lit(' ') >> (lit(';') | lit(',')) >> *lit(' ')));
     mdscaps = grants  [_val = phoenix::construct<MDSAuthCaps>(_1)]; 
   }
   qi::rule<Iterator> spaces;
-  qi::rule<Iterator, string()> quoted_path, unquoted_path;
+  qi::rule<Iterator, string()> quoted_path, unquoted_path, network_str;
   qi::rule<Iterator, MDSCapSpec()> capspec;
   qi::rule<Iterator, string()> path;
   qi::rule<Iterator, uint32_t()> uid;
@@ -163,6 +167,12 @@ bool MDSCapMatch::match_path(std::string_view target_path) const
   return true;
 }
 
+void MDSCapGrant::parse_network()
+{
+  network_valid = ::parse_network(network.c_str(), &network_parsed,
+				  &network_prefix);
+}
+
 /**
  * Is the client *potentially* able to access this path?  Actual
  * permission will depend on uids/modes in the full is_capable.
@@ -207,6 +217,13 @@ bool MDSAuthCaps::is_capable(std::string_view inode_path,
   for (std::vector<MDSCapGrant>::const_iterator i = grants.begin();
        i != grants.end();
        ++i) {
+    if (i->network.size() &&
+	(!i->network_valid ||
+	 !network_contains(i->network_parsed,
+			   i->network_prefix,
+			   addr))) {
+      continue;
+    }
 
     if (i->match.match(inode_path, caller_uid, caller_gid, caller_gid_list) &&
 	i->spec.allows(mask & (MAY_READ|MAY_EXECUTE), mask & MAY_WRITE)) {
@@ -287,7 +304,8 @@ bool MDSAuthCaps::is_capable(std::string_view inode_path,
 void MDSAuthCaps::set_allow_all()
 {
     grants.clear();
-    grants.push_back(MDSCapGrant(MDSCapSpec(MDSCapSpec::ALL), MDSCapMatch()));
+    grants.push_back(MDSCapGrant(MDSCapSpec(MDSCapSpec::ALL), MDSCapMatch(),
+				 {}));
 }
 
 bool MDSAuthCaps::parse(CephContext *c, std::string_view str, ostream *err)
@@ -295,7 +313,8 @@ bool MDSAuthCaps::parse(CephContext *c, std::string_view str, ostream *err)
   // Special case for legacy caps
   if (str == "allow") {
     grants.clear();
-    grants.push_back(MDSCapGrant(MDSCapSpec(MDSCapSpec::RWPS), MDSCapMatch()));
+    grants.push_back(MDSCapGrant(MDSCapSpec(MDSCapSpec::RWPS), MDSCapMatch(),
+				 {}));
     return true;
   }
 
@@ -308,6 +327,7 @@ bool MDSAuthCaps::parse(CephContext *c, std::string_view str, ostream *err)
   if (r && iter == end) {
     for (auto& grant : grants) {
       std::sort(grant.match.gids.begin(), grant.match.gids.end());
+      grant.parse_network();
     }
     return true;
   } else {
@@ -390,7 +410,9 @@ ostream &operator<<(ostream &out, const MDSCapGrant &grant)
   if (!grant.match.is_match_all()) {
     out << " " << grant.match;
   }
-
+  if (grant.network.size()) {
+    out << " network " << grant.network;
+  }
   return out;
 }
 

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -157,7 +157,8 @@ public:
   bool is_capable(std::string_view inode_path,
 		  uid_t inode_uid, gid_t inode_gid, unsigned inode_mode,
 		  uid_t uid, gid_t gid, const vector<uint64_t> *caller_gid_list,
-		  unsigned mask, uid_t new_uid, gid_t new_gid) const;
+		  unsigned mask, uid_t new_uid, gid_t new_gid,
+		  const entity_addr_t& addr) const;
   bool path_capable(std::string_view inode_path) const;
 
   friend std::ostream &operator<<(std::ostream &out, const MDSAuthCaps &cap);

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -132,9 +132,23 @@ struct MDSCapGrant {
   MDSCapSpec spec;
   MDSCapMatch match;
 
-  MDSCapGrant(const MDSCapSpec &spec_, const MDSCapMatch &match_)
-    : spec(spec_), match(match_) {}
+  std::string network;
+
+  entity_addr_t network_parsed;
+  unsigned network_prefix = 0;
+  bool network_valid = true;
+
+  MDSCapGrant(const MDSCapSpec &spec_, const MDSCapMatch &match_,
+	      boost::optional<std::string> n)
+    : spec(spec_), match(match_) {
+    if (n) {
+      network = *n;
+      parse_network();
+    }
+  }
   MDSCapGrant() {}
+
+  void parse_network();
 };
 
 class MDSAuthCaps

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -584,7 +584,7 @@ void MDSDaemon::send_command_reply(MCommand *m, MDSRank *mds_rank,
     // This session only existed to issue commands, so terminate it
     // as soon as we can.
     assert(session->is_closed());
-    session->connection->mark_disposable();
+    session->get_connection()->mark_disposable();
   }
   priv.reset();
 
@@ -1362,7 +1362,8 @@ bool MDSDaemon::ms_verify_authorizer(Connection *con, int peer_type,
         mds_rank->kick_waiters_for_any_client_connection();
       }
     } else {
-      dout(10) << " existing session " << s << " for " << s->info.inst << " existing con " << s->connection
+      dout(10) << " existing session " << s << " for " << s->info.inst
+	       << " existing con " << s->get_connection()
 	       << ", new/authorizing con " << con << dendl;
       con->set_priv(RefCountedPtr{s});
 
@@ -1424,8 +1425,9 @@ void MDSDaemon::ms_handle_accept(Connection *con)
   auto s = static_cast<Session *>(priv.get());
   dout(10) << "ms_handle_accept " << con->get_peer_addr() << " con " << con << " session " << s << dendl;
   if (s) {
-    if (s->connection != con) {
-      dout(10) << " session connection " << s->connection << " -> " << con << dendl;
+    if (s->get_connection() != con) {
+      dout(10) << " session connection " << s->get_connection()
+	       << " -> " << con << dendl;
       s->set_connection(con);
 
       // send out any queued messages

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1352,13 +1352,12 @@ bool MDSDaemon::ms_verify_authorizer(Connection *con, int peer_type,
     // It doesn't go into a SessionMap instance until it sends an explicit
     // request to open a session (initial state of Session is `closed`)
     if (!s) {
-      s = new Session;
+      s = new Session(con);
       s->info.auth_name = name;
       s->info.inst.addr = con->get_peer_addr();
       s->info.inst.name = n;
       dout(10) << " new session " << s << " for " << s->info.inst << " con " << con << dendl;
       con->set_priv(RefCountedPtr{s, false});
-      s->connection = con;
       if (mds_rank) {
         mds_rank->kick_waiters_for_any_client_connection();
       }
@@ -1427,7 +1426,7 @@ void MDSDaemon::ms_handle_accept(Connection *con)
   if (s) {
     if (s->connection != con) {
       dout(10) << " session connection " << s->connection << " -> " << con << dendl;
-      s->connection = con;
+      s->set_connection(con);
 
       // send out any queued messages
       while (!s->preopen_out_queue.empty()) {

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -914,7 +914,7 @@ Session *MDSRank::get_session(Message *m)
         imported_session->info.auth_name = session->info.auth_name;
         //assert(session->info.auth_name == imported_session->info.auth_name);
         assert(session->info.inst == imported_session->info.inst);
-        imported_session->connection = session->connection;
+        imported_session->set_connection(session->connection);
         // send out any queued messages
         while (!session->preopen_out_queue.empty()) {
           imported_session->connection->send_message(session->preopen_out_queue.front());

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -910,19 +910,22 @@ Session *MDSRank::get_session(Message *m)
     if (session->is_closed()) {
       Session *imported_session = sessionmap.get_session(session->info.inst.name);
       if (imported_session && imported_session != session) {
-        dout(10) << __func__ << " replacing connection bootstrap session " << session << " with imported session " << imported_session << dendl;
+        dout(10) << __func__ << " replacing connection bootstrap session "
+		 << session << " with imported session " << imported_session
+		 << dendl;
         imported_session->info.auth_name = session->info.auth_name;
         //assert(session->info.auth_name == imported_session->info.auth_name);
         assert(session->info.inst == imported_session->info.inst);
-        imported_session->set_connection(session->connection);
+        imported_session->set_connection(session->get_connection().get());
         // send out any queued messages
         while (!session->preopen_out_queue.empty()) {
-          imported_session->connection->send_message(session->preopen_out_queue.front());
+          imported_session->get_connection()->send_message(
+	    session->preopen_out_queue.front());
           session->preopen_out_queue.pop_front();
         }
         imported_session->auth_caps = session->auth_caps;
         assert(session->get_nref() == 1);
-        imported_session->connection->set_priv(imported_session->get());
+        imported_session->get_connection()->set_priv(imported_session->get());
         session = imported_session;
       }
     }
@@ -1033,8 +1036,8 @@ void MDSRank::send_message_client_counted(Message *m, Session *session)
   version_t seq = session->inc_push_seq();
   dout(10) << "send_message_client_counted " << session->info.inst.name << " seq "
 	   << seq << " " << *m << dendl;
-  if (session->connection) {
-    session->connection->send_message(m);
+  if (session->get_connection()) {
+    session->get_connection()->send_message(m);
   } else {
     session->preopen_out_queue.push_back(m);
   }
@@ -1043,8 +1046,8 @@ void MDSRank::send_message_client_counted(Message *m, Session *session)
 void MDSRank::send_message_client(Message *m, Session *session)
 {
   dout(10) << "send_message_client " << session->info.inst << " " << *m << dendl;
-  if (session->connection) {
-    session->connection->send_message(m);
+  if (session->get_connection()) {
+    session->get_connection()->send_message(m);
   } else {
     session->preopen_out_queue.push_back(m);
   }
@@ -3025,7 +3028,7 @@ void MDSRank::bcast_mds_map()
   for (set<Session*>::const_iterator p = clients.begin();
        p != clients.end();
        ++p)
-    (*p)->connection->send_message(new MMDSMap(monc->get_fsid(), mdsmap));
+    (*p)->get_connection()->send_message(new MMDSMap(monc->get_fsid(), mdsmap));
   last_client_mdsmap_bcast = mdsmap->get_epoch();
 }
 

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -3103,7 +3103,7 @@ void Migrator::finish_import_inode_caps(CInode *in, mds_rank_t peer, bool auth_c
     // For non-auth caps, ask exporter mds to send cap export messages to
     // clients who haven't opened sessions. The cap export messages will
     // make clients open sessions.
-    if (auth_cap || session->connection == nullptr) {
+    if (auth_cap || !session->get_connection()) {
       Capability::Import& im = import_map[it.first];
       im.cap_id = cap->get_cap_id();
       im.mseq = auth_cap ? it.second.mseq : cap->get_mseq();

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -518,7 +518,7 @@ void SessionMapStore::decode_legacy(bufferlist::const_iterator& p)
     
     while (n-- && !p.end()) {
       auto p2 = p;
-      Session *s = new Session;
+      Session *s = new Session(nullptr);
       s->info.decode(p);
       if (session_map.count(s->info.inst.name)) {
 	// eager client connected too fast!  aie.

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -930,7 +930,8 @@ int Session::check_access(CInode *in, unsigned mask,
 
   if (!auth_caps.is_capable(path, in->inode.uid, in->inode.gid, in->inode.mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
-			    new_uid, new_gid)) {
+			    new_uid, new_gid,
+			    socket_addr)) {
     return -EACCES;
   }
   return 0;

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -139,6 +139,7 @@ public:
   MDSAuthCaps auth_caps;
 
   ConnectionRef connection;
+  entity_addr_t socket_addr;
   xlist<Session*>::item item_session_list;
 
   list<Message*> preopen_out_queue;  ///< messages for client, queued before they connect
@@ -321,7 +322,7 @@ public:
 		   const vector<uint64_t> *gid_list, int new_uid, int new_gid);
 
 
-  Session() : 
+  Session(Connection *con) :
     state(STATE_CLOSED), state_seq(0), importing_count(0),
     recall_count(0), recall_release_count(0),
     auth_caps(g_ceph_context),
@@ -331,7 +332,11 @@ public:
     lease_seq(0),
     completed_requests_dirty(false),
     num_trim_flushes_warnings(0),
-    num_trim_requests_warnings(0) { }
+    num_trim_requests_warnings(0) {
+    if (con) {
+      set_connection(con);
+    }
+  }
   ~Session() override {
     if (state == STATE_CLOSED) {
       item_session_list.remove_myself();
@@ -342,6 +347,11 @@ public:
       preopen_out_queue.front()->put();
       preopen_out_queue.pop_front();
     }
+  }
+
+  void set_connection(Connection *con) {
+    connection = con;
+    socket_addr = con->get_peer_socket_addr();
   }
 
   void clear() {
@@ -418,7 +428,7 @@ public:
     if (session_map_entry != session_map.end()) {
       s = session_map_entry->second;
     } else {
-      s = session_map[i.name] = new Session;
+      s = session_map[i.name] = new Session(nullptr);
       s->info.inst = i;
       s->last_cap_renew = ceph_clock_now();
       if (logger) {

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -138,7 +138,9 @@ public:
 
   MDSAuthCaps auth_caps;
 
+protected:
   ConnectionRef connection;
+public:
   entity_addr_t socket_addr;
   xlist<Session*>::item item_session_list;
 
@@ -352,6 +354,9 @@ public:
   void set_connection(Connection *con) {
     connection = con;
     socket_addr = con->get_peer_socket_addr();
+  }
+  const ConnectionRef& get_connection() const {
+    return connection;
   }
 
   void clear() {

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -1682,7 +1682,7 @@ void ESession::replay(MDSRank *mds)
     } else {
       session = mds->sessionmap.get_session(client_inst.name);
       if (session) { // there always should be a session, but there's a bug
-	if (session->connection == NULL) {
+	if (session->get_connection() == NULL) {
 	  dout(10) << " removed session " << session->info.inst << dendl;
 	  mds->sessionmap.remove_session(session);
           session = NULL;

--- a/src/messages/MForward.h
+++ b/src/messages/MForward.h
@@ -26,7 +26,9 @@
 
 struct MForward : public Message {
   uint64_t tid;
-  entity_inst_t client;
+  uint8_t client_type;
+  entity_addrvec_t client_addrs;
+  entity_addr_t client_socket_addr;
   MonCap client_caps;
   uint64_t con_features;
   EntityName entity_name;
@@ -34,8 +36,8 @@ struct MForward : public Message {
 
   string msg_desc;  // for operator<< only
   
-  static const int HEAD_VERSION = 3;
-  static const int COMPAT_VERSION = 3;
+  static const int HEAD_VERSION = 4;
+  static const int COMPAT_VERSION = 4;
 
   MForward() : Message(MSG_FORWARD, HEAD_VERSION, COMPAT_VERSION),
                tid(0), con_features(0), msg(NULL) {}
@@ -43,7 +45,11 @@ struct MForward : public Message {
   MForward(uint64_t t, PaxosServiceMessage *m, uint64_t feat) :
     Message(MSG_FORWARD, HEAD_VERSION, COMPAT_VERSION),
     tid(t), msg(NULL) {
-    client = m->get_source_inst();
+    client_type = m->get_source().type();
+    client_addrs = m->get_source_addrs();
+    if (auto con = m->get_connection()) {
+      client_socket_addr = con->get_peer_socket_addr();
+    }
     client_caps = m->get_session()->caps;
     con_features = feat;
     // we may need to reencode for the target mon
@@ -54,7 +60,11 @@ struct MForward : public Message {
            const MonCap& caps) :
     Message(MSG_FORWARD, HEAD_VERSION, COMPAT_VERSION),
     tid(t), client_caps(caps), msg(NULL) {
-    client = m->get_source_inst();
+    client_type = m->get_source().type();
+    client_addrs = m->get_source_addrs();
+    if (auto con = m->get_connection()) {
+      client_socket_addr = con->get_peer_socket_addr();
+    }
     con_features = feat;
     msg = (PaxosServiceMessage*)m->get();
   }
@@ -70,8 +80,34 @@ private:
 public:
   void encode_payload(uint64_t features) override {
     using ceph::encode;
+    if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
+      header.version = 3;
+      header.compat_version = 3;
+      encode(tid, payload);
+      entity_inst_t client;
+      client.name = entity_name_t(client_type, -1);
+      client.addr = client_addrs.legacy_addr();
+      encode(client, payload, features);
+      encode(client_caps, payload, features);
+      // Encode client message with intersection of target and source
+      // features.  This could matter if the semantics of the encoded
+      // message are changed when reencoding with more features than the
+      // client had originally.  That should never happen, but we may as
+      // well be defensive here.
+      if (con_features != features) {
+	msg->clear_payload();
+      }
+      encode_message(msg, features & con_features, payload);
+      encode(con_features, payload);
+      encode(entity_name, payload);
+      return;
+    }
+    header.version = HEAD_VERSION;
+    header.compat_version = COMPAT_VERSION;
     encode(tid, payload);
-    encode(client, payload, features);
+    encode(client_type, payload, features);
+    encode(client_addrs, payload, features);
+    encode(client_socket_addr, payload, features);
     encode(client_caps, payload, features);
     // Encode client message with intersection of target and source
     // features.  This could matter if the semantics of the encoded
@@ -89,7 +125,17 @@ public:
   void decode_payload() override {
     auto p = payload.cbegin();
     decode(tid, p);
-    decode(client, p);
+    if (header.version < 4) {
+      entity_inst_t client;
+      decode(client, p);
+      client_type = client.name.type();
+      client_addrs = entity_addrvec_t(client.addr);
+      client_socket_addr = client.addr;
+    } else {
+      decode(client_type, p);
+      decode(client_addrs, p);
+      decode(client_socket_addr, p);
+    }
     decode(client_caps, p);
     msg = (PaxosServiceMessage *)decode_message(NULL, 0, p);
     decode(con_features, p);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -713,7 +713,8 @@ bool DaemonServer::_allowed_command(
     CEPH_ENTITY_TYPE_MGR,
     s->entity_name,
     module, prefix, param_str_map,
-    cmd_r, cmd_w, cmd_x);
+    cmd_r, cmd_w, cmd_x,
+    s->get_peer_addr());
 
   dout(10) << " " << s->entity_name << " "
 	   << (capable ? "" : "not ") << "capable" << dendl;

--- a/src/mgr/MgrSession.h
+++ b/src/mgr/MgrSession.h
@@ -27,6 +27,10 @@ struct MgrSession : public RefCountedObject {
 
   explicit MgrSession(CephContext *cct) : RefCountedObject(cct, 0) {}
   ~MgrSession() override {}
+
+  const entity_addr_t& get_peer_addr() {
+    return inst.addr;
+  }
 };
 
 typedef boost::intrusive_ptr<MgrSession> MgrSessionRef;

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -381,18 +381,21 @@ void MonCap::set_allow_all()
   text = "allow *";
 }
 
-bool MonCap::is_capable(CephContext *cct,
-			int daemon_type,
-			EntityName name,
-			const string& service,
-			const string& command, const map<string,string>& command_args,
-			bool op_may_read, bool op_may_write, bool op_may_exec) const
+bool MonCap::is_capable(
+  CephContext *cct,
+  int daemon_type,
+  EntityName name,
+  const string& service,
+  const string& command, const map<string,string>& command_args,
+  bool op_may_read, bool op_may_write, bool op_may_exec,
+  const entity_addr_t& addr) const
 {
   if (cct)
     ldout(cct, 20) << "is_capable service=" << service << " command=" << command
 		   << (op_may_read ? " read":"")
 		   << (op_may_write ? " write":"")
 		   << (op_may_exec ? " exec":"")
+		   << " addr " << addr
 		   << " on cap " << *this
 		   << dendl;
   mon_rwxa_t allow = 0;

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -22,6 +22,7 @@
 
 #include "MonCap.h"
 #include "include/stringify.h"
+#include "include/ipaddr.h"
 #include "common/debug.h"
 #include "common/Formatter.h"
 
@@ -137,6 +138,12 @@ BOOST_FUSION_ADAPT_STRUCT(StringConstraint,
 			  (std::string, value))
 
 // </magic>
+
+void MonCapGrant::parse_network()
+{
+  network_valid = ::parse_network(network.c_str(), &network_parsed,
+				  &network_prefix);
+}
 
 void MonCapGrant::expand_profile(int daemon_type, const EntityName& name) const
 {
@@ -398,11 +405,21 @@ bool MonCap::is_capable(
 		   << " addr " << addr
 		   << " on cap " << *this
 		   << dendl;
+
   mon_rwxa_t allow = 0;
   for (vector<MonCapGrant>::const_iterator p = grants.begin();
        p != grants.end(); ++p) {
     if (cct)
-      ldout(cct, 20) << " allow so far " << allow << ", doing grant " << *p << dendl;
+      ldout(cct, 20) << " allow so far " << allow << ", doing grant " << *p
+		     << dendl;
+
+    if (p->network.size() &&
+	(!p->network_valid ||
+	 !network_contains(p->network_parsed,
+			   p->network_prefix,
+			   addr))) {
+      continue;
+    }
 
     if (p->is_allow_all()) {
       if (cct)
@@ -585,6 +602,9 @@ bool MonCap::parse(const string& str, ostream *err)
   //bool r = qi::phrase_parse(iter, end, g, ascii::space, foo);
   if (r && iter == end) {
     text = str;
+    for (auto& g : grants) {
+      g.parse_network();
+    }
     return true;
   }
 

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -166,7 +166,8 @@ struct MonCap {
 		  EntityName name,
 		  const string& service,
 		  const string& command, const map<string,string>& command_args,
-		  bool op_may_read, bool op_may_write, bool op_may_exec) const;
+		  bool op_may_read, bool op_may_write, bool op_may_exec,
+		  const entity_addr_t& addr) const;
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -83,6 +83,13 @@ struct MonCapGrant {
   // restrict by network
   std::string network;
 
+  // these are filled in by parse_network(), called by MonCap::parse()
+  entity_addr_t network_parsed;
+  unsigned network_prefix = 0;
+  bool network_valid = true;
+
+  void parse_network();
+
   mon_rwxa_t allow;
 
   // explicit grants that a profile grant expands to; populated as

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -80,6 +80,9 @@ struct MonCapGrant {
   std::string command;
   map<std::string,StringConstraint> command_args;
 
+  // restrict by network
+  std::string network;
+
   mon_rwxa_t allow;
 
   // explicit grants that a profile grant expands to; populated as

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2864,7 +2864,7 @@ bool Monitor::_allowed_command(MonSession *s, const string &module,
     s->entity_name,
     module, prefix, param_str_map,
     cmd_r, cmd_w, cmd_x,
-    s->get_peer_addr());
+    s->get_peer_socket_addr());
 
   dout(10) << __func__ << " " << (capable ? "" : "not ") << "capable" << dendl;
   return capable;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2863,7 +2863,8 @@ bool Monitor::_allowed_command(MonSession *s, const string &module,
     CEPH_ENTITY_TYPE_MON,
     s->entity_name,
     module, prefix, param_str_map,
-    cmd_r, cmd_w, cmd_x);
+    cmd_r, cmd_w, cmd_x,
+    s->get_peer_addr());
 
   dout(10) << __func__ << " " << (capable ? "" : "not ") << "capable" << dendl;
   return capable;

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -788,7 +788,6 @@ public:
     MonSession *session;
     ConnectionRef con;
     uint64_t con_features;
-    entity_inst_t client_inst;
     MonOpRequestRef op;
 
     RoutedRequest() : tid(0), session(NULL), con_features(0) {}

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -113,17 +113,20 @@ bool is_unmanaged_snap_op_permitted(CephContext* cct,
                                     const KeyServer& key_server,
                                     const EntityName& entity_name,
                                     const MonCap& mon_caps,
+				    const entity_addr_t& peer_socket_addr,
                                     const std::string* pool_name)
 {
   typedef std::map<std::string, std::string> CommandArgs;
 
-  if (mon_caps.is_capable(cct, CEPH_ENTITY_TYPE_MON,
-                               entity_name, "osd",
-                               "osd pool op unmanaged-snap",
-                               (pool_name == nullptr ?
-                                  CommandArgs{} /* pool DNE, require unrestricted cap */ :
-                                  CommandArgs{{"poolname", *pool_name}}),
-                                false, true, false)) {
+  if (mon_caps.is_capable(
+	cct, CEPH_ENTITY_TYPE_MON,
+	entity_name, "osd",
+	"osd pool op unmanaged-snap",
+	(pool_name == nullptr ?
+	 CommandArgs{} /* pool DNE, require unrestricted cap */ :
+	 CommandArgs{{"poolname", *pool_name}}),
+	false, true, false,
+	peer_socket_addr)) {
     return true;
   }
 
@@ -3340,7 +3343,8 @@ bool OSDMonitor::preprocess_remove_snaps(MonOpRequestRef op)
 	cct,
 	CEPH_ENTITY_TYPE_MON,
 	session->entity_name,
-        "osd", "osd pool rmsnap", {}, true, true, false)) {
+        "osd", "osd pool rmsnap", {}, true, true, false,
+	session->get_peer_addr())) {
     dout(0) << "got preprocess_remove_snaps from entity with insufficient caps "
 	    << session->caps << dendl;
     goto ignore;
@@ -11893,6 +11897,7 @@ bool OSDMonitor::enforce_pool_op_caps(MonOpRequestRef op)
 
       if (!is_unmanaged_snap_op_permitted(cct, mon->key_server,
                                           session->entity_name, session->caps,
+					  session->get_peer_addr(),
                                           pool_name)) {
         dout(0) << "got unmanaged-snap pool op from entity with insufficient "
                 << "privileges. message: " << *m  << std::endl

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3344,7 +3344,7 @@ bool OSDMonitor::preprocess_remove_snaps(MonOpRequestRef op)
 	CEPH_ENTITY_TYPE_MON,
 	session->entity_name,
         "osd", "osd pool rmsnap", {}, true, true, false,
-	session->get_peer_addr())) {
+	session->get_peer_socket_addr())) {
     dout(0) << "got preprocess_remove_snaps from entity with insufficient caps "
 	    << session->caps << dendl;
     goto ignore;
@@ -11897,7 +11897,7 @@ bool OSDMonitor::enforce_pool_op_caps(MonOpRequestRef op)
 
       if (!is_unmanaged_snap_op_permitted(cct, mon->key_server,
                                           session->entity_name, session->caps,
-					  session->get_peer_addr(),
+					  session->get_peer_socket_addr(),
                                           pool_name)) {
         dout(0) << "got unmanaged-snap pool op from entity with insufficient "
                 << "privileges. message: " << *m  << std::endl

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -94,7 +94,12 @@ struct MonSession : public RefCountedObject {
       CEPH_ENTITY_TYPE_MON,
       entity_name,
       service, "", args,
-      mask & MON_CAP_R, mask & MON_CAP_W, mask & MON_CAP_X);
+      mask & MON_CAP_R, mask & MON_CAP_W, mask & MON_CAP_X,
+      get_peer_addr());
+  }
+
+  const entity_addr_t& get_peer_addr() {
+    return inst.addr;
   }
 };
 

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -44,6 +44,7 @@ struct MonSession : public RefCountedObject {
   uint64_t con_features = 0;  // zero if AnonConnection
   entity_name_t name;
   entity_addrvec_t addrs;
+  entity_addr_t socket_addr;
   utime_t session_timeout;
   bool closed = false;
   xlist<MonSession*>::item item;
@@ -73,6 +74,7 @@ struct MonSession : public RefCountedObject {
     con_type(c->get_peer_type()),
     name(n),
     addrs(av),
+    socket_addr(c->get_peer_socket_addr()),
     item(this) {
     if (c->get_messenger()) {
       // only fill in features if this is a non-anonymous connection
@@ -95,11 +97,11 @@ struct MonSession : public RefCountedObject {
       entity_name,
       service, "", args,
       mask & MON_CAP_R, mask & MON_CAP_W, mask & MON_CAP_X,
-      get_peer_addr());
+      get_peer_socket_addr());
   }
 
-  const entity_addr_t& get_peer_addr() {
-    return inst.addr;
+  const entity_addr_t& get_peer_socket_addr() {
+    return socket_addr;
   }
 };
 

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -157,6 +157,9 @@ public:
   bool peer_is_osd() const { return peer_type == CEPH_ENTITY_TYPE_OSD; }
   bool peer_is_client() const { return peer_type == CEPH_ENTITY_TYPE_CLIENT; }
 
+  /// which of the peer's addrs is actually in use for this connection
+  virtual entity_addr_t get_peer_socket_addr() const = 0;
+
   entity_addr_t get_peer_addr() const {
     return peer_addrs.front();
   }

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -212,6 +212,9 @@ class AsyncConnection : public Connection {
     std::lock_guard<std::mutex> l(lock);
     policy.lossy = true;
   }
+  entity_addr_t get_peer_socket_addr() const override {
+    return target_addr;
+  }
   
  private:
   enum {

--- a/src/msg/simple/PipeConnection.h
+++ b/src/msg/simple/PipeConnection.h
@@ -48,6 +48,10 @@ public:
   void mark_down() override;
   void mark_disposable() override;
 
+  entity_addr_t get_peer_socket_addr() const override {
+    return peer_addrs.front();
+  }
+
 }; /* PipeConnection */
 
 typedef boost::intrusive_ptr<PipeConnection> PipeConnectionRef;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5159,9 +5159,8 @@ void OSD::ms_handle_fast_connect(Connection *con)
     auto priv = con->get_priv();
     auto s = static_cast<Session*>(priv.get());
     if (!s) {
-      s = new Session{cct};
+      s = new Session{cct, con};
       con->set_priv(RefCountedPtr{s, false});
-      s->con = con;
       dout(10) << " new session (outgoing) " << s << " con=" << s->con
           << " addr=" << s->con->get_peer_addr() << dendl;
       // we don't connect to clients
@@ -5178,9 +5177,8 @@ void OSD::ms_handle_fast_accept(Connection *con)
     auto priv = con->get_priv();
     auto s = static_cast<Session*>(priv.get());
     if (!s) {
-      s = new Session{cct};
+      s = new Session{cct, con};
       con->set_priv(RefCountedPtr{s, false});
-      s->con = con;
       dout(10) << "new session (incoming)" << s << " con=" << con
           << " addr=" << con->get_peer_addr()
           << " must have raced with connect" << dendl;
@@ -6625,9 +6623,8 @@ bool OSD::ms_verify_authorizer(
     auto priv = con->get_priv();
     auto s = static_cast<Session*>(priv.get());
     if (!s) {
-      s = new Session{cct};
+      s = new Session{cct, con};
       con->set_priv(RefCountedPtr{s, false});
-      s->con = con;
       dout(10) << " new session " << s << " con=" << s->con
 	       << " addr=" << con->get_peer_addr() << dendl;
     }

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -21,6 +21,7 @@
 #include "OSDCap.h"
 #include "common/config.h"
 #include "common/debug.h"
+#include "include/ipaddr.h"
 
 using std::ostream;
 using std::vector;
@@ -233,6 +234,12 @@ ostream& operator<<(ostream& out, const OSDCapGrant& g)
   return out;
 }
 
+void OSDCapGrant::set_network(const string& n)
+{
+  network = n;
+  network_valid = ::parse_network(n.c_str(), &network_parsed, &network_prefix);
+}
+
 bool OSDCapGrant::allow_all() const
 {
   if (profile.is_valid()) {
@@ -258,6 +265,15 @@ bool OSDCapGrant::is_capable(
   std::vector<bool>* class_allowed) const
 {
   osd_rwxa_t allow = 0;
+
+  if (network.size() &&
+      (!network_valid ||
+       !network_contains(network_parsed,
+			 network_prefix,
+			 addr))) {
+    return false;
+  }
+
   if (profile.is_valid()) {
     return std::any_of(profile_grants.cbegin(), profile_grants.cend(),
                        [&](const OSDCapGrant& grant) {

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -245,13 +245,17 @@ bool OSDCapGrant::allow_all() const
   return (match.is_match_all() && spec.allow_all());
 }
 
-bool OSDCapGrant::is_capable(const string& pool_name, const string& ns,
-                             int64_t pool_auid,
-			     const OSDCapPoolTag::app_map_t& application_metadata,
-			     const string& object,
-                             bool op_may_read, bool op_may_write,
-                             const std::vector<OpRequest::ClassInfo>& classes,
-                             std::vector<bool>* class_allowed) const
+bool OSDCapGrant::is_capable(
+  const string& pool_name,
+  const string& ns,
+  int64_t pool_auid,
+  const OSDCapPoolTag::app_map_t& application_metadata,
+  const string& object,
+  bool op_may_read,
+  bool op_may_write,
+  const std::vector<OpRequest::ClassInfo>& classes,
+  const entity_addr_t& addr,
+  std::vector<bool>* class_allowed) const
 {
   osd_rwxa_t allow = 0;
   if (profile.is_valid()) {
@@ -260,7 +264,7 @@ bool OSDCapGrant::is_capable(const string& pool_name, const string& ns,
 			   return grant.is_capable(pool_name, ns, pool_auid,
 						   application_metadata,
 						   object, op_may_read,
-						   op_may_write, classes,
+						   op_may_write, classes, addr,
 						   class_allowed);
 		       });
   } else {
@@ -367,12 +371,13 @@ bool OSDCap::is_capable(const string& pool_name, const string& ns,
 			const OSDCapPoolTag::app_map_t& application_metadata,
 			const string& object,
                         bool op_may_read, bool op_may_write,
-			const std::vector<OpRequest::ClassInfo>& classes) const
+			const std::vector<OpRequest::ClassInfo>& classes,
+			const entity_addr_t& addr) const
 {
   std::vector<bool> class_allowed(classes.size(), false);
   for (auto &grant : grants) {
     if (grant.is_capable(pool_name, ns, pool_auid, application_metadata,
-			 object, op_may_read, op_may_write, classes,
+			 object, op_may_read, op_may_write, classes, addr,
 			 &class_allowed)) {
       return true;
     }

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -185,14 +185,26 @@ struct OSDCapGrant {
   OSDCapMatch match;
   OSDCapSpec spec;
   OSDCapProfile profile;
+  string network;
 
   // explicit grants that a profile grant expands to; populated as
   // needed by expand_profile() and cached here.
   std::list<OSDCapGrant> profile_grants;
 
   OSDCapGrant() {}
-  OSDCapGrant(const OSDCapMatch& m, const OSDCapSpec& s) : match(m), spec(s) {}
-  explicit OSDCapGrant(const OSDCapProfile& profile) : profile(profile) {
+  OSDCapGrant(const OSDCapMatch& m, const OSDCapSpec& s,
+	      boost::optional<string> n = {})
+    : match(m), spec(s) {
+    if (n) {
+      network = *n;
+    }
+  }
+  explicit OSDCapGrant(const OSDCapProfile& profile,
+		       boost::optional<string> n = {})
+    : profile(profile) {
+    if (n) {
+      network = *n;
+    }
     expand_profile();
   }
 

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -213,6 +213,7 @@ struct OSDCapGrant {
 		  const OSDCapPoolTag::app_map_t& application_metadata,
                   const string& object, bool op_may_read, bool op_may_write,
                   const std::vector<OpRequest::ClassInfo>& classes,
+		  const entity_addr_t& addr,
                   std::vector<bool>* class_allowed) const;
 
   void expand_profile();
@@ -250,7 +251,8 @@ struct OSDCap {
   bool is_capable(const string& pool_name, const string& ns, int64_t pool_auid,
 		  const OSDCapPoolTag::app_map_t& application_metadata,
 		  const string& object, bool op_may_read, bool op_may_write,
-		  const std::vector<OpRequest::ClassInfo>& classes) const;
+		  const std::vector<OpRequest::ClassInfo>& classes,
+		  const entity_addr_t& addr) const;
 };
 
 static inline ostream& operator<<(ostream& out, const OSDCap& cap) 

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -186,6 +186,9 @@ struct OSDCapGrant {
   OSDCapSpec spec;
   OSDCapProfile profile;
   string network;
+  entity_addr_t network_parsed;
+  unsigned network_prefix = 0;
+  bool network_valid = true;
 
   // explicit grants that a profile grant expands to; populated as
   // needed by expand_profile() and cached here.
@@ -196,17 +199,19 @@ struct OSDCapGrant {
 	      boost::optional<string> n = {})
     : match(m), spec(s) {
     if (n) {
-      network = *n;
+      set_network(*n);
     }
   }
   explicit OSDCapGrant(const OSDCapProfile& profile,
 		       boost::optional<string> n = {})
     : profile(profile) {
     if (n) {
-      network = *n;
+      set_network(*n);
     }
     expand_profile();
   }
+
+  void set_network(const string& n);
 
   bool allow_all() const;
   bool is_capable(const string& pool_name, const string& ns, int64_t pool_auid,

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2136,7 +2136,8 @@ bool PG::op_has_sufficient_caps(OpRequestRef& op)
 			     key,
 			     op->need_read_cap(),
 			     op->need_write_cap(),
-			     op->classes());
+			     op->classes(),
+			     session->get_peer_socket_addr());
 
   dout(20) << "op_has_sufficient_caps "
            << "session=" << session

--- a/src/osd/Session.h
+++ b/src/osd/Session.h
@@ -132,6 +132,7 @@ struct Session : public RefCountedObject {
   OSDCap caps;
   int64_t auid;
   ConnectionRef con;
+  entity_addr_t socket_addr;
   WatchConState wstate;
 
   Mutex session_dispatch_lock;
@@ -149,14 +150,19 @@ struct Session : public RefCountedObject {
 
   std::atomic<uint64_t> backoff_seq = {0};
 
-  explicit Session(CephContext *cct) :
+  explicit Session(CephContext *cct, Connection *con_) :
     RefCountedObject(cct),
-    auid(-1), con(0),
+    auid(-1), con(con_),
+    socket_addr(con_->get_peer_socket_addr()),
     wstate(cct),
     session_dispatch_lock("Session::session_dispatch_lock"),
     last_sent_epoch(0), received_map_epoch(0),
     backoff_lock("Session::backoff_lock")
     {}
+
+  entity_addr_t& get_peer_socket_addr() {
+    return socket_addr;
+  }
 
   void ack_backoff(
     CephContext *cct,

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -22,6 +22,8 @@
 using std::string;
 using std::cout;
 
+entity_addr_t addr;
+
 const char *parse_good[] = {
   "allow rw uid=1 gids=1",
   "allow * path=\"/foo\"",
@@ -111,7 +113,7 @@ TEST(MDSAuthCaps, AllowAll) {
 
   ASSERT_TRUE(cap.parse(g_ceph_context, "allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable("foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo/bar", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, AllowUid) {
@@ -120,11 +122,11 @@ TEST(MDSAuthCaps, AllowUid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, AllowUidGid) {
@@ -133,24 +135,24 @@ TEST(MDSAuthCaps, AllowUidGid) {
   ASSERT_FALSE(cap.allow_all());
 
   // uid/gid must be valid
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 9, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0, addr));
 
   // user
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0500, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 11, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 12, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 12, 0, 0700, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0700, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 
   // group
   vector<uint64_t> glist10;
@@ -162,59 +164,59 @@ TEST(MDSAuthCaps, AllowUidGid) {
   glist11.push_back(11);
   vector<uint64_t> glist12;
   glist12.push_back(12);
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0750, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 10, 11, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 10, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 11, 0770, 10, 11, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0770, 12, 12, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &glist10, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 10, 0770, 12, 12, &dglist10, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 11, 0770, 12, 12, &glist11, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 12, 0770, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 12, 0770, 10, 10, &glist12, MAY_READ | MAY_WRITE, 0, 0, addr));
 
   // user > group
-  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 10, 10, 0570, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
 
   // other
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0770, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0775, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0773, 10, 10, NULL, MAY_READ, 0, 0, addr));
 
   // group > other
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 10, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
 
   // user > other
-  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0557, 10, 10, NULL, MAY_READ, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 10, 0, 0557, 10, 10, NULL, MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, AllowPath) {
   MDSAuthCaps cap;
   ASSERT_TRUE(cap.parse(g_ceph_context, "allow * path=/sandbox", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable("sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_TRUE(cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_TRUE(cap.is_capable("sandbox/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_TRUE(cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("sandboxed", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, AllowPathChars) {
   MDSAuthCaps unquo_cap;
   ASSERT_TRUE(unquo_cap.parse(g_ceph_context, "allow * path=/sandbox-._foo", NULL));
   ASSERT_FALSE(unquo_cap.allow_all());
-  ASSERT_TRUE(unquo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(unquo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(unquo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(unquo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_TRUE(unquo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(unquo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(unquo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(unquo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 
@@ -222,10 +224,10 @@ TEST(MDSAuthCaps, AllowPathCharsQuoted) {
   MDSAuthCaps quo_cap;
   ASSERT_TRUE(quo_cap.parse(g_ceph_context, "allow * path=\"/sandbox-._foo\"", NULL));
   ASSERT_FALSE(quo_cap.allow_all());
-  ASSERT_TRUE(quo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(quo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(quo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
-  ASSERT_FALSE(quo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0));
+  ASSERT_TRUE(quo_cap.is_capable("sandbox-._foo/foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(quo_cap.is_capable("sandbox", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(quo_cap.is_capable("sandbox-._food", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
+  ASSERT_FALSE(quo_cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ | MAY_WRITE, 0, 0, addr));
 }
 
 TEST(MDSAuthCaps, OutputParsed) {
@@ -258,6 +260,8 @@ TEST(MDSAuthCaps, OutputParsed) {
      "MDSAuthCaps[allow * path=\"/foo\" uid=1 gids=1,2,3]"},
     {"allow r uid=1 gids=1,2,3, allow * uid=2",
      "MDSAuthCaps[allow r uid=1 gids=1,2,3, allow * uid=2]"},
+    {"allow r uid=1 gids=1,2,3, allow * uid=2 network 10.0.0.0/8",
+     "MDSAuthCaps[allow r uid=1 gids=1,2,3, allow * uid=2 network 10.0.0.0/8]"},
   };
   size_t num_tests = sizeof(test_values) / sizeof(*test_values);
   for (size_t i = 0; i < num_tests; ++i) {

--- a/src/test/mds/TestSessionFilter.cc
+++ b/src/test/mds/TestSessionFilter.cc
@@ -74,8 +74,8 @@ TEST(MDSSessionFilter, IdEquality)
   SessionFilter filter;
   std::stringstream ss;
   filter.parse({"id=123"}, &ss);
-  Session *a = new Session();;
-  Session *b = new Session();;
+  Session *a = new Session(nullptr);;
+  Session *b = new Session(nullptr);;
   a->info.inst.name.parse("client.123");
   b->info.inst.name.parse("client.456");
 
@@ -90,9 +90,9 @@ TEST(MDSSessionFilter, StateEquality)
   SessionFilter filter;
   std::stringstream ss;
   filter.parse({"state=closing"}, &ss);
-  Session *a = new Session();
+  Session *a = new Session(nullptr);
   a->set_state(Session::STATE_CLOSING);
-  Session *b = new Session();
+  Session *b = new Session(nullptr);
   b->set_state(Session::STATE_OPENING);
 
   ASSERT_TRUE(filter.match(*a, [](client_t c) -> bool {return false;}));
@@ -106,9 +106,9 @@ TEST(MDSSessionFilter, AuthEquality)
   SessionFilter filter;
   std::stringstream ss;
   filter.parse({"auth_name=rhubarb"}, &ss);
-  Session *a = new Session();
+  Session *a = new Session(nullptr);
   a->info.auth_name.set_id("rhubarb");
-  Session *b = new Session();
+  Session *b = new Session(nullptr);
   b->info.auth_name.set_id("custard");
 
   ASSERT_TRUE(filter.match(*a, [](client_t c) -> bool {return false;}));
@@ -124,10 +124,10 @@ TEST(MDSSessionFilter, MetadataEquality)
   int r = filter.parse({"client_metadata.root=/rhubarb"}, &ss);
   ASSERT_EQ(r, 0);
   client_metadata_t meta;
-  Session *a = new Session();
+  Session *a = new Session(nullptr);
   meta.kv_map = {{"root", "/rhubarb"}};
   a->set_client_metadata(meta);
-  Session *b = new Session();
+  Session *b = new Session(nullptr);
   meta.kv_map = {{"root", "/custard"}};
   b->set_client_metadata(meta);
 
@@ -143,7 +143,7 @@ TEST(MDSSessionFilter, ReconnectingEquality)
   std::stringstream ss;
   int r = filter.parse({"reconnecting=true"}, &ss);
   ASSERT_EQ(r, 0);
-  Session *a = new Session();
+  Session *a = new Session(nullptr);
 
   ASSERT_TRUE(filter.match(*a, [](client_t c) -> bool {return true;}));
   ASSERT_FALSE(filter.match(*a, [](client_t c) -> bool {return false;}));

--- a/src/test/mon/moncap.cc
+++ b/src/test/mon/moncap.cc
@@ -59,6 +59,13 @@ const char *parse_good[] = {
   "allow command \"foo bar\" with arg=\"baz.xx\"",
   "profile osd",
   "profile \"mds-bootstrap\", profile foo",
+  "allow * network 1.2.3.4/24",
+  "allow * network ::1/128",
+  "allow * network [aa:bb::1]/128",
+  "allow service=foo x network 1.2.3.4/16",
+  "allow command abc network 1.2.3.4/8",
+  "profile osd network 1.2.3.4/32",
+  "allow profile mon network 1.2.3.4/32",
   0
 };
 

--- a/src/test/mon/moncap.cc
+++ b/src/test/mon/moncap.cc
@@ -197,6 +197,30 @@ TEST(MonCap, AllowAll) {
   ASSERT_TRUE(cap2.is_allow_all());
 }
 
+TEST(MonCap, Network) {
+  MonCap cap;
+  bool r = cap.parse("allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", NULL);
+  ASSERT_TRUE(r);
+
+  entity_addr_t a, b, c;
+  a.parse("10.1.2.3");
+  b.parse("192.168.2.3");
+  c.parse("192.167.2.3");
+
+  ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON, EntityName(),
+			     "foo", "asdf", map<string,string>(),
+			     true, true, true,
+			     a));
+  ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON, EntityName(),
+			     "foo", "asdf", map<string,string>(),
+			     true, true, true,
+			     b));
+  ASSERT_FALSE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON, EntityName(),
+			     "foo", "asdf", map<string,string>(),
+			     true, true, true,
+			     c));
+}
+
 TEST(MonCap, ProfileOSD) {
   MonCap cap;
   bool r = cap.parse("allow profile osd", NULL);

--- a/src/test/mon/moncap.cc
+++ b/src/test/mon/moncap.cc
@@ -189,7 +189,7 @@ TEST(MonCap, AllowAll) {
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.is_allow_all());
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON, EntityName(),
-			     "foo", "asdf", map<string,string>(), true, true, true));
+			     "foo", "asdf", map<string,string>(), true, true, true, entity_addr_t()));
 
   MonCap cap2;
   ASSERT_FALSE(cap2.is_allow_all());
@@ -207,48 +207,66 @@ TEST(MonCap, ProfileOSD) {
   map<string,string> ca;
 
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "osd", "", ca, true, false, false));
+			     name, "osd", "", ca, true, false, false,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "osd", "", ca, true, true, false));
+			     name, "osd", "", ca, true, true, false,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "osd", "", ca, true, true, true));
+			     name, "osd", "", ca, true, true, true,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "osd", "", ca, true, true, true));
+			     name, "osd", "", ca, true, true, true,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "mon", "", ca, true, false,false));
+			     name, "mon", "", ca, true, false,false,
+			     entity_addr_t()));
 
   ASSERT_FALSE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "mds", "", ca, true, true, true));
+			     name, "mds", "", ca, true, true, true,
+			     entity_addr_t()));
   ASSERT_FALSE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "mon", "", ca, true, true, true));
+			     name, "mon", "", ca, true, true, true,
+			     entity_addr_t()));
 
   ca.clear();
   ASSERT_FALSE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key get", ca, true, true, true));
+			     name, "", "config-key get", ca, true, true, true,
+			     entity_addr_t()));
   ca["key"] = "daemon-private/osd.123";
   ASSERT_FALSE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key get", ca, true, true, true));
+			     name, "", "config-key get", ca, true, true, true,
+			     entity_addr_t()));
   ca["key"] = "daemon-private/osd.12/asdf";
   ASSERT_FALSE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key get", ca, true, true, true));
+			     name, "", "config-key get", ca, true, true, true,
+			     entity_addr_t()));
   ca["key"] = "daemon-private/osd.123/";
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key get", ca, true, true, true));
+			     name, "", "config-key get", ca, true, true, true,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key get", ca, true, true, true));
+			     name, "", "config-key get", ca, true, true, true,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key get", ca, true, true, true));
+			     name, "", "config-key get", ca, true, true, true,
+			     entity_addr_t()));
   ca["key"] = "daemon-private/osd.123/foo";
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key get", ca, true, true, true));
+			     name, "", "config-key get", ca, true, true, true,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key put", ca, true, true, true));
+			     name, "", "config-key put", ca, true, true, true,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key set", ca, true, true, true));
+			     name, "", "config-key set", ca, true, true, true,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key exists", ca, true, true, true));
+			     name, "", "config-key exists", ca, true, true, true,
+			     entity_addr_t()));
   ASSERT_TRUE(cap.is_capable(NULL, CEPH_ENTITY_TYPE_MON,
-			     name, "", "config-key delete", ca, true, true, true));
+			     name, "", "config-key delete", ca, true, true, true,
+			     entity_addr_t()));
 }
 
 TEST(MonCap, CommandRegEx) {
@@ -259,13 +277,16 @@ TEST(MonCap, CommandRegEx) {
   EntityName name;
   name.from_str("osd.123");
   ASSERT_TRUE(cap.is_capable(nullptr, CEPH_ENTITY_TYPE_OSD, name, "",
-                             "abc", {{"arg", "12345abcde"}}, true, true, true));
+                             "abc", {{"arg", "12345abcde"}}, true, true, true,
+			     entity_addr_t()));
   ASSERT_FALSE(cap.is_capable(nullptr, CEPH_ENTITY_TYPE_OSD, name, "",
-                              "abc", {{"arg", "~!@#$"}}, true, true, true));
+                              "abc", {{"arg", "~!@#$"}}, true, true, true,
+			      entity_addr_t()));
 
   ASSERT_TRUE(cap.parse("allow command abc with arg regex \"[*\"", NULL));
   ASSERT_FALSE(cap.is_capable(nullptr, CEPH_ENTITY_TYPE_OSD, name, "",
-                              "abc", {{"arg", ""}}, true, true, true));
+                              "abc", {{"arg", ""}}, true, true, true,
+			      entity_addr_t()));
 }
 
 TEST(MonCap, ProfileBootstrapRBD) {
@@ -280,17 +301,20 @@ TEST(MonCap, ProfileBootstrapRBD) {
                                {"entity", "client.rbd"},
                                {"caps_mon", "profile rbd"},
                                {"caps_osd", "profile rbd pool=foo, profile rbd-read-only"},
-                             }, true, true, true));
+                             }, true, true, true,
+			     entity_addr_t()));
   ASSERT_FALSE(cap.is_capable(nullptr, CEPH_ENTITY_TYPE_MON, name, "",
                               "auth get-or-create", {
                                 {"entity", "client.rbd"},
                                 {"caps_mon", "allow *"},
                                 {"caps_osd", "profile rbd"},
-                              }, true, true, true));
+                              }, true, true, true,
+			      entity_addr_t()));
   ASSERT_FALSE(cap.is_capable(nullptr, CEPH_ENTITY_TYPE_MON, name, "",
                               "auth get-or-create", {
                                 {"entity", "client.rbd"},
                                 {"caps_mon", "profile rbd"},
                                 {"caps_osd", "profile rbd pool=foo, allow *, profile rbd-read-only"},
-                              }, true, true, true));
+                              }, true, true, true,
+			      entity_addr_t()));
 }

--- a/src/test/osd/osdcap.cc
+++ b/src/test/osd/osdcap.cc
@@ -80,6 +80,12 @@ const char *parse_good[] = {
   "allow rwx tag application key= value",
   "allow rwx tag application key  =   value",
   "allow all tag application all=all",
+  "allow rwx network 127.0.0.1/8",
+  "allow rwx network ::1/128",
+  "allow rwx network [ff::1]/128",
+  "profile foo network 127.0.0.1/8",
+  "allow rwx namespace foo tag cephfs data =cephfs_a network 127.0.0.1/8",
+  "allow pool foo rwx network 1.2.3.4/24",
   0
 };
 
@@ -911,10 +917,12 @@ TEST(OSDCap, OutputParsed)
      "osdcap[grant(app application key key val value rwx)]"},
     {"allow rwx namespace ns* tag application key=value",
      "osdcap[grant(namespace ns* app application key key val value rwx)]"},
-	 {"allow all",
-	  "osdcap[grant(*)]"},
-	 {"allow rwx tag application all=all",
-	  "osdcap[grant(app application key * val * rwx)]"}
+    {"allow all",
+     "osdcap[grant(*)]"},
+    {"allow rwx tag application all=all",
+     "osdcap[grant(app application key * val * rwx)]"},
+    {"allow rwx network 1.2.3.4/24",
+     "osdcap[grant(rwx network 1.2.3.4/24)]"},
   };
 
   size_t num_tests = sizeof(test_values) / sizeof(*test_values);

--- a/src/test/osd/osdcap.cc
+++ b/src/test/osd/osdcap.cc
@@ -1338,3 +1338,16 @@ TEST(OSDCap, AllowProfile) {
                               {{"rbd", "other function", true, true, true}}, addr));
 }
 
+TEST(OSDCap, network) {
+  entity_addr_t a, b, c;
+  a.parse("10.1.2.3");
+  b.parse("192.168.2.3");
+  c.parse("192.167.2.3");
+
+  OSDCap cap;
+  ASSERT_TRUE(cap.parse("allow * network 192.168.0.0/16, allow * network 10.0.0.0/8", NULL));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}, a));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}, b));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}, c));
+}

--- a/src/test/osd/osdcap.cc
+++ b/src/test/osd/osdcap.cc
@@ -136,6 +136,7 @@ TEST(OSDCap, ParseBad) {
 
 TEST(OSDCap, AllowAll) {
   OSDCap cap;
+  entity_addr_t addr;
   ASSERT_FALSE(cap.allow_all());
 
   ASSERT_TRUE(cap.parse("allow r", NULL));
@@ -168,706 +169,734 @@ TEST(OSDCap, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, true}}, addr));
   // 'allow *' overrides whitelist
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", "", true, true, false}}, addr));
 }
 
 TEST(OSDCap, AllowPool) {
   OSDCap cap;
+  entity_addr_t addr;
   bool r = cap.parse("allow rwx pool foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
   // true->false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}, addr));
 
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
 }
 
 TEST(OSDCap, AllowPools) {
+  entity_addr_t addr;
   OSDCap cap;
   bool r = cap.parse("allow rwx pool foo, allow r pool bar", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", "", true, true, true}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "ns", 0, {}, "", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "ns", 0, {}, "", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}, addr));
 }
 
 TEST(OSDCap, AllowPools2) {
+  entity_addr_t addr;
   OSDCap cap;
   bool r = cap.parse("allow r, allow rwx pool foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", "", true, true, true}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "", true, false, {}, addr));
 }
 
 TEST(OSDCap, ObjectPrefix) {
+  entity_addr_t addr;
   OSDCap cap;
   bool r = cap.parse("allow rwx object_prefix foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, true}}, addr));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "_foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, " foo ", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "fo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "_foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, " foo ", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "fo", true, true, {{"cls", "", true, true, true}}, addr));
 }
 
 TEST(OSDCap, ObjectPoolAndPrefix) {
+  entity_addr_t addr;
   OSDCap cap;
   bool r = cap.parse("allow rwx pool bar object_prefix foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, true}}, addr));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", "", true, true, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "food", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "fo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "food", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "fo", true, true, {{"cls", "", true, true, true}}, addr));
 }
 
 TEST(OSDCap, Namespace) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rw namespace=nfoo"));
 
-  ASSERT_TRUE(cap.is_capable("bar", "nfoo", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "nfoobar", 0, {}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "nfoo", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "nfoobar", 0, {}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, NamespaceGlob) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rw namespace=nfoo*"));
 
-  ASSERT_TRUE(cap.is_capable("bar", "nfoo", 0, {}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "nfoobar", 0, {}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "nfoo", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "nfoobar", 0, {}, "foo", true, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "nfo", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "nfo", 0, {}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, BasicR) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow r", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, BasicW) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow w", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, BasicX) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow x", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
   // true->false when class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
 
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, BasicRW) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rw", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
 }
 
 TEST(OSDCap, BasicRX) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, true, true}}, addr));
   // true->false for class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, true, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, BasicWX) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow wx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
   // true->false for class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, BasicRWX) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   // true->false for class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
 }
 
 TEST(OSDCap, BasicRWClassRClassW) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rw class-read class-write", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
 }
 
 TEST(OSDCap, ClassR) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class-read", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
 }
 
 TEST(OSDCap, ClassW) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class-write", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
 }
 
 TEST(OSDCap, ClassRW) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class-read class-write", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
 }
 
 TEST(OSDCap, BasicRClassR) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow r class-read", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, PoolClassR) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow pool bar r class-read, allow pool foo rwx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
 }
 
 TEST(OSDCap, PoolClassRNS) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow pool bar namespace='' r class-read, allow pool foo namespace=ns rwx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
 }
 
 TEST(OSDCap, NSClassR) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow namespace '' rw class-read class-write, allow namespace test r", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", "", true, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "test", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "test", 0, {}, "foo", true, false, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "test", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "test", 0, {}, "foo", true, false, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {{"application", {{"key", "value"}}}}, "foo", false, false, {{"cls", "", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {{"application", {{"key", "value"}}}}, "foo", false, false, {{"cls", "", false, true, true}}, addr));
 }
 
-TEST(OSDCap, PoolTagBasic)
-{
+TEST(OSDCap, PoolTagBasic) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx tag application key=value", NULL));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, false, true}}, addr));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", "", false, true, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", false, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", "", false, false, true}}, addr));
 }
 
 TEST(OSDCap, PoolTagWildK)
 {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx tag application *=value", NULL));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, PoolTagWildV)
 {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx tag application key=*", NULL));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, PoolTagWildKV)
 {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx tag application *=*", NULL));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {}}}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {}}}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, NSPool)
 {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx namespace ns tag application key=value", NULL));
 
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns2", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value2"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns2", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value2"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, NSPoolGlob)
 {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx namespace ns* tag application key=value", NULL));
 
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
 
-  ASSERT_TRUE(cap.is_capable("foo", "ns2", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value2"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns2", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value2"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}, addr));
 }
 
 TEST(OSDCap, OutputParsed)
 {
+  entity_addr_t addr;
   struct CapsTest {
     const char *input;
     const char *output;
@@ -935,370 +964,377 @@ TEST(OSDCap, OutputParsed)
 }
 
 TEST(OSDCap, AllowClass) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class foo", NULL));
 
   // can call any method on class foo regardless of whitelist status
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}}, addr));
 
   // does not permit invoking class bar
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}, addr));
 }
 
 TEST(OSDCap, AllowClassMethod) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class foo xyz", NULL));
 
   // can call the xyz method on class foo regardless of whitelist status
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, false, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", false, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "xyz", true, true, false}}, addr));
 
   // does not permit invoking class bar
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "xyz", true, true, false}}, addr));
 }
 
 TEST(OSDCap, AllowClass2) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class foo, allow class bar", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}, addr));
 }
 
 TEST(OSDCap, AllowClassRWX) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx, allow class foo", NULL));
 
   // can call any method on class foo regardless of whitelist status
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}}, addr));
 
   // does not permit invoking class bar
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, false}}, addr));
 
   // allows class bar if it is whitelisted
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", "", true, true, true}}, addr));
 }
 
 TEST(OSDCap, AllowClassMulti) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class foo", NULL));
 
   // can call any method on foo, but not bar, so the entire op is rejected
   // bar with whitelist is rejected because it still needs rwx/class-read,write
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}, addr));
 
   // these are OK because 'bar' is on the whitelist BUT the calls don't read or write
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}, addr));
 
   // can call any method on foo or bar regardless of whitelist status
   OSDCap cap2;
   ASSERT_TRUE(cap2.parse("allow class foo, allow class bar", NULL));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}, addr));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}, addr));
 }
 
 TEST(OSDCap, AllowClassMultiRWX) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx, allow class foo", NULL));
 
   // can call anything on foo, but only whitelisted methods on bar
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, true}}, addr));
 
   // fails because bar not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, true}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, true, false}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, true}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, true}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", true, false, false}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, true}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, true}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, true, false}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, true}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, true}, {"bar", "", false, false, false}}, addr));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, true}}, addr));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, true}}, addr));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", true, false, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, true, false}}, addr));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", "", false, false, false}, {"bar", "", false, false, false}}, addr));
 }
 
 TEST(OSDCap, AllowProfile) {
+  entity_addr_t addr;
   OSDCap cap;
   ASSERT_TRUE(cap.parse("profile read-only, profile read-write pool abc", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "asdf", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {}, addr));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, false, {}, addr));
+  ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "asdf", false, true, {}, addr));
 
   // RBD
   cap.grants.clear();
   ASSERT_TRUE(cap.parse("profile rbd pool abc", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "rbd_children", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {}, addr));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "rbd_children", true, false, {}, addr));
   ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "rbd_children", false, false,
-                             {{"rbd", "", true, false, true}}));
+                             {{"rbd", "", true, false, true}}, addr));
   ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "asdf", true, true,
-                             {{"rbd", "", true, true, true}}));
+                             {{"rbd", "", true, true, true}}, addr));
 
   cap.grants.clear();
   ASSERT_TRUE(cap.parse("profile rbd-read-only pool abc", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "rbd_children", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "rbd_children", true, false, {}, addr));
   ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "asdf", true, false,
-                             {{"rbd", "", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("abc", "", 0, {}, "asdf", true, true, {}));
+                             {{"rbd", "", true, false, true}}, addr));
+  ASSERT_FALSE(cap.is_capable("abc", "", 0, {}, "asdf", true, true, {}, addr));
   ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "rbd_header.ABC", false, false,
-                             {{"rbd", "child_attach", true, true, true}}));
+                             {{"rbd", "child_attach", true, true, true}}, addr));
   ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "rbd_header.ABC", false, false,
-                             {{"rbd", "child_detach", true, true, true}}));
+                             {{"rbd", "child_detach", true, true, true}}, addr));
   ASSERT_FALSE(cap.is_capable("abc", "", 0, {}, "rbd_header.ABC", false, false,
-                              {{"rbd", "other function", true, true, true}}));
+                              {{"rbd", "other function", true, true, true}}, addr));
 }
 

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -542,6 +542,42 @@ TEST(CommonIPAddr, ParseNetwork_IPv6_9000)
   ASSERT_EQ(0, memcmp(want.sin6_addr.s6_addr, network.sin6_addr.s6_addr, sizeof(network.sin6_addr.s6_addr)));
 }
 
+TEST(CommonIPAddr, network_contains)
+{
+  entity_addr_t network, addr;
+  unsigned int prefix;
+  bool ok;
+
+  ok = parse_network("2001:1234:5678:90ab::dead:beef/32", &network, &prefix);
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(32U, prefix);
+  ok = addr.parse("2001:1234:5678:90ab::dead:beef", nullptr);
+  ASSERT_TRUE(ok);
+  ASSERT_TRUE(network_contains(network, prefix, addr));
+  ok = addr.parse("2001:1334:5678:90ab::dead:beef", nullptr);
+  ASSERT_TRUE(ok);
+  ASSERT_FALSE(network_contains(network, prefix, addr));
+  ok = addr.parse("127.0.0.1", nullptr);
+  ASSERT_TRUE(ok);
+  ASSERT_FALSE(network_contains(network, prefix, addr));
+
+  ok = parse_network("10.1.2.3/16", &network, &prefix);
+  ASSERT_TRUE(ok);
+  ASSERT_EQ(16U, prefix);
+  ok = addr.parse("2001:1234:5678:90ab::dead:beef", nullptr);
+  ASSERT_TRUE(ok);
+  ASSERT_FALSE(network_contains(network, prefix, addr));
+  ok = addr.parse("1.2.3.4", nullptr);
+  ASSERT_TRUE(ok);
+  ASSERT_FALSE(network_contains(network, prefix, addr));
+  ok = addr.parse("10.1.22.44", nullptr);
+  ASSERT_TRUE(ok);
+  ASSERT_TRUE(network_contains(network, prefix, addr));
+  ok = addr.parse("10.2.22.44", nullptr);
+  ASSERT_TRUE(ok);
+  ASSERT_FALSE(network_contains(network, prefix, addr));
+}
+
 TEST(pick_address, find_ip_in_subnet_list)
 {
   struct ifaddrs one, two, three;


### PR DESCRIPTION
MonCap gets a 'network foo/mask' suffix (optional).  For now this is considered sufficient because the clietn can't get other caps without a working mon session.

There are semi-unrelated commits in here fixing mon addrvec related items, and I left the initial commit based on pre-addrvec code so that it is easily backported.