### PR TITLE
mimic: rpm: should change ceph-mgr package depency from py-bcrypt to python2-bcrypt

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -228,12 +228,7 @@ BuildRequires:	python3-Cython
 BuildRequires:	python%{_python_buildid}-cherrypy
 BuildRequires:	python%{_python_buildid}-routes
 BuildRequires:	python%{_python_buildid}-werkzeug
-%if 0%{?fedora}
 BuildRequires:	python%{_python_buildid}-bcrypt
-%endif
-%if 0%{?rhel}
-BuildRequires:	py-bcrypt
-%endif
 %endif
 %if 0%{?suse_version}
 BuildRequires:	python%{_python_buildid}-CherryPy
@@ -373,12 +368,7 @@ Requires:       python%{_python_buildid}-jinja2
 Requires:       python%{_python_buildid}-routes
 Requires:       python%{_python_buildid}-werkzeug
 Requires:       pyOpenSSL%{_python_buildid}
-%if 0%{?fedora}
 Requires:	python%{_python_buildid}-bcrypt
-%endif
-%if 0%{?rhel}
-Requires:	py-bcrypt
-%endif
 %endif
 %if 0%{?suse_version}
 Requires:       python%{_python_buildid}-CherryPy


### PR DESCRIPTION
http://tracker.ceph.com/issues/27212