### PR TITLE
luminous: librbd: discard should wait for in-flight cache writeback to complete

### DIFF
--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -183,7 +183,7 @@ protected:
   virtual int prune_object_extents(ObjectExtents &object_extents) {
     return 0;
   }
-  virtual uint32_t get_object_cache_request_count(bool journaling) const {
+  virtual uint32_t get_object_cache_request_count() const {
     return 0;
   }
   virtual void send_object_cache_requests(const ObjectExtents &object_extents,
@@ -278,7 +278,7 @@ protected:
 
   void send_image_cache_request() override;
 
-  uint32_t get_object_cache_request_count(bool journaling) const override;
+  uint32_t get_object_cache_request_count() const override;
   void send_object_cache_requests(const ObjectExtents &object_extents,
                                   uint64_t journal_tid) override;
 
@@ -386,6 +386,7 @@ public:
 protected:
   void send_image_cache_request() override;
 
+  uint32_t get_object_cache_request_count() const override;
   void send_object_cache_requests(const ObjectExtents &object_extents,
                                   uint64_t journal_tid) override;
 

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -248,6 +248,8 @@ TEST_F(TestMockIoImageRequest, AioDiscardJournalAppendDisabled) {
   MockJournal mock_journal;
   mock_image_ctx.journal = &mock_journal;
 
+  expect_op_work_queue(mock_image_ctx);
+
   InSequence seq;
   expect_is_journal_appending(mock_journal, false);
   if (!ictx->skip_partial_discard) {
@@ -341,6 +343,8 @@ TEST_F(TestMockIoImageRequest, AioCompareAndWriteJournalAppendDisabled) {
   MockTestImageCtx mock_image_ctx(*ictx);
   MockJournal mock_journal;
   mock_image_ctx.journal = &mock_journal;
+
+  expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
   expect_is_journal_appending(mock_journal, false);


### PR DESCRIPTION
http://tracker.ceph.com/issues/23604