### PR TITLE
luminous: mds: explain delayed client_request due to subtree migration

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -326,10 +326,10 @@ int CDentry::get_num_dir_auth_pins() const
   return auth_pins;
 }
 
-bool CDentry::can_auth_pin() const
+bool CDentry::can_auth_pin(int *err_ret) const
 {
   assert(dir);
-  return dir->can_auth_pin();
+  return dir->can_auth_pin(err_ret);
 }
 
 void CDentry::auth_pin(void *by)

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -206,7 +206,7 @@ public:
   void _put() override;
 
   // auth pins
-  bool can_auth_pin() const override;
+  bool can_auth_pin(int *err_ret=nullptr) const override;
   void auth_pin(void *by) override;
   void auth_unpin(void *by) override;
   void adjust_nested_auth_pins(int adjustment, int diradj, void *by);

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2878,6 +2878,26 @@ void CDir::unfreeze_tree()
   }
 }
 
+bool CDir::can_auth_pin(int *err_ret) const
+{
+  int err;
+  if (!is_auth()) {
+    err = ERR_NOT_AUTH;
+  } else if (is_freezing_dir() || is_frozen_dir()) {
+    err = ERR_FRAGMENTING_DIR;
+  } else {
+    auto p = is_freezing_or_frozen_tree();
+    if (p.first || p.second) {
+      err = ERR_EXPORTING_TREE;
+    } else {
+      err = 0;
+    }
+  }
+  if (err && err_ret)
+    *err_ret = err;
+  return !err;
+}
+
 pair<bool,bool> CDir::is_freezing_or_frozen_tree() const
 {
   if (!num_freezing_trees && !num_frozen_trees)

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2878,34 +2878,26 @@ void CDir::unfreeze_tree()
   }
 }
 
-bool CDir::is_freezing_tree() const
+pair<bool,bool> CDir::is_freezing_or_frozen_tree() const
 {
-  if (num_freezing_trees == 0)
-    return false;
-  const CDir *dir = this;
-  while (1) {
-    if (dir->is_freezing_tree_root()) return true;
-    if (dir->is_subtree_root()) return false;
-    if (dir->inode->parent)
-      dir = dir->inode->parent->dir;
-    else
-      return false; // root on replica
-  }
-}
+  if (!num_freezing_trees && !num_frozen_trees)
+    return make_pair(false, false);
 
-bool CDir::is_frozen_tree() const
-{
-  if (num_frozen_trees == 0)
-    return false;
+  bool freezing, frozen;
   const CDir *dir = this;
   while (1) {
-    if (dir->is_frozen_tree_root()) return true;
-    if (dir->is_subtree_root()) return false;
+    freezing = dir->is_freezing_tree_root();
+    frozen = dir->is_frozen_tree_root();
+    if (freezing || frozen)
+      break;
+    if (dir->is_subtree_root())
+      break;
     if (dir->inode->parent)
       dir = dir->inode->parent->dir;
     else
-      return false;  // root on replica
+      break; // root on replica
   }
+  return make_pair(freezing, frozen);
 }
 
 CDir *CDir::get_frozen_tree_root() 

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -697,7 +697,16 @@ public:
   void decode_import(bufferlist::iterator& blp, utime_t now, LogSegment *ls);
 
   // -- auth pins --
-  bool can_auth_pin() const override { return is_auth() && !(is_frozen() || is_freezing()); }
+  bool can_auth_pin() const override {
+    if (!is_auth())
+      return false;
+    if (is_freezing_dir() || is_frozen_dir())
+      return false;
+    auto p = is_freezing_or_frozen_tree();
+    if (p.first || p.second)
+      return false;
+    return true;
+  }
   int get_cum_auth_pins() const { return auth_pins + nested_auth_pins; }
   int get_auth_pins() const { return auth_pins; }
   int get_nested_auth_pins() const { return nested_auth_pins; }
@@ -719,13 +728,23 @@ public:
 
   void maybe_finish_freeze();
 
-  bool is_freezing() const override { return is_freezing_tree() || is_freezing_dir(); }
-  bool is_freezing_tree() const;
+  pair<bool,bool> is_freezing_or_frozen_tree() const;
+
+  bool is_freezing() const override { return is_freezing_dir() || is_freezing_tree(); }
+  bool is_freezing_tree() const {
+    if (!num_freezing_trees)
+      return false;
+    return is_freezing_or_frozen_tree().first;
+  }
   bool is_freezing_tree_root() const { return state & STATE_FREEZINGTREE; }
   bool is_freezing_dir() const { return state & STATE_FREEZINGDIR; }
 
   bool is_frozen() const override { return is_frozen_dir() || is_frozen_tree(); }
-  bool is_frozen_tree() const;
+  bool is_frozen_tree() const {
+    if (!num_frozen_trees)
+      return false;
+    return is_freezing_or_frozen_tree().second;
+  }
   bool is_frozen_tree_root() const { return state & STATE_FROZENTREE; }
   bool is_frozen_dir() const { return state & STATE_FROZENDIR; }
   

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -697,16 +697,7 @@ public:
   void decode_import(bufferlist::iterator& blp, utime_t now, LogSegment *ls);
 
   // -- auth pins --
-  bool can_auth_pin() const override {
-    if (!is_auth())
-      return false;
-    if (is_freezing_dir() || is_frozen_dir())
-      return false;
-    auto p = is_freezing_or_frozen_tree();
-    if (p.first || p.second)
-      return false;
-    return true;
-  }
+  bool can_auth_pin(int *err_ret=nullptr) const override;
   int get_cum_auth_pins() const { return auth_pins + nested_auth_pins; }
   int get_auth_pins() const { return auth_pins; }
   int get_nested_auth_pins() const { return nested_auth_pins; }

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2405,12 +2405,20 @@ void CInode::clear_ambiguous_auth()
 }
 
 // auth_pins
-bool CInode::can_auth_pin() const {
-  if (!is_auth() || is_freezing_inode() || is_frozen_inode() || is_frozen_auth_pin())
-    return false;
-  if (parent)
-    return parent->can_auth_pin();
-  return true;
+bool CInode::can_auth_pin(int *err_ret) const {
+  int err;
+  if (!is_auth()) {
+    err = ERR_NOT_AUTH;
+  } else if (is_freezing_inode() || is_frozen_inode() || is_frozen_auth_pin()) {
+    err = ERR_EXPORTING_INODE;
+  } else {
+    if (parent)
+      return parent->can_auth_pin(err_ret);
+    err = 0;
+  }
+  if (err && err_ret)
+    *err_ret = err;
+  return !err;
 }
 
 void CInode::auth_pin(void *by) 

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -1004,7 +1004,7 @@ public:
 
   // -- auth pins --
   void adjust_nested_auth_pins(int a, void *by);
-  bool can_auth_pin() const override;
+  bool can_auth_pin(int *err_ret=nullptr) const override;
   void auth_pin(void *by) override;
   void auth_unpin(void *by) override;
 

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -382,6 +382,7 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
 	drop_locks(mdr.get());
       if (object->is_ambiguous_auth()) {
 	// wait
+	marker.message = "waiting for single auth, object is being migrated";
 	dout(10) << " ambiguous auth, waiting to authpin " << *object << dendl;
 	object->add_waiter(MDSCacheObject::WAIT_SINGLEAUTH, new C_MDS_RetryRequest(mdcache, mdr));
 	mdr->drop_local_auth_pins();
@@ -390,7 +391,8 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
       mustpin_remote[object->authority().first].insert(object);
       continue;
     }
-    if (!object->can_auth_pin()) {
+    int err = 0;
+    if (!object->can_auth_pin(&err)) {
       // wait
       drop_locks(mdr.get());
       mdr->drop_local_auth_pins();
@@ -398,6 +400,13 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
 	dout(10) << " can't auth_pin (freezing?) " << *object << ", nonblocking" << dendl;
 	mdr->aborted = true;
 	return false;
+      }
+      if (err == MDSCacheObject::ERR_EXPORTING_TREE) {
+	marker.message = "failed to authpin, subtree is being exported";
+      } else if (err == MDSCacheObject::ERR_FRAGMENTING_DIR) {
+	marker.message = "failed to authpin, dir is being fragmented";
+      } else if (err == MDSCacheObject::ERR_EXPORTING_INODE) {
+	marker.message = "failed to authpin, inode is being exported";
       }
       dout(10) << " can't auth_pin (freezing?), waiting to authpin " << *object << dendl;
       object->add_waiter(MDSCacheObject::WAIT_UNFREEZE, new C_MDS_RetryRequest(mdcache, mdr));

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -235,7 +235,14 @@ protected:
 
   // --------------------------------------------
   // auth pins
-  virtual bool can_auth_pin() const = 0;
+  enum {
+    // can_auth_pin() error codes
+    ERR_NOT_AUTH = 1,
+    ERR_EXPORTING_TREE,
+    ERR_FRAGMENTING_DIR,
+    ERR_EXPORTING_INODE,
+  };
+  virtual bool can_auth_pin(int *err_code=nullptr) const = 0;
   virtual void auth_pin(void *who) = 0;
   virtual void auth_unpin(void *who) = 0;
   virtual bool is_frozen() const = 0;


### PR DESCRIPTION
https://tracker.ceph.com/issues/26987