### PR TITLE
mimic: rbd: rbd-mirror simple image map policy doesn't always level-load instances

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6471,6 +6471,10 @@ static std::vector<Option> get_rbd_mirror_options() {
     .set_default(1)
     .set_min(1)
     .set_description("interval (in seconds) to throttle images for mirror daemon peer updates"),
+
+    Option("rbd_mirror_image_policy_rebalance_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("number of seconds policy should be idle before trigerring reshuffle (rebalance) of images"),
   });
 }
 

--- a/src/tools/rbd_mirror/ImageMap.cc
+++ b/src/tools/rbd_mirror/ImageMap.cc
@@ -65,6 +65,7 @@ template <typename I>
 ImageMap<I>::~ImageMap() {
   assert(m_async_op_tracker.empty());
   assert(m_timer_task == nullptr);
+  assert(m_rebalance_task == nullptr);
 }
 
 template <typename I>
@@ -199,6 +200,15 @@ void ImageMap<I>::process_updates() {
 template <typename I>
 void ImageMap<I>::schedule_update_task() {
   Mutex::Locker timer_lock(m_threads->timer_lock);
+  schedule_update_task(m_threads->timer_lock);
+}
+
+template <typename I>
+void ImageMap<I>::schedule_update_task(const Mutex &timer_lock) {
+  assert(m_threads->timer_lock.is_locked());
+
+  schedule_rebalance_task();
+
   if (m_timer_task != nullptr) {
     return;
   }
@@ -223,6 +233,57 @@ void ImageMap<I>::schedule_update_task() {
   dout(20) << "scheduling image check update (" << m_timer_task << ")"
            << " after " << after << " second(s)" << dendl;
   m_threads->timer->add_event_after(after, m_timer_task);
+}
+
+template <typename I>
+void ImageMap<I>::rebalance() {
+  assert(m_rebalance_task == nullptr);
+
+  {
+    Mutex::Locker locker(m_lock);
+    if (m_async_op_tracker.empty() && m_global_image_ids.empty()){
+      dout(20) << "starting rebalance" << dendl;
+
+      std::set<std::string> remap_global_image_ids;
+      m_policy->add_instances({}, &remap_global_image_ids);
+
+      for (auto const &global_image_id : remap_global_image_ids) {
+        schedule_action(global_image_id);
+      }
+    }
+  }
+
+  schedule_update_task(m_threads->timer_lock);
+}
+
+template <typename I>
+void ImageMap<I>::schedule_rebalance_task() {
+  assert(m_threads->timer_lock.is_locked());
+
+  CephContext *cct = reinterpret_cast<CephContext *>(m_ioctx.cct());
+
+  // fetch the updated value of idle timeout for (re)scheduling
+  double resched_after = cct->_conf->get_val<double>(
+    "rbd_mirror_image_policy_rebalance_timeout");
+  if (!resched_after) {
+    return;
+  }
+
+  // cancel existing rebalance task if any before scheduling
+  if (m_rebalance_task != nullptr) {
+    m_threads->timer->cancel_event(m_rebalance_task);
+  }
+
+  m_rebalance_task = new FunctionContext([this](int _) {
+      assert(m_threads->timer_lock.is_locked());
+      m_rebalance_task = nullptr;
+
+      rebalance();
+    });
+
+  dout(20) << "scheduling rebalance (" << m_rebalance_task << ")"
+           << " after " << resched_after << " second(s)" << dendl;
+  m_threads->timer->add_event_after(resched_after, m_rebalance_task);
 }
 
 template <typename I>
@@ -498,6 +559,10 @@ void ImageMap<I>::shut_down(Context *on_finish) {
     if (m_timer_task != nullptr) {
       m_threads->timer->cancel_event(m_timer_task);
       m_timer_task = nullptr;
+    }
+    if (m_rebalance_task != nullptr) {
+      m_threads->timer->cancel_event(m_rebalance_task);
+      m_rebalance_task = nullptr;
     }
   }
 

--- a/src/tools/rbd_mirror/ImageMap.h
+++ b/src/tools/rbd_mirror/ImageMap.h
@@ -98,6 +98,8 @@ private:
 
   std::set<std::string> m_global_image_ids;
 
+  Context *m_rebalance_task = nullptr;
+
   struct C_LoadMap : Context {
     ImageMap *image_map;
     Context *on_finish;
@@ -145,9 +147,13 @@ private:
   void schedule_action(const std::string &global_image_id);
 
   void schedule_update_task();
+  void schedule_update_task(const Mutex &timer_lock);
   void process_updates();
   void update_image_mapping(Updates&& map_updates,
                             std::set<std::string>&& map_removals);
+
+  void rebalance();
+  void schedule_rebalance_task();
 
   void notify_listener_acquire_release_images(const Updates &acquire, const Updates &release);
   void notify_listener_remove_images(const std::string &peer_uuid, const Updates &remove);

--- a/src/tools/rbd_mirror/image_map/Policy.cc
+++ b/src/tools/rbd_mirror/image_map/Policy.cc
@@ -395,9 +395,8 @@ bool Policy::set_state(ImageState* image_state, StateTransition::State state,
 
 bool Policy::is_state_scheduled(const ImageState& image_state,
                                 StateTransition::State state) const {
-  return (image_state.state == StateTransition::STATE_DISSOCIATING ||
-          (image_state.next_state &&
-           *image_state.next_state == StateTransition::STATE_DISSOCIATING));
+  return (image_state.state == state ||
+          (image_state.next_state && *image_state.next_state == state));
 }
 
 } // namespace image_map

--- a/src/tools/rbd_mirror/image_map/Policy.cc
+++ b/src/tools/rbd_mirror/image_map/Policy.cc
@@ -141,8 +141,7 @@ void Policy::add_instances(const InstanceIds &instance_ids,
   }
 
   GlobalImageIds shuffle_global_image_ids;
-  do_shuffle_add_instances(m_map, m_image_states.size(), instance_ids,
-                           &shuffle_global_image_ids);
+  do_shuffle_add_instances(m_map, m_image_states.size(), &shuffle_global_image_ids);
   dout(5) << "shuffling global_image_ids=[" << shuffle_global_image_ids
           << "]" << dendl;
   for (auto& global_image_id : shuffle_global_image_ids) {

--- a/src/tools/rbd_mirror/image_map/Policy.cc
+++ b/src/tools/rbd_mirror/image_map/Policy.cc
@@ -258,11 +258,13 @@ bool Policy::finish_action(const std::string &global_image_id, int r) {
     assert(start_action);
   }
 
+  // image state may get purged in execute_policy_action()
+  bool pending_action = image_state.transition.action_type != ACTION_TYPE_NONE;
   if (finish_policy_action) {
     execute_policy_action(global_image_id, &image_state, *finish_policy_action);
   }
 
-  return (image_state.transition.action_type != ACTION_TYPE_NONE);
+  return pending_action;
 }
 
 void Policy::execute_policy_action(

--- a/src/tools/rbd_mirror/image_map/Policy.h
+++ b/src/tools/rbd_mirror/image_map/Policy.h
@@ -65,7 +65,6 @@ protected:
   // shuffle images when instances are added/removed
   virtual void do_shuffle_add_instances(
       const InstanceToImageMap& map, size_t image_count,
-      const std::vector<std::string> &instance_ids,
       std::set<std::string> *remap_global_image_ids) = 0;
 
 private:

--- a/src/tools/rbd_mirror/image_map/SimplePolicy.cc
+++ b/src/tools/rbd_mirror/image_map/SimplePolicy.cc
@@ -39,7 +39,6 @@ size_t SimplePolicy::calc_images_per_instance(const InstanceToImageMap& map,
 
 void SimplePolicy::do_shuffle_add_instances(
     const InstanceToImageMap& map, size_t image_count,
-    const std::vector<std::string> &instance_ids,
     std::set<std::string> *remap_global_image_ids) {
   uint64_t images_per_instance = calc_images_per_instance(map, image_count);
   dout(5) << "images per instance=" << images_per_instance << dendl;

--- a/src/tools/rbd_mirror/image_map/SimplePolicy.h
+++ b/src/tools/rbd_mirror/image_map/SimplePolicy.h
@@ -24,7 +24,6 @@ protected:
 
   void do_shuffle_add_instances(
       const InstanceToImageMap& map, size_t image_count,
-      const std::vector<std::string> &instance_ids,
       std::set<std::string> *remap_global_image_ids) override;
 
 private:

--- a/src/tools/rbd_mirror/image_map/StateTransition.cc
+++ b/src/tools/rbd_mirror/image_map/StateTransition.cc
@@ -65,13 +65,12 @@ const StateTransition::TransitionTable StateTransition::s_transition_table {
   {{STATE_ASSOCIATING,  ACTION_TYPE_ACQUIRE},    {ACTION_TYPE_NONE, {}, {},
                                                   {STATE_ASSOCIATED}}},
 
-  {{STATE_DISSOCIATING, ACTION_TYPE_NONE},       {ACTION_TYPE_RELEASE, {}, {},
-                                                  {}}},
+  {{STATE_DISSOCIATING, ACTION_TYPE_NONE},       {ACTION_TYPE_RELEASE, {},
+                                                 {POLICY_ACTION_UNMAP}, {}}},
   {{STATE_DISSOCIATING, ACTION_TYPE_RELEASE},    {ACTION_TYPE_MAP_REMOVE, {},
-                                                  {POLICY_ACTION_UNMAP}, {}}},
+                                                  {POLICY_ACTION_REMOVE}, {}}},
   {{STATE_DISSOCIATING, ACTION_TYPE_MAP_REMOVE}, {ACTION_TYPE_NONE, {},
-                                                  {POLICY_ACTION_REMOVE},
-                                                  {STATE_UNASSOCIATED}}},
+                                                  {}, {STATE_UNASSOCIATED}}},
 
   {{STATE_SHUFFLING,    ACTION_TYPE_NONE},       {ACTION_TYPE_RELEASE, {},
                                                   {POLICY_ACTION_UNMAP}, {}}},


### PR DESCRIPTION
http://tracker.ceph.com/issues/24519