### PR TITLE
build/ops: install-deps.sh: set with_seastar

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -23,7 +23,7 @@ export LC_ALL=C # the following is vulnerable to i18n
 
 ARCH=`uname -m`
 
-if [ -n $WITH_SEASTAR ]; then
+if [ -n "$WITH_SEASTAR" ]; then
     with_seastar=true
 else
     with_seastar=false


### PR DESCRIPTION
25d5122b5538062e8282251c3d7bae0f9792d596 introduced code into
install-deps.sh which was intended to set a variable "with_seastar" to the
string "true" or "false" depending on whether or not an environment
variable WITH_SEASTAR is defined.

As originally implemented, the conditional is always true, so with_seastar
is set to "true" unconditionally. Fix this by putting $WITH_SEASTAR in
double quotes.

Signed-off-by: Nathan Cutler <ncutler@suse.com>