### PR TITLE
examples: add -Wno-unused-parameter to avoid compile error

### DIFF
--- a/examples/librados/Makefile
+++ b/examples/librados/Makefile
@@ -1,12 +1,12 @@
 
 CXX?=g++
-CXX_FLAGS?=-std=c++11 -Wall -Wextra -Werror -g
+CXX_FLAGS?=-std=c++11 -Wno-unused-parameter -Wall -Wextra -Werror -g
 CXX_LIBS?=-lrados -lradosstriper
 CXX_INC?=$(LOCAL_LIBRADOS_INC)
 CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS)
 
 CC?=gcc
-CC_FLAGS=-Wall -Wextra -Werror -g
+CC_FLAGS=-Wno-unused-parameter -Wall -Wextra -Werror -g
 CC_INC=$(LOCAL_LIBRADOS_INC)
 CC_LIBS?=-lrados
 CC_CC=$(CC) $(CC_FLAGS) $(CC_INC) $(LOCAL_LIBRADOS)

--- a/examples/librbd/Makefile
+++ b/examples/librbd/Makefile
@@ -1,6 +1,6 @@
 
 CXX?=g++
-CXX_FLAGS?=-std=c++11 -Wall -Wextra -Werror -g
+CXX_FLAGS?=-std=c++11 -Wno-unused-parameter -Wall -Wextra -Werror -g
 CXX_LIBS?=-lboost_system -lrbd -lrados
 CXX_INC?=$(LOCAL_LIBRADOS_INC)
 CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS)


### PR DESCRIPTION

Add `-Wno-unused-parameter` to avoid compile error:

```
../../src/include/rados/buffer.h: In member function ‘ceph::buffer::ptr::const_iterator ceph::buffer::ptr::begin_deep(size_t) const’:
../../src/include/rados/buffer.h:293:45: error: unused parameter ‘offset’ [-Werror=unused-parameter]
     const_iterator begin_deep(size_t offset=0) const {
                                             ^
cc1plus: all warnings being treated as errors
```

Signed-off-by: You Ji <youji@ebay.com>