### PR TITLE
qa: use cephfs standard configs for kclient

### DIFF
--- a/qa/suites/kcephfs/cephfs/begin.yaml
+++ b/qa/suites/kcephfs/cephfs/begin.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin.yaml

--- a/qa/suites/kcephfs/cephfs/inline/no.yaml
+++ b/qa/suites/kcephfs/cephfs/inline/no.yaml
@@ -1,3 +1,0 @@
-tasks:
-- install:
-- ceph:

--- a/qa/suites/kcephfs/cephfs/inline/yes.yaml
+++ b/qa/suites/kcephfs/cephfs/inline/yes.yaml
@@ -1,6 +1,4 @@
 tasks:
-- install:
-- ceph:
 - exec:
     client.0:
       - sudo ceph fs set cephfs inline_data true --yes-i-really-mean-it

--- a/qa/suites/kcephfs/mixed-clients/begin.yaml
+++ b/qa/suites/kcephfs/mixed-clients/begin.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin.yaml

--- a/qa/suites/kcephfs/mixed-clients/tasks/kernel_cfuse_workunits_dbench_iozone.yaml
+++ b/qa/suites/kcephfs/mixed-clients/tasks/kernel_cfuse_workunits_dbench_iozone.yaml
@@ -1,6 +1,4 @@
 tasks:
-- install:
-- ceph:
 - parallel:
    - user-workload
    - kclient-workload

--- a/qa/suites/kcephfs/mixed-clients/tasks/kernel_cfuse_workunits_untarbuild_blogbench.yaml
+++ b/qa/suites/kcephfs/mixed-clients/tasks/kernel_cfuse_workunits_untarbuild_blogbench.yaml
@@ -1,6 +1,4 @@
 tasks:
-- install:
-- ceph:
 - parallel:
    - user-workload
    - kclient-workload

--- a/qa/suites/kcephfs/recovery/begin.yaml
+++ b/qa/suites/kcephfs/recovery/begin.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin.yaml

--- a/qa/suites/kcephfs/recovery/mounts/kmounts.yaml
+++ b/qa/suites/kcephfs/recovery/mounts/kmounts.yaml
@@ -1,4 +1,2 @@
 tasks:
-- install:
-- ceph:
 - kclient:

--- a/qa/suites/kcephfs/thrash/begin.yaml
+++ b/qa/suites/kcephfs/thrash/begin.yaml
@@ -1,0 +1,1 @@
+.qa/cephfs/begin.yaml

--- a/qa/suites/kcephfs/thrash/thrashers/default.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/default.yaml
@@ -1,7 +1,7 @@
-tasks:
-- install:
-- ceph:
+overrides:
+  ceph:
     log-whitelist:
-    - but it is still running
-    - objects unfound and apparently lost
+      - but it is still running
+      - objects unfound and apparently lost
+tasks:
 - thrashosds:

--- a/qa/suites/kcephfs/thrash/thrashers/mds.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/mds.yaml
@@ -1,9 +1,7 @@
-tasks:
-- install:
-- ceph:
-- mds_thrash:
-
 overrides:
   ceph:
     log-whitelist:
       - not responding, replacing
+
+tasks:
+- mds_thrash:

--- a/qa/suites/kcephfs/thrash/thrashers/mon.yaml
+++ b/qa/suites/kcephfs/thrash/thrashers/mon.yaml
@@ -2,9 +2,8 @@ overrides:
   ceph:
     log-whitelist:
     - \(MON_DOWN\)
+
 tasks:
-- install:
-- ceph:
 - mon_thrash:
     revive_delay: 20
     thrash_delay: 1


### PR DESCRIPTION
Specifically, qa/cephfs/begin.yaml.

Fixes: http://tracker.ceph.com/issues/26967

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>