### PR TITLE
luminous: ceph-volume lvm.listing only include devices if they exist

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -49,8 +49,15 @@ def pretty_report(report):
                         value=value
                     )
                 )
-            output.append(
-                device_metadata_item_template.format(tag_name='devices', value=','.join(device['devices'])))
+            if not device.get('devices'):
+                continue
+            else:
+                output.append(
+                    device_metadata_item_template.format(
+                        tag_name='devices',
+                        value=','.join(device['devices'])
+                    )
+                )
 
     print(''.join(output))
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/24952
Backport of: https://github.com/ceph/ceph/pull/23129

Signed-off-by: Alfredo Deza <adeza@redhat.com>
(cherry picked from commit 37565f81634f47c389926d300ed5f92b223bddea)