### PR TITLE
mgr/dashboard: Fix growing table in firefox

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/monitor/monitor.component.html
@@ -44,19 +44,17 @@
   </div>
 
   <div class="col-md-8">
-    <fieldset>
-      <legend i18n
-              class="in-quorum">In Quorum</legend>
-      <cd-table [data]="inQuorum.data"
-                [columns]="inQuorum.columns">
-      </cd-table>
+    <legend i18n
+            class="in-quorum">In Quorum</legend>
+    <cd-table [data]="inQuorum.data"
+              [columns]="inQuorum.columns">
+    </cd-table>
 
-      <legend i18n
-              class="in-quorum">Not In Quorum</legend>
-      <cd-table [data]="notInQuorum.data"
-                (fetchData)="refresh()"
-                [columns]="notInQuorum.columns">
-      </cd-table>
-    </fieldset>
+    <legend i18n
+            class="in-quorum">Not In Quorum</legend>
+    <cd-table [data]="notInQuorum.data"
+              (fetchData)="refresh()"
+              [columns]="notInQuorum.columns">
+    </cd-table>
   </div>
 </div>


### PR DESCRIPTION
It seems Firefox 52 has some kind of problem when
rendering our table inside a fieldset.

Since we don't really require the fieldset in the monitor page,
I have removed it to "fix" this problem.

Fixes: http://tracker.ceph.com/issues/26999

`Signed-off-by: Tiago Melo <tmelo@suse.com>`