### PR TITLE
cmake: bump up the required fmt version

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -366,7 +366,7 @@ include_directories("${CMAKE_SOURCE_DIR}/src/dmclock/support/src")
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/googletest/googletest/include")
 
 if(WITH_SEASTAR)
-  find_package(fmt 3.0.2)
+  find_package(fmt 4.0.0)
   if(NOT fmt_FOUND)
     add_subdirectory(fmt)
   endif()


### PR DESCRIPTION
seastar actually requires fmt 4.0.0 and up, as 3.0.2 does not offer
fmt/printf.h. see
https://github.com/fmtlib/fmt/blob/master/ChangeLog.rst#400---2017-06-27
.

Signed-off-by: Kefu Chai <kchai@redhat.com>