### PR TITLE
rgw-multisite: enable zone sync from specified zone id

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4411,7 +4411,7 @@ int RGWRados::init_zg_from_local(bool *creating_defaults)
 
 bool RGWRados::zone_syncs_from(RGWZone& target_zone, RGWZone& source_zone)
 {
-  return target_zone.syncs_from(source_zone.name) &&
+  return target_zone.syncs_from(source_zone.id) &&
          sync_modules_manager->supports_data_export(source_zone.tier_type);
 }
 


### PR DESCRIPTION
The previous implementation needs setting both zone-name and zone-id to `sync_from` section in zonegroup config when we want to specify a sync source zone.  With this pr we only need set zone-id now.