### PR TITLE
qa/mgr: delete devicehealth pool after selftest

### DIFF
--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -53,6 +53,13 @@ class TestModuleSelftest(MgrTestCase):
 
     def test_devicehealth(self):
         self._selftest_plugin("devicehealth")
+        # Clean up the pool that the module creates, because otherwise
+        # it's low PG count causes test failures.
+        pool_name = "device_health_metrics"
+        self.mgr_cluster.mon_manager.raw_cluster_cmd(
+                "osd", "pool", "delete", pool_name, pool_name,
+                "--yes-i-really-really-mean-it")
+
 
     def test_selftest_run(self):
         self._load_module("selftest")


### PR DESCRIPTION
This is to un-break mgr tests, which are currently
polluted by the health warnings from having a 1-pg
pool created by device health.

When we're using a pool for a tiny bit of metadata,
it's arguably fine to have only a single PG, so perhaps
what we really need is a "tinypool" flag that suppresses
this warning per pool, or perhaps to tweak the warning
to only fire if the pool has more than a certain number
of objects.

Signed-off-by: John Spray <john.spray@redhat.com>