### PR TITLE
Add ceph_ll_fallocate

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13169,7 +13169,7 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
 #endif
 
 
-int Client::ll_fallocate(Fh *fh, int mode, loff_t offset, loff_t length)
+int Client::ll_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
 {
   Mutex::Locker lock(client_lock);
   ldout(cct, 3) << __func__ << " " << fh << " " << fh->inode->ino << " " << dendl;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1229,7 +1229,7 @@ public:
   int ll_flush(Fh *fh);
   int ll_fsync(Fh *fh, bool syncdataonly);
   int ll_sync_inode(Inode *in, bool syncdataonly);
-  int ll_fallocate(Fh *fh, int mode, loff_t offset, loff_t length);
+  int ll_fallocate(Fh *fh, int mode, int64_t offset, int64_t length);
   int ll_release(Fh *fh);
   int ll_getlk(Fh *fh, struct flock *fl, uint64_t owner);
   int ll_setlk(Fh *fh, struct flock *fl, uint64_t owner, int sleep);

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1508,6 +1508,8 @@ int ceph_ll_fsync(struct ceph_mount_info *cmount, struct Fh *fh,
 		  int syncdataonly);
 int ceph_ll_sync_inode(struct ceph_mount_info *cmount, struct Inode *in,
 		  int syncdataonly);
+int ceph_ll_fallocate(struct ceph_mount_info *cmount, struct Fh *fh,
+		      int mode, int64_t offset, int64_t length);
 int ceph_ll_write(struct ceph_mount_info *cmount, struct Fh* filehandle,
 		  int64_t off, uint64_t len, const char *data);
 int64_t ceph_ll_readv(struct ceph_mount_info *cmount, struct Fh *fh,

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -1546,6 +1546,12 @@ extern "C" int ceph_ll_sync_inode(class ceph_mount_info *cmount,
   return (cmount->get_client()->ll_sync_inode(in, syncdataonly));
 }
 
+extern "C" int ceph_ll_fallocate(class ceph_mount_info *cmount, Fh *fh,
+				 int mode, int64_t offset, int64_t length)
+{
+  return cmount->get_client()->ll_fallocate(fh, mode, offset, length);
+}
+
 extern "C" off_t ceph_ll_lseek(class ceph_mount_info *cmount,
 				Fh *fh, off_t offset, int whence)
 {


### PR DESCRIPTION
Two relatively trivial commits. One adds a simple ceph_ll_fallocate wrapper (that I'm planning to wire up in nfs-ganesha soon). The other commit removes what looks like completely superfluous cap reference acquisition in _write and _fallocate.