### PR TITLE
qa/tasks/cram: use suite_repo repository for all cram jobs

### DIFF
--- a/qa/suites/krbd/basic/tasks/krbd_blkroset.yaml
+++ b/qa/suites/krbd/basic/tasks/krbd_blkroset.yaml
@@ -2,4 +2,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/rbd/krbd_blkroset.t
+      - '{gh_url}/raw/{branch}/qa/rbd/krbd_blkroset.t'

--- a/qa/suites/krbd/basic/tasks/krbd_huge_image.yaml
+++ b/qa/suites/krbd/basic/tasks/krbd_huge_image.yaml
@@ -2,4 +2,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/rbd/krbd_huge_image.t
+      - '{gh_url}/raw/{branch}/qa/rbd/krbd_huge_image.t'

--- a/qa/suites/krbd/basic/tasks/krbd_msgr_segments.yaml
+++ b/qa/suites/krbd/basic/tasks/krbd_msgr_segments.yaml
@@ -2,4 +2,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/rbd/krbd_msgr_segments.t
+      - '{gh_url}/raw/{branch}/qa/rbd/krbd_msgr_segments.t'

--- a/qa/suites/krbd/basic/tasks/krbd_parent_overlap.yaml
+++ b/qa/suites/krbd/basic/tasks/krbd_parent_overlap.yaml
@@ -2,4 +2,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/rbd/krbd_parent_overlap.t
+      - '{gh_url}/raw/{branch}/qa/rbd/krbd_parent_overlap.t'

--- a/qa/suites/krbd/basic/tasks/krbd_whole_object_discard.yaml
+++ b/qa/suites/krbd/basic/tasks/krbd_whole_object_discard.yaml
@@ -2,4 +2,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/rbd/krbd_whole_object_discard.t
+      - '{gh_url}/raw/{branch}/qa/rbd/krbd_whole_object_discard.t'

--- a/qa/suites/krbd/unmap/tasks/unmap.yaml
+++ b/qa/suites/krbd/unmap/tasks/unmap.yaml
@@ -2,4 +2,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=src/test/cli-integration/rbd/unmap.t
+      - '{gh_url}/raw/{branch}/src/test/cli-integration/rbd/unmap.t'

--- a/qa/suites/rbd/singleton/all/formatted-output.yaml
+++ b/qa/suites/rbd/singleton/all/formatted-output.yaml
@@ -7,4 +7,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=src/test/cli-integration/rbd/formatted-output.t
+      - '{gh_url}/raw/{branch}/src/test/cli-integration/rbd/formatted-output.t'

--- a/qa/tasks/cram.py
+++ b/qa/tasks/cram.py
@@ -62,11 +62,9 @@ def task(ctx, config):
     if refspec is None:
         refspec = 'HEAD'
 
-    # hack: the git_url is always ceph-ci or ceph
-    git_url = teuth_config.get_ceph_git_url()
-    repo_name = 'ceph.git'
-    if git_url.count('ceph-ci'):
-        repo_name = 'ceph-ci.git'
+    git_url = teuth_config.get_ceph_qa_suite_git_url()
+    if git_url.endswith('.git'):
+        git_url = git_url[:-4]
 
     try:
         for client, tests in clients.iteritems():
@@ -83,7 +81,7 @@ def task(ctx, config):
                     ],
                 )
             for test in tests:
-                url = test.format(repo=repo_name, branch=refspec)
+                url = test.format(gh_url=git_url, branch=refspec)
                 log.info('fetching test %s for %s', url, client)
                 assert test.endswith('.t'), 'tests must end in .t'
                 remote.run(


### PR DESCRIPTION
Currently git.ceph.com is hardcoded for all cram jobs.  Testing
modifications is a pain: one needs to push to either ceph/ceph.git or
ceph/ceph-ci.git (depending on where the ceph branch is at, triggering
unnecessary builds in the latter case) and wait for the mirror to sync.
Runs scheduled against branches in developer's forks fail.

Move away from git.ceph.com to allow mixing branches and repositories,
similar to workunits.

Fixes: https://tracker.ceph.com/issues/27211
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>