### PR TITLE
ceph-volume: run tests without waiting on ceph repos

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -34,7 +34,7 @@ changedir=
 commands=
   git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
 
-  vagrant up {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
+  bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}
 
   cp {toxinidir}/../playbooks/deploy.yml {envdir}/tmp/ceph-ansible

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -7,6 +7,7 @@ whitelist_externals =
     vagrant
     bash
     git
+    cp
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
@@ -36,8 +37,10 @@ commands=
   vagrant up {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}
 
+  cp {toxinidir}/../playbooks/deploy.yml {envdir}/tmp/ceph-ansible
+
   # use ceph-ansible to deploy a ceph cluster on the vms
-  ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/site.yml.sample --extra-vars "fetch_directory={changedir}/fetch ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}"
+  ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/deploy.yml --extra-vars "fetch_directory={changedir}/fetch ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} toxinidir={toxinidir}"
 
   # prepare nodes for testing with testinfra
   ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -7,6 +7,7 @@ whitelist_externals =
     vagrant
     bash
     git
+    cp
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
@@ -53,8 +54,10 @@ commands=
   # ad-hoc/local test setup for lvm
   ansible-playbook -vv -i {changedir}/hosts {changedir}/setup.yml
 
+  cp {toxinidir}/../playbooks/deploy.yml {envdir}/tmp/ceph-ansible
+
   # use ceph-ansible to deploy a ceph cluster on the vms
-  ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/site.yml.sample --extra-vars "fetch_directory={changedir}/fetch ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}"
+  ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/deploy.yml --extra-vars "fetch_directory={changedir}/fetch ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} toxinidir={toxinidir}"
 
   # prepare nodes for testing with testinfra
   ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -8,6 +8,7 @@ whitelist_externals =
     bash
     git
     cp
+    sleep
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
@@ -45,7 +46,7 @@ commands=
   # but the master branch doesn't pin dependencies so we can't guarantee to work correctly
   #pip install -r {envdir}/tmp/ceph-ansible/requirements.txt
 
-  vagrant up {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
+  bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}
 
   # create logical volumes to test with on the vms

--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -1,0 +1,121 @@
+---
+# Defines deployment design and assigns role to server groups
+
+- hosts:
+  - mons
+  - osds
+  - mgrs
+
+  gather_facts: false
+  any_errors_fatal: true
+  become: true
+
+  tags:
+    - always
+
+  vars:
+    delegate_facts_host: True
+
+  pre_tasks:
+    # If we can't get python2 installed before any module is used we will fail
+    # so just try what we can to get it installed
+    - name: check for python2
+      stat:
+        path: /usr/bin/python
+      ignore_errors: yes
+      register: systempython2
+
+    - name: install python2 for debian based systems
+      raw: sudo apt-get -y install python-simplejson
+      ignore_errors: yes
+      when:
+        - systempython2.stat is undefined or systempython2.stat.exists == false
+
+    - name: install python2 for fedora
+      raw: sudo dnf -y install python creates=/usr/bin/python
+      ignore_errors: yes
+      when:
+        - systempython2.stat is undefined or systempython2.stat.exists == false
+
+    - name: install python2 for opensuse
+      raw: sudo zypper -n install python-base creates=/usr/bin/python2.7
+      ignore_errors: yes
+      when:
+        - systempython2.stat is undefined or systempython2.stat.exists == false
+
+    - name: gather facts
+      setup:
+      when:
+        - not delegate_facts_host | bool
+
+    - name: gather and delegate facts
+      setup:
+      delegate_to: "{{ item }}"
+      delegate_facts: True
+      with_items: "{{ groups['all'] }}"
+      run_once: true
+      when:
+        - delegate_facts_host | bool
+
+    - name: install required packages for fedora > 23
+      raw: sudo dnf -y install python2-dnf libselinux-python ntp
+      when:
+        - ansible_distribution == 'Fedora'
+        - ansible_distribution_major_version|int >= 23
+
+  roles:
+    - ceph-defaults
+    - ceph-validate
+
+- hosts:
+  - mons
+  - osds
+  - mgrs
+  gather_facts: false
+  become: True
+  roles:
+    - role: ceph-defaults
+      tags: ['ceph_update_config']
+    - role: ceph-common
+    - role: ceph-config
+      tags: ['ceph_update_config']
+
+- hosts: mons
+  gather_facts: false
+  become: True
+  roles:
+    - role: ceph-defaults
+    - role: ceph-common
+    - role: ceph-mon
+
+- hosts: mgrs
+  gather_facts: false
+  become: True
+  roles:
+    - role: ceph-defaults
+    - role: ceph-common
+    - role: ceph-mgr
+
+- hosts: osds
+  gather_facts: false
+  become: True
+  tasks:
+    - name: rsync ceph-volume to test nodes on centos
+      synchronize:
+        src: "{{ toxinidir}}/../../../../ceph_volume"
+        dest: "/usr/lib/python2.7/site-packages"
+      when: ansible_os_family == "RedHat"
+
+    - name: rsync ceph-volume to test nodes on ubuntu
+      synchronize:
+        src: "{{ toxinidir}}/../../../../ceph_volume"
+        dest: "/usr/lib/python2.7/dist-packages"
+      when: ansible_os_family == "Ubuntu"
+
+- hosts: osds
+  gather_facts: false
+  become: True
+  roles:
+    - role: ceph-defaults
+    - role: ceph-common
+    - role: ceph-osd

--- a/src/ceph-volume/ceph_volume/tests/functional/scripts/vagrant_up.sh
+++ b/src/ceph-volume/ceph_volume/tests/functional/scripts/vagrant_up.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+retries=0
+until [ $retries -ge 5 ]
+do
+  echo "Attempting to start VMs. Attempts: $retries"
+  timeout 10m vagrant up "$@" && break
+  retries=$[$retries+1]
+  sleep 5
+done
+
+sleep 10

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -8,6 +8,7 @@ whitelist_externals =
     bash
     git
     sleep
+    cp
 passenv=*
 setenv=
   ANSIBLE_SSH_ARGS = -F {changedir}/vagrant_ssh_config
@@ -44,8 +45,10 @@ commands=
   vagrant up {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}
 
+  cp {toxinidir}/../playbooks/deploy.yml {envdir}/tmp/ceph-ansible
+
   # use ceph-ansible to deploy a ceph cluster on the vms
-  ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/site.yml.sample --extra-vars "fetch_directory={changedir}/fetch ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest}"
+  ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/deploy.yml --extra-vars "fetch_directory={changedir}/fetch ceph_dev_branch={env:CEPH_DEV_BRANCH:master} ceph_dev_sha1={env:CEPH_DEV_SHA1:latest} toxinidir={toxinidir}"
 
   # prepare nodes for testing with testinfra
   ansible-playbook -vv -i {changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/setup.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -42,7 +42,7 @@ commands=
   # but the master branch doesn't pin dependencies so we can't guarantee to work correctly
   #pip install -r {envdir}/tmp/ceph-ansible/requirements.txt
 
-  vagrant up {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
+  bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}
 
   cp {toxinidir}/../playbooks/deploy.yml {envdir}/tmp/ceph-ansible


### PR DESCRIPTION
This provides a new playbook that installs ceph on all nodes and
generates the ceph config. Then it will rsync ceph-volume from the
control node, or jenkins slave, to all testing vms before completing
the deployment. This means we can run tests on PRs without waiting
for repos to be built for the branch in the PR.

Signed-off-by: Andrew Schoen <aschoen@redhat.com>