### PR TITLE
common/util: pass real hostname when running in kubernetes/rook container

### DIFF
--- a/src/common/hostname.cc
+++ b/src/common/hostname.cc
@@ -18,6 +18,12 @@
 
 std::string ceph_get_hostname()
 {
+  // are we in a container?  if so we would prefer the *real* hostname.
+  const char *node_name = getenv("NODE_NAME");
+  if (node_name) {
+    return node_name;
+  }
+
   char buf[1024];
   gethostname(buf, 1024);
   return std::string(buf);

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -152,6 +152,19 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
     (*m)["hostname"] = u.nodename;
     (*m)["arch"] = u.machine;
   }
+
+  // but wait, am i in a container?
+  if (const char *pod_name = getenv("POD_NAME")) {
+    (*m)["pod_name"] = pod_name;
+    if (const char *node_name = getenv("NODE_NAME")) {
+      (*m)["container_hostname"] = u.nodename;
+      (*m)["hostname"] = node_name;
+    }
+  }
+  if (const char *ns = getenv("POD_NAMESPACE")) {
+    (*m)["pod_namespace"] = ns;
+  }
+
 #ifdef __APPLE__
   // memory
   {

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -32,6 +32,7 @@
 #include "messages/MMonSubscribe.h"
 #include "messages/MMonSubscribeAck.h"
 #include "common/errno.h"
+#include "common/hostname.h"
 #include "common/LogClient.h"
 
 #include "MonClient.h"
@@ -847,6 +848,7 @@ void MonClient::_renew_subs()
   else {
     MMonSubscribe *m = new MMonSubscribe;
     m->what = sub.get_subs();
+    m->hostname = ceph_get_short_hostname();
     _send_mon_message(m);
     sub.renewed();
   }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4795,6 +4795,10 @@ void Monitor::handle_subscribe(MonOpRequestRef op)
   MonSession *s = op->get_session();
   ceph_assert(s);
 
+  if (m->hostname.size()) {
+    s->remote_host = m->hostname;
+  }
+
   for (map<string,ceph_mon_subscribe_item>::iterator p = m->what.begin();
        p != m->what.end();
        ++p) {

--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -22,6 +22,7 @@
 #include "common/config_proxy.h"
 #include "common/errno.h"
 #include "gtest/gtest.h"
+#include "common/hostname.h"
 
 extern std::string exec(const char* cmd); // defined in test_hostname.cc
 
@@ -60,7 +61,7 @@ public:
       std::string after = " AFTER ";
       std::string val(before + "$host${host}" + after);
       early_expand_meta(val, &oss);
-      std::string hostname = exec("hostname -s");
+      std::string hostname = ceph_get_short_hostname();
       EXPECT_EQ(before + hostname + hostname + after, val);
       EXPECT_EQ("", oss.str());
     }

--- a/src/test/common/test_hostname.cc
+++ b/src/test/common/test_hostname.cc
@@ -44,12 +44,24 @@ std::string exec(const char* cmd) {
 
 TEST(Hostname, full) {
   std::string hn = ceph_get_hostname();
-  ASSERT_EQ(hn, exec("hostname")) ;
-
-	
+  if (const char *nn = getenv("NODE_NAME")) {
+    // we are in a container
+    std::cout << "we are in a container on " << nn << ", reporting " << hn
+	      << std::endl;
+    ASSERT_EQ(hn, nn);
+  } else {
+    ASSERT_EQ(hn, exec("hostname")) ;
+  }
 }
 
 TEST(Hostname, short) {
   std::string shn = ceph_get_short_hostname();
-  ASSERT_EQ(shn, exec("hostname -s")) ;
+  if (const char *nn = getenv("NODE_NAME")) {
+    // we are in a container
+    std::cout << "we are in a container on " << nn << ", reporting short " << shn
+	 << ", skipping test because env var may or may not be short form"
+	      << std::endl;
+  } else {
+    ASSERT_EQ(shn, exec("hostname -s")) ;
+  }
 }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug