### PR TITLE
librbd: deep-copy should not write to objects that cannot exist

### DIFF
--- a/src/librbd/deep_copy/ObjectCopyRequest.h
+++ b/src/librbd/deep_copy/ObjectCopyRequest.h
@@ -161,6 +161,7 @@ private:
   std::map<librados::snap_t, interval_set<uint64_t>> m_zero_interval;
   std::map<librados::snap_t, interval_set<uint64_t>> m_dst_zero_interval;
   std::map<librados::snap_t, uint8_t> m_dst_object_state;
+  std::map<librados::snap_t, bool> m_dst_object_may_exist;
   bufferlist m_read_from_parent_data;
 
   void send_list_snaps();
@@ -187,6 +188,8 @@ private:
   void compute_read_from_parent_ops(io::Extents *image_extents);
   void merge_write_ops();
   void compute_zero_ops();
+
+  void compute_dst_object_may_exist();
 
   void finish(int r);
 };

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -147,6 +147,13 @@ public:
     mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
   }
 
+  void expect_get_object_count(librbd::MockImageCtx& mock_image_ctx) {
+    EXPECT_CALL(mock_image_ctx, get_object_count(_))
+      .WillRepeatedly(Invoke([&mock_image_ctx](librados::snap_t snap_id) {
+          return mock_image_ctx.image_ctx->get_object_count(snap_id);
+        }));
+  }
+
   void expect_test_features(librbd::MockImageCtx &mock_image_ctx) {
     EXPECT_CALL(mock_image_ctx, test_features(_))
       .WillRepeatedly(WithArg<0>(Invoke([&mock_image_ctx](uint64_t features) {
@@ -198,6 +205,7 @@ public:
       librbd::MockTestImageCtx &mock_src_image_ctx,
       librbd::MockTestImageCtx &mock_dst_image_ctx, Context *on_finish) {
     expect_get_object_name(mock_dst_image_ctx);
+    expect_get_object_count(mock_dst_image_ctx);
     return new MockObjectCopyRequest(&mock_src_image_ctx, nullptr,
                                      &mock_dst_image_ctx, m_snap_map, 0, false,
                                      on_finish);


### PR DESCRIPTION
If an image has a snapshot and is subsequently shrunk, ensure that
discard ops are not sent to the deep-copy objects beyond the bounds
of the image at a given snapshot/HEAD. Only a remove op should be
expected in such cases.

Fixes: http://tracker.ceph.com/issues/25000
Signed-off-by: Jason Dillaman <dillaman@redhat.com>