### PR TITLE
rgw: fix set removed zone master will affect original zonegroup

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1365,7 +1365,7 @@ int RGWPeriod::create(bool exclusive)
   new_uuid.print(uuid_str);
   id = uuid_str;
 
-  epoch = FIRST_EPOCH;
+  epoch += 1;
 
   period_map.id = id;
   

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -173,6 +173,14 @@ void RGWOp_Period_Post::execute()
       http_ret = -ENOENT; // XXX: error code
       return;
     }
+    if (period.get_epoch() <= current_period.get_epoch()) {
+      ldout(cct, 10) << "discarding period " << period.get_id()
+          << " with period epoch " << period.get_period_epoch()
+          << " not inherit from current period epoch " << current_period.get_epoch() << dendl;
+      // return success to ack that we have this period
+      return;
+    }
+
     // attach a copy of the period into the period history
     auto cursor = store->period_history->attach(RGWPeriod{period});
     if (!cursor) {


### PR DESCRIPTION
make period epoch always go forward in spite of switch master

Fixes: http://tracker.ceph.com/issues/36027

Signed-off-by: Tianshan Qu <tianshan@xsky.com>