### PR TITLE
rgw: add zonegroup.api_name in /admin/bucket?zonegroup&bucket={bucketname}

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1296,6 +1296,30 @@ int RGWBucketAdminOp::get_policy(RGWRados *store, RGWBucketAdminOpState& op_stat
   return 0;
 }
 
+int RGWBucketAdminOp::get_zonegroup(RGWRados *store, RGWBucketAdminOpState& op_state,
+                                 RGWFormatterFlusher& flusher)
+{
+  RGWBucket bucket;
+  int ret = bucket.init(store, op_state);
+  if (ret < 0)
+    return ret;
+
+  Formatter *formatter = flusher.get_formatter();
+  flusher.start(0);
+  formatter->open_object_section("zonegroup");
+  RGWZoneGroup zonegroup;
+  ret = store->get_zonegroup(bucket.get_bucket_info().zonegroup, zonegroup);
+  if (ret >= 0) {
+    encode_json("zonegroup", zonegroup.api_name, formatter);
+  } else  {
+    encode_json("zonegroup", "", formatter);
+  }
+  formatter->close_section();
+  flusher.flush();
+
+  return 0;
+}
+
 int RGWBucketAdminOp::dump_s3_policy(RGWRados *store, RGWBucketAdminOpState& op_state,
                   ostream& os)
 {

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -309,6 +309,7 @@ public:
   int remove_object(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
   int policy_bl_to_stream(bufferlist& bl, ostream& o);
   int get_policy(RGWBucketAdminOpState& op_state, RGWAccessControlPolicy& policy);
+  RGWBucketInfo get_bucket_info() { return bucket_info; }
 
   void clear_failure() { failure = false; }
 };
@@ -316,6 +317,8 @@ public:
 class RGWBucketAdminOp
 {
 public:
+  static int get_zonegroup(RGWRados *store, RGWBucketAdminOpState& op_state,
+                        RGWFormatterFlusher& flusher);
   static int get_policy(RGWRados *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher);
   static int get_policy(RGWRados *store, RGWBucketAdminOpState& op_state,

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -948,7 +948,8 @@ void RGWHTTPArgs::append(const string& name, const string& val)
               (name.compare("index") == 0) ||
               (name.compare("policy") == 0) ||
               (name.compare("quota") == 0) ||
-              (name.compare("object") == 0)) {
+              (name.compare("object") == 0) ||
+              (name.compare("zonegroup") == 0)) {
 
     if (!admin_subresource_added) {
       sub_resources[name] = "";

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -76,6 +76,33 @@ void RGWOp_Get_Policy::execute()
   http_ret = RGWBucketAdminOp::get_policy(store, op_state, flusher);
 }
 
+class RGWOp_Get_Zonegroup : public RGWRESTOp {
+
+public:
+  RGWOp_Get_Zonegroup() {}
+
+  int check_caps(RGWUserCaps& caps) override {
+    return caps.check_cap("buckets", RGW_CAP_READ);
+  }
+
+  void execute() override;
+
+  const char* name() const override { return "get_zonegroup"; }
+};
+
+void RGWOp_Get_Zonegroup::execute()
+{
+  RGWBucketAdminOpState op_state;
+
+  std::string bucket;
+
+  RESTArgs::get_string(s, "bucket", bucket, &bucket);
+
+  op_state.set_bucket_name(bucket);
+
+  http_ret = RGWBucketAdminOp::get_zonegroup(store, op_state, flusher);
+}
+
 class RGWOp_Check_Bucket_Index : public RGWRESTOp {
 
 public:
@@ -322,6 +349,9 @@ RGWOp *RGWHandler_Bucket::op_get()
 
   if (s->info.args.sub_resource_exists("index"))
     return new RGWOp_Check_Bucket_Index;
+
+  if (s->info.args.sub_resource_exists("zonegroup"))
+    return new RGWOp_Get_Zonegroup;
 
   return new RGWOp_Bucket_Info;
 }


### PR DESCRIPTION
we may need  zonegroup info in some  case  
we have zonegroup zgp1 and zonegroup zgp2, bucket zgp1b4 is created with s3cmd --bucket-location=zgp1 and bucket zgp2b4 is created with s3cmd --bucket-location=zgp2

zgp1 endpoint 127.0.0.1:8001
zgp2 endpoint 127.0.0.1:8002

[root@localhost build]# ceph-request get "/admin/bucket?zonegroup&bucket=zgp2b4" -c admin.request
{"zonegroup":"zgp2"}
[root@localhost build]# ceph-request get "/admin/bucket?zonegroup&bucket=zgp1b4" -c admin.request
{"zonegroup":"zgp1"}
```

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>