### PR TITLE
messages/MMDSMap: fix reencoding for older clients

### DIFF
--- a/src/messages/MMDSMap.h
+++ b/src/messages/MMDSMap.h
@@ -62,7 +62,8 @@ public:
     encode(epoch, payload);
     if ((features & CEPH_FEATURE_PGID64) == 0 ||
 	(features & CEPH_FEATURE_MDSENC) == 0 ||
-	(features & CEPH_FEATURE_MSG_ADDR2) == 0) {
+	(features & CEPH_FEATURE_MSG_ADDR2) == 0 ||
+	!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
       // reencode for old clients.
       MDSMap m;
       m.decode(encoded);


### PR DESCRIPTION
This was broken by ea1481d08d561cdf0229e440b70b88fe336d3f89.

Fixes: http://tracker.ceph.com/issues/24819
Signed-off-by: Sage Weil <sage@redhat.com>