### PR TITLE
mimic: kv: MergeOperator name() returns string, and caller calls c_str() on the temporary

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -387,7 +387,7 @@ public:
       const char *rdata, size_t rlen,
       std::string *new_value) = 0;
     /// We use each operator name and each prefix to construct the overall RocksDB operator name for consistency check at open time.
-    virtual string name() const = 0;
+    virtual const char *name() const = 0;
 
     virtual ~MergeOperator() {}
   };

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -127,7 +127,7 @@ public:
   MergeOperatorLinker(const std::shared_ptr<KeyValueDB::MergeOperator> &o) : mop(o) {}
 
   const char *Name() const override {
-    return mop->name().c_str();
+    return mop->name();
   }
 
   bool Merge(const rocksdb::Slice& key,

--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -35,7 +35,7 @@ struct XorMergeOperator : public KeyValueDB::MergeOperator {
   }
   // We use each operator name and each prefix to construct the
   // overall RocksDB operator name for consistency check at open time.
-  string name() const override {
+  const char *name() const override {
     return "bitwise_xor";
   }
 };

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -558,7 +558,7 @@ struct Int64ArrayMergeOperator : public KeyValueDB::MergeOperator {
   }
   // We use each operator name and each prefix to construct the
   // overall RocksDB operator name for consistency check at open time.
-  string name() const override {
+  const char *name() const override {
     return "int64_array";
   }
 };

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -208,7 +208,7 @@ struct AppendMOP : public KeyValueDB::MergeOperator {
   }
   // We use each operator name and each prefix to construct the
   // overall RocksDB operator name for consistency check at open time.
-  string name() const override {
+  const char *name() const override {
     return "Append";
   }
 };


### PR DESCRIPTION
http://tracker.ceph.com/issues/26907