### PR TITLE
cmake: no libradosstriper headers if WITH_LIBRADOSSTRIPER=OFF

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -438,10 +438,11 @@ add_subdirectory(perfglue)
 
 add_library(rados_snap_set_diff_obj OBJECT librados/snap_set_diff.cc)
 
+option(WITH_LIBRADOSSTRIPER "build with libradosstriper support" ON)
+
 add_subdirectory(include)
 add_subdirectory(librados)
 
-option(WITH_LIBRADOSSTRIPER "build with libradosstriper support" ON)
 if(WITH_LIBRADOSSTRIPER)
   add_subdirectory(libradosstriper)
 endif()

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -9,10 +9,12 @@ install(FILES rados/librados.h
   crc32c.h
   rados/objclass.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rados)
-install(FILES
-  radosstriper/libradosstriper.h
-  radosstriper/libradosstriper.hpp
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/radosstriper)
+if(WITH_LIBRADOSSTRIPER)
+  install(FILES
+    radosstriper/libradosstriper.h
+    radosstriper/libradosstriper.hpp
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/radosstriper)
+endif()
 
 if(WITH_RBD)
   install(FILES


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/35922


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
~~- [ ] Updates documentation if necessary~~
~~- [ ] Includes tests for new functionality or reproducer for bug~~

