### PR TITLE
core: Clang misses <optional> include

### DIFF
--- a/src/common/async/detail/shared_mutex.h
+++ b/src/common/async/detail/shared_mutex.h
@@ -16,6 +16,7 @@
 
 #include <condition_variable>
 #include <mutex>
+#include <optional>
 #include <shared_mutex> // for std::shared_lock
 
 #include <boost/smart_ptr/intrusive_ref_counter.hpp>


### PR DESCRIPTION
Clang complains:
```
src/common/async/detail/shared_mutex.h:76:8: error: no template named 'optional' in namespace 'std'
  std::optional<boost::system::error_code> ec;
  ~~~~~^
```
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug