### PR TITLE
luminous: debian/rules: fix ceph-mgr .pyc files left behind

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -183,6 +183,8 @@ override_dh_python2:
 	dh_python2 -p ceph-base
 	dh_python2 -p ceph-osd
 	dh_python2 -p ceph-mgr
+	# batch-compile, and set up for delete, all the module files
+	dh_python2 -p ceph-mgr usr/lib/ceph/mgr
 
 override_dh_python3:
 	for binding in rados cephfs rbd rgw; do \


### PR DESCRIPTION
http://tracker.ceph.com/issues/27058