### PR TITLE
mds: mark beacons as high priority

### DIFF
--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -208,13 +208,15 @@ class MMDSBeacon : public PaxosServiceMessage {
     : PaxosServiceMessage(MSG_MDS_BEACON, 0, HEAD_VERSION, COMPAT_VERSION),
     global_id(0), state(MDSMap::STATE_NULL), standby_for_rank(MDS_RANK_NONE),
     standby_for_fscid(FS_CLUSTER_ID_NONE), standby_replay(false),
-    mds_features(0)
-  { }
+    mds_features(0) {
+    set_priority(CEPH_MSG_PRIO_HIGH);
+  }
   MMDSBeacon(const uuid_d &f, mds_gid_t g, string& n, epoch_t les, MDSMap::DaemonState st, version_t se, uint64_t feat) :
     PaxosServiceMessage(MSG_MDS_BEACON, les, HEAD_VERSION, COMPAT_VERSION),
     fsid(f), global_id(g), name(n), state(st), seq(se),
     standby_for_rank(MDS_RANK_NONE), standby_for_fscid(FS_CLUSTER_ID_NONE),
     standby_replay(false), mds_features(feat) {
+    set_priority(CEPH_MSG_PRIO_HIGH);
   }
 private:
   ~MMDSBeacon() override {}


### PR DESCRIPTION
The mons already mark beacon replies as high priority (via default mon message
priority). We should expect that the mons handle our beacons at the same
priority so the MDS doesn't wrongly get marked laggy.

Fixes: http://tracker.ceph.com/issues/26899

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>