### PR TITLE
luminous: debian/control: require fuse for ceph-fuse

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -269,7 +269,7 @@ Package: ceph-fuse
 Architecture: linux-any
 Depends: ${misc:Depends},
          ${shlibs:Depends},
-Recommends: fuse,
+         fuse,
 Description: FUSE-based client for the Ceph distributed file system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,


### PR DESCRIPTION
Installing "ceph-fuse" should pull in the "fuse" package automatically.

This is a backport of https://github.com/ceph/ceph/pull/23675

Signed-off-by: Thomas Serlin <tserlin@redhat.com>

