### PR TITLE
mgr/dashboard: Grafana graphs integration with dashboard

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -71,7 +71,7 @@ various aspects of your Ceph cluster:
 * **Object Gateway**: Lists all active object gateways and their performance
   counters. Display and manage (add/edit/delete) object gateway users and their
   details (e.g. quotas) as well as the users' buckets and their details (e.g.
-  owner, quotas). 
+  owner, quotas).
 
 Enabling
 --------
@@ -252,13 +252,6 @@ The default value is 45 seconds.
 Enabling the Embedding of Grafana Dashboards
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. note:: 
-  The embedding of Grafana dashboards into the Ceph Manager Dashboard is
-  currently work in progress. This section documents the backend configuration.
-  The corresponding changes to the WebUI have not been merged yet. You can
-  follow the development process in `PR#23666
-  <https://github.com/ceph/ceph/pull/23666>`_.
-
 Grafana and Prometheus are likely going to be bundled and installed by some
 orchestration tools along Ceph in the near future, but currently, you will have
 to install and configure both manually. After you have installed Prometheus and
@@ -268,9 +261,7 @@ Grafana on your preferred hosts, proceed with the following steps.
 
     $ ceph mgr module enable prometheus
 
-    More details can be found on the `documentation
-    <http://docs.ceph.com/docs/master/mgr/prometheus/>`_ of the prometheus
-    module.
+More details can be found on the `documentation <http://docs.ceph.com/docs/master/mgr/prometheus/>`_ of the prometheus module.
 
 #. Add the corresponding scrape configuration to Prometheus. This may look
    like::
@@ -291,42 +282,29 @@ Grafana on your preferred hosts, proceed with the following steps.
 
 #. Add Prometheus as data source to Grafana
 
-#. Install the `vonage-status-panel` plugin using::
+#. Install the `vonage-status-panel and grafana-piechart-panel` plugins using::
 
         grafana-cli plugins install vonage-status-panel
+        grafana-cli plugins install grafana-piechart-panel
 
 #. Add the Dashboards to Grafana by importing them
 
-#. Configure Grafana in `/etc/grafana/grafana.ini` to adapt the URLs to the
-   Ceph Dashboard properly::
+#. Configure Grafana in `/etc/grafana/grafana.ini` to adapt anonymous mode::
 
-        root_url = http://localhost:3000/api/grafana/proxy
+        [auth.anonymous]
+        enabled = true
+        org_name = Main Org.
+        org_role = Viewer
 
 After you have set up Grafana and Prometheus, you will need to configure the
 connection information that the Ceph Manager Dashboard will use to access Grafana.
-This includes setting the authentication method to be used, the corresponding login
-credentials as well as the URL at which the Grafana instance can be reached.
 
-The URL and TCP port can be set by using the following command::
+You need to tell the dashboard on which url Grafana instance is running/deployed::
 
-  $ ceph dashboard set-grafana-api-url <url>  # default: 'http://localhost:3000'
+  $ ceph dashboard set-grafana-api-url <grafana-server-url>  # default: ''
 
-You need to tell the dashboard which authentication method should be
-used::
-
-  $ ceph dashboard set-grafana-api-auth-method <method>  # default: ''
-
-Possible values are either 'password' or 'token'.
-
-To authenticate via username and password, you will need to set the following
-values::
-
-  $ ceph dashboard set-grafana-api-username <username>  # default: 'admin'
-  $ ceph dashboard set-grafana-api-password <password>  # default: 'admin'
-
-To use token based authentication, you will ned to set the token by issuing::
-
-  $ ceph dashboard set-grafana-api-token <token>  # default: ''
+The format of url is : `<protocol>:<IP-address>:<port>`
+You can directly access Grafana Instance as well to monitor your cluster.
 
 Accessing the dashboard
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -523,4 +501,3 @@ to use hyperlinks that include your prefix, you can set the
   ceph config set mgr mgr/dashboard/url_prefix $PREFIX
 
 so you can access the dashboard at ``http://$IP:$PORT/$PREFIX/``.
-

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.html
@@ -40,6 +40,12 @@
                        *ngIf="clientsSelect">
     </cd-cephfs-clients>
   </tab>
+  <tab i18n-heading
+       heading="Performance Details">
+    <cd-grafana [grafanaPath]="'rRfFzWtik/mds-performance?var-mds_servers=mds.' + grafanaId"
+                grafanaStyle="one">
+    </cd-grafana>
+  </tab>
 </tabset>
 
 <!-- templates -->

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-detail/cephfs-detail.component.ts
@@ -30,6 +30,7 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
   standbys = [];
   clientCount: number;
   mdsCounters = {};
+  grafanaId: any;
 
   objectValues = Object.values;
   clientsSelect = false;
@@ -43,6 +44,8 @@ export class CephfsDetailComponent implements OnChanges, OnInit {
   ngOnChanges() {
     if (this.selection.hasSelection) {
       this.selectedItem = this.selection.first();
+      const mdsInfo: any[] = this.selectedItem.mdsmap.info;
+      this.grafanaId = Object.values(mdsInfo)[0].name;
 
       if (this.id !== this.selectedItem.id) {
         this.id = this.selectedItem.id;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/cluster.module.ts
@@ -10,6 +10,7 @@ import { TabsModule } from 'ngx-bootstrap/tabs';
 import { SharedModule } from '../../shared/shared.module';
 import { PerformanceCounterModule } from '../performance-counter/performance-counter.module';
 import { ConfigurationComponent } from './configuration/configuration.component';
+import { HostDetailsComponent } from './hosts/host-details/host-details.component';
 import { HostsComponent } from './hosts/hosts.component';
 import { MonitorComponent } from './monitor/monitor.component';
 import { OsdDetailsComponent } from './osd/osd-details/osd-details.component';
@@ -39,7 +40,8 @@ import { OsdScrubModalComponent } from './osd/osd-scrub-modal/osd-scrub-modal.co
     OsdDetailsComponent,
     OsdPerformanceHistogramComponent,
     OsdScrubModalComponent,
-    OsdFlagsModalComponent
+    OsdFlagsModalComponent,
+    HostDetailsComponent
   ]
 })
 export class ClusterModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.html
@@ -1,0 +1,8 @@
+<tabset *ngIf="selection.hasSingleSelection">
+  <tab i18n-heading
+       heading="Performance Details">
+    <cd-grafana [grafanaPath]="'7IGu2Ttmz/host-details?'"
+                grafanaStyle="three">
+    </cd-grafana>
+  </tab>
+</tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.spec.ts
@@ -1,0 +1,38 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { BsDropdownModule } from 'ngx-bootstrap';
+import { TabsModule } from 'ngx-bootstrap/tabs';
+
+import { configureTestBed } from '../../../../../testing/unit-test-helper';
+import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
+import { SharedModule } from '../../../../shared/shared.module';
+import { HostDetailsComponent } from './host-details.component';
+
+describe('HostDetailsComponent', () => {
+  let component: HostDetailsComponent;
+  let fixture: ComponentFixture<HostDetailsComponent>;
+
+  configureTestBed({
+    imports: [
+      HttpClientTestingModule,
+      TabsModule.forRoot(),
+      BsDropdownModule.forRoot(),
+      SharedModule
+    ],
+    declarations: [HostDetailsComponent]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(HostDetailsComponent);
+    component = fixture.componentInstance;
+
+    component.selection = new CdTableSelection();
+
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/host-details/host-details.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input, OnChanges } from '@angular/core';
+
+import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
+
+@Component({
+  selector: 'cd-host-details',
+  templateUrl: './host-details.component.html',
+  styleUrls: ['./host-details.component.scss']
+})
+export class HostDetailsComponent implements OnChanges {
+  @Input()
+  selection: CdTableSelection;
+  host: any;
+
+  constructor() {}
+
+  ngOnChanges() {
+    if (this.selection.hasSelection) {
+      this.host = this.selection.first();
+    }
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.html
@@ -1,14 +1,33 @@
-<cd-table [data]="hosts"
-          [columns]="columns"
-          columnMode="flex"
-          (fetchData)="getHosts($event)">
-  <ng-template #servicesTpl let-value="value">
-    <span *ngFor="let service of value; last as isLast">
-      <a [routerLink]="[service.cdLink]"
-         [queryParams]="cdParams"
-         *ngIf="service.canRead">{{ service.type }}.{{ service.id }}</a>
-      <span *ngIf="!service.canRead">{{ service.type }}.{{ service.id }}</span>
-      {{ !isLast ? ", " : "" }}
-    </span>
-  </ng-template>
-</cd-table>
+<tabset>
+  <tab i18n-heading
+       heading="Hosts List">
+    <cd-table [data]="hosts"
+              [columns]="columns"
+              columnMode="flex"
+              (fetchData)="getHosts($event)"
+              selectionType="single"
+              (updateSelection)="updateSelection($event)">
+      <ng-template #servicesTpl let-value="value">
+        <span *ngFor="let service of value; last as isLast">
+          <a [routerLink]="[service.cdLink]"
+             [queryParams]="cdParams"
+             *ngIf="service.canRead">{{ service.type }}.{{ service.id }}
+          </a>
+          <span *ngIf="!service.canRead">
+            {{ service.type }}.{{ service.id }}
+          </span>
+          {{ !isLast ? ", " : "" }}
+        </span>
+      </ng-template>
+      <cd-host-details cdTableDetail
+                       [selection]="selection">
+      </cd-host-details>
+    </cd-table>
+  </tab>
+  <tab i18n-heading
+       heading="Overall Performance">
+    <cd-grafana [grafanaPath]="'lxnjcTAmk/host-overview?'"
+                grafanaStyle="two">
+    </cd-grafana>
+  </tab>
+</tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -3,12 +3,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap';
+import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ComponentsModule } from '../../../shared/components/components.module';
 import { Permissions } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { SharedModule } from '../../../shared/shared.module';
+import { HostDetailsComponent } from './host-details/host-details.component';
 import { HostsComponent } from './hosts.component';
 
 describe('HostsComponent', () => {
@@ -25,12 +27,13 @@ describe('HostsComponent', () => {
     imports: [
       SharedModule,
       HttpClientTestingModule,
+      TabsModule.forRoot(),
       ComponentsModule,
       BsDropdownModule.forRoot(),
       RouterTestingModule
     ],
     providers: [{ provide: AuthStorageService, useValue: fakeAuthStorageService }],
-    declarations: [HostsComponent]
+    declarations: [HostsComponent, HostDetailsComponent]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { HostService } from '../../../shared/api/host.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
 import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
+import { CdTableSelection } from '../../../shared/models/cd-table-selection';
 import { Permissions } from '../../../shared/models/permissions';
 import { CephShortVersionPipe } from '../../../shared/pipes/ceph-short-version.pipe';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
@@ -18,6 +19,7 @@ export class HostsComponent implements OnInit {
   hosts: Array<object> = [];
   isLoadingHosts = false;
   cdParams = { fromLink: '/hosts' };
+  selection = new CdTableSelection();
 
   @ViewChild('servicesTpl')
   public servicesTpl: TemplateRef<any>;
@@ -50,6 +52,10 @@ export class HostsComponent implements OnInit {
         pipe: this.cephShortVersionPipe
       }
     ];
+  }
+
+  updateSelection(selection: CdTableSelection) {
+    this.selection = selection;
   }
 
   getHosts(context: CdTableFetchDataContext) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
@@ -34,4 +34,10 @@
       </div>
     </div>
   </tab>
+  <tab i18n-heading
+       heading="Performance Details">
+    <cd-grafana [grafanaPath]="'MKj_9ipiz/osd-device-details?var-osd_id=' + osd['id']"
+                grafanaStyle="GrafanaStyles.two">
+    </cd-grafana>
+  </tab>
 </tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -1,45 +1,57 @@
-<cd-table [data]="osds"
-          (fetchData)="getOsdList()"
-          [columns]="columns"
-          selectionType="single"
-          (updateSelection)="updateSelection($event)"
-          [updateSelectionOnRefresh]="'never'">
-  <div class="table-actions btn-toolbar"
-       *ngIf="permission.update">
-    <cd-table-actions [permission]="permission"
-                      [selection]="selection"
-                      onlyDropDown="Perform Task"
-                      class="btn-group"
-                      [tableActions]="tableActions">
-    </cd-table-actions>
+<tabset>
+  <tab i18n-heading
+       heading="OSDs List">
+    <cd-table [data]="osds"
+              (fetchData)="getOsdList()"
+              [columns]="columns"
+              selectionType="single"
+              (updateSelection)="updateSelection($event)"
+              [updateSelectionOnRefresh]="'never'">
+      <div class="table-actions btn-toolbar" *ngIf="permission.update">
+        <cd-table-actions [permission]="permission"
+                          [selection]="selection"
+                          onlyDropDown="Perform Task"
+                          class="btn-group"
+                          [tableActions]="tableActions">
+        </cd-table-actions>
 
-    <button class="btn btn-sm btn-default btn-label tc_configureCluster"
-            type="button"
-            (click)="configureClusterAction()">
-      <i class="fa fa-fw fa-cog"
-         aria-hidden="true"></i>
-      <ng-container i18n>Set Cluster-wide OSD Flags</ng-container>
-    </button>
-  </div>
+        <button class="btn btn-sm btn-default btn-label tc_configureCluster"
+                type="button"
+                (click)="configureClusterAction()">
+          <i class="fa fa-fw fa-cog"
+             aria-hidden="true">
+          </i>
+          <ng-container i18n>Set Cluster-wide OSD Flags</ng-container>
+        </button>
+      </div>
 
-  <cd-osd-details cdTableDetail
-                  [selection]="selection">
-  </cd-osd-details>
-</cd-table>
+      <cd-osd-details cdTableDetail
+                      [selection]="selection">
+      </cd-osd-details>
+    </cd-table>
 
-<ng-template #statusColor
-             let-value="value">
-  <span *ngFor="let state of value; last as last">
-    <span class="label"
-          [ngClass]="{'label-success': ['in', 'up'].includes(state), 'label-danger': ['down', 'out'].includes(state)}">
-      {{ state }}
-    </span>
-    <span *ngIf="!last">&nbsp;</span>
-  </span>
-</ng-template>
+    <ng-template #statusColor
+                 let-value="value">
+      <span *ngFor="let state of value; last as last">
+        <span class="label"
+              [ngClass]="{'label-success': ['in', 'up'].includes(state), 'label-danger': ['down', 'out'].includes(state)}">
+         {{ state }}
+        </span>
+        <span *ngIf="!last">&nbsp;</span>
+      </span>
+    </ng-template>
 
-<ng-template #osdUsageTpl
-             let-row="row">
-  <cd-usage-bar [totalBytes]="row.stats.stat_bytes"
-                [usedBytes]="row.stats.stat_bytes_used"></cd-usage-bar>
-</ng-template>
+    <ng-template #osdUsageTpl
+                 let-row="row">
+      <cd-usage-bar [totalBytes]="row.stats.stat_bytes"
+                    [usedBytes]="row.stats.stat_bytes_used">
+      </cd-usage-bar>
+    </ng-template>
+  </tab>
+  <tab i18n-heading
+       heading="Overall Performance">
+    <cd-grafana [grafanaPath]="'lo02I1Aiz/osd-overview?'"
+                grafanaStyle="three">
+    </cd-grafana>
+  </tab>
+</tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -1,6 +1,7 @@
 import { HttpClientModule } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
@@ -35,7 +36,8 @@ describe('OsdListComponent', () => {
       TabsModule.forRoot(),
       DataTableModule,
       ComponentsModule,
-      SharedModule
+      SharedModule,
+      RouterTestingModule
     ],
     declarations: [OsdListComponent, OsdDetailsComponent, OsdPerformanceHistogramComponent],
     providers: [

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.html
@@ -1,14 +1,31 @@
-<cd-table [data]="pools"
-          (fetchData)="getPoolList($event)"
-          [columns]="columns"
-          selectionType="single"
-          (updateSelection)="updateSelection($event)">
-  <tabset cdTableDetail *ngIf="selection.hasSingleSelection">
-    <tab i18n-heading
-         heading="Details">
-      <cd-table-key-value [data]="selection.first()" [autoReload]="false">
-      </cd-table-key-value>
-    </tab>
-  </tabset>
-</cd-table>
+<tabset>
+  <tab i18n-heading heading="Pools List">
+    <cd-table [data]="pools"
+              (fetchData)="getPoolList($event)"
+              [columns]="columns" selectionType="single"
+              (updateSelection)="updateSelection($event)">
+      <tabset cdTableDetail
+              *ngIf="selection.hasSingleSelection">
+        <tab i18n-heading heading="Details">
+          <cd-table-key-value [data]="selection.first()"
+                              [autoReload]="false">
+          </cd-table-key-value>
+        </tab>
+        <tab i18n-heading
+             heading="Performance Details">
+          <cd-grafana [grafanaPath]="'8ypfkWpik/ceph-pool-detail?var-pool_name='
+                      + selection.first()['pool_name']"
+                      grafanaStyle="one">
+          </cd-grafana>
+        </tab>
+      </tabset>
+    </cd-table>
+  </tab>
 
+  <tab i18n-heading
+       heading="Overall Performance">
+    <cd-grafana [grafanaPath]="'z99hzWtmk/ceph-pools-overview?'"
+                grafanaStyle="two">
+    </cd-grafana>
+  </tab>
+</tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs/tabs.module';
 
@@ -13,7 +14,7 @@ describe('PoolListComponent', () => {
 
   configureTestBed({
     declarations: [PoolListComponent],
-    imports: [SharedModule, TabsModule.forRoot(), HttpClientTestingModule]
+    imports: [SharedModule, TabsModule.forRoot(), HttpClientTestingModule, RouterTestingModule]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-details/rgw-daemon-details.component.html
@@ -11,4 +11,10 @@
                                   [serviceId]="serviceId">
     </cd-table-performance-counter>
   </tab>
+  <tab i18n-heading
+       heading="Performance Details">
+    <cd-grafana [grafanaPath]="'x5ARzZtmk/rgw-instance-detail?var-rgw_servers=rgw.' + this.selection.first().id"
+                grafanaStyle="one">
+    </cd-grafana>
+  </tab>
 </tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.html
@@ -1,10 +1,20 @@
-<cd-table [data]="daemons"
-          [columns]="columns"
-          columnMode="flex"
-          selectionType="single"
-          (updateSelection)="updateSelection($event)"
-          (fetchData)="getDaemonList($event)">
-  <cd-rgw-daemon-details cdTableDetail
-                         [selection]="selection">
-  </cd-rgw-daemon-details>
-</cd-table>
+<tabset>
+  <tab i18n-heading heading="Daemons List">
+    <cd-table [data]="daemons"
+              [columns]="columns"
+              columnMode="flex"
+              selectionType="single"
+              (updateSelection)="updateSelection($event)"
+              (fetchData)="getDaemonList($event)">
+      <cd-rgw-daemon-details cdTableDetail [selection]="selection">
+      </cd-rgw-daemon-details>
+    </cd-table>
+  </tab>
+
+  <tab i18n-heading
+       heading="Overall Performance">
+    <cd-grafana [grafanaPath]="'WAkugZpiz/rgw-overview?'"
+                grafanaStyle="two">
+    </cd-grafana>
+  </tab>
+</tabset>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-daemon-list/rgw-daemon-list.component.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientModule } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
@@ -15,7 +16,13 @@ describe('RgwDaemonListComponent', () => {
 
   configureTestBed({
     declarations: [RgwDaemonListComponent, RgwDaemonDetailsComponent],
-    imports: [HttpClientModule, TabsModule.forRoot(), PerformanceCounterModule, SharedModule]
+    imports: [
+      HttpClientModule,
+      TabsModule.forRoot(),
+      PerformanceCounterModule,
+      SharedModule,
+      RouterTestingModule
+    ]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.spec.ts
@@ -1,0 +1,34 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+
+import { configureTestBed } from '../../../testing/unit-test-helper';
+import { SettingsService } from './settings.service';
+
+describe('SettingsService', () => {
+  let service: SettingsService;
+  let httpTesting: HttpTestingController;
+
+  configureTestBed({
+    providers: [SettingsService],
+    imports: [HttpClientTestingModule]
+  });
+
+  beforeEach(() => {
+    service = TestBed.get(SettingsService);
+    httpTesting = TestBed.get(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should get protocol', () => {
+    service.getGrafanaApiUrl().subscribe();
+    const req = httpTesting.expectOne('api/settings/GRAFANA_API_URL');
+    expect(req.request.method).toBe('GET');
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/settings.service.ts
@@ -1,0 +1,15 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+import { ApiModule } from './api.module';
+
+@Injectable({
+  providedIn: ApiModule
+})
+export class SettingsService {
+  constructor(private http: HttpClient) {}
+
+  getGrafanaApiUrl() {
+    return this.http.get('api/settings/GRAFANA_API_URL');
+  }
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -4,12 +4,14 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
 import { ChartsModule } from 'ng2-charts/ng2-charts';
 import { AlertModule, ModalModule, PopoverModule, TooltipModule } from 'ngx-bootstrap';
+import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 
 import { DirectivesModule } from '../directives/directives.module';
 import { PipesModule } from '../pipes/pipes.module';
 import { ConfirmationModalComponent } from './confirmation-modal/confirmation-modal.component';
 import { DeletionModalComponent } from './deletion-modal/deletion-modal.component';
 import { ErrorPanelComponent } from './error-panel/error-panel.component';
+import { GrafanaComponent } from './grafana/grafana.component';
 import { HelperComponent } from './helper/helper.component';
 import { InfoPanelComponent } from './info-panel/info-panel.component';
 import { LoadingPanelComponent } from './loading-panel/loading-panel.component';
@@ -33,7 +35,8 @@ import { WarningPanelComponent } from './warning-panel/warning-panel.component';
     ReactiveFormsModule,
     PipesModule,
     ModalModule.forRoot(),
-    DirectivesModule
+    DirectivesModule,
+    BsDropdownModule
   ],
   declarations: [
     ViewCacheComponent,
@@ -48,7 +51,8 @@ import { WarningPanelComponent } from './warning-panel/warning-panel.component';
     ModalComponent,
     DeletionModalComponent,
     ConfirmationModalComponent,
-    WarningPanelComponent
+    WarningPanelComponent,
+    GrafanaComponent
   ],
   providers: [],
   exports: [
@@ -62,7 +66,8 @@ import { WarningPanelComponent } from './warning-panel/warning-panel.component';
     InfoPanelComponent,
     UsageBarComponent,
     ModalComponent,
-    WarningPanelComponent
+    WarningPanelComponent,
+    GrafanaComponent
   ],
   entryComponents: [ModalComponent, DeletionModalComponent, ConfirmationModalComponent]
 })

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.html
@@ -5,7 +5,10 @@
 </cd-loading-panel>
 <cd-info-panel *ngIf="!grafanaExist">
   <ng-container i18n>
-    Please consult the <a href="http://docs.ceph.com/docs/luminous/mgr/dashboard/" target="_blank">documentation</a> on how to configure and enable the monitoring functionality.
+    Please consult the
+    <a href="{{ docsUrl }}"
+       target="_blank">documentation
+    </a> on how to configure and enable the monitoring functionality.
   </ng-container>
 </cd-info-panel>
 <div class="row" *ngIf="grafanaExist">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.html
@@ -1,0 +1,42 @@
+<!-- Embed dashboard -->
+<cd-loading-panel *ngIf="loading && grafanaExist"
+                  i18n>
+  Loading panel data...
+</cd-loading-panel>
+<cd-info-panel *ngIf="!grafanaExist">
+  <ng-container i18n>
+    Please consult the <a href="http://docs.ceph.com/docs/luminous/mgr/dashboard/" target="_blank">documentation</a> on how to configure and enable the monitoring functionality.
+  </ng-container>
+</cd-info-panel>
+<div class="row" *ngIf="grafanaExist">
+  <div class="col-md-12">
+    <div dropdown>
+      <button dropdownToggle
+              class="btn btn-sm dropdown-toggle"
+              data-toggle="dropdown"
+              title="Advanced Settings">
+        <i class="fa fa-cog"></i>
+        <span class="caret"></span>
+      </button>
+      <ul *dropdownMenu
+          class="dropdown-menu">
+        <li>
+          <a i18n
+             class="dropdown-item"
+             (click)="timePickerToggle()">{{ modeText }}
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div class="grafana-container">
+      <iframe #iframe
+              id="iframe"
+              [src]="grafanaSrc"
+              class="grafana"
+              [ngClass]="panelStyle"
+              frameborder="0"
+              scrolling="no">
+      </iframe>
+    </div>
+  </div>
+</div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.scss
@@ -1,0 +1,33 @@
+.grafana {
+  width: 100%;
+  height: 600px;
+  z-index: 0;
+}
+
+.grafana_one {
+  height: 400px;
+}
+
+.grafana_two {
+  height: 750px;
+}
+
+.grafana_three {
+  height: 900px;
+}
+
+button {
+  margin-bottom: 10px;
+  margin-left: 10px;
+  float: right;
+  i {
+    font-size: 14px;
+    padding: 2px;
+  }
+}
+
+.dropdown-menu {
+  top: 20px;
+  right: 20px;
+  left: auto;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
@@ -1,11 +1,14 @@
 import { HttpClientModule } from '@angular/common/http';
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 
 import { AlertModule } from 'ngx-bootstrap';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { SettingsService } from '../../../shared/api/settings.service';
+import { SummaryService } from '../../../shared/services/summary.service';
+import { CephReleaseNamePipe } from '../../pipes/ceph-release-name.pipe';
 import { InfoPanelComponent } from '../info-panel/info-panel.component';
 import { LoadingPanelComponent } from '../loading-panel/loading-panel.component';
 import { GrafanaComponent } from './grafana.component';
@@ -16,8 +19,8 @@ describe('GrafanaComponent', () => {
 
   configureTestBed({
     declarations: [GrafanaComponent, InfoPanelComponent, LoadingPanelComponent],
-    imports: [AlertModule.forRoot(), HttpClientModule],
-    providers: [SettingsService]
+    imports: [AlertModule.forRoot(), HttpClientModule, RouterTestingModule],
+    providers: [CephReleaseNamePipe, SettingsService, SummaryService]
   });
 
   beforeEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.spec.ts
@@ -1,0 +1,32 @@
+import { HttpClientModule } from '@angular/common/http';
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AlertModule } from 'ngx-bootstrap';
+
+import { configureTestBed } from '../../../../testing/unit-test-helper';
+import { SettingsService } from '../../../shared/api/settings.service';
+import { InfoPanelComponent } from '../info-panel/info-panel.component';
+import { LoadingPanelComponent } from '../loading-panel/loading-panel.component';
+import { GrafanaComponent } from './grafana.component';
+
+describe('GrafanaComponent', () => {
+  let component: GrafanaComponent;
+  let fixture: ComponentFixture<GrafanaComponent>;
+
+  configureTestBed({
+    declarations: [GrafanaComponent, InfoPanelComponent, LoadingPanelComponent],
+    imports: [AlertModule.forRoot(), HttpClientModule],
+    providers: [SettingsService]
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(GrafanaComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -4,6 +4,8 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { SafeUrl } from '@angular/platform-browser';
 
 import { SettingsService } from '../../../shared/api/settings.service';
+import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
+import { SummaryService } from '../../../shared/services/summary.service';
 
 @Component({
   selector: 'cd-grafana',
@@ -31,8 +33,14 @@ export class GrafanaComponent implements OnInit, OnChanges {
   @Input()
   grafanaStyle: string;
   grafanaUrl: any;
+  docsUrl: string;
 
-  constructor(private sanitizer: DomSanitizer, private settingsService: SettingsService) {}
+  constructor(
+    private summaryService: SummaryService,
+    private sanitizer: DomSanitizer,
+    private settingsService: SettingsService,
+    private cephReleaseNamePipe: CephReleaseNamePipe
+  ) {}
 
   ngOnInit() {
     this.styles = {
@@ -40,6 +48,20 @@ export class GrafanaComponent implements OnInit, OnChanges {
       two: 'grafana_two',
       three: 'grafana_three'
     };
+
+    const subs = this.summaryService.subscribe((summary: any) => {
+      if (!summary) {
+        return;
+      }
+
+      const releaseName = this.cephReleaseNamePipe.transform(summary.version);
+      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/`;
+
+      setTimeout(() => {
+        subs.unsubscribe();
+      }, 0);
+    });
+
     this.settingsService.getGrafanaApiUrl().subscribe((data: any) => {
       this.grafanaUrl = data.value;
       if (this.grafanaUrl === '') {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -1,0 +1,85 @@
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
+
+import { DomSanitizer } from '@angular/platform-browser';
+import { SafeUrl } from '@angular/platform-browser';
+
+import { SettingsService } from '../../../shared/api/settings.service';
+
+@Component({
+  selector: 'cd-grafana',
+  templateUrl: './grafana.component.html',
+  styleUrls: ['./grafana.component.scss']
+})
+export class GrafanaComponent implements OnInit, OnChanges {
+  grafanaSrc: SafeUrl;
+  url: string;
+  protocol: string;
+  host: string;
+  dashboardPath: string;
+  port: number;
+  baseUrl: any;
+  panelStyle: any;
+  grafanaExist = false;
+  mode = '&kiosk';
+  modeFlag = false;
+  modeText = 'Change time selection';
+  loading = true;
+  styles = {};
+
+  @Input()
+  grafanaPath: string;
+  @Input()
+  grafanaStyle: string;
+  grafanaUrl: any;
+
+  constructor(private sanitizer: DomSanitizer, private settingsService: SettingsService) {}
+
+  ngOnInit() {
+    this.styles = {
+      one: 'grafana_one',
+      two: 'grafana_two',
+      three: 'grafana_three'
+    };
+    this.settingsService.getGrafanaApiUrl().subscribe((data: any) => {
+      this.grafanaUrl = data.value;
+      if (this.grafanaUrl === '') {
+        this.grafanaExist = false;
+        return;
+      } else {
+        this.getFrame();
+      }
+    });
+    this.panelStyle = this.styles[this.grafanaStyle];
+  }
+
+  getFrame() {
+    this.baseUrl = this.grafanaUrl + '/d/';
+    this.grafanaExist = true;
+    this.loading = false;
+    this.url = this.baseUrl + this.grafanaPath + '&refresh=2s' + this.mode;
+    this.grafanaSrc = this.sanitizer.bypassSecurityTrustResourceUrl(this.url);
+  }
+
+  timePickerToggle() {
+    this.modeFlag = true;
+    this.mode = this.mode ? '' : '&kiosk';
+    if (this.modeText === 'Return to default') {
+      this.modeText = 'Change time selection';
+      this.reset();
+    } else {
+      this.modeText = 'Return to default';
+    }
+    this.getFrame();
+    this.modeFlag = false;
+  }
+
+  reset() {
+    this.mode = '&kiosk';
+    this.modeText = 'Change time selection';
+    this.getFrame();
+  }
+
+  ngOnChanges(changes) {
+    this.getFrame();
+  }
+}

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -32,7 +32,7 @@ class Options(object):
     RGW_API_SSL_VERIFY = (True, bool)
 
     # Grafana settings
-    GRAFANA_API_URL = ('http://localhost:3000', str)
+    GRAFANA_API_URL = ('', str)
     GRAFANA_API_USERNAME = ('admin', str)
     GRAFANA_API_PASSWORD = ('admin', str)
     GRAFANA_API_TOKEN = ('', str)

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -35,8 +35,6 @@ class Options(object):
     GRAFANA_API_URL = ('', str)
     GRAFANA_API_USERNAME = ('admin', str)
     GRAFANA_API_PASSWORD = ('admin', str)
-    GRAFANA_API_TOKEN = ('', str)
-    GRAFANA_API_AUTH_METHOD = ('', str)  # Either 'password' or 'token'
 
     @staticmethod
     def has_default_value(name):

--- a/src/pybind/mgr/dashboard/tests/test_grafana.py
+++ b/src/pybind/mgr/dashboard/tests/test_grafana.py
@@ -11,21 +11,15 @@ from .helper import ControllerTestCase
 
 class Grafana(TestCase):
     def test_missing_credentials(self):
-        with six.assertRaisesRegex(self, LookupError,
-                                   r'username and/or password'):
+        with six.assertRaisesRegex(self, LookupError, r'^No credentials.*'):
             GrafanaRestClient(
                 url='http://localhost:3000', username='', password='admin')
-        with six.assertRaisesRegex(self, LookupError, r'token'):
-            GrafanaRestClient(
-                url='http://localhost:3000',
-                token='',
-            )
         with six.assertRaisesRegex(self, LookupError, r'^No URL.*'):
             GrafanaRestClient(
                 url='//localhost:3000', username='admin', password='admin')
 
 
-@Controller('/grafana/mocked', secure=False)
+@Controller('grafana/mocked', secure=False)
 class GrafanaMockInstance(BaseController):
     @Proxy()
     def __call__(self, path, **params):
@@ -39,8 +33,7 @@ class GrafanaControllerTestCase(ControllerTestCase):
         settings = {
             'GRAFANA_API_URL': 'http://localhost:{}/grafana/mocked/'.format(54583),
             'GRAFANA_API_USERNAME': 'admin',
-            'GRAFANA_API_PASSWORD': 'admin',
-            'GRAFANA_API_AUTH_METHOD': 'password',
+            'GRAFANA_API_PASSWORD': 'admin'
         }
         mgr.get_config.side_effect = settings.get
         GrafanaProxy._cp_config['tools.authenticate.on'] = False  # pylint: disable=protected-access


### PR DESCRIPTION
This PR adds Grafana Graphs to Dashboard. Views affected:-
1. Cluster -> Hosts
2. Cluster -> OSDs
3. Pools
4. FileSystems
5. Object Gateways -> Daemons

CLI commands to see graphs from Grafana
```
$ ceph mgr module enable prometheus
$ ceph dashboard set-grafana-api-url <url-of-grafana-instance>	       # default: ''
```

Tracker: https://tracker.ceph.com/issues/24999
Signed-off-by: Kanika <kmurarka@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

