### PR TITLE
mgr/dashboard: More configs for table `updateSelectionOnRefresh`

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -3,7 +3,7 @@
           [columns]="columns"
           selectionType="single"
           (updateSelection)="updateSelection($event)"
-          [updateSelectionOnRefresh]="false">
+          [updateSelectionOnRefresh]="'never'">
   <div class="table-actions btn-toolbar"
        *ngIf="permission.update">
     <div class="btn-group"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.spec.ts
@@ -3,6 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { NgxDatatableModule } from '@swimlane/ngx-datatable';
+import * as _ from 'lodash';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ComponentsModule } from '../../components/components.module';
@@ -285,6 +286,42 @@ describe('TableComponent', () => {
         expect(component.updating).toBeFalsy();
       });
       component.reloadData();
+    });
+
+    it('should update selection on refresh - "onChange"', () => {
+      spyOn(component, 'onSelect').and.callThrough();
+      component.data = createFakeData(10);
+      component.selection.selected = [_.clone(component.data[1])];
+      component.updateSelectionOnRefresh = 'onChange';
+      component.updateSelected();
+      expect(component.onSelect).toHaveBeenCalledTimes(0);
+      component.data[1].d = !component.data[1].d;
+      component.updateSelected();
+      expect(component.onSelect).toHaveBeenCalled();
+    });
+
+    it('should update selection on refresh - "always"', () => {
+      spyOn(component, 'onSelect').and.callThrough();
+      component.data = createFakeData(10);
+      component.selection.selected = [_.clone(component.data[1])];
+      component.updateSelectionOnRefresh = 'always';
+      component.updateSelected();
+      expect(component.onSelect).toHaveBeenCalled();
+      component.data[1].d = !component.data[1].d;
+      component.updateSelected();
+      expect(component.onSelect).toHaveBeenCalled();
+    });
+
+    it('should update selection on refresh - "never"', () => {
+      spyOn(component, 'onSelect').and.callThrough();
+      component.data = createFakeData(10);
+      component.selection.selected = [_.clone(component.data[1])];
+      component.updateSelectionOnRefresh = 'never';
+      component.updateSelected();
+      expect(component.onSelect).toHaveBeenCalledTimes(0);
+      component.data[1].d = !component.data[1].d;
+      component.updateSelected();
+      expect(component.onSelect).toHaveBeenCalledTimes(0);
     });
 
     afterEach(() => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.ts
@@ -93,9 +93,9 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
   // e.g. 'single' or 'multi'.
   @Input()
   selectionType: string = undefined;
-  // If `true` selected item details will be updated on table refresh
+  // By default selected item details will be updated on table refresh, if data has changed
   @Input()
-  updateSelectionOnRefresh = true;
+  updateSelectionOnRefresh: 'always' | 'never' | 'onChange' = 'onChange';
 
   @Input()
   autoSave = true;
@@ -367,9 +367,7 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
       this.updateFilter(true);
     }
     this.reset();
-    if (this.updateSelectionOnRefresh) {
-      this.updateSelected();
-    }
+    this.updateSelected();
   }
 
   /**
@@ -388,6 +386,9 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
    * or some selected items may have been removed.
    */
   updateSelected() {
+    if (this.updateSelectionOnRefresh === 'never') {
+      return;
+    }
     const newSelected = [];
     this.selection.selected.forEach((selectedItem) => {
       for (const row of this.data) {
@@ -396,6 +397,12 @@ export class TableComponent implements AfterContentChecked, OnInit, OnChanges, O
         }
       }
     });
+    if (
+      this.updateSelectionOnRefresh === 'onChange' &&
+      _.isEqual(this.selection.selected, newSelected)
+    ) {
+      return;
+    }
     this.selection.selected = newSelected;
     this.onSelect();
   }


### PR DESCRIPTION
This PR increases the number of configurations for table `updateSelectionOnRefresh` input.

Instead of simply support `true` or `false`, this attribute will now support:

- **onChange**: `updateSelection` method will be invoked on table refresh, but only if the selected data changed _(__default__ behavior after this PR)_ 

- **always**: `updateSelection` method will be invoked on table refresh, regardless of selected data change (__default__ behavior before this PR)

- **never**: `updateSelection` method will never be called on table refresh


Fixes: https://tracker.ceph.com/issues/35904

Signed-off-by: Ricardo Marques <rimarques@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

