### PR TITLE
osd/OSD: fix pg merge vs split race

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -399,7 +399,6 @@ void OSDService::identify_splits_and_merges(
 		       << " pg_num " << pgnum << " -> " << q->second
 		       << " is merge source, target " << parent
 		       << ", source(s) " << children << dendl;
-	      merge_pgs->insert(make_pair(cur, q->first));
 	      merge_pgs->insert(make_pair(parent, q->first));
 	      for (auto c : children) {
 		merge_pgs->insert(make_pair(c, q->first));
@@ -10108,11 +10107,11 @@ void OSDShard::prime_merges(const OSDMapRef& as_of_osdmap,
     slot = r.first->second.get();
     if (slot->pg) {
       // already have pg
-      dout(20) << __func__ << "  have merge target pg " << pgid
+      dout(20) << __func__ << "  have merge participant pg " << pgid
 	       << " " << slot->pg << dendl;
     } else if (!slot->waiting_for_split.empty() &&
 	       *slot->waiting_for_split.begin() < epoch) {
-      dout(20) << __func__ << "  pending split on merge target pg " << pgid
+      dout(20) << __func__ << "  pending split on merge participant pg " << pgid
 	       << " " << slot->waiting_for_split << dendl;
     } else {
       dout(20) << __func__ << "  creating empty merge participant " << pgid

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1895,7 +1895,7 @@ protected:
 
   PGRef _lookup_pg(spg_t pgid);
   PGRef _lookup_lock_pg(spg_t pgid);
-  void register_pg(PGRef pg);
+  void maybe_register_pg(PGRef pg);
   bool try_finish_pg_delete(PG *pg, unsigned old_pg_num);
 
   void _get_pgs(vector<PGRef> *v, bool clear_too=false);


### PR DESCRIPTION
http://pulpito.ceph.com/xxg-2018-09-15_05:36:56-rados-wip-pph-distro-basic-smithi/3026332/
revealed a bug that the pg merge process could race with pg split:
```
2018-09-15 08:07:50.439 7f448da3e700 20 osd.5 284 identify_splits_and_merges 1.5 e253 pg_num 14 -> 13 is merge target, source 1.d
2018-09-15 08:07:50.439 7f448da3e700 20 osd.5 284 identify_splits_and_merges 1.5 e263 pg_num 12 -> 18 children 1.d
2018-09-15 08:07:50.439 7f448da3e700 20 osd.5 284 identify_splits_and_merges 1.5 e269 pg_num 18 -> 28 children 1.15
2018-09-15 08:07:50.439 7f448da3e700 20 osd.5 284 identify_splits_and_merges 1.d e253 pg_num 14 -> 13 is merge source, target 1.5
, source(s) 1.d
2018-09-15 08:07:50.439 7f448da3e700 20 osd.5 284 identify_splits_and_merges 1.d e257 pg_num 13 -> 12 is beyond old pgnum, skippi
ng
2018-09-15 08:07:50.439 7f448da3e700 20 osd.5 284 identify_splits_and_merges 1.d e263 pg_num 12 -> 18 is a child
2018-09-15 08:07:50.443 7f4481a26700 20 osd.5 284 advance_pg 1.5 is merge target, sources are 1.d
2018-09-15 08:07:50.443 7f4481a26700 20 osd.5 284 advance_pg kicking source 1.d
2018-09-15 08:07:50.443 7f447da1e700 10 osd.5 284 add_merge_waiter added merge_waiter 1.d for 1.5, have 1/1
2018-09-15 08:07:50.443 7f4481a26700  1 osd.5 284 advance_pg merging 1.5
2018-09-15 08:07:50.443 7f4481a26700 10 osd.5 284 split_pgs splitting pg[1.5( empty lb MIN (NIBBLEWISE) local-lis/les=167
        /168 n=0 ec=14/14 lis/c 167/167 les/c/f 168/168/0 206/263/114) [3,4] r=-1 lpr=263 pi=[167,263)/1 crt=0'0 unknown NOTIFY m
        bc={}] into 1.d
```
E.g., in the above case, pg 1.d should merge into 1.5 at epoch
253 and then re-split from 1.5 at epoch 263. However, pg 1.d
was detached from the shard's pg_slots first when the merge was
done, and then later hit an assert in the callback triggered by
the split process, which always assume the corresponding pg
should already be primed into the correct pg_slot by the
__prime_split__ process:
```
2018-09-15T08:07:50.444 INFO:tasks.ceph.osd.5.smithi066.stderr:/build/ceph-14.0.0-3264-gcde5206/src/osd/OSD.cc: In function 'void OSDShard::register_and_wake_split_child(PG*)' thread 7f448da3e700 time 2018-09-15 08:07:50.450627
2018-09-15T08:07:50.444 INFO:tasks.ceph.osd.5.smithi066.stderr:/build/ceph-14.0.0-3264-gcde5206/src/osd/OSD.cc: 10029: FAILED ceph_assert(p != pg_slots.end())
```

Fix the above problem by re-registering the pg (into the pg_slots)
if necessay.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

