### PR TITLE
tools/cephfs-shell: add support for batch file processing and execute commands from arguments.

### DIFF
--- a/doc/cephfs/cephfs-shell.rst
+++ b/doc/cephfs/cephfs-shell.rst
@@ -5,6 +5,15 @@ Ceph FS Shell
 
 The File System (FS) shell includes various shell-like commands that directly interact with the Ceph File System.
 
+Usage :
+
+    cephfs-shell [-options] -- [command, command,...]
+
+Options :
+    -c, --config FILE     Set Configuration file.
+    -b, --batch FILE      Process a batch file.
+    -t, --test FILE       Test against transcript(s) in FILE
+
 Commands
 ========
 

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -911,9 +911,23 @@ sub-directories, files')
 
 if __name__ == '__main__':
     config_file = ''
-    if sys.argv[1] == '-c':
-        config_file = sys.argv[2]
+    exe = sys.argv[0]
+    main_parser = argparse.ArgumentParser(description = '')
+    main_parser.add_argument('-c', '--config', action = 'store', help = 'Configuration file_path', type = str)
+    main_parser.add_argument('-b', '--batch', action = 'store', help = 'Batch File path.', type = str)
+    main_parser.add_argument('-t', '--test', action='store', help='Test against transcript(s) in FILE', nargs = '+')
+    main_parser.add_argument('commands', nargs='*', help='comma delimited commands')  
+    args = main_parser.parse_args()
+    if args.config:
+        config_file = args.config
+        sys.argv = [sys.argv[0]] + sys.argv[3:]  
+    if args.batch:
+        sys.argv[1] = 'load ' + args.batch
+        sys.argv[2] = 'quit'
+        sys.argv = sys.argv[:3]   
+    sys.argv.clear()
+    sys.argv.append(exe)
+    sys.argv.extend(' '.join(args.commands).split(','))
     setup_cephfs(config_file)
-    sys.argv = [sys.argv[0]]
     c = CephFSShell()
     c.cmdloop()

--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -916,15 +916,12 @@ if __name__ == '__main__':
     main_parser.add_argument('-c', '--config', action = 'store', help = 'Configuration file_path', type = str)
     main_parser.add_argument('-b', '--batch', action = 'store', help = 'Batch File path.', type = str)
     main_parser.add_argument('-t', '--test', action='store', help='Test against transcript(s) in FILE', nargs = '+')
-    main_parser.add_argument('commands', nargs='*', help='comma delimited commands')  
+    main_parser.add_argument('commands', nargs='*', help='comma delimited commands', default=[])
     args = main_parser.parse_args()
     if args.config:
         config_file = args.config
-        sys.argv = [sys.argv[0]] + sys.argv[3:]  
     if args.batch:
-        sys.argv[1] = 'load ' + args.batch
-        sys.argv[2] = 'quit'
-        sys.argv = sys.argv[:3]   
+        args.commands = ['load ' + args.batch, 'quit']
     sys.argv.clear()
     sys.argv.append(exe)
     sys.argv.extend(' '.join(args.commands).split(','))


### PR DESCRIPTION
Features to cephfs-shell:
1) to process a batch file instead of interactive commands.
2) execute commands from arguments

Fixes:http://tracker.ceph.com/issues/26853
Fixes:http://tracker.ceph.com/issues/26855
Signed-off-by: Pavani Rajula <rpavani1998@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

