### PR TITLE
change ceph-mgr package depency from py-bcrypt to python2-bcrypt

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -250,12 +250,7 @@ BuildRequires:	python3-Cython
 BuildRequires:	python%{_python_buildid}-cherrypy
 BuildRequires:	python%{_python_buildid}-routes
 BuildRequires:	python%{_python_buildid}-werkzeug
-%if 0%{?fedora}
 BuildRequires:	python%{_python_buildid}-bcrypt
-%endif
-%if 0%{?rhel}
-BuildRequires:	py-bcrypt
-%endif
 %endif
 %if 0%{?suse_version}
 BuildRequires:	python%{_python_buildid}-CherryPy
@@ -409,12 +404,7 @@ Requires:       python%{_python_buildid}-jinja2
 Requires:       python%{_python_buildid}-routes
 Requires:       python%{_python_buildid}-werkzeug
 Requires:       pyOpenSSL%{_python_buildid}
-%if 0%{?fedora}
 Requires:	python%{_python_buildid}-bcrypt
-%endif
-%if 0%{?rhel}
-Requires:	py-bcrypt
-%endif
 %endif
 %if 0%{?suse_version}
 Requires:       python%{_python_buildid}-CherryPy


### PR DESCRIPTION
rpm: change ceph-mgr package depency from py-bcrypt to python2-bcrypt 

Current deplist of ceph-mgr rpm package contains py-bcrypt depency which conflicts with python2-bcrypt needed for python-keystone package on systems with all-in-one installation of openstack+ceph on CentOS 7.
Proposed change fixes this incompatibility by changing ceph-mgr package depency from by-bcrypt to python2-bcrypt.

Fixes: [can't create tracker task], needs backport to mimic.

Signed-off-by: Konstantin Sakhinov <sakhinov@gmail.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

