### PR TITLE
rgw: fix deadlock on RGWIndexCompletionManager::stop

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3650,7 +3650,6 @@ public:
     for (int i = 0; i < num_shards; ++i) {
       Mutex::Locker l(*locks[i]);
       for (auto c : completions[i]) {
-        Mutex::Locker cl(c->lock);
         c->stop();
       }
     }


### PR DESCRIPTION
The lock has been acquired in complete_op_data::stop

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>