### PR TITLE
luminous: build/ops: rpm: selinux-policy fixes

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -44,7 +44,7 @@
 
 %if %{with selinux}
 # get selinux policy version
-%{!?_selinux_policy_version: %global _selinux_policy_version %(sed -e 's,.*selinux-policy-\\([^/]*\\)/.*,\\1,' /usr/share/selinux/devel/policyhelp 2>/dev/null || echo 0.0.0)}
+%{!?_selinux_policy_version: %global _selinux_policy_version 0.0.0}
 %endif
 
 %{!?_udevrulesdir: %global _udevrulesdir /lib/udev/rules.d}
@@ -100,7 +100,6 @@ BuildRequires:	sharutils
 %if 0%{with selinux}
 BuildRequires:	checkpolicy
 BuildRequires:	selinux-policy-devel
-BuildRequires:	/usr/share/selinux/devel/policyhelp
 %endif
 %if 0%{with make_check}
 %if 0%{?fedora} || 0%{?rhel}


### PR DESCRIPTION
This patch has been in master for ages, but without it I cannot do
run-make-check.sh on my Fedora 27 box. This displeases me. ;)

Requiring the file /usr/share/selinux/devel/policyhelp breaks fc27 and
Rawhide builds as they do not have that file. This exposed the fact this
code had not worked in some time due to changes in selinux policy
modules packaging. See
https://bugzilla.redhat.com/show_bug.cgi?id=999584

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>
(cherry picked from commit ee4f172f983aaaa7f2c1b674084e0f12591bc0ea)