### PR TITLE
mon: add command ceph mon status 

### DIFF
--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -110,7 +110,7 @@ bool cmd_getval_throws(
     }
   } else {
     val = defval;
-    return true;
+    return false;
   }
 }
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -276,6 +276,7 @@ COMMAND("mon versions",
 COMMAND("versions",
 	"check running versions of ceph daemons",
 	"mon", "r", "cli,rest")
+COMMAND("mon status", "print status of monitors", "mon", "r", "cli,rest")
 
 
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -682,7 +682,7 @@ public:
                         const cmdmap_t& cmdmap,
                         const map<string,string>& param_str_map,
                         const MonCommand *this_cmd);
-  void get_mon_status(Formatter *f, ostream& ss);
+  void get_mon_status(Formatter *f, ostream& ss, bool plain = false);
   void _quorum_status(Formatter *f, ostream& ss);
   bool _add_bootstrap_peer_hint(std::string_view cmd, const cmdmap_t& cmdmap,
 				std::ostream& ss);


### PR DESCRIPTION
This command should provide service-related status; e.g.,`ceph mon status` should provide information on the running monitor daemons, election epoch, quorum, etc, much like `ceph mon_status`, except that with a user interface that sort of makes sense.

issue : [https://tracker.ceph.com/issues/24232](https://tracker.ceph.com/issues/24232)

Signed-off-by: Hsiao-Yin <s02561084s@gmail.com>

