### PR TITLE
osd: Change osd_skip_data_digest default to false and make it LEVEL_DEV

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2387,7 +2387,7 @@ std::vector<Option> get_global_options() {
 
     Option("osd_skip_data_digest", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
-    .set_description("Do not store full-object checksums if the backend (bluestore) does its own checksums.  Do not ever turn this off if it has ever been turned on."),
+    .set_description("Do not store full-object checksums if the backend (bluestore) does its own checksums.  Only usable with all BlueStore OSDs."),
 
     Option("osd_op_queue", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("wpq")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2385,9 +2385,9 @@ std::vector<Option> get_global_options() {
     .set_flag(Option::FLAG_STARTUP)
     .set_description(""),
 
-    Option("osd_skip_data_digest", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    Option("osd_skip_data_digest", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
-    .set_description(""),
+    .set_description("Do not store full-object checksums if the backend (bluestore) does its own checksums.  Do not ever turn this off if it has ever been turned on."),
 
     Option("osd_op_queue", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("wpq")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2386,7 +2386,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_skip_data_digest", Option::TYPE_BOOL, Option::LEVEL_DEV)
-    .set_default(true)
+    .set_default(false)
     .set_description("Do not store full-object checksums if the backend (bluestore) does its own checksums.  Do not ever turn this off if it has ever been turned on."),
 
     Option("osd_op_queue", Option::TYPE_STR, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
This has to be a feature bit that can only be turned on when all OSDs
are running BlueStore on the right version.  Once it is turned on a
FileStore OSD can not join the cluster.

Fixes: http://tracker.ceph.com/issues/24950