### PR TITLE
Wip luminous rgw bucketmv

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -284,9 +284,10 @@ Options
 
 	Set the system flag on the user.
 
-.. option:: --bucket=bucket
+.. option:: --bucket=[tenant-id/]bucket
 
-   Specify the bucket name.
+   Specify the bucket name.  If tenant-id is not specified, the tenant-id
+   of the user (--uid) is used.
 
 .. option:: --object=object
 
@@ -307,8 +308,8 @@ Options
 .. option:: --bucket-new-name=[tenant-id/]<bucket>
 
    Optional for `bucket link`; use to rename a bucket.
-        When using implicit tenants, prefix the name
-        with the desired tenant-id.
+        While tenant-id/ can be specified, this is never
+        necessary for normal operation.
 
 .. option:: --shard-id=<shard-id>
 
@@ -486,6 +487,14 @@ Link bucket to specified user::
 Unlink bucket from specified user::
 
         $ radosgw-admin bucket unlink --bucket=foo --uid=johnny
+
+Rename a bucket::
+
+        $ radosgw-admin bucket link --bucket=foo --bucket-new-name=bar --uid=johnny
+
+Move a bucket from the old global tenant space to a specified tenant::
+
+        $ radosgw-admin bucket link --bucket=/foo --uid=12345678$12345678'
 
 Show the logs of a bucket from April 1st, 2012::
 

--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -304,6 +304,12 @@ Options
 
    The end date needed for some commands.
 
+.. option:: --bucket-new-name=[tenant-id/]<bucket>
+
+   Optional for `bucket link`; use to rename a bucket.
+        When using implicit tenants, prefix the name
+        with the desired tenant-id.
+
 .. option:: --shard-id=<shard-id>
 
 	Optional for mdlog list, data sync status. Required for ``mdlog trim``,

--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -1516,7 +1516,7 @@ Request Parameters
 :Description: The bucket id to unlink.
 :Type: String
 :Example: ``dev.6607669.420``
-:Required: Yes
+:Required: No
 
 ``uid``
 

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -47,6 +47,7 @@ struct obj_version {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(list<obj_version*>& o);
 };
 WRITE_CLASS_ENCODER(obj_version)
 

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -226,6 +226,8 @@ void usage()
   cout << "   --start-date=<date>       start date in the format yyyy-mm-dd\n";
   cout << "   --end-date=<date>         end date in the format yyyy-mm-dd\n";
   cout << "   --bucket-id=<bucket-id>   bucket id\n";
+  cout << "   --bucket-new-name=<bucket>\n";
+  cout << "                             for bucket link: optional new name\n";
   cout << "   --shard-id=<shard-id>     optional for: \n";
   cout << "                               mdlog list\n";
   cout << "                               data sync status\n";
@@ -2557,6 +2559,7 @@ int main(int argc, const char **argv)
   bool set_temp_url_key = false;
   map<int, string> temp_url_keys;
   string bucket_id;
+  string new_bucket_name;
   Formatter *formatter = NULL;
   int purge_data = false;
   int pretty_format = false;
@@ -2819,6 +2822,8 @@ int main(int argc, const char **argv)
         usage();
 	assert(false);
       }
+    } else if (ceph_argparse_witharg(args, i, &val, "--bucket-new-name", (char*)NULL)) {
+      new_bucket_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--format", (char*)NULL)) {
       format = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--categories", (char*)NULL)) {
@@ -5230,6 +5235,7 @@ int main(int argc, const char **argv)
 
   if (opt_cmd == OPT_BUCKET_LINK) {
     bucket_op.set_bucket_id(bucket_id);
+    bucket_op.set_new_bucket_name(new_bucket_name);
     string err;
     int r = RGWBucketAdminOp::link(store, bucket_op, &err);
     if (r < 0) {

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -103,6 +103,8 @@ struct rgw_user {
     }
     return (id < rhs.id);
   }
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<rgw_user*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_user)
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -844,26 +844,32 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state,
   string bucket_id = op_state.get_bucket_id();
 
   std::string display_name = op_state.get_user_display_name();
-  rgw_bucket bucket = op_state.get_bucket();
+  rgw_bucket& bucket = op_state.get_bucket();
   if (!bucket_id.empty() && bucket_id != bucket.bucket_id) {
-    set_err_msg(err_msg, "specified bucket id does not match");
+    set_err_msg(err_msg,
+	"specified bucket id does not match " + bucket.bucket_id);
     return -EINVAL;
   }
 
   rgw_bucket old_bucket = bucket;
   bucket.tenant = tenant;
+  if (!op_state.new_bucket_name.empty()) {
+    auto pos = op_state.new_bucket_name.find('/');
+    if (pos != boost::string_ref::npos) {
+      bucket.tenant = op_state.new_bucket_name.substr(0, pos);
+      bucket.name = op_state.new_bucket_name.substr(pos + 1);
+    } else {
+      bucket.name = op_state.new_bucket_name;
+    }
+  }
 
-  const rgw_pool& root_pool = store->get_zone_params().domain_root;
-  std::string bucket_entry;
-  rgw_make_bucket_entry_name(tenant, bucket_name, bucket_entry);
-  rgw_raw_obj obj(root_pool, bucket_entry);
   RGWObjVersionTracker objv_tracker;
   RGWObjVersionTracker old_version = bucket_info.objv_tracker;
 
   map<string, bufferlist>::iterator aiter = attrs.find(RGW_ATTR_ACL);
   if (aiter == attrs.end()) {
     // XXX why isn't this an error?  mdw 20180825
-    ldout(store->ctx(), 0) << "WARNING: bucket link will do nothing because no acl on bucket=" << bucket_name << dendl;
+    ldout(store->ctx(), 0) << "WARNING: bucket link will do nothing because no acl on bucket=" << old_bucket.name << dendl;
     return 0;
   }
   bufferlist aclbl = aiter->second;
@@ -916,7 +922,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state,
     }
   } else {
     attrs[RGW_ATTR_ACL] = aclbl;
-    bucket_info.bucket.tenant = tenant;
+    bucket_info.bucket = bucket;
     bucket_info.owner = user_info.user_id;
     bucket_info.objv_tracker.version_for_read()->ver = 0;
     r = store->put_bucket_instance_info(bucket_info, true, real_time(), &attrs);
@@ -950,15 +956,16 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state,
     RGWObjVersionTracker ep_version;
     *ep_version.version_for_read() = bucket_info.ep_objv;
     // like RGWRados::delete_bucket -- excepting no bucket_index work.
-    r = rgw_bucket_delete_bucket_obj(store, old_bucket.tenant, old_bucket.name, ep_version);
+    r = rgw_bucket_delete_bucket_obj(store,
+	old_bucket.tenant, old_bucket.name, ep_version);
     if (r < 0) {
-      set_err_msg(err_msg, "failed to unlink old bucket endpoint");
+      set_err_msg(err_msg, "failed to unlink old bucket endpoint " + old_bucket.tenant + "/" + old_bucket.name);
       return r;
     }
     string entry = old_bucket.get_key();
     r = rgw_bucket_instance_remove_entry(store, entry, &old_version);
     if (r < 0) {
-      set_err_msg(err_msg, "failed to unlink old bucket info");
+      set_err_msg(err_msg, "failed to unlink old bucket info " + entry);
       return r;
     }
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -767,7 +767,7 @@ static void set_err_msg(std::string *sink, std::string msg)
 }
 
 int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state,
-	std::string *err_msg)
+	std::string *err_msg, map<string, bufferlist> *pattrs)
 {
   std::string bucket_tenant;
   if (!storage) {
@@ -795,7 +795,9 @@ int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state,
   }
 
   if (!bucket_name.empty()) {
-    int r = store->get_bucket_info(obj_ctx, bucket_tenant, bucket_name, bucket_info, NULL);
+    ceph::real_time mtime;
+    int r = store->get_bucket_info(obj_ctx, bucket_tenant, bucket_name,
+	bucket_info, &mtime, pattrs);
     if (r < 0) {
       set_err_msg(err_msg, "failed to fetch bucket info for bucket=" + bucket_name);
       ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket_name << dendl;
@@ -819,7 +821,8 @@ int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state,
   return 0;
 }
 
-int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
+int RGWBucket::link(RGWBucketAdminOpState& op_state,
+	map<string, bufferlist>& attrs, std::string *err_msg)
 {
   if (!op_state.is_user_op()) {
     set_err_msg(err_msg, "empty user id");
@@ -827,12 +830,6 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
   }
 
   string bucket_id = op_state.get_bucket_id();
-#if 0
-  if (bucket_id.empty()) {
-    set_err_msg(err_msg, "empty bucket instance id");
-    return -EINVAL;
-  }
-#endif
 
   std::string display_name = op_state.get_user_display_name();
   rgw_bucket bucket = op_state.get_bucket();
@@ -846,16 +843,6 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
   rgw_make_bucket_entry_name(tenant, bucket_name, bucket_entry);
   rgw_raw_obj obj(root_pool, bucket_entry);
   RGWObjVersionTracker objv_tracker;
-
-  map<string, bufferlist> attrs;
-  RGWBucketInfo bucket_info;
-
-  RGWObjectCtx obj_ctx(store);
-  int r = store->get_bucket_instance_info(obj_ctx, bucket, bucket_info, NULL, &attrs);
-  if (r < 0) {
-    set_err_msg(err_msg, "failed to refetch bucket info");
-    return r;
-  }
 
   map<string, bufferlist>::iterator aiter = attrs.find(RGW_ATTR_ACL);
   if (aiter != attrs.end()) {
@@ -871,7 +858,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
       return -EIO;
     }
 
-    r = rgw_unlink_bucket(store, owner.get_id(), bucket.tenant, bucket.name, false);
+    int r = rgw_unlink_bucket(store, owner.get_id(), bucket.tenant, bucket.name, false);
     if (r < 0) {
       set_err_msg(err_msg, "could not unlink policy from user " + owner.get_id().to_str());
       return r;
@@ -1353,12 +1340,13 @@ int RGWBucketAdminOp::unlink(RGWRados *store, RGWBucketAdminOpState& op_state)
 int RGWBucketAdminOp::link(RGWRados *store, RGWBucketAdminOpState& op_state, string *err)
 {
   RGWBucket bucket;
+  map<string, bufferlist> attrs;
 
-  int ret = bucket.init(store, op_state, err);
+  int ret = bucket.init(store, op_state, err, &attrs);
   if (ret < 0)
     return ret;
 
-  return bucket.link(op_state, err);
+  return bucket.link(op_state, attrs, err);
 
 }
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -858,6 +858,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state,
   rgw_make_bucket_entry_name(tenant, bucket_name, bucket_entry);
   rgw_raw_obj obj(root_pool, bucket_entry);
   RGWObjVersionTracker objv_tracker;
+  RGWObjVersionTracker old_version = bucket_info.objv_tracker;
 
   map<string, bufferlist>::iterator aiter = attrs.find(RGW_ATTR_ACL);
   if (aiter == attrs.end()) {
@@ -917,7 +918,8 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state,
     attrs[RGW_ATTR_ACL] = aclbl;
     bucket_info.bucket.tenant = tenant;
     bucket_info.owner = user_info.user_id;
-    r = store->put_bucket_instance_info(bucket_info, false, real_time(), &attrs);
+    bucket_info.objv_tracker.version_for_read()->ver = 0;
+    r = store->put_bucket_instance_info(bucket_info, true, real_time(), &attrs);
     if (r < 0) {
       set_err_msg(err_msg, "ERROR: failed writing bucket instance info: " + cpp_strerror(-r));
       return r;
@@ -945,7 +947,21 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state,
     return r;
   }
   if (bucket != old_bucket) {
-	// howto remove old bucket ?
+    RGWObjVersionTracker ep_version;
+    *ep_version.version_for_read() = bucket_info.ep_objv;
+    // like RGWRados::delete_bucket -- excepting no bucket_index work.
+    r = rgw_bucket_delete_bucket_obj(store, old_bucket.tenant, old_bucket.name, ep_version);
+    if (r < 0) {
+      set_err_msg(err_msg, "failed to unlink old bucket endpoint");
+      return r;
+    }
+    string entry = old_bucket.get_key();
+    r = rgw_bucket_instance_remove_entry(store, entry, &old_version);
+    if (r < 0) {
+      set_err_msg(err_msg, "failed to unlink old bucket info");
+      return r;
+    }
+
   }
 
   return 0;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -850,6 +850,9 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state,
     return -EINVAL;
   }
 
+  rgw_bucket old_bucket = bucket;
+  bucket.tenant = tenant;
+
   const rgw_pool& root_pool = store->get_zone_params().domain_root;
   std::string bucket_entry;
   rgw_make_bucket_entry_name(tenant, bucket_name, bucket_entry);
@@ -857,81 +860,92 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state,
   RGWObjVersionTracker objv_tracker;
 
   map<string, bufferlist>::iterator aiter = attrs.find(RGW_ATTR_ACL);
-  if (aiter != attrs.end()) {
-    bufferlist aclbl = aiter->second;
-    RGWAccessControlPolicy policy;
-    ACLOwner owner;
-    try {
-     bufferlist::iterator iter = aclbl.begin();
-     ::decode(policy, iter);
-     owner = policy.get_owner();
-    } catch (buffer::error& err) {
-      set_err_msg(err_msg, "couldn't decode policy");
-      return -EIO;
-    }
+  if (aiter == attrs.end()) {
+    // XXX why isn't this an error?  mdw 20180825
+    ldout(store->ctx(), 0) << "WARNING: bucket link will do nothing because no acl on bucket=" << bucket_name << dendl;
+    return 0;
+  }
+  bufferlist aclbl = aiter->second;
+  RGWAccessControlPolicy policy;
+  ACLOwner owner;
+  try {
+   auto iter = aclbl.begin();
+   ::decode(policy, iter);
+   owner = policy.get_owner();
+  } catch (buffer::error& err) {
+    set_err_msg(err_msg, "couldn't decode policy");
+    return -EIO;
+  }
 
-    int r = rgw_unlink_bucket(store, owner.get_id(), bucket.tenant, bucket.name, false);
-    if (r < 0) {
-      set_err_msg(err_msg, "could not unlink policy from user " + owner.get_id().to_str());
-      return r;
-    }
+  int r = rgw_unlink_bucket(store, owner.get_id(),
+	old_bucket.tenant, old_bucket.name, false);
+  if (r < 0) {
+    set_err_msg(err_msg, "could not unlink policy from user " + owner.get_id().to_str());
+    return r;
+  }
 
-    // now update the user for the bucket...
-    if (display_name.empty()) {
-      ldout(store->ctx(), 0) << "WARNING: user " << user_info.user_id << " has no display name set" << dendl;
-    }
-    policy.create_default(user_info.user_id, display_name);
+  // now update the user for the bucket...
+  if (display_name.empty()) {
+    ldout(store->ctx(), 0) << "WARNING: user " << user_info.user_id << " has no display name set" << dendl;
+  }
 
-    owner = policy.get_owner();
+  RGWAccessControlPolicy policy_instance;
+  policy_instance.create_default(user_info.user_id, display_name);
+  owner = policy_instance.get_owner();
+
+  aclbl.clear();
+  policy_instance.encode(aclbl);
+
+	// in jewel, rgw_bucket == ignores tenant.  MUST use newly
+	// added !=
+	//	...ick !
+  if (!(bucket != old_bucket)) {
     r = store->set_bucket_owner(bucket_info.bucket, owner);
     if (r < 0) {
       set_err_msg(err_msg, "failed to set bucket owner: " + cpp_strerror(-r));
       return r;
     }
 
-    // ...and encode the acl
-    aclbl.clear();
-    policy.encode(aclbl);
-
-    r = store->system_obj_set_attr(NULL, obj, RGW_ATTR_ACL, aclbl, &objv_tracker);
-    if (r < 0) {
-      set_err_msg(err_msg, "failed to set new acl");
-      return r;
-    }
-
-    RGWAccessControlPolicy policy_instance;
-    policy_instance.create_default(user_info.user_id, display_name);
-    aclbl.clear();
-    policy_instance.encode(aclbl);
-
     rgw_raw_obj obj_bucket_instance;
     store->get_bucket_instance_obj(bucket, obj_bucket_instance);
     r = store->system_obj_set_attr(NULL, obj_bucket_instance, RGW_ATTR_ACL, aclbl, &objv_tracker);
     if (r < 0) {
-      set_err_msg(err_msg, "failed to set bucket policy");
+      set_err_msg(err_msg, "failed to set new acl");
       return r;
     }
-
-    RGWBucketEntryPoint ep;
-    ep.bucket = bucket_info.bucket;
-    ep.owner = user_info.user_id;
-    ep.creation_time = bucket_info.creation_time;
-    ep.linked = true;
-    map<string, bufferlist> ep_attrs;
-    // XXX I am not convinced this is at all necessary; but previous
-    //	versions would have found and copied VERSION_ATTR so I will
-    //	do likewise for now...  mdw 20180825
-    auto version_iter = attrs.find(VERSION_ATTR);
-    if (version_iter != attrs.end())
-      ep_attrs[VERSION_ATTR] = version_iter->second;
-    rgw_ep_info ep_data{ep, ep_attrs};
-
-    r = rgw_link_bucket(store, user_info.user_id, bucket_info.bucket,
-                        ceph::real_time(), true, &ep_data);
+  } else {
+    attrs[RGW_ATTR_ACL] = aclbl;
+    bucket_info.bucket.tenant = tenant;
+    bucket_info.owner = user_info.user_id;
+    r = store->put_bucket_instance_info(bucket_info, false, real_time(), &attrs);
     if (r < 0) {
-      set_err_msg(err_msg, "failed to relink bucket");
+      set_err_msg(err_msg, "ERROR: failed writing bucket instance info: " + cpp_strerror(-r));
       return r;
     }
+  }
+
+  RGWBucketEntryPoint ep;
+  ep.bucket = bucket_info.bucket;
+  ep.owner = user_info.user_id;
+  ep.creation_time = bucket_info.creation_time;
+  ep.linked = true;
+  map<string, bufferlist> ep_attrs;
+  // XXX I am not convinced this is at all necessary; but previous
+  //	versions would have found and copied VERSION_ATTR so I will
+  //	do likewise for now...  mdw 20180825
+  auto version_iter = attrs.find(VERSION_ATTR);
+  if (version_iter != attrs.end())
+    ep_attrs[VERSION_ATTR] = version_iter->second;
+  rgw_ep_info ep_data{ep, ep_attrs};
+
+  r = rgw_link_bucket(store, user_info.user_id, bucket_info.bucket,
+		      ceph::real_time(), true, &ep_data);
+  if (r < 0) {
+    set_err_msg(err_msg, "failed to relink bucket");
+    return r;
+  }
+  if (bucket != old_bucket) {
+	// howto remove old bucket ?
   }
 
   return 0;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -766,15 +766,20 @@ static void set_err_msg(std::string *sink, std::string msg)
     *sink = msg;
 }
 
-int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state)
+int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state,
+	std::string *err_msg)
 {
-  if (!storage)
+  std::string bucket_tenant;
+  if (!storage) {
+    set_err_msg(err_msg, "no storage!");
     return -EINVAL;
+  }
 
   store = storage;
 
   rgw_user user_id = op_state.get_user_id();
   tenant = user_id.tenant;
+  bucket_tenant = tenant;
   bucket_name = op_state.get_bucket_name();
   RGWUserBuckets user_buckets;
   RGWObjectCtx obj_ctx(store);
@@ -782,9 +787,17 @@ int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state)
   if (bucket_name.empty() && user_id.empty())
     return -EINVAL;
 
+  // split possible tenant/name
+  auto pos = bucket_name.find('/');
+  if (pos != boost::string_ref::npos) {
+    bucket_tenant = bucket_name.substr(0, pos);
+    bucket_name = bucket_name.substr(pos + 1);
+  }
+
   if (!bucket_name.empty()) {
-    int r = store->get_bucket_info(obj_ctx, tenant, bucket_name, bucket_info, NULL);
+    int r = store->get_bucket_info(obj_ctx, bucket_tenant, bucket_name, bucket_info, NULL);
     if (r < 0) {
+      set_err_msg(err_msg, "failed to fetch bucket info for bucket=" + bucket_name);
       ldout(store->ctx(), 0) << "could not get bucket info for bucket=" << bucket_name << dendl;
       return r;
     }
@@ -794,8 +807,10 @@ int RGWBucket::init(RGWRados *storage, RGWBucketAdminOpState& op_state)
 
   if (!user_id.empty()) {
     int r = rgw_get_user_info_by_uid(store, user_id, user_info);
-    if (r < 0)
+    if (r < 0) {
+      set_err_msg(err_msg, "failed to fetch user info");
       return r;
+    }
 
     op_state.display_name = user_info.display_name;
   }
@@ -812,13 +827,19 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
   }
 
   string bucket_id = op_state.get_bucket_id();
+#if 0
   if (bucket_id.empty()) {
     set_err_msg(err_msg, "empty bucket instance id");
     return -EINVAL;
   }
+#endif
 
   std::string display_name = op_state.get_user_display_name();
   rgw_bucket bucket = op_state.get_bucket();
+  if (!bucket_id.empty() && bucket_id != bucket.bucket_id) {
+    set_err_msg(err_msg, "specified bucket id does not match");
+    return -EINVAL;
+  }
 
   const rgw_pool& root_pool = store->get_zone_params().domain_root;
   std::string bucket_entry;
@@ -832,6 +853,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
   RGWObjectCtx obj_ctx(store);
   int r = store->get_bucket_instance_info(obj_ctx, bucket, bucket_info, NULL, &attrs);
   if (r < 0) {
+    set_err_msg(err_msg, "failed to refetch bucket info");
     return r;
   }
 
@@ -874,6 +896,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
 
     r = store->system_obj_set_attr(NULL, obj, RGW_ATTR_ACL, aclbl, &objv_tracker);
     if (r < 0) {
+      set_err_msg(err_msg, "failed to set new acl");
       return r;
     }
 
@@ -886,12 +909,14 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
     store->get_bucket_instance_obj(bucket, obj_bucket_instance);
     r = store->system_obj_set_attr(NULL, obj_bucket_instance, RGW_ATTR_ACL, aclbl, &objv_tracker);
     if (r < 0) {
+      set_err_msg(err_msg, "failed to set bucket policy");
       return r;
     }
 
     r = rgw_link_bucket(store, user_info.user_id, bucket_info.bucket,
                         ceph::real_time());
     if (r < 0) {
+      set_err_msg(err_msg, "failed to relink bucket");
       return r;
     }
   }
@@ -1329,7 +1354,7 @@ int RGWBucketAdminOp::link(RGWRados *store, RGWBucketAdminOpState& op_state, str
 {
   RGWBucket bucket;
 
-  int ret = bucket.init(store, op_state);
+  int ret = bucket.init(store, op_state, err);
   if (ret < 0)
     return ret;
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -289,7 +289,8 @@ class RGWBucket
 
 public:
   RGWBucket() : store(NULL), handle(NULL), failure(false) {}
-  int init(RGWRados *storage, RGWBucketAdminOpState& op_state);
+  int init(RGWRados *storage, RGWBucketAdminOpState& op_state,
+              std::string *err_msg = NULL);
 
   int check_bad_index_multipart(RGWBucketAdminOpState& op_state,
               RGWFormatterFlusher& flusher, std::string *err_msg = NULL);

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -290,7 +290,7 @@ class RGWBucket
 public:
   RGWBucket() : store(NULL), handle(NULL), failure(false) {}
   int init(RGWRados *storage, RGWBucketAdminOpState& op_state,
-              std::string *err_msg = NULL);
+              std::string *err_msg = NULL, map<string, bufferlist> *pattrs = NULL);
 
   int check_bad_index_multipart(RGWBucketAdminOpState& op_state,
               RGWFormatterFlusher& flusher, std::string *err_msg = NULL);
@@ -305,7 +305,8 @@ public:
           std::string *err_msg = NULL);
 
   int remove(RGWBucketAdminOpState& op_state, bool bypass_gc = false, bool keep_index_consistent = true, std::string *err_msg = NULL);
-  int link(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
+  int link(RGWBucketAdminOpState& op_state, map<string, bufferlist>& attrs,
+	std::string *err_msg = NULL);
   int unlink(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
   int set_quota(RGWBucketAdminOpState& op_state, std::string *err_msg = NULL);
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -176,11 +176,19 @@ extern int rgw_read_user_buckets(RGWRados *store,
 				 bool* is_truncated,
                                  uint64_t default_amount = 1000);
 
+struct rgw_ep_info {
+    RGWBucketEntryPoint &ep;
+    map<string, bufferlist>& attrs;
+    rgw_ep_info(RGWBucketEntryPoint &ep, map<string, bufferlist>& attrs)
+	: ep(ep), attrs(attrs) { }
+};
+
 extern int rgw_link_bucket(RGWRados* store,
                            const rgw_user& user_id,
                            rgw_bucket& bucket,
                            ceph::real_time creation_time,
-                           bool update_entrypoint = true);
+                           bool update_entrypoint = true,
+                           rgw_ep_info *pinfo = nullptr);
 extern int rgw_unlink_bucket(RGWRados *store, const rgw_user& user_id,
                              const string& tenant_name, const string& bucket_name, bool update_entrypoint = true);
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -200,6 +200,7 @@ struct RGWBucketAdminOpState {
   std::string bucket_name;
   std::string bucket_id;
   std::string object_name;
+  std::string new_bucket_name;
 
   bool list_buckets;
   bool stat_buckets;
@@ -229,6 +230,9 @@ struct RGWBucketAdminOpState {
   }
   void set_object(std::string& object_str) {
     object_name = object_str;
+  }
+  void set_new_bucket_name(std::string& new_bucket_str) {
+    new_bucket_name = new_bucket_str;
   }
   void set_quota(RGWQuotaInfo& value) {
     quota = value;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1399,6 +1399,7 @@ struct RGWBucketEntryPoint
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(list<RGWBucketEntryPoint*>& o);
 };
 WRITE_CLASS_ENCODER(RGWBucketEntryPoint)
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1094,6 +1094,10 @@ struct rgw_bucket {
   bool operator==(const rgw_bucket& b) const {
     return (name == b.name) && (bucket_id == b.bucket_id);
   }
+  bool operator!=(const rgw_bucket& b) const {
+    return (tenant != b.tenant) || (name != b.name) ||
+           (bucket_id != b.bucket_id);
+  }
 };
 WRITE_CLASS_ENCODER(rgw_bucket)
 

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -547,3 +547,32 @@ void rgw_data_sync_status::generate_test_instances(list<rgw_data_sync_status*>& 
 {
   o.push_back(new rgw_data_sync_status);
 }
+
+void RGWBucketEntryPoint::generate_test_instances(list<RGWBucketEntryPoint*>& o)
+{
+  RGWBucketEntryPoint *bp = new RGWBucketEntryPoint();
+  init_bucket(&bp->bucket, "tenant", "bucket", "pool", ".index.pool", "marker", "10");
+  bp->owner = "owner";
+  bp->creation_time = ceph::real_clock::from_ceph_timespec({{2}, {3}});
+
+  o.push_back(bp);
+  o.push_back(new RGWBucketEntryPoint);
+}
+
+void rgw_user::generate_test_instances(list<rgw_user*>& o)
+{
+  rgw_user *u = new rgw_user("tenant", "user");
+
+  o.push_back(u);
+  o.push_back(new rgw_user);
+}
+
+void obj_version::generate_test_instances(list<obj_version*>& o)
+{
+  obj_version *v = new obj_version;
+  v->ver = 5;
+  v->tag = "tag";
+
+  o.push_back(v);
+  o.push_back(new obj_version);
+}

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1561,3 +1561,8 @@ void RGWOrphanSearchState::dump(Formatter *f) const
   encode_json("stage", stage, f);
   f->close_section();
 }
+
+void rgw_user::dump(Formatter *f) const
+{
+  ::encode_json("user", *this, f);
+}

--- a/src/rgw/rgw_rest_bucket.cc
+++ b/src/rgw/rgw_rest_bucket.cc
@@ -129,17 +129,20 @@ void RGWOp_Bucket_Link::execute()
   std::string uid_str;
   std::string bucket;
   std::string bucket_id;
+  std::string new_bucket_name;
 
   RGWBucketAdminOpState op_state;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   RESTArgs::get_string(s, "bucket", bucket, &bucket);
   RESTArgs::get_string(s, "bucket-id", bucket_id, &bucket_id);
+  RESTArgs::get_string(s, "new-bucket-name", new_bucket_name, &new_bucket_name);
 
   rgw_user uid(uid_str);
   op_state.set_user_id(uid);
   op_state.set_bucket_name(bucket);
   op_state.set_bucket_id(bucket_id);
+  op_state.set_new_bucket_name(new_bucket_name);
 
   http_ret = RGWBucketAdminOp::link(store, op_state);
 }

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -167,6 +167,8 @@
      --start-date=<date>       start date in the format yyyy-mm-dd
      --end-date=<date>         end date in the format yyyy-mm-dd
      --bucket-id=<bucket-id>   bucket id
+     --bucket-new-name=<bucket>
+                               for bucket link: optional new name
      --shard-id=<shard-id>     optional for: 
                                  mdlog list
                                  data sync status

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -302,6 +302,9 @@ TYPE(RGWAccessControlList)
 TYPE(ACLOwner)
 TYPE(RGWAccessControlPolicy)
 
+#include "rgw/rgw_basic_types.h"
+TYPE(rgw_user)
+
 #include "rgw/rgw_cache.h"
 TYPE(ObjectMetaInfo)
 TYPE(ObjectCacheInfo)
@@ -371,6 +374,9 @@ TYPE(cls_user_get_header_op)
 TYPE(cls_user_get_header_ret)
 TYPE(cls_user_complete_stats_sync_op)
 
+#include "cls/version/cls_version_types.h"
+TYPE(obj_version)
+
 #include "cls/journal/cls_journal_types.h"
 TYPE(cls::journal::ObjectPosition)
 TYPE(cls::journal::ObjectSetPosition)
@@ -383,6 +389,7 @@ TYPE(RGWUserInfo)
 TYPE(rgw_bucket)
 TYPE(RGWBucketInfo)
 TYPE(RGWBucketEnt)
+TYPE(RGWBucketEntryPoint)
 TYPE(RGWUploadPartInfo)
 TYPE(rgw_obj)
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/36178

---

This is a backport of https://github.com/ceph/ceph/pull/23994 to luminous.
Also see tracker http://tracker.ceph.com/issues/35885
Commits here include,
5a72d6de0f rgw: RGWBucket::link supports tenant
b99d2a6220 Add several types to ceph-dencoder.
53246a2751 Add "--bucket-new-name" option to radosgw-admin.
bd7e930985 rgw: bucket link: Add ability to name bucket w/ different tenant.
9de55e2b79 rgw: bucket link: simplify use of get bucket info.
7f7746f02a rgw: bucket link: use data from bucket_info to rewrite bucket_endpoint.
d766d5eed2 rearrange / simplify RGWBucket::link logic - start bucket move support
be78d12b33 rgw: bucket link: base "bucket move" (tenant id only)
33b1475dd2 rgw: bucket link: "bucket move"; handle bucket names too.
61d9b1524c rgw: bucket link: "bucket move" documentation changes

Differences from the commit series for master,
ADDED 5a72d6de0f (rgw: RGWBucket::link supports tenant) is a backport of a pr against master that had not been backported, see http://tracker.ceph.com/issues/22666 https://github.com/ceph/ceph/pull/23119
REMOVED 8297f4cfc7 already existed in luminous as d2bdea8e7b (rgw: making implicit_tenants backwards compatible.) also see https://github.com/ceph/ceph/pull/22363 https://github.com/ceph/ceph/pull/22378)

Note that reviewers found some nits in the commit series against master, if those are addressed that may need to be propagated here as well.