### PR TITLE
crush/CrushWrapper: fix crush tree json dumper

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -3128,10 +3128,28 @@ public:
     : Parent(crush, wsnames, show_shadow) {}
 
   void dump(Formatter *f) {
+    f->open_object_section("crush_tree");
+
     f->open_array_section("nodes");
     Parent::dump(f);
     f->close_section();
+
     f->open_array_section("stray");
+    auto &name_map = this->crush->name_map;
+	int32_t min_id = numeric_limits<int32_t>::max();
+    int32_t max_id = numeric_limits<int32_t>::min();
+    for (auto ite = name_map.begin(); ite != name_map.end(); ++ite) {
+        if (ite->first <= min_id) min_id = ite->first;
+        if (ite->first >= max_id) max_id = ite->first;
+    }
+    for (int32_t i = min_id; i <= max_id; i++) {
+        if (this->crush->item_exists(i) &&
+            !this->is_touched(i) && this->should_dump(i)) {
+            this->dump_item(CrushTreeDumper::Item(i, 0, 0, 0), f);
+        }
+    }
+    f->close_section();
+
     f->close_section();
   }
 };


### PR DESCRIPTION
The output json string is invalid for 'osd crush tree --format=json'
command. It contains a array of 'nodes' and a array of 'stray', but
not in a json object, and the stray array was not implemented.
Applications which depends on the output of the above MonCommand will
occur json parse error.

Signed-off-by: Oshyn Song <dualyangsong@gmail.com>