### PR TITLE
mgr: fix beacon interruption caused by deadlock

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -314,9 +314,9 @@ PyObject *ActivePyModules::get_python(const std::string &what)
   } else if (what == "df") {
     PyFormatter f;
 
-    cluster_state.with_osdmap([this, &f](const OSDMap &osd_map){
-      cluster_state.with_pgmap(
-          [&osd_map, &f](const PGMap &pg_map) {
+    cluster_state.with_pgmap([this, &f](const PGMap &pg_map) {
+      cluster_state.with_osdmap(
+          [&pg_map, &f](const OSDMap &osd_map) {
         pg_map.dump_fs_stats(nullptr, &f, true);
         pg_map.dump_pool_stats_full(osd_map, nullptr, &f, true);
       });


### PR DESCRIPTION
There is potential deadlock between this code and DaemonServer::send_report()
```
Thread 20 (Thread 0x7f2ab9987700 (LWP 5311)):
0  0x00007f2ae4a2c42d in __lll_lock_wait () from /lib64/libpthread.so.0
1  0x00007f2ae4a27dcb in _L_lock_812 () from /lib64/libpthread.so.0
2  0x00007f2ae4a27c98 in pthread_mutex_lock () from /lib64/libpthread.so.0
3  0x00007f2ae71101e8 in Mutex::Lock (this=this@entry=0x7f2af38ce608, no_lockdep=no_lockdep@entry=false) at /usr/src/debug/ceph-12.2.2/src/common/Mutex.cc:107
4  0x00007f2ae6fd2ef3 in Locker (m=..., this=<synthetic pointer>) at /usr/src/debug/ceph-12.2.2/src/common/Mutex.h:115
5  with_pgmap<ActivePyModules::get_python(const string&)::__lambda18::__lambda19> (cb=<optimized out>, this=0x7f2af38ce430) at /usr/src/debug/ceph-12.2.2/src/mgr/ClusterState.h:107
6  operator() (osd_map=..., __closure=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/mgr/ActivePyModules.cc:290
7  with_osdmap<ActivePyModules::get_python(const string&)::__lambda18> (cb=<optimized out>, this=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/osdc/Objecter.h:2064
8  with_osdmap<ActivePyModules::get_python(const string&)::__lambda18> (this=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/mgr/ClusterState.h:132
9  ActivePyModules::get_python (this=0x7f2af17ea700, what="df") at /usr/src/debug/ceph-12.2.2/src/mgr/ActivePyModules.cc:291
10 0x00007f2ae6fe8d8d in ceph_state_get (self=0x7f2af3760cd0, args=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/mgr/BaseMgrModule.cc:325
11 0x00007f2ae67f5bb0 in PyEval_EvalFrameEx () from /lib64/libpython2.7.so.1.0
12 0x00007f2ae67f557d in PyEval_EvalFrameEx () from /lib64/libpython2.7.so.1.0
13 0x00007f2ae67f557d in PyEval_EvalFrameEx () from /lib64/libpython2.7.so.1.0
14 0x00007f2ae67f7efd in PyEval_EvalCodeEx () from /lib64/libpython2.7.so.1.0
15 0x00007f2ae6781858 in function_call () from /lib64/libpython2.7.so.1.0
16 0x00007f2ae675c9a3 in PyObject_Call () from /lib64/libpython2.7.so.1.0
17 0x00007f2ae676b995 in instancemethod_call () from /lib64/libpython2.7.so.1.0
18 0x00007f2ae675c9a3 in PyObject_Call () from /lib64/libpython2.7.so.1.0
19 0x00007f2ae675ca85 in call_function_tail () from /lib64/libpython2.7.so.1.0
20 0x00007f2ae675cdbb in PyObject_CallMethod () from /lib64/libpython2.7.so.1.0
21 0x00007f2ae6fed79f in ActivePyModule::notify (this=0x7f2af17c6880, notify_type="pg_summary", notify_id="") at /usr/src/debug/ceph-12.2.2/src/mgr/ActivePyModule.cc:90
22 0x00007f2ae6fbdfaa in operator() (a0=<optimized out>, this=<optimized out>) at /usr/src/debug/ceph-12.2.2/build/boost/include/boost/function/function_template.hpp:771
23 FunctionContext::finish (this=<optimized out>, r=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/include/Context.h:493
24 0x00007f2ae6fb8d89 in Context::complete (this=0x7f2af7442ae0, r=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/include/Context.h:70
25 0x00007f2ae712e3f8 in Finisher::finisher_thread_entry (this=0x7f2af38ce140) at /usr/src/debug/ceph-12.2.2/src/common/Finisher.cc:72
26 0x00007f2ae4a25e25 in start_thread () from /lib64/libpthread.so.0
27 0x00007f2ae3d1c34d in clone () from /lib64/libc.so.6

Thread 22 (Thread 0x7f2ad867a700 (LWP 5241)):
0  0x00007f2ae4a29945 in pthread_cond_wait@@GLIBC_2.3.2 () from /lib64/libpthread.so.0
1  0x00007f2ae6fbe4a5 in wait (m=..., this=0x7ffe44776f00) at /usr/src/debug/ceph-12.2.2/build/boost/include/boost/thread/pthread/condition_variable.hpp:76
2  lock_shared (this=0x7ffe44776ed0) at /usr/src/debug/ceph-12.2.2/build/boost/include/boost/thread/pthread/shared_mutex.hpp:191
3  boost::shared_lock<boost::shared_mutex>::lock (this=this@entry=0x7f2ad86783e0) at /usr/src/debug/ceph-12.2.2/build/boost/include/boost/thread/lock_types.hpp:645
4  0x00007f2ae6fadae3 in shared_lock (m_=..., this=0x7f2ad86783e0) at /usr/src/debug/ceph-12.2.2/build/boost/include/boost/thread/lock_types.hpp:520
5  with_osdmap<DaemonServer::send_report()::__lambda37::__lambda38> (cb=<optimized out>, this=0x7ffe44776df0) at /usr/src/debug/ceph-12.2.2/src/osdc/Objecter.h:2063
6  with_osdmap<DaemonServer::send_report()::__lambda37::__lambda38> (this=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/mgr/ClusterState.h:132
7  operator() (pg_map=..., __closure=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/mgr/DaemonServer.cc:1647
8  with_pgmap<DaemonServer::send_report()::__lambda37> (cb=<optimized out>, this=0x7f2af38ce430) at /usr/src/debug/ceph-12.2.2/src/mgr/ClusterState.h:108
9  DaemonServer::send_report (this=this@entry=0x7f2af38cf188) at /usr/src/debug/ceph-12.2.2/src/mgr/DaemonServer.cc:1648
10 0x00007f2ae6ffebbe in Mgr::tick (this=0x7f2af38ce000) at /usr/src/debug/ceph-12.2.2/src/mgr/Mgr.cc:650
11 0x00007f2ae6ff3dcd in MgrStandby::tick (this=0x7ffe44776830) at /usr/src/debug/ceph-12.2.2/src/mgr/MgrStandby.cc:197
12 0x00007f2ae6fbdfaa in operator() (a0=<optimized out>, this=<optimized out>) at /usr/src/debug/ceph-12.2.2/build/boost/include/boost/function/function_template.hpp:771
13 FunctionContext::finish (this=<optimized out>, r=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/include/Context.h:493
14 0x00007f2ae6fb8d89 in Context::complete (this=0x7f2afe91a7e0, r=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/include/Context.h:70
15 0x00007f2ae712bd24 in SafeTimer::timer_thread (this=0x7ffe447786c8) at /usr/src/debug/ceph-12.2.2/src/common/Timer.cc:97
16 0x00007f2ae712d74d in SafeTimerThread::entry (this=<optimized out>) at /usr/src/debug/ceph-12.2.2/src/common/Timer.cc:30
17 0x00007f2ae4a25e25 in start_thread () from /lib64/libpthread.so.0
18 0x00007f2ae3d1c34d in clone () from /lib64/libc.so.6

```

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

