### PR TITLE
luminous: mds: unset deleted vars in shutdown_pass

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7707,9 +7707,11 @@ bool MDCache::shutdown_pass()
   }
   assert(subtrees.empty());
 
-  if (myin)
+  if (myin) {
     remove_inode(myin);
-  
+    assert(!myin);
+  }
+
   // done!
   dout(2) << "shutdown done." << dendl;
   return true;


### PR DESCRIPTION
https://tracker.ceph.com/issues/23766