### PR TITLE
ceph-volume: do not pin the testinfra version for the simple tests

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -19,7 +19,7 @@ setenv=
   CEPH_VOLUME_DEBUG = 1
 deps=
   ansible~=2.6,<2.7
-  testinfra==1.7.1
+  testinfra
   pytest-xdist
   notario>=0.0.13
 changedir=


### PR DESCRIPTION
For testinfra to work with a 2.6.x version of ansible it must use the
latest version.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>