### PR TITLE
cmake: no need to add "-D" before definitions

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -129,8 +129,8 @@ add_library(common-common-objs OBJECT
   ${common_srcs})
 # for options.cc
 target_compile_definitions(common-common-objs PRIVATE
-  "-DCEPH_LIBDIR=\"${CMAKE_INSTALL_FULL_LIBDIR}\""
-  "-DCEPH_PKGLIBDIR=\"${CMAKE_INSTALL_FULL_PKGLIBDIR}\"")
+  "CEPH_LIBDIR=\"${CMAKE_INSTALL_FULL_LIBDIR}\""
+  "CEPH_PKGLIBDIR=\"${CMAKE_INSTALL_FULL_PKGLIBDIR}\"")
 
 set(common_mountcephfs_srcs
   armor.c

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -90,7 +90,7 @@ set(unittest_librbd_srcs
 add_executable(unittest_librbd
   ${unittest_librbd_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
-target_compile_definitions(unittest_librbd PUBLIC "-DTEST_LIBRBD_INTERNALS")
+target_compile_definitions(unittest_librbd PRIVATE "TEST_LIBRBD_INTERNALS")
 target_link_libraries(unittest_librbd
   cls_rbd
   cls_rbd_client
@@ -127,7 +127,7 @@ target_link_libraries(ceph_test_librbd
   librados
   ${UNITTEST_LIBS}
   radostest)
-target_compile_definitions(ceph_test_librbd PUBLIC "-DTEST_LIBRBD_INTERNALS")
+target_compile_definitions(ceph_test_librbd PRIVATE "TEST_LIBRBD_INTERNALS")
 
 add_executable(ceph_test_librbd_api
   test_support.cc


### PR DESCRIPTION
and there is no need to make the definition public for the executable
target.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

