### PR TITLE
mimic:rgw: return x-amz-version-id: null when delete obj in versioning

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9094,6 +9094,8 @@ int RGWRados::Object::Delete::delete_obj()
       }
 
       result.version_id = marker.key.instance;
+      if (result.version_id.empty())
+        result.version_id = "null";
       result.delete_marker = true;
 
       struct rgw_bucket_dir_entry_meta meta;


### PR DESCRIPTION
https://tracker.ceph.com/issues/36142