### PR TITLE
doc: updated Ceph Block Device resource links

### DIFF
--- a/doc/rbd/index.rst
+++ b/doc/rbd/index.rst
@@ -63,10 +63,10 @@ devices simultaneously.
 
 	APIs <api/index>
 
-.. _RBD Caching: ../rbd-config-ref/
-.. _kernel modules: ../rbd-ko/
-.. _QEMU: ../qemu-rbd/
-.. _OpenStack: ../rbd-openstack
-.. _CloudStack: ../rbd-cloudstack
-.. _Ceph RADOS Gateway: ../../radosgw/
-.. _CephFS filesystem: ../../cephfs/
+.. _RBD Caching: ../rbd/rbd-config-ref/
+.. _kernel modules: ../rbd/rbd-ko/
+.. _QEMU: ../rbd/qemu-rbd/
+.. _OpenStack: ../rbd/rbd-openstack
+.. _CloudStack: ../rbd/rbd-cloudstack
+.. _Ceph RADOS Gateway: ../../doc/radosgw/
+.. _CephFS filesystem: ../../doc/cephfs/


### PR DESCRIPTION
Some of the links on the Ceph Block Device documentation were broken (404 error).

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug