### PR TITLE
jewel: Revert "rgw: fix index update in dir_suggest_changes"

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1927,7 +1927,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx, bufferlist *in, bufferlis
     string cur_change_key;
     encode_obj_index_key(cur_change.key, &cur_change_key);
     int ret = cls_cxx_map_get_val(hctx, cur_change_key, &cur_disk_bl);
-    if (ret < 0)
+    if (ret < 0 && ret != -ENOENT)
       return -EINVAL;
 
     if (cur_disk_bl.length()) {
@@ -1983,6 +1983,18 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx, bufferlist *in, bufferlis
         }
         break;
       case CEPH_RGW_UPDATE:
+	if (!cur_disk.exists) {
+	  // this update would only have been sent by the rgw client
+	  // if the rgw_bucket_dir_entry existed, however between that
+	  // check and now the entry has diappeared, so we were likely
+	  // in the midst of a delete op, and we will not recreate the
+	  // entry
+	  CLS_LOG(10,
+		  "CEPH_RGW_UPDATE not applied because rgw_bucket_dir_entry"
+		  " no longer exists\n");
+	  break;
+	}
+
         CLS_LOG(10, "CEPH_RGW_UPDATE name=%s instance=%s total_entries: %" PRId64 " -> %" PRId64 "\n",
                 cur_change.key.name.c_str(), cur_change.key.instance.c_str(), stats.num_entries, stats.num_entries + 1);
         stats.num_entries++;


### PR DESCRIPTION
This reverts commit 2e3f9de81959d4dc8becb17e3e11d5a69e927d04.

This causes a regression in the cls_rgw index_suggest test, see
http://tracker.ceph.com/issues/24640.

Marking http://tracker.ceph.com/issues/24627 back to In Progress.

Signed-off-by: Sage Weil <sage@redhat.com>