### PR TITLE
ceph-volume tests/functional run lvm list after OSD provisioning

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
@@ -81,3 +81,8 @@
       command: "ceph-volume lvm activate --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
@@ -65,3 +65,8 @@
       command: "ceph-volume lvm activate --filestore --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
@@ -55,3 +55,8 @@
       command: "ceph-volume lvm activate --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
@@ -67,3 +67,8 @@
       command: "ceph-volume lvm activate --filestore --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
@@ -81,3 +81,8 @@
       command: "ceph-volume lvm activate --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
@@ -65,3 +65,8 @@
       command: "ceph-volume lvm activate --filestore --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1


### PR DESCRIPTION
Needed to track down multiple `lvm list` failures. Everything will turn red after merging this one because it will trigger failures

Fixes: http://tracker.ceph.com/issues/24961