### PR TITLE
mgr/orchestrator: Add RGW service support

### DIFF
--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -175,6 +175,20 @@ class OrchestratorCli(MgrModule):
             self._wait([completion])
 
             return 0, "", "Success."
+        elif svc_type == "rgw":
+            store_name = cmd['svc_arg']
+
+            spec = orchestrator.StatelessServiceSpec()
+            spec.name = store_name
+
+            completion = self._oremote(
+                "add_stateless_service",
+                svc_type,
+                spec
+            )
+            self._wait([completion])
+
+            return 0, "", "Success."
         else:
             raise NotImplementedError(svc_type)
 

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -359,6 +359,10 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             return RookWriteCompletion(
                 lambda: self.rook_cluster.add_filesystem(spec), None,
                 "Creating Filesystem services for {0}".format(spec.name))
+        elif service_type == "rgw" :
+            return RookWriteCompletion(
+                lambda: self.rook_cluster.add_objectstore(spec), None,
+                "Creating RGW services for {0}".format(spec.name))
         else:
             # TODO: RGW, NFS
             raise NotImplementedError(service_type)


### PR DESCRIPTION
Adds support for launching objectstore via orchestrator CLI.

`ceph orchestrator service add rgw <store-name>`

Signed-off-by: Rubab-Syed <rubab.syed21@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

