### PR TITLE
mimic: multisite: RGWSyncTraceNode released twice and crashed in reload

### DIFF
--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -134,6 +134,8 @@ RGWSyncTraceManager::~RGWSyncTraceManager()
 
   service_map_thread->stop();
   delete service_map_thread;
+
+  nodes.clear();
 }
 
 int RGWSyncTraceManager::hook_to_admin_command()


### PR DESCRIPTION
http://tracker.ceph.com/issues/24619