### PR TITLE
mimic: qa: fix ceph-disk suite and add coverage for ceph-detect-init

### DIFF
--- a/qa/suites/ceph-disk/basic/distros
+++ b/qa/suites/ceph-disk/basic/distros
@@ -1,1 +1,1 @@
-../../../distros/supported
+.qa/distros/supported

--- a/qa/suites/ceph-disk/basic/tasks/ceph-detect-init.yaml
+++ b/qa/suites/ceph-disk/basic/tasks/ceph-detect-init.yaml
@@ -1,0 +1,11 @@
+openstack:
+- volumes: # attached to each instance
+    count: 0
+roles:
+- [client.0]
+tasks:
+- install:
+- exec:
+    client.0:
+      - ceph-detect-init
+      - test "$(ceph-detect-init)" = "systemd"

--- a/qa/suites/ceph-disk/basic/tasks/ceph-disk.yaml
+++ b/qa/suites/ceph-disk/basic/tasks/ceph-disk.yaml
@@ -1,6 +1,3 @@
-overrides:
-  ansible.cephlab:
-    skip_tags: entitlements,packages,repos
 roles:
 - - mon.a
   - mgr.x

--- a/qa/workunits/ceph-disk/ceph-disk.sh
+++ b/qa/workunits/ceph-disk/ceph-disk.sh
@@ -1,13 +1,23 @@
 #!/usr/bin/env bash
-if [ -f $(dirname $0)/../ceph-helpers-root.sh ]; then
-    source $(dirname $0)/../ceph-helpers-root.sh
+BASEDIR=$(dirname $0)
+if [ -f $BASEDIR/../ceph-helpers-root.sh ]; then
+    source $BASEDIR/../ceph-helpers-root.sh
 else
-    echo "$(dirname $0)/../ceph-helpers-root.sh does not exist."
+    echo "$BASEDIR/../ceph-helpers-root.sh does not exist."
     exit 1
 fi
 
-install python-pytest || true
-install pytest || true
+PATH=$BASEDIR:$BASEDIR/..:$PATH
+
+: ${PYTHON:=python}
+$PYTHON --version
+
+type pip
+
+# newer versions of pytest (e.g. 3.7.0) seem to work fine with Python 2.7,
+# so just grab the latest version
+sudo -H pip install pytest
+$PYTHON -m pytest --version
 
 # complete the cluster setup done by the teuthology ceph task
 sudo chown $(id -u) /etc/ceph/ceph.conf
@@ -20,27 +30,18 @@ fi
 sudo ceph osd crush rm osd.0 || true
 sudo ceph osd crush rm osd.1 || true
 
-sudo cp $(dirname $0)/60-ceph-by-partuuid.rules /lib/udev/rules.d
+sudo cp $BASEDIR/60-ceph-by-partuuid.rules /lib/udev/rules.d
 sudo udevadm control --reload
 
-perl -pi -e 's|pid file.*|pid file = /var/run/ceph/\$cluster-\$name.pid|' /etc/ceph/ceph.conf
+sudo perl -pi -e 's|pid file.*|pid file = /var/run/ceph/\$cluster-\$name.pid|' /etc/ceph/ceph.conf
 
-PATH=$(dirname $0):$(dirname $0)/..:$PATH
-
-: ${PYTHON:=python}
-PY_VERSION=$($PYTHON --version 2>&1)
-
-if ! ${PYTHON} -m pytest --version > /dev/null 2>&1; then
-    echo "py.test not installed for ${PY_VERSION}"
-    exit 1
-fi
-
-sudo env PATH=$(dirname $0):$(dirname $0)/..:$PATH PYTHONWARNINGS=ignore ${PYTHON} -m pytest -s -v $(dirname $0)/ceph-disk-test.py
+sudo env PATH=$PATH PYTHONWARNINGS=ignore ${PYTHON} -m pytest -s -v --rootdir=$BASEDIR $BASEDIR/ceph-disk-test.py
 result=$?
 
+sudo rm -rf $BASEDIR/.pytest_cache
 sudo rm -f /lib/udev/rules.d/60-ceph-by-partuuid.rules
 # own whatever was created as a side effect of the py.test run
 # so that it can successfully be removed later on by a non privileged
 # process
-sudo chown -R $(id -u) $(dirname $0)
+sudo chown -R $(id -u) $BASEDIR
 exit $result


### PR DESCRIPTION
With the move to OVH and the addition of RHEL as a supported distro, the
ceph-disk/basic suite was no longer green. This commit brings it back into
a green state.

Also, although ceph-disk/basic presumably exercises ceph-detect-init, it
seemed prudent to add a test case that runs it explicitly.

Can not be cherry-picked because ceph-disk and ceph-detect-init are no longer
present in master.

Reverts: 230c030fad091ae9c136a421e6206d3e8c9378f8
Fixes: https://tracker.ceph.com/issues/25031