### PR TITLE
mgr/dashboard: User password should be optional

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -363,7 +363,7 @@ We provide a set of CLI commands to manage user accounts:
 
 - *Create User*::
 
-  $ ceph dashboard ac-user-create <username> <password> [<rolename>] [<name>] [<email>]
+  $ ceph dashboard ac-user-create <username> [<password>] [<rolename>] [<name>] [<email>]
 
 - *Delete User*::
 

--- a/qa/tasks/mgr/dashboard/test_auth.py
+++ b/qa/tasks/mgr/dashboard/test_auth.py
@@ -76,6 +76,17 @@ class AuthTest(DashboardTestCase):
             "detail": "Invalid credentials"
         })
 
+    def test_login_without_password(self):
+        self.create_user('admin2', '', ['administrator'])
+        self._post("/api/auth", {'username': 'admin2', 'password': ''})
+        self.assertStatus(400)
+        self.assertJsonBody({
+            "component": "auth",
+            "code": "invalid_credentials",
+            "detail": "Invalid credentials"
+        })
+        self.delete_user('admin2')
+
     def test_logout(self):
         self._post("/api/auth", {'username': 'admin', 'password': 'admin'})
         self._delete("/api/auth")

--- a/qa/tasks/mgr/dashboard/test_user.py
+++ b/qa/tasks/mgr/dashboard/test_user.py
@@ -75,15 +75,6 @@ class UserTest(DashboardTestCase):
         self.assertError(code='username_already_exists',
                          component='user')
 
-    def test_create_user_no_password(self):
-        self._create_user(username='user1',
-                          name='My Name',
-                          email='admin@email.com',
-                          roles=['administrator'])
-        self.assertStatus(400)
-        self.assertError(code='password_required',
-                         component='user')
-
     def test_create_user_invalid_role(self):
         self._create_user(username='user1',
                           password='mypassword',

--- a/src/pybind/mgr/dashboard/controllers/user.py
+++ b/src/pybind/mgr/dashboard/controllers/user.py
@@ -47,10 +47,6 @@ class User(RESTController):
             raise DashboardException(msg='Username is required',
                                      code='username_required',
                                      component='user')
-        if not password:
-            raise DashboardException(msg='Password is required',
-                                     code='password_required',
-                                     component='user')
         user_roles = None
         if roles:
             user_roles = User._get_user_roles(roles)

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.html
@@ -43,8 +43,6 @@
           <label i18n
                  class="control-label col-sm-3"
                  for="name">Password
-            <span class="required"
-                  *ngIf="mode !== userFormMode.editing"></span>
           </label>
           <div class="col-sm-9">
             <div class="input-group">
@@ -75,8 +73,6 @@
           <label i18n
                  class="control-label col-sm-3"
                  for="name">Confirm password
-            <span class="required"
-                  *ngIf="mode !== userFormMode.editing"></span>
           </label>
           <div class="col-sm-9">
             <div class="input-group">

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.spec.ts
@@ -88,12 +88,8 @@ describe('UserFormComponent', () => {
     it('should validate username required', () => {
       form.get('username').setValue('');
       expect(form.get('username').hasError('required')).toBeTruthy();
-    });
-
-    it('should validate password required', () => {
-      ['password', 'confirmpassword'].forEach((key) =>
-        expect(form.get(key).hasError('required')).toBeTruthy()
-      );
+      form.get('username').setValue('user1');
+      expect(form.get('username').hasError('required')).toBeFalsy();
     });
 
     it('should validate password match', () => {
@@ -107,6 +103,13 @@ describe('UserFormComponent', () => {
     it('should validate email', () => {
       form.get('email').setValue('aaa');
       expect(form.get('email').hasError('email')).toBeTruthy();
+    });
+
+    it('should validate all required fields', () => {
+      form.get('username').setValue('');
+      expect(form.valid).toBeFalsy();
+      form.get('username').setValue('user1');
+      expect(form.valid).toBeTruthy();
     });
 
     it('should set mode', () => {
@@ -194,13 +197,6 @@ describe('UserFormComponent', () => {
 
     it('should set mode', () => {
       expect(component.mode).toBe('editing');
-    });
-
-    it('should validate password not required', () => {
-      ['password', 'confirmpassword'].forEach((key) => {
-        form.get(key).setValue('');
-        expect(form.get(key).hasError('required')).toBeFalsy();
-      });
     });
 
     it('should alert if user is removing needed role permission', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/core/auth/user-form/user-form.component.ts
@@ -83,21 +83,10 @@ export class UserFormComponent implements OnInit {
     });
     if (this.mode === this.userFormMode.editing) {
       this.initEdit();
-    } else {
-      this.initAdd();
     }
   }
 
-  initAdd() {
-    ['password', 'confirmpassword'].forEach((controlName) =>
-      this.userForm.get(controlName).setValidators([Validators.required])
-    );
-  }
-
   initEdit() {
-    ['password', 'confirmpassword'].forEach((controlName) =>
-      this.userForm.get(controlName).setValidators([])
-    );
     this.disableForEdit();
     this.route.params.subscribe((params: { username: string }) => {
       const username = params.username;


### PR DESCRIPTION
With this PR, user password will be optional which is a requirement to introduce SSO support.

If no password is defined for a user, local authentication will fail.

Fixes: https://tracker.ceph.com/issues/36031

Signed-off-by: Ricardo Marques <rimarques@suse.com>