### PR TITLE
mds: use vector of contexts instead of list

### DIFF
--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -149,42 +149,18 @@ GenContextURef<T> make_gen_lambda_context(F &&f) {
 /*
  * finish and destroy a list of Contexts
  */
-template<class A>
-inline void finish_contexts(CephContext *cct, std::list<A*>& finished, 
-                            int result = 0)
+template<class C>
+inline void finish_contexts(CephContext *cct, C& finished, int result = 0)
 {
   if (finished.empty())
     return;
 
-  list<A*> ls;
-  ls.swap(finished); // swap out of place to avoid weird loops
-
-  if (cct)
-    mydout(cct, 10) << ls.size() << " contexts to finish with " << result << dendl;
-  typename std::list<A*>::iterator it;
-  for (it = ls.begin(); it != ls.end(); it++) {
-    A *c = *it;
-    if (cct)
-      mydout(cct,10) << "---- " << c << dendl;
-    c->complete(result);
-  }
-}
-
-inline void finish_contexts(CephContext *cct, std::vector<Context*>& finished, 
-                            int result = 0)
-{
-  if (finished.empty())
-    return;
-
-  vector<Context*> ls;
+  C ls;
   ls.swap(finished); // swap out of place to avoid weird loops
 
   if (cct)
     mydout(cct,10) << ls.size() << " contexts to finish with " << result << dendl;
-  for (std::vector<Context*>::iterator it = ls.begin(); 
-       it != ls.end(); 
-       it++) {
-    Context *c = *it;
+  for (Context* c : ls) {
     if (cct)
       mydout(cct,10) << "---- " << c << dendl;
     c->complete(result);

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -405,6 +405,10 @@ public:
     using compact_map = compact_map<k, v, cmp,                          \
 			 pool_allocator<std::pair<const k,v>>>;         \
                                                                         \
+    template<typename k,typename v, typename cmp = std::less<k> >       \
+    using compact_multimap = compact_multimap<k, v, cmp,                \
+			 pool_allocator<std::pair<const k,v>>>;         \
+                                                                        \
     template<typename k, typename cmp = std::less<k> >                  \
     using compact_set = compact_set<k, cmp, pool_allocator<k>>;         \
                                                                         \

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -29,6 +29,7 @@
 #include "include/filepath.h"
 
 #include "MDSCacheObject.h"
+#include "MDSContext.h"
 #include "SimpleLock.h"
 #include "LocalLock.h"
 #include "ScrubHeader.h"

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -32,6 +32,7 @@
 
 #include "CInode.h"
 #include "MDSCacheObject.h"
+#include "MDSContext.h"
 
 class CDentry;
 class MDCache;
@@ -501,8 +502,8 @@ public:
 
 
 public:
-  void split(int bits, std::list<CDir*>& subs, list<MDSInternalContextBase*>& waiters, bool replay);
-  void merge(std::list<CDir*>& subs, std::list<MDSInternalContextBase*>& waiters, bool replay);
+  void split(int bits, std::list<CDir*>& subs, MDSInternalContextBase::vec& waiters, bool replay);
+  void merge(std::list<CDir*>& subs, MDSInternalContextBase::vec& waiters, bool replay);
 
   bool should_split() const {
     return (int)get_frag_size() > g_conf()->mds_bal_split_size;
@@ -514,9 +515,9 @@ public:
 
 private:
   void prepare_new_fragment(bool replay);
-  void prepare_old_fragment(map<string_snap_t, std::list<MDSInternalContextBase*> >& dentry_waiters, bool replay);
+  void prepare_old_fragment(map<string_snap_t, MDSInternalContextBase::vec >& dentry_waiters, bool replay);
   void steal_dentry(CDentry *dn);  // from another dir.  used by merge/split.
-  void finish_old_fragment(std::list<MDSInternalContextBase*>& waiters, bool replay);
+  void finish_old_fragment(MDSInternalContextBase::vec& waiters, bool replay);
   void init_fragment_pins();
 
 
@@ -658,7 +659,7 @@ protected:
 		     bool complete, int r);
 
   // -- commit --
-  mempool::mds_co::compact_map<version_t, mempool::mds_co::list<MDSInternalContextBase*> > waiting_for_commit;
+  mempool::mds_co::compact_map<version_t, MDSInternalContextBase::vec_alloc<mempool::mds_co::pool_allocator> > waiting_for_commit;
   void _commit(version_t want, int op_prio);
   void _omap_commit(int op_prio);
   void _encode_dentry(CDentry *dn, bufferlist& bl, const std::set<snapid_t> *snaps);
@@ -694,18 +695,18 @@ public:
 
   // -- waiters --
 protected:
-  mempool::mds_co::compact_map< string_snap_t, mempool::mds_co::list<MDSInternalContextBase*> > waiting_on_dentry; // FIXME string_snap_t not in mempool
+  mempool::mds_co::compact_map< string_snap_t, MDSInternalContextBase::vec_alloc<mempool::mds_co::pool_allocator> > waiting_on_dentry; // FIXME string_snap_t not in mempool
 
 public:
   bool is_waiting_for_dentry(std::string_view dname, snapid_t snap) {
     return waiting_on_dentry.count(string_snap_t(dname, snap));
   }
   void add_dentry_waiter(std::string_view dentry, snapid_t snap, MDSInternalContextBase *c);
-  void take_dentry_waiting(std::string_view dentry, snapid_t first, snapid_t last, std::list<MDSInternalContextBase*>& ls);
-  void take_sub_waiting(std::list<MDSInternalContextBase*>& ls);  // dentry or ino
+  void take_dentry_waiting(std::string_view dentry, snapid_t first, snapid_t last, MDSInternalContextBase::vec& ls);
+  void take_sub_waiting(MDSInternalContextBase::vec& ls);  // dentry or ino
 
   void add_waiter(uint64_t mask, MDSInternalContextBase *c) override;
-  void take_waiting(uint64_t mask, std::list<MDSInternalContextBase*>& ls) override;  // may include dentry waiters
+  void take_waiting(uint64_t mask, MDSInternalContextBase::vec& ls) override;  // may include dentry waiters
   void finish_waiting(uint64_t mask, int result = 0);    // ditto
   
 

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -30,6 +30,7 @@
 #include "include/compact_set.h"
 
 #include "MDSCacheObject.h"
+#include "MDSContext.h"
 #include "flock.h"
 
 #include "CDentry.h"
@@ -720,7 +721,7 @@ public:
   void set_ambiguous_auth() {
     state_set(STATE_AMBIGUOUSAUTH);
   }
-  void clear_ambiguous_auth(std::list<MDSInternalContextBase*>& finished);
+  void clear_ambiguous_auth(MDSInternalContextBase::vec& finished);
   void clear_ambiguous_auth();
 
   inodeno_t ino() const { return inode.ino; }
@@ -828,15 +829,15 @@ public:
 
   // -- waiting --
 protected:
-  mempool::mds_co::compact_map<frag_t, std::list<MDSInternalContextBase*> > waiting_on_dir;
+  mempool::mds_co::compact_map<frag_t, MDSInternalContextBase::vec > waiting_on_dir;
 public:
   void add_dir_waiter(frag_t fg, MDSInternalContextBase *c);
-  void take_dir_waiting(frag_t fg, std::list<MDSInternalContextBase*>& ls);
+  void take_dir_waiting(frag_t fg, MDSInternalContextBase::vec& ls);
   bool is_waiting_for_dir(frag_t fg) {
     return waiting_on_dir.count(fg);
   }
   void add_waiter(uint64_t tag, MDSInternalContextBase *c) override;
-  void take_waiting(uint64_t tag, std::list<MDSInternalContextBase*>& ls) override;
+  void take_waiting(uint64_t tag, MDSInternalContextBase::vec& ls) override;
 
   // -- encode/decode helpers --
   void _encode_base(bufferlist& bl, uint64_t features);
@@ -846,7 +847,7 @@ public:
   void _encode_locks_state_for_replica(bufferlist& bl, bool need_recover);
   void _encode_locks_state_for_rejoin(bufferlist& bl, int rep);
   void _decode_locks_state(bufferlist::const_iterator& p, bool is_new);
-  void _decode_locks_rejoin(bufferlist::const_iterator& p, std::list<MDSInternalContextBase*>& waiters,
+  void _decode_locks_rejoin(bufferlist::const_iterator& p, MDSInternalContextBase::vec& waiters,
 			    std::list<SimpleLock*>& eval_locks, bool survivor);
 
   // -- import/export --
@@ -1046,7 +1047,7 @@ public:
   /* Freeze the inode. auth_pin_allowance lets the caller account for any
    * auth_pins it is itself holding/responsible for. */
   bool freeze_inode(int auth_pin_allowance=0);
-  void unfreeze_inode(std::list<MDSInternalContextBase*>& finished);
+  void unfreeze_inode(MDSInternalContextBase::vec& finished);
   void unfreeze_inode();
 
   void freeze_auth_pin();

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -816,7 +816,7 @@ void Locker::drop_rdlocks_for_early_reply(MutationImpl *mut)
 
 // generics
 
-void Locker::eval_gather(SimpleLock *lock, bool first, bool *pneed_issue, list<MDSInternalContextBase*> *pfinishers)
+void Locker::eval_gather(SimpleLock *lock, bool first, bool *pneed_issue, MDSInternalContextBase::vec *pfinishers)
 {
   dout(10) << "eval_gather " << *lock << " on " << *lock->get_parent() << dendl;
   assert(!lock->is_stable());
@@ -1040,7 +1040,7 @@ void Locker::eval_gather(SimpleLock *lock, bool first, bool *pneed_issue, list<M
 bool Locker::eval(CInode *in, int mask, bool caps_imported)
 {
   bool need_issue = caps_imported;
-  list<MDSInternalContextBase*> finishers;
+  MDSInternalContextBase::vec finishers;
   
   dout(10) << "eval " << mask << " " << *in << dendl;
 
@@ -1203,7 +1203,7 @@ void Locker::try_eval(SimpleLock *lock, bool *pneed_issue)
 void Locker::eval_cap_gather(CInode *in, set<CInode*> *issue_set)
 {
   bool need_issue = false;
-  list<MDSInternalContextBase*> finishers;
+  MDSInternalContextBase::vec finishers;
 
   // kick locks now
   if (!in->filelock.is_stable())
@@ -1228,7 +1228,7 @@ void Locker::eval_cap_gather(CInode *in, set<CInode*> *issue_set)
 void Locker::eval_scatter_gathers(CInode *in)
 {
   bool need_issue = false;
-  list<MDSInternalContextBase*> finishers;
+  MDSInternalContextBase::vec finishers;
 
   dout(10) << "eval_scatter_gathers " << *in << dendl;
 

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -43,6 +43,7 @@ class LocalLock;
 
 #include "CInode.h"
 #include "SimpleLock.h"
+#include "MDSContext.h"
 #include "Mutation.h"
 
 class Locker {
@@ -89,9 +90,9 @@ public:
   void drop_non_rdlocks(MutationImpl *mut, set<CInode*> *pneed_issue=0);
   void drop_rdlocks_for_early_reply(MutationImpl *mut);
 
-  void eval_gather(SimpleLock *lock, bool first=false, bool *need_issue=0, list<MDSInternalContextBase*> *pfinishers=0);
+  void eval_gather(SimpleLock *lock, bool first=false, bool *need_issue=0, MDSInternalContextBase::vec *pfinishers=0);
   void eval(SimpleLock *lock, bool *need_issue);
-  void eval_any(SimpleLock *lock, bool *need_issue, list<MDSInternalContextBase*> *pfinishers=0, bool first=false) {
+  void eval_any(SimpleLock *lock, bool *need_issue, MDSInternalContextBase::vec *pfinishers=0, bool first=false) {
     if (!lock->is_stable())
       eval_gather(lock, first, need_issue, pfinishers);
     else if (lock->get_parent()->is_auth())

--- a/src/mds/LogSegment.h
+++ b/src/mds/LogSegment.h
@@ -18,11 +18,11 @@
 #include "include/elist.h"
 #include "include/interval_set.h"
 #include "include/Context.h"
+#include "MDSContext.h"
 #include "mdstypes.h"
 #include "CInode.h"
 #include "CDentry.h"
 #include "CDir.h"
-#include "MDSContext.h"
 
 #include "include/unordered_set.h"
 using ceph::unordered_set;
@@ -74,7 +74,7 @@ class LogSegment {
   // try to expire
   void try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int op_prio);
 
-  std::list<MDSInternalContextBase*> expiry_waiters;
+  MDSInternalContextBase::vec expiry_waiters;
 
   void wait_for_expiry(MDSInternalContextBase *c)
   {

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -285,7 +285,7 @@ public:
   }
 
   // waiters
-  map<int, map<inodeno_t, list<MDSInternalContextBase*> > > waiting_for_base_ino;
+  map<int, map<inodeno_t, MDSInternalContextBase::vec > > waiting_for_base_ino;
 
   void discover_base_ino(inodeno_t want_ino, MDSInternalContextBase *onfinish, mds_rank_t from=MDS_RANK_NONE);
   void discover_dir_frag(CInode *base, frag_t approx_fg, MDSInternalContextBase *onfinish,
@@ -450,7 +450,7 @@ protected:
   struct umaster {
     set<mds_rank_t> slaves;
     LogSegment *ls;
-    list<MDSInternalContextBase*> waiters;
+    MDSInternalContextBase::vec waiters;
     bool safe;
     bool committing;
     bool recovering;
@@ -557,7 +557,7 @@ protected:
 
   map<inodeno_t,map<client_t,map<mds_rank_t,cap_reconnect_t> > > cap_imports;  // ino -> client -> frommds -> capex
   set<inodeno_t> cap_imports_missing;
-  map<inodeno_t, list<MDSInternalContextBase*> > cap_reconnect_waiters;
+  map<inodeno_t, MDSInternalContextBase::vec > cap_reconnect_waiters;
   int cap_imports_num_opening;
   
   set<CInode*> rejoin_undef_inodes;
@@ -567,7 +567,7 @@ protected:
 
   vector<CInode*> rejoin_recover_q, rejoin_check_q;
   list<SimpleLock*> rejoin_eval_locks;
-  list<MDSInternalContextBase*> rejoin_waiters;
+  MDSInternalContextBase::vec rejoin_waiters;
 
   void rejoin_walk(CDir *dir, MMDSCacheRejoin *rejoin);
   void handle_cache_rejoin(MMDSCacheRejoin *m);
@@ -899,7 +899,7 @@ protected:
 
 private:
   bool opening_root, open;
-  list<MDSInternalContextBase*> waiting_for_open;
+  MDSInternalContextBase::vec waiting_for_open;
 
 public:
   void init_layouts();
@@ -1000,7 +1000,7 @@ protected:
     version_t tid;
     int64_t pool;
     int last_err;
-    list<MDSInternalContextBase*> waiters;
+    MDSInternalContextBase::vec waiters;
     open_ino_info_t() : checking(MDS_RANK_NONE), auth_hint(MDS_RANK_NONE),
       check_peers(true), fetch_backtrace(true), discover(false),
       want_replica(false), want_xlocked(false), tid(0), pool(-1),
@@ -1089,9 +1089,9 @@ public:
   void replicate_inode(CInode *in, mds_rank_t to, bufferlist& bl,
 		       uint64_t features);
   
-  CDir* add_replica_dir(bufferlist::const_iterator& p, CInode *diri, mds_rank_t from, list<MDSInternalContextBase*>& finished);
-  CDentry *add_replica_dentry(bufferlist::const_iterator& p, CDir *dir, list<MDSInternalContextBase*>& finished);
-  CInode *add_replica_inode(bufferlist::const_iterator& p, CDentry *dn, list<MDSInternalContextBase*>& finished);
+  CDir* add_replica_dir(bufferlist::const_iterator& p, CInode *diri, mds_rank_t from, MDSInternalContextBase::vec& finished);
+  CDentry *add_replica_dentry(bufferlist::const_iterator& p, CDir *dir, MDSInternalContextBase::vec& finished);
+  CInode *add_replica_inode(bufferlist::const_iterator& p, CDentry *dn, MDSInternalContextBase::vec& finished);
 
   void replicate_stray(CDentry *straydn, mds_rank_t who, bufferlist& bl);
   CDentry *add_replica_stray(bufferlist &bl, mds_rank_t from);
@@ -1111,7 +1111,7 @@ private:
     int bits;
     bool committed;
     LogSegment *ls;
-    list<MDSInternalContextBase*> waiters;
+    MDSInternalContextBase::vec waiters;
     list<frag_t> old_frags;
     bufferlist rollback;
     ufragment() : bits(0), committed(false), ls(NULL) {}
@@ -1134,12 +1134,12 @@ private:
   map<dirfrag_t,fragment_info_t> fragments;
 
   void adjust_dir_fragments(CInode *diri, frag_t basefrag, int bits,
-			    list<CDir*>& frags, list<MDSInternalContextBase*>& waiters, bool replay);
+			    list<CDir*>& frags, MDSInternalContextBase::vec& waiters, bool replay);
   void adjust_dir_fragments(CInode *diri,
 			    list<CDir*>& srcfrags,
 			    frag_t basefrag, int bits,
 			    list<CDir*>& resultfrags, 
-			    list<MDSInternalContextBase*>& waiters,
+			    MDSInternalContextBase::vec& waiters,
 			    bool replay);
   CDir *force_dir_fragment(CInode *diri, frag_t fg, bool replay=true);
   void get_force_dirfrag_bound_set(vector<dirfrag_t>& dfs, set<CDir*>& bounds);

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -874,11 +874,7 @@ void MDLog::_expired(LogSegment *ls)
     expired_events += ls->num_events;
 
     // Trigger all waiters
-    for (std::list<MDSInternalContextBase*>::iterator i = ls->expiry_waiters.begin();
-        i != ls->expiry_waiters.end(); ++i) {
-      (*i)->complete(0);
-    }
-    ls->expiry_waiters.clear();
+    finish_contexts(g_ceph_context, ls->expiry_waiters);
     
     logger->inc(l_mdl_evex, ls->num_events);
     logger->inc(l_mdl_segex);

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -41,6 +41,7 @@ enum {
 #include "include/types.h"
 #include "include/Context.h"
 
+#include "MDSContext.h"
 #include "common/Thread.h"
 #include "common/Cond.h"
 
@@ -99,7 +100,7 @@ protected:
   friend class ReplayThread;
   friend class C_MDL_Replay;
 
-  list<MDSInternalContextBase*> waitfor_replay;
+  MDSInternalContextBase::vec waitfor_replay;
 
   void _replay();         // old way
   void _replay_thread();  // new way

--- a/src/mds/MDSCacheObject.cc
+++ b/src/mds/MDSCacheObject.cc
@@ -8,7 +8,7 @@
 uint64_t MDSCacheObject::last_wait_seq = 0;
 
 void MDSCacheObject::finish_waiting(uint64_t mask, int result) {
-  std::list<MDSInternalContextBase*> finished;
+  MDSInternalContextBase::vec finished;
   take_waiting(mask, finished);
   finish_contexts(g_ceph_context, finished, result);
 }

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -12,6 +12,7 @@
 #include "include/xlist.h"
 
 #include "mdstypes.h"
+#include "MDSContext.h"
 
 #define MDS_REF_SET      // define me for improved debug output, sanity checking
 //#define MDS_AUTHPIN_SET  // define me for debugging auth pin leaks
@@ -332,7 +333,7 @@ protected:
 //			       << dendl;
     
   }
-  virtual void take_waiting(uint64_t mask, std::list<MDSInternalContextBase*>& ls) {
+  virtual void take_waiting(uint64_t mask, MDSInternalContextBase::vec& ls) {
     if (waiting.empty()) return;
 
     // process ordered waiters in the same order that they were added.

--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -16,6 +16,9 @@
 #ifndef MDS_CONTEXT_H
 #define MDS_CONTEXT_H
 
+#include <vector>
+#include <queue>
+
 #include "include/Context.h"
 #include "include/elist.h"
 #include "common/ceph_time.h"
@@ -44,6 +47,14 @@ protected:
 class MDSInternalContextBase : public MDSContext
 {
 public:
+    template<template<typename> class A>
+    using vec_alloc = std::vector<MDSInternalContextBase *, A<MDSInternalContextBase *>>;
+    using vec = vec_alloc<std::allocator>;
+
+    template<template<typename> class A>
+    using que_alloc = std::queue<MDSInternalContextBase *, std::deque<MDSInternalContextBase *, A<MDSInternalContextBase *>>>;
+    using que = que_alloc<std::allocator>;
+
     void complete(int r) override;
 };
 

--- a/src/mds/MDSContinuation.h
+++ b/src/mds/MDSContinuation.h
@@ -15,6 +15,8 @@
 #include "common/Continuation.h"
 #include "mds/Mutation.h"
 #include "mds/Server.h"
+
+#include "MDSContext.h"
  
 class MDSContinuation : public Continuation {
 protected:

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -821,13 +821,11 @@ void MDSRank::_advance_queues()
   while (!finished_queue.empty()) {
     dout(7) << "mds has " << finished_queue.size() << " queued contexts" << dendl;
     dout(10) << finished_queue << dendl;
-    list<MDSInternalContextBase*> ls;
+    decltype(finished_queue) ls;
     ls.swap(finished_queue);
-    while (!ls.empty()) {
-      dout(10) << " finish " << ls.front() << dendl;
-      ls.front()->complete(0);
-      ls.pop_front();
-
+    for (auto& c : ls) {
+      dout(10) << " finish " << c << dendl;
+      c->complete(0);
       heartbeat_reset();
     }
   }
@@ -1537,7 +1535,7 @@ bool MDSRank::queue_one_replay()
     return false;
   }
   queue_waiter(replay_queue.front());
-  replay_queue.pop_front();
+  replay_queue.pop();
   return true;
 }
 
@@ -1943,9 +1941,9 @@ void MDSRankDispatcher::handle_mds_map(
   }
 
   {
-    map<epoch_t,list<MDSInternalContextBase*> >::iterator p = waiting_for_mdsmap.begin();
+    map<epoch_t,MDSInternalContextBase::vec >::iterator p = waiting_for_mdsmap.begin();
     while (p != waiting_for_mdsmap.end() && p->first <= mdsmap->get_epoch()) {
-      list<MDSInternalContextBase*> ls;
+      MDSInternalContextBase::vec ls;
       ls.swap(p->second);
       waiting_for_mdsmap.erase(p++);
       finish_contexts(g_ceph_context, ls);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -30,6 +30,7 @@
 #include "SessionMap.h"
 #include "MDCache.h"
 #include "MDLog.h"
+#include "MDSContext.h"
 #include "PurgeQueue.h"
 #include "osdc/Journaler.h"
 
@@ -248,7 +249,7 @@ class MDSRank {
     } progress_thread;
 
     list<Message*> waiting_for_nolaggy;
-    list<MDSInternalContextBase*> finished_queue;
+    MDSInternalContextBase::vec finished_queue;
     // Dispatch, retry, queues
     int dispatch_depth;
     void inc_dispatch_depth() { ++dispatch_depth; }
@@ -266,11 +267,11 @@ class MDSRank {
 
     ceph_tid_t last_tid;    // for mds-initiated requests (e.g. stray rename)
 
-    list<MDSInternalContextBase*> waiting_for_active, waiting_for_replay, waiting_for_reconnect, waiting_for_resolve;
-    list<MDSInternalContextBase*> waiting_for_any_client_connection;
-    list<MDSInternalContextBase*> replay_queue;
-    map<mds_rank_t, list<MDSInternalContextBase*> > waiting_for_active_peer;
-    map<epoch_t, list<MDSInternalContextBase*> > waiting_for_mdsmap;
+    MDSInternalContextBase::vec waiting_for_active, waiting_for_replay, waiting_for_reconnect, waiting_for_resolve;
+    MDSInternalContextBase::vec waiting_for_any_client_connection;
+    MDSInternalContextBase::que replay_queue;
+    map<mds_rank_t, MDSInternalContextBase::vec > waiting_for_active_peer;
+    map<epoch_t, MDSInternalContextBase::vec > waiting_for_mdsmap;
 
     epoch_t osd_epoch_barrier;
 
@@ -300,8 +301,10 @@ class MDSRank {
       finished_queue.push_back(c);
       progress_thread.signal();
     }
-    void queue_waiters(std::list<MDSInternalContextBase*>& ls) {
-      finished_queue.splice( finished_queue.end(), ls );
+    void queue_waiters(MDSInternalContextBase::vec& ls) {
+      MDSInternalContextBase::vec v;
+      v.swap(ls);
+      finished_queue.insert(finished_queue.end(), v.begin(), v.end());
       progress_thread.signal();
     }
 
@@ -404,7 +407,7 @@ class MDSRank {
       waiting_for_mdsmap[e].push_back(c);
     }
     void enqueue_replay(MDSInternalContextBase *c) {
-      replay_queue.push_back(c);
+      replay_queue.push(c);
     }
 
     bool queue_one_replay();

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -104,13 +104,15 @@ void MDSTable::save_2(int r, version_t v)
   dout(10) << "save_2 v " << v << dendl;
   committed_version = v;
   
-  list<MDSInternalContextBase*> ls;
+  MDSInternalContextBase::vec ls;
   while (!waitfor_save.empty()) {
-    if (waitfor_save.begin()->first > v) break;
-    ls.splice(ls.end(), waitfor_save.begin()->second);
-    waitfor_save.erase(waitfor_save.begin());
+    auto it = waitfor_save.begin();
+    if (it->first > v) break;
+    auto& v = it->second;
+    ls.insert(ls.end(), v.begin(), v.end());
+    waitfor_save.erase(it);
   }
-  finish_contexts(g_ceph_context, ls,0);
+  finish_contexts(g_ceph_context, ls, 0);
 }
 
 

--- a/src/mds/MDSTable.h
+++ b/src/mds/MDSTable.h
@@ -19,9 +19,9 @@
 #include "mds_table_types.h"
 #include "include/buffer_fwd.h"
 
+#include "MDSContext.h"
+
 class MDSRank;
-class Context;
-class MDSInternalContextBase;
 
 class MDSTable {
 public:
@@ -41,7 +41,7 @@ protected:
   
   version_t version, committing_version, committed_version, projected_version;
   
-  map<version_t, list<MDSInternalContextBase*> > waitfor_save;
+  map<version_t, MDSInternalContextBase::vec > waitfor_save;
   
 public:
   MDSTable(MDSRank *m, const char *n, bool is_per_mds) :

--- a/src/mds/MDSTableClient.h
+++ b/src/mds/MDSTableClient.h
@@ -50,7 +50,7 @@ protected:
 
   // pending commits
   map<version_t, LogSegment*> pending_commit;
-  map<version_t, list<MDSInternalContextBase*> > ack_waiters;
+  map<version_t, MDSInternalContextBase::vec > ack_waiters;
 
   void handle_reply(class MMDSTableQuery *m);  
   void _logged_ack(version_t tid);

--- a/src/mds/MDSTableServer.h
+++ b/src/mds/MDSTableServer.h
@@ -16,6 +16,7 @@
 #define CEPH_MDSTABLESERVER_H
 
 #include "MDSTable.h"
+#include "MDSContext.h"
 
 class MMDSTableRequest;
 

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -19,6 +19,8 @@
 
 #include "include/types.h"
 
+#include "MDSContext.h"
+
 #include <map>
 #include <list>
 #include <set>
@@ -312,7 +314,7 @@ public:
 				map<client_t,client_metadata_t>& exported_client_metadata_map);
   void finish_export_inode(CInode *in, mds_rank_t target,
 			   map<client_t,Capability::Import>& peer_imported,
-			   list<MDSInternalContextBase*>& finished);
+			   MDSInternalContextBase::vec& finished);
   void finish_export_inode_caps(CInode *in, mds_rank_t target,
 			        map<client_t,Capability::Import>& peer_imported);
 
@@ -323,7 +325,7 @@ public:
 			map<client_t,client_metadata_t>& exported_client_metadata_map);
   void finish_export_dir(CDir *dir, mds_rank_t target,
 			 map<inodeno_t,map<client_t,Capability::Import> >& peer_imported,
-			 list<MDSInternalContextBase*>& finished, int *num_dentries);
+			 MDSInternalContextBase::vec& finished, int *num_dentries);
 
   void clear_export_proxy_pins(CDir *dir);
 

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -20,6 +20,7 @@
 #include "include/filepath.h"
 
 #include "MDSCacheObject.h"
+#include "MDSContext.h"
 
 #include "SimpleLock.h"
 #include "Capability.h"
@@ -262,7 +263,7 @@ struct MDRequestImpl : public MutationImpl {
     Context *slave_commit;
     bufferlist rollback_bl;
 
-    list<MDSInternalContextBase*> waiting_for_finish;
+    MDSInternalContextBase::vec waiting_for_finish;
 
     // export & fragment
     CDir* export_dir;

--- a/src/mds/OpenFileTable.h
+++ b/src/mds/OpenFileTable.h
@@ -18,10 +18,11 @@
 #include "mdstypes.h"
 #include "Anchor.h"
 
+#include "MDSContext.h"
+
 class CDir;
 class CInode;
 class MDSRank;
-class MDSInternalContextBase;
 
 class OpenFileTable
 {
@@ -104,7 +105,7 @@ protected:
   std::vector<std::map<std::string, bufferlist> > loaded_journals;
   map<inodeno_t, RecoveredAnchor> loaded_anchor_map;
   set<dirfrag_t> loaded_dirfrags;
-  list<MDSInternalContextBase*> waiting_for_load;
+  MDSInternalContextBase::vec waiting_for_load;
   bool load_done = false;
 
   void _reset_states() {
@@ -129,7 +130,7 @@ protected:
   };
   unsigned prefetch_state = 0;
   unsigned num_opening_inodes = 0;
-  list<MDSInternalContextBase*> waiting_for_prefetch;
+  MDSInternalContextBase::vec waiting_for_prefetch;
   void _open_ino_finish(inodeno_t ino, int r);
   void _prefetch_inodes();
   void _prefetch_dirfrags();

--- a/src/mds/ScatterLock.h
+++ b/src/mds/ScatterLock.h
@@ -18,6 +18,8 @@
 
 #include "SimpleLock.h"
 
+#include "MDSContext.h"
+
 class ScatterLock : public SimpleLock {
 
   struct more_bits_t {
@@ -194,7 +196,7 @@ public:
     encode(s, bl);
   }
 
-  void decode_state_rejoin(bufferlist::const_iterator& p, list<MDSInternalContextBase*>& waiters, bool survivor) {
+  void decode_state_rejoin(bufferlist::const_iterator& p, MDSInternalContextBase::vec& waiters, bool survivor) {
     SimpleLock::decode_state_rejoin(p, waiters, survivor);
     if (is_flushing()) {
       set_dirty();

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -521,7 +521,7 @@ void Server::flush_client_sessions(set<client_t>& client_set, MDSGatherBuilder& 
 
 void Server::finish_flush_session(Session *session, version_t seq)
 {
-  list<MDSInternalContextBase*> finished;
+  MDSInternalContextBase::vec finished;
   session->finish_flush(seq, finished);
   mds->queue_waiters(finished);
 }
@@ -4213,7 +4213,7 @@ void Server::handle_client_file_setlock(MDRequestRef& mdr)
   dout(10) << " state prior to lock change: " << *lock_state << dendl;
   if (CEPH_LOCK_UNLOCK == set_lock.type) {
     list<ceph_filelock> activated_locks;
-    list<MDSInternalContextBase*> waiters;
+    MDSInternalContextBase::vec waiters;
     if (lock_state->is_waiting(set_lock)) {
       dout(10) << " unlock removing waiting lock " << set_lock << dendl;
       lock_state->remove_waiting(set_lock);
@@ -8467,7 +8467,7 @@ void Server::_commit_slave_rename(MDRequestRef& mdr, int r,
 
   CDentry::linkage_t *destdnl = destdn->get_linkage();
 
-  list<MDSInternalContextBase*> finished;
+  MDSInternalContextBase::vec finished;
   if (r == 0) {
     // unfreeze+singleauth inode
     //  hmm, do i really need to delay this?
@@ -8978,7 +8978,7 @@ void Server::_rename_rollback_finish(MutationRef& mut, MDRequestRef& mdr, CDentr
   }
 
   if (mdr) {
-    list<MDSInternalContextBase*> finished;
+    MDSInternalContextBase::vec finished;
     if (mdr->more()->is_ambiguous_auth) {
       if (srcdn->is_auth())
 	mdr->more()->rename_inode->unfreeze_inode(finished);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -19,6 +19,7 @@
 
 #include "MDSRank.h"
 #include "Mutation.h"
+#include "MDSContext.h"
 
 class OSDMap;
 class PerfCounters;

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -33,6 +33,7 @@ struct MDRequestImpl;
 
 #include "CInode.h"
 #include "Capability.h"
+#include "MDSContext.h"
 #include "msg/Message.h"
 
 enum {
@@ -201,7 +202,7 @@ public:
   // -- caps --
 private:
   version_t cap_push_seq;        // cap push seq #
-  map<version_t, list<MDSInternalContextBase*> > waitfor_flush; // flush session messages
+  map<version_t, MDSInternalContextBase::vec > waitfor_flush; // flush session messages
 
 public:
   xlist<Capability*> caps;     // inodes with caps; front=most recently used
@@ -216,12 +217,14 @@ public:
     waitfor_flush[get_push_seq()].push_back(c);
     return get_push_seq();
   }
-  void finish_flush(version_t seq, list<MDSInternalContextBase*>& ls) {
+  void finish_flush(version_t seq, MDSInternalContextBase::vec& ls) {
     while (!waitfor_flush.empty()) {
-      if (waitfor_flush.begin()->first > seq)
+      auto it = waitfor_flush.begin();
+      if (it->first > seq)
 	break;
-      ls.splice(ls.end(), waitfor_flush.begin()->second);
-      waitfor_flush.erase(waitfor_flush.begin());
+      auto& v = it->second;
+      ls.insert(ls.end(), v.begin(), v.end());
+      waitfor_flush.erase(it);
     }
   }
 
@@ -447,7 +450,7 @@ protected:
 public:
   map<int,xlist<Session*>* > by_state;
   uint64_t set_state(Session *session, int state);
-  map<version_t, list<MDSInternalContextBase*> > commit_waiters;
+  map<version_t, MDSInternalContextBase::vec > commit_waiters;
 
   explicit SessionMap(MDSRank *m) : mds(m),
 		       projected(0), committing(0), committed(0),
@@ -595,7 +598,7 @@ public:
 
   // -- loading, saving --
   inodeno_t ino;
-  list<MDSInternalContextBase*> waiting_for_load;
+  MDSInternalContextBase::vec waiting_for_load;
 
   object_t get_object_name() const;
 

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -305,7 +305,7 @@ public:
   void finish_waiters(uint64_t mask, int r=0) {
     parent->finish_waiting(mask << get_wait_shift(), r);
   }
-  void take_waiting(uint64_t mask, list<MDSInternalContextBase*>& ls) {
+  void take_waiting(uint64_t mask, MDSInternalContextBase::vec& ls) {
     parent->take_waiting(mask << get_wait_shift(), ls);
   }
   void add_waiter(uint64_t mask, MDSInternalContextBase *c) {
@@ -324,7 +324,7 @@ public:
     //assert(!is_stable() || gather_set.size() == 0);  // gather should be empty in stable states.
     return s;
   }
-  void set_state_rejoin(int s, list<MDSInternalContextBase*>& waiters, bool survivor) {
+  void set_state_rejoin(int s, MDSInternalContextBase::vec& waiters, bool survivor) {
     assert(!get_parent()->is_auth());
 
     // If lock in the replica object was not in SYNC state when auth mds of the object failed.
@@ -589,7 +589,7 @@ public:
     if (is_new)
       state = s;
   }
-  void decode_state_rejoin(bufferlist::const_iterator& p, list<MDSInternalContextBase*>& waiters, bool survivor) {
+  void decode_state_rejoin(bufferlist::const_iterator& p, MDSInternalContextBase::vec& waiters, bool survivor) {
     __s16 s;
     using ceph::decode;
     decode(s, p);

--- a/src/mds/SnapClient.cc
+++ b/src/mds/SnapClient.cc
@@ -97,13 +97,14 @@ void SnapClient::handle_query_result(MMDSTableRequest *m)
     synced = true;
 
   if (synced && !waiting_for_version.empty()) {
-    std::list<MDSInternalContextBase*> finished;
-    for (auto p = waiting_for_version.begin();
-	p != waiting_for_version.end(); ) {
-      if (p->first > cached_version)
+    MDSInternalContextBase::vec finished;
+    while (!waiting_for_version.empty()) {
+      auto it = waiting_for_version.begin();
+      if (it->first > cached_version)
 	break;
-      finished.splice(finished.end(), p->second);
-      waiting_for_version.erase(p++);
+      auto& v = it->second;
+      finished.insert(finished.end(), v.begin(), v.end());
+      waiting_for_version.erase(it);
     }
     if (!finished.empty())
       mds->queue_waiters(finished);

--- a/src/mds/SnapClient.h
+++ b/src/mds/SnapClient.h
@@ -19,8 +19,8 @@
 
 #include "MDSTableClient.h"
 #include "snap.h"
+#include "MDSContext.h"
 
-class MDSInternalContextBase;
 class MDSRank;
 class LogSegment;
 
@@ -33,7 +33,7 @@ class SnapClient : public MDSTableClient {
 
   set<version_t> committing_tids;
 
-  map<version_t, std::list<MDSInternalContextBase*> > waiting_for_version;
+  map<version_t, MDSInternalContextBase::vec > waiting_for_version;
 
   uint64_t sync_reqid;
   bool synced;

--- a/src/mds/SnapRealm.h
+++ b/src/mds/SnapRealm.h
@@ -22,8 +22,7 @@
 #include "include/xlist.h"
 #include "include/elist.h"
 #include "common/snap_types.h"
-
-class MDSInternalContextBase;
+#include "MDSContext.h"
 
 struct SnapRealm {
 protected:

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -2722,7 +2722,7 @@ void EFragment::replay(MDSRank *mds)
   dout(10) << "EFragment.replay " << op_name(op) << " " << ino << " " << basefrag << " by " << bits << dendl;
 
   list<CDir*> resultfrags;
-  list<MDSInternalContextBase*> waiters;
+  MDSInternalContextBase::vec waiters;
   list<frag_t> old_frags;
 
   // in may be NULL if it wasn't in our cache yet.  if it's a prepare


### PR DESCRIPTION
This PR is all about the usual benefits of converting a list to a vector without any of the potential drawbacks:

* We don't need a memory allocation for each `Context *` with all accompanying overhead.
* Access is contiguous and cache-friendly.
* Clearing a vector is a single free internally; no destructors need be called.

Splicing is theoretically more expensive but due to the cache friendliness of vectors, this is likely to be negligible.

I plan to do some performance testing to confirm this is an improvement.