### PR TITLE
ceph-volume batch: allow --osds-per-device, default it to 1

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -206,6 +206,12 @@ class Batch(object):
             action='store_true',
             help='Skip creating and enabling systemd units and starting OSD services',
         )
+        parser.add_argument(
+            '--osds-per-device',
+            type=int,
+            default=1,
+            help='Provision more than 1 (the default) OSD per device',
+        )
         args = parser.parse_args(self.argv)
 
         if not args.devices:

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 import json
-from uuid import uuid4
 from ceph_volume.util import disk, prepare
 from ceph_volume.api import lvm
 from . import validators
@@ -59,7 +58,9 @@ class SingleType(object):
         met, raise an error if the provided devices would not work
         """
         # validate minimum size for all devices
-        validators.minimum_device_size(self.devices)
+        validators.minimum_device_size(
+            self.devices, osds_per_device=self.osds_per_device
+        )
 
         # make sure that data devices do not have any LVs
         validators.no_lvm_membership(self.hdds)
@@ -130,14 +131,14 @@ class MixedType(object):
     def __init__(self, devices, args):
         self.args = args
         self.devices = devices
+        self.osds_per_device = args.osds_per_device
         # TODO: add --fast-devices and --slow-devices so these can be customized
         self.hdds = [device for device in devices if device.sys_api['rotational'] == '1']
         self.ssds = [device for device in devices if device.sys_api['rotational'] == '0']
         self.computed = {'osds': []}
         self.block_db_size = prepare.get_block_db_size(lv_format=False) or disk.Size(b=0)
         self.system_vgs = lvm.VolumeGroups()
-        # For every HDD we get 1 block.db
-        self.dbs_needed = len(self.hdds)
+        self.dbs_needed = len(self.hdds) * self.osds_per_device
         self.validate()
         self.compute()
 
@@ -150,13 +151,13 @@ class MixedType(object):
 
         string = ""
         string += templates.total_osds.format(
-            total_osds=len(self.hdds)
+            total_osds=len(self.hdds) * self.osds_per_device
         )
 
         string += templates.ssd_volume_group.format(
             target='block.db',
             total_lv_size=str(self.total_available_db_space),
-            total_lvs=vg_extents['parts'],
+            total_lvs=vg_extents['parts'] * self.osds_per_device,
             block_lv_size=db_size,
             block_db_devices=', '.join([ssd.abspath for ssd in self.ssds]),
             lv_size=self.block_db_size or str(disk.Size(b=(vg_extents['sizes']))),
@@ -200,21 +201,24 @@ class MixedType(object):
                 'human_readable_sizes': str(self.block_db_size),
                 'human_readable_size': str(self.total_available_db_space),
             }
-            vg_name = 'lv/vg'
+            vg_name = 'vg/lv'
         else:
             vg_name = self.common_vg.name
 
         for device in self.hdds:
-            osd = {'data': {}, 'block.db': {}}
-            osd['data']['path'] = device.abspath
-            osd['data']['size'] = device.sys_api['size']
-            osd['data']['percentage'] = 100
-            osd['data']['human_readable_size'] = str(disk.Size(b=(device.sys_api['size'])))
-            osd['block.db']['path'] = 'vg: %s' % vg_name
-            osd['block.db']['size'] = int(self.block_db_size.b)
-            osd['block.db']['human_readable_size'] = str(self.block_db_size)
-            osd['block.db']['percentage'] = self.vg_extents['percentages']
-            osds.append(osd)
+            for hdd in range(self.osds_per_device):
+                osd = {'data': {}, 'block.db': {}}
+                osd['data']['path'] = device.abspath
+                osd['data']['size'] = device.sys_api['size'] / self.osds_per_device
+                osd['data']['percentage'] = 100 / self.osds_per_device
+                osd['data']['human_readable_size'] = str(
+                    disk.Size(b=(device.sys_api['size'])) / self.osds_per_device
+                )
+                osd['block.db']['path'] = 'vg: %s' % vg_name
+                osd['block.db']['size'] = int(self.block_db_size.b)
+                osd['block.db']['human_readable_size'] = str(self.block_db_size)
+                osd['block.db']['percentage'] = self.vg_extents['percentages']
+                osds.append(osd)
 
     def execute(self):
         """
@@ -223,10 +227,11 @@ class MixedType(object):
         ``lvm create``
         """
         blank_ssd_paths = [d.abspath for d in self.blank_ssds]
+        data_vgs = dict([(osd['data']['path'], None) for osd in self.computed['osds']])
 
         # no common vg is found, create one with all the blank SSDs
         if not self.common_vg:
-            db_vg = lvm.create_vg(blank_ssd_paths, name_prefix='ceph-dbs')
+            db_vg = lvm.create_vg(blank_ssd_paths, name_prefix='ceph-block-dbs')
 
         # if a common vg exists then extend it with any blank ssds
         elif self.common_vg and blank_ssd_paths:
@@ -243,10 +248,25 @@ class MixedType(object):
         # function that looks up this value
         block_db_size = "%sG" % self.block_db_size.gb.as_int()
 
-        # create the data lvs, and create the OSD with the matching block.db lvs from before
+        # create 1 vg per data device first, mapping them to the device path,
+        # when the lv gets created later, it can create as many as needed (or
+        # even just 1)
         for osd in self.computed['osds']:
-            data_vg = lvm.create_vg(osd['data']['path'], name_prefix='ceph-block-db')
-            data_lv = lvm.create_lv('osd-data-%s' % str(uuid4()), data_vg.name)
+            vg = data_vgs.get(osd['data']['path'])
+            if not vg:
+                vg = lvm.create_vg(osd['data']['path'], name_prefix='ceph-block')
+                data_vgs[osd['data']['path']] = vg
+
+        # create the data lvs, and create the OSD with an lv from the common
+        # block.db vg from before
+        for osd in self.computed['osds']:
+            data_path = osd['data']['path']
+            data_lv_size = disk.Size(b=osd['data']['size']).gb.as_int()
+            data_vg = data_vgs[data_path]
+            data_lv_extents = data_vg.sizing(size=data_lv_size)['extents']
+            data_lv = lvm.create_lv(
+                'osd-block', data_vg.name, extents=data_lv_extents, uuid_name=True
+            )
             db_lv = lvm.create_lv(
                 'osd-block-db', db_vg.name, size=block_db_size, uuid_name=True
             )
@@ -282,7 +302,7 @@ class MixedType(object):
         those LVs would be large enough to accommodate a block.db
         """
         # validate minimum size for all devices
-        validators.minimum_device_size(self.devices)
+        validators.minimum_device_size(self.devices, osds_per_device=self.osds_per_device)
 
         # make sure that data devices do not have any LVs
         validators.no_lvm_membership(self.hdds)
@@ -313,11 +333,13 @@ class MixedType(object):
         if self.block_db_size.gb > 0:
             try:
                 self.vg_extents = lvm.sizing(
-                    self.total_available_db_space.b, size=self.block_db_size.b
+                    self.total_available_db_space.b, size=self.block_db_size.b * self.osds_per_device
                 )
             except SizeAllocationError:
-                msg = "Not enough space in fast devices (%s) to create a %s block.db LV"
-                raise RuntimeError(msg % (self.total_available_db_space, self.block_db_size))
+                msg = "Not enough space in fast devices (%s) to create %s x %s block.db LV"
+                raise RuntimeError(
+                    msg % (self.total_available_db_space, self.osds_per_device, self.block_db_size)
+                )
         else:
             self.vg_extents = lvm.sizing(
                 self.total_available_db_space.b, parts=self.dbs_needed
@@ -337,8 +359,8 @@ class MixedType(object):
 
         total_dbs_possible = self.total_available_db_space / self.block_db_size
 
-        if len(self.hdds) > total_dbs_possible:
-            msg = "%s is not enough to create %s x %s block.db LVs" % (
-                self.block_db_size, len(self.hdds), self.block_db_size,
+        if self.dbs_needed > total_dbs_possible:
+            msg = "Not enough space (%s) to create %s x %s block.db LVs" % (
+                self.total_available_db_space, self.dbs_needed, self.block_db_size,
             )
             raise RuntimeError(msg)

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -53,6 +53,24 @@ def fake_call(monkeypatch):
 
 
 @pytest.fixture
+def fakedevice(factory):
+    def apply(**kw):
+        params = dict(
+            path='/dev/sda',
+            abspath='/dev/sda',
+            lv_api=None,
+            pvs_api=[],
+            disk_api={},
+            sys_api={},
+            exists=True,
+            is_lvm_member=True,
+        )
+        params.update(dict(kw))
+        return factory(**params)
+    return apply
+
+
+@pytest.fixture
 def stub_call(monkeypatch):
     """
     Monkeypatches process.call, so that a caller can add behavior to the response
@@ -115,6 +133,13 @@ def volume_groups(monkeypatch):
     vgs = lvm_api.VolumeGroups()
     vgs._purge()
     return vgs
+
+
+@pytest.fixture
+def stub_vgs(monkeypatch, volume_groups):
+    def apply(vgs):
+        monkeypatch.setattr(lvm_api, 'get_api_vgs', lambda: vgs)
+    return apply
 
 
 @pytest.fixture

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -1,0 +1,139 @@
+import pytest
+from ceph_volume.devices.lvm.strategies import bluestore
+
+
+class TestSingleType(object):
+
+    def test_hdd_device_is_large_enough(self, fakedevice, factory):
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ]
+        computed_osd = bluestore.SingleType(devices, args).computed['osds'][0]
+        assert computed_osd['data']['percentage'] == 100
+        assert computed_osd['data']['parts'] == 1
+        assert computed_osd['data']['human_readable_size'] == '5.66 GB'
+        assert computed_osd['data']['path'] == '/dev/sda'
+
+    def test_sdd_device_is_large_enough(self, fakedevice, factory):
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+        ]
+        computed_osd = bluestore.SingleType(devices, args).computed['osds'][0]
+        assert computed_osd['data']['percentage'] == 100
+        assert computed_osd['data']['parts'] == 1
+        assert computed_osd['data']['human_readable_size'] == '5.66 GB'
+        assert computed_osd['data']['path'] == '/dev/sda'
+
+    def test_device_cannot_have_many_osds_per_device(self, fakedevice, factory):
+        args = factory(osds_per_device=3)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            bluestore.SingleType(devices, args)
+        assert 'Unable to use device 5.66 GB /dev/sda' in str(error)
+
+    def test_device_is_lvm_member_fails(self, fakedevice, factory):
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            bluestore.SingleType(devices, args)
+        assert 'Unable to use device, already a member of LVM' in str(error)
+
+
+class TestMixedTypeConfiguredSize(object):
+    # uses a block.db size that has been configured via ceph.conf, instead of
+    # defaulting to 'as large as possible'
+
+    def test_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
+        # 3GB block.db in ceph.conf
+        conf_ceph(get_safe=lambda *a: 3147483640)
+        args = factory(osds_per_device=1)
+        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        devices = [ssd, hdd]
+
+        osd = bluestore.MixedType(devices, args).computed['osds'][0]
+        assert osd['data']['percentage'] == 100
+        assert osd['data']['human_readable_size'] == '5.66 GB'
+        assert osd['data']['path'] == '/dev/sda'
+        # a new vg will be created
+        assert osd['block.db']['path'] == 'vg: vg/lv'
+        assert osd['block.db']['percentage'] == 100
+
+    def test_ssd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
+        # 7GB block.db in ceph.conf
+        conf_ceph(get_safe=lambda *a: 7747483640)
+        args = factory(osds_per_device=1)
+        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        devices = [ssd, hdd]
+
+        with pytest.raises(RuntimeError) as error:
+            bluestore.MixedType(devices, args).computed['osds'][0]
+        expected = 'Not enough space in fast devices (5.66 GB) to create 1 x 7.22 GB block.db LV'
+        assert expected in str(error)
+
+    def test_multi_hdd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
+        # 3GB block.db in ceph.conf
+        conf_ceph(get_safe=lambda *a: 3147483640)
+        args = factory(osds_per_device=2)
+        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
+        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        devices = [ssd, hdd]
+
+        with pytest.raises(RuntimeError) as error:
+            bluestore.MixedType(devices, args)
+        expected = 'Unable to use device 5.66 GB /dev/sda, LVs would be smaller than 5GB'
+        assert expected in str(error)
+
+
+class TestMixedTypeLargeAsPossible(object):
+
+    def test_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: None)
+        args = factory(osds_per_device=1)
+        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        devices = [ssd, hdd]
+
+        osd = bluestore.MixedType(devices, args).computed['osds'][0]
+        assert osd['data']['percentage'] == 100
+        assert osd['data']['human_readable_size'] == '5.66 GB'
+        assert osd['data']['path'] == '/dev/sda'
+        # a new vg will be created
+        assert osd['block.db']['path'] == 'vg: vg/lv'
+        # as large as possible
+        assert osd['block.db']['percentage'] == 100
+
+    def test_multi_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: None)
+        args = factory(osds_per_device=2)
+        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=60073740000))
+        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=60073740000))
+        devices = [ssd, hdd]
+
+        osd = bluestore.MixedType(devices, args).computed['osds'][0]
+        assert osd['data']['percentage'] == 50
+        assert osd['data']['human_readable_size'] == '27.97 GB'
+        assert osd['data']['path'] == '/dev/sda'
+        # a new vg will be created
+        assert osd['block.db']['path'] == 'vg: vg/lv'
+        # as large as possible
+        assert osd['block.db']['percentage'] == 50
+
+    def test_multi_hdd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: None)
+        args = factory(osds_per_device=2)
+        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
+        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        devices = [ssd, hdd]
+
+        with pytest.raises(RuntimeError) as error:
+            bluestore.MixedType(devices, args)
+        expected = 'Unable to use device 5.66 GB /dev/sda, LVs would be smaller than 5GB'
+        assert expected in str(error)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
@@ -1,0 +1,210 @@
+import pytest
+from ceph_volume.devices.lvm.strategies import filestore
+from ceph_volume.api import lvm
+
+
+class TestSingleType(object):
+
+    def test_hdd_device_is_large_enough(self, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=12073740000))
+        ]
+        computed_osd = filestore.SingleType(devices, args).computed['osds'][0]
+        assert computed_osd['data']['percentage'] == 55
+        assert computed_osd['data']['parts'] == 1
+        assert computed_osd['data']['human_readable_size'] == '6.24 GB'
+        assert computed_osd['data']['path'] == '/dev/sda'
+
+    def test_hdd_device_with_large_journal(self, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.SingleType(devices, args)
+        msg = "Unable to use device 5.66 GB /dev/sda, LVs would be smaller than 5GB"
+        assert msg in str(error)
+
+    def test_ssd_device_is_large_enough(self, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=12073740000))
+        ]
+        computed_osd = filestore.SingleType(devices, args).computed['osds'][0]
+        assert computed_osd['data']['percentage'] == 55
+        assert computed_osd['data']['parts'] == 1
+        assert computed_osd['data']['human_readable_size'] == '6.24 GB'
+        assert computed_osd['data']['path'] == '/dev/sda'
+
+    def test_ssd_device_with_large_journal(self, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.SingleType(devices, args)
+        msg = "Unable to use device 5.66 GB /dev/sda, LVs would be smaller than 5GB"
+        assert msg in str(error)
+
+    def test_ssd_device_multi_osd(self, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=4)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.SingleType(devices, args)
+        msg = "Unable to use device 14.97 GB /dev/sda, LVs would be smaller than 5GB"
+        assert msg in str(error)
+
+    def test_hdd_device_multi_osd(self, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=4)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.SingleType(devices, args)
+        msg = "Unable to use device 14.97 GB /dev/sda, LVs would be smaller than 5GB"
+        assert msg in str(error)
+
+    def test_device_is_lvm_member_fails(self, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=True, sys_api=dict(rotational='1', size=12073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.SingleType(devices, args)
+        assert 'Unable to use device, already a member of LVM' in str(error)
+
+    def test_hdd_device_with_small_configured_journal(self, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.SingleType(devices, args)
+        msg = "journal sizes must be larger than 2GB, detected: 120.00 MB"
+        assert msg in str(error)
+
+    def test_ssd_device_with_small_configured_journal(self, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.SingleType(devices, args)
+        msg = "journal sizes must be larger than 2GB, detected: 120.00 MB"
+        assert msg in str(error)
+
+
+class TestMixedType(object):
+
+    def test_minimum_size_is_not_met(self, stub_vgs, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.MixedType(devices, args)
+        msg = "journal sizes must be larger than 2GB, detected: 120.00 MB"
+        assert msg in str(error)
+
+    def test_ssd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '7120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.MixedType(devices, args)
+        msg = "Not enough space in fast devices (5.66 GB) to create 1 x 6.95 GB journal LV"
+        assert msg in str(error)
+
+    def test_hdd_device_is_lvm_member_fails(self, stub_vgs, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=1)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
+            fakedevice(is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.MixedType(devices, args)
+        assert 'Unable to use device, already a member of LVM' in str(error)
+
+    def test_ssd_is_lvm_member_doesnt_fail(self, volumes, stub_vgs, fakedevice, factory, conf_ceph):
+        # fast PV, because ssd is an LVM member
+        CephPV = lvm.PVolume(vg_name='fast', pv_name='/dev/sda', pv_tags='')
+        ssd = fakedevice(
+            is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV]
+        )
+        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        # when get_api_vgs() gets called, it will return this one VG
+        stub_vgs([
+            dict(
+                vg_free='7g', vg_name='fast', lv_name='foo',
+                lv_path='/dev/vg/foo', lv_tags="ceph.type=data"
+            )
+        ])
+
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=1)
+        devices = [ssd, hdd]
+        result = filestore.MixedType(devices, args).computed['osds'][0]
+        assert result['journal']['path'] == 'vg: fast'
+        assert result['journal']['percentage'] == 71
+        assert result['journal']['human_readable_size'] == '5.00 GB'
+
+    def test_no_common_vg(self, volumes, stub_vgs, fakedevice, factory, conf_ceph):
+        # fast PV, because ssd is an LVM member
+        CephPV1 = lvm.PVolume(vg_name='fast1', pv_name='/dev/sda', pv_tags='')
+        CephPV2 = lvm.PVolume(vg_name='fast2', pv_name='/dev/sdb', pv_tags='')
+        ssd1 = fakedevice(
+            is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV1]
+        )
+        ssd2 = fakedevice(
+            is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV2]
+        )
+        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        # when get_api_vgs() gets called, it will return this one VG
+        stub_vgs([
+            dict(
+                vg_free='7g', vg_name='fast1', lv_name='foo',
+                lv_path='/dev/vg/fast1', lv_tags="ceph.type=data"
+            ),
+            dict(
+                vg_free='7g', vg_name='fast2', lv_name='foo',
+                lv_path='/dev/vg/fast2', lv_tags="ceph.type=data"
+            )
+        ])
+
+        conf_ceph(get_safe=lambda *a: '5120')
+        args = factory(osds_per_device=1)
+        devices = [ssd1, ssd2, hdd]
+        with pytest.raises(RuntimeError) as error:
+            filestore.MixedType(devices, args)
+
+        assert 'Could not find a common VG between devices' in str(error)
+
+    def test_ssd_device_fails_multiple_osds(self, stub_vgs, fakedevice, factory, conf_ceph):
+        conf_ceph(get_safe=lambda *a: '15120')
+        args = factory(osds_per_device=2)
+        devices = [
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000)),
+            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))
+        ]
+        with pytest.raises(RuntimeError) as error:
+            filestore.MixedType(devices, args)
+        msg = "Not enough space in fast devices (14.97 GB) to create 2 x 14.77 GB journal LV"
+        assert msg in str(error)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_validate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_validate.py
@@ -1,0 +1,52 @@
+import pytest
+from ceph_volume.util import disk
+from ceph_volume.devices.lvm.strategies import validators
+
+
+class TestMinimumDeviceSize(object):
+
+    def test_size_is_larger_than_5gb(self, fakedevice):
+        devices = [fakedevice(sys_api=dict(size=6073740000))]
+        assert validators.minimum_device_size(devices) is None
+
+    def test_size_is_smaller_than_5gb(self, fakedevice):
+        devices = [fakedevice(sys_api=dict(size=1073740000))]
+        with pytest.raises(RuntimeError) as error:
+            validators.minimum_device_size(devices)
+        msg = "LVs would be smaller than 5GB"
+        assert msg in str(error)
+
+    def test_large_device_multiple_osds_fails(self, fakedevice):
+        devices = [fakedevice(sys_api=dict(size=6073740000))]
+        with pytest.raises(RuntimeError) as error:
+            validators.minimum_device_size(
+                devices, osds_per_device=4
+            )
+        msg = "LVs would be smaller than 5GB"
+        assert msg in str(error)
+
+
+class TestMinimumCollocatedDeviceSize(object):
+
+    def setup(self):
+        self.journal_size = disk.Size(gb=5)
+
+    def test_size_is_larger_than_5gb_large_journal(self, fakedevice):
+        devices = [fakedevice(sys_api=dict(size=6073740000))]
+        assert validators.minimum_device_collocated_size(devices, disk.Size(mb=1)) is None
+
+    def test_size_is_larger_than_5gb_large_journal_fails(self, fakedevice):
+        devices = [fakedevice(sys_api=dict(size=1073740000))]
+        with pytest.raises(RuntimeError) as error:
+            validators.minimum_device_collocated_size(devices, self.journal_size)
+        msg = "LVs would be smaller than 5GB"
+        assert msg in str(error)
+
+    def test_large_device_multiple_osds_fails(self, fakedevice):
+        devices = [fakedevice(sys_api=dict(size=16073740000))]
+        with pytest.raises(RuntimeError) as error:
+            validators.minimum_device_collocated_size(
+                devices, self.journal_size, osds_per_device=3
+            )
+        msg = "LVs would be smaller than 5GB"
+        assert msg in str(error)


### PR DESCRIPTION
The batch operations allow more than one OSD per device, we need to default it to 1 since we can't reliably tell NVMe vs. SSDs, but we still want to be able to allow multiple OSDs per device

Fixes: http://tracker.ceph.com/issues/35913