### PR TITLE
debian/control: require fuse for ceph-fuse

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -277,7 +277,7 @@ Package: ceph-fuse
 Architecture: linux-any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-Recommends: fuse,
+         fuse,
 Description: FUSE-based client for the Ceph distributed file system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,


### PR DESCRIPTION
This is the Ubuntu equivalent for:

https://github.com/ceph/ceph/pull/17120
http://tracker.ceph.com/issues/21057

Installing "ceph-fuse" should pull in the "fuse" package automatically.

Signed-off-by: Thomas Serlin <tserlin@redhat.com>

