### PR TITLE
ceph.in: friendlier message on EPERM

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -375,8 +375,15 @@ def do_extended_help(parser, args, target, partial):
                                          prefix='get_command_descriptions',
                                          timeout=10)
         if ret:
-            print("couldn't get command descriptions for {0}: {1} ({2})".
-                  format(target, outs, ret), file=sys.stderr)
+            if ret == -errno.EPERM and target[0] in ('osd', 'mds'):
+                print("Permission denied.  Check that your user has 'allow *' "
+                      "capabilities for the target daemon type.", file=sys.stderr)
+            elif ret == -errno.EPERM:
+                print("Permission denied.  Check your user has proper "
+                      "capabilities configured", file=sys.stderr)
+            else:
+                print("couldn't get command descriptions for {0}: {1} ({2})".
+                      format(target, outs, ret), file=sys.stderr)
             return ret
         else:
             return help_for_sigs(outbuf.decode('utf-8'), partial)


### PR DESCRIPTION
When we get an EPERM, we can make an informed
guess at what the problem is.  This is a reasonably
common user error if they have e.g. "mds allow"
instead of "mds allow *", or "osd allow rwx" instead
of "osd allow *".

Fixes: http://tracker.ceph.com/issues/25172
Signed-off-by: John Spray <john.spray@redhat.com>