### PR TITLE
osd: do not treat an IO hint as an IOP for PG stats

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6296,7 +6296,6 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
         t->set_alloc_hint(soid, op.alloc_hint.expected_object_size,
                           op.alloc_hint.expected_write_size,
 			  op.alloc_hint.flags);
-        ctx->delta_stats.num_wr++;
         result = 0;
       }
       break;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/24909
Signed-off-by: Jason Dillaman <dillaman@redhat.com>