### PR TITLE
jewel:rgw: return x-amz-version-id: null when delete obj in versioning

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7987,6 +7987,8 @@ int RGWRados::Object::Delete::delete_obj()
       }
 
       result.version_id = marker.get_instance();
+      if (result.version_id.empty())
+        result.version_id = "null";
       result.delete_marker = true;
 
       struct rgw_bucket_dir_entry_meta meta;


### PR DESCRIPTION
Backport tracker: http://tracker.ceph.com/issues/35814

> https://github.com/ceph/ceph/pull/23927

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>

(cherry picked from commit 9c39147)