### PR TITLE
mgr/dashboard: Refactoring of `DeletionModalComponent`

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-list/rbd-list.component.ts
@@ -198,18 +198,19 @@ export class RbdListComponent implements OnInit {
   deleteRbdModal() {
     const poolName = this.selection.first().pool_name;
     const imageName = this.selection.first().name;
-    this.modalRef = this.modalService.show(DeletionModalComponent);
-    this.modalRef.content.setUp({
-      metaType: 'RBD',
-      deletionObserver: () =>
-        this.taskWrapper.wrapTaskAroundCall({
-          task: new FinishedTask('rbd/delete', {
-            pool_name: poolName,
-            image_name: imageName
-          }),
-          call: this.rbdService.delete(poolName, imageName)
-        }),
-      modalRef: this.modalRef
+
+    this.modalRef = this.modalService.show(DeletionModalComponent, {
+      initialState: {
+        itemDescription: 'RBD',
+        submitActionObservable: () =>
+          this.taskWrapper.wrapTaskAroundCall({
+            task: new FinishedTask('rbd/delete', {
+              pool_name: poolName,
+              image_name: imageName
+            }),
+            call: this.rbdService.delete(poolName, imageName)
+          })
+      }
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -253,11 +253,11 @@ export class RbdSnapshotListComponent implements OnInit, OnChanges {
 
   deleteSnapshotModal() {
     const snapshotName = this.selection.selected[0].name;
-    this.modalRef = this.modalService.show(DeletionModalComponent);
-    this.modalRef.content.setUp({
-      metaType: 'RBD snapshot',
-      deletionMethod: () => this._asyncTask('deleteSnapshot', 'rbd/snap/delete', snapshotName),
-      modalRef: this.modalRef
+    this.modalRef = this.modalService.show(DeletionModalComponent, {
+      initialState: {
+        itemDescription: 'RBD snapshot',
+        submitAction: () => this._asyncTask('deleteSnapshot', 'rbd/snap/delete', snapshotName)
+      }
     });
   }
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-bucket-list/rgw-bucket-list.component.ts
@@ -62,35 +62,35 @@ export class RgwBucketListComponent {
   }
 
   deleteAction() {
-    const modalRef = this.bsModalService.show(DeletionModalComponent);
-    modalRef.content.setUp({
-      metaType: this.selection.hasSingleSelection ? 'bucket' : 'buckets',
-      deletionObserver: (): Observable<any> => {
-        return new Observable((observer: Subscriber<any>) => {
-          // Delete all selected data table rows.
-          observableForkJoin(
-            this.selection.selected.map((bucket: any) => {
-              return this.rgwBucketService.delete(bucket.bucket);
-            })
-          ).subscribe(
-            null,
-            (error) => {
-              // Forward the error to the observer.
-              observer.error(error);
-              // Reload the data table content because some deletions might
-              // have been executed successfully in the meanwhile.
-              this.table.refreshBtn();
-            },
-            () => {
-              // Notify the observer that we are done.
-              observer.complete();
-              // Reload the data table content.
-              this.table.refreshBtn();
-            }
-          );
-        });
-      },
-      modalRef: modalRef
+    this.bsModalService.show(DeletionModalComponent, {
+      initialState: {
+        itemDescription: this.selection.hasSingleSelection ? 'bucket' : 'buckets',
+        submitActionObservable: () => {
+          return new Observable((observer: Subscriber<any>) => {
+            // Delete all selected data table rows.
+            observableForkJoin(
+              this.selection.selected.map((bucket: any) => {
+                return this.rgwBucketService.delete(bucket.bucket);
+              })
+            ).subscribe(
+              null,
+              (error) => {
+                // Forward the error to the observer.
+                observer.error(error);
+                // Reload the data table content because some deletions might
+                // have been executed successfully in the meanwhile.
+                this.table.refreshBtn();
+              },
+              () => {
+                // Notify the observer that we are done.
+                observer.complete();
+                // Reload the data table content.
+                this.table.refreshBtn();
+              }
+            );
+          });
+        }
+      }
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
@@ -79,7 +79,7 @@ export class RgwUserListComponent {
   }
 
   deleteAction() {
-    const modalRef = this.bsModalService.show(DeletionModalComponent, {
+    this.bsModalService.show(DeletionModalComponent, {
       initialState: {
         itemDescription: this.selection.hasSingleSelection ? 'user' : 'users',
         submitActionObservable: (): Observable<any> => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-list/rgw-user-list.component.ts
@@ -79,35 +79,35 @@ export class RgwUserListComponent {
   }
 
   deleteAction() {
-    const modalRef = this.bsModalService.show(DeletionModalComponent);
-    modalRef.content.setUp({
-      metaType: this.selection.hasSingleSelection ? 'user' : 'users',
-      deletionObserver: (): Observable<any> => {
-        return new Observable((observer: Subscriber<any>) => {
-          // Delete all selected data table rows.
-          observableForkJoin(
-            this.selection.selected.map((user: any) => {
-              return this.rgwUserService.delete(user.user_id);
-            })
-          ).subscribe(
-            null,
-            (error) => {
-              // Forward the error to the observer.
-              observer.error(error);
-              // Reload the data table content because some deletions might
-              // have been executed successfully in the meanwhile.
-              this.table.refreshBtn();
-            },
-            () => {
-              // Notify the observer that we are done.
-              observer.complete();
-              // Reload the data table content.
-              this.table.refreshBtn();
-            }
-          );
-        });
-      },
-      modalRef: modalRef
+    const modalRef = this.bsModalService.show(DeletionModalComponent, {
+      initialState: {
+        itemDescription: this.selection.hasSingleSelection ? 'user' : 'users',
+        submitActionObservable: (): Observable<any> => {
+          return new Observable((observer: Subscriber<any>) => {
+            // Delete all selected data table rows.
+            observableForkJoin(
+              this.selection.selected.map((user: any) => {
+                return this.rgwUserService.delete(user.user_id);
+              })
+            ).subscribe(
+              null,
+              (error) => {
+                // Forward the error to the observer.
+                observer.error(error);
+                // Reload the data table content because some deletions might
+                // have been executed successfully in the meanwhile.
+                this.table.refreshBtn();
+              },
+              () => {
+                // Notify the observer that we are done.
+                observer.complete();
+                // Reload the data table content.
+                this.table.refreshBtn();
+              }
+            );
+          });
+        }
+      }
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/role-list/role-list.component.ts
@@ -90,12 +90,12 @@ export class RoleListComponent implements OnInit {
   }
 
   deleteRoleModal() {
-    this.modalRef = this.modalService.show(DeletionModalComponent);
     const name = this.selection.first().name;
-    this.modalRef.content.setUp({
-      metaType: 'Role',
-      deletionMethod: () => this.deleteRole(name),
-      modalRef: this.modalRef
+    this.modalRef = this.modalService.show(DeletionModalComponent, {
+      initialState: {
+        itemDescription: 'Role',
+        submitAction: () => this.deleteRole(name)
+      }
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-list/user-list.component.ts
@@ -100,11 +100,11 @@ export class UserListComponent implements OnInit {
       );
       return;
     }
-    this.modalRef = this.modalService.show(DeletionModalComponent);
-    this.modalRef.content.setUp({
-      metaType: 'User',
-      deletionMethod: () => this.deleteUser(username),
-      modalRef: this.modalRef
+    this.modalRef = this.modalService.show(DeletionModalComponent, {
+      initialState: {
+        itemDescription: 'User',
+        submitAction: () => this.deleteUser(username)
+      }
     });
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.html
@@ -10,13 +10,10 @@
           [formGroup]="deletionForm"
           novalidate>
       <div class="modal-body">
-        <ng-container *ngTemplateOutlet="description"></ng-container>
+        <ng-container *ngTemplateOutlet="bodyTemplate"></ng-container>
         <div class="question">
-          <p>
-            <ng-container i18n>
-              Are you sure you want to delete the selected
-            </ng-container>
-            {{ metaType }}?
+          <p i18n>
+            Are you sure that you want to {{ actionDescription | lowercase }} the selected {{ itemDescription }}?
           </p>
           <div class="form-group"
                [ngClass]="{'has-error': deletionForm.showError('confirmation', formDir)}">
@@ -28,7 +25,7 @@
                      autofocus>
               <label i18n
                      for="confirmation">
-                I'm sure I want to proceed with the deletion.
+                Yes, I am sure.
               </label>
             </div>
           </div>
@@ -37,7 +34,7 @@
       <div class="modal-footer">
         <cd-submit-button #submitButton
                           [form]="deletionForm"
-                          (submitAction)="deletionCall()">
+                          (submitAction)="callSubmitAction()">
           <ng-container *ngTemplateOutlet="deletionHeading"></ng-container>
         </cd-submit-button>
         <button class="btn btn-link btn-sm"
@@ -52,7 +49,6 @@
 
 <ng-template #deletionHeading>
   <ng-container i18n>
-    Delete
+    {{ actionDescription | titlecase }} {{ itemDescription }}
   </ng-container>
-  {{ metaType }}
 </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/deletion-modal/deletion-modal.component.ts
@@ -15,57 +15,34 @@ import { SubmitButtonComponent } from '../submit-button/submit-button.component'
 export class DeletionModalComponent implements OnInit {
   @ViewChild(SubmitButtonComponent)
   submitButton: SubmitButtonComponent;
-  description: TemplateRef<any>;
-  metaType: string;
-  deletionObserver: () => Observable<any>;
-  deletionMethod: Function;
-  modalRef: BsModalRef;
-
+  bodyTemplate: TemplateRef<any>;
+  submitActionObservable: () => Observable<any>;
+  submitAction: Function;
   deletionForm: CdFormGroup;
+  itemDescription: 'entry';
+  actionDescription = 'delete';
 
-  // Parameters are destructed here than assigned to specific types and marked as optional
-  setUp({
-    modalRef,
-    metaType,
-    deletionMethod,
-    deletionObserver,
-    description
-  }: {
-    modalRef: BsModalRef;
-    metaType: string;
-    deletionMethod?: Function;
-    deletionObserver?: () => Observable<any>;
-    description?: TemplateRef<any>;
-  }) {
-    if (!modalRef) {
-      throw new Error('No modal reference');
-    } else if (!metaType) {
-      throw new Error('No meta type');
-    } else if (!(deletionMethod || deletionObserver)) {
-      throw new Error('No deletion method');
-    }
-    this.metaType = metaType;
-    this.modalRef = modalRef;
-    this.deletionMethod = deletionMethod;
-    this.deletionObserver = deletionObserver;
-    this.description = description;
-  }
+  constructor(public modalRef: BsModalRef) {}
 
   ngOnInit() {
     this.deletionForm = new CdFormGroup({
       confirmation: new FormControl(false, [Validators.requiredTrue])
     });
+
+    if (!(this.submitAction || this.submitActionObservable)) {
+      throw new Error('No submit action defined');
+    }
   }
 
-  deletionCall() {
-    if (this.deletionObserver) {
-      this.deletionObserver().subscribe(
-        undefined,
+  callSubmitAction() {
+    if (this.submitActionObservable) {
+      this.submitActionObservable().subscribe(
+        null,
         this.stopLoadingSpinner.bind(this),
         this.hideModal.bind(this)
       );
     } else {
-      this.deletionMethod();
+      this.submitAction();
     }
   }
 


### PR DESCRIPTION
- Simpler variable names:

    Examples:

	- `actionDescription` instead of `metaType`
	- `bodyTemplate` instead of `description`
	- `validationPattern` instead of `pattern`

    Some of these variable names have been generalized to ease the
    unification/generalization of dialog components:

	- `submitAction` instead of `deletionMethod`

- Removed unique `setUp` method.

    Benefits:

    - Creation of the component is done as intended by the developers of
    the `ngx-boostrap` package and as expected by developers which use
    the package. The `setUp` method does not have to be called anymore
    on the `DeletionModalComponent` exclusively but instead the
    component is instantiated as all other modals. Property assignment
    on the instantiated object isn't handled by the `setUp` method
    anymore but by the `modalService`.

    - With the removal of the `setUp` method, some tests could be
    removed as well.

    - No need to pass the reference of the created modal to the modal
    manually.

    Preserved:

    - The provided check within the `setUp` method, which checked if the
    component had been correctly instantiated, has been moved to the
    `ngOnInit` method of the component.

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>

