### PR TITLE
ceph-volume process.call with stdin in Python 3 fix

### DIFF
--- a/src/ceph-volume/ceph_volume/process.py
+++ b/src/ceph-volume/ceph_volume/process.py
@@ -52,7 +52,10 @@ def log_descriptors(reads, process, terminal_logging):
     for descriptor in reads:
         descriptor_name = descriptor_names[descriptor]
         try:
-            log_output(descriptor_name, read(descriptor, 1024), terminal_logging, True)
+            message = read(descriptor, 1024)
+            if not isinstance(message, str):
+                message = message.decode('utf-8')
+            log_output(descriptor_name, message, terminal_logging, True)
         except (IOError, OSError):
             # nothing else to log
             pass

--- a/src/ceph-volume/ceph_volume/process.py
+++ b/src/ceph-volume/ceph_volume/process.py
@@ -196,8 +196,11 @@ def call(command, **kw):
         close_fds=True,
         **kw
     )
+
     if stdin:
-        stdout_stream, stderr_stream = process.communicate(stdin)
+        stdout_stream, stderr_stream = process.communicate(
+            stdin.encode(encoding='utf-8', errors='ignore')
+        )
     else:
         stdout_stream = process.stdout.read()
         stderr_stream = process.stderr.read()

--- a/src/ceph-volume/ceph_volume/tests/test_process.py
+++ b/src/ceph-volume/ceph_volume/tests/test_process.py
@@ -75,3 +75,9 @@ class TestFunctionalCall(object):
 
     def test_unicode_encoding(self):
         process.call(['echo', u'\xd0'])
+
+
+class TestFunctionalRun(object):
+
+    def test_log_descriptors(self):
+        process.run(['ls', '-l'])

--- a/src/ceph-volume/ceph_volume/tests/test_process.py
+++ b/src/ceph-volume/ceph_volume/tests/test_process.py
@@ -66,3 +66,12 @@ class TestCall(object):
         assert 'ls' in log_lines
         assert 'stderr' in log_lines
         assert out == ''
+
+
+class TestFunctionalCall(object):
+
+    def test_stdin(self):
+        process.call(['xargs', 'ls'], stdin="echo '/'")
+
+    def test_unicode_encoding(self):
+        process.call(['echo', u'\xd0'])


### PR DESCRIPTION
Adds a couple of more functional tests for `process.call`, should expand these in the future. For now they caught the stdin problem in Python 3, and verified the fix

Fixes http://tracker.ceph.com/issues/24993