### PR TITLE
common/buffer.cc/create_page_aligned: set 4k align when len<64k (whil…

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -715,7 +715,10 @@ using namespace ceph;
   }
 
   buffer::raw* buffer::create_page_aligned(unsigned len) {
-    return create_aligned(len, CEPH_PAGE_SIZE);
+    if (len < CEPH_PAGE_SIZE) {
+      return create_aligned(len, 0x1000);
+    } else
+      return create_aligned(len, CEPH_PAGE_SIZE);
   }
 
   buffer::raw* buffer::create_zero_copy(unsigned len, int fd, int64_t *offset) {


### PR DESCRIPTION
…e OS PAGESIZE = 64k)

On my arm64 dev board, CentOS 7.4, the default OS pagesize is 64k, one SSD disk.
When I make fio performance reading test(bs=4k), the ceph-osd process uses a
large amount of memory(more than 20G), while do fio(bs=64), just use about 2G.
After traceing the mem allocate prcess, it is found to be related to page size
alignment.
Useing 4K alignment when applying for small mem(less then 64k - the CEPH_PAGE_SIZE
and OS default page size) will reduce the waste of mem. By applying the current
patch, when doing FIO performance reading test(bs=4k), the memory used by the
ceph-osd process will be reduced from more than 20G to about 3G, while the
reading performance has not been reduced.

Signed-off-by: Jiang Yutang <yutang2.jiang@hxt-semitech.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

