### PR TITLE
osd/PG: write pg epoch when resurrecting pg after delete vs merge race

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6741,6 +6741,7 @@ void PG::_delete_some(ObjectStore::Transaction *t)
 	      info.pgid,
 	      info.pgid.get_split_bits(pool.info.get_pg_num()));
       _init(*t, info.pgid, &pool.info);
+      last_epoch = 0;  // to ensure pg epoch is also written
       dirty_info = true;
       dirty_big_info = true;
     } else {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/35923
Signed-off-by: Sage Weil <sage@redhat.com>