### PR TITLE
tools/cephfs-shell: Used cmd2 inbuilt colorize method instead of colorama

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -161,13 +161,13 @@ def humansize(nbytes):
     return '%s%s' % (f, suffixes[i])
 
 
-def print_long(shell, file_name, flag, human_readable):
+def print_long(shell, file_name, is_dir, human_readable):
     if not isinstance(file_name, bytes):
         file_name = to_bytes(file_name)
     info = cephfs.stat(file_name)
     file_name = os.path.basename(file_name.decode('utf-8'))
-    if flag:
-        file_name = colorama.Fore.BLUE + file_name + '/' + colorama.Style.RESET_ALL
+    if is_dir:
+        file_name = shell.colorize(file_name.decode('utf-8').rsplit('/', 1)[1] + '/',  'blue')
     if human_readable:
         shell.poutput('{}\t{:10s} {} {} {} {}'.format(
             mode_notation(info.st_mode),
@@ -306,7 +306,6 @@ class CephFSShell(Cmd):
         super().__init__(use_ipython=False)
         self.working_dir = cephfs.getcwd().decode('utf-8')
         self.set_prompt()
-        self.intro = 'Ceph File System Shell'
         self.interactive = False
         self.umask = '2'
 
@@ -579,18 +578,19 @@ exists.')
                 if not isinstance(item, str):
                     path = item.d_name.decode('utf-8')
                     if item.is_dir():
-                        flag = 1
+                        is_dir = True
                     else:
-                        flag = 0
+                        is_dir = False
                 if args.long and args.H:
                     print_long(self, cephfs.getcwd().decode(
-                        'utf-8') + dir_name + '/' + path, flag, True)
+                        'utf-8') + dir_name + '/' + path, is_dir, True)
                 elif args.long:
                     print_long(self, cephfs.getcwd().decode(
-                        'utf-8') + dir_name + '/' + path, flag, False)
+                        'utf-8') + dir_name + '/' + path, is_dir, False)
+                elif is_dir:
+                    values.append(self.colorize(path + '/', 'blue'))
                 else:
-                    values.append(colorama.Fore.BLUE * flag + path +
-                                  '/' * flag + colorama.Style.RESET_ALL * flag)
+                    values.append(path)
             if not args.long:
                 print_list(self, values, shutil.get_terminal_size().columns)
                 if dir_name != directories[-1]:


### PR DESCRIPTION
When testing the shell, due to the colored output it was difficult to compare with expected output. Using cmd2 inbuilt colorize method there is a option to turn off the colors when testing.
Signed-off-by: Pavani Rajula <rpavani1998@gmail.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

