### PR TITLE
add ceph-crash service

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1041,13 +1041,14 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/mon
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/osd
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/mds
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/mgr
+mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/crash
+mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/crash/posted
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/radosgw
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-osd
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mds
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mgr
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd
-mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/crash
 
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents
@@ -1063,6 +1064,7 @@ rm -rf %{buildroot}
 %files
 
 %files base
+%{_bindir}/ceph-crash
 %{_bindir}/crushtool
 %{_bindir}/monmaptool
 %{_bindir}/osdmaptool
@@ -1079,6 +1081,7 @@ rm -rf %{buildroot}
 %{_libdir}/ceph/erasure-code/libec_*.so*
 %dir %{_libdir}/ceph/compressor
 %{_libdir}/ceph/compressor/libceph_*.so*
+%{_unitdir}/ceph-crash.service
 %ifarch x86_64
 %dir %{_libdir}/ceph/crypto
 %{_libdir}/ceph/crypto/libceph_*.so*
@@ -1114,6 +1117,8 @@ rm -rf %{buildroot}
 %{_mandir}/man8/monmaptool.8*
 %{_mandir}/man8/ceph-kvstore-tool.8*
 #set up placeholder directories
+%attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/crash
+%attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/crash/posted
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/tmp
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-osd
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-mds
@@ -1126,22 +1131,22 @@ rm -rf %{buildroot}
 %if 0%{?suse_version}
 %fillup_only
 if [ $1 -eq 1 ] ; then
-/usr/bin/systemctl preset ceph.target >/dev/null 2>&1 || :
+/usr/bin/systemctl preset ceph.target ceph-crash.service >/dev/null 2>&1 || :
 fi
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_post ceph.target
+%systemd_post ceph.target ceph-crash.service
 %endif
 if [ $1 -eq 1 ] ; then
-/usr/bin/systemctl start ceph.target >/dev/null 2>&1 || :
+/usr/bin/systemctl start ceph.target ceph-crash.service >/dev/null 2>&1 || :
 fi
 
 %preun base
 %if 0%{?suse_version}
-%service_del_preun ceph.target
+%service_del_preun ceph.target ceph-crash.service
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_preun ceph.target
+%systemd_preun ceph.target ceph-crash.service
 %endif
 
 %postun base

--- a/debian/ceph-base.dirs
+++ b/debian/ceph-base.dirs
@@ -5,3 +5,4 @@ var/lib/ceph/bootstrap-rgw
 var/lib/ceph/bootstrap-rbd
 var/lib/ceph/tmp
 var/lib/ceph/crash
+var/lib/ceph/crash/posted

--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -1,4 +1,6 @@
 etc/init.d/ceph
+lib/systemd/system/ceph-crash.service
+usr/bin/ceph-crash
 usr/bin/ceph-debugpack
 usr/bin/ceph-run
 usr/bin/crushtool

--- a/qa/suites/rados/singleton/all/test-crash.yaml
+++ b/qa/suites/rados/singleton/all/test-crash.yaml
@@ -1,0 +1,14 @@
+roles:
+  - [client.0, mon.a, mgr.x, osd.0, osd.1, osd.2]
+
+tasks:
+  - install:
+  - ceph:
+      log-whitelist:
+        - Reduced data availability
+        - OSD_.*DOWN
+  - workunit:
+      clients:
+         client.0:
+           - rados/test_crash.sh
+  - ceph.restart: [osd.*]

--- a/qa/workunits/rados/test_crash.sh
+++ b/qa/workunits/rados/test_crash.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+
+set -x
+
+# run on a single-node three-OSD cluster
+
+sudo killall -ABRT ceph-osd
+sleep 5
+
+# kill caused coredumps; find them and delete them, carefully, so as
+# not to disturb other coredumps, or else teuthology will see them
+# and assume test failure.  sudos are because the core files are
+# root/600
+for f in $(find $TESTDIR/archive/coredump -type f); do
+	gdb_output=$(echo "quit" | sudo gdb /usr/bin/ceph-osd $f)
+	if expr match "$gdb_output" ".*generated.*ceph-osd.*" && \
+	   ( \
+
+	   	expr match "$gdb_output" ".*terminated.*signal 6.*" || \
+	   	expr match "$gdb_output" ".*terminated.*signal SIGABRT.*" \
+	   )
+	then
+		sudo rm $f
+	fi
+done
+
+# let daemon find crashdumps on startup
+sudo systemctl restart ceph-crash
+sleep 30
+
+# must be 3 crashdumps registered and moved to crash/posted
+[ $(ceph crash ls | wc -l) = 3 ]  || exit 1
+[ $(sudo find /var/lib/ceph/crash/posted/ -name meta | wc -l) = 3 ] || exit 1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -581,6 +581,9 @@ configure_file(${CMAKE_SOURCE_DIR}/src/init-ceph.in
 configure_file(ceph-post-file.in
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-post-file @ONLY)
 
+configure_file(ceph-crash.in
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-crash @ONLY)
+
 if(WITH_TESTS)
   install(PROGRAMS
     ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-debugpack
@@ -591,6 +594,7 @@ endif()
 install(PROGRAMS
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-post-file
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-crash
   ${CMAKE_SOURCE_DIR}/src/ceph-run
   ${CMAKE_SOURCE_DIR}/src/ceph-clsinfo
   DESTINATION bin)

--- a/src/ceph-crash.in
+++ b/src/ceph-crash.in
@@ -1,0 +1,83 @@
+#!@PYTHON_EXECUTABLE@
+# -*- mode:python -*-
+# vim: ts=4 sw=4 smarttab expandtab
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+import time
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger(__name__)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-p', '--path', default='/var/lib/ceph/crash',
+        help='base path to monitor for crash dumps')
+    parser.add_argument(
+        '-d', '--delay', default=10.0, type=float,
+        help='minutes to delay between scans (0 to exit after one)',
+    )
+    return parser.parse_args()
+
+
+def post_crash(path):
+    pr = subprocess.Popen(
+        args=['timeout', '30', 'ceph', 'crash', 'post', '-i', '-'],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    f = open(os.path.join(path, 'meta'), 'r')
+    stdout, stderr = pr.communicate(input=f.read())
+    rc = pr.wait()
+    f.close()
+    if rc != 0:
+        log.warning('post %s failed: %s' % (path, stderr))
+    return rc
+
+
+def scrape_path(path):
+    for p in os.listdir(path):
+        crashpath = os.path.join(path, p)
+        metapath = os.path.join(crashpath, 'meta')
+        donepath = os.path.join(crashpath, 'done')
+        if os.path.isfile(metapath):
+            if not os.path.isfile(donepath):
+                # hang out just for a bit; either we interrupted the dump
+                # or the daemon crashed before finishing it
+                time.sleep(1)
+                if not os.path.isfile(donepath):
+                    return
+            # ok, we can process this one
+            rc = post_crash(crashpath)
+            if rc == 0:
+                os.rename(crashpath, os.path.join(path, 'posted/', p))
+                log.debug(
+                    "posted %s and renamed %s -> %s " %
+                    (metapath, p, os.path.join('posted/', p))
+                )
+
+
+def main():
+    args = parse_args()
+    postdir = os.path.join(args.path, 'posted')
+
+    while not os.path.isdir(postdir):
+        log.error("%s does not exist; please create" % postdir)
+        time.sleep(30)
+
+    log.info("monitoring path %s, delay %ds" % (args.path, args.delay * 60.0))
+    while True:
+        scrape_path(args.path)
+        if args.delay == 0:
+            sys.exit(0)
+        time.sleep(args.delay * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4801,7 +4801,7 @@ std::vector<Option> get_global_options() {
     .set_description("Filesystem path to manager modules."),
 
     Option("mgr_initial_modules", Option::TYPE_STR, Option::LEVEL_BASIC)
-    .set_default("restful status balancer iostat devicehealth")
+    .set_default("restful status balancer iostat devicehealth crash")
     .set_flag(Option::FLAG_NO_MON_UPDATE)
     .set_flag(Option::FLAG_CLUSTER_CREATE)
     .add_service("mon")

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -261,6 +261,8 @@ static void handle_fatal_signal(int signum)
 	(void)r;
 	::close(fd);
       }
+      snprintf(fn, sizeof(fn)-1, "%s/done", base);
+      ::creat(fn, 0444);
     }
   }
 

--- a/systemd/50-ceph.preset
+++ b/systemd/50-ceph.preset
@@ -4,3 +4,4 @@ enable ceph-mgr.target
 enable ceph-mon.target
 enable ceph-osd.target
 enable ceph-radosgw.target
+enable ceph-crash.service

--- a/systemd/CMakeLists.txt
+++ b/systemd/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CEPH_SYSTEMD_ENV_DIR "/etc/sysconfig"
   CACHE PATH "Location for systemd service environmental variable settings files")
 set(SYSTEMD_ENV_FILE "${CEPH_SYSTEMD_ENV_DIR}/ceph")
 foreach(service
+    ceph-crash
     ceph-fuse@
     ceph-mds@
     ceph-mgr@

--- a/systemd/ceph-crash.service.in
+++ b/systemd/ceph-crash.service.in
@@ -1,0 +1,13 @@
+[Unit]
+Description=Ceph crash dump collector
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ceph-crash
+Restart=always
+RestartSec=10
+StartLimitInterval=10min
+StartLimitBurst=10
+
+[Install]
+WantedBy=ceph.target


### PR DESCRIPTION
This is a small persistent program to run under systemd (as here) or in a container env to watch for crash dumps in /var/lib/ceph/crash and post them to the monitor through the mgr crash module.

Yet to be done: teuthology test for this service and integration with mgr telemetry module