### PR TITLE
mds: print mdsmap processed at low debug level

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -871,15 +871,16 @@ out:
 void MDSDaemon::handle_mds_map(MMDSMap *m)
 {
   version_t epoch = m->get_epoch();
-  dout(5) << "handle_mds_map epoch " << epoch << " from " << m->get_source() << dendl;
 
   // is it new?
   if (epoch <= mdsmap->get_epoch()) {
-    dout(5) << " old map epoch " << epoch << " <= " << mdsmap->get_epoch()
-	    << ", discarding" << dendl;
+    dout(5) << "handle_mds_map old map epoch " << epoch << " <= "
+            << mdsmap->get_epoch() << ", discarding" << dendl;
     m->put();
     return;
   }
+
+  dout(1) << "Updating MDS map to version " << epoch << " from " << m->get_source() << dendl;
 
   entity_addrvec_t addrs;
 
@@ -940,7 +941,7 @@ void MDSDaemon::handle_mds_map(MMDSMap *m)
         if (mds_gid_t existing = mdsmap->find_mds_gid_by_name(name)) {
           const MDSMap::mds_info_t& i = mdsmap->get_info_gid(existing);
           if (i.global_id > myid) {
-            dout(1) << "map replaced me with another mds." << whoami
+            dout(1) << "Map replaced me with another mds." << whoami
                     << " with gid (" << i.global_id << ") larger than myself ("
                     << myid << "); quitting!" << dendl;
             // Call suicide() rather than respawn() because if someone else
@@ -953,7 +954,7 @@ void MDSDaemon::handle_mds_map(MMDSMap *m)
         }
       }
 
-      dout(1) << "map removed me (mds." << whoami << " gid:"
+      dout(1) << "Map removed me (mds." << whoami << " gid:"
               << myid << ") from cluster due to lost contact; respawning" << dendl;
       respawn();
     }
@@ -1001,7 +1002,7 @@ void MDSDaemon::_handle_mds_map(MDSMap *oldmap)
   // Normal rankless case, we're marked as standby
   if (new_state == MDSMap::STATE_STANDBY) {
     beacon.set_want_state(mdsmap, new_state);
-    dout(1) << "handle_mds_map standby" << dendl;
+    dout(1) << "Map has assigned me to become a standby" << dendl;
 
     return;
   }
@@ -1041,7 +1042,7 @@ void MDSDaemon::suicide()
   assert(stopping == false);
   stopping = true;
 
-  dout(1) << "suicide.  wanted state "
+  dout(1) << "suicide! Wanted state "
           << ceph_mds_state_name(beacon.get_want_state()) << dendl;
 
   if (tick_event) {
@@ -1080,7 +1081,7 @@ void MDSDaemon::suicide()
 
 void MDSDaemon::respawn()
 {
-  dout(1) << "respawn" << dendl;
+  dout(1) << "respawn!" << dendl;
 
   char *new_argv[orig_argc+1];
   dout(1) << " e: '" << orig_argv[0] << "'" << dendl;


### PR DESCRIPTION
Production deployments use low debugging but it'd be useful to always know what
MDSMap epoch the MDS is currently processing. (In the case of skipped epochs or
unsynchronized processing.)

Fixes: https://tracker.ceph.com/issues/24852

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>