### PR TITLE
common: prevent daemon's log with level -1 from writing to system log file

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -511,11 +511,11 @@ flushjournal_out:
   ms_hb_back_server->set_cluster_protocol(CEPH_OSD_PROTOCOL);
   ms_hb_front_server->set_cluster_protocol(CEPH_OSD_PROTOCOL);
 
-  cout << "starting osd." << whoami
-       << " osd_data " << data_path
-       << " " << ((journal_path.empty()) ?
-		  "(no journal)" : journal_path)
-       << std::endl;
+  dout(0) << "starting osd." << whoami
+          << " osd_data " << data_path
+          << " " << ((journal_path.empty()) ?
+		    "(no journal)" : journal_path)
+          << dendl;
 
   uint64_t message_size =
     g_conf().get_val<Option::size_t>("osd_client_message_size_cap");

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -514,7 +514,8 @@ void global_init_chdir(const CephContext *cct)
 int global_init_shutdown_stderr(CephContext *cct)
 {
   reopen_as_null(cct, STDERR_FILENO);
-  cct->_log->set_stderr_level(-1, -1);
+  int l = cct->_conf->err_to_stderr ? -1 : -2;
+  cct->_log->set_stderr_level(l, l);
   return 0;
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3419,7 +3419,7 @@ int OSD::shutdown()
     osd_lock.Unlock();
     return 0;
   }
-  derr << "shutdown" << dendl;
+  dout(0) << "shutdown" << dendl;
 
   set_state(STATE_STOPPING);
 


### PR DESCRIPTION
while switching to systemd(the systemd service manager invokes all service processes with standard output and standard error connected to the journal by default), we see too many osd or mon's logs in the system log file ( `/var/log/messages` ), that cause the system log file too big, and these logs are duplicated and helpless since we can get the same logs in osd/mon's own log file.  
Further more, it seems not the original intention to write these -1 level log to system log file, if we really want to do that, we should use -2 level as the m_syslog_log configurated.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>