### PR TITLE
luminous: rgw: fix deadlock on RGWIndexCompletionManager::stop

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3602,7 +3602,6 @@ public:
     for (int i = 0; i < num_shards; ++i) {
       Mutex::Locker l(*locks[i]);
       for (auto c : completions[i]) {
-        Mutex::Locker cl(c->lock);
         c->stop();
       }
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/35709