### PR TITLE
mgr/MgrClient: Protect daemon_health_metrics

### DIFF
--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -510,6 +510,7 @@ int MgrClient::service_daemon_update_status(
 
 void MgrClient::update_daemon_health(std::vector<DaemonHealthMetric>&& metrics)
 {
+  Mutex::Locker l(lock);
   daemon_health_metrics = std::move(metrics);
 }
 


### PR DESCRIPTION
Without holiding the lock update_daemon_health() can race with
send_report() corrupting the daemon_health_metrics vector.

Fixes: http://tracker.ceph.com/issues/23352

Signed-off-by: Kjetil Joergensen <kjetil@medallia.com>
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>