### PR TITLE
ceph-volume ensure encoded bytes are always used

### DIFF
--- a/src/ceph-volume/ceph_volume/process.py
+++ b/src/ceph-volume/ceph_volume/process.py
@@ -3,6 +3,7 @@ from os import O_NONBLOCK, read
 import subprocess
 from select import select
 from ceph_volume import terminal
+from ceph_volume.util import as_bytes
 
 import logging
 
@@ -201,9 +202,7 @@ def call(command, **kw):
     )
 
     if stdin:
-        stdout_stream, stderr_stream = process.communicate(
-            stdin.encode(encoding='utf-8', errors='ignore')
-        )
+        stdout_stream, stderr_stream = process.communicate(as_bytes(stdin))
     else:
         stdout_stream = process.stdout.read()
         stderr_stream = process.stderr.read()

--- a/src/ceph-volume/ceph_volume/tests/test_process.py
+++ b/src/ceph-volume/ceph_volume/tests/test_process.py
@@ -76,6 +76,9 @@ class TestFunctionalCall(object):
     def test_unicode_encoding(self):
         process.call(['echo', u'\xd0'])
 
+    def test_unicode_encoding_stdin(self):
+        process.call(['echo'], stdin=u'\xd0'.encode('utf-8'))
+
 
 class TestFunctionalRun(object):
 

--- a/src/ceph-volume/ceph_volume/tests/util/test_util.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_util.py
@@ -2,6 +2,17 @@ import pytest
 from ceph_volume import util
 
 
+class TestAsBytes(object):
+
+    def test_bytes_just_gets_returned(self):
+        bytes_string = "contents".encode('utf-8')
+        assert util.as_bytes(bytes_string) == bytes_string
+
+    def test_string_gets_converted_to_bytes(self):
+        result = util.as_bytes('contents')
+        assert isinstance(result, bytes)
+
+
 class TestStrToInt(object):
 
     def test_passing_a_float_str(self):

--- a/src/ceph-volume/ceph_volume/util/__init__.py
+++ b/src/ceph-volume/ceph_volume/util/__init__.py
@@ -16,6 +16,16 @@ def as_string(string):
     return string
 
 
+def as_bytes(string):
+    """
+    Ensure that whatever type of string is incoming, it is returned as bytes,
+    encoding to utf-8 otherwise
+    """
+    if isinstance(string, bytes):
+        return string
+    return string.encode('utf-8', errors='ignore')
+
+
 def str_to_int(string, round_down=True):
     """
     Parses a string number into an integer, optionally converting to a float


### PR DESCRIPTION
Follow up fix for http://tracker.ceph.com/issues/24993

For some reason the issues weren't triggered up until the backports #23239 #23238