### PR TITLE
tools/rados: fix the unit of target-throughput

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -3276,7 +3276,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     if (max_backlog)
       lg.max_backlog = max_backlog;
     if (target_throughput)
-      lg.target_throughput = target_throughput << 20;
+      lg.target_throughput = target_throughput;
     if (read_percent >= 0)
       lg.read_percent = read_percent;
     if (num_objs)


### PR DESCRIPTION
Make the unit of target-throughtput in bytes as the usage of rados load-gen said.

Signed-off-by: Xiaofei Cui <cuixiaofei@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

