### PR TITLE
mimic: client: requests that do name lookup may be sent to wrong mds

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1461,6 +1461,10 @@ mds_rank_t Client::choose_target_mds(MetaRequest *req, Inode** phash_diri)
 	mds = in->fragmap[fg];
 	if (phash_diri)
 	  *phash_diri = in;
+      } else if (in->auth_cap) {
+	mds = in->auth_cap->session->mds_num;
+      }
+      if (mds >= 0) {
 	ldout(cct, 10) << __func__ << " from dirfragtree hash" << dendl;
 	goto out;
       }


### PR DESCRIPTION
http://tracker.ceph.com/issues/26984