### PR TITLE
mimic: mon: don't require CEPHX_V2 from mons until nautilus

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2198,8 +2198,7 @@ void Monitor::calc_quorum_requirements()
     required_features |= CEPH_FEATUREMASK_SERVER_LUMINOUS;
   }
   if (features.incompat.contains(CEPH_MON_FEATURE_INCOMPAT_MIMIC)) {
-    required_features |= CEPH_FEATUREMASK_SERVER_MIMIC |
-      CEPH_FEATUREMASK_CEPHX_V2;
+    required_features |= CEPH_FEATUREMASK_SERVER_MIMIC;
   }
 
   // monmap
@@ -2213,8 +2212,7 @@ void Monitor::calc_quorum_requirements()
   }
   if (monmap->get_required_features().contains_all(
 	ceph::features::mon::FEATURE_MIMIC)) {
-    required_features |= CEPH_FEATUREMASK_SERVER_MIMIC |
-      CEPH_FEATUREMASK_CEPHX_V2;
+    required_features |= CEPH_FEATUREMASK_SERVER_MIMIC;
   }
   dout(10) << __func__ << " required_features " << required_features << dendl;
 }


### PR DESCRIPTION
The mimic 13.2.0 didn't have it.

Fixes: 3dc80e5f9b6ebf1bc1cecbd95b288005216bdbec
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 7ba0c14ce75f6936b59a3c61ea34a6f0fb909280)


- dropped the nautilus cases in the original commit