### PR TITLE
global/signal_handler.cc: report assert_file as correct name

### DIFF
--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -244,7 +244,7 @@ static void handle_fatal_signal(int signum)
 	  jf.dump_string("assert_file", g_assert_file);
 	}
 	if (g_assert_line) {
-	  jf.dump_unsigned("assert_file", g_assert_line);
+	  jf.dump_unsigned("assert_line", g_assert_line);
 	}
 	if (g_assert_thread_name[0]) {
 	  jf.dump_string("assert_thread_name", g_assert_thread_name);


### PR DESCRIPTION
Boilerplate error led to two 'assert_line' items in the dump

Signed-off-by: Dan Mick <dan.mick@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

