### PR TITLE
rgw: http client: print curl error messages during curl failures

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -1156,6 +1156,7 @@ void *RGWHTTPManager::reqs_thread_entry()
               << cct->_conf->rgw_curl_low_speed_limit << " Bytes per second during " << cct->_conf->rgw_curl_low_speed_time << " seconds." << dendl;
           default:
             dout(20) << "ERROR: msg->data.result=" << result << " req_data->id=" << id << " http_status=" << http_status << dendl;
+            dout(20) << "ERROR: curl error: " << curl_easy_strerror((CURLcode)result) << dendl;
 	    break;
         }
       }


### PR DESCRIPTION
When curl fails, curl has a curl error code which can be useful to understand
the failure. Print this error message, as http status in these cases can likely
be 0, which makes it harder to debug. Example error message::

ERROR: msg->data.result=27 req_data->id=1 http_status=0
ERROR: curl error: Out of memory

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>