### PR TITLE
ceph-volume: fix mkfs error in filestore seen during ceph-deploy tests

### DIFF
--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -124,7 +124,7 @@ def create_osd_path(osd_id, tmpfs=False):
 
 def format_device(device):
     # only supports xfs
-    command = ['mkfs', '-t', 'xfs']
+    command = ['sudo', 'mkfs', '-t', 'xfs']
 
     # get the mkfs options if any for xfs,
     # fallback to the default options defined in constants.mkfs


### PR DESCRIPTION
when running osd prepare with filestore, ceph-deploy fails during mkfs as its running on osd's node without sudo permissions, even though we have mkfs.xfs it results in command
not found error.

Fixes: https://tracker.ceph.com/issues/23295

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>