### PR TITLE
mgr/dashboard: Fix flaky QA tests

### DIFF
--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 
 import json
-from time import sleep
 
 from .helper import DashboardTestCase, JObj, JAny, JList, JLeaf, JTuple
 

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
-import re
 from . import ApiController, RESTController, UpdatePermission
 from .. import mgr, logger
 from ..security import Scope
@@ -154,16 +153,10 @@ class Osd(RESTController):
                 'mon', 'osd safe-to-destroy', ids=svc_id, target=('mgr', ''))
             return {'safe-to-destroy': True}
         except SendCommandError as e:
-            match = re.match(
-                r'OSD\(s\) (\d+) have (\d+) pgs currently mapped to them',
-                e.message)
-            if match:
-                return {
-                    'message': e.message,
-                    'safe-to-destroy': False
-                }
-            else:
-                raise e
+            return {
+                'message': e.message,
+                'safe-to-destroy': False,
+            }
 
 
 @ApiController('/osd/flags', Scope.OSD)


### PR DESCRIPTION
Fixes some errors in QA test runs by passing all errors as message in the response. I likely should have done that from the beginning.

See http://qa-proxy.ceph.com/teuthology/sage-2018-09-10_02:11:51-rados-master-distro-basic-smithi/2999041/teuthology.log

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>