### PR TITLE
osd/osd_types: fix pg_t::contains() to check pool id too

### DIFF
--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -42,6 +42,7 @@ private:
   bool max;
   uint32_t nibblewise_key_cache;
   uint32_t hash_reverse_bits;
+public:
   static const int64_t POOL_META = -1;
   static const int64_t POOL_TEMP_START = -2; // and then negative
   friend class spg_t;  // for POOL_TEMP_START

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -101,6 +101,12 @@ public:
   bool is_meta() const {
     return is_meta_pool(pool);
   }
+  int64_t get_logical_pool() const {
+    if (is_temp_pool(pool))
+      return get_temp_pool(pool);  // it's reversible
+    else
+      return pool;
+  }
 
   hobject_t() : snap(0), hash(0), max(false), pool(INT64_MIN) {
     build_hash_cache();

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -35,6 +35,21 @@ namespace ceph {
 #endif
 
 struct hobject_t {
+public:
+  static const int64_t POOL_META = -1;
+  static const int64_t POOL_TEMP_START = -2; // and then negative
+
+  static bool is_temp_pool(int64_t pool) {
+    return pool <= POOL_TEMP_START;
+  }
+  static int64_t get_temp_pool(int64_t pool) {
+    return POOL_TEMP_START - pool;
+  }
+  static bool is_meta_pool(int64_t pool) {
+    return pool == POOL_META;
+  }
+
+public:
   object_t oid;
   snapid_t snap;
 private:
@@ -42,10 +57,6 @@ private:
   bool max;
   uint32_t nibblewise_key_cache;
   uint32_t hash_reverse_bits;
-public:
-  static const int64_t POOL_META = -1;
-  static const int64_t POOL_TEMP_START = -2; // and then negative
-  friend class spg_t;  // for POOL_TEMP_START
 public:
   int64_t pool;
   string nspace;
@@ -85,10 +96,10 @@ public:
   }
 
   bool is_temp() const {
-    return pool <= POOL_TEMP_START && pool != INT64_MIN;
+    return is_temp_pool(pool) && pool != INT64_MIN;
   }
   bool is_meta() const {
-    return pool == POOL_META;
+    return is_meta_pool(pool);
   }
 
   hobject_t() : snap(0), hash(0), max(false), pool(INT64_MIN) {
@@ -259,7 +270,8 @@ public:
   hobject_t make_temp_hobject(const string& name) const {
     return hobject_t(object_t(name), "", CEPH_NOSNAP,
 		     hash,
-		     hobject_t::POOL_TEMP_START - pool, "");
+		     get_temp_pool(pool),
+		     "");
   }
 
   void swap(hobject_t &o) {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -426,13 +426,13 @@ struct pg_t {
   bool contains(int bits, const ghobject_t& oid) {
     return
       ((int64_t)m_pool == oid.hobj.pool ||
-       hobject_t::POOL_TEMP_START-(int64_t)m_pool == oid.hobj.pool) &&
+       hobject_t::get_temp_pool(m_pool) == oid.hobj.pool) &&
       oid.match(bits, ps());
   }
   bool contains(int bits, const hobject_t& oid) {
     return
       ((int64_t)m_pool == oid.pool ||
-       hobject_t::POOL_TEMP_START-(int64_t)m_pool == oid.pool) &&
+       hobject_t::get_temp_pool(m_pool) == oid.pool) &&
       oid.match(bits, ps());
   }
 
@@ -588,7 +588,8 @@ struct spg_t {
     return ghobject_t(
       hobject_t(object_t(name), "", CEPH_NOSNAP,
 		pgid.ps(),
-		hobject_t::POOL_TEMP_START - pgid.pool(), ""),
+		hobject_t::get_temp_pool(pgid.pool()),
+		""),
       ghobject_t::NO_GEN,
       shard);
   }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -425,14 +425,12 @@ struct pg_t {
 
   bool contains(int bits, const ghobject_t& oid) {
     return
-      ((int64_t)m_pool == oid.hobj.pool ||
-       hobject_t::get_temp_pool(m_pool) == oid.hobj.pool) &&
+      (int64_t)m_pool == oid.hobj.get_logical_pool() &&
       oid.match(bits, ps());
   }
   bool contains(int bits, const hobject_t& oid) {
     return
-      ((int64_t)m_pool == oid.pool ||
-       hobject_t::get_temp_pool(m_pool) == oid.pool) &&
+      (int64_t)m_pool == oid.get_logical_pool() &&
       oid.match(bits, ps());
   }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -424,10 +424,16 @@ struct pg_t {
   unsigned get_split_bits(unsigned pg_num) const;
 
   bool contains(int bits, const ghobject_t& oid) {
-    return oid.match(bits, ps());
+    return
+      ((int64_t)m_pool == oid.hobj.pool ||
+       hobject_t::POOL_TEMP_START-(int64_t)m_pool == oid.hobj.pool) &&
+      oid.match(bits, ps());
   }
   bool contains(int bits, const hobject_t& oid) {
-    return oid.match(bits, ps());
+    return
+      ((int64_t)m_pool == oid.pool ||
+       hobject_t::POOL_TEMP_START-(int64_t)m_pool == oid.pool) &&
+      oid.match(bits, ps());
   }
 
   hobject_t get_hobj_start() const;


### PR DESCRIPTION
This is used by bluestore fsck to ensure we're looking at the right
collection.  It needs to validate both that the pool id matches the
object (including the temp objects) and that the hash matches; we were
only checking the hash before.

Fixes: http://tracker.ceph.com/issues/32731
Signed-off-by: Sage Weil <sage@redhat.com>