### PR TITLE
rgw multisite: incremental data sync uses truncated flag to detect end of listing

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1511,8 +1511,9 @@ public:
             }
           }
 	}
-	tn->log(20, SSTR("shard_id=" << shard_id << " datalog_marker=" << datalog_marker << " sync_marker.marker=" << sync_marker.marker));
-	if (datalog_marker == sync_marker.marker || remote_trimmed == RemoteTrimmed) {
+	tn->log(20, SSTR("shard_id=" << shard_id << " datalog_marker=" << datalog_marker << " sync_marker.marker=" << sync_marker.marker << " truncated=" << truncated));
+	if (!truncated) {
+          // we reached the end, wait a while before checking for more
           tn->unset_flag(RGW_SNS_FLAG_ACTIVE);
 #define INCREMENTAL_INTERVAL 20
 	  yield wait(utime_t(INCREMENTAL_INTERVAL, 0));

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1146,12 +1146,6 @@ public:
 #define BUCKET_SHARD_SYNC_SPAWN_WINDOW 20
 #define DATA_SYNC_MAX_ERR_ENTRIES 10
 
-enum RemoteDatalogStatus {
-  RemoteNotTrimmed = 0,
-  RemoteTrimmed = 1,
-  RemoteMightTrimmed = 2
-};
-
 class RGWDataSyncShardCR : public RGWCoroutine {
   RGWDataSyncEnv *sync_env;
 
@@ -1175,7 +1169,6 @@ class RGWDataSyncShardCR : public RGWCoroutine {
   RGWDataChangesLogInfo shard_info;
   string datalog_marker;
 
-  RemoteDatalogStatus remote_trimmed;
   Mutex inc_lock;
   Cond inc_cond;
 
@@ -1227,7 +1220,7 @@ public:
 						      pool(_pool),
 						      shard_id(_shard_id),
 						      sync_marker(_marker),
-                                                      marker_tracker(NULL), truncated(false), remote_trimmed(RemoteNotTrimmed), inc_lock("RGWDataSyncShardCR::inc_lock"),
+                                                      marker_tracker(NULL), truncated(false), inc_lock("RGWDataSyncShardCR::inc_lock"),
                                                       total_entries(0), spawn_window(BUCKET_SHARD_SYNC_SPAWN_WINDOW), reset_backoff(NULL),
                                                       lease_cr(nullptr), lease_stack(nullptr), error_repo(nullptr), max_error_entries(DATA_SYNC_MAX_ERR_ENTRIES),
                                                       retry_backoff_secs(RETRY_BACKOFF_SECS_DEFAULT), tn(_tn) {
@@ -1450,13 +1443,10 @@ public:
           return set_cr_error(retcode);
         }
         datalog_marker = shard_info.marker;
-        remote_trimmed = RemoteNotTrimmed;
 #define INCREMENTAL_MAX_ENTRIES 100
 	tn->log(20, SSTR("shard_id=" << shard_id << " datalog_marker=" << datalog_marker << " sync_marker.marker=" << sync_marker.marker));
 	if (datalog_marker > sync_marker.marker) {
           spawned_keys.clear();
-          if (sync_marker.marker.empty())
-            remote_trimmed = RemoteMightTrimmed; //remote data log shard might be trimmed;
           yield call(new RGWReadRemoteDataLogShardCR(sync_env, shard_id, &sync_marker.marker, &log_entries, &truncated));
           if (retcode < 0) {
             tn->log(0, SSTR("ERROR: failed to read remote data log info: ret=" << retcode));
@@ -1464,11 +1454,6 @@ public:
             drain_all();
             return set_cr_error(retcode);
           }
-
-          if ((remote_trimmed == RemoteMightTrimmed) && sync_marker.marker.empty() && log_entries.empty())
-            remote_trimmed = RemoteTrimmed;
-          else
-            remote_trimmed = RemoteNotTrimmed;
 
           if (log_entries.size() > 0) {
             tn->set_flag(RGW_SNS_FLAG_ACTIVE); /* actually have entries to sync */

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1166,9 +1166,6 @@ class RGWDataSyncShardCR : public RGWCoroutine {
   list<rgw_data_change_log_entry>::iterator log_iter;
   bool truncated;
 
-  RGWDataChangesLogInfo shard_info;
-  string datalog_marker;
-
   Mutex inc_lock;
   Cond inc_cond;
 
@@ -1435,17 +1432,9 @@ public:
         }
 
 
-        yield call(new RGWReadRemoteDataLogShardInfoCR(sync_env, shard_id, &shard_info));
-        if (retcode < 0) {
-          tn->log(0, SSTR("ERROR: failed to fetch remote data log info: ret=" << retcode));
-          stop_spawned_services();
-          drain_all();
-          return set_cr_error(retcode);
-        }
-        datalog_marker = shard_info.marker;
 #define INCREMENTAL_MAX_ENTRIES 100
-	tn->log(20, SSTR("shard_id=" << shard_id << " datalog_marker=" << datalog_marker << " sync_marker.marker=" << sync_marker.marker));
-	if (datalog_marker > sync_marker.marker) {
+	tn->log(20, SSTR("shard_id=" << shard_id << " sync_marker=" << sync_marker.marker));
+	{
           spawned_keys.clear();
           yield call(new RGWReadRemoteDataLogShardCR(sync_env, shard_id, &sync_marker.marker, &log_entries, &truncated));
           if (retcode < 0) {
@@ -1496,7 +1485,7 @@ public:
             }
           }
 	}
-	tn->log(20, SSTR("shard_id=" << shard_id << " datalog_marker=" << datalog_marker << " sync_marker.marker=" << sync_marker.marker << " truncated=" << truncated));
+	tn->log(20, SSTR("shard_id=" << shard_id << " sync_marker=" << sync_marker.marker << " truncated=" << truncated));
 	if (!truncated) {
           // we reached the end, wait a while before checking for more
           tn->unset_flag(RGW_SNS_FLAG_ACTIVE);


### PR DESCRIPTION
we call wait() after incremental sync if we've reached the end of the datalog listing. the existing logic compares our local marker with the remote's high marker, with some extra code to handle the case where the remote log was trimmed

all of this can be simplified by using the 'truncated' flag returned with the RGWReadRemoteDataLogShardCR used to list the remote datalog

Fixes: http://tracker.ceph.com/issues/26952

there's a slight optimization here, as we no longer need to call RGWReadRemoteDataLogShardInfoCR to query the remote's high marker before each listing

most of this diff comes from the final commit that changes indentation, so it may be easier to review each commit separately