### PR TITLE
jewel: rgw: recalc stats command implemention

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -75,6 +75,7 @@ void _usage()
   cout << "  bucket rm                  remove bucket\n";
   cout << "  bucket check               check bucket index\n";
   cout << "  bucket reshard             reshard bucket\n";
+  cout << "  bucket recalc-stats        recalculate bucket stats\n";
   cout << "  bi get                     retrieve bucket index object entries\n";
   cout << "  bi put                     store bucket index object entries\n";
   cout << "  bi list                    list raw bucket index entries\n";
@@ -311,6 +312,7 @@ enum {
   OPT_BUCKET_RM,
   OPT_BUCKET_REWRITE,
   OPT_BUCKET_RESHARD,
+  OPT_BUCKET_RECALC_STATS,
   OPT_POLICY,
   OPT_POOL_ADD,
   OPT_POOL_RM,
@@ -513,6 +515,8 @@ static int get_cmd(const char *cmd, const char *prev_cmd, const char *prev_prev_
       return OPT_BUCKET_REWRITE;
     if (strcmp(cmd, "reshard") == 0)
       return OPT_BUCKET_RESHARD;
+    if (strcmp(cmd, "recalc-stats") == 0)
+      return OPT_BUCKET_RECALC_STATS;
     if (strcmp(cmd, "check") == 0)
       return OPT_BUCKET_CHECK;
     if (strcmp(cmd, "sync") == 0) {
@@ -5227,6 +5231,126 @@ next:
 			  << cpp_strerror(-ret) << ")" << dendl;
       return -ret;
    }
+  }
+
+  if (opt_cmd == OPT_BUCKET_RECALC_STATS) {
+    if (bucket_name.empty()) {
+      cerr << "ERROR: bucket not specified" << std::endl;
+      return -EINVAL;
+    }
+
+    rgw_bucket bucket;
+    RGWBucketInfo bucket_info;
+    map<string, bufferlist> attrs;
+    int ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket, &attrs);
+    if (ret < 0) {
+      cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
+      return -ret;
+    }
+
+    cout << "tenant: " << bucket_info.bucket.tenant << std::endl;
+    cout << "bucket name: " << bucket_info.bucket.name << std::endl;
+    cout << "bucket instance id: " << bucket_info.bucket.bucket_id << std::endl;
+
+    /* update bucket info  -- in progress*/
+    list<rgw_cls_bi_entry> entries;
+
+    if (max_entries < 0) {
+      max_entries = 1000;
+    }
+
+    if (verbose) {
+      formatter->open_array_section("entries");
+    }
+
+    uint64_t total_entries = 0;
+
+    int num_source_shards = (bucket_info.num_shards > 0 ? bucket_info.num_shards : 1);
+    string marker;
+    map<uint8_t, rgw_bucket_category_stats> stats;
+
+    for (int i = 0; i < num_source_shards; ++i) {
+      RGWRados::BucketShard bs(store);
+      int ret = bs.init(bucket, i);
+      if (ret < 0) {
+	cerr << "bs.init() returned ret=" << ret << std::endl;
+	return ret;
+      }
+      bool is_truncated = true;
+      marker.clear();
+      while (is_truncated) {
+	entries.clear();
+	ret = store->bi_list(bucket, i, string(), marker, max_entries, &entries, &is_truncated);
+	if (ret < 0 && ret != -ENOENT) {
+	  derr << "ERROR: bi_list(): " << cpp_strerror(-ret) << dendl;
+	  return -ret;
+	}
+
+	list<rgw_cls_bi_entry>::iterator iter;
+	for (iter = entries.begin(); iter != entries.end(); ++iter) {
+	  rgw_cls_bi_entry& entry = *iter;
+
+	  if (verbose) {
+	    formatter->open_object_section("entry");
+	    encode_json("shard_id", i, formatter);
+	    encode_json("num_entry", total_entries, formatter);
+	    encode_json("entry", entry, formatter);
+	  }
+	  total_entries++;
+
+	  if (entry.type == PlainIdx) {
+	    librados::ObjectWriteOperation op;
+	    rgw_bucket_dir_entry dir_entry;
+	    auto bi_iter = entry.data.begin();
+	    ::decode(dir_entry, bi_iter);
+	    if (dir_entry.meta.accounted_size == 0 && dir_entry.meta.size != 0) {
+	      rgw_obj obj(bucket,dir_entry.key.name);
+	      obj.set_instance(dir_entry.key.instance);
+	      cout << "Fixing entry accounted_size for " << dir_entry.key << std::endl;
+	      dir_entry.meta.accounted_size = dir_entry.meta.size;
+	      bufferlist bl;
+	      ::encode(dir_entry, bl);
+	      entry.data = bl;
+	      encode_json("entry", entry, formatter);
+	      formatter->flush(cout);
+	      store->bi_put(op, bs, entry);
+	      ret = bs.index_ctx.operate(bs.bucket_obj, &op);
+	      if (ret != 0) {
+		cerr << " Error in bi_put operate " << ret << std::endl;
+		return ret;
+	      }
+	    }
+	  }
+
+	  cls_rgw_obj_key cls_key;
+	  uint8_t category;
+	  rgw_bucket_category_stats entry_stats;
+	  bool account = entry.get_info(&cls_key, &category, &entry_stats);
+
+	  if (account) {
+	    rgw_bucket_category_stats& target = stats[category];
+	    target.num_entries += entry_stats.num_entries;
+	    target.total_size += entry_stats.total_size;
+	    target.total_size_rounded += entry_stats.total_size_rounded;
+	  }
+
+	  marker = entry.idx;
+
+	  if (verbose) {
+	    formatter->close_section();
+	    formatter->flush(cout);
+	  }
+	}
+      }
+
+      cout << "updating stats " << std::endl;
+      librados::ObjectWriteOperation op;
+      cls_rgw_bucket_update_stats(op, true, stats);
+      ret = bs.index_ctx.operate(bs.bucket_obj, &op);
+      if (ret != 0) {
+	return ret;
+      }
+    }
   }
 
   if (opt_cmd == OPT_OBJECT_UNLINK) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5239,6 +5239,12 @@ next:
       return -EINVAL;
     }
 
+    if (!yes_i_really_mean_it) {
+      cerr << "This command will update bucket stats and object stats" << std::endl;
+      cerr << "do you really mean it? (requires --yes-i-really-mean-it)" << std::endl;
+      return 1;
+    }
+
     rgw_bucket bucket;
     RGWBucketInfo bucket_info;
     map<string, bufferlist> attrs;

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -24,6 +24,7 @@
     bucket rm                  remove bucket
     bucket check               check bucket index
     bucket reshard             reshard bucket
+    bucket recalc-stats        recalculate bucket stats
     bi get                     retrieve bucket index object entries
     bi put                     store bucket index object entries
     bi list                    list raw bucket index entries


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
The command in newer ceph versions arebased on the resharding code and is implement in rgw_reshard.cc file.

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

