### PR TITLE
rgw: delete some unused code about std::regex

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -11,7 +11,6 @@
 
 #include <experimental/iterator>
 
-#include <boost/regex.hpp>
 #include "rapidjson/reader.h"
 
 #include "rgw_auth.h"
@@ -27,10 +26,7 @@ using std::find;
 using std::int64_t;
 using std::move;
 using std::pair;
-using std::regex;
-using std::regex_match;
 using std::size_t;
-using std::smatch;
 using std::string;
 using std::stringstream;
 using std::ostream;


### PR DESCRIPTION
Delete some unused code about std::regex in  rgw_iam_policy.cc. 
Signed-off-by: Xueyu Bai \<baixueyu@inspur.com\>