### PR TITLE
os/bluestore: fix bloom filter num entry miscalculation in repairer

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2882,7 +2882,7 @@ public:
 	granularity = round_up_to(granularity, min_alloc_size);
       }
 
-      uint64_t entries = p2roundup(total, granularity) / granularity;
+      uint64_t entries = round_up_to(total, granularity) / granularity;
       collections_bfs.resize(entries,
         bloom_filter(BLOOM_FILTER_SALT_COUNT,
                      BLOOM_FILTER_TABLE_SIZE,

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1529,6 +1529,17 @@ TEST(BlueStoreRepairer, StoreSpaceTracker)
   ASSERT_EQ(3u, bmap.filter_out(extents));
   ASSERT_TRUE(bmap.is_used(cid));
   ASSERT_TRUE(bmap.is_used(hoid));
+ 
+  BlueStoreRepairer::StoreSpaceTracker bmap2;
+  bmap2.init((uint64_t)0x3223b1d1000, 0x10000);
+  ASSERT_EQ(bmap2.granularity, 0x1a0000);
+  ASSERT_EQ(bmap2.collections_bfs.size(), 0x1edae4);
+  ASSERT_EQ(bmap2.objects_bfs.size(), 0x1edae4);
+  bmap2.set_used(0x3223b190000, 0x10000, cid, hoid);
+  ASSERT_TRUE(bmap2.is_used(cid, 0x3223b190000));
+  ASSERT_TRUE(bmap2.is_used(hoid, 0x3223b190000));
+  ASSERT_TRUE(bmap2.is_used(cid, 0x3223b19f000));
+  ASSERT_TRUE(bmap2.is_used(hoid, 0x3223b19ffff));
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
This could  cause an assertion due to an access to uninitialized bloom
filter. This happened  when detected errors involving physical extents were 
close to the end of a large partition.
E.g. it was observed in http://tracker.ceph.com/issues/25001 while trying to repair an OSD.

Fixes: https://tracker.ceph.com/issues/35971
Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

