### PR TITLE
cmake: link compressor plugins against lib the modern way

### DIFF
--- a/src/compressor/brotli/CMakeLists.txt
+++ b/src/compressor/brotli/CMakeLists.txt
@@ -26,12 +26,13 @@ set(bortli_libs enc dec common)
 foreach(lib ${bortli_libs})
   add_library(brotli::${lib} STATIC IMPORTED)
   add_dependencies(brotli::${lib} brotli_ext)
-  set_property(TARGET brotli::${lib} PROPERTY IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/src/brotli/libbrotli${lib}-static.a")
+  set_target_properties(brotli::${lib} PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/src/brotli/c/include"
+    IMPORTED_LOCATION "${CMAKE_BINARY_DIR}/src/brotli/libbrotli${lib}-static.a")
   list(APPEND BROTLI_LIBRARIES brotli::${lib})
 endforeach()
 
 add_library(ceph_brotli SHARED ${brotli_sources})
-target_include_directories(ceph_brotli	PRIVATE "${CMAKE_BINARY_DIR}/src/brotli/c/include")
-List(REVERSE bortli_libs)
-target_link_libraries(ceph_brotli ${BROTLI_LIBRARIES})
+list(REVERSE bortli_libs)
+target_link_libraries(ceph_brotli PRIVATE ${BROTLI_LIBRARIES})
 install(TARGETS ceph_brotli DESTINATION ${compressor_plugin_dir})

--- a/src/compressor/lz4/CMakeLists.txt
+++ b/src/compressor/lz4/CMakeLists.txt
@@ -5,7 +5,7 @@ set(lz4_sources
 )
 
 add_library(ceph_lz4 SHARED ${lz4_sources})
-target_link_libraries(ceph_lz4 ${LZ4_LIBRARY})
+target_link_libraries(ceph_lz4 PRIVATE LZ4::LZ4)
 set_target_properties(ceph_lz4 PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -5,9 +5,7 @@ set(snappy_sources
 )
 
 add_library(ceph_snappy SHARED ${snappy_sources})
-target_include_directories(ceph_snappy SYSTEM PRIVATE
-  "${SNAPPY_INCLUDE_DIR}")
-target_link_libraries(ceph_snappy snappy::snappy)
+target_link_libraries(ceph_snappy PRIVATE snappy::snappy)
 set_target_properties(ceph_snappy PROPERTIES
   VERSION 2.0.0
   SOVERSION 2

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -38,7 +38,7 @@ else(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))
 endif(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))
 
 add_library(ceph_zlib SHARED ${zlib_sources})
-target_link_libraries(ceph_zlib ${ZLIB_LIBRARIES})
+target_link_libraries(ceph_zlib ZLIB::ZLIB)
 target_include_directories(ceph_zlib SYSTEM PRIVATE "${CMAKE_SOURCE_DIR}/src/isa-l/include")
 set_target_properties(ceph_zlib PROPERTIES
   VERSION 2.0.0

--- a/src/compressor/zstd/CMakeLists.txt
+++ b/src/compressor/zstd/CMakeLists.txt
@@ -22,18 +22,17 @@ ExternalProject_Add_Step(zstd_ext forcebuild
   ALWAYS 1)
 
 add_library(zstd STATIC IMPORTED)
-set_property(TARGET zstd PROPERTY
+set_target_properties(zstd PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/src/zstd/lib"
   IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/libzstd/lib/libzstd.a")
 add_dependencies(zstd zstd_ext)
-set(ZSTD_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/zstd/lib)
 
-#
 set(zstd_sources
   CompressionPluginZstd.cc
 )
 
 add_library(ceph_zstd SHARED ${zstd_sources})
-target_link_libraries(ceph_zstd zstd)
+target_link_libraries(ceph_zstd PRIVATE zstd)
 set_target_properties(ceph_zstd PROPERTIES
   VERSION 2.0.0
   SOVERSION 2


### PR DESCRIPTION
* always link against the target library not library paths
* import their include directories by linking against their target
  library, instead of doing so using target_include_directories()
  manually.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

