### PR TITLE
luminous: ceph-volume enable the ceph-osd during lvm activation

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -74,6 +74,9 @@ def activate_filestore(lvs, no_systemd=False):
         # enable the ceph-volume unit for this OSD
         systemctl.enable_volume(osd_id, osd_fsid, 'lvm')
 
+        # enable the OSD
+        systemctl.enable_osd(osd_id)
+
         # start the OSD
         systemctl.start_osd(osd_id)
     terminal.success("ceph-volume lvm activate successful for osd ID: %s" % osd_id)
@@ -172,6 +175,9 @@ def activate_bluestore(lvs, no_systemd=False):
     if no_systemd is False:
         # enable the ceph-volume unit for this OSD
         systemctl.enable_volume(osd_id, osd_fsid, 'lvm')
+
+        # enable the OSD
+        systemctl.enable_osd(osd_id)
 
         # start the OSD
         systemctl.start_osd(osd_id)

--- a/src/ceph-volume/ceph_volume/systemd/systemctl.py
+++ b/src/ceph-volume/ceph_volume/systemd/systemctl.py
@@ -12,8 +12,11 @@ def stop(unit):
     process.run(['systemctl', 'stop', unit])
 
 
-def enable(unit):
-    process.run(['systemctl', 'enable', unit])
+def enable(unit, runtime=False):
+    if runtime:
+        process.run(['systemctl', 'enable', '--runtime', unit])
+    else:
+        process.run(['systemctl', 'enable', unit])
 
 
 def disable(unit):
@@ -41,7 +44,7 @@ def stop_osd(id_):
 
 
 def enable_osd(id_):
-    return enable(osd_unit % id_)
+    return enable(osd_unit % id_, runtime=True)
 
 
 def disable_osd(id_):

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -145,6 +145,7 @@ class TestOsdMkfsFilestore(object):
 
     @pytest.mark.parametrize('flag', mkfs_filestore_flags)
     def test_keyring_is_used(self, fake_call, monkeypatch, flag):
+        monkeypatch.setattr(prepare, '__release__', 'mimic')
         monkeypatch.setattr(system, 'chown', lambda path: True)
         prepare.osd_mkfs_filestore(1, 'asdf', keyring='secret')
         assert flag in fake_call.calls[0]['args'][0]


### PR DESCRIPTION
Backport of #23321
Fixes: http://tracker.ceph.com/issues/24152