### PR TITLE
tools/cephfs: make cephfs-data-scan prints the max used ino

### DIFF
--- a/doc/cephfs/disaster-recovery-experts.rst
+++ b/doc/cephfs/disaster-recovery-experts.rst
@@ -183,6 +183,14 @@ The example below shows how to run 4 workers simultaneously:
 It is **important** to ensure that all workers have completed the
 scan_extents phase before any workers enter the scan_inodes phase.
 
+Output of 'scan_links' command includes max used inode number for each
+MDS rank. You may need to update InoTables of each MDS rank.
+
+::
+    cephfs-table-tool recovery-fs:x show inode
+    cephfs-table-tool recovery-fs:x take_inos <max ino of mds.x)
+
+
 After completing the metadata recovery, you may want to run cleanup
 operation to delete ancillary data geneated during recovery.
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/26925
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

