### PR TITLE
qa/rgw: reduce number of multisite log shards

### DIFF
--- a/qa/suites/rgw/multisite/overrides.yaml
+++ b/qa/suites/rgw/multisite/overrides.yaml
@@ -8,5 +8,7 @@ overrides:
         rgw crypt require ssl: false
         rgw sync log trim interval: 0
         rgw curl low speed time: 300
+        rgw md log max shards: 4
+        rgw data log num shards: 4
   rgw:
     compression type: random


### PR DESCRIPTION
the three-zone multisite tests have been taking over 4 hours to run on smithi machines. reducing the number of mdlog/datalog shards to 4 cuts down a lot of polling traffic (both between gateways, and for sync checkpoints) and cuts the runtime of these tests to ~1 hour