### PR TITLE
os/bluestore: check bluefs_extents consistency (DB vs. BlueFS)

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6018,6 +6018,26 @@ int BlueStore::_fsck(bool deep, bool repair)
   }
 
   if (bluefs) {
+    interval_set<uint64_t> bset;
+    r = bluefs->get_block_extents(bluefs_shared_bdev, &bset);
+    assert(r == 0);
+    if (!(bset == bluefs_extents)) {
+      dout(10) << __func__ << " bluefs says 0x" << std::hex << bset << std::dec
+	       << dendl;
+      dout(10) << __func__ << " super says  0x" << std::hex << bluefs_extents
+	       << std::dec << dendl;
+
+      interval_set<uint64_t> overlap;
+      overlap.intersection_of(bset, bluefs_extents);
+
+      bset.subtract(overlap);
+      if (!bset.empty()) {
+	derr << "fsck error: bluefs extra 0x" << std::hex << bset << std::dec
+	     << dendl;
+	++errors;
+      }
+    }
+
     for (auto e = bluefs_extents.begin(); e != bluefs_extents.end(); ++e) {
       apply(
         e.get_start(), e.get_len(), fm->get_alloc_size(), used_blocks,


### PR DESCRIPTION
Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

