### PR TITLE
mgr/orchestrator: Improve debuggability

### DIFF
--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -90,6 +90,9 @@ class OrchestratorCli(MgrModule):
                 else:
                     done = True
 
+        if all(hasattr(c, 'error') and getattr(c, 'error')for c in completions):
+            raise Exception([getattr(c, 'error') for c in completions])
+
     def _list_devices(self, cmd):
         node = cmd.get('node', None)
 


### PR DESCRIPTION
* `OrchestratorCli._wait()`: raise exception if all completions
  failed. Otherwise we will have an infinite loop here.
* The "Kubernetes module" is actually called `kubernetes`.
* Ignore k8s errors in `RookOrchestrator.serve()` , in
  order to provide an error message in `orchestrator status`
* Assert with error message

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

