### PR TITLE
mgr/dashboard: Fix OSD down error display

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -13,20 +13,24 @@ from ..tools import str_to_bool
 class Osd(RESTController):
     def list(self):
         osds = self.get_osd_map()
+
         # Extending by osd stats information
         for s in mgr.get('osd_stats')['osd_stats']:
             osds[str(s['osd'])].update({'osd_stats': s})
+
         # Extending by osd node information
         nodes = mgr.get('osd_map_tree')['nodes']
         osd_tree = [(str(o['id']), o) for o in nodes if o['id'] >= 0]
         for o in osd_tree:
             osds[o[0]].update({'tree': o[1]})
+
         # Extending by osd parent node information
         hosts = [(h['name'], h) for h in nodes if h['id'] < 0]
         for h in hosts:
             for o_id in h[1]['children']:
                 if o_id >= 0:
                     osds[str(o_id)]['host'] = h[1]
+
         # Extending by osd histogram data
         for o_id in osds:
             o = osds[o_id]
@@ -40,6 +44,7 @@ class Osd(RESTController):
             # Gauge stats
             for s in ['osd.numpg', 'osd.stat_bytes', 'osd.stat_bytes_used']:
                 o['stats'][s.split('.')[1]] = mgr.get_latest('osd', osd_spec, s)
+
         return list(osds.values())
 
     def get_osd_map(self):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
@@ -17,9 +17,10 @@
     </cd-table-performance-counter>
   </tab>
   <tab heading="Histogram">
-    <h3 *ngIf="osd.loaded && osd.histogram_failed">
-      Histogram not available -> <span class="text-warning">{{ osd.histogram_failed }}</span>
-    </h3>
+    <cd-warning-panel i18n *ngIf="osd.loaded && osd.histogram_failed">
+      Histogram not available: {{ osd.histogram_failed }}
+    </cd-warning-panel>
+
     <div class="row" *ngIf="osd.loaded && osd.details.histogram">
       <div class="col-md-6">
         <h4>Writes</h4>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.spec.ts
@@ -1,9 +1,13 @@
 import { HttpClientModule } from '@angular/common/http';
+import { DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { of } from 'rxjs';
 
 import { TabsModule } from 'ngx-bootstrap';
 
 import { configureTestBed } from '../../../../../testing/unit-test-helper';
+import { OsdService } from '../../../../shared/api/osd.service';
 import { DataTableModule } from '../../../../shared/datatable/datatable.module';
 import { CdTableSelection } from '../../../../shared/models/cd-table-selection';
 import { SharedModule } from '../../../../shared/shared.module';
@@ -14,6 +18,9 @@ import { OsdDetailsComponent } from './osd-details.component';
 describe('OsdDetailsComponent', () => {
   let component: OsdDetailsComponent;
   let fixture: ComponentFixture<OsdDetailsComponent>;
+  let debugElement: DebugElement;
+  let osdService: OsdService;
+  let getDetailsSpy;
 
   configureTestBed({
     imports: [
@@ -23,7 +30,8 @@ describe('OsdDetailsComponent', () => {
       DataTableModule,
       SharedModule
     ],
-    declarations: [OsdDetailsComponent, OsdPerformanceHistogramComponent]
+    declarations: [OsdDetailsComponent, OsdPerformanceHistogramComponent],
+    providers: [OsdService]
   });
 
   beforeEach(() => {
@@ -31,11 +39,41 @@ describe('OsdDetailsComponent', () => {
     component = fixture.componentInstance;
 
     component.selection = new CdTableSelection();
+    debugElement = fixture.debugElement;
+    osdService = debugElement.injector.get(OsdService);
+
+    getDetailsSpy = spyOn(osdService, 'getDetails');
 
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should fail creating a histogram', () => {
+    const detailDataWithoutHistogram = {
+      osd_map: {},
+      osd_metadata: {},
+      histogram: 'osd down'
+    };
+    getDetailsSpy.and.returnValue(of(detailDataWithoutHistogram));
+    component.osd = { tree: { id: 0 } };
+    component.refresh();
+    expect(getDetailsSpy).toHaveBeenCalled();
+    expect(component.osd.histogram_failed).toBe('osd down');
+  });
+
+  it('should succeed creating a histogram', () => {
+    const detailDataWithHistogram = {
+      osd_map: {},
+      osd_metdata: {},
+      histogram: {}
+    };
+    getDetailsSpy.and.returnValue(of(detailDataWithHistogram));
+    component.osd = { tree: { id: 0 } };
+    component.refresh();
+    expect(getDetailsSpy).toHaveBeenCalled();
+    expect(component.osd.histogram_failed).toBe('');
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.ts
@@ -34,6 +34,7 @@ export class OsdDetailsComponent implements OnChanges {
   refresh() {
     this.osdService.getDetails(this.osd.tree.id).subscribe((data: any) => {
       this.osd.details = data;
+      this.osd.histogram_failed = '';
       if (!_.isObject(data.histogram)) {
         this.osd.histogram_failed = data.histogram;
         this.osd.details.histogram = undefined;

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -12,7 +12,7 @@
               type="button"
               class="btn btn-sm btn-primary dropdown-toggle tc_scrub_toggle"
               [ngClass]="{disabled: !tableComponent.selection.hasSelection}">
-        <ng-container i18n> Perform Task</ng-container>
+        <ng-container i18n>Perform Task </ng-container>
         <span class="caret"></span>
       </button>
       <ul *dropdownMenu

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -49,13 +49,11 @@
   </cd-osd-details>
 </cd-table>
 
-<ng-template #statusColor
-             let-value="value">
+<ng-template #statusColor let-value="value">
   <span *ngFor="let state of value; last as last">
-    <span [class.text-success]="'up' === state || 'in' === state"
-          [class.text-warning]="'down' === state || 'out' === state">
-      {{ state }}</span>
-    <span *ngIf="!last">, </span>
+    <span class="label"
+           [ngClass]="{'label-success': ['in', 'up'].includes(state), 'label-danger': ['down', 'out'].includes(state)}">{{ state }}</span>
+    <span *ngIf="!last">&nbsp;</span>
   </span>
 </ng-template>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -56,7 +56,6 @@
           [class.text-warning]="'down' === state || 'out' === state">
       {{ state }}</span>
     <span *ngIf="!last">, </span>
-    <!-- Has to be on the same line to prevent a space between state and comma. -->
   </span>
 </ng-template>
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -185,6 +185,9 @@
       padding-bottom: 5px;
     }
     .datatable-body-row {
+      .label {
+        font-size: 0.9em;
+      }
       &.clickable:hover .datatable-row-group {
         background-color: $color-table-hover-row;
         transition-property: background;


### PR DESCRIPTION
This PR fixes the errors displayed on the frontend when the users click on an OSD which is down.

![osd-down-error 1](https://user-images.githubusercontent.com/9606095/44663304-72fa3900-aa10-11e8-9674-4f8256431dfe.png)

The backend will not send a response containing a failing HTTP status code anymore, which indicated to the frontend that the request failed and which simply has been displayed as a popup notification.

Instead the response contains the error message in case of an error, which will be displayed by the frontend. This enables the frontend to display the error, but also allows to display data about the OSD which, caused by the error, wasn't displayed but still available. The data which is available although the OSD has been marked down is `Attributes (OSD map)` and `Metadata`. The `Histogram` will fail immediately if the OSD is down and display a corresponding warning. The `Performance data` may fail sooner or later and will state `no data available` in the data table (default) without a reason why that's the case. For the latter and for consistency reasons, I'd prefer to have the same kind of warning displayed as for the `Histogram` tab, but that's not how the rest of the data tables are handled when there's no data available. Hence, I have left it as it is and want to ask you for your feedback. Feedback regarding the look of the warning and everything else what comes to your mind is also welcome.

![histogram_not_available](https://user-images.githubusercontent.com/9606095/44792334-f1d3ab00-aba3-11e8-8d47-cdb09b6e40df.png)

Notes: 
- Unit tests are going to be added soon.
- The color of the status of the OSDs has changed to a brighter red (as requested in the corresponding issue on the bug tracker).
