### PR TITLE
msg: entity_addr_t::parse doesn't do memset(this, 0, ...) for clean-up

### DIFF
--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -64,7 +64,7 @@ void entity_inst_t::generate_test_instances(list<entity_inst_t*>& o)
 
 bool entity_addr_t::parse(const char *s, const char **end)
 {
-  memset(this, 0, sizeof(*this));
+  *this = entity_addr_t();
 
   const char *start = s;
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/26937
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>