### PR TITLE
rgw: continue enoent index in dir_suggest

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1912,8 +1912,12 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
     string cur_change_key;
     encode_obj_index_key(cur_change.key, &cur_change_key);
     int ret = cls_cxx_map_get_val(hctx, cur_change_key, &cur_disk_bl);
-    if (ret < 0)
+    if (ret < 0 && ret != -ENOENT)
       return -EINVAL;
+
+    if (ret == -ENOENT) {
+      continue;
+    }
 
     if (cur_disk_bl.length()) {
       auto cur_disk_iter = cur_disk_bl.cbegin();


### PR DESCRIPTION
since we do nothing to the not exists index, just continue to
process other indexes and pass the test case

Fixes: http://tracker.ceph.com/issues/24640

Signed-off-by: Tianshan Qu <tianshan@xsky.com>