### PR TITLE
jewel: rgw: add support for account and container quotas of Swift API

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1096,9 +1096,9 @@ void set_quota_info(RGWQuotaInfo& quota, int opt_cmd, int64_t max_size, int64_t 
       }
       if (have_max_size) {
         if (max_size < 0) {
-          quota.max_size_kb = -1;
+          quota.max_size = -1;
         } else {
-          quota.max_size_kb = rgw_rounded_kb(max_size);
+          quota.max_size = rgw_rounded_kb(max_size) * 1024;
         }
       }
       break;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -870,8 +870,10 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
     RGWStorageStats& s = iter->second;
     const char *cat_name = rgw_obj_category_name(iter->first);
     formatter->open_object_section(cat_name);
-    formatter->dump_int("size_kb", s.num_kb);
-    formatter->dump_int("size_kb_actual", s.num_kb_rounded);
+    formatter->dump_int("size", s.size);
+    formatter->dump_int("size_actual", s.size_rounded);
+    formatter->dump_int("size_kb", rgw_rounded_kb(s.size));
+    formatter->dump_int("size_kb_actual", rgw_rounded_kb(s.size_rounded));
     formatter->dump_int("num_objects", s.num_objects);
     formatter->close_section();
     formatter->flush(cout);

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -978,8 +978,10 @@ static void dump_bucket_usage(map<RGWObjCategory, RGWStorageStats>& stats, Forma
     RGWStorageStats& s = iter->second;
     const char *cat_name = rgw_obj_category_name(iter->first);
     formatter->open_object_section(cat_name);
-    formatter->dump_int("size_kb", s.num_kb);
-    formatter->dump_int("size_kb_actual", s.num_kb_rounded);
+    formatter->dump_int("size", s.size);
+    formatter->dump_int("size_actual", s.size_rounded);
+    formatter->dump_int("size_kb", rgw_rounded_kb(s.size));
+    formatter->dump_int("size_kb_actual", rgw_rounded_kb(s.size_rounded));
     formatter->dump_int("num_objects", s.num_objects);
     formatter->close_section();
   }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -88,6 +88,10 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_TEMPURL_KEY1   RGW_ATTR_META_PREFIX "temp-url-key"
 #define RGW_ATTR_TEMPURL_KEY2   RGW_ATTR_META_PREFIX "temp-url-key-2"
 
+/* Container quota of the Swift API. */
+#define RGW_ATTR_CQUOTA_NOBJS   RGW_ATTR_META_PREFIX "quota-count"
+#define RGW_ATTR_CQUOTA_MSIZE   RGW_ATTR_META_PREFIX "quota-bytes"
+
 #define RGW_ATTR_OLH_PREFIX     RGW_ATTR_PREFIX "olh."
 
 #define RGW_ATTR_OLH_INFO       RGW_ATTR_OLH_PREFIX "info"

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -88,9 +88,9 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_TEMPURL_KEY1   RGW_ATTR_META_PREFIX "temp-url-key"
 #define RGW_ATTR_TEMPURL_KEY2   RGW_ATTR_META_PREFIX "temp-url-key-2"
 
-/* Container quota of the Swift API. */
-#define RGW_ATTR_CQUOTA_NOBJS   RGW_ATTR_META_PREFIX "quota-count"
-#define RGW_ATTR_CQUOTA_MSIZE   RGW_ATTR_META_PREFIX "quota-bytes"
+/* Account/container quota of the Swift API. */
+#define RGW_ATTR_QUOTA_NOBJS    RGW_ATTR_META_PREFIX "quota-count"
+#define RGW_ATTR_QUOTA_MSIZE    RGW_ATTR_META_PREFIX "quota-bytes"
 
 #define RGW_ATTR_OLH_PREFIX     RGW_ATTR_PREFIX "olh."
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1083,11 +1083,15 @@ WRITE_CLASS_ENCODER(RGWBucketEntryPoint)
 struct RGWStorageStats
 {
   RGWObjCategory category;
-  uint64_t num_kb;
-  uint64_t num_kb_rounded;
+  uint64_t size;
+  uint64_t size_rounded;
   uint64_t num_objects;
 
-  RGWStorageStats() : category(RGW_OBJ_CATEGORY_NONE), num_kb(0), num_kb_rounded(0), num_objects(0) {}
+  RGWStorageStats()
+    : category(RGW_OBJ_CATEGORY_NONE),
+      size(0),
+      size_rounded(0),
+      num_objects(0) {}
 
   void dump(Formatter *f) const;
 };
@@ -1858,6 +1862,11 @@ static inline const char *rgw_obj_category_name(RGWObjCategory category)
 static inline uint64_t rgw_rounded_kb(uint64_t bytes)
 {
   return (bytes + 1023) / 1024;
+}
+
+static inline uint64_t rgw_rounded_objsize(uint64_t bytes)
+{
+  return ((bytes + 4095) & ~4095);
 }
 
 static inline uint64_t rgw_rounded_objsize_kb(uint64_t bytes)

--- a/src/rgw/rgw_http_errors.h
+++ b/src/rgw/rgw_http_errors.h
@@ -76,7 +76,8 @@ const static struct rgw_http_errors RGW_HTTP_SWIFT_ERRORS[] = {
     { ERR_USER_SUSPENDED, 401, "UserSuspended" },
     { ERR_INVALID_UTF8, 412, "Invalid UTF8" },
     { ERR_BAD_URL, 412, "Bad URL" },
-    { ERR_NOT_SLO_MANIFEST, 400, "Not an SLO manifest" }
+    { ERR_NOT_SLO_MANIFEST, 400, "Not an SLO manifest" },
+    { ERR_QUOTA_EXCEEDED, 413, "QuotaExceeded" }
 };
 
 struct rgw_http_status_code {

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -488,13 +488,20 @@ void RGWUserInfo::decode_json(JSONObj *obj)
 void RGWQuotaInfo::dump(Formatter *f) const
 {
   f->dump_bool("enabled", enabled);
-  f->dump_int("max_size_kb", max_size_kb);
+  f->dump_int("max_size", max_size);
+  f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
 }
 
 void RGWQuotaInfo::decode_json(JSONObj *obj)
 {
-  JSONDecoder::decode_json("max_size_kb", max_size_kb, obj);
+  if (false == JSONDecoder::decode_json("max_size", max_size, obj)) {
+    /* We're parsing an older version of the struct. */
+    int64_t max_size_kb = 0;
+
+    JSONDecoder::decode_json("max_size_kb", max_size_kb, obj);
+    max_size = max_size_kb * 1024;
+  }
   JSONDecoder::decode_json("max_objects", max_objects, obj);
   JSONDecoder::decode_json("enabled", enabled, obj);
 }

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -488,6 +488,8 @@ void RGWUserInfo::decode_json(JSONObj *obj)
 void RGWQuotaInfo::dump(Formatter *f) const
 {
   f->dump_bool("enabled", enabled);
+  f->dump_bool("check_on_raw", check_on_raw);
+
   f->dump_int("max_size", max_size);
   f->dump_int("max_size_kb", rgw_rounded_kb(max_size));
   f->dump_int("max_objects", max_objects);
@@ -503,6 +505,8 @@ void RGWQuotaInfo::decode_json(JSONObj *obj)
     max_size = max_size_kb * 1024;
   }
   JSONDecoder::decode_json("max_objects", max_objects, obj);
+
+  JSONDecoder::decode_json("check_on_raw", check_on_raw, obj);
   JSONDecoder::decode_json("enabled", enabled, obj);
 }
 

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -548,8 +548,10 @@ void RGWBucketEntryPoint::decode_json(JSONObj *obj) {
 
 void RGWStorageStats::dump(Formatter *f) const
 {
-  encode_json("num_kb", num_kb, f);
-  encode_json("num_kb_rounded", num_kb_rounded, f);
+  encode_json("size", size, f);
+  encode_json("size_rounded", size_rounded, f);
+  encode_json("num_kb", rgw_rounded_kb(size), f);
+  encode_json("num_kb_rounded", rgw_rounded_kb(size_rounded), f);
   encode_json("num_objects", num_objects, f);
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2058,6 +2058,8 @@ static int filter_out_bucket_quota(std::map<std::string, bufferlist>& add_attrs,
     }
   }
 
+  /* Swift requries checking on raw usage instead of the 4 KiB rounded one. */
+  quota.check_on_raw = true;
   quota.enabled = quota.max_size > 0 || quota.max_objects > 0;
   return 0;
 }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -773,7 +773,12 @@ public:
 
 class RGWPutMetadataAccount : public RGWOp {
 protected:
-  set<string> rmattr_names;
+  std::set<std::string> rmattr_names;
+  std::map<std::string, bufferlist> attrs, orig_attrs;
+  std::map<int, std::string> temp_url_keys;
+
+  RGWObjVersionTracker acct_op_tracker;
+
   RGWAccessControlPolicy policy;
 
 public:
@@ -783,6 +788,7 @@ public:
     RGWOp::init(store, s, h);
     policy.set_ctx(s->cct);
   }
+  int init_processing();
   int verify_permission();
   void pre_exec() { }
   void execute();

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -792,7 +792,6 @@ public:
   virtual void filter_out_temp_url(map<string, bufferlist>& add_attrs,
                                    const set<string>& rmattr_names,
                                    map<int, string>& temp_url_keys);
-  virtual int handle_temp_url_update(const map<int, string>& temp_url_keys);
   virtual const string name() { return "put_account_metadata"; }
   virtual RGWOpType get_type() { return RGW_OP_PUT_METADATA_ACCOUNT; }
   virtual uint32_t op_mask() { return RGW_OP_TYPE_WRITE; }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -776,13 +776,17 @@ protected:
   std::set<std::string> rmattr_names;
   std::map<std::string, bufferlist> attrs, orig_attrs;
   std::map<int, std::string> temp_url_keys;
+  RGWQuotaInfo new_quota;
+  bool new_quota_extracted;
 
   RGWObjVersionTracker acct_op_tracker;
 
   RGWAccessControlPolicy policy;
 
 public:
-  RGWPutMetadataAccount() {}
+  RGWPutMetadataAccount()
+    : new_quota_extracted(false) {
+  }
 
   virtual void init(RGWRados *store, struct req_state *s, RGWHandler *h) {
     RGWOp::init(store, s, h);

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -695,6 +695,97 @@ void RGWUserStatsCache::data_modified(const rgw_user& user, rgw_bucket& bucket)
 }
 
 
+class RGWQuotaInfoApplier {
+  /* NOTE: no non-static field allowed as instances are supposed to live in
+   * the static memory only. */
+protected:
+  RGWQuotaInfoApplier() = default;
+
+public:
+  virtual ~RGWQuotaInfoApplier() {}
+
+  virtual bool is_size_exceeded(const char * const entity,
+                                const RGWQuotaInfo& qinfo,
+                                const RGWStorageStats& stats,
+                                const uint64_t size) const = 0;
+
+  virtual bool is_num_objs_exceeded(const char * const entity,
+                                    const RGWQuotaInfo& qinfo,
+                                    const RGWStorageStats& stats,
+                                    const uint64_t num_objs) const = 0;
+
+  static const RGWQuotaInfoApplier& get_instance(const RGWQuotaInfo& qinfo);
+};
+
+class RGWQuotaInfoDefApplier : public RGWQuotaInfoApplier {
+public:
+  virtual bool is_size_exceeded(const char * const entity,
+                                const RGWQuotaInfo& qinfo,
+                                const RGWStorageStats& stats,
+                                const uint64_t size) const;
+
+  virtual bool is_num_objs_exceeded(const char * const entity,
+                                    const RGWQuotaInfo& qinfo,
+                                    const RGWStorageStats& stats,
+                                    const uint64_t num_objs) const;
+};
+
+
+bool RGWQuotaInfoDefApplier::is_size_exceeded(const char * const entity,
+                                              const RGWQuotaInfo& qinfo,
+                                              const RGWStorageStats& stats,
+                                              const uint64_t size) const
+{
+  if (qinfo.max_size_kb < 0) {
+    /* The limit is not enabled. */
+    return false;
+  }
+
+  /* Handling quota in KiBs due to backward compatibility. */
+  const uint64_t add_size_kb = rgw_rounded_objsize_kb(size);
+  /* XXX: just div 1024 should be enough. */
+  const uint64_t cur_size_kb = rgw_rounded_kb(stats.size_rounded);
+  const uint64_t stats_num_kb_rounded = rgw_rounded_kb(stats.size_rounded);
+
+  if (cur_size_kb + add_size_kb > static_cast<uint64_t>(qinfo.max_size_kb)) {
+    dout(10) << "quota exceeded: stats_num_kb_rounded=" << stats_num_kb_rounded
+             << " size_kb=" << add_size_kb << " "
+             << entity << "_quota.max_size_kb=" << qinfo.max_size_kb << dendl;
+    return true;
+  }
+
+  return false;
+}
+
+bool RGWQuotaInfoDefApplier::is_num_objs_exceeded(const char * const entity,
+                                                  const RGWQuotaInfo& qinfo,
+                                                  const RGWStorageStats& stats,
+                                                  const uint64_t num_objs) const
+{
+  if (qinfo.max_objects < 0) {
+    /* The limit is not enabled. */
+    return false;
+  }
+
+  if (stats.num_objects + num_objs > static_cast<uint64_t>(qinfo.max_objects)) {
+    dout(10) << "quota exceeded: stats.num_objects=" << stats.num_objects
+             << " " << entity << "_quota.max_objects=" << qinfo.max_objects
+             << dendl;
+    return true;
+  }
+
+  return false;
+}
+
+const RGWQuotaInfoApplier& RGWQuotaInfoApplier::get_instance(
+  const RGWQuotaInfo& qinfo)
+{
+  static RGWQuotaInfoDefApplier default_qapplier;
+
+  return default_qapplier;
+}
+
+
 class RGWQuotaHandlerImpl : public RGWQuotaHandler {
   RGWRados *store;
   RGWBucketStatsCache bucket_stats_cache;
@@ -711,37 +802,24 @@ class RGWQuotaHandlerImpl : public RGWQuotaHandler {
       return 0;
     }
 
+    const auto& quota_applier = RGWQuotaInfoApplier::get_instance(quota);
+
     ldout(store->ctx(), 20) << entity
                             << " quota: max_objects=" << quota.max_objects
                             << " max_size_kb=" << quota.max_size_kb << dendl;
 
-    if (quota.max_objects >= 0 &&
-        stats.num_objects + num_objs > (uint64_t)quota.max_objects) {
-      ldout(store->ctx(), 10) << "quota exceeded: stats.num_objects="
-                              << stats.num_objects
-                              << " " << entity << "_quota.max_objects="
-                              << quota.max_objects << dendl;
 
+    if (quota_applier.is_num_objs_exceeded(entity, quota, stats, num_objs)) {
       return -ERR_QUOTA_EXCEEDED;
     }
 
-    /* Handling quota in KiBs due to backward compatibility. */
-    if (quota.max_size_kb >= 0) {
-      const uint64_t size_kb = rgw_rounded_objsize_kb(size);
-      /* XXX: just div 1024 should be enough. */
-      const uint64_t stats_num_kb_rounded = rgw_rounded_kb(stats.size_rounded);
-
-      if (stats_num_kb_rounded + size_kb > (uint64_t)quota.max_size_kb) {
-        ldout(store->ctx(), 10) << "quota exceeded: stats_num_kb_rounded="
-                                << stats_num_kb_rounded
-                                << " size_kb=" << size_kb << " " << entity
-                                << "_quota.max_size_kb="
-                                << quota.max_size_kb << dendl;
-
-        return -ERR_QUOTA_EXCEEDED;
-      }
+    if (quota_applier.is_size_exceeded(entity, quota, stats, size)) {
+      return -ERR_QUOTA_EXCEEDED;
     }
 
+    ldout(store->ctx(), 20) << entity << " quota OK:"
+                            << " stats.num_objects=" << stats.num_objects
+                            << " stats.size=" << stats.size << dendl;
     return 0;
   }
 public:

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -755,10 +755,11 @@ bool RGWQuotaInfoDefApplier::is_size_exceeded(const char * const entity,
   }
 
   const uint64_t cur_size = stats.size_rounded;
+  const uint64_t new_size = rgw_rounded_objsize(size);
 
-  if (cur_size + size > static_cast<uint64_t>(qinfo.max_size)) {
+  if (cur_size + new_size > static_cast<uint64_t>(qinfo.max_size)) {
     dout(10) << "quota exceeded: stats.size_rounded=" << stats.size_rounded
-             << " size=" << size << " "
+             << " size=" << new_size << " "
              << entity << "_quota.max_size=" << qinfo.max_size << dendl;
     return true;
   }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -730,6 +730,19 @@ public:
                                     const uint64_t num_objs) const;
 };
 
+class RGWQuotaInfoRawApplier : public RGWQuotaInfoApplier {
+public:
+  virtual bool is_size_exceeded(const char * const entity,
+                                const RGWQuotaInfo& qinfo,
+                                const RGWStorageStats& stats,
+                                const uint64_t size) const;
+
+  virtual bool is_num_objs_exceeded(const char * const entity,
+                                    const RGWQuotaInfo& qinfo,
+                                    const RGWStorageStats& stats,
+                                    const uint64_t num_objs) const;
+};
+
 
 bool RGWQuotaInfoDefApplier::is_size_exceeded(const char * const entity,
                                               const RGWQuotaInfo& qinfo,
@@ -773,12 +786,59 @@ bool RGWQuotaInfoDefApplier::is_num_objs_exceeded(const char * const entity,
   return false;
 }
 
+bool RGWQuotaInfoRawApplier::is_size_exceeded(const char * const entity,
+                                              const RGWQuotaInfo& qinfo,
+                                              const RGWStorageStats& stats,
+                                              const uint64_t size) const
+{
+  if (qinfo.max_size < 0) {
+    /* The limit is not enabled. */
+    return false;
+  }
+
+  const uint64_t cur_size = stats.size;
+
+  if (cur_size + size > static_cast<uint64_t>(qinfo.max_size)) {
+    dout(10) << "quota exceeded: stats.size=" << stats.size
+             << " size=" << size << " "
+             << entity << "_quota.max_size=" << qinfo.max_size << dendl;
+    return true;
+  }
+
+  return false;
+}
+
+bool RGWQuotaInfoRawApplier::is_num_objs_exceeded(const char * const entity,
+                                                  const RGWQuotaInfo& qinfo,
+                                                  const RGWStorageStats& stats,
+                                                  const uint64_t num_objs) const
+{
+  if (qinfo.max_objects < 0) {
+    /* The limit is not enabled. */
+    return false;
+  }
+
+  if (stats.num_objects + num_objs > static_cast<uint64_t>(qinfo.max_objects)) {
+    dout(10) << "quota exceeded: stats.num_objects=" << stats.num_objects
+             << " " << entity << "_quota.max_objects=" << qinfo.max_objects
+             << dendl;
+    return true;
+  }
+
+  return false;
+}
+
 const RGWQuotaInfoApplier& RGWQuotaInfoApplier::get_instance(
   const RGWQuotaInfo& qinfo)
 {
   static RGWQuotaInfoDefApplier default_qapplier;
+  static RGWQuotaInfoRawApplier raw_qapplier;
 
-  return default_qapplier;
+  if (qinfo.check_on_raw) {
+    return raw_qapplier;
+  } else {
+    return default_qapplier;
+  }
 }
 
 

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -102,9 +102,9 @@ public:
 template<class T>
 bool RGWQuotaCache<T>::can_use_cached_stats(RGWQuotaInfo& quota, RGWStorageStats& cached_stats)
 {
-  if (quota.max_size_kb >= 0) {
+  if (quota.max_size >= 0) {
     if (quota.max_size_soft_threshold < 0) {
-      quota.max_size_soft_threshold = quota.max_size_kb * store->ctx()->_conf->rgw_bucket_quota_soft_threshold;
+      quota.max_size_soft_threshold = quota.max_size * store->ctx()->_conf->rgw_bucket_quota_soft_threshold;
     }
 
     const auto cached_stats_num_kb_rounded = rgw_rounded_kb(cached_stats.size_rounded);
@@ -736,21 +736,17 @@ bool RGWQuotaInfoDefApplier::is_size_exceeded(const char * const entity,
                                               const RGWStorageStats& stats,
                                               const uint64_t size) const
 {
-  if (qinfo.max_size_kb < 0) {
+  if (qinfo.max_size < 0) {
     /* The limit is not enabled. */
     return false;
   }
 
-  /* Handling quota in KiBs due to backward compatibility. */
-  const uint64_t add_size_kb = rgw_rounded_objsize_kb(size);
-  /* XXX: just div 1024 should be enough. */
-  const uint64_t cur_size_kb = rgw_rounded_kb(stats.size_rounded);
-  const uint64_t stats_num_kb_rounded = rgw_rounded_kb(stats.size_rounded);
+  const uint64_t cur_size = stats.size_rounded;
 
-  if (cur_size_kb + add_size_kb > static_cast<uint64_t>(qinfo.max_size_kb)) {
-    dout(10) << "quota exceeded: stats_num_kb_rounded=" << stats_num_kb_rounded
-             << " size_kb=" << add_size_kb << " "
-             << entity << "_quota.max_size_kb=" << qinfo.max_size_kb << dendl;
+  if (cur_size + size > static_cast<uint64_t>(qinfo.max_size)) {
+    dout(10) << "quota exceeded: stats.size_rounded=" << stats.size_rounded
+             << " size=" << size << " "
+             << entity << "_quota.max_size=" << qinfo.max_size << dendl;
     return true;
   }
 
@@ -806,7 +802,7 @@ class RGWQuotaHandlerImpl : public RGWQuotaHandler {
 
     ldout(store->ctx(), 20) << entity
                             << " quota: max_objects=" << quota.max_objects
-                            << " max_size_kb=" << quota.max_size_kb << dendl;
+                            << " max_size=" << quota.max_size << dendl;
 
 
     if (quota_applier.is_num_objs_exceeded(entity, quota, stats, num_objs)) {

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -42,17 +42,21 @@ public:
   int64_t max_size;
   int64_t max_objects;
   bool enabled;
+  /* Do we want to compare with raw, not rounded RGWStorageStats::size (true)
+   * or maybe rounded-to-4KiB RGWStorageStats::size_rounded (false)? */
+  bool check_on_raw;
 
   RGWQuotaInfo()
     : max_size_soft_threshold(-1),
       max_objs_soft_threshold(-1),
       max_size(-1),
       max_objects(-1),
-      enabled(false) {
+      enabled(false),
+      check_on_raw(false) {
   }
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     if (max_size < 0) {
       ::encode(-rgw_rounded_kb(abs(max_size)), bl);
     } else {
@@ -61,10 +65,11 @@ public:
     ::encode(max_objects, bl);
     ::encode(enabled, bl);
     ::encode(max_size, bl);
+    ::encode(check_on_raw, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(2, 1, 1, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(3, 1, 1, bl);
     int64_t max_size_kb;
     ::decode(max_size_kb, bl);
     ::decode(max_objects, bl);
@@ -73,6 +78,9 @@ public:
       max_size = max_size_kb * 1024;
     } else {
       ::decode(max_size, bl);
+    }
+    if (struct_v >= 3) {
+      ::decode(check_on_raw, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_quota.h
+++ b/src/rgw/rgw_quota.h
@@ -24,14 +24,27 @@ class RGWRados;
 class JSONObj;
 
 struct RGWQuotaInfo {
-  int64_t max_size_kb;
-  int64_t max_objects;
-  bool enabled;
+  template<class T> friend class RGWQuotaCache;
+protected:
+  /* The quota thresholds after which comparing against cached storage stats
+   * is disallowed. Those fields may be accessed only by the RGWQuotaCache.
+   * They are not intended as tunables but rather as a mean to store results
+   * of repeating calculations in the quota cache subsystem. */
   int64_t max_size_soft_threshold;
   int64_t max_objs_soft_threshold;
 
-  RGWQuotaInfo() : max_size_kb(-1), max_objects(-1), enabled(false),
-                   max_size_soft_threshold(-1), max_objs_soft_threshold(-1) {}
+public:
+  int64_t max_size_kb;
+  int64_t max_objects;
+  bool enabled;
+
+  RGWQuotaInfo()
+    : max_size_soft_threshold(-1),
+      max_objs_soft_threshold(-1),
+      max_size_kb(-1),
+      max_objects(-1),
+      enabled(false) {
+  }
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5300,6 +5300,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& zonegroup_id,
                             const string& placement_rule,
                             const string& swift_ver_location,
+                            const RGWQuotaInfo * pquota_info,
 			    map<std::string, bufferlist>& attrs,
                             RGWBucketInfo& info,
                             obj_version *pobjv,
@@ -5366,10 +5367,14 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.swift_versioning = (!swift_ver_location.empty());
     info.bucket_index_shard_hash_type = RGWBucketInfo::MOD;
     info.requester_pays = false;
-    if (real_clock::is_zero(creation_time))
+    if (real_clock::is_zero(creation_time)) {
       info.creation_time = ceph::real_clock::now(cct);
-    else
+    } else {
       info.creation_time = creation_time;
+    }
+    if (pquota_info) {
+      info.quota = *pquota_info;
+    }
     ret = put_linked_bucket_info(info, exclusive, ceph::real_time(), pep_objv, &attrs, true);
     if (ret == -EEXIST) {
        /* we need to reread the info and return it, caller will have a use for it */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7852,16 +7852,18 @@ int RGWRados::open_bucket_index_shard(rgw_bucket& bucket, librados::IoCtx& index
   return 0;
 }
 
-static void accumulate_raw_stats(rgw_bucket_dir_header& header, map<RGWObjCategory, RGWStorageStats>& stats)
+static void accumulate_raw_stats(const rgw_bucket_dir_header& header,
+                                 map<RGWObjCategory, RGWStorageStats>& stats)
 {
-  map<uint8_t, struct rgw_bucket_category_stats>::iterator iter = header.stats.begin();
-  for (; iter != header.stats.end(); ++iter) {
-    RGWObjCategory category = (RGWObjCategory)iter->first;
+  for (const auto& pair : header.stats) {
+    const RGWObjCategory category = static_cast<RGWObjCategory>(pair.first);
+    const rgw_bucket_category_stats& header_stats = pair.second;
+
     RGWStorageStats& s = stats[category];
-    struct rgw_bucket_category_stats& header_stats = iter->second;
-    s.category = (RGWObjCategory)iter->first;
-    s.num_kb += ((header_stats.total_size + 1023) / 1024);
-    s.num_kb_rounded += ((header_stats.total_size_rounded + 1023) / 1024);
+
+    s.category = category;
+    s.size += header_stats.total_size;
+    s.size_rounded += header_stats.total_size_rounded;
     s.num_objects += header_stats.num_entries;
   }
 }
@@ -10816,14 +10818,16 @@ class RGWGetUserStatsContext : public RGWGetUserHeader_CB {
   RGWGetUserStats_CB *cb;
 
 public:
-  explicit RGWGetUserStatsContext(RGWGetUserStats_CB *_cb) : cb(_cb) {}
+  explicit RGWGetUserStatsContext(RGWGetUserStats_CB * const cb)
+    : cb(cb) {}
+
   void handle_response(int r, cls_user_header& header) {
-    cls_user_stats& hs = header.stats;
+    const cls_user_stats& hs = header.stats;
     if (r >= 0) {
       RGWStorageStats stats;
 
-      stats.num_kb = (hs.total_bytes + 1023) / 1024;
-      stats.num_kb_rounded = (hs.total_bytes_rounded + 1023) / 1024;
+      stats.size = hs.total_bytes;
+      stats.size_rounded = hs.total_bytes_rounded;
       stats.num_objects = hs.total_entries;
 
       cb->set_response(stats);
@@ -10844,10 +10848,10 @@ int RGWRados::get_user_stats(const rgw_user& user, RGWStorageStats& stats)
   if (r < 0)
     return r;
 
-  cls_user_stats& hs = header.stats;
+  const cls_user_stats& hs = header.stats;
 
-  stats.num_kb = (hs.total_bytes + 1023) / 1024;
-  stats.num_kb_rounded = (hs.total_bytes_rounded + 1023) / 1024;
+  stats.size = hs.total_bytes;
+  stats.size_rounded = hs.total_bytes_rounded;
   stats.num_objects = hs.total_entries;
 
   return 0;
@@ -12281,8 +12285,8 @@ int RGWRados::update_user_bucket_stats(const string& user_id, rgw_bucket& bucket
 {
   cls_user_bucket_entry entry;
 
-  entry.size = stats.num_kb * 1024;
-  entry.size_rounded = stats.num_kb_rounded * 1024;
+  entry.size = stats.size;
+  entry.size_rounded = stats.size_rounded;
   entry.count += stats.num_objects;
 
   list<cls_user_bucket_entry> entries;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2141,6 +2141,7 @@ public:
                             const string& zonegroup_id,
                             const string& placement_rule,
                             const string& swift_ver_location,
+                            const RGWQuotaInfo * pquota_info,
                             map<std::string,bufferlist>& attrs,
                             RGWBucketInfo& bucket_info,
                             obj_version *pobjv,

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -928,8 +928,11 @@ void RGWOp_Quota_Set::execute()
         old_quota = &info.bucket_quota;
       }
 
+      int64_t old_max_size_kb = rgw_rounded_kb(old_quota->max_size);
+      int64_t max_size_kb;
       RESTArgs::get_int64(s, "max-objects", old_quota->max_objects, &quota.max_objects);
-      RESTArgs::get_int64(s, "max-size-kb", old_quota->max_size_kb, &quota.max_size_kb);
+      RESTArgs::get_int64(s, "max-size-kb", old_max_size_kb, &max_size_kb);
+      quota.max_size = max_size_kb * 1024;
       RESTArgs::get_bool(s, "enabled", old_quota->enabled, &quota.enabled);
     }
 

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -156,7 +156,7 @@ void RGWOp_User_Create::execute()
   }
 
   if (s->cct->_conf->rgw_bucket_default_quota_max_size >= 0) {
-    bucket_quota.max_size_kb = s->cct->_conf->rgw_bucket_default_quota_max_size;
+    bucket_quota.max_size = s->cct->_conf->rgw_bucket_default_quota_max_size;
     bucket_quota.enabled = true;
   }
 
@@ -166,7 +166,7 @@ void RGWOp_User_Create::execute()
   }
 
   if (s->cct->_conf->rgw_user_default_quota_max_size >= 0) {
-    user_quota.max_size_kb = s->cct->_conf->rgw_user_default_quota_max_size;
+    user_quota.max_size = s->cct->_conf->rgw_user_default_quota_max_size;
     user_quota.enabled = true;
   }
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1949,7 +1949,7 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
       user_info.bucket_quota.enabled = true;
     }
     if (cct->_conf->rgw_bucket_default_quota_max_size >= 0) {
-      user_info.bucket_quota.max_size_kb = cct->_conf->rgw_bucket_default_quota_max_size;
+      user_info.bucket_quota.max_size = cct->_conf->rgw_bucket_default_quota_max_size;
       user_info.bucket_quota.enabled = true;
     }
   }
@@ -1970,7 +1970,7 @@ int RGWUser::execute_add(RGWUserAdminOpState& op_state, std::string *err_msg)
       user_info.user_quota.enabled = true;
     }
     if (cct->_conf->rgw_user_default_quota_max_size >= 0) {
-      user_info.user_quota.max_size_kb = cct->_conf->rgw_user_default_quota_max_size;
+      user_info.user_quota.max_size = cct->_conf->rgw_user_default_quota_max_size;
       user_info.user_quota.enabled = true;
     }
   }


### PR DESCRIPTION
This is a variation of PR #9037 backported to jewel.

The only diferences here are those because of logic differences in jewel, or backports of other commits that were done in a different order on jewel than on master (such as 17d2c1712a/22348154ad).