### PR TITLE
debian/rules: fix ceph-mgr .pyc files left behind

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -143,6 +143,8 @@ override_dh_python2:
 	dh_python2 -p ceph-base
 	dh_python2 -p ceph-osd
 	dh_python2 -p ceph-mgr
+	# batch-compile, and set up for delete, all the module files
+	dh_python2 -p ceph-mgr usr/lib/ceph/mgr
 
 override_dh_python3:
 	for binding in rados cephfs rbd rgw; do \


### PR DESCRIPTION
Add second dh_python2 call with the "private" dir /usr/lib/ceph/mgr

Fixes: http://tracker.ceph.com/issues/26883
Signed-off-by: Dan Mick <dan.mick@redhat.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

