### PR TITLE
mgr/dashboard: Improve prettier scripts and documentation

### DIFF
--- a/CodingStyle
+++ b/CodingStyle
@@ -53,7 +53,7 @@ by section.
          private:
           int m_foo;
    	};
-   
+
 * Naming > Constant Names:
 
    Google uses kSomeThing for constants.  We prefer SOME_THING.
@@ -155,8 +155,10 @@ For Angular code, we follow the official Angular style guide:
 
     https://angular.io/guide/styleguide
 
-To check whether your code is conformant with the style guide, we suggest
-using TSLint with Codelyzer:
+To check whether your code is conformant with the style guide, we use a
+combination of TSLint, Codelyzer and Prettier:
 
-    https://www.npmjs.com/package/codelyzer
+    https://palantir.github.io/tslint/
+    http://codelyzer.com/
+    https://prettier.io/
 

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -63,6 +63,18 @@ Run ``npm run build`` to build the project. The build artifacts will be
 stored in the ``dist/`` directory. Use the ``-prod`` flag for a
 production build. Navigate to ``https://localhost:8443``.
 
+Formating TS and SCSS files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We use `Prettier <https://prettier.io/>`_ to automatically format TS and SCSS
+files.
+To use this plugin you can either install it in your IDE, if supported, or use
+it via the cli.
+
+We added 2 npm scripts to help running prettier commands:
+- ``npm run prettier``, will run prettier formatter on all frontend files
+- ``npm run prettier:lint``, will check all frontend files against prettier linter
+
 Running Unit Tests
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/pybind/mgr/dashboard/frontend/e2e/helper.po.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/helper.po.ts
@@ -16,7 +16,7 @@ export class Helper {
       .logs()
       .get('browser')
       .then(function(browserLog) {
-        browserLog = browserLog.filter(log => {
+        browserLog = browserLog.filter((log) => {
           return log.level.value > 900; // SEVERE level
         });
 

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -10,7 +10,8 @@
     "test:ci": "jest --coverage",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "makePretty": "pretty-quick --staged"
+    "prettier": "prettier --write \"{src,e2e}/**/*.{ts,scss}\"",
+    "prettier:lint": "prettier --list-different \"{src,e2e}/**/*.{ts,scss}\""
   },
   "private": true,
   "jest": {
@@ -76,12 +77,10 @@
     "jest": "23.2.0",
     "jest-canvas-mock": "1.0.3",
     "jest-preset-angular": "5.2.3",
-    "prettier": "1.13.6",
-    "pretty-quick": "1.6.0",
+    "prettier": "1.13.7",
     "protractor": "5.3.2",
     "ts-node": "5.0.1",
     "tslint": "5.10.0",
-    "tslint-eslint-rules": "5.3.1",
     "typescript": "2.7.2"
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.module.ts
@@ -22,9 +22,7 @@ export class CustomOption extends ToastOptions {
 }
 
 @NgModule({
-  declarations: [
-    AppComponent
-  ],
+  declarations: [AppComponent],
   imports: [
     HttpClientModule,
     BrowserModule,
@@ -42,7 +40,7 @@ export class CustomOption extends ToastOptions {
   providers: [
     {
       provide: ErrorHandler,
-      useClass: JsErrorHandler,
+      useClass: JsErrorHandler
     },
     {
       provide: HTTP_INTERCEPTORS,
@@ -52,8 +50,8 @@ export class CustomOption extends ToastOptions {
     {
       provide: ToastOptions,
       useClass: CustomOption
-    },
+    }
   ],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.ts
@@ -13,17 +13,18 @@ import { RelativeDatePipe } from '../../../shared/pipes/relative-date.pipe';
   styleUrls: ['./iscsi.component.scss']
 })
 export class IscsiComponent {
-
   daemons = [];
   daemonsColumns: any;
   images = [];
   imagesColumns: any;
 
-  constructor(private tcmuIscsiService: TcmuIscsiService,
-              cephShortVersionPipe: CephShortVersionPipe,
-              dimlessPipe: DimlessPipe,
-              relativeDatePipe: RelativeDatePipe,
-              listPipe: ListPipe) {
+  constructor(
+    private tcmuIscsiService: TcmuIscsiService,
+    cephShortVersionPipe: CephShortVersionPipe,
+    dimlessPipe: DimlessPipe,
+    relativeDatePipe: RelativeDatePipe,
+    listPipe: ListPipe
+  ) {
     this.daemonsColumns = [
       {
         name: 'Hostname',
@@ -31,7 +32,7 @@ export class IscsiComponent {
       },
       {
         name: '# Active/Optimized',
-        prop: 'optimized_paths',
+        prop: 'optimized_paths'
       },
       {
         name: '# Active/Non-Optimized',
@@ -88,9 +89,8 @@ export class IscsiComponent {
         name: 'A/O Since',
         prop: 'optimized_since',
         pipe: relativeDatePipe
-      },
+      }
     ];
-
   }
 
   refresh() {
@@ -98,11 +98,10 @@ export class IscsiComponent {
       this.daemons = resp.daemons;
       this.images = resp.images;
       this.images.map((image) => {
-        image.stats_history.rd_bytes = image.stats_history.rd_bytes.map(i => i[1]);
-        image.stats_history.wr_bytes = image.stats_history.wr_bytes.map(i => i[1]);
+        image.stats_history.rd_bytes = image.stats_history.rd_bytes.map((i) => i[1]);
+        image.stats_history.wr_bytes = image.stats_history.wr_bytes.map((i) => i[1]);
         return image;
       });
     });
   }
-
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.ts
@@ -8,11 +8,10 @@ import { CdTableSelection } from '../../../shared/models/cd-table-selection';
   styleUrls: ['./rbd-details.component.scss']
 })
 export class RbdDetailsComponent implements OnChanges {
-
   @Input() selection: CdTableSelection;
   selectedItem: any;
 
-  constructor() { }
+  constructor() {}
 
   ngOnChanges() {
     if (this.selection.hasSelection) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/ceph.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/ceph.module.ts
@@ -24,4 +24,4 @@ import { RgwModule } from './rgw/rgw.module';
   ],
   declarations: []
 })
-export class CephModule { }
+export class CephModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.scss
@@ -1,4 +1,3 @@
-
 .filter {
   padding-right: 8px;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
@@ -67,7 +67,7 @@ export class ConfigurationComponent implements OnInit {
     runtime: 'The value can be updated at runtime.',
     no_mon_update:
       'Daemons/clients do not pull this value from the monitor config database. ' +
-      'We disallow setting this option via \'ceph config set ...\'. This option should be ' +
+      `We disallow setting this option via 'ceph config set ...'. This option should be ` +
       'configured via ceph.conf or via the command line.',
     startup: 'Option takes effect only during daemon startup.',
     cluster_create: 'Option only affects cluster creation.',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -63,21 +63,24 @@ export class HostsComponent implements OnInit {
       mgr: 'manager'
     };
     this.isLoadingHosts = true;
-    this.hostService.list().then((resp) => {
-      resp.map((host) => {
-        host.services.map((service) => {
-          service.cdLink = `/perf_counters/${service.type}/${service.id}`;
-          const permissionKey = typeToPermissionKey[service.type];
-          service.canRead = this.permissions[permissionKey].read;
-          return service;
+    this.hostService
+      .list()
+      .then((resp) => {
+        resp.map((host) => {
+          host.services.map((service) => {
+            service.cdLink = `/perf_counters/${service.type}/${service.id}`;
+            const permissionKey = typeToPermissionKey[service.type];
+            service.canRead = this.permissions[permissionKey].read;
+            return service;
+          });
+          return host;
         });
-        return host;
+        this.hosts = resp;
+        this.isLoadingHosts = false;
+      })
+      .catch(() => {
+        this.isLoadingHosts = false;
+        context.error();
       });
-      this.hosts = resp;
-      this.isLoadingHosts = false;
-    }).catch(() => {
-      this.isLoadingHosts = false;
-      context.error();
-    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.ts
@@ -9,7 +9,6 @@ import { CellTemplate } from '../../../shared/enum/cell-template.enum';
   styleUrls: ['./monitor.component.scss']
 })
 export class MonitorComponent {
-
   mon_status: any;
   inQuorum: any;
   notInQuorum: any;
@@ -48,15 +47,15 @@ export class MonitorComponent {
   refresh() {
     this.monitorService.getMonitor().subscribe((data: any) => {
       data.in_quorum.map((row) => {
-        row.cdOpenSessions = row.stats.num_sessions.map(i => i[1]);
+        row.cdOpenSessions = row.stats.num_sessions.map((i) => i[1]);
         row.cdLink = '/perf_counters/mon/' + row.name;
-        row.cdParams = {fromLink: '/monitor'};
+        row.cdParams = { fromLink: '/monitor' };
         return row;
       });
 
       data.out_quorum.map((row) => {
         row.cdLink = '/perf_counters/mon/' + row.name;
-        row.cdParams = {fromLink: '/monitor'};
+        row.cdParams = { fromLink: '/monitor' };
         return row;
       });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.ts
@@ -31,14 +31,13 @@ export class OsdDetailsComponent implements OnChanges {
   }
 
   refresh() {
-    this.osdService.getDetails(this.osd.tree.id)
-      .subscribe((data: any) => {
-        this.osd.details = data;
-        if (!_.isObject(data.histogram)) {
-          this.osd.histogram_failed = data.histogram;
-          this.osd.details.histogram = undefined;
-        }
-        this.osd.loaded = true;
-      });
+    this.osdService.getDetails(this.osd.tree.id).subscribe((data: any) => {
+      this.osd.details = data;
+      if (!_.isObject(data.histogram)) {
+        this.osd.histogram_failed = data.histogram;
+        this.osd.details.histogram = undefined;
+      }
+      this.osd.loaded = true;
+    });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-flags-modal/osd-flags-modal.component.scss
@@ -1,5 +1,5 @@
 .osd-modal {
-  .oa-hr-small{
+  .oa-hr-small {
     margin: 5px;
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-performance-histogram/osd-performance-histogram.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-performance-histogram/osd-performance-histogram.component.ts
@@ -12,7 +12,7 @@ export class OsdPerformanceHistogramComponent implements OnChanges {
   valuesStyle: any;
   last = {};
 
-  constructor() { }
+  constructor() {}
 
   ngOnChanges() {
     this.render();
@@ -50,7 +50,7 @@ export class OsdPerformanceHistogramComponent implements OnChanges {
         const val = this.last && this.last[i] && this.last[i][j] ? col - this.last[i][j] : col;
         const g = max ? val / max : 0;
         const r = 1 - g;
-        return {backgroundColor: this.hexcolor(r, g, 0)};
+        return { backgroundColor: this.hexcolor(r, g, 0) };
       });
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/dashboard/dashboard.component.ts
@@ -8,9 +8,7 @@ import { Component, OnInit } from '@angular/core';
 export class DashboardComponent implements OnInit {
   hasGrafana = false; // TODO: Temporary var, remove when grafana is implemented
 
-  constructor() { }
+  constructor() {}
 
-  ngOnInit() {
-  }
-
+  ngOnInit() {}
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/pg-status-style.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/pg-status-style.pipe.spec.ts
@@ -13,7 +13,7 @@ describe('PgStatusStylePipe', () => {
   });
 
   it('transforms with pg status warning', () => {
-    const value = { 'active': 8 };
+    const value = { active: 8 };
     expect(pipe.transform(value)).toEqual({ color: '#FFC200' });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter.module.ts
@@ -3,25 +3,12 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 import { SharedModule } from '../../shared/shared.module';
-import {
-  PerformanceCounterComponent
-} from './performance-counter/performance-counter.component';
-import {
-  TablePerformanceCounterComponent
-} from './table-performance-counter/table-performance-counter.component';
+import { PerformanceCounterComponent } from './performance-counter/performance-counter.component';
+import { TablePerformanceCounterComponent } from './table-performance-counter/table-performance-counter.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    SharedModule,
-    RouterModule
-  ],
-  declarations: [
-    TablePerformanceCounterComponent,
-    PerformanceCounterComponent
-  ],
-  exports: [
-    TablePerformanceCounterComponent
-  ]
+  imports: [CommonModule, SharedModule, RouterModule],
+  declarations: [TablePerformanceCounterComponent, PerformanceCounterComponent],
+  exports: [TablePerformanceCounterComponent]
 })
-export class PerformanceCounterModule { }
+export class PerformanceCounterModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/performance-counter/performance-counter.component.ts
@@ -7,7 +7,6 @@ import { ActivatedRoute } from '@angular/router';
   styleUrls: ['./performance-counter.component.scss']
 })
 export class PerformanceCounterComponent {
-
   static defaultFromLink = '/hosts';
 
   serviceId: string;
@@ -15,17 +14,12 @@ export class PerformanceCounterComponent {
   fromLink: string;
 
   constructor(private route: ActivatedRoute) {
-    this.route.queryParams.subscribe(
-      (params: { fromLink: string }) => {
-        this.fromLink = params.fromLink || PerformanceCounterComponent.defaultFromLink;
-      }
-    );
-    this.route.params.subscribe(
-      (params: { type: string; id: string }) => {
-        this.serviceId = params.id;
-        this.serviceType = params.type;
-      }
-    );
+    this.route.queryParams.subscribe((params: { fromLink: string }) => {
+      this.fromLink = params.fromLink || PerformanceCounterComponent.defaultFromLink;
+    });
+    this.route.params.subscribe((params: { type: string; id: string }) => {
+      this.serviceId = params.id;
+      this.serviceType = params.type;
+    });
   }
-
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
@@ -1,8 +1,6 @@
 import { Component, Input, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
-import {
-  PerformanceCounterService
-} from '../../../shared/api/performance-counter.service';
+import { PerformanceCounterService } from '../../../shared/api/performance-counter.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
 
 /**
@@ -14,7 +12,6 @@ import { CdTableColumn } from '../../../shared/models/cd-table-column';
   styleUrls: ['./table-performance-counter.component.scss']
 })
 export class TablePerformanceCounterComponent implements OnInit {
-
   columns: Array<CdTableColumn> = [];
   counters: Array<object> = [];
 
@@ -30,7 +27,7 @@ export class TablePerformanceCounterComponent implements OnInit {
    */
   @Input() serviceId: string;
 
-  constructor(private performanceCounterService: PerformanceCounterService) { }
+  constructor(private performanceCounterService: PerformanceCounterService) {}
 
   ngOnInit() {
     this.columns = [
@@ -53,7 +50,8 @@ export class TablePerformanceCounterComponent implements OnInit {
   }
 
   getCounters() {
-    this.performanceCounterService.get(this.serviceType, this.serviceId)
+    this.performanceCounterService
+      .get(this.serviceType, this.serviceId)
       .subscribe((resp: object[]) => {
         this.counters = resp;
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool.module.ts
@@ -8,17 +8,8 @@ import { SharedModule } from '../../shared/shared.module';
 import { PoolListComponent } from './pool-list/pool-list.component';
 
 @NgModule({
-  imports: [
-    CommonModule,
-    TabsModule,
-    SharedModule,
-    ServicesModule
-  ],
-  exports: [
-    PoolListComponent
-  ],
-  declarations: [
-    PoolListComponent
-  ]
+  imports: [CommonModule, TabsModule, SharedModule, ServicesModule],
+  exports: [PoolListComponent],
+  declarations: [PoolListComponent]
 })
-export class PoolModule { }
+export class PoolModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/auth.module.ts
@@ -25,4 +25,4 @@ import { UserListComponent } from './user-list/user-list.component';
   declarations: [LoginComponent, LogoutComponent, UserListComponent, UserFormComponent],
   exports: [LogoutComponent]
 })
-export class AuthModule { }
+export class AuthModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.scss
@@ -23,8 +23,8 @@
     outline-color: $color-password-toggle-focus;
   }
 
-  .checkbox-primary input[type="checkbox"]:checked + label::before,
-  .checkbox-primary input[type="radio"]:checked + label::before {
+  .checkbox-primary input[type='checkbox']:checked + label::before,
+  .checkbox-primary input[type='radio']:checked + label::before {
     background-color: $color-login-checkbox-bg;
     border-color: $color-login-checkbox-border;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -38,18 +38,21 @@ describe('UserFormComponent', () => {
     { path: 'users', component: FakeComponent }
   ];
 
-  configureTestBed({
-    imports: [
-      [RouterTestingModule.withRoutes(routes)],
-      HttpClientTestingModule,
-      ReactiveFormsModule,
-      RouterTestingModule,
-      ComponentsModule,
-      ToastModule.forRoot(),
-      SharedModule
-    ],
-    declarations: [UserFormComponent, FakeComponent]
-  }, true);
+  configureTestBed(
+    {
+      imports: [
+        [RouterTestingModule.withRoutes(routes)],
+        HttpClientTestingModule,
+        ReactiveFormsModule,
+        RouterTestingModule,
+        ComponentsModule,
+        ToastModule.forRoot(),
+        SharedModule
+      ],
+      declarations: [UserFormComponent, FakeComponent]
+    },
+    true
+  );
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UserFormComponent);

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.scss
@@ -14,7 +14,8 @@
     float: none;
   }
 
-  .navbar-brand,.navbar-brand:hover{
+  .navbar-brand,
+  .navbar-brand:hover {
     color: $color-navbar-brand;
     height: auto;
     margin: 15px 0 15px 20px;
@@ -23,7 +24,7 @@
     align-self: flex-start;
   }
 
-  .navbar-brand>img {
+  .navbar-brand > img {
     height: 25px;
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/notifications/notifications.component.ts
@@ -25,7 +25,7 @@ export class NotificationsComponent implements OnInit {
     });
   }
 
-  removeAll () {
+  removeAll() {
     this.notificationService.removeAll();
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/not-found/not-found.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/not-found/not-found.component.scss
@@ -2,10 +2,10 @@ h1 {
   font-size: -webkit-xxx-large;
 }
 
-*{
+* {
   font-family: monospace;
 }
 
-img{
+img {
   width: 50vw;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/host.service.ts
@@ -7,13 +7,14 @@ import { ApiModule } from './api.module';
   providedIn: ApiModule
 })
 export class HostService {
-
-  constructor(private http: HttpClient) {
-  }
+  constructor(private http: HttpClient) {}
 
   list() {
-    return this.http.get('api/host').toPromise().then((resp: any) => {
-      return resp;
-    });
+    return this.http
+      .get('api/host')
+      .toPromise()
+      .then((resp: any) => {
+        return resp;
+      });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/role.service.spec.ts
@@ -31,5 +31,4 @@ describe('RoleService', () => {
     const req = httpTesting.expectOne('api/role');
     expect(req.request.method).toBe('GET');
   });
-
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/tcmu-iscsi.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/tcmu-iscsi.service.ts
@@ -7,13 +7,14 @@ import { ApiModule } from './api.module';
   providedIn: ApiModule
 })
 export class TcmuIscsiService {
-
-  constructor(private http: HttpClient) {
-  }
+  constructor(private http: HttpClient) {}
 
   tcmuiscsi() {
-    return this.http.get('api/tcmuiscsi').toPromise().then((resp: any) => {
-      return resp;
-    });
+    return this.http
+      .get('api/tcmuiscsi')
+      .toPromise()
+      .then((resp: any) => {
+        return resp;
+      });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/user.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/user.service.spec.ts
@@ -70,5 +70,4 @@ describe('UserService', () => {
     const req = httpTesting.expectOne('api/user');
     expect(req.request.method).toBe('GET');
   });
-
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.ts
@@ -6,9 +6,7 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./helper.component.scss']
 })
 export class HelperComponent {
-
   @Input() html: any;
 
-  constructor() { }
-
+  constructor() {}
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/loading-panel/loading-panel.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/loading-panel/loading-panel.component.ts
@@ -5,5 +5,4 @@ import { Component } from '@angular/core';
   templateUrl: './loading-panel.component.html',
   styleUrls: ['./loading-panel.component.scss']
 })
-export class LoadingPanelComponent {
-}
+export class LoadingPanelComponent {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select-badges/select-badges.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select-badges/select-badges.component.scss
@@ -1,7 +1,7 @@
 @import '../../../../defaults';
 
 .select-menu-edit {
-  margin-left: -20px
+  margin-left: -20px;
 }
 .select-menu-item {
   display: block;

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select-badges/select-badges.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/select-badges/select-badges.component.spec.ts
@@ -26,8 +26,8 @@ describe('SelectBadgesComponent', () => {
 
   it('should add item', () => {
     component.options = [
-      {name: 'option1', description: '', selected: false},
-      {name: 'option2', description: '', selected: false}
+      { name: 'option1', description: '', selected: false },
+      { name: 'option2', description: '', selected: false }
     ];
     component.data = [];
     component.selectOption(component.options[1]);
@@ -36,8 +36,8 @@ describe('SelectBadgesComponent', () => {
 
   it('should update selected', () => {
     component.options = [
-      {name: 'option1', description: '', selected: false},
-      {name: 'option2', description: '', selected: false}
+      { name: 'option1', description: '', selected: false },
+      { name: 'option2', description: '', selected: false }
     ];
     component.data = ['option2'];
     component.ngOnChanges();
@@ -47,12 +47,11 @@ describe('SelectBadgesComponent', () => {
 
   it('should remove item', () => {
     component.options = [
-      {name: 'option1', description: '', selected: true},
-      {name: 'option2', description: '', selected: true}
+      { name: 'option1', description: '', selected: true },
+      { name: 'option2', description: '', selected: true }
     ];
     component.data = ['option1', 'option2'];
     component.removeItem('option1');
     expect(component.data).toEqual(['option2']);
   });
-
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sparkline/sparkline.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/sparkline/sparkline.component.ts
@@ -76,7 +76,7 @@ export class SparklineComponent implements OnInit, OnChanges {
 
   ngOnInit() {
     const getStyleTop = (tooltip, positionY) => {
-      return (tooltip.caretY - tooltip.height - tooltip.yPadding - 5) + 'px';
+      return tooltip.caretY - tooltip.height - tooltip.yPadding - 5 + 'px';
     };
 
     const getStyleLeft = (tooltip, positionX) => {
@@ -95,7 +95,7 @@ export class SparklineComponent implements OnInit, OnChanges {
       borderColor: this.colors[0].pointBorderColor
     };
 
-    this.options.tooltips.custom = tooltip => {
+    this.options.tooltips.custom = (tooltip) => {
       chartTooltip.customTooltips(tooltip);
     };
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/submit-button/submit-button.component.ts
@@ -40,7 +40,7 @@ export class SubmitButtonComponent implements OnInit {
       if (_.has(this.form.errors, 'cdSubmitButton')) {
         this.loading = false;
         _.unset(this.form.errors, 'cdSubmitButton');
-         // Handle Reactive forms.
+        // Handle Reactive forms.
         if (this.form instanceof AbstractControl) {
           (<AbstractControl>this.form).updateValueAndValidity();
         }
@@ -66,9 +66,7 @@ export class SubmitButtonComponent implements OnInit {
   }
 
   focusButton() {
-    this.elRef.nativeElement.offsetParent.querySelector(
-      `button[type="${this.type}"]`
-    ).focus();
+    this.elRef.nativeElement.offsetParent.querySelector(`button[type="${this.type}"]`).focus();
   }
 
   focusInvalid() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/usage-bar/usage-bar.component.ts
@@ -16,7 +16,7 @@ export class UsageBarComponent implements OnChanges {
   constructor() {}
 
   ngOnChanges() {
-    this.usedPercentage = Math.round(this.usedBytes / this.totalBytes * 100);
+    this.usedPercentage = Math.round((this.usedBytes / this.totalBytes) * 100);
     this.freePercentage = 100 - this.usedPercentage;
     this.freeBytes = this.totalBytes - this.usedBytes;
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/datatable.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/datatable.module.ts
@@ -21,14 +21,7 @@ import { TableComponent } from './table/table.component';
     ComponentsModule,
     RouterModule
   ],
-  declarations: [
-    TableComponent,
-    TableKeyValueComponent
-  ],
-  exports: [
-    TableComponent,
-    NgxDatatableModule,
-    TableKeyValueComponent
-  ]
+  declarations: [TableComponent, TableKeyValueComponent],
+  exports: [TableComponent, NgxDatatableModule, TableKeyValueComponent]
 })
-export class DataTableModule { }
+export class DataTableModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -44,7 +44,7 @@
   th.oadatatablecheckbox {
     width: 16px;
   }
-  .dataTables_length>input {
+  .dataTables_length > input {
     line-height: 25px;
     text-align: right;
   }
@@ -85,7 +85,7 @@
 }
 
 ::ng-deep .oadatatable {
-  border:1px solid $color-table-header-border;
+  border: 1px solid $color-table-header-border;
   margin-bottom: 0;
   max-width: none !important;
   .progress-linear {
@@ -105,10 +105,10 @@
         overflow: hidden;
         background-color: $color-table-active-row;
       }
-      .bar:before{
+      .bar:before {
         display: block;
         position: absolute;
-        content: "";
+        content: '';
         left: -200px;
         width: 200px;
         height: 100%;
@@ -120,15 +120,28 @@
   .datatable-header {
     background-clip: padding-box;
     background-color: $color-table-datatable-header;
-    background-image: -webkit-linear-gradient(top,$color-table-gradient-1 0,$color-table-gradient-2 100%);
-    background-image: -o-linear-gradient(top,$color-table-gradient-1 0,$color-table-gradient-2 100%);
-    background-image: linear-gradient(to bottom,$color-table-gradient-1 0,$color-table-gradient-2 100%);
+    background-image: -webkit-linear-gradient(
+      top,
+      $color-table-gradient-1 0,
+      $color-table-gradient-2 100%
+    );
+    background-image: -o-linear-gradient(
+      top,
+      $color-table-gradient-1 0,
+      $color-table-gradient-2 100%
+    );
+    background-image: linear-gradient(
+      to bottom,
+      $color-table-gradient-1 0,
+      $color-table-gradient-2 100%
+    );
     background-repeat: repeat-x;
     filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fffafafa', endColorstr='#ffededed', GradientType=0);
-    .sort-asc, .sort-desc {
+    .sort-asc,
+    .sort-desc {
       color: $color-table-sort;
     }
-    .datatable-header-cell{
+    .datatable-header-cell {
       @include table-cell;
       text-align: left;
       font-weight: bold;
@@ -146,14 +159,14 @@
       }
       &.sortable {
         .datatable-header-cell-label:after {
-          content: " \f0dc";
+          content: ' \f0dc';
         }
         &.sort-active {
           &.sort-asc .datatable-header-cell-label:after {
-            content: " \f160";
+            content: ' \f160';
           }
           &.sort-desc .datatable-header-cell-label:after {
-            content: " \f161";
+            content: ' \f161';
           }
         }
       }
@@ -173,9 +186,9 @@
     }
     .datatable-body-row {
       &.clickable:hover .datatable-row-group {
-        background-color: $color-table-hover-row ;
+        background-color: $color-table-hover-row;
         transition-property: background;
-        transition-duration: .3s;
+        transition-duration: 0.3s;
         transition-timing-function: linear;
       }
       &.datatable-row-even {
@@ -184,10 +197,11 @@
       &.datatable-row-odd {
         background-color: $color-table-odd-row-bg;
       }
-      &.active, &.active:hover {
+      &.active,
+      &.active:hover {
         background-color: $color-table-active-row-hover;
       }
-      .datatable-body-cell{
+      .datatable-body-cell {
         @include table-cell;
         &:first-child {
           border-left: none;
@@ -199,7 +213,8 @@
     }
   }
   .datatable-footer {
-    .selected-count, .page-count {
+    .selected-count,
+    .page-count {
       font-style: italic;
       padding-left: 5px;
     }
@@ -209,11 +224,13 @@
         /** Add space between buttons */
         margin-left: 3px;
       }
-      & li > a, & li > span {
+      & li > a,
+      & li > span {
         border-radius: 3px;
       }
       .pages {
-        & > a, & > span {
+        & > a,
+        & > span {
           display: inline-block;
           padding: 5px 10px;
           margin-bottom: 5px;
@@ -231,23 +248,23 @@
 }
 
 @keyframes progress-loading {
-    from {
-      left: -200px;
-      width: 15%;
-    }
-    50% {
-      width: 30%;
-    }
-    70% {
-      width: 70%;
-    }
-    80% {
-      left: 50%;
-    }
-    95% {
-      left: 120%;
-    }
-    to {
-      left: 100%;
-    }
+  from {
+    left: -200px;
+    width: 15%;
+  }
+  50% {
+    width: 30%;
+  }
+  70% {
+    width: 70%;
+  }
+  80% {
+    left: 50%;
+  }
+  95% {
+    left: 120%;
+  }
+  to {
+    left: 100%;
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/autofocus.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/autofocus.directive.ts
@@ -4,7 +4,6 @@ import { Directive, ElementRef, OnInit } from '@angular/core';
   selector: '[autofocus]' // tslint:disable-line
 })
 export class AutofocusDirective implements OnInit {
-
   constructor(private elementRef: ElementRef) {}
 
   ngOnInit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/copy2clipboard-button.directive.ts
@@ -6,12 +6,13 @@ import { ToastsManager } from 'ng2-toastr';
   selector: '[cdCopy2ClipboardButton]'
 })
 export class Copy2ClipboardButtonDirective implements OnInit {
-
   @Input('cdCopy2ClipboardButton') private cdCopy2ClipboardButton: string;
 
-  constructor(private elementRef: ElementRef,
-              private renderer: Renderer2,
-              private toastr: ToastsManager) {}
+  constructor(
+    private elementRef: ElementRef,
+    private renderer: Renderer2,
+    private toastr: ToastsManager
+  ) {}
 
   ngOnInit() {
     const iElement = this.renderer.createElement('i');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dimless-binary.directive.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/dimless-binary.directive.ts
@@ -18,7 +18,6 @@ import { FormatterService } from '../services/formatter.service';
   selector: '[cdDimlessBinary]'
 })
 export class DimlessBinaryDirective implements OnInit {
-
   @Output() ngModelChange: EventEmitter<any> = new EventEmitter();
 
   /**
@@ -66,10 +65,12 @@ export class DimlessBinaryDirective implements OnInit {
 
   private el: HTMLInputElement;
 
-  constructor(private elementRef: ElementRef,
-              private control: NgControl,
-              private dimlessBinaryPipe: DimlessBinaryPipe,
-              private formatter: FormatterService) {
+  constructor(
+    private elementRef: ElementRef,
+    private control: NgControl,
+    private dimlessBinaryPipe: DimlessBinaryPipe,
+    private formatter: FormatterService
+  ) {
     this.el = this.elementRef.nativeElement;
   }
 
@@ -113,5 +114,4 @@ export class DimlessBinaryDirective implements OnInit {
   onBlur(value) {
     this.setValue(value);
   }
-
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/empty.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/empty.pipe.ts
@@ -6,9 +6,7 @@ import * as _ from 'lodash';
   name: 'empty'
 })
 export class EmptyPipe implements PipeTransform {
-
   transform(value: any, args?: any): any {
     return _.isUndefined(value) || _.isNull(value) ? '-' : value;
   }
-
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/unix_errno.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/enum/unix_errno.enum.ts
@@ -1,4 +1,4 @@
 // http://www.virtsync.com/c-error-codes-include-errno
 export enum UnixErrno {
-  EEXIST = 17, // File exists
+  EEXIST = 17 // File exists
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-group.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-group.spec.ts
@@ -33,8 +33,8 @@ describe('FormsHelperService', () => {
     });
 
     it('should throw an error if element could be found', () => {
-      expect(() => form.get('d')).toThrowError('Control \'d\' could not be found!');
-      expect(() => form.get('sth')).toThrowError('Control \'sth\' could not be found!');
+      expect(() => form.get('d')).toThrowError(`Control 'd' could not be found!`);
+      expect(() => form.get('sth')).toThrowError(`Control 'sth' could not be found!`);
     });
   });
 
@@ -83,8 +83,8 @@ describe('FormsHelperService', () => {
     });
 
     it('should nested throw an error if control could not be found', () => {
-      expect(() => form.get('d')).toThrowError('Control \'d\' could not be found!');
-      expect(() => form.getValue('sth')).toThrowError('Control \'sth\' could not be found!');
+      expect(() => form.get('d')).toThrowError(`Control 'd' could not be found!`);
+      expect(() => form.getValue('sth')).toThrowError(`Control 'sth' could not be found!`);
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -81,20 +81,20 @@ export class CdValidators {
    * @param {Function} condition
    * @param {ValidatorFn[]} validators
    */
-  static validateIf(
-    formControl: AbstractControl,
-    condition: Function,
-    validators: ValidatorFn[]
-  ) {
-    formControl.setValidators((control: AbstractControl): {
-      [key: string]: any;
-    } => {
-      const value = condition.call(this);
-      if (value) {
-        return Validators.compose(validators)(control);
+  static validateIf(formControl: AbstractControl, condition: Function, validators: ValidatorFn[]) {
+    formControl.setValidators(
+      (
+        control: AbstractControl
+      ): {
+        [key: string]: any;
+      } => {
+        const value = condition.call(this);
+        if (value) {
+          return Validators.compose(validators)(control);
+        }
+        return null;
       }
-      return null;
-    });
+    );
   }
 
   /**

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-fetch-data-context.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-table-fetch-data-context.ts
@@ -1,6 +1,6 @@
 export class CdTableFetchDataContext {
   errorConfig = {
-    resetData: true,   // Force data table to show no data
+    resetData: true, // Force data table to show no data
     displayError: true // Show an error panel above the data table
   };
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/cd-date.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/cd-date.pipe.ts
@@ -5,16 +5,16 @@ import { Pipe, PipeTransform } from '@angular/core';
   name: 'cdDate'
 })
 export class CdDatePipe implements PipeTransform {
-
-  constructor(private datePipe: DatePipe) {
-  }
+  constructor(private datePipe: DatePipe) {}
 
   transform(value: any, args?: any): any {
     if (value === null || value === '') {
       return '';
     }
-    return this.datePipe.transform(value, 'shortDate') + ' ' +
-      this.datePipe.transform(value, 'mediumTime');
+    return (
+      this.datePipe.transform(value, 'shortDate') +
+      ' ' +
+      this.datePipe.transform(value, 'mediumTime')
+    );
   }
-
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-short-version.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-short-version.pipe.spec.ts
@@ -15,8 +15,7 @@ describe('CephShortVersionPipe', () => {
   });
 
   it('transforms with wrong version format', () => {
-    const value =
-      'foo';
+    const value = 'foo';
     expect(pipe.transform(value)).toBe('foo');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/dimless.pipe.ts
@@ -8,16 +8,6 @@ export class DimlessPipe implements PipeTransform {
   constructor(private formatter: FormatterService) {}
 
   transform(value: any, args?: any): any {
-    return this.formatter.format_number(value, 1000, [
-      '',
-      'k',
-      'M',
-      'G',
-      'T',
-      'P',
-      'E',
-      'Z',
-      'Y'
-    ]);
+    return this.formatter.format_number(value, 1000, ['', 'k', 'M', 'G', 'T', 'P', 'E', 'Z', 'Y']);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/filter.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/filter.pipe.ts
@@ -5,10 +5,10 @@ import { Pipe, PipeTransform } from '@angular/core';
 })
 export class FilterPipe implements PipeTransform {
   transform(value: any, args?: any): any {
-    return value.filter(row => {
+    return value.filter((row) => {
       let result = true;
 
-      args.forEach(filter => {
+      args.forEach((filter) => {
         if (!filter.value) {
           return;
         }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/relative-date.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/relative-date.pipe.spec.ts
@@ -15,12 +15,16 @@ describe('RelativeDatePipe', () => {
   });
 
   it('transforms "in 7 days"', () => {
-    const value = moment().add(7, 'days').unix();
+    const value = moment()
+      .add(7, 'days')
+      .unix();
     expect(pipe.transform(value)).toBe('in 7 days');
   });
 
   it('transforms "7 days ago"', () => {
-    const value = moment().subtract(7, 'days').unix();
+    const value = moment()
+      .subtract(7, 'days')
+      .unix();
     expect(pipe.transform(value)).toBe('7 days ago');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/auth-guard.service.ts
@@ -8,9 +8,7 @@ import { ServicesModule } from './services.module';
   providedIn: ServicesModule
 })
 export class AuthGuardService implements CanActivate {
-
-  constructor(private router: Router, private authStorageService: AuthStorageService) {
-  }
+  constructor(private router: Router, private authStorageService: AuthStorageService) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
     if (this.authStorageService.isLoggedIn()) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/formatter.service.ts
@@ -18,7 +18,7 @@ export class FormatterService {
       return '-';
     }
     let unit = n < 1 ? 0 : Math.floor(Math.log(n) / Math.log(divisor));
-    unit = (unit >= units.length) ? units.length - 1 : unit;
+    unit = unit >= units.length ? units.length - 1 : unit;
     let result = _.round(n / Math.pow(divisor, unit), decimals).toString();
     if (result === '') {
       return '-';

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/js-error-handler.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/js-error-handler.service.ts
@@ -3,8 +3,7 @@ import { LoggingService } from '../api/logging.service';
 
 @Injectable()
 export class JsErrorHandler implements ErrorHandler {
-
-  constructor(private injector: Injector) { }
+  constructor(private injector: Injector) {}
 
   handleError(error) {
     const loggingService = this.injector.get(LoggingService);
@@ -14,5 +13,4 @@ export class JsErrorHandler implements ErrorHandler {
     loggingService.jsError(url, message, stack).subscribe();
     throw error;
   }
-
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -67,7 +67,7 @@ describe('SummaryService', () => {
     });
 
     it('should call getCurrentSummary', () => {
-      expect(summaryService.getCurrentSummary ()).toEqual(summary);
+      expect(summaryService.getCurrentSummary()).toEqual(summary);
     });
 
     it('should call subscribe', () => {
@@ -86,7 +86,7 @@ describe('SummaryService', () => {
           image_name: 'someImage'
         })
       );
-      const result = summaryService.getCurrentSummary ();
+      const result = summaryService.getCurrentSummary();
       expect(result.executing_tasks.length).toBe(1);
       expect(result.executing_tasks[0]).toEqual({
         metadata: { image_name: 'someImage', pool_name: 'somePool' },

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
@@ -48,7 +48,7 @@ export class SummaryService {
    * @returns {object}
    * @memberof SummaryService
    */
-  getCurrentSummary () {
+  getCurrentSummary() {
     return this.summaryDataSource.getValue();
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-manager-message.service.spec.ts
@@ -44,7 +44,7 @@ describe('TaskManagerMessageService', () => {
       image_name: 'someImage'
     };
     const message = service.getRunningMessage(finishedTask);
-    expect(message).toBe('Creating RBD \'somePool/someImage\'');
+    expect(message).toBe(`Creating RBD 'somePool/someImage'`);
   });
 
   it('should getErrorMessage', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/shared.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/shared.module.ts
@@ -40,10 +40,6 @@ import { ServicesModule } from './services/services.module';
     ApiModule,
     AutofocusDirective
   ],
-  providers: [
-    AuthStorageService,
-    AuthGuardService,
-    FormatterService
-  ]
+  providers: [AuthStorageService, AuthGuardService, FormatterService]
 })
 export class SharedModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/defaults.scss
@@ -13,7 +13,7 @@ $color-bright-green: #00bb00;
 $color-green: #71843f;
 
 $color-darker-blue: #2172bf;
-$color-dark-blue: #2582D9;
+$color-dark-blue: #2582d9;
 $color-blue: #288cea;
 $color-light-blue: #d9edf7;
 $color-sky-blue: #afd9ee;
@@ -30,7 +30,7 @@ $color-light-gray: #d1d1d1;
 $color-white-gray: #eee;
 $color-off-white: #f5f5f5;
 $color-solid-white: #ffffff;
-$color-transparent: rgba(0,0,0,.09);
+$color-transparent: rgba(0, 0, 0, 0.09);
 
 $color-app-bg: $color-solid-white;
 $color-bg-darken: $color-dark-gray;

--- a/src/pybind/mgr/dashboard/frontend/src/jestGlobalMocks.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/jestGlobalMocks.ts
@@ -1,15 +1,15 @@
 const mock = () => {
   let storage = {};
   return {
-    getItem: key => key in storage ? storage[key] : null,
-    setItem: (key, value) => storage[key] = value || '',
-    removeItem: key => delete storage[key],
-    clear: () => storage = {},
+    getItem: (key) => (key in storage ? storage[key] : null),
+    setItem: (key, value) => (storage[key] = value || ''),
+    removeItem: (key) => delete storage[key],
+    clear: () => (storage = {})
   };
 };
 
-Object.defineProperty(window, 'localStorage', {value: mock()});
-Object.defineProperty(window, 'sessionStorage', {value: mock()});
+Object.defineProperty(window, 'localStorage', { value: mock() });
+Object.defineProperty(window, 'sessionStorage', { value: mock() });
 Object.defineProperty(window, 'getComputedStyle', {
   value: () => ['-webkit-appearance']
 });

--- a/src/pybind/mgr/dashboard/frontend/src/main.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/main.ts
@@ -8,5 +8,6 @@ if (environment.production) {
   enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.log(err));
+platformBrowserDynamic()
+  .bootstrapModule(AppModule)
+  .catch((err) => console.log(err));

--- a/src/pybind/mgr/dashboard/frontend/src/polyfills.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/polyfills.ts
@@ -54,7 +54,7 @@ import 'core-js/es7/reflect';
 /***************************************************************************************************
  * Zone JS is required by Angular itself.
  */
-import 'zone.js/dist/zone';  // Included with Angular CLI.
+import 'zone.js/dist/zone'; // Included with Angular CLI.
 
 /***************************************************************************************************
  * APPLICATION IMPORTS

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -1,8 +1,8 @@
 /* You can add global styles to this file, and also import other style files */
 
 @import 'defaults';
-$fa-font-path: "../node_modules/fork-awesome/fonts";
-@import "../node_modules/fork-awesome/scss/fork-awesome";
+$fa-font-path: '../node_modules/fork-awesome/fonts';
+@import '../node_modules/fork-awesome/scss/fork-awesome';
 $font_family_1: 'ForkAwesome';
 
 /* Basics */
@@ -20,8 +20,8 @@ a {
   cursor: pointer;
 }
 a:hover,
-a:focus{
-  color: $color-links-focus
+a:focus {
+  color: $color-links-focus;
 }
 h1 {
   letter-spacing: -1px;
@@ -31,14 +31,14 @@ h2 {
   letter-spacing: -1px;
   font-size: 1.833em;
 }
-h3{
+h3 {
   display: block;
   font-size: 1.583em;
   font-weight: 400;
 }
-h4{
+h4 {
   font-size: 1.5em;
-  line-height: normal
+  line-height: normal;
 }
 option {
   font-weight: normal;
@@ -62,7 +62,7 @@ option {
   left: 50%;
 }
 .margin-right-md {
-  margin-right: 15px
+  margin-right: 15px;
 }
 .no-border {
   border: 0px;
@@ -86,13 +86,13 @@ option {
   background-color: transparent;
   border-radius: 0;
 }
-.breadcrumb>li+li:before {
+.breadcrumb > li + li:before {
   padding: 0 5px 0 7px;
   color: $color-breadcrumb;
-  font-family: "ForkAwesome";
-  content: "\f101";
+  font-family: 'ForkAwesome';
+  content: '\f101';
 }
-.breadcrumb>li>span {
+.breadcrumb > li > span {
   color: $color-breadcrumb;
 }
 /* Buttons */
@@ -140,8 +140,8 @@ fieldset[disabled] .btn-primary.active {
 .btn-primary .caret {
   color: $color-button-caret;
 }
-.btn-group>.btn>i.fa,
-button.btn.btn-label>i.fa {
+.btn-group > .btn > i.fa,
+button.btn.btn-label > i.fa {
   /** Add space between icon and text */
   padding-right: 5px;
 }
@@ -150,19 +150,19 @@ button.btn.btn-label>i.fa {
 .dropdown-menu {
   min-width: 50px;
 }
-.dropdown-menu>li>a {
+.dropdown-menu > li > a {
   color: $color-dropdown-menu;
   cursor: pointer;
 }
-.dropdown-menu>li>a>i.fa {
+.dropdown-menu > li > a > i.fa {
   /** Add space between icon and text */
   padding-right: 5px;
 }
-.dropdown-menu>.active>a {
+.dropdown-menu > .active > a {
   color: $color-dropdown-active-text;
   background-color: $color-dropdown-active-bg;
 }
-.dataTables_wrapper .dropdown-menu>li.divider {
+.dataTables_wrapper .dropdown-menu > li.divider {
   cursor: auto;
 }
 
@@ -176,10 +176,54 @@ button.btn.btn-label>i.fa {
   margin-left: -30px;
   margin-right: -30px;
 }
-.col-lg-1, .col-lg-10, .col-lg-11, .col-lg-12, .col-lg-2, .col-lg-3, .col-lg-4, .col-lg-5, .col-lg-6, .col-lg-7, .col-lg-8, .col-lg-9,
-.col-md-1, .col-md-10, .col-md-11, .col-md-12, .col-md-2, .col-md-3, .col-md-4, .col-md-5, .col-md-6, .col-md-7, .col-md-8, .col-md-9,
-.col-sm-1, .col-sm-10, .col-sm-11, .col-sm-12, .col-sm-2, .col-sm-3, .col-sm-4, .col-sm-5, .col-sm-6, .col-sm-7, .col-sm-8, .col-sm-9,
-.col-xs-1, .col-xs-10, .col-xs-11, .col-xs-12, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6, .col-xs-7, .col-xs-8, .col-xs-9 {
+.col-lg-1,
+.col-lg-10,
+.col-lg-11,
+.col-lg-12,
+.col-lg-2,
+.col-lg-3,
+.col-lg-4,
+.col-lg-5,
+.col-lg-6,
+.col-lg-7,
+.col-lg-8,
+.col-lg-9,
+.col-md-1,
+.col-md-10,
+.col-md-11,
+.col-md-12,
+.col-md-2,
+.col-md-3,
+.col-md-4,
+.col-md-5,
+.col-md-6,
+.col-md-7,
+.col-md-8,
+.col-md-9,
+.col-sm-1,
+.col-sm-10,
+.col-sm-11,
+.col-sm-12,
+.col-sm-2,
+.col-sm-3,
+.col-sm-4,
+.col-sm-5,
+.col-sm-6,
+.col-sm-7,
+.col-sm-8,
+.col-sm-9,
+.col-xs-1,
+.col-xs-10,
+.col-xs-11,
+.col-xs-12,
+.col-xs-2,
+.col-xs-3,
+.col-xs-4,
+.col-xs-5,
+.col-xs-6,
+.col-xs-7,
+.col-xs-8,
+.col-xs-9 {
   padding-left: 30px;
   padding-right: 30px;
 }
@@ -232,7 +276,8 @@ uib-accordion .panel-title,
 .clickable {
   cursor: pointer;
 }
-.has-error .has-error-btn, .has-error .has-error-btn:disabled:hover {
+.has-error .has-error-btn,
+.has-error .has-error-btn:disabled:hover {
   background-color: $color-error-btn-bg;
   border-color: $color-error-btn-border;
 }
@@ -247,7 +292,7 @@ uib-accordion .panel-title,
   color: $color-required-text;
 }
 /* Forms */
-.form-group>.control-label>span.required {
+.form-group > .control-label > span.required {
   @extend .fa;
   @extend .fa-asterisk;
   @extend .required;
@@ -260,7 +305,7 @@ uib-accordion .panel-title,
   margin-left: 5px;
 }
 .margin-right-sm {
-  margin-right: 10px
+  margin-right: 10px;
 }
 .nav-tabs {
   margin-bottom: 15px;

--- a/src/pybind/mgr/dashboard/frontend/tslint.json
+++ b/src/pybind/mgr/dashboard/frontend/tslint.json
@@ -1,6 +1,5 @@
 {
   "rulesDirectory": ["node_modules/codelyzer"],
-  "extends": ["tslint-eslint-rules"],
   "rules": {
     "no-consecutive-blank-lines": true,
     "arrow-return-shorthand": true,
@@ -10,10 +9,7 @@
     "curly": true,
     "eofline": true,
     "forin": true,
-    "import-blacklist": [
-      true,
-      "rxjs/Rx"
-    ],
+    "import-blacklist": [true, "rxjs/Rx"],
     "import-spacing": true,
     "indent": [true, "spaces"],
     "interface-over-type-literal": true,
@@ -91,32 +87,6 @@
     "directive-class-suffix": true,
     "no-forward-ref": true,
     "no-output-named-after-standard-event": true,
-    "ordered-imports": true,
-    "no-extra-semi": true,
-    "ter-no-irregular-whitespace": true,
-    "no-multi-spaces": true,
-    "brace-style": [
-      true,
-      "1tbs",
-      {
-        "allowSingleLine": false
-      }
-    ],
-    "ter-indent": [
-      true,
-      2,
-      {
-        "SwitchCase": 1,
-        "FunctionDeclaration": {
-          "body": 1,
-          "parameters": "first"
-        },
-        "FunctionExpression": {
-          "body": 1,
-          "parameters": "first"
-        }
-      }
-    ],
-    "space-in-parens": [true, "never"]
+    "ordered-imports": true
   }
 }


### PR DESCRIPTION
Added prettier validation to the run-frontend-unittests script. This will make
sure we are always running prettier in our commits.

Added 2 new npm scripts:
- 'prettier', will run prettier formatter on all frontend files
- 'prettier:lint', will check all frontend files against prettier linter

Removed 'pretty-quick' and related scripts. Since we now have all files
prettified we can simply run prettier on them.

Remove 'tslint-eslint-rules' package and all related rules. Prettier can check
all the removed rules.

Updated HACKING.rst with some information about prettier.

Prettify all remaining files.

Add reference to prettier in CodingStyle.