### PR TITLE
mgr/dashboard config options add

### DIFF
--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -25,28 +25,23 @@ class ClusterConfigurationTest(DashboardTestCase):
         self.assertStatus(404)
 
     def test_get_specific_db_config_option(self):
-        def _get_mon_allow_pool_delete_config():
-            data = self._get('/api/cluster_conf/mon_allow_pool_delete')
-            if 'value' in data:
-                return data['value'][0]
-            return None
+        config_name = 'mon_allow_pool_delete'
 
-        orig_value = _get_mon_allow_pool_delete_config()
+        orig_value = self._get_config_by_name(config_name)
 
-        self._ceph_cmd(['config', 'set', 'mon', 'mon_allow_pool_delete', 'true'])
-        result = self._wait_for_expected_get_result(_get_mon_allow_pool_delete_config,
-                                                    {'section': 'mon', 'value': 'true'})
-        self.assertEqual(result, {'section': 'mon', 'value': 'true'})
+        self._ceph_cmd(['config', 'set', 'mon', config_name, 'true'])
+        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
+                                                    [{'section': 'mon', 'value': 'true'}])
+        self.assertEqual(result, [{'section': 'mon', 'value': 'true'}])
 
-        self._ceph_cmd(['config', 'set', 'mon', 'mon_allow_pool_delete', 'false'])
-        result = self._wait_for_expected_get_result(_get_mon_allow_pool_delete_config,
-                                                    {'section': 'mon', 'value': 'false'})
-        self.assertEqual(result, {'section': 'mon', 'value': 'false'})
+        self._ceph_cmd(['config', 'set', 'mon', config_name, 'false'])
+        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
+                                                    [{'section': 'mon', 'value': 'false'}])
+        self.assertEqual(result, [{'section': 'mon', 'value': 'false'}])
 
         # restore value
         if orig_value:
-            self._ceph_cmd(['config', 'set', 'mon', 'mon_allow_pool_delete',
-                           orig_value['value']])
+            self._ceph_cmd(['config', 'set', 'mon', config_name, orig_value[0]['value']])
 
     def _validate_single(self, data):
         self.assertIn('name', data)
@@ -71,14 +66,20 @@ class ClusterConfigurationTest(DashboardTestCase):
                 self.assertIn('section', entry)
                 self.assertIn('value', entry)
 
-    def _wait_for_expected_get_result(self, get_func, expected_result, max_attempts=30,
+    def _wait_for_expected_get_result(self, get_func, get_params, expected_result, max_attempts=30,
                                       sleep_time=1):
         attempts = 0
         while attempts < max_attempts:
-            get_result = get_func()
+            get_result = get_func(get_params)
             if get_result == expected_result:
                 self.assertStatus(200)
                 return get_result
 
             time.sleep(sleep_time)
             attempts += 1
+
+    def _get_config_by_name(self, conf_name):
+        data = self._get('/api/cluster_conf/{}'.format(conf_name))
+        if 'value' in data:
+            return data['value']
+        return None

--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -43,6 +43,96 @@ class ClusterConfigurationTest(DashboardTestCase):
         if orig_value:
             self._ceph_cmd(['config', 'set', 'mon', config_name, orig_value[0]['value']])
 
+    def test_create(self):
+        config_name = 'debug_ms'
+        orig_value = self._get_config_by_name(config_name)
+
+        # remove all existing settings for equal preconditions
+        self._clear_all_values_for_config_option(config_name)
+
+        expected_result = [{'section': 'mon', 'value': '0/3'}]
+
+        self._post('/api/cluster_conf', {
+            'name': config_name,
+            'value': expected_result
+        })
+        self.assertStatus(201)
+        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
+                                                    expected_result)
+        self.assertEqual(result, expected_result)
+
+        # reset original value
+        self._clear_all_values_for_config_option(config_name)
+        self._reset_original_values(config_name, orig_value)
+
+    def test_create_two_values(self):
+        config_name = 'debug_ms'
+        orig_value = self._get_config_by_name(config_name)
+
+        # remove all existing settings for equal preconditions
+        self._clear_all_values_for_config_option(config_name)
+
+        expected_result = [{'section': 'mon', 'value': '0/3'},
+                           {'section': 'osd', 'value': '0/5'}]
+
+        self._post('/api/cluster_conf', {
+            'name': config_name,
+            'value': expected_result
+        })
+        self.assertStatus(201)
+        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
+                                                    expected_result)
+        self.assertEqual(result, expected_result)
+
+        # reset original value
+        self._clear_all_values_for_config_option(config_name)
+        self._reset_original_values(config_name, orig_value)
+
+    def test_create_can_handle_none_values(self):
+        config_name = 'debug_ms'
+        orig_value = self._get_config_by_name(config_name)
+
+        # remove all existing settings for equal preconditions
+        self._clear_all_values_for_config_option(config_name)
+
+        self._post('/api/cluster_conf', {
+            'name': config_name,
+            'value': [{'section': 'mon', 'value': '0/3'},
+                      {'section': 'osd', 'value': None}]
+        })
+        self.assertStatus(201)
+
+        expected_result = [{'section': 'mon', 'value': '0/3'}]
+        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
+                                                    expected_result)
+        self.assertEqual(result, expected_result)
+
+        # reset original value
+        self._clear_all_values_for_config_option(config_name)
+        self._reset_original_values(config_name, orig_value)
+
+    def test_create_can_handle_boolean_values(self):
+        config_name = 'mon_allow_pool_delete'
+        orig_value = self._get_config_by_name(config_name)
+
+        # remove all existing settings for equal preconditions
+        self._clear_all_values_for_config_option(config_name)
+
+        expected_result = [{'section': 'mon', 'value': 'true'}]
+
+        self._post('/api/cluster_conf', {
+            'name': config_name,
+            'value': [{'section': 'mon', 'value': True}]})
+        self.assertStatus(201)
+
+        result = self._wait_for_expected_get_result(self._get_config_by_name, config_name,
+                                                    expected_result)
+        self.assertEqual(result, expected_result)
+
+        # reset original value
+        self._clear_all_values_for_config_option(config_name)
+        self._reset_original_values(config_name, orig_value)
+
     def _validate_single(self, data):
         self.assertIn('name', data)
         self.assertIn('daemon_default', data)
@@ -83,3 +173,14 @@ class ClusterConfigurationTest(DashboardTestCase):
         if 'value' in data:
             return data['value']
         return None
+
+    def _clear_all_values_for_config_option(self, config_name):
+        values = self._get_config_by_name(config_name)
+        if values:
+            for value in values:
+                self._ceph_cmd(['config', 'rm', value['section'], config_name])
+
+    def _reset_original_values(self, config_name, orig_values):
+        if orig_values:
+            for value in orig_values:
+                self._ceph_cmd(['config', 'set', value['section'], config_name, value['value']])

--- a/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.e2e-spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/e2e/cluster/monitors.e2e-spec.ts
@@ -12,7 +12,7 @@ describe('Monitors page', () => {
     Helper.checkConsole();
   });
 
-  it('should open and show breadcrumnb', () => {
+  it('should open and show breadcrumb', () => {
     page.navigateTo();
     expect(Helper.getBreadcrumbText()).toEqual('Monitors');
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -78,7 +78,7 @@ const routes: Routes = [
   },
   {
     path: 'configuration',
-    data: { breadcrumbs: 'Cluster/Configuration Documentation' },
+    data: { breadcrumbs: 'Cluster/Configuration' },
     children: [
       { path: '', component: ConfigurationComponent },
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app-routing.module.ts
@@ -6,6 +6,7 @@ import { MirroringComponent } from './ceph/block/mirroring/mirroring.component';
 import { RbdFormComponent } from './ceph/block/rbd-form/rbd-form.component';
 import { RbdImagesComponent } from './ceph/block/rbd-images/rbd-images.component';
 import { CephfsListComponent } from './ceph/cephfs/cephfs-list/cephfs-list.component';
+import { ConfigurationFormComponent } from './ceph/cluster/configuration/configuration-form/configuration-form.component';
 import { ConfigurationComponent } from './ceph/cluster/configuration/configuration.component';
 import { HostsComponent } from './ceph/cluster/hosts/hosts.component';
 import { MonitorComponent } from './ceph/cluster/monitor/monitor.component';
@@ -77,9 +78,15 @@ const routes: Routes = [
   },
   {
     path: 'configuration',
-    component: ConfigurationComponent,
-    canActivate: [AuthGuardService],
-    data: { breadcrumbs: 'Cluster/Configuration Documentation' }
+    data: { breadcrumbs: 'Cluster/Configuration Documentation' },
+    children: [
+      { path: '', component: ConfigurationComponent },
+      {
+        path: 'edit/:name',
+        component: ConfigurationFormComponent,
+        data: { breadcrumbs: 'Edit' }
+      }
+    ]
   },
   {
     path: 'perf_counters/:type/:id',

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -9,6 +9,7 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { SharedModule } from '../../shared/shared.module';
 import { PerformanceCounterModule } from '../performance-counter/performance-counter.module';
+import { ConfigurationDetailsComponent } from './configuration/configuration-details/configuration-details.component';
 import { ConfigurationComponent } from './configuration/configuration.component';
 import { HostDetailsComponent } from './hosts/host-details/host-details.component';
 import { HostsComponent } from './hosts/hosts.component';
@@ -41,7 +42,8 @@ import { OsdScrubModalComponent } from './osd/osd-scrub-modal/osd-scrub-modal.co
     OsdPerformanceHistogramComponent,
     OsdScrubModalComponent,
     OsdFlagsModalComponent,
-    HostDetailsComponent
+    HostDetailsComponent,
+    ConfigurationDetailsComponent
   ]
 })
 export class ClusterModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -10,6 +10,7 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 import { SharedModule } from '../../shared/shared.module';
 import { PerformanceCounterModule } from '../performance-counter/performance-counter.module';
 import { ConfigurationDetailsComponent } from './configuration/configuration-details/configuration-details.component';
+import { ConfigurationFormComponent } from './configuration/configuration-form/configuration-form.component';
 import { ConfigurationComponent } from './configuration/configuration.component';
 import { HostDetailsComponent } from './hosts/host-details/host-details.component';
 import { HostsComponent } from './hosts/hosts.component';
@@ -43,7 +44,8 @@ import { OsdScrubModalComponent } from './osd/osd-scrub-modal/osd-scrub-modal.co
     OsdScrubModalComponent,
     OsdFlagsModalComponent,
     HostDetailsComponent,
-    ConfigurationDetailsComponent
+    ConfigurationDetailsComponent,
+    ConfigurationFormComponent
   ]
 })
 export class ClusterModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.html
@@ -1,0 +1,7 @@
+<tabset cdTableDetail *ngIf="selection?.hasSingleSelection">
+  <tab i18n-heading
+       heading="Details">
+    <cd-table-key-value [data]="selection.first()" [autoReload]="false">
+    </cd-table-key-value>
+  </tab>
+</tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.spec.ts
@@ -1,0 +1,27 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TabsModule } from 'ngx-bootstrap';
+
+import { configureTestBed } from '../../../../../testing/unit-test-helper';
+import { DataTableModule } from '../../../../shared/datatable/datatable.module';
+import { ConfigurationDetailsComponent } from './configuration-details.component';
+
+describe('ConfigurationDetailsComponent', () => {
+  let component: ConfigurationDetailsComponent;
+  let fixture: ComponentFixture<ConfigurationDetailsComponent>;
+
+  configureTestBed({
+    declarations: [ConfigurationDetailsComponent],
+    imports: [DataTableModule, TabsModule.forRoot()]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfigurationDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-details/configuration-details.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input, OnChanges } from '@angular/core';
+
+import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
+
+@Component({
+  selector: 'cd-configuration-details',
+  templateUrl: './configuration-details.component.html',
+  styleUrls: ['./configuration-details.component.scss']
+})
+export class ConfigurationDetailsComponent implements OnChanges {
+  @Input()
+  selection: CdTableSelection;
+  selectedItem: any;
+
+  constructor() {}
+
+  ngOnChanges() {
+    if (this.selection.hasSelection) {
+      this.selectedItem = this.selection.first();
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form-create-request.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form-create-request.model.ts
@@ -1,0 +1,4 @@
+export class ConfigFormCreateRequestModel {
+  name: string;
+  value: Array<any> = [];
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -1,0 +1,167 @@
+<div class="col-sm-12 col-lg-6">
+  <form name="configForm"
+        class="form-horizontal"
+        #formDir="ngForm"
+        [formGroup]="configForm"
+        novalidate>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h3 class="panel-title">
+          <ng-container i18>Edit</ng-container> {{ configForm.getValue('name') }}
+        </h3>
+      </div>
+      <div class="panel-body">
+
+        <!-- Name -->
+        <div class="form-group">
+          <label i18n
+                 class="control-label col-sm-3">Name
+          </label>
+          <div class="col-sm-9">
+            <input class="form-control"
+                   type="text"
+                   id="name"
+                   formControlName="name"
+                   readonly>
+          </div>
+        </div>
+
+        <!-- Description -->
+        <div class="form-group"
+             *ngIf="configForm.getValue('desc')">
+          <label i18n
+                 class="control-label col-sm-3">Description
+          </label>
+          <div class="col-sm-9">
+            <textarea class="form-control"
+                      id="desc"
+                      formControlName="desc"
+                      readonly>
+            </textarea>
+          </div>
+        </div>
+
+        <!-- Long description -->
+        <div class="form-group"
+             *ngIf="configForm.getValue('long_desc')">
+          <label i18n
+                 class="control-label col-sm-3">Long description
+          </label>
+          <div class="col-sm-9">
+            <textarea class="form-control"
+                      id="long_desc"
+                      formControlName="long_desc"
+                      readonly>
+            </textarea>
+          </div>
+        </div>
+
+        <!-- Default -->
+        <div class="form-group"
+             *ngIf="configForm.getValue('default') !== ''">
+          <label i18n
+                 class="control-label col-sm-3">Default
+          </label>
+          <div class="col-sm-9">
+            <input class="form-control"
+                   type="text"
+                   id="default"
+                   formControlName="default"
+                   readonly>
+          </div>
+        </div>
+
+        <!-- Daemon default -->
+        <div class="form-group"
+             *ngIf="configForm.getValue('daemon_default') !== ''">
+          <label i18n
+                 class="control-label col-sm-3">Daemon default
+          </label>
+          <div class="col-sm-9">
+            <input class="form-control"
+                   type="text"
+                   id="daemon_default"
+                   formControlName="daemon_default"
+                   readonly>
+          </div>
+        </div>
+
+        <!-- Services -->
+        <div class="form-group"
+             *ngIf="configForm.getValue('services').length > 0">
+          <label i18n
+                 class="control-label col-sm-3">Services
+          </label>
+          <div class="col-sm-9">
+            <span *ngFor="let service of configForm.getValue('services')"
+                  class="form-component-badge">
+              <span class="badge badge-pill badge-primary">{{ service }}</span>
+            </span>
+          </div>
+        </div>
+
+        <!-- Values -->
+        <div class="col-sm-12">
+          <h2 i18n
+              class="page-header">Values</h2>
+          <div class="row" *ngFor="let section of availSections">
+            <div class="form-group" *ngIf="type === 'bool'">
+              <div class="col-sm-offset-3 col-sm-9">
+                <div class="checkbox checkbox-primary">
+                  <input [id]="section"
+                         type="checkbox"
+                         [formControlName]="section">
+                  <label [for]="section"
+                         i18n>{{ section }}
+                  </label>
+                </div>
+              </div>
+            </div>
+            <div class="form-group"
+                 [ngClass]="{'has-error': configForm.showError(section, formDir)}"
+                 *ngIf="type !== 'bool'">
+              <label class="control-label col-sm-3"
+                     [for]="section"
+                     i18n>{{ section }}
+              </label>
+              <div class="col-sm-9">
+                <input class="form-control"
+                       [type]="inputType"
+                       [id]="section"
+                       [placeholder]="humanReadableType"
+                       [formControlName]="section"
+                       [step]="getStep(type, this.configForm.getValue(section))">
+                <span class="help-block"
+                      *ngIf="configForm.showError(section, formDir, 'pattern')"
+                      i18n>
+                  {{ patternHelpText }}
+                </span>
+                <span class="help-block"
+                      *ngIf="configForm.showError(section, formDir, 'max')"
+                      i18n>
+                  The entered value is too high! It must not be greater than {{ maxValue }}.
+                </span>
+                <span class="help-block"
+                      *ngIf="configForm.showError(section, formDir, 'min')"
+                      i18n>
+                  The entered value is too low! It must not be lower than {{ minValue }}.
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- Footer -->
+      <div class="panel-footer">
+        <div class="button-group text-right">
+          <button type="button"
+                  class="btn btn-sm btn-default"
+                  routerLink="/configuration"
+                  i18n>
+            Back
+          </button>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -154,6 +154,11 @@
       <!-- Footer -->
       <div class="panel-footer">
         <div class="button-group text-right">
+          <cd-submit-button [form]="formDir"
+                            type="button"
+                            (submitAction)="submit()">
+            <span i18n>Save</span>
+          </cd-submit-button>
           <button type="button"
                   class="btn btn-sm btn-default"
                   routerLink="/configuration"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.scss
@@ -1,0 +1,8 @@
+.form-component-badge {
+  height: 34px;
+  display: block;
+
+  span {
+    margin-top: 7px;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
@@ -4,6 +4,8 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 
+import { ToastModule } from 'ng2-toastr';
+
 import { configureTestBed } from '../../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../../shared/shared.module';
 import { ConfigurationFormComponent } from './configuration-form.component';
@@ -15,7 +17,13 @@ describe('ConfigurationFormComponent', () => {
   let activatedRoute: ActivatedRoute;
 
   configureTestBed({
-    imports: [HttpClientTestingModule, ReactiveFormsModule, RouterTestingModule, SharedModule],
+    imports: [
+      HttpClientTestingModule,
+      ReactiveFormsModule,
+      RouterTestingModule,
+      ToastModule.forRoot(),
+      SharedModule
+    ],
     declarations: [ConfigurationFormComponent],
     providers: [
       {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
@@ -1,0 +1,275 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReactiveFormsModule } from '@angular/forms';
+import { ActivatedRoute } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { configureTestBed } from '../../../../../testing/unit-test-helper';
+import { SharedModule } from '../../../../shared/shared.module';
+import { ConfigurationFormComponent } from './configuration-form.component';
+import { ConfigFormModel } from './configuration-form.model';
+
+describe('ConfigurationFormComponent', () => {
+  let component: ConfigurationFormComponent;
+  let fixture: ComponentFixture<ConfigurationFormComponent>;
+  let activatedRoute: ActivatedRoute;
+
+  configureTestBed({
+    imports: [HttpClientTestingModule, ReactiveFormsModule, RouterTestingModule, SharedModule],
+    declarations: [ConfigurationFormComponent],
+    providers: [
+      {
+        provide: ActivatedRoute
+      }
+    ]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfigurationFormComponent);
+    component = fixture.componentInstance;
+    activatedRoute = TestBed.get(ActivatedRoute);
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('getType', () => {
+    it('should return uint64_t type', () => {
+      const ret = component.getType('uint64_t');
+      expect(ret).toBeTruthy();
+      expect(ret.name).toBe('uint64_t');
+      expect(ret.inputType).toBe('number');
+      expect(ret.humanReadable).toBe('Positive integer value');
+      expect(ret.defaultMin).toBe(0);
+      expect(ret.patternHelpText).toBe('The entered value needs to be a positive number.');
+      expect(ret.isNumberType).toBe(true);
+      expect(ret.allowsNegative).toBe(false);
+    });
+
+    it('should return int64_t type', () => {
+      const ret = component.getType('int64_t');
+      expect(ret).toBeTruthy();
+      expect(ret.name).toBe('int64_t');
+      expect(ret.inputType).toBe('number');
+      expect(ret.humanReadable).toBe('Integer value');
+      expect(ret.defaultMin).toBeUndefined();
+      expect(ret.patternHelpText).toBe('The entered value needs to be a number.');
+      expect(ret.isNumberType).toBe(true);
+      expect(ret.allowsNegative).toBe(true);
+    });
+
+    it('should return size_t type', () => {
+      const ret = component.getType('size_t');
+      expect(ret).toBeTruthy();
+      expect(ret.name).toBe('size_t');
+      expect(ret.inputType).toBe('number');
+      expect(ret.humanReadable).toBe('Positive integer value (size)');
+      expect(ret.defaultMin).toBe(0);
+      expect(ret.patternHelpText).toBe('The entered value needs to be a positive number.');
+      expect(ret.isNumberType).toBe(true);
+      expect(ret.allowsNegative).toBe(false);
+    });
+
+    it('should return secs type', () => {
+      const ret = component.getType('secs');
+      expect(ret).toBeTruthy();
+      expect(ret.name).toBe('secs');
+      expect(ret.inputType).toBe('number');
+      expect(ret.humanReadable).toBe('Positive integer value (secs)');
+      expect(ret.defaultMin).toBe(1);
+      expect(ret.patternHelpText).toBe('The entered value needs to be a positive number.');
+      expect(ret.isNumberType).toBe(true);
+      expect(ret.allowsNegative).toBe(false);
+    });
+
+    it('should return double type', () => {
+      const ret = component.getType('double');
+      expect(ret).toBeTruthy();
+      expect(ret.name).toBe('double');
+      expect(ret.inputType).toBe('number');
+      expect(ret.humanReadable).toBe('Decimal value');
+      expect(ret.defaultMin).toBeUndefined();
+      expect(ret.patternHelpText).toBe('The entered value needs to be a number or decimal.');
+      expect(ret.isNumberType).toBe(true);
+      expect(ret.allowsNegative).toBe(true);
+    });
+
+    it('should return std::string type', () => {
+      const ret = component.getType('std::string');
+      expect(ret).toBeTruthy();
+      expect(ret.name).toBe('std::string');
+      expect(ret.inputType).toBe('text');
+      expect(ret.humanReadable).toBe('Text');
+      expect(ret.defaultMin).toBeUndefined();
+      expect(ret.patternHelpText).toBeUndefined();
+      expect(ret.isNumberType).toBe(false);
+      expect(ret.allowsNegative).toBeUndefined();
+    });
+
+    it('should return entity_addr_t type', () => {
+      const ret = component.getType('entity_addr_t');
+      expect(ret).toBeTruthy();
+      expect(ret.name).toBe('entity_addr_t');
+      expect(ret.inputType).toBe('text');
+      expect(ret.humanReadable).toBe('IPv4 or IPv6 address');
+      expect(ret.defaultMin).toBeUndefined();
+      expect(ret.patternHelpText).toBe('The entered value needs to be a valid IP address.');
+      expect(ret.isNumberType).toBe(false);
+      expect(ret.allowsNegative).toBeUndefined();
+    });
+
+    it('should return uuid_d type', () => {
+      const ret = component.getType('uuid_d');
+      expect(ret).toBeTruthy();
+      expect(ret.name).toBe('uuid_d');
+      expect(ret.inputType).toBe('text');
+      expect(ret.humanReadable).toBe('UUID');
+      expect(ret.defaultMin).toBeUndefined();
+      expect(ret.patternHelpText).toBe(
+        'The entered value is not a valid UUID, e.g.: 67dcac9f-2c03-4d6c-b7bd-1210b3a259a8'
+      );
+      expect(ret.isNumberType).toBe(false);
+      expect(ret.allowsNegative).toBeUndefined();
+    });
+
+    it('should return bool type', () => {
+      const ret = component.getType('bool');
+      expect(ret).toBeTruthy();
+      expect(ret.name).toBe('bool');
+      expect(ret.inputType).toBe('checkbox');
+      expect(ret.humanReadable).toBe('Boolean value');
+      expect(ret.defaultMin).toBeUndefined();
+      expect(ret.patternHelpText).toBeUndefined();
+      expect(ret.isNumberType).toBe(false);
+      expect(ret.allowsNegative).toBeUndefined();
+    });
+
+    it('should throw an error for unknown type', () => {
+      expect(() =>
+        component.getType('unknown').toThrowError('Found unknown type "unknown" for config option.')
+      );
+    });
+  });
+
+  describe('getValidators', () => {
+    it('should return a validator for types double, entity_addr_t and uuid_d', () => {
+      const types = ['double', 'entity_addr_t', 'uuid_d'];
+
+      types.forEach((valType) => {
+        const configOption = new ConfigFormModel();
+        configOption.type = valType;
+
+        const ret = component.getValidators(configOption);
+        expect(ret).toBeTruthy();
+        expect(ret.length).toBe(1);
+      });
+    });
+
+    it('should not return a validator for types std::string and bool', () => {
+      const types = ['std::string', 'bool'];
+
+      types.forEach((valType) => {
+        const configOption = new ConfigFormModel();
+        configOption.type = valType;
+
+        const ret = component.getValidators(configOption);
+        expect(ret).toBeUndefined();
+      });
+    });
+
+    it('should return a pattern and a min validator', () => {
+      const configOption = new ConfigFormModel();
+      configOption.type = 'int64_t';
+      configOption.min = 2;
+
+      const ret = component.getValidators(configOption);
+      expect(ret).toBeTruthy();
+      expect(ret.length).toBe(2);
+      expect(component.minValue).toBe(2);
+      expect(component.maxValue).toBeUndefined();
+    });
+
+    it('should return a pattern and a max validator', () => {
+      const configOption = new ConfigFormModel();
+      configOption.type = 'int64_t';
+      configOption.max = 5;
+
+      const ret = component.getValidators(configOption);
+      expect(ret).toBeTruthy();
+      expect(ret.length).toBe(2);
+      expect(component.minValue).toBeUndefined();
+      expect(component.maxValue).toBe(5);
+    });
+
+    it('should return multiple validators', () => {
+      const configOption = new ConfigFormModel();
+      configOption.type = 'double';
+      configOption.max = 5.2;
+      configOption.min = 1.5;
+
+      const ret = component.getValidators(configOption);
+      expect(ret).toBeTruthy();
+      expect(ret.length).toBe(3);
+      expect(component.minValue).toBe(1.5);
+      expect(component.maxValue).toBe(5.2);
+    });
+  });
+
+  describe('getStep', () => {
+    it('should return the correct step for type uint64_t and value 0', () => {
+      const ret = component.getStep('uint64_t', 0);
+      expect(ret).toBe(1);
+    });
+
+    it('should return the correct step for type int64_t and value 1', () => {
+      const ret = component.getStep('int64_t', 1);
+      expect(ret).toBe(1);
+    });
+
+    it('should return the correct step for type int64_t and value null', () => {
+      const ret = component.getStep('int64_t', null);
+      expect(ret).toBe(1);
+    });
+
+    it('should return the correct step for type size_t and value 2', () => {
+      const ret = component.getStep('size_t', 2);
+      expect(ret).toBe(1);
+    });
+
+    it('should return the correct step for type secs and value 3', () => {
+      const ret = component.getStep('secs', 3);
+      expect(ret).toBe(1);
+    });
+
+    it('should return the correct step for type double and value 1', () => {
+      const ret = component.getStep('double', 1);
+      expect(ret).toBe(0.1);
+    });
+
+    it('should return the correct step for type double and value 0.1', () => {
+      const ret = component.getStep('double', 0.1);
+      expect(ret).toBe(0.1);
+    });
+
+    it('should return the correct step for type double and value 0.02', () => {
+      const ret = component.getStep('double', 0.02);
+      expect(ret).toBe(0.01);
+    });
+
+    it('should return the correct step for type double and value 0.003', () => {
+      const ret = component.getStep('double', 0.003);
+      expect(ret).toBe(0.001);
+    });
+
+    it('should return the correct step for type double and value null', () => {
+      const ret = component.getStep('double', null);
+      expect(ret).toBe(0.1);
+    });
+
+    it('should return undefined for unknown type', () => {
+      const ret = component.getStep('unknown', 1);
+      expect(ret).toBeUndefined();
+    });
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -1,0 +1,242 @@
+import { Component, OnInit } from '@angular/core';
+import { FormControl, FormGroup, ValidatorFn, Validators } from '@angular/forms';
+import { ActivatedRoute, Router } from '@angular/router';
+
+import { ConfigurationService } from '../../../../shared/api/configuration.service';
+import { CdFormGroup } from '../../../../shared/forms/cd-form-group';
+import { CdValidators } from '../../../../shared/forms/cd-validators';
+import { ConfigFormModel } from './configuration-form.model';
+
+@Component({
+  selector: 'cd-configuration-form',
+  templateUrl: './configuration-form.component.html',
+  styleUrls: ['./configuration-form.component.scss']
+})
+export class ConfigurationFormComponent implements OnInit {
+  configForm: CdFormGroup;
+  response: ConfigFormModel;
+  type: string;
+  inputType: string;
+  humanReadableType: string;
+  minValue: number;
+  maxValue: number;
+  patternHelpText: string;
+  availSections = ['global', 'mon', 'mgr', 'osd', 'mds', 'client'];
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private configService: ConfigurationService
+  ) {
+    this.createForm();
+  }
+
+  createForm() {
+    const formControls = {
+      name: new FormControl({ value: null }),
+      desc: new FormControl({ value: null }),
+      long_desc: new FormControl({ value: null }),
+      values: new FormGroup({}),
+      default: new FormControl({ value: null }),
+      daemon_default: new FormControl({ value: null }),
+      services: new FormControl([])
+    };
+
+    this.availSections.forEach((section) => {
+      formControls.values.controls[section] = new FormControl(null);
+    });
+
+    this.configForm = new CdFormGroup(formControls);
+    this.configForm._filterValue = (value) => {
+      return value;
+    };
+  }
+
+  ngOnInit() {
+    this.route.params.subscribe((params: { name: string }) => {
+      const configName = params.name;
+      this.configService.get(configName).subscribe((resp: ConfigFormModel) => {
+        this.setResponse(resp);
+      });
+    });
+  }
+
+  getType(type: string): any {
+    const knownTypes = [
+      {
+        name: 'uint64_t',
+        inputType: 'number',
+        humanReadable: 'Positive integer value',
+        defaultMin: 0,
+        patternHelpText: 'The entered value needs to be a positive number.',
+        isNumberType: true,
+        allowsNegative: false
+      },
+      {
+        name: 'int64_t',
+        inputType: 'number',
+        humanReadable: 'Integer value',
+        patternHelpText: 'The entered value needs to be a number.',
+        isNumberType: true,
+        allowsNegative: true
+      },
+      {
+        name: 'size_t',
+        inputType: 'number',
+        humanReadable: 'Positive integer value (size)',
+        defaultMin: 0,
+        patternHelpText: 'The entered value needs to be a positive number.',
+        isNumberType: true,
+        allowsNegative: false
+      },
+      {
+        name: 'secs',
+        inputType: 'number',
+        humanReadable: 'Positive integer value (secs)',
+        defaultMin: 1,
+        patternHelpText: 'The entered value needs to be a positive number.',
+        isNumberType: true,
+        allowsNegative: false
+      },
+      {
+        name: 'double',
+        inputType: 'number',
+        humanReadable: 'Decimal value',
+        patternHelpText: 'The entered value needs to be a number or decimal.',
+        isNumberType: true,
+        allowsNegative: true
+      },
+      { name: 'std::string', inputType: 'text', humanReadable: 'Text', isNumberType: false },
+      {
+        name: 'entity_addr_t',
+        inputType: 'text',
+        humanReadable: 'IPv4 or IPv6 address',
+        patternHelpText: 'The entered value needs to be a valid IP address.',
+        isNumberType: false
+      },
+      {
+        name: 'uuid_d',
+        inputType: 'text',
+        humanReadable: 'UUID',
+        patternHelpText:
+          'The entered value is not a valid UUID, e.g.: 67dcac9f-2c03-4d6c-b7bd-1210b3a259a8',
+        isNumberType: false
+      },
+      { name: 'bool', inputType: 'checkbox', humanReadable: 'Boolean value', isNumberType: false }
+    ];
+
+    let currentType = null;
+
+    knownTypes.forEach((knownType) => {
+      if (knownType.name === type) {
+        currentType = knownType;
+      }
+    });
+
+    if (currentType !== null) {
+      return currentType;
+    }
+
+    throw new Error('Found unknown type "' + type + '" for config option.');
+  }
+
+  getValidators(configOption: any): ValidatorFn[] {
+    const typeParams = this.getType(configOption.type);
+    this.patternHelpText = typeParams.patternHelpText;
+
+    if (typeParams.isNumberType) {
+      const validators = [];
+
+      if (configOption.max && configOption.max !== '') {
+        this.maxValue = configOption.max;
+        validators.push(Validators.max(configOption.max));
+      }
+
+      if ('min' in configOption && configOption.min !== '') {
+        this.minValue = configOption.min;
+        validators.push(Validators.min(configOption.min));
+      } else if ('defaultMin' in typeParams) {
+        this.minValue = typeParams.defaultMin;
+        validators.push(Validators.min(typeParams.defaultMin));
+      }
+
+      if (configOption.type === 'double') {
+        validators.push(CdValidators.decimalNumber());
+      } else {
+        validators.push(CdValidators.number(typeParams.allowsNegative));
+      }
+
+      return validators;
+    } else if (configOption.type === 'entity_addr_t') {
+      return [CdValidators.ip()];
+    } else if (configOption.type === 'uuid_d') {
+      return [CdValidators.uuid()];
+    }
+  }
+
+  getStep(type: string, value: number): number | undefined {
+    const numberTypes = ['uint64_t', 'int64_t', 'size_t', 'secs'];
+
+    if (numberTypes.includes(type)) {
+      return 1;
+    }
+
+    if (type === 'double') {
+      if (value !== null) {
+        const stringVal = value.toString();
+        if (stringVal.indexOf('.') !== -1) {
+          // Value type double and contains decimal characters
+          const decimal = value.toString().split('.');
+          return Math.pow(10, -decimal[1].length);
+        }
+      }
+
+      return 0.1;
+    }
+
+    return undefined;
+  }
+
+  setResponse(response: ConfigFormModel) {
+    this.response = response;
+    const validators = this.getValidators(response);
+
+    this.configForm.get('name').setValue(response.name);
+    this.configForm.get('desc').setValue(response.desc);
+    this.configForm.get('long_desc').setValue(response.long_desc);
+    this.configForm.get('default').setValue(response.default);
+    this.configForm.get('daemon_default').setValue(response.daemon_default);
+    this.configForm.get('services').setValue(response.services);
+
+    if (this.response.value) {
+      this.response.value.forEach((value) => {
+        // Check value type. If it's a boolean value we need to convert it because otherwise we
+        // would use the string representation. That would cause issues for e.g. checkboxes.
+        let sectionValue = null;
+        if (value.value === 'true') {
+          sectionValue = true;
+        } else if (value.value === 'false') {
+          sectionValue = false;
+        } else {
+          sectionValue = value.value;
+        }
+        this.configForm
+          .get('values')
+          .get(value.section)
+          .setValue(sectionValue);
+      });
+    }
+
+    this.availSections.forEach((section) => {
+      this.configForm
+        .get('values')
+        .get(section)
+        .setValidators(validators);
+    });
+
+    const currentType = this.getType(response.type);
+    this.type = currentType.name;
+    this.inputType = currentType.inputType;
+    this.humanReadableType = currentType.humanReadable;
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.model.ts
@@ -1,0 +1,12 @@
+export class ConfigFormModel {
+  name: string;
+  desc: string;
+  long_desc: string;
+  type: string;
+  value: Array<any>;
+  default: any;
+  daemon_default: any;
+  min: any;
+  max: any;
+  services: Array<string>;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
@@ -3,7 +3,12 @@
           [columns]="columns"
           selectionType="single"
           (updateSelection)="updateSelection($event)">
-  <div class="table-actions form-inline">
+  <cd-table-actions class="table-actions"
+                    [permission]="permission"
+                    [selection]="selection"
+                    [tableActions]="tableActions">
+  </cd-table-actions>
+  <div class="table-filters">
     <div class="form-group filter"
          *ngFor="let filter of filters">
       <label>{{ filter.label }}: </label>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.html
@@ -14,27 +14,25 @@
       </select>
     </div>
   </div>
-  <tabset cdTableDetail *ngIf="selection.hasSingleSelection">
-    <tab i18n-heading
-         heading="Details">
-      <cd-table-key-value [data]="selection.first()" [autoReload]="false">
-      </cd-table-key-value>
-    </tab>
-  </tabset>
-  <ng-template #confValTpl let-value="value">
-    <span *ngIf="value">
-      <span *ngFor="let conf of value; last as isLast">
-        {{ conf.section }}: {{ conf.value }}{{ !isLast ? "," : "" }}<br/>
-      </span>
-    </span>
-  </ng-template>
-  <ng-template #confFlagTpl let-value="value">
-    <span *ngIf="value !== ''">
-      <span *ngFor="let flag of value; last as isLast">
-        <span title="{{ flags[flag] }}">
-          {{ flag | uppercase }}{{ !isLast ? "," : "" }}<br/>
-        </span>
-      </span>
-    </span>
-  </ng-template>
+  <cd-configuration-details cdTableDetail
+                            [selection]="selection">
+  </cd-configuration-details>
 </cd-table>
+
+<ng-template #confValTpl let-value="value">
+  <span *ngIf="value">
+    <span *ngFor="let conf of value; last as isLast">
+      {{ conf.section }}: {{ conf.value }}{{ !isLast ? "," : "" }}<br/>
+    </span>
+  </span>
+</ng-template>
+
+<ng-template #confFlagTpl let-value="value">
+  <span *ngIf="value !== ''">
+    <span *ngFor="let flag of value; last as isLast">
+      <span title="{{ flags[flag] }}">
+        {{ flag | uppercase }}{{ !isLast ? "," : "" }}<br/>
+      </span>
+    </span>
+  </span>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs/tabs.module';
 
@@ -16,7 +17,13 @@ describe('ConfigurationComponent', () => {
   configureTestBed({
     declarations: [ConfigurationComponent],
     providers: [ConfigurationService],
-    imports: [SharedModule, FormsModule, TabsModule.forRoot(), HttpClientTestingModule]
+    imports: [
+      SharedModule,
+      FormsModule,
+      TabsModule.forRoot(),
+      HttpClientTestingModule,
+      RouterTestingModule
+    ]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.spec.ts
@@ -8,6 +8,7 @@ import { TabsModule } from 'ngx-bootstrap/tabs/tabs.module';
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ConfigurationService } from '../../../shared/api/configuration.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { ConfigurationDetailsComponent } from './configuration-details/configuration-details.component';
 import { ConfigurationComponent } from './configuration.component';
 
 describe('ConfigurationComponent', () => {
@@ -15,7 +16,7 @@ describe('ConfigurationComponent', () => {
   let fixture: ComponentFixture<ConfigurationComponent>;
 
   configureTestBed({
-    declarations: [ConfigurationComponent],
+    declarations: [ConfigurationComponent, ConfigurationDetailsComponent],
     providers: [ConfigurationService],
     imports: [
       SharedModule,

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration.component.ts
@@ -1,9 +1,12 @@
 import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
 import { ConfigurationService } from '../../../shared/api/configuration.service';
+import { CdTableAction } from '../../../shared/models/cd-table-action';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
+import { Permission } from '../../../shared/models/permissions';
+import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 
 @Component({
   selector: 'cd-configuration',
@@ -11,6 +14,8 @@ import { CdTableSelection } from '../../../shared/models/cd-table-selection';
   styleUrls: ['./configuration.component.scss']
 })
 export class ConfigurationComponent implements OnInit {
+  permission: Permission;
+  tableActions: CdTableAction[];
   data = [];
   columns: CdTableColumn[];
   selection = new CdTableSelection();
@@ -79,7 +84,21 @@ export class ConfigurationComponent implements OnInit {
   @ViewChild('confFlagTpl')
   public confFlagTpl: TemplateRef<any>;
 
-  constructor(private configurationService: ConfigurationService) {}
+  constructor(
+    private authStorageService: AuthStorageService,
+    private configurationService: ConfigurationService
+  ) {
+    this.permission = this.authStorageService.getPermissions().configOpt;
+    const getConfigOptUri = () =>
+      this.selection.first() && `${encodeURI(this.selection.first().name)}`;
+    const editAction: CdTableAction = {
+      permission: 'update',
+      icon: 'fa-pencil',
+      routerLink: () => `/configuration/edit/${getConfigOptUri()}`,
+      name: 'Edit'
+    };
+    this.tableActions = [editAction];
+  }
 
   ngOnInit() {
     this.columns = [

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/navigation/navigation.component.html
@@ -79,7 +79,7 @@
               *ngIf="permissions.configOpt.read">
             <a i18n
                class="dropdown-item"
-               routerLink="/configuration">Configuration Doc.
+               routerLink="/configuration">Configuration
             </a>
           </li>
         </ul>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { TestBed } from '@angular/core/testing';
 
 import { configureTestBed } from '../../../testing/unit-test-helper';
+import { ConfigFormCreateRequestModel } from '../../ceph/cluster/configuration/configuration-form/configuration-form-create-request.model';
 import { ConfigurationService } from './configuration.service';
 
 describe('ConfigurationService', () => {
@@ -36,5 +37,18 @@ describe('ConfigurationService', () => {
     service.get('configOption').subscribe();
     const req = httpTesting.expectOne('api/cluster_conf/configOption');
     expect(req.request.method).toBe('GET');
+  });
+
+  it('should call create', () => {
+    const configOption = new ConfigFormCreateRequestModel();
+    configOption.name = 'Test option';
+    configOption.value = [
+      { section: 'section1', value: 'value1' },
+      { section: 'section2', value: 'value2' }
+    ];
+    service.create(configOption).subscribe();
+    const req = httpTesting.expectOne('api/cluster_conf/');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body).toEqual(configOption);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.spec.ts
@@ -31,4 +31,10 @@ describe('ConfigurationService', () => {
     const req = httpTesting.expectOne('api/cluster_conf/');
     expect(req.request.method).toBe('GET');
   });
+
+  it('should call get', () => {
+    service.get('configOption').subscribe();
+    const req = httpTesting.expectOne('api/cluster_conf/configOption');
+    expect(req.request.method).toBe('GET');
+  });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.ts
@@ -12,4 +12,8 @@ export class ConfigurationService {
   getConfigData() {
     return this.http.get('api/cluster_conf/');
   }
+
+  get(configOption) {
+    return this.http.get(`api/cluster_conf/${configOption}`);
+  }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
+import { ConfigFormCreateRequestModel } from '../../ceph/cluster/configuration/configuration-form/configuration-form-create-request.model';
 import { ApiModule } from './api.module';
 
 @Injectable({
@@ -15,5 +16,9 @@ export class ConfigurationService {
 
   get(configOption: string) {
     return this.http.get(`api/cluster_conf/${configOption}`);
+  }
+
+  create(configOption: ConfigFormCreateRequestModel) {
+    return this.http.post('api/cluster_conf/', configOption);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/configuration.service.ts
@@ -13,7 +13,7 @@ export class ConfigurationService {
     return this.http.get('api/cluster_conf/');
   }
 
-  get(configOption) {
+  get(configOption: string) {
     return this.http.get(`api/cluster_conf/${configOption}`);
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.html
@@ -3,13 +3,17 @@
   Failed to load data.
 </cd-error-panel>
 <div class="dataTables_wrapper">
-  <div class="dataTables_header clearfix"
+  <div class="dataTables_header clearfix form-inline"
        *ngIf="toolHeader">
     <!-- actions -->
     <div class="oadatatableactions">
       <ng-content select=".table-actions"></ng-content>
     </div>
     <!-- end actions -->
+
+    <!-- filters -->
+    <ng-content select=".table-filters"></ng-content>
+    <!-- end filters -->
 
     <!-- search -->
     <div class="input-group">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -58,6 +58,14 @@
   .oadatatableactions {
     display: inline-block;
   }
+  ::ng-deep .table-filters {
+    float: right;
+    border-left: 1px solid $color-table-seperator-border;
+    padding-left: 8px;
+  }
+  ::ng-deep .table-filters label {
+    margin-right: 4px;
+  }
   .form-group {
     padding-left: 8px;
   }
@@ -65,6 +73,7 @@
     float: right;
     border-left: 1px solid $color-table-input-border;
     padding-left: 8px;
+    padding-right: 8px;
     width: 40%;
     max-width: 250px;
     .form-control {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.spec.ts
@@ -23,6 +23,420 @@ describe('CdValidators', () => {
     });
   });
 
+  describe('ip validator', () => {
+    let form: FormGroup;
+
+    beforeEach(() => {
+      form = new FormGroup({
+        x: new FormControl()
+      });
+    });
+
+    it('should not error on empty IPv4 addresses', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(4));
+      x.setValue('');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should accept valid IPv4 address', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(4));
+      x.setValue('19.117.23.141');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should error on IPv4 address containing whitespace', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(4));
+      x.setValue('155.144.133.122 ');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('155. 144.133 .122');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue(' 155.144.133.122');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on IPv4 address containing invalid char', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(4));
+      x.setValue('155.144.eee.122 ');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('155.1?.133 .1&2');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on IPv4 address containing blocks higher than 255', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(4));
+      x.setValue('155.270.133.122 ');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('155.144.133.290 ');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should not error on empty IPv6 addresses', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(4));
+      x.setValue('');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should accept valid IPv6 address', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(6));
+      x.setValue('c4dc:1475:cb0b:24ed:3c80:468b:70cd:1a95');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should error on IPv6 address containing too many blocks', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(6));
+      x.setValue('c4dc:14753:cb0b:24ed:3c80:468b:70cd:1a95:a3f3');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on IPv6 address containing more than 4 digits per block', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(6));
+      x.setValue('c4dc:14753:cb0b:24ed:3c80:468b:70cd:1a95');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on IPv6 address containing whitespace', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(6));
+      x.setValue('c4dc:14753:cb0b:24ed:3c80:468b:70cd:1a95 ');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('c4dc:14753 :cb0b:24ed:3c80 :468b:70cd :1a95');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue(' c4dc:14753:cb0b:24ed:3c80:468b:70cd:1a95');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on IPv6 address containing invalid char', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip(6));
+      x.setValue('c4dx:14753:cb0b:24ed:3c80:468b:70cd:1a95 ');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('c4dx:14753:cb0b:24ed:3$80:468b:70cd:1a95 ');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should accept valid IPv4/6 addresses if not protocol version is given', () => {
+      const x = form.get('x');
+      x.setValidators(CdValidators.ip());
+      x.setValue('19.117.23.141');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue('c4dc:1475:cb0b:24ed:3c80:468b:70cd:1a95');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+  });
+
+  describe('uuid validator', () => {
+    let form: FormGroup;
+
+    beforeEach(() => {
+      form = new FormGroup({
+        x: new FormControl()
+      });
+      form.controls['x'].setValidators(CdValidators.uuid());
+    });
+
+    it('should accept empty value', () => {
+      const x = form.get('x');
+      x.setValue('');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should accept valid version 1 uuid', () => {
+      const x = form.get('x');
+      x.setValue('171af0b2-c305-11e8-a355-529269fb1459');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should accept valid version 4 uuid', () => {
+      const x = form.get('x');
+      x.setValue('e33bbcb6-fcc3-40b1-ae81-3f81706a35d5');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should error on uuid containing too many blocks', () => {
+      const x = form.get('x');
+      x.setValue('e33bbcb6-fcc3-40b1-ae81-3f81706a35d5-23d3');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on uuid containing too many chars in block', () => {
+      const x = form.get('x');
+      x.setValue('aae33bbcb6-fcc3-40b1-ae81-3f81706a35d5');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on uuid containing invalid char', () => {
+      const x = form.get('x');
+      x.setValue('x33bbcb6-fcc3-40b1-ae81-3f81706a35d5');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('$33bbcb6-fcc3-40b1-ae81-3f81706a35d5');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+  });
+
+  describe('number validator', () => {
+    let form: FormGroup;
+
+    beforeEach(() => {
+      form = new FormGroup({
+        x: new FormControl()
+      });
+      form.controls['x'].setValidators(CdValidators.number());
+    });
+
+    it('should accept empty value', () => {
+      const x = form.get('x');
+      x.setValue('');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should accept numbers', () => {
+      const x = form.get('x');
+      x.setValue(42);
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue(-42);
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue('42');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should error on decimal numbers', () => {
+      const x = form.get('x');
+      x.setValue(42.3);
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue(-42.3);
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('42.3');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on chars', () => {
+      const x = form.get('x');
+      x.setValue('char');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('42char');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on whitespaces', () => {
+      const x = form.get('x');
+      x.setValue('42 ');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('4 2');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+  });
+
+  describe('number validator (without negative values)', () => {
+    let form: FormGroup;
+
+    beforeEach(() => {
+      form = new FormGroup({
+        x: new FormControl()
+      });
+      form.controls['x'].setValidators(CdValidators.number(false));
+    });
+
+    it('should accept positive numbers', () => {
+      const x = form.get('x');
+      x.setValue(42);
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue('42');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should error on negative numbers', () => {
+      const x = form.get('x');
+      x.setValue(-42);
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('-42');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+  });
+
+  describe('decimal number validator', () => {
+    let form: FormGroup;
+
+    beforeEach(() => {
+      form = new FormGroup({
+        x: new FormControl()
+      });
+      form.controls['x'].setValidators(CdValidators.decimalNumber());
+    });
+
+    it('should accept empty value', () => {
+      const x = form.get('x');
+      x.setValue('');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should accept numbers and decimal numbers', () => {
+      const x = form.get('x');
+      x.setValue(42);
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue(-42);
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue(42.3);
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue(-42.3);
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue('42');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue('42.3');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should error on chars', () => {
+      const x = form.get('x');
+      x.setValue('42e');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('e42.3');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+
+    it('should error on whitespaces', () => {
+      const x = form.get('x');
+      x.setValue('42.3 ');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('42 .3');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+  });
+
+  describe('decimal number validator (without negative values)', () => {
+    let form: FormGroup;
+
+    beforeEach(() => {
+      form = new FormGroup({
+        x: new FormControl()
+      });
+      form.controls['x'].setValidators(CdValidators.decimalNumber(false));
+    });
+
+    it('should accept positive numbers and decimals', () => {
+      const x = form.get('x');
+      x.setValue(42);
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue(42.3);
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue('42');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+
+      x.setValue('42.3');
+      expect(x.valid).toBeTruthy();
+      expect(x.hasError('pattern')).toBeFalsy();
+    });
+
+    it('should error on negative numbers and decimals', () => {
+      const x = form.get('x');
+      x.setValue(-42);
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('-42');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue(-42.3);
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+
+      x.setValue('-42.3');
+      expect(x.valid).toBeFalsy();
+      expect(x.hasError('pattern')).toBeTruthy();
+    });
+  });
+
   describe('requiredIf', () => {
     let form: FormGroup;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -30,6 +30,65 @@ export class CdValidators {
   }
 
   /**
+   * Validator function in order to validate IP addresses.
+   * @param {number} version determines the protocol version. It needs to be set to 4 for IPv4 and
+   * to 6 for IPv6 validation. For any other number (it's also the default case) it will return a
+   * function to validate the input string against IPv4 OR IPv6.
+   * @returns {ValidatorFn} A validator function that returns an error map containing `pattern`
+   * if the validation failed, otherwise `null`.
+   */
+  static ip(version: number = 0): ValidatorFn {
+    // prettier-ignore
+    const ipv4Rgx =
+      /^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$/i;
+    const ipv6Rgx = /^(?:[a-f0-9]{1,4}:){7}[a-f0-9]{1,4}$/i;
+
+    if (version === 4) {
+      return Validators.pattern(ipv4Rgx);
+    } else if (version === 6) {
+      return Validators.pattern(ipv6Rgx);
+    } else {
+      return Validators.pattern(new RegExp(ipv4Rgx.source + '|' + ipv6Rgx.source));
+    }
+  }
+
+  /**
+   * Validator function in order to validate uuids.
+   * @returns {ValidatorFn} A validator function that returns an error map containing `pattern`
+   * if the validation failed, otherwise `null`.
+   */
+  static uuid(): ValidatorFn {
+    const uuidRgx = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    return Validators.pattern(uuidRgx);
+  }
+
+  /**
+   * Validator function in order to validate numbers.
+   * @returns {ValidatorFn} A validator function that returns an error map containing `pattern`
+   * if the validation failed, otherwise `null`.
+   */
+  static number(allowsNegative: boolean = true): ValidatorFn {
+    if (allowsNegative) {
+      return Validators.pattern(/^-?[0-9]+$/i);
+    } else {
+      return Validators.pattern(/^[0-9]+$/i);
+    }
+  }
+
+  /**
+   * Validator function in order to validate decimal numbers.
+   * @returns {ValidatorFn} A validator function that returns an error map containing `pattern`
+   * if the validation failed, otherwise `null`.
+   */
+  static decimalNumber(allowsNegative: boolean = true): ValidatorFn {
+    if (allowsNegative) {
+      return Validators.pattern(/^-?[0-9]+(.[0-9]+)?$/i);
+    } else {
+      return Validators.pattern(/^[0-9]+(.[0-9]+)?$/i);
+    }
+  }
+
+  /**
    * Validator that requires controls to fulfill the specified condition if
    * the specified prerequisites matches. If the prerequisites are fulfilled,
    * then the given function is executed and if it succeeds, the 'required'


### PR DESCRIPTION
This PR adds the following functionalities:

Backend:
- refactor of '_get_mon_allow_pool_delete_config' to be more general
- backend functionality to add config options + related tests

Frontend:
- a config options form
- a placeholder for filters (dropdown menu) to the dashboard datatable
- a fix for an import issue in configuration.component.spec.ts
- a fix for a typo in monitors.e2e-spec.ts
- the missing parameter type to an existing configuration service method and a related test 
- frontend functionality to add config options + related tests
- pattern validators for IP-addresses, UUIDs, numbers and decimal numbers
- moved the configuration table details to their own component

ToDo:
This PR is just a first step in order to manage config options. Of course there are a bunch of things still missing.They should be handled in separate PRs in my opinion. I will update the list and create issues as soon as possible.

- Load only relevant sections in detail view (if possible)
- Don't allow editing of read-only fields (http://tracker.ceph.com/issues/34528)
- Add a filter for config options that have been adjusted by a user (http://tracker.ceph.com/issues/24996)
- Button to reset filters (http://tracker.ceph.com/issues/36173)
- Enhance layout of the config options page (https://tracker.ceph.com/issues/34533)

Signed-off-by: Tatjana Dehler <tdehler@suse.com>