### PR TITLE
tools/rbd: assert(g_ceph_context) not g_conf

### DIFF
--- a/src/tools/rbd/action/Create.cc
+++ b/src/tools/rbd/action/Create.cc
@@ -56,7 +56,7 @@ struct thick_provision_writer {
   {
     // If error cases occur, the code is aborted, because
     // constructor cannot return error value.
-    assert(g_conf != nullptr);
+    assert(g_ceph_context != nullptr);
     bl.append_zero(block_size);
 
     librbd::image_info_t info;


### PR DESCRIPTION
this addresses a warning introduced by f528475d:

src/tools/rbd/action/Create.cc:59:19: warning: the address of
'ConfigProxy& g_conf()' will never be NULL [-Waddress]
     assert(g_conf != nullptr);
            ~~~~~~~^~~~

Signed-off-by: Kefu Chai <kchai@redhat.com>