### PR TITLE
mimic: client: fix use-after-free in Client::link()

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3019,8 +3019,10 @@ Dentry* Client::link(Dir *dir, const string& name, Inode *in, Dentry *dn)
   }
 
   if (in) {    // link to inode
+    InodeRef tmp_ref;
     // only one parent for directories!
     if (in->is_dir() && !in->dentries.empty()) {
+      tmp_ref = in; // prevent unlink below from freeing the inode.
       Dentry *olddn = in->get_first_parent();
       assert(olddn->dir != dir || olddn->name != name);
       Inode *old_diri = olddn->dir->parent_inode;


### PR DESCRIPTION
http://tracker.ceph.com/issues/35841