### PR TITLE
mgr/dashboard: Make deletion dialog more touch device friendly

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -201,7 +201,6 @@ export class RbdListComponent implements OnInit {
     this.modalRef = this.modalService.show(DeletionModalComponent);
     this.modalRef.content.setUp({
       metaType: 'RBD',
-      pattern: `${poolName}/${imageName}`,
       deletionObserver: () =>
         this.taskWrapper.wrapTaskAroundCall({
           task: new FinishedTask('rbd/delete', {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -256,7 +256,6 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
     this.modalRef = this.modalService.show(DeletionModalComponent);
     this.modalRef.content.setUp({
       metaType: 'RBD snapshot',
-      pattern: snapshotName,
       deletionMethod: () => this._asyncTask('deleteSnapshot', 'rbd/snap/delete', snapshotName),
       modalRef: this.modalRef
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.ts
@@ -94,7 +94,6 @@ export class RoleListComponent implements OnInit {
     const name = this.selection.first().name;
     this.modalRef.content.setUp({
       metaType: 'Role',
-      pattern: `${name}`,
       deletionMethod: () => this.deleteRole(name),
       modalRef: this.modalRef
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
@@ -103,7 +103,6 @@ export class UserListComponent implements OnInit {
     this.modalRef = this.modalService.show(DeletionModalComponent);
     this.modalRef.content.setUp({
       metaType: 'User',
-      pattern: `${username}`,
       deletionMethod: () => this.deleteUser(username),
       modalRef: this.modalRef
     });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/components.module.ts
@@ -5,6 +5,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { ChartsModule } from 'ng2-charts/ng2-charts';
 import { AlertModule, ModalModule, PopoverModule, TooltipModule } from 'ngx-bootstrap';
 
+import { DirectivesModule } from '../directives/directives.module';
 import { PipesModule } from '../pipes/pipes.module';
 import { ConfirmationModalComponent } from './confirmation-modal/confirmation-modal.component';
 import { DeletionModalComponent } from './deletion-modal/deletion-modal.component';
@@ -31,7 +32,8 @@ import { WarningPanelComponent } from './warning-panel/warning-panel.component';
     ChartsModule,
     ReactiveFormsModule,
     PipesModule,
-    ModalModule.forRoot()
+    ModalModule.forRoot(),
+    DirectivesModule
   ],
   declarations: [
     ViewCacheComponent,

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.html
@@ -11,41 +11,27 @@
           novalidate>
       <div class="modal-body">
         <ng-container *ngTemplateOutlet="description"></ng-container>
-        <p>
-          <ng-container i18n>
-            To confirm the deletion, enter
-          </ng-container>
-          <kbd>{{ pattern }}</kbd>
-          <ng-container i18n>
-            and click on
-          </ng-container>
-          <kbd>
-            <ng-container *ngTemplateOutlet="deletionHeading"></ng-container>
-          </kbd>.
-        </p>
-        <div class="form-group"
-             [ngClass]="{'has-error': deletionForm.showError('confirmation', formDir)}">
-          <input type="text"
-                 class="form-control"
-                 name="confirmation"
-                 id="confirmation"
-                 [placeholder]="pattern"
-                 [pattern]="escapeRegExp(pattern)"
-                 autocomplete="off"
-                 (keyup)="updateConfirmation($event)"
-                 formControlName="confirmation"
-                 autofocus>
-          <span class="help-block"
-                *ngIf="deletionForm.showError('confirmation', formDir, 'required')"
-                i18n>
-          This field is required.
-        </span>
-          <span class="help-block"
-                *ngIf="deletionForm.showError('confirmation', formDir, 'pattern')">
-          '{{ confirmation.value }}'
-          <span i18n>doesn't match</span>
-          '{{ pattern }}'.
-        </span>
+        <div class="question">
+          <p>
+            <ng-container i18n>
+              Are you sure you want to delete the selected
+            </ng-container>
+            {{ metaType }}?
+          </p>
+          <div class="form-group"
+               [ngClass]="{'has-error': deletionForm.showError('confirmation', formDir)}">
+            <div class="checkbox checkbox-primary">
+              <input type="checkbox"
+                     name="confirmation"
+                     id="confirmation"
+                     formControlName="confirmation"
+                     autofocus>
+              <label i18n
+                     for="confirmation">
+                I'm sure I want to proceed with the deletion.
+              </label>
+            </div>
+          </div>
         </div>
       </div>
       <div class="modal-footer">

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.scss
@@ -1,0 +1,6 @@
+.modal-body .question {
+  font-weight: bold;
+}
+.modal-body .question .checkbox {
+  padding-top: 7px;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.ts
@@ -17,27 +17,23 @@ export class DeletionModalComponent implements OnInit {
   submitButton: SubmitButtonComponent;
   description: TemplateRef<any>;
   metaType: string;
-  pattern = 'yes';
   deletionObserver: () => Observable<any>;
   deletionMethod: Function;
   modalRef: BsModalRef;
 
   deletionForm: CdFormGroup;
-  confirmation: FormControl;
 
   // Parameters are destructed here than assigned to specific types and marked as optional
   setUp({
     modalRef,
     metaType,
     deletionMethod,
-    pattern,
     deletionObserver,
     description
   }: {
     modalRef: BsModalRef;
     metaType: string;
     deletionMethod?: Function;
-    pattern?: string;
     deletionObserver?: () => Observable<any>;
     description?: TemplateRef<any>;
   }) {
@@ -51,28 +47,14 @@ export class DeletionModalComponent implements OnInit {
     this.metaType = metaType;
     this.modalRef = modalRef;
     this.deletionMethod = deletionMethod;
-    this.pattern = pattern || this.pattern;
     this.deletionObserver = deletionObserver;
     this.description = description;
   }
 
   ngOnInit() {
-    this.confirmation = new FormControl('', {
-      validators: [Validators.required],
-      updateOn: 'blur'
-    });
     this.deletionForm = new CdFormGroup({
-      confirmation: this.confirmation
+      confirmation: new FormControl(false, [Validators.requiredTrue])
     });
-  }
-
-  updateConfirmation($e) {
-    if ($e.key !== 'Enter') {
-      return;
-    }
-    this.confirmation.setValue($e.target.value);
-    this.confirmation.markAsDirty();
-    this.confirmation.updateValueAndValidity();
   }
 
   deletionCall() {
@@ -93,9 +75,5 @@ export class DeletionModalComponent implements OnInit {
 
   stopLoadingSpinner() {
     this.deletionForm.setErrors({ cdSubmitButton: true });
-  }
-
-  escapeRegExp(text) {
-    return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/directives/directives.module.ts
@@ -1,0 +1,24 @@
+import { NgModule } from '@angular/core';
+
+import { AutofocusDirective } from './autofocus.directive';
+import { Copy2ClipboardButtonDirective } from './copy2clipboard-button.directive';
+import { DimlessBinaryDirective } from './dimless-binary.directive';
+import { PasswordButtonDirective } from './password-button.directive';
+
+@NgModule({
+  imports: [],
+  declarations: [
+    AutofocusDirective,
+    Copy2ClipboardButtonDirective,
+    DimlessBinaryDirective,
+    PasswordButtonDirective
+  ],
+  exports: [
+    AutofocusDirective,
+    Copy2ClipboardButtonDirective,
+    DimlessBinaryDirective,
+    PasswordButtonDirective
+  ],
+  providers: []
+})
+export class DirectivesModule {}

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/shared.module.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/shared.module.ts
@@ -4,10 +4,7 @@ import { NgModule } from '@angular/core';
 import { ApiModule } from './api/api.module';
 import { ComponentsModule } from './components/components.module';
 import { DataTableModule } from './datatable/datatable.module';
-import { AutofocusDirective } from './directives/autofocus.directive';
-import { Copy2ClipboardButtonDirective } from './directives/copy2clipboard-button.directive';
-import { DimlessBinaryDirective } from './directives/dimless-binary.directive';
-import { PasswordButtonDirective } from './directives/password-button.directive';
+import { DirectivesModule } from './directives/directives.module';
 import { PipesModule } from './pipes/pipes.module';
 import { AuthGuardService } from './services/auth-guard.service';
 import { AuthStorageService } from './services/auth-storage.service';
@@ -21,24 +18,17 @@ import { ServicesModule } from './services/services.module';
     ComponentsModule,
     ServicesModule,
     DataTableModule,
-    ApiModule
+    ApiModule,
+    DirectivesModule
   ],
-  declarations: [
-    PasswordButtonDirective,
-    DimlessBinaryDirective,
-    Copy2ClipboardButtonDirective,
-    AutofocusDirective
-  ],
+  declarations: [],
   exports: [
     ComponentsModule,
     PipesModule,
     ServicesModule,
-    PasswordButtonDirective,
-    Copy2ClipboardButtonDirective,
-    DimlessBinaryDirective,
     DataTableModule,
     ApiModule,
-    AutofocusDirective
+    DirectivesModule
   ],
   providers: [AuthStorageService, AuthGuardService, FormatterService]
 })


### PR DESCRIPTION
* Refactor deletion dialog
* Add directives.module.ts to be able to use 'autofocus' in deletion dialog

The current delete dialog requires the user to type the name of the object to delete as confirmation. On desktop systems this can be done easily with copy&paste for longer names, but this makes it really difficult on touch devices. Because of that this PR simplifies the confirmation.

![auswahl_004](https://user-images.githubusercontent.com/1897962/45356510-b7b2d200-b5c3-11e8-9f2a-188cd035b5ec.png)

If the checkbox is not checked, then the field is marked in red color. Compared to normal forms the message ``This field is required`` won't be displayed.

![auswahl_005](https://user-images.githubusercontent.com/1897962/45356515-bc778600-b5c3-11e8-9fab-36c1107ca995.png)

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug