### PR TITLE
include/types: move operator<< into the proper namespace

### DIFF
--- a/src/include/types.h
+++ b/src/include/types.h
@@ -95,38 +95,47 @@ typedef off_t loff_t;
 // the case of containers of containers. I'm tempted to abstract this
 // stuff using template templates like I did for denc.
 
+namespace std {
 template<class A, class B>
-inline ostream& operator<<(ostream&out, const pair<A,B>& v);
+inline std::ostream& operator<<(std::ostream&out, const std::pair<A,B>& v);
 template<class A, class Alloc>
-inline ostream& operator<<(ostream& out, const vector<A,Alloc>& v);
+inline std::ostream& operator<<(std::ostream& out, const std::vector<A,Alloc>& v);
 template<class A, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const deque<A,Alloc>& v);
+inline std::ostream& operator<<(std::ostream& out, const std::deque<A,Alloc>& v);
 template<typename... Ts>
-inline ostream& operator<<(ostream& out, const std::tuple<Ts...> &t);
-template<typename... Ts>
-inline ostream& operator<<(ostream& out, const boost::tuple<Ts...> &t);
+inline std::ostream& operator<<(std::ostream& out, const std::tuple<Ts...> &t);
 template<class A, class Alloc>
-inline ostream& operator<<(ostream& out, const list<A,Alloc>& ilist);
+inline std::ostream& operator<<(std::ostream& out, const std::list<A,Alloc>& ilist);
 template<class A, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const set<A, Comp, Alloc>& iset);
+inline std::ostream& operator<<(std::ostream& out, const std::set<A, Comp, Alloc>& iset);
 template<class A, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const boost::container::flat_set<A, Comp, Alloc>& iset);
+inline std::ostream& operator<<(std::ostream& out, const std::multiset<A,Comp,Alloc>& iset);
 template<class A, class B, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const boost::container::flat_map<A, B, Comp, Alloc>& iset);
-template<class A, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const multiset<A,Comp,Alloc>& iset);
+inline std::ostream& operator<<(std::ostream& out, const std::map<A,B,Comp,Alloc>& m);
 template<class A, class B, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const map<A,B,Comp,Alloc>& m);
-template<class A, class B, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const multimap<A,B,Comp,Alloc>& m);
+inline std::ostream& operator<<(std::ostream& out, const std::multimap<A,B,Comp,Alloc>& m);
+}
 
+namespace boost {
+template<typename... Ts>
+inline std::ostream& operator<<(std::ostream& out, const boost::tuple<Ts...> &t);
+
+namespace container {
+template<class A, class Comp, class Alloc>
+inline std::ostream& operator<<(std::ostream& out, const boost::container::flat_set<A, Comp, Alloc>& iset);
+template<class A, class B, class Comp, class Alloc>
+inline std::ostream& operator<<(std::ostream& out, const boost::container::flat_map<A, B, Comp, Alloc>& iset);
+}
+}
+
+namespace std {
 template<class A, class B>
-inline ostream& operator<<(ostream& out, const pair<A,B>& v) {
+inline std::ostream& operator<<(std::ostream& out, const std::pair<A,B>& v) {
   return out << v.first << "," << v.second;
 }
 
 template<class A, class Alloc>
-inline ostream& operator<<(ostream& out, const vector<A,Alloc>& v) {
+inline std::ostream& operator<<(std::ostream& out, const std::vector<A,Alloc>& v) {
   out << "[";
   for (auto p = v.begin(); p != v.end(); ++p) {
     if (p != v.begin()) out << ",";
@@ -135,8 +144,9 @@ inline ostream& operator<<(ostream& out, const vector<A,Alloc>& v) {
   out << "]";
   return out;
 }
+
 template<class A, class Alloc>
-inline ostream& operator<<(ostream& out, const deque<A,Alloc>& v) {
+inline std::ostream& operator<<(std::ostream& out, const std::deque<A,Alloc>& v) {
   out << "<";
   for (auto p = v.begin(); p != v.end(); ++p) {
     if (p != v.begin()) out << ",";
@@ -146,15 +156,8 @@ inline ostream& operator<<(ostream& out, const deque<A,Alloc>& v) {
   return out;
 }
 
-template<typename A, typename B, typename C>
-inline ostream& operator<<(ostream& out, const boost::tuple<A, B, C> &t) {
-  return out << boost::get<0>(t) << ","
-	     << boost::get<1>(t) << ","
-	     << boost::get<2>(t);
-}
-
 template<typename... Ts>
-inline ostream& operator<<(ostream& out, const std::tuple<Ts...> &t) {
+inline std::ostream& operator<<(std::ostream& out, const std::tuple<Ts...> &t) {
   auto f = [n = sizeof...(Ts), i = 0, &out](const auto& e) mutable {
     out << e;
     if (++i != n)
@@ -165,7 +168,7 @@ inline ostream& operator<<(ostream& out, const std::tuple<Ts...> &t) {
 }
 
 template<class A, class Alloc>
-inline ostream& operator<<(ostream& out, const list<A,Alloc>& ilist) {
+inline std::ostream& operator<<(std::ostream& out, const std::list<A,Alloc>& ilist) {
   for (auto it = ilist.begin();
        it != ilist.end();
        ++it) {
@@ -176,7 +179,7 @@ inline ostream& operator<<(ostream& out, const list<A,Alloc>& ilist) {
 }
 
 template<class A, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const set<A, Comp, Alloc>& iset) {
+inline std::ostream& operator<<(std::ostream& out, const std::set<A, Comp, Alloc>& iset) {
   for (auto it = iset.begin();
        it != iset.end();
        ++it) {
@@ -187,7 +190,7 @@ inline ostream& operator<<(ostream& out, const set<A, Comp, Alloc>& iset) {
 }
 
 template<class A, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const boost::container::flat_set<A, Comp, Alloc>& iset) {
+inline std::ostream& operator<<(std::ostream& out, const std::multiset<A,Comp,Alloc>& iset) {
   for (auto it = iset.begin();
        it != iset.end();
        ++it) {
@@ -198,29 +201,7 @@ inline ostream& operator<<(ostream& out, const boost::container::flat_set<A, Com
 }
 
 template<class A, class B, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const boost::container::flat_map<A, B, Comp, Alloc>& m) {
-  for (auto it = m.begin();
-       it != m.end();
-       ++it) {
-    if (it != m.begin()) out << ",";
-    out << it->first << "=" << it->second;
-  }
-  return out;
-}
-
-template<class A, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const multiset<A,Comp,Alloc>& iset) {
-  for (auto it = iset.begin();
-       it != iset.end();
-       ++it) {
-    if (it != iset.begin()) out << ",";
-    out << *it;
-  }
-  return out;
-}
-
-template<class A, class B, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const map<A,B,Comp,Alloc>& m)
+inline std::ostream& operator<<(std::ostream& out, const std::map<A,B,Comp,Alloc>& m)
 {
   out << "{";
   for (auto it = m.begin();
@@ -234,7 +215,7 @@ inline ostream& operator<<(ostream& out, const map<A,B,Comp,Alloc>& m)
 }
 
 template<class A, class B, class Comp, class Alloc>
-inline ostream& operator<<(ostream& out, const multimap<A,B,Comp,Alloc>& m)
+inline std::ostream& operator<<(std::ostream& out, const std::multimap<A,B,Comp,Alloc>& m)
 {
   out << "{{";
   for (auto it = m.begin();
@@ -247,6 +228,41 @@ inline ostream& operator<<(ostream& out, const multimap<A,B,Comp,Alloc>& m)
   return out;
 }
 
+} // namespace std
+
+namespace boost {
+namespace tuples {
+template<typename A, typename B, typename C>
+inline std::ostream& operator<<(std::ostream& out, const boost::tuples::tuple<A, B, C> &t) {
+  return out << boost::get<0>(t) << ","
+	     << boost::get<1>(t) << ","
+	     << boost::get<2>(t);
+}
+}
+namespace container {
+template<class A, class Comp, class Alloc>
+inline std::ostream& operator<<(std::ostream& out, const boost::container::flat_set<A, Comp, Alloc>& iset) {
+  for (auto it = iset.begin();
+       it != iset.end();
+       ++it) {
+    if (it != iset.begin()) out << ",";
+    out << *it;
+  }
+  return out;
+}
+
+template<class A, class B, class Comp, class Alloc>
+inline std::ostream& operator<<(std::ostream& out, const boost::container::flat_map<A, B, Comp, Alloc>& m) {
+  for (auto it = m.begin();
+       it != m.end();
+       ++it) {
+    if (it != m.begin()) out << ",";
+    out << it->first << "=" << it->second;
+  }
+  return out;
+}
+}
+} // namespace boost
 
 
 


### PR DESCRIPTION
we should define the operator<< in the namespace of its 2nd parameter.

normally, the operator<< defined in the global namespace works. but
there is a subtle difference between the operator<< defined in std
namespace and the global one because of Koenig lookup.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

