### PR TITLE
mgr: orchestrator interface and experimental Rook module

### DIFF
--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -203,6 +203,11 @@ Development-mode cluster
 
 See :doc:`/dev/quick_guide`.
 
+Kubernetes/Rook development cluster
+-----------------------------------
+
+See :doc:`/dev/kubernetes`.
+
 Backporting
 -----------
 

--- a/doc/dev/kubernetes.rst
+++ b/doc/dev/kubernetes.rst
@@ -1,4 +1,6 @@
 
+.. _kubernetes-dev:
+
 =======================================
 Hacking on Ceph in Kubernetes with Rook
 =======================================

--- a/doc/dev/kubernetes.rst
+++ b/doc/dev/kubernetes.rst
@@ -1,0 +1,222 @@
+
+=======================================
+Hacking on Ceph in Kubernetes with Rook
+=======================================
+
+.. warning:
+
+    This is *not* official user documentation for setting up production
+    Ceph clusters with Kubernetes.  It is aimed at developers who want
+    to hack on Ceph in Kubernetes.
+
+This guide is aimed at Ceph developers getting started with running
+in a Kubernetes environment.  It assumes that you may be hacking on Rook,
+Ceph or both, so everything is built from source.
+
+1. Build a kubernetes cluster
+=============================
+
+Before installing Ceph/Rook, make sure you've got a working kubernetes
+cluster with some nodes added (i.e. ``kubectl get nodes`` shows you something).
+The rest of this guide assumes that your development workstation has network
+access to your kubernetes cluster, such that ``kubectl`` works from your
+workstation.
+
+There are many ways (https://kubernetes.io/docs/setup/pick-right-solution/)
+to build a kubernetes cluster: here we include some tips/pointers on where
+to get started.
+
+Host your own
+-------------
+
+If you already have some linux servers (bare metal or VMs), you can set up
+your own kubernetes cluster using the ``kubeadm`` tool.
+
+https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/
+
+Here are some tips for a smoother ride with ``kubeadm``:
+
+- Don't worry if your servers aren't powerful: at time of writing, @jcsp is
+  running his home kubernetes cluster on 3 nodes Turion N54L nodes with 8GB RAM.
+- If you have installed any kubernetes/etcd/flannel packages before, make sure
+  they (and their configuration) are erased before you start.  kubeadm
+  installs containerised daemons that will be oblivious to any non-containerised
+  services you might already have running.
+- If you have previously added any yum/deb repos for kubernetes packages,
+  disable them before trying to use the packages.cloud.google.com repository.
+  If you don't, you'll get quite confusing conflicts.
+- Even if your distro already has docker, make sure you're installing it
+  a version from docker.com that is within the range mentioned in the
+  kubeadm install instructions.  Especially, note that the docker in CentOS 7
+  will *not* work.
+
+Hosted elsewhere
+----------------
+
+If you do not have any servers to hand, you might try a pure
+container provider such as Google Compute Engine.  Your mileage may
+vary when it comes to what kinds of storage devices are visible
+to your kubernetes cluster.
+
+Make sure you check how much it's costing you before you spin up a big cluster!
+
+
+2. Run a docker repository
+===========================
+
+Ideally, run this somewhere accessible from both your workstation and your
+kubernetes cluster (i.e. so that "docker push/pull" just works everywhere).
+This is likely to be the same host you're using as your kubernetes master.
+
+1. Install the ``docker-distribution`` package.
+2. If you want to configure the port, edit ``/etc/docker-distribution/registry/config.yml``
+3. Enable the registry service:
+
+::
+
+    systemctl enable docker-distribution
+    systemctl start docker-distribution
+
+
+3. Build Rook
+=============
+
+.. info:
+
+    Work within your $GOPATH -- here we assume it's ~/go
+
+Install Go if you don't already have it.
+
+Download the Rook source code:
+
+::
+
+    go get github.com/rook/rook
+
+    # Ignore this warning, as Rook is not a conventional go package
+    can't load package: package github.com/rook/rook: no Go files in /home/jspray/go/src/github.com/rook/rook
+
+You will now have a Rook source tree in ~/go/src/github.com/rook/rook -- you may
+be tempted to clone it elsewhere, but your life will be easier if you
+leave it in your GOPATH.
+
+Run ``make`` in the root of your Rook tree to build its binaries and containers:
+
+::
+
+    make
+    ...
+    === saving image build-9204c79b/ceph-amd64
+    === docker build build-9204c79b/ceph-toolbox-base-amd64
+    sha256:653bb4f8d26d6178570f146fe637278957e9371014ea9fce79d8935d108f1eaa
+    === docker build build-9204c79b/ceph-toolbox-amd64
+    sha256:445d97b71e6f8de68ca1c40793058db0b7dd1ebb5d05789694307fd567e13863
+    === caching image build-9204c79b/ceph-toolbox-base-amd64
+
+You can use ``docker image ls`` to see the resulting built images.  The
+images you care about are the ones with tags ending "ceph-amd64" (used
+for the Rook operator and Ceph daemons) and "ceph-toolbox-amd64" (used
+for the "toolbox" container where the CLI is run).
+
+The rest of this guide assumes that you will want to load your own binaries,
+and then push the container directly into your docker repository.  
+
+
+4. Build Ceph
+=============
+
+It is important that you build Ceph in an environment compatible with
+the base OS used in the Rook containers.  By default, the Rook containers
+are built with a CentOS base OS.  The simplest way to approach this
+is to build Ceph inside a docker container on your workstation.
+
+You can run a centos docker container with access to your Ceph source
+tree using a command like:
+
+::
+
+    docker run -i -v /my/ceph/src:/my/ceph/src -t centos:7 /bin/bash
+
+Once you have built Ceph, you can inject the resulting binaries into
+the Rook container image using the ``kubejacker.sh`` script (run from
+your build directory but from *outside* your build container).
+
+Setting the ``$REPO`` environment variable to your docker repository,
+execute the script to build a docker image containing your latest Ceph
+binaries:
+
+::
+
+    build$ REPO=<host>:<port> sh ../src/script/kubejacker/kubejacker.sh
+
+.. info:
+
+    You can also set ``BASEIMAGE`` to control that Rook image used
+    as the base -- by default this is set to any "ceph-amd64" image.
+    
+
+Now you've got your freshly built Rook and freshly built Ceph into
+a single container image, ready to run.  Next time you change something
+in Ceph, you can re-run this to update your image and restart your
+kubernetes containers.  If you change something in Rook, then re-run the Rook
+build, and the Ceph build too.
+
+5. Run a Rook cluster
+=====================
+
+.. info:
+
+    This is just some basic instructions: the Rook documentation
+    is much more expansive, at https://github.com/rook/rook/tree/master/Documentation
+
+The Rook source tree includes example .yaml files in
+``cluster/examples/kubernetes/ceph/``.  The important ones are:
+
+- ``operator.yaml`` -- runs the Rook operator, which will execute any other
+  rook objects we create.
+- ``cluster.yaml`` -- defines a Ceph cluster
+- ``toolbox.yaml`` -- runs the toolbox container, which contains the Ceph
+  CLI client.
+
+Copy these into a working directory, and edit as necessary to configure
+the setup you want:
+
+- Ensure that the ``image`` field in the operator matches the built Ceph image
+  you have uploaded to your Docker repository.
+- Edit the ``storage`` section of the cluster: set ``useAllNodes`` and
+  ``useAllDevices`` to false if you want to create OSDs explicitly
+  using ceph-mgr.
+    
+Then, load the configuration into the kubernetes API using ``kubectl``:
+
+::
+
+    kubectl apply -f ./operator.yaml 
+    kubectl apply -f ./cluster.yaml 
+    kubectl apply -f ./toolbox.yaml 
+
+Use ``kubectl -n rook-ceph-system get pods`` to check the operator
+pod is coming up, then ``kubectl -n rook-ceph get pods`` to check on
+the Ceph daemons and toolbox.  Once everything is up and running,
+you should be able to open a shell in the toolbox container and
+run ``ceph status``.
+
+If your mon services start but the rest don't, it could be that they're
+unable to form a quorum due to a Kubernetes networking issue: check that
+containers in your Kubernetes cluster can ping containers on other nodes.
+
+Cheat sheet
+===========
+
+Open a shell in your toolbox container::
+
+    kubectl -n rook-ceph exec -it rook-ceph-tools bash
+
+Inspect the Rook operator container's logs::
+
+    kubectl -n rook-ceph-system logs -l app=rook-ceph-operator
+
+Inspect the ceph-mgr container's logs::
+
+    kubectl -n rook-ceph logs -l app=rook-ceph-mgr
+

--- a/doc/mgr/index.rst
+++ b/doc/mgr/index.rst
@@ -27,6 +27,7 @@ sensible.
 
     Installation and Configuration <administrator>
     Writing plugins <plugins>
+    Writing orchestrator plugins <orchestrator_modules>
     Balancer plugin <balancer>
     Dashboard plugin <dashboard>
     Local pool plugin <localpool>
@@ -40,4 +41,5 @@ sensible.
     Iostat plugin <iostat>
     Crash plugin <crash>
     Devicehealth plugin <devicehealth>
+    Orchestrator CLI plugin <orchestrator_cli>
     Rook plugin <rook>

--- a/doc/mgr/index.rst
+++ b/doc/mgr/index.rst
@@ -40,3 +40,4 @@ sensible.
     Iostat plugin <iostat>
     Crash plugin <crash>
     Devicehealth plugin <devicehealth>
+    Rook plugin <rook>

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -1,0 +1,54 @@
+
+.. _orchestrator-cli-module:
+
+================
+Orchestrator CLI
+================
+
+This module provides a command line interface (CLI) to orchestrator
+modules (ceph-mgr modules which interface with external orchestation services)
+
+Configuration
+=============
+
+You can select the orchestrator module to use with the ``set backend`` command:
+
+::
+
+    ceph orchestrator set backend <module>
+
+For example, to enable the Rook orchestrator module and use it with the CLI:
+
+::
+
+    ceph mgr module enable orchestrator_cli
+    ceph mgr module enable rook
+    ceph orchestrator set backend rook
+
+
+Usage
+=====
+
+Print a list of discovered devices, grouped by node and optionally
+filtered to a particular node:
+
+::
+
+    orchestrator device ls [node]
+
+Query the status of a particular service (mon, osd, mds, rgw).  For OSDs
+the id is the numeric OSD ID, for MDS services it is the filesystem name:
+
+::
+
+    orchestrator service status <type> <id>
+
+Create a service.  For an OSD, the "what" is <node>:<device>, where the
+device naming should match what was reported in ``device ls``.  For an MDS
+service, the "what" is the filesystem name:
+
+::
+
+    orchestrator service add <type> <what>
+
+

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -26,6 +26,13 @@ For example, to enable the Rook orchestrator module and use it with the CLI:
     ceph orchestrator set backend rook
 
 
+You can then check backend is properly configured:
+
+::
+
+    ceph orchestrator status
+
+
 Usage
 =====
 

--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -1,0 +1,158 @@
+
+
+.. _orchestrator-modules:
+
+.. py:currentmodule:: orchestrator
+
+ceph-mgr orchestrator modules
+=============================
+
+.. warning::
+
+    This is developer documentation, describing Ceph internals that
+    are only relevant to people writing ceph-mgr orchestrator modules.
+
+In this context, *orchestrator* refers to some external service that
+provides the ability to discover devices and create Ceph services.  This
+includes external projects such as ceph-ansible, DeepSea, and Rook.
+
+An *orchestrator module* is a ceph-mgr module (:ref:`mgr-module-dev`)
+which implements common managment operations using a particular
+orchestrator.
+
+Orchestrator modules subclass the ``Orchestrator`` class: this class is
+an interface, it only provides method definitions to be implemented
+by subclasses.  The purpose of defining this common interface
+for different orchestrators is to enable common UI code, such as
+the dashboard, to work with various different backends.
+
+Behind all the abstraction, the purpose of orchestrator modules is simple:
+enable Ceph to do things like discover available hardware, create and
+destroy OSDs, and run MDS and RGW services.
+
+A tutorial is not included here: for full and concrete examples, see
+the existing implemented orchestrator modules in the Ceph source tree.
+
+Glossary
+--------
+
+Stateful service
+  a daemon that uses local storage, such as OSD or mon.
+
+Stateless service
+  a daemon that doesn't use any local storage, such
+  as an MDS, RGW, nfs-ganesha, iSCSI gateway.
+
+Label
+  arbitrary string tags that may be applied by administrators
+  to nodes.  Typically administrators use labels to indicate
+  which nodes should run which kinds of service.  Labels are
+  advisory (from human input) and do not guarantee that nodes
+  have particular physical capabilities.
+
+Drive group
+  collection of block devices with common/shared OSD
+  formatting (typically one or more SSDs acting as
+  journals/dbs for a group of HDDs).
+
+Placement
+  choice of which node is used to run a service.
+
+Key Concepts
+------------
+
+The underlying orchestrator remains the source of truth for information
+about whether a service is running, what is running where, which
+nodes are available, etc.  Orchestrator modules should avoid taking
+any internal copies of this information, and read it directly from
+the orchestrator backend as much as possible.
+
+Bootstrapping nodes and adding them to the underlying orchestration
+system is outside the scope of Ceph's orchestrator interface.  Ceph
+can only work on nodes when the orchestrator is already aware of them.
+
+Calls to orchestrator modules are all asynchronous, and return *completion*
+objects (see below) rather than returning values immediately.
+
+Where possible, placement of stateless services should be left up to the
+orchestrator.
+
+Completions and batching
+------------------------
+
+All methods that read or modify the state of the system can potentially
+be long running.  To handle that, all such methods return a *completion*
+object (a *ReadCompletion* or a *WriteCompletion*).  Orchestrator modules
+must implement the *wait* method: this takes a list of completions, and
+is responsible for checking if they're finished, and advancing the underlying
+operations as needed.
+
+Each orchestrator module implements its own underlying mechanisms
+for completions.  This might involve running the underlying operations
+in threads, or batching the operations up before later executing
+in one go in the background.  If implementing such a batching pattern, the
+module would do no work on any operation until it appeared in a list
+of completions passed into *wait*.
+
+*WriteCompletion* objects have a two-stage execution.  First they become
+*persistent*, meaning that the write has made it to the orchestrator
+itself, and been persisted there (e.g. a manifest file has been updated).
+If ceph-mgr crashed at this point, the operation would still eventually take
+effect.  Second, the completion becomes *effective*, meaning that the operation has really happened (e.g. a service has actually been started).
+
+.. automethod:: Orchestrator.wait
+
+.. autoclass:: ReadCompletion
+.. autoclass:: WriteCompletion
+
+Placement
+---------
+
+In general, stateless services do not require any specific placement
+rules, as they can run anywhere that sufficient system resources
+are available.  However, some orchestrators may not include the
+functionality to choose a location in this way, so we can optionally
+specify a location when creating a stateless service.
+
+OSD services generally require a specific placement choice, as this
+will determine which storage devices are used.
+
+Excluded functionality
+----------------------
+
+- Ceph's orchestrator interface is not a general purpose framework for
+  managing linux servers -- it is deliberately constrained to manage
+  the Ceph cluster's services only.
+- Multipathed storage is not handled (multipathing is unnecessary for
+  Ceph clusters).  Each drive is assumed to be visible only on
+  a single node.
+
+Inventory and status
+--------------------
+
+.. automethod:: Orchestrator.get_inventory
+.. autoclass:: InventoryFilter
+.. autoclass:: InventoryNode
+.. autoclass:: InventoryDevice
+
+.. automethod:: Orchestrator.describe_service
+.. autoclass:: ServiceDescription
+.. autoclass:: ServiceLocation
+
+OSD management
+--------------
+
+.. automethod:: Orchestrator.create_osds
+.. automethod:: Orchestrator.replace_osds
+.. automethod:: Orchestrator.remove_osds
+.. autoclass:: OsdCreationSpec
+.. autoclass:: DriveGroupSpec
+
+Upgrades
+--------
+
+.. automethod:: Orchestrator.upgrade_available
+.. automethod:: Orchestrator.upgrade_start
+.. automethod:: Orchestrator.upgrade_status
+.. autoclass:: UpgradeSpec
+.. autoclass:: UpgradeStatusSpec

--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -156,3 +156,9 @@ Upgrades
 .. automethod:: Orchestrator.upgrade_status
 .. autoclass:: UpgradeSpec
 .. autoclass:: UpgradeStatusSpec
+
+Utility
+-------
+
+.. automethod:: Orchestrator.available
+

--- a/doc/mgr/plugins.rst
+++ b/doc/mgr/plugins.rst
@@ -1,6 +1,14 @@
 
-ceph-mgr plugin author guide
-============================
+
+.. _mgr-module-dev:
+
+ceph-mgr module developer's guide
+=================================
+
+.. warning::
+
+    This is developer documentation, describing Ceph internals that
+    are only relevant to people writing ceph-mgr modules.
 
 Creating a plugin
 -----------------
@@ -17,6 +25,12 @@ The most important methods to override are:
   take action when new cluster data is available.
 * a ``handle_command`` member function if your module
   exposes CLI commands.
+
+Some modules interface with external orchestrators to deploy
+Ceph services.  These also inherit from ``Orchestrator``, which adds
+additional methods to the base ``MgrModule`` class.  See
+:ref:`Orchestrator modules <orchestrator-modules>` for more on
+creating these modules.
 
 Installing a plugin
 -------------------

--- a/doc/mgr/rook.rst
+++ b/doc/mgr/rook.rst
@@ -1,0 +1,36 @@
+
+=============================
+Rook orchestrator integration
+=============================
+
+Rook (https://rook.io/) is an orchestration tool that can run Ceph inside
+a Kubernetes cluster.
+
+The ``rook`` module provides integration between Ceph's orchestrator framework
+(used by modules such as ``dashboard`` to control cluster services) and
+Rook.
+
+Orchestrator modules only provide services to other modules, which in turn
+provide user interfaces.  To try out the rook module, you might like
+to use the :ref:`Orchestrator CLI <orchestrator-cli-module>` module.
+
+Requirements
+------------
+
+- Running ceph-mon and ceph-mgr services that were set up with Rook in
+  Kubernetes.
+- A sufficiently recent version of Rook. (**TODO: update once required Rook
+  tweaks are in a release**)
+
+If you are a developer, please see :ref:`kubernetes-dev` for instructions
+on setting up a development environment to work with this.
+
+Configuration
+-------------
+
+Because a Rook cluster's ceph-mgr daemon is running as a Kubernetes pod, 
+the ``rook`` module can connect to the Kubernetes API without any explicit
+configuration.
+
+
+

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -1,0 +1,478 @@
+
+"""
+ceph-mgr orchestrator interface
+
+This is a DRAFT for discussion.
+
+Goal: enable UI workflows for cluster service management
+      (such as creating OSDs, in addition to stateless services)
+      using common concepts that are implemented by
+      diverse backends such as Rook, DeepSea, ceph-ansible
+
+Concepts:
+    "Stateful service": a daemon that uses local storage, such as OSD or mon.
+    "Stateless service": a daemon that doesn't use any local storage, such
+                         as an MDS, RGW, nfs-ganesha, iSCSI gateway.
+    "Label": arbitrary string tags that may be applied by administrators
+             to nodes.  Typically administrators use labels to indicate
+             which nodes should run which kinds of service.  Labels are
+             advisory (from human input) and do not guarantee that nodes
+             have particular physical capabilities.
+    "Drive group": collection of block devices with common/shared OSD
+                   formatting (typically one or more SSDs acting as
+                   journals/dbs for a group of HDDs).
+    "Placement": choice of which node is used to run a service.
+
+Design choices:
+    1. The orchestrator is to be the source of truth for
+       all the physical information, and will be queried directly
+       as needed (i.e. no in-Ceph database of hardware etc).
+    2. The orchestrator handles placement of collections of stateless
+       services.
+    3. The orchestrator accepts explicit placement of individual stateful
+       services, and optionally also accepts label-based automatic placement.
+       (i.e. it *must* support "create OSD at host1:/dev/sdb", and it *may*
+        support "create OSDs on nodes with label=ceph-osd")
+    4. Bootstrapping nodes and connecting them to the orchestrator's
+       infrastructure is out of scope: this interface operates only
+       on nodes that are already visible to the orchestrator.
+    5. Methods all run in background, returning an instance of WriteCompletion
+       or ReadCompletion, to be polled by the caller using the wait() method
+
+Optional features:
+    1. Extensions to OSDs, such as block-level encryption.  See OsdSpec.extended
+    2. Label-based placement of OSDs.  If an orchestrator does not support
+       a labelling concept then only explicit per-node placement will work.
+    3. Explicit placement of stateless services.  Some orchestrators
+       may only support a basic round-robin placement of stateless services,
+       in which case they would also enable users to do explicit placement
+       for
+
+Excluded functionality:
+    1. No support for multipathed drives: all block devices are to be
+       reported from one node only.
+    2. No networking inventory or configuration.  Network configuration
+       is not Ceph-specific functionality, and by the time ceph-mgr
+       starts, we know that some external entity has already taken
+       care of at least the public network configuration.  This does
+       not preclude orchestrators implementing smart networking functionality
+       internally, it just isn't exposed up into ceph-mgr.
+    3. No OSD configuration outside the scope of Drive Group rules.
+"""
+
+
+class _Completion(object):
+    def get_result(self):
+        """
+        Return the result of the operation that we were waited
+        for.  Only valid after calling Orchestrator.wait() on this
+        completion.
+        """
+        raise NotImplementedError()
+
+    @property
+    def is_read(self):
+        raise NotImplementedError()
+
+    @property
+    def is_complete(self):
+        raise NotImplementedError()
+
+    @property
+    def is_errored(self):
+        raise NotImplementedError()
+
+
+class ReadCompletion(_Completion):
+    """
+    ``Orchestrator`` implementations should inherit from this
+    class to implement their own handles to operations in progress, and
+    return an instance of their subclass from calls into methods.
+
+    Read operations are
+    """
+
+    def __init__(self):
+        pass
+
+    @property
+    def is_read(self):
+        return True
+
+
+class WriteCompletion(_Completion):
+    """
+    ``Orchestrator`` implementations should inherit from this
+    class to implement their own handles to operations in progress, and
+    return an instance of their subclass from calls into methods.
+    """
+
+    def __init__(self):
+        pass
+
+    @property
+    def is_persistent(self):
+        """
+        Has the operation updated the orchestrator's configuration
+        persistently?  Typically this would indicate that an update
+        had been written to a manifest, but that the update
+        had not necessarily been pushed out to the cluster.
+        """
+        raise NotImplementedError()
+
+    @property
+    def is_effective(self):
+        """
+        Has the operation taken effect on the cluster?  For example,
+        if we were adding a service, has it come up and appeared
+        in Ceph's cluster maps?
+        """
+        raise NotImplementedError()
+
+    @property
+    def is_complete(self):
+        return self.is_errored or (self.is_persistent and self.is_effective)
+
+    @property
+    def is_read(self):
+        return False
+
+
+class Orchestrator(object):
+    """
+    Calls in this class may do long running remote operations, with time
+    periods ranging from network latencies to package install latencies and large
+    internet downloads.  For that reason, all are asynchronous, and return
+    ``Completion`` objects.
+
+    Implementations are not required to start work on an operation until
+    the caller waits on the relevant Completion objects.  Callers making
+    multiple updates should not wait on Completions until they're done
+    sending operations: this enables implementations to batch up a series
+    of updates when wait() is called on a set of Completion objects.
+
+    Implementations are encouraged to keep reasonably fresh caches of
+    the status of the system: it is better to serve a stale-but-recent
+    result read of e.g. device inventory than it is to keep the caller waiting
+    while you scan hosts every time.
+    """
+
+    def wait(self, completions):
+        """
+        Given a list of Completion instances, progress any which are
+        incomplete.  Return a true if everything is done.
+
+        Callers should inspect the detail of each completion to identify
+        partial completion/progress information, and present that information
+        to the user.
+
+        For fast operations (e.g. reading from a database), implementations
+        may choose to do blocking IO in this call.
+        """
+        raise NotImplementedError()
+
+    def get_inventory(self, node_filter=None):
+        # Return list of InventoryHost
+        raise NotImplementedError()
+
+    def describe_service(self, service_type, service_id):
+        """
+        Describe a service (of any kind) that is already configured in
+        the orchestrator.  For example, when viewing an OSD in the dashboard
+        we might like to also display information about the orchestrator's
+        view of the service (like the kubernetes pod ID).
+
+        When viewing a CephFS filesystem in the dashboard, we would use this
+        to display the pods being currently run for MDS daemons.
+        """
+        raise NotImplementedError()
+
+    def add_mon(self, node_name):
+        """
+        We operate on a node rather than a particular device: it is
+        assumed/expected that proper SSD storage is already available
+        and accessible in /var.
+
+        :param node_name:
+        :return:
+        """
+        raise NotImplementedError()
+
+    def remove_mon(self, node_name):
+        """
+
+        :param node_name:
+        :return:
+        """
+        raise NotImplementedError()
+
+    def create_osds(self, osd_spec):
+        """
+        Create one or more OSDs within a single Drive Group.
+
+        The principal argument here is the drive_group member
+        of OsdSpec: other fields are advisory/extensible for any
+        finer-grained OSD feature enablement (choice of backing store,
+        compression/encryption, etc).
+
+        :param osd_spec: OsdCreationSpec
+        :return:
+        """
+        raise NotImplementedError()
+
+    def replace_osds(self, osd_spec):
+        """
+        Like create_osds, but the osd_id_claims must be fully
+        populated.
+        """
+        raise NotImplementedError()
+
+    def remove_osds(self, node, osd_ids):
+        """
+        :param node: A node name, must exist.
+        :param osd_ids: list of OSD IDs
+
+        Note that this can only remove OSDs that were successfully
+        created (i.e. got an OSD ID).
+        """
+        raise NotImplementedError()
+
+    def add_stateless_service(self, service_type, spec):
+        assert isinstance(spec, StatelessServiceSpec)
+        raise NotImplementedError()
+
+    def update_stateless_service(self, service_type, id_, spec):
+        assert isinstance(spec, StatelessServiceSpec)
+        raise NotImplementedError()
+
+    def remove_stateless_service(self, service_type, id_):
+        raise NotImplementedError()
+
+    def upgrade_start(self, upgrade_spec):
+        assert isinstance(upgrade_spec, UpgradeSpec)
+        raise NotImplementedError()
+
+    def upgrade_status(self):
+        """
+        If an upgrade is currently underway, report on where
+        we are in the process, or if some error has occurred.
+
+        :return: UpgradeStatusSpec instance
+        """
+        raise NotImplementedError()
+
+    def upgrade_available(self):
+        """
+        Report on what versions are available to upgrade to
+
+        :return: List of strings
+        """
+        raise NotImplementedError()
+
+    def add_stateful_service_rule(self, service_type, stateful_service_spec,
+                                  placement_spec):
+        """
+        Stateful service rules serve two purposes:
+         - Optionally delegate device selection to the orchestrator
+         - Enable the orchestrator to auto-assimilate new hardware if it
+           matches the placement spec, without any further calls from ceph-mgr.
+
+        To create a confidence-inspiring UI workflow, use test_stateful_service_rule
+        beforehand to show the user where stateful services will be placed
+        if they proceed.
+        """
+        raise NotImplementedError()
+
+    def test_stateful_service_rule(self, service_type, stateful_service_spec,
+                                   placement_spec):
+        """
+        See add_stateful_service_rule.
+        """
+        raise NotImplementedError()
+
+    def remove_stateful_service_rule(self, service_type, id_):
+        """
+        This will remove the *rule* but not the services that were
+        created as a result.  Those should be converted into statically
+        placed services as if they had been created with add_stateful_service,
+        so that they can be removed with remove_stateless_service
+        if desired.
+        """
+        raise NotImplementedError()
+
+
+class UpgradeSpec(object):
+    # Request to orchestrator to initiate an upgrade to a particular
+    # version of Ceph
+    def __init__(self):
+        self.target_version = None
+
+
+class UpgradeStatusSpec(object):
+    # Orchestrator's report on what's going on with any ongoing upgrade
+    def __init__(self):
+        self.in_progress = False  # Is an upgrade underway?
+        self.services_complete = []  # Which daemon types are fully updated?
+        self.message = ""  # Freeform description
+
+
+class PlacementSpec(object):
+    """
+    For APIs that need to specify a node subset
+    """
+    def __init__(self):
+        self.label = None
+
+
+class ServiceLocation(object):
+    """
+    See ServiceDescription
+    """
+    def __init__(self):
+        # Node is at the same granularity as InventoryNode
+        self.nodename = None
+
+        # Not everyone runs in containers, but enough people do to
+        # justify having this field here.
+        self.container_id = None
+
+        # The orchestrator will have picked some names for daemons,
+        # typically either based on hostnames or on pod names.
+        # This is the <foo> in mds.<foo>, the ID that will appear
+        # in the FSMap/ServiceMap.
+        self.daemon_name = None
+
+
+class ServiceDescription(object):
+    """
+    For responding to queries about the status of a particular service,
+    stateful or stateless.
+
+    This is not about health or performance monitoring of services: it's
+    about letting the orchestrator tell Ceph whether and where a 
+    service is scheduled in the cluster.  When an orchestrator tells
+    Ceph "it's running on node123", that's not a promise that the process
+    is literally up this second, it's a description of where the orchestrator
+    has decided the service should run.
+    """
+
+    def __init__(self):
+        self.locations = []
+
+
+class DriveGroupSpec(object):
+    """
+    Describe a drive group in the same form that ceph-volume
+    understands.
+    """
+    def __init__(self, devices):
+        self.devices = devices
+
+
+class OsdCreationSpec(object):
+    """
+    Used during OSD creation.
+
+    The drive names used here may be ephemeral.
+    """
+    def __init__(self):
+        self.format = None  # filestore, bluestore
+
+        self.node = None  # name of a node
+
+        # List of device names
+        self.drive_group = None
+
+        # Optional: mapping of drive to OSD ID, used when the
+        # created OSDs are meant to replace previous OSDs on
+        # the same node.
+        self.osd_id_claims = {}
+
+        # Arbitrary JSON-serializable object.
+        # Maybe your orchestrator knows how to do something
+        # special like encrypting drives
+        self.extended = {}
+
+
+class StatelessServiceSpec(object):
+    # Request to orchestrator for a group of stateless services
+    # such as MDS, RGW, nfs gateway, iscsi gateway
+    """
+    Details of stateless service creation.
+
+    This is *not* supposed to contain all the configuration
+    of the services: it's just supposed to be enough information to
+    execute the binaries.
+    """
+
+    def __init__(self):
+        self.placement = PlacementSpec()
+
+        # Give this set of statelss services a name: typically it would
+        # be the name of a CephFS filesystem, RGW zone, etc.  Must be unique
+        # within one ceph cluster.
+        self.name = ""
+
+        # Minimum and maximum number of service instances
+        self.min_size = 1
+        self.max_size = 1
+
+        # Arbitrary JSON-serializable object.
+        # Maybe you're using e.g. kubenetes and you want to pass through
+        # some replicaset special sauce for autoscaling?
+        self.extended = {}
+
+
+class InventoryFilter(object):
+    """
+    When fetching inventory, use this filter to avoid unnecessarily
+    scanning the whole estate.
+
+    Typical use: filter by node when presenting UI workflow for configuring
+                 a particular server.
+                 filter by label when not all of estate is Ceph servers,
+                 and we want to only learn about the Ceph servers.
+                 filter by label when we are interested particularly
+                 in e.g. OSD servers.
+
+    """
+    def __init__(self):
+        self.labels = None  # Optional: get info about nodes matching labels
+        self.nodes = None  # Optional: get info about certain named nodes only
+
+
+class InventoryBlockDevice(object):
+    """
+    When fetching inventory, block devices are reported in this format.
+
+    Note on device identifiers: the format of this is up to the orchestrator,
+    but the same identifier must also work when passed into StatefulServiceSpec.
+    The identifier should be something meaningful like a device WWID or
+    stable device node path -- not something made up by the orchestrator.
+
+    "Extended" is for reporting any special configuration that may have
+    already been done out of band on the block device.  For example, if
+    the device has already been configured for encryption, report that
+    here so that it can be indicated to the user.  The set of
+    extended properties may differ between orchestrators.  An orchestrator
+    is permitted to support no extended properties (only normal block
+    devices)
+    """
+    def __init__(self):
+        self.blank = False
+        self.type = None  # 'ssd', 'hdd', 'nvme'
+        self.id = None  # unique within a node (or globally if you like).
+        self.size = None  # byte integer.
+        self.extended = None  # arbitrary JSON-serializable object
+
+        # If this drive is not empty, but is suitable for appending
+        # additional journals, wals, or bluestore dbs, then report
+        # how much space is available.
+        self.metadata_space_free = None
+
+
+class InventoryNode(object):
+    def __init__(self, name, devices):
+        assert isinstance(devices, list)
+        self.name = name  # unique within cluster.  For example a hostname.
+        self.devices = devices  # list of InventoryBlockDevice

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -106,8 +106,30 @@ class Orchestrator(object):
         """
         Enable other modules to interrogate this module to discover
         whether it's usable as an orchestrator module.
+
+        Subclasses do not need to override this.
         """
         return True
+
+    def available(self):
+        """
+        Report whether we can talk to the orchestrator.  This is the
+        place to give the user a meaningful message if the orchestrator
+        isn't running or can't be contacted.
+
+        This method may be called frequently (e.g. every page load
+        to conditionally display a warning banner), so make sure it's
+        not too expensive.  It's okay to give a slightly stale status
+        (e.g. based on a periodic background ping of the orchestrator)
+        if that's necessary to make this method fast.
+
+        Do not override this method if you don't have a meaningful
+        status to return: the default None, None return value is used
+        to indicate that a module is unable to indicate its availability.
+
+        @return two-tuple of boolean, string
+        """
+        return None, None
 
     def wait(self, completions):
         """

--- a/src/pybind/mgr/orchestrator_cli/__init__.py
+++ b/src/pybind/mgr/orchestrator_cli/__init__.py
@@ -1,0 +1,2 @@
+
+from module import OrchestratorCli

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -1,0 +1,245 @@
+import errno
+import time
+from mgr_module import MgrModule
+
+import orchestrator
+
+
+class NoOrchestrator(Exception):
+    pass
+
+
+class OrchestratorCli(MgrModule):
+    OPTIONS = [
+        {'name': 'orchestrator'}
+    ]
+    COMMANDS = [
+        {
+            'cmd': "orchestrator device ls "
+                   "name=node,type=CephString,req=false",
+            "desc": "List devices on a node",
+            "perm": "r"
+        },
+        {
+            'cmd': "orchestrator service status "
+                   "name=svc_type,type=CephString "
+                   "name=svc_id,type=CephString ",
+            "desc": "Get orchestrator state for Ceph service",
+            "perm": "r"
+        },
+        {
+            'cmd': "orchestrator service add "
+                   "name=svc_type,type=CephString "
+                   "name=svc_arg,type=CephString ",
+            "desc": "Create a service of any type",
+            "perm": "rw"
+        },
+        {
+            'cmd': "orchestrator set backend "
+                   "name=module,type=CephString,req=true",
+            "desc": "Select orchestrator module backend",
+            "perm": "rw"
+        },
+    ]
+
+    def _select_orchestrator(self):
+        o = self.get_config("orchestrator")
+        if o is None:
+            raise NoOrchestrator()
+
+        return o
+
+    def _oremote(self, *args, **kwargs):
+        """
+        Helper for invoking `remote` on whichever orchestrator is enabled
+        """
+        return self.remote(self._select_orchestrator(),
+                           *args, **kwargs)
+
+    def _wait(self, completions):
+        """
+        Helper to wait for completions to complete (reads) or
+        become persistent (writes).
+
+        Waits for writes to be *persistent* but not *effective*.
+        """
+        done = False
+
+        while done is False:
+            done = self._oremote("wait", completions)
+
+            if not done:
+                any_nonpersistent = False
+                for c in completions:
+                    if c.is_read:
+                        if not c.is_complete:
+                            any_nonpersistent = True
+                            break
+                    else:
+                        if not c.is_persistent:
+                            any_nonpersistent = True
+                            break
+
+                if any_nonpersistent:
+                    time.sleep(5)
+                else:
+                    done = True
+
+    def _list_devices(self, cmd):
+        node = cmd.get('node', None)
+
+        if node:
+            nf = orchestrator.InventoryFilter()
+            nf.nodes = [node]
+        else:
+            nf = None
+
+        completion = self._oremote("get_inventory", node_filter=nf)
+
+        self._wait([completion])
+
+        # Spit out a human readable version
+        result = ""
+
+        for inventory_node in completion.result:
+            result += "{0}:\n".format(inventory_node.name)
+            for d in inventory_node.devices:
+                result += "  {0} ({1}, {2}b)\n".format(
+                    d.id, d.type, d.size)
+            result += "\n"
+
+        return 0, result, ""
+
+    def _service_status(self, cmd):
+        svc_type = cmd['svc_type']
+        svc_id = cmd['svc_id']
+
+        # XXX this is kind of confusing for people because in the orchestrator
+        # context the service ID for MDS is the filesystem ID, not the daemon ID
+
+        completion = self._oremote("describe_service", svc_type, svc_id)
+
+        self._wait([completion])
+
+        service_description = completion.result
+        #assert isinstance(service_description, orchestrator.ServiceDescription)
+
+        if len(service_description.locations) == 0:
+            return 0, "", "No locations reported"
+        else:
+            lines = []
+            for l in service_description.locations:
+                lines.append("{0}.{1} {2} {3}".format(
+                    svc_type,
+                    l.daemon_name,
+                    l.nodename,
+                    l.container_id))
+
+            return 0, "\n".join(lines), ""
+
+    def _service_add(self, cmd):
+        svc_type = cmd['svc_type']
+        if svc_type == "osd":
+            device_spec = cmd['svc_arg']
+            try:
+                node_name, block_device = device_spec.split(":")
+            except TypeError:
+                return -errno.EINVAL, "", "Invalid device spec, should be <node>:<device>"
+
+            spec = orchestrator.OsdCreationSpec()
+            spec.node = node_name
+            spec.format = "bluestore"
+            spec.drive_group = orchestrator.DriveGroupSpec([block_device])
+
+            completion = self._oremote("create_osds", spec)
+            self._wait([completion])
+
+            return 0, "", "Success."
+
+        elif svc_type == "mds":
+            fs_name = cmd['svc_arg']
+
+            spec = orchestrator.StatelessServiceSpec()
+            spec.name = fs_name
+
+            completion = self._oremote(
+                "add_stateless_service",
+                svc_type,
+                spec
+            )
+            self._wait([completion])
+
+            return 0, "", "Success."
+        else:
+            raise NotImplementedError(svc_type)
+
+    def _set_backend(self, cmd):
+        """
+        We implement a setter command instead of just having the user
+        modify the setting directly, so that we can validate they're setting
+        it to a module that really exists and is enabled.
+
+        There isn't a mechanism for ensuring they don't *disable* the module
+        later, but this is better than nothing.
+        """
+
+        mgr_map = self.get("mgr_map")
+        module_name = cmd['module']
+
+        if module_name == "":
+            self.set_config("orchestrator", None)
+            return 0, "", ""
+
+        for module in mgr_map['available_modules']:
+            if module['name'] != module_name:
+                continue
+
+            if not module['can_run']:
+                continue
+
+            enabled = module['name'] in mgr_map['modules']
+            if not enabled:
+                return -errno.EINVAL, "", "Module '{0}' is not enabled".format(
+                    module_name
+                )
+
+            try:
+                is_orchestrator = self.remote(module_name,
+                                              "is_orchestrator_module")
+            except NameError:
+                is_orchestrator = False
+
+            if not is_orchestrator:
+                return -errno.EINVAL, "",\
+                       "'{0}' is not an orchestrator module".format(
+                           module_name)
+
+            self.set_config("orchestrator", module_name)
+
+            return 0, "", ""
+
+        return -errno.ENOENT, "", "Module '{0}' not found".format(
+            module_name
+        )
+
+    def handle_command(self, inbuf, cmd):
+        try:
+            return self._handle_command(inbuf, cmd)
+        except NoOrchestrator:
+            return -errno.ENODEV, "", "No orchestrator configured"
+        except ImportError as e:
+            return -errno.ENOENT, "", e.message
+        except NotImplementedError:
+            return -errno.EINVAL, "", "Command not found"
+
+    def _handle_command(self, _, cmd):
+        if cmd['prefix'] == "orchestrator device ls":
+            return self._list_devices(cmd)
+        elif cmd['prefix'] == "orchestrator service status":
+            return self._service_status(cmd)
+        elif cmd['prefix'] == "orchestrator service add":
+            return self._service_add(cmd)
+        if cmd['prefix'] == "orchestrator set backend":
+            return self._set_backend(cmd)
+        else:
+            raise NotImplementedError()

--- a/src/pybind/mgr/rook/__init__.py
+++ b/src/pybind/mgr/rook/__init__.py
@@ -1,0 +1,2 @@
+
+from module import RookOrchestrator

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -1,0 +1,392 @@
+import threading
+import functools
+import os
+import uuid
+
+from mgr_module import MgrModule
+
+import orchestrator
+
+try:
+    from kubernetes import client, config
+
+    kubernetes_imported = True
+except ImportError:
+    kubernetes_imported = False
+    client = None
+    config = None
+
+from rook_cluster import RookCluster, ApplyException
+
+
+all_completions = []
+
+
+class RookReadCompletion(orchestrator.ReadCompletion):
+    """
+    All reads are simply API calls: avoid spawning
+    huge numbers of threads by just running them
+    inline when someone calls wait()
+    """
+
+    def __init__(self, cb):
+        super(RookReadCompletion, self).__init__()
+        self.cb = cb
+        self.result = None
+        self._complete = False
+
+        self.message = "<read op>"
+
+        # XXX hacky global
+        global all_completions
+        all_completions.append(self)
+
+    @property
+    def is_complete(self):
+        return self._complete
+
+    def execute(self):
+        self.result = self.cb()
+        self._complete = True
+
+
+class RookWriteCompletion(orchestrator.WriteCompletion):
+    """
+    Writes are a two-phase thing, firstly sending
+    the write to the k8s API (fast) and then waiting
+    for the corresponding change to appear in the
+    Ceph cluster (slow)
+    """
+    # XXX kubernetes bindings call_api already usefully has
+    # a completion= param that uses threads.  Maybe just
+    # use that?
+    def __init__(self, execute_cb, complete_cb, message):
+        super(RookWriteCompletion, self).__init__()
+        self.execute_cb = execute_cb
+        self.complete_cb = complete_cb
+
+        # Executed means I executed my k8s API call, it may or may
+        # not have succeeded
+        self.executed = False
+
+        # Result of k8s API call, this is set if executed==True
+        self.k8s_result = None
+
+        self.effective = False
+
+        self.id = str(uuid.uuid4())
+
+        self.message = message
+
+        self.error = None
+
+        # XXX hacky global
+        global all_completions
+        all_completions.append(self)
+
+    @property
+    def is_persistent(self):
+        return (not self.is_errored) and self.executed
+
+    @property
+    def is_effective(self):
+        return self.effective
+
+    @property
+    def is_errored(self):
+        return self.error is not None
+
+    def execute(self):
+        if not self.executed:
+            self.k8s_result = self.execute_cb()
+            self.executed = True
+
+        if not self.effective:
+            # TODO: check self.result for API errors
+            if self.complete_cb is None:
+                self.effective = True
+            else:
+                self.effective = self.complete_cb()
+
+
+def deferred_read(f):
+    """
+    Decorator to make RookOrchestrator methods return
+    a completion object that executes themselves.
+    """
+
+    @functools.wraps(f)
+    def wrapper(*args, **kwargs):
+        return RookReadCompletion(lambda: f(*args, **kwargs))
+
+    return wrapper
+
+
+class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
+    OPTIONS = [
+        # TODO: configure k8s API addr instead of assuming local
+    ]
+
+    def _progress(self, *args, **kwargs):
+        try:
+            self.remote("progress", *args, **kwargs)
+        except ImportError:
+            # If the progress module is disabled that's fine,
+            # they just won't see the output.
+            pass
+
+    def wait(self, completions):
+        self.log.info("wait: completions={0}".format(completions))
+
+        incomplete = False
+
+        # Our `wait` implementation is very simple because everything's
+        # just an API call.
+        for c in completions:
+            if not isinstance(c, RookReadCompletion) and \
+                    not isinstance(c, RookWriteCompletion):
+                raise TypeError(
+                    "wait() requires list of completions, not {0}".format(
+                        c.__class__
+                    ))
+
+            if c.is_complete:
+                continue
+
+            if not c.is_read:
+                self._progress("update", c.id, c.message, 0.5)
+
+            try:
+                c.execute()
+            except Exception as e:
+                self.log.exception("Completion {0} threw an exception:".format(
+                    c.message
+                ))
+                c.error = e
+                if not c.is_read:
+                    self._progress("complete", c.id)
+            else:
+                if c.is_complete:
+                    if not c.is_read:
+                        self._progress("complete", c.id)
+
+            if not c.is_complete:
+                incomplete = True
+
+        return not incomplete
+
+    @staticmethod
+    def can_run():
+        if kubernetes_imported:
+            return True, ""
+        else:
+            return False, "kubernetes module not found"
+
+    def __init__(self, *args, **kwargs):
+        super(RookOrchestrator, self).__init__(*args, **kwargs)
+
+        self._initialized = threading.Event()
+        self._k8s = None
+        self._rook_cluster = None
+
+        self._shutdown = threading.Event()
+
+    def shutdown(self):
+        self._shutdown.set()
+
+    @property
+    def k8s(self):
+        self._initialized.wait()
+        return self._k8s
+
+    @property
+    def rook_cluster(self):
+        self._initialized.wait()
+        return self._rook_cluster
+
+    def serve(self):
+        # For deployed clusters, we should always be running inside
+        # a Rook cluster.  For development convenience, also support
+        # running outside (reading ~/.kube config)
+        in_cluster = 'ROOK_CLUSTER_NAME' in os.environ
+        if in_cluster:
+            config.load_incluster_config()
+            cluster_name = os.environ['ROOK_CLUSTER_NAME']
+        else:
+            self.log.warning("DEVELOPMENT ONLY: Reading kube config from ~")
+            config.load_kube_config()
+
+            cluster_name = "rook"
+
+            # So that I can do port forwarding from my workstation - jcsp
+            from kubernetes.client import configuration
+            configuration.verify_ssl = False
+
+        self._k8s = client.CoreV1Api()
+
+        # XXX mystery hack -- I need to do an API call from
+        # this context, or subsequent API usage from handle_command
+        # fails with SSLError('bad handshake').  Suspect some kind of
+        # thread context setup in SSL lib?
+        self._k8s.list_namespaced_pod(cluster_name)
+
+        self._rook_cluster = RookCluster(
+            self._k8s,
+            cluster_name)
+
+        # In case Rook isn't already clued in to this ceph
+        # cluster's existence, initialize it.
+        # self._rook_cluster.init_rook()
+
+        self._initialized.set()
+
+        while not self._shutdown.is_set():
+            # XXX hack (or is it?) to kick all completions periodically,
+            # in case we had a caller that wait()'ed on them long enough
+            # to get persistence but not long enough to get completion
+
+            global all_completions
+            self.wait(all_completions)
+            all_completions = filter(lambda x: not x.is_complete,
+                                     all_completions)
+
+            self._shutdown.wait(5)
+
+        # TODO: watch Rook for config changes to complain/update if
+        # things look a bit out of sync?
+
+    @deferred_read
+    def get_inventory(self, node_filter=None):
+        node_list = None
+        if node_filter and node_filter.nodes:
+            # Explicit node list
+            node_list = node_filter.nodes
+        elif node_filter and node_filter.labels:
+            # TODO: query k8s API to resolve to node list, and pass
+            # it into RookCluster.get_discovered_devices
+            raise NotImplementedError()
+
+        devs = self.rook_cluster.get_discovered_devices(node_list)
+
+        result = []
+        for node_name, node_devs in devs.items():
+            devs = []
+            for d in node_devs:
+                dev = orchestrator.InventoryDevice()
+
+                # XXX CAUTION!  https://github.com/rook/rook/issues/1716
+                # Passing this through for the sake of completeness but it
+                # is not trustworthy!
+                dev.blank = d['empty']
+                dev.type = 'hdd' if d['rotational'] else 'ssd'
+                dev.id = d['name']
+                dev.size = d['size']
+
+                if d['filesystem'] == "" and not d['rotational']:
+                    # Empty or partitioned SSD
+                    partitioned_space = sum(
+                        [p['size'] for p in d['Partitions']])
+                    dev.metadata_space_free = max(0, d[
+                        'size'] - partitioned_space)
+
+                devs.append(dev)
+
+            result.append(orchestrator.InventoryNode(node_name, devs))
+
+        return result
+
+    @deferred_read
+    def describe_service(self, service_type, service_id):
+        assert service_type in ("mds", "osd", "mon", "rgw")
+
+        pods = self.rook_cluster.describe_pods(service_type, service_id)
+
+        result = orchestrator.ServiceDescription()
+        for p in pods:
+            sl = orchestrator.ServiceLocation()
+            sl.nodename = p['nodename']
+            sl.container_id = p['name']
+
+            if service_type == "osd":
+                sl.daemon_name = "%s" % p['labels']["ceph-osd-id"]
+            elif service_type == "mds":
+                # MDS daemon names are the tail of the pod name with
+                # an 'm' prefix.
+                # TODO: Would be nice to get this out a label though.
+                sl.daemon_name = "m" + sl.container_id.split("-")[-1]
+            elif service_type == "mon":
+                sl.daemon_name = p['labels']["mon"]
+            elif service_type == "mgr":
+                # FIXME: put a label on the pod to consume
+                # from here
+                raise NotImplementedError("mgr")
+            elif service_type == "rgw":
+                # FIXME: put a label on the pod to consume
+                # from here
+                raise NotImplementedError("rgw")
+
+            result.locations.append(sl)
+
+        return result
+
+    def add_stateless_service(self, service_type, spec):
+        # assert isinstance(spec, orchestrator.StatelessServiceSpec)
+
+        if service_type == "mds":
+            return RookWriteCompletion(
+                lambda: self.rook_cluster.add_filesystem(spec), None,
+                "Creating Filesystem services for {0}".format(spec.name))
+        else:
+            # TODO: RGW, NFS
+            raise NotImplementedError(service_type)
+
+    def create_osds(self, spec):
+        # Validate spec.node
+        if not self.rook_cluster.node_exists(spec.node):
+            raise RuntimeError("Node '{0}' is not in the Kubernetes "
+                               "cluster".format(spec.node))
+
+        # Validate whether cluster CRD can accept individual OSD
+        # creations (i.e. not useAllDevices)
+        if not self.rook_cluster.can_create_osd():
+            raise RuntimeError("Rook cluster configuration does not "
+                               "support OSD creation.")
+
+        def execute():
+            self.rook_cluster.add_osds(spec)
+
+        def is_complete():
+            # Find OSD pods on this host
+            pod_osd_ids = set()
+            pods = self._k8s.list_namespaced_pod("rook-ceph",
+                                                 label_selector="rook_cluster=rook-ceph,app=rook-ceph-osd",
+                                                 field_selector="spec.nodeName={0}".format(
+                                                     spec.node
+                                                 )).items
+            for p in pods:
+                pod_osd_ids.add(int(p.metadata.labels['ceph-osd-id']))
+
+            self.log.debug('pod_osd_ids={0}'.format(pod_osd_ids))
+
+            found = []
+            osdmap = self.get("osd_map")
+            for osd in osdmap['osds']:
+                osd_id = osd['osd']
+                if osd_id not in pod_osd_ids:
+                    continue
+
+                metadata = self.get_metadata('osd', "%s" % osd_id)
+                if metadata and metadata['devices'] in spec.drive_group.devices:
+                    found.append(osd_id)
+                else:
+                    self.log.info("ignoring osd {0} {1}".format(
+                        osd_id, metadata['devices']
+                    ))
+
+            return found is not None
+
+        return RookWriteCompletion(execute, is_complete,
+                                   "Creating OSD on {0}:{1}".format(
+                                       spec.node,
+                                       spec.drive_group.devices
+                                   ))

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -1,0 +1,320 @@
+"""
+This module wrap's Rook + Kubernetes APIs to expose the calls
+needed to implement an orchestrator module.  While the orchestrator
+module exposes an async API, this module simply exposes blocking API
+call methods.
+
+This module is runnable outside of ceph-mgr, useful for testing.
+"""
+
+import urlparse
+import logging
+import json
+
+# Optional kubernetes imports to enable MgrModule.can_run
+# to behave cleanly.
+try:
+    from kubernetes.client.rest import ApiException
+except ImportError:
+    ApiException = None
+
+ROOK_SYSTEM_NS = "rook-ceph-system"
+ROOK_API_VERSION = "v1alpha1"
+ROOK_API_NAME = "ceph.rook.io/%s" % ROOK_API_VERSION
+
+log = logging.getLogger('rook')
+
+
+class ApplyException(Exception):
+    """
+    For failures to update the Rook CRDs, usually indicating
+    some kind of interference between our attempted update
+    and other conflicting activity.
+    """
+
+
+class RookCluster(object):
+    def __init__(self, k8s, cluster_name):
+        self.cluster_name = cluster_name
+        self.k8s = k8s
+
+    @property
+    def rook_namespace(self):
+        # For the moment, assume Rook NS always equal to cluster name
+        # (this is also assumed some places in Rook source, may
+        #  be formalized at some point)
+        return self.cluster_name
+
+    def init_rook(self):
+        """
+        Create a passive Rook configuration for this Ceph cluster.  This
+        will prompt Rook to start watching for other resources within
+        the cluster (e.g. Filesystem CRDs), but no other action will happen.
+        """
+
+        # TODO: complete or remove this functionality: if Rook wasn't
+        # already running, then we would need to supply it with
+        # keys and ceph.conf as well as creating the cluster CRD
+
+        cluster_crd = {
+            "apiVersion": ROOK_API_NAME,
+            "kind": "Cluster",
+            "metadata": {
+                "name": self.cluster_name,
+                "namespace": self.cluster_name
+            },
+            "spec": {
+                "backend": "ceph",
+                "hostNetwork": True
+            }
+        }
+
+        self.rook_api_post("clusters", body=cluster_crd)
+
+    def rook_url(self, path):
+        prefix = "/apis/ceph.rook.io/%s/namespaces/%s/" % (
+            ROOK_API_VERSION, self.rook_namespace)
+        return urlparse.urljoin(prefix, path)
+
+    def rook_api_call(self, verb, path, **kwargs):
+        full_path = self.rook_url(path)
+        log.debug("[%s] %s" % (verb, full_path))
+
+        return self.k8s.api_client.call_api(
+            full_path,
+            verb,
+            auth_settings=['BearerToken'],
+            response_type="object",
+            _return_http_data_only=True,
+            _preload_content=True,
+            **kwargs)
+
+    def rook_api_get(self, path, **kwargs):
+        return self.rook_api_call("GET", path, **kwargs)
+
+    def rook_api_patch(self, path, **kwargs):
+        return self.rook_api_call("PATCH", path,
+                                  header_params={"Content-Type": "application/json-patch+json"},
+                                  **kwargs)
+
+    def rook_api_post(self, path, **kwargs):
+        return self.rook_api_call("POST", path, **kwargs)
+
+    def get_discovered_devices(self, nodenames=None):
+        # TODO: replace direct k8s calls with Rook API calls
+        # when they're implemented
+        label_selector = "app=rook-discover"
+        if nodenames is not None:
+            # FIXME: is there a practical or official limit on the
+            # number of entries in a label selector
+            label_selector += ", rook.io/node in ({0})".format(
+                ", ".join(nodenames))
+
+        try:
+            result = self.k8s.list_namespaced_config_map(
+                ROOK_SYSTEM_NS,
+                label_selector=label_selector)
+        except ApiException as e:
+            log.warn("Failed to fetch device metadata: {0}".format(e))
+            raise
+
+        nodename_to_devices = {}
+        for i in result.items:
+            drives = json.loads(i.data['devices'])
+            nodename_to_devices[i.metadata.labels['rook.io/node']] = drives
+
+        return nodename_to_devices
+
+    def describe_pods(self, service_type, service_id):
+        # Go query the k8s API about deployment, containers related to this
+        # filesystem
+
+        # Inspect the Rook YAML, to decide whether this filesystem
+        # is Ceph-managed or Rook-managed
+        # TODO: extend Orchestrator interface to describe whether FS
+        # is manageable by us or not
+
+        # Example Rook Pod labels for a mgr daemon:
+        # Labels:         app=rook-ceph-mgr
+        #                 pod-template-hash=2171958073
+        #                 rook_cluster=rook
+        # And MDS containers additionally have `rook_filesystem` label
+
+        # Label filter is rook_cluster=<cluster name>
+        #                 rook_file_system=<self.fs_name>
+
+        label_filter = "rook_cluster={0},app=rook-ceph-{1}".format(
+            self.cluster_name, service_type)
+        if service_type == "mds":
+            label_filter += ",rook_file_system={0}".format(service_id)
+        elif service_type == "osd":
+            # Label added in https://github.com/rook/rook/pull/1698
+            label_filter += ",ceph-osd-id={0}".format(service_id)
+        elif service_type == "mon":
+            # label like mon=rook-ceph-mon0
+            label_filter += ",mon={0}".format(service_id)
+        elif service_type == "mgr":
+            # TODO: get Rook to label mgr pods
+            pass
+        elif service_type == "rgw":
+            # TODO: rgw
+            pass
+
+        pods = self.k8s.list_namespaced_pod(
+            self.rook_namespace,
+            label_selector=label_filter)
+
+        # import json
+        # print json.dumps(pods.items[0])
+
+        pods_summary = []
+
+        for p in pods.items:
+            d = p.to_dict()
+            # p['metadata']['creationTimestamp']
+            # p['metadata']['nodeName']
+            pods_summary.append({
+                "name": d['metadata']['name'],
+                "nodename": d['spec']['node_name'],
+                "labels": d['metadata']['labels']
+            })
+            pass
+
+        return pods_summary
+
+    def add_filesystem(self, spec):
+        # TODO use spec.placement
+        # TODO use spec.min_size (and use max_size meaningfully)
+        # TODO warn if spec.extended has entries we don't kow how
+        #      to action.
+
+        rook_fs = {
+            "apiVersion": ROOK_API_NAME,
+            "kind": "Filesystem",
+            "metadata": {
+                "name": spec.name,
+                "namespace": self.rook_namespace
+            },
+            "spec": {
+                "preservePoolsOnRemove": True,
+                "skipPoolCreation": True,
+                "metadataServer": {
+                    "activeCount": spec.max_size,
+                    "activeStandby": True
+
+                }
+            }
+        }
+
+        try:
+            self.rook_api_post(
+                "filesystems/",
+                body=rook_fs
+            )
+        except ApiException as e:
+            if e.status == 409:
+                log.info("Filesystem '{0}' already exists".format(spec.name))
+                # Idempotent, succeed.
+            else:
+                raise
+
+    def can_create_osd(self):
+        current_cluster = self.rook_api_get(
+            "clusters/{0}".format(self.cluster_name))
+        use_all_nodes = current_cluster['spec'].get('useAllNodes', False)
+
+        # If useAllNodes is set, then Rook will not be paying attention
+        # to anything we put in 'nodes', so can't do OSD creation.
+        return not use_all_nodes
+
+    def node_exists(self, node_name):
+        try:
+            self.k8s.read_node(node_name)
+        except ApiException as e:
+            if e.status == 404:
+                return False
+            else:
+                raise
+        else:
+            return True
+
+    def add_osds(self, spec):
+        """
+        Rook currently (0.8) can only do single-drive OSDs, so we
+        treat all drive groups as just a list of individual OSDs.
+        """
+        # assert isinstance(spec, orchestrator.OsdSpec)
+
+        block_devices = spec.drive_group.devices
+
+        assert spec.format in ("bluestore", "filestore")
+
+        # The CRD looks something like this:
+        #     nodes:
+        #       - name: "gravel1.rockery"
+        #         devices:
+        #          - name: "sdb"
+        #         storeConfig:
+        #           storeType: bluestore
+
+        current_cluster = self.rook_api_get(
+            "clusters/{0}".format(self.cluster_name))
+
+        patch = []
+
+        # FIXME: this is all not really atomic, because jsonpatch doesn't
+        # let us do "test" operations that would check if items with
+        # matching names were in existing lists.
+
+        if 'nodes' not in current_cluster['spec']['storage']:
+            patch.append({
+                'op': 'add', 'path': '/spec/storage/nodes', 'value': []
+            })
+
+        current_nodes = current_cluster['spec']['storage'].get('nodes', [])
+
+        if spec.node not in [n['name'] for n in current_nodes]:
+            patch.append({
+                "op": "add", "path": "/spec/storage/nodes/-", "value": {
+                    "name": spec.node,
+                    "devices": [{'name': d} for d in block_devices],
+                    "storeConfig": {
+                        "storeType": spec.format
+                    }
+                }
+            })
+        else:
+            # Extend existing node
+            node_idx = None
+            current_node = None
+            for i, c in enumerate(current_nodes):
+                if c['name'] == spec.node:
+                    current_node = c
+                    node_idx = i
+                    break
+
+            assert node_idx is not None
+            assert current_node is not None
+
+            new_devices = list(set(block_devices) - set([d['name'] for d in current_node['devices']]))
+
+            for n in new_devices:
+                patch.append({
+                    "op": "add",
+                    "path": "/spec/storage/nodes/{0}/devices/-".format(node_idx),
+                    "value": {'name': n}
+                })
+
+        if len(patch) == 0:
+            log.warning("No-op adding stateful service")
+            return
+
+        try:
+            self.rook_api_patch(
+                "clusters/{0}".format(self.cluster_name),
+                body=patch)
+        except ApiException as e:
+            log.exception("API exception: {0}".format(e.message))
+            raise ApplyException(
+                "Failed to create OSD entries in Cluster CRD: {0}".format(
+                    e.message))

--- a/src/script/kubejacker/Dockerfile
+++ b/src/script/kubejacker/Dockerfile
@@ -1,0 +1,26 @@
+
+from BASEIMAGE
+
+# Some apt-get commands fail in docker builds because they try
+# and do interactive prompts
+ENV TERM linux
+
+# Baseline rook images may be from before the `rook` ceph-mgr module,
+# so let's install the dependencies of that
+RUN yum install -y python-pip
+RUN pip install kubernetes==6.0.0
+
+# New RGW dependency since luminous
+RUN yum install -y liboath
+
+# For the dashboard, if the rook images are pre-Mimic
+RUN yum install -y python-bcrypt librdmacm
+
+ADD bin.tar.gz /usr/bin/
+ADD lib.tar.gz /usr/lib64/
+
+# Assume developer is using default paths (i.e. /usr/local), so
+# build binaries will be looking for libs there.
+ADD eclib.tar.gz /usr/local/lib64/ceph/erasure-code/
+ADD mgr_plugins.tar.gz /usr/local/lib64/ceph/mgr
+

--- a/src/script/kubejacker/README.rst
+++ b/src/script/kubejacker/README.rst
@@ -1,0 +1,11 @@
+
+This tool is for developers who want to run their WIP Ceph code
+inside a Rook/kubernetes cluster without waiting for packages
+to build.
+
+It simply takes a Rook image, overlays all the binaries from your
+built Ceph tree into it, and spits out a new Rook image.  This will
+only work as long as your build environment is sufficiently similar
+(in terms of dependencies etc) to the version of Ceph that was
+originally in the images you're injecting into.
+

--- a/src/script/kubejacker/kubejacker.sh
+++ b/src/script/kubejacker/kubejacker.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -x
+set -e
+SCRIPT=$(readlink -f "$0")
+SCRIPTPATH=$(dirname "$SCRIPT")
+
+# Run me from your build dir!  I look for binaries in bin/, lib/ etc.
+BUILDPATH=$(pwd)
+
+# PREREQUISITE: a built rook image to use as a base, either self built
+# or from dockerhub.  If you ran "make" in your rook source checkout
+# you'll have one like build-<hash>/rook-amd64
+DEFAULT_BASEIMAGE="`docker image ls | grep ceph-amd64 | cut -d " " -f 1`"
+BASEIMAGE="${BASEIMAGE:-$DEFAULT_BASEIMAGE}"
+
+# PREREQUISITE: a repo that you can push to.  You are probably running
+# a local docker registry that your kubelet nodes also have access to.
+if [ -z "$REPO" ]
+then
+    echo "ERROR: no \$REPO set!"
+    echo "Run a docker repository and set REPO to <hostname>:<port>"
+    exit -1
+fi
+
+# The output image name: this should match whatever is configured as
+# the image name in your Rook cluster CRD object.
+IMAGE=rook/ceph
+TAG=$(git rev-parse --short HEAD)
+
+# The namespace where ceph containers are running in your
+# test cluster: used for bouncing the containers.
+NAMESPACE=rook-ceph
+
+mkdir -p kubejacker
+cp $SCRIPTPATH/Dockerfile kubejacker
+sed -i s@BASEIMAGE@$BASEIMAGE@ kubejacker/Dockerfile
+
+# TODO: let user specify which daemon they're interested
+# in -- doing all bins all the time is too slow and bloaty
+BINS="ceph-mgr ceph-mon ceph-mds ceph-osd rados radosgw-admin radosgw"
+pushd bin
+strip $BINS  #TODO: make stripping optional
+tar czf $BUILDPATH/kubejacker/bin.tar.gz $BINS
+popd
+
+# We need ceph-common to support the binaries
+# We need librados/rbd to support mgr modules
+# that import the python bindings
+LIBS="libceph-common.so.0 libceph-common.so librados.so.2 librados.so librados.so.2.0.0 librbd.so librbd.so.1 librbd.so.1.12.0"
+pushd lib
+strip $LIBS  #TODO: make stripping optional
+tar czf $BUILDPATH/kubejacker/lib.tar.gz $LIBS
+popd
+
+pushd ../src/pybind/mgr
+find ./ -name "*.pyc" -exec rm -f {} \;
+# Exclude node_modules because it's the huge sources in dashboard/frontend
+tar --exclude=node_modules --exclude=tests --exclude-backups -czf $BUILDPATH/kubejacker/mgr_plugins.tar.gz *
+popd
+
+ECLIBS="libec_*.so"
+pushd lib
+strip $ECLIBS  #TODO: make stripping optional
+tar czf $BUILDPATH/kubejacker/eclib.tar.gz $ECLIBS
+popd
+
+
+pushd kubejacker
+docker build -t $REPO/$IMAGE:$TAG .
+popd
+
+# Push the image to the repository
+docker tag $REPO/$IMAGE:$TAG $REPO/$IMAGE:latest
+docker push $REPO/$IMAGE:latest
+docker push $REPO/$IMAGE:$TAG 
+
+# Finally, bounce the containers to pick up the new image
+kubectl -n $NAMESPACE delete pod -l app=rook-ceph-mds
+kubectl -n $NAMESPACE delete pod -l app=rook-ceph-mgr
+kubectl -n $NAMESPACE delete pod -l app=rook-ceph-mon


### PR DESCRIPTION
This includes two modules:
- orchestrator_cli, a handy way to drive orchestrator modules until we have GUI support
- rook, the first implementation of the orchestrator interface

The orchestrator interface itself will still need follow-on work to full flesh out the OSD lifecycle (drive replacement) once we've defined that.

Monitor management isn't there: initially monitors shared the "stateful_service" calls with OSDs, but there was enough OSD-specific stuff that it didn't make sense for them to share any more.  Monitor management needs adding back in later.