### PR TITLE
mgr/dashboard: Improve SummaryService and TaskWrapperService

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.spec.ts
@@ -2,20 +2,24 @@ import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { BsModalRef } from 'ngx-bootstrap';
-import 'rxjs/add/observable/of';
-import { Observable } from 'rxjs/Observable';
+import { BehaviorSubject } from 'rxjs';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SummaryService } from '../../../shared/services/summary.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { AboutComponent } from './about.component';
 
-class SummaryServiceMock {
-  summaryData$ = Observable.of({
+export class SummaryServiceMock {
+  summaryDataSource = new BehaviorSubject({
     version:
       'ceph version 14.0.0-855-gb8193bb4cd ' +
       '(b8193bb4cda16ccc5b028c3e1df62bc72350a15d) nautilus (dev)'
   });
+  summaryData$ = this.summaryDataSource.asObservable();
+
+  subscribe(call) {
+    return this.summaryData$.subscribe(call);
+  }
 }
 
 describe('AboutComponent', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/about/about.component.ts
@@ -19,7 +19,7 @@ export class AboutComponent implements OnInit, OnDestroy {
   constructor(public modalRef: BsModalRef, private summaryService: SummaryService) {}
 
   ngOnInit() {
-    this.subs = this.summaryService.summaryData$.subscribe((summary: any) => {
+    this.subs = this.summaryService.subscribe((summary: any) => {
       if (!summary) {
         return;
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.ts
@@ -22,13 +22,17 @@ export class DashboardHelpComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    const subs = this.summaryService.summaryData$.subscribe((summary: any) => {
+    const subs = this.summaryService.subscribe((summary: any) => {
       if (!summary) {
         return;
       }
+
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
       this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/`;
-      subs.unsubscribe();
+
+      setTimeout(() => {
+        subs.unsubscribe();
+      }, 0);
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.ts
@@ -22,7 +22,7 @@ export class NavigationComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.summaryService.summaryData$.subscribe((data: any) => {
+    this.summaryService.subscribe((data: any) => {
       if (!data) {
         return;
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.ts
@@ -22,7 +22,7 @@ export class TaskManagerComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    this.summaryService.summaryData$.subscribe((data: any) => {
+    this.summaryService.subscribe((data: any) => {
       if (!data) {
         return;
       }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -1,9 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
-import { of as observableOf } from 'rxjs';
+import { of as observableOf, Subscriber } from 'rxjs';
 
 import { configureTestBed } from '../../../testing/unit-test-helper';
+import { ExecutingTask } from '../models/executing-task';
 import { AuthStorageService } from './auth-storage.service';
 import { SummaryService } from './summary.service';
 
@@ -11,18 +12,19 @@ describe('SummaryService', () => {
   let summaryService: SummaryService;
   let authStorageService: AuthStorageService;
 
+  const summary = {
+    executing_tasks: [],
+    health_status: 'HEALTH_OK',
+    mgr_id: 'x',
+    rbd_mirroring: { errors: 0, warnings: 0 },
+    rbd_pools: [],
+    have_mon_connection: true,
+    finished_tasks: [],
+    filesystems: [{ id: 1, name: 'cephfs_a' }]
+  };
+
   const httpClientSpy = {
-    get: () =>
-      observableOf({
-        executing_tasks: [],
-        health_status: 'HEALTH_OK',
-        mgr_id: 'x',
-        rbd_mirroring: { errors: 0, warnings: 0 },
-        rbd_pools: [],
-        have_mon_connection: true,
-        finished_tasks: [],
-        filesystems: [{ id: 1, name: 'cephfs_a' }]
-      })
+    get: () => observableOf(summary)
   };
 
   configureTestBed({
@@ -48,7 +50,7 @@ describe('SummaryService', () => {
       authStorageService.set('foobar');
       let result = false;
       summaryService.refresh();
-      summaryService.summaryData$.subscribe((res) => {
+      summaryService.subscribe(() => {
         result = true;
       });
       tick(5000);
@@ -58,7 +60,38 @@ describe('SummaryService', () => {
     })
   );
 
-  it('should get summary', () => {
-    expect(summaryService.get()).toEqual(jasmine.any(Object));
+  describe('Should test methods after first refresh', () => {
+    beforeEach(() => {
+      authStorageService.set('foobar');
+      summaryService.refresh();
+    });
+
+    it('should call getCurrentSummary', () => {
+      expect(summaryService.getCurrentSummary ()).toEqual(summary);
+    });
+
+    it('should call subscribe', () => {
+      let result;
+      const subscriber = summaryService.subscribe((data) => {
+        result = data;
+      });
+      expect(subscriber).toEqual(jasmine.any(Subscriber));
+      expect(result).toEqual(summary);
+    });
+
+    it('should call addRunningTask', () => {
+      summaryService.addRunningTask(
+        new ExecutingTask('rbd/delete', {
+          pool_name: 'somePool',
+          image_name: 'someImage'
+        })
+      );
+      const result = summaryService.getCurrentSummary ();
+      expect(result.executing_tasks.length).toBe(1);
+      expect(result.executing_tasks[0]).toEqual({
+        metadata: { image_name: 'someImage', pool_name: 'somePool' },
+        name: 'rbd/delete'
+      });
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
@@ -1,8 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, NgZone } from '@angular/core';
 
-import { BehaviorSubject } from 'rxjs';
+import * as _ from 'lodash';
+import { BehaviorSubject, Subscription } from 'rxjs';
 
+import { ExecutingTask } from '../models/executing-task';
 import { AuthStorageService } from './auth-storage.service';
 import { ServicesModule } from './services.module';
 
@@ -26,7 +28,7 @@ export class SummaryService {
 
   refresh() {
     if (this.authStorageService.isLoggedIn()) {
-      this.http.get('api/summary').subscribe(data => {
+      this.http.get('api/summary').subscribe((data) => {
         this.summaryDataSource.next(data);
       });
     }
@@ -40,7 +42,48 @@ export class SummaryService {
     });
   }
 
-  get() {
-    return this.http.get('api/summary');
+  /**
+   * Returns the current value of summaryData
+   *
+   * @returns {object}
+   * @memberof SummaryService
+   */
+  getCurrentSummary () {
+    return this.summaryDataSource.getValue();
+  }
+
+  /**
+   * Subscribes to the summaryData,
+   * which is updated once every 5 seconds or when a new task is created.
+   *
+   * @param {(summary: any) => void} call
+   * @returns {Subscription}
+   * @memberof SummaryService
+   */
+  subscribe(call: (summary: any) => void): Subscription {
+    return this.summaryData$.subscribe(call);
+  }
+
+  /**
+   * Inserts a newly created task to the local list of executing tasks.
+   * After that, it will automatically push that new information
+   * to all subscribers.
+   *
+   * @param {ExecutingTask} task
+   * @memberof SummaryService
+   */
+  addRunningTask(task: ExecutingTask) {
+    const current = this.summaryDataSource.getValue();
+    if (!current) {
+      return;
+    }
+
+    if (_.isArray(current.executing_tasks)) {
+      current.executing_tasks.push(task);
+    } else {
+      current.executing_tasks = [task];
+    }
+
+    this.summaryDataSource.next(current);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager.service.ts
@@ -27,7 +27,7 @@ export class TaskManagerService {
   subscriptions: Array<TaskSubscription> = [];
 
   constructor(summaryService: SummaryService) {
-    summaryService.summaryData$.subscribe((data: any) => {
+    summaryService.subscribe((data: any) => {
       if (!data) {
         return;
       }


### PR DESCRIPTION
When you create a new task, and it stays running, it will be added automatically
to the summary data.

This will allows for us to deal with it more quickly, by subscribing
to the summaryService, and removes the need to pass a runningTasks array
between services.

Added 3 new methods to SummaryService.

Signed-off-by: Tiago Melo <tmelo@suse.com>