### PR TITLE
 mgr/dashboard: Possible fix for some dashboard timing issues

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -144,6 +144,7 @@ class DashboardTestCase(MgrTestCase):
     def setUp(self):
         if not self._loggedin and self.AUTO_AUTHENTICATE:
             self.login('admin', 'admin')
+        self.wait_for_health_clear(20)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Specifically tries to fix the recurringly occurring `test_osd.py` error on `test_scrub` method but this change should also prevent other issues of the same kind. The "same kind" are issues which occurr due to tests which do not immediately result in a clean cluster status and aren't manually programmed to wait for it.
 Such kind of issues will automatically be taken care of with this PR.

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>
