### PR TITLE
include: fix build with older clang

### DIFF
--- a/src/common/convenience.h
+++ b/src/common/convenience.h
@@ -32,7 +32,6 @@
 #ifndef CEPH_COMMON_CONVENIENCE_H
 #define CEPH_COMMON_CONVENIENCE_H
 
-#if __has_include(<optional>)
 namespace ceph {
 
 // Lock Factories
@@ -150,7 +149,6 @@ inline auto with_shared_lock(Mutex&& mutex, Fun&& fun, Args&&... args)
   return std::forward<Fun>(fun)(std::forward<Args>(args)...);
 }
 }
-#endif // __has_include(<optional>)
 
 // Lock Types
 // ----------
@@ -205,7 +203,7 @@ auto maybe_do_or(const boost::optional<T>& t, F&& f, U&& u) ->
     return std::forward<U>(u);
 }
 
-
+#if __has_include(<optional>)
 // Same thing but for std::optional
 
 template<typename T, typename F>
@@ -233,6 +231,8 @@ auto maybe_do_or(const std::optional<T>& t, F&& f, U&& u) ->
   else
     return std::forward<U>(u);
 }
+#endif // __has_include(<optional>)
+
 
 namespace _convenience {
 template<typename... Ts, typename F,  std::size_t... Is>


### PR DESCRIPTION
to fix the FTBFS on clang shipped with xcode 9.1 (based on Clang 4.0).
This fixes ceph client library builds for the OSX target
initally targetted with PR #23034.

refs: #23034

Signed-off-by: Christopher Blum <zeichenanonym@web.de>