### PR TITLE
mgr/MgrClient: make some noise for a user if no mgr daemon is running

### DIFF
--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -428,7 +428,7 @@ int MgrClient::start_command(const vector<string>& cmd, const bufferlist& inbl,
     MCommand *m = op.get_message({});
     session->con->send_message(m);
   } else {
-    ldout(cct, 4) << "start_command: no mgr session, waiting" << dendl;
+    ldout(cct, 0) << "no mgr session (no running mgr daemon?), waiting" << dendl;
   }
   return 0;
 }


### PR DESCRIPTION
Otherwise a cli command may unexpectedly hang forever with no output
because no ceph-mgr is running, which can be confusing for an admin.

Output is now more like

```
$ ceph pg stat 
2018-08-08 08:49:32.411 7f0de3bf0700  0 mgrc start_command no mgr session (no running mgr daemon?), waiting
^CError EINTR: Interrupted!
```