### PR TITLE
mgr/dashboard: Remove angular build progress logs during cmake

### DIFF
--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -76,9 +76,9 @@ file(
   frontend/src/*/*/*/*/*/*.html)
 
 if(NOT CMAKE_BUILD_TYPE STREQUAL Debug)
-  set(npm_command npm run build -- --prod)
+  set(npm_command npm run build -- --prod --progress=false)
 else()
-  set(npm_command npm run build)
+  set(npm_command npm run build -- --progress=false)
 endif()
 
 add_npm_command(


### PR DESCRIPTION
Currently Angular CLI is polluting the jenkins logs, by inserting a new line
each time the build process is updated.
With this change Angular Cli will only output the necessary information about
the start and end of the build.

before: 
![image](https://user-images.githubusercontent.com/399326/43070677-63ef8802-8e68-11e8-8858-5e74c5e07e01.png)
after:
![image](https://user-images.githubusercontent.com/399326/43071170-d526a130-8e69-11e8-8967-49874216e0a7.png)