### PR TITLE
mon,mgr: make mgr controller adjust both pg_num and pgp_num in a consistent way

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -124,6 +124,12 @@
   additional 500 MB to 1 GB of RAM for large clusters, and much less
   for small clusters.
 
+* The ``mgr/balancer/max_misplaced`` option has been replaced by a new
+  global ``target_max_misplaced_ratio`` option that throttles both
+  balancer activity and automated adjustments to ``pgp_num`` (normally as a
+  result of ``pg_num`` changes).  If you have customized the balancer module
+  option, you will need to adjust your config to set the new global option
+  or revert to the default of .05 (5%).
 
 
 Upgrading from Luminous

--- a/qa/suites/rados/thrash-erasure-code-big/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/thrashers/careful.yaml
@@ -1,0 +1,20 @@
+overrides:
+  ceph:
+    log-whitelist:
+    - but it is still running
+    - objects unfound and apparently lost
+    - slow request
+    conf:
+      osd:
+        osd debug reject backfill probability: .3
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+        osd max backfills: 6
+tasks:
+- thrashosds:
+    timeout: 1200
+    chance_pgnum_grow: 1
+    chance_pgnum_shrink: 1
+    chance_pgpnum_fix: 1
+    min_in: 8
+    aggressive_pg_num_changes: false

--- a/qa/suites/rados/thrash-erasure-code-shec/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code-shec/thrashers/careful.yaml
@@ -1,0 +1,20 @@
+overrides:
+  ceph:
+    log-whitelist:
+    - but it is still running
+    - objects unfound and apparently lost
+    - slow request
+    conf:
+      osd:
+        osd debug reject backfill probability: .3
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+        osd max backfills: 3
+tasks:
+- thrashosds:
+    timeout: 1200
+    chance_pgnum_grow: 1
+    chance_pgnum_shrink: 1
+    chance_pgpnum_fix: 1
+    min_in: 8
+    aggressive_pg_num_changes: false

--- a/qa/suites/rados/thrash-erasure-code/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-erasure-code/thrashers/careful.yaml
@@ -1,0 +1,19 @@
+overrides:
+  ceph:
+    log-whitelist:
+    - but it is still running
+    - objects unfound and apparently lost
+    conf:
+      osd:
+        osd debug reject backfill probability: .3
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+        osd max backfills: 2
+tasks:
+- thrashosds:
+    timeout: 1200
+    chance_pgnum_grow: 1
+    chance_pgnum_shrink: 1
+    chance_pgpnum_fix: 1
+    min_in: 4
+    aggressive_pg_num_changes: false

--- a/qa/suites/rados/thrash-old-clients/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash-old-clients/thrashers/careful.yaml
@@ -1,0 +1,25 @@
+overrides:
+  ceph:
+    log-whitelist:
+    - but it is still running
+    - objects unfound and apparently lost
+    conf:
+      osd:
+        osd debug reject backfill probability: .3
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+        osd max backfills: 3
+        osd snap trim sleep: 2
+      mon:
+        mon min osdmap epochs: 50
+        paxos service trim min: 10
+        # prune full osdmaps regularly
+        mon osdmap full prune min: 15
+        mon osdmap full prune interval: 2
+        mon osdmap full prune txsize: 2
+tasks:
+- thrashosds:
+    timeout: 1200
+    chance_pgnum_grow: 1
+    chance_pgpnum_fix: 1
+    aggressive_pg_num_changes: false

--- a/qa/suites/rados/thrash/thrashers/careful.yaml
+++ b/qa/suites/rados/thrash/thrashers/careful.yaml
@@ -1,0 +1,26 @@
+overrides:
+  ceph:
+    log-whitelist:
+    - but it is still running
+    - objects unfound and apparently lost
+    conf:
+      osd:
+        osd debug reject backfill probability: .3
+        osd scrub min interval: 60
+        osd scrub max interval: 120
+        osd max backfills: 3
+        osd snap trim sleep: 2
+      mon:
+        mon min osdmap epochs: 50
+        paxos service trim min: 10
+        # prune full osdmaps regularly
+        mon osdmap full prune min: 15
+        mon osdmap full prune interval: 2
+        mon osdmap full prune txsize: 2
+tasks:
+- thrashosds:
+    timeout: 1200
+    chance_pgnum_grow: 1
+    chance_pgnum_shrink: 1
+    chance_pgpnum_fix: 1
+    aggressive_pg_num_changes: false

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4927,6 +4927,11 @@ std::vector<Option> get_global_options() {
     .set_default(1.0)
     .set_description("Time to wait during shutdown to deregister service with mgr"),
 
+    Option("mgr_debug_aggressive_pg_num_changes", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("Bypass most throttling and safety checks in pg[p]_num controller")
+    .add_service("mgr"),
+
     Option("mon_mgr_digest_period", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(5)
     .add_service("mon")

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4974,6 +4974,10 @@ std::vector<Option> get_global_options() {
     Option("debug_asok_assert_abort", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description("allow commands 'assert' and 'abort' via asok for testing crash dumps etc"),
+
+    Option("target_max_misplaced_ratio", Option::TYPE_FLOAT, Option::LEVEL_BASIC)
+    .set_default(.05)
+    .set_description("Max ratio of misplaced objects to target when throttling data rebalancing activity"),
   });
 }
 

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -348,6 +348,26 @@ ceph_get_mgr_id(BaseMgrModule *self, PyObject *args)
 }
 
 static PyObject*
+ceph_option_get(BaseMgrModule *self, PyObject *args)
+{
+  char *what = nullptr;
+  if (!PyArg_ParseTuple(args, "s:ceph_option_get", &what)) {
+    derr << "Invalid args!" << dendl;
+    return nullptr;
+  }
+
+  std::string value;
+  int r = g_conf().get_val(string(what), &value);
+  if (r >= 0) {
+    dout(10) << "ceph_option_get " << what << " found: " << value << dendl;
+    return PyString_FromString(value.c_str());
+  } else {
+    dout(4) << "ceph_config_get " << what << " not found " << dendl;
+    Py_RETURN_NONE;
+  }
+}
+
+static PyObject*
 ceph_config_get(BaseMgrModule *self, PyObject *args)
 {
   char *what = nullptr;
@@ -689,6 +709,9 @@ PyMethodDef BaseMgrModule_methods[] = {
 
   {"_ceph_get_mgr_id", (PyCFunction)ceph_get_mgr_id, METH_NOARGS,
    "Get the name of the Mgr daemon where we are running"},
+
+  {"_ceph_get_option", (PyCFunction)ceph_option_get, METH_VARARGS,
+   "Get a configuration option value"},
 
   {"_ceph_get_config", (PyCFunction)ceph_config_get, METH_VARARGS,
    "Get a configuration value"},

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2277,20 +2277,20 @@ void DaemonServer::adjust_pgs()
 			 << " pg_num " << p.get_pg_num()
 			 << " - still creating initial pgs"
 			 << dendl;
-	      } else if (p.get_pg_num() != p.get_pg_num_pending() &&
-			 p.get_pg_num_target() < p.get_pg_num()) {
-		dout(10) << "pool " << i.first
-			 << " pg_num_target " << p.get_pg_num_target()
-			 << " pg_num " << p.get_pg_num()
-			 << " - decrease and pg_num_pending != pg_num, waiting"
-			 << dendl;
 	      } else if (p.get_pg_num_target() < p.get_pg_num()) {
 		// pg_num decrease (merge)
 		pg_t merge_source(p.get_pg_num() - 1, i.first);
 		pg_t merge_target = merge_source.get_parent();
 		bool ok = true;
 		auto q = pg_map.pg_stat.find(merge_source);
-		if (p.get_pg_num() == p.get_pgp_num()) {
+		if (p.get_pg_num() != p.get_pg_num_pending()) {
+		  dout(10) << "pool " << i.first
+			   << " pg_num_target " << p.get_pg_num_target()
+			   << " pg_num " << p.get_pg_num()
+			   << " - decrease and pg_num_pending != pg_num, waiting"
+			   << dendl;
+		  ok = false;
+		} else if (p.get_pg_num() == p.get_pgp_num()) {
 		  dout(10) << "pool " << i.first
 			   << " pg_num_target " << p.get_pg_num_target()
 			   << " pg_num " << p.get_pg_num()

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2262,14 +2262,14 @@ void DaemonServer::adjust_pgs()
 		       << dendl;
 	      if (p.has_flag(pg_pool_t::FLAG_CREATING)) {
 		dout(10) << "pool " << i.first
-			 << " target " << p.get_pg_num_target()
+			 << " pg_num_target " << p.get_pg_num_target()
 			 << " pg_num " << p.get_pg_num()
 			 << " - still creating initial pgs"
 			 << dendl;
 	      } else if (p.get_pg_num() != p.get_pg_num_pending() &&
 			 p.get_pg_num_target() < p.get_pg_num()) {
 		dout(10) << "pool " << i.first
-			 << " target " << p.get_pg_num_target()
+			 << " pg_num_target " << p.get_pg_num_target()
 			 << " pg_num " << p.get_pg_num()
 			 << " - decrease and pg_num_pending != pg_num, waiting"
 			 << dendl;
@@ -2280,8 +2280,9 @@ void DaemonServer::adjust_pgs()
 		bool ok = true;
 		auto q = pg_map.pg_stat.find(merge_source);
 		if (q == pg_map.pg_stat.end()) {
+		} else if (q == pg_map.pg_stat.end()) {
 		  dout(10) << "pool " << i.first
-			   << " target " << p.get_pg_num_target()
+			   << " pg_num_target " << p.get_pg_num_target()
 			   << " pg_num " << p.get_pg_num()
 			   << " - no state for " << merge_source
 			   << " (merge source)"
@@ -2290,7 +2291,7 @@ void DaemonServer::adjust_pgs()
 		} else if (!(q->second.state & (PG_STATE_ACTIVE |
 						PG_STATE_CLEAN))) {
 		  dout(10) << "pool " << i.first
-			   << " target " << p.get_pg_num_target()
+			   << " pg_num_target " << p.get_pg_num_target()
 			   << " pg_num " << p.get_pg_num()
 			   << " - merge source " << merge_source
 			   << " not clean (" << pg_state_string(q->second.state)
@@ -2300,7 +2301,7 @@ void DaemonServer::adjust_pgs()
 		q = pg_map.pg_stat.find(merge_target);
 		if (q == pg_map.pg_stat.end()) {
 		  dout(10) << "pool " << i.first
-			   << " target " << p.get_pg_num_target()
+			   << " pg_num_target " << p.get_pg_num_target()
 			   << " pg_num " << p.get_pg_num()
 			   << " - no state for " << merge_target
 			   << " (merge target)"
@@ -2309,7 +2310,7 @@ void DaemonServer::adjust_pgs()
 		} else if (!(q->second.state & (PG_STATE_ACTIVE |
 						PG_STATE_CLEAN))) {
 		  dout(10) << "pool " << i.first
-			   << " target " << p.get_pg_num_target()
+			   << " pg_num_target " << p.get_pg_num_target()
 			   << " pg_num " << p.get_pg_num()
 			   << " - merge target " << merge_target
 			   << " not clean (" << pg_state_string(q->second.state)
@@ -2319,7 +2320,7 @@ void DaemonServer::adjust_pgs()
 		if (ok) {
 		  unsigned target = p.get_pg_num() - 1;
 		  dout(10) << "pool " << i.first
-			   << " target " << p.get_pg_num_target()
+			   << " pg_num_target " << p.get_pg_num_target()
 			   << " pg_num " << p.get_pg_num()
 			   << " -> " << target
 			   << " (merging " << merge_source
@@ -2346,7 +2347,7 @@ void DaemonServer::adjust_pgs()
 		}
 		if (!active) {
 		  dout(10) << "pool " << i.first
-			   << " target " << p.get_pg_num_target()
+			   << " pg_num_target " << p.get_pg_num_target()
 			   << " pg_num " << p.get_pg_num()
 			   << " - not all pgs active"
 			   << dendl;
@@ -2357,7 +2358,7 @@ void DaemonServer::adjust_pgs()
 		  unsigned target = p.get_pg_num() + add;
 		  left -= add;
 		  dout(10) << "pool " << i.first
-			   << " target " << p.get_pg_num_target()
+			   << " pg_num_target " << p.get_pg_num_target()
 			   << " pg_num " << p.get_pg_num()
 			   << " -> " << target << dendl;
 		  pg_num_to_set[osdmap.get_pool_name(i.first)] = target;

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2266,14 +2266,13 @@ void DaemonServer::adjust_pgs()
 			 << " pg_num " << p.get_pg_num()
 			 << " - still creating initial pgs"
 			 << dendl;
-	      } else if (p.get_pg_num() != p.get_pg_num_pending()) {
+	      } else if (p.get_pg_num() != p.get_pg_num_pending() &&
+			 p.get_pg_num_target() < p.get_pg_num()) {
 		dout(10) << "pool " << i.first
 			 << " target " << p.get_pg_num_target()
 			 << " pg_num " << p.get_pg_num()
-			 << " - pg_num_pending != pg_num, waiting"
+			 << " - decrease and pg_num_pending != pg_num, waiting"
 			 << dendl;
-		// FIXME: we might consider allowing pg_num increases without
-		// waiting for the previously planned merge to complete.
 	      } else if (p.get_pg_num_target() < p.get_pg_num()) {
 		// pg_num decrease (merge)
 		pg_t merge_source(p.get_pg_num() - 1, i.first);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2261,12 +2261,6 @@ void DaemonServer::adjust_pgs()
 	       << dendl;
 
       cluster_state.with_osdmap([&](const OSDMap& osdmap) {
-	  if (pg_map.last_osdmap_epoch != osdmap.get_epoch()) {
-	    // do nothing if maps aren't in sync
-	    dout(10) << "last_osdmap_epoch " << pg_map.last_osdmap_epoch
-		     << " osdmap " << osdmap.get_epoch() << dendl;
-	    //return;
-	  }
 	  for (auto& i : osdmap.get_pools()) {
 	    const pg_pool_t& p = i.second;
 

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2279,7 +2279,14 @@ void DaemonServer::adjust_pgs()
 		pg_t merge_target = merge_source.get_parent();
 		bool ok = true;
 		auto q = pg_map.pg_stat.find(merge_source);
-		if (q == pg_map.pg_stat.end()) {
+		if (p.get_pg_num() == p.get_pgp_num()) {
+		  dout(10) << "pool " << i.first
+			   << " pg_num_target " << p.get_pg_num_target()
+			   << " pg_num " << p.get_pg_num()
+			   << " - decrease blocked by pgp_num "
+			   << p.get_pgp_num()
+			   << dendl;
+		  ok = false;
 		} else if (q == pg_map.pg_stat.end()) {
 		  dout(10) << "pool " << i.first
 			   << " pg_num_target " << p.get_pg_num_target()

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6918,6 +6918,11 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
       return -EBUSY;
     }
     if (n > (int)p.get_pg_num()) {
+      if (p.get_pg_num() != p.get_pg_num_pending()) {
+	// force pre-nautilus clients to resend their ops, since they
+	// don't understand pg_num_pending changes form a new interval
+	p.last_force_op_resend_prenautilus = pending_inc.epoch;
+      }
       p.set_pg_num(n);
     } else {
       if (osdmap.require_osd_release < CEPH_RELEASE_NAUTILUS) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6987,12 +6987,14 @@ int OSDMonitor::prepare_command_pool_set(const cmdmap_t& cmdmap,
 	return -EPERM;
       }
     }
-    // set target; mgr will adjust pg_num_actual later
-    p.set_pg_num_target(n);
-    // adjust pgp_num_target down too (as needed)
-    if (p.get_pgp_num_target() > n) {
+    // set targets; mgr will adjust pg_num_actual and pgp_num later.
+    // make pgp_num track pg_num if it already matches.  if it is set
+    // differently, leave it different and let the user control it
+    // manually.
+    if (p.get_pg_num_target() == p.get_pgp_num_target()) {
       p.set_pgp_num_target(n);
     }
+    p.set_pg_num_target(n);
   } else if (var == "pgp_num_actual") {
     if (p.has_flag(pg_pool_t::FLAG_NOPGCHANGE)) {
       ss << "pool pgp_num change is disabled; you must unset nopgchange flag for the pool first";

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -392,6 +392,36 @@ void PGMapDigest::print_oneline_summary(Formatter *f, ostream *out) const
     *out << "; " << ssr.str() << " recovering";
 }
 
+void PGMapDigest::get_recovery_stats(
+    double *misplaced_ratio,
+    double *degraded_ratio,
+    double *inactive_pgs_ratio,
+    double *unknown_pgs_ratio) const
+{
+  if (pg_sum.stats.sum.num_objects_degraded &&
+      pg_sum.stats.sum.num_object_copies > 0) {
+    *degraded_ratio = (double)pg_sum.stats.sum.num_objects_degraded /
+      (double)pg_sum.stats.sum.num_object_copies;
+  } else {
+    *degraded_ratio = 0;
+  }
+  if (pg_sum.stats.sum.num_objects_misplaced &&
+      pg_sum.stats.sum.num_object_copies > 0) {
+    *misplaced_ratio = (double)pg_sum.stats.sum.num_objects_misplaced /
+      (double)pg_sum.stats.sum.num_object_copies;
+  } else {
+    *misplaced_ratio = 0;
+  }
+  if (num_pg > 0) {
+    int num_pg_inactive = num_pg - num_pg_active - num_pg_unknown;
+    *inactive_pgs_ratio = (double)num_pg_inactive / (double)num_pg;
+    *unknown_pgs_ratio = (double)num_pg_unknown / (double)num_pg;
+ } else {
+    *inactive_pgs_ratio = 0;
+    *unknown_pgs_ratio = 0;
+  }
+}
+
 void PGMapDigest::recovery_summary(Formatter *f, list<string> *psl,
                              const pool_stat_t& pool_sum) const
 {

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -92,6 +92,11 @@ public:
   pool_stat_t pg_sum_delta;
   utime_t stamp_delta;
 
+  void get_recovery_stats(
+    double *misplaced_ratio,
+    double *degraded_ratio,
+    double *inactive_ratio,
+    double *unknown_pgs_ratio) const;
 
   void print_summary(Formatter *f, ostream *out) const;
   void print_oneline_summary(Formatter *f, ostream *out) const;

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1381,6 +1381,11 @@ public:
 
   int get_osds_by_bucket_name(const string &name, set<int> *osds) const;
 
+  bool have_pg_upmaps(pg_t pg) const {
+    return pg_upmap.count(pg) ||
+      pg_upmap_items.count(pg);
+  }
+
   /*
    * handy helpers to build simple maps...
    */

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -17,7 +17,6 @@ from mgr_module import CRUSHMap
 # available modes: 'none', 'crush', 'crush-compat', 'upmap', 'osd_weight'
 default_mode = 'none'
 default_sleep_interval = 60   # seconds
-default_max_misplaced = .05    # max ratio of pgs replaced at a time
 
 TIME_FORMAT = '%Y-%m-%d_%H:%M:%S'
 
@@ -208,7 +207,6 @@ class Module(MgrModule):
             {'name': 'crush_compat_max_iterations'},
             {'name': 'crush_compat_step'},
             {'name': 'end_time'},
-            {'name': 'max_misplaced'},
             {'name': 'min_score'},
             {'name': 'mode'},
             {'name': 'sleep_interval'},
@@ -644,8 +642,7 @@ class Module(MgrModule):
     def optimize(self, plan):
         self.log.info('Optimize plan %s' % plan.name)
         plan.mode = self.get_config('mode', default_mode)
-        max_misplaced = float(self.get_config('max_misplaced',
-                                              default_max_misplaced))
+        max_misplaced = float(self.get_option('target_max_misplaced_ratio'))
         self.log.info('Mode %s, max misplaced %f' %
                       (plan.mode, max_misplaced))
 
@@ -729,8 +726,7 @@ class Module(MgrModule):
         step = float(self.get_config('crush_compat_step', .5))
         if step <= 0 or step >= 1.0:
             return -errno.EINVAL, '"crush_compat_step" must be in (0, 1)'
-        max_misplaced = float(self.get_config('max_misplaced',
-                                              default_max_misplaced))
+        max_misplaced = float(self.get_option('target_max_misplaced_ratio'))
         min_pg_per_osd = 2
 
         ms = plan.initial

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -630,6 +630,9 @@ class MgrModule(ceph_module.BaseMgrModule):
         """
         return self._ceph_get_mgr_id()
 
+    def get_option(self, key):
+        return self._ceph_get_option(key)
+
     def _validate_option(self, key):
         """
         Helper: don't allow get/set config callers to 


### PR DESCRIPTION
- pgp_num tracks pg_num unless/until it is set explicitly different than pg_num
- mgr adjusts pg_num upward aggressively (splits are cheap) (no change here)
- mgr adjusts pg_num downward by 1 pg at a time (merges are done carefully) (no change here)
- mgr adjusts pgp_num up or down, throttling based on the new global target_max_misplaced_ratio option
- mgr/balancer/max_misplaced is now replaced by target_max_misplaced_ratio