### PR TITLE
example/librados: remove dependency on Boost system library

### DIFF
--- a/examples/librados/Makefile
+++ b/examples/librados/Makefile
@@ -1,7 +1,7 @@
 
 CXX?=g++
 CXX_FLAGS?=-std=c++11 -Wall -Wextra -Werror -g
-CXX_LIBS?=-lboost_system -lrados -lradosstriper
+CXX_LIBS?=-lrados -lradosstriper
 CXX_INC?=$(LOCAL_LIBRADOS_INC)
 CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS)
 


### PR DESCRIPTION
109e6022beb0920f2a4746bd8c541e975494f251 introduced "-lboost_system" into
example/librados/Makefile but the Boost system library is no longer required to
compile and link hello_world.cc.

Fixes: http://tracker.ceph.com/issues/25054