### PR TITLE
mon: fix mgr module config option handling

### DIFF
--- a/src/mon/ConfigMap.cc
+++ b/src/mon/ConfigMap.cc
@@ -39,6 +39,9 @@ void MaskedOption::dump(Formatter *f) const
 {
   f->dump_string("name", opt->name);
   f->dump_string("value", raw_value);
+  f->dump_string("level", Option::level_to_str(opt->level));
+  f->dump_bool("can_update_at_runtime", opt->can_update_at_runtime());
+  f->dump_string("mask", mask.to_str());
   mask.dump(f);
 }
 

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -647,22 +647,23 @@ void ConfigMonitor::load_config()
     }
 
     string section_name;
-    if (key.find("mgr") == 0) {
-      name = key.substr(key.find('/') + 1);    
-      MaskedOption mopt(new Option(name, Option::TYPE_STR, Option::LEVEL_UNKNOWN));
+    if (key.find("/mgr/") != std::string::npos) {
+      // mgr module option, "something/mgr/foo"
+      name = key.substr(key.find("/mgr/") + 1);
+      MaskedOption mopt(new Option(name, Option::TYPE_STR,
+				   Option::LEVEL_UNKNOWN));
       mopt.raw_value = value;      
       Section *section = &config_map.global;;
       section_name = "mgr";
-      if (section_name.size()) {
-	if (section_name.find('.') != std::string::npos) {
-	  section = &config_map.by_id[section_name];
-	} else {
-	  section = &config_map.by_type[section_name];
-	}
+      if (section_name.find('.') != std::string::npos) {
+	section = &config_map.by_id[section_name];
+      } else {
+	section = &config_map.by_type[section_name];
       }
       section->options.insert(make_pair(name, std::move(mopt)));
       ++num;      
     } else {
+      // normal option
       const Option *opt = g_conf().find_option(name);
       if (!opt) {
 	dout(10) << __func__ << " unrecognized option '" << name << "'" << dendl;


### PR DESCRIPTION
Before all mgr config options showed up as unknown in the 'config dump' output, now it's fixed.

http://tracker.ceph.com/issues/35076