### PR TITLE
luminous: rpm,deb: chown bluestore block* links to ceph.ceph on install/upgrade

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1447,6 +1447,8 @@ fi
 %else
     /usr/lib/systemd/systemd-sysctl %{_sysctldir}/90-ceph-osd.conf > /dev/null 2>&1 || :
 %endif
+# work around https://tracker.ceph.com/issues/24903
+chown ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
 
 %preun osd
 %if 0%{?suse_version}

--- a/debian/ceph-osd.postinst
+++ b/debian/ceph-osd.postinst
@@ -25,6 +25,8 @@ case "$1" in
     configure)
 	[ -x /etc/init.d/procps ] && invoke-rc.d procps restart || :
 	[ -x /sbin/start ] && start ceph-osd-all || :
+	# work around https://tracker.ceph.com/issues/24903
+	chown ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
 	:


### PR DESCRIPTION
This works around https://tracker.ceph.com/issues/24903

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 58cde3fd793c037beca6645cc30b2ae1c30e2af1)