### PR TITLE
rgw: don't sync lc configuration in multisite

### DIFF
--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -284,7 +284,7 @@ public:
 
   int get(RGWRados *store, string& entry, RGWMetadataObject **obj) override { return -ENOTSUP; }
   int put(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker,
-                  real_time mtime, JSONObj *obj, sync_type_t sync_type) override { return -ENOTSUP; }
+                  real_time mtime, JSONObj *obj, sync_type_t sync_type, bool meta_sync) override { return -ENOTSUP; }
 
   virtual void get_pool_and_oid(RGWRados *store, const string& key, rgw_pool& pool, string& oid) override {}
 
@@ -749,7 +749,7 @@ int RGWMetadataManager::get(string& metadata_key, Formatter *f)
 
 int RGWMetadataManager::put(string& metadata_key, bufferlist& bl,
                             RGWMetadataHandler::sync_type_t sync_type,
-                            obj_version *existing_version)
+                            obj_version *existing_version, bool meta_sync)
 {
   RGWMetadataHandler *handler;
   string entry;
@@ -782,7 +782,7 @@ int RGWMetadataManager::put(string& metadata_key, bufferlist& bl,
     return -EINVAL;
   }
 
-  ret = handler->put(store, entry, objv_tracker, mtime.to_real_time(), jo, sync_type);
+  ret = handler->put(store, entry, objv_tracker, mtime.to_real_time(), jo, sync_type, meta_sync);
   if (existing_version) {
     *existing_version = objv_tracker.read_version;
   }

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -77,7 +77,7 @@ public:
 
   virtual int get(RGWRados *store, string& entry, RGWMetadataObject **obj) = 0;
   virtual int put(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker,
-                  real_time mtime, JSONObj *obj, sync_type_t type) = 0;
+                  real_time mtime, JSONObj *obj, sync_type_t type, bool meta_sync) = 0;
   virtual int remove(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker) = 0;
 
   virtual int list_keys_init(RGWRados *store, const string& marker, void **phandle) = 0;
@@ -363,7 +363,7 @@ public:
   int get(string& metadata_key, Formatter *f);
   int put(string& metadata_key, bufferlist& bl,
           RGWMetadataHandler::sync_type_t sync_mode,
-          obj_version *existing_version = NULL);
+          obj_version *existing_version = NULL, bool meta_sync = false);
   int remove(string& metadata_key);
 
   int list_keys_init(const string& section, void **phandle);

--- a/src/rgw/rgw_otp.cc
+++ b/src/rgw/rgw_otp.cc
@@ -58,7 +58,7 @@ public:
   }
 
   int put(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker,
-          real_time mtime, JSONObj *obj, sync_type_t sync_mode) override {
+          real_time mtime, JSONObj *obj, sync_type_t sync_mode, bool meta_sync) override {
 
     list<rados::cls::otp::otp_info_t> devices;
     try {

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1062,7 +1062,7 @@ class RGWAsyncMetaStoreEntry : public RGWAsyncRadosRequest {
   bufferlist bl;
 protected:
   int _send_request() override {
-    int ret = store->meta_mgr->put(raw_key, bl, RGWMetadataHandler::APPLY_ALWAYS);
+    int ret = store->meta_mgr->put(raw_key, bl, RGWMetadataHandler::APPLY_ALWAYS, nullptr, true);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: can't store key: " << raw_key << " ret=" << ret << dendl;
       return ret;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2699,7 +2699,7 @@ public:
   }
 
   int put(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker,
-          real_time mtime, JSONObj *obj, sync_type_t sync_mode) override {
+          real_time mtime, JSONObj *obj, sync_type_t sync_mode, bool meta_sync) override {
     RGWUserCompleteInfo uci;
 
     try {


### PR DESCRIPTION
 Ignore lc configuration in metadata sync.

Fixes:  http://tracker.ceph.com/issues/22648

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->


