### PR TITLE
mgr/orchestrator: Fix Python 3 issues

### DIFF
--- a/src/pybind/mgr/orchestrator_cli/__init__.py
+++ b/src/pybind/mgr/orchestrator_cli/__init__.py
@@ -1,2 +1,2 @@
 
-from module import OrchestratorCli
+from .module import OrchestratorCli

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -268,7 +268,7 @@ class OrchestratorCli(MgrModule):
         except NoOrchestrator:
             return -errno.ENODEV, "", "No orchestrator configured"
         except ImportError as e:
-            return -errno.ENOENT, "", e.message
+            return -errno.ENOENT, "", str(e)
         except NotImplementedError:
             return -errno.EINVAL, "", "Command not found"
 

--- a/src/pybind/mgr/progress/__init__.py
+++ b/src/pybind/mgr/progress/__init__.py
@@ -1,2 +1,2 @@
 
-from module import *
+from .module import *

--- a/src/pybind/mgr/rook/__init__.py
+++ b/src/pybind/mgr/rook/__init__.py
@@ -1,2 +1,2 @@
 
-from module import RookOrchestrator
+from .module import RookOrchestrator

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -17,7 +17,7 @@ except ImportError:
     client = None
     config = None
 
-from rook_cluster import RookCluster, ApplyException
+from .rook_cluster import RookCluster
 
 
 all_completions = []
@@ -276,8 +276,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
             global all_completions
             self.wait(all_completions)
-            all_completions = filter(lambda x: not x.is_complete,
-                                     all_completions)
+            all_completions = [c for c in all_completions if not c.is_complete]
 
             self._shutdown.wait(5)
 

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -7,7 +7,7 @@ call methods.
 This module is runnable outside of ceph-mgr, useful for testing.
 """
 
-import urlparse
+from six.moves.urllib import parse
 import logging
 import json
 
@@ -115,7 +115,7 @@ class RookCluster(object):
                 ROOK_SYSTEM_NS,
                 label_selector=label_selector)
         except ApiException as e:
-            log.warn("Failed to fetch device metadata: {0}".format(e))
+            log.warning("Failed to fetch device metadata: {0}".format(e))
             raise
 
         nodename_to_devices = {}
@@ -356,7 +356,7 @@ class RookCluster(object):
                 "clusters/{0}".format(self.cluster_name),
                 body=patch)
         except ApiException as e:
-            log.exception("API exception: {0}".format(e.message))
+            log.exception("API exception: {0}".format(e))
             raise ApplyException(
                 "Failed to create OSD entries in Cluster CRD: {0}".format(
-                    e.message))
+                    e))

--- a/src/script/kubejacker/Dockerfile
+++ b/src/script/kubejacker/Dockerfile
@@ -12,19 +12,17 @@ ENV TERM linux
 RUN (grep -q rhel /etc/os-release && ( \
         yum install -y python-pip && \
         yum install -y liboath && \
-        yum install -y python-bcrypt librdmacm \
+        yum install -y python-bcrypt librdmacm && \
+        pip install kubernetes==6.0.0 \
     )) || (grep -q suse /etc/os-release && ( \
         zypper --non-interactive --gpg-auto-import-keys install --no-recommends --auto-agree-with-licenses --replacefiles --details \
-            python-pip \
+            python3-kubernetes \
             liboauth-devel \
             python-bcrypt \
             lz4 \
             librdmacm1 \
             libopenssl1_1 \
     ))
-
-
-RUN pip install kubernetes==6.0.0
 
 ADD bin.tar.gz /usr/bin/
 ADD lib.tar.gz /usr/lib64/


### PR DESCRIPTION
* `Exception.message` is deprecated.
* Use relative imports.
* `filter` returns an iterator in Py3
* `urlparse` moved.
* `s/log.warn/log.warning`
* Dockerfile: install Py3 versions.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>
