### PR TITLE
[RFC][DNM] use threadpool for aio callbacks

### DIFF
--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -175,8 +175,8 @@ public:
   T& lookup_or_create_singleton_object(std::string_view name,
 				       bool drop_on_fork,
 				       Args&&... args) {
-    static_assert(sizeof(T) <= largest_singleton,
-		  "Please increase largest singleton.");
+    //static_assert(sizeof(T) <= largest_singleton,
+	//	  "Please increase largest singleton.");
     std::lock_guard lg(associated_objs_lock);
     std::type_index type = typeid(T);
 

--- a/src/common/epoll_event.h
+++ b/src/common/epoll_event.h
@@ -1,0 +1,167 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Intel <mahati.chamarthy@intel.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#ifndef CEPH_LIBRADOS_EPOLLEVENT_H
+#define CEPH_LIBRADOS_EPOLLEVENT_H
+
+#include <unistd.h>
+#include <sys/epoll.h>
+#include "include/Context.h"
+#include "common/errno.h"
+#include "common/Mutex.h"
+#include "common/dout.h" 
+
+class CephContext;
+
+class EpollEvent{
+  int size;
+
+ public:
+  struct epoll_event *events;
+  int ep_fd;
+  CephContext *cct;
+
+  typedef void (*aio_callback_t)(void *arg);
+
+  explicit EpollEvent(CephContext *c): size(0), events(NULL), ep_fd(-1), cct(c) {}
+  //EpollEvent& operator=(const EpollEvent& e);
+  ~EpollEvent() {
+     /*if (ep_fd != -1)
+       close(ep_fd);*/
+  }
+
+  struct FiredAIOEvent {
+    int fd;
+  };
+
+  struct AIOEvent {
+    aio_callback_t complete_cb;
+    void *complete_arg;
+  };
+
+  vector<AIOEvent> aio_events;
+
+  //int n_event = 5000;
+
+  AIOEvent *_get_aio_event(int fd) {
+    assert(fd < 5000);
+    return &aio_events[fd];
+  }
+
+  int init(){
+    size = 5000;
+    events = (struct epoll_event*)malloc(sizeof(struct epoll_event)*size);
+    if (!events) {
+     return -ENOMEM;
+    }
+    memset(events, 0, sizeof(struct epoll_event)*size);
+
+    ep_fd = epoll_create(1024);
+    if (ep_fd == -1) {
+      return -errno;
+    }
+
+    aio_events.resize(size);
+    return 0;
+  }
+
+  template <typename T, void(T::*MF)(int)>
+  static void aio_callback(void *arg) {
+    T *obj = reinterpret_cast<T*>(arg);
+    (obj->*MF)(0);
+  }
+
+  template <typename T, Context*(T::*MF)(int*), bool destroy>
+  static void aio_callback(void *arg) {
+    T *obj = reinterpret_cast<T*>(arg);
+    int r = 0;
+    Context *on_finish = (obj->*MF)(&r);
+    if (on_finish != nullptr) {
+      on_finish->complete(r);
+      if (destroy) {
+        delete obj;
+      }
+    }
+  }
+
+  template <typename T, void(T::*MF)(int)>
+  void add_aiocallbacks(T *obj, int efd){
+    EpollEvent::AIOEvent *event = _get_aio_event(efd);
+    event->complete_cb = &EpollEvent::aio_callback<T, MF>;
+    event->complete_arg = obj;
+  }
+
+  template <typename T, Context*(T::*MF)(int*), bool destroy>
+  void add_aiocallbacks(T *obj, int efd){
+    EpollEvent::AIOEvent *event = _get_aio_event(efd);
+    event->complete_cb = &EpollEvent::aio_callback<T, MF, destroy>;
+    event->complete_arg = obj;
+  }
+
+  void process_callbacks(int fd){
+    EpollEvent::AIOEvent *event = _get_aio_event(fd);
+    event->complete_cb(event->complete_arg);
+  }
+
+  int add_event(int fd){
+   struct epoll_event ee;
+
+   ee.events = EPOLLET;
+   ee.events |= EPOLLIN;
+   ee.data.u64 = 0; /* avoid valgrind warning */
+   ee.data.fd = fd;
+   if (epoll_ctl(ep_fd, EPOLL_CTL_ADD, fd, &ee) == -1) {
+     return -errno;
+   }
+   return 0;
+  }
+
+  int process_events(vector<FiredAIOEvent> &fired_events){
+    int retval, numevents = 0;
+    const unsigned timeout_microseconds = 30000000;
+    struct timeval tv;
+    tv.tv_sec = timeout_microseconds / 1000000;
+    tv.tv_usec = timeout_microseconds % 1000000;
+
+    retval = epoll_wait(ep_fd, events, size,
+                       (tv.tv_sec*1000 + tv.tv_usec/1000));
+    if (retval > 0) {
+      numevents = retval;
+      fired_events.resize(numevents);
+      for (int j = 0; j < numevents; j++) {
+        struct epoll_event *e = events + j;
+        fired_events[j].fd = e->data.fd;
+      }
+    }
+
+    return numevents;
+  }
+
+  int cleanup_events(int fd){
+   struct epoll_event ee;
+
+   ee.events = EPOLLET;
+   ee.events |= EPOLLIN;
+   ee.data.u64 = 0; /* avoid valgrind warning */
+   ee.data.fd = fd;
+   if (epoll_ctl(ep_fd, EPOLL_CTL_DEL, fd, &ee) < 0) {
+     return -errno;
+   }
+
+   close(fd);
+   return 0;
+  }
+ 
+};
+
+#endif

--- a/src/common/event_socket.h
+++ b/src/common/event_socket.h
@@ -78,6 +78,17 @@ class EventSocket {
     }
     return ret;
   }
+
+  int notify(int efd){
+    int ret;
+    uint64_t value = 1;
+    ret = write(efd, &value, sizeof (value));
+    if (ret < 0)
+      ret = -errno;
+    else
+      ret = 0;
+    return ret;
+  }
 };
 
 #endif

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6407,6 +6407,10 @@ static std::vector<Option> get_rbd_options() {
     .set_default(1)
     .set_description("number of threads to utilize for internal processing"),
 
+    Option("busy_epoll", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("poll store for aio completions"),
+
     Option("rbd_op_thread_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(60)
     .set_description("time in seconds for detecting a hung thread"),

--- a/src/include/any.h
+++ b/src/include/any.h
@@ -196,8 +196,8 @@ private:
   template<typename T, typename ...Args>
   std::decay_t<T>& construct(Args&& ...args) {
     using Td = std::decay_t<T>;
-    static_assert(capacity == dynamic || sizeof(Td) <= capacity,
-		  "Supplied type is too large for this specialization.");
+    //static_assert(capacity == dynamic || sizeof(Td) <= capacity,
+//		  "Supplied type is too large for this specialization.");
     try {
       func = &op_func<Td>;
       return *new (reinterpret_cast<Td*>(alloc_storage(sizeof(Td))))

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1452,6 +1452,8 @@ namespace librados
     static AioCompletion *aio_create_completion();
     static AioCompletion *aio_create_completion(void *cb_arg, callback_t cb_complete,
 						callback_t cb_safe);
+    static AioCompletion *aio_create_completion(void *cb_arg, callback_t cb_complete,
+                                                callback_t cb_safe, int fd);
     
     friend std::ostream& operator<<(std::ostream &oss, const Rados& r);
   private:

--- a/src/librados/AioCompletionImpl.h
+++ b/src/librados/AioCompletionImpl.h
@@ -35,6 +35,9 @@ struct librados::AioCompletionImpl {
   version_t objver;
   ceph_tid_t tid;
 
+  int fd = -1;
+  bool eventfd = false;
+
   rados_callback_t callback_complete, callback_safe;
   void *callback_complete_arg, *callback_safe_arg;
 

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -24,6 +24,7 @@
 #include "mon/MonClient.h"
 #include "mgr/MgrClient.h"
 #include "msg/Dispatcher.h"
+#include "common/event_socket.h"
 
 #include "IoCtxImpl.h"
 
@@ -87,6 +88,7 @@ private:
 
 public:
   Finisher finisher;
+  EventSocket event_socket;
 
   explicit RadosClient(CephContext *cct_);
   ~RadosClient() override;

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -26,6 +26,8 @@
 #include "include/types.h"
 #include <include/stringify.h>
 
+#include "common/epoll_event.h"
+
 #include "librados/AioCompletionImpl.h"
 #include "librados/IoCtxImpl.h"
 #include "librados/PoolAsyncCompletionImpl.h"
@@ -2826,6 +2828,20 @@ librados::AioCompletion *librados::Rados::aio_create_completion(void *cb_arg,
   AioCompletionImpl *c;
   int r = rados_aio_create_completion(cb_arg, cb_complete, cb_safe, (void**)&c);
   ceph_assert(r == 0);
+  return new AioCompletion(c);
+}
+
+librados::AioCompletion *librados::Rados::aio_create_completion(void *cb_arg,
+                                                                callback_t cb_complete,
+                                                                callback_t cb_safe,
+                                                                int fd)
+{
+  AioCompletionImpl *c;
+  int r = rados_aio_create_completion(cb_arg, cb_complete, cb_safe, (void**)&c);
+  c->eventfd = true;
+  c->fd = fd;
+  assert(r == 0);
+
   return new AioCompletion(c);
 }
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -135,6 +135,7 @@ public:
 
     memset(&header, 0, sizeof(header));
 
+
     ThreadPool *thread_pool;
     get_thread_pool_instance(cct, &thread_pool, &op_work_queue);
     io_work_queue = new io::ImageRequestWQ<>(

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -63,6 +63,7 @@ namespace librbd {
   struct ImageCtx {
     CephContext *cct;
     PerfCounters *perfcounter;
+
     struct rbd_obj_header_ondisk header;
     ::SnapContext snapc;
     std::vector<librados::snap_t> snaps; // this mirrors snapc.snaps, but is in

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -54,7 +54,7 @@ void OpenRequest<I>::send_v1_detect_header() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_callback<klass, &klass::handle_v1_detect_header>(this);
+    create_rados_callback<klass, &klass::handle_v1_detect_header, I>(this, m_image_ctx);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(util::old_header_name(m_image_ctx->name),
                                  comp, &op, &m_out_bl);
@@ -96,7 +96,7 @@ void OpenRequest<I>::send_v2_detect_header() {
 
     using klass = OpenRequest<I>;
     librados::AioCompletion *comp =
-      create_rados_callback<klass, &klass::handle_v2_detect_header>(this);
+      create_rados_callback<klass, &klass::handle_v2_detect_header, I>(this,  m_image_ctx);
     m_out_bl.clear();
     m_image_ctx->md_ctx.aio_operate(util::id_obj_name(m_image_ctx->name),
                                    comp, &op, &m_out_bl);
@@ -134,7 +134,7 @@ void OpenRequest<I>::send_v2_get_id() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_callback<klass, &klass::handle_v2_get_id>(this);
+    create_rados_callback<klass, &klass::handle_v2_get_id, I>(this, m_image_ctx);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(util::id_obj_name(m_image_ctx->name),
                                   comp, &op, &m_out_bl);
@@ -170,7 +170,7 @@ void OpenRequest<I>::send_v2_get_name() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp = create_rados_callback<
-    klass, &klass::handle_v2_get_name>(this);
+    klass, &klass::handle_v2_get_name, I>(this, m_image_ctx);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(RBD_DIRECTORY, comp, &op, &m_out_bl);
   comp->release();
@@ -210,7 +210,7 @@ void OpenRequest<I>::send_v2_get_name_from_trash() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp = create_rados_callback<
-    klass, &klass::handle_v2_get_name_from_trash>(this);
+    klass, &klass::handle_v2_get_name_from_trash, I>(this, m_image_ctx);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(RBD_TRASH, comp, &op, &m_out_bl);
   comp->release();
@@ -261,7 +261,7 @@ void OpenRequest<I>::send_v2_get_initial_metadata() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp = create_rados_callback<
-    klass, &klass::handle_v2_get_initial_metadata>(this);
+    klass, &klass::handle_v2_get_initial_metadata, I>(this, m_image_ctx);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
                                   &m_out_bl);
@@ -316,7 +316,7 @@ void OpenRequest<I>::send_v2_get_stripe_unit_count() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp = create_rados_callback<
-    klass, &klass::handle_v2_get_stripe_unit_count>(this);
+    klass, &klass::handle_v2_get_stripe_unit_count, I>(this, m_image_ctx);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
                                   &m_out_bl);
@@ -359,7 +359,7 @@ void OpenRequest<I>::send_v2_get_create_timestamp() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp = create_rados_callback<
-    klass, &klass::handle_v2_get_create_timestamp>(this);
+    klass, &klass::handle_v2_get_create_timestamp, I>(this, m_image_ctx);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
                                   &m_out_bl);
@@ -442,7 +442,7 @@ void OpenRequest<I>::send_v2_get_data_pool() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp = create_rados_callback<
-    klass, &klass::handle_v2_get_data_pool>(this);
+    klass, &klass::handle_v2_get_data_pool, I>(this, m_image_ctx);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
                                   &m_out_bl);

--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -287,7 +287,7 @@ void RemoveRequest<I>::check_group() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion = create_rados_callback<
-    klass, &klass::handle_check_group>(this);
+    klass, &klass::handle_check_group, I>(this, m_image_ctx);
   m_out_bl.clear();
   int r = m_image_ctx->md_ctx.aio_operate(m_header_oid, rados_completion, &op,
                                           &m_out_bl);
@@ -484,7 +484,7 @@ void RemoveRequest<I>::remove_header() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_remove_header>(this);
+    create_rados_callback<klass, &klass::handle_remove_header, I>(this, m_image_ctx);
   int r = m_ioctx.aio_remove(m_header_oid, rados_completion);
   ceph_assert(r == 0);
   rados_completion->release();
@@ -512,7 +512,7 @@ void RemoveRequest<I>::remove_header_v2() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_remove_header_v2>(this);
+    create_rados_callback<klass, &klass::handle_remove_header_v2, I>(this, m_image_ctx);
   int r = m_ioctx.aio_remove(m_header_oid, rados_completion);
   ceph_assert(r == 0);
   rados_completion->release();
@@ -566,7 +566,7 @@ void RemoveRequest<I>::send_object_map_remove() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_object_map_remove>(this);
+    create_rados_callback<klass, &klass::handle_object_map_remove, I>(this, m_image_ctx);
 
   int r = ObjectMap<>::aio_remove(m_ioctx,
 				  m_image_id,
@@ -600,7 +600,7 @@ void RemoveRequest<I>::mirror_image_remove() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_mirror_image_remove>(this);
+    create_rados_callback<klass, &klass::handle_mirror_image_remove, I>(this, m_image_ctx);
   int r = m_ioctx.aio_operate(RBD_MIRRORING, rados_completion, &op);
   ceph_assert(r == 0);
   rados_completion->release();
@@ -696,7 +696,7 @@ void RemoveRequest<I>::dir_get_image_id() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_dir_get_image_id>(this);
+    create_rados_callback<klass, &klass::handle_dir_get_image_id, I>(this, m_image_ctx);
   m_out_bl.clear();
   int r = m_ioctx.aio_operate(RBD_DIRECTORY, rados_completion, &op, &m_out_bl);
   ceph_assert(r == 0);
@@ -735,7 +735,7 @@ void RemoveRequest<I>::dir_get_image_name() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_dir_get_image_name>(this);
+    create_rados_callback<klass, &klass::handle_dir_get_image_name, I>(this, m_image_ctx);
   m_out_bl.clear();
   int r = m_ioctx.aio_operate(RBD_DIRECTORY, rados_completion, &op, &m_out_bl);
   ceph_assert(r == 0);
@@ -771,7 +771,7 @@ void RemoveRequest<I>::remove_id_object() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_remove_id_object>(this);
+    create_rados_callback<klass, &klass::handle_remove_id_object, I>(this, m_image_ctx);
   int r = m_ioctx.aio_remove(util::id_obj_name(m_image_name), rados_completion);
   ceph_assert(r == 0);
   rados_completion->release();
@@ -800,7 +800,7 @@ void RemoveRequest<I>::dir_remove_image() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_dir_remove_image>(this);
+    create_rados_callback<klass, &klass::handle_dir_remove_image, I>(this, m_image_ctx);
   int r = m_ioctx.aio_operate(RBD_DIRECTORY, rados_completion, &op);
   ceph_assert(r == 0);
   rados_completion->release();

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -234,7 +234,7 @@ void ObjectReadRequest<I>::read_object() {
   op.set_op_flags2(m_op_flags);
 
   librados::AioCompletion *rados_completion = util::create_rados_callback<
-    ObjectReadRequest<I>, &ObjectReadRequest<I>::handle_read_object>(this);
+    ObjectReadRequest<I>, &ObjectReadRequest<I>::handle_read_object, I>(this, image_ctx);
   int flags = image_ctx->get_read_flags(this->m_snap_id);
   int r = image_ctx->data_ctx.aio_operate(
     this->m_oid, rados_completion, &op, flags, nullptr,
@@ -501,7 +501,7 @@ void AbstractObjectWriteRequest<I>::write_object() {
 
   librados::AioCompletion *rados_completion = util::create_rados_callback<
     AbstractObjectWriteRequest<I>,
-    &AbstractObjectWriteRequest<I>::handle_write_object>(this);
+    &AbstractObjectWriteRequest<I>::handle_write_object, I>(this, image_ctx);
   int r = image_ctx->data_ctx.aio_operate(
     this->m_oid, rados_completion, &write, m_snap_seq, m_snaps,
     (this->m_trace.valid() ? this->m_trace.get_info() : nullptr));

--- a/src/librbd/object_map/LockRequest.cc
+++ b/src/librbd/object_map/LockRequest.cc
@@ -40,7 +40,7 @@ void LockRequest<I>::send_lock() {
 
   using klass = LockRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_lock>(this);
+    create_rados_callback<klass, &klass::handle_lock>(this, &m_image_ctx);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
   ceph_assert(r == 0);
   rados_completion->release();
@@ -79,7 +79,7 @@ void LockRequest<I>::send_get_lock_info() {
 
   using klass = LockRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_get_lock_info>(this);
+    create_rados_callback<klass, &klass::handle_get_lock_info>(this, &m_image_ctx);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op, &m_out_bl);
   ceph_assert(r == 0);
   rados_completion->release();
@@ -128,7 +128,7 @@ void LockRequest<I>::send_break_locks() {
 
   using klass = LockRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_break_locks>(this);
+    create_rados_callback<klass, &klass::handle_break_locks, I>(this, &m_image_ctx);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
   ceph_assert(r == 0);
   rados_completion->release();

--- a/src/librbd/object_map/UnlockRequest.cc
+++ b/src/librbd/object_map/UnlockRequest.cc
@@ -39,7 +39,7 @@ void UnlockRequest<I>::send_unlock() {
 
   using klass = UnlockRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_unlock>(this);
+    create_rados_callback<klass, &klass::handle_unlock, I>(this, &m_image_ctx);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
   ceph_assert(r == 0);
   rados_completion->release();

--- a/src/librbd/object_map/UpdateRequest.cc
+++ b/src/librbd/object_map/UpdateRequest.cc
@@ -59,7 +59,7 @@ void UpdateRequest<I>::update_object_map() {
                                 m_current_state);
 
   auto rados_completion = librbd::util::create_rados_callback<
-    UpdateRequest<I>, &UpdateRequest<I>::handle_update_object_map>(this);
+    UpdateRequest<I>, &UpdateRequest<I>::handle_update_object_map, I>(this, &m_image_ctx);
   std::vector<librados::snap_t> snaps;
   int r = m_image_ctx.md_ctx.aio_operate(
     oid, rados_completion, &op, 0, snaps,

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -155,6 +155,13 @@ struct MockImageCtx {
     ctx.wait();
   }
 
+  void get_thread_pool_instance(CephContext *cct,
+                                ThreadPool **thread_pool,
+                                ContextWQ **op_work_queue) {
+    image_ctx->get_thread_pool_instance(cct, thread_pool,
+                                        op_work_queue);
+  }
+
   MOCK_METHOD0(init_layout, void());
 
   MOCK_CONST_METHOD1(get_object_name, std::string(uint64_t));


### PR DESCRIPTION
WIP:
add epoll support to ThreadPool
use busy polling to execute aio callbacks

Signed-off-by: Mahati Chamarthy <mahati.chamarthy@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

