### PR TITLE
mon,mgr: track mon devices like we do OSDs'

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -23,6 +23,19 @@
 #include "include/uuid.h"
 #include "blkdev.h"
 
+int get_device_by_path(const char *path, char* partition, char* device,
+		       size_t max)
+{
+  int fd = ::open(path, O_RDONLY|O_DIRECTORY);
+  if (fd < 0) {
+    return -errno;
+  }
+  int r = get_device_by_fd(fd, partition, device, max);
+  ::close(fd);
+  return r;
+}
+
+
 #ifdef __linux__
 #include <libudev.h>
 #include <linux/fs.h>

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -30,6 +30,9 @@ extern int block_device_serial(const char *devname, char *serial, size_t max);
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
 extern std::string get_device_id(const std::string& devname);
 
+extern int block_device_run_smartctl(const char *device, int timeout,
+				     std::string *result);
+
 // for VDO
 
 /// return an op fd for the sysfs stats dir, if this is a VDO device

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -13,6 +13,7 @@ extern int get_block_device_base(const char *path, char *devname, size_t len);
 // from an fd
 extern int block_device_discard(int fd, int64_t offset, int64_t len);
 extern int get_block_device_size(int fd, int64_t *psize);
+extern int get_device_by_path(const char *path, char* partition, char* device, size_t max);
 extern int get_device_by_fd(int fd, char* partition, char* device, size_t max);
 
 // from a device (e.g., "sdb")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1803,6 +1803,11 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description(""),
 
+    Option("mon_smart_report_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(5)
+    .set_description("Timeout (in seconds) for smarctl to run, default is set to 5"),
+
+
     Option("paxos_stash_full_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(25)
     .set_description(""),
@@ -2019,7 +2024,7 @@ std::vector<Option> get_global_options() {
     .set_min(2)
     .set_description("Number of striping periods to zero head of MDS journal write position"),
 
-     Option("osd_smart_report_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    Option("osd_smart_report_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(5)
     .set_description("Timeout (in seconds) for smarctl to run, default is set to 5"),
 

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -351,9 +351,11 @@ void Mgr::load_all_metadata()
     daemon_meta.erase("name");
     daemon_meta.erase("hostname");
 
+    map<string,string> m;
     for (const auto &i : daemon_meta) {
-      dm->metadata[i.first] = i.second.get_str();
+      m[i.first] = i.second.get_str();
     }
+    dm->set_metadata(m);
 
     daemon_state.insert(dm);
   }

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1149,3 +1149,8 @@ COMMAND("config reset" \
 	" name=num,type=CephInt",
 	"Revert configuration to previous state",
 	"config", "rw", "cli,rest")
+
+COMMAND_WITH_FLAG("smart name=devid,type=CephString,req=false",
+		  "Query health metrics for underlying device",
+		  "mon", "rw", "cli,rest",
+		  FLAG(HIDDEN))

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -22,6 +22,9 @@
 #include <boost/scope_exit.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
+#include "json_spirit/json_spirit_reader.h"
+#include "json_spirit/json_spirit_writer.h"
+
 #include "Monitor.h"
 #include "common/version.h"
 #include "common/blkdev.h"
@@ -3601,6 +3604,39 @@ void Monitor::handle_command(MonOpRequestRef op)
     f->flush(rdata);
     rs = "";
     r = 0;
+  } else if (prefix == "smart") {
+    string want_devid;
+    cmd_getval(cct, cmdmap, "devid", want_devid);
+
+    string dev = store->get_devname();
+    string devid = get_device_id(dev);
+    if (want_devid.size() && want_devid != devid) {
+      r = -ENOENT;
+    } else {
+      uint64_t smart_timeout = cct->_conf.get_val<uint64_t>(
+	"mon_smart_report_timeout");
+      json_spirit::mObject json_map;
+      json_spirit::mValue smart_json;
+      std::string result;
+      if (block_device_run_smartctl(("/dev/" + dev).c_str(), smart_timeout,
+				    &result)) {
+	dout(10) << "probe_smart_device failed for /dev/" << dev << dendl;
+	result = "{\"error\": \"smartctl failed\", \"dev\": \"" + dev +
+	  "\", \"smartctl_error\": \"" + result + "\"}";
+      }
+
+      if (!json_spirit::read(result, smart_json)) {
+	derr << "smartctl JSON output of /dev/" + dev + " is invalid"
+	     << dendl;
+      } else {
+	json_map[devid] = smart_json;
+      }
+      ostringstream ss;
+      json_spirit::write(json_map, ss, json_spirit::pretty_print);
+      rdata.append(ss.str());
+      r = 0;
+      rs = "";
+    }
   }
 
  out:

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -24,6 +24,7 @@
 
 #include "Monitor.h"
 #include "common/version.h"
+#include "common/blkdev.h"
 
 #include "osd/OSDMap.h"
 
@@ -2094,6 +2095,18 @@ void Monitor::collect_metadata(Metadata *m)
   collect_sys_info(m, g_ceph_context);
   (*m)["addr"] = stringify(messenger->get_myaddr());
   (*m)["compression_algorithms"] = collect_compression_algorithms();
+
+  // infer storage device
+  string devname = store->get_devname();
+  if (devname.size()) {
+    (*m)["devices"] = devname;
+    string id = get_device_id(devname);
+    if (id.size()) {
+      (*m)["device_ids"] = string(devname) + "=" + id;
+    } else {
+      derr << "failed to get devid for " << devname << dendl;
+    }
+  }
 }
 
 void Monitor::finish_election()

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -29,6 +29,7 @@
 #include "common/errno.h"
 #include "common/debug.h"
 #include "common/safe_io.h"
+#include "common/blkdev.h"
 
 #define dout_context g_ceph_context
 
@@ -47,6 +48,13 @@ class MonitorDBStore
   bool is_open;
 
  public:
+
+  string get_devname() {
+    char devname[4096] = {0}, partition[4096];
+    get_device_by_path(path.c_str(), partition, devname,
+		       sizeof(devname));
+    return devname;
+  }
 
   struct Op {
     uint8_t type;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2279,7 +2279,6 @@ private:
   float get_osd_recovery_sleep();
 
   void probe_smart(const string& devid, ostream& ss);
-  int probe_smart_device(const char *device, int timeout, std::string *result);
 
 public:
   static int peek_meta(ObjectStore *store, string& magic,

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -63,7 +63,7 @@ class Module(MgrModule):
         {
             "cmd": "device query-daemon-health-metrics "
                    "name=who,type=CephString",
-            "desc": "Get device health metrics for a given daemon (OSD)",
+            "desc": "Get device health metrics for a given daemon",
             "perm": "r"
         },
         {
@@ -118,23 +118,21 @@ class Module(MgrModule):
         self.log.error("handle_command")
 
         if cmd['prefix'] == 'device query-daemon-health-metrics':
-            who = cmd.get('who', '')
-            if who[0:4] != 'osd.':
-                return -errno.EINVAL, '', 'not a valid <osd.NNN> id'
-            osd_id = who[4:]
+            (daemon_type, daemon_id) = cmd.get('who', '').split('.')
+            if daemon_type not in ('osd', 'mon'):
+                return -errno.EINVAL, '', 'not a valid daemon name'
             result = CommandResult('')
-            self.send_command(result, 'osd', osd_id, json.dumps({
+            self.send_command(result, daemon_type, daemon_id, json.dumps({
                 'prefix': 'smart',
                 'format': 'json',
             }), '')
             r, outb, outs = result.wait()
             return r, outb, outs
         elif cmd['prefix'] == 'device scrape-daemon-health-metrics':
-            who = cmd.get('who', '')
-            if who[0:4] != 'osd.':
-                return -errno.EINVAL, '', 'not a valid <osd.NNN> id'
-            osd_id = int(who[4:])
-            return self.scrape_osd(osd_id)
+            (daemon_type, daemon_id) = cmd.get('who', '').split('.')
+            if daemon_type not in ('osd', 'mon'):
+                return -errno.EINVAL, '', 'not a valid daemon name'
+            return self.scrape_daemon(daemon_type, daemon_id)
         elif cmd['prefix'] == 'device scrape-health-metrics':
             if 'devid' in cmd:
                 return self.scrape_device(cmd['devid'])
@@ -267,9 +265,9 @@ class Module(MgrModule):
         ioctx = self.rados.open_ioctx(self.pool_name)
         return ioctx
 
-    def scrape_osd(self, osd_id):
+    def scrape_daemon(self, daemon_type, daemon_id):
         ioctx = self.open_connection()
-        raw_smart_data = self.do_scrape_osd(osd_id)
+        raw_smart_data = self.do_scrape_daemon(daemon_type, daemon_id)
         if raw_smart_data:
             for device, raw_data in raw_smart_data.items():
                 data = self.extract_smart_features(raw_data)
@@ -282,9 +280,14 @@ class Module(MgrModule):
         assert osdmap is not None
         ioctx = self.open_connection()
         did_device = {}
+        ids = []
         for osd in osdmap['osds']:
-            osd_id = osd['osd']
-            raw_smart_data = self.do_scrape_osd(osd_id)
+            ids.append(('osd', str(osd['osd'])))
+        monmap = self.get("mon_map")
+        for mon in monmap['mons']:
+            ids.append(('mon', mon['name']))
+        for daemon_type, daemon_id in ids:
+            raw_smart_data = self.do_scrape_daemon(daemon_type, daemon_id)
             if not raw_smart_data:
                 continue
             for device, raw_data in raw_smart_data.items():
@@ -294,7 +297,6 @@ class Module(MgrModule):
                 did_device[device] = 1
                 data = self.extract_smart_features(raw_data)
                 self.put_device_metrics(ioctx, device, data)
-
         ioctx.close()
         return 0, "", ""
 
@@ -303,14 +305,13 @@ class Module(MgrModule):
         if not r or 'device' not in r.keys():
             return -errno.ENOENT, '', 'device ' + devid + ' not found'
         daemons = r['device'].get('daemons', [])
-        osds = [int(r[4:]) for r in daemons if r.startswith('osd.')]
-        if not osds:
+        if not daemons:
             return (-errno.EAGAIN, '',
-                    'device ' + devid + ' not claimed by any active '
-                                        'OSD daemons')
-        osd_id = osds[0]
+                    'device ' + devid + ' not claimed by any active daemons')
+        (daemon_type, daemon_id) = daemons[0].split('.')
         ioctx = self.open_connection()
-        raw_smart_data = self.do_scrape_osd(osd_id, devid=devid)
+        raw_smart_data = self.do_scrape_daemon(daemon_type, daemon_id,
+                                               devid=devid)
         if raw_smart_data:
             for device, raw_data in raw_smart_data.items():
                 data = self.extract_smart_features(raw_data)
@@ -318,15 +319,13 @@ class Module(MgrModule):
         ioctx.close()
         return 0, "", ""
 
-    def do_scrape_osd(self, osd_id, devid=''):
+    def do_scrape_daemon(self, daemon_type, daemon_id, devid=''):
         """
         :return: a dict, or None if the scrape failed.
         """
-        self.log.debug('do_scrape_osd osd.%d' % osd_id)
-
-        # scrape from osd
+        self.log.debug('do_scrape_daemon %s.%s' % (daemon_type, daemon_id))
         result = CommandResult('')
-        self.send_command(result, 'osd', str(osd_id), json.dumps({
+        self.send_command(result, daemon_type, daemon_id, json.dumps({
             'prefix': 'smart',
             'format': 'json',
             'devid': devid,
@@ -337,8 +336,8 @@ class Module(MgrModule):
             return json.loads(outb)
         except (IndexError, ValueError):
             self.log.error(
-                "Fail to parse JSON result from OSD {0} ({1})".format(
-                    osd_id, outb))
+                "Fail to parse JSON result from daemon {0}.{1} ({2})".format(
+                    daemon_type, daemon_id, outb))
 
     def put_device_metrics(self, ioctx, devid, data):
         old_key = datetime.utcnow() - timedelta(


### PR DESCRIPTION
```
$ ceph device ls
DEVICE                                 HOST:DEV     DAEMONS                 LIFE EXPECTANCY 
INTEL_SSDPEDMD400G4_CVFT520200G7400BGN gnit:nvme0n1 mon.a osd.0 osd.1 osd.2                 
```
- also enables scraping of metrics from monitor daemons, just like osds.