### PR TITLE
mimic: ceph-disk: return a list instead of an iterator

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1498,7 +1498,7 @@ def unmount(
 
 def extract_parted_partition_numbers(partitions):
     numbers_as_strings = re.findall('^\d+', partitions, re.MULTILINE)
-    return map(int, numbers_as_strings)
+    return list(map(int, numbers_as_strings))
 
 
 def get_free_partition_index(dev):


### PR DESCRIPTION
Python2 to Python3 changed the return of map() from a list to a
"map object" which is an interator. This commit turns the returned
"map object" of extract_parted_partition_numbers() back into a list.

Fixes: https://tracker.ceph.com/issues/26830
Signed-off-by: Alexander Graul <agraul@suse.com>