### PR TITLE
mon: don't require CEPHX_V2 from mons until nautilus

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2206,11 +2206,11 @@ void Monitor::calc_quorum_requirements()
     required_features |= CEPH_FEATUREMASK_SERVER_LUMINOUS;
   }
   if (features.incompat.contains(CEPH_MON_FEATURE_INCOMPAT_MIMIC)) {
-    required_features |= CEPH_FEATUREMASK_SERVER_MIMIC |
-      CEPH_FEATUREMASK_CEPHX_V2;
+    required_features |= CEPH_FEATUREMASK_SERVER_MIMIC;
   }
   if (features.incompat.contains(CEPH_MON_FEATURE_INCOMPAT_NAUTILUS)) {
-    required_features |= CEPH_FEATUREMASK_SERVER_NAUTILUS;
+    required_features |= CEPH_FEATUREMASK_SERVER_NAUTILUS |
+      CEPH_FEATUREMASK_CEPHX_V2;
   }
 
   // monmap
@@ -2224,12 +2224,12 @@ void Monitor::calc_quorum_requirements()
   }
   if (monmap->get_required_features().contains_all(
 	ceph::features::mon::FEATURE_MIMIC)) {
-    required_features |= CEPH_FEATUREMASK_SERVER_MIMIC |
-      CEPH_FEATUREMASK_CEPHX_V2;
+    required_features |= CEPH_FEATUREMASK_SERVER_MIMIC;
   }
   if (monmap->get_required_features().contains_all(
 	ceph::features::mon::FEATURE_NAUTILUS)) {
-    required_features |= CEPH_FEATUREMASK_SERVER_NAUTILUS;
+    required_features |= CEPH_FEATUREMASK_SERVER_NAUTILUS |
+      CEPH_FEATUREMASK_CEPHX_V2;
   }
   dout(10) << __func__ << " required_features " << required_features << dendl;
 }


### PR DESCRIPTION
The mimic 13.2.0 didn't have it.

Fixes: 3dc80e5f9b6ebf1bc1cecbd95b288005216bdbec
Signed-off-by: Sage Weil <sage@redhat.com>