### PR TITLE
mon: include ages in 'ceph status'

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -385,7 +385,8 @@ function unfound_erasure_coded() {
 	ceph -s | grep "1/1 objects unfound" && break
 	sleep 1
     done
-    ceph -s|grep "4 osds: 4 up, 4 in" || return 1
+    ceph -s|grep "4 up" || return 1
+    ceph -s|grep "4 in" || return 1
     ceph -s|grep "1/1 objects unfound" || return 1
 
     teardown $dir || return 1

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1658,7 +1658,7 @@ function test_mon_osd()
   ceph osd perf
   ceph osd blocked-by
 
-  ceph osd stat | grep up,
+  ceph osd stat | grep up
 }
 
 function test_mon_crush()

--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -533,4 +533,9 @@ inline std::ostream& operator<<(std::ostream& out, const utime_t& t)
   return t.localtime(out);
 }
 
+inline std::string utimespan_str(const utime_t& age) {
+  auto age_ts = ceph::timespan(age.nsec()) + std::chrono::seconds(age.sec());
+  return timespan_str(age_ts);
+}
+
 #endif

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -366,16 +366,24 @@ public:
     if (f) {
       dump(f);
     } else {
+      utime_t now = ceph_clock_now();
       if (get_active_gid() != 0) {
 	*ss << get_active_name();
         if (!available) {
           // If the daemon hasn't gone active yet, indicate that.
-          *ss << "(active, starting)";
+          *ss << "(active, starting";
         } else {
-          *ss << "(active)";
+          *ss << "(active";
         }
+	if (active_change) {
+	  *ss << ", since " << utimespan_str(now - active_change);
+	}
+	*ss << ")";
       } else {
 	*ss << "no daemons active";
+	if (active_change) {
+	  *ss << " (since " << utimespan_str(now - active_change) << ")";
+	}
       }
       if (standbys.size()) {
 	*ss << ", standbys: ";

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -137,6 +137,8 @@ public:
   bool available = false;
   /// the name (foo in mgr.<foo>) of the active daemon
   std::string active_name;
+  /// when the active mgr became active, or we lost the active mgr
+  utime_t active_change;
 
   std::map<uint64_t, StandbyInfo> standbys;
 
@@ -155,6 +157,7 @@ public:
   uint64_t get_active_gid() const { return active_gid; }
   bool get_available() const { return available; }
   const std::string &get_active_name() const { return active_name; }
+  const utime_t& get_active_change() const { return active_change; }
 
   bool all_support_module(const std::string& module) {
     if (!have_module(module)) {
@@ -258,7 +261,7 @@ public:
       ENCODE_FINISH(bl);
       return;
     }
-    ENCODE_START(6, 6, bl);
+    ENCODE_START(7, 6, bl);
     encode(epoch, bl);
     encode(active_addrs, bl, features);
     encode(active_gid, bl);
@@ -268,13 +271,14 @@ public:
     encode(modules, bl);
     encode(services, bl);
     encode(available_modules, bl);
+    encode(active_change, bl);
     ENCODE_FINISH(bl);
     return;
   }
 
   void decode(bufferlist::const_iterator& p)
   {
-    DECODE_START(6, p);
+    DECODE_START(7, p);
     decode(epoch, p);
     decode(active_addrs, p);
     decode(active_gid, p);
@@ -305,6 +309,11 @@ public:
     if (struct_v >= 4) {
       decode(available_modules, p);
     }
+    if (struct_v >= 7) {
+      decode(active_change, p);
+    } else {
+      active_change = {};
+    }
     DECODE_FINISH(p);
   }
 
@@ -313,6 +322,7 @@ public:
     f->dump_int("active_gid", get_active_gid());
     f->dump_string("active_name", get_active_name());
     f->dump_object("active_addrs", active_addrs);
+    f->dump_stream("active_change") << active_change;
     f->dump_bool("available", available);
     f->open_array_section("standbys");
     for (const auto &i : standbys) {

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -409,6 +409,7 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
 	    << pending_map.active_name << ")" << dendl;
     pending_map.active_gid = m->get_gid();
     pending_map.active_name = m->get_name();
+    pending_map.active_change = ceph_clock_now();
     pending_map.available_modules = m->get_available_modules();
     encode(m->get_metadata(), pending_metadata[m->get_name()]);
     pending_metadata_rm.erase(m->get_name());
@@ -666,6 +667,7 @@ bool MgrMonitor::promote_standby()
     pending_map.active_name = pending_map.standbys.at(replacement_gid).name;
     pending_map.available = false;
     pending_map.active_addrs = entity_addrvec_t();
+    pending_map.active_change = ceph_clock_now();
 
     drop_standby(replacement_gid, false);
 
@@ -685,6 +687,7 @@ void MgrMonitor::drop_active()
   pending_metadata.erase(pending_map.active_name);
   pending_map.active_name = "";
   pending_map.active_gid = 0;
+  pending_map.active_change = ceph_clock_now();
   pending_map.available = false;
   pending_map.active_addrs = entity_addrvec_t();
   pending_map.services.clear();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -230,6 +230,7 @@ private:
   
   int leader;            // current leader (to best of knowledge)
   set<int> quorum;       // current active set of monitors (if !starting)
+  mono_clock::time_point quorum_since;  // when quorum formed
   utime_t leader_since;  // when this monitor became the leader, if it is the leader
   utime_t exited_quorum; // time detected as not in quorum; 0 if in
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1059,7 +1059,24 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
       dout(10) << "new_state for osd." << p->first << " is 0, removing" << dendl;
       p = pending_inc.new_state.erase(p);
     } else {
+      if (p->second & CEPH_OSD_UP) {
+	pending_inc.new_last_up_change = pending_inc.modified;
+      }
       ++p;
+    }
+  }
+  if (!pending_inc.new_up_client.empty()) {
+    pending_inc.new_last_up_change = pending_inc.modified;
+  }
+  for (auto& i : pending_inc.new_weight) {
+    if (i.first > osdmap.max_osd) {
+      if (i.second) {
+	// new osd is already marked in
+	pending_inc.new_last_in_change = pending_inc.modified;
+      }
+    } else if (!!i.second != !!osdmap.osd_weight[i.first]) {
+      // existing osd marked in or out
+      pending_inc.new_last_in_change = pending_inc.modified;
     }
   }
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3689,9 +3689,16 @@ void OSDMap::print_summary(Formatter *f, ostream& out,
     f->dump_unsigned("num_remapped_pgs", get_num_pg_temp());
     f->close_section();
   } else {
+    utime_t now = ceph_clock_now();
     out << get_num_osds() << " osds: "
-	<< get_num_up_osds() << " up, "
-	<< get_num_in_osds() << " in";
+	<< get_num_up_osds() << " up";
+    if (last_up_change != utime_t()) {
+      out << " (since " << utimespan_str(now - last_up_change) << ")";
+    }
+    out << ", " << get_num_in_osds() << " in";
+    if (last_in_change != utime_t()) {
+      out << " (since " << utimespan_str(now - last_in_change) << ")";
+    }
     if (extra)
       out << "; epoch: e" << get_epoch();
     if (get_num_pg_temp())

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -514,7 +514,7 @@ void OSDMap::Incremental::encode(bufferlist& bl, uint64_t features) const
   ENCODE_START(8, 7, bl);
 
   {
-    uint8_t v = 7;
+    uint8_t v = 8;
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       v = 3;
     } else if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
@@ -565,6 +565,10 @@ void OSDMap::Incremental::encode(bufferlist& bl, uint64_t features) const
     if (v >= 6) {
       encode(new_removed_snaps, bl);
       encode(new_purged_snaps, bl);
+    }
+    if (v >= 8) {
+      encode(new_last_up_change, bl);
+      encode(new_last_in_change, bl);
     }
     ENCODE_FINISH(bl); // client-usable data
   }
@@ -763,7 +767,7 @@ void OSDMap::Incremental::decode(bufferlist::const_iterator& bl)
     return;
   }
   {
-    DECODE_START(7, bl); // client-usable data
+    DECODE_START(8, bl); // client-usable data
     decode(fsid, bl);
     decode(epoch, bl);
     decode(modified, bl);
@@ -809,6 +813,10 @@ void OSDMap::Incremental::decode(bufferlist::const_iterator& bl)
     if (struct_v >= 6) {
       decode(new_removed_snaps, bl);
       decode(new_purged_snaps, bl);
+    }
+    if (struct_v >= 8) {
+      decode(new_last_up_change, bl);
+      decode(new_last_in_change, bl);
     }
     DECODE_FINISH(bl); // client-usable data
   }
@@ -904,6 +912,8 @@ void OSDMap::Incremental::dump(Formatter *f) const
   f->dump_int("epoch", epoch);
   f->dump_stream("fsid") << fsid;
   f->dump_stream("modified") << modified;
+  f->dump_stream("new_last_up_change") << new_last_up_change;
+  f->dump_stream("new_last_in_change") << new_last_in_change;
   f->dump_int("new_pool_max", new_pool_max);
   f->dump_int("new_flags", new_flags);
   f->dump_float("new_full_ratio", new_full_ratio);
@@ -1910,6 +1920,13 @@ int OSDMap::apply_incremental(const Incremental &inc)
     }
   }
 
+  if (inc.new_last_up_change != utime_t()) {
+    last_up_change = inc.new_last_up_change;
+  }
+  if (inc.new_last_in_change != utime_t()) {
+    last_in_change = inc.new_last_in_change;
+  }
+
   for (const auto &pname : inc.new_pool_names) {
     auto pool_name_entry = pool_name.find(pname.first);
     if (pool_name_entry != pool_name.end()) {
@@ -2640,7 +2657,7 @@ void OSDMap::encode(bufferlist& bl, uint64_t features) const
   {
     // NOTE: any new encoding dependencies must be reflected by
     // SIGNIFICANT_FEATURES
-    uint8_t v = 8;
+    uint8_t v = 9;
     if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       v = 3;
     } else if (!HAVE_FEATURE(features, SERVER_MIMIC)) {
@@ -2717,6 +2734,10 @@ void OSDMap::encode(bufferlist& bl, uint64_t features) const
     if (v >= 7) {
       encode(new_removed_snaps, bl);
       encode(new_purged_snaps, bl);
+    }
+    if (v >= 9) {
+      encode(last_up_change, bl);
+      encode(last_in_change, bl);
     }
     ENCODE_FINISH(bl); // client-usable data
   }
@@ -2951,7 +2972,7 @@ void OSDMap::decode(bufferlist::const_iterator& bl)
    * Since we made it past that hurdle, we can use our normal paths.
    */
   {
-    DECODE_START(8, bl); // client-usable data
+    DECODE_START(9, bl); // client-usable data
     // base
     decode(fsid, bl);
     decode(epoch, bl);
@@ -3012,6 +3033,10 @@ void OSDMap::decode(bufferlist::const_iterator& bl)
     if (struct_v >= 7) {
       decode(new_removed_snaps, bl);
       decode(new_purged_snaps, bl);
+    }
+    if (struct_v >= 9) {
+      decode(last_up_change, bl);
+      decode(last_in_change, bl);
     }
     DECODE_FINISH(bl); // client-usable data
   }
@@ -3136,6 +3161,8 @@ void OSDMap::dump(Formatter *f) const
   f->dump_stream("fsid") << get_fsid();
   f->dump_stream("created") << get_created();
   f->dump_stream("modified") << get_modified();
+  f->dump_stream("last_up_change") << last_up_change;
+  f->dump_stream("last_in_change") << last_in_change;
   f->dump_string("flags", get_flag_string());
   f->dump_unsigned("flags_num", flags);
   f->open_array_section("flags_set");

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -407,6 +407,8 @@ public:
 
     int8_t new_require_min_compat_client = -1;
 
+    utime_t new_last_up_change, new_last_in_change;
+
     mutable bool have_crc;      ///< crc values are defined
     uint32_t full_crc;  ///< crc of the resulting OSDMap
     mutable uint32_t inc_crc;   ///< crc of this incremental
@@ -505,6 +507,8 @@ private:
 
   int32_t max_osd;
   vector<uint32_t> osd_state;
+
+  utime_t last_up_change, last_in_change;
 
   // These features affect OSDMap[::Incremental] encoding, or the
   // encoding of some type embedded therein (CrushWrapper, something


### PR DESCRIPTION
```
  services:
    mon: 1 daemons, quorum a (44s)
    mgr: x(active, 41s)
    mds: cephfs_a-1/1/1 up  {0=a=up:creating}
    osd: 1 osds: 1 up (6s), 1 in (30s)
```