### PR TITLE
osd: fix deep scrub with osd_skip_data_digest=true (default) and bluestore

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2414,8 +2414,6 @@ int ECBackend::be_deep_scrub(
 {
   dout(10) << __func__ << " " << poid << " pos " << pos << dendl;
   int r;
-  bool skip_data_digest = store->has_builtin_csum() &&
-    g_conf()->osd_skip_data_digest;
 
   uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
                            CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
@@ -2456,7 +2454,7 @@ int ECBackend::be_deep_scrub(
     o.read_error = true;
     return 0;
   }
-  if (r > 0 && !skip_data_digest) {
+  if (r > 0) {
     pos.data_hash << bl;
   }
   pos.data_pos += r;
@@ -2482,8 +2480,7 @@ int ECBackend::be_deep_scrub(
 	return 0;
       }
 
-      if (!skip_data_digest &&
-          hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) !=
+      if (hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) !=
 	  pos.data_hash.digest()) {
 	dout(0) << "_scan_list  " << poid << " got incorrect hash on read 0x"
 		<< std::hex << pos.data_hash.digest() << " !=  expected 0x"

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -600,9 +600,6 @@ int ReplicatedBackend::be_deep_scrub(
   uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
                            CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
 
-  bool skip_data_digest = store->has_builtin_csum() &&
-    g_conf()->osd_skip_data_digest;
-
   utime_t sleeptime;
   sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
   if (sleeptime != utime_t()) {
@@ -630,7 +627,7 @@ int ReplicatedBackend::be_deep_scrub(
       o.read_error = true;
       return 0;
     }
-    if (r > 0 && !skip_data_digest) {
+    if (r > 0) {
       pos.data_hash << bl;
     }
     pos.data_pos += r;
@@ -641,10 +638,8 @@ int ReplicatedBackend::be_deep_scrub(
     }
     // done with bytes
     pos.data_pos = -1;
-    if (!skip_data_digest) {
-      o.digest = pos.data_hash.digest();
-      o.digest_present = true;
-    }
+    o.digest = pos.data_hash.digest();
+    o.digest_present = true;
     dout(20) << __func__ << "  " << poid << " done with data, digest 0x"
 	     << std::hex << o.digest << std::dec << dendl;
   }


### PR DESCRIPTION
The osd_skip_data_digest is about skipping the storing and checking of a
full-object data digest.  Here it is also disabling crc checks during
deep-scrub, which prevents us from detecting crc differences across
replicas.  Fix!

Fixes: http://tracker.ceph.com/issues/24922
Signed-off-by: Sage Weil <sage@redhat.com>