### PR TITLE
rgw: fix leak of curl handle on shutdown

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -1165,14 +1165,14 @@ void *RGWHTTPManager::reqs_thread_entry()
 
   RWLock::WLocker rl(reqs_lock);
   for (auto r : unregistered_reqs) {
-    _finish_request(r, -ECANCELED);
+    _unlink_request(r);
   }
 
   unregistered_reqs.clear();
 
   auto all_reqs = std::move(reqs);
   for (auto iter : all_reqs) {
-    _finish_request(iter.second, -ECANCELED);
+    _unlink_request(iter.second);
   }
 
   reqs.clear();


### PR DESCRIPTION
addresses a valgrind leak reported from curl_multi_add_handle(). requests that are still linked to the curl_multi handle need to be unlinked and finished with ECANCELED, rather than just finished

Fixes: http://tracker.ceph.com/issues/35715