### PR TITLE
cmake: find a python2 interpreter for gtest-parallel

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -25,15 +25,19 @@ endfunction()
 
 option(WITH_GTEST_PARALLEL "Enable running gtest based tests in parallel" OFF)
 if(WITH_GTEST_PARALLEL)
+  set(gtest_parallel_source_dir ${CMAKE_CURRENT_BINARY_DIR}/gtest-parallel)
   include(ExternalProject)
   ExternalProject_Add(gtest-parallel_ext
-    SOURCE_DIR ${CMAKE_CURRENT_BINARY_DIR}/gtest-parallel
+    SOURCE_DIR "${gtest_parallel_source_dir}"
     GIT_REPOSITORY "https://github.com/google/gtest-parallel.git"
     GIT_TAG "master"
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ""
     INSTALL_COMMAND "")
   add_dependencies(tests gtest-parallel_ext)
+  find_package(PythonInterp 2.7 REQUIRED)
+  set(GTEST_PARALLEL_COMMAND
+    ${PYTHON_EXECUTABLE} ${gtest_parallel_source_dir}/gtest-parallel)
 endif()
 
 #sets uniform compiler flags and link libraries
@@ -41,8 +45,7 @@ function(add_ceph_unittest unittest_name)
   set(UNITTEST "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${unittest_name}")
   # If the second argument is "parallel", it means we want a parallel run
   if(WITH_GTEST_PARALLEL AND "${ARGV1}" STREQUAL "parallel")
-    ExternalProject_Get_Property(gtest-parallel_ext source_dir)
-    set(UNITTEST ${source_dir}/gtest-parallel ${UNITTEST})
+    set(UNITTEST ${GTEST_PARALLEL_COMMAND} ${UNITTEST})
   endif()
   add_ceph_test(${unittest_name} "${UNITTEST}")
   target_link_libraries(${unittest_name} ${UNITTEST_LIBS})


### PR DESCRIPTION
gtest-parallel uses python2 by default, but it supports python3 as well.
what we need to do to run gtest-parallel in a py3 only box, is just to
use "python3 ${path_to_gtest_parallel}/gtest-parallel" instead.

also, gtest-parallel depends on a python interpreter, so check for it
if it is enabled.

Signed-off-by: Kefu Chai <kchai@redhat.com>