### PR TITLE
qa: cleanup parallel execution of fsstress

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -408,16 +408,13 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                     args=args,
                     label="workunit test {workunit}".format(workunit=workunit)
                 )
-                if cleanup:
-                    remote.run(
-                        logger=log.getChild(role),
-                        args=['sudo', 'rm', '-rf', '--', scratch_tmp],
-                    )
     finally:
         log.info('Stopping %s on %s...', tests, role)
+        args=['rm', '-rf', '--', workunits_file, clonedir]
+        if cleanup:
+            log.info("and cleaning up scratch: {}".format(scratch_tmp))
+            args.append(scratch_tmp)
         remote.run(
             logger=log.getChild(role),
-            args=[
-                'rm', '-rf', '--', workunits_file, clonedir,
-            ],
+            args=args,
         )

--- a/qa/workunits/suites/fsstress.sh
+++ b/qa/workunits/suites/fsstress.sh
@@ -1,20 +1,17 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
-BIN_PATH=${TESTDIR}/fsstress/ltp-full-20091231/testcases/kernel/fs/fsstress/fsstress
+set -ex
 
-path=`pwd`
-trap "rm -rf ${TESTDIR}/fsstress" EXIT
-mkdir -p ${TESTDIR}/fsstress
-cd ${TESTDIR}/fsstress
-wget -q -O ${TESTDIR}/fsstress/ltp-full.tgz http://download.ceph.com/qa/ltp-full-20091231.tgz
-tar xzf ${TESTDIR}/fsstress/ltp-full.tgz
-rm ${TESTDIR}/fsstress/ltp-full.tgz
-cd ${TESTDIR}/fsstress/ltp-full-20091231/testcases/kernel/fs/fsstress
+mkdir -p fsstress
+pushd fsstress
+wget -q -O ltp-full.tgz http://download.ceph.com/qa/ltp-full-20091231.tgz
+tar xzf ltp-full.tgz
+pushd ltp-full-20091231/testcases/kernel/fs/fsstress
 make
-cd $path
+BIN=$(realpath fsstress)
+popd
+popd
 
-command="${BIN_PATH} -d fsstress-`hostname`$$ -l 1 -n 1000 -p 10 -v"
-
-echo "Starting fsstress $command"
-mkdir fsstress`hostname`-$$
-$command
+T=$(mktemp -d -p .)
+"$BIN" -d "$T" -l 1 -n 1000 -p 10 -v
+rm -rf -- "$T"


### PR DESCRIPTION
Two instances of fsstress clobber each other. Just build it in the local sandbox.

Fixes: http://tracker.ceph.com/issues/24177