### PR TITLE
rgw: cpp_strerror needs common/errno.h

### DIFF
--- a/src/rgw/rgw_admin_user.cc
+++ b/src/rgw/rgw_admin_user.cc
@@ -1,3 +1,4 @@
+#include "common/errno.h"
 #include "include/rgw/librgw_admin_user.h"
 #include "rgw_admin_user.h"
 #include "rgw_user.h"


### PR DESCRIPTION
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>