### PR TITLE
osd/PG: avoid choose_acting picking want with > pool size items

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1400,6 +1400,9 @@ void PG::calc_replicated_acting(
       acting_backfill->insert(up_cand);
       ss << " osd." << i << " (up) accepted " << cur_info << std::endl;
     }
+    if (want->size() >= size) {
+      break;
+    }
   }
 
   if (want->size() >= size) {


### PR DESCRIPTION
If the pool size recently changed, we might see an up that is larger than
the pool size.  Or, we might already have selected a primary that is not
part of up, and then add all up osds and end up with a want that is too
big.

Fixes: http://tracker.ceph.com/issues/35924
Signed-off-by: Sage Weil <sage@redhat.com>