### PR TITLE
mds: update MDSRank::cluster_degraded before handling mds failure

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1745,6 +1745,8 @@ void MDSRankDispatcher::handle_mds_map(
   if (g_conf()->mds_dump_cache_on_map)
     mdcache->dump_cache();
 
+  cluster_degraded = mdsmap->is_degraded();
+
   // mdsmap and oldmap can be discontinuous. failover might happen in the missing mdsmap.
   // the 'restart' set tracks ranks that have restarted since the old mdsmap
   set<mds_rank_t> restart;
@@ -1903,7 +1905,6 @@ void MDSRankDispatcher::handle_mds_map(
     }
   }
 
-  cluster_degraded = mdsmap->is_degraded();
   if (oldmap->is_degraded() && !cluster_degraded && state >= MDSMap::STATE_ACTIVE) {
     dout(1) << "cluster recovered." << dendl;
     auto it = waiting_for_active_peer.find(MDS_RANK_NONE);


### PR DESCRIPTION
Migrator checks MDSRank::is_cluster_degraded() to decide if it needs to
send message to other mds. MDSRank::cluster_degraded should get updated
before calling Migrator::handle_mds_failure_or_stop().

Introduced by commit 7de9da4a "mds: handle discontinuous mdsmap"

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>