### PR TITLE
doc: remove deprecated 'scrubq' from ceph(8)

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1262,11 +1262,11 @@ Subcommand ``ls`` lists pg with specific pool, osd, state
 Usage::
 
 	ceph pg ls {<int>} {active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale| remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized [active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale|remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized...]}
@@ -1277,11 +1277,11 @@ Usage::
 
 	ceph pg ls-by-osd <osdname (id|osd.id)> {<int>}
 	{active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale| remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized [active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale|remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized...]}
@@ -1292,11 +1292,11 @@ Usage::
 
 	ceph pg ls-by-pool <poolstr> {<int>} {active|
 	clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale| remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized [active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale|remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized...]}
@@ -1307,11 +1307,11 @@ Usage::
 
 	ceph pg ls-by-primary <osdname (id|osd.id)> {<int>}
 	{active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale| remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized [active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale|remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized...]}


### PR DESCRIPTION
The option was removed in a30cbe9adea34782be8699c010d4281d245feb6b

Signed-off-by: Ruben Kerkhof <ruben@rubenkerkhof.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

