### PR TITLE
luminous: Revert "Merge pull request #20851 from jdurgin/wip-pg-log-trim-error-luminous"

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5153,18 +5153,12 @@ bool PG::append_log_entries_update_missing(
   assert(entries.begin()->version > info.last_update);
 
   PGLogEntryHandler rollbacker{this, &t};
-  if (roll_forward_to) {
-    pg_log.roll_forward(&rollbacker);
-  }
   bool invalidate_stats =
     pg_log.append_new_log_entries(info.last_backfill,
 				  info.last_backfill_bitwise,
 				  entries,
 				  &rollbacker);
 
-  if (roll_forward_to && entries.rbegin()->soid > info.last_backfill) {
-    pg_log.roll_forward(&rollbacker);
-  }
   if (roll_forward_to && *roll_forward_to > pg_log.get_can_rollback_to()) {
     pg_log.roll_forward_to(*roll_forward_to, &rollbacker);
     last_rollback_info_trimmed_to_applied = *roll_forward_to;


### PR DESCRIPTION
This reverts commit 31928fea79076a73b873d9491947bdf28f418327, reversing
changes made to eb3c67fe7dc9040960a73ce780585d10072ac20a.

I believe this is causing http://tracker.ceph.com/issues/24597 due to the call to
roll_forward() without passing in the *roll_forward_to value.

Signed-off-by: Sage Weil <sage@redhat.com>