### PR TITLE
luminous: qa/tests -  added overrides stanza to allow runs on ovh on rhel OS

### DIFF
--- a/qa/suites/ceph-disk/basic/tasks/ceph-disk.yaml
+++ b/qa/suites/ceph-disk/basic/tasks/ceph-disk.yaml
@@ -1,3 +1,6 @@
+overrides:
+  ansible.cephlab:
+    skip_tags: entitlements,packages,repos
 roles:
 - - mon.a
   - mgr.x


### PR DESCRIPTION
http://tracker.ceph.com/issues/25082