### PR TITLE
mgr/dashboard: Fix redirect to login page on session lost

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { ToastModule } from 'ng2-toastr';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap';
@@ -23,7 +24,8 @@ describe('RbdSnapshotFormComponent', () => {
       HttpClientTestingModule,
       ServicesModule,
       ApiModule,
-      ToastModule.forRoot()
+      ToastModule.forRoot(),
+      RouterTestingModule
     ],
     declarations: [RbdSnapshotFormComponent],
     providers: [BsModalRef, BsModalService, AuthStorageService]

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/dashboard-help/dashboard-help.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SharedModule } from '../../../shared/shared.module';
@@ -10,7 +11,7 @@ describe('DashboardHelpComponent', () => {
   let fixture: ComponentFixture<DashboardHelpComponent>;
 
   configureTestBed({
-    imports: [HttpClientTestingModule, SharedModule],
+    imports: [HttpClientTestingModule, SharedModule, RouterTestingModule],
     declarations: [DashboardHelpComponent]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/task-manager/task-manager.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { PopoverModule } from 'ngx-bootstrap';
 
@@ -18,7 +19,7 @@ describe('TaskManagerComponent', () => {
   };
 
   configureTestBed({
-    imports: [SharedModule, PopoverModule.forRoot(), HttpClientTestingModule],
+    imports: [SharedModule, PopoverModule.forRoot(), HttpClientTestingModule, RouterTestingModule],
     declarations: [TaskManagerComponent]
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { of as observableOf, Subscriber } from 'rxjs';
 
@@ -28,6 +29,7 @@ describe('SummaryService', () => {
   };
 
   configureTestBed({
+    imports: [RouterTestingModule],
     providers: [
       SummaryService,
       AuthStorageService,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
@@ -1,11 +1,11 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable, NgZone } from '@angular/core';
+import { Router } from '@angular/router';
 
 import * as _ from 'lodash';
 import { BehaviorSubject, Subscription } from 'rxjs';
 
 import { ExecutingTask } from '../models/executing-task';
-import { AuthStorageService } from './auth-storage.service';
 import { ServicesModule } from './services.module';
 
 @Injectable({
@@ -18,16 +18,12 @@ export class SummaryService {
   // Observable streams
   summaryData$ = this.summaryDataSource.asObservable();
 
-  constructor(
-    private http: HttpClient,
-    private authStorageService: AuthStorageService,
-    private ngZone: NgZone
-  ) {
+  constructor(private http: HttpClient, private router: Router, private ngZone: NgZone) {
     this.refresh();
   }
 
   refresh() {
-    if (this.authStorageService.isLoggedIn()) {
+    if (this.router.url !== '/login') {
       this.http.get('api/summary').subscribe((data) => {
         this.summaryDataSource.next(data);
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-wrapper.service.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { inject, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { ToastModule } from 'ng2-toastr';
 import { Observable } from 'rxjs/Observable';
@@ -16,7 +17,7 @@ describe('TaskWrapperService', () => {
   let service: TaskWrapperService;
 
   configureTestBed({
-    imports: [HttpClientTestingModule, ToastModule.forRoot(), SharedModule],
+    imports: [HttpClientTestingModule, ToastModule.forRoot(), SharedModule, RouterTestingModule],
     providers: [TaskWrapperService]
   });
 


### PR DESCRIPTION
This PR fixes the redirect to the login page when session is lost.

The behavior implemented in this PR is:

![rbd-list-lost-session-after](https://user-images.githubusercontent.com/14297426/43579924-8ddc3ee0-964b-11e8-8c72-128ddd97ae85.gif)

To see the previous/wrong behavior see the description of issue [#25344](https://tracker.ceph.com/issues/25344).

Fixes: https://tracker.ceph.com/issues/25344

Signed-off-by: Ricardo Marques <rimarques@suse.com>