### PR TITLE
Documentation: Hardware page

### DIFF
--- a/doc/start/hardware-recommendations.rst
+++ b/doc/start/hardware-recommendations.rst
@@ -123,8 +123,6 @@ sequential write throughput when storing multiple journals for multiple OSDs.
    recommend** both reviewing the performance metrics of an SSD and testing the
    SSD in a test configuration to gauge performance. 
 
-Since SSDs have no moving mechanical parts, it makes sense to use them in the
-areas of Ceph that do not use a lot of storage space (e.g., journals).
 Relatively inexpensive SSDs may appeal to your sense of economy. Use caution.
 Acceptable IOPS are not enough when selecting an SSD for use with Ceph. There
 are a few important performance considerations for journals and SSDs:
@@ -145,7 +143,7 @@ are a few important performance considerations for journals and SSDs:
   proper partition alignment with SSDs, which can cause SSDs to transfer data 
   much more slowly. Ensure that SSD partitions are properly aligned.
 
-While SSDs are cost prohibitive for object storage, OSDs may see a significant
+If SSDs are cost prohibitive for object storage, OSDs may still see a significant
 performance improvement by storing an OSD's journal on an SSD and the OSD's
 object data on a separate hard disk drive. The ``osd journal`` configuration
 setting defaults to ``/var/lib/ceph/osd/$cluster-$id/journal``. You can mount


### PR DESCRIPTION
This PR contains a couple of changes to correct two things that I had to read twice in the Hardware page.

The sentence starting Since... was confusingly poor english imho (as the fact that SSDs have no moving parts is irrelevant to their size and whether it makes sense to use them in the areas of Ceph that do not use a lot of storage space) as the suggestion to use them for journals exists later on I think just removing that sentence is cleanest.

Whether SSDs are cost prohibitive for OSDs is a question for the owner of the system and changes everyday, so I think 'If' (or perhaps even 'Where') is better than 'While' (unless 'While' meant until the price comes down or they stop selling HDDs ;) )