### PR TITLE
os/bluestore: Fix concurrency conflicts

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -77,7 +77,8 @@ public:
   uint64_t get_num_ios() const;
 
   void try_aio_wake() {
-    if (num_running == 1) {
+    assert(num_running >= 1);
+    if (num_running.fetch_sub(1) == 1) {
 
       // we might have some pending IOs submitted after the check
       // as there is no lock protection for aio_submit.
@@ -85,10 +86,6 @@ public:
       // aio_wait has to handle that hence do not care here.
       std::lock_guard<std::mutex> l(lock);
       cond.notify_all();
-      --num_running;
-      ceph_assert(num_running >= 0);
-    } else {
-      --num_running;
     }
   }
 


### PR DESCRIPTION
When the last two IOs of the same Context return at the same time, their
num_running may be 2 at the same time, causing the thread to not be
woken up, eventually resulting in a timeout.

Signed-off-by: Wang Hongxu <wanghongxu@t2cloud.net>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

