### PR TITLE
mimic: build/ops: install-deps.sh fails on newest openSUSE Leap

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -256,7 +256,7 @@ else
 	fi
         ! grep -q -i error: $DIR/yum-builddep.out || exit 1
         ;;
-    opensuse|suse|sles|opensuse-tumbleweed)
+    opensuse*|suse|sles)
         echo "Using zypper to install dependencies"
         zypp_install="zypper --gpg-auto-import-keys --non-interactive install --no-recommends"
         $SUDO $zypp_install lsb-release systemd-rpm-macros


### PR DESCRIPTION
http://tracker.ceph.com/issues/25065