### PR TITLE
build/ops: rpm: fix seastar build dependencies

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -178,9 +178,7 @@ BuildRequires:	socat
 %endif
 %if 0%{with seastar}
 BuildRequires:  c-ares-devel
-BuildRequires:  cryptopp-devel
 BuildRequires:  gnutls-devel
-BuildRequires:  fmt-devel
 BuildRequires:  hwloc-devel
 BuildRequires:  libpciaccess-devel
 BuildRequires:  lksctp-tools-devel
@@ -286,11 +284,13 @@ BuildRequires:  redhat-rpm-config
 %if 0%{with seastar}
 %if 0%{?fedora} || 0%{?rhel}
 BuildRequires:  cryptopp-devel
+BuildRequires:  fmt-devel
 BuildRequires:  numactl-devel
 BuildRequires:  protobuf-compiler
 %endif
 %if 0%{?suse_version}
 BuildRequires:  libcryptopp-devel
+BuildRequires:  libfmt-devel
 BuildRequires:  libnuma-devel
 %endif
 %endif


### PR DESCRIPTION
1. cryptopp-devel was moved to the distro-specific section by
aeb974b9139d49f13e162cd90da8a0a4b3fc3b33, then
96196e9d774ab55fabb792935a09a81cf0ca9786 reintroduced it in the
non-distro-specific section, breaking install-deps.sh for SUSE

2. fmt-devel is called libfmt-devel on SUSE

Fixes: install-deps.sh on SUSE
Signed-off-by: Nathan Cutler <ncutler@suse.com>