### PR TITLE
msg: take another few steps toward addrvec-based interfaces

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -227,7 +227,7 @@ int MonClient::ping_monitor(const string &mon_id, string *result_reply)
   smsgr->add_dispatcher_head(pinger);
   smsgr->start();
 
-  ConnectionRef con = smsgr->get_connection(monmap.get_inst(new_mon_id));
+  ConnectionRef con = smsgr->connect_to_mon(monmap.get_addrs(new_mon_id));
   ldout(cct, 10) << __func__ << " ping mon." << new_mon_id
                  << " " << con->get_peer_addr() << dendl;
   con->send_message(new MPing);
@@ -665,7 +665,7 @@ void MonClient::_reopen_session(int rank)
 MonConnection& MonClient::_add_conn(unsigned rank, uint64_t global_id)
 {
   auto peer = monmap.get_addr(rank);
-  auto conn = messenger->get_connection(monmap.get_inst(rank));
+  auto conn = messenger->connect_to_mon(monmap.get_addrs(rank));
   MonConnection mc(cct, conn, global_id);
   auto inserted = pending_cons.insert(make_pair(peer, move(mc)));
   ldout(cct, 10) << "picked mon." << monmap.get_name(rank)

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -409,17 +409,11 @@ public:
     return monmap.fsid;
   }
 
-  entity_addr_t get_mon_addr(unsigned i) const {
+  entity_addrvec_t get_mon_addrs(unsigned i) const {
     Mutex::Locker l(monc_lock);
     if (i < monmap.size())
-      return monmap.get_addr(i);
-    return entity_addr_t();
-  }
-  entity_inst_t get_mon_inst(unsigned i) const {
-    Mutex::Locker l(monc_lock);
-    if (i < monmap.size())
-      return monmap.get_inst(i);
-    return entity_inst_t();
+      return monmap.get_addrs(i);
+    return entity_addrvec_t();
   }
   int get_num_mon() const {
     Mutex::Locker l(monc_lock);

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -100,8 +100,10 @@ void MonMap::encode(bufferlist& blist, uint64_t con_features) const
     encode_raw(fsid, blist);
     encode(epoch, blist);
     vector<entity_inst_t> mon_inst(ranks.size());
-    for (unsigned n = 0; n < ranks.size(); n++)
-      mon_inst[n] = get_inst(n);
+    for (unsigned n = 0; n < ranks.size(); n++) {
+      mon_inst[n].name = entity_name_t::MON(n);
+      mon_inst[n].addr = get_addrs(n).legacy_addr();
+    }
     encode(mon_inst, blist, con_features);
     encode(last_changed, blist);
     encode(created, blist);

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -291,6 +291,13 @@ public:
     return true;
   }
 
+  entity_addrvec_t get_addrs(const string& n) const {
+    return entity_addrvec_t(get_addr(n));
+  }
+  entity_addrvec_t get_addrs(unsigned m) const {
+    return entity_addrvec_t(get_addr(m));
+  }
+
   const entity_addr_t& get_addr(const string& n) const {
     assert(mon_info.count(n));
     map<string,mon_info_t>::const_iterator p = mon_info.find(n);

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -311,19 +311,6 @@ public:
     assert(mon_info.count(n));
     mon_info[n].public_addr = a;
   }
-  entity_inst_t get_inst(const string& n) {
-    assert(mon_info.count(n));
-    int m = get_rank(n);
-    assert(m >= 0); // vector can't take negative indicies
-    return get_inst(m);
-  }
-  entity_inst_t get_inst(unsigned m) const {
-    assert(m < ranks.size());
-    entity_inst_t i;
-    i.addr = get_addr(m);
-    i.name = entity_name_t::MON(m);
-    return i;
-  }
 
   void encode(bufferlist& blist, uint64_t con_features) const;
   void decode(bufferlist& blist) {

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3941,7 +3941,7 @@ void Monitor::remove_all_sessions()
 
 void Monitor::send_mon_message(Message *m, int rank)
 {
-  messenger->send_message(m, monmap->get_inst(rank));
+  messenger->send_to_mon(m, monmap->get_addrs(rank));
 }
 
 void Monitor::waitlist_or_zap_client(MonOpRequestRef op)

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -484,14 +484,14 @@ public:
    *
    * @param dest The entity to get a connection for.
    */
-  virtual ConnectionRef get_connection(const entity_inst_t& dest) = 0;
+  virtual ConnectionRef get_connection(const entity_inst_t& dest) {
+    // temporary
+    return connect_to(dest.name.type(),
+		      entity_addrvec_t(dest.addr));
+  }
 
   virtual ConnectionRef connect_to(
-    int type, const entity_addrvec_t& dest) {
-    // temporary
-    return get_connection(entity_inst_t(entity_name_t(type, -1),
-					dest.legacy_addr()));
-  }
+    int type, const entity_addrvec_t& dest) = 0;
   ConnectionRef connect_to_mon(const entity_addrvec_t& dest) {
     return connect_to(CEPH_ENTITY_TYPE_MON, dest);
   }

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -442,16 +442,14 @@ public:
    *
    * @return 0 on success, or -errno on failure.
    */
-  virtual int send_message(Message *m, const entity_inst_t& dest) = 0;
+  virtual int send_message(Message *m, const entity_inst_t& dest) {
+    return send_to(m, dest.name.type(), entity_addrvec_t(dest.addr));
+  }
 
   virtual int send_to(
     Message *m,
     int type,
-    const entity_addrvec_t& addr) {
-    // temporary
-    return send_message(m, entity_inst_t(entity_name_t(type, -1),
-					 addr.legacy_addr()));
-  }
+    const entity_addrvec_t& addr) = 0;
   int send_to_mon(
     Message *m, const entity_addrvec_t& addrs) {
     return send_to(m, CEPH_ENTITY_TYPE_MON, addrs);

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -605,7 +605,7 @@ ConnectionRef AsyncMessenger::get_loopback_connection()
   return local_connection;
 }
 
-int AsyncMessenger::_send_message(Message *m, const entity_inst_t& dest)
+int AsyncMessenger::_send_to(Message *m, int type, const entity_addrvec_t& addrs)
 {
   FUNCTRACE(cct);
   assert(m);
@@ -615,24 +615,25 @@ int AsyncMessenger::_send_message(Message *m, const entity_inst_t& dest)
   else if (m->get_type() == CEPH_MSG_OSD_OPREPLY)
     OID_EVENT_TRACE(((MOSDOpReply *)m)->get_oid().name.c_str(), "SEND_MSG_OSD_OP_REPLY");
 
-  ldout(cct, 1) << __func__ << "--> " << dest.name << " "
-      << dest.addr << " -- " << *m << " -- ?+"
+  ldout(cct, 1) << __func__ << "--> " << ceph_entity_type_name(type) << " "
+      << addrs << " -- " << *m << " -- ?+"
       << m->get_data().length() << " " << m << dendl;
 
-  if (dest.addr == entity_addr_t()) {
+  if (addrs.empty()) {
     ldout(cct,0) << __func__ <<  " message " << *m
-        << " with empty dest " << dest.addr << dendl;
+        << " with empty dest " << addrs << dendl;
     m->put();
     return -EINVAL;
   }
 
-  AsyncConnectionRef conn = _lookup_conn(entity_addrvec_t(dest.addr));
-  submit_message(m, conn, dest.addr, dest.name.type());
+  AsyncConnectionRef conn = _lookup_conn(addrs);
+  submit_message(m, conn, addrs, type);
   return 0;
 }
 
 void AsyncMessenger::submit_message(Message *m, AsyncConnectionRef con,
-                                    const entity_addr_t& dest_addr, int dest_type)
+                                    const entity_addrvec_t& dest_addrs,
+				    int dest_type)
 {
   if (cct->_conf->ms_dump_on_send) {
     m->encode(-1, MSG_CRC_ALL);
@@ -653,7 +654,7 @@ void AsyncMessenger::submit_message(Message *m, AsyncConnectionRef con,
   }
 
   // local?
-  if (my_addrs->legacy_addr() == dest_addr) {
+  if (*my_addrs == dest_addrs) {
     // local
     local_connection->send_message(m);
     return ;
@@ -662,13 +663,14 @@ void AsyncMessenger::submit_message(Message *m, AsyncConnectionRef con,
   // remote, no existing connection.
   const Policy& policy = get_policy(dest_type);
   if (policy.server) {
-    ldout(cct, 20) << __func__ << " " << *m << " remote, " << dest_addr
+    ldout(cct, 20) << __func__ << " " << *m << " remote, " << dest_addrs
         << ", lossy server for target type "
         << ceph_entity_type_name(dest_type) << ", no session, dropping." << dendl;
     m->put();
   } else {
-    ldout(cct,20) << __func__ << " " << *m << " remote, " << dest_addr << ", new connection." << dendl;
-    con = create_connect(entity_addrvec_t(dest_addr), dest_type);
+    ldout(cct,20) << __func__ << " " << *m << " remote, " << dest_addrs
+		  << ", new connection." << dendl;
+    con = create_connect(dest_addrs, dest_type);
     con->send_message(m);
   }
 }

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -581,20 +581,20 @@ AsyncConnectionRef AsyncMessenger::create_connect(
   return conn;
 }
 
-ConnectionRef AsyncMessenger::get_connection(const entity_inst_t& dest)
+ConnectionRef AsyncMessenger::connect_to(int type, const entity_addrvec_t& addrs)
 {
   Mutex::Locker l(lock);
-  if (my_addrs->legacy_addr() == dest.addr) {
+  if (*my_addrs == addrs) {
     // local
     return local_connection;
   }
 
-  AsyncConnectionRef conn = _lookup_conn(entity_addrvec_t(dest.addr));
+  AsyncConnectionRef conn = _lookup_conn(addrs);
   if (conn) {
-    ldout(cct, 10) << __func__ << " " << dest << " existing " << conn << dendl;
+    ldout(cct, 10) << __func__ << " " << addrs << " existing " << conn << dendl;
   } else {
-    conn = create_connect(entity_addrvec_t(dest.addr), dest.name.type());
-    ldout(cct, 10) << __func__ << " " << dest << " new " << conn << dendl;
+    conn = create_connect(addrs, type);
+    ldout(cct, 10) << __func__ << " " << addrs << " new " << conn << dendl;
   }
 
   return conn;

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -149,7 +149,8 @@ public:
    * @defgroup Connection Management
    * @{
    */
-  ConnectionRef get_connection(const entity_inst_t& dest) override;
+  ConnectionRef connect_to(int type,
+			   const entity_addrvec_t& addrs) override;
   ConnectionRef get_loopback_connection() override;
   void mark_down(const entity_addr_t& addr) override {
     mark_down_addrs(entity_addrvec_t(addr));

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -137,10 +137,10 @@ public:
    * @defgroup Messaging
    * @{
    */
-  int send_message(Message *m, const entity_inst_t& dest) override {
+  int send_to(Message *m, int type, const entity_addrvec_t& addrs) override {
     Mutex::Locker l(lock);
 
-    return _send_message(m, dest);
+    return _send_to(m, type, addrs);
   }
 
   /** @} // Messaging */
@@ -214,9 +214,9 @@ private:
    * just drop silently under failure.
    */
   void submit_message(Message *m, AsyncConnectionRef con,
-                      const entity_addr_t& dest_addr, int dest_type);
+                      const entity_addrvec_t& dest_addrs, int dest_type);
 
-  int _send_message(Message *m, const entity_inst_t& dest);
+  int _send_to(Message *m, int type, const entity_addrvec_t& addrs);
   void _finish_bind(const entity_addrvec_t& bind_addrs,
 		    const entity_addrvec_t& listen_addrs);
 

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -554,6 +554,17 @@ struct entity_addrvec_t {
     }
     return entity_addr_t();
   }
+  entity_addr_t legacy_or_front_addr() const {
+    for (auto& a : v) {
+      if (a.type == entity_addr_t::TYPE_LEGACY) {
+	return a;
+      }
+    }
+    if (!v.empty()) {
+      return v.front();
+    }
+    return entity_addr_t();
+  }
 
   bool parse(const char *s, const char **end = 0);
 

--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -440,22 +440,23 @@ bool SimpleMessenger::verify_authorizer(Connection *con, int peer_type,
 				      challenge);
 }
 
-ConnectionRef SimpleMessenger::get_connection(const entity_inst_t& dest)
+ConnectionRef SimpleMessenger::connect_to(int type,
+					  const entity_addrvec_t& addrs)
 {
   Mutex::Locker l(lock);
-  if (my_addr == dest.addr) {
+  if (my_addr == addrs.front()) {
     // local
     return local_connection;
   }
 
   // remote
   while (true) {
-    Pipe *pipe = _lookup_pipe(dest.addr);
+    Pipe *pipe = _lookup_pipe(addrs.front());
     if (pipe) {
-      ldout(cct, 10) << "get_connection " << dest << " existing " << pipe << dendl;
+      ldout(cct, 10) << "get_connection " << addrs << " existing " << pipe << dendl;
     } else {
-      pipe = connect_rank(dest.addr, dest.name.type(), NULL, NULL);
-      ldout(cct, 10) << "get_connection " << dest << " new " << pipe << dendl;
+      pipe = connect_rank(addrs.front(), type, NULL, NULL);
+      ldout(cct, 10) << "get_connection " << addrs << " new " << pipe << dendl;
     }
     Mutex::Locker l(pipe->pipe_lock);
     if (pipe->connection_state)

--- a/src/msg/simple/SimpleMessenger.h
+++ b/src/msg/simple/SimpleMessenger.h
@@ -138,6 +138,14 @@ public:
   int send_message(Message *m, const entity_inst_t& dest) override {
     return _send_message(m, dest);
   }
+  int send_to(
+    Message *m,
+    int type,
+    const entity_addrvec_t& addr) override {
+    // temporary
+    return send_message(m, entity_inst_t(entity_name_t(type, -1),
+					 addr.legacy_addr()));
+  }
 
   int send_message(Message *m, Connection *con) {
     return _send_message(m, con);

--- a/src/msg/simple/SimpleMessenger.h
+++ b/src/msg/simple/SimpleMessenger.h
@@ -149,7 +149,7 @@ public:
    * @defgroup Connection Management
    * @{
    */
-  ConnectionRef get_connection(const entity_inst_t& dest) override;
+  ConnectionRef connect_to(int type, const entity_addrvec_t& addrs) override;
   ConnectionRef get_loopback_connection() override;
   int send_keepalive(Connection *con);
   void mark_down(const entity_addr_t& addr) override;

--- a/src/msg/xio/XioMessenger.h
+++ b/src/msg/xio/XioMessenger.h
@@ -134,6 +134,13 @@ public:
 
   virtual ConnectionRef get_connection(const entity_inst_t& dest);
 
+  // compat hack
+  ConnectionRef connect_to(
+    int type, const entity_addrvec_t& dest) override {
+    return get_connection(entity_inst_t(entity_name_t(type, -1),
+					dest.legacy_addr()));
+  }
+
   virtual ConnectionRef get_loopback_connection();
 
   void unregister_xcon(XioConnection *xcon);

--- a/src/test/messenger/simple_client.cc
+++ b/src/test/messenger/simple_client.cc
@@ -116,7 +116,7 @@ int main(int argc, const char **argv)
 	dest_str += ":";
 	dest_str += port;
 	entity_addr_from_url(&dest_addr, dest_str.c_str());
-	entity_inst_t dest_server(entity_name_t::MON(-1), dest_addr);
+	entity_addrvec_t dest_addrs(dest_addr);
 
 	dispatcher = new SimpleDispatcher(messenger);
 	messenger->add_dispatcher_head(dispatcher);
@@ -127,7 +127,7 @@ int main(int argc, const char **argv)
 	if (r < 0)
 		goto out;
 
-	conn = messenger->get_connection(dest_server);
+	conn = messenger->connect_to_mon(dest_addrs);
 
 	// do stuff
 	time_t t1, t2;

--- a/src/test/msgr/perf_msgr_client.cc
+++ b/src/test/msgr/perf_msgr_client.cc
@@ -139,8 +139,8 @@ class MessengerClient {
       Messenger *msgr = Messenger::create(g_ceph_context, type, entity_name_t::CLIENT(0), "client", getpid()+i, 0);
       msgr->set_default_policy(Messenger::Policy::lossless_client(0));
       msgr->start();
-      entity_inst_t inst(entity_name_t::OSD(0), addr);
-      ConnectionRef conn = msgr->get_connection(inst);
+      entity_addrvec_t addrs(addr);
+      ConnectionRef conn = msgr->connect_to_osd(addrs);
       ClientThread *t = new ClientThread(msgr, c, conn, msg_len, ops, think_time_us);
       msgrs.push_back(msgr);
       clients.push_back(t);

--- a/src/test/testmsgr.cc
+++ b/src/test/testmsgr.cc
@@ -128,11 +128,11 @@ int main(int argc, const char **argv, const char *envp[]) {
     if (rand() % 10 == 0) {
       //cerr << "mark_down " << t << std::endl;
       dout(0) << "mark_down " << t << dendl;
-      messenger->mark_down(mc.get_mon_addr(t));
+      messenger->mark_down_addrs(mc.get_mon_addrs(t));
     } 
     //cerr << "pinging " << t << std::endl;
     dout(0) << "pinging " << t << dendl;
-    messenger->send_message(new MPing, mc.get_mon_inst(t));
+    messenger->send_to_mon(new MPing, mc.get_mon_addrs(t));
     cerr << isend << "\t" << ++sent << "\t" << received << "\r";
   }
   test_lock.Unlock();


### PR DESCRIPTION
- connect_to instead of get_connection
- send_to instead of send_message
- avoid entity_inst_t where we can

There's another pile of patches that takes this the rest of the way, but it's not really mergeable until the messenger changes are ready (msgr2 addrs aren't passed across the messenger to the peer, which breaks mon quorum).