### PR TITLE
mgrc: enable disabling stats via mgr_stats_threshold

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4777,7 +4777,7 @@ std::vector<Option> get_global_options() {
   .set_long_description("Daemons only set perf counter data to the manager "
     "daemon if the counter has a priority higher than this.")
   .set_min_max((int64_t)PerfCountersBuilder::PRIO_DEBUGONLY,
-               (int64_t)PerfCountersBuilder::PRIO_CRITICAL),
+               (int64_t)PerfCountersBuilder::PRIO_CRITICAL + 1),
 
     Option("journal_zero_on_create", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)


### PR DESCRIPTION
Because we had a min_max setting with CRIT the maximum,
it wasn't possible to actually turn off stats entirely.

Fixes: http://tracker.ceph.com/issues/25197
Signed-off-by: John Spray <john.spray@redhat.com>