### PR TITLE
rbd-mirror: prevent creation of clones when parents are syncing

### DIFF
--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -196,12 +196,12 @@ struct BootstrapRequest<librbd::MockTestImageCtx> {
   bool *do_resync = nullptr;
 
   static BootstrapRequest* create(
+      Threads<librbd::MockTestImageCtx>* threads,
       librados::IoCtx &local_io_ctx, librados::IoCtx &remote_io_ctx,
       rbd::mirror::InstanceWatcher<librbd::MockTestImageCtx> *instance_watcher,
       librbd::MockTestImageCtx **local_image_ctx,
       const std::string &local_image_name, const std::string &remote_image_id,
-      const std::string &global_image_id, MockContextWQ *work_queue,
-      MockSafeTimer *timer, Mutex *timer_lock,
+      const std::string &global_image_id,
       const std::string &local_mirror_uuid,
       const std::string &remote_mirror_uuid,
       ::journal::MockJournalerProxy *journaler,

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -41,6 +41,7 @@ set(rbd_mirror_internal
   image_replayer/PrepareLocalImageRequest.cc
   image_replayer/PrepareRemoteImageRequest.cc
   image_replayer/ReplayStatusFormatter.cc
+  image_replayer/Utils.cc
   image_sync/SyncPointCreateRequest.cc
   image_sync/SyncPointPruneRequest.cc
   pool_watcher/RefreshImagesRequest.cc

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -492,10 +492,9 @@ void ImageReplayer<I>::bootstrap() {
     ImageReplayer, &ImageReplayer<I>::handle_bootstrap>(this);
 
   BootstrapRequest<I> *request = BootstrapRequest<I>::create(
-    *m_local_ioctx, m_remote_image.io_ctx, m_instance_watcher,
+    m_threads, *m_local_ioctx, m_remote_image.io_ctx, m_instance_watcher,
     &m_local_image_ctx, m_local_image_id, m_remote_image.image_id,
-    m_global_image_id, m_threads->work_queue, m_threads->timer,
-    &m_threads->timer_lock, m_local_mirror_uuid, m_remote_image.mirror_uuid,
+    m_global_image_id, m_local_mirror_uuid, m_remote_image.mirror_uuid,
     m_remote_journaler, &m_client_state, &m_client_meta, ctx,
     &m_resync_requested, &m_progress_cxt);
 

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
@@ -30,6 +30,7 @@ class ProgressContext;
 
 template <typename> class ImageSync;
 template <typename> class InstanceWatcher;
+template <typename> struct Threads;
 
 namespace image_replayer {
 
@@ -42,6 +43,7 @@ public:
   typedef rbd::mirror::ProgressContext ProgressContext;
 
   static BootstrapRequest* create(
+        Threads<ImageCtxT>* threads,
         librados::IoCtx &local_io_ctx,
         librados::IoCtx &remote_io_ctx,
         InstanceWatcher<ImageCtxT> *instance_watcher,
@@ -49,8 +51,6 @@ public:
         const std::string &local_image_id,
         const std::string &remote_image_id,
         const std::string &global_image_id,
-        ContextWQ *work_queue, SafeTimer *timer,
-        Mutex *timer_lock,
         const std::string &local_mirror_uuid,
         const std::string &remote_mirror_uuid,
         Journaler *journaler,
@@ -59,23 +59,23 @@ public:
         Context *on_finish,
         bool *do_resync,
         ProgressContext *progress_ctx = nullptr) {
-    return new BootstrapRequest(local_io_ctx, remote_io_ctx,
+    return new BootstrapRequest(threads, local_io_ctx, remote_io_ctx,
                                 instance_watcher, local_image_ctx,
                                 local_image_id, remote_image_id,
-                                global_image_id, work_queue, timer, timer_lock,
-                                local_mirror_uuid, remote_mirror_uuid,
-                                journaler, client_state, client_meta, on_finish,
-                                do_resync, progress_ctx);
+                                global_image_id, local_mirror_uuid,
+                                remote_mirror_uuid, journaler, client_state,
+                                client_meta, on_finish, do_resync,
+                                progress_ctx);
   }
 
-  BootstrapRequest(librados::IoCtx &local_io_ctx,
+  BootstrapRequest(Threads<ImageCtxT>* threads,
+                   librados::IoCtx &local_io_ctx,
                    librados::IoCtx &remote_io_ctx,
                    InstanceWatcher<ImageCtxT> *instance_watcher,
                    ImageCtxT **local_image_ctx,
                    const std::string &local_image_id,
                    const std::string &remote_image_id,
-                   const std::string &global_image_id, ContextWQ *work_queue,
-                   SafeTimer *timer, Mutex *timer_lock,
+                   const std::string &global_image_id,
                    const std::string &local_mirror_uuid,
                    const std::string &remote_mirror_uuid, Journaler *journaler,
                    cls::journal::ClientState *client_state,
@@ -146,6 +146,7 @@ private:
    */
   typedef std::list<cls::journal::Tag> Tags;
 
+  Threads<ImageCtxT>* m_threads;
   librados::IoCtx &m_local_io_ctx;
   librados::IoCtx &m_remote_io_ctx;
   InstanceWatcher<ImageCtxT> *m_instance_watcher;
@@ -153,9 +154,6 @@ private:
   std::string m_local_image_id;
   std::string m_remote_image_id;
   std::string m_global_image_id;
-  ContextWQ *m_work_queue;
-  SafeTimer *m_timer;
-  Mutex *m_timer_lock;
   std::string m_local_mirror_uuid;
   std::string m_remote_mirror_uuid;
   Journaler *m_journaler;

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
@@ -7,35 +7,41 @@
 #include "include/int_types.h"
 #include "include/types.h"
 #include "include/rados/librados.hpp"
+#include "cls/journal/cls_journal_types.h"
 #include "librbd/Types.h"
+#include "librbd/journal/TypeTraits.h"
 #include <string>
 
 class Context;
 class ContextWQ;
+namespace journal { class Journaler; }
 namespace librbd { class ImageCtx; }
 namespace librbd { class ImageOptions; }
 
 namespace rbd {
 namespace mirror {
+
+template <typename> struct Threads;
+
 namespace image_replayer {
 
 template <typename ImageCtxT = librbd::ImageCtx>
 class CreateImageRequest {
 public:
-  static CreateImageRequest *create(librados::IoCtx &local_io_ctx,
-                                    ContextWQ *work_queue,
+  static CreateImageRequest *create(Threads<ImageCtxT> *threads,
+                                    librados::IoCtx &local_io_ctx,
                                     const std::string &global_image_id,
                                     const std::string &remote_mirror_uuid,
                                     const std::string &local_image_name,
 				    const std::string &local_image_id,
                                     ImageCtxT *remote_image_ctx,
                                     Context *on_finish) {
-    return new CreateImageRequest(local_io_ctx, work_queue, global_image_id,
+    return new CreateImageRequest(threads, local_io_ctx, global_image_id,
                                   remote_mirror_uuid, local_image_name,
                                   local_image_id, remote_image_ctx, on_finish);
   }
 
-  CreateImageRequest(librados::IoCtx &local_io_ctx, ContextWQ *work_queue,
+  CreateImageRequest(Threads<ImageCtxT> *threads, librados::IoCtx &local_io_ctx,
                      const std::string &global_image_id,
                      const std::string &remote_mirror_uuid,
                      const std::string &local_image_name,
@@ -55,7 +61,13 @@ private:
    *    |\------------> CREATE_IMAGE ---------------------\         * (error)
    *    |                                                 |         *
    *    | (clone)                                         |         *
-   *    \-------------> GET_PARENT_GLOBAL_IMAGE_ID  * * * | * * *   *
+   *    \-------------> GET_LOCAL_PARENT_MIRROR_UUID  * * | * * *   *
+   *                        |                             |       * *
+   *                        v                             |         *
+   *                    GET_REMOTE_PARENT_CLIENT_STATE  * | * * *   *
+   *                        |                             |       * *
+   *                        v                             |         *
+   *                    GET_PARENT_GLOBAL_IMAGE_ID  * * * | * * *   *
    *                        |                             |       * *
    *                        v                             |         *
    *                    GET_LOCAL_PARENT_IMAGE_ID * * * * | * * *   *
@@ -73,8 +85,11 @@ private:
    * @endverbatim
    */
 
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+
+  Threads<ImageCtxT> *m_threads;
   librados::IoCtx &m_local_io_ctx;
-  ContextWQ *m_work_queue;
   std::string m_global_image_id;
   std::string m_remote_mirror_uuid;
   std::string m_local_image_name;
@@ -83,6 +98,8 @@ private:
   Context *m_on_finish;
 
   librados::IoCtx m_remote_parent_io_ctx;
+  std::string m_local_parent_mirror_uuid;
+  Journaler *m_remote_journaler = nullptr;
   ImageCtxT *m_remote_parent_image_ctx = nullptr;
   librbd::ParentSpec m_remote_parent_spec;
 
@@ -92,10 +109,17 @@ private:
   bufferlist m_out_bl;
   std::string m_parent_global_image_id;
   std::string m_parent_pool_name;
+  cls::journal::Client m_client;
   int m_ret_val = 0;
 
   void create_image();
   void handle_create_image(int r);
+
+  void get_local_parent_mirror_uuid();
+  void handle_get_local_parent_mirror_uuid(int r);
+
+  void get_remote_parent_client_state();
+  void handle_get_remote_parent_client_state(int r);
 
   void get_parent_global_image_id();
   void handle_get_parent_global_image_id(int r);

--- a/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/PrepareRemoteImageRequest.h
@@ -123,8 +123,6 @@ private:
   void handle_register_client(int r);
 
   void finish(int r);
-
-  bool decode_client_meta();
 };
 
 } // namespace image_replayer

--- a/src/tools/rbd_mirror/image_replayer/Utils.cc
+++ b/src/tools/rbd_mirror/image_replayer/Utils.cc
@@ -1,0 +1,50 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "tools/rbd_mirror/image_replayer/Utils.h"
+#include "common/debug.h"
+#include "common/errno.h"
+#include "cls/journal/cls_journal_types.h"
+#include "librbd/journal/Types.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_replayer::util::" \
+                           << __func__ << ": "
+
+namespace rbd {
+namespace mirror {
+namespace image_replayer {
+namespace util {
+
+bool decode_client_meta(const cls::journal::Client& client,
+                        librbd::journal::MirrorPeerClientMeta* client_meta) {
+  dout(15) << dendl;
+
+  librbd::journal::ClientData client_data;
+  auto it = client.data.cbegin();
+  try {
+    decode(client_data, it);
+  } catch (const buffer::error &err) {
+    derr << "failed to decode client meta data: " << err.what() << dendl;
+    return false;
+  }
+
+  auto local_client_meta = boost::get<librbd::journal::MirrorPeerClientMeta>(
+    &client_data.client_meta);
+  if (local_client_meta == nullptr) {
+    derr << "unknown peer registration" << dendl;
+    return false;
+  }
+
+  *client_meta = *local_client_meta;
+  dout(15) << "client found: client_meta=" << *client_meta << dendl;
+  return true;
+}
+
+} // namespace util
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd
+

--- a/src/tools/rbd_mirror/image_replayer/Utils.h
+++ b/src/tools/rbd_mirror/image_replayer/Utils.h
@@ -1,0 +1,23 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_REPLAYER_UTILS_H
+#define RBD_MIRROR_IMAGE_REPLAYER_UTILS_H
+
+namespace cls { namespace journal { struct Client; } }
+namespace librbd { namespace journal { struct MirrorPeerClientMeta; } }
+
+namespace rbd {
+namespace mirror {
+namespace image_replayer {
+namespace util {
+
+bool decode_client_meta(const cls::journal::Client& client,
+                        librbd::journal::MirrorPeerClientMeta* client_meta);
+
+} // namespace util
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd
+
+#endif // RBD_MIRROR_IMAGE_REPLAYER_UTILS_H


### PR DESCRIPTION
This will prevent a possible race condition where a thrashing rbd-mirror
daemon in mid-sync with a parent image would result in the deletion of
all snapshots when it restarts the sync.

Fixes: http://tracker.ceph.com/issues/24140
Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

