### PR TITLE
mgr/dashboard: Extract/Refactor Task merge

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-details/rbd-details.component.html
@@ -130,7 +130,6 @@
        heading="Snapshots">
     <cd-rbd-snapshot-list [snapshots]="selectedItem.snapshots"
                           [poolName]="selectedItem.pool_name"
-                          [rbdName]="selectedItem.name"
-                          [executingTasks]="selectedItem.executingTasks"></cd-rbd-snapshot-list>
+                          [rbdName]="selectedItem.name"></cd-rbd-snapshot-list>
   </tab>
 </tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.spec.ts
@@ -10,31 +10,30 @@ import {
   TabsModule,
   TooltipModule
 } from 'ngx-bootstrap';
+import { BehaviorSubject, of } from 'rxjs';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
+import { RbdService } from '../../../shared/api/rbd.service';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { ViewCacheStatus } from '../../../shared/enum/view-cache-status.enum';
+import { ExecutingTask } from '../../../shared/models/executing-task';
 import { SummaryService } from '../../../shared/services/summary.service';
+import { TaskListService } from '../../../shared/services/task-list.service';
 import { SharedModule } from '../../../shared/shared.module';
 import { RbdDetailsComponent } from '../rbd-details/rbd-details.component';
 import { RbdSnapshotListComponent } from '../rbd-snapshot-list/rbd-snapshot-list.component';
 import { RbdListComponent } from './rbd-list.component';
+import { RbdModel } from './rbd-model';
 
 describe('RbdListComponent', () => {
-  let component: RbdListComponent;
   let fixture: ComponentFixture<RbdListComponent>;
+  let component: RbdListComponent;
+  let summaryService: SummaryService;
+  let rbdService: RbdService;
 
-  class SummaryServiceMock extends SummaryService {
-    data: any;
-
-    raiseError() {
-      this.summaryDataSource.error(undefined);
-    }
-
-    refresh() {
-      this.summaryDataSource.next(this.data);
-    }
-  }
+  const refresh = (data) => {
+    summaryService['summaryDataSource'].next(data);
+  };
 
   configureTestBed({
     imports: [
@@ -50,12 +49,18 @@ describe('RbdListComponent', () => {
       HttpClientTestingModule
     ],
     declarations: [RbdListComponent, RbdDetailsComponent, RbdSnapshotListComponent],
-    providers: [{ provide: SummaryService, useClass: SummaryServiceMock }]
+    providers: [SummaryService, TaskListService, RbdService]
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(RbdListComponent);
     component = fixture.componentInstance;
+    summaryService = TestBed.get(SummaryService);
+    rbdService = TestBed.get(RbdService);
+
+    // this is needed because summaryService isn't being reseted after each test.
+    summaryService['summaryDataSource'] = new BehaviorSubject(null);
+    summaryService['summaryData$'] = summaryService['summaryDataSource'].asObservable();
   });
 
   it('should create', () => {
@@ -63,32 +68,111 @@ describe('RbdListComponent', () => {
   });
 
   describe('after ngOnInit', () => {
-    let summaryService: SummaryServiceMock;
-
     beforeEach(() => {
-      summaryService = TestBed.get(SummaryService);
-      summaryService.data = undefined;
       fixture.detectChanges();
+      spyOn(rbdService, 'list').and.callThrough();
     });
 
     it('should load images on init', () => {
-      spyOn(component, 'loadImages');
-      summaryService.data = {};
-      summaryService.refresh();
-      expect(component.loadImages).toHaveBeenCalled();
+      refresh({});
+      expect(rbdService.list).toHaveBeenCalled();
     });
 
     it('should not load images on init because no data', () => {
-      spyOn(component, 'loadImages');
-      summaryService.refresh();
-      expect(component.loadImages).not.toHaveBeenCalled();
+      refresh(undefined);
+      expect(rbdService.list).not.toHaveBeenCalled();
     });
 
     it('should call error function on init when summary service fails', () => {
       spyOn(component.table, 'reset');
-      summaryService.raiseError();
+      summaryService['summaryDataSource'].error(undefined);
       expect(component.table.reset).toHaveBeenCalled();
       expect(component.viewCacheStatusList).toEqual([{ status: ViewCacheStatus.ValueException }]);
+    });
+  });
+
+  describe('handling of executing tasks', () => {
+    let images: RbdModel[];
+
+    const addImage = (name) => {
+      const model = new RbdModel();
+      model.id = '-1';
+      model.name = name;
+      model.pool_name = 'rbd';
+      images.push(model);
+    };
+
+    const addTask = (name: string, image_name: string) => {
+      const task = new ExecutingTask();
+      task.name = name;
+      task.metadata = {
+        pool_name: 'rbd',
+        image_name: image_name,
+        child_pool_name: 'rbd',
+        child_image_name: 'd',
+        dest_pool_name: 'rbd',
+        dest_image_name: 'd'
+      };
+      summaryService.addRunningTask(task);
+    };
+
+    const expectImageTasks = (image: RbdModel, executing: string) => {
+      expect(image.cdExecuting).toEqual(executing);
+    };
+
+    beforeEach(() => {
+      images = [];
+      addImage('a');
+      addImage('b');
+      addImage('c');
+      component.images = images;
+      refresh({ executing_tasks: [], finished_tasks: [] });
+      spyOn(rbdService, 'list').and.callFake(() =>
+        of([{ poool_name: 'rbd', status: 1, value: images }])
+      );
+      fixture.detectChanges();
+    });
+
+    it('should gets all images without tasks', () => {
+      expect(component.images.length).toBe(3);
+      expect(component.images.every((image) => !image.cdExecuting)).toBeTruthy();
+    });
+
+    it('should add a new image from a task', () => {
+      addTask('rbd/create', 'd');
+      expect(component.images.length).toBe(4);
+      expectImageTasks(component.images[0], undefined);
+      expectImageTasks(component.images[1], undefined);
+      expectImageTasks(component.images[2], undefined);
+      expectImageTasks(component.images[3], 'Creating');
+    });
+
+    it('should show when a image is being cloned', () => {
+      addTask('rbd/clone', 'd');
+      expect(component.images.length).toBe(4);
+      expectImageTasks(component.images[0], undefined);
+      expectImageTasks(component.images[1], undefined);
+      expectImageTasks(component.images[2], undefined);
+      expectImageTasks(component.images[3], 'Cloning');
+    });
+
+    it('should show when a image is being copied', () => {
+      addTask('rbd/copy', 'd');
+      expect(component.images.length).toBe(4);
+      expectImageTasks(component.images[0], undefined);
+      expectImageTasks(component.images[1], undefined);
+      expectImageTasks(component.images[2], undefined);
+      expectImageTasks(component.images[3], 'Copying');
+    });
+
+    it('should show when an existing image is being modified', () => {
+      addTask('rbd/edit', 'a');
+      addTask('rbd/delete', 'b');
+      addTask('rbd/flatten', 'c');
+      expect(component.images.length).toBe(3);
+      expectImageTasks(component.images[0], 'Updating');
+      expectImageTasks(component.images[1], 'Deleting');
+      expectImageTasks(component.images[2], 'Flattening');
     });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-model.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-model.ts
@@ -1,4 +1,5 @@
 export class RbdModel {
+  id: string;
   name: string;
   pool_name: string;
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.spec.ts
@@ -1,0 +1,129 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { of } from 'rxjs';
+
+import { configureTestBed } from '../../../testing/unit-test-helper';
+import { ExecutingTask } from '../models/executing-task';
+import { SummaryService } from './summary.service';
+import { TaskListService } from './task-list.service';
+import { TaskMessageService } from './task-message.service';
+
+describe('TaskListService', () => {
+  let service: TaskListService;
+  let summaryService: SummaryService;
+  let taskMessageService: TaskMessageService;
+
+  let reset: boolean;
+  let list: any[];
+  let apiResp: any;
+  let tasks: any[];
+
+  const addItem = (name) => {
+    apiResp.push({ name: name });
+  };
+
+  configureTestBed({
+    providers: [TaskListService, TaskMessageService, SummaryService],
+    imports: [HttpClientTestingModule, RouterTestingModule]
+  });
+
+  beforeEach(() => {
+    service = TestBed.get(TaskListService);
+    summaryService = TestBed.get(SummaryService);
+    taskMessageService = TestBed.get(TaskMessageService);
+    summaryService['summaryDataSource'].next({ executing_tasks: [] });
+
+    taskMessageService.messages['test/create'] = taskMessageService.messages['rbd/create'];
+    taskMessageService.messages['test/edit'] = taskMessageService.messages['rbd/edit'];
+    taskMessageService.messages['test/delete'] = taskMessageService.messages['rbd/delete'];
+
+    reset = false;
+    tasks = [];
+    apiResp = [];
+    list = [];
+    addItem('a');
+    addItem('b');
+    addItem('c');
+
+    service.init(
+      () => of(apiResp),
+      undefined,
+      (updatedList) => (list = updatedList),
+      () => (reset = true),
+      (task) => task.name.startsWith('test'),
+      (item, task) => item.name === task.metadata['name'],
+      {
+        default: (task) => ({ name: task.metadata['name'] })
+      }
+    );
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  const addTask = (name: string, itemName: string) => {
+    const task = new ExecutingTask();
+    task.name = name;
+    task.metadata = { name: itemName };
+    tasks.push(task);
+    summaryService.addRunningTask(task);
+  };
+
+  const expectItemTasks = (item: any, executing: string) => {
+    expect(item.cdExecuting).toBe(executing);
+  };
+
+  it('gets all items without any executing items', () => {
+    expect(list.length).toBe(3);
+    expect(list.every((item) => !item.cdExecuting)).toBeTruthy();
+  });
+
+  it('gets an item from a task during creation', () => {
+    addTask('test/create', 'd');
+    expect(list.length).toBe(4);
+    expectItemTasks(list[3], 'Creating');
+  });
+
+  it('gets all items with one executing items', () => {
+    addTask('test/create', 'a');
+    expect(list.length).toBe(3);
+    expectItemTasks(list[0], 'Creating');
+    expectItemTasks(list[1], undefined);
+    expectItemTasks(list[2], undefined);
+  });
+
+  it('gets all items with multiple executing items', () => {
+    addTask('test/create', 'a');
+    addTask('test/edit', 'a');
+    addTask('test/delete', 'a');
+    addTask('test/edit', 'b');
+    addTask('test/delete', 'b');
+    addTask('test/delete', 'c');
+    expect(list.length).toBe(3);
+    expectItemTasks(list[0], 'Creating, Updating, Deleting');
+    expectItemTasks(list[1], 'Updating, Deleting');
+    expectItemTasks(list[2], 'Deleting');
+  });
+
+  it('gets all items with multiple executing tasks (not only item tasks', () => {
+    addTask('rbd/create', 'a');
+    addTask('rbd/edit', 'a');
+    addTask('test/delete', 'a');
+    addTask('test/edit', 'b');
+    addTask('rbd/delete', 'b');
+    addTask('rbd/delete', 'c');
+    expect(list.length).toBe(3);
+    expectItemTasks(list[0], 'Deleting');
+    expectItemTasks(list[1], 'Updating');
+    expectItemTasks(list[2], undefined);
+  });
+
+  it('should call ngOnDestroy', () => {
+    expect(service.summaryDataSubscription.closed).toBeFalsy();
+    service.ngOnDestroy();
+    expect(service.summaryDataSubscription.closed).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-list.service.ts
@@ -1,0 +1,101 @@
+import { Injectable, OnDestroy } from '@angular/core';
+
+import { Observable, Subscription } from 'rxjs';
+
+import { ExecutingTask } from '../models/executing-task';
+import { SummaryService } from './summary.service';
+import { TaskMessageService } from './task-message.service';
+
+@Injectable()
+export class TaskListService implements OnDestroy {
+  summaryDataSubscription: Subscription;
+
+  getUpdate: () => Observable<object>;
+  preProcessing: (_: any) => any[];
+  setList: (_: any[]) => void;
+  onFetchError: (error: any) => void;
+  taskFilter: (task: ExecutingTask) => boolean;
+  itemFilter: (item, task: ExecutingTask) => boolean;
+  builders: object;
+
+  constructor(
+    private taskMessageService: TaskMessageService,
+    private summaryService: SummaryService
+  ) {}
+
+  /**
+   * @param {() => Observable<object>} getUpdate Method that calls the api and
+   * returns that without subscribing.
+   * @param {(_: any) => any[]} preProcessing Method executed before merging
+   * Tasks with Items
+   * @param {(_: any[]) => void} setList  Method used to update array of item in the component.
+   * @param {(error: any) => void} onFetchError Method called when there were
+   * problems while fetching data.
+   * @param {(task: ExecutingTask) => boolean} taskFilter callback used in tasks_array.filter()
+   * @param {(item, task: ExecutingTask) => boolean} itemFilter callback used in
+   * items_array.filter()
+   * @param {object} builders
+   * object with builders for each type of task.
+   * You can also use a 'default' one.
+   * @memberof TaskListService
+   */
+  init(
+    getUpdate: () => Observable<object>,
+    preProcessing: (_: any) => any[],
+    setList: (_: any[]) => void,
+    onFetchError: (error: any) => void,
+    taskFilter: (task: ExecutingTask) => boolean,
+    itemFilter: (item, task: ExecutingTask) => boolean,
+    builders: object
+  ) {
+    this.getUpdate = getUpdate;
+    this.preProcessing = preProcessing;
+    this.setList = setList;
+    this.onFetchError = onFetchError;
+    this.taskFilter = taskFilter;
+    this.itemFilter = itemFilter;
+    this.builders = builders;
+
+    this.summaryDataSubscription = this.summaryService.subscribe((tasks: any) => {
+      if (tasks) {
+        this.getUpdate().subscribe((resp: any) => {
+          this.updateData(resp, tasks.executing_tasks.filter(this.taskFilter));
+        }, this.onFetchError);
+      }
+    }, this.onFetchError);
+  }
+
+  private updateData(resp: any, tasks: ExecutingTask[]) {
+    const data: any[] = this.preProcessing ? this.preProcessing(resp) : resp;
+    this.addMissing(data, tasks);
+    data.forEach((item) => {
+      const executingTasks = tasks.filter((task) => this.itemFilter(item, task));
+      item.cdExecuting = this.getTaskAction(executingTasks);
+    });
+    this.setList(data);
+  }
+
+  private addMissing(data: any[], tasks: ExecutingTask[]) {
+    const defaultBuilder = this.builders['default'];
+    tasks.forEach((task) => {
+      const existing = data.find((item) => this.itemFilter(item, task));
+      const builder = this.builders[task.name];
+      if (!existing && (builder || defaultBuilder)) {
+        data.push(builder ? builder(task.metadata) : defaultBuilder(task));
+      }
+    });
+  }
+
+  private getTaskAction(tasks: ExecutingTask[]): string {
+    if (tasks.length === 0) {
+      return;
+    }
+    return tasks.map((task) => this.taskMessageService.getRunningText(task)).join(', ');
+  }
+
+  ngOnDestroy() {
+    if (this.summaryDataSubscription) {
+      this.summaryDataSubscription.unsubscribe();
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/task-message.service.ts
@@ -152,4 +152,8 @@ export class TaskMessageService {
   getRunningTitle(task: Task) {
     return this._getTaskTitle(task).running(task.metadata);
   }
+
+  getRunningText(task: Task) {
+    return this._getTaskTitle(task).operation.running;
+  }
 }


### PR DESCRIPTION
Like the title says, I have extracted and refactor the merge method from the rbd component.
This will help when we need to use the merge in other tables, like RBD Trash [#23351], Pools [#21614] and NFS.

I have implement this in the RBD and RBD Snapshots, and also tested it with RBD Trash List.
It would be nice if this could be tested in the #21614.

The actual changes are in 69544dfc9bce67769bcc23219092f00a0dbf74ba, rest of the changes are part of other PR or just unrelated linting fixes.

This PR includes #23315.