### PR TITLE
cmake: should link against libatomic if libcxx/libstdc++ does not off…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,11 @@ if(WITH_STATIC_LIBSTDCXX)
     message(FATAL_ERROR "Please use GCC to enable WITH_STATIC_LIBSTDCXX")
   endif()
 endif()
+include(CheckCxxAtomic)
+if(NOT HAVE_CXX11_ATOMIC)
+  set(CMAKE_CXX_STANDARD_LIBRARIES
+    "${CMAKE_CXX_STANDARD_LIBRARIES} ${LIBATOMIC_LINK_FLAGS}")
+endif()
 
 option(WITH_RDMA "Enable RDMA in async messenger" ON)
 if(WITH_RDMA)

--- a/cmake/modules/CheckCxxAtomic.cmake
+++ b/cmake/modules/CheckCxxAtomic.cmake
@@ -1,0 +1,38 @@
+# some platforms do not offer support for atomic primitive for all integer
+# types, in that case we need to link against libatomic
+
+include(CheckCXXSourceCompiles)
+include(CMakePushCheckState)
+
+
+function(check_cxx_atomics var)
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -std=c++11")
+    check_cxx_source_compiles("
+#include <atomic>
+#include <cstdint>
+int main() {
+  std::atomic<uint8_t> w1;
+  std::atomic<uint16_t> w2;
+  std::atomic<uint32_t> w4;
+  std::atomic<uint64_t> w8;
+  return w1 + w2 + w4 + w8;
+}
+" ${var})
+endfunction(check_cxx_atomics)
+
+cmake_push_check_state()
+check_cxx_atomics(HAVE_CXX11_ATOMIC)
+cmake_pop_check_state()
+
+if(NOT HAVE_CXX11_ATOMIC)
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_LIBRARIES "atomic")
+  check_cxx_atomics(HAVE_LIBATOMIC)
+  cmake_pop_check_state()
+  if(HAVE_LIBATOMIC)
+    set(LIBATOMIC_LINK_FLAGS "-Wl,--as-needed -latomic")
+  else()
+    message(FATAL_ERROR
+      "Host compiler ${CMAKE_CXX_COMPILER} requires libatomic, but it is not found")
+  endif()
+endif()


### PR DESCRIPTION
…er atomic ops

for instance,  GCC-8 on riscv64 does not offer atomic ops like
__atomic_fetch_or_1, so we need to link against libatomic to get access
to these symbols.

Signed-off-by: Kefu Chai <kchai@redhat.com>