### PR TITLE
luminous: mgrc: enable disabling stats via mgr_stats_threshold

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4189,7 +4189,7 @@ std::vector<Option> get_global_options() {
   .set_long_description("Daemons only set perf counter data to the manager "
     "daemon if the counter has a priority higher than this.")
   .set_min_max((int64_t)PerfCountersBuilder::PRIO_DEBUGONLY,
-               (int64_t)PerfCountersBuilder::PRIO_CRITICAL),
+               (int64_t)PerfCountersBuilder::PRIO_CRITICAL + 1),
 
     Option("journal_zero_on_create", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)


### PR DESCRIPTION
http://tracker.ceph.com/issues/26838