### PR TITLE
mimic: osd/OSDMap: fix CEPHX_V2 osd requirement to nautilus, not mimic

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1420,13 +1420,13 @@ uint64_t OSDMap::get_features(int entity_type, uint64_t *pmask) const
     mask |= kraken_features;
   }
 
-  if (require_min_compat_client >= CEPH_RELEASE_MIMIC) {
-    // if min_compat_client is >= mimic, require v2 cephx signatures
+  if (require_min_compat_client >= CEPH_RELEASE_NAUTILUS) {
+    // if min_compat_client is >= nautilus, require v2 cephx signatures
     // from everyone
     features |= CEPH_FEATUREMASK_CEPHX_V2;
-  } else if (require_osd_release >= CEPH_RELEASE_MIMIC &&
+  } else if (require_osd_release >= CEPH_RELEASE_NAUTILUS &&
 	     entity_type == CEPH_ENTITY_TYPE_OSD) {
-    // if osds are >= mimic, at least require the signatures from them
+    // if osds are >= nautilus, at least require the signatures from them
     features |= CEPH_FEATUREMASK_CEPHX_V2;
   }
   mask |= CEPH_FEATUREMASK_CEPHX_V2;


### PR DESCRIPTION
This was delayed and did not appear in 13.2.0.

Fixes: 1fdc85f224d52655d74eff9a29b6029b974661b3
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 37781061022a92e88dff91ff18fd0fc14b5436de)