### PR TITLE
mimic: tools/ceph-detect-init: support RHEL as a platform

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -88,7 +88,7 @@ def _get_distro(distro, use_rhceph=False):
 
 def _normalized_distro_name(distro):
     distro = distro.lower()
-    if distro.startswith(('redhat', 'red hat')):
+    if distro.startswith(('redhat', 'red hat', 'rhel')):
         return 'redhat'
     elif distro.startswith(('scientific', 'scientific linux')):
         return 'scientific'


### PR DESCRIPTION
12d94ca introduced a regression in that it
started returning `''` (empty string) as the codename for most supported distros, and also
(apparently) changed the distro string returned on Red Hat Enterprise Linux (to
"rhel"). As a result, ceph-detect-init began throwing an UnsupportedPlatform
exception on RHEL.

```
Running: 'sudo TESTDIR=/home/ubuntu/cephtest bash -c ceph-detect-init'
stderr:Traceback (most recent call last):
stderr:  File "/bin/ceph-detect-init", line 9, in <module>
stderr:    load_entry_point('ceph-detect-init==1.0.1', 'console_scripts', 'ceph-detect-init')()
stderr:  File "/usr/lib/python2.7/site-packages/ceph_detect_init/main.py", line 56, in run
stderr:    print(ceph_detect_init.get(args.use_rhceph).init)
stderr:  File "/usr/lib/python2.7/site-packages/ceph_detect_init/__init__.py", line 42, in get
stderr:    release=release)
stderr:ceph_detect_init.exc.UnsupportedPlatform: Platform is not supported.: rhel  7.5
```

Fixes: 12d94ca
Fixes: http://tracker.ceph.com/issues/18163