### PR TITLE
mgr/dashboard: Fix cherrypy static content URL prefix config

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -289,7 +289,7 @@ class Module(MgrModule, SSLCherryPyConfig):
         mapper, parent_urls = generate_routes(self.url_prefix)
 
         config = {
-            '{}/'.format(self.url_prefix): {
+            self.url_prefix or '/': {
                 'tools.staticdir.on': True,
                 'tools.staticdir.dir': self.get_frontend_path(),
                 'tools.staticdir.index': 'index.html'


### PR DESCRIPTION
This PR fixes the configuration of cherrypy, when URL prefix is defined.

See issue description for more info.

Fixes: https://tracker.ceph.com/issues/25067

Signed-off-by: Ricardo Marques <rimarques@suse.com>