### PR TITLE
osd: refactor heartbeat health check

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4651,7 +4651,7 @@ void OSD::heartbeat_check()
              << " (oldest deadline " << oldest_deadline << ")"
              << dendl;
 	// fail
-	failure_queue[p->first] = p->second.last_tx;
+	failure_queue[p->first] = p->second.first_tx;
       } else {
 	derr << "heartbeat_check: no reply from "
              << p->second.con_front->get_peer_addr().get_sockaddr()

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1508,20 +1508,26 @@ private:
     utime_t last_rx_front;  ///< last time we got a ping reply on the front side
     utime_t last_rx_back;   ///< last time we got a ping reply on the back side
     epoch_t epoch;      ///< most recent epoch we wanted this peer
+    /// number of connections we send and receive heartbeat pings/replies
+    const static int HEARTBEAT_MAX_CONN = 2;
+    /// history of inflight pings, arranging by timestamp we sent
+    /// send time -> deadline -> remaining replies
+    map<utime_t, pair<utime_t, int>> ping_history;
 
-    bool is_unhealthy(utime_t cutoff) const {
-      return
-	! ((last_rx_front > cutoff ||
-	    (last_rx_front == utime_t() && (last_tx == utime_t() ||
-					    first_tx > cutoff))) &&
-	   (last_rx_back > cutoff ||
-	    (last_rx_back == utime_t() && (last_tx == utime_t() ||
-					   first_tx > cutoff))));
-    }
-    bool is_healthy(utime_t cutoff) const {
-      return last_rx_front > cutoff && last_rx_back > cutoff;
+    bool is_unhealthy(utime_t now) {
+      if (ping_history.empty()) {
+        /// we haven't sent a ping yet or we have got all replies,
+        /// in either way we are safe and healthy for now
+        return false;
+      }
+
+      utime_t oldest_deadline = ping_history.begin()->second.first;
+      return now > oldest_deadline;
     }
 
+    bool is_healthy(utime_t now) {
+      return !is_unhealthy(now);
+    }
   };
   /// state attached to outgoing heartbeat connections
   struct HeartbeatSession : public RefCountedObject {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1526,6 +1526,11 @@ private:
     }
 
     bool is_healthy(utime_t now) {
+      if (last_rx_front == utime_t() || last_rx_back == utime_t()) {
+        // only declare to be healthy until we have received the first
+        // replies from both front/back connections
+        return false;
+      }
       return !is_unhealthy(now);
     }
   };


### PR DESCRIPTION
The idea was originally introduced two years ago in https://github.com/ceph/ceph/pull/9095.
We found it worked fair well if we intended to use a very short heartbeat interval(e.g., 1s) to detect
host or osd failure quickly and perform failover as fast as possible.

I am tired of backporting this from time to time. Since it has been widely verified in our products, I am taking another try here to (hopefully) get it into upstream to end my pain...