### PR TITLE
luminous ceph-volume do not use stdin in luminous

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -69,7 +69,7 @@ def prepare_filestore(device, journal, secrets, tags, osd_id, fsid):
     # get the latest monmap
     prepare_utils.get_monmap(osd_id)
     # prepare the osd filesystem
-    prepare_utils.osd_mkfs_filestore(osd_id, fsid)
+    prepare_utils.osd_mkfs_filestore(osd_id, fsid, cephx_secret)
     # write the OSD keyring if it doesn't exist already
     prepare_utils.write_keyring(osd_id, cephx_secret)
     if secrets.get('dmcrypt_key'):

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -125,6 +125,31 @@ class TestFormatDevice(object):
         assert expected == fake_run.calls[0]['args'][0]
 
 
+mkfs_filestore_flags = [
+    'ceph-osd',
+    '--cluster',
+    '--osd-objectstore', 'filestore',
+    '--mkfs',
+    '-i',
+    '--monmap',
+    '--keyfile', '-', # goes through stdin
+    '--osd-data',
+    '--osd-journal',
+    '--osd-uuid',
+    '--setuser', 'ceph',
+    '--setgroup', 'ceph'
+]
+
+
+class TestOsdMkfsFilestore(object):
+
+    @pytest.mark.parametrize('flag', mkfs_filestore_flags)
+    def test_keyring_is_used(self, fake_call, monkeypatch, flag):
+        monkeypatch.setattr(system, 'chown', lambda path: True)
+        prepare.osd_mkfs_filestore(1, 'asdf', keyring='secret')
+        assert flag in fake_call.calls[0]['args'][0]
+
+
 class TestOsdMkfsBluestore(object):
 
     def test_keyring_is_added(self, fake_call, monkeypatch):

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -149,6 +149,12 @@ class TestOsdMkfsFilestore(object):
         prepare.osd_mkfs_filestore(1, 'asdf', keyring='secret')
         assert flag in fake_call.calls[0]['args'][0]
 
+    def test_keyring_is_used_luminous(self, fake_call, monkeypatch):
+        monkeypatch.setattr(prepare, '__release__', 'luminous')
+        monkeypatch.setattr(system, 'chown', lambda path: True)
+        prepare.osd_mkfs_filestore(1, 'asdf', keyring='secret')
+        assert '--keyfile' not in fake_call.calls[0]['args'][0]
+
 
 class TestOsdMkfsBluestore(object):
 
@@ -160,6 +166,12 @@ class TestOsdMkfsBluestore(object):
     def test_keyring_is_not_added(self, fake_call, monkeypatch):
         monkeypatch.setattr(system, 'chown', lambda path: True)
         prepare.osd_mkfs_bluestore(1, 'asdf')
+        assert '--keyfile' not in fake_call.calls[0]['args'][0]
+
+    def test_keyring_is_not_added_luminous(self, fake_call, monkeypatch):
+        monkeypatch.setattr(system, 'chown', lambda path: True)
+        prepare.osd_mkfs_bluestore(1, 'asdf')
+        monkeypatch.setattr(prepare, '__release__', 'luminous')
         assert '--keyfile' not in fake_call.calls[0]['args'][0]
 
     def test_wal_is_added(self, fake_call, monkeypatch):

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -339,7 +339,7 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
         raise RuntimeError('Command failed with exit code %s: %s' % (returncode, ' '.join(command)))
 
 
-def osd_mkfs_filestore(osd_id, fsid):
+def osd_mkfs_filestore(osd_id, fsid, keyring):
     """
     Create the files for the OSD to function. A normal call will look like:
 
@@ -359,7 +359,7 @@ def osd_mkfs_filestore(osd_id, fsid):
     system.chown(journal)
     system.chown(path)
 
-    process.run([
+    command = [
         'ceph-osd',
         '--cluster', conf.cluster,
         # undocumented flag, sets the `type` file to contain 'filestore'
@@ -367,9 +367,11 @@ def osd_mkfs_filestore(osd_id, fsid):
         '--mkfs',
         '-i', osd_id,
         '--monmap', monmap,
+        '--keyfile', '-', # goes through stdin
         '--osd-data', path,
         '--osd-journal', journal,
         '--osd-uuid', fsid,
         '--setuser', 'ceph',
         '--setgroup', 'ceph'
-    ])
+    ]
+    process.call(command, stdin=keyring, terminal_verbose=True, show_command=True)

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -7,7 +7,7 @@ the single-call helper
 import os
 import logging
 import json
-from ceph_volume import process, conf
+from ceph_volume import process, conf, __release__
 from ceph_volume.util import system, constants
 
 logger = logging.getLogger(__name__)
@@ -367,11 +367,22 @@ def osd_mkfs_filestore(osd_id, fsid, keyring):
         '--mkfs',
         '-i', osd_id,
         '--monmap', monmap,
-        '--keyfile', '-', # goes through stdin
+    ]
+
+    if __release__ != 'luminous':
+        # goes through stdin
+        command.extend(['--keyfile', '-'])
+
+    command.extend([
         '--osd-data', path,
         '--osd-journal', journal,
         '--osd-uuid', fsid,
         '--setuser', 'ceph',
         '--setgroup', 'ceph'
-    ]
-    process.call(command, stdin=keyring, terminal_verbose=True, show_command=True)
+    ])
+
+    _, _, returncode = process.call(
+        command, stdin=keyring, terminal_verbose=True, show_command=True
+    )
+    if returncode != 0:
+        raise RuntimeError('Command failed with exit code %s: %s' % (returncode, ' '.join(command)))


### PR DESCRIPTION
This backports conditional functionality to be able to get changes that work for mimic and nautilus into luminous, so that the related code additions can be added as well.

It first backports pr #20787 which depended on mon-config changes available only for Mimic and newer, and it then adds the commits for #23355 which makes sure this is conditioned based on the ``__release__``

Backport of: https://github.com/ceph/ceph/pull/23355
Backport of: https://github.com/ceph/ceph/pull/20787