### PR TITLE
crush/CrushWrapper: fix crush tree json dumper

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -3128,28 +3128,24 @@ public:
     : Parent(crush, wsnames, show_shadow) {}
 
   void dump(Formatter *f) {
-    f->open_object_section("crush_tree");
-
     f->open_array_section("nodes");
     Parent::dump(f);
     f->close_section();
 
+    // There is no stray bucket whose id is a negative number, so just get
+    // the max_id and iterate from 0 to max_id to dump stray osds.
     f->open_array_section("stray");
     auto &name_map = this->crush->name_map;
-	int32_t min_id = std::numeric_limits<int32_t>::max();
     int32_t max_id = std::numeric_limits<int32_t>::min();
     for (auto ite = name_map.begin(); ite != name_map.end(); ++ite) {
-        if (ite->first <= min_id) min_id = ite->first;
         if (ite->first >= max_id) max_id = ite->first;
     }
-    for (int32_t i = min_id; i <= max_id; i++) {
+    for (int32_t i = 0; i <= max_id; i++) {
         if (this->crush->item_exists(i) &&
             !this->is_touched(i) && this->should_dump(i)) {
             this->dump_item(CrushTreeDumper::Item(i, 0, 0, 0), f);
         }
     }
-    f->close_section();
-
     f->close_section();
   }
 };

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -3128,10 +3128,28 @@ public:
     : Parent(crush, wsnames, show_shadow) {}
 
   void dump(Formatter *f) {
+    f->open_object_section("crush_tree");
+
     f->open_array_section("nodes");
     Parent::dump(f);
     f->close_section();
+
     f->open_array_section("stray");
+    auto &name_map = this->crush->name_map;
+	int32_t min_id = numeric_limits<int32_t>::max();
+    int32_t max_id = numeric_limits<int32_t>::min();
+    for (auto ite = name_map.begin(); ite != name_map.end(); ++ite) {
+        if (ite->first <= min_id) min_id = ite->first;
+        if (ite->first >= max_id) max_id = ite->first;
+    }
+    for (int32_t i = min_id; i <= max_id; i++) {
+        if (this->crush->item_exists(i) &&
+            !this->is_touched(i) && this->should_dump(i)) {
+            this->dump_item(CrushTreeDumper::Item(i, 0, 0, 0), f);
+        }
+    }
+    f->close_section();
+
     f->close_section();
   }
 };

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5437,10 +5437,12 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
     bool show_shadow = shadow == "--show-shadow";
     boost::scoped_ptr<Formatter> f(Formatter::create(format));
     if (f) {
+      f->open_object_section("crush_tree");
       osdmap.crush->dump_tree(nullptr,
                               f.get(),
                               osdmap.get_pool_names(),
                               show_shadow);
+      f->close_section();
       f->flush(rdata);
     } else {
       ostringstream ss;


### PR DESCRIPTION
The output json string is invalid for "ceph osd crush tree --format=json" command.  Reference the issue https://tracker.ceph.com/issues/25153.

Signed-off-by: Oshyn Song <dualyangsong@gmail.com>