### PR TITLE
qa: add cephfs-shell test

### DIFF
--- a/qa/cephfs/begin.yaml
+++ b/qa/cephfs/begin.yaml
@@ -1,5 +1,6 @@
 tasks:
   - install:
       extra_packages:
-        - python3-cephfs
+        rpm: ['python3-cephfs']
+        deb: ['python3-cephfs', 'cephfs-shell']
   - ceph:

--- a/qa/suites/fs/basic_functional/tasks/cephfs-shell/py-3.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cephfs-shell/py-3.yaml
@@ -1,0 +1,2 @@
+overrides:
+  python: python3

--- a/qa/suites/fs/basic_functional/tasks/cephfs-shell/test.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cephfs-shell/test.yaml
@@ -1,0 +1,15 @@
+# Right now, cephfs-shell is only available as a package on Ubuntu
+# This overrides the random distribution that's chosen in the other yaml fragments.
+os_type: ubuntu
+os_version: "18.04"
+
+overrides:
+  ceph:
+    conf:
+      global:
+        ms type: simple
+
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_cephfs_shell

--- a/qa/tasks/cephfs/test_cephfs_shell.py
+++ b/qa/tasks/cephfs/test_cephfs_shell.py
@@ -1,0 +1,35 @@
+import logging
+from StringIO import StringIO
+from tasks.cephfs.cephfs_test_case import CephFSTestCase
+from tasks.cephfs.fuse_mount import FuseMount
+from teuthology.exceptions import CommandFailedError
+
+log = logging.getLogger(__name__)
+
+
+class TestCephFSShell(CephFSTestCase):
+    CLIENTS_REQUIRED = 1
+    py_version = 'python'
+
+    def setUp(self):
+        CephFSTestCase.setUp(self)
+        self.py_version = self.ctx.config.get('overrides', {}).get('python', 'python')
+        log.info("using python version: {}".format(self.py_version))
+
+    def _cephfs_shell(self, cmd, opts=None):
+        args = ["cephfs-shell", "-c", self.mount_a.config_path]
+        if opts is not None:
+            args.extend(opts)
+        args.extend(("--", cmd))
+        log.info("Running command: {}".format(" ".join(args)))
+        status = self.mount_a.client_remote.run(args=args, stdout=StringIO())
+        return status.stdout.getvalue().strip()
+
+    def test_help(self):
+        """
+        Test that help outputs commands.
+        """
+
+        o = self._cephfs_shell("help")
+
+        log.info("output:\n{}".format(o))


### PR DESCRIPTION
Example:

`run teuthology-suite --machine-type smithi --kernel testing --ceph master --ceph-repo https://github.com/ceph/ceph.git --suite-branch qa-cephfs-shell --suite-repo https://github.com/batrick/ceph.git --suite fs -p 44 --filter cephfs-shell --limit 1`

http://pulpito.ceph.com/pdonnell-2018-08-16_02:56:52-fs-master-testing-basic-smithi/

^ the test faliure is unrelated to the cephfs-shell test.