### PR TITLE
luminous: build/ops: install-deps.sh fails on newest openSUSE Leap

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -187,7 +187,7 @@ else
         $SUDO $builddepcmd $DIR/ceph.spec 2>&1 | tee $DIR/yum-builddep.out
         ! grep -q -i error: $DIR/yum-builddep.out || exit 1
         ;;
-    opensuse|suse|sles)
+    opensuse*|suse|sles)
         echo "Using zypper to install dependencies"
         $SUDO zypper --gpg-auto-import-keys --non-interactive install lsb-release systemd-rpm-macros
         munge_ceph_spec_in $DIR/ceph.spec


### PR DESCRIPTION
http://tracker.ceph.com/issues/25066