### PR TITLE
qa/workunits/cephtool/test_kvstore_tool.sh: run test in ., not /tmp

### DIFF
--- a/qa/workunits/cephtool/test_kvstore_tool.sh
+++ b/qa/workunits/cephtool/test_kvstore_tool.sh
@@ -18,8 +18,7 @@ expect_false()
     if "$@"; then return 1; else return 0; fi
 }
 
-TMPDIR=${TMPDIR:-${TESTDIR}}
-TEMP_DIR=$(mktemp -d ${TMPDIR:-/tmp}/cephtool.XXX)
+TEMP_DIR=$(mktemp -d ./cephtool.XXX)
 trap "rm -fr $TEMP_DIR" 0
 
 TEMP_FILE=$(mktemp $TEMP_DIR/test_invalid.XXX)


### PR DESCRIPTION
Notably, we can't make a bluestore store on a tmpfs.

Signed-off-by: Sage Weil <sage@redhat.com>