### PR TITLE
os/bluestore: fix race between remove_collection and object removals

### DIFF
--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -1012,12 +1012,10 @@ static int os_unlink(const char *path)
       keys.insert(key);
       t.omap_rmkeys(cid, oid, keys);
     }
-    ch = fs->store->open_collection(cid);
     break;
 
   case FN_OBJECT_ATTR_VAL:
     t.rmattr(cid, oid, key.c_str());
-    ch = fs->store->open_collection(cid);
     break;
 
   case FN_OBJECT_OMAP_HEADER:
@@ -1025,12 +1023,10 @@ static int os_unlink(const char *path)
       bufferlist empty;
       t.omap_setheader(cid, oid, empty);
     }
-    ch = fs->store->open_collection(cid);
     break;
 
   case FN_OBJECT:
     t.remove(cid, oid);
-    ch = fs->store->open_collection(cid);
     break;
 
   case FN_COLLECTION:
@@ -1043,12 +1039,10 @@ static int os_unlink(const char *path)
         return -ENOTEMPTY;
       t.remove_collection(cid);
     }
-    ch = fs->store->open_collection(coll_t::meta());
     break;
 
   case FN_OBJECT_DATA:
     t.truncate(cid, oid, 0);
-    ch = fs->store->open_collection(cid);
     break;
 
   default:

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3196,6 +3196,11 @@ void BlueStore::Collection::flush()
   osr->flush();
 }
 
+void BlueStore::Collection::flush_all_but_last()
+{
+  osr->flush_all_but_last();
+}
+
 void BlueStore::Collection::open_shared_blob(uint64_t sbid, BlobRef b)
 {
   assert(!b->shared_blob);
@@ -8616,8 +8621,7 @@ void BlueStore::_txc_finish_io(TransContext *txc)
   } while (p != osr->q.end() &&
 	   p->state == TransContext::STATE_IO_DONE);
 
-  if (osr->kv_submitted_waiters &&
-      osr->_is_all_kv_submitted()) {
+  if (osr->kv_submitted_waiters) {
     osr->qcond.notify_all();
   }
 }
@@ -9131,9 +9135,7 @@ void BlueStore::_kv_sync_thread()
 	  txc->state = TransContext::STATE_KV_SUBMITTED;
 	  if (txc->osr->kv_submitted_waiters) {
 	    std::lock_guard<std::mutex> l(txc->osr->qlock);
-	    if (txc->osr->_is_all_kv_submitted()) {
-	      txc->osr->qcond.notify_all();
-	    }
+	    txc->osr->qcond.notify_all();
 	  }
 
 	} else {
@@ -11395,7 +11397,9 @@ int BlueStore::_remove(TransContext *txc,
 		       CollectionRef& c,
 		       OnodeRef &o)
 {
-  dout(15) << __func__ << " " << c->cid << " " << o->oid << dendl;
+  dout(15) << __func__ << " " << c->cid << " " << o->oid
+	   << " onode " << o.get()
+	   << " txc "<< txc << dendl;
   int r = _do_remove(txc, c, o);
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;
   return r;
@@ -11929,6 +11933,7 @@ int BlueStore::_remove_collection(TransContext *txc, const coll_t &cid,
   dout(15) << __func__ << " " << cid << dendl;
   int r;
 
+  (*c)->flush_all_but_last();
   {
     RWLock::WLocker l(coll_lock);
     if (!*c) {
@@ -11967,7 +11972,9 @@ int BlueStore::_remove_collection(TransContext *txc, const coll_t &cid,
         exists = !onode || onode->exists;
         if (exists) {
           dout(10) << __func__ << " " << *it
-                   << " exists in db" << dendl;
+		   << " exists in db, "
+		   << (!onode ? "not present in ram" : "present in ram")
+		   << dendl;
         }
       }
       if (!exists) {


### PR DESCRIPTION
remove_collection() might start collection listing before previous removals land to KV. And cache trimming might remove onode entry from cache before the corresponding record from collection listring is processed. Hence we get onode record and no in-mem entry to check 'exist' flag against which forces remove_collection to assert due to existing object(s).

Fixes: https://tracker.ceph.com/issues/25077

Signe-off-by: Igor Fedotov <ifedotov@suse.com>