### PR TITLE
osd: make random shuffle comply with C++17

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -19,6 +19,7 @@
 
 #include "OSDMap.h"
 #include <algorithm>
+#include <random>
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/Formatter.h"
@@ -5198,7 +5199,9 @@ void OSDMap::get_random_up_osds_by_subtree(int n,     // whoami
     return;
   vector<int> subtrees;
   crush->get_subtree_of_type(subtree_type, &subtrees);
-  std::random_shuffle(subtrees.begin(), subtrees.end());
+  std::random_device rd;
+  std::default_random_engine rng{rd()};
+  std::shuffle(subtrees.begin(), subtrees.end(), rng);
   for (auto s : subtrees) {
     if (limit <= 0)
       break;


### PR DESCRIPTION
random_shuffle is deprecated in C++14 and removed in C++17 on FreeBSD
(As per the standard)

So this code does not compile on FreeBSD with Clang 6

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>