### PR TITLE
osd/OSD: fix project_pg_history vs osdmap injection race

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4158,6 +4158,7 @@ void OSD::build_initial_pg_history(
  * and same_primary_since.
  */
 bool OSD::project_pg_history(spg_t pgid, pg_history_t& h, epoch_t from,
+                             const OSDMapRef& osdmap,
 			     const vector<int>& currentup,
 			     int currentupprimary,
 			     const vector<int>& currentacting,
@@ -8625,7 +8626,7 @@ void OSD::handle_pg_query_nopg(const MQuery& q)
   // same primary?
   pg_history_t history = q.query.history;
   bool valid_history = project_pg_history(
-    pgid, history, q.query.epoch_sent,
+    pgid, history, q.query.epoch_sent, osdmap,
     up, up_primary, acting, acting_primary);
 
   if (!valid_history ||

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1886,6 +1886,7 @@ protected:
   /// project pg history from from to now
   bool project_pg_history(
     spg_t pgid, pg_history_t& h, epoch_t from,
+    const OSDMapRef& osdmap,
     const vector<int>& lastup,
     int lastupprimary,
     const vector<int>& lastacting,


### PR DESCRIPTION
The peering events are used to be processed under the protection
of osd_lock, which as result can eliminate a race condition with
the new osdmap injection process.

However, the above case is not applicable any more as we now start
fast dispatching peering events.

Fix the potential race condition by passing in a sane, verified but
perhaps not necessarily the latest osdmap.
This should be fine because the peering process
will restart each time a new osdmap triggering a new pg-interval.

Fixes: http://tracker.ceph.com/issues/26970
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

