### PR TITLE
client: fix compile warning

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1123,7 +1123,7 @@ int CephFuse::Handle::init(int argc, const char *argv[])
     char strsplice[65];
     newargv[newargc++] = "-o";
     newargv[newargc++] = strsplice;
-    sprintf(strsplice, "max_write=%" PRIu64, fuse_max_write);
+    sprintf(strsplice, "max_write=%zu", (size_t)fuse_max_write);
     newargv[newargc++] = strsplice;
   }
   if (fuse_atomic_o_trunc) {


### PR DESCRIPTION
	/home/pdonnell/ceph/src/client/fuse_ll.cc: In member function ‘int CephFuse::Handle::init(int, const char**)’:
	/home/pdonnell/ceph/src/client/fuse_ll.cc:1126:59: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘Option::size_t’ [-Wformat=]
     	sprintf(strsplice, "max_write=%" PRIu64, fuse_max_write);

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>