### PR TITLE
luminous: osd: backport 'bench' and stdout changes

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6885,9 +6885,9 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       f->dump_int("blocksize", bsize);
       f->dump_unsigned("bytes_per_sec", rate);
       f->close_section();
-      f->flush(ss);
+      f->flush(ds);
     } else {
-      ss << "bench: wrote " << byte_u_t(count)
+      ds << "bench: wrote " << byte_u_t(count)
 	 << " in blocks of " << byte_u_t(bsize) << " in "
 	 << (end-start) << " sec at " << byte_u_t(rate) << "/sec";
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6878,18 +6878,23 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       }
     }
 
-    uint64_t rate = (double)count / (end - start);
+    double elapsed = end - start;
+    double rate = count / elapsed;
+    double iops = rate / bsize;
     if (f) {
       f->open_object_section("osd_bench_results");
       f->dump_int("bytes_written", count);
       f->dump_int("blocksize", bsize);
-      f->dump_unsigned("bytes_per_sec", rate);
+      f->dump_float("elapsed_sec", elapsed);
+      f->dump_float("bytes_per_sec", rate);
+      f->dump_float("iops", iops);
       f->close_section();
       f->flush(ds);
     } else {
       ds << "bench: wrote " << byte_u_t(count)
 	 << " in blocks of " << byte_u_t(bsize) << " in "
-	 << (end-start) << " sec at " << byte_u_t(rate) << "/sec";
+	 << elapsed << " sec at " << byte_u_t(rate) << "/sec "
+	 << si_u_t(iops) << " IOPS";
     }
   }
 

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -1022,8 +1022,8 @@ class TestCommand(object):
         ret, buf, err = self.rados.osd_command(0, json.dumps(cmd), b'',
                                                timeout=30)
         eq(ret, 0)
-        assert len(err) > 0
-        out = json.loads(err)
+        assert len(buf) > 0
+        out = json.loads(buf.decode('utf-8'))
         eq(out['blocksize'], cmd['size'])
         eq(out['bytes_written'], cmd['count'])
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/35941

---

#21962 & http://tracker.ceph.com/issues/24022

cherry picked from commit 2cec8a54f6640b2f97be3326514004458544d2ee ~~8518c0f67cae5607357f4d733b8a9b33acd600c5~~
cherry picked from commit d9c2ddd9fe33aa342733762b9b0fece5c8d972d0 ~~d871fae1d3f34d3e25385b608c15ade7ab8c8f71~~
cherry picked from commit ffe4b045169b840b6bd3bbdb375eb137c99eaa84 ~~b35de797b79b6d9976131a10602ff979778183ac~~