### PR TITLE
mgr/dashboard: Close modal dialogs on login screen

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.spec.ts
@@ -1,11 +1,9 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
-import { AuthService } from '../../../shared/api/auth.service';
-import { AuthStorageService } from '../../../shared/services/auth-storage.service';
+import { AuthModule } from '../auth.module';
 import { LoginComponent } from './login.component';
 
 describe('LoginComponent', () => {
@@ -13,9 +11,7 @@ describe('LoginComponent', () => {
   let fixture: ComponentFixture<LoginComponent>;
 
   configureTestBed({
-    imports: [FormsModule, RouterTestingModule, HttpClientTestingModule],
-    declarations: [LoginComponent],
-    providers: [AuthService, AuthStorageService]
+    imports: [RouterTestingModule, HttpClientTestingModule, AuthModule]
   });
 
   beforeEach(() => {
@@ -26,5 +22,11 @@ describe('LoginComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should ensure no modal dialogs are opened', () => {
+    component.bsModalService.modalsCount = 2;
+    component.ngOnInit();
+    expect(component.bsModalService.getModalsCount()).toBe(0);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/login/login.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 
+import { BsModalService } from 'ngx-bootstrap';
+
 import { AuthService } from '../../../shared/api/auth.service';
 import { Credentials } from '../../../shared/models/credentials';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
@@ -16,12 +18,21 @@ export class LoginComponent implements OnInit {
   constructor(
     private authService: AuthService,
     private authStorageService: AuthStorageService,
+    private bsModalService: BsModalService,
     private router: Router
   ) {}
 
   ngOnInit() {
     if (this.authStorageService.isLoggedIn()) {
       this.router.navigate(['']);
+    } else {
+      // Make sure all open modal dialogs are closed. This might be
+      // necessary when the logged in user is redirected to the login
+      // page after a 401.
+      const modalsCount = this.bsModalService.getModalsCount();
+      for (let i = 1; i <= modalsCount; i++) {
+        this.bsModalService.hide(i);
+      }
     }
   }
 


### PR DESCRIPTION
Make sure all open modal dialogs are closed on the login screen. This might be necessary when the logged in user is redirected to the login page after a 401.

Simply open a dialog in the UI and restart the dashboard module from CLI. You should be redirected to the login page. Without this fix the current opened dialog is still shown.

Fixes https://tracker.ceph.com/issues/24570

Signed-off-by: Volker Theile <vtheile@suse.com>