### PR TITLE
qa: use root to find client admin socket

### DIFF
--- a/qa/tasks/cephfs/fuse_mount.py
+++ b/qa/tasks/cephfs/fuse_mount.py
@@ -394,7 +394,7 @@ print find_socket("{client_name}")
 
         # Find the admin socket
         p = self.client_remote.run(args=[
-            'python', '-c', pyscript
+            'sudo', 'python2', '-c', pyscript
         ], stdout=StringIO())
         asok_path = p.stdout.getvalue().strip()
         log.info("Found client admin socket at {0}".format(asok_path))


### PR DESCRIPTION
Permissions on /var/run/ceph changed post-Mimic.

Fixes: http://tracker.ceph.com/issues/24872

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>