### PR TITLE
doc/rados/operations: add balancer.rst to TOC

### DIFF
--- a/doc/rados/operations/index.rst
+++ b/doc/rados/operations/index.rst
@@ -37,6 +37,7 @@ CRUSH algorithm.
 	erasure-code
 	cache-tiering
 	placement-groups
+	balancer
 	upmap
 	crush-map
 	crush-map-edits


### PR DESCRIPTION
this helps user to find the balancer feature, and
also addresses the FTBFS of doc like

Warning, treated as error:
/home/jenkins-build/build/workspace/ceph-pr-docs/doc/rados/operations/balancer.rst:document
isn't included in any toctree

this doc was moved from doc/mgr/balancer.rst to
doc/rados/operations/balancer.rst in
a78d600e6b368255096d6f0bbee8e53553307118

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

