### PR TITLE
mimic: tests: osd sends op_reply out of order

### DIFF
--- a/qa/suites/powercycle/osd/tasks/cfuse_workunit_suites_fsync.yaml
+++ b/qa/suites/powercycle/osd/tasks/cfuse_workunit_suites_fsync.yaml
@@ -1,3 +1,9 @@
+overrides:
+  ceph:
+    conf:
+      global:
+        osd_pg_log_dups_tracked: 10000
+
 tasks:
 - ceph-fuse:
 - workunit:


### PR DESCRIPTION
http://tracker.ceph.com/issues/25010