### PR TITLE
doc: fix the broken urls

### DIFF
--- a/doc/radosgw/index.rst
+++ b/doc/radosgw/index.rst
@@ -1,3 +1,5 @@
+.. _object-gateway:
+
 =====================
  Ceph Object Gateway
 =====================

--- a/doc/rbd/index.rst
+++ b/doc/rbd/index.rst
@@ -32,8 +32,8 @@ Ceph's block devices deliver high performance with infinite scalability to
 `kernel modules`_, or to :abbr:`KVMs (kernel virtual machines)` such as `QEMU`_, and
 cloud-based computing systems like `OpenStack`_ and `CloudStack`_ that rely on
 libvirt and QEMU to integrate with Ceph block devices. You can use the same cluster
-to operate the `Ceph RADOS Gateway`_, the `CephFS filesystem`_, and Ceph block
-devices simultaneously.
+to operate the :ref:`Ceph RADOS Gateway <object-gateway>`, the
+:ref:`CephFS filesystem <ceph-filesystem>`, and Ceph block devices simultaneously.
 
 .. important:: To use Ceph Block Devices, you must have access to a running
    Ceph cluster.
@@ -63,10 +63,8 @@ devices simultaneously.
 
 	APIs <api/index>
 
-.. _RBD Caching: ../rbd-config-ref/
-.. _kernel modules: ../rbd-ko/
-.. _QEMU: ../qemu-rbd/
-.. _OpenStack: ../rbd-openstack
-.. _CloudStack: ../rbd-cloudstack
-.. _Ceph RADOS Gateway: ../../radosgw/
-.. _CephFS filesystem: ../../cephfs/
+.. _RBD Caching: ./rbd-config-ref/
+.. _kernel modules: ./rbd-ko/
+.. _QEMU: ./qemu-rbd/
+.. _OpenStack: ./rbd-openstack
+.. _CloudStack: ./rbd-cloudstack


### PR DESCRIPTION
Fixed the broken urls in http://docs.ceph.com/docs/master/rbd/

Fixes: http://tracker.ceph.com/issues/25185
Signed-off-by: Jos Collin <jcollin@redhat.com>