### PR TITLE
os/bluestore: limit OSD memory usage by tuning the cache size.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3681,6 +3681,31 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description(""),
 
+    Option("osd_memory_target", Option::TYPE_UINT, Option::LEVEL_BASIC)
+    .set_default(4_G)
+    .add_see_also("bluestore_cache_autotune")
+    .set_description("When tcmalloc and cache autotuning is enabled, try to keep this many bytes mapped in memory."),
+
+    Option("osd_memory_base", Option::TYPE_UINT, Option::LEVEL_DEV)
+    .set_default(768_M)
+    .add_see_also("bluestore_cache_autotune")
+    .set_description("When tcmalloc and cache autotuning is enabled, estimate the minimum amount of memory in bytes the OSD will need."),
+
+    Option("osd_memory_expected_fragmentation", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(0.15)
+    .add_see_also("bluestore_cache_autotune")
+    .set_description("When tcmalloc and cache autotuning is enabled, estimate the percent of memory fragmentation."),
+
+    Option("osd_memory_cache_min", Option::TYPE_UINT, Option::LEVEL_DEV)
+    .set_default(128_M)
+    .add_see_also("bluestore_cache_autotune")
+    .set_description("When tcmalloc and cache autotuning is enabled, set the minimum amount of memory used for caches."),
+
+    Option("osd_memory_cache_resize_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(1)
+    .add_see_also("bluestore_cache_autotune")
+    .set_description("When tcmalloc and cache autotuning is enabled, wait this many seconds between resizing caches."),
+
     Option("memstore_device_bytes", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(1_G)
     .set_description(""),
@@ -4081,41 +4106,41 @@ std::vector<Option> get_global_options() {
     .set_default(.5)
     .set_description("2Q paper suggests .5"),
 
-    Option("bluestore_cache_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    Option("bluestore_cache_size", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(0)
     .set_description("Cache size (in bytes) for BlueStore")
     .set_long_description("This includes data and metadata cached by BlueStore as well as memory devoted to rocksdb's cache(s)."),
 
-    Option("bluestore_cache_size_hdd", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    Option("bluestore_cache_size_hdd", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(1_G)
     .set_description("Default bluestore_cache_size for rotational media"),
 
-    Option("bluestore_cache_size_ssd", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    Option("bluestore_cache_size_ssd", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(3_G)
     .set_description("Default bluestore_cache_size for non-rotational (solid state) media"),
 
-    Option("bluestore_cache_meta_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(.5)
+    Option("bluestore_cache_meta_ratio", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(.4)
     .add_see_also("bluestore_cache_size")
     .set_description("Ratio of bluestore cache to devote to metadata"),
 
-    Option("bluestore_cache_kv_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(.5)
+    Option("bluestore_cache_kv_ratio", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(.4)
     .add_see_also("bluestore_cache_size")
     .set_description("Ratio of bluestore cache to devote to kv database (rocksdb)"),
 
-    Option("bluestore_cache_autotune", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("bluestore_cache_autotune", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
     .add_see_also("bluestore_cache_size")
     .add_see_also("bluestore_cache_meta_ratio")
     .set_description("Automatically tune the ratio of caches while respecting min values."),
 
-    Option("bluestore_cache_autotune_chunk_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    Option("bluestore_cache_autotune_chunk_size", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(33554432)
     .add_see_also("bluestore_cache_autotune")
     .set_description("The chunk size in bytes to allocate to caches when cache autotune is enabled."),
 
-    Option("bluestore_cache_autotune_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    Option("bluestore_cache_autotune_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(5)
     .add_see_also("bluestore_cache_autotune")
     .set_description("The number of seconds to wait between rebalances when cache autotune is enabled."),

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -71,7 +71,10 @@ if(WITH_SPDK)
     bluestore/NVMEDevice.cc)
 endif()
 
-add_library(os STATIC ${libos_srcs} $<TARGET_OBJECTS:kv_objs>)
+add_library(os STATIC ${libos_srcs}
+  $<TARGET_OBJECTS:kv_objs>)
+
+target_link_libraries(os heap_profiler)
 
 if(WITH_BLUEFS)
   add_library(bluefs SHARED 


### PR DESCRIPTION
This PR introduces the concept of an OSD memory target.  

- Currently this is only implemented for bluestore.
- Is only used when the memory allocator is tcmalloc (default true).
- Is only used when autotuning is enabled (default true).

Instead of requiring that a user set a bluestore cache size and hope that the OSD ends up consuming a reasonable amount of memory, this PR lets the user specify a target memory size for the OSD and bluestore will adjust it's cache size to try and stay close to that target.  A tricky aspect of doing this is that tcmalloc uses MADV_DONTNEED which unmaps memory, but doesn't guarantee that the kernel will reclaim it.  For that reason it's impossible for us to directly control the amount of RSS memory used by the process, however we can adjust the amount of mapped memory and any RSS memory used over that amount is available for the kernel to reclaim (though it may be heavily fragmented!).  In fact it is likely that in low-memory-pressure scenarios, the kernel will avoid reclaiming unmapped pages while in high-memory-pressure scenarios, the kernel will aggressively reclaim unmapped pages.  In general, mapped memory is generally kept just under the target value while RSS memory may be anywhere from 0-15% over.

The following graphs showcase this behavior.  Note that these tests were performed with https://github.com/ceph/ceph/pull/22838 applied.  In this round of testing, no significant performance or latency differences were measured, though the autotuner used less memory than the static cache size configuration.  It's possible that https://github.com/ceph/ceph/pull/22838 is improving the memory alignment of the rocksdb LRU cache improving the memory usage and performance of the static cache configuration vs what has previously been seen (up to ~7GB RSS usage in this test).  Note:  The system these tests were performed on may have been CPU limited.

RGW:
![4gb_osd_target_rgw](https://user-images.githubusercontent.com/1286295/42525044-cf4c9fa8-8437-11e8-8143-a0b0a7eb4e80.png)
![3gb_fixed_rgw](https://user-images.githubusercontent.com/1286295/42525043-cf35d610-8437-11e8-88b1-3b3505d8999e.png)
![rgw_perf](https://user-images.githubusercontent.com/1286295/42526028-5372f064-843a-11e8-98ff-f0527d0861ca.png)

RBD:
![4gb_osd_target_rbd](https://user-images.githubusercontent.com/1286295/42525071-dcaa4de4-8437-11e8-941d-c47282bbe7c1.png)
![3gb_fixed_rbd](https://user-images.githubusercontent.com/1286295/42525070-dc9603d4-8437-11e8-9874-87bbceb90c32.png)
![rbd_perf](https://user-images.githubusercontent.com/1286295/42526026-533c77aa-843a-11e8-98d1-eae8e4c5a656.png)



Signed-off-by: Mark Nelson <mnelson@redhat.com>