### PR TITLE
mimic: tools: ceph-detect-init: support SLED

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -92,7 +92,7 @@ def _normalized_distro_name(distro):
         return 'redhat'
     elif distro.startswith(('scientific', 'scientific linux')):
         return 'scientific'
-    elif distro.startswith(('suse', 'opensuse', 'sles')):
+    elif distro.startswith(('suse', 'opensuse', 'sles', 'sled')):
         return 'suse'
     elif distro.startswith('centos'):
         return 'centos'

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -422,7 +422,7 @@ HOME_URL="https://www.opensuse.org/"
         self.assertEqual('42.3', ceph_detect_init._extract_from_os_release(
                          os_release_opensuse_42_3, 'VERSION_ID'))
         os_release_opensuse_15_0 = """
-ME="openSUSE Leap"
+NAME="openSUSE Leap"
 VERSION="15.0"
 ID="opensuse-leap"
 ID_LIKE="suse opensuse"

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -451,6 +451,34 @@ CPE_NAME="cpe:/o:suse:sles:12:sp3"
                          os_release_sles_12_3, 'ID'))
         self.assertEqual('12.3', ceph_detect_init._extract_from_os_release(
                          os_release_sles_12_3, 'VERSION_ID'))
+        os_release_sled_15 = """
+NAME="SLED"
+VERSION="15"
+VERSION_ID="15"
+PRETTY_NAME="SUSE Linux Enterprise Desktop 15"
+ID="sled"
+ID_LIKE="suse"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sled:15"
+"""
+        self.assertEqual('sled', ceph_detect_init._extract_from_os_release(
+                         os_release_sled_15, 'ID'))
+        self.assertEqual('15', ceph_detect_init._extract_from_os_release(
+                         os_release_sled_15, 'VERSION_ID'))
+        os_release_sles_15 = """
+NAME="SLES"
+VERSION="15"
+VERSION_ID="15"
+PRETTY_NAME="SUSE Linux Enterprise Server 15"
+ID="sles"
+ID_LIKE="suse"
+ANSI_COLOR="0;32"
+CPE_NAME="cpe:/o:suse:sles:15"
+"""
+        self.assertEqual('sles', ceph_detect_init._extract_from_os_release(
+                         os_release_sles_15, 'ID'))
+        self.assertEqual('15', ceph_detect_init._extract_from_os_release(
+                         os_release_sles_15, 'VERSION_ID'))
         os_release_opensuse_tumbleweed_old_style = """
 NAME="openSUSE Tumbleweed"
 # VERSION="20170502"


### PR DESCRIPTION
SUSE Linux Enterprise (SLE) comes in two variants: SLES (for servers) and SLED
(for desktops). This commit adds support for the desktop variant as well as
adding test cases for SLE 15.
