### PR TITLE
docs: Fixed swift client authentication fail

### DIFF
--- a/doc/install/install-ceph-gateway.rst
+++ b/doc/install/install-ceph-gateway.rst
@@ -593,7 +593,7 @@ On Debian-based distributions::
 
 To test swift access, execute the following::
 
- swift -A http://{IP ADDRESS}:{port}/auth/1.0 -U testuser:swift -K '{swift_secret_key}' list
+ swift -V 1 -A http://{IP ADDRESS}:{port}/auth -U testuser:swift -K '{swift_secret_key}' list
 
 Replace ``{IP ADDRESS}`` with the public IP address of the gateway server and
 ``{swift_secret_key}`` with its value from the output of ``radosgw-admin key
@@ -603,7 +603,7 @@ don't replace the port, it will default to port ``80``.
 
 For example::
 
- swift -A http://10.19.143.116:7480/auth/1.0 -U testuser:swift -K '244+fz2gSqoHwR3lYtSbIyomyPHf3i7rgSJrF/IA' list
+ swift -V 1 -A http://10.19.143.116:7480/auth -U testuser:swift -K '244+fz2gSqoHwR3lYtSbIyomyPHf3i7rgSJrF/IA' list
 
 The output should be::
 


### PR DESCRIPTION
For now, swift client use V3 as a default, so
we should pass an explicit version for this example

My env:

- python-swiftclient==3.5.0
- ceph-radosgw-13.2.1-0.el7.x86_64

My problem:

```
swift -A http://10.0.0.11:7480/auth/1.0 -U  daikk115:swift -K IrPgTuqd6ObBTbLyWnLbZJx1asUZDpPF96KajM7J list --debug
DEBUG:keystoneclient.auth.identity.v3.base:Making authentication request to http://10.0.0.11:7480/auth/1.0/auth/tokens
DEBUG:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 10.0.0.11
DEBUG:requests.packages.urllib3.connectionpool:http://10.0.0.11:7480 "POST /auth/1.0/auth/tokens HTTP/1.1" 405 127
DEBUG:keystoneclient.session:Request returned failure status: 405
ERROR:swiftclient.service:Authorization Failure. Authorization failed: Method Not Allowed (HTTP 405)
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/swiftclient/service.py", line 909, in _list_account_job
    headers=req_headers
  File "/usr/lib/python2.7/site-packages/swiftclient/client.py", line 1742, in get_account
    full_listing=full_listing, headers=headers)
  File "/usr/lib/python2.7/site-packages/swiftclient/client.py", line 1679, in _retry
    self.url, self.token = self.get_auth()
  File "/usr/lib/python2.7/site-packages/swiftclient/client.py", line 1631, in get_auth
    timeout=self.timeout)
  File "/usr/lib/python2.7/site-packages/swiftclient/client.py", line 685, in get_auth
    auth_version=auth_version)
  File "/usr/lib/python2.7/site-packages/swiftclient/client.py", line 597, in get_auth_keystone
    raise ClientException('Authorization Failure. %s' % err)
ClientException: Authorization Failure. Authorization failed: Method Not Allowed (HTTP 405)
Authorization Failure. Authorization failed: Method Not Allowed (HTTP 405)

```

