### PR TITLE
qa: silence slow IO warnings for cephfs

### DIFF
--- a/qa/cephfs/conf/mds.yaml
+++ b/qa/cephfs/conf/mds.yaml
@@ -2,8 +2,10 @@ overrides:
   ceph:
     conf:
       mds:
-        mds debug scatterstat: true
-        mds verify scatter: true
-        mds debug frag: true
-        debug ms: 1
         debug mds: 20
+        debug ms: 1
+        mds debug frag: true
+        mds debug scatterstat: true
+        mds op complaint time: 180
+        mds verify scatter: true
+        osd op complaint time: 180

--- a/qa/cephfs/conf/mon.yaml
+++ b/qa/cephfs/conf/mon.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        mon op complaint time: 120

--- a/qa/cephfs/conf/osd.yaml
+++ b/qa/cephfs/conf/osd.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd op complaint time: 180


### PR DESCRIPTION
Generally the slow warnings we get are just over the threshold. These warnings
are related to deploying multiple Ceph daemons side-by-side. Let's see how we
do with two minutes.

Ignoring the warnings entirely is unsatisfactory as they serve as a useful
canary in the coal mine when you see warnings for ops > some unreasonably large
amount of time.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>