### PR TITLE
[RFC] osd: ec partial stripe reads

### DIFF
--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -365,3 +365,7 @@ int ErasureCode::decode_concat(const map<int, bufferlist> &chunks,
   }
   return r;
 }
+
+bool ErasureCode::is_systematic() {
+  return true;
+}

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -120,6 +120,8 @@ namespace ceph {
     int decode_concat(const std::map<int, bufferlist> &chunks,
 			      bufferlist *decoded) override;
 
+    virtual bool is_systematic();
+
   protected:
     int parse(const ErasureCodeProfile &profile,
 	      std::ostream *ss);

--- a/src/erasure-code/ErasureCodeInterface.h
+++ b/src/erasure-code/ErasureCodeInterface.h
@@ -459,6 +459,11 @@ namespace ceph {
      */
     virtual int decode_concat(const std::map<int, bufferlist> &chunks,
 			      bufferlist *decoded) = 0;
+
+    /**
+     * @return **true** if the EC plugin's data placement is systematic.
+     */
+    virtual bool is_systematic() = 0;
   };
 
   typedef std::shared_ptr<ErasureCodeInterface> ErasureCodeInterfaceRef;

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -2413,6 +2413,10 @@ bool ECBackend::is_partial_read_avail(
     set<pg_shard_t> error_shards;
     set<int> data_shards;
 
+    if (!ec_impl->is_systematic()) {
+      return false;
+    }
+
     get_want_to_read_shards(&data_shards);
 
     get_all_avail_shards(hoid, error_shards, have, shards, for_recovery);

--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -38,7 +38,6 @@ int ECUtil::decode(
     bufferlist bl;
     int r = ec_impl->decode_concat(chunks, &bl);
     assert(r == 0);
-    assert(bl.length() == sinfo.get_stripe_width());
     out->claim_append(bl);
   }
   return 0;

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -66,15 +66,26 @@ public:
   }
   std::pair<uint64_t, uint64_t> aligned_offset_len_to_chunk(
     std::pair<uint64_t, uint64_t> in) const {
+    // we need to align to stripe again to deal with partial chunk read.
+    std::pair<uint64_t, uint64_t> tmp = offset_len_to_stripe_bounds(in);
     return std::make_pair(
-      aligned_logical_offset_to_chunk_offset(in.first),
-      aligned_logical_offset_to_chunk_offset(in.second));
+      aligned_logical_offset_to_chunk_offset(tmp.first),
+      aligned_logical_offset_to_chunk_offset(tmp.second));
   }
   std::pair<uint64_t, uint64_t> offset_len_to_stripe_bounds(
     std::pair<uint64_t, uint64_t> in) const {
     uint64_t off = logical_to_prev_stripe_offset(in.first);
     uint64_t len = logical_to_next_stripe_offset(
       (in.first - off) + in.second);
+    return std::make_pair(off, len);
+  }
+  std::pair<uint64_t, uint64_t> offset_len_to_chunk_bounds(
+    std::pair<uint64_t, uint64_t> in) const {
+    uint64_t off = in.first - (in.first % chunk_size);
+    uint64_t tmp_len = (in.first - off) + in.second;
+    uint64_t len = ((tmp_len % chunk_size) ?
+      (tmp_len - (tmp_len % chunk_size) + chunk_size) :
+      tmp_len);
     return std::make_pair(off, len);
   }
 };

--- a/src/test/erasure-code/TestErasureCodeExample.cc
+++ b/src/test/erasure-code/TestErasureCodeExample.cc
@@ -194,10 +194,14 @@ TEST(ErasureCodeExample, decode)
   bufferlist usable;
   usable.substr_of(out, 0, in.length());
   EXPECT_TRUE(usable == in);
+  // partial chunk decode
+  map<int, bufferlist> partial_decode;
+  partial_decode[0] = encoded[0];
+  EXPECT_EQ(0, example.decode_concat(partial_decode, &out));
 
   // cannot recover
   map<int, bufferlist> degraded;  
-  degraded[0] = encoded[0];
+  degraded[2] = encoded[2];
   EXPECT_EQ(-ERANGE, example.decode_concat(degraded, &out));
 }
 


### PR DESCRIPTION
If a read is limited at one stripe and all the original data
chunks are available. We will only read the chunks that contain
range <off, len> to reduce the read latency and bandwidth.

If the read is fast read or not all the original data chunks are
available we will do a normal read.

This idea comes from http://permalink.gmane.org/gmane.comp.file-systems.ceph.devel/23872.

Signed-off-by: Xiaofei Cui <cuixiaofei@sangfor.com.cn>