### PR TITLE
osd/PG: fix misused FORCE_RECOVERY[BACKFILL] flags

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2368,18 +2368,18 @@ bool PG::set_force_backfill(bool b)
 {
   bool did = false;
   if (b) {
-    if (!(state & PG_STATE_FORCED_RECOVERY) &&
+    if (!(state & PG_STATE_FORCED_BACKFILL) &&
 	(state & (PG_STATE_DEGRADED |
 		  PG_STATE_BACKFILL_WAIT |
 		  PG_STATE_BACKFILLING))) {
       dout(10) << __func__ << " set" << dendl;
-      state_set(PG_STATE_FORCED_RECOVERY);
+      state_set(PG_STATE_FORCED_BACKFILL);
       publish_stats_to_osd();
       did = true;
     }
-  } else if (state & PG_STATE_FORCED_RECOVERY) {
+  } else if (state & PG_STATE_FORCED_BACKFILL) {
     dout(10) << __func__ << " clear" << dendl;
-    state_clear(PG_STATE_FORCED_RECOVERY);
+    state_clear(PG_STATE_FORCED_BACKFILL);
     publish_stats_to_osd();
     did = true;
   }


### PR DESCRIPTION
__set_force_backfill__ should set PG_STATE_FORCED_BACKFILL
instead of PG_STATE_FORCED_RECOVERY.

Fixes: http://tracker.ceph.com/issues/27985
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

