### PR TITLE
crimson: port perfcounters to seastar

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -77,6 +77,7 @@ set(common_srcs
   options.cc
   page.cc
   perf_counters.cc
+  perf_counters_collection.cc
   perf_histogram.cc
   pick_address.cc
   reverse.c

--- a/src/common/Mutex.cc
+++ b/src/common/Mutex.cc
@@ -13,7 +13,6 @@
  */
 
 #include "common/Mutex.h"
-#include "common/perf_counters.h"
 #include "common/config.h"
 #include "common/Clock.h"
 #include "common/valgrind.h"

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -16,7 +16,7 @@
 #include "common/ThrottleInterface.h"
 #include "common/Timer.h"
 #include "common/convenience.h"
-#include "common/perf_counters.h"
+#include "common/perf_counters_collection.h"
 
 /**
  * @class Throttle

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -48,6 +48,7 @@ using ceph::HeartbeatMap;
 #ifdef WITH_SEASTAR
 CephContext::CephContext()
   : _conf{ceph::common::local_conf()},
+    _perf_counters_collection{ceph::common::local_perf_coll()},
     _crypto_random{std::make_unique<CryptoRandom>()}
 {}
 
@@ -73,9 +74,9 @@ void CephContext::put()
   }
 }
 
-PerfCountersCollection* CephContext::get_perfcounters_collection()
+PerfCountersCollectionImpl* CephContext::get_perfcounters_collection()
 {
-  throw std::runtime_error("not yet implemented");
+  return _perf_counters_collection.get_perf_collection();
 }
 
 #else  // WITH_SEASTAR

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -13,6 +13,8 @@
  *
  */
 
+#include "common/ceph_context.h"
+
 #include <mutex>
 #include <iostream>
 
@@ -22,7 +24,6 @@
 
 #include "include/mempool.h"
 #include "common/admin_socket.h"
-#include "common/perf_counters.h"
 #include "common/code_environment.h"
 #include "common/Cond.h"
 #include "common/config.h"

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -31,11 +31,12 @@
 #include "common/code_environment.h"
 #ifdef WITH_SEASTAR
 #include "crimson/common/config_proxy.h"
+#include "crimson/common/perf_counters_collection.h"
 #else
 #include "common/config_proxy.h"
 #include "include/spinlock.h"
-#endif
 #include "common/perf_counters_collection.h"
+#endif
 
 
 #include "crush/CrushLocation.h"
@@ -67,8 +68,9 @@ public:
   ~CephContext();
 
   CryptoRandom* random() const;
-  PerfCountersCollection* get_perfcounters_collection();
+  PerfCountersCollectionImpl* get_perfcounters_collection();
   ceph::common::ConfigProxy& _conf;
+  ceph::common::PerfCountersCollection& _perf_counters_collection;
   CephContext* get();
   void put();
 private:

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -35,14 +35,13 @@
 #include "common/config_proxy.h"
 #include "include/spinlock.h"
 #endif
+#include "common/perf_counters_collection.h"
 
 
 #include "crush/CrushLocation.h"
 
 class AdminSocket;
 class CephContextServiceThread;
-class PerfCountersCollection;
-class PerfCounters;
 class CephContextHook;
 class CephContextObs;
 class CryptoHandler;
@@ -70,7 +69,6 @@ public:
   CryptoRandom* random() const;
   PerfCountersCollection* get_perfcounters_collection();
   ceph::common::ConfigProxy& _conf;
-
   CephContext* get();
   void put();
 private:

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -19,21 +19,17 @@
 
 using std::ostringstream;
 
-PerfCountersCollection::PerfCountersCollection(CephContext *cct)
-  : m_cct(cct),
-    m_lock("PerfCountersCollection")
+PerfCountersCollectionImpl::PerfCountersCollectionImpl()
 {
 }
 
-PerfCountersCollection::~PerfCountersCollection()
+PerfCountersCollectionImpl::~PerfCountersCollectionImpl()
 {
   clear();
 }
 
-void PerfCountersCollection::add(class PerfCounters *l)
+void PerfCountersCollectionImpl::add(PerfCounters *l)
 {
-  std::lock_guard<Mutex> lck(m_lock);
-
   // make sure the name is unique
   perf_counters_set_t::iterator i;
   i = m_loggers.find(l);
@@ -57,10 +53,8 @@ void PerfCountersCollection::add(class PerfCounters *l)
   }
 }
 
-void PerfCountersCollection::remove(class PerfCounters *l)
+void PerfCountersCollectionImpl::remove(PerfCounters *l)
 {
-  std::lock_guard<Mutex> lck(m_lock);
-
   for (unsigned int i = 0; i < l->m_data.size(); ++i) {
     PerfCounters::perf_counter_data_any_d &data = l->m_data[i];
 
@@ -76,22 +70,21 @@ void PerfCountersCollection::remove(class PerfCounters *l)
   m_loggers.erase(i);
 }
 
-void PerfCountersCollection::clear()
+void PerfCountersCollectionImpl::clear()
 {
-  std::lock_guard<Mutex> lck(m_lock);
   perf_counters_set_t::iterator i = m_loggers.begin();
   perf_counters_set_t::iterator i_end = m_loggers.end();
   for (; i != i_end; ) {
+    delete *i;
     m_loggers.erase(i++);
   }
 
   by_path.clear();
 }
 
-bool PerfCountersCollection::reset(const std::string &name)
+bool PerfCountersCollectionImpl::reset(const std::string &name)
 {
   bool result = false;
-  std::lock_guard<Mutex> lck(m_lock);
   perf_counters_set_t::iterator i = m_loggers.begin();
   perf_counters_set_t::iterator i_end = m_loggers.end();
 
@@ -128,14 +121,13 @@ bool PerfCountersCollection::reset(const std::string &name)
  * @param histograms if true, dump histogram values,
  *                   if false dump all non-histogram counters
  */
-void PerfCountersCollection::dump_formatted_generic(
+void PerfCountersCollectionImpl::dump_formatted_generic(
     Formatter *f,
     bool schema,
     bool histograms,
     const std::string &logger,
     const std::string &counter)
 {
-  std::lock_guard<Mutex> lck(m_lock);
   f->open_object_section("perfcounter_collection");
   
   for (perf_counters_set_t::iterator l = m_loggers.begin();
@@ -148,11 +140,9 @@ void PerfCountersCollection::dump_formatted_generic(
   f->close_section();
 }
 
-void PerfCountersCollection::with_counters(std::function<void(
-      const PerfCountersCollection::CounterMap &)> fn) const
+void PerfCountersCollectionImpl::with_counters(std::function<void(
+      const PerfCountersCollectionImpl::CounterMap &)> fn) const
 {
-  std::lock_guard<Mutex> lck(m_lock);
-
   fn(by_path);
 }
 
@@ -164,8 +154,10 @@ PerfCounters::~PerfCounters()
 
 void PerfCounters::inc(int idx, uint64_t amt)
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return;
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -183,8 +175,10 @@ void PerfCounters::inc(int idx, uint64_t amt)
 
 void PerfCounters::dec(int idx, uint64_t amt)
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return;
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -197,8 +191,10 @@ void PerfCounters::dec(int idx, uint64_t amt)
 
 void PerfCounters::set(int idx, uint64_t amt)
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return;
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -219,8 +215,10 @@ void PerfCounters::set(int idx, uint64_t amt)
 
 uint64_t PerfCounters::get(int idx) const
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return 0;
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -232,8 +230,10 @@ uint64_t PerfCounters::get(int idx) const
 
 void PerfCounters::tinc(int idx, utime_t amt)
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return;
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -251,8 +251,10 @@ void PerfCounters::tinc(int idx, utime_t amt)
 
 void PerfCounters::tinc(int idx, ceph::timespan amt)
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return;
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -270,8 +272,10 @@ void PerfCounters::tinc(int idx, ceph::timespan amt)
 
 void PerfCounters::tset(int idx, utime_t amt)
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return;
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -285,8 +289,10 @@ void PerfCounters::tset(int idx, utime_t amt)
 
 utime_t PerfCounters::tget(int idx) const
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return utime_t();
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -299,8 +305,10 @@ utime_t PerfCounters::tget(int idx) const
 
 void PerfCounters::hinc(int idx, int64_t x, int64_t y)
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return;
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -314,8 +322,10 @@ void PerfCounters::hinc(int idx, int64_t x, int64_t y)
 
 pair<uint64_t, uint64_t> PerfCounters::get_tavg_ns(int idx) const
 {
+#ifndef WITH_SEASTAR
   if (!m_cct->_conf->perf)
     return make_pair(0, 0);
+#endif
 
   ceph_assert(idx > m_lower_bound);
   ceph_assert(idx < m_upper_bound);
@@ -463,9 +473,13 @@ PerfCounters::PerfCounters(CephContext *cct, const std::string &name,
   : m_cct(cct),
     m_lower_bound(lower_bound),
     m_upper_bound(upper_bound),
+#ifndef WITH_SEASTAR
     m_name(name.c_str()),
     m_lock_name(std::string("PerfCounters::") + name.c_str()),
-    m_lock(m_lock_name.c_str())
+    m_lock(ceph::make_mutex(m_lock_name))
+#else
+    m_name(name.c_str())
+#endif
 {
   m_data.resize(upper_bound - lower_bound - 1);
 }

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -25,12 +25,12 @@
 
 #include "common/perf_histogram.h"
 #include "include/utime.h"
-#include "common/Mutex.h"
-#include "common/ceph_context.h"
+#include "common/ceph_mutex.h"
 #include "common/ceph_time.h"
 
 class CephContext;
 class PerfCountersBuilder;
+class PerfCounters;
 
 enum perfcounter_type_d : uint8_t
 {
@@ -282,17 +282,21 @@ private:
   int m_lower_bound;
   int m_upper_bound;
   std::string m_name;
+#ifndef WITH_SEASTAR
   const std::string m_lock_name;
+#endif
 
   int prio_adjust = 0;
 
+#ifndef WITH_SEASTAR
   /** Protects m_data */
-  mutable Mutex m_lock;
+  ceph::mutex m_lock;
+#endif
 
   perf_counter_data_vec_t m_data;
 
   friend class PerfCountersBuilder;
-  friend class PerfCountersCollection;
+  friend class PerfCountersCollectionImpl;
 };
 
 class SortPerfCountersByName {
@@ -305,15 +309,15 @@ public:
 typedef std::set <PerfCounters*, SortPerfCountersByName> perf_counters_set_t;
 
 /*
- * PerfCountersCollection manages PerfCounters objects for a Ceph process.
+ * PerfCountersCollectionImp manages PerfCounters objects for a Ceph process.
  */
-class PerfCountersCollection
+class PerfCountersCollectionImpl
 {
 public:
-  PerfCountersCollection(CephContext *cct);
-  ~PerfCountersCollection();
-  void add(class PerfCounters *l);
-  void remove(class PerfCounters *l);
+  PerfCountersCollectionImpl();
+  ~PerfCountersCollectionImpl();
+  void add(PerfCounters *l);
+  void remove(PerfCounters *l);
   void clear();
   bool reset(const std::string &name);
 
@@ -348,16 +352,9 @@ private:
                               const std::string &logger = "",
                               const std::string &counter = "");
 
-  CephContext *m_cct;
-
-  /** Protects m_loggers */
-  mutable Mutex m_lock;
-
   perf_counters_set_t m_loggers;
 
   CounterMap by_path; 
-
-  friend class PerfCountersCollectionTest;
 };
 
 
@@ -379,20 +376,5 @@ public:
   }
 };
 
-
-class PerfCountersDeleter {
-  CephContext* cct;
-
-public:
-  PerfCountersDeleter() noexcept : cct(nullptr) {}
-  PerfCountersDeleter(CephContext* cct) noexcept : cct(cct) {}
-  void operator()(PerfCounters* p) noexcept {
-    if (cct)
-      cct->get_perfcounters_collection()->remove(p);
-    delete p;
-  }
-};
-
-using PerfCountersRef = std::unique_ptr<PerfCounters, PerfCountersDeleter>;
 
 #endif

--- a/src/common/perf_counters_collection.cc
+++ b/src/common/perf_counters_collection.cc
@@ -1,0 +1,60 @@
+#include "common/perf_counters_collection.h"
+#include "common/ceph_mutex.h"
+#include "common/ceph_context.h"
+
+/* PerfcounterCollection hold the lock for PerfCounterCollectionImp */
+PerfCountersCollection::PerfCountersCollection(CephContext *cct)
+  : m_cct(cct),
+    m_lock(ceph::make_mutex("PerfCountersCollection"))
+{
+}
+PerfCountersCollection::~PerfCountersCollection()
+{
+  clear();
+}
+void PerfCountersCollection::add(PerfCounters *l)
+{
+  std::lock_guard lck(m_lock);
+  perf_impl.add(l);
+}
+void PerfCountersCollection::remove(PerfCounters *l)
+{
+  std::lock_guard lck(m_lock);
+  perf_impl.remove(l);
+}
+void PerfCountersCollection::clear()
+{
+  std::lock_guard lck(m_lock);
+  perf_impl.clear();
+}
+bool PerfCountersCollection::reset(const std::string &name)
+{
+  std::lock_guard lck(m_lock);
+  return perf_impl.reset(name);
+}
+void PerfCountersCollection::dump_formatted(ceph::Formatter *f, bool schema,
+                      const std::string &logger,
+                      const std::string &counter)
+{
+  std::lock_guard lck(m_lock);
+  perf_impl.dump_formatted(f,schema,logger,counter);
+}
+void PerfCountersCollection::dump_formatted_histograms(ceph::Formatter *f, bool schema,
+                                 const std::string &logger,
+                                 const std::string &counter)
+{
+  std::lock_guard lck(m_lock);
+  perf_impl.dump_formatted_histograms(f,schema,logger,counter);
+}
+void PerfCountersCollection::with_counters(std::function<void(const PerfCountersCollectionImpl::CounterMap &)> fn) const
+{
+  std::lock_guard lck(m_lock);
+  perf_impl.with_counters(fn);
+}
+void PerfCountersDeleter::operator()(PerfCounters* p) noexcept
+{
+  if (cct)
+    cct->get_perfcounters_collection()->remove(p);
+  delete p;
+}
+

--- a/src/common/perf_counters_collection.h
+++ b/src/common/perf_counters_collection.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "common/perf_counters.h"
+#include "common/ceph_mutex.h"
+
+class CephContext;
+
+class PerfCountersCollection
+{
+  CephContext *m_cct;
+
+  /** Protects perf_impl->m_loggers */
+  mutable ceph::mutex m_lock;
+  PerfCountersCollectionImpl perf_impl;
+public:
+  PerfCountersCollection(CephContext *cct);
+  ~PerfCountersCollection();
+  void add(PerfCounters *l);
+  void remove(PerfCounters *l);
+  void clear();
+  bool reset(const std::string &name);
+
+  void dump_formatted(ceph::Formatter *f, bool schema,
+                      const std::string &logger = "",
+                      const std::string &counter = "");
+  void dump_formatted_histograms(ceph::Formatter *f, bool schema,
+                                 const std::string &logger = "",
+                                 const std::string &counter = "");
+
+  void with_counters(std::function<void(const PerfCountersCollectionImpl::CounterMap &)>) const;
+
+  friend class PerfCountersCollectionTest;
+};
+
+class PerfCountersDeleter {
+  CephContext* cct;
+
+public:
+  PerfCountersDeleter() noexcept : cct(nullptr) {}
+  PerfCountersDeleter(CephContext* cct) noexcept : cct(cct) {}
+  void operator()(PerfCounters* p) noexcept;
+};
+
+using PerfCountersRef = std::unique_ptr<PerfCounters, PerfCountersDeleter>;
+
+

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -5,6 +5,7 @@ set_target_properties(crimson::cflags PROPERTIES
 
 set(crimson_common_srcs
   common/config_proxy.cc
+  common/perf_counters_collection.cc
   common/assert.cc
   common/log.cc)
 

--- a/src/crimson/common/perf_counters_collection.cc
+++ b/src/crimson/common/perf_counters_collection.cc
@@ -1,0 +1,22 @@
+#include "perf_counters_collection.h"
+
+namespace ceph::common {
+PerfCountersCollection::PerfCountersCollection()
+{
+  perf_collection = std::make_unique<PerfCountersCollectionImpl>();
+}
+PerfCountersCollection::~PerfCountersCollection()
+{
+  perf_collection->clear();
+}
+
+PerfCountersCollectionImpl* PerfCountersCollection:: get_perf_collection()
+{
+  return perf_collection.get();
+}
+
+PerfCountersCollection::ShardedPerfCountersCollection PerfCountersCollection::sharded_perf_coll;
+
+}
+
+

--- a/src/crimson/common/perf_counters_collection.h
+++ b/src/crimson/common/perf_counters_collection.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "common/perf_counters.h"
+#include <seastar/core/sharded.hh>
+
+namespace ceph::common {
+class PerfCountersCollection: public seastar::sharded<PerfCountersCollection>
+{
+  using ShardedPerfCountersCollection = seastar::sharded<PerfCountersCollection>;
+
+private:
+  std::unique_ptr<PerfCountersCollectionImpl> perf_collection;
+  static ShardedPerfCountersCollection sharded_perf_coll;
+  friend PerfCountersCollection& local_perf_coll();
+  friend ShardedPerfCountersCollection& sharded_perf_coll();
+
+public:
+  PerfCountersCollection();
+  ~PerfCountersCollection();
+  PerfCountersCollectionImpl* get_perf_collection();
+
+};
+
+inline PerfCountersCollection::ShardedPerfCountersCollection& sharded_perf_coll(){
+  return PerfCountersCollection::sharded_perf_coll;
+}
+
+inline PerfCountersCollection& local_perf_coll() {
+  return PerfCountersCollection::sharded_perf_coll.local();
+}
+
+}
+

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -257,7 +257,7 @@ void MgrClient::_send_report()
   auto pcc = cct->get_perfcounters_collection();
 
   pcc->with_counters([this, report](
-        const PerfCountersCollection::CounterMap &by_path)
+        const PerfCountersCollectionImpl::CounterMap &by_path)
   {
     // Helper for checking whether a counter should be included
     auto include_counter = [this](

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -28,3 +28,9 @@ target_link_libraries(unittest_seastar_config crimson)
 add_executable(unittest_seastar_monc
   test_monc.cc)
 target_link_libraries(unittest_seastar_monc crimson)
+
+add_executable(unittest_seastar_perfcounters
+  test_perfcounters.cc)
+add_ceph_unittest(unittest_seastar_perfcounters)
+target_link_libraries(unittest_seastar_perfcounters crimson)
+

--- a/src/test/crimson/test_perfcounters.cc
+++ b/src/test/crimson/test_perfcounters.cc
@@ -1,0 +1,62 @@
+#include <pthread.h>
+#include <stdlib.h>
+#include <iostream>
+#include <fmt/format.h>
+
+#include "common/Formatter.h"
+#include "common/perf_counters.h"
+#include "crimson/common/perf_counters_collection.h"
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/sharded.hh>
+
+enum {
+  PERFTEST_FIRST = 1000000,
+  PERFTEST_INDEX,
+  PERFTEST_LAST,
+};
+
+static constexpr uint64_t PERF_VAL = 42;
+
+static seastar::future<> test_perfcounters(){
+  return ceph::common::sharded_perf_coll().start().then([] {
+    return ceph::common::sharded_perf_coll().invoke_on_all([] (auto& s){
+      std::string name =fmt::format("seastar-osd::shard-{}",seastar::engine().cpu_id());
+      PerfCountersBuilder plb(NULL, name, PERFTEST_FIRST,PERFTEST_LAST);
+      plb.add_u64_counter(PERFTEST_INDEX, "perftest_count", "count perftest");
+      auto perf_logger = plb.create_perf_counters();
+      perf_logger->inc(PERFTEST_INDEX,PERF_VAL);
+      s.get_perf_collection()->add(perf_logger);
+    });
+  }).then([]{
+    return ceph::common::sharded_perf_coll().invoke_on_all([] (auto& s){
+      auto pcc = s.get_perf_collection();
+      pcc->with_counters([=](auto& by_path){
+        for (const auto &[path, perf_counter_ref] : by_path) {
+          if (PERF_VAL != perf_counter_ref.perf_counters->get(PERFTEST_INDEX)) {
+            throw std::runtime_error("perf counter does not match");
+          }
+        }
+      });
+    });
+  }).finally([] {
+     return ceph::common::sharded_perf_coll().stop();
+  });
+
+}
+
+int main(int argc, char** argv)
+{
+  seastar::app_template app;
+  return app.run(argc, argv, [&] {
+    return test_perfcounters().then([] {
+      std::cout << "All tests succeeded" << std::endl;
+    }).handle_exception([] (auto eptr) {
+      std::cout << "Test failure" << std::endl;
+      return seastar::make_exception_future<>(eptr);
+    });
+  });
+
+}
+
+

--- a/src/test/perf_counters.cc
+++ b/src/test/perf_counters.cc
@@ -16,7 +16,7 @@
                            // now, this include has to come before the others.
 
 
-#include "common/perf_counters.h"
+#include "common/perf_counters_collection.h"
 #include "common/admin_socket_client.h"
 #include "common/ceph_context.h"
 #include "common/config.h"


### PR DESCRIPTION
[crimson]:seastar-osd perfcounters support move m_lock out
 from perfcounters.cc to upper,then seastar osd can reuse
 perfcounters.cc create shard service for perfcounters, each seastar thread
 has its own perfcounterscollection and perfcunters m_loggers.

Signed-off-by: chunmei Liu <chunmei.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

