### PR TITLE
luminous: rpm: silence osd block chown

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1448,7 +1448,7 @@ fi
     /usr/lib/systemd/systemd-sysctl %{_sysctldir}/90-ceph-osd.conf > /dev/null 2>&1 || :
 %endif
 # work around https://tracker.ceph.com/issues/24903
-chown -h ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
+chown -f -h ceph:ceph /var/lib/ceph/osd/*/block* 2>&1 > /dev/null || :
 
 %preun osd
 %if 0%{?suse_version}


### PR DESCRIPTION
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>
Fixes: http://tracker.ceph.com/issues/25152

Applying this to luminous because master reverted the chown https://github.com/ceph/ceph/pull/23247.