### PR TITLE
common/config: fix the lock in ConfigProxy::diff()

### DIFF
--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -71,8 +71,8 @@ public:
     return config.find_option(name);
   }
   void diff(Formatter *f, const std::string& name=string{}) const {
-    return config.diff(values, f, name);
     Mutex::Locker l{lock};
+    return config.diff(values, f, name);
   }
   void get_my_sections(std::vector <std::string> &sections) const {
     Mutex::Locker l{lock};


### PR DESCRIPTION
it's a regression introduced by e406d8eb9e1deb801ecb346169eaaf96adbb4b53

Signed-off-by: Kefu Chai <kchai@redhat.com>