### PR TITLE
ceph_volume_client: add delay for MDSMap to be distributed

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -633,6 +633,7 @@ class CephFSVolumeClient(object):
                     'fs_name': mds_map['fs_name'],
                     'pool': pool_name
                 })
+            time.sleep(5) # time for MDSMap to be distributed
             self.fs.setxattr(path, 'ceph.dir.layout.pool', pool_name, 0)
 
         # enforce security isolation, use separate namespace for this volume


### PR DESCRIPTION
Otherwise the setxattr will fail if the mds has not yet received the MDSMap
which adds the new data pool.

Fixes: https://tracker.ceph.com/issues/25141

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>