### PR TITLE
vstart_runner: pass additional argument to FuseMount()

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -390,7 +390,7 @@ def safe_kill(pid):
 
 class LocalFuseMount(FuseMount):
     def __init__(self, test_dir, client_id):
-        super(LocalFuseMount, self).__init__(None, test_dir, client_id, LocalRemote())
+        super(LocalFuseMount, self).__init__(None, None, test_dir, client_id, LocalRemote())
 
     @property
     def config_path(self):


### PR DESCRIPTION
Commit 441a2730e5 adds an additional context argument to
fuse_mount.FuseMount. vstart_runner uses LocalFuseMount
by subclassing fuse_mount.FuseMount but does not pass the
context agrument resulting in the following error:

```
Traceback (most recent call last):
  File "/work/ceph/qa/tasks/vstart_runner.py", line 1058, in <module>
    exec_test()
  File "/work/ceph/qa/tasks/vstart_runner.py", line 915, in exec_test
    mount = LocalFuseMount(test_dir, client_id)
  File "/work/ceph/qa/tasks/vstart_runner.py", line 393, in __init__
    super(LocalFuseMount, self).__init__(None, test_dir, client_id, LocalRemote())
TypeError: __init__() takes exactly 6 arguments (5 given)
```

Signed-off-by: Venky Shankar <vshankar@redhat.com>