### PR TITLE
common: Reverse deleted include

### DIFF
--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -14,6 +14,7 @@
 
 #include <algorithm>
 #include <map>
+#include <sstream>
 #include <sys/stat.h>
 #include <iostream>
 


### PR DESCRIPTION
Reversing 1 delete from
https://github.com/ceph/ceph/commit/09d3f546b32cdf126a1246899a0b0a3eb25282d8

Clang trips over this:
home/jenkins/workspace/ceph-master/src/common/ConfUtils.cc:94:19: error: implicit instantiation of undefined template 'std::__1::basic_ostringstream<char, std::
__1::char_traits<char>, std::__1::allocator<char> >'
    ostringstream oss;
                  ^
/usr/include/c++/v1/iosfwd:123:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_ostringstream;
                               ^




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug