### PR TITLE
run-make-check: increase fs.aio-max-nr to 1048576

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -137,7 +137,11 @@ EOM
         echo "***ulimit -n too small, better bigger than 1024 for test***"
         return 1
     fi
- 
+
+    # increase the aio-max-nr, which is by default 65536. we could reach this
+    # limit while running seastar tests and bluestore tests.
+    $DRY_RUN sysctl -q -w fs.aio-max-nr=$((65536 * 16))
+
     if ! $DRY_RUN ctest $CHECK_MAKEOPTS --output-on-failure; then
         rm -fr ${TMPDIR:-/tmp}/ceph-asok.*
         return 1


### PR DESCRIPTION
the solution was suggested by Yingxin Cheng. otherwise we could have
EAGAIN returned by io_setup(2).

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

