### PR TITLE
arch/arm: Allow ceph_crc32c_aarch64 to be chosen only if it is compil…

### DIFF
--- a/src/common/crc32c.cc
+++ b/src/common/crc32c.cc
@@ -27,9 +27,11 @@ ceph_crc32c_func_t ceph_choose_crc32(void)
     return ceph_crc32c_intel_fast;
   }
 #elif defined(__arm__) || defined(__aarch64__)
+# if defined(HAVE_ARMV8_CRC)
   if (ceph_arch_aarch64_crc32){
     return ceph_crc32c_aarch64;
   }
+# endif
 #elif defined(__powerpc__) || defined(__ppc__)
   if (ceph_arch_ppc_crc32) {
     return ceph_crc32c_ppc;


### PR DESCRIPTION
…ed in

If the build host does not support the crc32cx instruction, HAVE_ARMV8_CRC will not be set and ceph_crc32c_aarch64 will be a dummy function that always returns zero. However, if HWCAP_CRC32 is supported on the actual target machine, that dummy function will be selected anyway. This patch ensures ceph_crc32c_aarch64 will never be chosen if it is not compiled in.

Fixes: https://tracker.ceph.com/issues/36030
Signed-off-by: David Wang <planetbeing@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

