### PR TITLE
cephfs-journal-tool: enable purge_queue journal's event commands

### DIFF
--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -36,6 +36,11 @@ public:
     PURGE_DIR
   };
 
+  utime_t stamp;
+  //None PurgeItem serves as NoOp for splicing out journal entries;
+  //so there has to be a "pad_size" to specify the size of journal
+  //space to be spliced.
+  uint32_t pad_size;
   Action action;
   inodeno_t ino;
   uint64_t size;
@@ -45,11 +50,35 @@ public:
   fragtree_t fragtree;
 
   PurgeItem()
-   : action(NONE), ino(0), size(0)
+   : pad_size(0), action(NONE), ino(0), size(0)
   {}
 
   void encode(bufferlist &bl) const;
   void decode(bufferlist::const_iterator &p);
+
+  static Action str_to_type(std::string_view str) {
+    return PurgeItem::actions.at(std::string(str));
+  }
+
+  void dump(Formatter *f) const
+  {
+    f->dump_int("action", action);
+    f->dump_int("ino", ino);
+    f->dump_int("size", size);
+    f->open_object_section("layout");
+    layout.dump(f);
+    f->close_section();
+    f->open_object_section("SnapContext");
+    snapc.dump(f);
+    f->close_section();
+    f->open_object_section("fragtree");
+    fragtree.dump(f);
+    f->close_section();
+  }
+
+  std::string get_type_str() const;
+private:
+  static const std::map<std::string, PurgeItem::Action> actions;
 };
 WRITE_CLASS_ENCODER(PurgeItem)
 

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -98,6 +98,7 @@ void StrayManager::purge(CDentry *dn)
 
   PurgeItem item;
   item.ino = in->inode.ino;
+  item.stamp = ceph_clock_now();
   if (in->is_dir()) {
     item.action = PurgeItem::PURGE_DIR;
     item.fragtree = in->dirfragtree;
@@ -733,6 +734,7 @@ void StrayManager::truncate(CDentry *dn)
   item.layout = in->inode.layout;
   item.snapc = *snapc;
   item.size = to;
+  item.stamp = ceph_clock_now();
 
   purge_queue.push(item, new C_IO_PurgeStrayPurged(
         this, dn, true));

--- a/src/tools/cephfs/EventOutput.cc
+++ b/src/tools/cephfs/EventOutput.cc
@@ -37,15 +37,21 @@ int EventOutput::binary() const
   }
 
   for (JournalScanner::EventMap::const_iterator i = scan.events.begin(); i != scan.events.end(); ++i) {
-    LogEvent *le = i->second.log_event;
-    bufferlist le_bin;
-    le->encode(le_bin, CEPH_FEATURES_SUPPORTED_DEFAULT);
-
+    bufferlist bin;
     std::stringstream filename;
-    filename << "0x" << std::hex << i->first << std::dec << "_" << le->get_type_str() << ".bin";
+    if (i->second.log_event) {
+      LogEvent *le = i->second.log_event;
+      le->encode(bin, CEPH_FEATURES_SUPPORTED_DEFAULT);
+      filename << "0x" << std::hex << i->first << std::dec << "_" << le->get_type_str() << ".bin";
+    } else if (i->second.pi) {
+      PurgeItem* pi = i->second.pi;
+      pi->encode(bin);
+      filename << "0x" << std::hex << i->first << std::dec << "_" << pi->get_type_str() << ".bin";
+    }
+
     std::string const file_path = path + std::string("/") + filename.str();
     std::ofstream bin_file(file_path.c_str(), std::ofstream::out | std::ofstream::binary);
-    le_bin.write_stream(bin_file);
+    bin.write_stream(bin_file);
     bin_file.close();
     if (bin_file.fail()) {
       return -EIO;
@@ -63,12 +69,19 @@ int EventOutput::json() const
   jf.open_array_section("journal");
   {
     for (JournalScanner::EventMap::const_iterator i = scan.events.begin(); i != scan.events.end(); ++i) {
-      LogEvent *le = i->second.log_event;
-      jf.open_object_section("log_event");
-      {
-        le->dump(&jf);
+      if (i->second.log_event) {
+	LogEvent *le = i->second.log_event;
+	jf.open_object_section("log_event");
+	{
+	  le->dump(&jf);
+	}
+	jf.close_section();  // log_event
+      } else if (i->second.pi) {
+	PurgeItem* pi = i->second.pi;
+	jf.open_object_section("purge_action");
+	pi->dump(&jf);
+	jf.close_section();
       }
-      jf.close_section();  // log_event
     }
   }
   jf.close_section();  // journal
@@ -86,24 +99,30 @@ int EventOutput::json() const
 void EventOutput::list() const
 {
   for (JournalScanner::EventMap::const_iterator i = scan.events.begin(); i != scan.events.end(); ++i) {
-    std::vector<std::string> ev_paths;
-    EMetaBlob const *emb = i->second.log_event->get_metablob();
-    if (emb) {
-      emb->get_paths(ev_paths);
-    }
+    if (i->second.log_event) {
+      std::vector<std::string> ev_paths;
+      EMetaBlob const *emb = i->second.log_event->get_metablob();
+      if (emb) {
+	emb->get_paths(ev_paths);
+      }
 
-    std::string detail;
-    if (i->second.log_event->get_type() == EVENT_UPDATE) {
-      EUpdate *eu = reinterpret_cast<EUpdate*>(i->second.log_event);
-      detail = eu->type;
-    }
+      std::string detail;
+      if (i->second.log_event->get_type() == EVENT_UPDATE) {
+	EUpdate *eu = reinterpret_cast<EUpdate*>(i->second.log_event);
+	detail = eu->type;
+      }
 
-    std::cout <<i->second.log_event->get_stamp() << " 0x"
-      << std::hex << i->first << std::dec << " "
-      << i->second.log_event->get_type_str() << ": "
-      << " (" << detail << ")" << std::endl;
-    for (std::vector<std::string>::iterator i = ev_paths.begin(); i != ev_paths.end(); ++i) {
-        std::cout << "  " << *i << std::endl;
+      std::cout <<i->second.log_event->get_stamp() << " 0x"
+	<< std::hex << i->first << std::dec << " "
+	<< i->second.log_event->get_type_str() << ": "
+	<< " (" << detail << ")" << std::endl;
+      for (std::vector<std::string>::iterator i = ev_paths.begin(); i != ev_paths.end(); ++i) {
+	std::cout << "  " << *i << std::endl;
+      }
+    } else if (i->second.pi) {
+      std::cout << i->second.pi->stamp << " 0x"
+	<< std::hex << i->first << std::dec << " "
+	<< i->second.pi->get_type_str() << std::endl;
     }
   }
 }
@@ -112,7 +131,11 @@ void EventOutput::summary() const
 {
   std::map<std::string, int> type_count;
   for (JournalScanner::EventMap::const_iterator i = scan.events.begin(); i != scan.events.end(); ++i) {
-    std::string const type = i->second.log_event->get_type_str();
+    std::string type;
+    if (i->second.log_event)
+      type = i->second.log_event->get_type_str();
+    else if (i->second.pi)
+      type = i->second.pi->get_type_str();
     if (type_count.count(type) == 0) {
       type_count[type] = 0;
     }

--- a/src/tools/cephfs/JournalFilter.cc
+++ b/src/tools/cephfs/JournalFilter.cc
@@ -25,6 +25,24 @@
 
 const string JournalFilter::range_separator("..");
 
+bool JournalFilter::apply(uint64_t pos, PurgeItem &pi) const
+{
+  /* Filtering by journal offset range */
+  if (pos < range_start || pos >= range_end) {
+    return false;
+  }
+
+  if (purge_action != PurgeItem::NONE) {
+    if (pi.action != purge_action)
+      return false;
+  }
+
+  if (inode) {
+    if (inode != pi.ino)
+      return false;
+  }
+  return true;
+}
 
 /*
  * Return whether a LogEvent is to be included or excluded.
@@ -187,6 +205,10 @@ int JournalFilter::parse_args(
         }
       }
     } else if (ceph_argparse_witharg(argv, arg, &arg_str, "--path", (char*)NULL)) {
+      if (!type.compare("purge_queue")) {
+	derr << "Invalid filter arguments: purge_queue doesn't take \"--path\"." << dendl;
+	return -EINVAL;
+      }
       dout(4) << "Filtering by path '" << arg_str << "'" << dendl;
       path_expr = arg_str;
     } else if (ceph_argparse_witharg(argv, arg, &arg_str, "--inode", (char*)NULL)) {
@@ -198,14 +220,21 @@ int JournalFilter::parse_args(
         return -EINVAL;
       }
     } else if (ceph_argparse_witharg(argv, arg, &arg_str, "--type", (char*)NULL)) {
-      std::string parse_err;
-      event_type = LogEvent::str_to_type(arg_str);
-      if (event_type == LogEvent::EventType(-1)) {
-        derr << "Invalid event type '" << arg_str << "': " << parse_err << dendl;
-        return -EINVAL;
+      try {
+	if (!type.compare("mdlog")) {
+	  event_type = LogEvent::str_to_type(arg_str);
+	} else if (!type.compare("purge_queue")) {
+	  purge_action = PurgeItem::str_to_type(arg_str);
+	}
+      } catch (std::out_of_range) {
+	 derr << "Invalid event type '" << arg_str << "'" << dendl;
+	 return -EINVAL;
       }
-
     } else if (ceph_argparse_witharg(argv, arg, &arg_str, "--frag", (char*)NULL)) {
+      if (!type.compare("purge_queue")) {
+	derr << "Invalid filter arguments: purge_queue doesn't take \"--frag\"." << dendl;
+	return -EINVAL;
+      }
       std::string const frag_sep = ".";
       size_t sep_loc = arg_str.find(frag_sep);
       std::string inode_str;
@@ -234,9 +263,18 @@ int JournalFilter::parse_args(
       frag = dirfrag_t(frag_ino, frag_t(frag_enc));
       dout(4) << "dirfrag filter: '" << frag << "'" << dendl;
     } else if (ceph_argparse_witharg(argv, arg, &arg_str, "--dname", (char*)NULL)) {
+      if (!type.compare("purge_queue")) {
+	derr << "Invalid filter arguments: purge_queue doesn't take \"--dname\"." << dendl;
+	return -EINVAL;
+      }
       frag_dentry = arg_str;
       dout(4) << "dentry filter: '" << frag_dentry << "'" << dendl;
     } else if (ceph_argparse_witharg(argv, arg, &arg_str, "--client", (char*)NULL)) {
+      if (!type.compare("purge_queue")) {
+	derr << "Invalid filter arguments: purge_queue doesn't take \"--client\"." << dendl;
+	return -EINVAL;
+      }
+
       std::string parse_err;
       int64_t client_num = strict_strtoll(arg_str.c_str(), 0, &parse_err);
       if (!parse_err.empty()) {

--- a/src/tools/cephfs/JournalFilter.h
+++ b/src/tools/cephfs/JournalFilter.h
@@ -17,6 +17,7 @@
 
 #include "mds/mdstypes.h"
 #include "mds/LogEvent.h"
+#include "mds/PurgeQueue.h"
 
 /**
  * A set of conditions for narrowing down a search through the journal
@@ -39,6 +40,11 @@ class JournalFilter
   /* Filtering by type */
   LogEvent::EventType event_type;
 
+  std::string type;
+
+  /* Filtering by PurgeItem::Action */
+  PurgeItem::Action purge_action;
+
   /* Filtering by dirfrag */
   dirfrag_t frag;
   std::string frag_dentry;  //< optional, filter dentry name within fragment
@@ -47,14 +53,17 @@ class JournalFilter
   entity_name_t client_name;
 
   public:
-  JournalFilter() : 
+  JournalFilter(std::string t) :
     range_start(0),
     range_end(-1),
     inode(0),
-    event_type(0) {}
+    event_type(0),
+    type(t),
+    purge_action(PurgeItem::NONE) {}
 
   bool get_range(uint64_t &start, uint64_t &end) const;
   bool apply(uint64_t pos, LogEvent &le) const;
+  bool apply(uint64_t pos, PurgeItem &pi) const;
   int parse_args(
     std::vector<const char*> &argv, 
     std::vector<const char*>::iterator &arg);

--- a/src/tools/cephfs/JournalScanner.h
+++ b/src/tools/cephfs/JournalScanner.h
@@ -65,6 +65,7 @@ class JournalScanner
     io(io_),
     rank(rank_),
     type(type_),
+    filter(type_),
     is_mdlog(false),
     pointer_present(false),
     pointer_valid(false),
@@ -89,8 +90,10 @@ class JournalScanner
   class EventRecord {
     public:
     EventRecord() : log_event(NULL), raw_size(0) {}
-    EventRecord(LogEvent *le, uint32_t rs) : log_event(le), raw_size(rs) {}
+    EventRecord(LogEvent *le, uint32_t rs) : log_event(le), pi(NULL), raw_size(rs) {}
+    EventRecord(PurgeItem* p, uint32_t rs) : log_event(NULL), pi(p), raw_size(rs) {}
     LogEvent *log_event;
+    PurgeItem *pi;
     uint32_t raw_size;  //< Size from start offset including all encoding overhead
   };
 


### PR DESCRIPTION
A new PR with increased struct version of PurgeItem for PR https://github.com/ceph/ceph/pull/22850

Resolves: http://tracker.ceph.com/issues/24604
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

