### PR TITLE
mon,mgr,osd: Warn if queue of scrubs ready to run exceeds some threshold

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -8,6 +8,12 @@
 * Nautilus is not supported on any distros still running upstart so upstart
   specific files and references have been removed.
 
+* Configuration values mon_warn_not_scrubbed/mon_warn_not_deep_scrubbed have been
+  renamed.  They are now mon_warn_pg_not_scrubbed/mon_warn_pg_not_deep_scrubbed
+  respectively.  This is to clarify that these warnings are related to pg scrubbing
+  NOT the mon scrub mechanism.  These options are disabled by default, but
+  if they are present in your ceph.conf please update the names.
+
 >=13.1.0
 --------
 

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -612,3 +612,15 @@ happen if they are misplaced or degraded (see *PG_AVAILABILITY* and
 You can manually initiate a scrub of a clean PG with::
 
   ceph pg deep-scrub <pgid>
+
+OSD_ALL_SCRUBS_OVERDUE
+----------------------
+
+If the ratio of overdue scrubs to total pgs is greater than
+``mon_warn_pg_scrubs_overdue_ratio`` this warning is triggered.
+
+OSD_PER_OSD_SCRUBS_OVERDUE
+--------------------------
+
+On each OSD if the ratio of overdue scheduled scrubs to OSD's total pgs is
+greater than ``mon_warn_pg_scrubs_overdue_ratio`` this warning is triggered.

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -586,7 +586,7 @@ _______________
 
 One or more PGs has not been scrubbed recently.  PGs are normally
 scrubbed every ``mon_scrub_interval`` seconds, and this warning
-triggers when ``mon_warn_not_scrubbed`` such intervals have elapsed
+triggers when ``mon_warn_pg_not_scrubbed`` such intervals have elapsed
 without a scrub.
 
 PGs will not scrub if they are not flagged as *clean*, which may
@@ -602,7 +602,7 @@ ____________________
 
 One or more PGs has not been deep scrubbed recently.  PGs are normally
 scrubbed every ``osd_deep_mon_scrub_interval`` seconds, and this warning
-triggers when ``mon_warn_not_deep_scrubbed`` such intervals have elapsed
+triggers when ``mon_warn_pg_not_deep_scrubbed`` such intervals have elapsed
 without a scrub.
 
 PGs will not (deep) scrub if they are not flagged as *clean*, which may

--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -5555,6 +5555,67 @@ EOF
     teardown $dir || return 1
 }
 
+function TEST_request_scrub_priority() {
+    local dir=$1
+    local poolname=psr_pool
+    local objname=POBJ
+    local OBJECTS=64
+    local PGS=8
+
+    setup $dir || return 1
+    run_mon $dir a --osd_pool_default_size=1 || return 1
+    run_mgr $dir x || return 1
+    local ceph_osd_args="--osd-scrub-interval-randomize-ratio=0 --osd-deep-scrub-randomize-ratio=0 "
+    ceph_osd_args+="--osd_scrub_backoff_ratio=0"
+    run_osd $dir 0 $ceph_osd_args || return 1
+
+    create_pool $poolname $PGS $PGS || return 1
+    wait_for_clean || return 1
+
+    local osd=0
+    add_something $dir $poolname $objname noscrub || return 1
+    local primary=$(get_primary $poolname $objname)
+    local pg=$(get_pg $poolname $objname)
+    poolid=$(ceph osd dump | grep "^pool.*[']${poolname}[']" | awk '{ print $2 }')
+
+    local otherpgs
+    for i in $(seq 0 $(expr $PGS - 1))
+    do
+        opg="${poolid}.${i}"
+        if [ "$opg" = "$pg" ]; then
+          continue
+        fi
+        otherpgs="${otherpgs}${opg} "
+        local other_last_scrub=$(get_last_scrub_stamp $pg)
+        # Fake a schedule scrub
+        CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${primary}) \
+             trigger_scrub $opg || return 1
+    done
+
+    sleep 15
+    flush_pg_stats
+
+    # Request a regular scrub and it will be done
+    local last_scrub=$(get_last_scrub_stamp $pg)
+    ceph pg scrub $pg
+
+    ceph osd unset noscrub || return 1
+    ceph osd unset nodeep-scrub || return 1
+
+    wait_for_scrub $pg "$last_scrub"
+
+    for opg in $otherpgs $pg
+    do
+        wait_for_scrub $opg "$other_last_scrub"
+    done
+
+    # Verify that the requested scrub ran first
+    grep "log_channel.*scrub ok" $dir/osd.${primary}.log | head -1 | sed 's/.*[[]DBG[]]//' | grep -q $pg || return 1
+
+    return 0
+}
+
+
 main osd-scrub-repair "$@"
 
 # Local Variables:

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -274,8 +274,8 @@ OPTION(mon_health_preluminous_compat, OPT_BOOL)
 OPTION(mon_data_avail_crit, OPT_INT)
 OPTION(mon_data_avail_warn, OPT_INT)
 OPTION(mon_data_size_warn, OPT_U64) // issue a warning when the monitor's data store goes over 15GB (in bytes)
-OPTION(mon_warn_not_scrubbed, OPT_INT)
-OPTION(mon_warn_not_deep_scrubbed, OPT_INT)
+OPTION(mon_warn_pg_not_scrubbed, OPT_INT)
+OPTION(mon_warn_pg_not_deep_scrubbed, OPT_INT)
 OPTION(mon_scrub_interval, OPT_INT) // once a day
 OPTION(mon_scrub_timeout, OPT_INT) // let's give it 5 minutes; why not.
 OPTION(mon_scrub_max_keys, OPT_INT) // max number of keys to scrub each time

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -276,6 +276,7 @@ OPTION(mon_data_avail_warn, OPT_INT)
 OPTION(mon_data_size_warn, OPT_U64) // issue a warning when the monitor's data store goes over 15GB (in bytes)
 OPTION(mon_warn_pg_not_scrubbed, OPT_INT)
 OPTION(mon_warn_pg_not_deep_scrubbed, OPT_INT)
+OPTION(mon_warn_pg_scrubs_overdue_ratio, OPT_FLOAT)
 OPTION(mon_scrub_interval, OPT_INT) // once a day
 OPTION(mon_scrub_timeout, OPT_INT) // let's give it 5 minutes; why not.
 OPTION(mon_scrub_max_keys, OPT_INT) // max number of keys to scrub each time

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1632,6 +1632,12 @@ std::vector<Option> get_global_options() {
     .set_default(0)
     .set_description(""),
 
+    Option("mon_warn_pg_scrubs_overdue_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(.25)
+    .set_description("Warn when any osd has this percentage of pgs or this percentage of all pgs with scrubs overdue. "
+                     "The value of osd_max_scrubs is also accounted for.")
+    .add_see_also("osd_max_scrubs"),
+
     Option("mon_scrub_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1_day)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1624,11 +1624,11 @@ std::vector<Option> get_global_options() {
     .set_default(15_G)
     .set_description(""),
 
-    Option("mon_warn_not_scrubbed", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    Option("mon_warn_pg_not_scrubbed", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description(""),
 
-    Option("mon_warn_not_deep_scrubbed", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    Option("mon_warn_pg_not_deep_scrubbed", Option::TYPE_SECS, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description(""),
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2826,22 +2826,22 @@ void PGMap::get_health_checks(
   // PG_NOT_SCRUBBED
   // PG_NOT_DEEP_SCRUBBED
   {
-    if (cct->_conf->mon_warn_not_scrubbed ||
-        cct->_conf->mon_warn_not_deep_scrubbed) {
+    if (cct->_conf->mon_warn_pg_not_scrubbed ||
+        cct->_conf->mon_warn_pg_not_deep_scrubbed) {
       list<string> detail, deep_detail;
       int detail_max = max, deep_detail_max = max;
       int detail_more = 0, deep_detail_more = 0;
       int detail_total = 0, deep_detail_total = 0;
-      const double age = cct->_conf->mon_warn_not_scrubbed +
-        cct->_conf->mon_scrub_interval;
+      const double age = cct->_conf->mon_warn_pg_not_scrubbed +
+        cct->_conf->osd_scrub_max_interval;
       utime_t cutoff = now;
       cutoff -= age;
-      const double deep_age = cct->_conf->mon_warn_not_deep_scrubbed +
+      const double deep_age = cct->_conf->mon_warn_pg_not_deep_scrubbed +
         cct->_conf->osd_deep_scrub_interval;
       utime_t deep_cutoff = now;
       deep_cutoff -= deep_age;
       for (auto& p : pg_stat) {
-        if (cct->_conf->mon_warn_not_scrubbed &&
+        if (cct->_conf->mon_warn_pg_not_scrubbed &&
             p.second.last_scrub_stamp < cutoff) {
           if (detail_max > 0) {
             ostringstream ss;
@@ -2854,7 +2854,7 @@ void PGMap::get_health_checks(
           }
           ++detail_total;
         }
-        if (cct->_conf->mon_warn_not_deep_scrubbed &&
+        if (cct->_conf->mon_warn_pg_not_deep_scrubbed &&
             p.second.last_deep_scrub_stamp < deep_cutoff) {
           if (deep_detail_max > 0) {
             ostringstream ss;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4411,6 +4411,8 @@ void OSD::maybe_update_heartbeat_peers()
     _remove_heartbeat_peer(*p);
   }
 
+  service.set_scrubs_overdue(service.scrub_overdue_length());
+
   dout(10) << "maybe_update_heartbeat_peers " << heartbeat_peers.size() << " peers, extras " << extras << dendl;
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6826,7 +6826,8 @@ OSDService::ScrubJob::ScrubJob(CephContext* cct,
   : cct(cct),
     pgid(pg),
     sched_time(timestamp),
-    deadline(timestamp)
+    deadline(timestamp),
+    must(must)
 {
   // if not explicitly requested, postpone the scrub with a random delay
   if (!must) {
@@ -6849,6 +6850,10 @@ OSDService::ScrubJob::ScrubJob(CephContext* cct,
 }
 
 bool OSDService::ScrubJob::ScrubJob::operator<(const OSDService::ScrubJob& rhs) const {
+  if (must && !rhs.must)
+    return true;
+  if (!must && rhs.must)
+    return false;
   if (sched_time < rhs.sched_time)
     return true;
   if (sched_time > rhs.sched_time)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4139,7 +4139,7 @@ void PG::reg_next_scrub()
 void PG::unreg_next_scrub()
 {
   if (is_primary()) {
-    osd->unreg_pg_scrub(info.pgid, scrubber.scrub_reg_stamp);
+    osd->unreg_pg_scrub(info.pgid);
     scrubber.scrub_reg_stamp = utime_t();
   }
 }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -353,11 +353,13 @@ void osd_stat_t::dump(Formatter *f) const
   f->open_object_section("perf_stat");
   os_perf_stat.dump(f);
   f->close_section();
+  f->dump_unsigned("sched_scrubs_overdue", sched_scrubs_overdue);
+  f->dump_unsigned("total_scrubs_overdue", total_scrubs_overdue);
 }
 
 void osd_stat_t::encode(bufferlist &bl, uint64_t features) const
 {
-  ENCODE_START(8, 2, bl);
+  ENCODE_START(9, 2, bl);
   encode(kb, bl);
   encode(kb_used, bl);
   encode(kb_avail, bl);
@@ -373,12 +375,14 @@ void osd_stat_t::encode(bufferlist &bl, uint64_t features) const
   encode(kb_used_data, bl);
   encode(kb_used_omap, bl);
   encode(kb_used_meta, bl);
+  encode(sched_scrubs_overdue, bl);
+  encode(total_scrubs_overdue, bl);
   ENCODE_FINISH(bl);
 }
 
 void osd_stat_t::decode(bufferlist::const_iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(8, 2, 2, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(9, 2, 2, bl);
   decode(kb, bl);
   decode(kb_used, bl);
   decode(kb_avail, bl);
@@ -406,6 +410,13 @@ void osd_stat_t::decode(bufferlist::const_iterator &bl)
     kb_used_data = kb_used;
     kb_used_omap = 0;
     kb_used_meta = 0;
+  }
+  if (struct_v >= 9) {
+    decode(sched_scrubs_overdue, bl);
+    decode(total_scrubs_overdue, bl);
+  } else {
+    sched_scrubs_overdue = 0;
+    total_scrubs_overdue = 0;
   }
   DECODE_FINISH(bl);
 }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -925,6 +925,9 @@ struct osd_stat_t {
 
   uint32_t num_pgs = 0;
 
+  uint32_t sched_scrubs_overdue = 0;
+  uint32_t total_scrubs_overdue = 0;
+
   void add(const osd_stat_t& o) {
     kb += o.kb;
     kb_used += o.kb_used;
@@ -937,6 +940,8 @@ struct osd_stat_t {
     op_queue_age_hist.add(o.op_queue_age_hist);
     os_perf_stat.add(o.os_perf_stat);
     num_pgs += o.num_pgs;
+    sched_scrubs_overdue += o.sched_scrubs_overdue;
+    total_scrubs_overdue += o.total_scrubs_overdue;
   }
   void sub(const osd_stat_t& o) {
     kb -= o.kb;
@@ -950,6 +955,8 @@ struct osd_stat_t {
     op_queue_age_hist.sub(o.op_queue_age_hist);
     os_perf_stat.sub(o.os_perf_stat);
     num_pgs -= o.num_pgs;
+    sched_scrubs_overdue -= o.sched_scrubs_overdue;
+    total_scrubs_overdue -= o.total_scrubs_overdue;
   }
 
   void dump(Formatter *f) const;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] Check that any specific osd doesn't have too many overdue scrubs
- [x] Test priority of user specified scrubs
- [x] Enhance testing to cover both osd specific and overall overdue scrubs
- [x] References tracker ticket
- [x] Updates README for renamed config values
- [x] Ignore requested scrubs when checking per osd scrubs overdue
