### PR TITLE
mimic: rgw: do not ignore EEXIST in RGWPutObj::execute

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3630,7 +3630,7 @@ void RGWPutObj::execute()
 
     op_ret = put_data_and_throttle(filter, data, ofs, need_to_wait);
     if (op_ret < 0) {
-      if (!need_to_wait || op_ret != -EEXIST) {
+      if (op_ret != -EEXIST) {
         ldout(s->cct, 20) << "processor->thottle_data() returned ret="
 			  << op_ret << dendl;
         goto done;


### PR DESCRIPTION
http://tracker.ceph.com/issues/25078

---

The existing logic appears able to cause propagation of a failed
exclusive create to the client, when it should instead have been
retried, due to disagreement about the logical write offset. (The
value of ofs here could be > 0 due to the operation of a stacked
write filter [e.g., compressor], when the RADOS write offset was
0 and hence an exclusive write that should be retried).

Rationale for fix by Casey.

http://tracker.ceph.com/issues/22790

(cherry picked from commit 7c18258e54741a54bdeb59d4da7fd4fee73e8618)
Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>