### PR TITLE
dout: add DoutPrefixPipe for composing prefix providers

### DIFF
--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -44,6 +44,23 @@ public:
   virtual ~DoutPrefixProvider() {}
 };
 
+// a prefix provider that composes itself on top of another
+class DoutPrefixPipe : public DoutPrefixProvider {
+  const DoutPrefixProvider& dpp;
+ public:
+  DoutPrefixPipe(const DoutPrefixProvider& dpp) : dpp(dpp) {}
+
+  std::ostream& gen_prefix(std::ostream& out) const override final {
+    dpp.gen_prefix(out);
+    add_prefix(out);
+    return out;
+  }
+  CephContext *get_cct() const override { return dpp.get_cct(); }
+  unsigned get_subsys() const override { return dpp.get_subsys(); }
+
+  virtual void add_prefix(std::ostream& out) const = 0;
+};
+
 // helpers
 namespace ceph::dout {
 

--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -44,6 +44,30 @@ public:
   virtual ~DoutPrefixProvider() {}
 };
 
+// a prefix provider with empty prefix
+class NoDoutPrefix : public DoutPrefixProvider {
+  CephContext *const cct;
+  const unsigned subsys;
+ public:
+  NoDoutPrefix(CephContext *cct, unsigned subsys) : cct(cct), subsys(subsys) {}
+
+  std::ostream& gen_prefix(std::ostream& out) const override { return out; }
+  CephContext *get_cct() const override { return cct; }
+  unsigned get_subsys() const override { return subsys; }
+};
+
+// a prefix provider with static (const char*) prefix
+class DoutPrefix : public NoDoutPrefix {
+  const char *const prefix;
+ public:
+  DoutPrefix(CephContext *cct, unsigned subsys, const char *prefix)
+    : NoDoutPrefix(cct, subsys), prefix(prefix) {}
+
+  std::ostream& gen_prefix(std::ostream& out) const override {
+    return out << prefix;
+  }
+};
+
 // a prefix provider that composes itself on top of another
 class DoutPrefixPipe : public DoutPrefixProvider {
   const DoutPrefixProvider& dpp;


### PR DESCRIPTION
a wonderful feature of DoutPrefixProviders is that they can be composed, with each Provider adding onto the prefix of the previous one

to aid with this composition, add a DoutPrefixPipe that takes an existing Provider and forwards the DoutPrefixProvider interface to it

the class that implements the DoutPrefixPipe interface only has to override one virtual function, and never has to reference the previous Provider after passing it to the DoutPrefixPipe constructor

a contrived example:
```c++
#include "common/dout.h"

class Bucket : public DoutPrefixPipe {
  const char *name;
 public:
  Bucket(const DoutPrefixProvider& dpp, const char *name)
    : DoutPrefixPipe(dpp), name(name) {}

  void add_prefix(std::ostream& out) const override {
    out << "bucket[" << name << "] ";
  }
};

class Object : public DoutPrefixPipe {
  const char *name;
 public:
  Object(const DoutPrefixProvider& dpp, const char *name)
    : DoutPrefixPipe(dpp), name(name) {}

  void add_prefix(std::ostream& out) const override {
    out << "object[" << name << "] ";
  }
};

int main(int argc, char **argv)
{
  DoutPrefix dpp(g_ceph_context, ceph_subsys_rgw, "rgw: ");
  ldpp_dout(&dpp, 0) << "starting.." << dendl;

  Bucket bucket(dpp, "cats");
  ldpp_dout(&bucket, 0) << "creating bucket.." << dendl;

  Object object(bucket, "tiger");
  ldpp_dout(&object, 0) << "uploading image.." << dendl;
  return 0;
}
```

and its resulting log output:
```
2018-09-06 10:04:12.925 7ff8c188d9c0  0 rgw: starting..
2018-09-06 10:04:12.925 7ff8c188d9c0  0 rgw: bucket[cats] creating bucket..
2018-09-06 10:04:12.925 7ff8c188d9c0  0 rgw: bucket[cats] object[tiger] uploading image..
```