### PR TITLE
mgr/dashboard: Add unique validator

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.html
@@ -45,7 +45,7 @@
               This field is required.
             </span>
             <span class="help-block"
-                  *ngIf="userForm.showError('user_id', frm, 'userIdExists')"
+                  *ngIf="userForm.showError('user_id', frm, 'notUnique')"
                   i18n>
               The chosen user ID is already in use.
             </span>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rgw-user.service.ts
@@ -2,7 +2,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 import * as _ from 'lodash';
-import { forkJoin as observableForkJoin, of as observableOf } from 'rxjs';
+import { forkJoin as observableForkJoin, Observable, of as observableOf } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 
 import { cdEncode } from '../decorators/cd-encode';
@@ -127,7 +127,7 @@ export class RgwUserService {
    * @param {string} uid The user ID to check.
    * @return {Observable<boolean>}
    */
-  exists(uid: string) {
+  exists(uid: string): Observable<boolean> {
     return this.enumerate().pipe(
       mergeMap((resp: string[]) => {
         const index = _.indexOf(resp, uid);

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-validators.ts
@@ -1,10 +1,20 @@
-import { AbstractControl, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
+import {
+  AbstractControl,
+  AsyncValidatorFn,
+  ValidationErrors,
+  ValidatorFn,
+  Validators
+} from '@angular/forms';
 
 import * as _ from 'lodash';
+import { Observable, of as observableOf, timer as observableTimer } from 'rxjs';
+import { map, switchMapTo, take } from 'rxjs/operators';
 
 export function isEmptyInputValue(value: any): boolean {
   return value == null || value.length === 0;
 }
+
+export type existsServiceFn = (value: any) => Observable<boolean>;
 
 export class CdValidators {
   /**
@@ -110,6 +120,49 @@ export class CdValidators {
         control.get(control2).setErrors({ ['match']: true });
       }
       return null;
+    };
+  }
+
+  /**
+   * Asynchronous validator that requires the control's value to be unique.
+   * The validation is only executed after the specified delay. Every
+   * keystroke during this delay will restart the timer.
+   * @param serviceFn {existsServiceFn} The service function that is
+   *   called to check whether the given value exists. It must return
+   *   boolean 'true' if the given value exists, otherwise 'false'.
+   * @param serviceFnThis {any} The object to be used as the 'this' object
+   *   when calling the serviceFn function. Defaults to null.
+   * @param {number|Date} dueTime The delay time to wait before the
+   *   serviceFn call is executed. This is useful to prevent calls on
+   *   every keystroke. Defaults to 500.
+   * @return {AsyncValidatorFn} Returns an asynchronous validator function
+   *   that returns an error map with the `notUnique` property if the
+   *   validation check succeeds, otherwise `null`.
+   */
+  static unique(
+    serviceFn: existsServiceFn,
+    serviceFnThis: any = null,
+    dueTime = 500
+  ): AsyncValidatorFn {
+    return (control: AbstractControl): Observable<ValidationErrors | null> => {
+      // Exit immediately if user has not interacted with the control yet
+      // or the control value is empty.
+      if (control.pristine || isEmptyInputValue(control.value)) {
+        return observableOf(null);
+      }
+      // Forgot previous requests if a new one arrives within the specified
+      // delay time.
+      return observableTimer(dueTime).pipe(
+        switchMapTo(serviceFn.call(serviceFnThis, control.value)),
+        map((resp: boolean) => {
+          if (!resp) {
+            return null;
+          } else {
+            return { notUnique: true };
+          }
+        }),
+        take(1)
+      );
     };
   }
 }


### PR DESCRIPTION
Relocate an already existing async validator into a separate validator that can be reused by every other form. This validator is useful to check immediately after typing if an entered value, e.g. username, already exists.

The API request will be triggered after a delay of 500ms (can be modified). During this delay, every keystroke will reset the timer, so the REST API is not flooded with request.

Signed-off-by: Volker Theile <vtheile@suse.com>
