### PR TITLE
config: drop config_proxy::lock when invoking config observer

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1048,8 +1048,11 @@ void MDSDaemon::suicide()
 
   //because add_observer is called after set_up_admin_socket
   //so we can use asok_hook to avoid assert in the remove_observer
-  if (asok_hook != NULL)
+  if (asok_hook != NULL) {
+    mds_lock.Unlock();
     g_conf().remove_observer(this);
+    mds_lock.Lock();
+  }
 
   clean_up_admin_socket();
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -941,7 +941,9 @@ void Monitor::shutdown()
 
   state = STATE_SHUTDOWN;
 
+  lock.Unlock();
   g_conf().remove_observer(this);
+  lock.Lock();
 
   if (admin_hook) {
     cct->get_admin_socket()->unregister_commands(admin_hook);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3650,7 +3650,10 @@ int OSD::shutdown()
 #ifdef PG_DEBUG_REFS
   service.dump_live_pgids();
 #endif
+
+  osd_lock.Unlock();
   cct->_conf.remove_observer(this);
+  osd_lock.Lock();
 
   service.meta_ch.reset();
 
@@ -9515,6 +9518,7 @@ const char** OSD::get_tracked_conf_keys() const
 void OSD::handle_conf_change(const ConfigProxy& conf,
 			     const std::set <std::string> &changed)
 {
+  Mutex::Locker l(osd_lock);
   if (changed.count("osd_max_backfills")) {
     service.local_reserver.set_max(cct->_conf->osd_max_backfills);
     service.remote_reserver.set_max(cct->_conf->osd_max_backfills);

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -404,7 +404,9 @@ void Objecter::shutdown()
 
   initialized = false;
 
+  wl.unlock();
   cct->_conf.remove_observer(this);
+  wl.lock();
 
   map<int,OSDSession*>::iterator p;
   while (!osd_sessions.empty()) {


### PR DESCRIPTION
This is WIP -- sending out for early reviews and discussions. For details of the issue see: http://tracker.ceph.com/issues/24823 (basically locking order deadlock in the MDS on `config set` via admin socket during active IO).

This PR invokes observer callback without holding `md_config_impl::lock` (before falling back in doing it this way I tried to pass the lock reference (`std::unique_lock`*) to the observer callback so as to acquire locks in the MDS in a sane order, but I'm not sure if that would be the preferred way).

I'm not sure what else would break due to this (`config.h` mentions that the lock needs to be held when calling config observers).

(*): commit a0a4c483bc1 mentions about this

Signed-off-by: Venky Shankar <vshankar@redhat.com>