### PR TITLE
OSD: change SrubJob comparison rule to avoid repeated injection

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6849,9 +6849,9 @@ OSDService::ScrubJob::ScrubJob(CephContext* cct,
 }
 
 bool OSDService::ScrubJob::ScrubJob::operator<(const OSDService::ScrubJob& rhs) const {
-  if (sched_time < rhs.sched_time)
+  if (sched_time < rhs.sched_time && pgid < rhs.pgid)
     return true;
-  if (sched_time > rhs.sched_time)
+  if (sched_time > rhs.sched_time && pgid > rhs.pgid)
     return false;
   return pgid < rhs.pgid;
 }


### PR DESCRIPTION
Signed-off-by: lvshuhua <lvshuhua@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

