### PR TITLE
mimic: doc: Fix broken urls

### DIFF
--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -1444,7 +1444,7 @@ architecture.
 
 .. ditaa::
             +--------------+  +----------------+  +-------------+
-            | Block Device |  | Object Storage |  |   Ceph FS   |
+            | Block Device |  | Object Storage |  |   CephFS    |
             +--------------+  +----------------+  +-------------+            
 
             +--------------+  +----------------+  +-------------+
@@ -1513,14 +1513,14 @@ client. Other virtualization technologies such as Xen can access the Ceph Block
 Device kernel object(s). This is done with the  command-line tool ``rbd``.
 
 
-.. index:: Ceph FS; Ceph Filesystem; libcephfs; MDS; metadata server; ceph-mds
+.. index:: CephFS; Ceph Filesystem; libcephfs; MDS; metadata server; ceph-mds
 
 Ceph Filesystem
 ---------------
 
-The Ceph Filesystem (Ceph FS) provides a POSIX-compliant filesystem as a 
+The Ceph Filesystem (CephFS) provides a POSIX-compliant filesystem as a
 service that is layered on top of the object-based Ceph Storage Cluster.
-Ceph FS files get mapped to objects that Ceph stores in the Ceph Storage
+CephFS files get mapped to objects that Ceph stores in the Ceph Storage
 Cluster. Ceph Clients mount a CephFS filesystem as a kernel object or as
 a Filesystem in User Space (FUSE).
 
@@ -1530,7 +1530,7 @@ a Filesystem in User Space (FUSE).
             +-----------------------+  +------------------------+            
 
             +---------------------------------------------------+
-            |            Ceph FS Library (libcephfs)            |
+            |            CephFS Library (libcephfs)             |
             +---------------------------------------------------+
 
             +---------------------------------------------------+
@@ -1552,7 +1552,7 @@ would tax the Ceph OSD Daemons unnecessarily. So separating the metadata from
 the data means that the Ceph Filesystem can provide high performance services
 without taxing the Ceph Storage Cluster.
 
-Ceph FS separates the metadata from the data, storing the metadata in the MDS, 
+CephFS separates the metadata from the data, storing the metadata in the MDS,
 and storing the file data in one or more objects in the Ceph Storage Cluster.
 The Ceph filesystem aims for POSIX compatibility. ``ceph-mds`` can run as a
 single process, or it can be distributed out to multiple physical machines,

--- a/doc/architecture.rst
+++ b/doc/architecture.rst
@@ -1515,6 +1515,8 @@ Device kernel object(s). This is done with the  command-line tool ``rbd``.
 
 .. index:: CephFS; Ceph Filesystem; libcephfs; MDS; metadata server; ceph-mds
 
+.. _arch-cephfs:
+
 Ceph Filesystem
 ---------------
 

--- a/doc/cephfs/fstab.rst
+++ b/doc/cephfs/fstab.rst
@@ -1,14 +1,14 @@
-==========================================
- Mount Ceph FS in your File Systems Table
-==========================================
+========================================
+ Mount CephFS in your File Systems Table
+========================================
 
-If you mount Ceph FS in your file systems table, the Ceph file system will mount 
+If you mount CephFS in your file systems table, the Ceph file system will mount
 automatically on startup. 
 
 Kernel Driver
 =============
 
-To mount Ceph FS in your file systems table as a kernel driver, add the
+To mount CephFS in your file systems table as a kernel driver, add the
 following to ``/etc/fstab``::
 
 	{ipaddress}:{port}:/ {mount}/{mountpoint} {filesystem-name}	[name=username,secret=secretkey|secretfile=/path/to/secretfile],[{mount.options}]
@@ -26,7 +26,7 @@ See `User Management`_ for details.
 FUSE
 ====
 
-To mount Ceph FS in your file systems table as a filesystem in user space, add the
+To mount CephFS in your file systems table as a filesystem in user space, add the
 following to ``/etc/fstab``::
 
        #DEVICE PATH       TYPE      OPTIONS

--- a/doc/cephfs/fuse.rst
+++ b/doc/cephfs/fuse.rst
@@ -1,6 +1,6 @@
-=========================
-Mount Ceph FS using FUSE
-=========================
+=======================
+Mount CephFS using FUSE
+=======================
 
 Before mounting a Ceph File System in User Space (FUSE), ensure that the client
 host has a copy of the Ceph configuration file and a keyring with CAPS for the

--- a/doc/cephfs/index.rst
+++ b/doc/cephfs/index.rst
@@ -1,3 +1,5 @@
+.. _ceph-filesystem:
+
 =================
  Ceph Filesystem
 =================

--- a/doc/cephfs/kernel.rst
+++ b/doc/cephfs/kernel.rst
@@ -1,6 +1,6 @@
-======================================
- Mount Ceph FS with the Kernel Driver
-======================================
+====================================
+ Mount CephFS with the Kernel Driver
+====================================
 
 To mount the Ceph file system you may use the ``mount`` command if you know the
 monitor host IP address(es), or use the ``mount.ceph`` utility to resolve the 

--- a/doc/glossary.rst
+++ b/doc/glossary.rst
@@ -69,7 +69,9 @@ reflect either technical terms or legacy ways of referring to Ceph systems.
 	Ceph Filesystem
 	CephFS
 	Ceph FS
-		The POSIX filesystem components of Ceph.
+		The POSIX filesystem components of Ceph. Refer
+		:ref:`CephFS Architecture <arch-cephfs>` and :ref:`ceph-filesystem` for
+		more details.
 
 	Cloud Platforms
 	Cloud Stacks

--- a/doc/man/8/ceph-fuse.rst
+++ b/doc/man/8/ceph-fuse.rst
@@ -18,7 +18,7 @@ Description
 **ceph-fuse** is a FUSE (File system in USErspace) client for Ceph
 distributed file system. It will mount a ceph file system specified
 via the -m option or described by ceph.conf (see below) at the
-specific mount point. See `Mount Ceph FS using FUSE`_ for detailed
+specific mount point. See `Mount CephFS using FUSE`_ for detailed
 information.
 
 The file system can be unmounted with::
@@ -75,4 +75,4 @@ See also
 fusermount(8),
 :doc:`ceph <ceph>`\(8)
 
-.. _Mount Ceph FS using FUSE: ../../../cephfs/fuse/
+.. _Mount CephFS using FUSE: ../../../cephfs/fuse/

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -311,7 +311,7 @@ three monitors may return the following:
 Checking MDS Status
 ===================
 
-Metadata servers provide metadata services for  Ceph FS. Metadata servers have
+Metadata servers provide metadata services for  CephFS. Metadata servers have
 two sets of states: ``up | down`` and ``active | inactive``. To ensure your
 metadata servers are ``up`` and ``active``,  execute the following:: 
 

--- a/doc/radosgw/index.rst
+++ b/doc/radosgw/index.rst
@@ -1,3 +1,5 @@
+.. _object-gateway:
+
 =====================
  Ceph Object Gateway
 =====================

--- a/doc/rbd/index.rst
+++ b/doc/rbd/index.rst
@@ -32,8 +32,8 @@ Ceph's block devices deliver high performance with infinite scalability to
 `kernel modules`_, or to :abbr:`KVMs (kernel virtual machines)` such as `QEMU`_, and
 cloud-based computing systems like `OpenStack`_ and `CloudStack`_ that rely on
 libvirt and QEMU to integrate with Ceph block devices. You can use the same cluster
-to operate the `Ceph RADOS Gateway`_, the `CephFS filesystem`_, and Ceph block
-devices simultaneously.
+to operate the :ref:`Ceph RADOS Gateway <object-gateway>`, the
+:ref:`CephFS filesystem <ceph-filesystem>`, and Ceph block devices simultaneously.
 
 .. important:: To use Ceph Block Devices, you must have access to a running
    Ceph cluster.
@@ -63,10 +63,8 @@ devices simultaneously.
 
 	APIs <api/index>
 
-.. _RBD Caching: ../rbd-config-ref/
-.. _kernel modules: ../rbd-ko/
-.. _QEMU: ../qemu-rbd/
-.. _OpenStack: ../rbd-openstack
-.. _CloudStack: ../rbd-cloudstack
-.. _Ceph RADOS Gateway: ../../radosgw/
-.. _CephFS filesystem: ../../cephfs/
+.. _RBD Caching: ./rbd-config-ref/
+.. _kernel modules: ./rbd-ko/
+.. _QEMU: ./qemu-rbd/
+.. _OpenStack: ./rbd-openstack
+.. _CloudStack: ./rbd-cloudstack

--- a/doc/rbd/index.rst
+++ b/doc/rbd/index.rst
@@ -32,7 +32,7 @@ Ceph's block devices deliver high performance with infinite scalability to
 `kernel modules`_, or to :abbr:`KVMs (kernel virtual machines)` such as `QEMU`_, and
 cloud-based computing systems like `OpenStack`_ and `CloudStack`_ that rely on
 libvirt and QEMU to integrate with Ceph block devices. You can use the same cluster
-to operate the `Ceph RADOS Gateway`_, the `Ceph FS filesystem`_, and Ceph block
+to operate the `Ceph RADOS Gateway`_, the `CephFS filesystem`_, and Ceph block
 devices simultaneously.
 
 .. important:: To use Ceph Block Devices, you must have access to a running
@@ -69,4 +69,4 @@ devices simultaneously.
 .. _OpenStack: ../rbd-openstack
 .. _CloudStack: ../rbd-cloudstack
 .. _Ceph RADOS Gateway: ../../radosgw/
-.. _Ceph FS filesystem: ../../cephfs/
+.. _CephFS filesystem: ../../cephfs/

--- a/doc/start/quick-cephfs.rst
+++ b/doc/start/quick-cephfs.rst
@@ -1,8 +1,8 @@
-=====================
- Ceph FS Quick Start
-=====================
+===================
+ CephFS Quick Start
+===================
 
-To use the :term:`Ceph FS` Quick Start guide, you must have executed the
+To use the :term:`CephFS` Quick Start guide, you must have executed the
 procedures in the `Storage Cluster Quick Start`_ guide first. Execute this quick
 start on the Admin Host.
 
@@ -53,7 +53,7 @@ following procedure:
 
 	cat ceph.client.admin.keyring
 
-#. Copy the key of the user who will be using the mounted Ceph FS filesystem.
+#. Copy the key of the user who will be using the mounted CephFS filesystem.
    It should look something like this:: 
 	
 	[client.admin]
@@ -75,7 +75,7 @@ following procedure:
 Kernel Driver
 =============
 
-Mount Ceph FS as a kernel driver. :: 
+Mount CephFS as a kernel driver. ::
 
 	sudo mkdir /mnt/mycephfs
 	sudo mount -t ceph {ip-address-of-monitor}:6789:/ /mnt/mycephfs
@@ -87,14 +87,14 @@ example::
 	sudo mount -t ceph 192.168.0.1:6789:/ /mnt/mycephfs -o name=admin,secretfile=admin.secret
 
 
-.. note:: Mount the Ceph FS filesystem on the admin node,
+.. note:: Mount the CephFS filesystem on the admin node,
    not the server node. See `FAQ`_ for details.
 
 
 Filesystem in User Space (FUSE)
 ===============================
 
-Mount Ceph FS as a Filesystem in User Space (FUSE). ::
+Mount CephFS as a Filesystem in User Space (FUSE). ::
 
 	sudo mkdir ~/mycephfs
 	sudo ceph-fuse -m {ip-address-of-monitor}:6789 ~/mycephfs
@@ -108,12 +108,12 @@ is not in the default location (i.e., ``/etc/ceph``)::
 Additional Information
 ======================
 
-See `Ceph FS`_ for additional information. Ceph FS is not quite as stable
+See `CephFS`_ for additional information. CephFS is not quite as stable
 as the Ceph Block Device and Ceph Object Storage. See `Troubleshooting`_
 if you encounter trouble. 
 
 .. _Storage Cluster Quick Start: ../quick-ceph-deploy
-.. _Ceph FS: ../../cephfs/
+.. _CephFS: ../../cephfs/
 .. _FAQ: http://wiki.ceph.com/How_Can_I_Give_Ceph_a_Try
 .. _Troubleshooting: ../../cephfs/troubleshooting
 .. _OS Recommendations: ../os-recommendations


### PR DESCRIPTION
http://tracker.ceph.com/issues/26916

This [commit](https://github.com/ceph/ceph/commit/81c0a328ac38a12865702c80a73ed3ecf8c4affe) is cherry-picked additionally to fix the doc build failure.