### PR TITLE
rgw: dont access rgw_http_req_data::client of canceled request

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -292,13 +292,6 @@ size_t RGWHTTPClient::receive_http_data(void * const ptr,
 
   bool pause = false;
 
-  size_t& skip_bytes = req_data->client->receive_pause_skip;
-
-  if (skip_bytes >= len) {
-    skip_bytes -= len;
-    return len;
-  }
-
   RGWHTTPClient *client;
 
   {
@@ -308,6 +301,13 @@ size_t RGWHTTPClient::receive_http_data(void * const ptr,
     }
 
     client = req_data->client;
+  }
+
+  size_t& skip_bytes = client->receive_pause_skip;
+
+  if (skip_bytes >= len) {
+    skip_bytes -= len;
+    return len;
   }
 
   int ret = client->receive_data((char *)ptr + skip_bytes, len - skip_bytes, &pause);


### PR DESCRIPTION
if a request has been canceled with RGWHTTPClient::cancel(), the client may have been destroyed. check req_data->registered before reading from req_data->client->receive_pause_skip

Fixes: http://tracker.ceph.com/issues/35851