### PR TITLE
osd/OSD: kill off __project_pg_history__

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4365,95 +4365,6 @@ void OSD::build_initial_pg_history(
 	   << dendl;
 }
 
-/**
- * Fill in the passed history so you know same_interval_since, same_up_since,
- * and same_primary_since.
- */
-bool OSD::project_pg_history(spg_t pgid, pg_history_t& h, epoch_t from,
-			     const OSDMapRef& endmap,
-			     const vector<int>& currentup,
-			     int currentupprimary,
-			     const vector<int>& currentacting,
-			     int currentactingprimary)
-{
-  dout(15) << "project_pg_history " << pgid
-           << " from " << from << " to " << endmap->get_epoch()
-           << ", start " << h
-           << dendl;
-
-  epoch_t e;
-  for (e = endmap->get_epoch();
-       e > from;
-       e--) {
-    // verify during intermediate epoch (e-1)
-    OSDMapRef oldmap = service.try_get_map(e-1);
-    if (!oldmap) {
-      dout(15) << __func__ << ": found map gap, returning false" << dendl;
-      return false;
-    }
-
-    int upprimary, actingprimary;
-    vector<int> up, acting;
-    oldmap->pg_to_up_acting_osds(
-      pgid.pgid,
-      &up,
-      &upprimary,
-      &acting,
-      &actingprimary);
-
-    if (e > h.same_interval_since &&
-	PastIntervals::is_new_interval(
-	  actingprimary, currentactingprimary,
-	  acting, currentacting,
-	  upprimary, currentupprimary,
-	  up, currentup,
-	  oldmap, endmap,
-	  pgid.pgid)) {
-      dout(15) << "project_pg_history " << pgid << " interval changed in " << e << dendl;
-      h.same_interval_since = e;
-    }
-
-    // up set change?
-    if ((up != currentup || upprimary != currentupprimary)
-	&& e > h.same_up_since) {
-      dout(15) << "project_pg_history " << pgid << " up changed in " << e
-	       << " from " << up << " " << upprimary
-	       << " -> " << currentup << " " << currentupprimary << dendl;
-      h.same_up_since = e;
-    }
-
-    // primary change?
-    if (OSDMap::primary_changed(
-	  actingprimary,
-	  acting,
-	  currentactingprimary,
-	  currentacting) &&
-        e > h.same_primary_since) {
-      dout(15) << "project_pg_history " << pgid << " primary changed in " << e << dendl;
-      h.same_primary_since = e;
-    }
-
-    if (h.same_interval_since >= e && h.same_up_since >= e && h.same_primary_since >= e)
-      break;
-  }
-
-  // base case: these floors should be the pg creation epoch if we didn't
-  // find any changes.
-  if (e == h.epoch_created) {
-    if (!h.same_interval_since)
-      h.same_interval_since = e;
-    if (!h.same_up_since)
-      h.same_up_since = e;
-    if (!h.same_primary_since)
-      h.same_primary_since = e;
-  }
-
-  dout(15) << "project_pg_history end " << h << dendl;
-  return true;
-}
-
-
-
 void OSD::_add_heartbeat_peer(int p)
 {
   if (p == whoami)
@@ -9041,27 +8952,6 @@ void OSD::handle_pg_query_nopg(const MQuery& q)
   OSDMapRef osdmap = get_osdmap();
   if (!osdmap->have_pg_pool(pgid.pool()))
     return;
-
-  // get active crush mapping
-  int up_primary, acting_primary;
-  vector<int> up, acting;
-  osdmap->pg_to_up_acting_osds(
-    pgid.pgid, &up, &up_primary, &acting, &acting_primary);
-
-  // same primary?
-  pg_history_t history = q.query.history;
-  bool valid_history = project_pg_history(
-    pgid, history, q.query.epoch_sent,
-    osdmap,
-    up, up_primary, acting, acting_primary);
-
-  if (!valid_history ||
-      q.query.epoch_sent < history.same_interval_since) {
-    dout(10) << " pg " << pgid << " dne, and pg has changed in "
-	     << history.same_interval_since
-	     << " (msg from " << q.query.epoch_sent << ")" << dendl;
-    return;
-  }
 
   dout(10) << " pg " << pgid << " dne" << dendl;
   pg_info_t empty(spg_t(pgid.pgid, q.query.to));

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1923,16 +1923,6 @@ protected:
     pg_history_t *h,
     PastIntervals *pi);
 
-  /// project pg history from from to now
-  bool project_pg_history(
-    spg_t pgid, pg_history_t& h, epoch_t from,
-    const OSDMapRef &osdmap,
-    const vector<int>& lastup,
-    int lastupprimary,
-    const vector<int>& lastacting,
-    int lastactingprimary
-    ); ///< @return false if there was a map gap between from and now
-
   epoch_t last_pg_create_epoch;
 
   void handle_pg_create(OpRequestRef op);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6542,18 +6542,6 @@ void PG::queue_null(epoch_t msg_epoch,
 					 NullEvt())));
 }
 
-void PG::queue_query(epoch_t msg_epoch,
-		     epoch_t query_epoch,
-		     pg_shard_t from, const pg_query_t& q)
-{
-  dout(10) << "handle_query " << q << " from replica " << from << dendl;
-  queue_peering_event(
-    PGPeeringEventRef(
-      std::make_shared<PGPeeringEvent>(
-	msg_epoch, query_epoch,
-	MQuery(info.pgid, from, q, query_epoch))));
-}
-
 void PG::find_unfound(epoch_t queued, RecoveryCtx *rctx)
 {
   /*

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -414,8 +414,6 @@ public:
 
   void queue_peering_event(PGPeeringEventRef evt);
   void do_peering_event(PGPeeringEventRef evt, RecoveryCtx *rcx);
-  void queue_query(epoch_t msg_epoch, epoch_t query_epoch,
-		   pg_shard_t from, const pg_query_t& q);
   void queue_null(epoch_t msg_epoch, epoch_t query_epoch);
   void queue_flushed(epoch_t started_at);
   void handle_advance_map(


### PR DESCRIPTION
__project_pg_history__ does an inverse traverse of the series
of osdmaps passed in to get a pg's pg_history_t filled, which
can become super inefficient if the osdmap list is very long.
E.g., in one of our clusters, we've observed it took approximate
10s for a PG to finish it's projecting:
```
2018-08-27 13:51:58.694823 7f1e1335a700 15 osd.9 823276 project_pg_history 34.6e9 from 821893 to 823276, start ec=380829/380829 l
is/c 820412/820412 les/c/f 820413/820413/0 821785/821785/821785
2018-08-27 13:52:08.634230 7f1e1335a700 15 osd.9 823276 project_pg_history 34.6e9 acting|up changed in 822265 from [57]/[57] 57/5
7 -> [58,57]/[58,57] 58/58
2018-08-27 13:52:08.634244 7f1e1335a700 15 osd.9 823276 project_pg_history 34.6e9 up changed in 822265 from [57] 57 -> [58,57] 58
2018-08-27 13:52:08.634248 7f1e1335a700 15 osd.9 823276 project_pg_history 34.6e9 primary changed in 822265
2018-08-27 13:52:08.634250 7f1e1335a700 15 osd.9 823276 project_pg_history end ec=380829/380829 lis/c 820412/820412 les/c/f 82041
3/820413/0 822265/822265/822265
```
Replace __project_pg_history__ with a new __pg_interval_changed__
method since now what really matters is whether the past series of
osdmaps will cause pg entering a new pg_interval_t or not. Also
we add a initial check for the begin and end map, which can avoid a
situation like:
    from    e1 [1, 2, 3]
            e2 [1, 4, 5]
            e3 [1, 4, 5]
            e4 [1, 4, 5]
            ...
    end   e999 [1, 4, 5]
since our approach (and the traditional __project_pg_history__) is
pure inverse and hence is super inefficient for the above case...

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>
Signed-off-by: yanjun <yan.jun8@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

