### PR TITLE
ceph-volume  batch: allow journal+block.db sizing on the CLI

### DIFF
--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -65,6 +65,9 @@ Optional arguments:
                      current input (requires devices to be passed in)
 * [--format]         Output format when reporting (used along with
                      --report), can be one of 'pretty' (default) or 'json'
+* [--block-db-size]     Set (or override) the "bluestore_block_db_size" value,
+                        in bytes
+* [--journal-size]      Override the "osd_journal_size" value, in megabytes
 
 Required positional arguments:
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -212,6 +212,16 @@ class Batch(object):
             default=1,
             help='Provision more than 1 (the default) OSD per device',
         )
+        parser.add_argument(
+            '--block-db-size',
+            type=int,
+            help='Set (or override) the "bluestore_block_db_size" value, in bytes'
+        )
+        parser.add_argument(
+            '--journal-size',
+            type=int,
+            help='Override the "osd_journal_size" value, in megabytes'
+        )
         args = parser.parse_args(self.argv)
 
         if not args.devices:

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -136,7 +136,7 @@ class MixedType(object):
         self.hdds = [device for device in devices if device.sys_api['rotational'] == '1']
         self.ssds = [device for device in devices if device.sys_api['rotational'] == '0']
         self.computed = {'osds': []}
-        self.block_db_size = prepare.get_block_db_size(lv_format=False) or disk.Size(b=0)
+        self.block_db_size = self.get_block_size()
         self.system_vgs = lvm.VolumeGroups()
         self.dbs_needed = len(self.hdds) * self.osds_per_device
         self.validate()
@@ -144,6 +144,12 @@ class MixedType(object):
 
     def report_json(self):
         print(json.dumps(self.computed, indent=4, sort_keys=True))
+
+    def get_block_size(self):
+        if self.args.block_db_size:
+            return disk.Size(b=self.args.block_db_size)
+        else:
+            return prepare.get_block_db_size(lv_format=False) or disk.Size(b=0)
 
     def report_pretty(self):
         vg_extents = lvm.sizing(self.total_available_db_space.b, parts=self.dbs_needed)

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -5,7 +5,7 @@ from ceph_volume.devices.lvm.strategies import bluestore
 class TestSingleType(object):
 
     def test_hdd_device_is_large_enough(self, fakedevice, factory):
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, block_db_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
@@ -16,7 +16,7 @@ class TestSingleType(object):
         assert computed_osd['data']['path'] == '/dev/sda'
 
     def test_sdd_device_is_large_enough(self, fakedevice, factory):
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, block_db_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
         ]
@@ -27,7 +27,7 @@ class TestSingleType(object):
         assert computed_osd['data']['path'] == '/dev/sda'
 
     def test_device_cannot_have_many_osds_per_device(self, fakedevice, factory):
-        args = factory(osds_per_device=3)
+        args = factory(osds_per_device=3, block_db_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
@@ -36,7 +36,7 @@ class TestSingleType(object):
         assert 'Unable to use device 5.66 GB /dev/sda' in str(error)
 
     def test_device_is_lvm_member_fails(self, fakedevice, factory):
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, block_db_size=None)
         devices = [
             fakedevice(is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
         ]
@@ -52,7 +52,7 @@ class TestMixedTypeConfiguredSize(object):
     def test_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         # 3GB block.db in ceph.conf
         conf_ceph(get_safe=lambda *a: 3147483640)
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, block_db_size=None)
         ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
         hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]
@@ -68,7 +68,7 @@ class TestMixedTypeConfiguredSize(object):
     def test_ssd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         # 7GB block.db in ceph.conf
         conf_ceph(get_safe=lambda *a: 7747483640)
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, block_db_size=None)
         ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
         hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]
@@ -81,7 +81,7 @@ class TestMixedTypeConfiguredSize(object):
     def test_multi_hdd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         # 3GB block.db in ceph.conf
         conf_ceph(get_safe=lambda *a: 3147483640)
-        args = factory(osds_per_device=2)
+        args = factory(osds_per_device=2, block_db_size=None)
         ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
         hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]
@@ -96,7 +96,7 @@ class TestMixedTypeLargeAsPossible(object):
 
     def test_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: None)
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, block_db_size=None)
         ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
         hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]
@@ -112,7 +112,7 @@ class TestMixedTypeLargeAsPossible(object):
 
     def test_multi_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: None)
-        args = factory(osds_per_device=2)
+        args = factory(osds_per_device=2, block_db_size=None)
         ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=60073740000))
         hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=60073740000))
         devices = [ssd, hdd]
@@ -128,7 +128,7 @@ class TestMixedTypeLargeAsPossible(object):
 
     def test_multi_hdd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: None)
-        args = factory(osds_per_device=2)
+        args = factory(osds_per_device=2, block_db_size=None)
         ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
         hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
@@ -7,7 +7,7 @@ class TestSingleType(object):
 
     def test_hdd_device_is_large_enough(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=12073740000))
         ]
@@ -19,7 +19,7 @@ class TestSingleType(object):
 
     def test_hdd_device_with_large_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
@@ -30,7 +30,7 @@ class TestSingleType(object):
 
     def test_ssd_device_is_large_enough(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=12073740000))
         ]
@@ -42,7 +42,7 @@ class TestSingleType(object):
 
     def test_ssd_device_with_large_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
         ]
@@ -53,7 +53,7 @@ class TestSingleType(object):
 
     def test_ssd_device_multi_osd(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=4)
+        args = factory(osds_per_device=4, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000))
         ]
@@ -64,7 +64,7 @@ class TestSingleType(object):
 
     def test_hdd_device_multi_osd(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=4)
+        args = factory(osds_per_device=4, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))
         ]
@@ -75,7 +75,7 @@ class TestSingleType(object):
 
     def test_device_is_lvm_member_fails(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=True, sys_api=dict(rotational='1', size=12073740000))
         ]
@@ -85,7 +85,7 @@ class TestSingleType(object):
 
     def test_hdd_device_with_small_configured_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
@@ -96,7 +96,7 @@ class TestSingleType(object):
 
     def test_ssd_device_with_small_configured_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
         ]
@@ -110,7 +110,7 @@ class TestMixedType(object):
 
     def test_minimum_size_is_not_met(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
@@ -122,7 +122,7 @@ class TestMixedType(object):
 
     def test_ssd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '7120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
@@ -134,7 +134,7 @@ class TestMixedType(object):
 
     def test_hdd_device_is_lvm_member_fails(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
             fakedevice(is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
@@ -159,7 +159,7 @@ class TestMixedType(object):
         ])
 
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [ssd, hdd]
         result = filestore.MixedType(devices, args).computed['osds'][0]
         assert result['journal']['path'] == 'vg: fast'
@@ -190,7 +190,7 @@ class TestMixedType(object):
         ])
 
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1)
+        args = factory(osds_per_device=1, journal_size=None)
         devices = [ssd1, ssd2, hdd]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType(devices, args)
@@ -199,7 +199,7 @@ class TestMixedType(object):
 
     def test_ssd_device_fails_multiple_osds(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '15120')
-        args = factory(osds_per_device=2)
+        args = factory(osds_per_device=2, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000)),
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))


### PR DESCRIPTION
Because there is tooling (e.g. ceph-ansible) that may not have a configured cluster that ceph-volume can work with to use these values

Fixes: http://tracker.ceph.com/issues/36088
