### PR TITLE
librbd: flatten operation should use object map

### DIFF
--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -111,6 +111,32 @@ bool ObjectMap<I>::object_may_exist(uint64_t object_no) const
 }
 
 template <typename I>
+bool ObjectMap<I>::object_may_not_exist(uint64_t object_no) const
+{
+  ceph_assert(m_image_ctx.snap_lock.is_locked());
+
+  // Fall back to default logic if object map is disabled or invalid
+  if (!m_image_ctx.test_features(RBD_FEATURE_OBJECT_MAP,
+                                 m_image_ctx.snap_lock)) {
+    return true;
+  }
+
+  bool flags_set;
+  int r = m_image_ctx.test_flags(RBD_FLAG_OBJECT_MAP_INVALID,
+                                 m_image_ctx.snap_lock, &flags_set);
+  if (r < 0 || flags_set) {
+    return true;
+  }
+
+  RWLock::RLocker l(m_image_ctx.object_map_lock);
+  uint8_t state = (*this)[object_no];
+  bool nonexistent = (state != OBJECT_EXISTS && state != OBJECT_EXISTS_CLEAN);
+  ldout(m_image_ctx.cct, 20) << "object_no=" << object_no << " r="
+                             << nonexistent << dendl;
+  return nonexistent;
+}
+
+template <typename I>
 bool ObjectMap<I>::update_required(const ceph::BitVector<2>::Iterator& it,
                                    uint8_t new_state) {
   ceph_assert(m_image_ctx.object_map_lock.is_wlocked());

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -48,6 +48,7 @@ public:
   void close(Context *on_finish);
   bool set_object_map(ceph::BitVector<2> &target_object_map);
   bool object_may_exist(uint64_t object_no) const;
+  bool object_may_not_exist(uint64_t object_no) const;
 
   void aio_save(Context *on_finish);
   void aio_resize(uint64_t new_size, uint8_t default_object_state,

--- a/src/librbd/operation/FlattenRequest.cc
+++ b/src/librbd/operation/FlattenRequest.cc
@@ -40,6 +40,15 @@ public:
       return -ERESTART;
     }
 
+    {
+      RWLock::RLocker snap_lock(image_ctx.snap_lock);
+      if (image_ctx.object_map != nullptr &&
+          !image_ctx.object_map->object_may_not_exist(m_object_no)) {
+        // can skip because the object already exists
+        return 1;
+      }
+    }
+
     bufferlist bl;
     string oid = image_ctx.get_object_name(m_object_no);
     auto req = new io::ObjectWriteRequest<I>(&image_ctx, oid, m_object_no, 0,


### PR DESCRIPTION
If the object is known to exist in the image, the copy-up operation
can be skipped for that object.

Fixes: http://tracker.ceph.com/issues/23445
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

