### PR TITLE
luminous: ceph-volume add a __release__ string, to help version-conditional calls

### DIFF
--- a/src/ceph-volume/ceph_volume/__init__.py
+++ b/src/ceph-volume/ceph_volume/__init__.py
@@ -14,3 +14,5 @@ conf = namedtuple('config', ['ceph', 'cluster', 'verbosity', 'path', 'log_path']
 conf.ceph = UnloadedConfig()
 
 __version__ = "1.0.0"
+
+__release__ = "luminous"


### PR DESCRIPTION
Fixes http://tracker.ceph.com/issues/25170