### PR TITLE
ceph-volume tests/functional use Ansible 2.6

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -17,7 +17,7 @@ setenv=
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
 deps=
-  ansible==2.4.1
+  ansible~=2.6,<2.7
   testinfra==1.7.1
   pytest-xdist
   notario>=0.0.13

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -18,7 +18,7 @@ setenv=
   CEPH_VOLUME_DEBUG = 1
 deps=
   ansible~=2.6,<2.7
-  testinfra==1.7.1
+  testinfra
   pytest-xdist
   notario>=0.0.13
 changedir=


### PR DESCRIPTION
The ceph-ansible project now refuses to use 2.4 even though it works
with that version

Signed-off-by: Alfredo Deza <adeza@redhat.com>