### PR TITLE
mgr/dashboard: Fix duplicate error messages

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
@@ -54,6 +54,7 @@ describe('TaskWrapperService', () => {
       notify = TestBed.get(NotificationService);
       summaryService = TestBed.get(SummaryService);
       spyOn(notify, 'show');
+      spyOn(notify, 'notifyTask').and.stub();
       spyOn(service, '_handleExecutingTasks').and.callThrough();
       spyOn(summaryService, 'addRunningTask').and.callThrough();
     });
@@ -77,7 +78,6 @@ describe('TaskWrapperService', () => {
       spyOn(taskManager, 'subscribe').and.callFake((name, metadata, onTaskFinished) => {
         onTaskFinished();
       });
-      spyOn(notify, 'notifyTask').and.stub();
       callWrapTaskAroundCall(202, 'async').subscribe(null, null, () => (passed = true));
       expect(notify.notifyTask).toHaveBeenCalled();
     });
@@ -87,6 +87,11 @@ describe('TaskWrapperService', () => {
       expect(service._handleExecutingTasks).not.toHaveBeenCalled();
       expect(passed).toBeTruthy();
       expect(summaryService.addRunningTask).not.toHaveBeenCalled();
+      /**
+       * A notification will be raised by the API interceptor.
+       * This resolves this bug https://tracker.ceph.com/issues/25139
+       */
+      expect(notify.notifyTask).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.ts
@@ -38,7 +38,6 @@ export class TaskWrapperService {
         (resp) => {
           task.success = false;
           task.exception = resp.error;
-          this.notificationService.notifyTask(task);
           observer.error();
         },
         () => {


### PR DESCRIPTION
Duplicate error messages currently appear if the task wrapper service is
used. It calls 'notifyTask' on a failed task, this would be fine if
we didn't have the API interceptor, which watches all API requests and
triggers 'notifyTask' itself if an error appears.

Fixes issue #25139

Signed-off-by: Stephan Müller <smueller@suse.com>