### PR TITLE
luminous: Boost system library is no longer required to compile and link example librados program

### DIFF
--- a/examples/librados/Makefile
+++ b/examples/librados/Makefile
@@ -1,7 +1,7 @@
 
 CXX?=g++
 CXX_FLAGS?=-std=c++11 -Wall -Wextra -Werror -g
-CXX_LIBS?=-lboost_system -lrados -lradosstriper
+CXX_LIBS?=-lrados -lradosstriper
 CXX_INC?=$(LOCAL_LIBRADOS_INC)
 CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS) $(CXX_LIBS)
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/25074