### PR TITLE
osd/PG: fix not_ready_to_merge behavior for merge target

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -719,11 +719,13 @@ public:
   set<pg_t> ready_to_merge_source;
   map<pg_t,epoch_t> ready_to_merge_target;  // pg -> last_epoch_clean
   set<pg_t> not_ready_to_merge_source;
+  map<pg_t,pg_t> not_ready_to_merge_target;
   set<pg_t> sent_ready_to_merge_source;
 
   void set_ready_to_merge_source(PG *pg);
   void set_ready_to_merge_target(PG *pg, epoch_t last_epoch_clean);
-  void set_not_ready_to_merge_source(pg_t pgid);
+  void set_not_ready_to_merge_source(pg_t source);
+  void set_not_ready_to_merge_target(pg_t target, pg_t source);
   void clear_ready_to_merge(PG *pg);
   void send_ready_to_merge();
   void _send_ready_to_merge();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -8430,7 +8430,7 @@ boost::statechart::result PG::RecoveryState::Active::react(const AllReplicasActi
 	pg_t src = pgid;
 	src.set_ps(pg->pool.info.get_pg_num_pending());
 	assert(src.get_parent() == pgid);
-	pg->osd->set_not_ready_to_merge_source(src);
+	pg->osd->set_not_ready_to_merge_target(pgid, src);
       } else {
 	pg->osd->set_not_ready_to_merge_source(pgid);
       }


### PR DESCRIPTION
Track the *target* not being ready to merge independently from the source,
so that we do not have two PGs fighting over the state of
not_ready_ready_to_merge_source, and so that the map reflects the *source*
PGs readiness only.

Signed-off-by: Sage Weil <sage@redhat.com>