### PR TITLE
run-make-check: Showing configuration before the build

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -123,7 +123,7 @@ EOM
         echo "Current ccache max_size setting:"
         ccache -p | grep max_size
     fi
-    $DRY_RUN ccache -z # Reset the ccache statistics
+    $DRY_RUN ccache -sz # Reset the ccache statistics and show the current configuration
 
     $DRY_RUN ./do_cmake.sh $CMAKE_BUILD_OPTS $@ || return 1
     $DRY_RUN cd build


### PR DESCRIPTION
The actual code is resetting the statistics before doing the actual compilation and prints them after the build.

That is nice to understand how much the cache was used but doesn't help understanding how much it _could_ have been used.

This patch is adding a reporting (-s) when cleaning the statistics so we can estimate :
- the actual number of files in cache
- the actual size of the cache

With this two missing information, its now possible estimate if there is some miss-usage of the cache.

Signed-off-by: Erwan Velu <erwan@redhat.com>