### PR TITLE
client: fix fuse client can't write data due to don't have Fw capability

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1091,6 +1091,7 @@ private:
   int _removexattr(InodeRef &in, const char *nm, const UserPerm& perms);
   int _open(Inode *in, int flags, mode_t mode, Fh **fhp,
 	    const UserPerm& perms);
+  int _reopen_files();
   int _renew_caps(Inode *in);
   int _create(Inode *in, const char *name, int flags, mode_t mode, InodeRef *inp,
 	      Fh **fhp, int stripe_unit, int stripe_count, int object_size,
@@ -1195,6 +1196,7 @@ private:
   client_umask_callback_t umask_cb = nullptr;
   void *callback_handle = nullptr;
   bool can_invalidate_dentries = false;
+  bool require_reopen_files = false;
 
   Finisher async_ino_invalidator;
   Finisher async_dentry_invalidator;

--- a/src/common/ceph_fs.cc
+++ b/src/common/ceph_fs.cc
@@ -36,6 +36,30 @@ int ceph_flags_to_mode(int flags)
 	return mode;
 }
 
+int ceph_mode_for_flags(int mode)
+{
+	int flags = -1;
+
+#ifdef O_DIRECTORY
+	if (mode == CEPH_FILE_MODE_PIN)
+		flags = O_DIRECTORY;
+#endif
+
+	switch (mode & O_ACCMODE) {
+	case CEPH_FILE_MODE_WR:
+		flags = O_WRONLY;
+		break;
+	case CEPH_FILE_MODE_RD:
+		flags = O_RDONLY;
+		break;
+	case CEPH_FILE_MODE_RDWR:
+		flags = O_RDWR;
+		break;
+	}
+
+	return flags;
+}
+
 int ceph_caps_for_mode(int mode)
 {
 	int caps = CEPH_CAP_PIN;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -359,6 +359,7 @@ OPTION(client_readahead_min, OPT_LONGLONG)  // readahead at _least_ this much.
 OPTION(client_readahead_max_bytes, OPT_LONGLONG)  // default unlimited
 OPTION(client_readahead_max_periods, OPT_LONGLONG)  // as multiple of file layout period (object size * num stripes)
 OPTION(client_reconnect_stale, OPT_BOOL)  // automatically reconnect stale session
+OPTION(client_reopen_files, OPT_BOOL) // reopen files after closing session
 OPTION(client_snapdir, OPT_STR)
 OPTION(client_mount_uid, OPT_INT)
 OPTION(client_mount_gid, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7265,7 +7265,11 @@ std::vector<Option> get_mds_client_options() {
     Option("client_reconnect_stale", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)
     .set_description("reconnect when the session becomes stale"),
-
+      
+    Option("client_reopen_files", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("reopen files has been opened by client"),
+  
     Option("client_snapdir", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default(".snap")
     .set_description("pseudo directory for snapshot access to a directory"),

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -678,6 +678,7 @@ struct ceph_filelock {
 #define CEPH_FILE_MODE_NUM        8  /* bc these are bit fields.. mostly */
 
 int ceph_flags_to_mode(int flags);
+int ceph_mode_for_flags(int mode);
 
 /* inline data state */
 #define CEPH_INLINE_NONE	((__u64)-1)


### PR DESCRIPTION
A file's wnat caps be pAsxXsxFsxcrwb if we open a file with O_RDWR flag
and the want caps are also recorded on MDS side.The MDS will grant the
caps to client according the want and the lock state machine.But if kill
session happen in mds due to the bad network the caps of all files will
be cleared. Whereafter the network back to normal the session will be
recreated but the wanted cap of all files will be lost.So, the client can’t
acquire the caps it needed and will waiting all the time.

Fixes: http://tracker.ceph.com/issues/36072
Signed-off-by: Guan yunfei <yunfei.guan@xtaotech.com>