### PR TITLE
tools/rbd: assert(g_ceph_context) not g_conf

### DIFF
--- a/src/tools/rbd/action/Create.cc
+++ b/src/tools/rbd/action/Create.cc
@@ -180,7 +180,7 @@ int thick_write(const std::string &image_name,librados::IoCtx &io_ctx,
 
   // To prevent writesame from discarding data, thick_write sets
   // the rbd_discard_on_zeroed_write_same option to false.
-  assert(g_conf != nullptr);
+  assert(g_ceph_context != nullptr);
   r = g_conf().set_val("rbd_discard_on_zeroed_write_same", "false");
   assert(r == 0);
   r = utils::open_image(io_ctx, image_name, false, &image);


### PR DESCRIPTION
see also 813cd5d5910c266c076d38277eddf32d908d5ae3

Signed-off-by: Kefu Chai <kchai@redhat.com>