### PR TITLE
mimic : doc: remove deprecated 'scrubq' from ceph(8)

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1263,11 +1263,11 @@ Subcommand ``ls`` lists pg with specific pool, osd, state
 Usage::
 
 	ceph pg ls {<int>} {active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale| remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized [active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale|remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized...]}
@@ -1278,11 +1278,11 @@ Usage::
 
 	ceph pg ls-by-osd <osdname (id|osd.id)> {<int>}
 	{active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale| remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized [active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale|remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized...]}
@@ -1293,11 +1293,11 @@ Usage::
 
 	ceph pg ls-by-pool <poolstr> {<int>} {active|
 	clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale| remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized [active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale|remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized...]}
@@ -1308,11 +1308,11 @@ Usage::
 
 	ceph pg ls-by-primary <osdname (id|osd.id)> {<int>}
 	{active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale| remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized [active|clean|down|replay|splitting|
-	scrubbing|scrubq|degraded|inconsistent|peering|repair|
+	scrubbing|degraded|inconsistent|peering|repair|
 	recovery|backfill_wait|incomplete|stale|remapped|
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized...]}


### PR DESCRIPTION
http://tracker.ceph.com/issues/35855