### PR TITLE
osd/PG: async-recovery should respect historical missing objects

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3227,9 +3227,11 @@ std::vector<Option> get_global_options() {
     .set_default(100)
     .set_description("Approximate missing objects above which to force auth_log_shard to be primary temporarily"),
 
-    Option("osd_async_recovery_min_pg_log_entries", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    Option("osd_async_recovery_min_cost", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(100)
-    .set_description("Number of entries difference above which to use asynchronous recovery when appropriate"),
+    .set_description("A mixture measure of number of current log entries difference "
+                     "and historical missing objects,  above which we switch to use "
+                     "asynchronous recovery when appropriate"),
 
     Option("osd_max_pg_per_osd_hard_ratio", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(3)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1564,9 +1564,14 @@ void PG::choose_async_recovery_ec(const map<pg_shard_t, pg_info_t> &all_info,
     // past the authoritative last_update the same as those equal to it.
     version_t auth_version = auth_info.last_update.version;
     version_t candidate_version = shard_info.last_update.version;
-    if (auth_version > candidate_version &&
-        (auth_version - candidate_version) > cct->_conf.get_val<uint64_t>("osd_async_recovery_min_pg_log_entries")) {
-      candidates_by_cost.insert(make_pair(auth_version - candidate_version, shard_i));
+    auto approx_missing_objects =
+      shard_info.stats.stats.sum.num_objects_missing;
+    if (auth_version > candidate_version) {
+      approx_missing_objects += auth_version - candidate_version;
+    }
+    if (approx_missing_objects > cct->_conf.get_val<uint64_t>(
+        "osd_async_recovery_min_cost")) {
+      candidates_by_cost.insert(make_pair(approx_missing_objects, shard_i));
     }
   }
 
@@ -1607,17 +1612,19 @@ void PG::choose_async_recovery_replicated(const map<pg_shard_t, pg_info_t> &all_
       continue;
     auto shard_info = all_info.find(shard_i)->second;
     // use the approximate magnitude of the difference in length of
-    // logs as the cost of recovery
+    // logs plus historical missing objects as the cost of recovery
     version_t auth_version = auth_info.last_update.version;
     version_t candidate_version = shard_info.last_update.version;
-    size_t approx_entries;
+    auto approx_missing_objects =
+      shard_info.stats.stats.sum.num_objects_missing;
     if (auth_version > candidate_version) {
-      approx_entries = auth_version - candidate_version;
+      approx_missing_objects += auth_version - candidate_version;
     } else {
-      approx_entries = candidate_version - auth_version;
+      approx_missing_objects += candidate_version - auth_version;
     }
-    if (approx_entries > cct->_conf.get_val<uint64_t>("osd_async_recovery_min_pg_log_entries")) {
-      candidates_by_cost.insert(make_pair(approx_entries, shard_i));
+    if (approx_missing_objects  > cct->_conf.get_val<uint64_t>(
+        "osd_async_recovery_min_cost")) {
+      candidates_by_cost.insert(make_pair(approx_missing_objects, shard_i));
     }
   }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1914,6 +1914,7 @@ void PG::activate(ObjectStore::Transaction& t,
     dout(10) << "activate - no missing, moving last_complete " << info.last_complete 
 	     << " -> " << info.last_update << dendl;
     info.last_complete = info.last_update;
+    info.stats.stats.sum.num_objects_missing = 0;
     pg_log.reset_recovery_pointers();
   } else {
     dout(10) << "activate - not complete, " << missing << dendl;


### PR DESCRIPTION
Peers with async-recovery enabled are usually having a update-to-date
last-update iterator and hence might be moved out from the __async_recovery_targets__
set during the next peering circles.

7de35629f562436d2bdb85788bdf97b10db3f556 makes num_objects_missing
trace historical missing objects correctly, hence we could take
num_objects_missing into account when determing __async_recovery_targets__.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

