### PR TITLE
luminous: FAILED assert(0 == ERROR: source must exist) in FileStore::_collection_move_rename()

### DIFF
--- a/qa/standalone/osd/ec-error-rollforward.sh
+++ b/qa/standalone/osd/ec-error-rollforward.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    # Fix port????
+    export CEPH_MON="127.0.0.1:7132" # git grep '\<7132\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON --osd-objectstore filestore"
+    export margin=10
+    export objects=200
+    export poolname=test
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+        $func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_ec_error_rollforward() {
+    local dir=$1
+    run_mon $dir a || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+    run_osd $dir 3 || return 1
+
+    ceph osd erasure-code-profile set ec-profile m=2 k=2 crush-failure-domain=osd
+    ceph osd pool create ec 1 1 erasure ec-profile
+
+    rados -p ec put foo /etc/passwd
+
+    kill -STOP `cat $dir/osd.2.pid`
+
+    rados -p ec rm foo &
+    sleep 1
+    rados -p ec rm a &
+    rados -p ec rm b &
+    rados -p ec rm c &
+    sleep 1
+    kill -9 `cat $dir/osd.?.pid`
+    kill %1 %2 %3 %4
+
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+    run_osd $dir 3 || return 1
+
+    wait_for_clean || return 1
+}
+
+main ec-error-rollforward "$@"

--- a/qa/standalone/osd/repro_long_log.sh
+++ b/qa/standalone/osd/repro_long_log.sh
@@ -138,10 +138,11 @@ function TEST_trim_max_entries()
     rados -p test rm foo
     test_log_size $PGID 3
     rados -p test rm foo
-    test_log_size $PGID 4
-
+    test_log_size $PGID 3
     rados -p test rm foo
-    test_log_size $PGID 2
+    test_log_size $PGID 3
+    rados -p test rm foo
+    test_log_size $PGID 3
 }
 
 main repro-long-log "$@"

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5319,9 +5319,6 @@ bool PG::append_log_entries_update_missing(
   assert(entries.begin()->version > info.last_update);
 
   PGLogEntryHandler rollbacker{this, &t};
-  if (roll_forward_to) {
-    pg_log.roll_forward(&rollbacker);
-  }
   bool invalidate_stats =
     pg_log.append_new_log_entries(info.last_backfill,
 				  info.last_backfill_bitwise,


### PR DESCRIPTION
http://tracker.ceph.com/issues/24890