### PR TITLE
luminous: messages,mon,osd: silence gcc-8 warnings related to memset()

### DIFF
--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -255,7 +255,6 @@ struct Inode {
       fcntl_locks(NULL), flock_locks(NULL)
   {
     memset(&dir_layout, 0, sizeof(dir_layout));
-    memset(&quota, 0, sizeof(quota));
   }
   ~Inode();
 

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -182,7 +182,7 @@ struct InodeStat {
     if (features & CEPH_FEATURE_MDS_QUOTA)
       ::decode(quota, p);
     else
-      memset(&quota, 0, sizeof(quota));
+      quota = quota_info_t{};
 
     if ((features & CEPH_FEATURE_FS_FILE_LAYOUT_V2))
       ::decode(layout.pool_ns, p);

--- a/src/messages/MMonSubscribeAck.h
+++ b/src/messages/MMonSubscribeAck.h
@@ -23,7 +23,6 @@ struct MMonSubscribeAck : public Message {
   
   MMonSubscribeAck() : Message(CEPH_MSG_MON_SUBSCRIBE_ACK),
 		       interval(0) {
-    memset(&fsid, 0, sizeof(fsid));
   }
   MMonSubscribeAck(uuid_d& f, int i) : Message(CEPH_MSG_MON_SUBSCRIBE_ACK),
 				       interval(i), fsid(f) { }

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -62,7 +62,6 @@ void LogMonitor::create_initial()
 {
   dout(10) << "create_initial -- creating initial map" << dendl;
   LogEntry e;
-  memset(&e.who, 0, sizeof(e.who));
   e.name = g_conf->name;
   e.stamp = ceph_clock_now();
   e.prio = CLOG_INFO;

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -118,7 +118,6 @@ public:
 
   MonMap()
     : epoch(0) {
-    memset(&fsid, 0, sizeof(fsid));
   }
 
   uuid_d& get_fsid() { return fsid; }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -431,7 +431,6 @@ public:
       encode_features(0),
       epoch(e), new_pool_max(-1), new_flags(-1), new_max_osd(-1),
       have_crc(false), full_crc(0), inc_crc(0) {
-      memset(&fsid, 0, sizeof(fsid));
     }
     explicit Incremental(bufferlist &bl) {
       bufferlist::iterator p = bl.begin();
@@ -596,7 +595,6 @@ private:
 	     cached_up_osd_features(0),
 	     crc_defined(false), crc(0),
 	     crush(std::make_shared<CrushWrapper>()) {
-    memset(&fsid, 0, sizeof(fsid));
   }
 
   // no copying


### PR DESCRIPTION
this silences warnings like:

warning: ‘void* memset(void*, int, size_t)’ writing to an object of
non-trivial type ‘struct uuid_d’; use assignment instead [-Wcl\
ass-memaccess]

uuid_d only contains boost::uuids::uuid, which is "nil" initialized in
uuid_d's ctor. so we don't need to bother with memset() it with 0.
the same applies to entity_inst_t.

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 557cb0614586880512c9213676f8f6dcd226eb38)