### PR TITLE
cmake: do not link against common_crc_aarch64

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -435,10 +435,6 @@ if(HAVE_QATZIP)
   list(APPEND ceph_common_deps ${QATZIP_LIBRARIES})
 endif()
 
-if(HAVE_ARMV8_CRC)
-  list(APPEND ceph_common_deps common_crc_aarch64)
-endif()
-
 if(WITH_DPDK)
   list(APPEND ceph_common_deps common_async_dpdk)
 endif()


### PR DESCRIPTION
it's included by libcrc32 already

Signed-off-by: Kefu Chai <kchai@redhat.com>