### PR TITLE
tools/cephfs: do not split args if it's already a list

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -21,11 +21,14 @@ try:
 except ImportError:
     def with_argparser(argparser):
         import functools
+
         def argparser_decorator(func):
             @functools.wraps(func)
             def wrapper(thiz, cmdline):
-                # do not split if it's already a list
-                if not isinstance(cmdline, list):
+                if isinstance(cmdline, list):
+                    arglist = cmdline
+                else:
+                    # do not split if it's already a list
                     arglist = shlex.split(cmdline, posix=False)
                     # in case user quotes the command args
                     arglist = [arg.strip('\'""') for arg in arglist]
@@ -119,7 +122,8 @@ def glob(dir_name, pattern):
             if fnmatch.fnmatch(i.d_name.decode('utf-8'), pattern):
                 paths.append(os.path.join(dir_name, i.d_name.decode('utf-8')))
     return paths
-       
+
+
 def get_all_possible_paths(pattern):
     paths = []
     is_rel_path = not os.path.isabs(pattern)


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

