### PR TITLE
mgr/dashboard: run backend api tests

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -89,8 +89,8 @@ EOF
         fi
     fi
 
-    export COVERAGE_ENABLED=true
-    export COVERAGE_FILE=.coverage.mgr.dashboard
+#    export COVERAGE_ENABLED=true
+#    export COVERAGE_FILE=.coverage.mgr.dashboard
 
     MGR=2 RGW=1 ../src/vstart.sh -n -d
     sleep 10


### PR DESCRIPTION
Disable coverage by default as this info is not checked
anymore and it is causing an error in environment:
docker centos7 + python 2.7

Signed-off-by: Alfonso Martínez <almartin@redhat.com>

