### PR TITLE
[luminous] ceph-volume: Restore SELinux context

### DIFF
--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -120,6 +120,9 @@ def mount_tmpfs(path):
         path
     ])
 
+    # Restore SELinux context
+    system.set_context(path)
+
 
 def create_osd_path(osd_id, tmpfs=False):
     path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
@@ -218,6 +221,9 @@ def mount_osd(device, osd_id, **kw):
     command.append(device)
     command.append(destination)
     process.run(command)
+
+    # Restore SELinux context
+    system.set_context(destination)
 
 
 def _link_device(device, device_type, osd_id):

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -260,3 +260,12 @@ def get_mounts(devices=False, paths=False, realpath=False):
         return devices_mounted
     else:
         return paths_mounted
+
+
+def set_context(path, recursive = False):
+    # restore selinux context to default policy values
+    if which('restorecon').startswith('/'):
+        if recursive:
+            process.run(['restorecon', '-R', path])
+        else:
+            process.run(['restorecon', path])


### PR DESCRIPTION
https://tracker.ceph.com/issues/25143

---

We need to reset the root context of the file system after mounting it.
Otherwise, the SELinux policy rules will not be preserved.

Fixes: https://tracker.ceph.com/issues/24785
Signed-off-by: Boris Ranto <branto@redhat.com>
(cherry picked from commit 61dbf4ac2af7d1e9da927bbc4006c9fbccb55478)