### PR TITLE
mon,osd: normalize si_u_t usage

### DIFF
--- a/src/include/types.h
+++ b/src/include/types.h
@@ -363,11 +363,11 @@ namespace {
     char buffer[32];
 
     if (index == 0) {
-      (void) snprintf(buffer, sizeof(buffer), "%" PRId64 " %s", n, u);
+      (void) snprintf(buffer, sizeof(buffer), "%" PRId64 "%s", n, u);
     } else if ((v % mult) == 0) {
       // If this is an even multiple of the base, always display
       // without any decimal fraction.
-      (void) snprintf(buffer, sizeof(buffer), "%" PRId64 " %s", n, u);
+      (void) snprintf(buffer, sizeof(buffer), "%" PRId64 "%s", n, u);
     } else {
       // We want to choose a precision that reflects the best choice
       // for fitting in 5 characters.  This can get rather tricky when
@@ -378,7 +378,7 @@ namespace {
       // easier just to try each combination in turn.
       int i;
       for (i = 2; i >= 0; i--) {
-        if (snprintf(buffer, sizeof(buffer), "%.*f %s", i,
+        if (snprintf(buffer, sizeof(buffer), "%.*f%s", i,
           static_cast<double>(v) / mult, u) <= 7)
           break;
       }
@@ -402,7 +402,7 @@ inline ostream& operator<<(ostream& out, const si_u_t& b)
   uint64_t n = b.v;
   int index = 0;
   uint64_t mult = 1;
-  const char* u[] = {"", "k", "M", "G", "T", "P", "E"};
+  const char* u[] = {"", " k", " M", " G", " T", " P", " E"};
 
   while (n >= 1000 && index < 7) {
     n /= 1000;
@@ -429,7 +429,7 @@ inline ostream& operator<<(ostream& out, const byte_u_t& b)
 {
   uint64_t n = b.v;
   int index = 0;
-  const char* u[] = {"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"};
+  const char* u[] = {" B", " KiB", " MiB", " GiB", " TiB", " PiB", " EiB"};
 
   while (n >= 1024 && index < 7) {
     n /= 1024;

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -376,7 +376,7 @@ void PGMapDigest::print_oneline_summary(Formatter *f, ostream *out) const
     }
     int64_t iops = (pos_delta.stats.sum.num_rd + pos_delta.stats.sum.num_wr) / (double)stamp_delta;
     if (out)
-      *out << si_u_t(iops) << "op/s";
+      *out << si_u_t(iops) << " op/s";
     if (f)
       f->dump_unsigned("io_sec", iops);
   }
@@ -470,8 +470,8 @@ void PGMapDigest::recovery_rate_summary(Formatter *f, ostream *out,
     } else {
       *out << byte_u_t(bps) << "/s";
       if (pos_delta.stats.sum.num_keys_recovered)
-	*out << ", " << si_u_t(kps) << "keys/s";
-      *out << ", " << si_u_t(objps) << "objects/s";
+	*out << ", " << si_u_t(kps) << " keys/s";
+      *out << ", " << si_u_t(objps) << " objects/s";
     }
   }
 }
@@ -538,7 +538,7 @@ void PGMapDigest::client_io_rate_summary(Formatter *f, ostream *out,
       f->dump_int("read_op_per_sec", iops_rd);
       f->dump_int("write_op_per_sec", iops_wr);
     } else {
-      *out << si_u_t(iops_rd) << "op/s rd, " << si_u_t(iops_wr) << "op/s wr";
+      *out << si_u_t(iops_rd) << " op/s rd, " << si_u_t(iops_wr) << " op/s wr";
     }
   }
 }
@@ -595,7 +595,7 @@ void PGMapDigest::cache_io_rate_summary(Formatter *f, ostream *out,
     } else {
       if (have_output)
 	*out << ", ";
-      *out << si_u_t(promote) << "op/s promote";
+      *out << si_u_t(promote) << " op/s promote";
       have_output = true;
     }
   }
@@ -605,7 +605,7 @@ void PGMapDigest::cache_io_rate_summary(Formatter *f, ostream *out,
     } else {
       if (have_output)
 	*out << ", ";
-      *out << si_u_t(pos_delta.stats.sum.num_flush_mode_low) << "PG(s) flushing";
+      *out << si_u_t(pos_delta.stats.sum.num_flush_mode_low) << " PG(s) flushing";
       have_output = true;
     }
   }
@@ -615,7 +615,7 @@ void PGMapDigest::cache_io_rate_summary(Formatter *f, ostream *out,
     } else {
       if (have_output)
 	*out << ", ";
-      *out << si_u_t(pos_delta.stats.sum.num_flush_mode_high) << "PG(s) flushing (high)";
+      *out << si_u_t(pos_delta.stats.sum.num_flush_mode_high) << " PG(s) flushing (high)";
       have_output = true;
     }
   }
@@ -625,7 +625,7 @@ void PGMapDigest::cache_io_rate_summary(Formatter *f, ostream *out,
     } else {
       if (have_output)
 	*out << ", ";
-      *out << si_u_t(pos_delta.stats.sum.num_evict_mode_some) << "PG(s) evicting";
+      *out << si_u_t(pos_delta.stats.sum.num_evict_mode_some) << " PG(s) evicting";
       have_output = true;
     }
   }
@@ -635,7 +635,7 @@ void PGMapDigest::cache_io_rate_summary(Formatter *f, ostream *out,
     } else {
       if (have_output)
 	*out << ", ";
-      *out << si_u_t(pos_delta.stats.sum.num_evict_mode_full) << "PG(s) evicting (full)";
+      *out << si_u_t(pos_delta.stats.sum.num_evict_mode_full) << " PG(s) evicting (full)";
     }
   }
 }
@@ -2493,8 +2493,7 @@ void PGMap::get_health_checks(
 	  p.second.target_max_objects * (ratio / 1000000.0)) {
 	ostringstream ss;
 	ss << "cache pool '" << name << "' with "
-	   << si_u_t(st.stats.sum.num_objects)
-	   << " objects at/near target max "
+	   << si_u_t(st.stats.sum.num_objects) << " objects at/near target max "
 	   << si_u_t(p.second.target_max_objects) << " objects";
 	detail.push_back(ss.str());
 	nearfull = true;


### PR DESCRIPTION
"1 objects"
"2.3 k objects"
"12 M objects"
"2 op/s"
"23 k ops/s"
"23 M PG(s)"

Alternatively, see https://github.com/ceph/ceph/pull/23451