### PR TITLE
mon/HealthMonitor: add MON_NUM_EVEN warning

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -334,6 +334,27 @@ bool HealthMonitor::check_leader_health()
     }
   }
 
+  // MON_NUM_EVEN
+  {
+    int num_mons = mon->monmap->size();
+    if (!(num_mons & 1)) {
+      ostringstream ss;
+      ss << "Mon map contains an even number of mons (" << num_mons << ")";
+      auto& d = next.add("MON_NUM_EVEN", HEALTH_WARN, ss.str());
+      ostringstream detail;
+      detail << "Ceph requires a majority of the monitors to be online to function"
+             << ", the current configuration can tolerate ";
+      if (num_mons == 2) {
+        detail << "no monitor failures";
+      } else if (num_mons == 4) {
+        detail << "only 1 monitor failure";
+      } else {
+        detail << "only " << (num_mons / 2 - 1) << " monitor failures";
+      }
+      d.detail.push_back(detail.str());
+    }
+  }
+
   // MON_CLOCK_SKEW
   if (!mon->timecheck_skews.empty()) {
     list<string> warns;


### PR DESCRIPTION
This warning triggers when the total number of monitors in the mon map is even.

I've seen this several times in the wild, especially with 4 mons. The reasoning for that is usually something like "well, we got two racks, and 2 mons clearly isn't enough so 4 seems like a good number". I've even seen two servers with two mons each 😱 

Open question: there are several QA suites that define 2 mons and one with 6 mons. What should we do about them? 
These files in `/qa/` contain the string "mon.b" but not "mon.c":
```
./standalone/mon/misc.sh
./standalone/mon/mon-handle-forward.sh
./suites/fs/upgrade/featureful_client/old_client/tasks/2-upgrade.yaml
./suites/fs/upgrade/featureful_client/upgraded_client/tasks/2-upgrade.yaml
./suites/fs/upgrade/snaps/tasks/2-upgrade.yaml
./suites/rados/multimon/tasks/mon_clock_with_skews.yaml
./suites/rados/thrash-old-clients/1-install/hammer.yaml
./suites/rados/thrash-old-clients/1-install/jewel.yaml
./suites/rados/thrash-old-clients/1-install/luminous.yaml
./suites/rgw/hadoop-s3a/s3a-hadoop.yaml
./suites/smoke/systemd/clusters/fixed-4.yaml
./suites/teuthology/multi-cluster/all/ceph.yaml
./suites/teuthology/multi-cluster/all/upgrade.yaml
./suites/upgrade/luminous-x/parallel/1-ceph-install/luminous.yaml
./suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
./tasks/ceph_deploy.py
./workunits/cephtool/test.sh
```

Options would be:

1. ignore MON_NUM_EVEN in the tests
2. change them to use a different number of mons?
3. just merge it and handle it when the qa suites fail ;)
4. change the warning to only trigger on 4 mons which seems to be the most common misconfiguration

Fixes: http://tracker.ceph.com/issues/35545



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary (N/A, other mon warnings don't seem to have an explicit docs page?)
- [ ] Includes tests for new functionality or reproducer for bug (well...)

