### PR TITLE
rgw multisite: uses local DataChangesLog to track active buckets for trim

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1799,6 +1799,10 @@ int RGWDataChangesLog::add_entry(rgw_bucket& bucket, int shard_id) {
   if (!store->need_to_log_data())
     return 0;
 
+  if (observer) {
+    observer->on_bucket_changed(bucket.get_key());
+  }
+
   rgw_bucket_shard bs(bucket, shard_id);
 
   int index = choose_oid(bs);

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -408,9 +408,14 @@ struct RGWDataChangesLogInfo {
   void decode_json(JSONObj *obj);
 };
 
+namespace rgw {
+struct BucketChangeObserver;
+}
+
 class RGWDataChangesLog {
   CephContext *cct;
   RGWRados *store;
+  rgw::BucketChangeObserver *observer = nullptr;
 
   int num_shards;
   string *oids;
@@ -520,6 +525,10 @@ public:
 
   void mark_modified(int shard_id, const rgw_bucket_shard& bs);
   void read_clear_modified(map<int, set<string> > &modified);
+
+  void set_observer(rgw::BucketChangeObserver *observer) {
+    this->observer = observer;
+  }
 
   bool going_down();
 };

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -593,7 +593,7 @@ int RGWRemoteDataLog::init(const string& _source_zone, RGWRESTConn *_conn, RGWSy
                            RGWSyncTraceManager *_sync_tracer, RGWSyncModuleInstanceRef& _sync_module)
 {
   sync_env.init(store->ctx(), store, _conn, async_rados, &http_manager, _error_logger,
-                _sync_tracer, _source_zone, _sync_module, observer);
+                _sync_tracer, _source_zone, _sync_module);
 
   if (initialized) {
     return 0;
@@ -1040,9 +1040,6 @@ public:
           tn->log(0, SSTR("ERROR: failed to remove omap key from error repo ("
              << error_repo->get_obj() << " retcode=" << retcode));
         }
-      }
-      if (sync_env->observer) {
-        sync_env->observer->on_bucket_changed(bs.bucket.get_key());
       }
       /* FIXME: what do do in case of error */
       if (marker_tracker && !entry_marker.empty()) {
@@ -1825,8 +1822,7 @@ int RGWRemoteBucketLog::init(const string& _source_zone, RGWRESTConn *_conn,
   bs.shard_id = shard_id;
 
   sync_env.init(store->ctx(), store, conn, async_rados, http_manager,
-                _error_logger, _sync_tracer, source_zone, _sync_module,
-                nullptr);
+                _error_logger, _sync_tracer, source_zone, _sync_module);
 
   return 0;
 }
@@ -3330,7 +3326,7 @@ int rgw_bucket_sync_status(RGWRados *store, const std::string& source_zone,
   RGWDataSyncEnv env;
   RGWSyncModuleInstanceRef module; // null sync module
   env.init(store->ctx(), store, nullptr, store->get_async_rados(),
-           nullptr, nullptr, nullptr, source_zone, module, nullptr);
+           nullptr, nullptr, nullptr, source_zone, module);
 
   RGWCoroutinesManager crs(store->ctx(), store->get_cr_registry());
   return crs.run(new RGWCollectBucketSyncStatusCR(store, &env, num_shards,

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -14,10 +14,6 @@
 #include "rgw_sync_module.h"
 #include "rgw_sync_trace.h"
 
-namespace rgw {
-struct BucketChangeObserver;
-}
-
 struct rgw_datalog_info {
   uint32_t num_shards;
 
@@ -243,15 +239,13 @@ struct RGWDataSyncEnv {
   RGWSyncTraceManager *sync_tracer{nullptr};
   string source_zone;
   RGWSyncModuleInstanceRef sync_module{nullptr};
-  rgw::BucketChangeObserver *observer{nullptr};
 
   RGWDataSyncEnv() {}
 
   void init(CephContext *_cct, RGWRados *_store, RGWRESTConn *_conn,
             RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
             RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer,
-            const string& _source_zone, RGWSyncModuleInstanceRef& _sync_module,
-            rgw::BucketChangeObserver *_observer) {
+            const string& _source_zone, RGWSyncModuleInstanceRef& _sync_module) {
     cct = _cct;
     store = _store;
     conn = _conn;
@@ -261,7 +255,6 @@ struct RGWDataSyncEnv {
     sync_tracer = _sync_tracer;
     source_zone = _source_zone;
     sync_module = _sync_module;
-    observer = _observer;
   }
 
   string shard_obj_name(int shard_id);
@@ -272,7 +265,6 @@ class RGWRemoteDataLog : public RGWCoroutinesManager {
   const DoutPrefixProvider *dpp;
   RGWRados *store;
   RGWAsyncRadosProcessor *async_rados;
-  rgw::BucketChangeObserver *observer;
   RGWHTTPManager http_manager;
 
   RGWDataSyncEnv sync_env;
@@ -286,10 +278,9 @@ class RGWRemoteDataLog : public RGWCoroutinesManager {
 
 public:
   RGWRemoteDataLog(const DoutPrefixProvider *dpp, RGWRados *_store,
-                   RGWAsyncRadosProcessor *async_rados,
-                   rgw::BucketChangeObserver *observer)
+                   RGWAsyncRadosProcessor *async_rados)
     : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()),
-      dpp(dpp), store(_store), async_rados(async_rados), observer(observer),
+      dpp(dpp), store(_store), async_rados(async_rados),
       http_manager(store->ctx(), completion_mgr),
       lock("RGWRemoteDataLog::lock"), data_sync_cr(NULL),
       initialized(false) {}
@@ -329,17 +320,15 @@ class RGWDataSyncStatusManager : public DoutPrefixProvider {
 
 public:
   RGWDataSyncStatusManager(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
-                           const string& _source_zone,
-                           rgw::BucketChangeObserver *observer = nullptr)
+                           const string& _source_zone)
     : store(_store), source_zone(_source_zone), conn(NULL), error_logger(NULL),
       sync_module(nullptr),
-      source_log(this, store, async_rados, observer), num_shards(0) {}
+      source_log(this, store, async_rados), num_shards(0) {}
   RGWDataSyncStatusManager(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
-                           const string& _source_zone, const RGWSyncModuleInstanceRef& _sync_module,
-                           rgw::BucketChangeObserver *observer = nullptr)
+                           const string& _source_zone, const RGWSyncModuleInstanceRef& _sync_module)
     : store(_store), source_zone(_source_zone), conn(NULL), error_logger(NULL),
       sync_module(_sync_module),
-      source_log(this, store, async_rados, observer), num_shards(0) {}
+      source_log(this, store, async_rados), num_shards(0) {}
   ~RGWDataSyncStatusManager() {
     finalize();
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3279,10 +3279,9 @@ class RGWDataSyncProcessorThread : public RGWSyncProcessorThread
   }
 public:
   RGWDataSyncProcessorThread(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
-                             const string& _source_zone,
-                             rgw::BucketChangeObserver *observer)
+                             const string& _source_zone)
     : RGWSyncProcessorThread(_store, "data-sync"),
-      sync(_store, async_rados, _source_zone, observer),
+      sync(_store, async_rados, _source_zone),
       initialized(false) {}
 
   void wakeup_sync_shards(map<int, set<string> >& shard_ids) {
@@ -4671,8 +4670,7 @@ int RGWRados::init_complete()
     Mutex::Locker dl(data_sync_thread_lock);
     for (auto iter : zone_data_sync_from_map) {
       ldout(cct, 5) << "starting data sync thread for zone " << iter.first << dendl;
-      auto *thread = new RGWDataSyncProcessorThread(this, async_rados, iter.first,
-                                                    &*bucket_trim);
+      auto *thread = new RGWDataSyncProcessorThread(this, async_rados, iter.first);
       ret = thread->init();
       if (ret < 0) {
         ldout(cct, 0) << "ERROR: failed to initialize data sync thread" << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4666,6 +4666,7 @@ int RGWRados::init_complete()
       ldout(cct, 0) << "ERROR: failed to start bucket trim manager" << dendl;
       return ret;
     }
+    data_log->set_observer(&*bucket_trim);
 
     Mutex::Locker dl(data_sync_thread_lock);
     for (auto iter : zone_data_sync_from_map) {


### PR DESCRIPTION
The `test_bucket_index_log_trim` test has been failing once in a while, and it looks like it's caused by races between bucket checkpoints and calls to the `on_bucket_changed()` observer. Even after bucket sync completes and the test's bucket checkpoint finishes, `RGWDataSyncSingleEntryCR` could run again (either triggered by the error_repo or another zone's datalog). The result is that even if `RunBucketSync` fails (with EBUSY for example) or completes without making any changes, `BucketTrimManager` will consider that bucket 'active' and trim that instead of the one that the test expects.

By moving this `on_bucket_changed()` callback to our local `RGWDataChangesLog`, we only consider buckets 'active' if we've actually mutated them locally - and it's these local bucket index changes that `BucketTrimManager` is interested in trimming.

Fixes: http://tracker.ceph.com/issues/36034