### PR TITLE
mgr/dashboard: Catch LookupError when checking the RGW status

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -38,7 +38,7 @@ class Rgw(BaseController):
                     instance.userid)
                 raise RequestException(status['message'])
             status['available'] = True
-        except RequestException:
+        except (RequestException, LookupError):
             pass
         return status
 


### PR DESCRIPTION
This exception is thrown by the RGW client function [_determine_rgw_addr()](https://github.com/ceph/ceph/blob/master/src/pybind/mgr/dashboard/services/rgw_client.py#L62). Without catching that exception a 'The server encountered an unexpected condition which prevented it from fulfilling the request.' error will be displayed in the UI instead of displaying a notification panel with a hint that the Object Gateway is not running.

Fixes: https://tracker.ceph.com/issues/35921

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

