### PR TITLE
ceph-disk: compatibility fix for python 3

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -909,8 +909,8 @@ def is_mounted(dev):
     """
     Check if the given device is mounted.
     """
-    dev = os.path.realpath(dev)
-    with open(PROCDIR + '/mounts', 'rb') as proc_mounts:
+    dev = os.path.realpath(_bytes2str(dev))
+    with open(PROCDIR + '/mounts', 'r') as proc_mounts:
         for line in proc_mounts:
             fields = line.split()
             if len(fields) < 3:


### PR DESCRIPTION
In python 3, dev is a string, but mounts_dev is bytes, so they can't
compare equal, resulting in is_mounted() returning None for mounted
OSDs.

Fixes: https://tracker.ceph.com/issues/35906
Signed-off-by: Tim Serong <tserong@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

