### PR TITLE
librbd: reduce the TokenBucket fill cycle and support bursting io configuration.

### DIFF
--- a/qa/suites/rbd/thrash/workloads/rbd_fsx_rate_limit.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_fsx_rate_limit.yaml
@@ -7,3 +7,4 @@ overrides:
     conf:
       client:
         rbd qos iops limit: 50
+        rbd qos iops burst: 100

--- a/qa/suites/rbd/thrash/workloads/rbd_fsx_rate_limit.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_fsx_rate_limit.yaml
@@ -8,3 +8,4 @@ overrides:
       client:
         rbd qos iops limit: 50
         rbd qos iops burst: 100
+        rbd qos schedule tick min: 100

--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -764,6 +764,13 @@ int TokenBucketThrottle::set_limit(uint64_t average, uint64_t burst) {
   return 0;
 }
 
+void TokenBucketThrottle::set_schedule_tick_min(uint64_t tick) {
+  std::lock_guard<Mutex> lock(m_lock);
+  if (tick != 0) {
+    m_tick_min = tick;
+  }
+}
+
 uint64_t TokenBucketThrottle::tokens_filled(double tick) {
   return (0 == m_avg) ? 0 : (tick / m_ticks_per_second * m_avg);
 }

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -334,17 +334,15 @@ private:
 
 
 class TokenBucketThrottle {
-
   struct Bucket {
     CephContext *cct;
     const std::string name;
-    std::atomic<uint64_t> remain = { 0 }, max = { 0 };
 
-    Bucket(CephContext *cct, const std::string& n, uint64_t m)
-      : cct(cct), name(n),
-	remain(m), max(m)
-    {
-    }
+    uint64_t remain;
+    uint64_t max;
+
+    Bucket(CephContext *cct, const std::string &name, uint64_t m)
+      : cct(cct), name(name), remain(m), max(m) {}
 
     uint64_t get(uint64_t c);
     uint64_t put(uint64_t c);
@@ -362,15 +360,55 @@ class TokenBucketThrottle {
   CephContext *m_cct;
   Bucket m_throttle;
   uint64_t m_avg = 0;
+  uint64_t m_burst = 0;
   SafeTimer *m_timer;
   Mutex *m_timer_lock;
   FunctionContext *m_token_ctx = nullptr;
   list<Blocker> m_blockers;
   Mutex m_lock;
 
+  // minimum of the filling period.
+  static const uint64_t m_tick_min = 50;
+  // tokens filling period, its unit is millisecond.
+  uint64_t m_tick = 0;
+  /**
+   * These variables are used to calculate how many tokens need to be put into
+   * the bucket within each tick.
+   *
+   * In actual use, the tokens to be put per tick(m_avg / m_ticks_per_second)
+   * may be a floating point number, but we need an 'uint64_t' to put into the
+   * bucket.
+   *
+   * For example, we set the value of rate to be 950, means 950 iops(or bps).
+   *
+   * In this case, the filling period(m_tick) should be 1000 / 950 = 1.052,
+   * which is too small for the SafeTimer. So we should set the period(m_tick)
+   * to be 50(m_tick_min), and 20 ticks in one second(m_ticks_per_second).
+   * The tokens filled in bucket per tick is 950 / 20 = 47.5, not an integer.
+   *
+   * To resolve this, we use a method called tokens_filled(m_current_tick) to
+   * calculate how many tokens will be put so far(until m_current_tick):
+   *
+   *   tokens_filled = m_current_tick / m_ticks_per_second * m_avg
+   *
+   * And the difference between two ticks will be the result we expect.
+   *   tokens in tick 0: (1 / 20 * 950) - (0 / 20 * 950) =  47 -   0 = 47
+   *   tokens in tick 1: (2 / 20 * 950) - (1 / 20 * 950) =  95 -  47 = 48
+   *   tokens in tick 2: (3 / 20 * 950) - (2 / 20 * 950) = 142 -  95 = 47
+   *
+   * As a result, the tokens filled in one second will shown as this:
+   *   tick    | 1| 2| 3| 4| 5| 6| 7| 8| 9|10|11|12|13|14|15|16|17|18|19|20|
+   *   tokens  |47|48|47|48|47|48|47|48|47|48|47|48|47|48|47|48|47|48|47|48|
+   */
+  uint64_t m_ticks_per_second = 0;
+  uint64_t m_current_tick = 0;
+
+  // period for the bucket filling tokens, its unit is seconds.
+  double m_schedule_tick = 1.0;
+
 public:
   TokenBucketThrottle(CephContext *cct, uint64_t capacity, uint64_t avg,
-  		    SafeTimer *timer, Mutex *timer_lock);
+                      SafeTimer *timer, Mutex *timer_lock);
   
   ~TokenBucketThrottle();
 
@@ -384,7 +422,7 @@ public:
   
   template <typename T, typename I, void(T::*MF)(int, I*, uint64_t)>
   bool get(uint64_t c, T *handler, I *item, uint64_t flag) {
-    if (0 == m_throttle.max)
+    if (0 == m_avg)
       return false;
   
     bool wait = false;
@@ -407,10 +445,12 @@ public:
     return wait;
   }
   
-  void set_max(uint64_t m);
-  void set_average(uint64_t avg);
+  int set_burst(uint64_t burst);
+  int set_average(uint64_t avg);
 
 private:
+  uint64_t tokens_filled(double tick);
+  uint64_t tokens_this_tick();
   void add_tokens();
   void schedule_timer();
   void cancel_timer();

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -445,8 +445,7 @@ public:
     return wait;
   }
   
-  int set_burst(uint64_t burst);
-  int set_average(uint64_t avg);
+  int set_limit(uint64_t average, uint64_t burst);
 
 private:
   uint64_t tokens_filled(double tick);

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -368,7 +368,7 @@ class TokenBucketThrottle {
   Mutex m_lock;
 
   // minimum of the filling period.
-  static const uint64_t m_tick_min = 50;
+  uint64_t m_tick_min = 50;
   // tokens filling period, its unit is millisecond.
   uint64_t m_tick = 0;
   /**
@@ -446,6 +446,7 @@ public:
   }
   
   int set_limit(uint64_t average, uint64_t burst);
+  void set_schedule_tick_min(uint64_t tick);
 
 private:
   uint64_t tokens_filled(double tick);

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6676,6 +6676,30 @@ static std::vector<Option> get_rbd_options() {
     .set_default(0)
     .set_description("the desired limit of write bytes per second"),
 
+    Option("rbd_qos_iops_burst", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("the desired burst limit of IO operations"),
+
+    Option("rbd_qos_bps_burst", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("the desired burst limit of IO bytes"),
+
+    Option("rbd_qos_read_iops_burst", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("the desired burst limit of read operations"),
+
+    Option("rbd_qos_write_iops_burst", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("the desired burst limit of write operations"),
+
+    Option("rbd_qos_read_bps_burst", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("the desired burst limit of read bytes"),
+
+    Option("rbd_qos_write_bps_burst", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("the desired burst limit of write bytes"),
+
     Option("rbd_discard_on_zeroed_write_same", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("discard data on zeroed write same instead of writing zero"),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6700,6 +6700,11 @@ static std::vector<Option> get_rbd_options() {
     .set_default(0)
     .set_description("the desired burst limit of write bytes"),
 
+    Option("rbd_qos_schedule_tick_min", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(50)
+    .set_min(1)
+    .set_description("minimum schedule tick (in milliseconds) for QoS"),
+
     Option("rbd_discard_on_zeroed_write_same", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description("discard data on zeroed write same instead of writing zero"),

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -809,6 +809,9 @@ public:
       sparse_read_threshold_bytes = get_object_size();
     }
 
+    io_work_queue->apply_qos_schedule_tick_min(
+      config.get_val<uint64_t>("rbd_qos_schedule_tick_min"));
+
     io_work_queue->apply_qos_limit(
       RBD_QOS_IOPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_iops_limit"),

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -810,23 +810,29 @@ public:
     }
 
     io_work_queue->apply_qos_limit(
+      RBD_QOS_IOPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_iops_limit"),
-      RBD_QOS_IOPS_THROTTLE);
+      config.get_val<uint64_t>("rbd_qos_iops_burst"));
     io_work_queue->apply_qos_limit(
+      RBD_QOS_BPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_bps_limit"),
-      RBD_QOS_BPS_THROTTLE);
+      config.get_val<uint64_t>("rbd_qos_bps_burst"));
     io_work_queue->apply_qos_limit(
+      RBD_QOS_READ_IOPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_read_iops_limit"),
-      RBD_QOS_READ_IOPS_THROTTLE);
+      config.get_val<uint64_t>("rbd_qos_read_iops_burst"));
     io_work_queue->apply_qos_limit(
+      RBD_QOS_WRITE_IOPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_write_iops_limit"),
-      RBD_QOS_WRITE_IOPS_THROTTLE);
+      config.get_val<uint64_t>("rbd_qos_write_iops_burst"));
     io_work_queue->apply_qos_limit(
+      RBD_QOS_READ_BPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_read_bps_limit"),
-      RBD_QOS_READ_BPS_THROTTLE);
+      config.get_val<uint64_t>("rbd_qos_read_bps_burst"));
     io_work_queue->apply_qos_limit(
+      RBD_QOS_WRITE_BPS_THROTTLE,
       config.get_val<uint64_t>("rbd_qos_write_bps_limit"),
-      RBD_QOS_WRITE_BPS_THROTTLE);
+      config.get_val<uint64_t>("rbd_qos_write_bps_burst"));
   }
 
   ExclusiveLock<ImageCtx> *ImageCtx::create_exclusive_lock() {

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -615,6 +615,13 @@ void ImageRequestWQ<I>::set_require_lock(Direction direction, bool enabled) {
 }
 
 template <typename I>
+void ImageRequestWQ<I>::apply_qos_schedule_tick_min(uint64_t tick){
+  for (auto pair : m_throttles) {
+    pair.second->set_schedule_tick_min(tick);
+  }
+}
+
+template <typename I>
 void ImageRequestWQ<I>::apply_qos_limit(const uint64_t flag,
                                         uint64_t limit,
                                         uint64_t burst) {

--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -624,7 +624,7 @@ void ImageRequestWQ<I>::apply_qos_limit(uint64_t limit, const uint64_t flag) {
     }
   }
   ceph_assert(throttle != nullptr);
-  throttle->set_max(limit);
+  throttle->set_burst(limit);
   throttle->set_average(limit);
   if (limit)
     m_qos_enabled_flag |= flag;

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -73,6 +73,8 @@ public:
 
   void set_require_lock(Direction direction, bool enabled);
 
+  void apply_qos_schedule_tick_min(uint64_t tick);
+
   void apply_qos_limit(const uint64_t flag, uint64_t limit, uint64_t burst);
 protected:
   void *_void_dequeue() override;

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -73,8 +73,7 @@ public:
 
   void set_require_lock(Direction direction, bool enabled);
 
-  void apply_qos_limit(uint64_t limit, const uint64_t flag);
-
+  void apply_qos_limit(const uint64_t flag, uint64_t limit, uint64_t burst);
 protected:
   void *_void_dequeue() override;
   void process(ImageDispatchSpec<ImageCtxT> *req) override;

--- a/src/test/librbd/io/test_mock_ImageRequestWQ.cc
+++ b/src/test/librbd/io/test_mock_ImageRequestWQ.cc
@@ -391,7 +391,7 @@ TEST_F(TestMockIoImageRequestWQ, QosNoLimit) {
   InSequence seq;
   MockImageRequestWQ mock_image_request_wq(&mock_image_ctx, "io", 60, nullptr);
 
-  mock_image_request_wq.apply_qos_limit(0, RBD_QOS_BPS_THROTTLE);
+  mock_image_request_wq.apply_qos_limit(RBD_QOS_BPS_THROTTLE, 0, 0);
 
   expect_front(mock_image_request_wq, &mock_queued_image_request);
   expect_is_refresh_request(mock_image_ctx, false);
@@ -414,7 +414,7 @@ TEST_F(TestMockIoImageRequestWQ, BPSQos) {
   InSequence seq;
   MockImageRequestWQ mock_image_request_wq(&mock_image_ctx, "io", 60, nullptr);
 
-  mock_image_request_wq.apply_qos_limit(1, RBD_QOS_BPS_THROTTLE);
+  mock_image_request_wq.apply_qos_limit(RBD_QOS_BPS_THROTTLE, 1, 0);
 
   expect_front(mock_image_request_wq, &mock_queued_image_request);
   expect_tokens_requested(mock_queued_image_request, 2);


### PR DESCRIPTION
Firstly, the TokenBucket shall put one token per 1/cir second(one tick), and I set the minimum of tick to 50ms for good accuracy.
Secondly, the bursting limit configuration is supported. The default is 0 for disabling bursting io.

Signed-off-by: Shiyang Ruan <ruansy.fnst@cn.fujitsu.com>