### PR TITLE
mgr: fixup pgs show in unknown state

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -1230,7 +1230,7 @@ function get_num_active_clean() {
     expression+="select(contains(\"active\") and contains(\"clean\")) | "
     expression+="select(contains(\"stale\") | not)"
     ceph --format json pg dump pgs 2>/dev/null | \
-        jq "[.[] | .state | $expression] | length"
+        jq ".pg_stats | [.[] | .state | $expression] | length"
 }
 
 function test_get_num_active_clean() {
@@ -1287,7 +1287,7 @@ function test_get_num_pgs() {
 # @return 0 on success, 1 on error
 #
 function get_osd_id_used_by_pgs() {
-    ceph --format json pg dump pgs 2>/dev/null | jq '.[] | .up[], .acting[]' | sort
+    ceph --format json pg dump pgs 2>/dev/null | jq '.pg_stats | .[] | .up[], .acting[]' | sort
 }
 
 function test_get_osd_id_used_by_pgs() {
@@ -1361,7 +1361,7 @@ function get_last_scrub_stamp() {
     local pgid=$1
     local sname=${2:-last_scrub_stamp}
     ceph --format json pg dump pgs 2>/dev/null | \
-        jq -r ".[] | select(.pgid==\"$pgid\") | .$sname"
+        jq -r ".pg_stats | .[] | select(.pgid==\"$pgid\") | .$sname"
 }
 
 function test_get_last_scrub_stamp() {

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1786,7 +1786,10 @@ class CephManager:
         """
         out = self.raw_cluster_cmd('pg', 'dump', '--format=json')
         j = json.loads('\n'.join(out.split('\n')[1:]))
-        return j['pg_stats']
+        try:
+            return j['pg_map']['pg_stats']
+        except KeyError:
+            return j['pg_stats']
 
     def get_pgids_to_force(self, backfill):
         """

--- a/qa/workunits/rados/test_large_omap_detection.py
+++ b/qa/workunits/rados/test_large_omap_detection.py
@@ -73,7 +73,11 @@ def get_deep_scrub_timestamp(pgid):
     cmd = ['ceph', 'pg', 'dump', '--format=json-pretty']
     proc = subprocess.Popen(cmd, stdout=subprocess.PIPE)
     out = proc.communicate()[0]
-    for stat in json.loads(out)['pg_stats']:
+    try:
+        pgstats = json.loads(out)['pg_map']['pg_stats']
+    except KeyError:
+        pgstats = json.loads(out)['pg_stats']
+    for stat in pgstats:
         if stat['pgid'] == pgid:
             return stat['last_deep_scrub_stamp']
 

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -836,7 +836,11 @@ def get_scrub_timestamps(childargs):
     devnull = open(os.devnull, 'w')
     out = subprocess.check_output(['ceph', 'pg', 'dump', '--format=json-pretty'],
                                   stderr=devnull)
-    for stat in json.loads(out)['pg_stats']:
+    try:
+        pgstats = json.loads(out)['pg_map']['pg_stats']
+    except KeyError:
+        pgstats = json.loads(out)['pg_stats']
+    for stat in pgstats:
         if scruball or stat['up_primary'] == int(childargs[2]):
             scrub_tuple = (stat['up_primary'], stat[last_scrub_stamp])
             results[stat['pgid']] = scrub_tuple

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2701,10 +2701,22 @@ namespace {
     if (!parser.parse(outbl.c_str(), outbl.length())) {
       return -EINVAL;
     }
+    
+    vector<string> v;
     if (!parser.is_array()) {
-      return -EINVAL;
+      JSONObj *pgstat_obj = parser.find_obj("pg_stats");
+      if (NULL == pgstat_obj)
+        return 0;
+      string s = pgstat_obj->get_data();
+      JSONParser pg_stats;
+      if (!pg_stats.parse(s.c_str(), s.length()))
+        return -EINVAL;
+      v = pg_stats.get_array_elements();
     }
-    vector<string> v = parser.get_array_elements();
+    else {
+      v = parser.get_array_elements();
+    }
+
     for (auto i : v) {
       JSONParser pg_json;
       if (!pg_json.parse(i.c_str(), i.length())) {


### PR DESCRIPTION
pgs show the unknown state, when the mgr has just started, use the command ceph pg dump pgs_brief\pgs\...,
because the pgs state has not been reported from the Osd to the Mgr service,
We need to wait for this state before we can run the ceph pg related state on Mgr.

Fixes: http://tracker.ceph.com/issues/25103
Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

