### PR TITLE
osd: avoid unncecessary ref-counting in OSD::enqueue_op.

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1779,7 +1779,7 @@ protected:
   } op_shardedwq;
 
 
-  void enqueue_op(spg_t pg, OpRequestRef& op, epoch_t epoch);
+  void enqueue_op(spg_t pg, OpRequestRef&& op, epoch_t epoch);
   void dequeue_op(
     PGRef pg, OpRequestRef op,
     ThreadPool::TPHandle &handle);

--- a/src/osd/OpQueueItem.h
+++ b/src/osd/OpQueueItem.h
@@ -201,7 +201,7 @@ public:
 class PGOpItem : public PGOpQueueable {
   OpRequestRef op;
 public:
-  PGOpItem(spg_t pg, OpRequestRef op) : PGOpQueueable(pg), op(op) {}
+  PGOpItem(spg_t pg, OpRequestRef op) : PGOpQueueable(pg), op(std::move(op)) {}
   op_type_t get_op_type() const override final {
     return op_type_t::client_op;
   }


### PR DESCRIPTION
This is small improvement for `OSD::enqueue_op` made on the occasion of `OpTracker` rework. Dissecting and sending separately as it solely targets OSD.

```
-    4,30%     0,32%  msgr-worker-0  ceph-osd  [.] OSD::enqueue_op
   - 3,98% OSD::enqueue_op
      + 2,40% OSD::ShardedOpWQ::_enqueue
      + 0,42% OpRequest::mark_flag_point
        0,37% operator new
        0,36% PerfCounters::tinc
      + 0,21% Mutex::Unlock
```

Annotate (self is 0,32%):
```
OSD::enqueue_op  /home/perf/src/ceph-rzarzynski3/build/bin/ceph-osd
       │93           if( px != 0 ) intrusive_ptr_add_ref( px );
       │       test   %rbx,%rbx
       │95   _ZN13PGOpQueueableC4E5spg_t():
       │175    explicit PGOpQueueable(spg_t pg) : pgid(pg) {}
  0,70 │       mov    %cl,0x18(%rax)
       │177  _ZN8PGOpItemC4E5spg_tN5boost13intrusive_ptrI9OpRequestEE():
       │204    PGOpItem(spg_t pg, OpRequestRef op) : PGOpQueueable(pg), op(op) {
       │       mov    %rdx,(%rax)
       │206  _ZN5boost13intrusive_ptrI9OpRequestEC4ERKS2_():
       │     ↓ je     166
       │94   _ZNSt13__atomic_baseIiEppEv():
 48,25 │       lock   addl   $0x1,0x30(%rbx)
       │166:   mov    0x158(%rbp),%ecx
       │       mov    0x15c(%rbp),%edx
       │299  _ZN17ShardedThreadPool9ShardedWQI11OpQueueItemE5queueEOS1_():
       │669        tp->set_wq(this);
       │670      }
       │671      ~ShardedWQ() override {}
       │
       │673      void queue(T&& item) {
       │674        _enqueue(std::move(item));
  2,80 │       mov    %r12,%rsi
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>