### PR TITLE
luminous: mgr/MgrClient: Protect daemon_health_metrics

### DIFF
--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -465,5 +465,6 @@ int MgrClient::service_daemon_update_status(
 
 void MgrClient::update_osd_health(std::vector<OSDHealthMetric>&& metrics)
 {
+  Mutex::Locker l(lock);
   osd_health_metrics = std::move(metrics);
 }


### PR DESCRIPTION
Without holding the lock update_daemon_health() can race with
send_report() corrupting the daemon_health_metrics vector.

Fixes: http://tracker.ceph.com/issues/23352

Signed-off-by: Kjetil Joergensen <kjetil@medallia.com>
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>
(cherry picked from commit 4996506a6b4ab309110039ea29a075f14d09a379)

Conflicts:
	src/mgr/MgrClient.cc Function name is different in luminous


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

