### PR TITLE
rgw_file: deep stat handling

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -2265,6 +2265,9 @@ public:
 			     << " target = " << path << ""
 			     << dendl;
       matched = true;
+      /* match-dir case (trailing '/') */
+      if (name == prefix + "/")
+	exact_matched = true;
       is_dir = true;
       break;
     }


### PR DESCRIPTION
A change to the exact-match behavior in leaf stat operations is
required to support instantiation of a full path hierarchy when
one or more intervening directories has not been enumerated.

Fixes: http://tracker.ceph.com/issues/24915

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>