### PR TITLE
crush/CrushWrapper: fix crush tree json dumper

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -3131,7 +3131,19 @@ public:
     f->open_array_section("nodes");
     Parent::dump(f);
     f->close_section();
+
+    // There is no stray bucket whose id is a negative number, so just get
+    // the max_id and iterate from 0 to max_id to dump stray osds.
     f->open_array_section("stray");
+    int32_t max_id = -1;
+    if (!crush->name_map.empty()) {
+      max_id = crush->name_map.rbegin()->first;
+    }
+    for (int32_t i = 0; i <= max_id; i++) {
+      if (crush->item_exists(i) && !is_touched(i) && should_dump(i)) {
+        dump_item(CrushTreeDumper::Item(i, 0, 0, 0), f);
+      }
+    }
     f->close_section();
   }
 };

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5437,10 +5437,12 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
     bool show_shadow = shadow == "--show-shadow";
     boost::scoped_ptr<Formatter> f(Formatter::create(format));
     if (f) {
+      f->open_object_section("crush_tree");
       osdmap.crush->dump_tree(nullptr,
                               f.get(),
                               osdmap.get_pool_names(),
                               show_shadow);
+      f->close_section();
       f->flush(rdata);
     } else {
       ostringstream ss;


### PR DESCRIPTION
Fix the problems commented by @tchaikov https://github.com/ceph/ceph/pull/23319#discussion_r207565792. See the previous PR https://github.com/ceph/ceph/pull/23319 or refer to the issue https://tracker.ceph.com/issues/25153. 

Signed-off-by: Oshyn Song dualyangsong@gmail.com