### PR TITLE
luminous: osd: work around data digest problems in 12.2.6 (version 2)

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -790,6 +790,7 @@ OPTION(osd_deep_scrub_stride, OPT_INT)
 OPTION(osd_deep_scrub_keys, OPT_INT)
 OPTION(osd_deep_scrub_update_digest_min_age, OPT_INT)   // objects must be this old (seconds) before we update the whole-object digest on scrub
 OPTION(osd_skip_data_digest, OPT_BOOL)
+OPTION(osd_distrust_data_digest, OPT_BOOL)
 OPTION(osd_deep_scrub_large_omap_object_key_threshold, OPT_U64)
 OPTION(osd_deep_scrub_large_omap_object_value_sum_threshold, OPT_U64)
 OPTION(osd_class_dir, OPT_STR) // where rados plugins are stored

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1986,7 +1986,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_skip_data_digest", Option::TYPE_BOOL, Option::LEVEL_DEV)
-    .set_default(true)
+    .set_default(false)
     .set_description("Do not store full-object checksums if the backend (bluestore) does its own checksums.  Do not ever turn this off if it has ever been turned on."),
 
     Option("osd_distrust_data_digest", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1985,9 +1985,9 @@ std::vector<Option> get_global_options() {
     .set_default(8)
     .set_description(""),
 
-    Option("osd_skip_data_digest", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("osd_skip_data_digest", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
-    .set_description(""),
+    .set_description("Do not store full-object checksums if the backend (bluestore) does its own checksums.  Do not ever turn this off if it has ever been turned on."),
 
     Option("osd_distrust_data_digest", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1989,6 +1989,10 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description(""),
 
+    Option("osd_distrust_data_digest", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Do not trust stored data_digest (due to previous bug or corruption)"),
+
     Option("osd_op_queue", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("wpq")
     .set_enum_allowed( { "wpq", "prioritized", "mclock_opclass", "mclock_client", "debug_random" } )

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2426,8 +2426,6 @@ int ECBackend::be_deep_scrub(
 {
   dout(10) << __func__ << " " << poid << " pos " << pos << dendl;
   int r;
-  bool skip_data_digest = store->has_builtin_csum() &&
-    g_conf->osd_skip_data_digest;
 
   uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
                            CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
@@ -2468,7 +2466,7 @@ int ECBackend::be_deep_scrub(
     o.read_error = true;
     return 0;
   }
-  if (r > 0 && !skip_data_digest) {
+  if (r > 0) {
     pos.data_hash << bl;
   }
   pos.data_pos += r;
@@ -2494,8 +2492,7 @@ int ECBackend::be_deep_scrub(
 	return 0;
       }
 
-      if (!skip_data_digest &&
-          hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) !=
+      if (hinfo->get_chunk_hash(get_parent()->whoami_shard().shard) !=
 	  pos.data_hash.digest()) {
 	dout(0) << "_scan_list  " << poid << " got incorrect hash on read 0x"
 		<< std::hex << pos.data_hash.digest() << " !=  expected 0x"

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5046,7 +5046,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   object_info_t& oi = obs.oi;
   const hobject_t& soid = oi.soid;
   bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->get_val<bool>("osd_skip_data_digest");
+    g_conf->osd_skip_data_digest;
 
   PGTransaction* t = ctx->op_t.get();
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4532,8 +4532,9 @@ int PrimaryLogPG::do_checksum(OpContext *ctx, OSDOp& osd_op,
 			      bufferlist::iterator *bl_it)
 {
   dout(20) << __func__ << dendl;
-  bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->osd_skip_data_digest;
+  bool skip_data_digest =
+    (osd->store->has_builtin_csum() && g_conf->osd_skip_data_digest) ||
+    g_conf->osd_distrust_data_digest;
 
   auto& op = osd_op.op;
   if (op.checksum.chunk_size > 0) {
@@ -4737,8 +4738,9 @@ int PrimaryLogPG::do_extent_cmp(OpContext *ctx, OSDOp& osd_op)
 {
   dout(20) << __func__ << dendl;
   ceph_osd_op& op = osd_op.op;
-  bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->osd_skip_data_digest;
+  bool skip_data_digest =
+    (osd->store->has_builtin_csum() && g_conf->osd_skip_data_digest) ||
+    g_conf->osd_distrust_data_digest;
 
   auto& oi = ctx->new_obs.oi;
   uint64_t size = oi.size;
@@ -4822,8 +4824,9 @@ int PrimaryLogPG::do_read(OpContext *ctx, OSDOp& osd_op) {
   __u32 seq = oi.truncate_seq;
   uint64_t size = oi.size;
   bool trimmed_read = false;
-  bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->osd_skip_data_digest;
+  bool skip_data_digest =
+    (osd->store->has_builtin_csum() && g_conf->osd_skip_data_digest) ||
+    g_conf->osd_distrust_data_digest;
 
   // are we beyond truncate_size?
   if ( (seq < op.extent.truncate_seq) &&
@@ -4909,8 +4912,9 @@ int PrimaryLogPG::do_sparse_read(OpContext *ctx, OSDOp& osd_op) {
   auto& op = osd_op.op;
   auto& oi = ctx->new_obs.oi;
   auto& soid = oi.soid;
-  bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->osd_skip_data_digest;
+  bool skip_data_digest =
+    (osd->store->has_builtin_csum() && g_conf->osd_skip_data_digest) ||
+    g_conf->osd_distrust_data_digest;
 
   if (op.extent.truncate_seq) {
     dout(0) << "sparse_read does not support truncation sequence " << dendl;
@@ -5058,8 +5062,9 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   ObjectState& obs = ctx->new_obs;
   object_info_t& oi = obs.oi;
   const hobject_t& soid = oi.soid;
-  bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->osd_skip_data_digest;
+  bool skip_data_digest =
+    (osd->store->has_builtin_csum() && g_conf->osd_skip_data_digest) ||
+    g_conf->osd_distrust_data_digest;
 
   PGTransaction* t = ctx->op_t.get();
 
@@ -7849,8 +7854,9 @@ int PrimaryLogPG::do_copy_get(OpContext *ctx, bufferlist::iterator& bp,
   int result = 0;
   object_copy_cursor_t cursor;
   uint64_t out_max;
-  bool skip_data_digest = osd->store->has_builtin_csum() &&
-    g_conf->osd_skip_data_digest;
+  bool skip_data_digest =
+    (osd->store->has_builtin_csum() && g_conf->osd_skip_data_digest) ||
+    g_conf->osd_distrust_data_digest;
 
   try {
     ::decode(cursor, bp);

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -714,9 +714,6 @@ int ReplicatedBackend::be_deep_scrub(
   uint32_t fadvise_flags = CEPH_OSD_OP_FLAG_FADVISE_SEQUENTIAL |
                            CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
 
-  bool skip_data_digest = store->has_builtin_csum() &&
-    g_conf->osd_skip_data_digest;
-
   utime_t sleeptime;
   sleeptime.set_from_double(cct->_conf->osd_debug_deep_scrub_sleep);
   if (sleeptime != utime_t()) {
@@ -744,7 +741,7 @@ int ReplicatedBackend::be_deep_scrub(
       o.read_error = true;
       return 0;
     }
-    if (r > 0 && !skip_data_digest) {
+    if (r > 0) {
       pos.data_hash << bl;
     }
     pos.data_pos += r;
@@ -755,10 +752,8 @@ int ReplicatedBackend::be_deep_scrub(
     }
     // done with bytes
     pos.data_pos = -1;
-    if (!skip_data_digest) {
-      o.digest = pos.data_hash.digest();
-      o.digest_present = true;
-    }
+    o.digest = pos.data_hash.digest();
+    o.digest_present = true;
     dout(20) << __func__ << "  " << poid << " done with data, digest 0x"
 	     << std::hex << o.digest << std::dec << dendl;
   }


### PR DESCRIPTION
- fix performance nit
- fix deep scrub vs skip_data_digests bug http://tracker.ceph.com/issues/24922

For the hard part, we take a 2 part approach:

- make the skip_data_digests logic apply to *reads* as well as *writes*, so that if we corrupted it via 12.2.6 but would have cleared it then we ignore the stored value.  This works as long as the primary doesn't move from a bluestore OSD to a filestore OSD (which won't be affected b the skip_data_digest option)
- add a distrust_data_digest option for the above case that is off by default but forces us to ignore digests on *all* osds.

Finally,

- turn off osd_skip_data_digest by default
- make osd_skip_data_digest a DEV option and warn the user to never turn it off after it's been on.

See the proposed release notes to go with this at https://github.com/ceph/ceph/pull/23057