### PR TITLE
rgw: fix Etag error in multipart copy response

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1436,7 +1436,7 @@ void RGWPutObj_ObjStore_S3::send_response()
       if (strftime(buf, sizeof(buf), "%Y-%m-%dT%T.000Z", &tmp) > 0) {
         s->formatter->dump_string("LastModified", buf);
       }
-      dump_etag(s, etag);
+      s->formatter->dump_string("ETag", etag);
       s->formatter->close_section();
       rgw_flush_formatter_and_reset(s, s->formatter);
       return;


### PR DESCRIPTION
test script
```
# -*- coding: utf-8 -*-
import math
from boto3.session import Session

access_key = "yly"
secret_key = "yly"
url = "http://127.0.0.1:7480"
session = Session(access_key, secret_key)
s3_client = session.client('s3', endpoint_url=url)


source_b = "test1"
source_k = "10M"
dest_b = "test1"
dest_k = "10M_cp"
objectSize = s3_client.head_object(Bucket=source_b, Key=source_k)['ContentLength']
mpu = s3_client.create_multipart_upload(Bucket=dest_b, Key=dest_k)
psize = 5 * 1024 * 1024
part_info = {
    'Parts': []
}
bytePosition = 0
i = 1
while bytePosition < objectSize:
    lastbyte = bytePosition + psize - 1
    if lastbyte >= objectSize:
        lastbyte = objectSize - 1
    print "mp.copy_part_from_key part %d (%d %d)" % (i, bytePosition, lastbyte)
    res = s3_client.upload_part_copy(Bucket=dest_b, CopySource=source_b + "/" + source_k ,
                                     CopySourceRange='bytes=%d-%d'%(bytePosition,lastbyte),
                                     Key=dest_k,
                                     PartNumber=i, UploadId=mpu["UploadId"])
    part_info['Parts'].append({
        'PartNumber': i,
        'ETag': res['CopyPartResult']['ETag']
    })
    i = i + 1
    bytePosition += psize
s3_client.complete_multipart_upload(Bucket=dest_b, Key=dest_k, UploadId=mpu["UploadId"], MultipartUpload=part_info)
```

res:

```
[root@localhost build]# python copypart.py
mp.copy_part_from_key part 1 (0 5242879)
Traceback (most recent call last):
  File "copypart.py", line 35, in <module>
    'ETag': res['CopyPartResult']['ETag']
KeyError: 'ETag'

```

wireshark
```
PUT /ylybucket/10M_cp?partNumber=1&uploadId=2~xwfJiE6dopTQe5cD83cNrRfxN6sP730 HTTP/1.1
Host: 10.254.3.68:9999
Accept-Encoding: identity
Content-Length: 0
User-Agent: Boto3/1.7.54 Python/2.7.5 Linux/3.10.0-327.el7.x86_64 Botocore/1.10.54
x-amz-copy-source-range: bytes=0-5242879
x-amz-copy-source: ylybucket/10M
Date: Mon, 27 Aug 2018 08:52:14 GMT
Authorization: AWS yly:iDbBVlH9uGdE689QPtIs8XQkknI=

HTTP/1.1 200 OK
x-amz-request-id: tx000000000000000000011-005b83ba0c-29354b-default
Content-Type: application/xml
Content-Length: 217
Date: Mon, 27 Aug 2018 08:45:05 GMT

<?xml version="1.0" encoding="UTF-8"?><CopyPartResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2018-08-27T08:48:53.000Z</LastModified></CopyPartResult>
```

no etag found

use dump_string , not dump_etag(which dump etag in header)

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>

