### PR TITLE
tests: make test_ceph_argparse.py pass on py3-only systems

### DIFF
--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -24,7 +24,10 @@ import os
 import re
 import sys
 import json
-from StringIO import StringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 def get_command_descriptions(what):
     CEPH_BIN = os.environ['CEPH_BIN']


### PR DESCRIPTION
On systems that do not have Python 2 installed, this test fails to
import StringIO.

Fixes: http://tracker.ceph.com/issues/24816
Signed-off-by: Nathan Cutler <ncutler@suse.com>