### PR TITLE
librados: Include memory for unique_ptr definition

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <list>
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 #include <utility>


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/35833

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

