### PR TITLE
vstart: set admin socket for RGW in conf

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -525,6 +525,7 @@ EOF
 $extra_conf
 [client.rgw]
         rgw frontends = $rgw_frontend port=$CEPH_RGW_PORT
+        admin socket = ${CEPH_OUT_DIR}/radosgw.${CEPH_RGW_PORT}.asok
         ; needed for s3tests
         rgw crypt s3 kms encryption keys = testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
         rgw crypt require ssl = false


### PR DESCRIPTION
Currently ceph daemon cannot find rgw socket as client section sets the admin
socket to the tmp dir. whereas we actually write the socket in the out/
directory. Add this to ceph.conf, so that `ceph daemon` commands can find the
socket, avoiding the need for explicit path via `--admin-daemon`. When multiple
RGWs are created ceph daemon will only find the first configured RGW (as we are
only configuring one RGW per ceph.conf) and the others will have to be
explicitly passed via --admin-daemon or so.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>



