### PR TITLE
qa/workunits/rbd: replace usage of 'rados mkpool'

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -668,7 +668,7 @@ get_migration_state() {
 test_migration() {
     echo "testing migration..."
     remove_images
-    rados mkpool rbd2
+    ceph osd pool create rbd2 8
     rbd pool init rbd2
 
     # Convert to new format


### PR DESCRIPTION
This command was dropped under commit 2c26fb0fe1, so use
'ceph osd pool create' instead.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>