### PR TITLE
unittest_config: $host expands to ceph_get_short_hostname(), not hostname -s

### DIFF
--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -22,6 +22,7 @@
 #include "common/config.h"
 #include "common/errno.h"
 #include "gtest/gtest.h"
+#include "common/hostname.h"
 
 extern std::string exec(const char* cmd); // defined in test_hostname.cc
 
@@ -51,7 +52,7 @@ public:
       std::string after = " AFTER ";
       std::string val(before + "$host${host}" + after);
       EXPECT_TRUE(expand_meta(val, &oss));
-      std::string hostname = exec("hostname -s");
+      std::string hostname = ceph_get_short_hostname();
       EXPECT_EQ(before + hostname + hostname + after, val);
       EXPECT_EQ("", oss.str());
     }


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit c7916097c207494618c56a6526cf63ff22ba64c3)
- conflict due to expand_meta changes