### PR TITLE
vstart: disable dashboard when rbd not built

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -134,7 +134,8 @@ spdk_enabled=0 #disable SPDK by default
 pci_id=""
 
 with_mgr_dashboard=true
-if [[ "$(get_cmake_variable WITH_MGR_DASHBOARD_FRONTEND)" != "ON" ]]; then
+if [[ "$(get_cmake_variable WITH_MGR_DASHBOARD_FRONTEND)" != "ON" ]] ||
+   [[ "$(get_cmake_variable WITH_RBD)" != "ON" ]]; then
   echo "ceph-mgr dashboard not built - disabling."
   with_mgr_dashboard=false
 fi


### PR DESCRIPTION
dashboard doesn't load correctly without the rbd module, which means
vstart commands that interact with dashboard fail and vstart exits.

Signed-off-by: Noah Watkins <nwatkins@redhat.com>