### PR TITLE
mds: use fast dispatch to handle MDSBeacon

### DIFF
--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -79,12 +79,24 @@ void Beacon::shutdown()
   timer.shutdown();
 }
 
+bool Beacon::ms_can_fast_dispatch(const Message *m) const
+{
+  return m->get_type() == MSG_MDS_BEACON;
+}
+
+void Beacon::ms_fast_dispatch(Message *m)
+{
+  bool handled = ms_dispatch(m);
+  assert(handled);
+}
 
 bool Beacon::ms_dispatch(Message *m)
 {
   if (m->get_type() == MSG_MDS_BEACON) {
     if (m->get_connection()->get_peer_type() == CEPH_ENTITY_TYPE_MON) {
       handle_mds_beacon(static_cast<MMDSBeacon*>(m));
+    } else {
+      m->put();
     }
     return true;
   }

--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -48,6 +48,9 @@ public:
   void init(MDSMap const *mdsmap);
   void shutdown();
 
+  bool ms_can_fast_dispatch_any() const override { return true; }
+  bool ms_can_fast_dispatch(const Message *m) const override;
+  void ms_fast_dispatch(Message *m) override;
   bool ms_dispatch(Message *m) override;
   void ms_handle_connect(Connection *c) override {}
   bool ms_handle_reset(Connection *c) override {return false;}


### PR DESCRIPTION
Current mds handles MDSBeacon messages through MDSRank::ms_dispatch().
MDSRank::ms_dispatch() locks mds_lock at the very beginning. This means
that long running task (such as processing finished contexts) can delay
MMDSBeacon. Using fast dispatch for MDSBeacon can avoid this issue.

Fixes: http://tracker.ceph.com/issues/23519
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

