### PR TITLE
osd/PrimaryLogPG: roll forward to last_update_ondisk

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10408,7 +10408,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
     ctx->at_version,
     std::move(ctx->op_t),
     pg_trim_to,
-    min_last_complete_ondisk,
+    last_update_ondisk,
     ctx->log,
     ctx->updated_hset_history,
     on_all_commit,


### PR DESCRIPTION
when peering ec pg, auth log has min last_update, all shards will rollback to it. so we cannot roll forward over min_last_udpate, rather than min_last_complete.
for recovering pg, last_complete of the recovering shards may grow slower than last_update, so last_update - last_complete may become larger and larger, leave huge number of objects with historic versions.

Signed-off-by: wumingqiao <wumingqiao@inspur.com>