### PR TITLE
qa/tests: fix supported distro lists for ceph-deploy 

### DIFF
--- a/qa/suites/ceph-deploy/basic/distros
+++ b/qa/suites/ceph-deploy/basic/distros
@@ -1,1 +1,0 @@
-../../../distros/supported

--- a/qa/suites/ceph-deploy/basic/distros/centos_7.4.yaml
+++ b/qa/suites/ceph-deploy/basic/distros/centos_7.4.yaml
@@ -1,0 +1,1 @@
+../../../../distros/all/centos_7.4.yaml

--- a/qa/suites/ceph-deploy/basic/distros/ubuntu_16.04.yaml
+++ b/qa/suites/ceph-deploy/basic/distros/ubuntu_16.04.yaml
@@ -1,0 +1,1 @@
+../../../../distros/all/ubuntu_16.04.yaml


### PR DESCRIPTION
use only centos and ubuntu for ceph-deploy tests.

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>