### PR TITLE
mgr/dashboard: no side-effects on failed user creation

### DIFF
--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -550,14 +550,16 @@ Username and password updated''', ''
         name = cmd['name'] if 'name' in cmd else None
         email = cmd['email'] if 'email' in cmd else None
         try:
-            user = ACCESS_CTRL_DB.create_user(username, password, name, email)
             role = ACCESS_CTRL_DB.get_role(rolename) if rolename else None
-        except UserAlreadyExists as ex:
-            return -errno.EEXIST, '', str(ex)
         except RoleDoesNotExist as ex:
             if rolename not in SYSTEM_ROLES:
                 return -errno.ENOENT, '', str(ex)
             role = SYSTEM_ROLES[rolename]
+
+        try:
+            user = ACCESS_CTRL_DB.create_user(username, password, name, email)
+        except UserAlreadyExists as ex:
+            return -errno.EEXIST, '', str(ex)
 
         if role:
             user.set_roles([role])


### PR DESCRIPTION
Read operations go first, operations with side-effects go last.
Otherwise, something like

1) create user A with non-existent role R1; fails due to R1 DNE
2) create user B with existent role R2; success

will result in both A and B being created; B will have a R2 assigned, A
will have no roles.

Signed-off-by: Joao Eduardo Luis <joao@suse.de>