### PR TITLE
cmake: do not depend on ${DPDK_LIBRARIES} if not using bundled dpdk

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -691,8 +691,9 @@ if(WITH_DPDK)
   add_library(common_async_dpdk STATIC
     ${common_async_dpdk_files})
   # to ready the dpdk header files
-  add_dependencies(common_async_dpdk
-    ${DPDK_LIBRARIES})
+  if(TARGET dpdk-ext)
+    add_dependencies(common_async_dpdk dpdk-ext)
+  endif()
   list(APPEND ceph_common_deps common_async_dpdk)
   target_link_libraries(common_async_dpdk
     ${DPDK_LIBRARIES})


### PR DESCRIPTION
${DPDK_LIBRARIES} will be link flags instead of library targets if
libdpdk is not built using the bundled source.

Fixes: http://tracker.ceph.com/issues/24449
Signed-off-by: Kefu Chai <kchai@redhat.com>