### PR TITLE
luminous: client: drop null child dentries before try pruning inode's alias

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -539,6 +539,7 @@ protected:
   void trim_dentry(Dentry *dn);
   void trim_caps(MetaSession *s, uint64_t max);
   void _invalidate_kernel_dcache();
+  void _trim_negative_child_dentries(InodeRef& in);
   
   void dump_inode(Formatter *f, Inode *in, set<Inode*>& did, bool disconnected);
   void dump_cache(Formatter *f);  // debug

--- a/src/client/Dir.h
+++ b/src/client/Dir.h
@@ -7,6 +7,8 @@ class Dir {
  public:
   Inode    *parent_inode;  // my inode
   ceph::unordered_map<string, Dentry*> dentries;
+  unsigned num_null_dentries = 0;
+
   vector<Dentry*> readdir_cache;
 
   explicit Dir(Inode* in) { parent_inode = in; }


### PR DESCRIPTION
http://tracker.ceph.com/issues/22504