### PR TITLE
rgw: remove repetitive conditional statement in RGWHandler_REST_Obj_S3

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3137,9 +3137,6 @@ RGWOp *RGWHandler_REST_Bucket_S3::op_options()
 
 RGWOp *RGWHandler_REST_Obj_S3::get_obj_op(bool get_data)
 {
-  if (is_acl_op()) {
-    return new RGWGetACLs_ObjStore_S3;
-  }
   RGWGetObj_ObjStore_S3 *get_obj_op = new RGWGetObj_ObjStore_S3;
   get_obj_op->set_get_data(get_data);
   return get_obj_op;


### PR DESCRIPTION
is_acl_op() has been called in RGWHandler_REST_Obj_S3::op_head() and RGWHandler_REST_Obj_S3::op_get(). 
Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>




