### PR TITLE
rgw: website routing rules num limit

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1546,3 +1546,4 @@ OPTION(rgw_reshard_thread_interval, OPT_U32) // maximum time between rounds of r
 OPTION(rgw_acl_grants_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html), An ACL can have up to 100 grants.
 OPTION(rgw_cors_rules_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html), An cors can have up to 100 rules.
 OPTION(rgw_delete_multi_obj_max_num, OPT_INT) // According to AWS S3(https://docs.aws.amazon.com/AmazonS3/latest/dev/DeletingObjects.html), Amazon S3 also provides the Multi-Object Delete API that you can use to delete up to 1000 objects in a single HTTP request.
+OPTION(rgw_website_routing_rules_max_num, OPT_INT) // According to AWS S3, An website routing config can have up to 50 rules.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4996,6 +4996,10 @@ std::vector<Option> get_rgw_options() {
     .set_default(1000)
     .set_description("Max number of objects in a single multi-object delete request"),
 
+    Option("rgw_website_routing_rules_max_num", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(50)
+    .set_description("Max number of website routing rules in a single request"),
+
     Option("rgw_rados_tracing", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description("true if LTTng-UST tracepoints should be enabled"),

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -76,6 +76,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_INVALID_TAG, {400, "InvalidTag"}},
     { ERR_MALFORMED_ACL_ERROR, {400, "MalformedACLError" }},
     { ERR_INVALID_CORS_RULES_ERROR, {400, "InvalidRequest" }},
+    { ERR_INVALID_WEBSITE_ROUTING_RULES_ERROR, {400, "InvalidRequest" }},
     { ERR_INVALID_ENCRYPTION_ALGORITHM, {400, "InvalidEncryptionAlgorithmError" }},
     { ERR_LENGTH_REQUIRED, {411, "MissingContentLength" }},
     { EACCES, {403, "AccessDenied" }},

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -219,6 +219,7 @@ using ceph::crypto::MD5;
 #define ERR_INVALID_ENCRYPTION_ALGORITHM                 2214
 #define ERR_INVALID_CORS_RULES_ERROR                     2215
 #define ERR_NO_CORS_FOUND        2216
+#define ERR_INVALID_WEBSITE_ROUTING_RULES_ERROR          2217
 
 #define ERR_BUSY_RESHARDING      2300
 #define ERR_NO_SUCH_ENTITY       2301

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1037,6 +1037,24 @@ int RGWSetBucketWebsite_ObjStore_S3::get_params()
     return -EINVAL;
   }
 
+#define WEBSITE_ROUTING_RULES_MAX_NUM      50
+  int max_num = s->cct->_conf->rgw_website_routing_rules_max_num;
+  if (max_num < 0) {
+    max_num = WEBSITE_ROUTING_RULES_MAX_NUM;
+  }
+  int routing_rules_num = website_conf.routing_rules.rules.size();
+  if (routing_rules_num > max_num) {
+    ldout(s->cct, 4) << "An website routing config can have up to "
+                     << max_num
+                     << " rules, request website routing rules num: "
+                     << routing_rules_num << dendl;
+    op_ret = -ERR_INVALID_WEBSITE_ROUTING_RULES_ERROR;
+    s->err.message = std::to_string(routing_rules_num) +" routing rules provided, the number of routing rules in a website configuration is limited to "
+                     + std::to_string(max_num)
+                     + ".";
+    return -ERR_INVALID_REQUEST;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
According to AWS S3 , an website routing rules can
have up to 50 rules.

in aws,  website rules can not more than 50

```
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (InvalidRequest) when calling the PutBucketWebsite operation: 51 routing rules provided, the number of routing rules in a website configuration is limited to 50.
```


test.py
```
from boto3.session import Session
import boto3
access_key = "yly"
secret_key = "yly"
url = 'http://127.0.0.1:7480'
session = Session(access_key, secret_key)
s3_client = session.client('s3', endpoint_url=url )
config = {}
config["RoutingRules"] = []
config["ErrorDocument"] = {'Key': 'error.html'}
config["IndexDocument"] = {'Suffix': 'index.html'}
for i in range (1, 51):
  rule = {
                "Condition": {
                        "KeyPrefixEquals": "v1/%s/" % (i,)
                },
                "Redirect": {
                        "ReplaceKeyPrefixWith": "v2/%s/" % (i,) ,
                        "HttpRedirectCode": "302",
                        "Protocol": "https",
                },
        }
  config["RoutingRules"].append(rule)

response = s3_client.put_bucket_website(
    Bucket='test1',
    WebsiteConfiguration=config
)
```


Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>