### PR TITLE
mon: emplace mon_caps in Monitor

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -204,7 +204,6 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
 
   config_key_service = new ConfigKeyService(this, paxos);
 
-  mon_caps = new MonCap();
   bool r = mon_caps->parse("allow *", NULL);
   assert(r);
 
@@ -233,7 +232,6 @@ Monitor::~Monitor()
   delete config_key_service;
   delete paxos;
   assert(session_map.sessions.empty());
-  delete mon_caps;
 }
 
 
@@ -4055,7 +4053,7 @@ void Monitor::_ms_dispatch(Message *m)
       // give it monitor caps; the peer type has been authenticated
       dout(5) << __func__ << " setting monitor caps on this connection" << dendl;
       if (!s->caps.is_allow_all()) // but no need to repeatedly copy
-        s->caps = *mon_caps;
+        s->caps = mon_caps;
       s->authenticated = true;
     }
   } else {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -882,7 +882,7 @@ public:
   }
   void dispatch_op(MonOpRequestRef op);
   //mon_caps is used for un-connected messages from monitors
-  MonCap * mon_caps;
+  MonCap mon_caps;
   bool ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer, bool force_new) override;
   bool ms_verify_authorizer(Connection *con, int peer_type,
 			    int protocol, bufferlist& authorizer_data, bufferlist& authorizer_reply,


### PR DESCRIPTION
Avoiding unnecessary pointer management.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>