### PR TITLE
doc: Fix a couple typos and improve diagram formatting

### DIFF
--- a/doc/rados/operations/crush-map.rst
+++ b/doc/rados/operations/crush-map.rst
@@ -154,19 +154,19 @@ leaves, interior nodes with non-device types, and a root node of type
 .. ditaa::
 
                         +-----------------+
-                        | {o}root default |
+                        |{o}root default  |
                         +--------+--------+
                                  |
                  +---------------+---------------+
                  |                               |
-         +-------+-------+                 +-----+-------+
-         | {o}host foo   |                 | {o}host bar |
-         +-------+-------+                 +-----+-------+
+          +------+------+                 +------+------+
+          |{o}host foo  |                 |{o}host bar  |
+          +------+------+                 +------+------+
                  |                               |
          +-------+-------+               +-------+-------+
          |               |               |               |
    +-----+-----+   +-----+-----+   +-----+-----+   +-----+-----+
-   |  osd.0    |   |   osd.1   |   |   osd.2   |   |   osd.3   |
+   |   osd.0   |   |   osd.1   |   |   osd.2   |   |   osd.3   |
    +-----------+   +-----------+   +-----------+   +-----------+
 
 Each node (device or bucket) in the hierarchy has a *weight*
@@ -279,7 +279,7 @@ There are two types of weight sets supported:
  #. A **per-pool** weight set is more flexible in that it allows
     placement to be optimized for each data pool.  Additionally,
     weights can be adjusted for each position of placement, allowing
-    the optimizer to correct for a suble skew of data toward devices
+    the optimizer to correct for a subtle skew of data toward devices
     with small weights relative to their peers (and effect that is
     usually only apparently in very large clusters but which can cause
     balancing problems).
@@ -903,7 +903,7 @@ A few important points
    effectively grandfathered in, and will misbehave if they do not
    support the new feature.
  * If the CRUSH tunables are set to non-legacy values and then later
-   changed back to the defult values, ``ceph-osd`` daemons will not be
+   changed back to the default values, ``ceph-osd`` daemons will not be
    required to support the feature.  However, the OSD peering process
    requires examining and understanding old maps.  Therefore, you
    should not run old versions of the ``ceph-osd`` daemon


### PR DESCRIPTION
I found a couple misspelled words in the crush-map documentation and also tweaked the formatting of the CRUSH hierarchy diagram to center some of the entries.

Signed-off-by: Bryan Stillwell <bstillwell@godaddy.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

