### PR TITLE
luminous: qa/tasks/thrashosds-health.yaml: whitelist slow requests

### DIFF
--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -12,3 +12,4 @@ overrides:
       - \(REQUEST_SLOW\)
       - \(TOO_FEW_PGS\)
       - \(MON_DOWN\)
+      - slow requests


### PR DESCRIPTION
http://tracker.ceph.com/issues/26887

@neha-ojha @liewegas can you check if the conflict resolution is correct? ie. do we keep MON_DOWN as well
