### PR TITLE
cmake: add option WITH_LIBRADOSSTRIPER

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -439,7 +439,11 @@ add_library(rados_snap_set_diff_obj OBJECT librados/snap_set_diff.cc)
 
 add_subdirectory(include)
 add_subdirectory(librados)
-add_subdirectory(libradosstriper)
+
+option(WITH_LIBRADOSSTRIPER "build with libradosstriper support" ON)
+if(WITH_LIBRADOSSTRIPER)
+  add_subdirectory(libradosstriper)
+endif()
 
 if(WITH_MGR)
   add_subdirectory(mgr)

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -18,6 +18,7 @@
 #include "include/rados/librados.hpp"
 #include "include/rados/rados_types.hpp"
 
+#include "acconfig.h"
 #ifdef WITH_LIBRADOSSTRIPER
  #include "include/radosstriper/libradosstriper.hpp"
  using namespace libradosstriper;


### PR DESCRIPTION
otherwise this cmake variable is never defined, hence all tests
requiring libstriper are broken.

this is a regresssion introduced by 5513a90c62 .

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

