### PR TITLE
rgw: abort_bucket_multiparts() ignores individual NoSuchUpload errors

### DIFF
--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -285,7 +285,7 @@ int abort_bucket_multiparts(RGWRados *store, CephContext *cct, RGWBucketInfo& bu
         if (!mp.from_meta(key.name))
           continue;
         ret = abort_multipart_upload(store, cct, &obj_ctx, bucket_info, mp);
-        if (ret < 0) {
+        if (ret < 0 && ret != -ENOENT && ret != -ERR_NO_SUCH_UPLOAD) {
           return ret;
         }
         num_deleted++;


### PR DESCRIPTION
if the bucket index lists multipart meta objects that don't actually exist in rados, this error prevents the bucket from being deleted

Fixes: http://tracker.ceph.com/issues/35986

(note: this checks both ENOENT and ERR_NO_SUCH_UPLOAD so the backports don't depend on c806855d9046de6c8c1f32679569a1c7c98d8706)