### PR TITLE
osd/OSD: choose heartbeat peers more carefully 

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2941,6 +2941,10 @@ std::vector<Option> get_global_options() {
     .set_default(10)
     .set_description(""),
 
+    Option("osd_heartbeat_disable_rand_choose_threshold", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(200)
+    .set_description("If total number of osds is greater than this, we'll no longer randomized choose heartbeat peers by failure domain"),
+
     Option("osd_heartbeat_use_min_delay_socket", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description(""),

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -907,6 +907,18 @@ int CrushWrapper::get_rule_failure_domain(int rule_id)
   return type;
 }
 
+int CrushWrapper::get_top_failure_domain()
+{
+  int max_type = 0; // default to osd-level
+  for (unsigned i = 0; i < crush->max_rules; i++) {
+    int type = get_rule_failure_domain(i);
+    if (type > max_type) {
+      max_type = type;
+    }
+  }
+  return max_type;
+}
+
 int CrushWrapper::_get_leaves(int id, list<int> *leaves) const
 {
   assert(leaves);

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -891,7 +891,7 @@ void CrushWrapper::get_children_of_type(int id,
 int CrushWrapper::get_rule_failure_domain(int rule_id)
 {
   crush_rule *rule = get_rule(rule_id);
-  if (IS_ERR(rule)) {
+  if (IS_ERR(rule) || !rule) {
     return -ENOENT;
   }
   int type = 0; // default to osd-level

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -737,6 +737,9 @@ public:
    * @return number of items, or error
    */
   int get_children(int id, list<int> *children) const;
+  /**
+   * returns children of type, by bucket id
+   */
   void get_children_of_type(int id,
                             int type,
 			    set<int> *children,
@@ -748,6 +751,11 @@ public:
     * @return type of failure-domain or a negative errno on error.
     */
   int get_rule_failure_domain(int rule_id);
+  /**
+   * enumerate failure-domains of all rules and return the biggest
+   * of them all
+   */
+  int get_top_failure_domain();
 
   /**
     * enumerate leaves(devices) of given node

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4306,7 +4306,7 @@ void OSD::maybe_update_heartbeat_peers()
 {
   assert(osd_lock.is_locked());
 
-  if (is_waiting_for_healthy()) {
+  if (is_waiting_for_healthy() || is_active()) {
     utime_t now = ceph_clock_now();
     if (last_heartbeat_resample == utime_t()) {
       last_heartbeat_resample = now;
@@ -4317,7 +4317,9 @@ void OSD::maybe_update_heartbeat_peers()
 	dout(10) << "maybe_update_heartbeat_peers forcing update after " << dur << " seconds" << dendl;
 	heartbeat_set_peers_need_update();
 	last_heartbeat_resample = now;
-	reset_heartbeat_peers();   // we want *new* peers!
+        if (is_waiting_for_healthy()) {
+	  reset_heartbeat_peers();   // we want *new* peers!
+        }
       }
     }
   }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -5187,3 +5187,144 @@ int OSDMap::parse_osd_id_list(const vector<string>& ls, set<int> *out,
   }
   return 0;
 }
+
+void OSDMap::get_random_up_osds_by_failure_domain(int n,     // whoami
+                                                  int limit, // how many
+                                                  set<int> skip,
+                                                  set<int> *out) const {
+  int failure_domain = crush->get_top_failure_domain();
+  if (failure_domain < 1)
+    failure_domain = 1; // promote to host-level
+  auto loc = crush->get_full_location(n);
+  string my_host_name = "unknown";
+  auto it = loc.find(crush->get_type_name(1));
+  if (it != loc.end())
+    my_host_name = it->second;
+  string my_failure_domain_name = "unknown";
+  it = loc.find(crush->get_type_name(failure_domain));
+  if (it != loc.end())
+    my_failure_domain_name = it->second;
+
+  skip.insert(n); // skip myself
+  // classify
+  // *preferred* traces osds from different failure domains
+  // *secondary* traces osds from same failure domain but different hosts
+  // *last* traces osds from same failure domain and same host
+  map<string, map<string, set<int>>> preferred;
+  map<string, set<int>> secondary;
+  vector<int> last;
+  for (int o = 0; o < max_osd; o++) {
+    if (!is_up(o) || skip.count(o))
+      continue;
+    loc = crush->get_full_location(o);
+    string host_name = "unknown";
+    it = loc.find(crush->get_type_name(1));
+    if (it != loc.end())
+      host_name = it->second;
+    string failure_domain_name = "unknown";
+    it = loc.find(crush->get_type_name(failure_domain));
+    if (it != loc.end())
+      failure_domain_name = it->second;
+    if (failure_domain_name == my_failure_domain_name) {
+      if (host_name != my_host_name)
+        secondary[host_name].insert(o);
+      else
+        last.push_back(o);
+    } else
+      preferred[failure_domain_name][host_name].insert(o);
+  }
+  map<string, vector<int>> preferred_list;
+  for (auto &p: preferred) {
+    int num = 0;
+    auto &l = preferred_list[p.first];
+    for (auto &q: p.second)
+      num += q.second.size();
+    l.reserve(num);
+    while (num > 0) {
+      for (auto &q: p.second) {
+        auto &o = q.second;
+        if (o.empty())
+          continue;
+        auto it = o.begin();
+        l.push_back(*it);
+        o.erase(it);
+        --num;
+      }
+    }
+  }
+  vector<int> candidates;
+  // *preferred* first
+  {
+    // use whoami as seed to randomized arrange osds,
+    // so we don't end up choosing same osds for different inputs
+    int index = preferred_list.size() ? (n % preferred_list.size()) : 0;
+    int num = 0;
+    for (auto &p: preferred_list)
+      num += p.second.size();
+    candidates.reserve(num);
+    bool begin = false;
+    int c = 0;
+    while (num > 0) {
+      for (auto &p: preferred_list) {
+        if (c == index)
+          begin = true;
+        c++;
+        if (!begin)
+          continue;
+        auto &o = p.second;
+        if (o.empty())
+          continue;
+        auto it = o.begin();
+        candidates.push_back(*it);
+        o.erase(it);
+        --num;
+      }
+    }
+  }
+  // then *secondary*
+  {
+    int index = secondary.size() ? (n % secondary.size()) : 0;
+    int num = 0;
+    for (auto &p: secondary)
+      num += p.second.size();
+    candidates.reserve(candidates.size() + num + last.size());
+    bool begin = false;
+    int c = 0;
+    while (num > 0) {
+      for (auto &p: secondary) {
+        if (c == index)
+          begin = true;
+        c++;
+        if (!begin)
+          continue;
+        auto &o = p.second;
+        if (o.empty())
+          continue;
+        auto it = o.begin();
+        candidates.push_back(*it);
+        o.erase(it);
+        --num;
+      }
+    }
+  }
+  // *last* too, in case we fail to collect enough candidates above
+  {
+    int index = last.size() ? (n % last.size()) : 0;
+    auto it = last.begin();
+    std::advance(it, index);
+    candidates.insert(candidates.end(), it, last.end());
+    candidates.insert(candidates.end(), last.begin(), it);
+  }
+  if ((int)candidates.size() <= limit) {
+    // all
+    for (auto i : candidates)
+      out->insert(i);
+  } else {
+    for (auto i : candidates) {
+      if (limit <= 0)
+        break;
+      out->insert(i);
+      limit--;
+    }
+  }
+}

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1453,6 +1453,10 @@ public:
   int parse_osd_id_list(const vector<string>& ls,
 			set<int> *out,
 			ostream *ss) const;
+  void get_random_up_osds_by_failure_domain(int n,     // whoami
+                                            int limit, // how many
+                                            set<int> skip,
+                                            set<int> *out) const;
 };
 WRITE_CLASS_ENCODER_FEATURES(OSDMap)
 WRITE_CLASS_ENCODER_FEATURES(OSDMap::Incremental)


### PR DESCRIPTION
By default, monitor requires at least two valid failure votes/reports from
different hosts to mark an OSD down, which turns out to be impossible sometimes
for a replicated-pool of size of 2 in those clusters made up of hosts
with contiguous labeled OSDs.

This patch instead does a breadth-first search based on the highest level of
failure domain at cluster-wide, to try to make heartbeat peers can cover all failure domains
whenever possible, which can hopefully help accelerating osd failure detection
in the above case..