### PR TITLE
ceph-volume: tests.functional inherit SSH_ARGS from ansible

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -137,7 +137,7 @@ class Batch(object):
             raise RuntimeError('report format must be "pretty" or "json"')
 
     def execute(self, args):
-        strategy = get_strategy(self.get_filtered_devices(args.devices), args)
+        strategy = get_strategy(args)
         if not args.yes:
             strategy.report_pretty()
             terminal.info('The above OSDs would be created if the operation continues')

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -181,7 +181,7 @@ class MixedType(object):
             osds.append(osd)
 
         self.computed['vgs'] = [{
-            'devices': [d['path'] for d in self.ssds],
+            'devices': [d.abspath for d in self.ssds],
             'parts': self.db_lvs,
             'percentages': self.vg_extents['percentages'],
             'sizes': self.vg_extents['sizes'],

--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -112,7 +112,7 @@
         src: "{{ toxinidir}}/../../../../ceph_volume"
         dest: "/usr/lib/python2.7/dist-packages"
         use_ssh_args: true
-      when: ansible_os_family == "Ubuntu"
+      when: ansible_os_family == "Debian"
 
 - hosts: osds
   gather_facts: false

--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -104,12 +104,14 @@
       synchronize:
         src: "{{ toxinidir}}/../../../../ceph_volume"
         dest: "/usr/lib/python2.7/site-packages"
+        use_ssh_args: true
       when: ansible_os_family == "RedHat"
 
     - name: rsync ceph-volume to test nodes on ubuntu
       synchronize:
         src: "{{ toxinidir}}/../../../../ceph_volume"
         dest: "/usr/lib/python2.7/dist-packages"
+        use_ssh_args: true
       when: ansible_os_family == "Ubuntu"
 
 - hosts: osds


### PR DESCRIPTION
This was causing our rsync calls to fail because they don't understand how to translate the hosts like `osd0`

Fixes: http://tracker.ceph.com/issues/34311
