### PR TITLE
cmake: remove workarounds for supporting cmake 2.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.1)
 
 project(ceph CXX C ASM)
 set(VERSION 13.1.0)

--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -149,10 +149,8 @@ function(do_build_boost version)
     endif()
     set(source_dir
       URL ${boost_url}
-      URL_HASH SHA256=${boost_sha256})
-    if(CMAKE_VERSION VERSION_GREATER 3.1)
-      list(APPEND source_dir DOWNLOAD_NO_PROGRESS 1)
-    endif()
+      URL_HASH SHA256=${boost_sha256}
+      DOWNLOAD_NO_PROGRESS 1)
   endif()
   # build all components in a single shot
   include(ExternalProject)
@@ -230,16 +228,10 @@ macro(build_boost version)
   endforeach()
 
   # for header-only libraries
-  if(CMAKE_VERSION VERSION_LESS 3.3)
-    # only ALIAS and INTERFACE target names allow ":" in it, but
-    # INTERFACE library is not allowed until cmake 3.1
-    add_custom_target(Boost.boost DEPENDS Boost)
-  else()
-    add_library(Boost::boost INTERFACE IMPORTED)
-    set_target_properties(Boost::boost PROPERTIES
-      INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
-    add_dependencies(Boost::boost Boost)
-  endif()
+  add_library(Boost::boost INTERFACE IMPORTED)
+  set_target_properties(Boost::boost PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}")
+  add_dependencies(Boost::boost Boost)
   find_package_handle_standard_args(Boost DEFAULT_MSG
     Boost_INCLUDE_DIRS Boost_LIBRARIES)
   mark_as_advanced(Boost_LIBRARIES BOOST_INCLUDE_DIRS)
@@ -251,18 +243,12 @@ function(maybe_add_boost_dep target)
     return()
   endif()
   get_target_property(sources ${target} SOURCES)
-  if(NOT CMAKE_VERSION VERSION_LESS 3.1)
-    string(GENEX_STRIP "${sources}" sources)
-  endif()
+  string(GENEX_STRIP "${sources}" sources)
   foreach(src ${sources})
     get_filename_component(ext ${src} EXT)
     # assuming all cxx source files include boost header(s)
     if(ext MATCHES ".cc|.cpp|.cxx")
-      if(CMAKE_VERSION VERSION_LESS 3.3)
-        add_dependencies(${target} Boost.boost)
-      else()
-        add_dependencies(${target} Boost::boost)
-      endif()
+      add_dependencies(${target} Boost::boost)
       return()
     endif()
   endforeach()

--- a/src/test/fio/CMakeLists.txt
+++ b/src/test/fio/CMakeLists.txt
@@ -5,14 +5,9 @@ target_include_directories(fio_ceph_objectstore SYSTEM PUBLIC ${FIO_INCLUDE_DIR}
 set(FIO_CFLAGS "-DCONFIG_HAVE_BOOL")
 
 # fio headers use typeof(), which requires c++11 extensions
-if(CMAKE_VERSION VERSION_LESS "3.1")
-  set_target_properties(fio_ceph_objectstore PROPERTIES
-    COMPILE_FLAGS "-std=gnu++11 ${FIO_CFLAGS}")
-else()
-  set_target_properties(fio_ceph_objectstore PROPERTIES
-    CXX_EXTENSIONS ON
-    COMPILE_FLAGS "${FIO_CFLAGS}")
-endif()
+set_target_properties(fio_ceph_objectstore PROPERTIES
+  CXX_EXTENSIONS ON
+  COMPILE_FLAGS "${FIO_CFLAGS}")
 
 if(WITH_FIO)
   add_dependencies(fio_ceph_objectstore fio_ext)


### PR DESCRIPTION
and bump up the required cmake version to 3.5.1

Signed-off-by: Kefu Chai <kchai@redhat.com>