### PR TITLE
osd: parent process restart log service after fork

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -190,6 +190,11 @@ int main(int argc, const char **argv)
   if (global_init_prefork(g_ceph_context) >= 0) {
     std::string err;
     int r = forker.prefork(err);
+    if (r < 0 || forker.is_parent()) {
+      // Start log if current process is about to exit. Otherwise, we hit an assert
+      // in the Ceph context destructor.
+      g_ceph_context->_log->start();
+    }
     if (r < 0) {
       cerr << err << std::endl;
       return r;


### PR DESCRIPTION
ceph-osd parent process need to restart log service after fork, or ceph-osd will not work correctly when the option log_max_new in ceph.conf set to zero

Fix:https://tracker.ceph.com/issues/24956
Signed-off-by: Hsiao-Yin <s02561084s@gmail.com>
