### PR TITLE
crimson/net: fixes for error code framework

### DIFF
--- a/src/crimson/net/Errors.cc
+++ b/src/crimson/net/Errors.cc
@@ -63,6 +63,9 @@ const std::error_category& net_category()
     }
 
     bool equivalent(int code, const std::error_condition& cond) const noexcept override {
+      if (error_category::equivalent(code, cond)) {
+        return true;
+      }
       switch (static_cast<error>(code)) {
         case error::connection_aborted:
           return cond == std::errc::connection_aborted
@@ -79,6 +82,9 @@ const std::error_category& net_category()
     }
 
     bool equivalent(const std::error_code& code, int cond) const noexcept override {
+      if (error_category::equivalent(code, cond)) {
+        return true;
+      }
       switch (static_cast<error>(cond)) {
         case error::connection_aborted:
           return code == std::errc::connection_aborted

--- a/src/crimson/net/Errors.cc
+++ b/src/crimson/net/Errors.cc
@@ -25,6 +25,8 @@ const std::error_category& net_category()
 
     std::string message(int ev) const override {
       switch (static_cast<error>(ev)) {
+        case error::success:
+          return "success";
         case error::bad_connect_banner:
           return "bad connect banner";
         case error::bad_peer_address:

--- a/src/crimson/net/Errors.h
+++ b/src/crimson/net/Errors.h
@@ -20,6 +20,7 @@ namespace ceph::net {
 
 /// net error codes
 enum class error {
+  success = 0,
   bad_connect_banner,
   bad_peer_address,
   negotiation_failure,


### PR DESCRIPTION
reserve value 0 for success for consistency with operator bool, i.e. if (ec) is true when non-zero

for the equivalent() functions, consult base class for equivalence (which will match errors within
this category) before applying the extra error code mappings