### PR TITLE
jewel: cls/rgw: gc_iterate_entries segfaults on invalid iterator

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3268,8 +3268,12 @@ static int gc_iterate_entries(cls_method_context_t hctx, const string& marker, b
       if (max_entries && (i >= max_entries)) {
         if (truncated)
           *truncated = true;
-        --iter;
-        key_iter = iter->first;
+        if (iter == keys.begin()) {
+          key_iter = start_key;
+        } else {
+          --iter;
+          key_iter = iter->first;
+        }
         return 0;
       }
 


### PR DESCRIPTION
it's unsafe to decrement/deref iter when it's at keys.begin(). in that case, return the start_key instead

Fixes: http://tracker.ceph.com/issues/26882

this logic was rewritten in luminous, so this commit only applies to jewel