### PR TITLE
luminous: ceph-volume: unmount lvs correctly before zapping

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -70,12 +70,15 @@ class Zap(object):
         dmcrypt = False
         dmcrypt_uuid = None
         if lv:
-            osd_path = "/var/lib/ceph/osd/{}-{}".format(lv.tags['ceph.cluster_name'], lv.tags['ceph.osd_id'])
+            if lv.tags.get('ceph.cluster_name') and lv.tags.get('ceph.osd_id'):
+                lv_path = "/var/lib/ceph/osd/{}-{}".format(lv.tags['ceph.cluster_name'], lv.tags['ceph.osd_id'])
+            else:
+                lv_path = lv.path
             dmcrypt_uuid = lv.lv_uuid
             dmcrypt = lv.encrypted
-            if system.path_is_mounted(osd_path):
-                mlogger.info("Unmounting %s", osd_path)
-                system.unmount(osd_path)
+            if system.path_is_mounted(lv_path):
+                mlogger.info("Unmounting %s", lv_path)
+                system.unmount(lv_path)
         else:
             # we're most likely dealing with a partition here, check to
             # see if it was encrypted


### PR DESCRIPTION
If the lv found does not include the meatadata to construct an osd path,
then we should try to unmount it's path instead.

Fixes: http://tracker.ceph.com/issues/24796

Signed-off-by: Andrew Schoen <aschoen@redhat.com>
(cherry picked from commit 5b175a5bb68264b80c00cb4f04026a4d19ca20ad)

backport of #23117