### PR TITLE
mgr/dashboard: Do not require cert for http

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -138,32 +138,6 @@ class SSLCherryPyConfig(object):
         cherrypy.tools.dashboard_exception_handler = HandlerWrapperTool(dashboard_exception_handler,
                                                                         priority=31)
 
-        # SSL initialization
-        cert = self.get_store("crt")
-        if cert is not None:
-            self.cert_tmp = tempfile.NamedTemporaryFile()
-            self.cert_tmp.write(cert.encode('utf-8'))
-            self.cert_tmp.flush()  # cert_tmp must not be gc'ed
-            cert_fname = self.cert_tmp.name
-        else:
-            cert_fname = self.get_localized_config('crt_file')
-
-        pkey = self.get_store("key")
-        if pkey is not None:
-            self.pkey_tmp = tempfile.NamedTemporaryFile()
-            self.pkey_tmp.write(pkey.encode('utf-8'))
-            self.pkey_tmp.flush()  # pkey_tmp must not be gc'ed
-            pkey_fname = self.pkey_tmp.name
-        else:
-            pkey_fname = self.get_localized_config('key_file')
-
-        if not cert_fname or not pkey_fname:
-            raise ServerConfigException('no certificate configured')
-        if not os.path.isfile(cert_fname):
-            raise ServerConfigException('certificate %s does not exist' % cert_fname)
-        if not os.path.isfile(pkey_fname):
-            raise ServerConfigException('private key %s does not exist' % pkey_fname)
-
         # Apply the 'global' CherryPy configuration.
         config = {
             'engine.autoreload.on': False,
@@ -174,6 +148,32 @@ class SSLCherryPyConfig(object):
         }
 
         if ssl:
+            # SSL initialization
+            cert = self.get_store("crt")
+            if cert is not None:
+                self.cert_tmp = tempfile.NamedTemporaryFile()
+                self.cert_tmp.write(cert.encode('utf-8'))
+                self.cert_tmp.flush()  # cert_tmp must not be gc'ed
+                cert_fname = self.cert_tmp.name
+            else:
+                cert_fname = self.get_localized_config('crt_file')
+
+            pkey = self.get_store("key")
+            if pkey is not None:
+                self.pkey_tmp = tempfile.NamedTemporaryFile()
+                self.pkey_tmp.write(pkey.encode('utf-8'))
+                self.pkey_tmp.flush()  # pkey_tmp must not be gc'ed
+                pkey_fname = self.pkey_tmp.name
+            else:
+                pkey_fname = self.get_localized_config('key_file')
+
+            if not cert_fname or not pkey_fname:
+                raise ServerConfigException('no certificate configured')
+            if not os.path.isfile(cert_fname):
+                raise ServerConfigException('certificate %s does not exist' % cert_fname)
+            if not os.path.isfile(pkey_fname):
+                raise ServerConfigException('private key %s does not exist' % pkey_fname)
+
             config['server.ssl_module'] = 'builtin'
             config['server.ssl_certificate'] = cert_fname
             config['server.ssl_private_key'] = pkey_fname

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -91,7 +91,7 @@ class ServerConfigException(Exception):
     pass
 
 
-class SSLCherryPyConfig(object):
+class CherryPyConfig(object):
     """
     Class for common server configuration done by both active and
     standby module, especially setting up SSL.
@@ -213,7 +213,7 @@ class SSLCherryPyConfig(object):
                 return uri
 
 
-class Module(MgrModule, SSLCherryPyConfig):
+class Module(MgrModule, CherryPyConfig):
     """
     dashboard module entrypoint
     """
@@ -249,7 +249,7 @@ class Module(MgrModule, SSLCherryPyConfig):
 
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)
-        SSLCherryPyConfig.__init__(self)
+        CherryPyConfig.__init__(self)
 
         mgr.init(self)
 
@@ -317,7 +317,7 @@ class Module(MgrModule, SSLCherryPyConfig):
 
     def shutdown(self):
         super(Module, self).shutdown()
-        SSLCherryPyConfig.shutdown(self)
+        CherryPyConfig.shutdown(self)
         logger.info('Stopping engine...')
         self.shutdown_event.set()
 
@@ -364,10 +364,10 @@ class Module(MgrModule, SSLCherryPyConfig):
         NotificationQueue.new_notification(notify_type, notify_id)
 
 
-class StandbyModule(MgrStandbyModule, SSLCherryPyConfig):
+class StandbyModule(MgrStandbyModule, CherryPyConfig):
     def __init__(self, *args, **kwargs):
         super(StandbyModule, self).__init__(*args, **kwargs)
-        SSLCherryPyConfig.__init__(self)
+        CherryPyConfig.__init__(self)
         self.shutdown_event = threading.Event()
 
         # We can set the global mgr instance to ourselves even though
@@ -419,7 +419,7 @@ class StandbyModule(MgrStandbyModule, SSLCherryPyConfig):
         self.log.info("Engine stopped.")
 
     def shutdown(self):
-        SSLCherryPyConfig.shutdown(self)
+        CherryPyConfig.shutdown(self)
 
         self.log.info("Stopping engine...")
         self.shutdown_event.set()


### PR DESCRIPTION
The ceph dashboard currently requires a SSL certificate even if it is
not running in the SSL mode since it is always querying for the
certificate file/key pair.

This patch fixes the behaviour by querying for the certificate file/key
only if it is running in the SSL mode.

Signed-off-by: Boris Ranto <branto@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

