### PR TITLE
os/bluestore: remove redundant fault_range.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11032,7 +11032,6 @@ int BlueStore::_do_gc(
     int r = _do_read(c.get(), o, it->offset, it->length, bl, 0);
     assert(r == (int)it->length);
 
-    o->extent_map.fault_range(db, it->offset, it->length);
     _do_write_data(txc, c, o, it->offset, it->length, bl, &wctx_gc);
     logger->inc(l_bluestore_gc_merged, it->length);
 


### PR DESCRIPTION
In fact, _do_read already did fault_range for the same offset and
length.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>