### PR TITLE
mgr/status: Add standby-replay MDS ceph version

### DIFF
--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -200,6 +200,9 @@ class Module(MgrModule):
                     5
                 ) + "/s"
 
+                metadata = self.get_metadata('mds', daemon_info['name'])
+                mds_versions[metadata.get('ceph_version', "unknown")].append(daemon_info['name'])
+
                 rank_table.add_row([
                     "{0}-s".format(daemon_info['rank']), "standby-replay",
                     daemon_info['name'], activity,


### PR DESCRIPTION
We have 3 MDSes, but `mgr fs status` only shows 2 MDSes' ceph version without standby-replay MDS's version.
```
[ceph@c167 ~]$ ceph tell mgr fs status
cephfs - 0 clients
======
+------+----------------+------+---------------+-------+-------+
| Rank |     State      | MDS  |    Activity   |  dns  |  inos |
+------+----------------+------+---------------+-------+-------+
|  0   |     active     | c166 | Reqs:    0 /s |  344  |  346  |
| 0-s  | standby-replay | c165 | Evts:    0 /s |    0  |    0  |
+------+----------------+------+---------------+-------+-------+
...
+-------------+
| Standby MDS |
+-------------+
|     c167    |
+-------------+
+-------------------------------------------------------------------------------------------------+---------+
|                                             version                                             | daemons |
+-------------------------------------------------------------------------------------------------+---------+
|   ceph version 12.2.7-60-g81de5ac (81de5ac4f95a30fa7c5563aad8119c119c07ab56) luminous (stable)  |   c166  |
| ceph version 12.2.7-60-g81de5ac4f9 (81de5ac4f95a30fa7c5563aad8119c119c07ab56) luminous (stable) |   c167  |
+-------------------------------------------------------------------------------------------------+---------+
```

After the fix, all the version will be shown.
```
+-------------------------------------------------------------------------------------------------+------------+
|                                             version                                             |  daemons   |
+-------------------------------------------------------------------------------------------------+------------+
|   ceph version 12.2.7-60-g81de5ac (81de5ac4f95a30fa7c5563aad8119c119c07ab56) luminous (stable)  |    c166    |
| ceph version 12.2.7-60-g81de5ac4f9 (81de5ac4f95a30fa7c5563aad8119c119c07ab56) luminous (stable) | c165, c167 |
+-------------------------------------------------------------------------------------------------+------------+
```

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

