### PR TITLE
 mds: use smart pointer to manager CInode::{inode,xattrs}

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -28,12 +28,12 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
-#define dout_prefix *_dout << "mds." << dir->cache->mds->get_nodeid() << ".cache.den(" << dir->dirfrag() << " " << name << ") "
+#define dout_prefix *_dout << "mds." << dir->mdcache->mds->get_nodeid() << ".cache.den(" << dir->dirfrag() << " " << name << ") "
 
 
 ostream& CDentry::print_db_line_prefix(ostream& out)
 {
-  return out << ceph_clock_now() << " mds." << dir->cache->mds->get_nodeid() << ".cache.den(" << dir->ino() << " " << name << ") ";
+  return out << ceph_clock_now() << " mds." << dir->mdcache->mds->get_nodeid() << ".cache.den(" << dir->ino() << " " << name << ") ";
 }
 
 LockType CDentry::lock_type(CEPH_LOCK_DN);

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -414,7 +414,7 @@ void CDentry::encode_lock_state(int type, bufferlist& bl)
   if (linkage.is_primary()) {
     c = 1;
     encode(c, bl);
-    encode(linkage.get_inode()->inode.ino, bl);
+    encode(linkage.get_inode()->ino(), bl);
   }
   else if (linkage.is_remote()) {
     c = 2;

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -190,7 +190,7 @@ void CDentry::mark_dirty(version_t pv, LogSegment *ls)
   _mark_dirty(ls);
 
   // mark dir too
-  dir->mark_dirty(pv, ls);
+  dir->mark_dirty(ls, pv);
 }
 
 

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -237,7 +237,7 @@ public:
 
   version_t pre_dirty(version_t min=0);
   void _mark_dirty(LogSegment *ls);
-  void mark_dirty(version_t projected_dirv, LogSegment *ls);
+  void mark_dirty(version_t pv, LogSegment *ls);
   void mark_clean();
 
   void mark_new();

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -41,7 +41,7 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
-#define dout_prefix *_dout << "mds." << cache->mds->get_nodeid() << ".cache.dir(" << this->dirfrag() << ") "
+#define dout_prefix *_dout << "mds." << mdcache->mds->get_nodeid() << ".cache.dir(" << this->dirfrag() << ") "
 
 int CDir::num_frozen_trees = 0;
 int CDir::num_freezing_trees = 0;
@@ -52,7 +52,7 @@ class CDirContext : public MDSContext
 {
 protected:
   CDir *dir;
-  MDSRank* get_mds() override {return dir->cache->mds;}
+  MDSRank* get_mds() override {return dir->mdcache->mds;}
 
 public:
   explicit CDirContext(CDir *d) : dir(d) {
@@ -65,7 +65,7 @@ class CDirIOContext : public MDSIOContextBase
 {
 protected:
   CDir *dir;
-  MDSRank* get_mds() override {return dir->cache->mds;}
+  MDSRank* get_mds() override {return dir->mdcache->mds;}
 
 public:
   explicit CDirIOContext(CDir *d) : dir(d) {
@@ -184,7 +184,7 @@ void CDir::print(ostream& out)
 
 ostream& CDir::print_db_line_prefix(ostream& out) 
 {
-  return out << ceph_clock_now() << " mds." << cache->mds->get_nodeid() << ".cache.dir(" << this->dirfrag() << ") ";
+  return out << ceph_clock_now() << " mds." << mdcache->mds->get_nodeid() << ".cache.dir(" << this->dirfrag() << ") ";
 }
 
 
@@ -192,19 +192,19 @@ ostream& CDir::print_db_line_prefix(ostream& out)
 // -------------------------------------------------------------------
 // CDir
 
-CDir::CDir(CInode *in, frag_t fg, MDCache *mdcache, bool auth) :
-  cache(mdcache), inode(in), frag(fg),
+CDir::CDir(CInode *in, frag_t fg, MDCache *mdc, bool auth) :
+  mdcache(mdc), inode(in), frag(fg),
   dirty_rstat_inodes(member_offset(CInode, dirty_rstat_item)),
   dirty_dentries(member_offset(CDentry, item_dir_dirty)),
   item_dirty(this), item_new(this),
   lock_caches_with_auth_pins(member_offset(MDLockCache::DirItem, item_dir)),
   freezing_inodes(member_offset(CInode, item_freezing_inode)),
   dir_rep(REP_NONE),
-  pop_me(mdcache->decayrate),
-  pop_nested(mdcache->decayrate),
-  pop_auth_subtree(mdcache->decayrate),
-  pop_auth_subtree_nested(mdcache->decayrate),
-  pop_spread(mdcache->decayrate),
+  pop_me(mdc->decayrate),
+  pop_nested(mdc->decayrate),
+  pop_auth_subtree(mdc->decayrate),
+  pop_auth_subtree_nested(mdc->decayrate),
+  pop_spread(mdc->decayrate),
   pop_lru_subdirs(member_offset(CInode, item_pop_lru)),
   dir_auth(CDIR_AUTH_DEFAULT)
 {
@@ -301,9 +301,9 @@ void CDir::adjust_num_inodes_with_caps(int d)
 {
   // FIXME: smarter way to decide if adding 'this' to open file table
   if (num_inodes_with_caps == 0 && d > 0)
-    cache->open_file_table.add_dirfrag(this);
+    mdcache->open_file_table.add_dirfrag(this);
   else if (num_inodes_with_caps > 0 && num_inodes_with_caps == -d)
-    cache->open_file_table.remove_dirfrag(this);
+    mdcache->open_file_table.remove_dirfrag(this);
 
   num_inodes_with_caps += d;
   ceph_assert(num_inodes_with_caps >= 0);
@@ -348,7 +348,7 @@ CDentry* CDir::add_null_dentry(std::string_view dname,
   if (is_auth()) 
     dn->state_set(CDentry::STATE_AUTH);
 
-  cache->bottom_lru.lru_insert_mid(dn);
+  mdcache->bottom_lru.lru_insert_mid(dn);
   dn->state_set(CDentry::STATE_BOTTOMLRU);
 
   dn->dir = this;
@@ -391,9 +391,9 @@ CDentry* CDir::add_primary_dentry(std::string_view dname, CInode *in,
   if (is_auth()) 
     dn->state_set(CDentry::STATE_AUTH);
   if (is_auth() || !inode->is_stray()) {
-    cache->lru.lru_insert_mid(dn);
+    mdcache->lru.lru_insert_mid(dn);
   } else {
-    cache->bottom_lru.lru_insert_mid(dn);
+    mdcache->bottom_lru.lru_insert_mid(dn);
     dn->state_set(CDentry::STATE_BOTTOMLRU);
   }
 
@@ -439,7 +439,7 @@ CDentry* CDir::add_remote_dentry(std::string_view dname, inodeno_t ino, unsigned
   CDentry* dn = new CDentry(dname, inode->hash_dentry_name(dname), ino, d_type, first, last);
   if (is_auth()) 
     dn->state_set(CDentry::STATE_AUTH);
-  cache->lru.lru_insert_mid(dn);
+  mdcache->lru.lru_insert_mid(dn);
 
   dn->dir = this;
   dn->version = get_projected_version();
@@ -508,9 +508,9 @@ void CDir::remove_dentry(CDentry *dn)
     dn->mark_clean();
 
   if (dn->state_test(CDentry::STATE_BOTTOMLRU))
-    cache->bottom_lru.lru_remove(dn);
+    mdcache->bottom_lru.lru_remove(dn);
   else
-    cache->lru.lru_remove(dn);
+    mdcache->lru.lru_remove(dn);
   delete dn;
 
   // unpin?
@@ -532,8 +532,8 @@ void CDir::link_remote_inode(CDentry *dn, inodeno_t ino, unsigned char d_type)
   dn->get_linkage()->set_remote(ino, d_type);
 
   if (dn->state_test(CDentry::STATE_BOTTOMLRU)) {
-    cache->bottom_lru.lru_remove(dn);
-    cache->lru.lru_insert_mid(dn);
+    mdcache->bottom_lru.lru_remove(dn);
+    mdcache->lru.lru_insert_mid(dn);
     dn->state_clear(CDentry::STATE_BOTTOMLRU);
   }
 
@@ -558,8 +558,8 @@ void CDir::link_primary_inode(CDentry *dn, CInode *in)
 
   if (dn->state_test(CDentry::STATE_BOTTOMLRU) &&
       (is_auth() || !inode->is_stray())) {
-    cache->bottom_lru.lru_remove(dn);
-    cache->lru.lru_insert_mid(dn);
+    mdcache->bottom_lru.lru_remove(dn);
+    mdcache->lru.lru_insert_mid(dn);
     dn->state_clear(CDentry::STATE_BOTTOMLRU);
   }
   
@@ -587,7 +587,7 @@ void CDir::link_inode_work( CDentry *dn, CInode *in)
     dn->get(CDentry::PIN_INODEPIN);
 
   if (in->state_test(CInode::STATE_TRACKEDBYOFT))
-    inode->mdcache->open_file_table.notify_link(in);
+    mdcache->open_file_table.notify_link(in);
   if (in->is_any_caps())
     adjust_num_inodes_with_caps(1);
   
@@ -618,8 +618,8 @@ void CDir::unlink_inode(CDentry *dn, bool adjust_lru)
   unlink_inode_work(dn);
 
   if (adjust_lru && !dn->state_test(CDentry::STATE_BOTTOMLRU)) {
-    cache->lru.lru_remove(dn);
-    cache->bottom_lru.lru_insert_mid(dn);
+    mdcache->lru.lru_remove(dn);
+    mdcache->bottom_lru.lru_insert_mid(dn);
     dn->state_set(CDentry::STATE_BOTTOMLRU);
   }
 
@@ -673,7 +673,7 @@ void CDir::unlink_inode_work(CDentry *dn)
       dn->put(CDentry::PIN_INODEPIN);
 
     if (in->state_test(CInode::STATE_TRACKEDBYOFT))
-      inode->mdcache->open_file_table.notify_unlink(in);
+      mdcache->open_file_table.notify_unlink(in);
     if (in->is_any_caps())
       adjust_num_inodes_with_caps(-1);
     
@@ -706,7 +706,7 @@ void CDir::add_to_bloom(CDentry *dn)
 
     /* don't maintain bloom filters in standby replay (saves cycles, and also
      * avoids need to implement clearing it in EExport for #16924) */
-    if (cache->mds->is_standby_replay()) {
+    if (mdcache->mds->is_standby_replay()) {
       return;
     }
 
@@ -768,7 +768,7 @@ void CDir::try_remove_dentries_for_stray()
       // It's OK to remove lease prematurely because we will never link
       // the dentry to inode again.
       if (dn->is_any_leases())
-	dn->remove_client_leases(cache->mds->locker);
+	dn->remove_client_leases(mdcache->mds->locker);
       if (dn->get_num_ref() == 0)
 	remove_dentry(dn);
     } else {
@@ -785,7 +785,7 @@ void CDir::try_remove_dentries_for_stray()
       if (dn->get_num_ref() == 0) {
 	remove_dentry(dn);
 	if (in)
-	  cache->remove_inode(in);
+	  mdcache->remove_inode(in);
       }
     }
   }
@@ -811,7 +811,7 @@ bool CDir::try_trim_snap_dentry(CDentry *dn, const set<snapid_t>& snaps)
     remove_dentry(dn);
     if (in) {
       dout(10) << " purging snapped " << *in << dendl;
-      cache->remove_inode(in);
+      mdcache->remove_inode(in);
     }
     return true;
   }
@@ -1026,7 +1026,7 @@ void CDir::split(int bits, std::vector<CDir*>* subs, MDSContext::vec& waiters, b
   // create subfrag dirs
   int n = 0;
   for (const auto& fg : frags) {
-    CDir *f = new CDir(inode, fg, cache, is_auth());
+    CDir *f = new CDir(inode, fg, mdcache, is_auth());
     f->state_set(state & (MASK_STATE_FRAGMENT_KEPT | STATE_COMPLETE));
     f->get_replicas() = get_replicas();
     f->pop_me = pop_me;
@@ -1232,7 +1232,7 @@ void CDir::assimilate_dirty_rstat_inodes(MutationRef& mut)
     auto pi = in->project_inode(mut);
     pi.inode->version = in->pre_dirty();
 
-    inode->mdcache->project_rstat_inode_to_frag(mut, in, this, 0, 0, nullptr);
+    mdcache->project_rstat_inode_to_frag(mut, in, this, 0, 0, nullptr);
   }
   state_set(STATE_ASSIMRSTAT);
   dout(10) << __func__ << " done" << dendl;
@@ -1259,7 +1259,7 @@ void CDir::assimilate_dirty_rstat_inodes_finish(EMetaBlob *blob)
   }
 
   if (!dirty_rstat_inodes.empty())
-    inode->mdcache->mds->locker->mark_updated_scatterlock(&inode->nestlock);
+    mdcache->mds->locker->mark_updated_scatterlock(&inode->nestlock);
 }
 
 
@@ -1371,7 +1371,7 @@ void CDir::finish_waiting(uint64_t mask, int result)
   if (result < 0)
     finish_contexts(g_ceph_context, finished, result);
   else
-    cache->mds->queue_waiters(finished);
+    mdcache->mds->queue_waiters(finished);
 }
 
 
@@ -1465,7 +1465,7 @@ void CDir::mark_new(LogSegment *ls)
 
   MDSContext::vec waiters;
   take_waiting(CDir::WAIT_CREATED, waiters);
-  cache->mds->queue_waiters(waiters);
+  mdcache->mds->queue_waiters(waiters);
 }
 
 void CDir::mark_clean()
@@ -1489,7 +1489,7 @@ void CDir::log_mark_dirty()
   auto _fnode = allocate_fnode(*get_fnode());
   _fnode->version = pre_dirty();
   reset_fnode(std::move(_fnode));
-  mark_dirty(cache->mds->mdlog->get_current_segment());
+  mark_dirty(mdcache->mds->mdlog->get_current_segment());
 }
 
 void CDir::mark_complete() {
@@ -1548,15 +1548,15 @@ void CDir::fetch(MDSContext *c, std::string_view want_dn, bool ignore_authpinnab
       reset_fnode(std::move(_fnode));
 
       if (state_test(STATE_REJOINUNDEF)) {
-	ceph_assert(cache->mds->is_rejoin());
+	ceph_assert(mdcache->mds->is_rejoin());
 	state_clear(STATE_REJOINUNDEF);
-	cache->opened_undef_dirfrag(this);
+	mdcache->opened_undef_dirfrag(this);
       }
     }
     mark_complete();
 
     if (c)
-      cache->mds->queue_waiter(c);
+      mdcache->mds->queue_waiter(c);
     return;
   }
 
@@ -1572,7 +1572,7 @@ void CDir::fetch(MDSContext *c, std::string_view want_dn, bool ignore_authpinnab
   auth_pin(this);
   state_set(CDir::STATE_FETCHING);
 
-  if (cache->mds->logger) cache->mds->logger->inc(l_mds_dir_fetch);
+  if (mdcache->mds->logger) mdcache->mds->logger->inc(l_mds_dir_fetch);
 
   std::set<dentry_key_t> empty;
   _omap_fetch(NULL, empty);
@@ -1597,7 +1597,7 @@ void CDir::fetch(MDSContext *c, const std::set<dentry_key_t>& keys)
   }
 
   auth_pin(this);
-  if (cache->mds->logger) cache->mds->logger->inc(l_mds_dir_fetch);
+  if (mdcache->mds->logger) mdcache->mds->logger->inc(l_mds_dir_fetch);
 
   _omap_fetch(c, keys);
 }
@@ -1666,7 +1666,7 @@ void CDir::_omap_fetch(MDSContext *c, const std::set<dentry_key_t>& keys)
 {
   C_IO_Dir_OMAP_Fetched *fin = new C_IO_Dir_OMAP_Fetched(this, c);
   object_t oid = get_ondisk_object();
-  object_locator_t oloc(cache->mds->mdsmap->get_metadata_pool());
+  object_locator_t oloc(mdcache->mds->mdsmap->get_metadata_pool());
   ObjectOperation rd;
   rd.omap_get_header(&fin->hdrbl, &fin->ret1);
   if (keys.empty()) {
@@ -1691,8 +1691,8 @@ void CDir::_omap_fetch(MDSContext *c, const std::set<dentry_key_t>& keys)
     fin->ret3 = -ECANCELED;
   }
 
-  cache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
-			     new C_OnFinisher(fin, cache->mds->finisher));
+  mdcache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
+			     new C_OnFinisher(fin, mdcache->mds->finisher));
 }
 
 void CDir::_omap_fetch_more(
@@ -1702,7 +1702,7 @@ void CDir::_omap_fetch_more(
 {
   // we have more omap keys to fetch!
   object_t oid = get_ondisk_object();
-  object_locator_t oloc(cache->mds->mdsmap->get_metadata_pool());
+  object_locator_t oloc(mdcache->mds->mdsmap->get_metadata_pool());
   C_IO_Dir_OMAP_FetchedMore *fin = new C_IO_Dir_OMAP_FetchedMore(this, c);
   fin->hdrbl = std::move(hdrbl);
   fin->omap.swap(omap);
@@ -1713,8 +1713,8 @@ void CDir::_omap_fetch_more(
 		   &fin->omap_more,
 		   &fin->more,
 		   &fin->ret);
-  cache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
-			     new C_OnFinisher(fin, cache->mds->finisher));
+  mdcache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
+			     new C_OnFinisher(fin, mdcache->mds->finisher));
 }
 
 CDentry *CDir::_load_dentry(
@@ -1793,7 +1793,7 @@ CDentry *CDir::_load_dentry(
       dn = add_remote_dentry(dname, ino, d_type, first, last);
       
       // link to inode?
-      CInode *in = cache->get_inode(ino);   // we may or may not have it.
+      CInode *in = mdcache->get_inode(ino);   // we may or may not have it.
       if (in) {
         dn->link_remote(dn->get_linkage(), in);
         dout(12) << "_fetched  got remote link " << ino << " which we have " << *in << dendl;
@@ -1852,12 +1852,12 @@ CDentry *CDir::_load_dentry(
 
     if (!dn || undef_inode) {
       // add inode
-      CInode *in = cache->get_inode(inode_data.inode->ino, last);
+      CInode *in = mdcache->get_inode(inode_data.inode->ino, last);
       if (!in || undef_inode) {
         if (undef_inode && in)
           in->first = first;
         else
-          in = new CInode(cache, true, first, last);
+          in = new CInode(mdcache, true, first, last);
         
         in->reset_inode(std::move(inode_data.inode));
         in->reset_xattrs(std::move(inode_data.xattrs));
@@ -1879,7 +1879,7 @@ CDentry *CDir::_load_dentry(
           in->purge_stale_snap_data(*snaps);
 
         if (!undef_inode) {
-          cache->add_inode(in); // add
+          mdcache->add_inode(in); // add
           dn = add_primary_dentry(dname, in, first, last); // link
         }
         dout(12) << "_fetched  got " << *dn << " " << *in << dendl;
@@ -1901,7 +1901,7 @@ CDentry *CDir::_load_dentry(
         string dirpath, inopath;
         this->inode->make_path_string(dirpath);
         in->make_path_string(inopath);
-        cache->mds->clog->error() << "loaded dup inode " << inode_data.inode->ino
+        mdcache->mds->clog->error() << "loaded dup inode " << inode_data.inode->ino
           << " [" << first << "," << last << "] v" << inode_data.inode->version
           << " at " << dirpath << "/" << dname
           << ", but inode " << in->vino() << " v" << in->get_version()
@@ -1921,7 +1921,7 @@ CDentry *CDir::_load_dentry(
 void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
 			 bool complete, int r)
 {
-  LogChannelRef clog = cache->mds->clog;
+  LogChannelRef clog = mdcache->mds->clog;
   dout(10) << "_fetched header " << hdrbl.length() << " bytes "
 	   << omap.size() << " keys for " << *this << dendl;
 
@@ -1973,9 +1973,9 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
     projected_version = committing_version = committed_version = get_version();
 
     if (state_test(STATE_REJOINUNDEF)) {
-      ceph_assert(cache->mds->is_rejoin());
+      ceph_assert(mdcache->mds->is_rejoin());
       state_clear(STATE_REJOINUNDEF);
-      cache->opened_undef_dirfrag(this);
+      mdcache->opened_undef_dirfrag(this);
     }
   }
 
@@ -2014,7 +2014,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
             p->first, dname, last, p->second, pos, snaps,
             rand_threshold, &force_dirty);
     } catch (const buffer::error &err) {
-      cache->mds->clog->warn() << "Corrupt dentry '" << dname << "' in "
+      mdcache->mds->clog->warn() << "Corrupt dentry '" << dname << "' in "
                                   "dir frag " << dirfrag() << ": "
                                << err.what() << "(" << get_path() << ")";
 
@@ -2040,7 +2040,7 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
 
     if (wanted_items.count(mempool::mds_co::string(dname)) > 0 || !complete) {
       dout(10) << " touching wanted dn " << *dn << dendl;
-      inode->mdcache->touch_dentry(dn);
+      mdcache->touch_dentry(dn);
     }
   }
 
@@ -2063,11 +2063,11 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
     CInode *in = undef_inodes.front();
     undef_inodes.pop_front();
     in->state_clear(CInode::STATE_REJOINUNDEF);
-    cache->opened_undef_inode(in);
+    mdcache->opened_undef_inode(in);
   }
 
   // dirty myself to remove stale snap dentries
-  if (force_dirty && !inode->mdcache->is_readonly())
+  if (force_dirty && !mdcache->is_readonly())
     log_mark_dirty();
 
   auth_unpin(this);
@@ -2084,10 +2084,10 @@ void CDir::go_bad_dentry(snapid_t last, std::string_view dname)
   std::string path(get_path());
   path += "/";
   path += dname;
-  const bool fatal = cache->mds->damage_table.notify_dentry(
+  const bool fatal = mdcache->mds->damage_table.notify_dentry(
       inode->ino(), frag, last, dname, path);
   if (fatal) {
-    cache->mds->damaged();
+    mdcache->mds->damaged();
     ceph_abort();  // unreachable, damaged() respawns us
   }
 }
@@ -2095,10 +2095,10 @@ void CDir::go_bad_dentry(snapid_t last, std::string_view dname)
 void CDir::go_bad(bool complete)
 {
   dout(10) << __func__ << " " << frag << dendl;
-  const bool fatal = cache->mds->damage_table.notify_dirfrag(
+  const bool fatal = mdcache->mds->damage_table.notify_dirfrag(
       inode->ino(), frag, get_path());
   if (fatal) {
-    cache->mds->damaged();
+    mdcache->mds->damaged();
     ceph_abort();  // unreachable, damaged() respawns us
   }
 
@@ -2172,7 +2172,7 @@ void CDir::_omap_commit(int op_prio)
 {
   dout(10) << __func__ << dendl;
 
-  unsigned max_write_size = cache->max_dir_commit_size;
+  unsigned max_write_size = mdcache->max_dir_commit_size;
   unsigned write_size = 0;
 
   if (op_prio < 0)
@@ -2197,11 +2197,11 @@ void CDir::_omap_commit(int op_prio)
   C_GatherBuilder gather(g_ceph_context,
 			 new C_OnFinisher(new C_IO_Dir_Committed(this,
 								 get_version()),
-					  cache->mds->finisher));
+					  mdcache->mds->finisher));
 
   SnapContext snapc;
   object_t oid = get_ondisk_object();
-  object_locator_t oloc(cache->mds->mdsmap->get_metadata_pool());
+  object_locator_t oloc(mdcache->mds->mdsmap->get_metadata_pool());
 
   if (!stale_items.empty()) {
     for (const auto &p : stale_items) {
@@ -2248,7 +2248,7 @@ void CDir::_omap_commit(int op_prio)
       if (!to_remove.empty())
 	op.omap_rm_keys(to_remove);
 
-      cache->mds->objecter->mutate(oid, oloc, op, snapc,
+      mdcache->mds->objecter->mutate(oid, oloc, op, snapc,
 				   ceph::real_clock::now(),
 				   0, gather.new_sub());
 
@@ -2299,7 +2299,7 @@ void CDir::_omap_commit(int op_prio)
   if (!to_remove.empty())
     op.omap_rm_keys(to_remove);
 
-  cache->mds->objecter->mutate(oid, oloc, op, snapc,
+  mdcache->mds->objecter->mutate(oid, oloc, op, snapc,
 			       ceph::real_clock::now(),
 			       0, gather.new_sub());
 
@@ -2345,7 +2345,7 @@ void CDir::_encode_dentry(CDentry *dn, bufferlist& bl,
 
     bufferlist snap_blob;
     in->encode_snap_blob(snap_blob);
-    in->encode_bare(bl, cache->mds->mdsmap->get_up_features(), &snap_blob);
+    in->encode_bare(bl, mdcache->mds->mdsmap->get_up_features(), &snap_blob);
   } else {
     ceph_assert(!dn->linkage.is_null());
   }
@@ -2389,7 +2389,7 @@ void CDir::_commit(version_t want, int op_prio)
     state_set(STATE_COMMITTING);
   }
   
-  if (cache->mds->logger) cache->mds->logger->inc(l_mds_dir_commit);
+  if (mdcache->mds->logger) mdcache->mds->logger->inc(l_mds_dir_commit);
 
   _omap_commit(op_prio);
 }
@@ -2412,9 +2412,9 @@ void CDir::_committed(int r, version_t v)
     }
     if (r < 0) {
       dout(1) << "commit error " << r << " v " << v << dendl;
-      cache->mds->clog->error() << "failed to commit dir " << dirfrag() << " object,"
+      mdcache->mds->clog->error() << "failed to commit dir " << dirfrag() << " object,"
 				<< " errno " << r;
-      cache->mds->handle_write_error(r);
+      mdcache->mds->handle_write_error(r);
       return;
     }
   }
@@ -2494,7 +2494,7 @@ void CDir::_committed(int r, version_t v)
     MDSContext::vec t;
     for (const auto &waiter : it->second)
       t.push_back(waiter);
-    cache->mds->queue_waiters(t);
+    mdcache->mds->queue_waiters(t);
     waiting_for_commit.erase(it);
     it = _it;
   } 
@@ -2502,7 +2502,7 @@ void CDir::_committed(int r, version_t v)
   // try drop dentries in this dirfrag if it's about to be purged
   if (!inode->is_base() && get_parent_dir()->inode->is_stray() &&
       inode->snaprealm)
-    cache->maybe_eval_stray(inode, true);
+    mdcache->maybe_eval_stray(inode, true);
 
   // unpin if we kicked the last waiter.
   if (were_waiters &&
@@ -2589,11 +2589,11 @@ void CDir::decode_import(bufferlist::const_iterator& blp, LogSegment *ls)
   // did we import some dirty scatterlock data?
   if (dirty_old_rstat.size() ||
       !(fnode->rstat == fnode->accounted_rstat)) {
-    cache->mds->locker->mark_updated_scatterlock(&inode->nestlock);
+    mdcache->mds->locker->mark_updated_scatterlock(&inode->nestlock);
     ls->dirty_dirfrag_nest.push_back(&inode->item_dirty_dirfrag_nest);
   }
   if (!(fnode->fragstat == fnode->accounted_fragstat)) {
-    cache->mds->locker->mark_updated_scatterlock(&inode->filelock);
+    mdcache->mds->locker->mark_updated_scatterlock(&inode->filelock);
     ls->dirty_dirfrag_dir.push_back(&inode->item_dirty_dirfrag_dir);
   }
   if (is_dirty_dft()) {
@@ -2602,7 +2602,7 @@ void CDir::decode_import(bufferlist::const_iterator& blp, LogSegment *ls)
       // clear stale dirtydft
       state_clear(STATE_DIRTYDFT);
     } else {
-      cache->mds->locker->mark_updated_scatterlock(&inode->dirfragtreelock);
+      mdcache->mds->locker->mark_updated_scatterlock(&inode->dirfragtreelock);
       ls->dirty_dirfrag_dirfragtree.push_back(&inode->item_dirty_dirfrag_dirfragtree);
     }
   }
@@ -2746,7 +2746,7 @@ void CDir::set_dir_auth(const mds_authority_t &a)
   if (was_ambiguous && dir_auth.second == CDIR_AUTH_UNKNOWN) {
     MDSContext::vec ls;
     take_waiting(WAIT_SINGLEAUTH, ls);
-    cache->mds->queue_waiters(ls);
+    mdcache->mds->queue_waiters(ls);
   }
 }
 
@@ -2916,7 +2916,7 @@ bool CDir::freeze_tree()
   freeze_tree_state = std::make_shared<freeze_tree_state_t>(this);
   freeze_tree_state->auth_pins += get_auth_pins() + get_dir_auth_pins();
   if (!lock_caches_with_auth_pins.empty())
-    cache->mds->locker->invalidate_lock_caches(this);
+    mdcache->mds->locker->invalidate_lock_caches(this);
 
   _walk_tree([this](CDir *dir) {
       if (dir->freeze_tree_state)
@@ -2924,7 +2924,7 @@ bool CDir::freeze_tree()
       dir->freeze_tree_state = freeze_tree_state;
       freeze_tree_state->auth_pins += dir->get_auth_pins() + dir->get_dir_auth_pins();
       if (!dir->lock_caches_with_auth_pins.empty())
-	cache->mds->locker->invalidate_lock_caches(dir);
+	mdcache->mds->locker->invalidate_lock_caches(dir);
       return true;
     }
   );
@@ -2968,7 +2968,7 @@ void CDir::_freeze_tree()
 
     _walk_tree([this, &auth] (CDir *dir) {
 	if (dir->freeze_tree_state != freeze_tree_state) {
-	  inode->mdcache->adjust_subtree_auth(dir, auth);
+	  mdcache->adjust_subtree_auth(dir, auth);
 	  return false;
 	}
 	return true;
@@ -2978,7 +2978,7 @@ void CDir::_freeze_tree()
     ceph_assert(auth.first >= 0);
     ceph_assert(auth.second == CDIR_AUTH_UNKNOWN);
     auth.second = auth.first;
-    inode->mdcache->adjust_subtree_auth(this, auth);
+    mdcache->adjust_subtree_auth(this, auth);
     if (!was_subtree)
       inode->auth_unpin(this);
   } else {
@@ -3035,7 +3035,7 @@ void CDir::unfreeze_tree()
       ceph_assert(auth.first >= 0);
       ceph_assert(auth.second == auth.first);
       auth.second = CDIR_AUTH_UNKNOWN;
-      inode->mdcache->adjust_subtree_auth(this, auth);
+      mdcache->adjust_subtree_auth(this, auth);
     }
     freeze_tree_state.reset();
   } else {
@@ -3050,7 +3050,7 @@ void CDir::unfreeze_tree()
     auth_unpin(this);
   }
 
-  cache->mds->queue_waiters(unfreeze_waiters);
+  mdcache->mds->queue_waiters(unfreeze_waiters);
 }
 
 void CDir::adjust_freeze_after_rename(CDir *dir)
@@ -3081,7 +3081,7 @@ void CDir::adjust_freeze_after_rename(CDir *dir)
   unfreeze(dir);
   dir->_walk_tree(unfreeze);
 
-  cache->mds->queue_waiters(unfreeze_waiters);
+  mdcache->mds->queue_waiters(unfreeze_waiters);
 }
 
 bool CDir::can_auth_pin(int *err_ret) const
@@ -3170,7 +3170,7 @@ bool CDir::freeze_dir()
   } else {
     state_set(STATE_FREEZINGDIR);
     if (!lock_caches_with_auth_pins.empty())
-      cache->mds->locker->invalidate_lock_caches(this);
+      mdcache->mds->locker->invalidate_lock_caches(this);
     dout(10) << "freeze_dir + wait " << *this << dendl;
     return false;
   } 
@@ -3540,7 +3540,7 @@ bool CDir::scrub_local()
   } else {
     scrub_infop->pending_scrub_error = true;
     if (scrub_infop->header->get_repair())
-      cache->repair_dirfrag_stats(this);
+      mdcache->repair_dirfrag_stats(this);
   }
   return rval;
 }

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -50,6 +50,15 @@ public:
   typedef mempool::mds_co::map<dentry_key_t, CDentry*> dentry_key_map;
   typedef mempool::mds_co::set<dentry_key_t> dentry_key_set;
 
+  using fnode_ptr = std::shared_ptr<fnode_t>;
+  using fnode_const_ptr = std::shared_ptr<const fnode_t>;
+
+  template <typename ...Args>
+  static fnode_ptr allocate_fnode(Args && ...args) {
+    static mempool::mds_co::pool_allocator<fnode_t> allocator;
+    return std::allocate_shared<fnode_t>(allocator, std::forward<Args>(args)...);
+  }
+
   // -- freezing --
   struct freeze_tree_state_t {
     CDir *dir; // freezing/frozen tree root
@@ -231,27 +240,42 @@ public:
     inode->num_exporting_dirs--;
   }
 
-  version_t get_version() const { return fnode.version; }
-  void set_version(version_t v) { 
+  version_t get_version() const { return fnode->version; }
+  void update_projected_version() {
     ceph_assert(projected_fnode.empty());
-    projected_version = fnode.version = v; 
+    projected_version = fnode->version;
   }
   version_t get_projected_version() const { return projected_version; }
 
-  const fnode_t *get_projected_fnode() const {
-    if (projected_fnode.empty())
-      return &fnode;
-    else
-      return &projected_fnode.back();
+  void reset_fnode(fnode_const_ptr&& ptr) {
+    fnode = std::move(ptr);
   }
 
-  fnode_t *get_projected_fnode() {
-    if (projected_fnode.empty())
-      return &fnode;
-    else
-      return &projected_fnode.back();
+  const fnode_const_ptr& get_fnode() const {
+    return fnode;
   }
-  fnode_t *project_fnode();
+
+  // only used for updating newly allocated CDir
+  fnode_t* _get_fnode() {
+    if (fnode == empty_fnode)
+      reset_fnode(allocate_fnode());
+    return const_cast<fnode_t*>(fnode.get());
+  }
+
+  const fnode_const_ptr& get_projected_fnode() const {
+    if (projected_fnode.empty())
+      return fnode;
+    else
+      return projected_fnode.back();
+  }
+
+  // fnode should have already been projected in caller's context
+  fnode_t* _get_projected_fnode() {
+    ceph_assert(!projected_fnode.empty());
+    return const_cast<fnode_t*>(projected_fnode.back().get());
+  }
+
+  fnode_ptr project_fnode();
 
   void pop_and_dirty_projected_fnode(LogSegment *ls);
   bool is_projected() const { return !projected_fnode.empty(); }
@@ -263,7 +287,7 @@ public:
       get(PIN_DIRTY);
     }
   }
-  void mark_dirty(version_t pv, LogSegment *ls);
+  void mark_dirty(LogSegment *ls, version_t pv=0);
   void mark_clean();
 
   bool is_new() { return item_new.is_on_list(); }
@@ -435,7 +459,7 @@ public:
   void _encode_base(ceph::buffer::list& bl) {
     ENCODE_START(1, 1, bl);
     encode(first, bl);
-    encode(fnode, bl);
+    encode(*fnode, bl);
     encode(dir_rep, bl);
     encode(dir_rep_by, bl);
     ENCODE_FINISH(bl);
@@ -443,7 +467,11 @@ public:
   void _decode_base(ceph::buffer::list::const_iterator& p) {
     DECODE_START(1, p);
     decode(first, p);
-    decode(fnode, p);
+    {
+      auto _fnode = allocate_fnode();
+      decode(*_fnode, p);
+      reset_fnode(std::move(_fnode));
+    }
     decode(dir_rep, p);
     decode(dir_rep_by, p);
     DECODE_FINISH(p);
@@ -604,7 +632,6 @@ public:
   CInode *inode;  // my inode
   frag_t frag;   // my frag
 
-  fnode_t fnode;
   snapid_t first = 2;
   mempool::mds_co::compact_map<snapid_t,old_rstat_t> dirty_old_rstat;  // [value.first,key]
 
@@ -668,8 +695,14 @@ protected:
   void _encode_dentry(CDentry *dn, ceph::buffer::list& bl, const std::set<snapid_t> *snaps);
   void _committed(int r, version_t v);
 
+  static fnode_const_ptr empty_fnode;
+  // fnode is a pointer to constant fnode_t, the constant fnode_t can be shared
+  // by CDir and log events. To update fnode, read-copy-update should be used.
+
+  fnode_const_ptr fnode = empty_fnode;
+
   version_t projected_version = 0;
-  mempool::mds_co::list<fnode_t> projected_fnode;
+  mempool::mds_co::list<fnode_const_ptr> projected_fnode;
 
   std::unique_ptr<scrub_info_t> scrub_infop;
 

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -228,8 +228,8 @@ public:
 
   void resync_accounted_fragstat();
   void resync_accounted_rstat();
-  void assimilate_dirty_rstat_inodes();
-  void assimilate_dirty_rstat_inodes_finish(MutationRef& mut, EMetaBlob *blob);
+  void assimilate_dirty_rstat_inodes(MutationRef& mut);
+  void assimilate_dirty_rstat_inodes_finish(EMetaBlob *blob);
 
   void mark_exporting() {
     state_set(CDir::STATE_EXPORTING);
@@ -275,9 +275,9 @@ public:
     return const_cast<fnode_t*>(projected_fnode.back().get());
   }
 
-  fnode_ptr project_fnode();
+  fnode_ptr project_fnode(const MutationRef& mut);
 
-  void pop_and_dirty_projected_fnode(LogSegment *ls);
+  void pop_and_dirty_projected_fnode(LogSegment *ls, const MutationRef& mut);
   bool is_projected() const { return !projected_fnode.empty(); }
   version_t pre_dirty(version_t min=0);
   void _mark_dirty(LogSegment *ls);

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -204,7 +204,7 @@ public:
   static const int DUMP_ALL              = (-1);
   static const int DUMP_DEFAULT          = DUMP_ALL & (~DUMP_ITEMS);
 
-  CDir(CInode *in, frag_t fg, MDCache *mdcache, bool auth);
+  CDir(CInode *in, frag_t fg, MDCache *mdc, bool auth);
 
   std::string_view pin_name(int p) const override {
     switch (p) {
@@ -627,7 +627,7 @@ public:
   void dump_load(ceph::Formatter *f);
 
   // context
-  MDCache *cache;
+  MDCache *mdcache;
 
   CInode *inode;  // my inode
   frag_t frag;   // my frag

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -49,7 +49,7 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
-#define dout_prefix *_dout << "mds." << mdcache->mds->get_nodeid() << ".cache.ino(" << inode.ino << ") "
+#define dout_prefix *_dout << "mds." << mdcache->mds->get_nodeid() << ".cache.ino(" << ino() << ") "
 
 
 class CInodeIOContext : public MDSIOContextBase
@@ -108,7 +108,7 @@ std::string_view CInode::pin_name(int p) const
 //int cinode_pins[CINODE_NUM_PINS];  // counts
 ostream& CInode::print_db_line_prefix(ostream& out)
 {
-  return out << ceph_clock_now() << " mds." << mdcache->mds->get_nodeid() << ".cache.ino(" << inode.ino << ") ";
+  return out << ceph_clock_now() << " mds." << mdcache->mds->get_nodeid() << ".cache.ino(" << ino() << ") ";
 }
 
 /*
@@ -127,7 +127,7 @@ ostream& operator<<(ostream& out, const CInode& in)
   string path;
   in.make_path_string(path, true);
 
-  out << "[inode " << in.inode.ino;
+  out << "[inode " << in.ino();
   out << " [" 
       << (in.is_multiversion() ? "...":"")
       << in.first << "," << in.last << "]";
@@ -173,43 +173,44 @@ ostream& operator<<(ostream& out, const CInode& in)
   if (in.is_frozen_inode()) out << " FROZEN";
   if (in.is_frozen_auth_pin()) out << " FROZEN_AUTHPIN";
 
-  const CInode::mempool_inode *pi = in.get_projected_inode();
+  const auto& pi = in.get_projected_inode();
   if (pi->is_truncating())
     out << " truncating(" << pi->truncate_from << " to " << pi->truncate_size << ")";
 
-  if (in.inode.is_dir()) {
-    out << " " << in.inode.dirstat;
+  if (in.is_dir()) {
+    out << " " << in.get_inode()->dirstat;
     if (g_conf()->mds_debug_scatterstat && in.is_projected()) {
-      const CInode::mempool_inode *pi = in.get_projected_inode();
       out << "->" << pi->dirstat;
     }
   } else {
-    out << " s=" << in.inode.size;
-    if (in.inode.nlink != 1)
-      out << " nl=" << in.inode.nlink;
+    out << " s=" << in.get_inode()->size;
+    if (in.get_inode()->nlink != 1)
+      out << " nl=" << in.get_inode()->nlink;
   }
 
   // rstat
-  out << " " << in.inode.rstat;
-  if (!(in.inode.rstat == in.inode.accounted_rstat))
-    out << "/" << in.inode.accounted_rstat;
+  out << " " << in.get_inode()->rstat;
+  if (!(in.get_inode()->rstat == in.get_inode()->accounted_rstat))
+    out << "/" << in.get_inode()->accounted_rstat;
   if (g_conf()->mds_debug_scatterstat && in.is_projected()) {
-    const CInode::mempool_inode *pi = in.get_projected_inode();
     out << "->" << pi->rstat;
     if (!(pi->rstat == pi->accounted_rstat))
       out << "/" << pi->accounted_rstat;
   }
 
+  if (in.is_any_old_inodes()) {
+    out << " old_inodes=" << in.get_old_inodes()->size();
+  }
+
   if (!in.client_need_snapflush.empty())
     out << " need_snapflush=" << in.client_need_snapflush;
-
 
   // locks
   if (!in.authlock.is_sync_and_unlocked())
     out << " " << in.authlock;
   if (!in.linklock.is_sync_and_unlocked())
     out << " " << in.linklock;
-  if (in.inode.is_dir()) {
+  if (in.get_inode()->is_dir()) {
     if (!in.dirfragtreelock.is_sync_and_unlocked())
       out << " " << in.dirfragtreelock;
     if (!in.snaplock.is_sync_and_unlocked())
@@ -230,8 +231,8 @@ ostream& operator<<(ostream& out, const CInode& in)
     out << " " << in.versionlock;
 
   // hack: spit out crap on which clients have caps
-  if (in.inode.client_ranges.size())
-    out << " cr=" << in.inode.client_ranges;
+  if (in.get_inode()->client_ranges.size())
+    out << " cr=" << in.get_inode()->client_ranges;
 
   if (!in.get_client_caps().empty()) {
     out << " caps={";
@@ -270,8 +271,8 @@ ostream& operator<<(ostream& out, const CInode& in)
     in.print_pin_set(out);
   }
 
-  if (in.inode.export_pin != MDS_RANK_NONE) {
-    out << " export_pin=" << in.inode.export_pin;
+  if (in.get_inode()->export_pin != MDS_RANK_NONE) {
+    out << " export_pin=" << in.get_inode()->export_pin;
   }
   if (in.state_test(CInode::STATE_DISTEPHEMERALPIN)) {
     out << " distepin";
@@ -294,11 +295,8 @@ ostream& operator<<(ostream& out, const CInode::scrub_stamp_info_t& si)
   return out;
 }
 
-CInode::CInode(MDCache *c, bool auth, snapid_t f, snapid_t l)
-  :
-    mdcache(c),
-    first(f), last(l),
-    item_dirty(this),
+CInode::CInode(MDCache *c, bool auth, snapid_t f, snapid_t l) :
+    mdcache(c), first(f), last(l), item_dirty(this),
     item_caps(this),
     item_open_file(this),
     item_dirty_parent(this),
@@ -317,7 +315,8 @@ CInode::CInode(MDCache *c, bool auth, snapid_t f, snapid_t l)
     flocklock(this, &flocklock_type),
     policylock(this, &policylock_type)
 {
-  if (auth) state_set(STATE_AUTH);
+  if (auth)
+    state_set(STATE_AUTH);
 }
 
 void CInode::print(ostream& out)
@@ -334,7 +333,7 @@ void CInode::add_need_snapflush(CInode *snapin, snapid_t snapid, client_t client
 
     // FIXME: this is non-optimal, as we'll block freezes/migrations for potentially
     // long periods waiting for clients to flush their snaps.
-    auth_pin(this);   // pin head inode...
+    auth_pin(this);   // pin head get_inode()->..
   }
 
   auto &clients = client_need_snapflush[snapid];
@@ -420,88 +419,67 @@ void CInode::clear_dirty_rstat()
   }
 }
 
-CInode::projected_inode &CInode::project_inode(bool xattr, bool snap)
+CInode::projected_inode CInode::project_inode(bool xattr, bool snap)
 {
-  auto &pi = projected_nodes.empty() ?
-    projected_nodes.emplace_back(inode) :
-    projected_nodes.emplace_back(projected_nodes.back().inode);
+  auto pi = allocate_inode(*get_projected_inode());
 
   if (scrub_infop && scrub_infop->last_scrub_dirty) {
-    pi.inode.last_scrub_stamp = scrub_infop->last_scrub_stamp;
-    pi.inode.last_scrub_version = scrub_infop->last_scrub_version;
+    pi->last_scrub_stamp = scrub_infop->last_scrub_stamp;
+    pi->last_scrub_version = scrub_infop->last_scrub_version;
     scrub_infop->last_scrub_dirty = false;
     scrub_maybe_delete_info();
   }
 
+  const auto& ox = get_projected_xattrs();
+  xattr_map_ptr px;
   if (xattr) {
-    pi.xattrs.reset(new mempool_xattr_map(*get_projected_xattrs()));
-    ++num_projected_xattrs;
+    px = allocate_xattr_map();
+    if (ox)
+      *px = *ox;
   }
 
+  sr_t* ps = projected_inode::UNDEF_SRNODE;
   if (snap) {
-    project_snaprealm();
+    ps = prepare_new_srnode(0);
+    ++num_projected_srnodes;
   }
 
-  dout(15) << __func__ << " " << pi.inode.ino << dendl;
-  return pi;
+  projected_nodes.emplace_back(pi, xattr ? px : ox , ps);
+
+  dout(15) << __func__ << " " << pi->ino << dendl;
+  return projected_inode(std::move(pi), std::move(px), ps);
 }
 
 void CInode::pop_and_dirty_projected_inode(LogSegment *ls) 
 {
   ceph_assert(!projected_nodes.empty());
-  auto& front = projected_nodes.front();
+  auto front = std::move(projected_nodes.front());
+  dout(15) << __func__ << " v" << front.inode->version << dendl;
 
-  dout(15) << __func__ << " " << front.inode.ino
-	   << " v" << front.inode.version << dendl;
+  projected_nodes.pop_front();
 
-  int64_t old_pool = inode.layout.pool_id;
-  bool pin_update = inode.export_pin != front.inode.export_pin;
-  bool dist_update = inode.export_ephemeral_distributed_pin
-                     != front.inode.export_ephemeral_distributed_pin;
+  bool pool_update = get_inode()->layout.pool_id != front.inode->layout.pool_id;
+  bool pin_update = get_inode()->export_pin != front.inode->export_pin;
+  bool dist_update = get_inode()->export_ephemeral_distributed_pin !=
+		     front.inode->export_ephemeral_distributed_pin;
 
-  mark_dirty(front.inode.version, ls);
+  reset_inode(std::move(front.inode));
+  if (front.xattrs != get_xattrs())
+    reset_xattrs(std::move(front.xattrs));
 
-  inode = std::move(front.inode);
+  if (front.snapnode != projected_inode::UNDEF_SRNODE) {
+    --num_projected_srnodes;
+    pop_projected_snaprealm(front.snapnode, false);
+  }
+
+  mark_dirty(ls);
+  if (get_inode()->is_backtrace_updated())
+    mark_dirty_parent(ls, pool_update);
 
   if (pin_update)
     maybe_export_pin(true);
   if (dist_update)
     maybe_ephemeral_dist_children(true);
-
-  if (inode.is_backtrace_updated())
-    mark_dirty_parent(ls, old_pool != inode.layout.pool_id);
-
-  if (front.xattrs) {
-    --num_projected_xattrs;
-    xattrs = *front.xattrs;
-  }
-
-  if (projected_nodes.front().snapnode != projected_inode::UNDEF_SRNODE) {
-    pop_projected_snaprealm(projected_nodes.front().snapnode, false);
-    --num_projected_srnodes;
-  }
-
-  projected_nodes.pop_front();
-}
-
-CInode::mempool_xattr_map *CInode::get_projected_xattrs()
-{
-  if (num_projected_xattrs > 0) {
-    for (auto it = projected_nodes.rbegin(); it != projected_nodes.rend(); ++it)
-      if (it->xattrs)
-	return it->xattrs.get();
-  }
-  return &xattrs;
-}
-
-CInode::mempool_xattr_map *CInode::get_previous_projected_xattrs()
-{
-  if (num_projected_xattrs > 0) {
-    for (auto it = ++projected_nodes.rbegin(); it != projected_nodes.rend(); ++it)
-      if (it->xattrs)
-	return it->xattrs.get();
-  }
-  return &xattrs;
 }
 
 sr_t *CInode::prepare_new_srnode(snapid_t snapid)
@@ -693,9 +671,11 @@ void CInode::pop_projected_snaprealm(sr_t *next_snaprealm, bool early)
 
 // dirfrags
 
+InodeStoreBase::inode_const_ptr InodeStoreBase::empty_inode = InodeStoreBase::allocate_inode();
+
 __u32 InodeStoreBase::hash_dentry_name(std::string_view dn)
 {
-  int which = inode.dir_layout.dl_dir_hash;
+  int which = inode->dir_layout.dl_dir_hash;
   if (!which)
     which = CEPH_STR_HASH_LINUX;
   ceph_assert(ceph_str_hash_valid(which));
@@ -1060,7 +1040,7 @@ void CInode::make_path(filepath& fp, bool projected) const
 void CInode::name_stray_dentry(string& dname)
 {
   char s[20];
-  snprintf(s, sizeof(s), "%llx", (unsigned long long)inode.ino.val);
+  snprintf(s, sizeof(s), "%llx", (unsigned long long)ino().val);
   dname = s;
 }
 
@@ -1070,16 +1050,16 @@ version_t CInode::pre_dirty()
   CDentry* _cdentry = get_projected_parent_dn(); 
   if (_cdentry) {
     pv = _cdentry->pre_dirty(get_projected_version());
-    dout(10) << "pre_dirty " << pv << " (current v " << inode.version << ")" << dendl;
+    dout(10) << "pre_dirty " << pv << " (current v " << get_inode()->version << ")" << dendl;
   } else {
     ceph_assert(is_base());
     pv = get_projected_version() + 1;
   }
   // force update backtrace for old format inode (see mempool_inode::decode)
-  if (inode.backtrace_version == 0 && !projected_nodes.empty()) {
-    mempool_inode &pi = projected_nodes.back().inode;
-    if (pi.backtrace_version == 0)
-      pi.update_backtrace(pv);
+  if (get_inode()->backtrace_version == 0 && !projected_nodes.empty()) {
+    auto pi = _get_projected_inode();
+    if (pi->backtrace_version == 0)
+      pi->update_backtrace(pv);
   }
   return pv;
 }
@@ -1097,7 +1077,7 @@ void CInode::_mark_dirty(LogSegment *ls)
     ls->dirty_inodes.push_back(&item_dirty);
 }
 
-void CInode::mark_dirty(version_t pv, LogSegment *ls) {
+void CInode::mark_dirty(LogSegment *ls) {
   
   dout(10) << __func__ << " " << *this << dendl;
 
@@ -1112,13 +1092,11 @@ void CInode::mark_dirty(version_t pv, LogSegment *ls) {
   ceph_assert(is_auth());
   
   // touch my private version
-  ceph_assert(inode.version < pv);
-  inode.version = pv;
   _mark_dirty(ls);
 
   // mark dentry too
   if (parent)
-    parent->mark_dirty(pv, ls);
+    parent->mark_dirty(get_version(), ls);
 }
 
 
@@ -1309,7 +1287,7 @@ void CInode::_fetched(bufferlist& bl, bufferlist& bl2, Context *fin)
 
 void CInode::build_backtrace(int64_t pool, inode_backtrace_t& bt)
 {
-  bt.ino = inode.ino;
+  bt.ino = ino();
   bt.ancestors.clear();
   bt.pool = pool;
 
@@ -1317,11 +1295,11 @@ void CInode::build_backtrace(int64_t pool, inode_backtrace_t& bt)
   CDentry *pdn = get_parent_dn();
   while (pdn) {
     CInode *diri = pdn->get_dir()->get_inode();
-    bt.ancestors.push_back(inode_backpointer_t(diri->ino(), pdn->get_name(), in->inode.version));
+    bt.ancestors.push_back(inode_backpointer_t(diri->ino(), pdn->get_name(), in->get_inode()->version));
     in = diri;
     pdn = in->get_parent_dn();
   }
-  for (auto &p : inode.old_pools) {
+  for (auto &p : get_inode()->old_pools) {
     // don't add our own pool id to old_pools to avoid looping (e.g. setlayout 0, 1, 0)
     if (p != pool)
       bt.old_pools.insert(p);
@@ -1363,17 +1341,17 @@ void CInode::store_backtrace(MDSContext *fin, int op_prio)
   op.setxattr("parent", parent_bl);
 
   bufferlist layout_bl;
-  encode(inode.layout, layout_bl, mdcache->mds->mdsmap->get_up_features());
+  encode(get_inode()->layout, layout_bl, mdcache->mds->mdsmap->get_up_features());
   op.setxattr("layout", layout_bl);
 
   SnapContext snapc;
   object_t oid = get_object_name(ino(), frag_t(), "");
   object_locator_t oloc(pool);
   Context *fin2 = new C_OnFinisher(
-    new C_IO_Inode_StoredBacktrace(this, inode.backtrace_version, fin),
+    new C_IO_Inode_StoredBacktrace(this, get_inode()->backtrace_version, fin),
     mdcache->mds->finisher);
 
-  if (!state_test(STATE_DIRTYPOOL) || inode.old_pools.empty()) {
+  if (!state_test(STATE_DIRTYPOOL) || get_inode()->old_pools.empty()) {
     dout(20) << __func__ << ": no dirtypool or no old pools" << dendl;
     mdcache->mds->objecter->mutate(oid, oloc, op, snapc,
 				   ceph::real_clock::now(),
@@ -1389,7 +1367,7 @@ void CInode::store_backtrace(MDSContext *fin, int op_prio)
   // In the case where DIRTYPOOL is set, we update all old pools backtraces
   // such that anyone reading them will see the new pool ID in
   // inode_backtrace_t::pool and go read everything else from there.
-  for (const auto &p : inode.old_pools) {
+  for (const auto &p : get_inode()->old_pools) {
     if (p == pool)
       continue;
 
@@ -1442,7 +1420,7 @@ void CInode::_stored_backtrace(int r, version_t v, Context *fin)
   dout(10) << __func__ << " v " << v <<  dendl;
 
   auth_unpin(this);
-  if (v == inode.backtrace_version)
+  if (v == get_inode()->backtrace_version)
     clear_dirty_parent();
   if (fin)
     fin->complete(0);
@@ -1450,7 +1428,7 @@ void CInode::_stored_backtrace(int r, version_t v, Context *fin)
 
 void CInode::fetch_backtrace(Context *fin, bufferlist *backtrace)
 {
-  mdcache->fetch_backtrace(inode.ino, get_backtrace_pool(), *backtrace, fin);
+  mdcache->fetch_backtrace(ino(), get_backtrace_pool(), *backtrace, fin);
 }
 
 void CInode::mark_dirty_parent(LogSegment *ls, bool dirty_pool)
@@ -1510,20 +1488,59 @@ void CInode::verify_diri_backtrace(bufferlist &bl, int err)
 // parent dir
 
 
+void InodeStoreBase::encode_xattrs(bufferlist &bl) const {
+  using ceph::encode;
+  if (xattrs)
+    encode(*xattrs, bl);
+  else
+    encode((__u32)0, bl);
+}
+
+void InodeStoreBase::decode_xattrs(bufferlist::const_iterator &p) {
+  using ceph::decode;
+  mempool_xattr_map tmp;
+  decode_noshare(tmp, p);
+  if (tmp.empty()) {
+    reset_xattrs(xattr_map_ptr());
+  } else {
+    reset_xattrs(allocate_xattr_map(std::move(tmp)));
+  }
+}
+
+void InodeStoreBase::encode_old_inodes(bufferlist &bl, uint64_t features) const {
+  using ceph::encode;
+  if (old_inodes)
+    encode(*old_inodes, bl, features);
+  else
+    encode((__u32)0, bl);
+}
+
+void InodeStoreBase::decode_old_inodes(bufferlist::const_iterator &p) {
+  using ceph::decode;
+  mempool_old_inode_map tmp;
+  decode(tmp, p);
+  if (tmp.empty()) {
+    reset_old_inodes(old_inode_map_ptr());
+  } else {
+    reset_old_inodes(allocate_old_inode_map(std::move(tmp)));
+  }
+}
+
 void InodeStoreBase::encode_bare(bufferlist &bl, uint64_t features,
 				 const bufferlist *snap_blob) const
 {
   using ceph::encode;
-  encode(inode, bl, features);
-  if (is_symlink())
+  encode(*inode, bl, features);
+  if (inode->is_symlink())
     encode(symlink, bl);
   encode(dirfragtree, bl);
-  encode(xattrs, bl);
+  encode_xattrs(bl);
+
   if (snap_blob)
     encode(*snap_blob, bl);
   else
     encode(bufferlist(), bl);
-  encode(old_inodes, bl, features);
+  encode_old_inodes(bl, features);
   encode(oldest_snap, bl);
   encode(damage_flags, bl);
 }
@@ -1548,23 +1565,26 @@ void InodeStoreBase::decode_bare(bufferlist::const_iterator &bl,
 			      bufferlist& snap_blob, __u8 struct_v)
 {
   using ceph::decode;
-  decode(inode, bl);
-  if (is_symlink()) {
+
+  auto _inode = allocate_inode();
+  decode(*_inode, bl);
+
+  if (_inode->is_symlink()) {
     std::string tmp;
     decode(tmp, bl);
     symlink = std::string_view(tmp);
   }
   decode(dirfragtree, bl);
-  decode_noshare(xattrs, bl);
+  decode_xattrs(bl);
   decode(snap_blob, bl);
 
-  decode(old_inodes, bl);
-  if (struct_v == 2 && inode.is_dir()) {
+  decode_old_inodes(bl);
+  if (struct_v == 2 && _inode->is_dir()) {
     bool default_layout_exists;
     decode(default_layout_exists, bl);
     if (default_layout_exists) {
       decode(struct_v, bl); // this was a default_file_layout
-      decode(inode.layout, bl); // but we only care about the layout portion
+      decode(_inode->layout, bl); // but we only care about the layout portion
     }
   }
 
@@ -1579,6 +1599,8 @@ void InodeStoreBase::decode_bare(bufferlist::const_iterator &bl,
       decode(damage_flags, bl);
     }
   }
+
+  reset_inode(std::move(_inode));
 }
 
 
@@ -1625,52 +1647,58 @@ void CInode::set_object_info(MDSCacheObjectInfo &info)
 void CInode::encode_lock_iauth(bufferlist& bl)
 {
   ENCODE_START(1, 1, bl);
-  encode(inode.version, bl);
-  encode(inode.ctime, bl);
-  encode(inode.mode, bl);
-  encode(inode.uid, bl);
-  encode(inode.gid, bl);  
+  encode(get_inode()->version, bl);
+  encode(get_inode()->ctime, bl);
+  encode(get_inode()->mode, bl);
+  encode(get_inode()->uid, bl);
+  encode(get_inode()->gid, bl);  
   ENCODE_FINISH(bl);
 }
 
 void CInode::decode_lock_iauth(bufferlist::const_iterator& p)
 {
+  ceph_assert(!is_auth());
+  auto _inode = allocate_inode(*get_inode());
   DECODE_START(1, p);
-  decode(inode.version, p);
+  decode(_inode->version, p);
   utime_t tm;
   decode(tm, p);
-  if (inode.ctime < tm) inode.ctime = tm;
-  decode(inode.mode, p);
-  decode(inode.uid, p);
-  decode(inode.gid, p);
+  if (_inode->ctime < tm) _inode->ctime = tm;
+  decode(_inode->mode, p);
+  decode(_inode->uid, p);
+  decode(_inode->gid, p);
   DECODE_FINISH(p);
+  reset_inode(std::move(_inode));
 }
 
 void CInode::encode_lock_ilink(bufferlist& bl)
 {
   ENCODE_START(1, 1, bl);
-  encode(inode.version, bl);
-  encode(inode.ctime, bl);
-  encode(inode.nlink, bl);
+  encode(get_inode()->version, bl);
+  encode(get_inode()->ctime, bl);
+  encode(get_inode()->nlink, bl);
   ENCODE_FINISH(bl);
 }
 
 void CInode::decode_lock_ilink(bufferlist::const_iterator& p)
 {
+  ceph_assert(!is_auth());
+  auto _inode = allocate_inode(*get_inode());
   DECODE_START(1, p);
-  decode(inode.version, p);
+  decode(_inode->version, p);
   utime_t tm;
   decode(tm, p);
-  if (inode.ctime < tm) inode.ctime = tm;
-  decode(inode.nlink, p);
+  if (_inode->ctime < tm) _inode->ctime = tm;
+  decode(_inode->nlink, p);
   DECODE_FINISH(p);
+  reset_inode(std::move(_inode));
 }
 
 void CInode::encode_lock_idft(bufferlist& bl)
 {
   ENCODE_START(1, 1, bl);
   if (is_auth()) {
-    encode(inode.version, bl);
+    encode(get_inode()->version, bl);
   } else {
     // treat flushing as dirty when rejoining cache
     bool dirty = dirfragtreelock.is_dirty_or_flushing();
@@ -1696,6 +1724,8 @@ void CInode::encode_lock_idft(bufferlist& bl)
 
 void CInode::decode_lock_idft(bufferlist::const_iterator& p)
 {
+  inode_ptr _inode;
+
   DECODE_START(1, p);
   if (is_auth()) {
     bool replica_dirty;
@@ -1705,7 +1735,8 @@ void CInode::decode_lock_idft(bufferlist::const_iterator& p)
       dirfragtreelock.mark_dirty();  // ok bc we're auth and caller will handle
     }
   } else {
-    decode(inode.version, p);
+    _inode = allocate_inode(*get_inode());
+    decode(_inode->version, p);
   }
   {
     fragtree_t temp;
@@ -1740,32 +1771,35 @@ void CInode::decode_lock_idft(bufferlist::const_iterator& p)
       verify_dirfrags();
   }
   DECODE_FINISH(p);
+
+  if (_inode)
+    reset_inode(std::move(_inode));
 }
 
 void CInode::encode_lock_ifile(bufferlist& bl)
 {
   ENCODE_START(1, 1, bl);
   if (is_auth()) {
-    encode(inode.version, bl); 
-    encode(inode.ctime, bl); 
-    encode(inode.mtime, bl); 
-    encode(inode.atime, bl); 
-    encode(inode.time_warp_seq, bl); 
+    encode(get_inode()->version, bl); 
+    encode(get_inode()->ctime, bl); 
+    encode(get_inode()->mtime, bl); 
+    encode(get_inode()->atime, bl); 
+    encode(get_inode()->time_warp_seq, bl); 
     if (!is_dir()) {
-      encode(inode.layout, bl, mdcache->mds->mdsmap->get_up_features());
-      encode(inode.size, bl); 
-      encode(inode.truncate_seq, bl); 
-      encode(inode.truncate_size, bl); 
-      encode(inode.client_ranges, bl); 
-      encode(inode.inline_data, bl); 
+      encode(get_inode()->layout, bl, mdcache->mds->mdsmap->get_up_features());
+      encode(get_inode()->size, bl); 
+      encode(get_inode()->truncate_seq, bl); 
+      encode(get_inode()->truncate_size, bl); 
+      encode(get_inode()->client_ranges, bl); 
+      encode(get_inode()->inline_data, bl); 
     }    
   } else {
     // treat flushing as dirty when rejoining cache
     bool dirty = filelock.is_dirty_or_flushing();
     encode(dirty, bl); 
   }    
-  dout(15) << __func__ << " inode.dirstat is " << inode.dirstat << dendl;
-  encode(inode.dirstat, bl);  // only meaningful if i am auth.
+  dout(15) << __func__ << " inode.dirstat is " << get_inode()->dirstat << dendl;
+  encode(get_inode()->dirstat, bl);  // only meaningful if i am auth.
   bufferlist tmp;
   __u32 n = 0;
   for (const auto &p : dirfrags) {
@@ -1790,22 +1824,26 @@ void CInode::encode_lock_ifile(bufferlist& bl)
 
 void CInode::decode_lock_ifile(bufferlist::const_iterator& p)
 {
+  inode_ptr _inode;
+
   DECODE_START(1, p);
   if (!is_auth()) {
-    decode(inode.version, p);
+    _inode = allocate_inode(*get_inode());
+
+    decode(_inode->version, p);
     utime_t tm;
     decode(tm, p);
-    if (inode.ctime < tm) inode.ctime = tm;
-    decode(inode.mtime, p);
-    decode(inode.atime, p);
-    decode(inode.time_warp_seq, p);
+    if (_inode->ctime < tm) _inode->ctime = tm;
+    decode(_inode->mtime, p);
+    decode(_inode->atime, p);
+    decode(_inode->time_warp_seq, p);
     if (!is_dir()) {
-      decode(inode.layout, p);
-      decode(inode.size, p);
-      decode(inode.truncate_seq, p);
-      decode(inode.truncate_size, p);
-      decode(inode.client_ranges, p);
-      decode(inode.inline_data, p);
+      decode(_inode->layout, p);
+      decode(_inode->size, p);
+      decode(_inode->truncate_seq, p);
+      decode(_inode->truncate_size, p);
+      decode(_inode->client_ranges, p);
+      decode(_inode->inline_data, p);
     }
   } else {
     bool replica_dirty;
@@ -1820,7 +1858,7 @@ void CInode::decode_lock_ifile(bufferlist::const_iterator& p)
   decode(dirstat, p);
   if (!is_auth()) {
     dout(10) << " taking inode dirstat " << dirstat << " for " << *this << dendl;
-    inode.dirstat = dirstat;    // take inode summation if replica
+    _inode->dirstat = dirstat;    // take inode summation if replica
   }
   __u32 n;
   decode(n, p);
@@ -1857,25 +1895,28 @@ void CInode::decode_lock_ifile(bufferlist::const_iterator& p)
         dir->first = fgfirst;
         fnode_t *pf = dir->get_projected_fnode();
         finish_scatter_update(&filelock, dir,
-                              inode.dirstat.version, pf->accounted_fragstat.version);
+                              _inode->dirstat.version, pf->accounted_fragstat.version);
       }
     }
   }
   DECODE_FINISH(p);
+
+  if (_inode)
+    reset_inode(std::move(_inode));
 }
 
 void CInode::encode_lock_inest(bufferlist& bl)
 {
   ENCODE_START(1, 1, bl);
   if (is_auth()) {
-    encode(inode.version, bl);
+    encode(get_inode()->version, bl);
   } else {
     // treat flushing as dirty when rejoining cache
     bool dirty = nestlock.is_dirty_or_flushing();
     encode(dirty, bl);
   }
-  dout(15) << __func__ << " inode.rstat is " << inode.rstat << dendl;
-  encode(inode.rstat, bl);  // only meaningful if i am auth.
+  dout(15) << __func__ << " inode.rstat is " << get_inode()->rstat << dendl;
+  encode(get_inode()->rstat, bl);  // only meaningful if i am auth.
   bufferlist tmp;
   __u32 n = 0;
   for (const auto &p : dirfrags) {
@@ -1902,6 +1943,8 @@ void CInode::encode_lock_inest(bufferlist& bl)
 
 void CInode::decode_lock_inest(bufferlist::const_iterator& p)
 {
+  inode_ptr _inode;
+
   DECODE_START(1, p);
   if (is_auth()) {
     bool replica_dirty;
@@ -1911,13 +1954,14 @@ void CInode::decode_lock_inest(bufferlist::const_iterator& p)
       nestlock.mark_dirty();  // ok bc we're auth and caller will handle
     }
   } else {
-    decode(inode.version, p);
+    _inode = allocate_inode(*get_inode());
+    decode(_inode->version, p);
   }
   nest_info_t rstat;
   decode(rstat, p);
   if (!is_auth()) {
     dout(10) << __func__ << " taking inode rstat " << rstat << " for " << *this << dendl;
-    inode.rstat = rstat;    // take inode summation if replica
+    _inode->rstat = rstat;    // take inode summation if replica
   }
   __u32 n;
   decode(n, p);
@@ -1956,109 +2000,122 @@ void CInode::decode_lock_inest(bufferlist::const_iterator& p)
         dir->first = fgfirst;
         fnode_t *pf = dir->get_projected_fnode();
         finish_scatter_update(&nestlock, dir,
-                              inode.rstat.version, pf->accounted_rstat.version);
+                              _inode->rstat.version, pf->accounted_rstat.version);
       }
     }
   }
   DECODE_FINISH(p);
+
+  if (_inode)
+    reset_inode(std::move(_inode));
 }
 
 void CInode::encode_lock_ixattr(bufferlist& bl)
 {
   ENCODE_START(1, 1, bl);
-  encode(inode.version, bl);
-  encode(inode.ctime, bl);
-  encode(xattrs, bl);
+  encode(get_inode()->version, bl);
+  encode(get_inode()->ctime, bl);
+  encode_xattrs(bl);
   ENCODE_FINISH(bl);
 }
 
 void CInode::decode_lock_ixattr(bufferlist::const_iterator& p)
 {
+  ceph_assert(!is_auth());
+  auto _inode = allocate_inode(*get_inode());
   DECODE_START(1, p);
-  decode(inode.version, p);
+  decode(_inode->version, p);
   utime_t tm;
   decode(tm, p);
-  if (inode.ctime < tm) inode.ctime = tm;
-  decode_noshare(xattrs, p);
+  if (_inode->ctime < tm)
+    _inode->ctime = tm;
+  decode_xattrs(p);
   DECODE_FINISH(p);
+  reset_inode(std::move(_inode));
 }
 
 void CInode::encode_lock_isnap(bufferlist& bl)
 {
   ENCODE_START(1, 1, bl);
-  encode(inode.version, bl);
-  encode(inode.ctime, bl);
+  encode(get_inode()->version, bl);
+  encode(get_inode()->ctime, bl);
   encode_snap(bl);
   ENCODE_FINISH(bl);
 }
 
 void CInode::decode_lock_isnap(bufferlist::const_iterator& p)
 {
+  ceph_assert(!is_auth());
+  auto _inode = allocate_inode(*get_inode());
   DECODE_START(1, p);
-  decode(inode.version, p);
+  decode(_inode->version, p);
   utime_t tm;
   decode(tm, p);
-  if (inode.ctime < tm) inode.ctime = tm;
+  if (_inode->ctime < tm) _inode->ctime = tm;
   decode_snap(p);
   DECODE_FINISH(p);
+  reset_inode(std::move(_inode));
 }
 
 void CInode::encode_lock_iflock(bufferlist& bl)
 {
   ENCODE_START(1, 1, bl);
-  encode(inode.version, bl);
+  encode(get_inode()->version, bl);
   _encode_file_locks(bl);
   ENCODE_FINISH(bl);
 }
 
 void CInode::decode_lock_iflock(bufferlist::const_iterator& p)
 {
+  ceph_assert(!is_auth());
+  auto _inode = allocate_inode(*get_inode());
   DECODE_START(1, p);
-  decode(inode.version, p);
+  decode(_inode->version, p);
   _decode_file_locks(p);
   DECODE_FINISH(p);
+  reset_inode(std::move(_inode));
 }
 
 void CInode::encode_lock_ipolicy(bufferlist& bl)
 {
   ENCODE_START(2, 1, bl);
-  if (inode.is_dir()) {
-    encode(inode.version, bl);
-    encode(inode.ctime, bl);
-    encode(inode.layout, bl, mdcache->mds->mdsmap->get_up_features());
-    encode(inode.quota, bl);
-    encode(inode.export_pin, bl);
-    encode(inode.export_ephemeral_distributed_pin, bl);
-    encode(inode.export_ephemeral_random_pin, bl);
+  if (is_dir()) {
+    encode(get_inode()->version, bl);
+    encode(get_inode()->ctime, bl);
+    encode(get_inode()->layout, bl, mdcache->mds->mdsmap->get_up_features());
+    encode(get_inode()->quota, bl);
+    encode(get_inode()->export_pin, bl);
+    encode(get_inode()->export_ephemeral_distributed_pin, bl);
+    encode(get_inode()->export_ephemeral_random_pin, bl);
   }
   ENCODE_FINISH(bl);
 }
 
 void CInode::decode_lock_ipolicy(bufferlist::const_iterator& p)
 {
-  DECODE_START(2, p);
-  if (inode.is_dir()) {
-    decode(inode.version, p);
+  ceph_assert(!is_auth());
+  auto _inode = allocate_inode(*get_inode());
+  DECODE_START(1, p);
+  if (is_dir()) {
+    decode(_inode->version, p);
     utime_t tm;
     decode(tm, p);
-    if (inode.ctime < tm) inode.ctime = tm;
-    decode(inode.layout, p);
-    decode(inode.quota, p);
-    {
-      mds_rank_t old_pin = inode.export_pin;
-      decode(inode.export_pin, p);
-      maybe_export_pin(old_pin != inode.export_pin);
-    }
+    if (_inode->ctime < tm)
+      _inode->ctime = tm;
+    decode(_inode->layout, p);
+    decode(_inode->quota, p);
+    decode(_inode->export_pin, p);
     if (struct_v >= 2) {
-      {
-        bool old_ephemeral_pin = inode.export_ephemeral_distributed_pin;
-        decode(inode.export_ephemeral_distributed_pin, p);
-        maybe_ephemeral_dist_children(old_ephemeral_pin != inode.export_ephemeral_distributed_pin);
-      }
-      decode(inode.export_ephemeral_random_pin, p);
+      decode(_inode->export_ephemeral_distributed_pin, p);
+      decode(_inode->export_ephemeral_random_pin, p);
     }
   }
   DECODE_FINISH(p);
+  mds_rank_t old_export_pin = get_inode()->export_pin;
+  bool old_ephemeral_pin = get_inode()->export_ephemeral_distributed_pin;
+  reset_inode(std::move(_inode));
+  maybe_export_pin(old_export_pin != get_inode()->export_pin);
+  maybe_ephemeral_dist_children(old_ephemeral_pin != get_inode()->export_ephemeral_distributed_pin);
 }
 
 void CInode::encode_lock_state(int type, bufferlist& bl)
@@ -2226,7 +2283,7 @@ void CInode::start_scatter(ScatterLock *lock)
 {
   dout(10) << __func__ << " " << *lock << " on " << *this << dendl;
   ceph_assert(is_auth());
-  mempool_inode *pi = get_projected_inode();
+  const auto& pi = get_projected_inode();
 
   for (const auto &p : dirfrags) {
     frag_t fg = p.first;
@@ -2286,18 +2343,17 @@ void CInode::finish_scatter_update(ScatterLock *lock, CDir *dir,
       MutationRef mut(new MutationImpl());
       mut->ls = mdlog->get_current_segment();
 
-      mempool_inode *pi = get_projected_inode();
       fnode_t *pf = dir->project_fnode();
 
       std::string_view ename;
       switch (lock->get_type()) {
       case CEPH_LOCK_IFILE:
-	pf->fragstat.version = pi->dirstat.version;
+	pf->fragstat.version = inode_version;
 	pf->accounted_fragstat = pf->fragstat;
 	ename = "lock ifile accounted scatter stat update";
 	break;
       case CEPH_LOCK_INEST:
-	pf->rstat.version = pi->rstat.version;
+	pf->rstat.version = inode_version;
 	pf->accounted_rstat = pf->rstat;
 	ename = "lock inest accounted scatter stat update";
 
@@ -2390,7 +2446,7 @@ void CInode::finish_scatter_gather_update(int type)
 
       // adjust summation
       ceph_assert(is_auth());
-      mempool_inode *pi = get_projected_inode();
+      auto pi = _get_projected_inode();
 
       bool touched_mtime = false, touched_chattr = false;
       dout(20) << "  orig dirstat " << pi->dirstat << dendl;
@@ -2504,7 +2560,7 @@ void CInode::finish_scatter_gather_update(int type)
       if (const sr_t *srnode = get_projected_srnode(); srnode)
 	rstat.rsnaps = srnode->snaps.size();
 
-      mempool_inode *pi = get_projected_inode();
+      auto pi = _get_projected_inode();
       dout(20) << "  orig rstat " << pi->rstat << dendl;
       pi->rstat.version++;
       for (const auto &p : dirfrags) {
@@ -2907,27 +2963,32 @@ mds_authority_t CInode::authority() const
 snapid_t CInode::get_oldest_snap()
 {
   snapid_t t = first;
-  if (!old_inodes.empty())
-    t = old_inodes.begin()->second.first;
+  if (is_any_old_inodes())
+    t = get_old_inodes()->begin()->second.first;
   return std::min(t, oldest_snap);
 }
 
-CInode::mempool_old_inode& CInode::cow_old_inode(snapid_t follows, bool cow_head)
+const CInode::mempool_old_inode& CInode::cow_old_inode(snapid_t follows, bool cow_head)
 {
   ceph_assert(follows >= first);
 
-  mempool_inode *pi = cow_head ? get_projected_inode() : get_previous_projected_inode();
-  mempool_xattr_map *px = cow_head ? get_projected_xattrs() : get_previous_projected_xattrs();
+  const auto& pi = cow_head ? get_projected_inode() : get_previous_projected_inode();
+  const auto& px = cow_head ? get_projected_xattrs() : get_previous_projected_xattrs();
 
-  mempool_old_inode &old = old_inodes[follows];
+  auto _old_inodes = allocate_old_inode_map();
+  if (old_inodes)
+    *_old_inodes = *old_inodes;
+
+  mempool_old_inode &old = (*_old_inodes)[follows];
   old.first = first;
   old.inode = *pi;
-  old.xattrs = *px;
+  if (px) {
+    dout(10) << " " << px->size() << " xattrs cowed, " << *px << dendl;
+    old.xattrs = *px;
+  }
 
   if (first < oldest_snap)
     oldest_snap = first;
-  
-  dout(10) << " " << px->size() << " xattrs cowed, " << *px << dendl;
 
   old.inode.trim_client_ranges(follows);
 
@@ -2941,20 +3002,8 @@ CInode::mempool_old_inode& CInode::cow_old_inode(snapid_t follows, bool cow_head
 	   << " to [" << old.first << "," << follows << "] on "
 	   << *this << dendl;
 
+  reset_old_inodes(std::move(_old_inodes));
   return old;
-}
-
-void CInode::split_old_inode(snapid_t snap)
-{
-  auto it = old_inodes.lower_bound(snap);
-  ceph_assert(it != old_inodes.end() && it->second.first < snap);
-
-  mempool_old_inode &old = old_inodes[snap - 1];
-  old = it->second;
-
-  it->second.first = snap;
-  dout(10) << __func__ << " " << "[" << old.first << "," << it->first
-	   << "] to [" << snap << "," << it->first << "] on " << *this << dendl;
 }
 
 void CInode::pre_cow_old_inode()
@@ -2967,11 +3016,11 @@ void CInode::pre_cow_old_inode()
 bool CInode::has_snap_data(snapid_t snapid)
 {
   bool found = snapid >= first && snapid <= last;
-  if (!found && is_multiversion()) {
-    auto p = old_inodes.lower_bound(snapid);
-    if (p != old_inodes.end()) {
+  if (!found && is_any_old_inodes()) {
+    auto p = old_inodes->lower_bound(snapid);
+    if (p != old_inodes->end()) {
       if (p->second.first > snapid) {
-	if  (p != old_inodes.begin())
+	if  (p != old_inodes->begin())
 	  --p;
       }
       if (p->second.first <= snapid && snapid <= p->first) {
@@ -2986,30 +3035,43 @@ void CInode::purge_stale_snap_data(const set<snapid_t>& snaps)
 {
   dout(10) << __func__ << " " << snaps << dendl;
 
-  for (auto it = old_inodes.begin(); it != old_inodes.end(); ) {
-    const snapid_t &id = it->first;
-    const auto &s = snaps.lower_bound(it->second.first);
+  if (!get_old_inodes())
+    return;
+
+  std::vector<snapid_t> to_remove;
+  for (auto p : *get_old_inodes()) {
+    const snapid_t &id = p.first;
+    const auto &s = snaps.lower_bound(p.second.first);
     if (s == snaps.end() || *s > id) {
-      dout(10) << " purging old_inode [" << it->second.first << "," << id << "]" << dendl;
-      it = old_inodes.erase(it);
-    } else {
-      ++it;
+      dout(10) << " purging old_inode [" << p.second.first << "," << id << "]" << dendl;
+      to_remove.push_back(id);
     }
+  }
+
+  if (to_remove.size() == get_old_inodes()->size()) {
+    reset_old_inodes(old_inode_map_ptr());
+  } else if (!to_remove.empty()) {
+    auto _old_inodes = allocate_old_inode_map(*get_old_inodes());
+    for (auto id : to_remove)
+      _old_inodes->erase(id);
+    reset_old_inodes(std::move(_old_inodes));
   }
 }
 
 /*
  * pick/create an old_inode
  */
-CInode::mempool_old_inode * CInode::pick_old_inode(snapid_t snap)
+snapid_t CInode::pick_old_inode(snapid_t snap) const
 {
-  auto it = old_inodes.lower_bound(snap);  // p is first key >= to snap
-  if (it != old_inodes.end() && it->second.first <= snap) {
-    dout(10) << __func__ << " snap " << snap << " -> [" << it->second.first << "," << it->first << "]" << dendl;
-    return &it->second;
+  if (is_any_old_inodes()) {
+    auto it = old_inodes->lower_bound(snap);  // p is first key >= to snap
+    if (it != old_inodes->end() && it->second.first <= snap) {
+      dout(10) << __func__ << " snap " << snap << " -> [" << it->second.first << "," << it->first << "]" << dendl;
+      return it->first;
+    }
   }
   dout(10) << __func__ << " snap " << snap << " -> nothing" << dendl;
-  return NULL;
+  return 0;
 }
 
 void CInode::open_snaprealm(bool nosplit)
@@ -3462,7 +3524,7 @@ int CInode::get_xlocker_mask(client_t client) const
 }
 
 int CInode::get_caps_allowed_for_client(Session *session, Capability *cap,
-					mempool_inode *file_i) const
+					const mempool_inode *file_i) const
 {
   client_t client = session->get_client();
   int allowed;
@@ -3588,10 +3650,10 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
   bool valid = true;
 
   // pick a version!
-  mempool_inode *oi = &inode;
-  mempool_inode *pi = get_projected_inode();
+  const mempool_inode *oi = get_inode().get();
+  const mempool_inode *pi = get_projected_inode().get();
 
-  CInode::mempool_xattr_map *pxattrs = nullptr;
+  const mempool_xattr_map *pxattrs = nullptr;
 
   if (snapid != CEPH_NOSNAP) {
 
@@ -3599,11 +3661,11 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     if (!is_auth())
       valid = false;
 
-    if (is_multiversion()) {
-      auto it = old_inodes.lower_bound(snapid);
-      if (it != old_inodes.end()) {
+    if (is_any_old_inodes()) {
+      auto it = old_inodes->lower_bound(snapid);
+      if (it != old_inodes->end()) {
 	if (it->second.first > snapid) {
-	  if  (it != old_inodes.begin())
+	  if  (it != old_inodes->begin())
 	    --it;
 	}
 	if (it->second.first <= snapid && snapid <= it->first) {
@@ -3611,9 +3673,8 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
 		   << " to old_inode [" << it->second.first << "," << it->first << "]"
 		   << " " << it->second.inode.rstat
 		   << dendl;
-          auto &p = it->second;
-	  pi = oi = &p.inode;
-	  pxattrs = &p.xattrs;
+	  pi = oi = &it->second.inode;
+	  pxattrs = &it->second.xattrs;
 	} else {
 	  // snapshoted remote dentry can result this
 	  dout(0) << __func__ << " old_inode for snapid " << snapid
@@ -3671,7 +3732,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
   bool plocal = versionlock.get_last_wrlock_client() == client;
   bool ppolicy = policylock.is_xlocked_by_client(client) || get_loner()==client;
   
-  mempool_inode *any_i = (pfile|pauth|plink|pxattr|plocal) ? pi : oi;
+  const mempool_inode *any_i = (pfile|pauth|plink|pxattr|plocal) ? pi : oi;
   
   dout(20) << " pfile " << pfile << " pauth " << pauth
 	   << " plink " << plink << " pxattr " << pxattr
@@ -3680,7 +3741,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
 	   << " valid=" << valid << dendl;
 
   // file
-  mempool_inode *file_i = pfile ? pi:oi;
+  const mempool_inode *file_i = pfile ? pi:oi;
   file_layout_t layout;
   if (is_dir()) {
     layout = (ppolicy ? pi : oi)->layout;
@@ -3689,11 +3750,23 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
   }
 
   // max_size is min of projected, actual
-  uint64_t max_size =
-    std::min(oi->client_ranges.count(client) ?
-	oi->client_ranges[client].range.last : 0,
-	pi->client_ranges.count(client) ?
-	pi->client_ranges[client].range.last : 0);
+  uint64_t max_size;
+  {
+    auto it = oi->client_ranges.find(client);
+    if (it == oi->client_ranges.end()) {
+      max_size = 0;
+    } else {
+      max_size = it->second.range.last;
+      if (oi != pi) {
+	it = pi->client_ranges.find(client);
+	if (it == pi->client_ranges.end()) {
+	  max_size = 0;
+	} else {
+	  max_size = std::min(max_size, it->second.range.last);
+	}
+      }
+    }
+  }
 
   // inline data
   version_t inline_version = 0;
@@ -3705,7 +3778,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
 	     (getattr_caps & CEPH_CAP_FILE_RD)) { // client requests inline data
     inline_version = file_i->inline_data.version;
     if (file_i->inline_data.length() > 0)
-      inline_data = file_i->inline_data.get_data();
+      file_i->inline_data.get_data(inline_data);
   }
 
   // nest (do same as file... :/)
@@ -3715,13 +3788,13 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
   }
 
   // auth
-  mempool_inode *auth_i = pauth ? pi:oi;
+  const mempool_inode *auth_i = pauth ? pi:oi;
 
   // link
-  mempool_inode *link_i = plink ? pi:oi;
+  const mempool_inode *link_i = plink ? pi:oi;
   
   // xattr
-  mempool_inode *xattr_i = pxattr ? pi:oi;
+  const mempool_inode *xattr_i = pxattr ? pi:oi;
 
   using ceph::encode;
   // xattr
@@ -3730,7 +3803,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
       (cap && cap->client_xattr_version < xattr_i->xattr_version) ||
       (getattr_caps & CEPH_CAP_XATTR_SHARED)) { // client requests xattrs
     if (!pxattrs)
-      pxattrs = pxattr ? get_projected_xattrs() : &xattrs;
+      pxattrs = pxattr ? get_projected_xattrs().get() : get_xattrs().get();
     xattr_version = xattr_i->xattr_version;
   } else {
     xattr_version = 0;
@@ -3936,7 +4009,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     encode_xattrs();
     encode(inline_version, bl);
     encode(inline_data, bl);
-    mempool_inode *policy_i = ppolicy ? pi : oi;
+    const mempool_inode *policy_i = ppolicy ? pi : oi;
     encode(policy_i->quota, bl);
     encode(layout.pool_ns, bl);
     encode(any_i->btime, bl);
@@ -3989,7 +4062,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
       encode(inline_data, bl);
     }
     if (conn->has_feature(CEPH_FEATURE_MDS_QUOTA)) {
-      mempool_inode *policy_i = ppolicy ? pi : oi;
+      const mempool_inode *policy_i = ppolicy ? pi : oi;
       encode(policy_i->quota, bl);
     }
     if (conn->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
@@ -4015,9 +4088,9 @@ void CInode::encode_cap_message(const ref_t<MClientCaps> &m, Capability *cap)
   bool plink = linklock.is_xlocked_by_client(client);
   bool pxattr = xattrlock.is_xlocked_by_client(client);
  
-  mempool_inode *oi = &inode;
-  mempool_inode *pi = get_projected_inode();
-  mempool_inode *i = (pfile|pauth|plink|pxattr) ? pi : oi;
+  const mempool_inode *oi = get_inode().get();
+  const mempool_inode *pi = get_projected_inode().get();
+  const mempool_inode *i = (pfile|pauth|plink|pxattr) ? pi : oi;
 
   dout(20) << __func__ << " pfile " << pfile
 	   << " pauth " << pauth << " plink " << plink << " pxattr " << pxattr
@@ -4039,15 +4112,30 @@ void CInode::encode_cap_message(const ref_t<MClientCaps> &m, Capability *cap)
   if (cap->client_inline_version < i->inline_data.version) {
     m->inline_version = cap->client_inline_version = i->inline_data.version;
     if (i->inline_data.length() > 0)
-      m->inline_data = i->inline_data.get_data();
+      i->inline_data.get_data(m->inline_data);
   } else {
     m->inline_version = 0;
   }
 
   // max_size is min of projected, actual.
-  uint64_t oldms = oi->client_ranges.count(client) ? oi->client_ranges[client].range.last : 0;
-  uint64_t newms = pi->client_ranges.count(client) ? pi->client_ranges[client].range.last : 0;
-  m->max_size = std::min(oldms, newms);
+  {
+    uint64_t max_size;
+    auto it = oi->client_ranges.find(client);
+    if (it == oi->client_ranges.end()) {
+      max_size = 0;
+    } else {
+      max_size = it->second.range.last;
+      if (oi != pi) {
+	it = pi->client_ranges.find(client);
+	if (it == pi->client_ranges.end()) {
+	  max_size = 0;
+	} else {
+	  max_size = std::min(max_size, it->second.range.last);
+	}
+      }
+    }
+    m->max_size = max_size;
+  }
 
   i = pauth ? pi:oi;
   m->head.mode = i->mode;
@@ -4059,11 +4147,14 @@ void CInode::encode_cap_message(const ref_t<MClientCaps> &m, Capability *cap)
 
   using ceph::encode;
   i = pxattr ? pi:oi;
-  auto ix = pxattr ? get_projected_xattrs() : &xattrs;
+  const auto& ix = pxattr ? get_projected_xattrs() : get_xattrs();
   if ((cap->pending() & CEPH_CAP_XATTR_SHARED) &&
       i->xattr_version > cap->client_xattr_version) {
     dout(10) << "    including xattrs v " << i->xattr_version << dendl;
-    encode(*ix, m->xattrbl);
+    if (ix)
+      encode(*ix, m->xattrbl);
+    else
+      encode((__u32)0, m->xattrbl);
     m->head.xattr_version = i->xattr_version;
     cap->client_xattr_version = i->xattr_version;
   }
@@ -4075,11 +4166,11 @@ void CInode::_encode_base(bufferlist& bl, uint64_t features)
 {
   ENCODE_START(1, 1, bl);
   encode(first, bl);
-  encode(inode, bl, features);
+  encode(*get_inode(), bl, features);
   encode(symlink, bl);
   encode(dirfragtree, bl);
-  encode(xattrs, bl);
-  encode(old_inodes, bl, features);
+  encode_xattrs(bl);
+  encode_old_inodes(bl, features);
   encode(damage_flags, bl);
   encode_snap(bl);
   ENCODE_FINISH(bl);
@@ -4088,15 +4179,19 @@ void CInode::_decode_base(bufferlist::const_iterator& p)
 {
   DECODE_START(1, p);
   decode(first, p);
-  decode(inode, p);
+  {
+    auto _inode = allocate_inode();
+    decode(*_inode, p);
+    reset_inode(std::move(_inode));
+  }
   {
     std::string tmp;
     decode(tmp, p);
     symlink = std::string_view(tmp);
   }
   decode(dirfragtree, p);
-  decode_noshare(xattrs, p);
-  decode(old_inodes, p);
+  decode_xattrs(p);
+  decode_old_inodes(p);
   decode(damage_flags, p);
   decode_snap(p);
   DECODE_FINISH(p);
@@ -4231,7 +4326,7 @@ void CInode::encode_export(bufferlist& bl)
 
   // include scatterlock info for any bounding CDirs
   bufferlist bounding;
-  if (inode.is_dir())
+  if (get_inode()->is_dir())
     for (const auto &p : dirfrags) {
       CDir *dir = p.second;
       if (dir->state_test(CDir::STATE_EXPORTBOUND)) {
@@ -4360,16 +4455,18 @@ void CInode::decode_import(bufferlist::const_iterator& p,
 
 void InodeStoreBase::dump(Formatter *f) const
 {
-  inode.dump(f);
+  inode->dump(f);
   f->dump_string("symlink", symlink);
 
   f->open_array_section("xattrs");
-  for (const auto& [key, val] : xattrs) {
-    f->open_object_section("xattr");
-    f->dump_string("key", key);
-    std::string v(val.c_str(), val.length());
-    f->dump_string("val", v);
-    f->close_section();
+  if (xattrs) {
+    for (const auto& [key, val] : *xattrs) {
+      f->open_object_section("xattr");
+      f->dump_string("key", key);
+      std::string v(val.c_str(), val.length());
+      f->dump_string("val", v);
+      f->close_section();
+    }
   }
   f->close_section();
   f->open_object_section("dirfragtree");
@@ -4377,12 +4474,14 @@ void InodeStoreBase::dump(Formatter *f) const
   f->close_section(); // dirfragtree
   
   f->open_array_section("old_inodes");
-  for (const auto &p : old_inodes) {
-    f->open_object_section("old_inode");
-    // The key is the last snapid, the first is in the mempool_old_inode
-    f->dump_int("last", p.first);
-    p.second.dump(f);
-    f->close_section();  // old_inode
+  if (old_inodes) {
+    for (const auto &p : *old_inodes) {
+      f->open_object_section("old_inode");
+      // The key is the last snapid, the first is in the mempool_old_inode
+      f->dump_int("last", p.first);
+      p.second.dump(f);
+      f->close_section();  // old_inode
+    }
   }
   f->close_section();  // old_inodes
 
@@ -4396,12 +4495,26 @@ void decode_json_obj(mempool::mds_co::string& t, JSONObj *obj){
   t = mempool::mds_co::string(std::string_view(obj->get_data()));
 }
 
-void InodeStoreBase::decode_json(JSONObj *obj){
+void InodeStoreBase::decode_json(JSONObj *obj)
+{
+  {
+    auto _inode = allocate_inode();
+    _inode->decode_json(obj);
+    reset_inode(std::move(_inode));
+  }
 
-  inode.decode_json(obj);
   JSONDecoder::decode_json("symlink", symlink, obj, true);
   // JSONDecoder::decode_json("dirfragtree", dirfragtree, obj, true); // cann't decode it now
-  JSONDecoder::decode_json("xattrs", InodeStoreBase::xattrs, xattrs_cb, obj, true);
+  //
+  //
+  {
+    mempool_xattr_map tmp;
+    JSONDecoder::decode_json("xattrs", tmp, xattrs_cb, obj, true);
+    if (tmp.empty())
+      reset_xattrs(xattr_map_ptr());
+    else
+      reset_xattrs(allocate_xattr_map(std::move(tmp)));
+  }
   // JSONDecoder::decode_json("old_inodes", old_inodes, InodeStoreBase::old_indoes_cb, obj, true); // cann't decode old_inodes now
   JSONDecoder::decode_json("oldest_snap", oldest_snap.val, obj, true);
   JSONDecoder::decode_json("damage_flags", damage_flags, obj, true);
@@ -4431,7 +4544,7 @@ void InodeStoreBase::old_indoes_cb(InodeStoreBase::mempool_old_inode_map& c, JSO
 void InodeStore::generate_test_instances(std::list<InodeStore*> &ls)
 {
   InodeStore *populated = new InodeStore;
-  populated->inode.ino = 0xdeadbeef;
+  populated->get_inode()->ino = 0xdeadbeef;
   populated->symlink = "rhubarb";
   ls.push_back(populated);
 }
@@ -4439,7 +4552,7 @@ void InodeStore::generate_test_instances(std::list<InodeStore*> &ls)
 void InodeStoreBare::generate_test_instances(std::list<InodeStoreBare*> &ls)
 {
   InodeStoreBare *populated = new InodeStoreBare;
-  populated->inode.ino = 0xdeadbeef;
+  populated->get_inode()->ino = 0xdeadbeef;
   populated->symlink = "rhubarb";
   ls.push_back(populated);
 }
@@ -4514,10 +4627,10 @@ void CInode::validate_disk_state(CInode::validated_data *results,
 
     bool _start(int rval) {
       if (in->is_dirty()) {
-	MDCache *mdcache = in->mdcache;
-	mempool_inode& inode = in->inode;
+	MDCache *mdcache = in->mdcache;  // For the benefit of dout
+	auto ino = [this]() { return in->ino(); }; // For the benefit of dout
 	dout(20) << "validating a dirty CInode; results will be inconclusive"
-		 << dendl;
+	  << dendl;
       }
       if (in->is_symlink()) {
 	// there's nothing to do for symlinks!
@@ -4552,7 +4665,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
       int memory_newer;
 
       MDCache *mdcache = in->mdcache;  // For the benefit of dout
-      const mempool_inode& inode = in->inode;  // For the benefit of dout
+      auto ino = [this]() { return in->ino(); }; // For the benefit of dout
 
       // Ignore rval because it's the result of a FAILOK operation
       // from fetch_backtrace_and_tag: the real result is in
@@ -4621,18 +4734,18 @@ next:
       {
         InoTable *inotable = mdcache->mds->inotable;
 
-        dout(10) << "scrub: inotable ino = " << inode.ino << dendl;
+        dout(10) << "scrub: inotable ino = " << in->ino() << dendl;
         dout(10) << "scrub: inotable free says "
-          << inotable->is_marked_free(inode.ino) << dendl;
+          << inotable->is_marked_free(in->ino()) << dendl;
 
-        if (inotable->is_marked_free(inode.ino)) {
+        if (inotable->is_marked_free(in->ino())) {
           LogChannelRef clog = in->mdcache->mds->clog;
-          clog->error() << "scrub: inode wrongly marked free: " << inode.ino;
+          clog->error() << "scrub: inode wrongly marked free: " << in->ino();
 
           if (in->scrub_infop->header->get_repair()) {
-            bool repaired = inotable->repair(inode.ino);
+            bool repaired = inotable->repair(in->ino());
             if (repaired) {
-              clog->error() << "inode table repaired for inode: " << inode.ino;
+              clog->error() << "inode table repaired for inode: " << in->ino();
 
               inotable->save();
             } else {
@@ -4658,7 +4771,7 @@ next:
       if (in->is_base()) {
 	if (!shadow_in) {
 	  shadow_in = new CInode(in->mdcache);
-	  in->mdcache->create_unlinked_system_inode(shadow_in, in->inode.ino, in->inode.mode);
+	  in->mdcache->create_unlinked_system_inode(shadow_in, in->ino(), in->get_inode()->mode);
 	  in->mdcache->num_shadow_inodes++;
 	}
         shadow_in->fetch(get_internal_callback(INODE));
@@ -4671,20 +4784,21 @@ next:
     }
 
     bool _inode_disk(int rval) {
+      const auto& si = shadow_in->get_inode();
+      const auto& i = in->get_inode();
+
       results->inode.checked = true;
       results->inode.ondisk_read_retval = rval;
-      results->inode.ondisk_value = shadow_in->inode;
-      results->inode.memory_value = in->inode;
+      results->inode.ondisk_value = *si;
+      results->inode.memory_value = *i;
 
-      mempool_inode& si = shadow_in->inode;
-      mempool_inode& i = in->inode;
-      if (si.version > i.version) {
+      if (si->version > i->version) {
         // uh, what?
         results->inode.error_str << "On-disk inode is newer than in-memory one; ";
 	goto next;
       } else {
         bool divergent = false;
-        int r = i.compare(si, &divergent);
+        int r = i->compare(*si, &divergent);
         results->inode.passed = !divergent && r >= 0;
         if (!results->inode.passed) {
           results->inode.error_str <<
@@ -4727,8 +4841,8 @@ next:
       results->raw_stats.checked = true;
       results->raw_stats.ondisk_read_retval = rval;
 
-      results->raw_stats.memory_value.dirstat = in->inode.dirstat;
-      results->raw_stats.memory_value.rstat = in->inode.rstat;
+      results->raw_stats.memory_value.dirstat = in->get_inode()->dirstat;
+      results->raw_stats.memory_value.rstat = in->get_inode()->rstat;
       frag_info_t& dir_info = results->raw_stats.ondisk_value.dirstat;
       nest_info_t& nest_info = results->raw_stats.ondisk_value.rstat;
 
@@ -4761,8 +4875,8 @@ next:
 	nest_info.rsnaps += srnode->snaps.size();
 
       // ...and that their sum matches our inode settings
-      if (!dir_info.same_sums(in->inode.dirstat) ||
-	  !nest_info.same_sums(in->inode.rstat)) {
+      if (!dir_info.same_sums(in->get_inode()->dirstat) ||
+	  !nest_info.same_sums(in->get_inode()->rstat)) {
 	if (in->scrub_infop->header->get_repair()) {
 	  results->raw_stats.error_str
 	    << "freshly-calculated rstats don't match existing ones (will be fixed)";
@@ -5034,11 +5148,11 @@ void CInode::scrub_info_create() const
 
   // break out of const-land to set up implicit initial state
   CInode *me = const_cast<CInode*>(this);
-  mempool_inode *in = me->get_projected_inode();
+  const auto& pi = me->get_projected_inode();
 
   scrub_info_t *si = new scrub_info_t();
-  si->scrub_start_stamp = si->last_scrub_stamp = in->last_scrub_stamp;
-  si->scrub_start_version = si->last_scrub_version = in->last_scrub_version;
+  si->scrub_start_stamp = si->last_scrub_stamp = pi->last_scrub_stamp;
+  si->scrub_start_version = si->last_scrub_version = pi->last_scrub_version;
 
   me->scrub_infop = si;
 }
@@ -5222,8 +5336,8 @@ int64_t CInode::get_backtrace_pool() const
   } else {
     // Files are required to have an explicit layout that specifies
     // a pool
-    ceph_assert(inode.layout.pool_id != -1);
-    return inode.layout.pool_id;
+    ceph_assert(get_inode()->layout.pool_id != -1);
+    return get_inode()->layout.pool_id;
   }
 }
 
@@ -5309,7 +5423,7 @@ void CInode::maybe_ephemeral_dist(bool update)
     dout(15) << __func__ << " !dir or !normal: cannot ephemeral distributed pin " << *this << dendl;
     set_ephemeral_dist(false);
     return;
-  } else if (get_inode().nlink == 0) {
+  } else if (get_inode()->nlink == 0) {
     dout(15) << __func__ << " unlinked directory: cannot ephemeral distributed pin " << *this << dendl;
     set_ephemeral_dist(false);
     return;
@@ -5326,7 +5440,7 @@ void CInode::maybe_ephemeral_dist(bool update)
     return;
   }
 
-  bool pin = dir->get_inode()->get_inode().export_ephemeral_distributed_pin;
+  bool pin = dir->get_inode()->get_inode()->export_ephemeral_distributed_pin;
   if (pin) {
     dout(10) << __func__ << "  ephemeral distributed pinning " << *this << dendl;
     set_ephemeral_dist(true);
@@ -5345,12 +5459,12 @@ void CInode::maybe_ephemeral_dist_children(bool update)
   } else if (!is_dir() || !is_normal()) {
     dout(15) << __func__ << " !dir or !normal: cannot ephemeral distributed pin " << *this << dendl;
     return;
-  } else if (get_inode().nlink == 0) {
+  } else if (get_inode()->nlink == 0) {
     dout(15) << __func__ << " unlinked directory: cannot ephemeral distributed pin " << *this << dendl;
     return;
   }
 
-  bool pin = get_inode().export_ephemeral_distributed_pin;
+  bool pin = get_inode()->export_ephemeral_distributed_pin;
   /* FIXME: expensive to iterate children when not updating */
   if (!pin && !update) {
     return;
@@ -5398,7 +5512,7 @@ void CInode::maybe_ephemeral_rand(bool fresh, double threshold)
     dout(15) << __func__ << " !dir or !normal: cannot ephemeral random pin " << *this << dendl;
     set_ephemeral_rand(false);
     return;
-  } else if (get_inode().nlink == 0) {
+  } else if (get_inode()->nlink == 0) {
     dout(15) << __func__ << " unlinked directory: cannot ephemeral random pin " << *this << dendl;
     set_ephemeral_rand(false);
     return;
@@ -5432,22 +5546,20 @@ void CInode::maybe_ephemeral_rand(bool fresh, double threshold)
 void CInode::setxattr_ephemeral_rand(double probability)
 {
   ceph_assert(is_dir());
-  ceph_assert(is_projected());
-  get_projected_inode()->export_ephemeral_random_pin = probability;
+  _get_projected_inode()->export_ephemeral_random_pin = probability;
 }
 
 void CInode::setxattr_ephemeral_dist(bool val)
 {
   ceph_assert(is_dir());
-  ceph_assert(is_projected());
-  get_projected_inode()->export_ephemeral_distributed_pin = val;
+  _get_projected_inode()->export_ephemeral_distributed_pin = val;
 }
 
 void CInode::set_export_pin(mds_rank_t rank)
 {
   ceph_assert(is_dir());
-  ceph_assert(is_projected());
-  get_projected_inode()->export_pin = rank;
+  _get_projected_inode()->export_pin = rank;
+  maybe_export_pin(true);
 }
 
 void CInode::check_pin_policy()
@@ -5460,12 +5572,12 @@ void CInode::check_pin_policy()
     const CDentry *pdn = in->get_parent_dn();
     if (!pdn)
       break;
-    if (in->get_inode().nlink == 0) {
+    if (in->get_inode()->nlink == 0) {
       // ignore export pin for unlinked directory
       return;
     } else if (etarget != MDS_RANK_NONE && in->has_ephemeral_policy()) {
       return;
-    } else if (in->get_inode().export_pin >= 0) {
+    } else if (in->get_inode()->export_pin >= 0) {
       /* clear any epin policy */
       set_ephemeral_dist(false);
       set_ephemeral_rand(false);
@@ -5493,13 +5605,13 @@ mds_rank_t CInode::get_export_pin(bool inherit, bool ephemeral) const
     const CDentry *pdn = in->get_parent_dn();
     if (!pdn)
       break;
-    if (in->get_inode().nlink == 0) {
+    if (in->get_inode()->nlink == 0) {
       // ignore export pin for unlinked directory
       return MDS_RANK_NONE;
     } else if (etarget != MDS_RANK_NONE && in->has_ephemeral_policy()) {
       return etarget;
-    } else if (in->get_inode().export_pin >= 0) {
-      return in->get_inode().export_pin;
+    } else if (in->get_inode()->export_pin >= 0) {
+      return in->get_inode()->export_pin;
     } else if (etarget == MDS_RANK_NONE && ephemeral && in->is_ephemerally_pinned()) {
       /* If a parent overrides a grandparent ephemeral pin policy with an export pin, we use that export pin instead. */
       etarget = mdcache->hash_into_rank_bucket(in->ino());
@@ -5528,16 +5640,16 @@ double CInode::get_ephemeral_rand(bool inherit) const
     if (!pdn)
       break;
     // ignore export pin for unlinked directory
-    if (in->get_inode().nlink == 0)
+    if (in->get_inode()->nlink == 0)
       break;
 
-    if (in->get_inode().export_ephemeral_random_pin > 0.0)
-      return std::min(in->get_inode().export_ephemeral_random_pin, max);
+    if (in->get_inode()->export_ephemeral_random_pin > 0.0)
+      return std::min(in->get_inode()->export_ephemeral_random_pin, max);
 
     /* An export_pin overrides only if no closer parent (incl. this one) has a
      * random pin set.
      */
-    if (in->get_inode().export_pin >= 0)
+    if (in->get_inode()->export_pin >= 0)
       return 0.0;
 
     if (!inherit)

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -21,6 +21,7 @@
 #include <string_view>
 
 #include "common/config.h"
+#include "common/RefCountedObj.h"
 #include "include/counter.h"
 #include "include/elist.h"
 #include "include/types.h"
@@ -67,17 +68,55 @@ struct cinode_lock_info_t {
  */
 class InodeStoreBase {
 public:
-  typedef inode_t<mempool::mds_co::pool_allocator> mempool_inode;
-  typedef old_inode_t<mempool::mds_co::pool_allocator> mempool_old_inode;
-  typedef mempool::mds_co::compact_map<snapid_t, mempool_old_inode> mempool_old_inode_map;
-  typedef xattr_map<mempool::mds_co::pool_allocator> mempool_xattr_map; // FIXME bufferptr not in mempool
+  using mempool_inode = inode_t<mempool::mds_co::pool_allocator>;
+  using inode_ptr = std::shared_ptr<mempool_inode>;
+  using inode_const_ptr = std::shared_ptr<const mempool_inode>;
 
-  InodeStoreBase() {}
+  template <typename ...Args>
+  static inode_ptr allocate_inode(Args && ...args) {
+    static mempool::mds_co::pool_allocator<mempool_inode> allocator;
+    return std::allocate_shared<mempool_inode>(allocator, std::forward<Args>(args)...);
+  }
+  
+  using mempool_xattr_map = xattr_map<mempool::mds_co::pool_allocator>; // FIXME bufferptr not in mempool
+  using xattr_map_ptr = std::shared_ptr<mempool_xattr_map>;
+  using xattr_map_const_ptr = std::shared_ptr<const mempool_xattr_map>;
+
+  template <typename ...Args>
+  static xattr_map_ptr allocate_xattr_map(Args && ...args) {
+    static mempool::mds_co::pool_allocator<mempool_xattr_map> allocator;
+    return std::allocate_shared<mempool_xattr_map>(allocator, std::forward<Args>(args)...);
+  }
+
+  using mempool_old_inode = old_inode_t<mempool::mds_co::pool_allocator>;
+  using mempool_old_inode_map = mempool::mds_co::map<snapid_t, mempool_old_inode>;
+  using old_inode_map_ptr = std::shared_ptr<mempool_old_inode_map>;
+  using old_inode_map_const_ptr = std::shared_ptr<const mempool_old_inode_map>;
+
+  template <typename ...Args>
+  static old_inode_map_ptr allocate_old_inode_map(Args && ...args) {
+    static mempool::mds_co::pool_allocator<mempool_old_inode_map> allocator;
+    return std::allocate_shared<mempool_old_inode_map>(allocator, std::forward<Args>(args)...);
+  }
+
+  void reset_inode(inode_const_ptr&& ptr) {
+    inode = std::move(ptr);
+  }
+
+  void reset_xattrs(xattr_map_const_ptr&& ptr) {
+    xattrs = std::move(ptr);
+  }
+
+  void reset_old_inodes(old_inode_map_const_ptr&& ptr) {
+    old_inodes = std::move(ptr);
+  }
+
+  void encode_xattrs(bufferlist &bl) const;
+  void decode_xattrs(bufferlist::const_iterator &p);
+  void encode_old_inodes(bufferlist &bl, uint64_t features) const;
+  void decode_old_inodes(bufferlist::const_iterator &p);
 
   /* Helpers */
-  bool is_file() const    { return inode.is_file(); }
-  bool is_symlink() const { return inode.is_symlink(); }
-  bool is_dir() const     { return inode.is_dir(); }
   static object_t get_object_name(inodeno_t ino, frag_t fg, std::string_view suffix);
 
   /* Full serialization for use in ".inode" root inode objects */
@@ -99,13 +138,20 @@ public:
   __u32 hash_dentry_name(std::string_view dn);
   frag_t pick_dirfrag(std::string_view dn);
 
-  mempool_inode inode;        // the inode itself
-  mempool::mds_co::string symlink;      // symlink dest, if symlink
-  mempool_xattr_map xattrs;
-  fragtree_t dirfragtree;  // dir frag tree, if any.  always consistent with our dirfrag map.
-  mempool_old_inode_map old_inodes;   // key = last, value.first = first
-  snapid_t oldest_snap = CEPH_NOSNAP;
-  damage_flags_t damage_flags = 0;
+  mempool::mds_co::string	symlink;      // symlink dest, if symlink
+  fragtree_t			dirfragtree;  // dir frag tree, if any.  always consistent with our dirfrag map.
+  snapid_t 			oldest_snap = CEPH_NOSNAP;
+  damage_flags_t 		damage_flags = 0;
+
+protected:
+  static inode_const_ptr	empty_inode;
+
+  // Following members are pointers to constant data, the constant data can
+  // be shared by CInode and log events. To update these members in CInode,
+  // read-copy-update should be used.
+  inode_const_ptr		inode = empty_inode;
+  xattr_map_const_ptr		xattrs;
+  old_inode_map_const_ptr	old_inodes;   // key = last, value.first = first
 };
 
 inline void decode_noshare(InodeStoreBase::mempool_xattr_map& xattrs,
@@ -116,6 +162,13 @@ inline void decode_noshare(InodeStoreBase::mempool_xattr_map& xattrs,
 
 class InodeStore : public InodeStoreBase {
 public:
+  mempool_inode* get_inode() {
+    if (inode == empty_inode)
+      reset_inode(allocate_inode());
+    return const_cast<mempool_inode*>(inode.get());
+  }
+  mempool_xattr_map* get_xattrs() { return const_cast<mempool_xattr_map*>(xattrs.get()); }
+
   void encode(ceph::buffer::list &bl, uint64_t features) const {
     InodeStoreBase::encode(bl, features, &snap_blob);
   }
@@ -131,7 +184,11 @@ public:
 
   static void generate_test_instances(std::list<InodeStore*>& ls);
 
-  // FIXME ceph::buffer::list not part of mempool
+  using InodeStoreBase::inode;
+  using InodeStoreBase::xattrs;
+  using InodeStoreBase::old_inodes;
+
+  // FIXME bufferlist not part of mempool
   ceph::buffer::list snap_blob;  // Encoded copy of SnapRealm, because we can't
 			 // rehydrate it without full MDCache
 };
@@ -243,32 +300,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     ScrubHeaderRef header;
   };
 
-  /**
-   * Projection methods, used to store inode changes until they have been journaled,
-   * at which point they are popped.
-   * Usage:
-   * project_inode as needed. If you're changing xattrs or sr_t, then pass true
-   * as needed then change the xattrs/snapnode member as needed. (Dirty
-   * exception: project_past_snaprealm_parent allows you to project the
-   * snapnode after doing project_inode (i.e. you don't need to pass
-   * snap=true).
-   *
-   * Then, journal. Once journaling is done, pop_and_dirty_projected_inode.
-   * This function will take care of the inode itself, the xattrs, and the snaprealm.
-   */
-
-  class projected_inode {
-  public:
-    static sr_t* const UNDEF_SRNODE;
-
-    projected_inode() = delete;
-    explicit projected_inode(const mempool_inode &in) : inode(in) {}
-
-    mempool_inode inode;
-    std::unique_ptr<mempool_xattr_map> xattrs;
-    sr_t *snapnode = UNDEF_SRNODE;
-  };
-
   // -- pins --
   static const int PIN_DIRFRAG =         -1; 
   static const int PIN_CAPS =             2;  // client caps
@@ -368,7 +399,6 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     close_dirfrags();
     close_snaprealm();
     clear_file_locks();
-    ceph_assert(num_projected_xattrs == 0);
     ceph_assert(num_projected_srnodes == 0);
     ceph_assert(num_caps_wanted == 0);
     ceph_assert(num_subtree_roots == 0);
@@ -457,9 +487,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
 
   bool is_multiversion() const {
     return snaprealm ||  // other snaprealms will link to me
-      inode.is_dir() ||  // links to me in other snaps
-      inode.nlink > 1 || // there are remote links, possibly snapped, that will need to find me
-      !old_inodes.empty(); // once multiversion, always multiversion.  until old_inodes gets cleaned out.
+      get_inode()->is_dir() ||  // links to me in other snaps
+      get_inode()->nlink > 1 || // there are remote links, possibly snapped, that will need to find me
+      is_any_old_inodes(); // once multiversion, always multiversion.  until old_inodes gets cleaned out.
   }
   snapid_t get_oldest_snap();
 
@@ -469,50 +499,84 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void mark_dirty_rstat();
   void clear_dirty_rstat();
 
-  CInode::projected_inode &project_inode(bool xattr = false, bool snap = false);
-  void pop_and_dirty_projected_inode(LogSegment *ls);
+  //bool hack_accessed = false;
+  //utime_t hack_load_stamp;
 
-  projected_inode *get_projected_node() {
-    if (projected_nodes.empty())
-      return NULL;
-    else
-      return &projected_nodes.back();
-  }
+  /**
+   * Projection methods, used to store inode changes until they have been journaled,
+   * at which point they are popped.
+   * Usage:
+   * project_inode as needed. If you're changing xattrs or sr_t, then pass true
+   * as needed then change the xattrs/snapnode member as needed. (Dirty
+   * exception: project_past_snaprealm_parent allows you to project the
+   * snapnode after doing project_inode (i.e. you don't need to pass
+   * snap=true).
+   *
+   * Then, journal. Once journaling is done, pop_and_dirty_projected_inode.
+   * This function will take care of the inode itself, the xattrs, and the snaprealm.
+   */
+
+  struct projected_inode {
+    static sr_t* const UNDEF_SRNODE;
+
+    inode_ptr const inode;
+    xattr_map_ptr const xattrs;
+    sr_t* const snapnode;
+
+    projected_inode() = delete;
+    explicit projected_inode(inode_ptr&& i, xattr_map_ptr&& x, sr_t *s) :
+      inode(std::move(i)), xattrs(std::move(x)), snapnode(s) {}
+  };
+  projected_inode project_inode(bool xattr = false, bool snap = false);
+
+  void pop_and_dirty_projected_inode(LogSegment *ls);
 
   version_t get_projected_version() const {
     if (projected_nodes.empty())
-      return inode.version;
+      return get_inode()->version;
     else
-      return projected_nodes.back().inode.version;
+      return projected_nodes.back().inode->version;
   }
   bool is_projected() const {
     return !projected_nodes.empty();
   }
 
-  const mempool_inode *get_projected_inode() const {
+  const inode_const_ptr& get_projected_inode() const {
     if (projected_nodes.empty())
-      return &inode;
+      return get_inode();
     else
-      return &projected_nodes.back().inode;
+      return projected_nodes.back().inode;
   }
-  mempool_inode *get_projected_inode() {
-    if (projected_nodes.empty())
-      return &inode;
-    else
-      return &projected_nodes.back().inode;
+  // inode should have already been projected in caller's context
+  mempool_inode* _get_projected_inode() {
+    ceph_assert(!projected_nodes.empty());
+    return const_cast<mempool_inode*>(projected_nodes.back().inode.get());
   }
-  mempool_inode *get_previous_projected_inode() {
+  const inode_const_ptr& get_previous_projected_inode() const {
     ceph_assert(!projected_nodes.empty());
     auto it = projected_nodes.rbegin();
     ++it;
     if (it != projected_nodes.rend())
-      return &it->inode;
+      return it->inode;
     else
-      return &inode;
+      return get_inode();
   }
 
-  mempool_xattr_map *get_projected_xattrs();
-  mempool_xattr_map *get_previous_projected_xattrs();
+  const xattr_map_const_ptr& get_projected_xattrs() {
+    if (projected_nodes.empty())
+      return xattrs;
+    else
+      return projected_nodes.back().xattrs;
+  }
+  const xattr_map_const_ptr& get_previous_projected_xattrs() {
+    ceph_assert(!projected_nodes.empty());
+    auto it = projected_nodes.rbegin();
+    ++it;
+    if (it != projected_nodes.rend())
+      return it->xattrs;
+    else
+      return xattrs;
+  }
 
   sr_t *prepare_new_srnode(snapid_t snapid);
   void project_snaprealm(sr_t *new_srnode);
@@ -533,9 +597,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void project_snaprealm_past_parent(SnapRealm *newparent);
   void early_pop_projected_snaprealm();
 
-  mempool_old_inode& cow_old_inode(snapid_t follows, bool cow_head);
+  const mempool_old_inode& cow_old_inode(snapid_t follows, bool cow_head);
   void split_old_inode(snapid_t snap);
-  mempool_old_inode *pick_old_inode(snapid_t last);
+  snapid_t pick_old_inode(snapid_t last) const;
   void pre_cow_old_inode();
   bool has_snap_data(snapid_t s);
   void purge_stale_snap_data(const std::set<snapid_t>& snaps);
@@ -598,15 +662,22 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   std::pair<bool,bool> split_need_snapflush(CInode *cowin, CInode *in);
 
   // -- accessors --
-  bool is_root() const { return inode.ino == MDS_INO_ROOT; }
-  bool is_stray() const { return MDS_INO_IS_STRAY(inode.ino); }
+
+  inodeno_t ino() const { return get_inode()->ino; }
+  vinodeno_t vino() const { return vinodeno_t(ino(), last); }
+  int d_type() const { return IFTODT(get_inode()->mode); }
+  bool is_root() const { return ino() == MDS_INO_ROOT; }
+  bool is_stray() const { return MDS_INO_IS_STRAY(ino()); }
   mds_rank_t get_stray_owner() const {
-    return (mds_rank_t)MDS_INO_STRAY_OWNER(inode.ino);
+    return (mds_rank_t)MDS_INO_STRAY_OWNER(ino());
   }
-  bool is_mdsdir() const { return MDS_INO_IS_MDSDIR(inode.ino); }
-  bool is_base() const { return MDS_INO_IS_BASE(inode.ino); }
-  bool is_system() const { return inode.ino < MDS_INO_SYSTEM_BASE; }
+  bool is_mdsdir() const { return MDS_INO_IS_MDSDIR(ino()); }
+  bool is_base() const { return MDS_INO_IS_BASE(ino()); }
+  bool is_system() const { return ino() < MDS_INO_SYSTEM_BASE; }
   bool is_normal() const { return !(is_base() || is_system() || is_stray()); }
+  bool is_file() const    { return get_inode()->is_file(); }
+  bool is_symlink() const { return get_inode()->is_symlink(); }
+  bool is_dir() const     { return get_inode()->is_dir(); }
 
   bool is_head() const { return last == CEPH_NOSNAP; }
 
@@ -621,12 +692,22 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void clear_ambiguous_auth(MDSContext::vec& finished);
   void clear_ambiguous_auth();
 
-  inodeno_t ino() const { return inode.ino; }
-  vinodeno_t vino() const { return vinodeno_t(inode.ino, last); }
-  int d_type() const { return IFTODT(inode.mode); }
+  const inode_const_ptr& get_inode() const {
+    return inode;
+  }
 
-  mempool_inode& get_inode() { return inode; }
-  const mempool_inode& get_inode() const { return inode; }
+  // only used for updating newly allocated CInode
+  mempool_inode* _get_inode() {
+    if (inode == empty_inode)
+      reset_inode(allocate_inode());
+    return const_cast<mempool_inode*>(inode.get());
+  }
+
+  const xattr_map_const_ptr& get_xattrs() const { return xattrs; }
+
+  bool is_any_old_inodes() const { return old_inodes && !old_inodes->empty(); }
+  const old_inode_map_const_ptr& get_old_inodes() const { return old_inodes; }
+
   CDentry* get_parent_dn() { return parent; }
   const CDentry* get_parent_dn() const { return parent; }
   CDentry* get_projected_parent_dn() { return !projected_parent.empty() ? projected_parent.back() : parent; }
@@ -656,11 +737,11 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void name_stray_dentry(std::string& dname);
   
   // -- dirtyness --
-  version_t get_version() const { return inode.version; }
+  version_t get_version() const { return get_inode()->version; }
 
   version_t pre_dirty();
   void _mark_dirty(LogSegment *ls);
-  void mark_dirty(version_t projected_dirv, LogSegment *ls);
+  void mark_dirty(LogSegment *ls);
   void mark_clean();
 
   void store(MDSContext *fin);
@@ -837,7 +918,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   int get_caps_allowed_by_type(int type) const;
   int get_caps_careful() const;
   int get_xlocker_mask(client_t client) const;
-  int get_caps_allowed_for_client(Session *s, Capability *cap, mempool_inode *file_i) const;
+  int get_caps_allowed_for_client(Session *s, Capability *cap,
+				  const mempool_inode *file_i) const;
 
   // caps issued, wanted
   int get_caps_issued(int *ploner = 0, int *pother = 0, int *pxlocker = 0,
@@ -949,8 +1031,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   }
 
   bool has_ephemeral_policy() const {
-    return get_inode().export_ephemeral_random_pin > 0.0 ||
-           get_inode().export_ephemeral_distributed_pin;
+    return get_inode()->export_ephemeral_random_pin > 0.0 ||
+           get_inode()->export_ephemeral_distributed_pin;
   }
   bool is_ephemerally_pinned() const {
     return state_test(STATE_DISTEPHEMERALPIN) ||
@@ -1152,8 +1234,18 @@ private:
   bool _validate_disk_state(class ValidationContinuation *c,
                             int rval, int stage);
 
-  mempool::mds_co::list<projected_inode> projected_nodes;   // projected values (only defined while dirty)
-  size_t num_projected_xattrs = 0;
+  struct projected_const_node {
+    inode_const_ptr inode;
+    xattr_map_const_ptr xattrs;
+    sr_t *snapnode;
+
+    projected_const_node() = delete;
+    projected_const_node(projected_const_node&&) = default;
+    explicit projected_const_node(const inode_const_ptr& i, const xattr_map_const_ptr& x, sr_t *s) :
+      inode(i), xattrs(x), snapnode(s) {}
+  };
+
+  mempool::mds_co::list<projected_const_node> projected_nodes;   // projected values (only defined while dirty)
   size_t num_projected_srnodes = 0;
 
   // -- cache infrastructure --

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -524,12 +524,13 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
     sr_t* const snapnode;
 
     projected_inode() = delete;
-    explicit projected_inode(inode_ptr&& i, xattr_map_ptr&& x, sr_t *s) :
+    explicit projected_inode(inode_ptr&& i, xattr_map_ptr&& x, sr_t *s=nullptr) :
       inode(std::move(i)), xattrs(std::move(x)), snapnode(s) {}
   };
-  projected_inode project_inode(bool xattr = false, bool snap = false);
+  projected_inode project_inode(const MutationRef& mut,
+				bool xattr = false, bool snap = false);
 
-  void pop_and_dirty_projected_inode(LogSegment *ls);
+  void pop_and_dirty_projected_inode(LogSegment *ls, const MutationRef& mut);
 
   version_t get_projected_version() const {
     if (projected_nodes.empty())
@@ -843,8 +844,8 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   void start_scatter(ScatterLock *lock);
   void finish_scatter_update(ScatterLock *lock, CDir *dir,
 			     version_t inode_version, version_t dir_accounted_version);
-  void finish_scatter_gather_update(int type);
-  void finish_scatter_gather_update_accounted(int type, MutationRef& mut, EMetaBlob *metablob);
+  void finish_scatter_gather_update(int type, MutationRef& mut);
+  void finish_scatter_gather_update_accounted(int type, EMetaBlob *metablob);
 
   // -- snap --
   void open_snaprealm(bool no_split=false);

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2830,15 +2830,13 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
     le = eu;
   }
   mds->mdlog->start_entry(le);
-  if (update_size) {  // FIXME if/when we do max_size nested accounting
-    mdcache->predirty_journal_parents(mut, metablob, in, 0, PREDIRTY_PRIMARY);
-    // no cow, here!
-    CDentry *parent = in->get_projected_parent_dn();
-    metablob->add_primary_dentry(parent, in, true);
-  } else {
-    metablob->add_dir_context(in->get_projected_parent_dn()->get_dir());
-    mdcache->journal_dirty_inode(mut.get(), metablob, in);
-  }
+
+  mdcache->predirty_journal_parents(mut, metablob, in, 0, PREDIRTY_PRIMARY);
+  // no cow, here!
+  CDentry *parent = in->get_projected_parent_dn();
+  metablob->add_primary_dentry(parent, in, true);
+  mdcache->journal_dirty_inode(mut.get(), metablob, in);
+
   mds->mdlog->submit_entry(le, new C_Locker_FileUpdate_finish(this, in, mut,
       UPDATE_SHAREMAX, ref_t<MClientCaps>()));
   wrlock_force(&in->filelock, mut);  // wrlock for duration of journal

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2106,7 +2106,7 @@ void Locker::xlock_downgrade(SimpleLock *lock, MutationImpl *mut)
 version_t Locker::issue_file_data_version(CInode *in)
 {
   dout(7) << "issue_file_data_version on " << *in << dendl;
-  return in->inode.file_data_version;
+  return in->get_inode()->file_data_version;
 }
 
 class C_Locker_FileUpdate_finish : public LockerLogContext {
@@ -2316,9 +2316,9 @@ int Locker::issue_caps(CInode *in, Capability *only_cap)
 	allowed |= cap->get_lock_cache_allowed();
     }
 
-    if ((in->inode.inline_data.version != CEPH_INLINE_NONE &&
+    if ((in->get_inode()->inline_data.version != CEPH_INLINE_NONE &&
 	 cap->is_noinline()) ||
-	(!in->inode.layout.pool_ns.empty() &&
+	(!in->get_inode()->layout.pool_ns.empty() &&
 	 cap->is_nopoolns()))
       allowed &= ~(CEPH_CAP_FILE_RD | CEPH_CAP_FILE_WR);
 
@@ -2367,7 +2367,7 @@ int Locker::issue_caps(CInode *in, Capability *only_cap)
     }
 
     // notify clients about deleted inode, to make sure they release caps ASAP.
-    if (in->inode.nlink == 0)
+    if (in->get_inode()->nlink == 0)
       wanted |= CEPH_CAP_LINK_SHARED;
 
     // are there caps that the client _wants_ and can have, but aren't pending?
@@ -2455,7 +2455,7 @@ void Locker::revoke_stale_cap(CInode *in, client_t client)
 
   cap->revoke();
 
-  if (in->is_auth() && in->inode.client_ranges.count(cap->get_client()))
+  if (in->is_auth() && in->get_inode()->client_ranges.count(cap->get_client()))
     in->state_set(CInode::STATE_NEEDSRECOVER);
 
   if (in->state_test(CInode::STATE_EXPORTINGCAPS))
@@ -2513,7 +2513,7 @@ bool Locker::revoke_stale_caps(Session *session)
       eval_lock_caches(cap);
 
     if (in->is_auth() &&
-	in->inode.client_ranges.count(cap->get_client()))
+	in->get_inode()->client_ranges.count(cap->get_client()))
       in->state_set(CInode::STATE_NEEDSRECOVER);
 
     // eval lock/inode may finish contexts, which may modify other cap's position
@@ -2676,7 +2676,7 @@ public:
   }
 };
 
-uint64_t Locker::calc_new_max_size(CInode::mempool_inode *pi, uint64_t size)
+uint64_t Locker::calc_new_max_size(const CInode::inode_const_ptr &pi, uint64_t size)
 {
   uint64_t new_max = (size + 1) << 1;
   uint64_t max_inc = g_conf()->mds_client_writeable_range_max_inc_objs;
@@ -2691,7 +2691,7 @@ void Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool update,
 				    CInode::mempool_inode::client_range_map *new_ranges,
 				    bool *max_increased)
 {
-  auto latest = in->get_projected_inode();
+  const auto& latest = in->get_projected_inode();
   uint64_t ms;
   if (latest->has_layout()) {
     ms = calc_new_max_size(latest, size);
@@ -2706,8 +2706,9 @@ void Locker::calc_new_client_ranges(CInode *in, uint64_t size, bool update,
     if ((p.second.issued() | p.second.wanted()) & CEPH_CAP_ANY_FILE_WR) {
       client_writeable_range_t& nr = (*new_ranges)[p.first];
       nr.range.first = 0;
-      if (latest->client_ranges.count(p.first)) {
-	client_writeable_range_t& oldr = latest->client_ranges[p.first];
+      auto it = latest->client_ranges.find(p.first);
+      if (it != latest->client_ranges.end()) {
+	const client_writeable_range_t& oldr = it->second;
 	if (ms > oldr.range.last)
 	  *max_increased = true;
 	nr.range.last = std::max(ms, oldr.range.last);
@@ -2733,7 +2734,7 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
   ceph_assert(in->is_auth());
   ceph_assert(in->is_file());
 
-  CInode::mempool_inode *latest = in->get_projected_inode();
+  const auto& latest = in->get_projected_inode();
   CInode::mempool_inode::client_range_map new_ranges;
   uint64_t size = latest->size;
   bool update_size = new_size > 0;
@@ -2792,24 +2793,24 @@ bool Locker::check_inode_max_size(CInode *in, bool force_wrlock,
   MutationRef mut(new MutationImpl());
   mut->ls = mds->mdlog->get_current_segment();
     
-  auto &pi = in->project_inode();
-  pi.inode.version = in->pre_dirty();
+  auto pi = in->project_inode();
+  pi.inode->version = in->pre_dirty();
 
   if (update_max) {
-    dout(10) << "check_inode_max_size client_ranges " << pi.inode.client_ranges << " -> " << new_ranges << dendl;
-    pi.inode.client_ranges = new_ranges;
+    dout(10) << "check_inode_max_size client_ranges " << pi.inode->client_ranges << " -> " << new_ranges << dendl;
+    pi.inode->client_ranges = new_ranges;
   }
 
   if (update_size) {
-    dout(10) << "check_inode_max_size size " << pi.inode.size << " -> " << new_size << dendl;
-    pi.inode.size = new_size;
-    pi.inode.rstat.rbytes = new_size;
-    dout(10) << "check_inode_max_size mtime " << pi.inode.mtime << " -> " << new_mtime << dendl;
-    pi.inode.mtime = new_mtime;
-    if (new_mtime > pi.inode.ctime) {
-      pi.inode.ctime = new_mtime;
-      if (new_mtime > pi.inode.rstat.rctime)
-	pi.inode.rstat.rctime = new_mtime;
+    dout(10) << "check_inode_max_size size " << pi.inode->size << " -> " << new_size << dendl;
+    pi.inode->size = new_size;
+    pi.inode->rstat.rbytes = new_size;
+    dout(10) << "check_inode_max_size mtime " << pi.inode->mtime << " -> " << new_mtime << dendl;
+    pi.inode->mtime = new_mtime;
+    if (new_mtime > pi.inode->ctime) {
+      pi.inode->ctime = new_mtime;
+      if (new_mtime > pi.inode->rstat.rctime)
+	pi.inode->rstat.rctime = new_mtime;
     }
   }
 
@@ -3519,25 +3520,32 @@ void Locker::_do_snap_update(CInode *in, snapid_t snap, int dirty, snapid_t foll
                 m->xattrbl.length() &&
                 m->head.xattr_version > in->get_projected_inode()->xattr_version;
 
-  CInode::mempool_old_inode *oi = 0;
-  if (in->is_multiversion()) {
-    oi = in->pick_old_inode(snap);
+  CInode::mempool_old_inode *oi = nullptr;
+  CInode::old_inode_map_ptr _old_inodes;
+  if (in->is_any_old_inodes()) {
+    auto last = in->pick_old_inode(snap);
+    if (last) {
+      _old_inodes = CInode::allocate_old_inode_map(*in->get_old_inodes());
+      oi = &_old_inodes->at(last);
+      if (snap > oi->first) {
+	(*_old_inodes)[snap - 1] = *oi;;
+	oi->first = snap;
+      }
+    }
   }
 
   CInode::mempool_inode *i;
   if (oi) {
     dout(10) << " writing into old inode" << dendl;
-    auto &pi = in->project_inode();
-    pi.inode.version = in->pre_dirty();
-    if (snap > oi->first)
-      in->split_old_inode(snap);
+    auto pi = in->project_inode();
+    pi.inode->version = in->pre_dirty();
     i = &oi->inode;
     if (xattrs)
       px = &oi->xattrs;
   } else {
-    auto &pi = in->project_inode(xattrs);
-    pi.inode.version = in->pre_dirty();
-    i = &pi.inode;
+    auto pi = in->project_inode(xattrs);
+    pi.inode->version = in->pre_dirty();
+    i = pi.inode.get();
     if (xattrs)
       px = pi.xattrs.get();
   }
@@ -3565,6 +3573,9 @@ void Locker::_do_snap_update(CInode *in, snapid_t snap, int dirty, snapid_t foll
       }
     }
   }
+
+  if (_old_inodes)
+    in->reset_old_inodes(std::move(_old_inodes));
 
   mut->auth_pin(in);
   mdcache->predirty_journal_parents(mut, &le->metablob, in, 0, PREDIRTY_PRIMARY, 0, follows);
@@ -3618,19 +3629,19 @@ void Locker::_update_cap_fields(CInode *in, int dirty, const cref_t<MClientCaps>
       if (mtime > pi->rstat.rctime)
 	pi->rstat.rctime = mtime;
     }
-    if (in->inode.is_file() &&   // ONLY if regular file
+    if (in->is_file() &&   // ONLY if regular file
 	size > pi->size) {
       dout(7) << "  size " << pi->size << " -> " << size
 	      << " for " << *in << dendl;
       pi->size = size;
       pi->rstat.rbytes = size;
     }
-    if (in->inode.is_file() &&
+    if (in->is_file() &&
         (dirty & CEPH_CAP_FILE_WR) &&
         inline_version > pi->inline_data.version) {
       pi->inline_data.version = inline_version;
       if (inline_version != CEPH_INLINE_NONE && m->inline_data.length() > 0)
-	pi->inline_data.get_data() = m->inline_data;
+	pi->inline_data.set_data(m->inline_data);
       else
 	pi->inline_data.free_data();
     }
@@ -3691,12 +3702,16 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
 	   << " on " << *in << dendl;
   ceph_assert(in->is_auth());
   client_t client = m->get_source().num();
-  CInode::mempool_inode *latest = in->get_projected_inode();
+  const auto& latest = in->get_projected_inode();
 
   // increase or zero max_size?
   uint64_t size = m->get_size();
   bool change_max = false;
-  uint64_t old_max = latest->client_ranges.count(client) ? latest->client_ranges[client].range.last : 0;
+  uint64_t old_max;
+  {
+    auto it = latest->client_ranges.find(client);
+    old_max = it != latest->client_ranges.end() ? it->second.range.last: 0;
+  }
   uint64_t new_max = old_max;
   
   if (in->is_file()) {
@@ -3797,26 +3812,26 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
                m->xattrbl.length() &&
                m->head.xattr_version > in->get_projected_inode()->xattr_version;
 
-  auto &pi = in->project_inode(xattr);
-  pi.inode.version = in->pre_dirty();
+  auto pi = in->project_inode(xattr);
+  pi.inode->version = in->pre_dirty();
 
   MutationRef mut(new MutationImpl());
   mut->ls = mds->mdlog->get_current_segment();
 
-  _update_cap_fields(in, dirty, m, &pi.inode);
+  _update_cap_fields(in, dirty, m, pi.inode.get());
 
   if (change_max) {
     dout(7) << "  max_size " << old_max << " -> " << new_max
 	    << " for " << *in << dendl;
     if (new_max) {
-      auto &cr = pi.inode.client_ranges[client];
+      auto &cr = pi.inode->client_ranges[client];
       cr.range.first = 0;
       cr.range.last = new_max;
       cr.follows = in->first - 1;
       if (cap)
 	cap->mark_clientwriteable();
     } else {
-      pi.inode.client_ranges.erase(client);
+      pi.inode->client_ranges.erase(client);
       if (cap)
 	cap->clear_clientwriteable();
     }
@@ -3831,8 +3846,8 @@ bool Locker::_do_cap_update(CInode *in, Capability *cap,
 
   // xattrs update?
   if (xattr) {
-    dout(7) << " xattrs v" << pi.inode.xattr_version << " -> " << m->head.xattr_version << dendl;
-    pi.inode.xattr_version = m->head.xattr_version;
+    dout(7) << " xattrs v" << pi.inode->xattr_version << " -> " << m->head.xattr_version << dendl;
+    pi.inode->xattr_version = m->head.xattr_version;
     auto p = m->xattrbl.cbegin();
     decode_noshare(*pi.xattrs, p);
     wrlock_force(&in->xattrlock, mut);
@@ -3968,7 +3983,7 @@ void Locker::remove_client_cap(CInode *in, Capability *cap, bool kill)
   if (in->is_auth()) {
     // make sure we clear out the client byte range
     if (in->get_projected_inode()->client_ranges.count(client) &&
-	!(in->inode.nlink == 0 && !in->is_any_caps())) {  // unless it's unlink + stray
+	!(in->get_inode()->nlink == 0 && !in->is_any_caps())) {  // unless it's unlink + stray
       if (kill)
 	in->state_set(CInode::STATE_NEEDSRECOVER);
       else
@@ -4852,7 +4867,7 @@ public:
 void Locker::scatter_writebehind(ScatterLock *lock)
 {
   CInode *in = static_cast<CInode*>(lock->get_parent());
-  dout(10) << "scatter_writebehind " << in->inode.mtime << " on " << *lock << " on " << *in << dendl;
+  dout(10) << "scatter_writebehind " << in->get_inode()->mtime << " on " << *lock << " on " << *in << dendl;
 
   // journal
   MutationRef mut(new MutationImpl());
@@ -4864,8 +4879,8 @@ void Locker::scatter_writebehind(ScatterLock *lock)
 
   in->pre_cow_old_inode();  // avoid cow mayhem
 
-  auto &pi = in->project_inode();
-  pi.inode.version = in->pre_dirty();
+  auto pi = in->project_inode();
+  pi.inode->version = in->pre_dirty();
 
   in->finish_scatter_gather_update(lock->get_type());
   lock->start_flush();

--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -259,7 +259,7 @@ private:
   friend class LockerLogContext;
 
   bool any_late_revoking_caps(xlist<Capability*> const &revoking, double timeout) const;
-  uint64_t calc_new_max_size(CInode::mempool_inode *pi, uint64_t size);
+  uint64_t calc_new_max_size(const CInode::inode_const_ptr& pi, uint64_t size);
 
   MDSRank *mds;
   MDCache *mdcache;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -272,9 +272,9 @@ void MDCache::log_stat()
   mds->logger->set(l_mds_inodes_with_caps, num_inodes_with_caps);
   mds->logger->set(l_mds_caps, Capability::count());
   if (root) {
-    mds->logger->set(l_mds_root_rfiles, root->inode.rstat.rfiles);
-    mds->logger->set(l_mds_root_rbytes, root->inode.rstat.rbytes);
-    mds->logger->set(l_mds_root_rsnaps, root->inode.rstat.rsnaps);
+    mds->logger->set(l_mds_root_rfiles, root->get_inode()->rstat.rfiles);
+    mds->logger->set(l_mds_root_rbytes, root->get_inode()->rstat.rbytes);
+    mds->logger->set(l_mds_root_rsnaps, root->get_inode()->rstat.rsnaps);
   }
 }
 
@@ -413,33 +413,31 @@ void MDCache::init_layouts()
   default_log_layout = gen_default_log_layout(*(mds->mdsmap));
 }
 
-void MDCache::create_unlinked_system_inode(CInode *in, inodeno_t ino,
-                                              int mode) const
+void MDCache::create_unlinked_system_inode(CInode *in, inodeno_t ino, int mode) const
 {
-  in->inode.ino = ino;
-  in->inode.version = 1;
-  in->inode.xattr_version = 1;
-  in->inode.mode = 0500 | mode;
-  in->inode.size = 0;
-  in->inode.ctime = 
-    in->inode.mtime =
-    in->inode.btime = ceph_clock_now();
-  in->inode.nlink = 1;
-  in->inode.truncate_size = -1ull;
-  in->inode.change_attr = 0;
-  in->inode.export_pin = MDS_RANK_NONE;
+  auto _inode = in->_get_inode();
+  _inode->ino = ino;
+  _inode->version = 1;
+  _inode->xattr_version = 1;
+  _inode->mode = 0500 | mode;
+  _inode->size = 0;
+  _inode->ctime = _inode->mtime = _inode->btime = ceph_clock_now();
+  _inode->nlink = 1;
+  _inode->truncate_size = -1ull;
+  _inode->change_attr = 0;
+  _inode->export_pin = MDS_RANK_NONE;
 
   // FIPS zeroization audit 20191117: this memset is not security related.
-  memset(&in->inode.dir_layout, 0, sizeof(in->inode.dir_layout));
-  if (in->inode.is_dir()) {
-    in->inode.dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;
-    in->inode.rstat.rsubdirs = 1; /* itself */
-    in->inode.rstat.rctime = in->inode.ctime;
+  memset(&_inode->dir_layout, 0, sizeof(_inode->dir_layout));
+  if (_inode->is_dir()) {
+    _inode->dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;
+    _inode->rstat.rsubdirs = 1; /* itself */
+    _inode->rstat.rctime = in->get_inode()->ctime;
   } else {
-    in->inode.layout = default_file_layout;
-    ++in->inode.rstat.rfiles;
+    _inode->layout = default_file_layout;
+    ++_inode->rstat.rfiles;
   }
-  in->inode.accounted_rstat = in->inode.rstat;
+  _inode->accounted_rstat = _inode->rstat;
 
   if (in->is_base()) {
     if (in->is_root())
@@ -463,12 +461,13 @@ CInode *MDCache::create_system_inode(inodeno_t ino, int mode)
 
 CInode *MDCache::create_root_inode()
 {
-  CInode *i = create_system_inode(MDS_INO_ROOT, S_IFDIR|0755);
-  i->inode.uid = g_conf()->mds_root_ino_uid;
-  i->inode.gid = g_conf()->mds_root_ino_gid;
-  i->inode.layout = default_file_layout;
-  i->inode.layout.pool_id = mds->mdsmap->get_first_data_pool();
-  return i;
+  CInode *in = create_system_inode(MDS_INO_ROOT, S_IFDIR|0755);
+  auto _inode = in->_get_inode();
+  _inode->uid = g_conf()->mds_root_ino_uid;
+  _inode->gid = g_conf()->mds_root_ino_gid;
+  _inode->layout = default_file_layout;
+  _inode->layout.pool_id = mds->mdsmap->get_first_data_pool();
+  return in;
 }
 
 void MDCache::create_empty_hierarchy(MDSGather *gather)
@@ -482,7 +481,7 @@ void MDCache::create_empty_hierarchy(MDSGather *gather)
   rootdir->dir_rep = CDir::REP_ALL;   //NONE;
 
   ceph_assert(rootdir->fnode.accounted_fragstat == rootdir->fnode.fragstat);
-  ceph_assert(rootdir->fnode.fragstat == root->inode.dirstat);
+  ceph_assert(rootdir->fnode.fragstat == root->get_inode()->dirstat);
   ceph_assert(rootdir->fnode.accounted_rstat == rootdir->fnode.rstat);
   /* Do no update rootdir rstat information of the fragment, rstat upkeep magic
    * assume version 0 is stale/invalid.
@@ -492,10 +491,7 @@ void MDCache::create_empty_hierarchy(MDSGather *gather)
   rootdir->mark_dirty(rootdir->pre_dirty(), mds->mdlog->get_current_segment());
   rootdir->commit(0, gather->new_sub());
 
-  root->mark_clean();
-  root->mark_dirty(root->pre_dirty(), mds->mdlog->get_current_segment());
-  root->mark_dirty_parent(mds->mdlog->get_current_segment(), true);
-  root->flush(gather->new_sub());
+  root->store(gather->new_sub());
 }
 
 void MDCache::create_mydir_hierarchy(MDSGather *gather)
@@ -517,9 +513,9 @@ void MDCache::create_mydir_hierarchy(MDSGather *gather)
     CDentry *sdn = mydir->add_primary_dentry(name.str(), stray);
     sdn->_mark_dirty(mds->mdlog->get_current_segment());
 
-    stray->inode.dirstat = straydir->fnode.fragstat;
+    stray->_get_inode()->dirstat = straydir->fnode.fragstat;
 
-    mydir->fnode.rstat.add(stray->inode.rstat);
+    mydir->fnode.rstat.add(stray->get_inode()->rstat);
     mydir->fnode.fragstat.nsubdirs++;
     // save them
     straydir->mark_complete();
@@ -532,10 +528,11 @@ void MDCache::create_mydir_hierarchy(MDSGather *gather)
   mydir->fnode.accounted_fragstat = mydir->fnode.fragstat;
   mydir->fnode.accounted_rstat = mydir->fnode.rstat;
 
-  myin->inode.dirstat = mydir->fnode.fragstat;
-  myin->inode.rstat = mydir->fnode.rstat;
-  ++myin->inode.rstat.rsubdirs;
-  myin->inode.accounted_rstat = myin->inode.rstat;
+  auto inode = myin->_get_inode();
+  inode->dirstat = mydir->fnode.fragstat;
+  inode->rstat = mydir->fnode.rstat;
+  ++inode->rstat.rsubdirs;
+  inode->accounted_rstat = inode->rstat;
 
   mydir->mark_complete();
   mydir->mark_dirty(mydir->pre_dirty(), ls);
@@ -565,15 +562,16 @@ void MDCache::_create_system_file(CDir *dir, std::string_view name, CInode *in, 
   version_t dpv = dn->pre_dirty();
   
   CDir *mdir = 0;
-  if (in->inode.is_dir()) {
-    in->inode.rstat.rsubdirs = 1;
+  auto inode = in->_get_inode();
+  if (in->is_dir()) {
+    inode->rstat.rsubdirs = 1;
 
     mdir = in->get_or_open_dirfrag(this, frag_t());
     mdir->mark_complete();
     mdir->pre_dirty();
   } else
-    in->inode.rstat.rfiles = 1;
-  in->inode.version = dn->pre_dirty();
+    inode->rstat.rfiles = 1;
+  inode->version = dn->pre_dirty();
   
   SnapRealm *realm = dir->get_inode()->find_snaprealm();
   dn->first = in->first = realm->get_newest_seq() + 1;
@@ -613,10 +611,9 @@ void MDCache::_create_system_file_finish(MutationRef& mut, CDentry *dn, version_
   dn->mark_dirty(dpv, mut->ls);
 
   CInode *in = dn->get_linkage()->get_inode();
-  in->inode.version--;
-  in->mark_dirty(in->inode.version + 1, mut->ls);
+  in->mark_dirty(mut->ls);
 
-  if (in->inode.is_dir()) {
+  if (in->is_dir()) {
     CDir *dir = in->get_dirfrag(frag_t());
     ceph_assert(dir);
     dir->mark_dirty(1, mut->ls);
@@ -1553,10 +1550,13 @@ CInode *MDCache::cow_inode(CInode *in, snapid_t last)
   ceph_assert(last >= in->first);
 
   CInode *oldin = new CInode(this, true, in->first, last);
-  oldin->inode = *in->get_previous_projected_inode();
-  oldin->xattrs = *in->get_previous_projected_xattrs();
+  auto _inode = CInode::allocate_inode(*in->get_previous_projected_inode());
+  _inode->trim_client_ranges(last);
+  oldin->reset_inode(std::move(_inode));
+  auto _xattrs = in->get_previous_projected_xattrs();
+  oldin->reset_xattrs(std::move(_xattrs));
+
   oldin->symlink = in->symlink;
-  oldin->inode.trim_client_ranges(last);
 
   if (in->first < in->oldest_snap)
     in->oldest_snap = in->first;
@@ -1758,7 +1758,7 @@ void MDCache::journal_cow_dentry(MutationImpl *mut, EMetaBlob *metablob,
       if (pcow_inode)
 	*pcow_inode = oldin;
       CDentry *olddn = dn->dir->add_primary_dentry(dn->get_name(), oldin, oldfirst, follows);
-      oldin->inode.version = olddn->pre_dirty();
+      oldin->_get_inode()->version = olddn->pre_dirty();
       dout(10) << " olddn " << *olddn << dendl;
       bool need_snapflush = !oldin->client_snap_caps.empty();
       if (need_snapflush) {
@@ -1817,7 +1817,6 @@ void MDCache::project_rstat_inode_to_frag(CInode *cur, CDir *parent, snapid_t fi
 					  int linkunlink, SnapRealm *prealm)
 {
   CDentry *parentdn = cur->get_projected_parent_dn();
-  CInode::mempool_inode *curi = cur->get_projected_inode();
 
   if (cur->first > first)
     first = cur->first;
@@ -1855,44 +1854,54 @@ void MDCache::project_rstat_inode_to_frag(CInode *cur, CDir *parent, snapid_t fi
       ceph_assert(cur->is_frozen_inode());
       update = false;
     }
-    _project_rstat_inode_to_frag(*curi, std::max(first, floor), cur->last, parent,
+    // hacky
+    const CInode::mempool_inode *pi;
+    if (update && cur->is_projected()) {
+      pi = cur->_get_projected_inode();
+    } else {
+      pi = cur->get_projected_inode().get();
+      if (update) {
+	// new inode
+	ceph_assert(pi->rstat == pi->accounted_rstat);
+	update = false;
+      }
+    }
+    _project_rstat_inode_to_frag(pi, std::max(first, floor), cur->last, parent,
 				 linkunlink, update);
   }
 
   if (g_conf()->mds_snap_rstat) {
     for (const auto &p : cur->dirty_old_rstats) {
-      auto &old = cur->old_inodes[p];
+      const auto &old = cur->get_old_inodes()->at(p);
       snapid_t ofirst = std::max(old.first, floor);
       auto it = snaps.lower_bound(ofirst);
       if (it == snaps.end() || *it > p)
 	continue;
       if (p >= floor)
-	_project_rstat_inode_to_frag(old.inode, ofirst, p, parent, 0, false);
+	_project_rstat_inode_to_frag(&old.inode, ofirst, p, parent, 0, false);
     }
   }
   cur->dirty_old_rstats.clear();
 }
 
 
-void MDCache::_project_rstat_inode_to_frag(CInode::mempool_inode& inode, snapid_t ofirst, snapid_t last,
+void MDCache::_project_rstat_inode_to_frag(const CInode::mempool_inode* inode, snapid_t ofirst, snapid_t last,
 					  CDir *parent, int linkunlink, bool update_inode)
 {
   dout(10) << "_project_rstat_inode_to_frag [" << ofirst << "," << last << "]" << dendl;
-  dout(20) << "  inode           rstat " << inode.rstat << dendl;
-  dout(20) << "  inode accounted_rstat " << inode.accounted_rstat << dendl;
+  dout(20) << "  inode           rstat " << inode->rstat << dendl;
+  dout(20) << "  inode accounted_rstat " << inode->accounted_rstat << dendl;
   nest_info_t delta;
   if (linkunlink == 0) {
-    delta.add(inode.rstat);
-    delta.sub(inode.accounted_rstat);
+    delta.add(inode->rstat);
+    delta.sub(inode->accounted_rstat);
   } else if (linkunlink < 0) {
-    delta.sub(inode.accounted_rstat);
+    delta.sub(inode->accounted_rstat);
   } else {
-    delta.add(inode.rstat);
+    delta.add(inode->rstat);
   }
   dout(20) << "                  delta " << delta << dendl;
 
-  if (update_inode)
-    inode.accounted_rstat = inode.rstat;
 
   while (last >= ofirst) {
     /*
@@ -1985,11 +1994,14 @@ void MDCache::_project_rstat_inode_to_frag(CInode::mempool_inode& inode, snapid_
     dout(20) << "  project to [" << first << "," << last << "] " << *prstat << dendl;
     ceph_assert(last >= first);
     prstat->add(delta);
-    if (update_inode)
-      inode.accounted_rstat = inode.rstat;
     dout(20) << "      result [" << first << "," << last << "] " << *prstat << " " << *parent << dendl;
 
     last = first-1;
+  }
+
+  if (update_inode) {
+    auto _inode = const_cast<CInode::mempool_inode*>(inode);
+    _inode->accounted_rstat = _inode->rstat;
   }
 }
 
@@ -2004,25 +2016,31 @@ void MDCache::project_rstat_frag_to_inode(nest_info_t& rstat, nest_info_t& accou
   delta.sub(accounted_rstat);
   dout(20) << "                 delta " << delta << dendl;
 
+  CInode::old_inode_map_ptr _old_inodes;
   while (last >= ofirst) {
     CInode::mempool_inode *pi;
     snapid_t first;
     if (last == pin->last) {
-      pi = pin->get_projected_inode();
+      pi = pin->_get_projected_inode();
       first = std::max(ofirst, pin->first);
       if (first > pin->first) {
-	auto &old = pin->cow_old_inode(first-1, cow_head);
+	auto& old = pin->cow_old_inode(first-1, cow_head);
 	dout(20) << "   cloned old_inode rstat is " << old.inode.rstat << dendl;
       }
     } else {
+      if (!_old_inodes) {
+	_old_inodes = CInode::allocate_old_inode_map();
+	if (pin->is_any_old_inodes())
+	  *_old_inodes = *pin->get_old_inodes();
+      }
       if (last >= pin->first) {
 	first = pin->first;
 	pin->cow_old_inode(last, cow_head);
       } else {
 	// our life is easier here because old_inodes is not sparse
 	// (although it may not begin at snapid 1)
-	auto it = pin->old_inodes.lower_bound(last);
-	if (it == pin->old_inodes.end()) {
+	auto it = _old_inodes->lower_bound(last);
+	if (it == _old_inodes->end()) {
 	  dout(10) << " no old_inode <= " << last << ", done." << dendl;
 	  break;
 	}
@@ -2035,7 +2053,7 @@ void MDCache::project_rstat_frag_to_inode(nest_info_t& rstat, nest_info_t& accou
 	if (it->first > last) {
 	  dout(10) << " splitting right old_inode [" << first << "," << it->first << "] to ["
 		   << (last+1) << "," << it->first << "]" << dendl;
-	  pin->old_inodes[last] = it->second;
+	  (*_old_inodes)[last] = it->second;
 	  it->second.first = last+1;
 	  pin->dirty_old_rstats.insert(it->first);
 	}
@@ -2043,11 +2061,11 @@ void MDCache::project_rstat_frag_to_inode(nest_info_t& rstat, nest_info_t& accou
       if (first < ofirst) {
 	dout(10) << " splitting left old_inode [" << first << "," << last << "] to ["
 		 << first << "," << ofirst-1 << "]" << dendl;
-	pin->old_inodes[ofirst-1] = pin->old_inodes[last];
+	(*_old_inodes)[ofirst-1] = (*_old_inodes)[last];
 	pin->dirty_old_rstats.insert(ofirst-1);
-	pin->old_inodes[last].first = first = ofirst;
+	(*_old_inodes)[last].first = first = ofirst;
       }
-      pi = &pin->old_inodes[last].inode;
+      pi = &(*_old_inodes)[last].inode;
       pin->dirty_old_rstats.insert(last);
     }
     dout(20) << " projecting to [" << first << "," << last << "] " << pi->rstat << dendl;
@@ -2056,6 +2074,8 @@ void MDCache::project_rstat_frag_to_inode(nest_info_t& rstat, nest_info_t& accou
 
     last = first-1;
   }
+  if (_old_inodes)
+    pin->reset_old_inodes(std::move(_old_inodes));
 }
 
 void MDCache::broadcast_quota_to_client(CInode *in, client_t exclude_ct, bool quota_change)
@@ -2066,10 +2086,8 @@ void MDCache::broadcast_quota_to_client(CInode *in, client_t exclude_ct, bool qu
   if (!in->is_auth() || in->is_frozen())
     return;
 
-  auto i = in->get_projected_inode();
-  
-  if (!i->quota.is_enable() &&
-  	  !quota_change)
+  const auto& pi = in->get_projected_inode();
+  if (!pi->quota.is_enable() && !quota_change)
     return;
 
   // creaete snaprealm for quota inode (quota was set before mimic)
@@ -2084,38 +2102,38 @@ void MDCache::broadcast_quota_to_client(CInode *in, client_t exclude_ct, bool qu
     if (exclude_ct >= 0 && exclude_ct != p.first)
       goto update;
 
-    if (cap->last_rbytes == i->rstat.rbytes &&
-        cap->last_rsize == i->rstat.rsize())
+    if (cap->last_rbytes == pi->rstat.rbytes &&
+        cap->last_rsize == pi->rstat.rsize())
       continue;
 
-    if (i->quota.max_files > 0) {
-      if (i->rstat.rsize() >= i->quota.max_files)
+    if (pi->quota.max_files > 0) {
+      if (pi->rstat.rsize() >= pi->quota.max_files)
         goto update;
 
-      if ((abs(cap->last_rsize - i->quota.max_files) >> 4) <
-          abs(cap->last_rsize - i->rstat.rsize()))
+      if ((abs(cap->last_rsize - pi->quota.max_files) >> 4) <
+          abs(cap->last_rsize - pi->rstat.rsize()))
         goto update;
     }
 
-    if (i->quota.max_bytes > 0) {
-      if (i->rstat.rbytes > i->quota.max_bytes - (i->quota.max_bytes >> 3))
+    if (pi->quota.max_bytes > 0) {
+      if (pi->rstat.rbytes > pi->quota.max_bytes - (pi->quota.max_bytes >> 3))
         goto update;
 
-      if ((abs(cap->last_rbytes - i->quota.max_bytes) >> 4) <
-          abs(cap->last_rbytes - i->rstat.rbytes))
+      if ((abs(cap->last_rbytes - pi->quota.max_bytes) >> 4) <
+          abs(cap->last_rbytes - pi->rstat.rbytes))
         goto update;
     }
 
     continue;
 
 update:
-    cap->last_rsize = i->rstat.rsize();
-    cap->last_rbytes = i->rstat.rbytes;
+    cap->last_rsize = pi->rstat.rsize();
+    cap->last_rbytes = pi->rstat.rbytes;
 
     auto msg = make_message<MClientQuota>();
     msg->ino = in->ino();
-    msg->rstat = i->rstat;
-    msg->quota = i->quota;
+    msg->rstat = pi->rstat;
+    msg->quota = pi->quota;
     mds->send_message_client_counted(msg, cap->get_session());
   }
   for (const auto &it : in->get_replicas()) {
@@ -2339,32 +2357,32 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
 
     pin->pre_cow_old_inode();  // avoid cow mayhem!
 
-    auto &pi = pin->project_inode();
-    pi.inode.version = pin->pre_dirty();
+    auto pi = pin->project_inode();
+    pi.inode->version = pin->pre_dirty();
 
     // dirstat
     if (do_parent_mtime || linkunlink) {
       dout(20) << "predirty_journal_parents add_delta " << pf->fragstat << dendl;
       dout(20) << "predirty_journal_parents         - " << pf->accounted_fragstat << dendl;
       bool touched_mtime = false, touched_chattr = false;
-      pi.inode.dirstat.add_delta(pf->fragstat, pf->accounted_fragstat, &touched_mtime, &touched_chattr);
+      pi.inode->dirstat.add_delta(pf->fragstat, pf->accounted_fragstat, &touched_mtime, &touched_chattr);
       pf->accounted_fragstat = pf->fragstat;
       if (touched_mtime)
-	pi.inode.mtime = pi.inode.ctime = pi.inode.dirstat.mtime;
+	pi.inode->mtime = pi.inode->ctime = pi.inode->dirstat.mtime;
       if (touched_chattr)
-	pi.inode.change_attr = pi.inode.dirstat.change_attr;
-      dout(20) << "predirty_journal_parents     gives " << pi.inode.dirstat << " on " << *pin << dendl;
+	pi.inode->change_attr = pi.inode->dirstat.change_attr;
+      dout(20) << "predirty_journal_parents     gives " << pi.inode->dirstat << " on " << *pin << dendl;
 
       if (parent->get_frag() == frag_t()) { // i.e., we are the only frag
-	if (pi.inode.dirstat.size() < 0)
+	if (pi.inode->dirstat.size() < 0)
 	  ceph_assert(!"negative dirstat size" == g_conf()->mds_verify_scatter);
-	if (pi.inode.dirstat.size() != pf->fragstat.size()) {
+	if (pi.inode->dirstat.size() != pf->fragstat.size()) {
 	  mds->clog->error() << "unmatched fragstat size on single dirfrag "
-	     << parent->dirfrag() << ", inode has " << pi.inode.dirstat
+	     << parent->dirfrag() << ", inode has " << pi.inode->dirstat
 	     << ", dirfrag has " << pf->fragstat;
 	  
 	  // trust the dirfrag for now
-	  pi.inode.dirstat = pf->fragstat;
+	  pi.inode->dirstat = pf->fragstat;
 
 	  ceph_assert(!"unmatched fragstat size" == g_conf()->mds_verify_scatter);
 	}
@@ -2405,13 +2423,13 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
     pf->accounted_rstat = pf->rstat;
 
     if (parent->get_frag() == frag_t()) { // i.e., we are the only frag
-      if (pi.inode.rstat.rbytes != pf->rstat.rbytes) {
+      if (pi.inode->rstat.rbytes != pf->rstat.rbytes) {
 	mds->clog->error() << "unmatched rstat rbytes on single dirfrag "
-	  << parent->dirfrag() << ", inode has " << pi.inode.rstat
+	  << parent->dirfrag() << ", inode has " << pi.inode->rstat
 	  << ", dirfrag has " << pf->rstat;
 
 	// trust the dirfrag for now
-	pi.inode.rstat = pf->rstat;
+	pi.inode->rstat = pf->rstat;
 
 	ceph_assert(!"unmatched rstat rbytes" == g_conf()->mds_verify_scatter);
       }
@@ -3806,7 +3824,7 @@ bool MDCache::expire_recursive(CInode *in, expiremap &expiremap)
         /* Remote strays with linkage (i.e. hardlinks) should not be
          * expired, because they may be the target of
          * a rename() as the owning MDS shuts down */
-        if (!tin->is_stray() && tin->inode.nlink) {
+        if (!tin->is_stray() && tin->get_inode()->nlink) {
           dout(10) << __func__ << ": stray still has linkage " << *tin << dendl;
           return true;
         }
@@ -4713,8 +4731,8 @@ void MDCache::rejoin_scour_survivor_replicas(mds_rank_t from, const cref_t<MMDSC
 
 CInode *MDCache::rejoin_invent_inode(inodeno_t ino, snapid_t last)
 {
-  CInode *in = new CInode(this, true, 1, last);
-  in->inode.ino = ino;
+  CInode *in = new CInode(this, true, 2, last);
+  in->_get_inode()->ino = ino;
   in->state_set(CInode::STATE_REJOINUNDEF);
   add_inode(in);
   rejoin_undef_inodes.insert(in);
@@ -4729,8 +4747,8 @@ CDir *MDCache::rejoin_invent_dirfrag(dirfrag_t df)
     in = rejoin_invent_inode(df.ino, CEPH_NOSNAP);
   if (!in->is_dir()) {
     ceph_assert(in->state_test(CInode::STATE_REJOINUNDEF));
-    in->inode.mode = S_IFDIR;
-    in->inode.dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;
+    in->_get_inode()->mode = S_IFDIR;
+    in->_get_inode()->dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;
   }
   CDir *dir = in->get_or_open_dirfrag(this, df.frag);
   dir->state_set(CDir::STATE_REJOINUNDEF);
@@ -5036,9 +5054,11 @@ void MDCache::handle_cache_rejoin_ack(const cref_t<MMDSCacheRejoin> &ack)
       if (!diri) {
 	// barebones inode; the full inode loop below will clean up.
 	diri = new CInode(this, false);
-	diri->inode.ino = p.first.ino;
-	diri->inode.mode = S_IFDIR;
-	diri->inode.dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;
+	auto _inode = diri->_get_inode();
+	_inode->ino = p.first.ino;
+	_inode->mode = S_IFDIR;
+	_inode->dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;
+
 	add_inode(diri);
 	if (MDS_INO_MDSDIR(from) == p.first.ino) {
 	  diri->inode_auth = mds_authority_t(from, CDIR_AUTH_UNKNOWN);
@@ -5098,8 +5118,8 @@ void MDCache::handle_cache_rejoin_ack(const cref_t<MMDSCacheRejoin> &ack)
 	    dout(10) << " had bad linkage for " << *dn <<  dendl;
         }
 
-        // hmm, did we have the proper linkage here?
-        if (dnl->is_null() && !q.second.is_null()) {
+	// hmm, did we have the proper linkage here?
+	if (dnl->is_null() && !q.second.is_null()) {
 	  if (q.second.is_remote()) {
 	    dn->dir->link_remote_inode(dn, q.second.remote_ino, q.second.remote_d_type);
 	  } else {
@@ -5107,9 +5127,10 @@ void MDCache::handle_cache_rejoin_ack(const cref_t<MMDSCacheRejoin> &ack)
 	    if (!in) {
 	      // barebones inode; assume it's dir, the full inode loop below will clean up.
 	      in = new CInode(this, false, q.second.first, q.first.snapid);
-	      in->inode.ino = q.second.ino;
-	      in->inode.mode = S_IFDIR;
-	      in->inode.dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;
+	      auto _inode = in->_get_inode();
+	      _inode->ino = q.second.ino;
+	      _inode->mode = S_IFDIR;
+	      _inode->dir_layout.dl_dir_hash = g_conf()->mds_default_dir_hash;
 	      add_inode(in);
 	      dout(10) << " add inode " << *in << dendl;
 	    } else if (in->get_parent_dn()) {
@@ -5120,7 +5141,7 @@ void MDCache::handle_cache_rejoin_ack(const cref_t<MMDSCacheRejoin> &ack)
 	    dn->dir->link_primary_inode(dn, in);
 	    isolated_inodes.erase(in);
 	  }
-        }
+	}
 
         dn->set_replica_nonce(q.second.nonce);
         dn->lock.set_state_rejoin(q.second.lock, rejoin_waiters, survivor);
@@ -5628,7 +5649,7 @@ void MDCache::choose_lock_states_and_reconnect_caps()
     if (in->last != CEPH_NOSNAP)
       continue;
  
-    if (in->is_auth() && !in->is_base() && in->inode.is_dirty_rstat())
+    if (in->is_auth() && !in->is_base() && in->get_inode()->is_dirty_rstat())
       in->mark_dirty_rstat();
 
     int dirty_caps = 0;
@@ -6068,7 +6089,7 @@ void MDCache::opened_undef_inode(CInode *in) {
   rejoin_undef_inodes.erase(in);
   if (in->is_dir()) {
     // FIXME: re-hash dentries if necessary
-    ceph_assert(in->inode.dir_layout.dl_dir_hash == g_conf()->mds_default_dir_hash);
+    ceph_assert(in->get_inode()->dir_layout.dl_dir_hash == g_conf()->mds_default_dir_hash);
     if (in->get_num_dirfrags() && !in->dirfragtree.is_leaf(frag_t())) {
       CDir *dir = in->get_dirfrag(frag_t());
       ceph_assert(dir);
@@ -6396,14 +6417,12 @@ void MDCache::identify_files_to_recover()
     }
     
     bool recover = false;
-    for (map<client_t,client_writeable_range_t>::iterator p = in->inode.client_ranges.begin();
-	 p != in->inode.client_ranges.end();
-	 ++p) {
-      Capability *cap = in->get_client_cap(p->first);
+    for (auto& p : in->get_inode()->client_ranges) {
+      Capability *cap = in->get_client_cap(p.first);
       if (cap) {
 	cap->mark_clientwriteable();
       } else {
-	dout(10) << " client." << p->first << " has range " << p->second << " but no cap on " << *in << dendl;
+	dout(10) << " client." << p.first << " has range " << p.second << " but no cap on " << *in << dendl;
 	recover = true;
 	break;
       }
@@ -6467,7 +6486,7 @@ public:
 
 void MDCache::truncate_inode(CInode *in, LogSegment *ls)
 {
-  auto pi = in->get_projected_inode();
+  const auto& pi = in->get_projected_inode();
   dout(10) << "truncate_inode "
 	   << pi->truncate_from << " -> " << pi->truncate_size
 	   << " on " << *in
@@ -6505,7 +6524,7 @@ struct C_IO_MDC_TruncateFinish : public MDCacheIOContext {
 
 void MDCache::_truncate_inode(CInode *in, LogSegment *ls)
 {
-  auto pi = &in->inode;
+  const auto& pi = in->get_inode();
   dout(10) << "_truncate_inode "
 	   << pi->truncate_from << " -> " << pi->truncate_size
 	   << " on " << *in << dendl;
@@ -6528,7 +6547,8 @@ void MDCache::_truncate_inode(CInode *in, LogSegment *ls)
     ceph_assert(in->last == CEPH_NOSNAP);
   }
   dout(10) << "_truncate_inode  snapc " << snapc << " on " << *in << dendl;
-  filer.truncate(in->inode.ino, &in->inode.layout, *snapc,
+  auto layout = pi->layout;
+  filer.truncate(in->ino(), &layout, *snapc,
 		 pi->truncate_size, pi->truncate_from-pi->truncate_size,
 		 pi->truncate_seq, ceph::real_time::min(), 0,
 		 new C_OnFinisher(new C_IO_MDC_TruncateFinish(this, in, ls),
@@ -6554,10 +6574,10 @@ void MDCache::truncate_inode_finish(CInode *in, LogSegment *ls)
   ls->truncating_inodes.erase(p);
 
   // update
-  auto &pi = in->project_inode();
-  pi.inode.version = in->pre_dirty();
-  pi.inode.truncate_from = 0;
-  pi.inode.truncate_pending--;
+  auto pi = in->project_inode();
+  pi.inode->version = in->pre_dirty();
+  pi.inode->truncate_from = 0;
+  pi.inode->truncate_pending--;
 
   MutationRef mut(new MutationImpl());
   mut->ls = mds->mdlog->get_current_segment();
@@ -9232,7 +9252,7 @@ void MDCache::handle_open_ino(const cref_t<MMDSOpenIno> &m, int err)
 	  break;
 	CInode *diri = pdn->get_dir()->get_inode();
 	reply->ancestors.push_back(inode_backpointer_t(diri->ino(), pdn->get_name(),
-						       in->inode.version));
+						       in->get_version()));
 	in = diri;
       }
     } else {
@@ -10090,7 +10110,7 @@ void MDCache::scan_stray_dir(dirfrag_t next)
 	CDentry::linkage_t *dnl = dn->get_projected_linkage();
 	if (dnl->is_primary()) {
 	  CInode *in = dnl->get_inode();
-	  if (in->inode.nlink == 0)
+	  if (in->get_inode()->nlink == 0)
 	    in->state_set(CInode::STATE_ORPHAN);
 	  maybe_eval_stray(in);
 	}
@@ -10777,9 +10797,10 @@ void MDCache::encode_replica_dentry(CDentry *dn, mds_rank_t to, bufferlist& bl)
 void MDCache::encode_replica_inode(CInode *in, mds_rank_t to, bufferlist& bl,
 			      uint64_t features)
 {
-  ENCODE_START(2, 1, bl);
   ceph_assert(in->is_auth());
-  encode(in->inode.ino, bl);  // bleh, minor assymetry here
+
+  ENCODE_START(2, 1, bl);
+  encode(in->ino(), bl);  // bleh, minor assymetry here
   encode(in->last, bl);
 
   __u32 nonce = in->add_replica(to);
@@ -10896,7 +10917,7 @@ void MDCache::decode_replica_inode(CInode *&in, bufferlist::const_iterator& p, C
   decode(nonce, p);
   in = get_inode(ino, last);
   if (!in) {
-    in = new CInode(this, false, 1, last);
+    in = new CInode(this, false, 2, last);
     in->set_replica_nonce(nonce);
     in->_decode_base(p);
     in->_decode_locks_state_for_replica(p, true);
@@ -11957,8 +11978,8 @@ void MDCache::dispatch_fragment_dir(MDRequestRef& mdr)
   // dft lock
   if (diri->is_auth()) {
     // journal dirfragtree
-    auto &pi = diri->project_inode();
-    pi.inode.version = diri->pre_dirty();
+    auto pi = diri->project_inode();
+    pi.inode->version = diri->pre_dirty();
     journal_dirty_inode(mdr.get(), &le->metablob, diri);
   } else {
     mds->locker->mark_updated_scatterlock(&diri->dirfragtreelock);
@@ -12387,8 +12408,8 @@ void MDCache::rollback_uncommitted_fragments()
     }
 
     if (diri_auth) {
-      auto &pi = diri->project_inode();
-      pi.inode.version = diri->pre_dirty();
+      auto pi = diri->project_inode();
+      pi.inode->version = diri->pre_dirty();
       diri->pop_and_dirty_projected_inode(ls); // hacky
       le->metablob.add_primary_dentry(diri->get_projected_parent_dn(), diri, true);
     } else {
@@ -13159,8 +13180,8 @@ do_rdlocks:
     }
   }
 
-  if (!dir_info.same_sums(diri->inode.dirstat) ||
-      !nest_info.same_sums(diri->inode.rstat)) {
+  if (!dir_info.same_sums(diri->get_inode()->dirstat) ||
+      !nest_info.same_sums(diri->get_inode()->rstat)) {
     dout(10) << __func__ << " failed to fix fragstat/rstat on "
 	     << *diri << dendl;
   }
@@ -13193,9 +13214,9 @@ void MDCache::upgrade_inode_snaprealm_work(MDRequestRef& mdr)
     return;
 
   // project_snaprealm() upgrades snaprealm format
-  auto &pi = in->project_inode(false, true);
+  auto pi = in->project_inode(false, true);
   mdr->add_projected_inode(in);
-  pi.inode.version = in->pre_dirty();
+  pi.inode->version = in->pre_dirty();
 
   mdr->ls = mds->mdlog->get_current_segment();
   EUpdate *le = new EUpdate(mds->mdlog, "upgrade_snaprealm");
@@ -13324,7 +13345,7 @@ void MDCache::register_perfcounters()
  *              away.
  */
 void MDCache::maybe_eval_stray(CInode *in, bool delay) {
-  if (in->inode.nlink > 0 || in->is_base() || is_readonly() ||
+  if (in->get_inode()->nlink > 0 || in->is_base() || is_readonly() ||
       mds->get_state() <= MDSMap::STATE_REJOIN)
     return;
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -314,7 +314,6 @@ class MDCache {
   void map_dirfrag_set(const list<dirfrag_t>& dfs, set<CDir*>& result);
   void try_subtree_merge(CDir *root);
   void try_subtree_merge_at(CDir *root, set<CInode*> *to_eval, bool adjust_pop=true);
-  void subtree_merge_writebehind_finish(CInode *in, MutationRef& mut);
   void eval_subtree_root(CInode *diri);
   CDir *get_subtree_root(CDir *dir);
   CDir *get_projected_subtree_root(CDir *dir);
@@ -409,7 +408,8 @@ class MDCache {
 			  CInode **pcow_inode=0, CDentry::linkage_t *dnl=0);
   void journal_dirty_inode(MutationImpl *mut, EMetaBlob *metablob, CInode *in, snapid_t follows=CEPH_NOSNAP);
 
-  void project_rstat_inode_to_frag(CInode *cur, CDir *parent, snapid_t first,
+  void project_rstat_inode_to_frag(const MutationRef& mut,
+				   CInode *cur, CDir *parent, snapid_t first,
 				   int linkunlink, SnapRealm *prealm);
   void _project_rstat_inode_to_frag(const CInode::mempool_inode* inode, snapid_t ofirst, snapid_t last,
 				    CDir *parent, int linkunlink, bool update_inode);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -407,17 +407,14 @@ class MDCache {
   void journal_cow_dentry(MutationImpl *mut, EMetaBlob *metablob, CDentry *dn,
                           snapid_t follows=CEPH_NOSNAP,
 			  CInode **pcow_inode=0, CDentry::linkage_t *dnl=0);
-  void journal_cow_inode(MutationRef& mut, EMetaBlob *metablob, CInode *in, snapid_t follows=CEPH_NOSNAP,
-			  CInode **pcow_inode=0);
   void journal_dirty_inode(MutationImpl *mut, EMetaBlob *metablob, CInode *in, snapid_t follows=CEPH_NOSNAP);
 
   void project_rstat_inode_to_frag(CInode *cur, CDir *parent, snapid_t first,
 				   int linkunlink, SnapRealm *prealm);
   void _project_rstat_inode_to_frag(const CInode::mempool_inode* inode, snapid_t ofirst, snapid_t last,
 				    CDir *parent, int linkunlink, bool update_inode);
-  void project_rstat_frag_to_inode(nest_info_t& rstat, nest_info_t& accounted_rstat,
-				   snapid_t ofirst, snapid_t last, 
-				   CInode *pin, bool cow_head);
+  void project_rstat_frag_to_inode(const nest_info_t& rstat, const nest_info_t& accounted_rstat,
+				   snapid_t ofirst, snapid_t last, CInode *pin, bool cow_head);
   void broadcast_quota_to_client(CInode *in, client_t exclude_ct = -1, bool quota_change = false);
   void predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
 				CInode *in, CDir *parent,
@@ -1256,6 +1253,7 @@ class MDCache {
   friend class C_MDC_FragmentPrep;
   friend class C_MDC_FragmentStore;
   friend class C_MDC_FragmentCommit;
+  friend class C_MDC_FragmentRollback;
   friend class C_IO_MDC_FragmentPurgeOld;
 
   // -- subtrees --

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -413,7 +413,7 @@ class MDCache {
 
   void project_rstat_inode_to_frag(CInode *cur, CDir *parent, snapid_t first,
 				   int linkunlink, SnapRealm *prealm);
-  void _project_rstat_inode_to_frag(CInode::mempool_inode & inode, snapid_t ofirst, snapid_t last,
+  void _project_rstat_inode_to_frag(const CInode::mempool_inode* inode, snapid_t ofirst, snapid_t last,
 				    CDir *parent, int linkunlink, bool update_inode);
   void project_rstat_frag_to_inode(nest_info_t& rstat, nest_info_t& accounted_rstat,
 				   snapid_t ofirst, snapid_t last, 

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -113,7 +113,7 @@ class MDSCacheObject {
   // --------------------------------------------
   // authority
   virtual mds_authority_t authority() const = 0;
-  bool is_ambiguous_auth() const {
+  virtual bool is_ambiguous_auth() const {
     return authority().second != CDIR_AUTH_UNKNOWN;
   }
 

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -1626,7 +1626,7 @@ void Migrator::encode_export_inode(CInode *in, bufferlist& enc_state,
   dout(7) << *in << dendl;
   ceph_assert(!in->is_replica(mds->get_nodeid()));
 
-  encode(in->inode.ino, enc_state);
+  encode(in->ino(), enc_state);
   encode(in->last, enc_state);
   in->encode_export(enc_state);
 
@@ -3193,7 +3193,7 @@ void Migrator::decode_import_inode(CDentry *dn, bufferlist::const_iterator& blp,
 
   in = cache->get_inode(ino, last);
   if (!in) {
-    in = new CInode(mds->mdcache, true, 1, last);
+    in = new CInode(mds->mdcache, true, 2, last);
     added = true;
   }
 
@@ -3222,7 +3222,7 @@ void Migrator::decode_import_inode(CDentry *dn, bufferlist::const_iterator& blp,
     dout(10) << "  had " << *in << dendl;
   }
 
-  if (in->inode.is_dirty_rstat())
+  if (in->get_inode()->is_dirty_rstat())
     in->mark_dirty_rstat();
   
   // clear if dirtyscattered, since we're going to journal this

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -370,7 +370,7 @@ protected:
 
 private:
   MDSRank *mds;
-  MDCache *cache;
+  MDCache *mdcache;
   uint64_t max_export_size = 0;
   bool inject_session_race = false;
 };

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -262,15 +262,15 @@ void MutationImpl::add_cow_dentry(CDentry *dn)
 void MutationImpl::apply()
 {
   pop_and_dirty_projected_inodes();
-  pop_and_dirty_projected_fnodes();
   
-  for (const auto& in : dirty_cow_inodes) {
+  for (const auto& in : dirty_cow_inodes)
     in->_mark_dirty(ls);
-  }
-  for (const auto& [dentry, v] : dirty_cow_dentries) {
-    dentry->mark_dirty(v, ls);
-  }
-  
+
+  for (const auto& [dn, v] : dirty_cow_dentries)
+    dn->mark_dirty(v, ls);
+
+  pop_and_dirty_projected_fnodes();
+
   for (const auto& lock : updated_locks) {
     lock->mark_dirty();
   }

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -201,10 +201,15 @@ public:
   void set_remote_auth_pinned(MDSCacheObject* object, mds_rank_t from);
   void _clear_remote_auth_pinned(ObjectState& stat);
 
-  void add_projected_inode(CInode *in);
-  void pop_and_dirty_projected_inodes();
-  void add_projected_fnode(CDir *dir);
-  void pop_and_dirty_projected_fnodes();
+  void add_projected_node(MDSCacheObject* obj) {
+    projected_nodes.insert(obj);
+  }
+  void remove_projected_node(MDSCacheObject* obj) {
+    projected_nodes.erase(obj);
+  }
+  bool is_projected(MDSCacheObject *obj) const {
+    return projected_nodes.count(obj);
+  }
   void add_updated_lock(ScatterLock *lock);
   void add_cow_inode(CInode *in);
   void add_cow_dentry(CDentry *dn);
@@ -256,8 +261,7 @@ public:
   bool killed = false;
 
   // for applying projected inode changes
-  std::list<CInode*> projected_inodes;
-  std::vector<CDir*> projected_fnodes;
+  std::set<MDSCacheObject*> projected_nodes;
   std::list<ScatterLock*> updated_locks;
 
   std::list<CInode*> dirty_cow_inodes;

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -440,7 +440,7 @@ void ScrubStack::_validate_inode_done(CInode *in, int r,
   {
     // Record backtrace fails as remote linkage damage, as
     // we may not be able to resolve hard links to this inode
-    mdcache->mds->damage_table.notify_remote_damaged(in->inode.ino, path);
+    mdcache->mds->damage_table.notify_remote_damaged(in->ino(), path);
   } else if (result.inode.checked && !result.inode.passed &&
              !result.inode.repaired) {
     // Record damaged inode structures as damaged dentries as

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -4709,7 +4709,6 @@ public:
     ceph_assert(r == 0);
 
     // apply
-    in->pop_and_dirty_projected_inode(mdr->ls);
     mdr->apply();
 
     MDSRank *mds = get_mds();
@@ -4962,7 +4961,7 @@ void Server::handle_client_setattr(MDRequestRef& mdr)
   EUpdate *le = new EUpdate(mdlog, "setattr");
   mdlog->start_entry(le);
 
-  auto pi = cur->project_inode();
+  auto pi = cur->project_inode(mdr);
 
   if (mask & CEPH_SETATTR_UID)
     pi.inode->uid = req->head.args.setattr.uid;
@@ -5043,7 +5042,7 @@ void Server::do_open_truncate(MDRequestRef& mdr, int cmode)
   mdlog->start_entry(le);
 
   // prepare
-  auto pi = in->project_inode();
+  auto pi = in->project_inode(mdr);
   pi.inode->version = in->pre_dirty();
   pi.inode->mtime = pi.inode->ctime = mdr->get_op_stamp();
   if (mdr->get_op_stamp() > pi.inode->rstat.rctime)
@@ -5159,7 +5158,7 @@ void Server::handle_client_setlayout(MDRequestRef& mdr)
     return;
 
   // project update
-  auto pi = cur->project_inode();
+  auto pi = cur->project_inode(mdr);
   pi.inode->layout = layout;
   // add the old pool to the inode
   pi.inode->add_old_pool(old_layout.pool_id);
@@ -5287,7 +5286,7 @@ void Server::handle_client_setdirlayout(MDRequestRef& mdr)
   if (!check_access(mdr, cur, access))
     return;
 
-  auto pi = cur->project_inode();
+  auto pi = cur->project_inode(mdr);
   pi.inode->layout = layout;
   pi.inode->version = cur->pre_dirty();
 
@@ -5531,7 +5530,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     if (check_layout_vxattr(mdr, rest, value, &layout) < 0)
       return;
 
-    auto pi = cur->project_inode();
+    auto pi = cur->project_inode(mdr);
     pi.inode->layout = layout;
     mdr->no_early_reply = true;
     pip = pi.inode.get();
@@ -5555,7 +5554,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     if (!mds->locker->acquire_locks(mdr, lov))
       return;
 
-    auto pi = cur->project_inode();
+    auto pi = cur->project_inode(mdr);
     int64_t old_pool = pi.inode->layout.pool_id;
     pi.inode->add_old_pool(old_pool);
     pi.inode->layout = layout;
@@ -5581,7 +5580,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     if (!xlock_policylock(mdr, cur, false, new_realm))
       return;
 
-    auto pi = cur->project_inode(false, new_realm);
+    auto pi = cur->project_inode(mdr, false, new_realm);
     pi.inode->quota = quota;
 
     if (new_realm) {
@@ -5615,7 +5614,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     if (!xlock_policylock(mdr, cur))
       return;
 
-    auto pi = cur->project_inode();
+    auto pi = cur->project_inode(mdr);
     cur->set_export_pin(rank);
     pip = pi.inode.get();
   } else if (name == "ceph.dir.pin.random"sv) {
@@ -5644,7 +5643,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     if (!xlock_policylock(mdr, cur))
       return;
 
-    auto pi = cur->project_inode();
+    auto pi = cur->project_inode(mdr);
     cur->setxattr_ephemeral_rand(val);
     pip = pi.inode.get();
   } else if (name == "ceph.dir.pin.distributed"sv) {
@@ -5665,7 +5664,7 @@ void Server::handle_set_vxattr(MDRequestRef& mdr, CInode *cur)
     if (!xlock_policylock(mdr, cur))
       return;
 
-    auto pi = cur->project_inode();
+    auto pi = cur->project_inode(mdr);
     cur->setxattr_ephemeral_dist(val);
     pip = pi.inode.get();
   } else {
@@ -5723,7 +5722,7 @@ void Server::handle_remove_vxattr(MDRequestRef& mdr, CInode *cur)
     if (!mds->locker->acquire_locks(mdr, lov))
       return;
 
-    auto pi = cur->project_inode();
+    auto pi = cur->project_inode(mdr);
     pi.inode->clear_layout();
     pi.inode->version = cur->pre_dirty();
 
@@ -5750,26 +5749,6 @@ void Server::handle_remove_vxattr(MDRequestRef& mdr, CInode *cur)
 
   respond_to_request(mdr, -ENODATA);
 }
-
-class C_MDS_inode_xattr_update_finish : public ServerLogContext {
-  CInode *in;
-public:
-
-  C_MDS_inode_xattr_update_finish(Server *s, MDRequestRef& r, CInode *i) :
-    ServerLogContext(s, r), in(i) { }
-  void finish(int r) override {
-    ceph_assert(r == 0);
-
-    // apply
-    in->pop_and_dirty_projected_inode(mdr->ls);
-    
-    mdr->apply();
-
-    get_mds()->balancer->hit_inode(in, META_POP_IWR);
-
-    server->respond_to_request(mdr, 0);
-  }
-};
 
 void Server::handle_client_setxattr(MDRequestRef& mdr)
 {
@@ -5844,7 +5823,7 @@ void Server::handle_client_setxattr(MDRequestRef& mdr)
   dout(10) << "setxattr '" << name << "' len " << len << " on " << *cur << dendl;
 
   // project update
-  auto pi = cur->project_inode(true);
+  auto pi = cur->project_inode(mdr, true);
   pi.inode->version = cur->pre_dirty();
   pi.inode->ctime = mdr->get_op_stamp();
   if (mdr->get_op_stamp() > pi.inode->rstat.rctime)
@@ -5912,7 +5891,7 @@ void Server::handle_client_removexattr(MDRequestRef& mdr)
   dout(10) << "removexattr '" << name << "' on " << *cur << dendl;
 
   // project update
-  auto pi = cur->project_inode(true);
+  auto pi = cur->project_inode(mdr, true);
   auto &px = *pi.xattrs;
   pi.inode->version = cur->pre_dirty();
   pi.inode->ctime = mdr->get_op_stamp();
@@ -6351,7 +6330,7 @@ void Server::_link_local(MDRequestRef& mdr, CDentry *dn, CInode *targeti)
   version_t tipv = targeti->pre_dirty();
   
   // project inode update
-  auto pi = targeti->project_inode();
+  auto pi = targeti->project_inode(mdr);
   pi.inode->nlink++;
   pi.inode->ctime = mdr->get_op_stamp();
   if (mdr->get_op_stamp() > pi.inode->rstat.rctime)
@@ -6395,8 +6374,6 @@ void Server::_link_local_finish(MDRequestRef& mdr, CDentry *dn, CInode *targeti,
   dn->mark_dirty(dnpv, mdr->ls);
 
   // target inode
-  targeti->pop_and_dirty_projected_inode(mdr->ls);
-
   mdr->apply();
 
   MDRequestRef null_ref;
@@ -6608,7 +6585,7 @@ void Server::handle_peer_link_prep(MDRequestRef& mdr)
 				      EPeerUpdate::OP_PREPARE, EPeerUpdate::LINK);
   mdlog->start_entry(le);
 
-  auto pi = dnl->get_inode()->project_inode();
+  auto pi = dnl->get_inode()->project_inode(mdr);
 
   // update journaled target inode
   bool inc;
@@ -6689,7 +6666,6 @@ void Server::_logged_peer_link(MDRequestRef& mdr, CInode *targeti, bool adjust_r
   ceph_assert(g_conf()->mds_kill_link_at != 6);
 
   // update the target
-  targeti->pop_and_dirty_projected_inode(mdr->ls);
   mdr->apply();
 
   // hit pop
@@ -6794,14 +6770,12 @@ void Server::do_link_rollback(bufferlist &rbl, mds_rank_t leader, MDRequestRef& 
   dout(10) << " target is " << *in << dendl;
   ceph_assert(!in->is_projected());  // live peer request hold versionlock xlock.
   
-  auto pi = in->project_inode();
+  auto pi = in->project_inode(mut);
   pi.inode->version = in->pre_dirty();
-  mut->add_projected_inode(in);
 
   // parent dir rctime
   CDir *parent = in->get_projected_parent_dn()->get_dir();
-  auto pf = parent->project_fnode();
-  mut->add_projected_fnode(parent);
+  auto pf = parent->project_fnode(mut);
   pf->version = parent->pre_dirty();
   if (pf->fragstat.mtime == pi.inode->ctime) {
     pf->fragstat.mtime = rollback.old_dir_mtime;
@@ -7101,7 +7075,7 @@ void Server::_unlink_local(MDRequestRef& mdr, CDentry *dn, CDentry *straydn)
   // the unlinked dentry
   dn->pre_dirty();
 
-  auto pi = in->project_inode();
+  auto pi = in->project_inode(mdr);
   {
     std::string t;
     dn->make_path_string(t, true);
@@ -7132,7 +7106,6 @@ void Server::_unlink_local(MDRequestRef& mdr, CDentry *dn, CDentry *straydn)
     pi.inode->update_backtrace();
     le->metablob.add_primary_dentry(straydn, in, true, true);
   } else {
-    mdr->add_projected_inode(in);
     // remote link.  update remote inode.
     mdcache->predirty_journal_parents(mdr, &le->metablob, in, dn->get_dir(), PREDIRTY_DIR, -1);
     mdcache->predirty_journal_parents(mdr, &le->metablob, in, 0, PREDIRTY_PRIMARY);
@@ -7184,18 +7157,15 @@ void Server::_unlink_local_finish(MDRequestRef& mdr,
   // unlink main dentry
   dn->get_dir()->unlink_inode(dn);
   dn->pop_projected_linkage();
+  dn->mark_dirty(dnpv, mdr->ls);
 
   // relink as stray?  (i.e. was primary link?)
   if (straydn) {
     dout(20) << " straydn is " << *straydn << dendl;
     straydn->pop_projected_linkage();
-
-    strayin->pop_and_dirty_projected_inode(mdr->ls);
-
     mdcache->touch_dentry_bottom(straydn);
   }
 
-  dn->mark_dirty(dnpv, mdr->ls);
   mdr->apply();
   
   mdcache->send_dentry_unlink(dn, straydn, mdr);
@@ -8287,7 +8257,7 @@ void Server::_rename_prepare(MDRequestRef& mdr,
       ceph_assert(straydn);  // moving to straydn.
       // link--, and move.
       if (destdn->is_auth()) {
-	auto pi= oldin->project_inode(); //project_snaprealm
+	auto pi= oldin->project_inode(mdr); //project_snaprealm
 	pi.inode->version = straydn->pre_dirty(pi.inode->version);
 	pi.inode->update_backtrace();
         tpi = pi.inode.get();
@@ -8296,7 +8266,7 @@ void Server::_rename_prepare(MDRequestRef& mdr,
     } else if (destdnl->is_remote()) {
       // nlink-- targeti
       if (oldin->is_auth()) {
-	auto pi = oldin->project_inode();
+	auto pi = oldin->project_inode(mdr);
 	pi.inode->version = oldin->pre_dirty();
         tpi = pi.inode.get();
       }
@@ -8312,14 +8282,14 @@ void Server::_rename_prepare(MDRequestRef& mdr,
       destdn->push_projected_linkage(srcdnl->get_remote_ino(), srcdnl->get_remote_d_type());
       // srci
       if (srci->is_auth()) {
-	auto pi = srci->project_inode();
+	auto pi = srci->project_inode(mdr);
 	pi.inode->version = srci->pre_dirty();
         spi = pi.inode.get();
       }
     } else {
       dout(10) << " will merge remote onto primary link" << dendl;
       if (destdn->is_auth()) {
-	auto pi = oldin->project_inode();
+	auto pi = oldin->project_inode(mdr);
 	pi.inode->version = mdr->more()->pvmap[destdn] = destdn->pre_dirty(oldin->get_version());
         spi = pi.inode.get();
       }
@@ -8343,7 +8313,7 @@ void Server::_rename_prepare(MDRequestRef& mdr,
 	  dout(10) << " noting renamed dir open frags " << metablob->renamed_dir_frags << dendl;
 	}
       }
-      auto pi = srci->project_inode(); // project snaprealm if srcdnl->is_primary
+      auto pi = srci->project_inode(mdr); // project snaprealm if srcdnl->is_primary
                                                  // & srcdnl->snaprealm
       pi.inode->version = mdr->more()->pvmap[destdn] = destdn->pre_dirty(oldpv);
       pi.inode->update_backtrace();
@@ -8609,13 +8579,13 @@ void Server::_rename_apply(MDRequestRef& mdr, CDentry *srcdn, CDentry *destdn, C
 
       // nlink-- targeti
       if (destdn->is_auth())
-	oldin->pop_and_dirty_projected_inode(mdr->ls);
+	oldin->pop_and_dirty_projected_inode(mdr->ls, mdr);
 
       mdcache->touch_dentry_bottom(straydn);  // drop dn as quickly as possible.
     } else if (destdnl->is_remote()) {
       destdn->get_dir()->unlink_inode(destdn, false);
       if (oldin->is_auth()) {
-	oldin->pop_and_dirty_projected_inode(mdr->ls);
+	oldin->pop_and_dirty_projected_inode(mdr->ls, mdr);
       } else if (mdr->peer_request) {
 	if (mdr->peer_request->desti_snapbl.length() > 0) {
 	  ceph_assert(oldin->snaprealm);
@@ -8666,7 +8636,7 @@ void Server::_rename_apply(MDRequestRef& mdr, CDentry *srcdn, CDentry *destdn, C
 	destdn->mark_dirty(mdr->more()->pvmap[destdn], mdr->ls);
       // in
       if (in->is_auth()) {
-	in->pop_and_dirty_projected_inode(mdr->ls);
+	in->pop_and_dirty_projected_inode(mdr->ls, mdr);
       } else if (mdr->peer_request) {
 	if (mdr->peer_request->srci_snapbl.length() > 0) {
 	  ceph_assert(in->snaprealm);
@@ -8678,7 +8648,7 @@ void Server::_rename_apply(MDRequestRef& mdr, CDentry *srcdn, CDentry *destdn, C
       }
     } else {
       dout(10) << "merging remote onto primary link" << dendl;
-      oldin->pop_and_dirty_projected_inode(mdr->ls);
+      oldin->pop_and_dirty_projected_inode(mdr->ls, mdr);
     }
   } else { // primary
     if (linkmerge) {
@@ -8729,7 +8699,7 @@ void Server::_rename_apply(MDRequestRef& mdr, CDentry *srcdn, CDentry *destdn, C
     }
 
     if (destdn->is_auth())
-      in->pop_and_dirty_projected_inode(mdr->ls);
+      in->pop_and_dirty_projected_inode(mdr->ls, mdr);
   }
 
   // src
@@ -9222,8 +9192,7 @@ static void _rollback_repair_dir(MutationRef& mut, CDir *dir,
 				 rename_rollback::drec &r, utime_t ctime,
 				 bool isdir, const nest_info_t &rstat)
 {
-  auto pf = dir->project_fnode();
-  mut->add_projected_fnode(dir);
+  auto pf = dir->project_fnode(mut);
   pf->version = dir->pre_dirty();
 
   if (isdir) {
@@ -9376,12 +9345,10 @@ void Server::do_rename_rollback(bufferlist &rbl, mds_rank_t leader, MDRequestRef
     bool projected;
     CDir *pdir = in->get_projected_parent_dir();
     if (pdir->authority().first == whoami) {
-      auto pi = in->project_inode();
-      mut->add_projected_inode(in);
+      auto pi = in->project_inode(mut);
       pi.inode->version = in->pre_dirty();
       if (pdir != srcdir) {
-	auto pf = pdir->project_fnode();
-	mut->add_projected_fnode(pdir);
+	auto pf = pdir->project_fnode(mut);
 	pf->version = pdir->pre_dirty();
       }
       if (pi.inode->ctime == rollback.ctime)
@@ -9449,12 +9416,10 @@ void Server::do_rename_rollback(bufferlist &rbl, mds_rank_t leader, MDRequestRef
     CInode::inode_ptr ti;
     CDir *pdir = target->get_projected_parent_dir();
     if (pdir->authority().first == whoami) {
-      auto pi = target->project_inode();
-      mut->add_projected_inode(target);
+      auto pi = target->project_inode(mut);
       pi.inode->version = target->pre_dirty();
       if (pdir != srcdir) {
-	auto pf = pdir->project_fnode();
-	mut->add_projected_fnode(pdir);
+	auto pf = pdir->project_fnode(mut);
 	pf->version = pdir->pre_dirty();
       }
       ti = pi.inode;
@@ -9966,7 +9931,7 @@ void Server::handle_client_mksnap(MDRequestRef& mdr)
   info.name = snapname;
   info.stamp = mdr->get_op_stamp();
 
-  auto pi = diri->project_inode(false, true);
+  auto pi = diri->project_inode(mdr, false, true);
   pi.inode->ctime = info.stamp;
   if (info.stamp > pi.inode->rstat.rctime)
     pi.inode->rstat.rctime = info.stamp;
@@ -10004,7 +9969,6 @@ void Server::_mksnap_finish(MDRequestRef& mdr, CInode *diri, SnapInfo &info)
 
   int op = (diri->snaprealm? CEPH_SNAP_OP_CREATE : CEPH_SNAP_OP_SPLIT);
 
-  diri->pop_and_dirty_projected_inode(mdr->ls);
   mdr->apply();
 
   mds->snapclient->commit(mdr->more()->stid, mdr->ls);
@@ -10104,7 +10068,7 @@ void Server::handle_client_rmsnap(MDRequestRef& mdr)
   ceph_assert(mds->snapclient->get_cached_version() >= stid);
 
   // journal
-  auto pi = diri->project_inode(false, true);
+  auto pi = diri->project_inode(mdr, false, true);
   pi.inode->version = diri->pre_dirty();
   pi.inode->ctime = mdr->get_op_stamp();
   if (mdr->get_op_stamp() > pi.inode->rstat.rctime)
@@ -10139,7 +10103,6 @@ void Server::_rmsnap_finish(MDRequestRef& mdr, CInode *diri, snapid_t snapid)
   snapid_t seq;
   decode(seq, p);  
 
-  diri->pop_and_dirty_projected_inode(mdr->ls);
   mdr->apply();
 
   mds->snapclient->commit(stid, mdr->ls);
@@ -10248,7 +10211,7 @@ void Server::handle_client_renamesnap(MDRequestRef& mdr)
   ceph_assert(mds->snapclient->get_cached_version() >= stid);
 
   // journal
-  auto pi = diri->project_inode(false, true);
+  auto pi = diri->project_inode(mdr, false, true);
   pi.inode->ctime = mdr->get_op_stamp();
   if (mdr->get_op_stamp() > pi.inode->rstat.rctime)
     pi.inode->rstat.rctime = mdr->get_op_stamp();
@@ -10280,7 +10243,6 @@ void Server::_renamesnap_finish(MDRequestRef& mdr, CInode *diri, snapid_t snapid
 {
   dout(10) << "_renamesnap_finish " << *mdr << " " << snapid << dendl;
 
-  diri->pop_and_dirty_projected_inode(mdr->ls);
   mdr->apply();
 
   mds->snapclient->commit(mdr->more()->stid, mdr->ls);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5964,8 +5964,7 @@ public:
     if (newi->is_dir()) {
       CDir *dir = newi->get_dirfrag(frag_t());
       ceph_assert(dir);
-      dir->fnode.version--;
-      dir->mark_dirty(dir->fnode.version + 1, mdr->ls);
+      dir->mark_dirty(mdr->ls);
       dir->mark_new(mdr->ls);
     }
 
@@ -6130,7 +6129,7 @@ void Server::handle_client_mkdir(MDRequestRef& mdr)
   CDir *newdir = newi->get_or_open_dirfrag(mdcache, frag_t());
   newdir->state_set(CDir::STATE_CREATING);
   newdir->mark_complete();
-  newdir->fnode.version = newdir->pre_dirty();
+  newdir->_get_fnode()->version = newdir->pre_dirty();
 
   // prepare finisher
   mdr->ls = mdlog->get_current_segment();
@@ -6648,7 +6647,7 @@ void Server::handle_peer_link_prep(MDRequestRef& mdr)
   rollback.reqid = mdr->reqid;
   rollback.ino = targeti->ino();
   rollback.old_ctime = targeti->get_inode()->ctime;   // we hold versionlock xlock; no concorrent projections
-  const fnode_t *pf = targeti->get_parent_dn()->get_dir()->get_projected_fnode();
+  const auto& pf = targeti->get_parent_dn()->get_dir()->get_projected_fnode();
   rollback.old_dir_mtime = pf->fragstat.mtime;
   rollback.old_dir_rctime = pf->rstat.rctime;
   rollback.was_inc = inc;
@@ -6801,7 +6800,7 @@ void Server::do_link_rollback(bufferlist &rbl, mds_rank_t leader, MDRequestRef& 
 
   // parent dir rctime
   CDir *parent = in->get_projected_parent_dn()->get_dir();
-  fnode_t *pf = parent->project_fnode();
+  auto pf = parent->project_fnode();
   mut->add_projected_fnode(parent);
   pf->version = parent->pre_dirty();
   if (pf->fragstat.mtime == pi.inode->ctime) {
@@ -7603,7 +7602,7 @@ bool Server::_dir_is_nonempty(MDRequestRef& mdr, CInode *in)
 
   auto&& ls = in->get_dirfrags();
   for (const auto& dir : ls) {
-    const fnode_t *pf = dir->get_projected_fnode();
+    const auto& pf = dir->get_projected_fnode();
     if (pf->fragstat.size()) {
       dout(10) << "dir_is_nonempty dirstat has "
 	       << pf->fragstat.size() << " items " << *dir << dendl;
@@ -8405,6 +8404,12 @@ void Server::_rename_prepare(MDRequestRef& mdr,
       mdcache->predirty_journal_parents(mdr, metablob, oldin, straydn->get_dir(),
 					PREDIRTY_PRIMARY|PREDIRTY_DIR, 1);
     }
+  }
+
+  if (srcdnl->is_remote() && srci->is_auth()) {
+    CDir *srci_dir = srci->get_projected_parent_dir();
+    if (srci_dir != srcdn->get_dir() && srci_dir != destdn->get_dir())
+      mdcache->predirty_journal_parents(mdr, metablob, srci, srci_dir, PREDIRTY_PRIMARY);
   }
   
   // move srcdn
@@ -9213,24 +9218,24 @@ void Server::_commit_peer_rename(MDRequestRef& mdr, int r,
     mdcache->shutdown_export_stray_finish(migrated_stray);
 }
 
-void _rollback_repair_dir(MutationRef& mut, CDir *dir, rename_rollback::drec &r, utime_t ctime,
-			  bool isdir, int linkunlink, nest_info_t &rstat)
+static void _rollback_repair_dir(MutationRef& mut, CDir *dir,
+				 rename_rollback::drec &r, utime_t ctime,
+				 bool isdir, const nest_info_t &rstat)
 {
-  fnode_t *pf;
-  pf = dir->project_fnode();
+  auto pf = dir->project_fnode();
   mut->add_projected_fnode(dir);
   pf->version = dir->pre_dirty();
 
   if (isdir) {
-    pf->fragstat.nsubdirs += linkunlink;
+    pf->fragstat.nsubdirs += 1;
   } else {
-    pf->fragstat.nfiles += linkunlink;
+    pf->fragstat.nfiles += 1;
   }    
   if (r.ino) {
-    pf->rstat.rbytes += linkunlink * rstat.rbytes;
-    pf->rstat.rfiles += linkunlink * rstat.rfiles;
-    pf->rstat.rsubdirs += linkunlink * rstat.rsubdirs;
-    pf->rstat.rsnaps += linkunlink * rstat.rsnaps;
+    pf->rstat.rbytes += rstat.rbytes;
+    pf->rstat.rfiles += rstat.rfiles;
+    pf->rstat.rsubdirs += rstat.rsubdirs;
+    pf->rstat.rsnaps += rstat.rsnaps;
   }
   if (pf->fragstat.mtime == ctime) {
     pf->fragstat.mtime = r.dirfrag_old_mtime;
@@ -9366,21 +9371,31 @@ void Server::do_rename_rollback(bufferlist &rbl, mds_rank_t leader, MDRequestRef
 
   map<client_t,ref_t<MClientSnap>> splits[2];
 
-  CInode::mempool_inode *pip = nullptr;
+  const CInode::mempool_inode *pip = nullptr;
   if (in) {
     bool projected;
-    if (in->get_projected_parent_dn()->authority().first == whoami) {
+    CDir *pdir = in->get_projected_parent_dir();
+    if (pdir->authority().first == whoami) {
       auto pi = in->project_inode();
-      pip = pi.inode.get();
       mut->add_projected_inode(in);
-      pip->version = in->pre_dirty();
+      pi.inode->version = in->pre_dirty();
+      if (pdir != srcdir) {
+	auto pf = pdir->project_fnode();
+	mut->add_projected_fnode(pdir);
+	pf->version = pdir->pre_dirty();
+      }
+      if (pi.inode->ctime == rollback.ctime)
+	pi.inode->ctime = rollback.orig_src.old_ctime;
       projected = true;
     } else {
-      // FIXME: pip = in->get_projected_inode();
+      if (in->get_inode()->ctime == rollback.ctime) {
+	auto _inode = CInode::allocate_inode(*in->get_inode());
+	_inode->ctime = rollback.orig_src.old_ctime;
+	in->reset_inode(_inode);
+      }
       projected = false;
     }
-    if (pip->ctime == rollback.ctime)
-      pip->ctime = rollback.orig_src.old_ctime;
+    pip = in->get_projected_inode().get();
 
     if (rollback.srci_snapbl.length() && in->snaprealm) {
       bool hadrealm;
@@ -9411,12 +9426,6 @@ void Server::do_rename_rollback(bufferlist &rbl, mds_rank_t leader, MDRequestRef
     }
   }
 
-  if (srcdn && srcdn->authority().first == whoami) {
-    nest_info_t blah;
-    _rollback_repair_dir(mut, srcdir, rollback.orig_src, rollback.ctime,
-			 in ? in->is_dir() : false, 1, pip ? pip->accounted_rstat : blah);
-  }
-
   // repair dest
   if (destdn) {
     if (rollback.orig_dest.ino && target) {
@@ -9437,17 +9446,24 @@ void Server::do_rename_rollback(bufferlist &rbl, mds_rank_t leader, MDRequestRef
 
   if (target) {
     bool projected;
-    CInode::mempool_inode *ti = nullptr;
-    if (target->get_projected_parent_dn()->authority().first == whoami) {
+    CInode::inode_ptr ti;
+    CDir *pdir = target->get_projected_parent_dir();
+    if (pdir->authority().first == whoami) {
       auto pi = target->project_inode();
-      ti = pi.inode.get();
       mut->add_projected_inode(target);
-      ti->version = target->pre_dirty();
+      pi.inode->version = target->pre_dirty();
+      if (pdir != srcdir) {
+	auto pf = pdir->project_fnode();
+	mut->add_projected_fnode(pdir);
+	pf->version = pdir->pre_dirty();
+      }
+      ti = pi.inode;
       projected = true;
     } else {
-      //FIXME: ti = target->get_projected_inode();
+      ti = CInode::allocate_inode(*target->get_inode());
       projected = false;
     }
+
     if (ti->ctime == rollback.ctime)
       ti->ctime = rollback.orig_dest.old_ctime;
     if (MDS_INO_IS_STRAY(rollback.orig_src.dirfrag.ino)) {
@@ -9458,6 +9474,9 @@ void Server::do_rename_rollback(bufferlist &rbl, mds_rank_t leader, MDRequestRef
 	       rollback.orig_dest.remote_ino == rollback.orig_src.ino);
     } else
       ti->nlink++;
+
+    if (!projected)
+      target->reset_inode(ti);
 
     if (rollback.desti_snapbl.length() && target->snaprealm) {
       bool hadrealm;
@@ -9486,6 +9505,12 @@ void Server::do_rename_rollback(bufferlist &rbl, mds_rank_t leader, MDRequestRef
 	  target->snaprealm->merge_to(realm);
       }
     }
+  }
+
+  if (srcdn && srcdn->authority().first == whoami) {
+    nest_info_t blah;
+    _rollback_repair_dir(mut, srcdir, rollback.orig_src, rollback.ctime,
+			 in && in->is_dir(), pip ? pip->accounted_rstat : blah);
   }
 
   if (srcdn)

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -177,7 +177,7 @@ public:
   bool _check_access(Session *session, CInode *in, unsigned mask, int caller_uid, int caller_gid, int setattr_uid, int setattr_gid);
   CDentry *prepare_stray_dentry(MDRequestRef& mdr, CInode *in);
   CInode* prepare_new_inode(MDRequestRef& mdr, CDir *dir, inodeno_t useino, unsigned mode,
-			    file_layout_t *layout=NULL);
+			    const file_layout_t *layout=nullptr);
   void journal_allocated_inos(MDRequestRef& mdr, EMetaBlob *blob);
   void apply_allocated_inos(MDRequestRef& mdr, Session *session);
 

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -997,15 +997,16 @@ int Session::check_access(CInode *in, unsigned mask,
   if (path.length())
     path = path.substr(1);    // drop leading /
 
-  if (in->inode.is_dir() &&
-      in->inode.has_layout() &&
-      in->inode.layout.pool_ns.length() &&
+  const auto& inode = in->get_inode();
+  if (in->is_dir() &&
+      inode->has_layout() &&
+      inode->layout.pool_ns.length() &&
       !connection->has_feature(CEPH_FEATURE_FS_FILE_LAYOUT_V2)) {
     dout(10) << __func__ << " client doesn't support FS_FILE_LAYOUT_V2" << dendl;
     return -EIO;
   }
 
-  if (!auth_caps.is_capable(path, in->inode.uid, in->inode.gid, in->inode.mode,
+  if (!auth_caps.is_capable(path, inode->uid, inode->gid, inode->mode,
 			    caller_uid, caller_gid, caller_gid_list, mask,
 			    new_uid, new_gid,
 			    info.inst.addr)) {

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -181,8 +181,7 @@ void StrayManager::_purge_stray_purged(
     MutationRef mut(new MutationImpl());
     mut->ls = mds->mdlog->get_current_segment();
     
-    auto pi = in->project_inode();
-    mut->add_projected_inode(in);
+    auto pi = in->project_inode(mut);
     pi.inode->size = 0;
     pi.inode->max_size_ever = 0;
     pi.inode->client_ranges.clear();
@@ -191,8 +190,7 @@ void StrayManager::_purge_stray_purged(
     pi.inode->version = in->pre_dirty();
 
     CDir *dir = dn->get_dir();
-    auto pf = dir->project_fnode();
-    mut->add_projected_fnode(dir);
+    auto pf = dir->project_fnode(mut);
     pf->version = dir->pre_dirty();
 
     EUpdate *le = new EUpdate(mds->mdlog, "purge_stray truncate");
@@ -228,8 +226,7 @@ void StrayManager::_purge_stray_purged(
 
     // update dirfrag fragstat, rstat
     CDir *dir = dn->get_dir();
-    auto pf = dir->project_fnode();
-    mut->add_projected_fnode(dir);
+    auto pf = dir->project_fnode(mut);
     pf->version = dir->pre_dirty();
     if (in->is_dir())
       pf->fragstat.nsubdirs--;

--- a/src/mds/StrayManager.h
+++ b/src/mds/StrayManager.h
@@ -17,7 +17,8 @@
 #include "include/common_fwd.h"
 #include "include/elist.h"
 #include <list>
-#include "mds/PurgeQueue.h"
+#include "Mutation.h"
+#include "PurgeQueue.h"
 
 class MDSRank;
 class CInode;
@@ -123,13 +124,13 @@ protected:
    */
   void _purge_stray_purged(CDentry *dn, bool only_head);
 
-  void _purge_stray_logged(CDentry *dn, version_t pdv, LogSegment *ls);
+  void _purge_stray_logged(CDentry *dn, version_t pdv, MutationRef& mut);
 
   /**
    * Callback: we have logged the update to an inode's metadata
    * reflecting it's newly-zeroed length.
    */
-  void _truncate_stray_logged(CDentry *dn, LogSegment *ls);
+  void _truncate_stray_logged(CDentry *dn, MutationRef &mut);
   /**
    * Call this on a dentry that has been identified as
    * eligible for purging. It will be passed on to PurgeQueue.

--- a/src/mds/events/EFragment.h
+++ b/src/mds/events/EFragment.h
@@ -19,7 +19,7 @@
 #include "EMetaBlob.h"
 
 struct dirfrag_rollback {
-  fnode_t fnode;
+  CDir::fnode_const_ptr fnode;
   dirfrag_rollback() { }
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& bl);

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -450,11 +450,9 @@ private:
       state |= fullbit::STATE_EPHEMERAL_RANDOM;
     }
 
-    // make note of where this inode was last journaled
-    in->last_journaled = event_seq;
-    //cout << "journaling " << in->inode.ino << " at " << my_offset << std::endl;
-
     const auto& pi = in->get_projected_inode();
+    ceph_assert(pi->version > 0);
+
     if ((state & fullbit::STATE_DIRTY) && pi->is_backtrace_updated())
       state |= fullbit::STATE_DIRTYPARENT;
 
@@ -467,6 +465,10 @@ private:
     lump.add_dfull(dn->get_name(), dn->first, dn->last, dn->get_projected_version(),
 		   pi, in->dirfragtree, in->get_projected_xattrs(), in->symlink,
 		   in->oldest_snap, snapbl, state, in->get_old_inodes());
+
+    // make note of where this inode was last journaled
+    in->last_journaled = event_seq;
+    //cout << "journaling " << in->inode.ino << " at " << my_offset << std::endl;
   }
 
   // convenience: primary or remote?  figure it out.

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -199,7 +199,7 @@ public:
     static const int STATE_DIRTYDFT =	 (1<<5);  // dirty dirfragtree
 
     //version_t  dirv;
-    fnode_t fnode;
+    CDir::fnode_const_ptr fnode;
     __u32 state;
     __u32 nfull, nremote, nnull;
 
@@ -245,7 +245,7 @@ public:
     }
 
     void print(dirfrag_t dirfrag, ostream& out) const {
-      out << "dirlump " << dirfrag << " v " << fnode.version
+      out << "dirlump " << dirfrag << " v " << fnode->version
 	  << " state " << state
 	  << " num " << nfull << "/" << nremote << "/" << nnull
 	  << std::endl;
@@ -524,31 +524,30 @@ private:
   }
   
   dirlump& add_dir(CDir *dir, bool dirty, bool complete=false) {
-    return add_dir(dir->dirfrag(), dir->get_projected_fnode(), dir->get_projected_version(),
+    return add_dir(dir->dirfrag(), dir->get_projected_fnode(),
 		   dirty, complete);
   }
   dirlump& add_new_dir(CDir *dir) {
-    return add_dir(dir->dirfrag(), dir->get_projected_fnode(), dir->get_projected_version(),
+    return add_dir(dir->dirfrag(), dir->get_projected_fnode(),
 		   true, true, true); // dirty AND complete AND new
   }
   dirlump& add_import_dir(CDir *dir) {
     // dirty=false would be okay in some cases
-    return add_dir(dir->dirfrag(), dir->get_projected_fnode(), dir->get_projected_version(),
+    return add_dir(dir->dirfrag(), dir->get_projected_fnode(),
 		   dir->is_dirty(), dir->is_complete(), false, true, dir->is_dirty_dft());
   }
   dirlump& add_fragmented_dir(CDir *dir, bool dirty, bool dirtydft) {
-    return add_dir(dir->dirfrag(), dir->get_projected_fnode(), dir->get_projected_version(),
+    return add_dir(dir->dirfrag(), dir->get_projected_fnode(),
 		   dirty, false, false, false, dirtydft);
   }
-  dirlump& add_dir(dirfrag_t df, const fnode_t *pf, version_t pv, bool dirty,
+  dirlump& add_dir(dirfrag_t df, const CDir::fnode_const_ptr& pf, bool dirty,
 		   bool complete=false, bool isnew=false,
 		   bool importing=false, bool dirty_dft=false) {
     if (lump_map.count(df) == 0)
       lump_order.push_back(df);
 
     dirlump& l = lump_map[df];
-    l.fnode = *pf;
-    l.fnode.version = pv;
+    l.fnode = pf;
     if (complete) l.mark_complete();
     if (dirty) l.mark_dirty();
     if (isnew) l.mark_new();

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -279,7 +279,7 @@ void LogSegment::try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int o
 
 void EMetaBlob::add_dir_context(CDir *dir, int mode)
 {
-  MDSRank *mds = dir->cache->mds;
+  MDSRank *mds = dir->mdcache->mds;
 
   list<CDentry*> parents;
 

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -398,22 +398,26 @@ void EMetaBlob::fullbit::encode(bufferlist& bl, uint64_t features) const {
   encode(dnfirst, bl);
   encode(dnlast, bl);
   encode(dnv, bl);
-  encode(inode, bl, features);
-  encode(xattrs, bl);
-  if (inode.is_symlink())
+  encode(*inode, bl, features);
+  if (xattrs)
+    encode(*xattrs, bl);
+  else
+    encode((__u32)0, bl);
+
+  if (inode->is_symlink())
     encode(symlink, bl);
-  if (inode.is_dir()) {
+  if (inode->is_dir()) {
     encode(dirfragtree, bl);
     encode(snapbl, bl);
   }
   encode(state, bl);
-  if (old_inodes.empty()) {
+  if (!old_inodes || old_inodes->empty()) {
     encode(false, bl);
   } else {
     encode(true, bl);
-    encode(old_inodes, bl, features);
+    encode(*old_inodes, bl, features);
   }
-  if (!inode.is_dir())
+  if (!inode->is_dir())
     encode(snapbl, bl);
   encode(oldest_snap, bl);
   ENCODE_FINISH(bl);
@@ -425,11 +429,20 @@ void EMetaBlob::fullbit::decode(bufferlist::const_iterator &bl) {
   decode(dnfirst, bl);
   decode(dnlast, bl);
   decode(dnv, bl);
-  decode(inode, bl);
-  decode_noshare(xattrs, bl);
-  if (inode.is_symlink())
+  {
+    auto _inode = CInode::allocate_inode();
+    decode(*_inode, bl);
+    inode = std::move(_inode);
+  }
+  {
+    CInode::mempool_xattr_map tmp;
+    decode_noshare(tmp, bl);
+    if (!tmp.empty())
+      xattrs = CInode::allocate_xattr_map(std::move(tmp));
+  }
+  if (inode->is_symlink())
     decode(symlink, bl);
-  if (inode.is_dir()) {
+  if (inode->is_dir()) {
     decode(dirfragtree, bl);
     decode(snapbl, bl);
   }
@@ -437,9 +450,11 @@ void EMetaBlob::fullbit::decode(bufferlist::const_iterator &bl) {
   bool old_inodes_present;
   decode(old_inodes_present, bl);
   if (old_inodes_present) {
-    decode(old_inodes, bl);
+    auto _old_inodes = CInode::allocate_old_inode_map();
+    decode(*_old_inodes, bl);
+    old_inodes = std::move(_old_inodes);
   }
-  if (!inode.is_dir()) {
+  if (!inode->is_dir()) {
     decode(snapbl, bl);
   }
   decode(oldest_snap, bl);
@@ -453,21 +468,23 @@ void EMetaBlob::fullbit::dump(Formatter *f) const
   f->dump_stream("snapid.last") << dnlast;
   f->dump_int("dentry version", dnv);
   f->open_object_section("inode");
-  inode.dump(f);
+  inode->dump(f);
   f->close_section(); // inode
   f->open_object_section("xattrs");
-  for (const auto &p : xattrs) {
-    std::string s(p.second.c_str(), p.second.length());
-    f->dump_string(p.first.c_str(), s);
+  if (xattrs) {
+    for (const auto &p : *xattrs) {
+      std::string s(p.second.c_str(), p.second.length());
+      f->dump_string(p.first.c_str(), s);
+    }
   }
   f->close_section(); // xattrs
-  if (inode.is_symlink()) {
+  if (inode->is_symlink()) {
     f->dump_string("symlink", symlink);
   }
-  if (inode.is_dir()) {
+  if (inode->is_dir()) {
     f->dump_stream("frag tree") << dirfragtree;
     f->dump_string("has_snapbl", snapbl.length() ? "true" : "false");
-    if (inode.has_layout()) {
+    if (inode->has_layout()) {
       f->open_object_section("file layout policy");
       // FIXME
       f->dump_string("layout", "the layout exists");
@@ -475,9 +492,9 @@ void EMetaBlob::fullbit::dump(Formatter *f) const
     }
   }
   f->dump_string("state", state_string());
-  if (!old_inodes.empty()) {
+  if (old_inodes && !old_inodes->empty()) {
     f->open_array_section("old inodes");
-    for (const auto &p : old_inodes) {
+    for (const auto &p : *old_inodes) {
       f->open_object_section("inode");
       f->dump_int("snapid", p.first);
       p.second.dump(f);
@@ -489,21 +506,21 @@ void EMetaBlob::fullbit::dump(Formatter *f) const
 
 void EMetaBlob::fullbit::generate_test_instances(std::list<EMetaBlob::fullbit*>& ls)
 {
-  CInode::mempool_inode inode;
+  auto _inode = CInode::allocate_inode();
   fragtree_t fragtree;
-  CInode::mempool_xattr_map empty_xattrs;
+  auto _xattrs = CInode::allocate_xattr_map();
   bufferlist empty_snapbl;
   fullbit *sample = new fullbit("/testdn", 0, 0, 0,
-                                inode, fragtree, empty_xattrs, "", 0, empty_snapbl,
+                                _inode, fragtree, _xattrs, "", 0, empty_snapbl,
                                 false, NULL);
   ls.push_back(sample);
 }
 
 void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
 {
-  in->inode = inode;
-  in->xattrs = xattrs;
-  if (in->inode.is_dir()) {
+  in->reset_inode(std::move(inode));
+  in->reset_xattrs(std::move(xattrs));
+  if (in->is_dir()) {
     if (is_export_ephemeral_random()) {
       dout(15) << "random ephemeral pin on " << *in << dendl;
       in->set_ephemeral_rand(true);
@@ -514,7 +531,7 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
     if (!(in->dirfragtree == dirfragtree)) {
       dout(10) << "EMetaBlob::fullbit::update_inode dft " << in->dirfragtree << " -> "
 	       << dirfragtree << " on " << *in << dendl;
-      in->dirfragtree = dirfragtree;
+      in->dirfragtree = std::move(dirfragtree);
       in->force_dirfrags();
       if (in->get_num_dirfrags() && in->authority() == CDIR_AUTH_UNDEF) {
 	auto&& ls = in->get_nested_dirfrags();
@@ -527,12 +544,12 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
 	}
       }
     }
-  } else if (in->inode.is_symlink()) {
+  } else if (in->is_symlink()) {
     in->symlink = symlink;
   }
-  in->old_inodes = old_inodes;
-  if (!in->old_inodes.empty()) {
-    snapid_t min_first = in->old_inodes.rbegin()->first + 1;
+  in->reset_old_inodes(std::move(old_inodes));
+  if (in->is_any_old_inodes()) {
+    snapid_t min_first = in->get_old_inodes()->rbegin()->first + 1;
     if (min_first > in->first)
       in->first = min_first;
   }
@@ -552,9 +569,10 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
    */
   if (in->is_file()) {
     // Files must have valid layouts with a pool set
-    if (in->inode.layout.pool_id == -1 || !in->inode.layout.is_valid()) {
+    if (in->get_inode()->layout.pool_id == -1 ||
+	!in->get_inode()->layout.is_valid()) {
       dout(0) << "EMetaBlob.replay invalid layout on ino " << *in
-              << ": " << in->inode.layout << dendl;
+              << ": " << in->get_inode()->layout << dendl;
       std::ostringstream oss;
       oss << "Invalid layout for inode " << in->ino() << " in journal";
       mds->clog->error() << oss.str();
@@ -847,7 +865,7 @@ void EMetaBlob::get_inodes(
 
     // Record inodes of fullbits
     for (const auto& iter : dl.get_dfull()) {
-      inodes.insert(iter.inode.ino);
+      inodes.insert(iter.inode->ino);
     }
 
     // Record inodes of remotebits
@@ -922,7 +940,7 @@ void EMetaBlob::get_paths(
     for (const auto& iter : dl.get_dfull()) {
       std::string_view dentry = iter.dn;
       children[dir_ino].emplace_back(dentry);
-      ino_locations[iter.inode.ino] = Location(dir_ino, dentry);
+      ino_locations[iter.inode->ino] = Location(dir_ino, dentry);
     }
 
     for (const auto& iter : dl.get_dremote()) {
@@ -948,7 +966,7 @@ void EMetaBlob::get_paths(
 
     for (const auto& iter : dl.get_dfull()) {
       std::string_view dentry = iter.dn;
-      if (children.find(iter.inode.ino) == children.end()) {
+      if (children.find(iter.inode->ino) == children.end()) {
         leaf_locations.push_back(Location(dir_ino, dentry));
       }
     }
@@ -1081,7 +1099,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
   ceph_assert(g_conf()->mds_kill_journal_replay_at != 1);
 
   for (auto& p : roots) {
-    CInode *in = mds->mdcache->get_inode(p.inode.ino);
+    CInode *in = mds->mdcache->get_inode(p.inode->ino);
     bool isnew = in ? false:true;
     if (!in)
       in = new CInode(mds->mdcache, false, 2, CEPH_NOSNAP);
@@ -1209,7 +1227,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
       if (lump.is_importing())
 	dn->state_set(CDentry::STATE_AUTH);
 
-      CInode *in = mds->mdcache->get_inode(fb.inode.ino, fb.dnlast);
+      CInode *in = mds->mdcache->get_inode(fb.inode->ino, fb.dnlast);
       if (!in) {
 	in = new CInode(mds->mdcache, dn->is_auth(), fb.dnfirst, fb.dnlast);
 	fb.update_inode(mds, in);
@@ -1219,7 +1237,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
 	    unlinked[dn->get_linkage()->get_inode()] = dir;
 	    stringstream ss;
 	    ss << "EMetaBlob.replay FIXME had dentry linked to wrong inode " << *dn
-	       << " " << *dn->get_linkage()->get_inode() << " should be " << fb.inode.ino;
+	       << " " << *dn->get_linkage()->get_inode() << " should be " << in->ino();
 	    dout(0) << ss.str() << dendl;
 	    mds->clog->warn(ss);
 	  }
@@ -1243,7 +1261,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
 	      unlinked[dn->get_linkage()->get_inode()] = dir;
 	      stringstream ss;
 	      ss << "EMetaBlob.replay FIXME had dentry linked to wrong inode " << *dn
-		 << " " << *dn->get_linkage()->get_inode() << " should be " << fb.inode.ino;
+		 << " " << *dn->get_linkage()->get_inode() << " should be " << in->ino();
 	      dout(0) << ss.str() << dendl;
 	      mds->clog->warn(ss);
 	    }

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -694,7 +694,7 @@ void EMetaBlob::nullbit::generate_test_instances(std::list<nullbit*>& ls)
 void EMetaBlob::dirlump::encode(bufferlist& bl, uint64_t features) const
 {
   ENCODE_START(2, 2, bl);
-  encode(fnode, bl);
+  encode(*fnode, bl);
   encode(state, bl);
   encode(nfull, bl);
   encode(nremote, bl);
@@ -707,7 +707,11 @@ void EMetaBlob::dirlump::encode(bufferlist& bl, uint64_t features) const
 void EMetaBlob::dirlump::decode(bufferlist::const_iterator &bl)
 {
   DECODE_START_LEGACY_COMPAT_LEN(2, 2, 2, bl)
-  decode(fnode, bl);
+  {
+    auto _fnode = CDir::allocate_fnode();
+    decode(*_fnode, bl);
+    fnode = std::move(_fnode);
+  }
   decode(state, bl);
   decode(nfull, bl);
   decode(nremote, bl);
@@ -724,7 +728,7 @@ void EMetaBlob::dirlump::dump(Formatter *f) const
     me->_decode_bits();
   }
   f->open_object_section("fnode");
-  fnode.dump(f);
+  fnode->dump(f);
   f->close_section(); // fnode
   f->dump_string("state", state_string());
   f->dump_int("nfull", nfull);
@@ -756,7 +760,9 @@ void EMetaBlob::dirlump::dump(Formatter *f) const
 
 void EMetaBlob::dirlump::generate_test_instances(std::list<dirlump*>& ls)
 {
-  ls.push_back(new dirlump());
+  auto dl = new dirlump();
+  dl->fnode = CDir::allocate_fnode();
+  ls.push_back(dl);
 }
 
 /**
@@ -1168,8 +1174,8 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
 
       dout(10) << "EMetaBlob.replay added dir " << *dir << dendl;  
     }
-    dir->set_version( lump.fnode.version );
-    dir->fnode = lump.fnode;
+    dir->reset_fnode(std::move(lump.fnode));
+    dir->update_projected_version();
 
     if (lump.is_importing()) {
       dir->state_set(CDir::STATE_AUTH);
@@ -1178,14 +1184,14 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDPeerUpdate *peerup)
     if (lump.is_dirty()) {
       dir->_mark_dirty(logseg);
 
-      if (!(dir->fnode.rstat == dir->fnode.accounted_rstat)) {
+      if (!(dir->get_fnode()->rstat == dir->get_fnode()->accounted_rstat)) {
 	dout(10) << "EMetaBlob.replay      dirty nestinfo on " << *dir << dendl;
 	mds->locker->mark_updated_scatterlock(&dir->inode->nestlock);
 	logseg->dirty_dirfrag_nest.push_back(&dir->inode->item_dirty_dirfrag_nest);
       } else {
 	dout(10) << "EMetaBlob.replay      clean nestinfo on " << *dir << dendl;
       }
-      if (!(dir->fnode.fragstat == dir->fnode.accounted_fragstat)) {
+      if (!(dir->get_fnode()->fragstat == dir->get_fnode()->accounted_fragstat)) {
 	dout(10) << "EMetaBlob.replay      dirty fragstat on " << *dir << dendl;
 	mds->locker->mark_updated_scatterlock(&dir->inode->filelock);
 	logseg->dirty_dirfrag_dir.push_back(&dir->inode->item_dirty_dirfrag_dir);
@@ -2868,14 +2874,18 @@ void EFragment::generate_test_instances(std::list<EFragment*>& ls)
 void dirfrag_rollback::encode(bufferlist &bl) const
 {
   ENCODE_START(1, 1, bl);
-  encode(fnode, bl);
+  encode(*fnode, bl);
   ENCODE_FINISH(bl);
 }
 
 void dirfrag_rollback::decode(bufferlist::const_iterator &bl)
 {
   DECODE_START(1, bl);
-  decode(fnode, bl);
+  {
+    auto _fnode = CDir::allocate_fnode();
+    decode(*_fnode, bl);
+    fnode = std::move(_fnode);
+  }
   DECODE_FINISH(bl);
 }
 

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -275,9 +275,11 @@ void inline_data_t::decode(bufferlist::const_iterator &p)
   decode(version, p);
   uint32_t inline_len;
   decode(inline_len, p);
-  if (inline_len > 0)
-    ceph::decode_nohead(inline_len, get_data(), p);
-  else
+  if (inline_len > 0) {
+    ceph::buffer::list bl;
+    decode_nohead(inline_len, bl, p);
+    set_data(bl);
+  } else
     free_data();
 }
 

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -20,7 +20,6 @@
 #include "include/frag.h"
 #include "include/xlist.h"
 #include "include/interval_set.h"
-#include "include/compact_map.h"
 #include "include/compact_set.h"
 #include "include/fs_types.h"
 
@@ -397,12 +396,12 @@ public:
   inline_data_t() {}
   inline_data_t(const inline_data_t& o) : version(o.version) {
     if (o.blp)
-      get_data() = *o.blp;
+      set_data(*o.blp);
   }
   inline_data_t& operator=(const inline_data_t& o) {
     version = o.version;
     if (o.blp)
-      get_data() = *o.blp;
+      set_data(*o.blp);
     else
       free_data();
     return *this;
@@ -411,10 +410,16 @@ public:
   void free_data() {
     blp.reset();
   }
-  ceph::buffer::list& get_data() {
+  void get_data(ceph::buffer::list& ret) const {
+    if (blp)
+      ret = *blp;
+    else
+      ret.clear();
+  }
+  void set_data(const ceph::buffer::list& bl) {
     if (!blp)
       blp.reset(new ceph::buffer::list);
-    return *blp;
+    *blp = bl;
   }
   size_t length() const { return blp ? blp->length() : 0; }
 
@@ -1007,11 +1012,11 @@ template<template<typename> class Allocator>
 using alloc_string = std::basic_string<char,std::char_traits<char>,Allocator<char>>;
 
 template<template<typename> class Allocator>
-using xattr_map = compact_map<alloc_string<Allocator>,
-			      ceph::bufferptr,
-			      std::less<alloc_string<Allocator>>,
-			      Allocator<std::pair<const alloc_string<Allocator>,
-						  ceph::bufferptr>>>; // FIXME bufferptr not in mempool
+using xattr_map = std::map<alloc_string<Allocator>,
+			   ceph::bufferptr,
+			   std::less<alloc_string<Allocator>>,
+			   Allocator<std::pair<const alloc_string<Allocator>,
+					       ceph::bufferptr>>>; // FIXME bufferptr not in mempool
 
 template<template<typename> class Allocator>
 inline void decode_noshare(xattr_map<Allocator>& xattrs, ceph::buffer::list::const_iterator &p)

--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -188,14 +188,14 @@ public:
   }
   void add_inode_locks(CInode *in, __u32 nonce, ceph::buffer::list& bl) {
     using ceph::encode;
-    encode(in->inode.ino, inode_locks);
+    encode(in->ino(), inode_locks);
     encode(in->last, inode_locks);
     encode(nonce, inode_locks);
     encode(bl, inode_locks);
   }
   void add_inode_base(CInode *in, uint64_t features) {
     using ceph::encode;
-    encode(in->inode.ino, inode_base);
+    encode(in->ino(), inode_base);
     encode(in->last, inode_base);
     ceph::buffer::list bl;
     in->_encode_base(bl, features);

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -71,7 +71,7 @@ public:
 };
 
 int Filer::probe(inodeno_t ino,
-		 file_layout_t *layout,
+		 const file_layout_t *layout,
 		 snapid_t snapid,
 		 uint64_t start_from,
 		 uint64_t *end, // LB, when !fwd
@@ -94,7 +94,7 @@ int Filer::probe(inodeno_t ino,
 }
 
 int Filer::probe(inodeno_t ino,
-		 file_layout_t *layout,
+		 const file_layout_t *layout,
 		 snapid_t snapid,
 		 uint64_t start_from,
 		 uint64_t *end, // LB, when !fwd
@@ -115,7 +115,7 @@ int Filer::probe(inodeno_t ino,
   return probe_impl(probe, layout, start_from, end);
 }
 
-int Filer::probe_impl(Probe* probe, file_layout_t *layout,
+int Filer::probe_impl(Probe* probe, const file_layout_t *layout,
 		      uint64_t start_from, uint64_t *end) // LB, when !fwd
 {
   // period (bytes before we jump unto a new set of object(s))
@@ -404,7 +404,7 @@ struct TruncRange {
 };
 
 void Filer::truncate(inodeno_t ino,
-		     file_layout_t *layout,
+		     const file_layout_t *layout,
 		     const SnapContext& snapc,
 		     uint64_t offset,
 		     uint64_t len,

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -80,7 +80,7 @@ class Filer {
     int err;
     bool found_size;
 
-    Probe(inodeno_t i, file_layout_t &l, snapid_t sn,
+    Probe(inodeno_t i, const file_layout_t &l, snapid_t sn,
 	  uint64_t f, uint64_t *e, ceph::real_time *m, int fl, bool fw,
 	  Context *c) :
       ino(i), layout(l), snapid(sn),
@@ -88,7 +88,7 @@ class Filer {
       probing_off(f), probing_len(0),
       err(0), found_size(false) {}
 
-    Probe(inodeno_t i, file_layout_t &l, snapid_t sn,
+    Probe(inodeno_t i, const file_layout_t &l, snapid_t sn,
 	  uint64_t f, uint64_t *e, utime_t *m, int fl, bool fw,
 	  Context *c) :
       ino(i), layout(l), snapid(sn),
@@ -118,7 +118,7 @@ class Filer {
   /*** async file interface.  scatter/gather as needed. ***/
 
   void read(inodeno_t ino,
-	   file_layout_t *layout,
+	   const file_layout_t *layout,
 	   snapid_t snap,
 	   uint64_t offset,
 	   uint64_t len,
@@ -133,7 +133,7 @@ class Filer {
   }
 
   void read_trunc(inodeno_t ino,
-		 file_layout_t *layout,
+		 const file_layout_t *layout,
 		 snapid_t snap,
 		 uint64_t offset,
 		 uint64_t len,
@@ -152,7 +152,7 @@ class Filer {
   }
 
   void write(inodeno_t ino,
-	    file_layout_t *layout,
+	    const file_layout_t *layout,
 	    const SnapContext& snapc,
 	    uint64_t offset,
 	    uint64_t len,
@@ -167,7 +167,7 @@ class Filer {
   }
 
   void write_trunc(inodeno_t ino,
-		  file_layout_t *layout,
+		  const file_layout_t *layout,
 		  const SnapContext& snapc,
 		  uint64_t offset,
 		  uint64_t len,
@@ -186,7 +186,7 @@ class Filer {
   }
 
   void truncate(inodeno_t ino,
-	       file_layout_t *layout,
+	       const file_layout_t *layout,
 	       const SnapContext& snapc,
 	       uint64_t offset,
 	       uint64_t len,
@@ -233,7 +233,7 @@ class Filer {
   }
 
   void zero(inodeno_t ino,
-	   file_layout_t *layout,
+	   const file_layout_t *layout,
 	   const SnapContext& snapc,
 	   uint64_t offset,
 	   uint64_t len,
@@ -261,7 +261,7 @@ class Filer {
    *  and whether we stop when we find data, or hole.
    */
   int probe(inodeno_t ino,
-	    file_layout_t *layout,
+	    const file_layout_t *layout,
 	    snapid_t snapid,
 	    uint64_t start_from,
 	    uint64_t *end,
@@ -271,7 +271,7 @@ class Filer {
 	    Context *onfinish);
 
   int probe(inodeno_t ino,
-	    file_layout_t *layout,
+	    const file_layout_t *layout,
 	    snapid_t snapid,
 	    uint64_t start_from,
 	    uint64_t *end,
@@ -283,7 +283,7 @@ class Filer {
   }
 
   int probe(inodeno_t ino,
-	    file_layout_t *layout,
+	    const file_layout_t *layout,
 	    snapid_t snapid,
 	    uint64_t start_from,
 	    uint64_t *end,
@@ -293,7 +293,7 @@ class Filer {
 	    Context *onfinish);
 
 private:
-  int probe_impl(Probe* probe, file_layout_t *layout,
+  int probe_impl(Probe* probe, const file_layout_t *layout,
 		 uint64_t start_from, uint64_t *end);
 };
 

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -730,9 +730,9 @@ int JournalTool::recover_dentries(
       try {
         old_fnode.decode(old_fnode_iter);
         dout(4) << "frag " << frag_oid.name << " fnode old v" <<
-          old_fnode.version << " vs new v" << lump.fnode.version << dendl;
+          old_fnode.version << " vs new v" << lump.fnode->version << dendl;
         old_fnode_version = old_fnode.version;
-        write_fnode = old_fnode_version < lump.fnode.version;
+        write_fnode = old_fnode_version < lump.fnode->version;
       } catch (const buffer::error &err) {
         dout(1) << "frag " << frag_oid.name
                 << " is corrupt, overwriting" << dendl;
@@ -748,7 +748,7 @@ int JournalTool::recover_dentries(
     if ((other_pool || write_fnode) && !dry_run) {
       dout(4) << "writing fnode to omap header" << dendl;
       bufferlist fnode_bl;
-      lump.fnode.encode(fnode_bl);
+      lump.fnode->encode(fnode_bl);
       if (!other_pool || frag.ino >= MDS_INO_SYSTEM_BASE) {
 	r = output.omap_set_header(frag_oid.name, fnode_bl);
       }
@@ -830,9 +830,9 @@ int JournalTool::recover_dentries(
           // squash over it with what's in this fullbit
           dout(10) << "Existing remote inode in slot to be (maybe) written "
                << "by a full inode from the journal dn '" << fb.dn.c_str()
-               << "' with lump fnode version " << lump.fnode.version
+               << "' with lump fnode version " << lump.fnode->version
                << "vs existing fnode version " << old_fnode_version << dendl;
-          write_dentry = old_fnode_version < lump.fnode.version;
+          write_dentry = old_fnode_version < lump.fnode->version;
         } else if (dentry_type == 'I') {
           // Read out inode version to compare with backing store
           InodeStore inode;
@@ -893,15 +893,15 @@ int JournalTool::recover_dentries(
         if (dentry_type == 'L') {
           dout(10) << "Existing hardlink inode in slot to be (maybe) written "
                << "by a remote inode from the journal dn '" << rb.dn.c_str()
-               << "' with lump fnode version " << lump.fnode.version
+               << "' with lump fnode version " << lump.fnode->version
                << "vs existing fnode version " << old_fnode_version << dendl;
-          write_dentry = old_fnode_version < lump.fnode.version;
+          write_dentry = old_fnode_version < lump.fnode->version;
         } else if (dentry_type == 'I') {
           dout(10) << "Existing full inode in slot to be (maybe) written "
                << "by a remote inode from the journal dn '" << rb.dn.c_str()
-               << "' with lump fnode version " << lump.fnode.version
+               << "' with lump fnode version " << lump.fnode->version
                << "vs existing fnode version " << old_fnode_version << dendl;
-          write_dentry = old_fnode_version < lump.fnode.version;
+          write_dentry = old_fnode_version < lump.fnode->version;
         } else {
           dout(4) << "corrupt dentry in backing store, overwriting from "
             "journal" << dendl;
@@ -949,15 +949,15 @@ int JournalTool::recover_dentries(
 	if (dentry_type == 'L') {
 	  dout(10) << "Existing hardlink inode in slot to be (maybe) removed "
 	    << "by null journal dn '" << nb.dn.c_str()
-	    << "' with lump fnode version " << lump.fnode.version
+	    << "' with lump fnode version " << lump.fnode->version
 	    << "vs existing fnode version " << old_fnode_version << dendl;
-	  remove_dentry = old_fnode_version < lump.fnode.version;
+	  remove_dentry = old_fnode_version < lump.fnode->version;
 	} else if (dentry_type == 'I') {
 	  dout(10) << "Existing full inode in slot to be (maybe) removed "
 	    << "by null journal dn '" << nb.dn.c_str()
-	    << "' with lump fnode version " << lump.fnode.version
+	    << "' with lump fnode version " << lump.fnode->version
 	    << "vs existing fnode version " << old_fnode_version << dendl;
-	  remove_dentry = old_fnode_version < lump.fnode.version;
+	  remove_dentry = old_fnode_version < lump.fnode->version;
 	} else {
 	  dout(4) << "corrupt dentry in backing store, will remove" << dendl;
 	  remove_dentry = true;

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -838,9 +838,9 @@ int JournalTool::recover_dentries(
           InodeStore inode;
           inode.decode_bare(q);
           dout(4) << "decoded embedded inode version "
-            << inode.inode.version << " vs fullbit version "
-            << fb.inode.version << dendl;
-          if (inode.inode.version < fb.inode.version) {
+            << inode.inode->version << " vs fullbit version "
+            << fb.inode->version << dendl;
+          if (inode.inode->version < fb.inode->version) {
             write_dentry = true;
           }
         } else {
@@ -862,7 +862,7 @@ int JournalTool::recover_dentries(
 
         // Record for writing to RADOS
         write_vals[key] = dentry_bl;
-        consumed_inos->insert(fb.inode.ino);
+        consumed_inos->insert(fb.inode->ino);
       }
     }
 
@@ -996,7 +996,7 @@ int JournalTool::recover_dentries(
    * of directories
    */
   for (const auto& fb : metablob.roots) {
-    inodeno_t ino = fb.inode.ino;
+    inodeno_t ino = fb.inode->ino;
     dout(4) << "updating root 0x" << std::hex << ino << std::dec << dendl;
 
     object_t root_oid = InodeStore::get_object_name(ino, frag_t(), ".inode");
@@ -1020,7 +1020,7 @@ int JournalTool::recover_dentries(
         dout(4) << "magic ok" << dendl;
         old_inode.decode(inode_bl_iter);
 
-        if (old_inode.inode.version < fb.inode.version) {
+        if (old_inode.inode->version < fb.inode->version) {
           write_root_ino = true;
         }
       } else {
@@ -1035,7 +1035,7 @@ int JournalTool::recover_dentries(
 
     if (write_root_ino && !dry_run) {
       dout(4) << "writing root ino " << root_oid.name
-               << " version " << fb.inode.version << dendl;
+               << " version " << fb.inode->version << dendl;
 
       // Compose: root ino format is magic,InodeStore(bare=false)
       bufferlist new_root_ino_bl;

--- a/src/tools/cephfs/MetaTool.cc
+++ b/src/tools/cephfs/MetaTool.cc
@@ -425,7 +425,7 @@ int MetaTool::_show_fn(inode_meta_t& inode_meta, const string& fn)
   f->open_object_section("fnodes");
   for (const auto &frag : frags) {
     bufferlist hbl;
-    string oid = obj_name(inode_meta.get_meta()->inode.ino, frag);
+    string oid = obj_name(inode_meta.get_meta()->inode->ino, frag);
     int ret = io_meta.omap_get_header(oid, &hbl);
     if (ret < 0) {
       std::cerr << __func__ << " : can't find oid("<< oid << ")" << std::endl;
@@ -967,10 +967,10 @@ int MetaTool::show_child(std::string_view key,
     f->close_section();
     f->flush(ds);
 
-    if (sp_ino > 0 && op != NULL && sp_ino == inode_data.inode.ino) {
+    if (sp_ino > 0 && op != NULL && sp_ino == inode_data.inode->ino) {
       inode_meta_t* tmp = new inode_meta_t(first, type, &inode_data);
-      op->inodes[inode_data.inode.ino] = tmp;
-      op->okeys[inode_data.inode.ino] = key.data();
+      op->inodes[inode_data.inode->ino] = tmp;
+      op->okeys[inode_data.inode->ino] = key.data();
       return 1;
     } else {
       delete &inode_data;


### PR DESCRIPTION
this avoid copying whole inode_t and xattr map when journaling inodes.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

