### PR TITLE
ceph-volume tests/functional run lvm list after OSD provisioning

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
@@ -81,3 +81,8 @@
       command: "ceph-volume lvm activate --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
@@ -65,3 +65,8 @@
       command: "ceph-volume lvm activate --filestore --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
@@ -55,3 +55,8 @@
       command: "ceph-volume lvm activate --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
@@ -67,3 +67,8 @@
       command: "ceph-volume lvm activate --filestore --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
@@ -81,3 +81,8 @@
       command: "ceph-volume lvm activate --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
@@ -65,3 +65,8 @@
       command: "ceph-volume lvm activate --filestore --all"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: list all OSDs
+      command: "ceph-volume lvm list"
+      environment:
+        CEPH_VOLUME_DEBUG: 1


### PR DESCRIPTION
Backport of https://github.com/ceph/ceph/pull/23116

Fixes: http://tracker.ceph.com/issues/24961

Signed-off-by: Alfredo Deza <adeza@redhat.com>
(cherry picked from commit e01fb206d67f26724f3b03e4b22f5ba6eea22207)