### PR TITLE
librados: add a rados_omap_iter_size function

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1716,6 +1716,13 @@ CEPH_RADOS_API int rados_omap_get_next2(rados_omap_iter_t iter,
                                        size_t *val_len);
 
 /**
+ * Return number of elements in the iterator
+ *
+ * @param iter the iterator of which to return the size
+ */
+CEPH_RADOS_API unsigned int rados_omap_iter_size(rados_omap_iter_t iter);
+
+/**
  * Close the omap iterator.
  *
  * iter should not be used after this is called.

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -6370,6 +6370,12 @@ extern "C" int rados_omap_get_next2(rados_omap_iter_t iter,
   return 0;
 }
 
+extern "C" unsigned int rados_omap_iter_size(rados_omap_iter_t iter)
+{
+  RadosOmapIter *it = static_cast<RadosOmapIter *>(iter);
+  return it->values.size();
+}
+
 extern "C" void rados_omap_get_end(rados_omap_iter_t iter)
 {
   tracepoint(librados, rados_omap_get_end_enter, iter);

--- a/src/test/librados/c_read_operations.cc
+++ b/src/test/librados/c_read_operations.cc
@@ -74,6 +74,7 @@ protected:
     char *key = NULL;
     char *val = NULL;
     size_t val_len = 0;
+    ASSERT_EQ(len, rados_omap_iter_size(iter));
     while (i < len) {
       ASSERT_EQ(0, rados_omap_get_next(iter, &key, &val, &val_len));
       if (val_len == 0 && key == NULL && val == NULL)
@@ -125,6 +126,7 @@ protected:
     char *val = NULL;
     size_t key_len = 0;
     size_t val_len = 0;
+    ASSERT_EQ(len, rados_omap_iter_size(iter));
     while (i < len) {
       ASSERT_EQ(0, rados_omap_get_next2(iter, &key, &val, &key_len, &val_len));
       if (key_len == 0 && val_len == 0 && key == NULL && val == NULL)
@@ -646,6 +648,8 @@ TEST_F(CReadOpsTest, Omap) {
   rados_release_read_op(rop);
   EXPECT_EQ(0, r_vals);
   EXPECT_EQ(0, r_keys);
+  EXPECT_EQ(1, rados_omap_iter_size(iter_vals));
+  EXPECT_EQ(1, rados_omap_iter_size(iter_keys));
 
   compare_omap_vals(&keys[2], &vals[2], &lens[2], 1, iter_vals);
   compare_omap_vals(&keys[2], &vals[0], &lens[0], 1, iter_keys);


### PR DESCRIPTION
Sometimes we need to know how many elements are represented by an omap
iterator. Add a new rados_omap_iter_size to return the number of
elements in the returned iterator.

Also add some sanity checks for this to existing tests.

Tracker: http://tracker.ceph.com/issues/26948
Signed-off-by: Jeff Layton <jlayton@redhat.com>