### PR TITLE
rgw: data sync respects error_retry_time for backoff on error_repo

### DIFF
--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -181,6 +181,14 @@ namespace ceph {
 	return from_timespec(ts);
       }
 
+      static bool is_zero(const time_point& t) {
+	return (t == time_point::min());
+      }
+
+      static time_point zero() {
+	return time_point::min();
+      }
+
       static time_t to_time_t(const time_point& t) noexcept {
 	return duration_cast<seconds>(t.time_since_epoch()).count();
       }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1199,7 +1199,7 @@ class RGWDataSyncShardCR : public RGWCoroutine {
   string error_marker;
   int max_error_entries;
 
-  ceph::real_time error_retry_time;
+  ceph::coarse_real_time error_retry_time;
 
 #define RETRY_BACKOFF_SECS_MIN 60
 #define RETRY_BACKOFF_SECS_DEFAULT 60
@@ -1432,7 +1432,7 @@ public:
           } else {
             retry_backoff_secs = RETRY_BACKOFF_SECS_DEFAULT;
           }
-          error_retry_time = ceph::real_clock::now() + make_timespan(retry_backoff_secs);
+          error_retry_time = ceph::coarse_real_clock::now() + make_timespan(retry_backoff_secs);
           error_marker.clear();
         }
         omapkeys.reset();


### PR DESCRIPTION
don't restart processing the error_repo until error_retry_time. when data sync is otherwise idle, don't sleep past error_retry_time

Fixes: http://tracker.ceph.com/issues/26938