### PR TITLE
Revert "mgr/pybind: expose erasure code profiles"

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -362,13 +362,6 @@ PyObject *ActivePyModules::get_python(const std::string &what)
       mgr_map.dump(&f);
     });
     return f.get();
-  } else if (what == "ec_profiles") {
-    PyFormatter f;
-    cluster_state.with_osdmap([&f, &what](const OSDMap &osdmap){
-      const auto &profiles = osdmap.get_erasure_code_profiles();
-      osdmap.dump_erasure_code_profiles(profiles, &f);
-    });
-    return f.get();
   } else {
     derr << "Python module requested unknown data '" << what << "'" << dendl;
     Py_RETURN_NONE;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1128,9 +1128,7 @@ void OSDMap::Incremental::dump(Formatter *f) const
   }
   f->close_section();
 
-  f->open_object_section("erasure_code_profiles");
   OSDMap::dump_erasure_code_profiles(new_erasure_code_profiles, f);
-  f->close_section();
   f->open_array_section("old_erasure_code_profiles");
   for (const auto &erasure_code_profile : old_erasure_code_profiles) {
     f->dump_string("old", erasure_code_profile.c_str());
@@ -3118,6 +3116,7 @@ void OSDMap::dump_erasure_code_profiles(
   const mempool::osdmap::map<string,map<string,string>>& profiles,
   Formatter *f)
 {
+  f->open_object_section("erasure_code_profiles");
   for (const auto &profile : profiles) {
     f->open_object_section(profile.first.c_str());
     for (const auto &profm : profile.second) {
@@ -3125,6 +3124,7 @@ void OSDMap::dump_erasure_code_profiles(
     }
     f->close_section();
   }
+  f->close_section();
 }
 
 void OSDMap::dump(Formatter *f) const
@@ -3256,9 +3256,7 @@ void OSDMap::dump(Formatter *f) const
   }
   f->close_section();
 
-  f->open_object_section("erasure_code_profiles");
   dump_erasure_code_profiles(erasure_code_profiles, f);
-  f->close_section();
 
   f->open_array_section("removed_snaps_queue");
   for (auto& p : removed_snaps_queue) {

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -353,7 +353,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         :param str data_name: Valid things to fetch are osd_crush_map_text, 
                 osd_map, osd_map_tree, osd_map_crush, config, mon_map, fs_map,
                 osd_metadata, pg_summary, io_rate, pg_dump, df, osd_stats,
-                health, mon_status, devices, device <devid>, ec_profiles.
+                health, mon_status, devices, device <devid>.
 
         Note:
             All these structures have their own JSON representations: experiment

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -151,8 +151,7 @@ class Module(MgrModule):
                 "osd_stats",
                 "health",
                 "mon_status",
-                "mgr_map",
-                "ec_profiles"
+                "mgr_map"
                 ]
         for obj in objects:
             assert self.get(obj) is not None


### PR DESCRIPTION
The erasure code profiles are exposed through the OSD dump which was
originally overlooked on inspection.

This reverts commit b5487abb8b946c534d0e93f88c8b9b2d1cb35bae.

Signed-off-by: Noah Watkins <nwatkins@redhat.com>