### PR TITLE
common: expand meta in parse_argv()

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -609,6 +609,8 @@ int md_config_t::parse_argv(ConfigValues& values,
       }
     }
   }
+  // meta expands could have modified anything.  Copy it all out again.
+  update_legacy_vals(values);
   return 0;
 }
 


### PR DESCRIPTION
it fixes the issue where the conf->foo fails to expand if it is set
as "$bar" in a .conf file, and "bar" is another config var, and bar
is set using config_proxy.parse_argv().

because before 773ef117, apply_changes() calls update_legacy_vals(),
which expands meta vars for legacy config vals, but after 773ef117,
we cannot change config_values in apply_changes() anymore. so
update_legacy_vals() calls is moved to apply_changes()'s callers
accordingly. but the apply_changes() is also called by global_init()
directly instead of by the routines in config.cc. so in 773ef117,
i missed it.

in this change, it's put back into parse_argv() instead of into
global_init(), as update_legacy_vals() is a low level function, and
parse_argv() could change the config_values, it's better to call
update_legacy_vals() out there, just like set_mon_vals() and
parse_config_files().

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

