### PR TITLE
rgw: Key's ns is always empty in lifecycle process.

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -462,10 +462,6 @@ int RGWLC::bucket_lc_process(string& shard_id)
               continue;
             }
           }
-
-          if (!key.ns.empty()) {
-            continue;
-          }
           if (prefix_iter->second.expiration_date != boost::none) {
             //we have checked it before
             is_expired = true;


### PR DESCRIPTION
The list param ns is not set, so the key's ns is always empty. Remove the needless judgement.

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
