### PR TITLE
qa/tests: changed ceph qa email address to bypass dreamhost's spam filter

### DIFF
--- a/qa/crontab/teuthology-cronjobs
+++ b/qa/crontab/teuthology-cronjobs
@@ -1,6 +1,6 @@
 PATH=/home/teuthology/src/teuthology_master/virtualenv/bin:/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 MAILTO="ceph-infra@redhat.com;yweinste@redhat.com"
-CEPH_QA_EMAIL="ceph-qa@ceph.com"
+CEPH_QA_EMAIL="ceph-qa@lists.ceph.com"
 
 ### !!!!!!!!!!!!!!!!!!!!!!!!!!
 ## THIS CRONTAB MUST NOT BE EDITED MANUALLY !!!!


### PR DESCRIPTION
…

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>

