### PR TITLE
rgw: etag in rgw copy result response body rather in header

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2201,7 +2201,9 @@ void RGWCopyObj_ObjStore_S3::send_response()
 
   if (op_ret == 0) {
     dump_time(s, "LastModified", &mtime);
-    dump_etag(s, etag);
+    if (!etag.empty()) {
+      s->formatter->dump_string("ETag", std::move(etag));
+    }
     s->formatter->close_section();
     rgw_flush_formatter_and_reset(s, s->formatter);
   }


### PR DESCRIPTION
in aws copy op result

```
PUT /testbyyly/copyed HTTP/1.1
Host: s3.amazonaws.com
Accept-Encoding: identity
Date: Mon, 27 Aug 2018 10:55:27 GMT
Content-Length: 0
x-amz-copy-source: testbyyly/1.txt
Authorization: AWS AKIAIOHGX57FOXYYYOBQ:ZpqUpF8V2eY1De7S1SZvdgfTIZA=
User-Agent: Boto3/1.7.54 Python/2.7.5 Linux/3.10.0-327.el7.x86_64 Botocore/1.10.54

HTTP/1.1 200 OK
x-amz-id-2: 3F3Z1k1aw3PbszvfxKVb1GhuQoJXdbIl+N4drSoscC/GxnlaQ++nyYnInlzRpfrlRvxUu+2rMtY=
x-amz-request-id: 590A91A7ABB235C8
Date: Mon, 27 Aug 2018 10:55:54 GMT
Content-Type: application/xml
Transfer-Encoding: chunked
Server: AmazonS3

<?xml version="1.0" encoding="UTF-8"?>
<CopyObjectResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><LastModified>2018-08-27T10:55:54.000Z</LastModified><ETag>&quot;37cad470606e9e11537b44b589605a13&quot;</ETag></CopyObjectResult>
```
the etag is in response body xml rather in header


Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>
