### PR TITLE
rgw: refactor PutObjProcessor throttling

### DIFF
--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -8,11 +8,11 @@
 
 //------------RGWPutObj_Compress---------------
 
-int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again)
+int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs, bool *again)
 {
   bufferlist in_bl;
   if (*again) {
-    return next->handle_data(in_bl, ofs, phandle, pobj, again);
+    return next->handle_data(in_bl, ofs, again);
   }
   if (bl.length() > 0) {
     // compression stuff
@@ -46,7 +46,7 @@ int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs, void **phandle, r
     }
     // end of compression stuff
   }
-  return next->handle_data(in_bl, ofs, phandle, pobj, again);
+  return next->handle_data(in_bl, ofs, again);
 }
 
 //----------------RGWGetObj_Decompress---------------------

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -8,7 +8,7 @@
 
 //------------RGWPutObj_Compress---------------
 
-int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs)
+int RGWPutObj_Compress::handle_data(bufferlist&& bl, off_t ofs)
 {
   bufferlist in_bl;
   if (bl.length() > 0) {
@@ -43,7 +43,7 @@ int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs)
     }
     // end of compression stuff
   }
-  return next->handle_data(in_bl, ofs);
+  return next->handle_data(std::move(in_bl), ofs);
 }
 
 //----------------RGWGetObj_Decompress---------------------

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -8,12 +8,9 @@
 
 //------------RGWPutObj_Compress---------------
 
-int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs, bool *again)
+int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs)
 {
   bufferlist in_bl;
-  if (*again) {
-    return next->handle_data(in_bl, ofs, again);
-  }
   if (bl.length() > 0) {
     // compression stuff
     if ((ofs > 0 && compressed) ||                                // if previous part was compressed
@@ -46,7 +43,7 @@ int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs, bool *again)
     }
     // end of compression stuff
   }
-  return next->handle_data(in_bl, ofs, again);
+  return next->handle_data(in_bl, ofs);
 }
 
 //----------------RGWGetObj_Decompress---------------------

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -42,7 +42,7 @@ public:
                      RGWPutObjDataProcessor* next)
     : RGWPutObj_Filter(next), cct(cct_), compressor(compressor) {}
   ~RGWPutObj_Compress() override{}
-  int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) override;
+  int handle_data(bufferlist& bl, off_t ofs, bool *again) override;
 
   bool is_compressed() { return compressed; }
   vector<compression_block>& get_compression_blocks() { return blocks; }

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -42,7 +42,7 @@ public:
                      RGWPutObjDataProcessor* next)
     : RGWPutObj_Filter(next), cct(cct_), compressor(compressor) {}
   ~RGWPutObj_Compress() override{}
-  int handle_data(bufferlist& bl, off_t ofs, bool *again) override;
+  int handle_data(bufferlist& bl, off_t ofs) override;
 
   bool is_compressed() { return compressed; }
   vector<compression_block>& get_compression_blocks() { return blocks; }

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -42,7 +42,7 @@ public:
                      RGWPutObjDataProcessor* next)
     : RGWPutObj_Filter(next), cct(cct_), compressor(compressor) {}
   ~RGWPutObj_Compress() override{}
-  int handle_data(bufferlist& bl, off_t ofs) override;
+  int handle_data(bufferlist&& bl, off_t ofs) override;
 
   bool is_compressed() { return compressed; }
   vector<compression_block>& get_compression_blocks() { return blocks; }

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -677,15 +677,13 @@ RGWPutObj_BlockEncrypt::~RGWPutObj_BlockEncrypt() {
 
 int RGWPutObj_BlockEncrypt::handle_data(bufferlist& bl,
                                         off_t in_ofs,
-                                        void **phandle,
-                                        rgw_raw_obj *pobj,
                                         bool *again) {
   int res = 0;
   ldout(cct, 25) << "Encrypt " << bl.length() << " bytes" << dendl;
 
   if (*again) {
     bufferlist no_data;
-    res = next->handle_data(no_data, in_ofs, phandle, pobj, again);
+    res = next->handle_data(no_data, in_ofs, again);
     //if *again is not set to false, we will have endless loop
     //drop info on log
     if (*again) {
@@ -704,7 +702,7 @@ int RGWPutObj_BlockEncrypt::handle_data(bufferlist& bl,
     if (! crypt->encrypt(cache, 0, proc_size, data, ofs) ) {
       return -ERR_INTERNAL_ERROR;
     }
-    res = next->handle_data(data, ofs, phandle, pobj, again);
+    res = next->handle_data(data, ofs, again);
     ofs += proc_size;
     cache.splice(0, proc_size);
     if (res < 0)
@@ -713,7 +711,7 @@ int RGWPutObj_BlockEncrypt::handle_data(bufferlist& bl,
 
   if (bl.length() == 0) {
     /*replicate 0-sized handle_data*/
-    res = next->handle_data(bl, ofs, phandle, pobj, again);
+    res = next->handle_data(bl, ofs, again);
   }
   return res;
 }

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -718,13 +718,6 @@ int RGWPutObj_BlockEncrypt::handle_data(bufferlist& bl,
   return res;
 }
 
-int RGWPutObj_BlockEncrypt::throttle_data(void *handle,
-                                          const rgw_raw_obj& obj,
-                                          uint64_t size,
-                                          bool need_to_wait) {
-  return next->throttle_data(handle, obj, size, need_to_wait);
-}
-
 std::string create_random_key_selector(CephContext * const cct) {
   char random[AES_256_KEYSIZE];
   cct->random()->get_bytes(&random[0], sizeof(random));

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -123,8 +123,8 @@ public:
   RGWPutObj_BlockEncrypt(CephContext* cct,
                          RGWPutObjDataProcessor* next,
                          std::unique_ptr<BlockCrypt> crypt);
-  virtual ~RGWPutObj_BlockEncrypt();
-  virtual int handle_data(bufferlist& bl, off_t ofs) override;
+
+  int handle_data(bufferlist&& bl, off_t ofs) override;
 }; /* RGWPutObj_BlockEncrypt */
 
 

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -124,11 +124,7 @@ public:
                          RGWPutObjDataProcessor* next,
                          std::unique_ptr<BlockCrypt> crypt);
   virtual ~RGWPutObj_BlockEncrypt();
-  virtual int handle_data(bufferlist& bl,
-                          off_t ofs,
-                          void **phandle,
-                          rgw_raw_obj *pobj,
-                          bool *again) override;
+  virtual int handle_data(bufferlist& bl, off_t ofs, bool *again) override;
 }; /* RGWPutObj_BlockEncrypt */
 
 

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -124,7 +124,7 @@ public:
                          RGWPutObjDataProcessor* next,
                          std::unique_ptr<BlockCrypt> crypt);
   virtual ~RGWPutObj_BlockEncrypt();
-  virtual int handle_data(bufferlist& bl, off_t ofs, bool *again) override;
+  virtual int handle_data(bufferlist& bl, off_t ofs) override;
 }; /* RGWPutObj_BlockEncrypt */
 
 

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -129,10 +129,6 @@ public:
                           void **phandle,
                           rgw_raw_obj *pobj,
                           bool *again) override;
-  virtual int throttle_data(void *handle,
-                            const rgw_raw_obj& obj,
-                            uint64_t size,
-                            bool need_to_wait) override;
 }; /* RGWPutObj_BlockEncrypt */
 
 

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1366,7 +1366,7 @@ namespace rgw {
       orig_data = data;
     }
     hash.Update((const unsigned char *)data.c_str(), data.length());
-    op_ret = put_data_and_throttle(filter, data, ofs, need_to_wait);
+    op_ret = put_data_and_throttle(filter, data, ofs);
     if (op_ret < 0) {
       if (!need_to_wait || op_ret != -EEXIST) {
 	ldout(s->cct, 20) << "processor->handle_data() returned ret="
@@ -1403,7 +1403,7 @@ namespace rgw {
 	filter = &*compressor;
       }
 
-      op_ret = put_data_and_throttle(filter, data, ofs, false);
+      op_ret = put_data_and_throttle(filter, data, ofs);
       if (op_ret < 0) {
 	goto done;
       }

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1369,12 +1369,12 @@ namespace rgw {
     op_ret = put_data_and_throttle(filter, data, ofs, need_to_wait);
     if (op_ret < 0) {
       if (!need_to_wait || op_ret != -EEXIST) {
-	ldout(s->cct, 20) << "processor->thottle_data() returned ret="
+	ldout(s->cct, 20) << "processor->handle_data() returned ret="
 			  << op_ret << dendl;
 	goto done;
       }
 
-      ldout(s->cct, 5) << "NOTICE: processor->throttle_data() returned -EEXIST, need to restart write" << dendl;
+      ldout(s->cct, 5) << "NOTICE: processor->handle_data() returned -EEXIST, need to restart write" << dendl;
 
       /* restore original data */
       data.swap(orig_data);

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1366,7 +1366,7 @@ namespace rgw {
       orig_data = data;
     }
     hash.Update((const unsigned char *)data.c_str(), data.length());
-    op_ret = put_data_and_throttle(filter, data, ofs);
+    op_ret = filter->handle_data(data, ofs);
     if (op_ret < 0) {
       if (!need_to_wait || op_ret != -EEXIST) {
 	ldout(s->cct, 20) << "processor->handle_data() returned ret="
@@ -1403,7 +1403,7 @@ namespace rgw {
 	filter = &*compressor;
       }
 
-      op_ret = put_data_and_throttle(filter, data, ofs);
+      op_ret = filter->handle_data(data, ofs);
       if (op_ret < 0) {
 	goto done;
       }

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1366,7 +1366,7 @@ namespace rgw {
       orig_data = data;
     }
     hash.Update((const unsigned char *)data.c_str(), data.length());
-    op_ret = filter->handle_data(data, ofs);
+    op_ret = filter->handle_data(std::move(data), ofs);
     if (op_ret < 0) {
       if (!need_to_wait || op_ret != -EEXIST) {
 	ldout(s->cct, 20) << "processor->handle_data() returned ret="
@@ -1403,7 +1403,7 @@ namespace rgw {
 	filter = &*compressor;
       }
 
-      op_ret = filter->handle_data(data, ofs);
+      op_ret = filter->handle_data(std::move(data), ofs);
       if (op_ret < 0) {
 	goto done;
       }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3718,12 +3718,12 @@ void RGWPutObj::execute()
     op_ret = put_data_and_throttle(filter, data, ofs, need_to_wait);
     if (op_ret < 0) {
       if (op_ret != -EEXIST) {
-        ldpp_dout(this, 20) << "processor->thottle_data() returned ret="
+        ldpp_dout(this, 20) << "processor->handle_data() returned ret="
 			  << op_ret << dendl;
         goto done;
       }
       /* need_to_wait == true and op_ret == -EEXIST */
-      ldpp_dout(this, 5) << "NOTICE: processor->throttle_data() returned -EEXIST, need to restart write" << dendl;
+      ldpp_dout(this, 5) << "NOTICE: processor->handle_data() returned -EEXIST, need to restart write" << dendl;
 
       /* restore original data */
       data.swap(orig_data);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3715,7 +3715,7 @@ void RGWPutObj::execute()
       orig_data = data;
     }
 
-    op_ret = put_data_and_throttle(filter, data, ofs);
+    op_ret = filter->handle_data(data, ofs);
     if (op_ret < 0) {
       if (op_ret != -EEXIST) {
         ldpp_dout(this, 20) << "processor->handle_data() returned ret="
@@ -3758,7 +3758,7 @@ void RGWPutObj::execute()
           filter = &*compressor;
         }
       }
-      op_ret = put_data_and_throttle(filter, data, ofs);
+      op_ret = filter->handle_data(data, ofs);
       if (op_ret < 0) {
         goto done;
       }
@@ -3770,7 +3770,7 @@ void RGWPutObj::execute()
 
   {
     bufferlist flush;
-    op_ret = put_data_and_throttle(filter, flush, ofs);
+    op_ret = filter->handle_data(flush, ofs);
     if (op_ret < 0) {
       goto done;
     }
@@ -4045,7 +4045,7 @@ void RGWPostObj::execute()
       }
 
       hash.Update((const unsigned char *)data.c_str(), data.length());
-      op_ret = put_data_and_throttle(filter, data, ofs);
+      op_ret = filter->handle_data(data, ofs);
 
       ofs += len;
 
@@ -4057,7 +4057,7 @@ void RGWPostObj::execute()
 
     {
       bufferlist flush;
-      op_ret = put_data_and_throttle(filter, flush, ofs);
+      op_ret = filter->handle_data(flush, ofs);
     }
 
     if (len < min_len) {
@@ -6799,7 +6799,7 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
       return op_ret;
     } else if (len > 0) {
       hash.Update((const unsigned char *)data.c_str(), data.length());
-      op_ret = put_data_and_throttle(filter, data, ofs);
+      op_ret = filter->handle_data(data, ofs);
       if (op_ret < 0) {
         ldpp_dout(this, 20) << "processor->thottle_data() returned ret=" << op_ret << dendl;
         return op_ret;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3715,7 +3715,7 @@ void RGWPutObj::execute()
       orig_data = data;
     }
 
-    op_ret = filter->handle_data(data, ofs);
+    op_ret = filter->handle_data(std::move(data), ofs);
     if (op_ret < 0) {
       if (op_ret != -EEXIST) {
         ldpp_dout(this, 20) << "processor->handle_data() returned ret="
@@ -3758,7 +3758,7 @@ void RGWPutObj::execute()
           filter = &*compressor;
         }
       }
-      op_ret = filter->handle_data(data, ofs);
+      op_ret = filter->handle_data(std::move(data), ofs);
       if (op_ret < 0) {
         goto done;
       }
@@ -3768,12 +3768,10 @@ void RGWPutObj::execute()
   } while (len > 0);
   tracepoint(rgw_op, after_data_transfer, s->req_id.c_str(), ofs);
 
-  {
-    bufferlist flush;
-    op_ret = filter->handle_data(flush, ofs);
-    if (op_ret < 0) {
-      goto done;
-    }
+  // flush
+  op_ret = filter->handle_data({}, ofs);
+  if (op_ret < 0) {
+    goto done;
   }
 
   if (!chunked_upload && ofs != s->content_length) {
@@ -4045,7 +4043,7 @@ void RGWPostObj::execute()
       }
 
       hash.Update((const unsigned char *)data.c_str(), data.length());
-      op_ret = filter->handle_data(data, ofs);
+      op_ret = filter->handle_data(std::move(data), ofs);
 
       ofs += len;
 
@@ -4055,9 +4053,10 @@ void RGWPostObj::execute()
       }
     } while (again);
 
-    {
-      bufferlist flush;
-      op_ret = filter->handle_data(flush, ofs);
+    // flush
+    op_ret = filter->handle_data({}, ofs);
+    if (op_ret < 0) {
+      return;
     }
 
     if (len < min_len) {
@@ -6799,7 +6798,7 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
       return op_ret;
     } else if (len > 0) {
       hash.Update((const unsigned char *)data.c_str(), data.length());
-      op_ret = filter->handle_data(data, ofs);
+      op_ret = filter->handle_data(std::move(data), ofs);
       if (op_ret < 0) {
         ldpp_dout(this, 20) << "processor->thottle_data() returned ret=" << op_ret << dendl;
         return op_ret;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3715,7 +3715,7 @@ void RGWPutObj::execute()
       orig_data = data;
     }
 
-    op_ret = put_data_and_throttle(filter, data, ofs, need_to_wait);
+    op_ret = put_data_and_throttle(filter, data, ofs);
     if (op_ret < 0) {
       if (op_ret != -EEXIST) {
         ldpp_dout(this, 20) << "processor->handle_data() returned ret="
@@ -3758,7 +3758,7 @@ void RGWPutObj::execute()
           filter = &*compressor;
         }
       }
-      op_ret = put_data_and_throttle(filter, data, ofs, false);
+      op_ret = put_data_and_throttle(filter, data, ofs);
       if (op_ret < 0) {
         goto done;
       }
@@ -3770,7 +3770,7 @@ void RGWPutObj::execute()
 
   {
     bufferlist flush;
-    op_ret = put_data_and_throttle(filter, flush, ofs, false);
+    op_ret = put_data_and_throttle(filter, flush, ofs);
     if (op_ret < 0) {
       goto done;
     }
@@ -4045,7 +4045,7 @@ void RGWPostObj::execute()
       }
 
       hash.Update((const unsigned char *)data.c_str(), data.length());
-      op_ret = put_data_and_throttle(filter, data, ofs, false);
+      op_ret = put_data_and_throttle(filter, data, ofs);
 
       ofs += len;
 
@@ -4057,7 +4057,7 @@ void RGWPostObj::execute()
 
     {
       bufferlist flush;
-      op_ret = put_data_and_throttle(filter, flush, ofs, false);
+      op_ret = put_data_and_throttle(filter, flush, ofs);
     }
 
     if (len < min_len) {
@@ -6799,7 +6799,7 @@ int RGWBulkUploadOp::handle_file(const boost::string_ref path,
       return op_ret;
     } else if (len > 0) {
       hash.Update((const unsigned char *)data.c_str(), data.length());
-      op_ret = put_data_and_throttle(filter, data, ofs, false);
+      op_ret = put_data_and_throttle(filter, data, ofs);
       if (op_ret < 0) {
         ldpp_dout(this, 20) << "processor->thottle_data() returned ret=" << op_ret << dendl;
         return op_ret;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1092,8 +1092,8 @@ public:
   explicit RGWPutObj_Filter(RGWPutObjDataProcessor* next) :
   next(next){}
   ~RGWPutObj_Filter() override {}
-  int handle_data(bufferlist& bl, off_t ofs) override {
-    return next->handle_data(bl, ofs);
+  int handle_data(bufferlist&& bl, off_t ofs) override {
+    return next->handle_data(std::move(bl), ofs);
   }
 }; /* RGWPutObj_Filter */
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1092,8 +1092,8 @@ public:
   explicit RGWPutObj_Filter(RGWPutObjDataProcessor* next) :
   next(next){}
   ~RGWPutObj_Filter() override {}
-  int handle_data(bufferlist& bl, off_t ofs, bool *again) override {
-    return next->handle_data(bl, ofs, again);
+  int handle_data(bufferlist& bl, off_t ofs) override {
+    return next->handle_data(bl, ofs);
   }
 }; /* RGWPutObj_Filter */
 
@@ -1854,7 +1854,7 @@ static inline int put_data_and_throttle(RGWPutObjDataProcessor *processor,
 {
   bool again = false;
   do {
-    int ret = processor->handle_data(data, ofs, &again);
+    int ret = processor->handle_data(data, ofs);
     if (ret < 0)
       return ret;
   } while (again);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1095,9 +1095,6 @@ public:
   int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) override {
     return next->handle_data(bl, ofs, phandle, pobj, again);
   }
-  int throttle_data(void *handle, const rgw_raw_obj& obj, uint64_t size, bool need_to_wait) override {
-    return next->throttle_data(handle, obj, size, need_to_wait);
-  }
 }; /* RGWPutObj_Filter */
 
 class RGWPostObj : public RGWOp {
@@ -1861,21 +1858,9 @@ static inline int put_data_and_throttle(RGWPutObjDataProcessor *processor,
     void *handle = nullptr;
     rgw_raw_obj obj;
 
-    uint64_t size = data.length();
-
     int ret = processor->handle_data(data, ofs, &handle, &obj, &again);
     if (ret < 0)
       return ret;
-    if (handle != nullptr)
-    {
-      ret = processor->throttle_data(handle, obj, size, need_to_wait);
-      if (ret < 0)
-        return ret;
-    }
-    else
-      break;
-    need_to_wait = false; /* the need to wait only applies to the first
-			   * iteration */
   } while (again);
 
   return 0;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1849,15 +1849,6 @@ extern int rgw_build_object_policies(RGWRados *store, struct req_state *s,
 extern rgw::IAM::Environment rgw_build_iam_environment(RGWRados* store,
 						       struct req_state* s);
 
-static inline int put_data_and_throttle(RGWPutObjDataProcessor *processor,
-					bufferlist& data, off_t ofs)
-{
-  return processor->handle_data(data, ofs);
-} /* put_data_and_throttle */
-
-
-
-
 
 static inline int get_system_versioning_params(req_state *s,
 					      uint64_t *olh_epoch,

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1852,14 +1852,7 @@ extern rgw::IAM::Environment rgw_build_iam_environment(RGWRados* store,
 static inline int put_data_and_throttle(RGWPutObjDataProcessor *processor,
 					bufferlist& data, off_t ofs)
 {
-  bool again = false;
-  do {
-    int ret = processor->handle_data(data, ofs);
-    if (ret < 0)
-      return ret;
-  } while (again);
-
-  return 0;
+  return processor->handle_data(data, ofs);
 } /* put_data_and_throttle */
 
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1092,8 +1092,8 @@ public:
   explicit RGWPutObj_Filter(RGWPutObjDataProcessor* next) :
   next(next){}
   ~RGWPutObj_Filter() override {}
-  int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) override {
-    return next->handle_data(bl, ofs, phandle, pobj, again);
+  int handle_data(bufferlist& bl, off_t ofs, bool *again) override {
+    return next->handle_data(bl, ofs, again);
   }
 }; /* RGWPutObj_Filter */
 
@@ -1855,10 +1855,7 @@ static inline int put_data_and_throttle(RGWPutObjDataProcessor *processor,
 {
   bool again = false;
   do {
-    void *handle = nullptr;
-    rgw_raw_obj obj;
-
-    int ret = processor->handle_data(data, ofs, &handle, &obj, &again);
+    int ret = processor->handle_data(data, ofs, &again);
     if (ret < 0)
       return ret;
   } while (again);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1850,8 +1850,7 @@ extern rgw::IAM::Environment rgw_build_iam_environment(RGWRados* store,
 						       struct req_state* s);
 
 static inline int put_data_and_throttle(RGWPutObjDataProcessor *processor,
-					bufferlist& data, off_t ofs,
-					bool need_to_wait)
+					bufferlist& data, off_t ofs)
 {
   bool again = false;
   do {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7649,7 +7649,7 @@ public:
 
   int flush() {
     bufferlist bl;
-    return put_data_and_throttle(filter, bl, ofs);
+    return filter->handle_data(bl, ofs);
   }
 
   bufferlist& get_extra_data() { return extra_data_bl; }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7636,16 +7636,13 @@ public:
     lofs = ofs - extra_data_len;
 
     data_len += bl.length();
-    bool again = false;
 
-    do {
-      uint64_t size = bl.length();
-      int ret = filter->handle_data(bl, lofs);
-      if (ret < 0)
-        return ret;
+    uint64_t size = bl.length();
+    int ret = filter->handle_data(bl, lofs);
+    if (ret < 0)
+      return ret;
 
-      ofs += size;
-    } while (again);
+    ofs += size;
 
     return 0;
   }
@@ -8541,14 +8538,11 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
     }
 
     uint64_t read_len = ret;
-    bool again = false;
 
-    do {
-      ret = processor.handle_data(bl, ofs);
-      if (ret < 0) {
-        return ret;
-      }
-    } while (again);
+    ret = processor.handle_data(bl, ofs);
+    if (ret < 0) {
+      return ret;
+    }
 
     ofs += read_len;
   } while (ofs <= end);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7654,7 +7654,7 @@ public:
 
   int flush() {
     bufferlist bl;
-    return put_data_and_throttle(filter, bl, ofs, false);
+    return put_data_and_throttle(filter, bl, ofs);
   }
 
   bufferlist& get_extra_data() { return extra_data_bl; }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2635,11 +2635,6 @@ int RGWPutObjProcessor_Aio::throttle_pending(void *handle, const rgw_raw_obj& ob
   return 0;
 }
 
-int RGWPutObjProcessor_Aio::throttle_data(void *handle, const rgw_raw_obj& obj, uint64_t size, bool need_to_wait)
-{
-  return 0; // already did in throttle_pending()
-}
-
 int RGWPutObjProcessor_Atomic::write_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool exclusive)
 {
   if (ofs >= next_part_ofs) {
@@ -2797,11 +2792,6 @@ int RGWPutObjProcessor_Atomic::complete_writing_data()
       return r;
     }
     data_ofs += write_len;
-    r = throttle_data(handle, obj, write_len, false);
-    if (r < 0) {
-      ldout(store->ctx(), 0) << "ERROR: throttle_data() returned " << r << dendl;
-      return r;
-    }
 
     if (data_ofs >= next_part_ofs) {
       r = prepare_next_part(data_ofs);
@@ -7666,10 +7656,6 @@ public:
         return ret;
 
       ofs += size;
-
-      ret = filter->throttle_data(handle, obj, size, false);
-      if (ret < 0)
-        return ret;
     } while (again);
 
     return 0;
@@ -8576,9 +8562,6 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
       if (ret < 0) {
         return ret;
       }
-      ret = processor.throttle_data(handle, obj, read_len, false);
-      if (ret < 0)
-        return ret;
     } while (again);
 
     ofs += read_len;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2536,10 +2536,6 @@ int RGWPutObjProcessor_Aio::handle_obj_data(rgw_raw_obj& obj, bufferlist& bl, of
   if ((uint64_t)abs_ofs + bl.length() > obj_len)
     obj_len = abs_ofs + bl.length();
 
-  if (!(obj == last_written_obj)) {
-    last_written_obj = obj;
-  }
-
   // For the first call pass -1 as the offset to
   // do a write_full.
   return store->aio_put_obj_data(NULL, obj, bl, ((ofs != 0) ? ofs : -1), exclusive, phandle);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3846,7 +3846,6 @@ public:
   RGWPutObjDataProcessor(){}
   virtual ~RGWPutObjDataProcessor(){}
   virtual int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) = 0;
-  virtual int throttle_data(void *handle, const rgw_raw_obj& obj, uint64_t size, bool need_to_wait) = 0;
 }; /* RGWPutObjDataProcessor */
 
 
@@ -3923,7 +3922,6 @@ protected:
 
 public:
   int prepare(RGWRados *store, string *oid_rand) override;
-  int throttle_data(void *handle, const rgw_raw_obj& obj, uint64_t size, bool need_to_wait) override;
 
   RGWPutObjProcessor_Aio(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_info) : RGWPutObjProcessor(obj_ctx, bucket_info) {}
   ~RGWPutObjProcessor_Aio() override;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3906,8 +3906,6 @@ class RGWPutObjProcessor_Aio : public RGWPutObjProcessor
   int wait_pending_front();
   bool pending_has_completed();
 
-  rgw_raw_obj last_written_obj;
-
 protected:
   uint64_t obj_len{0};
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3845,7 +3845,7 @@ class RGWPutObjDataProcessor
 public:
   RGWPutObjDataProcessor(){}
   virtual ~RGWPutObjDataProcessor(){}
-  virtual int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) = 0;
+  virtual int handle_data(bufferlist& bl, off_t ofs, bool *again) = 0;
 }; /* RGWPutObjDataProcessor */
 
 
@@ -3918,7 +3918,7 @@ protected:
   }
 
   int drain_pending();
-  int handle_obj_data(rgw_raw_obj& obj, bufferlist& bl, off_t ofs, off_t abs_ofs, void **phandle, bool exclusive);
+  int handle_obj_data(rgw_raw_obj& obj, bufferlist& bl, off_t ofs, off_t abs_ofs, bool exclusive);
 
 public:
   int prepare(RGWRados *store, string *oid_rand) override;
@@ -3953,7 +3953,7 @@ protected:
   RGWObjManifest manifest;
   RGWObjManifest::generator manifest_gen;
 
-  int write_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool exclusive);
+  int write_data(bufferlist& bl, off_t ofs, bool exclusive);
   int do_complete(size_t accounted_size, const string& etag,
                   ceph::real_time *mtime, ceph::real_time set_mtime,
                   map<string, bufferlist>& attrs, ceph::real_time delete_at,
@@ -3982,7 +3982,7 @@ public:
                                 unique_tag(_t) {}
   int prepare(RGWRados *store, string *oid_rand) override;
   virtual bool immutable_head() { return false; }
-  int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) override;
+  int handle_data(bufferlist& bl, off_t ofs, bool *again) override;
 
   void set_olh_epoch(uint64_t epoch) {
     olh_epoch = epoch;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2996,7 +2996,7 @@ public:
   virtual int put_system_obj_data(void *ctx, rgw_raw_obj& obj,
               const bufferlist& bl, off_t ofs, bool exclusive,
               RGWObjVersionTracker *objv_tracker = nullptr);
-  int aio_put_obj_data(void *ctx, rgw_raw_obj& obj, bufferlist& bl,
+  int aio_put_obj_data(void *ctx, rgw_raw_obj& obj, const bufferlist& bl,
                         off_t ofs, bool exclusive, void **handle);
 
   int put_system_obj(void *ctx, rgw_raw_obj& obj, const bufferlist& data, bool exclusive,
@@ -3845,7 +3845,7 @@ class RGWPutObjDataProcessor
 public:
   RGWPutObjDataProcessor(){}
   virtual ~RGWPutObjDataProcessor(){}
-  virtual int handle_data(bufferlist& bl, off_t ofs) = 0;
+  virtual int handle_data(bufferlist&& bl, off_t ofs) = 0;
 }; /* RGWPutObjDataProcessor */
 
 
@@ -3918,7 +3918,8 @@ protected:
   }
 
   int drain_pending();
-  int handle_obj_data(rgw_raw_obj& obj, bufferlist& bl, off_t ofs, off_t abs_ofs, bool exclusive);
+  int handle_obj_data(rgw_raw_obj& obj, const bufferlist& bl,
+                      off_t ofs, off_t abs_ofs, bool exclusive);
 
 public:
   int prepare(RGWRados *store, string *oid_rand) override;
@@ -3953,7 +3954,7 @@ protected:
   RGWObjManifest manifest;
   RGWObjManifest::generator manifest_gen;
 
-  int write_data(bufferlist& bl, off_t ofs, bool exclusive);
+  int write_data(const bufferlist& bl, off_t ofs, bool exclusive);
   int do_complete(size_t accounted_size, const string& etag,
                   ceph::real_time *mtime, ceph::real_time set_mtime,
                   map<string, bufferlist>& attrs, ceph::real_time delete_at,
@@ -3982,7 +3983,7 @@ public:
                                 unique_tag(_t) {}
   int prepare(RGWRados *store, string *oid_rand) override;
   virtual bool immutable_head() { return false; }
-  int handle_data(bufferlist& bl, off_t ofs) override;
+  int handle_data(bufferlist&& bl, off_t ofs) override;
 
   void set_olh_epoch(uint64_t epoch) {
     olh_epoch = epoch;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3845,7 +3845,7 @@ class RGWPutObjDataProcessor
 public:
   RGWPutObjDataProcessor(){}
   virtual ~RGWPutObjDataProcessor(){}
-  virtual int handle_data(bufferlist& bl, off_t ofs, bool *again) = 0;
+  virtual int handle_data(bufferlist& bl, off_t ofs) = 0;
 }; /* RGWPutObjDataProcessor */
 
 
@@ -3982,7 +3982,7 @@ public:
                                 unique_tag(_t) {}
   int prepare(RGWRados *store, string *oid_rand) override;
   virtual bool immutable_head() { return false; }
-  int handle_data(bufferlist& bl, off_t ofs, bool *again) override;
+  int handle_data(bufferlist& bl, off_t ofs) override;
 
   void set_olh_epoch(uint64_t epoch) {
     olh_epoch = epoch;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3906,6 +3906,8 @@ class RGWPutObjProcessor_Aio : public RGWPutObjProcessor
   int wait_pending_front();
   bool pending_has_completed();
 
+  int throttle_pending(void *handle, const rgw_raw_obj& obj, uint64_t size, bool need_to_wait);
+
 protected:
   uint64_t obj_len{0};
 

--- a/src/test/rgw/test_rgw_compression.cc
+++ b/src/test/rgw/test_rgw_compression.cc
@@ -54,10 +54,9 @@ class ut_put_sink: public RGWPutObjDataProcessor
 public:
   ut_put_sink(){}
   virtual ~ut_put_sink(){}
-  int handle_data(bufferlist& bl, off_t ofs, bool *again) override
+  int handle_data(bufferlist& bl, off_t ofs) override
   {
     sink.append(bl);
-    *again = false;
     return 0;
   }
   bufferlist&  get_sink()
@@ -124,14 +123,11 @@ TEST(Compress, LimitedChunkSize)
     bufferlist bl;
     bl.append(bp);
 
-    bool again = false;
-
     ut_put_sink c_sink;
     RGWPutObj_Compress compressor(g_ceph_context, plugin, &c_sink);
-    compressor.handle_data(bl, 0, &again);
-
+    compressor.handle_data(bl, 0);
     bufferlist empty;
-    compressor.handle_data(empty, s, &again);
+    compressor.handle_data(empty, s);
 
     RGWCompressionInfo cs_info;
     cs_info.compression_type = plugin->get_type_name();
@@ -166,13 +162,11 @@ TEST(Compress, BillionZeros)
   bufferlist bl;
   bl.append(bp);
 
-  bool again = false;
 
   for (int i=0; i<1000;i++)
-    compressor.handle_data(bl, size*i, &again);
-
+    compressor.handle_data(bl, size*i);
   bufferlist empty;
-  compressor.handle_data(empty, size*1000, &again);
+  compressor.handle_data(empty, size*1000);
 
   RGWCompressionInfo cs_info;
   cs_info.compression_type = plugin->get_type_name();

--- a/src/test/rgw/test_rgw_compression.cc
+++ b/src/test/rgw/test_rgw_compression.cc
@@ -60,10 +60,6 @@ public:
     *again = false;
     return 0;
   }
-  int throttle_data(void *handle, const rgw_raw_obj& obj, uint64_t size, bool need_to_wait) override
-  {
-    return 0;
-  }
   bufferlist&  get_sink()
   {
     return sink;

--- a/src/test/rgw/test_rgw_compression.cc
+++ b/src/test/rgw/test_rgw_compression.cc
@@ -54,7 +54,7 @@ class ut_put_sink: public RGWPutObjDataProcessor
 public:
   ut_put_sink(){}
   virtual ~ut_put_sink(){}
-  int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) override
+  int handle_data(bufferlist& bl, off_t ofs, bool *again) override
   {
     sink.append(bl);
     *again = false;
@@ -124,16 +124,14 @@ TEST(Compress, LimitedChunkSize)
     bufferlist bl;
     bl.append(bp);
 
-    void* handle;
-    rgw_raw_obj obj;
     bool again = false;
 
     ut_put_sink c_sink;
     RGWPutObj_Compress compressor(g_ceph_context, plugin, &c_sink);
-    compressor.handle_data(bl, 0, &handle, &obj, &again);
+    compressor.handle_data(bl, 0, &again);
 
     bufferlist empty;
-    compressor.handle_data(empty, s, &handle, &obj, &again);
+    compressor.handle_data(empty, s, &again);
 
     RGWCompressionInfo cs_info;
     cs_info.compression_type = plugin->get_type_name();
@@ -168,15 +166,13 @@ TEST(Compress, BillionZeros)
   bufferlist bl;
   bl.append(bp);
 
-  void* handle;
-  rgw_raw_obj obj;
   bool again = false;
 
   for (int i=0; i<1000;i++)
-    compressor.handle_data(bl, size*i, &handle, &obj, &again);
+    compressor.handle_data(bl, size*i, &again);
 
   bufferlist empty;
-  compressor.handle_data(empty, size*1000, &handle, &obj, &again);
+  compressor.handle_data(empty, size*1000, &again);
 
   RGWCompressionInfo cs_info;
   cs_info.compression_type = plugin->get_type_name();

--- a/src/test/rgw/test_rgw_crypto.cc
+++ b/src/test/rgw/test_rgw_crypto.cc
@@ -56,10 +56,6 @@ public:
     *again = false;
     return 0;
   }
-  int throttle_data(void *handle, const rgw_raw_obj& obj, uint64_t size, bool need_to_wait) override
-  {
-    return 0;
-  }
   std::string get_sink()
   {
     return sink.str();
@@ -566,7 +562,6 @@ TEST(TestRGWCrypto, verify_RGWPutObj_BlockEncrypt_chunks)
       bool again = false;
       rgw_raw_obj ro;
       encrypt.handle_data(bl, 0, &handle, nullptr, &again);
-      encrypt.throttle_data(handle, ro, size, false);
 
       pos = pos + size;
     } while (pos < test_size);
@@ -623,7 +618,6 @@ TEST(TestRGWCrypto, verify_Encrypt_Decrypt)
     bool again = false;
     rgw_raw_obj ro;
     encrypt.handle_data(bl, 0, &handle, nullptr, &again);
-    encrypt.throttle_data(handle, ro, test_size, false);
     bl.clear();
     encrypt.handle_data(bl, 0, &handle, nullptr, &again);
     ASSERT_EQ(put_sink.get_sink().length(), test_size);

--- a/src/test/rgw/test_rgw_crypto.cc
+++ b/src/test/rgw/test_rgw_crypto.cc
@@ -50,7 +50,7 @@ class ut_put_sink: public RGWPutObjDataProcessor
 public:
   ut_put_sink(){}
   virtual ~ut_put_sink(){}
-  int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) override
+  int handle_data(bufferlist& bl, off_t ofs, bool *again) override
   {
     sink << boost::string_ref(bl.c_str(),bl.length());
     *again = false;
@@ -558,17 +558,14 @@ TEST(TestRGWCrypto, verify_RGWPutObj_BlockEncrypt_chunks)
 
       bufferlist bl;
       bl.append(input.c_str()+pos, size);
-      void* handle;
       bool again = false;
-      rgw_raw_obj ro;
-      encrypt.handle_data(bl, 0, &handle, nullptr, &again);
+      encrypt.handle_data(bl, 0, &again);
 
       pos = pos + size;
     } while (pos < test_size);
     bufferlist bl;
-    void* handle;
     bool again = false;
-    encrypt.handle_data(bl, 0, &handle, nullptr, &again);
+    encrypt.handle_data(bl, 0, &again);
 
     ASSERT_EQ(put_sink.get_sink().length(), static_cast<size_t>(test_size));
 
@@ -614,12 +611,10 @@ TEST(TestRGWCrypto, verify_Encrypt_Decrypt)
 				   AES_256_CBC_create(g_ceph_context, &key[0], 32) );
     bufferlist bl;
     bl.append((char*)test_in, test_size);
-    void* handle;
     bool again = false;
-    rgw_raw_obj ro;
-    encrypt.handle_data(bl, 0, &handle, nullptr, &again);
+    encrypt.handle_data(bl, 0, &again);
     bl.clear();
-    encrypt.handle_data(bl, 0, &handle, nullptr, &again);
+    encrypt.handle_data(bl, 0, &again);
     ASSERT_EQ(put_sink.get_sink().length(), test_size);
 
     bl.append(put_sink.get_sink().data(), put_sink.get_sink().length());

--- a/src/test/rgw/test_rgw_crypto.cc
+++ b/src/test/rgw/test_rgw_crypto.cc
@@ -50,10 +50,9 @@ class ut_put_sink: public RGWPutObjDataProcessor
 public:
   ut_put_sink(){}
   virtual ~ut_put_sink(){}
-  int handle_data(bufferlist& bl, off_t ofs, bool *again) override
+  int handle_data(bufferlist& bl, off_t ofs) override
   {
     sink << boost::string_ref(bl.c_str(),bl.length());
-    *again = false;
     return 0;
   }
   std::string get_sink()
@@ -558,14 +557,12 @@ TEST(TestRGWCrypto, verify_RGWPutObj_BlockEncrypt_chunks)
 
       bufferlist bl;
       bl.append(input.c_str()+pos, size);
-      bool again = false;
-      encrypt.handle_data(bl, 0, &again);
+      encrypt.handle_data(bl, 0);
 
       pos = pos + size;
     } while (pos < test_size);
     bufferlist bl;
-    bool again = false;
-    encrypt.handle_data(bl, 0, &again);
+    encrypt.handle_data(bl, 0);
 
     ASSERT_EQ(put_sink.get_sink().length(), static_cast<size_t>(test_size));
 
@@ -611,10 +608,9 @@ TEST(TestRGWCrypto, verify_Encrypt_Decrypt)
 				   AES_256_CBC_create(g_ceph_context, &key[0], 32) );
     bufferlist bl;
     bl.append((char*)test_in, test_size);
-    bool again = false;
-    encrypt.handle_data(bl, 0, &again);
+    encrypt.handle_data(bl, 0);
     bl.clear();
-    encrypt.handle_data(bl, 0, &again);
+    encrypt.handle_data(bl, test_size);
     ASSERT_EQ(put_sink.get_sink().length(), test_size);
 
     bl.append(put_sink.get_sink().data(), put_sink.get_sink().length());

--- a/src/test/rgw/test_rgw_crypto.cc
+++ b/src/test/rgw/test_rgw_crypto.cc
@@ -50,9 +50,10 @@ class ut_put_sink: public RGWPutObjDataProcessor
 public:
   ut_put_sink(){}
   virtual ~ut_put_sink(){}
-  int handle_data(bufferlist& bl, off_t ofs) override
+  int handle_data(bufferlist&& bl, off_t ofs) override
   {
     sink << boost::string_ref(bl.c_str(),bl.length());
+    bl.clear();
     return 0;
   }
   std::string get_sink()
@@ -557,12 +558,11 @@ TEST(TestRGWCrypto, verify_RGWPutObj_BlockEncrypt_chunks)
 
       bufferlist bl;
       bl.append(input.c_str()+pos, size);
-      encrypt.handle_data(bl, 0);
+      encrypt.handle_data(std::move(bl), 0);
 
       pos = pos + size;
     } while (pos < test_size);
-    bufferlist bl;
-    encrypt.handle_data(bl, 0);
+    encrypt.handle_data({}, 0);
 
     ASSERT_EQ(put_sink.get_sink().length(), static_cast<size_t>(test_size));
 
@@ -608,9 +608,8 @@ TEST(TestRGWCrypto, verify_Encrypt_Decrypt)
 				   AES_256_CBC_create(g_ceph_context, &key[0], 32) );
     bufferlist bl;
     bl.append((char*)test_in, test_size);
-    encrypt.handle_data(bl, 0);
-    bl.clear();
-    encrypt.handle_data(bl, test_size);
+    encrypt.handle_data(std::move(bl), 0);
+    encrypt.handle_data({}, test_size);
     ASSERT_EQ(put_sink.get_sink().length(), test_size);
 
     bl.append(put_sink.get_sink().data(), put_sink.get_sink().length());


### PR DESCRIPTION
this inverts the throttling logic so that it happens immediately after submitting rados writes, where we have an accurate value of the write size for throttling. before, the caller was expected to pass this size - but the caller's view is obstructed by filters (ie compression) and buffering

Fixes: http://tracker.ceph.com/issues/24594