### PR TITLE
client: check for unmounted condition before printing debug output

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13326,13 +13326,14 @@ int Client::fallocate(int fd, int mode, loff_t offset, loff_t length)
 int Client::ll_release(Fh *fh)
 {
   Mutex::Locker lock(client_lock);
+
+  if (unmounting)
+    return -ENOTCONN;
+
   ldout(cct, 3) << __func__ << " (fh)" << fh << " " << fh->inode->ino << " " <<
     dendl;
   tout(cct) << __func__ << " (fh)" << std::endl;
   tout(cct) << (unsigned long)fh << std::endl;
-
-  if (unmounting)
-    return -ENOTCONN;
 
   if (ll_unclosed_fh_set.count(fh))
     ll_unclosed_fh_set.erase(fh);


### PR DESCRIPTION
If the filesystem was unmounted before we attempt to call ceph_ll_close
on a Fh, then we can end up tripping over the dereferences in the
debug output. Check for unmounted filesystem first, and only print
the debug info if it's still mounted.

This patch only fixes up ceph_ll_close, which is the only call ganesha
makes after calling ceph_abort_conn. We may need to fix other paths in
the future though if that ever changes.

Tracker: http://tracker.ceph.com/issues/25213
Signed-off-by: Jeff Layton <jlayton@kernel.org>