### PR TITLE
mgr/dashboard: Added missing tooltip to settings icon

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/administration/administration.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/navigation/administration/administration.component.html
@@ -2,7 +2,9 @@
      *ngIf="userPermission.read">
   <a dropdownToggle
      class="dropdown-toggle"
-     data-toggle="dropdown">
+     data-toggle="dropdown"
+     i18n-title
+     title="Dashboard Settings">
     <i class="fa fa-cog"></i>
     <span class="caret"></span>
   </a>


### PR DESCRIPTION
The settings icon was missing a tooltip when hovering over it.

![dashboard-settings-tooltip](https://user-images.githubusercontent.com/263427/45087167-47103f00-b105-11e8-9c4b-36dc0d952923.png)

Fixes: https://tracker.ceph.com/issues/35686
Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

