### PR TITLE
OSD: ceph-osd parent process need to restart log service after fork

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -195,6 +195,7 @@ int main(int argc, const char **argv)
       return r;
     }
     if (forker.is_parent()) {
+      g_ceph_context->_log->start();
       if (forker.parent_wait(err) != 0) {
         return -ENXIO;
       }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/24956
Signed-off-by: redickwang <redickwang@tencent.com>

osd: ceph-osd parent process need to restart log service after fork
log service not started, osd will hang on ceph::logging::Log::submit_entry  when the option log_max_new in ceph.conf set to zero

