### PR TITLE
os/tests: fix garbageCollection test case from store_test suite.

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -6668,6 +6668,7 @@ TEST_P(StoreTestSpecificAUSize, garbageCollection) {
 
   SetVal(g_conf(), "bluestore_compression_max_blob_size", "524288");
   SetVal(g_conf(), "bluestore_compression_min_blob_size", "262144");
+  SetVal(g_conf(), "bluestore_max_blob_size", "524288");
   SetVal(g_conf(), "bluestore_compression_mode", "force");
   g_conf().apply_changes(nullptr);
 


### PR DESCRIPTION
While running the test case using SSD as block device one could face
a failure caused by unexpectidly small blob size limit - compression
resulted in two blocks rather than single one which violated was test case
constraints.
Here is the output for failing test case:
```
[ RUN      ] ObjectStore/StoreTestSpecificAUSize.garbageCollection/2
Creating collection meta
Creating object #-1:68309cac:::Object 1:head#
/home/if/nvme/ceph.3/src/test/objectstore/store_test.cc:6720: Failure
      Expected: statfs.data_compressed_allocated
      Which is: 0
To be equal to: 0x10000
      Which is: 65536
==> rm -r bluestore.test_temp_dir
[  FAILED  ] ObjectStore/StoreTestSpecificAUSize.garbageCollection/2, where GetParam() = "bluestore" (1173 ms)
[----------] 1 test from ObjectStore/StoreTestSpecificAUSize (1173 ms total)

```
Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

