### PR TITLE
 librbd: ensure exclusive lock acquired when removing sync point snapshots

### DIFF
--- a/src/librbd/mirror/DisableRequest.cc
+++ b/src/librbd/mirror/DisableRequest.cc
@@ -314,10 +314,9 @@ void DisableRequest<I>::send_remove_snap(const std::string &client_id,
     &DisableRequest<I>::handle_remove_snap, client_id);
 
   ctx = new FunctionContext([this, snap_namespace, snap_name, ctx](int r) {
-      RWLock::WLocker owner_locker(m_image_ctx->owner_lock);
-      m_image_ctx->operations->execute_snap_remove(snap_namespace,
-						   snap_name.c_str(),
-						   ctx);
+      m_image_ctx->operations->snap_remove(snap_namespace,
+                                           snap_name.c_str(),
+                                           ctx);
     });
 
   m_image_ctx->op_work_queue->queue(ctx, 0);

--- a/src/test/librbd/mirror/test_mock_DisableRequest.cc
+++ b/src/test/librbd/mirror/test_mock_DisableRequest.cc
@@ -195,7 +195,7 @@ public:
 
   void expect_snap_remove(MockTestImageCtx &mock_image_ctx,
                           const std::string &snap_name, int r) {
-    EXPECT_CALL(*mock_image_ctx.operations, execute_snap_remove(_, StrEq(snap_name), _))
+    EXPECT_CALL(*mock_image_ctx.operations, snap_remove(_, StrEq(snap_name), _))
       .WillOnce(WithArg<2>(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue)));
   }
 


### PR DESCRIPTION
The lock is needed if the mirror disable request wants to purge
sync point snapshots.

Fixes: http://tracker.ceph.com/issues/24898
Signed-off-by: Mykola Golub <mgolub@suse.com>