### PR TITLE
qa/suites/rgw/tempest: valgrind on centos only

### DIFF
--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -1,3 +1,6 @@
+# see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
+os_type: centos
+
 tasks:
 - install:
     flavor: notcmalloc


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>