### PR TITLE
luminous: MDSMonitor: consider raising priority of MMDSBeacons from MDS so they are processed before other client messages

### DIFF
--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -204,13 +204,15 @@ class MMDSBeacon : public PaxosServiceMessage {
     : PaxosServiceMessage(MSG_MDS_BEACON, 0, HEAD_VERSION, COMPAT_VERSION),
     global_id(0), state(MDSMap::STATE_NULL), standby_for_rank(MDS_RANK_NONE),
     standby_for_fscid(FS_CLUSTER_ID_NONE), standby_replay(false),
-    mds_features(0)
-  { }
+    mds_features(0) {
+    set_priority(CEPH_MSG_PRIO_HIGH);
+  }
   MMDSBeacon(const uuid_d &f, mds_gid_t g, string& n, epoch_t les, MDSMap::DaemonState st, version_t se, uint64_t feat) :
     PaxosServiceMessage(MSG_MDS_BEACON, les, HEAD_VERSION, COMPAT_VERSION),
     fsid(f), global_id(g), name(n), state(st), seq(se),
     standby_for_rank(MDS_RANK_NONE), standby_for_fscid(FS_CLUSTER_ID_NONE),
     standby_replay(false), mds_features(feat) {
+    set_priority(CEPH_MSG_PRIO_HIGH);
   }
 private:
   ~MMDSBeacon() override {}


### PR DESCRIPTION
http://tracker.ceph.com/issues/26906