### PR TITLE
mgr/dashboard: Auto-create a name for RBD image snapshots

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-form/rbd-snapshot-form.component.ts
@@ -50,7 +50,15 @@ export class RbdSnapshotFormComponent implements OnInit {
   setSnapName(snapName) {
     this.snapName = snapName;
     this.snapshotForm.get('snapshotName').setValue(snapName);
-    this.editing = true;
+  }
+
+  /**
+   * Set the 'editing' flag. If set to TRUE, the modal dialog is in
+   * 'Edit' mode, otherwise in 'Create' mode.
+   * @param {boolean} editing
+   */
+  setEditing(editing: boolean = true) {
+    this.editing = editing;
   }
 
   editAction() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
 import * as _ from 'lodash';
+import * as moment from 'moment';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 import { of } from 'rxjs';
 
@@ -139,13 +140,20 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
     );
   }
 
-  private openSnapshotModal(taskName: string, oldSnapshotName: string = null) {
+  private openSnapshotModal(taskName: string, snapName: string = null) {
     this.modalRef = this.modalService.show(RbdSnapshotFormComponent);
     this.modalRef.content.poolName = this.poolName;
     this.modalRef.content.imageName = this.rbdName;
-    if (oldSnapshotName) {
-      this.modalRef.content.setSnapName(this.selection.first().name);
+    if (snapName) {
+      this.modalRef.content.setEditing();
+    } else {
+      // Auto-create a name for the snapshot: <image_name>_<timestamp_ISO_8601>
+      // https://en.wikipedia.org/wiki/ISO_8601
+      snapName = `${this.rbdName}-${moment()
+        .utc()
+        .format('YYYYMMDD[T]HHmmss[Z]')}`;
     }
+    this.modalRef.content.setSnapName(snapName);
     this.modalRef.content.onSubmit.subscribe((snapshotName: string) => {
       const executingTask = new ExecutingTask();
       executingTask.name = taskName;


### PR DESCRIPTION
If the user creates an snapshot of a RBD image, then a name according to ISO 8601 (<image_name>_<timestamp_ISO_8601>, e.g. test01-20180824T170532Z) will be auto-created. This can still be modified by the user.

Note, the timestamp encoded in the snapshot name is NOT the real creation date (that's because the snapshot is created after you pressed the ``Create Snapshot`` button and the timestamp is the one when the dialog appears in the UI). To workaround this issue we can drop the HHMMSS part from the snapshot name if necessary.

Signed-off-by: Volker Theile <vtheile@suse.com>
