### PR TITLE
mgr: add get_latest_counter to C++ -> Py interface

### DIFF
--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -18,6 +18,8 @@
 #include "common/Finisher.h"
 #include "common/Mutex.h"
 
+#include "PyFormatter.h"
+
 #include "osdc/Objecter.h"
 #include "client/Client.h"
 #include "common/LogClient.h"
@@ -71,11 +73,23 @@ public:
     const std::string &svc_type,
     const std::string &svc_id,
     const std::string &path);
+  PyObject *get_latest_counter_python(
+    const std::string &svc_type,
+    const std::string &svc_id,
+    const std::string &path);
   PyObject *get_perf_schema_python(
      const std::string &svc_type,
      const std::string &svc_id);
   PyObject *get_context();
   PyObject *get_osdmap();
+  PyObject *with_perf_counters(
+      std::function<void(
+        PerfCounterInstance& counter_instance,
+        PerfCounterType& counter_type,
+        PyFormatter& f)> fct,
+      const std::string &svc_name,
+      const std::string &svc_id,
+      const std::string &path) const;
 
   bool get_store(const std::string &module_name,
       const std::string &key, std::string *val) const;

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -506,6 +506,20 @@ get_counter(BaseMgrModule *self, PyObject *args)
 }
 
 static PyObject*
+get_latest_counter(BaseMgrModule *self, PyObject *args)
+{
+  char *svc_name = nullptr;
+  char *svc_id = nullptr;
+  char *counter_path = nullptr;
+  if (!PyArg_ParseTuple(args, "sss:get_counter", &svc_name,
+                                                  &svc_id, &counter_path)) {
+    return nullptr;
+  }
+  return self->py_modules->get_latest_counter_python(
+      svc_name, svc_id, counter_path);
+}
+
+static PyObject*
 get_perf_schema(BaseMgrModule *self, PyObject *args)
 {
   char *type_str = nullptr;
@@ -640,6 +654,9 @@ PyMethodDef BaseMgrModule_methods[] = {
 
   {"_ceph_get_counter", (PyCFunction)get_counter, METH_VARARGS,
     "Get a performance counter"},
+
+  {"_ceph_get_latest_counter", (PyCFunction)get_latest_counter, METH_VARARGS,
+    "Get the latest performance counter"},
 
   {"_ceph_get_perf_schema", (PyCFunction)get_perf_schema, METH_VARARGS,
     "Get the performance counter schema"},

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -289,11 +289,6 @@ void DaemonPerfCounters::update(MMgrReport *report)
   DECODE_FINISH(p);
 }
 
-uint64_t PerfCounterInstance::get_current() const
-{
-  return buffer.front().v;
-}
-
 void PerfCounterInstance::push(utime_t t, uint64_t const &v)
 {
   buffer.push_back({t, v});

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -74,9 +74,17 @@ class PerfCounterInstance
   {
     return buffer;
   }
+  const DataPoint& get_latest_data() const
+  {
+    return buffer.back();
+  }
   const boost::circular_buffer<AvgDataPoint> & get_data_avg() const
   {
     return avg_buffer;
+  }
+  const AvgDataPoint& get_latest_data_avg() const
+  {
+    return avg_buffer.back();
   }
   void push(utime_t t, uint64_t const &v);
   void push_avg(utime_t t, uint64_t const &s, uint64_t const &c);

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -30,6 +30,8 @@
 class PyFormatter : public ceph::Formatter
 {
 public:
+  PyFormatter (const PyFormatter&) = delete;
+  PyFormatter& operator= (const PyFormatter&) = delete;
   PyFormatter(bool pretty = false, bool array = false)
   {
     // It is forbidden to instantiate me outside of the GIL,


### PR DESCRIPTION
Instead of getting all counters and and selecting the last one in python land, add a get_latest_counter in C++ land.
