### PR TITLE
osd/PGLog.cc: check if complete_to points to log.end()

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -51,7 +51,8 @@ void PGLog::IndexedLog::trim(
   eversion_t *write_from_dups)
 {
   assert(s <= can_rollback_to);
-  lgeneric_subdout(cct, osd, 20) << " complete_to " << complete_to->version << dendl;
+  if (complete_to != log.end())
+    lgeneric_subdout(cct, osd, 20) << " complete_to " << complete_to->version << dendl;
 
   auto earliest_dup_version =
     log.rbegin()->version.version < cct->_conf->osd_pg_log_dups_tracked
@@ -87,7 +88,7 @@ void PGLog::IndexedLog::trim(
 
     bool reset_complete_to = false;
     // we are trimming past complete_to, so reset complete_to
-    if (e.version >= complete_to->version)
+    if (complete_to != log.end() && e.version >= complete_to->version)
       reset_complete_to = true;
     if (rollback_info_trimmed_to_riter == log.rend() ||
 	e.version == rollback_info_trimmed_to_riter->version) {
@@ -181,7 +182,8 @@ void PGLog::trim(
     dout(10) << "trim " << log << " to " << trim_to << dendl;
     log.trim(cct, trim_to, &trimmed, &trimmed_dups, &write_from_dups);
     info.log_tail = log.tail;
-    dout(10) << " after trim complete_to " << log.complete_to->version << dendl;
+    if (log.complete_to != log.log.end())
+      dout(10) << " after trim complete_to " << log.complete_to->version << dendl;
   }
 }
 


### PR DESCRIPTION
Adding a check before dereferencing the complete_to iterator.

Fixes: https://tracker.ceph.com/issues/26868
Signed-off-by: Neha Ojha <nojha@redhat.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

