### PR TITLE
luminous: osd: drop peering_wq.clear() before peering_tp stop

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3412,7 +3412,6 @@ int OSD::shutdown()
   heartbeat_thread.join();
 
   peering_tp.drain();
-  peering_wq.clear();
   peering_tp.stop();
   dout(10) << "osd tp stopped" << dendl;
 


### PR DESCRIPTION
Signed-off-by: Leo Zhang <nguzcf@gmail.com>

Before peering_tp stopped, another thread will queue a pg to peering_wq, so peering_wq.clear() will assert failed. 

In the ending of OSD::shutdown(), called peering_wq.clear() again.

```cpp
int OSD::shutdown()
{
...
  hb_back_server_messenger->shutdown();

  peering_wq.clear();

  return r;
}

```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

