### PR TITLE
mgr/localpool: pg_num is an int arg to 'osd pool create'

### DIFF
--- a/src/pybind/mgr/localpool/module.py
+++ b/src/pybind/mgr/localpool/module.py
@@ -65,7 +65,7 @@ class Module(MgrModule):
                         "pool": pool_name,
                         'rule': pool_name,
                         "pool_type": 'replicated',
-                        'pg_num': str(pg_num),
+                        'pg_num': int(pg_num),
                     }), "")
                     r, outb, outs = result.wait()
 


### PR DESCRIPTION
In bd565bca3f42d7946c392b2833bb3d9982a8ac5d we start returning EINVAL if
the pg_num argument is not valid, whereas before it was silently ignored.

Signed-off-by: Sage Weil <sage@redhat.com>