### PR TITLE
doc: Fix Spelling Error of Cephfs Shell

### DIFF
--- a/doc/cephfs/cephfs-shell.rst
+++ b/doc/cephfs/cephfs-shell.rst
@@ -42,7 +42,7 @@ Usage :
         put [options] <source_path> [target_path]
 
 * source_path - local file/directory path to be copied to cephfs.
-    * if `.` copies all the file/directories in the local workind directory.
+    * if `.` copies all the file/directories in the local working directory.
     * if `-`  Reads the input from stdin. 
 
 * target_path - remote directory path where the files/directories are to be copied to.
@@ -62,7 +62,7 @@ Usage :
     get [options] <source_path> [target_path]
 
 * source_path - remote file/directory path which is to be copied to local file system.
-    * if `.` copies all the file/directories in the remote workind directory.
+    * if `.` copies all the file/directories in the remote working directory.
                     
 * target_path - local directory path where the files/directories are to be copied to.
     * if `.` files/directories are copied to the local working directory. 
@@ -236,7 +236,7 @@ Usage:
     pyscript <script_path> [script_arguments]
 
 * Console commands can be executed inside this script with cmd ("your command")
-  However, you cannot run nested "py" or "pyscript" commands from withinthis script
+  However, you cannot run nested "py" or "pyscript" commands from within this script
   Paths or arguments that contain spaces must be enclosed in quotes
 
 py


### PR DESCRIPTION
Signed-off-by: Li Bingyang <li.bingyang1@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

