### PR TITLE
Ceph-fuse: check_caps nodelay when handle_cap_grant

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5199,7 +5199,7 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, MClient
   }
 
   if (check)
-    check_caps(in, 0);
+    check_caps(in, CHECK_CAPS_NODELAY);
 
   // wake up waiters
   if (new_caps)


### PR DESCRIPTION

when client-A is writing a log to file F every second，and client-B exec “tail -f A”，client-B will stuck severl seconds frequently due caps delay revoke.

Fixes:
Signed-off-by: redickwang <redickwang@tencent.com>


