### PR TITLE
luminous: msg: "challenging authorizer" messages appear at debug_ms=0

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1538,7 +1538,7 @@ ssize_t AsyncConnection::handle_connect_msg(ceph_msg_connect &connect, bufferlis
     lock.lock();
     char tag;
     if (need_challenge && !had_challenge && authorizer_challenge) {
-      ldout(async_msgr->cct,0) << __func__ << ": challenging authorizer"
+      ldout(async_msgr->cct,10) << __func__ << ": challenging authorizer"
 			       << dendl;
       assert(authorizer_reply.length());
       tag = CEPH_MSGR_TAG_CHALLENGE_AUTHORIZER;

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -530,7 +530,7 @@ int Pipe::accept()
       if (state != STATE_ACCEPTING)
 	goto shutting_down_msgr_unlocked;
       if (!had_challenge && need_challenge && authorizer_challenge) {
-	ldout(msgr->cct,0) << "accept: challenging authorizer "
+	ldout(msgr->cct,10) << "accept: challenging authorizer "
 			   << authorizer_reply.length()
 			   << " bytes" << dendl;
 	assert(authorizer_reply.length());


### PR DESCRIPTION
http://tracker.ceph.com/issues/35716