### PR TITLE
build: 32 bit architecture fixes

### DIFF
--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -143,7 +143,7 @@ public:
   void do_command(std::string_view command, const cmdmap_t& cmdmap,
 		  std::string_view format, ceph::bufferlist *out);
 
-  static constexpr std::size_t largest_singleton = sizeof(void*) * 72;
+  static constexpr std::size_t largest_singleton = 8 * 72;
 
   template<typename T, typename... Args>
   T& lookup_or_create_singleton_object(std::string_view name,

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -826,8 +826,8 @@ OSDMonitor::update_pending_pgs(const OSDMap::Incremental& inc,
 	     << " modified " << p->second.modified
 	     << " [" << p->second.start << "-" << p->second.end << ")"
 	     << dendl;
-    int n = std::min(max - pending_creatings.pgs.size(),
-		p->second.end - p->second.start);
+    int64_t n = std::min<int64_t>(max - pending_creatings.pgs.size(),
+				  p->second.end - p->second.start);
     ps_t first = p->second.start;
     ps_t end = first + n;
     for (ps_t ps = first; ps < end; ++ps) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -12328,8 +12328,8 @@ size_t BlueStoreRepairer::StoreSpaceTracker::filter_out(
   assert(!was_filtered_out);
   assert(collections_bfs.size() == objects_bfs.size());
 
-  size_t prev_pos = 0;
-  size_t npos = collections_bfs.size();
+  uint64_t prev_pos = 0;
+  uint64_t npos = collections_bfs.size();
 
   bloom_vector collections_reduced;
   bloom_vector objects_reduced;
@@ -12338,8 +12338,8 @@ size_t BlueStoreRepairer::StoreSpaceTracker::filter_out(
     if (e.second == 0) {
       continue;
     }
-    size_t pos = max(e.first / granularity, prev_pos);
-    size_t end_pos = 1 + (e.first + e.second - 1) / granularity;
+    uint64_t pos = max(e.first / granularity, prev_pos);
+    uint64_t end_pos = 1 + (e.first + e.second - 1) / granularity;
     while (pos != npos && pos < end_pos)  {
         assert( collections_bfs[pos].element_count() ==
           objects_bfs[pos].element_count());

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1634,8 +1634,8 @@ void PrimaryLogPG::calc_trim_to()
       pg_log.get_log().approx_size() > target) {
     dout(10) << __func__ << " approx pg log length =  "
              << pg_log.get_log().approx_size() << dendl;
-    size_t num_to_trim = std::min(pg_log.get_log().approx_size() - target,
-				  cct->_conf->osd_pg_log_trim_max);
+    uint64_t num_to_trim = std::min<uint64_t>(pg_log.get_log().approx_size() - target,
+                                              cct->_conf->osd_pg_log_trim_max);
     dout(10) << __func__ << " num_to_trim =  " << num_to_trim << dendl;
     if (num_to_trim < cct->_conf->osd_pg_log_trim_min &&
 	cct->_conf->osd_pg_log_trim_max >= cct->_conf->osd_pg_log_trim_min) {
@@ -1643,7 +1643,7 @@ void PrimaryLogPG::calc_trim_to()
     }
     list<pg_log_entry_t>::const_iterator it = pg_log.get_log().log.begin();
     eversion_t new_trim_to;
-    for (size_t i = 0; i < num_to_trim; ++i) {
+    for (uint64_t i = 0; i < num_to_trim; ++i) {
       new_trim_to = it->version;
       ++it;
       if (new_trim_to >= limit) {

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -351,7 +351,7 @@ int take_min_status(CephContext *cct, Iter first, Iter last,
   status->clear();
   // The initialisation below is required to silence a false positive
   // -Wmaybe-uninitialized warning
-  boost::optional<size_t> num_shards = boost::make_optional(false, 0UL);
+  boost::optional<uint64_t> num_shards = boost::make_optional(false, uint64_t());
   for (auto peer = first; peer != last; ++peer) {
     const size_t peer_shards = peer->size();
     if (!num_shards) {

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -39,9 +39,9 @@ int flush(librbd::ImageCtx *image_ctx) {
   return ctx.wait();
 }
 
-void scribble(librbd::ImageCtx *image_ctx, int num_ops, size_t max_size)
+void scribble(librbd::ImageCtx *image_ctx, int num_ops, uint64_t max_size)
 {
-  max_size = std::min(image_ctx->size, max_size);
+  max_size = std::min<uint64_t>(image_ctx->size, max_size);
   for (int i=0; i<num_ops; i++) {
     uint64_t off = rand() % (image_ctx->size - max_size + 1);
     uint64_t len = 1 + rand() % max_size;


### PR DESCRIPTION
Misc fixes to resolve compilation failures on 32 bit
architectures.  These are mostly due to differences
in pointer sizes under 32 bit archs.

Signed-off-by: James Page <james.page@ubuntu.com>
