### PR TITLE
qa/rgw: override valgrind --max-threads for radosgw

### DIFF
--- a/qa/suites/rgw/multisite/tasks/test_multi.yaml
+++ b/qa/suites/rgw/multisite/tasks/test_multi.yaml
@@ -7,13 +7,13 @@ tasks:
 - ceph: {cluster: c2}
 - rgw:
     c1.client.0:
-      valgrind: [--tool=memcheck]
+      valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
     c1.client.1:
-      valgrind: [--tool=memcheck]
+      valgrind: [--tool=memcheck, --max-threads=1024]
     c2.client.0:
-      valgrind: [--tool=memcheck]
+      valgrind: [--tool=memcheck, --max-threads=1024]
     c2.client.1:
-      valgrind: [--tool=memcheck]
+      valgrind: [--tool=memcheck, --max-threads=1024]
 - rgw-multisite:
 - rgw-multisite-tests:
     config:

--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -28,7 +28,7 @@ tasks:
           description: Swift Service
 - rgw:
     client.0:
-      valgrind: [--tool=memcheck]
+      valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
       frontend_prefix: /swift
       use-keystone-role: client.0
 - tempest:

--- a/qa/suites/rgw/verify/tasks/0-install.yaml
+++ b/qa/suites/rgw/verify/tasks/0-install.yaml
@@ -8,7 +8,7 @@ tasks:
 - openssl_keys:
 - rgw:
     client.0:
-      valgrind: [--tool=memcheck]
+      valgrind: [--tool=memcheck, --max-threads=1024] # http://tracker.ceph.com/issues/25214
 
 overrides:
   ceph:


### PR DESCRIPTION
radosgw now uses 512 frontend threads by default, and valgrind won't start with its default --max-threads=500

Fixes: http://tracker.ceph.com/issues/25214