### PR TITLE
man: skip directive starting with ".."

### DIFF
--- a/man/conf.py
+++ b/man/conf.py
@@ -17,6 +17,8 @@ def _get_description(fname, base):
                 continue
             if line.startswith(':') and line.endswith(':'):
                 continue
+            if line.startswith('.. '):
+                continue
             one = line
             break
         two = f.readline().rstrip('\n')


### PR DESCRIPTION
the target definition of hyper link looks like:
```rst
.. _a-reference-label:
```
there is chance that we need to add `:ref:` referencing man pages,
and add target definition at the beginning of the manapges for the
references. in that case, we need to skip the ref directives when
looking for the title of the manpage.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

