### PR TITLE
ceph-volume tests patch __release__ to mimic always for stdin keys

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -145,6 +145,7 @@ class TestOsdMkfsFilestore(object):
 
     @pytest.mark.parametrize('flag', mkfs_filestore_flags)
     def test_keyring_is_used(self, fake_call, monkeypatch, flag):
+        monkeypatch.setattr(prepare, '__release__', 'mimic')
         monkeypatch.setattr(system, 'chown', lambda path: True)
         prepare.osd_mkfs_filestore(1, 'asdf', keyring='secret')
         assert flag in fake_call.calls[0]['args'][0]


### PR DESCRIPTION
This will be needed for Luminous tests, mainly on https://github.com/ceph/ceph/pull/23395