### PR TITLE
rgw: implement sts access key expire

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -961,3 +961,104 @@ int CLSRGWIssueSetBucketResharding::issue_op(int shard_id, const string& oid)
   return issue_set_bucket_resharding(io_ctx, oid, entry, &manager);
 }
 
+int cls_rgw_sts_get_head(IoCtx& io_ctx, string& oid, cls_rgw_sts_obj_head& head)
+{
+  bufferlist in, out;
+  int r = io_ctx.exec(oid, RGW_CLASS, RGW_STS_GET_HEAD, in, out);
+  if (r < 0)
+    return r;
+
+  cls_rgw_sts_get_head_ret ret;
+  try {
+    auto iter = out.cbegin();
+    decode(ret, iter);
+  } catch (buffer::error& err) {
+    return -EIO;
+  }
+  head = ret.head;
+
+ return r;
+}
+
+int cls_rgw_sts_put_head(IoCtx& io_ctx, string& oid, cls_rgw_sts_obj_head& head)
+{
+  bufferlist in, out;
+  cls_rgw_sts_put_head_op call;
+  call.head = head;
+  encode(call, in);
+  int r = io_ctx.exec(oid, RGW_CLASS, RGW_STS_PUT_HEAD, in, out);
+  return r;
+}
+
+int cls_rgw_sts_get_next_entry(IoCtx& io_ctx, string& oid, string& marker, pair<string, int>& entry)
+{
+  bufferlist in, out;
+  cls_rgw_sts_get_next_entry_op call;
+  call.marker = marker;
+  encode(call, in);
+  int r = io_ctx.exec(oid, RGW_CLASS, RGW_STS_GET_NEXT_ENTRY, in, out);
+  if (r < 0)
+    return r;
+
+  cls_rgw_sts_get_next_entry_ret ret;
+  try {
+    auto iter = out.cbegin();
+    decode(ret, iter);
+  } catch (buffer::error& err) {
+    return -EIO;
+  }
+  entry = ret.entry;
+
+ return r;
+}
+
+int cls_rgw_sts_rm_entry(IoCtx& io_ctx, string& oid, pair<string, int>& entry)
+{
+  bufferlist in, out;
+  cls_rgw_sts_rm_entry_op call;
+  call.entry = entry;
+  encode(call, in);
+  int r = io_ctx.exec(oid, RGW_CLASS, RGW_STS_RM_ENTRY, in, out);
+ return r;
+}
+
+int cls_rgw_sts_set_entry(IoCtx& io_ctx, string& oid, pair<string, int>& entry)
+{
+  bufferlist in, out;
+  cls_rgw_sts_set_entry_op call;
+  call.entry = entry;
+  encode(call, in);
+  int r = io_ctx.exec(oid, RGW_CLASS, RGW_STS_SET_ENTRY, in, out);
+  return r;
+}
+
+int cls_rgw_sts_list(IoCtx& io_ctx, string& oid,
+                    const string& marker,
+                    uint32_t max_entries,
+                    map<string, int>& entries)
+{
+  bufferlist in, out;
+  cls_rgw_sts_list_entries_op op;
+
+  entries.clear();
+
+  op.marker = marker;
+  op.max_entries = max_entries;
+
+  encode(op, in);
+
+  int r = io_ctx.exec(oid, RGW_CLASS, RGW_STS_LIST_ENTRIES, in, out);
+  if (r < 0)
+    return r;
+
+  cls_rgw_sts_list_entries_ret ret;
+  try {
+    auto iter = out.cbegin();
+    decode(ret, iter);
+  } catch (buffer::error& err) {
+    return -EIO;
+  }
+  entries.insert(ret.entries.begin(),ret.entries.end());
+
+ return r;
+}

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -545,4 +545,16 @@ void cls_rgw_guard_bucket_resharding(librados::ObjectOperation& op, int ret_err)
 int cls_rgw_get_bucket_resharding(librados::IoCtx& io_ctx, const string& oid,
                                   cls_rgw_bucket_instance_entry *entry);
 
+/* sts */
+int cls_rgw_sts_get_head(librados::IoCtx& io_ctx, string& oid, cls_rgw_sts_obj_head& head);
+int cls_rgw_sts_put_head(librados::IoCtx& io_ctx, string& oid, cls_rgw_sts_obj_head& head);
+int cls_rgw_sts_get_next_entry(librados::IoCtx& io_ctx, string& oid, string& marker, pair<string, int>& entry);
+int cls_rgw_sts_rm_entry(librados::IoCtx& io_ctx, string& oid, pair<string, int>& entry);
+int cls_rgw_sts_set_entry(librados::IoCtx& io_ctx, string& oid, pair<string, int>& entry);
+int cls_rgw_sts_list(librados::IoCtx& io_ctx, string& oid,
+                    const string& marker,
+                    uint32_t max_entries,
+                    map<string, int>& entries);
+
+
 #endif

--- a/src/cls/rgw/cls_rgw_const.h
+++ b/src/cls/rgw/cls_rgw_const.h
@@ -55,5 +55,12 @@
 #define RGW_LC_GET_HEAD "lc_get_head"
 #define RGW_LC_LIST_ENTRIES "lc_list_entries"
 
+/* sts */
+#define RGW_STS_SET_ENTRY "sts_set_entry"
+#define RGW_STS_RM_ENTRY "sts_rm_entry"
+#define RGW_STS_GET_NEXT_ENTRY "sts_get_next_entry"
+#define RGW_STS_PUT_HEAD "sts_put_head"
+#define RGW_STS_GET_HEAD "sts_get_head"
+#define RGW_STS_LIST_ENTRIES "sts_list_entries"
 
 #endif

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1375,4 +1375,168 @@ struct cls_rgw_get_bucket_resharding_ret  {
 };
 WRITE_CLASS_ENCODER(cls_rgw_get_bucket_resharding_ret)
 
+struct cls_rgw_sts_get_next_entry_op {
+  string marker;
+  cls_rgw_sts_get_next_entry_op() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(marker, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(marker, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_rgw_sts_get_next_entry_op)
+
+struct cls_rgw_sts_get_next_entry_ret {
+  pair<string, int> entry;
+
+  cls_rgw_sts_get_next_entry_ret() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(entry, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(entry, bl);
+    DECODE_FINISH(bl);
+  }
+
+};
+WRITE_CLASS_ENCODER(cls_rgw_sts_get_next_entry_ret)
+
+struct cls_rgw_sts_rm_entry_op {
+  pair<string, int> entry;
+  cls_rgw_sts_rm_entry_op() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(entry, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(entry, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_rgw_sts_rm_entry_op)
+
+struct cls_rgw_sts_set_entry_op {
+  pair<string, int> entry;
+  cls_rgw_sts_set_entry_op() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(entry, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(entry, bl);
+    DECODE_FINISH(bl);
+  }
+};
+WRITE_CLASS_ENCODER(cls_rgw_sts_set_entry_op)
+
+struct cls_rgw_sts_put_head_op {
+  cls_rgw_sts_obj_head head;
+
+
+  cls_rgw_sts_put_head_op() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(head, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(head, bl);
+    DECODE_FINISH(bl);
+  }
+
+};
+WRITE_CLASS_ENCODER(cls_rgw_sts_put_head_op)
+
+struct cls_rgw_sts_get_head_ret {
+  cls_rgw_sts_obj_head head;
+
+  cls_rgw_sts_get_head_ret() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(head, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(head, bl);
+    DECODE_FINISH(bl);
+  }
+
+};
+WRITE_CLASS_ENCODER(cls_rgw_sts_get_head_ret)
+
+struct cls_rgw_sts_list_entries_op {
+  string marker;
+  uint32_t max_entries = 0;
+
+  cls_rgw_sts_list_entries_op() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(marker, bl);
+    encode(max_entries, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    decode(marker, bl);
+    decode(max_entries, bl);
+    DECODE_FINISH(bl);
+  }
+
+};
+WRITE_CLASS_ENCODER(cls_rgw_sts_list_entries_op)
+
+struct cls_rgw_sts_list_entries_ret {
+  map<string, int> entries;
+  bool is_truncated{false};
+
+  cls_rgw_sts_list_entries_ret() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(2, 1, bl);
+    encode(entries, bl);
+    encode(is_truncated, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(2, bl);
+    decode(entries, bl);
+    if (struct_v >= 2) {
+      decode(is_truncated, bl);
+    }
+    DECODE_FINISH(bl);
+  }
+
+};
+WRITE_CLASS_ENCODER(cls_rgw_sts_list_entries_ret)
+
+
 #endif /* CEPH_CLS_RGW_OPS_H */

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1123,4 +1123,34 @@ struct cls_rgw_reshard_entry
 };
 WRITE_CLASS_ENCODER(cls_rgw_reshard_entry)
 
+struct cls_rgw_sts_obj_head
+{
+  time_t start_date = 0;
+  string marker;
+
+  cls_rgw_sts_obj_head() {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    uint64_t t = start_date;
+    encode(t, bl);
+    encode(marker, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::const_iterator& bl) {
+    DECODE_START(1, bl);
+    uint64_t t;
+    decode(t, bl);
+    start_date = static_cast<time_t>(t);
+    decode(marker, bl);
+    DECODE_FINISH(bl);
+  }
+
+  void dump(Formatter *f) const;
+};
+
+WRITE_CLASS_ENCODER(cls_rgw_sts_obj_head)
+
+
 #endif

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1281,6 +1281,7 @@ OPTION(rgw_bucket_index_max_aio, OPT_U32)
 OPTION(rgw_enable_quota_threads, OPT_BOOL)
 OPTION(rgw_enable_gc_threads, OPT_BOOL)
 OPTION(rgw_enable_lc_threads, OPT_BOOL)
+OPTION(rgw_enable_sts_threads, OPT_BOOL)
 
 
 OPTION(rgw_data, OPT_STR)
@@ -1299,6 +1300,10 @@ OPTION(rgw_lc_lock_max_time, OPT_INT)  // total run time for a single lc process
 OPTION(rgw_lc_max_objs, OPT_INT)
 OPTION(rgw_lc_max_rules, OPT_U32)  // Max rules set on one bucket
 OPTION(rgw_lc_debug_interval, OPT_INT)  // Debug run interval, in seconds
+OPTION(rgw_sts_work_time, OPT_STR) //job process sts  at 00:00-24:00s
+OPTION(rgw_sts_lock_max_time, OPT_INT)  // total run time for a single sts processor work
+OPTION(rgw_sts_max_objs, OPT_INT)
+OPTION(rgw_sts_debug_interval, OPT_INT)  // Debug run interval, in seconds
 OPTION(rgw_script_uri, OPT_STR) // alternative value for SCRIPT_URI if not set in request
 OPTION(rgw_request_uri, OPT_STR) // alternative value for REQUEST_URI if not set in request
 OPTION(rgw_ignore_get_invalid_range, OPT_BOOL) // treat invalid (e.g., negative) range requests as full

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5082,6 +5082,12 @@ std::vector<Option> get_rgw_options() {
         "some of the maintenance work between them.")
     .add_see_also({"rgw_enable_gc_threads", "rgw_enable_quota_threads"}),
 
+    Option("rgw_enable_sts_threads", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Enables the sts maintenance thread. This is required on at least one rgw for each zone.")
+    .set_long_description("")
+    .add_see_also({"rgw_enable_gc_threads", "rgw_enable_lc_threads", "rgw_enable_quota_threads"}),
+
     Option("rgw_data", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("/var/lib/ceph/radosgw/$cluster-$id")
     .set_flag(Option::FLAG_NO_MON_UPDATE)
@@ -5187,6 +5193,31 @@ std::vector<Option> get_rgw_options() {
     .set_long_description("Number of lifecycle rules set on one bucket should be limited."),
 
     Option("rgw_lc_debug_interval", Option::TYPE_INT, Option::LEVEL_DEV)
+    .set_default(-1)
+    .set_description(""),
+
+    Option("rgw_sts_work_time", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("00:00-24:00")
+    .set_description("STS allowed work time")
+    .set_long_description("Local time window in which the sts maintenance thread can work."),
+
+    Option("rgw_sts_lock_max_time", Option::TYPE_INT, Option::LEVEL_DEV)
+    .set_default(30)
+    .set_description(""),
+
+    Option("rgw_sts_thread_delay", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("Delay after processing of sts (i.e., per 1000 entries) in milliseconds"),
+
+    Option("rgw_sts_max_objs", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(32)
+    .set_description("Number of sts data shards")
+    .set_long_description(
+          "Number of RADOS objects to use for storing sts index. This can affect "
+          "concurrency of sts maintenance, but requires multiple RGW processes "
+          "running on the zone to be utilized."),
+
+    Option("rgw_sts_debug_interval", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(-1)
     .set_description(""),
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -61,6 +61,7 @@ set(librgw_common_srcs
   rgw_keystone.cc
   rgw_ldap.cc
   rgw_lc.cc
+  rgw_sts.cc
   rgw_lc_s3.cc
   rgw_metadata.cc
   rgw_multi.cc

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -493,6 +493,7 @@ namespace rgw {
     store = RGWStoreManager::get_storage(g_ceph_context,
 					 g_conf()->rgw_enable_gc_threads,
 					 g_conf()->rgw_enable_lc_threads,
+					 g_conf()->rgw_enable_sts_threads,
 					 g_conf()->rgw_enable_quota_threads,
 					 g_conf()->rgw_run_sync_thread,
 					 g_conf()->rgw_dynamic_resharding);

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -119,6 +119,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_NOT_IMPLEMENTED, {501, "NotImplemented" }},
     { ERR_SERVICE_UNAVAILABLE, {503, "ServiceUnavailable"}},
     { ERR_ZERO_IN_URL, {400, "InvalidRequest" }},
+    { ERR_STS_SET, {503, "ServiceUnavailable" }},
 });
 
 rgw_http_errors rgw_http_swift_errors({

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -221,6 +221,7 @@ using ceph::crypto::MD5;
 #define ERR_NO_CORS_FOUND        2216
 
 #define ERR_BUSY_RESHARDING      2300
+#define ERR_STS_SET      2400
 
 #ifndef UINT32_MAX
 #define UINT32_MAX (0xffffffffu)

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -299,7 +299,7 @@ int main(int argc, const char **argv)
 #endif
 
   RGWRados *store = RGWStoreManager::get_storage(g_ceph_context,
-      g_conf()->rgw_enable_gc_threads, g_conf()->rgw_enable_lc_threads, g_conf()->rgw_enable_quota_threads,
+      g_conf()->rgw_enable_gc_threads, g_conf()->rgw_enable_lc_threads, g_conf()->rgw_enable_sts_threads, g_conf()->rgw_enable_quota_threads,
       g_conf()->rgw_run_sync_thread, g_conf()->rgw_dynamic_resharding, g_conf()->rgw_cache_enabled);
   if (!store) {
     mutex.Lock();

--- a/src/rgw/rgw_object_expirer.cc
+++ b/src/rgw/rgw_object_expirer.cc
@@ -81,7 +81,7 @@ int main(const int argc, const char **argv)
 
   common_init_finish(g_ceph_context);
 
-  store = RGWStoreManager::get_storage(g_ceph_context, false, false, false, false, false);
+  store = RGWStoreManager::get_storage(g_ceph_context, false, false, false, false, false, false);
   if (!store) {
     std::cerr << "couldn't init storage provider" << std::endl;
     return EIO;

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -103,6 +103,7 @@ void RGWRealmReloader::reload()
     store = RGWStoreManager::get_storage(cct,
                                          cct->_conf->rgw_enable_gc_threads,
                                          cct->_conf->rgw_enable_lc_threads,
+                                         cct->_conf->rgw_enable_sts_threads,
                                          cct->_conf->rgw_enable_quota_threads,
                                          cct->_conf->rgw_run_sync_thread,
                                          cct->_conf->rgw_dynamic_resharding,

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -500,6 +500,8 @@ void RGWOp_Key_Create::execute()
   std::string access_key;
   std::string secret_key;
   std::string key_type_str;
+  bool sts;
+  int64_t sts_expire;
 
   bool gen_key;
 
@@ -513,11 +515,15 @@ void RGWOp_Key_Create::execute()
   RESTArgs::get_string(s, "secret-key", secret_key, &secret_key);
   RESTArgs::get_string(s, "key-type", key_type_str, &key_type_str);
   RESTArgs::get_bool(s, "generate-key", true, &gen_key);
+  RESTArgs::get_bool(s, "sts", false, &sts);
+  RESTArgs::get_int64(s, "expire", 0, &sts_expire);
 
   op_state.set_user_id(uid);
   op_state.set_subuser(subuser);
   op_state.set_access_key(access_key);
   op_state.set_secret_key(secret_key);
+  op_state.set_sts(sts);
+  op_state.set_expire(sts_expire);
 
   if (gen_key)
     op_state.set_generate_key();

--- a/src/rgw/rgw_sts.cc
+++ b/src/rgw/rgw_sts.cc
@@ -1,0 +1,355 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <string.h>
+#include <iostream>
+#include <map>
+
+#include <boost/algorithm/string/split.hpp>
+#include <boost/algorithm/string.hpp>
+
+#include "common/Formatter.h"
+#include <common/errno.h>
+#include "include/random.h"
+#include "cls/rgw/cls_rgw_client.h"
+#include "cls/lock/cls_lock_client.h"
+#include "rgw_common.h"
+#include "rgw_bucket.h"
+#include "rgw_sts.h"
+#include "rgw_user.h"
+#include "rgw_rest_user.h"
+
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rgw
+
+using namespace librados;
+
+void *RGWSTS::STSWorker::entry() {
+  do {
+    utime_t start = ceph_clock_now();
+    if (should_work(start)) {
+      ldout(cct, 2) << "sts: start" << dendl;
+      int r = sts->process();
+      if (r < 0) {
+        ldout(cct, 0) << "ERROR: do sts process() returned error r=" << r << dendl;
+      }
+      ldout(cct, 2) << "sts: stop" << dendl;
+    }
+    if (sts->going_down())
+      break;
+
+    utime_t end = ceph_clock_now();
+    int secs = schedule_next_start_time(start, end);
+    utime_t next;
+    next.set_from_double(end + secs);
+
+    ldout(cct, 5) << "schedule sts next start time: " << rgw_to_asctime(next) << dendl;
+
+    lock.Lock();
+    cond.WaitInterval(lock, utime_t(secs, 0));
+    lock.Unlock();
+  } while (!sts->going_down());
+
+  return NULL;
+}
+
+void RGWSTS::initialize(CephContext *_cct, RGWRados *_store) {
+  cct = _cct;
+  store = _store;
+  max_objs = 32;  //cct->_conf->rgw_sts_max_objs;
+  if (max_objs > HASH_PRIME)
+    max_objs = HASH_PRIME;
+
+  obj_names = new string[max_objs];
+
+  for (int i = 0; i < max_objs; i++) {
+    obj_names[i] = sts_oid_prefix;
+    char buf[32];
+    snprintf(buf, 32, ".%d", i);
+    obj_names[i].append(buf);
+  }
+
+#define COOKIE_LEN 16
+  char cookie_buf[COOKIE_LEN + 1];
+  gen_rand_alphanumeric(cct, cookie_buf, sizeof(cookie_buf) - 1);
+  cookie = cookie_buf;
+}
+
+void RGWSTS::finalize()
+{
+  delete[] obj_names;
+}
+
+bool RGWSTS::if_already_run_today(time_t& start_date)
+{
+  struct tm bdt;
+  time_t begin_of_day;
+  utime_t now = ceph_clock_now();
+  localtime_r(&start_date, &bdt);
+
+  if (cct->_conf->rgw_sts_debug_interval > 0) {
+    if (now - start_date < cct->_conf->rgw_lc_debug_interval)
+      return true;
+    else
+      return false;
+  }
+
+  bdt.tm_hour = 0;
+  bdt.tm_min = 0;
+  bdt.tm_sec = 0;
+  begin_of_day = mktime(&bdt);
+  if (now - begin_of_day < 24*60*60)
+    return true;
+  else
+    return false;
+}
+
+int RGWSTS::user_sts_process(const string& access_key, int64_t expire)
+{
+  if (expire <= ceph_clock_now().sec()) {
+    string uid_str;
+    string subuser;
+    string key_type_str;
+    rgw_user uid(uid_str);
+
+    RGWUserAdminOpState op_state;
+    op_state.set_user_id(uid);
+    op_state.set_subuser(subuser);
+    op_state.set_access_key(access_key);
+    op_state.set_key_type(KEY_TYPE_S3);
+
+    RGWRESTFlusher flusher;
+    int http_ret = RGWUserAdminOp_Key::remove(store, op_state, flusher);
+    if ( http_ret < 0) {
+      ldout(cct, 0) << "RGWSTS remove key failed, http_ret: " << http_ret  << dendl; 
+      return 0;
+    }
+    return -ENOENT;
+  }
+  return 0;
+}
+
+int RGWSTS::user_sts_post(int index, int max_lock_sec, pair<string, int >& entry, int& result)
+{
+  utime_t lock_duration(cct->_conf->rgw_sts_lock_max_time, 0);
+
+  rados::cls::lock::Lock l(sts_index_lock_name);
+  l.set_cookie(cookie);
+  l.set_duration(lock_duration);
+
+  do {
+    int ret = l.lock_exclusive(&store->sts_pool_ctx, obj_names[index]);
+    if (ret == -EBUSY) { /* already locked by another sts processor */
+      ldout(cct, 0) << "RGWSTS::user_sts_post() failed to acquire lock on "
+          << obj_names[index] << ", sleep 5, try again" << dendl;
+      sleep(5);
+      continue;
+    }
+    if (ret < 0)
+      return 0;
+    ldout(cct, 20) << "RGWSTS::user_sts_post() lock " << obj_names[index] << dendl;
+    if (result ==  -ENOENT) {
+      ret = cls_rgw_sts_rm_entry(store->sts_pool_ctx, obj_names[index],  entry);
+      if (ret < 0) {
+        ldout(cct, 0) << "RGWSTS::user_sts_post() failed to remove entry "
+            << obj_names[index] << dendl;
+      }
+      goto clean;
+    } 
+
+clean:
+    l.unlock(&store->sts_pool_ctx, obj_names[index]);
+    ldout(cct, 20) << "RGWSTS::user_sts_post() unlock " << obj_names[index] << dendl;
+    return 0;
+  } while (true);
+}
+
+int RGWSTS::list_sts_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map)
+{
+  int index = 0;
+  progress_map->clear();
+  for(; index <max_objs; index++) {
+    map<string, int > entries;
+    int ret = cls_rgw_sts_list(store->sts_pool_ctx, obj_names[index], marker, max_entries, entries);
+    if (ret < 0) {
+      if (ret == -ENOENT) {
+        ldout(cct, 10) << __func__ << "() ignoring unfound sts object="
+                             << obj_names[index] << dendl;
+        continue;
+      } else {
+        return ret;
+      }
+    }
+    map<string, int>::iterator iter;
+    for (iter = entries.begin(); iter != entries.end(); ++iter) {
+      progress_map->insert(*iter);
+    }
+  }
+  return 0;
+}
+
+int RGWSTS::process()
+{
+  int max_secs = cct->_conf->rgw_lc_lock_max_time;
+
+  const int start = ceph::util::generate_random_number(0, max_objs - 1);
+
+  for (int i = 0; i < max_objs; i++) {
+    int index = (i + start) % max_objs;
+    int ret = process(index, max_secs);
+    if (ret < 0)
+      return ret;
+  }
+
+  return 0;
+}
+
+int RGWSTS::process(int index, int max_lock_secs)
+{
+  rados::cls::lock::Lock l(sts_index_lock_name);
+  do {
+    utime_t now = ceph_clock_now();
+    pair<string, int> entry;
+    if (max_lock_secs <= 0)
+      return -EAGAIN;
+
+    utime_t time(max_lock_secs, 0);
+    l.set_duration(time);
+
+    int ret = l.lock_exclusive(&store->sts_pool_ctx, obj_names[index]);
+    if (ret == -EBUSY) { /* already locked by another sts processor */
+      ldout(cct, 0) << "RGWSTS::process() failed to acquire lock on "
+          << obj_names[index] << ", sleep 5, try again" << dendl;
+      sleep(5);
+      continue;
+    }
+    if (ret < 0)
+      return 0;
+
+    cls_rgw_sts_obj_head head;
+    ret = cls_rgw_sts_get_head(store->sts_pool_ctx, obj_names[index], head);
+    if (ret < 0) {
+      ldout(cct, 0) << "RGWSTS::process() failed to get obj head "
+          << obj_names[index] << ", ret=" << ret << dendl;
+      goto exit;
+    }
+
+    if(!if_already_run_today(head.start_date)) {
+      head.start_date = now;
+      head.marker.clear();
+      if (ret < 0) {
+      ldout(cct, 0) << "RGWSTS::process() failed to update sts object "
+          << obj_names[index] << ", ret=" << ret << dendl;
+      goto exit;
+      }
+    }
+
+    ret = cls_rgw_sts_get_next_entry(store->sts_pool_ctx, obj_names[index], head.marker, entry);
+    if (ret < 0) {
+      ldout(cct, 0) << "RGWSTS::process() failed to get obj entry "
+          << obj_names[index] << dendl;
+      goto exit;
+    }
+
+    if (entry.first.empty())
+      goto exit;
+
+    head.marker = entry.first;
+    ret = cls_rgw_sts_put_head(store->sts_pool_ctx, obj_names[index],  head);
+    if (ret < 0) {
+      ldout(cct, 0) << "RGWSTS::process() failed to put head " << obj_names[index] << dendl;
+      goto exit;
+    }
+    l.unlock(&store->sts_pool_ctx, obj_names[index]);
+    ret = user_sts_process(entry.first, entry.second);
+    user_sts_post(index, max_lock_secs, entry, ret);
+  }while(1);
+
+exit:
+    l.unlock(&store->sts_pool_ctx, obj_names[index]);
+    return 0;
+}
+
+void RGWSTS::start_processor()
+{
+  worker = new STSWorker(cct, this);
+  worker->create("sts_thr");
+}
+
+void RGWSTS::stop_processor()
+{
+  down_flag = true;
+  if (worker) {
+    worker->stop();
+    worker->join();
+  }
+  delete worker;
+  worker = NULL;
+}
+
+void RGWSTS::STSWorker::stop()
+{
+  Mutex::Locker l(lock);
+  cond.Signal();
+}
+
+bool RGWSTS::going_down()
+{
+  return down_flag;
+}
+
+bool RGWSTS::STSWorker::should_work(utime_t& now)
+{
+  int start_hour;
+  int start_minute;
+  int end_hour;
+  int end_minute;
+  string worktime = cct->_conf->rgw_sts_work_time;
+  sscanf(worktime.c_str(),"%d:%d-%d:%d",&start_hour, &start_minute, &end_hour, &end_minute);
+  struct tm bdt;
+  time_t tt = now.sec();
+  localtime_r(&tt, &bdt);
+
+  if (cct->_conf->rgw_sts_debug_interval > 0) {
+	  /* We're debugging, so say we can run */
+	  return true;
+  } else if ((bdt.tm_hour*60 + bdt.tm_min >= start_hour*60 + start_minute) &&
+		     (bdt.tm_hour*60 + bdt.tm_min <= end_hour*60 + end_minute)) {
+	  return true;
+  } else {
+	  return false;
+  }
+
+}
+
+int RGWSTS::STSWorker::schedule_next_start_time(utime_t &start, utime_t& now)
+{
+  int secs;
+
+  if (cct->_conf->rgw_sts_debug_interval > 0) {
+	secs = start + cct->_conf->rgw_sts_debug_interval - now;
+	if (secs < 0)
+	  secs = 0;
+	return (secs);
+  }
+
+  int start_hour;
+  int start_minute;
+  int end_hour;
+  int end_minute;
+  string worktime = cct->_conf->rgw_sts_work_time;
+  sscanf(worktime.c_str(),"%d:%d-%d:%d",&start_hour, &start_minute, &end_hour, &end_minute);
+  struct tm bdt;
+  time_t tt = now.sec();
+  time_t nt;
+  localtime_r(&tt, &bdt);
+  bdt.tm_hour = start_hour;
+  bdt.tm_min = start_minute;
+  bdt.tm_sec = 0;
+  nt = mktime(&bdt);
+  secs = nt - tt;
+
+  return secs>0 ? secs : secs+24*60*60;
+}
+

--- a/src/rgw/rgw_sts.h
+++ b/src/rgw/rgw_sts.h
@@ -1,0 +1,73 @@
+#ifndef CEPH_RGW_STS_H
+#define CEPH_RGW_STS_H
+
+#include <map>
+#include <string>
+#include <iostream>
+
+#include "common/debug.h"
+
+#include "include/types.h"
+#include "include/rados/librados.hpp"
+#include "common/Mutex.h"
+#include "common/Cond.h"
+#include "common/iso_8601.h"
+#include "common/Thread.h"
+#include "rgw_common.h"
+#include "rgw_rados.h"
+#include "rgw_multi.h"
+#include "cls/rgw/cls_rgw_types.h"
+#include "rgw_tag.h"
+
+#include <atomic>
+
+#define HASH_PRIME 7877
+#define MAX_ID_LEN 255
+static string sts_oid_prefix = "sts";
+static string sts_index_lock_name = "sts_process";
+
+class RGWSTS {
+  CephContext *cct;
+  RGWRados *store;
+  int max_objs{0};
+  string *obj_names{nullptr};
+  std::atomic<bool> down_flag = { false };
+  string cookie;
+
+  class STSWorker : public Thread {
+    CephContext *cct;
+    RGWSTS *sts;
+    Mutex lock;
+    Cond cond;
+
+  public:
+    STSWorker(CephContext *_cct, RGWSTS *_sts) : cct(_cct), sts(_sts), lock("STSWorker") {}
+    void *entry() override;
+    void stop();
+    bool should_work(utime_t& now);
+    int schedule_next_start_time(utime_t& start, utime_t& now);
+  };
+  
+  public:
+  STSWorker *worker;
+  RGWSTS() : cct(NULL), store(NULL), worker(NULL) {}
+  ~RGWSTS() {
+    stop_processor();
+    finalize();
+  }
+
+  void initialize(CephContext *_cct, RGWRados *_store);
+  void finalize();
+
+  int process();
+  int process(int index, int max_secs);
+  bool if_already_run_today(time_t& start_date);
+  int list_sts_progress(const string& marker, uint32_t max_entries, map<string, int> *progress_map);
+  int user_sts_process(const string& access_key, int64_t expire);
+  int user_sts_post(int index, int max_lock_sec, pair<string, int >& entry, int& result);
+  bool going_down();
+  void start_processor();
+  void stop_processor();
+};
+
+#endif

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -225,6 +225,8 @@ struct RGWUserAdminOpState {
 
   RGWQuotaInfo bucket_quota;
   RGWQuotaInfo user_quota;
+  bool sts;
+  int64_t sts_expire;
 
   void set_access_key(const std::string& access_key) {
     if (access_key.empty())
@@ -362,6 +364,14 @@ struct RGWUserAdminOpState {
   void set_gen_secret() {
     gen_secret = true;
     key_op = true;
+  }
+
+  void set_sts(bool _sts) {
+    sts = _sts; 
+  }
+
+  void set_expire(int64_t _sts_expire) {
+    sts_expire = _sts_expire; 
   }
 
   void set_generate_key() {

--- a/src/test/test_rgw_admin_opstate.cc
+++ b/src/test/test_rgw_admin_opstate.cc
@@ -808,7 +808,7 @@ int main(int argc, char *argv[]){
 			 CODE_ENVIRONMENT_UTILITY,
 			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
-  store = RGWStoreManager::get_storage(g_ceph_context, false, false, false, false, false);
+  store = RGWStoreManager::get_storage(g_ceph_context, false, false, false, false, false, false);
   g_test = new admin_log::test_helper();
   finisher = new Finisher(g_ceph_context);
 #ifdef GTEST


### PR DESCRIPTION
implement sts access key expire

```
 ./bin/rados -p default.rgw.log ls  --namespace=sts  -c cluster1/ceph.conf
sts.6
sts.10
sts.15
sts.17
sts.21
sts.3
sts.8
sts.2
sts.14
...
```
each sts.n object have key=access_key and value=expire

a sts thread will scan those and remove the key-value expired


step1. create tmp access key and secret key
```
< PUT /admin/user?key&format=json&uid=cyf&sts=true&expire=1536538784 HTTP/1.1
< Host: 127.0.0.1:8080
< Connection: keep-alive
< Accept-Encoding: gzip, deflate
< Accept: */*
< User-Agent: python-requests/2.19.1
< Content-Length: 0
< date: Mon, 10 Sep 2018 00:18:54 GMT
< Authorization: AWS admin:hnlj51a2sfswVjcb36E0F5finxM=
<

> HTTP/1.1 200 OK
> x-amz-request-id: tx000000000000000000001-005b95b86e-39e0-default
> Content-Length: 215
> Date: Mon, 10 Sep 2018 00:18:54 GMT
> Connection: Keep-Alive
>
[{"user":"cyf","access_key":"1FI10KAT3E6G3KBLKXPB","secret_key":"XfmdftvZwzZ2vIcxWCWv5ftGcCvBssLMlicCYpUq"},{"user":"cyf","access_key":"535ZCTB1B82O9173XCCF","secret_key":"z2JD2Vq99yY0TuMEd9Q

 response as:

{
...
    "keys": [
        {
            "user": "cyf",
            "access_key": "1FI10KAT3E6G3KBLKXPB",
            "secret_key": "XfmdftvZwzZ2vIcxWCWv5ftGcCvBssLMlicCYpUq"
        },
        {
            "user": "cyf",
            "access_key": "535ZCTB1B82O9173XCCF",
            "secret_key": "z2JD2Vq99yY0TuMEd9QErNhNFqztLsKm3nm8LfOG"
        }
    ],



./bin/radosgw-admin sts list -c cluster1/ceph.conf
[
    {
        "access_key": "1FI10KAT3E6G3KBLKXPB",
        "expire": 1536538784
    }
]


./bin/rados -p default.rgw.log listomapkeys  sts.0  --namespace=sts  -c cluster1/ceph.conf
1FI10KAT3E6G3KBLKXPB

and after some time 

 ./bin/radosgw-admin sts list -c cluster1/ceph.conf
[]
```



Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>