### PR TITLE
mgr/dashboard: Fix localStorage problem in Jest

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -32,7 +32,8 @@
     ],
     "modulePathIgnorePatterns": [
       "<rootDir>/coverage/"
-    ]
+    ],
+    "testURL": "http://localhost/"
   },
   "dependencies": {
     "@angular/animations": "6.0.6",


### PR DESCRIPTION
Latest version of Jest was showing the following error:
"SecurityError: localStorage is not available for opaque origins"

Signed-off-by: Tiago Melo <tmelo@suse.com>