### PR TITLE
pybind: do not check MFLAGS

### DIFF
--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -108,7 +108,7 @@ def check_sanity():
     compiler = new_compiler()
     distutils.sysconfig.customize_compiler(compiler)
 
-    if {'MAKEFLAGS', 'MFLAGS', 'MAKELEVEL'}.issubset(set(os.environ.keys())):
+    if {'MAKEFLAGS', 'MAKELEVEL'}.issubset(set(os.environ.keys())):
         # The setup.py has been invoked by a top-level Ceph make.
         # Set the appropriate CFLAGS and LDFLAGS
 


### PR DESCRIPTION
clang does not check for directories passed by -iquote/path/to/foo.h, if
a header is included using `#include <foo.h>`

it complains:

/home/kefu/ceph/src/pybind/rados/tmpwzjOsS/rados_dummy.c:2:10: error:
'rados/librados.h' file not found with <angled> include; use "quotes"
instead
         ^~~~~~~~~~~~~~~~~~
         "rados/librados.h"
1 error generated.

and MFLAGS does not exist in the env variables of setup.py launched by
the top-level make.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

