### PR TITLE
luminous: mds: MDBalancer::try_rebalance() may stop prematurely

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -874,9 +874,9 @@ void MDBalancer::try_rebalance(balance_state_t& state)
     mds_rank_t target = it.first;
     double amount = it.second;
 
-    if (amount / target_load < .2)
-      continue;
     if (amount < MIN_OFFLOAD)
+      continue;
+    if (amount * 10 * state.targets.size() < target_load)
       continue;
 
     dout(5) << "want to send " << amount << " to mds." << target

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -1148,7 +1148,9 @@ void MDBalancer::maybe_fragment(CDir *dir, bool hot)
 {
   // split/merge
   if (g_conf->mds_bal_frag && bal_fragment_interval > 0 &&
-      dir->is_auth() && !dir->inode->is_base()) {  // not root/base (for now at least)
+      dir->is_auth() &&
+      !dir->inode->is_base() &&  // not root/base (for now at least)
+      !dir->inode->is_stray()) { // not straydir
 
     // split
     if (g_conf->mds_bal_split_size > 0 &&


### PR DESCRIPTION
http://tracker.ceph.com/issues/32084