### PR TITLE
rgw: rewrite obj won't modify index.

### DIFF
--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -284,6 +284,7 @@ int AtomicObjectProcessor::complete(size_t accounted_size,
   obj_op.meta.user_data = user_data;
   obj_op.meta.zones_trace = zones_trace;
   obj_op.meta.modify_tail = true;
+  obj_op.meta.modify_index = modify_index;
 
   r = obj_op.write_meta(actual_size, accounted_size, attrs);
   if (r < 0) {

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -142,6 +142,7 @@ class ManifestObjectProcessor : public HeadObjectProcessor,
 class AtomicObjectProcessor : public ManifestObjectProcessor {
   const std::optional<uint64_t> olh_epoch;
   const std::string unique_tag;
+  bool modify_index{false};
   bufferlist first_chunk; // written with the head in complete()
 
   int process_first_chunk(bufferlist&& data, DataProcessor **processor) override;
@@ -165,6 +166,10 @@ class AtomicObjectProcessor : public ManifestObjectProcessor {
                const char *if_match, const char *if_nomatch,
                const std::string *user_data,
                rgw_zone_set *zones_trace, bool *canceled) override;
+
+  void set_modify_index(bool _modify_index) {
+    modify_index = _modify_index;
+  }
 };
 
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2743,11 +2743,12 @@ public:
         rgw_zone_set *zones_trace;
         bool modify_tail;
         bool completeMultipart;
+        bool modify_index;
 
         MetaParams() : mtime(NULL), rmattrs(NULL), data(NULL), manifest(NULL), ptag(NULL),
                  remove_objs(NULL), category(RGW_OBJ_CATEGORY_MAIN), flags(0),
                  if_match(NULL), if_nomatch(NULL), canceled(false), user_data(nullptr), zones_trace(nullptr),
-                 modify_tail(false),  completeMultipart(false) {}
+                 modify_tail(false),  completeMultipart(false), modify_index(true) {}
       } meta;
 
       explicit Write(RGWRados::Object *_target) : target(_target) {}
@@ -2899,6 +2900,10 @@ public:
       
       void set_zones_trace(rgw_zone_set *_zones_trace) {
         zones_trace = _zones_trace;
+      }
+
+      void set_blind(bool _blind) {
+        blind = _blind;
       }
 
       int prepare(RGWModifyOp, const string *write_tag);
@@ -3127,7 +3132,8 @@ public:
                map<string, bufferlist>& attrs,
                uint64_t olh_epoch,
 	       ceph::real_time delete_at,
-               string *petag);
+               string *petag,
+               bool modify_index = true);
   
   int check_bucket_empty(RGWBucketInfo& bucket_info);
 
@@ -3825,7 +3831,6 @@ public:
     entries.clear();
   }
 }; /* RGWChainedCacheImpl */
-
 
 #define MP_META_SUFFIX ".meta"
 


### PR DESCRIPTION
If we enable bucket versioning, upload object `A` twice. The we have:
```
A: versionID1   <-current
A: versionID2
```
After we execute radosgw-admin object rewrite ... --object-version=versionID2, then we have:
```
A: versionID1 
A: versionID2  <-current
```
Object rewrite doesn't need to change the bucket index and current state, we can just skip the index update. 

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

