### PR TITLE
doc/rados/operations/pg-states: fix PG state names, part 2

### DIFF
--- a/doc/rados/operations/pg-states.rst
+++ b/doc/rados/operations/pg-states.rst
@@ -106,3 +106,7 @@ map is ``active + clean``.
 
 *snaptrim_error*
   Error stopped trimming snaps.
+
+*unknown*
+  The ceph-mgr hasn't yet received any information about the PG's state from an
+  OSD since mgr started up.

--- a/doc/rados/operations/pg-states.rst
+++ b/doc/rados/operations/pg-states.rst
@@ -101,8 +101,8 @@ map is ``active + clean``.
 *snaptrim*
   Trimming snaps.
 
-*snaptrim_Wait*
+*snaptrim_wait*
   Queued to trim snaps.
 
-*snaptrim_Error*
+*snaptrim_error*
   Error stopped trimming snaps.


### PR DESCRIPTION
Follow-up on 7f8b40fc4664856998d204adcf092c16cbc933dd

See @jcsp review https://github.com/ceph/ceph/pull/21520#pullrequestreview-114316433

References: https://tracker.ceph.com/issues/24923
Signed-off-by: Nathan Cutler <ncutler@suse.com>