### PR TITLE
msg: lower verbosity on normal event

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1535,8 +1535,8 @@ ssize_t AsyncConnection::handle_connect_msg(ceph_msg_connect &connect, bufferlis
     lock.lock();
     char tag;
     if (need_challenge && !had_challenge && authorizer_challenge) {
-      ldout(async_msgr->cct,0) << __func__ << ": challenging authorizer"
-			       << dendl;
+      ldout(async_msgr->cct,10) << __func__ << ": challenging authorizer"
+			        << dendl;
       ceph_assert(authorizer_reply.length());
       tag = CEPH_MSGR_TAG_CHALLENGE_AUTHORIZER;
     } else {

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -531,9 +531,9 @@ int Pipe::accept()
       if (state != STATE_ACCEPTING)
 	goto shutting_down_msgr_unlocked;
       if (!had_challenge && need_challenge && authorizer_challenge) {
-	ldout(msgr->cct,0) << "accept: challenging authorizer "
-			   << authorizer_reply.length()
-			   << " bytes" << dendl;
+	ldout(msgr->cct,10) << "accept: challenging authorizer "
+			    << authorizer_reply.length()
+			    << " bytes" << dendl;
 	ceph_assert(authorizer_reply.length());
 	reply.tag = CEPH_MSGR_TAG_CHALLENGE_AUTHORIZER;
       } else {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/35251

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

