### PR TITLE
os/filestore: add pgid in filestore pg dir split log message

### DIFF
--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -321,7 +321,7 @@ int HashIndex::split_dirs(const vector<string> &path, int target_level) {
   if (must_split(info, target_level)) {
     dout(1) << __func__ << " " << path << " has " << info.objs
             << " objects, " << info.hash_level 
-            << " level, starting split." << dendl;
+            << " level, starting split in pg " << coll() << "." << dendl;
     r = initiate_split(path, info);
     if (r < 0) {
       dout(10) << "error initiating split on " << path << ": "
@@ -330,7 +330,7 @@ int HashIndex::split_dirs(const vector<string> &path, int target_level) {
     }
 
     r = complete_split(path, info);
-    dout(1) << __func__ << " " << path << " split completed."
+    dout(1) << __func__ << " " << path << " split completed in pg " << coll() << "."
             << dendl;
     if (r < 0) {
       dout(10) << "error completing split on " << path << ": "
@@ -425,12 +425,12 @@ int HashIndex::_created(const vector<string> &path,
 
   if (must_split(info)) {
     dout(1) << __func__ << " " << path << " has " << info.objs
-            << " objects, starting split." << dendl;
+            << " objects, starting split in pg " << coll() << "." << dendl;
     int r = initiate_split(path, info);
     if (r < 0)
       return r;
     r = complete_split(path, info);
-    dout(1) << __func__ << " " << path << " split completed."
+    dout(1) << __func__ << " " << path << " split completed in pg " << coll() << "."
             << dendl;
     return r;
   } else {


### PR DESCRIPTION
filestore: add pgid in filestore pg dir split log message
Fixes: http://tracker.ceph.com/issues/24878

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>