### PR TITLE
jewel: filestore: add pgid in filestore pg dir split log message

### DIFF
--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -317,7 +317,7 @@ int HashIndex::split_dirs(const vector<string> &path) {
 
   if (must_split(info)) {
     dout(1) << __func__ << " " << path << " has " << info.objs
-            << " objects, starting split." << dendl;
+            << " objects, starting split in pg " << coll() << "." << dendl;
     r = initiate_split(path, info);
     if (r < 0) {
       dout(10) << "error initiating split on " << path << ": "
@@ -326,7 +326,7 @@ int HashIndex::split_dirs(const vector<string> &path) {
     }
 
     r = complete_split(path, info);
-    dout(1) << __func__ << " " << path << " split completed."
+    dout(1) << __func__ << " " << path << " split completed in pg " << coll() << "."
             << dendl;
     if (r < 0) {
       dout(10) << "error completing split on " << path << ": "
@@ -420,12 +420,12 @@ int HashIndex::_created(const vector<string> &path,
 
   if (must_split(info)) {
     dout(1) << __func__ << " " << path << " has " << info.objs
-            << " objects, starting split." << dendl;
+            << " objects, starting split in pg " << coll() << "." << dendl;
     int r = initiate_split(path, info);
     if (r < 0)
       return r;
     r = complete_split(path, info);
-    dout(1) << __func__ << " " << path << " split completed."
+    dout(1) << __func__ << " " << path << " split completed in pg " << coll() << "."
             << dendl;
     return r;
   } else {


### PR DESCRIPTION
jewel: filestore: add pgid in filestore pg dir split log message
Fixes: http://tracker.ceph.com/issues/25224

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>
(cherry picked from commit d62ea5cc05857bc1a1f9cf4a0e3d4df315bef8af)

 Conflicts:
	src/os/filestore/HashIndex.cc
        - Kept old message only and removed new lines

