### PR TITLE
mimic: build/ops: ceph.git has two different versions of dpdk in the source tree

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,9 +37,6 @@
 	url = https://github.com/ceph/lua.git
 	branch = lua-5.3-ceph
 	ignore = dirty
-[submodule "src/dpdk"]
-	path = src/dpdk
-	url = https://github.com/ceph/dpdk
 [submodule "src/zstd"]
 	path = src/zstd
 	url = https://github.com/facebook/zstd


### PR DESCRIPTION
http://tracker.ceph.com/issues/24942