### PR TITLE
rgw: delete multi object num limit

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1542,3 +1542,4 @@ OPTION(rgw_reshard_thread_interval, OPT_U32) // maximum time between rounds of r
 
 OPTION(rgw_acl_grants_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html), An ACL can have up to 100 grants.
 OPTION(rgw_cors_rules_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html), An cors can have up to 100 rules.
+OPTION(rgw_delete_multi_obj_max_num, OPT_INT) // According to AWS S3(https://docs.aws.amazon.com/AmazonS3/latest/dev/DeletingObjects.html), Amazon S3 also provides the Multi-Object Delete API that you can use to delete up to 1000 objects in a single HTTP request.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4970,6 +4970,10 @@ std::vector<Option> get_rgw_options() {
     .set_default(100)
     .set_description("Max number of cors rules in a single request"),
 
+    Option("rgw_delete_multi_obj_max_num", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(1000)
+    .set_description("Max number of objects in a single multi-object delete request"),
+
     Option("rgw_rados_tracing", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description("true if LTTng-UST tracepoints should be enabled"),

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1808,7 +1808,6 @@ public:
 
 class RGWDeleteMultiObj : public RGWOp {
 protected:
-  int max_to_delete;
   int len;
   char *data;
   rgw_bucket bucket;
@@ -1818,7 +1817,6 @@ protected:
 
 public:
   RGWDeleteMultiObj() {
-    max_to_delete = 1000;
     len = 0;
     data = NULL;
     quiet = false;


### PR DESCRIPTION
according to https://docs.aws.amazon.com/AmazonS3/latest/dev/DeletingObjects.html

> Delete multiple objects—Amazon S3 also provides the Multi-Object Delete API that you can use to delete up to 1000 objects in a single HTTP request.

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>
