### PR TITLE
cmake,crimson/net: add keepalive support, and enable unittest_seastar_messenger in "make check"

### DIFF
--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -59,6 +59,10 @@ class Connection : public boost::intrusive_ref_counter<Connection,
   /// send a message over a connection that has completed its handshake
   virtual seastar::future<> send(MessageRef msg) = 0;
 
+  /// send a keepalive message over a connection that has completed its
+  /// handshake
+  virtual seastar::future<> keepalive() = 0;
+
   /// close the connection and cancel any any pending futures from read/send
   virtual seastar::future<> close() = 0;
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -109,9 +109,6 @@ class SocketConnection : public Connection {
   void set_features(uint64_t new_features) {
     features = new_features;
   }
-  bool has_feature(uint64_t feature) const {
-    return features & feature;
-  }
 
   /// the seq num of the last transmitted message
   seq_num_t out_seq = 0;

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -128,7 +128,14 @@ class SocketConnection : public Connection {
   static void discard_up_to(std::queue<MessageRef>*, seq_num_t);
 
   struct Keepalive {
-    ceph_timespec reply_stamp;
+    struct {
+      const char tag = CEPH_MSGR_TAG_KEEPALIVE2;
+      ceph_timespec stamp;
+    } __attribute__((packed)) req;
+    struct {
+      const char tag = CEPH_MSGR_TAG_KEEPALIVE2_ACK;
+      ceph_timespec stamp;
+    } __attribute__((packed)) ack;
     ceph_timespec ack_stamp;
   } k;
 
@@ -151,6 +158,8 @@ class SocketConnection : public Connection {
   seastar::future<MessageRef> read_message() override;
 
   seastar::future<> send(MessageRef msg) override;
+
+  seastar::future<> keepalive() override;
 
   seastar::future<> close() override;
 

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -10,6 +10,7 @@ add_ceph_unittest(unittest_seastar_denc)
 target_link_libraries(unittest_seastar_denc ceph-common global crimson)
 
 add_executable(unittest_seastar_messenger test_messenger.cc)
+add_ceph_unittest(unittest_seastar_messenger)
 target_link_libraries(unittest_seastar_messenger ceph-common crimson)
 
 add_executable(unittest_seastar_echo

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -2,11 +2,21 @@
 #include "crimson/net/Connection.h"
 #include "crimson/net/Dispatcher.h"
 #include "crimson/net/SocketMessenger.h"
+
+#include <random>
+#include <boost/program_options.hpp>
 #include <seastar/core/app-template.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/reactor.hh>
 
-static seastar::future<> test_echo()
+namespace bpo = boost::program_options;
+
+static std::random_device rd;
+static std::default_random_engine rng{rd()};
+static bool verbose = false;
+
+static seastar::future<> test_echo(unsigned rounds,
+                                   double keepalive_ratio)
 {
   struct test_state {
     entity_addr_t addr;
@@ -16,7 +26,9 @@ static seastar::future<> test_echo()
       struct ServerDispatcher : ceph::net::Dispatcher {
         seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
                                       MessageRef m) override {
-          std::cout << "server got " << *m << std::endl;
+          if (verbose) {
+            std::cout << "server got " << *m << std::endl;
+          }
           // reply with a pong
           return c->send(MessageRef{new MPing(), false});
         }
@@ -24,42 +36,86 @@ static seastar::future<> test_echo()
     } server;
 
     struct {
+      unsigned rounds;
+      std::bernoulli_distribution keepalive_dist{};
       ceph::net::SocketMessenger messenger{entity_name_t::OSD(0)};
       struct ClientDispatcher : ceph::net::Dispatcher {
         seastar::promise<MessageRef> reply;
+        unsigned count = 0u;
         seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
                                       MessageRef m) override {
+          ++count;
+          if (verbose) {
+            std::cout << "client ms_dispatch " << count << std::endl;
+          }
           reply.set_value(std::move(m));
           return seastar::now();
         }
       } dispatcher;
+      seastar::future<> pingpong(ceph::net::ConnectionRef c) {
+        return seastar::repeat([conn=std::move(c), this] {
+          if (keepalive_dist(rng)) {
+            return conn->keepalive().then([] {
+              return seastar::make_ready_future<seastar::stop_iteration>(
+                seastar::stop_iteration::no);
+              });
+          } else {
+            return conn->send(MessageRef{new MPing(), false}).then([&] {
+              return dispatcher.reply.get_future();
+            }).then([&] (MessageRef msg) {
+              dispatcher.reply = seastar::promise<MessageRef>{};
+              if (verbose) {
+                std::cout << "client got reply " << *msg << std::endl;
+              }
+              return seastar::make_ready_future<seastar::stop_iteration>(
+                  seastar::stop_iteration::yes);
+            });
+          };
+        });
+      }
+      bool done() const {
+        return dispatcher.count >= rounds;
+      }
     } client;
   };
   return seastar::do_with(test_state{},
-    [] (test_state& t) {
+    [rounds, keepalive_ratio] (test_state& t) {
       // bind the server
       t.addr.set_family(AF_INET);
       t.addr.set_port(9010);
       t.server.messenger.bind(t.addr);
 
+      t.client.rounds = rounds;
+      t.client.keepalive_dist = std::bernoulli_distribution{keepalive_ratio};
+
       return t.server.messenger.start(&t.server.dispatcher)
         .then([&] {
           return t.client.messenger.start(&t.client.dispatcher)
             .then([&] {
-              return t.client.messenger.connect(t.addr, entity_name_t::TYPE_OSD);
-            }).then([] (ceph::net::ConnectionRef conn) {
-              std::cout << "client connected" << std::endl;
-              return conn->send(MessageRef{new MPing(), false});
-            }).then([&] {
-              return t.client.dispatcher.reply.get_future();
-            }).then([&] (MessageRef msg) {
-              std::cout << "client got reply " << *msg << std::endl;
+              return t.client.messenger.connect(t.addr,
+                                                entity_name_t::TYPE_OSD);
+            }).then([&client=t.client] (ceph::net::ConnectionRef conn) {
+              if (verbose) {
+                std::cout << "client connected" << std::endl;
+              }
+              return seastar::repeat([&client,conn=std::move(conn)] {
+                return client.pingpong(conn).then([&client] {
+                  return seastar::make_ready_future<seastar::stop_iteration>(
+                    client.done() ?
+                    seastar::stop_iteration::yes :
+                    seastar::stop_iteration::no);
+                });
+              });
             }).finally([&] {
-              std::cout << "client shutting down" << std::endl;
+              if (verbose) {
+                std::cout << "client shutting down" << std::endl;
+              }
               return t.client.messenger.shutdown();
             });
         }).finally([&] {
-          std::cout << "server shutting down" << std::endl;
+          if (verbose) {
+            std::cout << "server shutting down" << std::endl;
+          }
           return t.server.messenger.shutdown();
         });
     });
@@ -68,8 +124,19 @@ static seastar::future<> test_echo()
 int main(int argc, char** argv)
 {
   seastar::app_template app;
-  return app.run(argc, argv, [] {
-    return test_echo().then([] {
+  app.add_options()
+    ("verbose,v", bpo::value<bool>()->default_value(false),
+     "chatty if true")
+    ("rounds", bpo::value<unsigned>()->default_value(512),
+     "number of pingpong rounds")
+    ("keepalive-ratio", bpo::value<double>()->default_value(0.1),
+     "ratio of keepalive in ping messages");
+  return app.run(argc, argv, [&] {
+    auto&& config = app.configuration();
+    verbose = config["verbose"].as<bool>();
+    auto rounds = config["rounds"].as<unsigned>();
+    auto keepalive_ratio = config["keepalive-ratio"].as<double>();
+    return test_echo(rounds, keepalive_ratio).then([] {
       std::cout << "All tests succeeded" << std::endl;
     }).handle_exception([] (auto eptr) {
       std::cout << "Test failure" << std::endl;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

