### PR TITLE
rgw: mitigate NIC problems like X710 transmit queue hang

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1435,6 +1435,8 @@ OPTION(rgw_md_log_max_shards, OPT_INT) // max shards for metadata log
 OPTION(rgw_num_zone_opstate_shards, OPT_INT) // max shards for keeping inter-region copy progress info
 OPTION(rgw_opstate_ratelimit_sec, OPT_INT) // min time between opstate updates on a single upload (0 for disabling ratelimit)
 OPTION(rgw_curl_wait_timeout_ms, OPT_INT) // timeout for certain curl calls
+OPTION(rgw_curl_low_speed_limit, OPT_INT) // low speed limit for certain curl calls
+OPTION(rgw_curl_low_speed_time, OPT_INT) // low speed time for certain curl calls
 OPTION(rgw_copy_obj_progress, OPT_BOOL) // should dump progress during long copy operations?
 OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT) // min bytes between copy progress output
 OPTION(rgw_obj_tombstone_cache_size, OPT_INT) // how many objects in tombstone cache, which is used in multi-zone sync to keep

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5818,13 +5818,13 @@ std::vector<Option> get_rgw_options() {
     .set_long_description(
         "It contains the average transfer speed in bytes per second that the "
         "transfer should be below during rgw_curl_low_speed_time seconds for libcurl "
-        " to consider it to be too slow and abort. Set it zero to disable this."),
+        "to consider it to be too slow and abort. Set it zero to disable this."),
 
     Option("rgw_curl_low_speed_time", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(30)
     .set_long_description(
-        "It contains the time in number seconds that the transfer speed should be below"
-        "the rgw_curl_low_speed_limit for the library to consider it too slow and abort."
+        "It contains the time in number seconds that the transfer speed should be below "
+        "the rgw_curl_low_speed_limit for the library to consider it too slow and abort. "
         "Set it zero to disable this."),
 
     Option("rgw_copy_obj_progress", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5813,6 +5813,20 @@ std::vector<Option> get_rgw_options() {
     .set_default(1000)
     .set_description(""),
 
+    Option("rgw_curl_low_speed_limit", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(1024)
+    .set_long_description(
+        "It contains the average transfer speed in bytes per second that the "
+        "transfer should be below during rgw_curl_low_speed_time seconds for libcurl "
+        " to consider it to be too slow and abort. Set it zero to disable this."),
+
+    Option("rgw_curl_low_speed_time", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(30)
+    .set_long_description(
+        "It contains the time in number seconds that the transfer speed should be below"
+        "the rgw_curl_low_speed_limit for the library to consider it too slow and abort."
+        "Set it zero to disable this."),
+
     Option("rgw_copy_obj_progress", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("Send progress report through copy operation")

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -493,6 +493,8 @@ int RGWHTTPClient::init_request(rgw_http_req_data *_req_data, bool send_data_hin
   curl_easy_setopt(easy_handle, CURLOPT_WRITEFUNCTION, receive_http_data);
   curl_easy_setopt(easy_handle, CURLOPT_WRITEDATA, (void *)req_data);
   curl_easy_setopt(easy_handle, CURLOPT_ERRORBUFFER, (void *)req_data->error_buf);
+  curl_easy_setopt(easy_handle, CURLOPT_LOW_SPEED_TIME, cct->_conf->rgw_curl_low_speed_time);
+  curl_easy_setopt(easy_handle, CURLOPT_LOW_SPEED_LIMIT, cct->_conf->rgw_curl_low_speed_limit);
   if (h) {
     curl_easy_setopt(easy_handle, CURLOPT_HTTPHEADER, (void *)h);
   }
@@ -1149,6 +1151,9 @@ void *RGWHTTPManager::reqs_thread_entry()
         switch (result) {
           case CURLE_OK:
             break;
+          case CURLE_OPERATION_TIMEDOUT:
+            dout(0) << "WARNING: curl operation timed out, network average transfer speed less than " 
+              << cct->_conf->rgw_curl_low_speed_limit << " Bytes per second during " << cct->_conf->rgw_curl_low_speed_time << " seconds." << dendl;
           default:
             dout(20) << "ERROR: msg->data.result=" << result << " req_data->id=" << id << " http_status=" << http_status << dendl;
 	    break;


### PR DESCRIPTION
Continuation of #19282

Squashed commit of the following:

commit a711334e0502cd3d863b509edf4c4fcd7a31a7ba
Author: Mark Kogan <mkogan@redhat.com>
Date:   Thu Jul 12 18:45:12 2018 -0400

    add explicit warning log message when curl timeout occures when network speed is below the configured limits

commit cc1a22481ff281732357b7daa2637bf2096e6626
Author: Mark Kogan <mkogan@redhat.com>
Date:   Thu Jul 12 18:02:34 2018 -0400

    change the default minimum required speed to 1KBps

commit 0c94c4c45220a80a32c8768f72ddb3dc3baec36d
Author: Mark Kogan <mkogan@redhat.com>
Date:   Thu Jul 12 18:13:18 2018 -0400

    Resolved merge conflict by incorporating master

Signed-off-by: Mark Kogan <mkogan@redhat.com>