### PR TITLE
qa/mgr/selftest: handle always-on module fall out

### DIFF
--- a/qa/tasks/mgr/test_module_selftest.py
+++ b/qa/tasks/mgr/test_module_selftest.py
@@ -231,15 +231,14 @@ class TestModuleSelftest(MgrTestCase):
         disabled/failed/recently-enabled modules.
         """
 
-        self._load_module("selftest")
-
         # Calling a command on a disabled module should return the proper
         # error code.
+        self._load_module("selftest")
         self.mgr_cluster.mon_manager.raw_cluster_cmd(
-            "mgr", "module", "disable", "hello")
+            "mgr", "module", "disable", "selftest")
         with self.assertRaises(CommandFailedError) as exc_raised:
             self.mgr_cluster.mon_manager.raw_cluster_cmd(
-                "hello")
+                "mgr", "self-test", "run")
 
         self.assertEqual(exc_raised.exception.exitstatus, errno.EOPNOTSUPP)
 
@@ -252,9 +251,9 @@ class TestModuleSelftest(MgrTestCase):
 
         # Enabling a module and then immediately using ones of its commands
         # should work (#21683)
+        self._load_module("selftest")
         self.mgr_cluster.mon_manager.raw_cluster_cmd(
-            "mgr", "module", "enable", "status")
-        self.mgr_cluster.mon_manager.raw_cluster_cmd("osd", "status")
+            "mgr", "self-test", "config", "get", "testkey")
 
         # Calling a command for a failed module should return the proper
         # error code.


### PR DESCRIPTION
…disabled command test

Per Noah Watkins,

> hello isn't packaged so it can't announce its commands.

so we should use "selftest" instead "hello" for disabled command test.

in this change, we make sure "selftest" is disabled and then, try to run
one of its announced command. then re-enable this module, so the
following tests can use this module for sending commands like 'mgr self-test'

Fixes: http://tracker.ceph.com/issues/26994
Signed-off-by: Noah Watkins <nwatkins@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

