### PR TITLE
mimic: rgw: Limit the number of lifecycle rules on one bucket.

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1287,6 +1287,7 @@ OPTION(rgw_content_length_compat, OPT_BOOL) // Check both HTTP_CONTENT_LENGTH an
 OPTION(rgw_lifecycle_work_time, OPT_STR) //job process lc  at 00:00-06:00s
 OPTION(rgw_lc_lock_max_time, OPT_INT)  // total run time for a single lc processor work
 OPTION(rgw_lc_max_objs, OPT_INT)
+OPTION(rgw_lc_max_rules, OPT_U32)  // Max rules set on one bucket
 OPTION(rgw_lc_debug_interval, OPT_INT)  // Debug run interval, in seconds
 OPTION(rgw_script_uri, OPT_STR) // alternative value for SCRIPT_URI if not set in request
 OPTION(rgw_request_uri, OPT_STR) // alternative value for REQUEST_URI if not set in request

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5050,6 +5050,11 @@ std::vector<Option> get_rgw_options() {
           "concurrency of lifecycle maintenance, but requires multiple RGW processes "
           "running on the zone to be utilized."),
 
+    Option("rgw_lc_max_rules", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1000)
+    .set_description("Max number of lifecycle rules set on one bucket")
+    .set_long_description("Number of lifecycle rules set on one bucket should be limited."),
+
     Option("rgw_lc_debug_interval", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(-1)
     .set_description(""),

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -70,6 +70,11 @@ bool RGWLifecycleConfiguration_S3::xml_end(const char *el) {
     add_rule(rule);
     rule = static_cast<LCRule_S3 *>(iter.get_next());
   }
+  if (cct->_conf->rgw_lc_max_rules < rule_map.size()) {
+    ldout(cct, 5) << "Warn: The lifecycle config has too many rules, rule number is:" 
+                  << rule_map.size() << ", max number is:" << cct->_conf->rgw_lc_max_rules << dendl;
+    return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/26845