### PR TITLE
 tools: ceph-authtool: report correct number of caps when creating keyring

### DIFF
--- a/src/auth/Auth.h
+++ b/src/auth/Auth.h
@@ -47,7 +47,7 @@ struct EntityAuth {
 WRITE_CLASS_ENCODER(EntityAuth)
 
 static inline ostream& operator<<(ostream& out, const EntityAuth& a) {
-  return out << "auth(key=" << a.key << " with " << a.caps.size() << " caps)";
+  return out << "auth(key=" << a.key << ")";
 }
 
 struct AuthCapsInfo {

--- a/src/test/cli/ceph-authtool/add-key.t
+++ b/src/test/cli/ceph-authtool/add-key.t
@@ -2,7 +2,7 @@
   creating kring
 
   $ ceph-authtool kring --add-key 'AQAK7yxNeF+nHBAA0SgSdbs8IkJrxroDeJ6SwQ== 18446744073709551615'
-  added entity client.admin auth auth(key=AQAK7yxNeF+nHBAA0SgSdbs8IkJrxroDeJ6SwQ== with 0 caps)
+  added entity client.admin auth(key=AQAK7yxNeF+nHBAA0SgSdbs8IkJrxroDeJ6SwQ==)
 
 # cram makes matching escape-containing lines with regexps a bit ugly
   $ ceph-authtool kring --list
@@ -18,3 +18,10 @@ Test --add-key with empty argument
   $ ceph-authtool kring -C --name=mon.* --add-key= --cap mon 'allow *'
   Option --add-key requires an argument
   [1]
+
+  $ ceph-authtool test.keyring --create-keyring --mode 0644
+  creating test.keyring
+
+  $ ceph-authtool test.keyring --name client.test --cap osd 'allow rwx' --cap mon 'allow r' --add-key 'AQAK7yxNeF+nHBAA0SgSdbs8IkJrxroDeJ6SwQ== 18446744073709551615'
+  added entity client.test auth(key=AQAK7yxNeF+nHBAA0SgSdbs8IkJrxroDeJ6SwQ==)
+  added 2 caps to entity client.test

--- a/src/tools/ceph_authtool.cc
+++ b/src/tools/ceph_authtool.cc
@@ -173,6 +173,7 @@ int main(int argc, const char **argv)
 
   // keyring --------
   bool modified = false;
+  bool added_entity = false;
   KeyRing keyring;
 
   bufferlist bl;
@@ -248,7 +249,8 @@ int main(int argc, const char **argv)
     }
     keyring.add(ename, eauth);
     modified = true;
-    cout << "added entity " << ename << " auth " << eauth << std::endl;
+    cout << "added entity " << ename << " " << eauth << std::endl;
+    added_entity = true;
   }
   if (!caps_fn.empty()) {
     ConfFile cf;
@@ -275,6 +277,9 @@ int main(int argc, const char **argv)
   if (!caps.empty()) {
     keyring.set_caps(ename, caps);
     modified = true;
+  }
+  if (added_entity && caps.size() > 0) {
+    cout << "added " << caps.size() << " caps to entity " << ename << std::endl;
   }
 
   // read commands


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/23776