### PR TITLE
osd: limit pg log length under all circumstances

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -908,8 +908,11 @@ void ECBackend::handle_sub_write(
   }
   clear_temp_objs(op.temp_removed);
   dout(30) << __func__ << " missing before " << get_parent()->get_log().get_missing().get_items() << dendl;
+  // flag set to true during async recovery
+  bool async = false;
   pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
   if (pmissing.is_missing(op.soid)) {
+    async = true;
     dout(30) << __func__ << " is_missing " << pmissing.is_missing(op.soid) << dendl;
     for (auto &&e: op.log_entries) {
       dout(30) << " add_next_event entry " << e << dendl;
@@ -923,7 +926,8 @@ void ECBackend::handle_sub_write(
     op.trim_to,
     op.roll_forward_to,
     !op.backfill_or_async_recovery,
-    localt);
+    localt,
+    async);
 
   if (!get_parent()->pg_is_undersized() &&
       (unsigned)get_parent()->whoami_shard().shard >=

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3626,7 +3626,8 @@ void PG::append_log(
   eversion_t trim_to,
   eversion_t roll_forward_to,
   ObjectStore::Transaction &t,
-  bool transaction_applied)
+  bool transaction_applied,
+  bool async)
 {
   if (transaction_applied)
     update_snap_map(logv, t);
@@ -3681,7 +3682,12 @@ void PG::append_log(
 
   dout(10) << __func__ << " approx pg log length =  "
            << pg_log.get_log().approx_size() << dendl;
-  pg_log.trim(trim_to, info);
+  dout(10) << __func__ << " transaction_applied = "
+           << transaction_applied << dendl;
+  if (!transaction_applied || async)
+    dout(10) << __func__ << " " << pg_whoami
+             << " is async_recovery or backfill target" << dendl;
+  pg_log.trim(trim_to, info, transaction_applied, async);
 
   // update the local pg, pg log
   dirty_info = true;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3679,6 +3679,8 @@ void PG::append_log(
     last_rollback_info_trimmed_to_applied = roll_forward_to;
   }
 
+  dout(10) << __func__ << " approx pg log length =  "
+           << pg_log.get_log().approx_size() << dendl;
   pg_log.trim(trim_to, info);
 
   // update the local pg, pg log

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2884,7 +2884,8 @@ protected:
     eversion_t trim_to,
     eversion_t roll_forward_to,
     ObjectStore::Transaction &t,
-    bool transaction_applied = true);
+    bool transaction_applied = true,
+    bool async = false);
   bool check_log_for_corruption(ObjectStore *store);
   void trim_log();
 

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -234,7 +234,8 @@ typedef std::shared_ptr<const OSDMap> OSDMapRef;
        const eversion_t &trim_to,
        const eversion_t &roll_forward_to,
        bool transaction_applied,
-       ObjectStore::Transaction &t) = 0;
+       ObjectStore::Transaction &t,
+       bool async = false) = 0;
 
      virtual void pgb_set_object_snap_mapping(
        const hobject_t &soid,

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -168,8 +168,10 @@ void PGLog::trim(
   dout(10) << __func__ << " proposed trim_to = " << trim_to << dendl;
   // trim?
   if (trim_to > log.tail) {
+    dout(10) << __func__ << " missing = " << missing.num_missing() << dendl;
     // Don't assert for async_recovery_targets or backfill_targets
-    if (transaction_applied && !async)
+    // or whenever there are missing items
+    if (transaction_applied && !async && (missing.num_missing() == 0))
       assert(trim_to <= info.last_complete);
 
     dout(10) << "trim " << log << " to " << trim_to << dendl;

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -59,6 +59,7 @@ void PGLog::IndexedLog::trim(
   }
 
   assert(s <= can_rollback_to);
+  generic_dout(0) << " complete_to " << complete_to->version << dendl;
 
   auto earliest_dup_version =
     log.rbegin()->version.version < cct->_conf->osd_pg_log_dups_tracked
@@ -92,12 +93,23 @@ void PGLog::IndexedLog::trim(
       }
     }
 
+    bool reset_complete_to = false;
+    // we are trimming past complete_to, so reset complete_to
+    if (e.version >= complete_to->version)
+      reset_complete_to = true;
     if (rollback_info_trimmed_to_riter == log.rend() ||
 	e.version == rollback_info_trimmed_to_riter->version) {
       log.pop_front();
       rollback_info_trimmed_to_riter = log.rend();
     } else {
       log.pop_front();
+    }
+
+    // reset complete_to to the beginning of the log
+    if (reset_complete_to) {
+      generic_dout(0) << " moving complete_to " << " to "
+                      << log.begin()->version << dendl;
+      complete_to = log.begin();
     }
   }
 
@@ -177,6 +189,7 @@ void PGLog::trim(
     dout(10) << "trim " << log << " to " << trim_to << dendl;
     log.trim(cct, trim_to, &trimmed, &trimmed_dups, &write_from_dups);
     info.log_tail = log.tail;
+    dout(10) << " after trim complete_to " << log.complete_to->version << dendl;
   }
 }
 

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -161,13 +161,16 @@ void PGLog::clear_info_log(
 
 void PGLog::trim(
   eversion_t trim_to,
-  pg_info_t &info)
+  pg_info_t &info,
+  bool transaction_applied,
+  bool async)
 {
   dout(10) << __func__ << " proposed trim_to = " << trim_to << dendl;
   // trim?
   if (trim_to > log.tail) {
-    // We shouldn't be trimming the log past last_complete
-    assert(trim_to <= info.last_complete);
+    // Don't assert for async_recovery_targets or backfill_targets
+    if (transaction_applied && !async)
+      assert(trim_to <= info.last_complete);
 
     dout(10) << "trim " << log << " to " << trim_to << dendl;
     log.trim(cct, trim_to, &trimmed, &trimmed_dups, &write_from_dups);

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -50,16 +50,8 @@ void PGLog::IndexedLog::trim(
   set<string>* trimmed_dups,
   eversion_t *write_from_dups)
 {
-  if (complete_to != log.end() &&
-      complete_to->version <= s) {
-    generic_derr << " bad trim to " << s << " when complete_to is "
-		 << complete_to->version
-		 << " on " << *this << dendl;
-    assert(0 == "out of order trim");
-  }
-
   assert(s <= can_rollback_to);
-  generic_dout(0) << " complete_to " << complete_to->version << dendl;
+  generic_dout(20) << " complete_to " << complete_to->version << dendl;
 
   auto earliest_dup_version =
     log.rbegin()->version.version < cct->_conf->osd_pg_log_dups_tracked

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -163,6 +163,7 @@ void PGLog::trim(
   eversion_t trim_to,
   pg_info_t &info)
 {
+  dout(10) << __func__ << " proposed trim_to = " << trim_to << dendl;
   // trim?
   if (trim_to > log.tail) {
     // We shouldn't be trimming the log past last_complete

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -704,7 +704,9 @@ public:
 
   void trim(
     eversion_t trim_to,
-    pg_info_t &info);
+    pg_info_t &info,
+    bool transaction_applied = true,
+    bool async = false);
 
   void roll_forward_to(
     eversion_t roll_forward_to,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11488,6 +11488,8 @@ void PrimaryLogPG::_applied_recovered_object_replica()
 void PrimaryLogPG::recover_got(hobject_t oid, eversion_t v)
 {
   dout(10) << "got missing " << oid << " v " << v << dendl;
+  dout(10) << __func__ << " complete_to "
+           << pg_log.get_log().complete_to->version << dendl;
   pg_log.recover_got(oid, v, info);
   if (pg_log.get_log().complete_to != pg_log.get_log().log.end()) {
     dout(10) << "last_complete now " << info.last_complete

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1625,15 +1625,18 @@ void PrimaryLogPG::calc_trim_to()
 		 PG_STATE_BACKFILL_TOOFULL)) {
     target = cct->_conf->osd_max_pg_log_entries;
   }
+  // limit pg log trimming up to the head of the log
+  eversion_t limit = pg_log.get_head();
+  dout(10) << __func__ << " limit = " << limit << dendl;
 
-  eversion_t limit = std::min(
-    min_last_complete_ondisk,
-    pg_log.get_can_rollback_to());
   if (limit != eversion_t() &&
       limit != pg_trim_to &&
       pg_log.get_log().approx_size() > target) {
+    dout(10) << __func__ << " approx pg log length =  "
+             << pg_log.get_log().approx_size() << dendl;
     size_t num_to_trim = std::min(pg_log.get_log().approx_size() - target,
 				  cct->_conf->osd_pg_log_trim_max);
+    dout(10) << __func__ << " num_to_trim =  " << num_to_trim << dendl;
     if (num_to_trim < cct->_conf->osd_pg_log_trim_min &&
 	cct->_conf->osd_pg_log_trim_max >= cct->_conf->osd_pg_log_trim_min) {
       return;
@@ -1643,16 +1646,15 @@ void PrimaryLogPG::calc_trim_to()
     for (size_t i = 0; i < num_to_trim; ++i) {
       new_trim_to = it->version;
       ++it;
-      if (new_trim_to > limit) {
+      if (new_trim_to >= limit) {
 	new_trim_to = limit;
-	dout(10) << "calc_trim_to trimming to min_last_complete_ondisk" << dendl;
+        dout(10) << "calc_trim_to trimming to limit: " << limit << dendl;
 	break;
       }
     }
     dout(10) << "calc_trim_to " << pg_trim_to << " -> " << new_trim_to << dendl;
     pg_trim_to = new_trim_to;
     assert(pg_trim_to <= pg_log.get_head());
-    assert(pg_trim_to <= min_last_complete_ondisk);
   }
 }
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -418,7 +418,8 @@ public:
     const eversion_t &trim_to,
     const eversion_t &roll_forward_to,
     bool transaction_applied,
-    ObjectStore::Transaction &t) override {
+    ObjectStore::Transaction &t,
+    bool async = false) override {
     if (hset_history) {
       info.hit_set = *hset_history;
     }

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -423,7 +423,7 @@ public:
     if (hset_history) {
       info.hit_set = *hset_history;
     }
-    append_log(logv, trim_to, roll_forward_to, t, transaction_applied);
+    append_log(logv, trim_to, roll_forward_to, t, transaction_applied, async);
   }
 
   void op_applied(const eversion_t &applied_version) override;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1058,8 +1058,11 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
     update_snaps = true;
   }
 
+  // flag set to true during async recovery
+  bool async = false;
   pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
   if (pmissing.is_missing(soid)) {
+    async = true;
     dout(30) << __func__ << " is_missing " << pmissing.is_missing(soid) << dendl;
     for (auto &&e: log) {
       dout(30) << " add_next_event entry " << e << dendl;
@@ -1075,7 +1078,8 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
     m->pg_trim_to,
     m->pg_roll_forward_to,
     update_snaps,
-    rm->localt);
+    rm->localt,
+    async);
 
   rm->opt.register_on_commit(
     parent->bless_context(


### PR DESCRIPTION
Before this, `osd_max_pg_log_entries` was not a hard limit for the pg log length. This PR puts a hard cap on the number of log entries (and thus memory consumed) in the pg log, even during recovery and backfill.

Fixes: https://tracker.ceph.com/issues/23979
Signed-off-by: Neha Ojha <nojha@redhat.com>