### PR TITLE
ceph-volume: update version of ansible to 2.6.x for simple tests

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -18,7 +18,7 @@ setenv=
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
 deps=
-  ansible==2.4.1
+  ansible~=2.6,<2.7
   testinfra==1.7.1
   pytest-xdist
   notario>=0.0.13


### PR DESCRIPTION
ceph-ansible now requires a 2.5.x or 2.6.x version of ansible if you're
using the master branch. This updates our functional tests for the
simple subcommand to use a 2.6.x version of ansible.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>