### PR TITLE
pybind/rbd: add memset after realloc

### DIFF
--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -21,7 +21,7 @@ from cpython cimport PyObject, ref, exc
 from libc cimport errno
 from libc.stdint cimport *
 from libc.stdlib cimport realloc, free
-from libc.string cimport strdup
+from libc.string cimport strdup, memset
 
 from collections import Iterable
 from datetime import datetime
@@ -748,6 +748,7 @@ cdef void* realloc_chk(void* ptr, size_t size) except NULL:
     cdef void *ret = realloc(ptr, size)
     if ret == NULL:
         raise MemoryError("realloc failed")
+    memset(ret, 0, size)
     return ret
 
 cdef class Completion


### PR DESCRIPTION
realloc applies memory space, but there may be some unknown data in
the memory space. So it is necessary to use memset to initialize the space.

Signed-off-by: Zheng Yin <zhengyin@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

