### PR TITLE
mds: evict cap revoke non-responding clients

### DIFF
--- a/doc/cephfs/eviction.rst
+++ b/doc/cephfs/eviction.rst
@@ -21,11 +21,15 @@ libcephfs.
 Automatic client eviction
 =========================
 
-There are two situations in which a client may be evicted automatically:
+There are three situations in which a client may be evicted automatically:
 
 On an active MDS daemon, if a client has not communicated with the MDS for over
 ``session_autoclose`` (a file system variable) seconds (300 seconds by
 default), then it will be evicted automatically.
+
+On an active MDS daemon, if a client has not responded to cap revoke messages
+for over ``mds_cap_revoke_eviction_timeout`` (configuration option) seconds.
+This is disabled by default.
 
 During MDS startup (including on failover), the MDS passes through a
 state called ``reconnect``.  During this state, it waits for all the

--- a/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
+++ b/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
@@ -8,3 +8,4 @@ overrides:
     log-whitelist:
       - evicting unresponsive client
       - POOL_APP_NOT_ENABLED
+      - has not responded to cap revoke by MDS for over

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7177,6 +7177,10 @@ std::vector<Option> get_mds_options() {
     Option("mds_request_load_average_decay_rate", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(60)
     .set_description("rate of decay in seconds for calculating request load average"),
+
+    Option("mds_cap_revoke_eviction_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+     .set_default(0)
+     .set_description("number of seconds after which clients which have not responded to cap revoke messages by the MDS are evicted."),
   });
 }
 

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -351,7 +351,8 @@ void Beacon::notify_health(MDSRank const *mds)
   // CLIENT_CAPS messages.
   {
     std::list<client_t> late_clients;
-    mds->locker->get_late_revoking_clients(&late_clients);
+    mds->locker->get_late_revoking_clients(&late_clients,
+                                           mds->mdsmap->get_session_timeout());
     std::list<MDSHealthMetric> late_cap_metrics;
 
     for (std::list<client_t>::iterator i = late_clients.begin(); i != late_clients.end(); ++i) {

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -188,8 +188,10 @@ public:
 
   void remove_client_cap(CInode *in, client_t client);
 
-  void get_late_revoking_clients(std::list<client_t> *result) const;
-  bool any_late_revoking_caps(xlist<Capability*> const &revoking) const;
+  void get_late_revoking_clients(std::list<client_t> *result, double timeout) const;
+
+private:
+  bool any_late_revoking_caps(xlist<Capability*> const &revoking, double timeout) const;
 
 protected:
   bool _need_flush_mdlog(CInode *in, int wanted_caps);

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -361,6 +361,7 @@ const char** MDSDaemon::get_tracked_conf_keys() const
     "host",
     "fsid",
     "mds_request_load_average_decay_rate",
+    "mds_cap_revoke_eviction_timeout",
     NULL
   };
   return KEYS;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -28,7 +28,6 @@
 #include "MDBalancer.h"
 #include "Migrator.h"
 #include "Locker.h"
-#include "Server.h"
 #include "InoTable.h"
 #include "mon/MonClient.h"
 #include "common/HeartbeatMap.h"
@@ -321,6 +320,7 @@ void MDSRankDispatcher::tick()
   // ...
   if (is_clientreplay() || is_active() || is_stopping()) {
     server->find_idle_sessions();
+    server->evict_cap_revoke_non_responders();
     locker->tick();
   }
 

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -34,6 +34,7 @@
 #include "MDLog.h"
 #include "MDSContext.h"
 #include "PurgeQueue.h"
+#include "Server.h"
 #include "osdc/Journaler.h"
 
 // Full .h import instead of forward declaration for PerfCounter, for the
@@ -104,7 +105,6 @@ namespace ceph {
   struct heartbeat_handle_d;
 }
 
-class Server;
 class Locker;
 class MDCache;
 class MDLog;
@@ -226,6 +226,7 @@ class MDSRank {
                             const std::set <std::string> &changed)
     {
       sessionmap.handle_conf_change(conf, changed);
+      server->handle_conf_change(conf, changed);
       mdcache->handle_conf_change(conf, changed, *mdsmap);
       purge_queue.handle_conf_change(conf, changed, *mdsmap);
     }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -107,6 +107,8 @@ void Server::create_logger()
   plb.add_u64_counter(l_mdss_handle_client_session,
                       "handle_client_session", "Client session messages", "hcs",
                       PerfCountersBuilder::PRIO_INTERESTING);
+  plb.add_u64_counter(l_mdss_cap_revoke_eviction, "cap_revoke_eviction",
+                      "Cap Revoke Client Eviction", "cre", PerfCountersBuilder::PRIO_INTERESTING);
 
   // fop latencies are useful
   plb.set_prio_default(PerfCountersBuilder::PRIO_USEFUL);
@@ -842,8 +844,12 @@ void Server::evict_cap_revoke_non_responders() {
             << client << dendl;
 
     std::stringstream ss;
-    mds->evict_client(client.v, false, g_conf()->mds_session_blacklist_on_evict,
-                      ss, nullptr);
+    bool evicted = mds->evict_client(client.v, false,
+                                     g_conf()->mds_session_blacklist_on_evict,
+                                     ss, nullptr);
+    if (evicted && logger) {
+      logger->inc(l_mdss_cap_revoke_eviction);
+    }
   }
 }
 

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -95,6 +95,8 @@ private:
   feature_bitset_t supported_features;
   feature_bitset_t required_client_features;
 
+  double cap_revoke_eviction_timeout = 0;
+
   friend class MDSContinuation;
   friend class ServerContext;
   friend class ServerLogContext;
@@ -318,6 +320,10 @@ public:
   void _rename_rollback_finish(MutationRef& mut, MDRequestRef& mdr, CDentry *srcdn, version_t srcdnpv,
 			       CDentry *destdn, CDentry *staydn, map<client_t,MClientSnap::ref> splits[2],
 			       bool finish_mdr);
+
+  void evict_cap_revoke_non_responders();
+  void handle_conf_change(const ConfigProxy& conf,
+                          const std::set <std::string> &changed);
 
 private:
   void reply_client_request(MDRequestRef& mdr, const MClientReply::ref &reply);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -71,6 +71,7 @@ enum {
   l_mdss_req_setxattr_latency,
   l_mdss_req_symlink_latency,
   l_mdss_req_unlink_latency,
+  l_mdss_cap_revoke_eviction,
   l_mdss_last,
 };
 


### PR DESCRIPTION
Client which have not responded to cap revoke messages by MDS for over `mds_cap_revoke_eviction_timeout` seconds get evicted. By default this is disabled.

Fixes: Fixes: http://tracker.ceph.com/issues/25188
Signed-off-by: Venky Shankar <vshankar@redhat.com>