### PR TITLE
doc: updated ceph documentation links

### DIFF
--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -820,7 +820,7 @@ The ``suites`` directory of the `ceph/qa sub-directory`_ contains
 all the integration tests, for all the Ceph components.
 
 `ceph-deploy <https://github.com/ceph/ceph/tree/master/qa/suites/ceph-deploy>`_
-  install a Ceph cluster with ``ceph-deploy`` (`ceph-deploy man page`_)
+  install a Ceph cluster with ``ceph-deploy`` (:ref:`ceph-deploy man page <ceph-deploy>`)
 
 `dummy <https://github.com/ceph/ceph/tree/master/qa/suites/dummy>`_
   get a machine, do nothing and return success (commonly used to

--- a/doc/man/8/ceph-deploy.rst
+++ b/doc/man/8/ceph-deploy.rst
@@ -1,5 +1,7 @@
 :orphan:
 
+.. _ceph-deploy:
+
 =====================================
  ceph-deploy -- Ceph deployment tool
 =====================================

--- a/doc/releases/infernalis.rst
+++ b/doc/releases/infernalis.rst
@@ -1,3 +1,5 @@
+.. _infernalis-release-notes:
+
 v9.2.1 Infernalis
 =================
 

--- a/doc/start/documenting-ceph.rst
+++ b/doc/start/documenting-ceph.rst
@@ -588,7 +588,7 @@ improves the readability of the document in a command line interface.
 .. _ditaa: http://ditaa.sourceforge.net/
 .. _Document Title: http://docutils.sourceforge.net/docs/user/rst/quickstart.html#document-title-subtitle
 .. _Sections: http://docutils.sourceforge.net/docs/user/rst/quickstart.html#sections
-.. _Cross referencing arbitrary locations: http://sphinx-doc.org/markup/inline.html#ref-role
+.. _Cross referencing arbitrary locations: http://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html#role-ref
 .. _The TOC tree: http://sphinx-doc.org/markup/toctree.html
 .. _Showing code examples: http://sphinx-doc.org/markup/code.html
 .. _paragraph level markup: http://sphinx-doc.org/markup/para.html

--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -166,7 +166,7 @@ hacks (e.g., ``root``,  ``admin``, ``{productname}``). The following procedure,
 substituting  ``{username}`` for the user name you define, describes how to
 create a user with passwordless ``sudo``.
 
-.. note:: Starting with the `Infernalis release`_ the "ceph" user name is reserved
+.. note:: Starting with the :ref:`Infernalis release <infernalis-release-notes>`, the "ceph" user name is reserved
    for the Ceph daemons. If the "ceph" user already exists on the Ceph nodes,
    removing the user must be done before attempting an upgrade.
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

Updated various Ceph documentation links. Added reference labels for ``ceph-deploy`` man page and Infernalis release notes.

Signed-off-by: James McClune jmcclune@mcclunetechnologies.net