### PR TITLE
[DNM] mgr: update MMgrReport message to include OSD dynamic key/value perf counters 

### DIFF
--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -18,6 +18,7 @@
 #include <boost/optional.hpp>
 
 #include "msg/Message.h"
+#include "mgr/OSDPerfMetricReport.h"
 
 #include "common/perf_counters.h"
 #include "mgr/DaemonHealthMetric.h"
@@ -29,6 +30,7 @@ public:
   std::string description;
   std::string nick;
   enum perfcounter_type_d type;
+
 
   // For older clients that did not send priority, pretend everything
   // is "useful" so that mgr plugins filtering on prio will get some
@@ -75,7 +77,7 @@ public:
   friend factory;
 private:
 
-  static constexpr int HEAD_VERSION = 6;
+  static constexpr int HEAD_VERSION = 7;
   static constexpr int COMPAT_VERSION = 1;
 
 public:
@@ -106,6 +108,8 @@ public:
   // encode map<string,map<int32_t,string>> of current config
   bufferlist config_bl;
 
+  OSDPerfMetricReport perf_report;
+
   void decode_payload() override
   {
     auto p = payload.cbegin();
@@ -124,6 +128,9 @@ public:
     if (header.version >= 6) {
       decode(config_bl, p);
     }
+    if (header.version >= 7) {
+      decode(perf_report, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
@@ -136,6 +143,7 @@ public:
     encode(daemon_status, payload);
     encode(daemon_health_metrics, payload);
     encode(config_bl, payload);
+    encode(perf_report, payload);
   }
 
   const char *get_type_name() const override { return "mgrreport"; }

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -31,7 +31,6 @@ public:
   std::string nick;
   enum perfcounter_type_d type;
 
-
   // For older clients that did not send priority, pretend everything
   // is "useful" so that mgr plugins filtering on prio will get some
   // data (albeit probably more than they wanted)
@@ -108,7 +107,7 @@ public:
   // encode map<string,map<int32_t,string>> of current config
   bufferlist config_bl;
 
-  OSDPerfMetricReport perf_report;
+  std::list<OSDPerfMetricReport>  osd_perf_metric_reports;
 
   void decode_payload() override
   {
@@ -129,7 +128,7 @@ public:
       decode(config_bl, p);
     }
     if (header.version >= 7) {
-      decode(perf_report, p);
+      decode(osd_perf_metric_reports, p);
     }
   }
 
@@ -143,7 +142,7 @@ public:
     encode(daemon_status, payload);
     encode(daemon_health_metrics, payload);
     encode(config_bl, payload);
-    encode(perf_report, payload);
+    encode(osd_perf_metric_reports, payload);
   }
 
   const char *get_type_name() const override { return "mgrreport"; }

--- a/src/mgr/OSDPerfMetricReport.h
+++ b/src/mgr/OSDPerfMetricReport.h
@@ -1,0 +1,29 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef OSD_PERF_METRIC_REPORT_H_
+#define OSD_PERF_METRIC_REPORT_H_
+#include "include/denc.h"
+//#include "mgr/OSDPerfMetricQuery"
+
+typedef int OSDPerfMetricQueryID;  //Temporary; to be moved in mgr/OSDPerfMetricQuery.h ?
+
+struct OSDPerfMetricReport
+{
+  OSDPerfMetricQueryID query_id; 
+
+  // Gather from OSD::PerfCounters ?
+  //  client reads/s
+  //  client writes/s
+  //  client read bytes
+  //  client write bytes
+  //  client read latency
+  //  client write latency
+
+  DENC(OSDPerfMetricReport, v, p) {
+      DENC_START(1, 1, p);
+      denc(v.query_id, p);
+      DENC_FINISH(p);
+  }
+};
+WRITE_CLASS_DENC(OSDPerfMetricReport)
+#endif // OSD_PERF_METRIC_REPORT_H_

--- a/src/mgr/OSDPerfMetricReport.h
+++ b/src/mgr/OSDPerfMetricReport.h
@@ -3,27 +3,25 @@
 #ifndef OSD_PERF_METRIC_REPORT_H_
 #define OSD_PERF_METRIC_REPORT_H_
 #include "include/denc.h"
-//#include "mgr/OSDPerfMetricQuery"
 
-typedef int OSDPerfMetricQueryID;  //Temporary; to be moved in mgr/OSDPerfMetricQuery.h ?
+#include "common/perf_counters.h"
 
-struct OSDPerfMetricReport
-{
-  OSDPerfMetricQueryID query_id; 
+struct PerformanceCounterDescriptor {
+  std::string name;
+  perfcounter_type_d type;
+};
 
-  // Gather from OSD::PerfCounters ?
-  //  client reads/s
-  //  client writes/s
-  //  client read bytes
-  //  client write bytes
-  //  client read latency
-  //  client write latency
+
+struct OSDPerfMetricReport {
+  std::vector<PerformanceCounterDescriptor> performance_counter_descriptors;
+  std::map<std::string, bufferlist> group_packed_performance_counters;
 
   DENC(OSDPerfMetricReport, v, p) {
       DENC_START(1, 1, p);
-      denc(v.query_id, p);
+//      denc(v.performance_counter_descriptors, p);
       DENC_FINISH(p);
   }
 };
 WRITE_CLASS_DENC(OSDPerfMetricReport)
+
 #endif // OSD_PERF_METRIC_REPORT_H_


### PR DESCRIPTION
Update MMgrReport message to include OSD dynamic key/value perf counters 

Fixes: https://tracker.ceph.com/issues/36090
Signed-off-by: Julien Collet <julien.collet@cern.ch>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

