### PR TITLE
cmake: do not build DPDK with -march=native

### DIFF
--- a/cmake/modules/Finddpdk.cmake
+++ b/cmake/modules/Finddpdk.cmake
@@ -25,8 +25,6 @@ foreach(c ${components})
     set_target_properties(dpdk::${c} PROPERTIES
       INTERFACE_INCLUDE_DIRECTORIES "${DPDK_INCLUDE_DIR}"
       IMPORTED_LOCATION "${DPDK_rte_${c}_LIBRARY}")
-    target_compile_options(dpdk::${c} INTERFACE
-      "-march=native")
     list(APPEND DPDK_LIBRARIES dpdk::${c})
   endif()
 endforeach()


### PR DESCRIPTION
-march=native causes gcc to use opcodes according to whichever CPU happens to
be installed in the build host, which can be different for every build. This
makes it impossible to achieve a reproducible build.

Also, if the build host has a very new CPU, running the resulting binaries on
older CPUs (of the same family, i.e. x86_64) could result in segmentation
fault.

References: http://tracker.ceph.com/issues/24948
Signed-off-by: Nathan Cutler <ncutler@suse.com>