### PR TITLE
Revert "src/test: Using gtest-parallel to speedup unittests"

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -38,13 +38,8 @@ endif()
 
 #sets uniform compiler flags and link libraries
 function(add_ceph_unittest unittest_name)
-  set(UNITTEST "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${unittest_name}")
-  # If the second argument is "parallel", it means we want a parallel run
-  if(WITH_GTEST_PARALLEL AND "${ARGV1}" STREQUAL "parallel")
-    ExternalProject_Get_Property(gtest-parallel_ext source_dir)
-    set(UNITTEST ${source_dir}/gtest-parallel ${UNITTEST})
-  endif()
-  add_ceph_test(${unittest_name} "${UNITTEST}")
+  add_ceph_test(${unittest_name} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${unittest_name})
   target_link_libraries(${unittest_name} ${UNITTEST_LIBS})
   set_target_properties(${unittest_name} PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 endfunction()
+

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -23,19 +23,6 @@ function(add_ceph_test test_name test_path)
     PROPERTY TIMEOUT 3600)
 endfunction()
 
-option(WITH_GTEST_PARALLEL "Enable running gtest based tests in parallel" OFF)
-if(WITH_GTEST_PARALLEL)
-  include(ExternalProject)
-  ExternalProject_Add(gtest-parallel_ext
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/gtest-parallel
-    GIT_REPOSITORY "https://github.com/google/gtest-parallel.git"
-    GIT_TAG "master"
-    CONFIGURE_COMMAND ""
-    BUILD_COMMAND ""
-    INSTALL_COMMAND "")
-  add_dependencies(tests gtest-parallel_ext)
-endif()
-
 #sets uniform compiler flags and link libraries
 function(add_ceph_unittest unittest_name)
   add_ceph_test(${unittest_name} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${unittest_name})

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -74,7 +74,7 @@ function run() {
         CMAKE_PYTHON_OPTS="-DWITH_PYTHON2=OFF -DWITH_PYTHON3=ON -DMGR_PYTHON_VERSION=3"
     fi
 
-    CMAKE_BUILD_OPTS="-DWITH_FIO=ON -DWITH_GTEST_PARALLEL=ON"
+    CMAKE_BUILD_OPTS="-DWITH_FIO=ON"
 
     # Are we in the CI ?
     if [ -n "$JENKINS_HOME" ]; then

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -113,7 +113,7 @@ add_executable(unittest_throttle
   Throttle.cc
   $<TARGET_OBJECTS:unit-main>
   )
-add_ceph_unittest(unittest_throttle parallel)
+add_ceph_unittest(unittest_throttle)
 target_link_libraries(unittest_throttle global) 
 
 # unittest_lru

--- a/src/test/crush/CMakeLists.txt
+++ b/src/test/crush/CMakeLists.txt
@@ -9,7 +9,7 @@ add_executable(unittest_crush
   crush.cc
   $<TARGET_OBJECTS:unit-main>
   )
-add_ceph_unittest(unittest_crush parallel)
+add_ceph_unittest(unittest_crush)
 target_link_libraries(unittest_crush global m ${BLKID_LIBRARIES})
 
 add_ceph_test(crush_weights.sh ${CMAKE_CURRENT_SOURCE_DIR}/crush_weights.sh)

--- a/src/test/erasure-code/CMakeLists.txt
+++ b/src/test/erasure-code/CMakeLists.txt
@@ -202,7 +202,7 @@ target_link_libraries(unittest_erasure_code_shec
 add_executable(unittest_erasure_code_shec_all
   TestErasureCodeShec_all.cc
   )
-add_ceph_unittest(unittest_erasure_code_shec_all parallel)
+add_ceph_unittest(unittest_erasure_code_shec_all)
 target_link_libraries(unittest_erasure_code_shec_all
   global
   ${CMAKE_DL_LIBS}


### PR DESCRIPTION
This reverts the first three commits of https://github.com/ceph/ceph/pull/22577.

See http://tracker.ceph.com/issues/24817 for the rationale (tl;dr - gtest-parallel isn't compatible with Python 3. Also, the way we're using it introduces an undeclared indirect dependency on Python 2.)