### PR TITLE
messages: fix get_opname return type

### DIFF
--- a/src/messages/MMDSSlaveRequest.h
+++ b/src/messages/MMDSSlaveRequest.h
@@ -55,7 +55,7 @@ public:
   //static constexpr int OP_COMMIT = 21;  // used for recovery only
 
 
-  static constexpr char *get_opname(int o) {
+  static const char *get_opname(int o) {
     switch (o) { 
     case OP_XLOCK: return "xlock";
     case OP_XLOCKACK: return "xlock_ack";

--- a/src/messages/MMonPaxos.h
+++ b/src/messages/MMonPaxos.h
@@ -36,7 +36,7 @@ private:
   static constexpr int OP_COMMIT =    5; // proposer: notify learners of agreed value
   static constexpr int OP_LEASE =     6; // leader: extend peon lease
   static constexpr int OP_LEASE_ACK = 7; // peon: lease ack
-  const static char *get_opname(int op) {
+  static const char *get_opname(int op) {
     switch (op) {
     case OP_COLLECT: return "collect";
     case OP_LAST: return "last";


### PR DESCRIPTION
It cannot be a constexpr.

Introduce-by: 00b867fae2e8e912119fc47348dee78631c6f66b / #23623

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>
