### PR TITLE
jewel: qa/suites/krbd: use 8 osds instead of 6

### DIFF
--- a/qa/suites/krbd/rbd-nomount/clusters/fixed-3-more.yaml
+++ b/qa/suites/krbd/rbd-nomount/clusters/fixed-3-more.yaml
@@ -1,0 +1,13 @@
+roles:
+- [mon.a, mon.c, osd.0, osd.1, osd.2, osd.3]
+- [mon.b, osd.4, osd.5, osd.6, osd.7]
+- [client.0]
+openstack:
+- volumes: # attached to each instance
+    count: 3
+    size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/qa/suites/krbd/rbd-nomount/clusters/fixed-3.yaml
+++ b/qa/suites/krbd/rbd-nomount/clusters/fixed-3.yaml
@@ -1,1 +1,0 @@
-../../../../clusters/fixed-3.yaml

--- a/qa/suites/krbd/rbd/clusters/fixed-3-more.yaml
+++ b/qa/suites/krbd/rbd/clusters/fixed-3-more.yaml
@@ -1,0 +1,13 @@
+roles:
+- [mon.a, mon.c, osd.0, osd.1, osd.2, osd.3]
+- [mon.b, osd.4, osd.5, osd.6, osd.7]
+- [client.0]
+openstack:
+- volumes: # attached to each instance
+    count: 3
+    size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/qa/suites/krbd/rbd/clusters/fixed-3.yaml
+++ b/qa/suites/krbd/rbd/clusters/fixed-3.yaml
@@ -1,1 +1,0 @@
-../../../../clusters/fixed-3.yaml

--- a/qa/suites/krbd/thrash/clusters/fixed-3-more.yaml
+++ b/qa/suites/krbd/thrash/clusters/fixed-3-more.yaml
@@ -1,0 +1,13 @@
+roles:
+- [mon.a, mon.c, osd.0, osd.1, osd.2, osd.3]
+- [mon.b, osd.4, osd.5, osd.6, osd.7]
+- [client.0]
+openstack:
+- volumes: # attached to each instance
+    count: 3
+    size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/qa/suites/krbd/thrash/clusters/fixed-3.yaml
+++ b/qa/suites/krbd/thrash/clusters/fixed-3.yaml
@@ -1,1 +1,0 @@
-../../../../clusters/fixed-3.yaml


### PR DESCRIPTION
This is done in master.

Signed-off-by: Sage Weil <sage@redhat.com>