### PR TITLE
mgr: update MMgrConfigure message to include optional OSD perf queries

### DIFF
--- a/src/messages/MMgrConfigure.h
+++ b/src/messages/MMgrConfigure.h
@@ -16,6 +16,7 @@
 #define CEPH_MMGRCONFIGURE_H_
 
 #include "msg/Message.h"
+#include "mgr/OSDPerfMetricQuery.h"
 
 /**
  * This message is sent from ceph-mgr to MgrClient, instructing it
@@ -26,7 +27,7 @@ public:
   friend factory;
 private:
 
-  static constexpr int HEAD_VERSION = 2;
+  static constexpr int HEAD_VERSION = 3;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
@@ -35,6 +36,8 @@ public:
   // Default 0 means if unspecified will include all stats
   uint32_t stats_threshold = 0;
 
+  std::list<OSDPerfMetricQuery> osd_perf_metric_queries;
+
   void decode_payload() override
   {
     auto p = payload.cbegin();
@@ -42,12 +45,16 @@ public:
     if (header.version >= 2) {
       decode(stats_threshold, p);
     }
+    if (header.version >= 3) {
+      decode(osd_perf_metric_queries, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
     using ceph::encode;
     encode(stats_period, payload);
     encode(stats_threshold, payload);
+    encode(osd_perf_metric_queries, payload);
   }
 
   const char *get_type_name() const override { return "mgrconfigure"; }

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2320,9 +2320,16 @@ void DaemonServer::_send_configure(ConnectionRef c)
 {
   assert(lock.is_locked_by_me());
 
+  OSDPerfMetricQuery query;
+
   auto configure = new MMgrConfigure();
   configure->stats_period = g_conf().get_val<int64_t>("mgr_stats_period");
   configure->stats_threshold = g_conf().get_val<int64_t>("mgr_stats_threshold");
+
+  if (c->peer_is_osd()) {
+    configure->osd_perf_metric_queries.push_back(query);
+  }
+
   c->send_message(configure);
 }
 

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -350,6 +350,10 @@ void MgrClient::_send_report()
   cct->_conf.get_config_bl(last_config_bl_version, &report->config_bl,
 			    &last_config_bl_version);
 
+  if (get_perf_report_cb) {
+    //get_perf_report_cb(&report->perf_report)
+  }
+
   session->con->send_message(report);
 }
 
@@ -389,6 +393,10 @@ bool MgrClient::handle_mgr_configure(MMgrConfigure *m)
   stats_period = m->stats_period;
   if (starting) {
     _send_stats();
+  }
+
+  if (set_perf_queries_cb) {
+    set_perf_queries_cb(m->osd_perf_metric_queries);
   }
 
   m->put();

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -19,9 +19,14 @@
 #include "mon/MgrMap.h"
 #include "mgr/DaemonHealthMetric.h"
 
+#include "messages/MMgrReport.h"
+#include "mgr/OSDPerfMetricQuery.h"
+
 #include "common/perf_counters.h"
 #include "common/Timer.h"
 #include "common/CommandTable.h"
+
+typedef int OSDPerfMetricReport; //Temporary
 
 class MMgrMap;
 class MMgrConfigure;
@@ -76,6 +81,8 @@ protected:
   // If provided, use this to compose an MPGStats to send with
   // our reports (hook for use by OSD)
   std::function<MPGStats*()> pgstats_cb;
+  std::function<void(const std::list<OSDPerfMetricQuery> &)> set_perf_queries_cb;
+  std::function<void(OSDPerfMetricReport *)> get_perf_report_cb;
 
   // for service registration and beacon
   bool service_daemon = false;
@@ -111,6 +118,17 @@ public:
   bool handle_mgr_configure(MMgrConfigure *m);
   bool handle_mgr_close(MMgrClose *m);
   bool handle_command_reply(MCommandReply *m);
+
+  void set_perf_metric_query_cb(
+          std::function<void(const std::list<OSDPerfMetricQuery> &)> cb_set,
+          std::function<void(OSDPerfMetricReport *)> cb_get)
+
+  {
+      Mutex::Locker l(lock);
+      set_perf_queries_cb = cb_set;
+      get_perf_report_cb = cb_get;
+  }
+
 
   void send_pgstats();
   void set_pgstats_cb(std::function<MPGStats*()>&& cb_)

--- a/src/mgr/OSDPerfMetricQuery.h
+++ b/src/mgr/OSDPerfMetricQuery.h
@@ -1,0 +1,23 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef OSD_PERF_METRIC_QUERY_H_
+#define OSD_PERF_METRIC_QUERY_H_
+
+#include "include/denc.h"
+
+typedef int OSDPerfMetricQueryID;
+
+struct OSDPerfMetricQuery
+{
+  OSDPerfMetricQueryID query_id;
+
+  DENC(OSDPerfMetricQuery, v, p) {
+      DENC_START(1, 1, p);
+      denc(v.query_id, p);
+      DENC_FINISH(p);
+  }
+};
+WRITE_CLASS_DENC(OSDPerfMetricQuery)
+
+#endif // OSD_PERF_METRIC_QUERY_H_

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2590,6 +2590,10 @@ int OSD::init()
     goto out;
 
   mgrc.set_pgstats_cb([this](){ return collect_pg_stats(); });
+  mgrc.set_perf_metric_query_cb(
+      [this](const std::list<OSDPerfMetricQuery> &queries){ set_perf_queries(queries);},
+      [this](OSDPerfMetricReport *report){ get_perf_report(report);
+    });
   mgrc.init();
   client_messenger->add_dispatcher_head(&mgrc);
 
@@ -9359,6 +9363,11 @@ int OSD::init_op_flags(OpRequestRef& op)
   return 0;
 }
 
+void OSD::set_perf_queries(const std::list<OSDPerfMetricQuery> &queries) {
+}
+
+void OSD::get_perf_report(OSDPerfMetricReport *report) {
+}
 
 // =============================================================
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2080,6 +2080,7 @@ protected:
   MPGStats *collect_pg_stats();
   std::vector<DaemonHealthMetric> get_health_metrics();
 
+
 private:
   bool ms_can_fast_dispatch_any() const override { return true; }
   bool ms_can_fast_dispatch(const Message *m) const override {
@@ -2248,6 +2249,10 @@ public:
 public:
   OSDService service;
   friend class OSDService;
+
+private:
+  void set_perf_queries(const std::list<OSDPerfMetricQuery> &queries);
+  void get_perf_report(OSDPerfMetricReport *report);
 };
 
 


### PR DESCRIPTION
mgr: update MMgrConfigure message to include optional OSD perf queries

Fixes: https://tracker.ceph.com/issues/35914
Signed-off-by: Julien COLLET <julien.collet@cern.ch>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

