### PR TITLE
os/filestore: Add switch to turn on/off filestore dir splitting

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1219,6 +1219,7 @@ OPTION(filestore_kill_at, OPT_INT)            // inject a failure at the n'th op
 OPTION(filestore_inject_stall, OPT_INT)       // artificially stall for N seconds in op queue thread
 OPTION(filestore_fail_eio, OPT_BOOL)       // fail/crash on EIO
 OPTION(filestore_debug_verify_split, OPT_BOOL)
+OPTION(filestore_auto_split_dirs, OPT_BOOL)
 OPTION(journal_dio, OPT_BOOL)
 OPTION(journal_aio, OPT_BOOL)
 OPTION(journal_force_aio, OPT_BOOL)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4699,6 +4699,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("filestore_auto_split_dirs", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(true)
+    .set_description(""),
+
     Option("journal_dio", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
     .set_description(""),


### PR DESCRIPTION
We had done pre-split and increased split multiple, etc, at the beginning of building cluster in order to reduce the performance impact of dir splitting. But with the number of objects increased to hundreds millions, our clusters would stilll experience dir splitting, which would bring performance impact to the online traffic.    

So we add this switch to easily control filestore dir splitting, that could turn it off dynamically when there is heavy online traffic, and turn it on again at night when traffic is very low.

Fixes: http://tracker.ceph.com/issues/26955

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>