### PR TITLE
deb,rpm: fix /var/lib/ceph/osd/*/block.db symlink ownership

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1533,6 +1533,8 @@ fi
 %else
     /usr/lib/systemd/systemd-sysctl %{_sysctldir}/90-ceph-osd.conf > /dev/null 2>&1 || :
 %endif
+# work around https://tracker.ceph.com/issues/24903
+chown ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
 
 %preun osd
 %if 0%{?suse_version}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1534,7 +1534,7 @@ fi
     /usr/lib/systemd/systemd-sysctl %{_sysctldir}/90-ceph-osd.conf > /dev/null 2>&1 || :
 %endif
 # work around https://tracker.ceph.com/issues/24903
-chown ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
+chown -h ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
 
 %preun osd
 %if 0%{?suse_version}

--- a/debian/ceph-osd.postinst
+++ b/debian/ceph-osd.postinst
@@ -26,7 +26,7 @@ case "$1" in
 	[ -x /etc/init.d/procps ] && invoke-rc.d procps restart || :
 	[ -x /sbin/start ] && start ceph-osd-all || :
 	# work around https://tracker.ceph.com/issues/24903
-	chown ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
+	chown -h ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
 	:

--- a/debian/ceph-osd.postinst
+++ b/debian/ceph-osd.postinst
@@ -25,6 +25,8 @@ case "$1" in
     configure)
 	[ -x /etc/init.d/procps ] && invoke-rc.d procps restart || :
 	[ -x /sbin/start ] && start ceph-osd-all || :
+	# work around https://tracker.ceph.com/issues/24903
+	chown ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
     ;;
     abort-upgrade|abort-remove|abort-deconfigure)
 	:


### PR DESCRIPTION
This is cherry-picked to luminous and mimic.  It's not needed in master (probably), but
I think it's better to merge and revert just so the cherry-pick -x refs work correctly.