### PR TITLE
common/buffer.cc: add create_small_page_aligned to avoid mem waste wh…

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -717,6 +717,9 @@ using namespace ceph;
   buffer::raw* buffer::create_page_aligned(unsigned len) {
     return create_aligned(len, CEPH_PAGE_SIZE);
   }
+  buffer::raw* buffer::create_small_page_aligned(unsigned len) {
+    return create_aligned(len, CEPH_BUFFER_ALLOC_UNIT);
+  }
 
   buffer::raw* buffer::create_zero_copy(unsigned len, int fd, int64_t *offset) {
 #ifdef CEPH_HAVE_SPLICE

--- a/src/compressor/QatAccel.cc
+++ b/src/compressor/QatAccel.cc
@@ -65,7 +65,9 @@ int QatAccel::compress(const bufferlist &in, bufferlist &out) {
     unsigned int len = i.length();
     unsigned int out_len = qzMaxCompressedLength(len);
 
-    bufferptr ptr = buffer::create_page_aligned(out_len);
+    bufferptr ptr = (out_len < CEPH_PAGE_SIZE)?
+      buffer::create_small_page_aligned(out_len):
+      buffer::create_page_aligned(out_len);
     int rc = qzCompress(&session, c_in, &len, (unsigned char *)ptr.c_str(), &out_len, 1);
     if (rc != QZ_OK)
       return -1;
@@ -103,7 +105,9 @@ int QatAccel::decompress(bufferlist::const_iterator &p,
       len = tmp.length();
     }
     unsigned int out_len = len * expansion_ratio[ratio_idx];
-    bufferptr ptr = buffer::create_page_aligned(out_len);
+    bufferptr ptr = (out_len < CEPH_PAGE_SIZE)?
+      buffer::create_small_page_aligned(out_len):
+      buffer::create_page_aligned(out_len);
 
     if (joint)
       rc = qzDecompress(&session, (const unsigned char*)tmp.c_str(), &len, (unsigned char*)ptr.c_str(), &out_len);

--- a/src/compressor/brotli/BrotliCompressor.cc
+++ b/src/compressor/brotli/BrotliCompressor.cc
@@ -20,7 +20,9 @@ int BrotliCompressor::compress(const bufferlist &in, bufferlist &out)
     size_t available_in = i->length();
     size_t max_comp_size = BrotliEncoderMaxCompressedSize(available_in);
     size_t available_out =  max_comp_size;
-    bufferptr ptr = buffer::create_page_aligned(max_comp_size);
+    bufferptr ptr = (max_comp_size < CEPH_PAGE_SIZE)?
+      buffer::create_small_page_aligned(max_comp_size):
+      buffer::create_page_aligned(max_comp_size);
     uint8_t* next_out = (uint8_t*)ptr.c_str();
     const uint8_t* next_in = (uint8_t*)i->c_str();
     ++i;
@@ -67,7 +69,9 @@ int BrotliCompressor::decompress(bufferlist::const_iterator &p,
     BrotliDecoderResult result = BROTLI_DECODER_RESULT_ERROR;
     do {
       size_t available_out = MAX_LEN;
-      bufferptr ptr = buffer::create_page_aligned(MAX_LEN);
+      bufferptr ptr = (MAX_LEN < CEPH_PAGE_SIZE)?
+        buffer::create_small_page_aligned(MAX_LEN):
+        buffer::create_page_aligned(MAX_LEN);
       uint8_t* next_out = (uint8_t*)ptr.c_str();
       result = BrotliDecoderDecompressStream(s,
                                              &available_in,

--- a/src/compressor/lz4/LZ4Compressor.h
+++ b/src/compressor/lz4/LZ4Compressor.h
@@ -40,8 +40,11 @@ class LZ4Compressor : public Compressor {
     if (qat_enabled)
       return qat_accel.compress(src, dst);
 #endif
-    bufferptr outptr = buffer::create_page_aligned(
-      LZ4_compressBound(src.length()));
+    unsigned len = LZ4_compressBound(src.length());
+    bufferptr outptr = (len < CEPH_PAGE_SIZE)?
+      buffer::create_small_page_aligned(len):
+      buffer::create_page_aligned(len);
+
     LZ4_stream_t lz4_stream;
     LZ4_resetStream(&lz4_stream);
 

--- a/src/compressor/snappy/SnappyCompressor.h
+++ b/src/compressor/snappy/SnappyCompressor.h
@@ -72,8 +72,11 @@ class SnappyCompressor : public Compressor {
       return qat_accel.compress(src, dst);
 #endif
     BufferlistSource source(const_cast<bufferlist&>(src).begin(), src.length());
-    bufferptr ptr = buffer::create_page_aligned(
-      snappy::MaxCompressedLength(src.length()));
+    unsigned len = snappy::MaxCompressedLength(src.length());
+    bufferptr ptr = (len < CEPH_PAGE_SIZE)?
+      buffer::create_small_page_aligned(len):
+      buffer::create_page_aligned(len);
+
     snappy::UncheckedByteArraySink sink(ptr.c_str());
     snappy::Compress(&source, &sink);
     dst.append(ptr, 0, sink.CurrentDestination() - ptr.c_str());

--- a/src/compressor/zlib/ZlibCompressor.cc
+++ b/src/compressor/zlib/ZlibCompressor.cc
@@ -78,7 +78,9 @@ int ZlibCompressor::zlib_compress(const bufferlist &in, bufferlist &out)
 
     strm.next_in = c_in;
     do {
-      bufferptr ptr = buffer::create_page_aligned(MAX_LEN);
+      bufferptr ptr = (MAX_LEN < CEPH_PAGE_SIZE)?
+        buffer::create_small_page_aligned(MAX_LEN):
+        buffer::create_page_aligned(MAX_LEN);
       strm.next_out = (unsigned char*)ptr.c_str() + begin;
       strm.avail_out = MAX_LEN - begin;
       if (begin) {
@@ -134,7 +136,9 @@ int ZlibCompressor::isal_compress(const bufferlist &in, bufferlist &out)
     strm.next_in = c_in;
 
     do {
-      bufferptr ptr = buffer::create_page_aligned(MAX_LEN);
+      bufferptr ptr = (MAX_LEN < CEPH_PAGE_SIZE)?
+        buffer::create_small_page_aligned(MAX_LEN):
+        buffer::create_page_aligned(MAX_LEN);
       strm.next_out = (unsigned char*)ptr.c_str() + begin;
       strm.avail_out = MAX_LEN - begin;
       if (begin) {
@@ -216,7 +220,9 @@ int ZlibCompressor::decompress(bufferlist::const_iterator &p, size_t compressed_
 
     do {
       strm.avail_out = MAX_LEN;
-      bufferptr ptr = buffer::create_page_aligned(MAX_LEN);
+      bufferptr ptr = (MAX_LEN < CEPH_PAGE_SIZE)?
+        buffer::create_small_page_aligned(MAX_LEN):
+        buffer::create_page_aligned(MAX_LEN);
       strm.next_out = (unsigned char*)ptr.c_str();
       ret = inflate(&strm, Z_NO_FLUSH);
       if (ret != Z_OK && ret != Z_STREAM_END && ret != Z_BUF_ERROR) {

--- a/src/compressor/zstd/ZstdCompressor.h
+++ b/src/compressor/zstd/ZstdCompressor.h
@@ -35,7 +35,9 @@ class ZstdCompressor : public Compressor {
     size_t left = src.length();
 
     size_t const out_max = ZSTD_compressBound(left);
-    bufferptr outptr = buffer::create_page_aligned(out_max);
+    bufferptr outptr = (out_max < CEPH_PAGE_SIZE)?
+      buffer::create_small_page_aligned(out_max):
+      buffer::create_page_aligned(out_max);
     ZSTD_outBuffer_s outbuf;
     outbuf.dst = outptr.c_str();
     outbuf.size = outptr.length();

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -171,6 +171,7 @@ namespace buffer CEPH_BUFFER_API {
   raw* create_aligned(unsigned len, unsigned align);
   raw* create_aligned_in_mempool(unsigned len, unsigned align, int mempool);
   raw* create_page_aligned(unsigned len);
+  raw* create_small_page_aligned(unsigned len);
   raw* create_zero_copy(unsigned len, int fd, int64_t *offset);
   raw* create_unshareable(unsigned len);
   raw* create_static(unsigned len, char *buf);

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -113,7 +113,10 @@ static void alloc_aligned_buffer(bufferlist& data, unsigned len, unsigned off)
     left -= head;
   }
   alloc_len += left;
-  bufferptr ptr(buffer::create_page_aligned(alloc_len));
+  bufferptr ptr((alloc_len < CEPH_PAGE_SIZE)?
+    buffer::create_small_page_aligned(alloc_len):
+    buffer::create_page_aligned(alloc_len));
+
   if (head)
     ptr.set_offset(CEPH_PAGE_SIZE - head);
   data.push_back(std::move(ptr));

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2043,7 +2043,9 @@ static void alloc_aligned_buffer(bufferlist& data, unsigned len, unsigned off)
   }
   unsigned middle = left & CEPH_PAGE_MASK;
   if (middle > 0) {
-    data.push_back(buffer::create_page_aligned(middle));
+    (middle < CEPH_PAGE_SIZE)?
+      data.push_back(buffer::create_small_page_aligned(middle)):
+      data.push_back(buffer::create_page_aligned(middle));
     left -= middle;
   }
   if (left) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10248,7 +10248,9 @@ void BlueStore::_pad_zeros(
   size_t pad_count = 0;
   if (front_pad) {
     size_t front_copy = std::min<uint64_t>(chunk_size - front_pad, length);
-    bufferptr z = buffer::create_page_aligned(chunk_size);
+    bufferptr z = (chunk_size < CEPH_PAGE_SIZE)?
+      buffer::create_small_page_aligned(chunk_size):
+      buffer::create_page_aligned(chunk_size);
     z.zero(0, front_pad, false);
     pad_count += front_pad;
     bl->copy(0, front_copy, z.c_str() + front_pad);

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -807,7 +807,9 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
 
   _aio_log_start(ioc, off, len);
 
-  bufferptr p = buffer::create_page_aligned(len);
+  bufferptr p = (len < CEPH_PAGE_SIZE)?
+    buffer::create_small_page_aligned(len):
+    buffer::create_page_aligned(len);
   int r = ::pread(buffered ? fd_buffered : fd_direct,
 		  p.c_str(), len, off);
   if (r < 0) {
@@ -861,7 +863,9 @@ int KernelDevice::direct_read_unaligned(uint64_t off, uint64_t len, char *buf)
 {
   uint64_t aligned_off = align_down(off, block_size);
   uint64_t aligned_len = align_up(off+len, block_size) - aligned_off;
-  bufferptr p = buffer::create_page_aligned(aligned_len);
+  bufferptr p = (aligned_len < CEPH_PAGE_SIZE)?
+    buffer::create_small_page_aligned(aligned_len):
+    buffer::create_page_aligned(aligned_len);
   int r = 0;
 
   r = ::pread(fd_direct, p.c_str(), aligned_len, aligned_off);

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -915,7 +915,9 @@ int NVMEDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   assert(is_valid_io(off, len));
 
   Task *t = new Task(this, IOCommand::READ_COMMAND, off, len, 1);
-  bufferptr p = buffer::create_page_aligned(len);
+  bufferptr p = (len < CEPH_PAGE_SIZE)?
+    buffer::create_small_page_aligned(len):
+    buffer::create_page_aligned(len);
   int r = 0;
   t->ctx = ioc;
   char *buf = p.c_str();
@@ -945,7 +947,9 @@ int NVMEDevice::aio_read(
 
   Task *t = new Task(this, IOCommand::READ_COMMAND, off, len);
 
-  bufferptr p = buffer::create_page_aligned(len);
+  bufferptr p = (len < CEPH_PAGE_SIZE)?
+    buffer::create_small_page_aligned(len):
+    buffer::create_page_aligned(len);
   pbl->append(p);
   t->ctx = ioc;
   char* buf = p.c_str();

--- a/src/os/bluestore/PMEMDevice.cc
+++ b/src/os/bluestore/PMEMDevice.cc
@@ -256,7 +256,9 @@ int PMEMDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   dout(5) << __func__ << " " << off << "~" << len  << dendl;
   assert(is_valid_io(off, len));
 
-  bufferptr p = buffer::create_page_aligned(len);
+  bufferptr p = (len < CEPH_PAGE_SIZE)?
+    buffer::create_small_page_aligned(len):
+    buffer::create_page_aligned(len);
   memcpy(p.c_str(), addr + off, len);
 
   pbl->clear();

--- a/src/os/bluestore/aio.h
+++ b/src/os/bluestore/aio.h
@@ -32,7 +32,9 @@ struct aio_t {
   void pread(uint64_t _offset, uint64_t len) {
     offset = _offset;
     length = len;
-    bufferptr p = buffer::create_page_aligned(length);
+    bufferptr p = (length < CEPH_PAGE_SIZE)?
+      buffer::create_small_page_aligned(length):
+      buffer::create_page_aligned(length);
     io_prep_pread(&iocb, fd, p.c_str(), length, offset);
     bl.append(std::move(p));
   }


### PR DESCRIPTION
…ile apply small mem in big pagesize(e.g. 64k)

On my arm64 dev board, CentOS 7.4, the default OS pagesize is 64k, one SSD disk.
When I make fio performance reading test(bs=4k), the ceph-osd process uses a
large amount of memory(more than 20G), while do fio(bs=64), just use about 2G.
After traceing the mem allocate prcess, it is found to be related to page size
alignment.
Useing 4K alignment when applying for small mem(less then 64k - the CEPH_PAGE_SIZE
and OS default page size) will reduce the waste of mem. By applying the current
patch, when doing FIO performance reading test(bs=4k), the memory used by the
ceph-osd process will be reduced from more than 20G to about 3G, while the
reading performance has not been reduced.

Signed-off-by: Jiang Yutang <yutang2.jiang@hxt-semitech.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

