### PR TITLE
mon/PGMap: print ages instead of timestamps in 'pg ls' output

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2179,6 +2179,7 @@ void PGMap::dump_filtered_pg_stats(Formatter *f, set<pg_t>& pgs) const
 void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
 {
   TextTable tab;
+  utime_t now = ceph_clock_now();
 
   tab.define_column("PG", TextTable::LEFT, TextTable::LEFT);
   tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
@@ -2188,7 +2189,7 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
   tab.define_column("BYTES", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("LOG", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("STATE", TextTable::LEFT, TextTable::RIGHT);
-  tab.define_column("STATE_STAMP", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("SINCE", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("VERSION", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("REPORTED", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("UP", TextTable::LEFT, TextTable::RIGHT);
@@ -2213,7 +2214,7 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
         << st.stats.sum.num_bytes
         << st.log_size
         << pg_state_string(st.state)
-        << st.last_change
+        << utimespan_str(now - st.last_change)
         << st.version
         << reported.str()
         << upstr.str()


### PR DESCRIPTION
This just replaces the pg state change timestamp with a SINCE value:
```
PG  OBJECTS DEGRADED MISPLACED UNFOUND BYTES    LOG STATE        SINCE VERSION REPORTED UP        ACTING    SCRUB_STAMP                DEEP_SCRUB_STAMP           
1.0      14        0         0       0 58720256  14 active+clean    3m   13'14    18:40 [1,0,2]p1 [1,0,2]p1 2019-01-02 16:34:40.013738 2019-01-02 16:34:40.013738 
1.1       6        0         0       0 25165824   6 active+clean    3m    13'6    19:32 [2,0,1]p2 [2,0,1]p2 2019-01-02 16:34:40.013738 2019-01-02 16:34:40.013738 
1.2      17        0         0       0 71303168  17 active+clean    4m   13'17    18:33 [0,1,2]p0 [0,1,2]p0 2019-01-02 16:34:40.013738 2019-01-02 16:34:40.013738 
1.3      17        0         0       0 71303168  17 active+clean    4m   13'17    18:33 [1,2,0]p1 [1,2,0]p1 2019-01-02 16:34:40.013738 2019-01-02 16:34:40.013738 
1.4      19        0         0       0 79691776  19 active+clean    4m   13'19    18:35 [1,0,2]p1 [1,0,2]p1 2019-01-02 16:34:40.013738 2019-01-02 16:34:40.013738 
1.5       9        0         0       0 37748736   9 active+clean    4m    13'9    18:25 [2,0,1]p2 [2,0,1]p2 2019-01-02 16:34:40.013738 2019-01-02 16:34:40.013738 
1.6      15        0         0       0 62914560  15 active+clean    4m   13'15    18:31 [1,0,2]p1 [1,0,2]p1 2019-01-02 16:34:40.013738 2019-01-02 16:34:40.013738 
1.7      19        0         0       0 79691776  19 active+clean    4m   13'19    18:35 [1,2,0]p1 [1,2,0]p1 2019-01-02 16:34:40.013738 2019-01-02 16:34:40.013738 
```
