### PR TITLE
qa/standalone/crush/crush-choose-args: run mgr

### DIFF
--- a/qa/standalone/crush/crush-choose-args.sh
+++ b/qa/standalone/crush/crush-choose-args.sh
@@ -49,6 +49,7 @@ function TEST_choose_args_update() {
     local dir=$1
 
     run_mon $dir a || return 1
+    run_mgr $dir x || return 1
     run_osd $dir 0 || return 1
 
     ceph osd set-require-min-compat-client luminous
@@ -103,6 +104,7 @@ function TEST_no_update_weight_set() {
     CEPH_ARGS+="--osd-crush-update-weight-set=false "
 
     run_mon $dir a || return 1
+    run_mgr $dir x || return 1
     run_osd $dir 0 || return 1
 
     ceph osd set-require-min-compat-client luminous


### PR DESCRIPTION
The osd purge command needs a running mgr.

Fixes: d2b41d4095074447df247907934626f4287cd91b
Signed-off-by: Sage Weil <sage@redhat.com>