### PR TITLE
mgr/dashboard: Add gap between panel footer buttons

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -286,6 +286,10 @@ uib-accordion .panel-title,
   padding-left: 4px;
   vertical-align: text-top;
 }
+/* Panel */
+.panel-footer button.btn:not(:first-child) {
+  margin-left: 5px;
+}
 /* Modal dialog */
 .modal-footer button.btn:not(:first-child) {
   margin-left: 5px;


### PR DESCRIPTION
In many forms there is no gap between the panel footer buttons.

![auswahl_005](https://user-images.githubusercontent.com/1897962/44779854-e15e0900-ab80-11e8-8495-a74d41219d50.png)

This seems to be a regression that was introduced when switching the Angular and Bootstrap versions.

Signed-off-by: Volker Theile <vtheile@suse.com>