### PR TITLE
ceph-volume  expand auto engine for multiple devices on filestore

### DIFF
--- a/src/ceph-volume/ceph_volume/__init__.py
+++ b/src/ceph-volume/ceph_volume/__init__.py
@@ -1,6 +1,10 @@
 from collections import namedtuple
 
 
+sys_info = namedtuple('sys_info', ['devices'])
+sys_info.devices = dict()
+
+
 class UnloadedConfig(object):
     """
     This class is used as the default value for conf.ceph so that if

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -434,6 +434,31 @@ def create_vg(devices, name=None, name_prefix=None):
     return vg
 
 
+def extend_vg(vg, devices):
+    """
+    Extend a Volume Group. Command looks like::
+
+        vgextend --force --yes group_name [device, ...]
+
+    Once created the volume group is extended and returned as a ``VolumeGroup`` object
+
+    :param vg: A VolumeGroup object
+    :param devices: A list of devices to extend the VG. Optionally, a single
+                    device (as a string) can be used.
+    """
+    if not isinstance(devices, list):
+        devices = [devices]
+    process.run([
+        'vgextend',
+        '--force',
+        '--yes',
+        vg.name] + devices
+    )
+
+    vg = get_vg(vg_name=vg.name)
+    return vg
+
+
 def remove_vg(vg_name):
     """
     Removes a volume group.

--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -401,7 +401,7 @@ def create_pv(device):
     ])
 
 
-def create_vg(devices, name=None):
+def create_vg(devices, name=None, name_prefix=None):
     """
     Create a Volume Group. Command looks like::
 
@@ -412,10 +412,16 @@ def create_vg(devices, name=None):
     :param devices: A list of devices to create a VG. Optionally, a single
                     device (as a string) can be used.
     :param name: Optionally set the name of the VG, defaults to 'ceph-{uuid}'
+    :param name_prefix: Optionally prefix the name of the VG, which will get combined
+                        with a UUID string
     """
+    if isinstance(devices, set):
+        devices = list(devices)
     if not isinstance(devices, list):
         devices = [devices]
-    if name is None:
+    if name_prefix:
+        name = "%s-%s" % (name_prefix, str(uuid.uuid4()))
+    elif name is None:
         name = "ceph-%s" % str(uuid.uuid4())
     process.run([
         'vgcreate',
@@ -482,7 +488,7 @@ def remove_lv(path):
     return True
 
 
-def create_lv(name, group, extents=None, size=None, tags=None):
+def create_lv(name, group, extents=None, size=None, tags=None, uuid_name=False):
     """
     Create a Logical Volume in a Volume Group. Command looks like::
 
@@ -493,7 +499,11 @@ def create_lv(name, group, extents=None, size=None, tags=None):
     conform to the convention of prefixing them with "ceph." like::
 
         {"ceph.block_device": "/dev/ceph/osd-1"}
+
+    :param uuid_name: Optionally combine the ``name`` with UUID to ensure uniqueness
     """
+    if uuid_name:
+        name = '%s-%s' % (name, uuid.uuid4())
     if tags is None:
         tags = {
             "ceph.osd_id": "null",

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -2,7 +2,6 @@ import argparse
 from textwrap import dedent
 from ceph_volume import terminal, decorators
 from ceph_volume.util import disk, prompt_bool
-from ceph_volume.util.device import Device
 from ceph_volume.util import arg_validators
 from . import strategies
 
@@ -16,7 +15,7 @@ def device_formatter(devices):
     for path, details in devices:
         lines.append(device_list_template.format(
             path=path, size=details['human_readable_size'],
-            state='solid' if details['rotational'] == '0' else 'rotational')
+            state='solid' if details.sys_api['rotational'] == '0' else 'rotational')
         )
 
     return ''.join(lines)
@@ -28,7 +27,7 @@ def bluestore_single_type(device_facts):
     Detect devices that are just HDDs or solid state so that a 1:1
     device-to-osd provisioning can be done
     """
-    types = [device['rotational'] for device in device_facts]
+    types = [device.sys_api['rotational'] for device in device_facts]
     if len(set(types)) == 1:
         return strategies.bluestore.SingleType
 
@@ -38,7 +37,7 @@ def bluestore_mixed_type(device_facts):
     Detect if devices are HDDs as well as solid state so that block.db can be
     placed in solid devices while data is kept in the spinning drives.
     """
-    types = [device['rotational'] for device in device_facts]
+    types = [device.sys_api['rotational'] for device in device_facts]
     if len(set(types)) > 1:
         return strategies.bluestore.MixedType
 
@@ -48,7 +47,7 @@ def filestore_single_type(device_facts):
     Detect devices that are just HDDs or solid state so that a 1:1
     device-to-osd provisioning can be done, keeping the journal on the OSD
     """
-    types = [device['rotational'] for device in device_facts]
+    types = [device.sys_api['rotational'] for device in device_facts]
     if len(set(types)) == 1:
         return strategies.filestore.SingleType
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -16,8 +16,8 @@ class SingleType(object):
     def __init__(self, devices, args):
         self.args = args
         self.devices = devices
-        self.hdds = [device for device in devices if device['rotational'] == '1']
-        self.ssds = [device for device in devices if device['rotational'] == '0']
+        self.hdds = [device for device in devices if device.sys_api['rotational'] == '1']
+        self.ssds = [device for device in devices if device.sys_api['rotational'] == '0']
         self.computed = {'osds': [], 'vgs': []}
         self.validate()
         self.compute()
@@ -96,11 +96,14 @@ class SingleType(object):
             vg = lvm.create_vg(osd['data']['path'])
             osd_vgs.append(vg)
 
+        journal_size = prepare.get_journal_size()
+
         # create the lvs from the vgs captured in the beginning
         for vg in osd_vgs:
             # this is called again, getting us the LVM formatted string
-            journal_size = prepare.get_journal_size()
-            journal_lv = lvm.create_lv('osd-journal', vg.name, size=journal_size)
+            journal_lv = lvm.create_lv(
+                'osd-journal', vg.name, size=journal_size, uuid_name=True
+            )
             # no extents or size means it will use 100%FREE
             data_lv = lvm.create_lv('osd-data', vg.name)
 
@@ -118,4 +121,198 @@ class SingleType(object):
 
 
 class MixedType(object):
-    pass
+    """
+    Supports HDDs with SSDs, journals will be placed on SSDs, while HDDs will
+    be used fully for data.
+
+    If an existing common VG is detected on SSDs, it will be extended if blank
+    SSDs are used, otherwise it will be used directly.
+    """
+
+    def __init__(self, devices, args):
+        self.args = args
+        self.devices = devices
+        self.hdds = [device for device in devices if device.sys_api['rotational'] == '1']
+        self.ssds = [device for device in devices if device.sys_api['rotational'] == '0']
+        self.computed = {'osds': [], 'vg': None}
+        self.blank_ssds = []
+        self.journals_needed = len(self.hdds)
+        self.journal_size = prepare.get_journal_size(lv_format=False)
+        self.system_vgs = lvm.VolumeGroups()
+        self.validate()
+        self.compute()
+
+    def report_json(self):
+        print(json.dumps(self.computed, indent=4, sort_keys=True))
+
+    def report_pretty(self):
+        string = ""
+        string += templates.total_osds.format(
+            total_osds=len(self.hdds) or len(self.ssds) * 2
+        )
+
+        string += templates.ssd_volume_group.format(
+            target='journal',
+            total_lv_size=str(self.total_available_journal_space),
+            total_lvs=self.journals_needed,
+            block_db_devices=', '.join([d.path for d in self.ssds]),
+            lv_size=str(self.journal_size),
+            total_osds=self.journals_needed
+        )
+
+        string += templates.osd_component_titles
+
+        for osd in self.computed['osds']:
+            string += templates.osd_header
+            string += templates.osd_component.format(
+                _type='[data]',
+                path=osd['data']['path'],
+                size=osd['data']['human_readable_size'],
+                percent=osd['data']['percentage'],
+            )
+            string += templates.osd_component.format(
+                _type='[journal]',
+                path=osd['journal']['path'],
+                size=osd['journal']['human_readable_size'],
+                percent=osd['journal']['percentage'],
+            )
+
+        print(string)
+
+    def get_common_vg(self):
+        # find all the vgs associated with the current device
+        for ssd in self.ssds:
+            for pv in ssd.pvs_api:
+                vg = self.system_vgs.get(vg_name=pv.vg_name)
+                if not vg:
+                    continue
+                # this should give us just one VG, it would've been caught by
+                # the validator otherwise
+                return vg
+
+    def validate(self):
+        """
+        Ensure that the minimum requirements for this type of scenario is
+        met, raise an error if the provided devices would not work
+        """
+        # validate minimum size for all devices
+        validators.minimum_device_size(self.devices)
+
+        # make sure that data devices do not have any LVs
+        validators.no_lvm_membership(self.hdds)
+
+        # do not allow non-common VG to continue
+        validators.has_common_vg(self.ssds)
+
+        # find the common VG to calculate how much is available
+        self.common_vg = self.get_common_vg()
+
+        # find how many journals are possible from the common VG
+        if self.common_vg:
+            common_vg_size = disk.Size(gb=self.common_vg.free)
+        else:
+            common_vg_size = disk.Size(gb=0)
+
+        # non-VG SSDs
+        self.vg_ssds = set([d for d in self.ssds if d.is_lvm_member])
+        self.blank_ssds = set(self.ssds).difference(self.vg_ssds)
+        self.total_blank_ssd_size = disk.Size(b=0)
+        for blank_ssd in self.blank_ssds:
+            self.total_blank_ssd_size += disk.Size(b=blank_ssd.sys_api['size'])
+
+        self.total_available_journal_space = self.total_blank_ssd_size + common_vg_size
+
+        try:
+            self.vg_extents = lvm.sizing(
+                self.total_available_journal_space.b, size=self.journal_size.b
+            )
+        # FIXME with real exception catching from sizing that happens when the
+        # journal space is not enough
+        except Exception:
+            self.vg_extents = {'parts': 0, 'percentages': 0, 'sizes': 0}
+
+        # validate that number of journals possible are enough for number of
+        # OSDs proposed
+        total_journals_possible = self.total_available_journal_space / self.journal_size
+        if len(self.hdds) > total_journals_possible:
+            msg = "Not enough %s journals (%s) can be created for %s OSDs" % (
+                self.journal_size, total_journals_possible, len(self.hdds)
+            )
+            raise RuntimeError(msg)
+
+    def compute(self):
+        """
+        Go through the rules needed to properly size the lvs, return
+        a dictionary with the result
+        """
+        osds = self.computed['osds']
+
+        vg_free = int(self.total_available_journal_space.gb)
+        if not self.common_vg:
+            # there isn't a common vg, so a new one must be created with all
+            # the blank SSDs
+            self.computed['vg'] = {
+                'devices': self.blank_ssds,
+                'parts': self.journals_needed,
+                'percentages': self.vg_extents['percentages'],
+                'sizes': self.journal_size.b,
+                'size': int(self.total_blank_ssd_size.b),
+                'human_readable_sizes': str(self.journal_size),
+                'human_readable_size': str(self.total_available_journal_space),
+            }
+            vg_name = 'lv/vg'
+        else:
+            vg_name = self.common_vg.name
+
+        for device in self.hdds:
+            device_size = disk.Size(b=device.sys_api['size'])
+            data_size = device_size - self.journal_size
+            osd = {'data': {}, 'journal': {}}
+            osd['data']['path'] = device.path
+            osd['data']['size'] = data_size.b
+            osd['data']['percentage'] = 100
+            osd['data']['human_readable_size'] = str(device_size)
+            osd['journal']['path'] = 'vg: %s' % vg_name
+            osd['journal']['size'] = self.journal_size.b
+            osd['journal']['percentage'] = int(self.journal_size.gb * 100 / vg_free)
+            osd['journal']['human_readable_size'] = str(self.journal_size)
+            osds.append(osd)
+
+    def execute(self):
+        """
+        Create vgs/lvs from the incoming set of devices, assign their roles
+        (data, journal) and offload the OSD creation to ``lvm create``
+        """
+        ssd_paths = [d.abspath for d in self.blank_ssds]
+
+        # no common vg is found, create one with all the blank SSDs
+        if not self.common_vg:
+            journal_vg = lvm.create_vg(ssd_paths, name_prefix='ceph-journals')
+        # a vg exists that can be extended
+        elif self.common_vg and ssd_paths:
+            journal_vg = lvm.extend_vg(self.common_vg, ssd_paths)
+        # one common vg with nothing else to extend can be used directly
+        else:
+            journal_vg = self.common_vg
+
+        journal_size = prepare.get_journal_size(lv_format=True)
+
+        for osd in self.computed['osds']:
+            data_vg = lvm.create_vg(osd['data']['path'], name_prefix='ceph-data')
+            # no extents or size means it will use 100%FREE
+            data_lv = lvm.create_lv('osd-data', data_vg.name)
+            journal_lv = lvm.create_lv(
+                'osd-journal', journal_vg.name, size=journal_size, uuid_name=True
+            )
+
+            command = ['--filestore', '--data']
+            command.append('%s/%s' % (data_vg.name, data_lv.name))
+            command.extend(['--journal', '%s/%s' % (journal_vg.name, journal_lv.name)])
+            if self.args.dmcrypt:
+                command.append('--dmcrypt')
+            if self.args.no_systemd:
+                command.append('--no-systemd')
+            if self.args.crush_device_class:
+                command.extend(['--crush-device-class', self.args.crush_device_class])
+
+            Create(command).main()

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -67,17 +67,17 @@ class SingleType(object):
         osds = self.computed['osds']
         vgs = self.computed['vgs']
         for device in devices:
-            device_size = disk.Size(b=device['size'])
+            device_size = disk.Size(b=device.sys_api['size'])
             journal_size = prepare.get_journal_size(lv_format=False)
             data_size = device_size - journal_size
             data_percentage = data_size * 100 / device_size
-            vgs.append({'devices': [device['path']], 'parts': 2})
+            vgs.append({'devices': [device.abspath], 'parts': 2})
             osd = {'data': {}, 'journal': {}}
-            osd['data']['path'] = device['path']
+            osd['data']['path'] = device.abspath
             osd['data']['size'] = data_size.b
             osd['data']['percentage'] = int(data_percentage)
             osd['data']['human_readable_size'] = str(data_size)
-            osd['journal']['path'] = device['path']
+            osd['journal']['path'] = device.abspath
             osd['journal']['size'] = journal_size.b
             osd['journal']['percentage'] = int(100 - data_percentage)
             osd['journal']['human_readable_size'] = str(journal_size)

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/validators.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/validators.py
@@ -1,4 +1,5 @@
 from ceph_volume.util import disk
+from ceph_volume.api import lvm
 
 
 def minimum_device_size(devices):
@@ -8,6 +9,40 @@ def minimum_device_size(devices):
     """
     msg = 'Unable to use device smaller than 5GB: %s (%s)'
     for device in devices:
-        device_size = disk.Size(b=device['size'])
+        device_size = disk.Size(b=device.sys_api['size'])
         if device_size < disk.Size(gb=5):
             raise RuntimeError(msg % (device, device_size))
+
+
+def no_lvm_membership(devices):
+    """
+    Do not allow devices that are part of LVM
+    """
+    msg = 'Unable to use device, already a member of LVM: %s'
+    for device in devices:
+        if device.is_lvm_member:
+            raise RuntimeError(msg % device.abspath)
+
+
+def has_common_vg(ssd_devices):
+    """
+    Ensure that devices have a common VG between them
+    """
+    msg = 'Could not find a common VG between devices: %s'
+    system_vgs = lvm.VolumeGroups()
+    ssd_vgs = {}
+
+    for ssd_device in ssd_devices:
+        for pv in ssd_device.pvs_api:
+            vg = system_vgs.get(vg_name=pv.vg_name)
+            if not vg:
+                continue
+            try:
+                ssd_vgs[vg.name].append(ssd_device.abspath)
+            except KeyError:
+                ssd_vgs[vg.name] = [ssd_device.abspath]
+    # len of 1 means they all have a common vg, and len of 0 means that these
+    # are blank
+    if len(ssd_vgs) <= 1:
+        return
+    raise RuntimeError(msg % ', '.join(ssd_vgs.keys()))

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -50,7 +50,7 @@ class Zap(object):
         if lv.tags.get('ceph.cluster_name') and lv.tags.get('ceph.osd_id'):
             lv_path = "/var/lib/ceph/osd/{}-{}".format(lv.tags['ceph.cluster_name'], lv.tags['ceph.osd_id'])
         else:
-            lv_path = lv.path
+            lv_path = lv.lv_path
         dmcrypt_uuid = lv.lv_uuid
         dmcrypt = lv.encrypted
         if system.path_is_mounted(lv_path):
@@ -89,7 +89,9 @@ class Zap(object):
         vgs = set([pv.vg_name for pv in pvs])
         for pv in pvs:
             vg_name = pv.vg_name
-            lv = api.get_lv(vg_name=vg_name, lv_uuid=pv.lv_uuid)
+            lv = None
+            if pv.lv_uuid:
+                lv = api.get_lv(vg_name=vg_name, lv_uuid=pv.lv_uuid)
 
             if lv:
                 self.unmount_lv(lv)

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -61,56 +61,56 @@ class Zap(object):
 
     @decorators.needs_root
     def zap(self, args):
-        device = args.device
-        if disk.is_mapper_device(device):
-            terminal.error("Refusing to zap the mapper device: {}".format(device))
-            raise SystemExit(1)
-        lv = api.get_lv_from_argument(device)
-        if lv:
-            # we are zapping a logical volume
-            path = lv.lv_path
-            self.unmount_lv(lv)
-        else:
-            # we are zapping a partition
-            #TODO: ensure device is a partition
-            path = device
-            # check to if it is encrypted to close
-            partuuid = disk.get_partuuid(device)
-            if encryption.status("/dev/mapper/{}".format(partuuid)):
-                dmcrypt_uuid = partuuid
-                self.dmcrypt_close(dmcrypt_uuid)
-
-        mlogger.info("Zapping: %s", path)
-
-        # check if there was a pv created with the
-        # name of device
-        pvs = api.PVolumes()
-        pvs.filter(pv_name=device)
-        vgs = set([pv.vg_name for pv in pvs])
-        for pv in pvs:
-            vg_name = pv.vg_name
-            lv = None
-            if pv.lv_uuid:
-                lv = api.get_lv(vg_name=vg_name, lv_uuid=pv.lv_uuid)
-
+        for device in args.devices:
+            if disk.is_mapper_device(device):
+                terminal.error("Refusing to zap the mapper device: {}".format(device))
+                raise SystemExit(1)
+            lv = api.get_lv_from_argument(device)
             if lv:
+                # we are zapping a logical volume
+                path = lv.lv_path
                 self.unmount_lv(lv)
+            else:
+                # we are zapping a partition
+                #TODO: ensure device is a partition
+                path = device
+                # check to if it is encrypted to close
+                partuuid = disk.get_partuuid(device)
+                if encryption.status("/dev/mapper/{}".format(partuuid)):
+                    dmcrypt_uuid = partuuid
+                    self.dmcrypt_close(dmcrypt_uuid)
 
-        if args.destroy:
-            for vg_name in vgs:
-                mlogger.info("Destroying volume group %s because --destroy was given", vg_name)
-                api.remove_vg(vg_name)
-            mlogger.info("Destroying physical volume %s because --destroy was given", device)
-            api.remove_pv(device)
+            mlogger.info("Zapping: %s", path)
 
-        wipefs(path)
-        zap_data(path)
+            # check if there was a pv created with the
+            # name of device
+            pvs = api.PVolumes()
+            pvs.filter(pv_name=device)
+            vgs = set([pv.vg_name for pv in pvs])
+            for pv in pvs:
+                vg_name = pv.vg_name
+                lv = None
+                if pv.lv_uuid:
+                    lv = api.get_lv(vg_name=vg_name, lv_uuid=pv.lv_uuid)
 
-        if lv and not pvs:
-            # remove all lvm metadata
-            lv.clear_tags()
+                if lv:
+                    self.unmount_lv(lv)
 
-        terminal.success("Zapping successful for: %s" % path)
+            if args.destroy:
+                for vg_name in vgs:
+                    mlogger.info("Destroying volume group %s because --destroy was given", vg_name)
+                    api.remove_vg(vg_name)
+                mlogger.info("Destroying physical volume %s because --destroy was given", device)
+                api.remove_pv(device)
+
+            wipefs(path)
+            zap_data(path)
+
+            if lv and not pvs:
+                # remove all lvm metadata
+                lv.clear_tags()
+
+        terminal.success("Zapping successful for: %s" % ", ".join(args.devices))
 
     def dmcrypt_close(self, dmcrypt_uuid):
         dmcrypt_path = "/dev/mapper/{}".format(dmcrypt_uuid)
@@ -119,7 +119,7 @@ class Zap(object):
 
     def main(self):
         sub_command_help = dedent("""
-        Zaps the given logical volume, raw device or partition for reuse by ceph-volume.
+        Zaps the given logical volume(s), raw device(s) or partition(s) for reuse by ceph-volume.
         If given a path to a logical volume it must be in the format of vg/lv. Any
         filesystems present on the given device, vg/lv, or partition will be removed and
         all data will be purged.
@@ -138,6 +138,10 @@ class Zap(object):
           Zapping a partition:
 
               ceph-volume lvm zap /dev/sdc1
+
+          Zapping many raw devices:
+
+              ceph-volume lvm zap /dev/sda /dev/sdb /db/sdc
 
         If the --destroy flag is given and you are zapping a raw device or partition
         then all vgs and lvs that exist on that raw device or partition will be destroyed.
@@ -160,10 +164,11 @@ class Zap(object):
         )
 
         parser.add_argument(
-            'device',
-            metavar='DEVICE',
-            nargs='?',
-            help='Path to an lv (as vg/lv), partition (as /dev/sda1) or device (as /dev/sda)'
+            'devices',
+            metavar='DEVICES',
+            nargs='*',
+            default=[],
+            help='Path to one or many lv (as vg/lv), partition (as /dev/sda1) or device (as /dev/sda)'
         )
         parser.add_argument(
             '--destroy',

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -578,6 +578,15 @@ class TestCreateLV(object):
         data_tag = ['lvchange', '--addtag', 'ceph.data_device=/path', '/path']
         assert capture.calls[2]['args'][0] == data_tag
 
+    def test_uses_uuid(self, monkeypatch, capture):
+        monkeypatch.setattr(process, 'run', capture)
+        monkeypatch.setattr(process, 'call', capture)
+        monkeypatch.setattr(api, 'get_lv', lambda *a, **kw: self.foo_volume)
+        api.create_lv('foo', 'foo_group', size='5G', tags={'ceph.type': 'data'}, uuid_name=True)
+        result = capture.calls[0]['args'][0][5]
+        assert result.startswith('foo-')
+        assert len(result) == 40
+
 
 class TestExtendVG(object):
 

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -579,6 +579,30 @@ class TestCreateLV(object):
         assert capture.calls[2]['args'][0] == data_tag
 
 
+class TestExtendVG(object):
+
+    def setup(self):
+        self.foo_volume = api.VolumeGroup(vg_name='foo', lv_tags='')
+
+    def test_uses_single_device_in_list(self, monkeypatch, fake_run):
+        monkeypatch.setattr(api, 'get_vg', lambda **kw: True)
+        api.extend_vg(self.foo_volume, ['/dev/sda'])
+        expected = ['vgextend', '--force', '--yes', 'foo', '/dev/sda']
+        assert fake_run.calls[0]['args'][0] == expected
+
+    def test_uses_single_device(self, monkeypatch, fake_run):
+        monkeypatch.setattr(api, 'get_vg', lambda **kw: True)
+        api.extend_vg(self.foo_volume, '/dev/sda')
+        expected = ['vgextend', '--force', '--yes', 'foo', '/dev/sda']
+        assert fake_run.calls[0]['args'][0] == expected
+
+    def test_uses_multiple_devices(self, monkeypatch, fake_run):
+        monkeypatch.setattr(api, 'get_vg', lambda **kw: True)
+        api.extend_vg(self.foo_volume, ['/dev/sda', '/dev/sdb'])
+        expected = ['vgextend', '--force', '--yes', 'foo', '/dev/sda', '/dev/sdb']
+        assert fake_run.calls[0]['args'][0] == expected
+
+
 #
 # The following tests are pretty gnarly. VDO detection is very convoluted and
 # involves correlating information from device mappers, realpaths, slaves of

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -155,6 +155,7 @@ def device_info(monkeypatch):
         devices = devices if devices else {}
         lsblk = lsblk if lsblk else {}
         lv = Factory(**lv) if lv else None
+        monkeypatch.setattr("ceph_volume.sys_info.devices", {})
         monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: devices)
         monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: lv)
         monkeypatch.setattr("ceph_volume.util.device.disk.lsblk", lambda path: lsblk)

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -147,3 +147,15 @@ def tmpfile(tmpdir):
             fp.write(contents)
         return path
     return generate_file
+
+
+@pytest.fixture
+def device_info(monkeypatch):
+    def apply(devices=None, lsblk=None, lv=None):
+        devices = devices if devices else {}
+        lsblk = lsblk if lsblk else {}
+        lv = Factory(**lv) if lv else None
+        monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: devices)
+        monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: lv)
+        monkeypatch.setattr("ceph_volume.util.device.disk.lsblk", lambda path: lsblk)
+    return apply

--- a/src/ceph-volume/ceph_volume/tests/devices/test_zap.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/test_zap.py
@@ -7,7 +7,7 @@ class TestZap(object):
     def test_main_spits_help_with_no_arguments(self, capsys):
         lvm.zap.Zap([]).main()
         stdout, stderr = capsys.readouterr()
-        assert 'Zaps the given logical volume, raw device or partition' in stdout
+        assert 'Zaps the given logical volume(s), raw device(s) or partition(s)' in stdout
 
     def test_main_shows_full_help(self, capsys):
         with pytest.raises(SystemExit):

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -96,3 +96,17 @@ class TestExcludeGroupOptions(object):
         )
         stdout, stderr = capsys.readouterr()
         assert 'Cannot use --filestore (filestore) with --bluestore (bluestore)' in stdout
+
+
+class TestValidDevice(object):
+
+    def setup(self):
+        self.validator = arg_validators.ValidDevice()
+
+    def test_path_is_valid(self, fake_call):
+        result = self.validator('/')
+        assert result.abspath == '/'
+
+    def test_path_is_invalid(self, fake_call):
+        with pytest.raises(argparse.ArgumentError):
+            self.validator('/device/does/not/exist')

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -1,0 +1,66 @@
+from ceph_volume.util import device
+from ceph_volume.api import lvm as api
+
+
+class TestDevice(object):
+
+    def test_sys_api(self, device_info):
+        data = {"/dev/sda": {"foo": "bar"}}
+        device_info(devices=data)
+        disk = device.Device("/dev/sda")
+        assert disk.sys_api
+        assert "foo" in disk.sys_api
+
+    def test_is_lv(self, device_info):
+        data = {"lv_path": "vg/lv"}
+        device_info(lv=data)
+        disk = device.Device("vg/lv")
+        assert disk.is_lv
+
+    def test_is_device(self, device_info):
+        data = {"/dev/sda": {"foo": "bar"}}
+        lsblk = {"TYPE": "device"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/sda")
+        assert disk.is_device
+
+    def test_is_partition(self, device_info, pvolumes):
+        data = {"/dev/sda": {"foo": "bar"}}
+        lsblk = {"TYPE": "part"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/sda")
+        assert disk.is_partition
+
+    def test_is_not_lvm_memeber(self, device_info, pvolumes):
+        data = {"/dev/sda": {"foo": "bar"}}
+        lsblk = {"TYPE": "part"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/sda")
+        assert not disk.is_lvm_member
+
+    def test_is_lvm_memeber(self, device_info, pvolumes):
+        data = {"/dev/sda": {"foo": "bar"}}
+        lsblk = {"TYPE": "part"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/sda")
+        assert not disk.is_lvm_member
+
+    def test_is_mapper_device(self, device_info):
+        device_info()
+        disk = device.Device("/dev/mapper/foo")
+        assert disk.is_mapper
+
+    def test_is_not_mapper_device(self, device_info):
+        device_info()
+        disk = device.Device("/dev/sda")
+        assert not disk.is_mapper
+
+    def test_pv_api(self, device_info, pvolumes, monkeypatch):
+        FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", pv_tags={}, vg_name="vg")
+        pvolumes.append(FooPVolume)
+        monkeypatch.setattr(api, 'PVolumes', lambda: pvolumes)
+        data = {"/dev/sda": {"foo": "bar"}}
+        lsblk = {"TYPE": "part"}
+        device_info(devices=data, lsblk=lsblk)
+        disk = device.Device("/dev/sda")
+        assert disk.pvs_api

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -3,6 +3,7 @@ import os
 from ceph_volume import terminal
 from ceph_volume import decorators
 from ceph_volume.util import disk
+from ceph_volume.util.device import Device
 
 
 class LVPath(object):
@@ -39,6 +40,18 @@ class LVPath(object):
         if error:
             raise argparse.ArgumentError(None, error)
         return string
+
+
+class ValidDevice(object):
+
+    def __call__(self, string):
+        device = Device(string)
+        if not device.exists:
+            raise argparse.ArgumentError(
+                None, "Unable to proceed with non-existing device: %s" % string
+            )
+
+        return device
 
 
 class OSDPath(object):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -1,4 +1,5 @@
 import os
+from ceph_volume import sys_info
 from ceph_volume.api import lvm
 from ceph_volume.util import disk
 
@@ -12,6 +13,7 @@ class Device(object):
         self.lv_api = None
         self.pvs_api = []
         self.disk_api = {}
+        self.sys_api = {}
         self._exists = None
         self._is_lvm_member = None
         self._parse()
@@ -29,6 +31,10 @@ class Device(object):
             # always check is this is an lvm member
             if device_type in ['part', 'disk']:
                 self._set_lvm_membership()
+
+        if not sys_info.devices:
+            sys_info.devices = disk.get_devices()
+        self.sys_api = sys_info.devices.get(self.abspath, {})
 
     def __repr__(self):
         prefix = 'Unknown'
@@ -63,9 +69,7 @@ class Device(object):
 
     @property
     def exists(self):
-        if self._exists is None:
-            self._exists = os.path.exists(self.abspath)
-        return self._exists
+        return os.path.exists(self.abspath)
 
     @property
     def is_lvm_member(self):
@@ -75,9 +79,7 @@ class Device(object):
 
     @property
     def is_mapper(self):
-        if self._is_mapper is None:
-            self._is_mapper = self.path.startswith('/dev/mapper')
-        return self._is_mapper
+        return self.path.startswith('/dev/mapper')
 
     @property
     def is_lv(self):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -55,7 +55,7 @@ class Device(object):
             if not pvs:
                 self._is_lvm_member = False
                 return self._is_lvm_member
-            has_vgs = [pv.vg_name for pv in pvs]
+            has_vgs = [pv.vg_name for pv in pvs if pv.vg_name]
             if has_vgs:
                 self._is_lvm_member = True
                 self.pvs_api = pvs

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -1,0 +1,96 @@
+import os
+from ceph_volume.api import lvm
+from ceph_volume.util import disk
+
+
+class Device(object):
+
+    def __init__(self, path):
+        self.path = path
+        # LVs can have a vg/lv path, while disks will have /dev/sda
+        self.abspath = path
+        self.lv_api = None
+        self.pvs_api = []
+        self.disk_api = {}
+        self._exists = None
+        self._is_lvm_member = None
+        self._parse()
+
+    def _parse(self):
+        # start with lvm since it can use an absolute or relative path
+        lv = lvm.get_lv_from_argument(self.path)
+        if lv:
+            self.lv_api = lv
+            self.abspath = lv.lv_path
+        else:
+            dev = disk.lsblk(self.path)
+            self.disk_api = dev
+            device_type = dev.get('TYPE', '')
+            # always check is this is an lvm member
+            if device_type in ['part', 'disk']:
+                self._set_lvm_membership()
+
+    def __repr__(self):
+        prefix = 'Unknown'
+        if self.is_lv:
+            prefix = 'LV'
+        elif self.is_partition:
+            prefix = 'Partition'
+        elif self.is_device:
+            prefix = 'Raw Device'
+        return '<%s: %s>' % (prefix, self.abspath)
+
+    def _set_lvm_membership(self):
+        if self._is_lvm_member is None:
+            # check if there was a pv created with the
+            # name of device
+            pvs = lvm.PVolumes()
+            pvs.filter(pv_name=self.abspath)
+            if not pvs:
+                self._is_lvm_member = False
+                return self._is_lvm_member
+            has_vgs = [pv.vg_name for pv in pvs]
+            if has_vgs:
+                self._is_lvm_member = True
+                self.pvs_api = pvs
+            else:
+                # this is contentious, if a PV is recognized by LVM but has no
+                # VGs, should we consider it as part of LVM? We choose not to
+                # here, because most likely, we need to use VGs from this PV.
+                self._is_lvm_member = False
+
+        return self._is_lvm_member
+
+    @property
+    def exists(self):
+        if self._exists is None:
+            self._exists = os.path.exists(self.abspath)
+        return self._exists
+
+    @property
+    def is_lvm_member(self):
+        if self._is_lvm_member is None:
+            self._set_lvm_membership()
+        return self._is_lvm_member
+
+    @property
+    def is_mapper(self):
+        if self._is_mapper is None:
+            self._is_mapper = self.path.startswith('/dev/mapper')
+        return self._is_mapper
+
+    @property
+    def is_lv(self):
+        return self.lv_api is not None
+
+    @property
+    def is_partition(self):
+        if self.disk_api:
+            return self.disk_api['TYPE'] == 'part'
+        return False
+
+    @property
+    def is_device(self):
+        if self.disk_api:
+            return self.disk_api['TYPE'] == 'device'
+        return False

--- a/src/ceph-volume/ceph_volume/util/templates.py
+++ b/src/ceph-volume/ceph_volume/util/templates.py
@@ -1,14 +1,14 @@
 
 osd_header = """
-{:-^80}""".format('')
+{:-^100}""".format('')
 
 
 osd_component_titles = """
-  Type            Path                      LV Size         % of device"""
+  Type            Path                                                    LV Size         % of device"""
 
 
 osd_component = """
-  {_type: <15} {path: <25} {size: <15} {percent}%"""
+  {_type: <15} {path: <55} {size: <15} {percent}%"""
 
 
 total_osds = """


### PR DESCRIPTION
Adds support for batch operations for mixed devices types (SSDs and HDDs). This support includes the addition of a `Device` class to better scan and check for devices before processing them.

It includes support for recognizing existing Volume Groups so that new LVs can be carved out

Fixes: http://tracker.ceph.com/issues/24553