### PR TITLE
rgw-admin: fix data sync report for master zone

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -651,10 +651,6 @@ int RGWRemoteDataLog::read_source_log_shards_info(map<int, RGWDataChangesLogInfo
 
 int RGWRemoteDataLog::read_source_log_shards_next(map<int, string> shard_markers, map<int, rgw_datalog_shard_data> *result)
 {
-  if (store->is_meta_master()) {
-    return 0;
-  }
-
   return run(new RGWListRemoteDataLogCR(&sync_env, shard_markers, 1, result));
 }
 


### PR DESCRIPTION
Fix the problem of not showing oldest timestamp of data not synced on master zone.
Signed-off-by: cfanz <songxinying@sensetime.com>

