### PR TITLE
include: fix build with older clang

### DIFF
--- a/src/common/convenience.h
+++ b/src/common/convenience.h
@@ -14,7 +14,9 @@
 
 #include <mutex>
 #include <memory>
+#if __has_include(<optional>)
 #include <optional>
+#endif
 #include <shared_mutex>
 #include <type_traits>
 #include <utility>
@@ -30,6 +32,7 @@
 #ifndef CEPH_COMMON_CONVENIENCE_H
 #define CEPH_COMMON_CONVENIENCE_H
 
+#if __has_include(<optional>)
 namespace ceph {
 
 // Lock Factories
@@ -147,6 +150,7 @@ inline auto with_shared_lock(Mutex&& mutex, Fun&& fun, Args&&... args)
   return std::forward<Fun>(fun)(std::forward<Args>(args)...);
 }
 }
+#endif // __has_include(<optional>)
 
 // Lock Types
 // ----------

--- a/src/include/any.h
+++ b/src/include/any.h
@@ -15,7 +15,18 @@
 #ifndef INCLUDE_STATIC_ANY
 #define INCLUDE_STATIC_ANY
 
+#if __has_include(<any>)
 #include <any>
+namespace ceph {
+  using std::bad_any_cast;
+}
+#else
+#include <boost/any.hpp>
+namespace ceph {
+  using boost::bad_any_cast;
+}
+#endif
+
 #include <cstddef>
 #include <initializer_list>
 #include <memory>
@@ -298,7 +309,7 @@ public:
   // only stores the decayed type. I suspect this was to get around
   // the question of whether, for a std::any holding a T&,
   // std::any_cast<T> should return a copy or throw
-  // std::bad_any_cast.
+  // ceph::bad_any_cast.
   //
   // I think the appropriate response in that case would be to make a
   // copy if the type supports it and fail otherwise. Once a concrete
@@ -453,7 +464,7 @@ inline T any_cast(_any::base<U, V>& a) {
   if (p) {
     return static_cast<T>(*p);
   }
-  throw std::bad_any_cast();
+  throw ceph::bad_any_cast();
 }
 
 template<typename T, typename U, typename V>
@@ -466,7 +477,7 @@ inline T any_cast(const _any::base<U, V>& a) {
   if (p) {
     return static_cast<T>(*p);
   }
-  throw std::bad_any_cast();
+  throw ceph::bad_any_cast();
 }
 
 template<typename T, typename U, typename V>
@@ -478,7 +489,7 @@ any_cast(_any::base<U, V>&& a) {
   if (p) {
     return std::move((*p));
   }
-  throw std::bad_any_cast();
+  throw ceph::bad_any_cast();
 }
 
 template<typename T, typename U, typename V>
@@ -488,7 +499,7 @@ any_cast(_any::base<U, V>&& a) {
   if (p) {
     return static_cast<T>(*p);
   }
-  throw std::bad_any_cast();
+  throw ceph::bad_any_cast();
 }
 
 // `immobile_any`

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -27,7 +27,9 @@
 #include <array>
 #include <cstring>
 #include <map>
+#if __has_include(<optional>)
 #include <optional>
+#endif
 #include <set>
 #include <string>
 #include <type_traits>
@@ -1288,6 +1290,7 @@ struct denc_traits<boost::none_t> {
   }
 };
 
+#if __has_include(<optional>)
 //
 // std::optional<T>
 //
@@ -1391,6 +1394,8 @@ struct denc_traits<std::nullopt_t> {
     denc(false, p);
   }
 };
+
+#endif // __has_include(<optional>)
 
 // ----------------------------------------------------------------------
 // class helpers


### PR DESCRIPTION
to fix the FTBFS on clang shipped with xcode 9.1 (based on Clang 4.0).

Signed-off-by: Kefu Chai <kchai@redhat.com>