### PR TITLE
common: kill backward iteration in bufferlist. Use hole appending instead

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -848,16 +848,6 @@ using namespace ceph;
   buffer::list::iterator_impl<is_const>::iterator_impl(const buffer::list::iterator& i)
     : iterator_impl<is_const>(i.bl, i.off, i.p, i.p_off) {}
 
-#ifdef BL_BACKWARD_COMPAT
-  /// The backward iteration over is bufferlist is DEPRECATED!
-  /// The old int-taking variant of advance() is solely for compatibility.
-  template<bool is_const>
-  void buffer::list::iterator_impl<is_const>::advance(int o)
-  {
-    seek(off + o);
-  }
-#endif // BL_BACKWARD_COMPAT
-
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::advance(unsigned o)
   {
@@ -1083,15 +1073,6 @@ using namespace ceph;
   buffer::list::iterator::iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po)
     : iterator_impl(l, o, ip, po)
   {}
-
-#ifdef BL_BACKWARD_COMPAT
-  /// The backward iteration over is bufferlist is DEPRECATED!
-  /// The old int-taking variant of advance() is solely for compatibility.
-  void buffer::list::iterator::advance(int o)
-  {
-    seek(off + o);
-  }
-#endif // BL_BACKWARD_COMPAT
 
   void buffer::list::iterator::advance(unsigned o)
   {

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1674,7 +1674,7 @@ using namespace ceph;
     }
   }
 
-  buffer::list::iterator buffer::list::append_hole(const unsigned len)
+  buffer::list::contiguous_filler buffer::list::append_hole(const unsigned len)
   {
     if (unlikely(append_buffer.unused_tail_length() < len)) {
       // make a new append_buffer.  fill out a complete page, factoring in
@@ -1690,8 +1690,7 @@ using namespace ceph;
     append_buffer.set_length(append_buffer.length() + len);
     append(append_buffer, append_buffer.length() - len, len);
 
-    const auto lastbuf = std::prev(std::end(_buffers));
-    return { this, length() - len, lastbuf, lastbuf->length() - len };
+    return { std::prev(std::end(_buffers))->end_c_str() - len };
   }
 
   void buffer::list::prepend_zero(unsigned len)

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -650,6 +650,22 @@ namespace buffer CEPH_BUFFER_API {
       return contiguous_appender(this, len, deep);
     }
 
+    class contiguous_filler {
+      friend buffer::list;
+      char* pos;
+
+      contiguous_filler(char* const pos) : pos(pos) {}
+
+    public:
+      void copy_in(const unsigned len, const char* const src) {
+	memcpy(pos, src, len);
+	pos += len;
+      }
+    };
+    // The contiguous_filler is supposed to be not costlier than a single
+    // pointer. Keep it dumb, please.
+    static_assert(sizeof(contiguous_filler) == sizeof(char*));
+
     class page_aligned_appender {
       bufferlist *pbl;
       unsigned min_alloc;
@@ -913,7 +929,7 @@ namespace buffer CEPH_BUFFER_API {
     void append(const ptr& bp, unsigned off, unsigned len);
     void append(const list& bl);
     void append(std::istream& in);
-    iterator append_hole(unsigned len);
+    contiguous_filler append_hole(unsigned len);
     void append_zero(unsigned len);
     void prepend_zero(unsigned len);
     

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -438,12 +438,7 @@ namespace buffer CEPH_BUFFER_API {
 	//return off == bl->length();
       }
 
-#ifdef BL_BACKWARD_COMPAT
-      void advance(int o);
-#else
       void advance(int o) = delete;
-#endif // BL_BACKWARD_COMPAT
-
       void advance(unsigned o);
       void advance(size_t o) { advance(static_cast<unsigned>(o)); }
       void seek(unsigned o);
@@ -491,12 +486,7 @@ namespace buffer CEPH_BUFFER_API {
       iterator(bl_t *l, unsigned o=0);
       iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po);
 
-#ifdef BL_BACKWARD_COMPAT
-      void advance(int o);
-#else
       void advance(int o) = delete;
-#endif // BL_BACKWARD_COMPAT
-
       void advance(unsigned o);
       void advance(size_t o) { advance(static_cast<unsigned>(o)); }
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -913,6 +913,7 @@ namespace buffer CEPH_BUFFER_API {
     void append(const ptr& bp, unsigned off, unsigned len);
     void append(const list& bl);
     void append(std::istream& in);
+    iterator append_hole(unsigned len);
     void append_zero(unsigned len);
     void prepend_zero(unsigned len);
     

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -438,7 +438,14 @@ namespace buffer CEPH_BUFFER_API {
 	//return off == bl->length();
       }
 
+#ifdef BL_BACKWARD_COMPAT
       void advance(int o);
+#else
+      void advance(int o) = delete;
+#endif // BL_BACKWARD_COMPAT
+
+      void advance(unsigned o);
+      void advance(size_t o) { advance(static_cast<unsigned>(o)); }
       void seek(unsigned o);
       char operator*() const;
       iterator_impl& operator++();
@@ -484,7 +491,15 @@ namespace buffer CEPH_BUFFER_API {
       iterator(bl_t *l, unsigned o=0);
       iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po);
 
+#ifdef BL_BACKWARD_COMPAT
       void advance(int o);
+#else
+      void advance(int o) = delete;
+#endif // BL_BACKWARD_COMPAT
+
+      void advance(unsigned o);
+      void advance(size_t o) { advance(static_cast<unsigned>(o)); }
+
       void seek(unsigned o);
       using iterator_impl<false>::operator*;
       char operator*();

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -1519,7 +1519,7 @@ inline std::enable_if_t<traits::supported && !traits::need_contiguous> decode(
     t.copy_shallow(remaining, tmp);
     auto cp = std::cbegin(tmp);
     traits::decode(o, cp);
-    p.advance((ssize_t)cp.get_offset());
+    p.advance(cp.get_offset());
   }
 }
 
@@ -1540,7 +1540,7 @@ inline std::enable_if_t<traits::supported && traits::need_contiguous> decode(
   t.copy_shallow(p.get_bl().length() - p.get_off(), tmp);
   auto cp = std::cbegin(tmp);
   traits::decode(o, cp);
-  p.advance((ssize_t)cp.get_offset());
+  p.advance(cp.get_offset());
 }
 
 // nohead variants
@@ -1571,7 +1571,7 @@ inline std::enable_if_t<traits::supported && !traits::featured> decode_nohead(
   t.copy_shallow(p.get_bl().length() - p.get_off(), tmp);
   auto cp = std::cbegin(tmp);
   traits::decode_nohead(num, o, cp);
-  p.advance((ssize_t)cp.get_offset());
+  p.advance(cp.get_offset());
 }
 }
 

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -1206,14 +1206,13 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  *
  */
 #define ENCODE_START(v, compat, bl)			     \
-  using ::ceph::encode;					     \
-  __u8 struct_v = v, struct_compat = compat;		     \
+  __u8 struct_v = v;                                         \
+  __u8 struct_compat = compat;		                     \
   ceph_le32 struct_len;				             \
-  encode(struct_v, (bl));				     \
-  ::ceph::buffer::list::iterator struct_compat_it =	     \
-    (bl).append_hole(sizeof(struct_compat));		     \
-  ::ceph::buffer::list::iterator struct_len_it =	     \
-    (bl).append_hole(sizeof(struct_len));		     \
+  auto filler = (bl).append_hole(sizeof(struct_v) + 	     \
+    sizeof(struct_compat) + sizeof(struct_len));	     \
+  const auto starting_bl_len = (bl).length();		     \
+  using ::ceph::encode;					     \
   do {
 
 /**
@@ -1222,14 +1221,16 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  * @param bl bufferlist we were encoding to
  * @param new_struct_compat struct-compat value to use
  */
-#define ENCODE_FINISH_NEW_COMPAT(bl, new_struct_compat)			\
-  } while (false);							\
-  struct_len = (bl).length() - struct_len_it.get_off() - sizeof(struct_len); \
-  struct_len_it.copy_in(4, (char *)&struct_len);			\
-  if (new_struct_compat) {						\
-    struct_compat = new_struct_compat;					\
-  }									\
-  struct_compat_it.copy_in(1, (char *)&struct_compat);
+#define ENCODE_FINISH_NEW_COMPAT(bl, new_struct_compat)      \
+  } while (false);                                           \
+  if (new_struct_compat) {                                   \
+    struct_compat = new_struct_compat;                       \
+  }                                                          \
+  struct_len = (bl).length() - starting_bl_len;              \
+  filler.copy_in(sizeof(struct_v), (char *)&struct_v);       \
+  filler.copy_in(sizeof(struct_compat),			     \
+    (char *)&struct_compat);				     \
+  filler.copy_in(sizeof(struct_len), (char *)&struct_len);
 
 #define ENCODE_FINISH(bl) ENCODE_FINISH_NEW_COMPAT(bl, 0)
 

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -1284,6 +1284,8 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
   unsigned struct_end = bl.get_off() + struct_len;			\
   do {
 
+/* BEWARE: any change to this macro MUST be also reflected in the duplicative
+ * DECODE_START_LEGACY_COMPAT_LEN! */
 #define __DECODE_START_LEGACY_COMPAT_LEN(v, compatv, lenv, skip_v, bl)	\
   using ::ceph::decode;							\
   __u8 struct_v;							\
@@ -1322,8 +1324,30 @@ decode(std::array<T, N>& v, bufferlist::const_iterator& p)
  * @param lenv oldest version that includes a __u32 length wrapper
  * @param bl bufferlist::iterator containing the encoded data
  */
+
+/* BEWARE: this is duplication of __DECODE_START_LEGACY_COMPAT_LEN which
+ * MUST be changed altogether. For the rationale behind code duplication,
+ * please `git blame` and refer to the commit message. */
 #define DECODE_START_LEGACY_COMPAT_LEN(v, compatv, lenv, bl)		\
-  __DECODE_START_LEGACY_COMPAT_LEN(v, compatv, lenv, 0u, bl)
+  using ::ceph::decode;							\
+  __u8 struct_v;							\
+  decode(struct_v, bl);							\
+  if (struct_v >= compatv) {						\
+    __u8 struct_compat;							\
+    decode(struct_compat, bl);						\
+    if (v < struct_compat)						\
+      throw buffer::malformed_input(DECODE_ERR_OLDVERSION(		\
+	__PRETTY_FUNCTION__, v, struct_compat));			\
+  }									\
+  unsigned struct_end = 0;						\
+  if (struct_v >= lenv) {						\
+    __u32 struct_len;							\
+    decode(struct_len, bl);						\
+    if (struct_len > bl.get_remaining())				\
+      throw buffer::malformed_input(DECODE_ERR_PAST(__PRETTY_FUNCTION__)); \
+    struct_end = bl.get_off() + struct_len;				\
+  }									\
+  do {
 
 /**
  * start a decoding block with legacy support for older encoding schemes

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3588,11 +3588,9 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     using ceph::encode;
     if (xattr_version) {
       ceph_le32 xbl_len;
+      auto xbl_len_it = bl.end();
       xbl_len = sizeof(__u32);
       encode(xbl_len, bl);
-
-      auto xbl_len_it = bl.end();
-      xbl_len_it.advance(-4);
       if (pxattrs)
 	encode(*pxattrs, bl);
       else

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3588,16 +3588,14 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     using ceph::encode;
     if (xattr_version) {
       ceph_le32 xbl_len;
-      auto xbl_len_it = bl.end();
-      xbl_len = sizeof(__u32);
-      encode(xbl_len, bl);
+      auto filler = bl.append_hole(sizeof(xbl_len));
+      const auto starting_bl_len = bl.length();
       if (pxattrs)
 	encode(*pxattrs, bl);
       else
 	encode((__u32)0, bl);
-      xbl_len = bl.length() - xbl_len_it.get_off() - sizeof(xbl_len);
-      if (xbl_len != sizeof(__u32))
-	xbl_len_it.copy_in(sizeof(xbl_len), (char *)&xbl_len);
+      xbl_len = bl.length() - starting_bl_len;
+      filler.copy_in(sizeof(xbl_len), (char *)&xbl_len);
     } else {
       encode((__u32)0, bl);
     }

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2185,7 +2185,7 @@ int Pipe::read_message(Message **pm, AuthSessionHandler* auth_handler)
       if (got < 0)
 	goto out_dethrottle;
       if (got > 0) {
-	blp.advance(got);
+	blp.advance(static_cast<size_t>(got));
 	data.append(bp, 0, got);
 	offset += got;
 	left -= got;

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -36,7 +36,7 @@ void bluestore_bdev_label_t::encode(bufferlist& bl) const
 
 void bluestore_bdev_label_t::decode(bufferlist::const_iterator& p)
 {
-  p.advance(60); // see above
+  p.advance(60u); // see above
   DECODE_START(2, p);
   decode(osd_uuid, p);
   decode(size, p);

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -182,7 +182,7 @@ public:
       decode(v, bl);
       if (v < 2) {  // normally 0, but conceivably 1
 	// decode old header_t struct (pre v0.40).
-	bl.advance(4); // skip __u32 flags (it was unused by any old code)
+	bl.advance(4u); // skip __u32 flags (it was unused by any old code)
 	flags = 0;
 	uint64_t tfsid;
 	decode(tfsid, bl);

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -618,9 +618,8 @@ void OSDMap::Incremental::encode(bufferlist& bl, uint64_t features) const
     ENCODE_FINISH(bl); // osd-only data
   }
 
-  encode((uint32_t)0, bl); // dummy inc_crc
   crc_it = bl.end();
-  crc_it.advance(-4);
+  encode((uint32_t)0, bl); // dummy inc_crc
   tail_offset = bl.length();
 
   encode(full_crc, bl);
@@ -756,8 +755,7 @@ void OSDMap::Incremental::decode(bufferlist::const_iterator& bl)
 
   DECODE_START_LEGACY_COMPAT_LEN(8, 7, 7, bl); // wrapper
   if (struct_v < 7) {
-    int struct_v_size = sizeof(struct_v);
-    bl.advance(-struct_v_size);
+    bl.seek(start_offset);
     decode_classic(bl);
     encode_features = 0;
     if (struct_v >= 6)
@@ -2805,9 +2803,8 @@ void OSDMap::encode(bufferlist& bl, uint64_t features) const
     ENCODE_FINISH(bl); // osd-only data
   }
 
-  encode((uint32_t)0, bl); // dummy crc
   crc_it = bl.end();
-  crc_it.advance(-4);
+  encode((uint32_t)0, bl); // dummy crc
   tail_offset = bl.length();
 
   ENCODE_FINISH(bl); // meta-encoding wrapper
@@ -2970,8 +2967,7 @@ void OSDMap::decode(bufferlist::const_iterator& bl)
 
   DECODE_START_LEGACY_COMPAT_LEN(8, 7, 7, bl); // wrapper
   if (struct_v < 7) {
-    int struct_v_size = sizeof(struct_v);
-    bl.advance(-struct_v_size);
+    bl.seek(start_offset);
     decode_classic(bl);
     return;
   }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -15,11 +15,13 @@
  *
  */
 
+#include <algorithm>
+#include <optional>
+#include <random>
+
 #include <boost/algorithm/string.hpp>
 
 #include "OSDMap.h"
-#include <algorithm>
-#include <random>
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/Formatter.h"
@@ -508,7 +510,8 @@ void OSDMap::Incremental::encode(bufferlist& bl, uint64_t features) const
 
   size_t start_offset = bl.length();
   size_t tail_offset;
-  buffer::list::iterator crc_it;
+  size_t crc_offset;
+  std::optional<buffer::list::contiguous_filler> crc_filler;
 
   // meta-encoding: how we include client-used and osd-specific data
   ENCODE_START(8, 7, bl);
@@ -618,8 +621,8 @@ void OSDMap::Incremental::encode(bufferlist& bl, uint64_t features) const
     ENCODE_FINISH(bl); // osd-only data
   }
 
-  crc_it = bl.end();
-  encode((uint32_t)0, bl); // dummy inc_crc
+  crc_offset = bl.length();
+  crc_filler = bl.append_hole(sizeof(uint32_t));
   tail_offset = bl.length();
 
   encode(full_crc, bl);
@@ -628,14 +631,14 @@ void OSDMap::Incremental::encode(bufferlist& bl, uint64_t features) const
 
   // fill in crc
   bufferlist front;
-  front.substr_of(bl, start_offset, crc_it.get_off() - start_offset);
+  front.substr_of(bl, start_offset, crc_offset - start_offset);
   inc_crc = front.crc32c(-1);
   bufferlist tail;
   tail.substr_of(bl, tail_offset, bl.length() - tail_offset);
   inc_crc = tail.crc32c(inc_crc);
   ceph_le32 crc_le;
   crc_le = inc_crc;
-  crc_it.copy_in(4, (char*)&crc_le);
+  crc_filler->copy_in(4u, (char*)&crc_le);
   have_crc = true;
 }
 
@@ -2654,7 +2657,8 @@ void OSDMap::encode(bufferlist& bl, uint64_t features) const
 
   size_t start_offset = bl.length();
   size_t tail_offset;
-  buffer::list::iterator crc_it;
+  size_t crc_offset;
+  std::optional<buffer::list::contiguous_filler> crc_filler;
 
   // meta-encoding: how we include client-used and osd-specific data
   ENCODE_START(8, 7, bl);
@@ -2803,15 +2807,15 @@ void OSDMap::encode(bufferlist& bl, uint64_t features) const
     ENCODE_FINISH(bl); // osd-only data
   }
 
-  crc_it = bl.end();
-  encode((uint32_t)0, bl); // dummy crc
+  crc_offset = bl.length();
+  crc_filler = bl.append_hole(sizeof(uint32_t));
   tail_offset = bl.length();
 
   ENCODE_FINISH(bl); // meta-encoding wrapper
 
   // fill in crc
   bufferlist front;
-  front.substr_of(bl, start_offset, crc_it.get_off() - start_offset);
+  front.substr_of(bl, start_offset, crc_offset - start_offset);
   crc = front.crc32c(-1);
   if (tail_offset < bl.length()) {
     bufferlist tail;
@@ -2820,7 +2824,7 @@ void OSDMap::encode(bufferlist& bl, uint64_t features) const
   }
   ceph_le32 crc_le;
   crc_le = crc;
-  crc_it.copy_in(4, (char*)&crc_le);
+  crc_filler->copy_in(4, (char*)&crc_le);
   crc_defined = true;
 }
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4867,7 +4867,7 @@ void SnapSet::decode(bufferlist::const_iterator& bl)
 {
   DECODE_START_LEGACY_COMPAT_LEN(3, 2, 2, bl);
   decode(seq, bl);
-  bl.advance(1);  // skip legacy head_exists (always true)
+  bl.advance(1u);  // skip legacy head_exists (always true)
   decode(snaps, bl);
   decode(clones, bl);
   decode(clone_overlap, bl);

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2110,6 +2110,48 @@ TEST(BufferList, append) {
   }
 }
 
+TEST(BufferList, append_hole) {
+  {
+    bufferlist bl;
+    auto iter = bl.append_hole(1);
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
+    EXPECT_EQ((unsigned)1, bl.length());
+
+    bl.append("BC", 2);
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
+    EXPECT_EQ((unsigned)3, bl.length());
+
+    const char a = 'A';
+    EXPECT_EQ((unsigned)2, bl.length() - iter.get_off() - sizeof(a));
+    iter.copy_in((unsigned)1, &a);
+    EXPECT_EQ((unsigned)3, bl.length());
+
+    EXPECT_EQ(0, ::memcmp("ABC", bl.c_str(), 3));
+  }
+
+  {
+    bufferlist bl;
+    bl.append('A');
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
+    EXPECT_EQ((unsigned)1, bl.length());
+
+    auto iter = bl.append_hole(1);
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
+    EXPECT_EQ((unsigned)2, bl.length());
+
+    bl.append('C');
+    EXPECT_EQ((unsigned)1, bl.get_num_buffers());
+    EXPECT_EQ((unsigned)3, bl.length());
+
+    const char b = 'B';
+    EXPECT_EQ((unsigned)1, bl.length() - iter.get_off() - sizeof(b));
+    iter.copy_in((unsigned)1, &b);
+    EXPECT_EQ((unsigned)3, bl.length());
+
+    EXPECT_EQ(0, ::memcmp("ABC", bl.c_str(), 3));
+  }
+}
+
 TEST(BufferList, append_zero) {
   bufferlist bl;
   bl.append('A');

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2113,7 +2113,7 @@ TEST(BufferList, append) {
 TEST(BufferList, append_hole) {
   {
     bufferlist bl;
-    auto iter = bl.append_hole(1);
+    auto filler = bl.append_hole(1);
     EXPECT_EQ((unsigned)1, bl.get_num_buffers());
     EXPECT_EQ((unsigned)1, bl.length());
 
@@ -2122,8 +2122,7 @@ TEST(BufferList, append_hole) {
     EXPECT_EQ((unsigned)3, bl.length());
 
     const char a = 'A';
-    EXPECT_EQ((unsigned)2, bl.length() - iter.get_off() - sizeof(a));
-    iter.copy_in((unsigned)1, &a);
+    filler.copy_in((unsigned)1, &a);
     EXPECT_EQ((unsigned)3, bl.length());
 
     EXPECT_EQ(0, ::memcmp("ABC", bl.c_str(), 3));
@@ -2135,7 +2134,7 @@ TEST(BufferList, append_hole) {
     EXPECT_EQ((unsigned)1, bl.get_num_buffers());
     EXPECT_EQ((unsigned)1, bl.length());
 
-    auto iter = bl.append_hole(1);
+    auto filler = bl.append_hole(1);
     EXPECT_EQ((unsigned)1, bl.get_num_buffers());
     EXPECT_EQ((unsigned)2, bl.length());
 
@@ -2144,8 +2143,7 @@ TEST(BufferList, append_hole) {
     EXPECT_EQ((unsigned)3, bl.length());
 
     const char b = 'B';
-    EXPECT_EQ((unsigned)1, bl.length() - iter.get_off() - sizeof(b));
-    iter.copy_in((unsigned)1, &b);
+    filler.copy_in((unsigned)1, &b);
     EXPECT_EQ((unsigned)3, bl.length());
 
     EXPECT_EQ(0, ::memcmp("ABC", bl.c_str(), 3));

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -810,10 +810,6 @@ TEST(BufferListIterator, constructors) {
     EXPECT_EQ('B', *i);
     EXPECT_EQ('C', *j);
     bl.c_str()[1] = 'X';
-#ifdef BL_BACKWARD_COMPAT
-    j.advance(-1);
-    EXPECT_EQ('X', *j);
-#endif // BL_BACKWARD_COMPAT
   }
 
   //
@@ -890,12 +886,6 @@ TEST(BufferListIterator, advance) {
     bufferlist::iterator i(&bl);
     EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
   }
-#ifdef BL_BACKWARD_COMPAT
-  {
-    bufferlist::iterator i(&bl);
-    EXPECT_THROW(i.advance(-1), buffer::end_of_buffer);
-  }
-#endif // BL_BACKWARD_COMPAT
   {
     bufferlist::iterator i(&bl);
     EXPECT_EQ('A', *i);
@@ -903,12 +893,6 @@ TEST(BufferListIterator, advance) {
     EXPECT_EQ('B', *i);
     i.advance(3u);
     EXPECT_EQ('E', *i);
-#ifdef BL_BACKWARD_COMPAT
-    i.advance(-3);
-    EXPECT_EQ('B', *i);
-    i.advance(-1);
-    EXPECT_EQ('A', *i);
-#endif // BL_BACKWARD_COMPAT
   }
 }
 

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -810,8 +810,10 @@ TEST(BufferListIterator, constructors) {
     EXPECT_EQ('B', *i);
     EXPECT_EQ('C', *j);
     bl.c_str()[1] = 'X';
+#ifdef BL_BACKWARD_COMPAT
     j.advance(-1);
     EXPECT_EQ('X', *j);
+#endif // BL_BACKWARD_COMPAT
   }
 
   //
@@ -886,23 +888,27 @@ TEST(BufferListIterator, advance) {
 
   {
     bufferlist::iterator i(&bl);
-    EXPECT_THROW(i.advance(200), buffer::end_of_buffer);
+    EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
   }
+#ifdef BL_BACKWARD_COMPAT
   {
     bufferlist::iterator i(&bl);
     EXPECT_THROW(i.advance(-1), buffer::end_of_buffer);
   }
+#endif // BL_BACKWARD_COMPAT
   {
     bufferlist::iterator i(&bl);
     EXPECT_EQ('A', *i);
-    i.advance(1);
+    i.advance(1u);
     EXPECT_EQ('B', *i);
-    i.advance(3);
+    i.advance(3u);
     EXPECT_EQ('E', *i);
+#ifdef BL_BACKWARD_COMPAT
     i.advance(-3);
     EXPECT_EQ('B', *i);
     i.advance(-1);
     EXPECT_EQ('A', *i);
+#endif // BL_BACKWARD_COMPAT
   }
 }
 
@@ -917,14 +923,14 @@ TEST(BufferListIterator, get_ptr_and_advance)
   bl.append(c);
   const char *ptr;
   bufferlist::iterator p = bl.begin();
-  ASSERT_EQ(3u, p.get_ptr_and_advance(11, &ptr));
+  ASSERT_EQ(3u, p.get_ptr_and_advance(11u, &ptr));
   ASSERT_EQ(bl.length() - 3u, p.get_remaining());
   ASSERT_EQ(0, memcmp(ptr, "one", 3));
-  ASSERT_EQ(2u, p.get_ptr_and_advance(2, &ptr));
+  ASSERT_EQ(2u, p.get_ptr_and_advance(2u, &ptr));
   ASSERT_EQ(0, memcmp(ptr, "tw", 2));
-  ASSERT_EQ(1u, p.get_ptr_and_advance(4, &ptr));
+  ASSERT_EQ(1u, p.get_ptr_and_advance(4u, &ptr));
   ASSERT_EQ(0, memcmp(ptr, "o", 1));
-  ASSERT_EQ(5u, p.get_ptr_and_advance(5, &ptr));
+  ASSERT_EQ(5u, p.get_ptr_and_advance(5u, &ptr));
   ASSERT_EQ(0, memcmp(ptr, "three", 5));
   ASSERT_EQ(0u, p.get_remaining());
 }
@@ -953,14 +959,14 @@ TEST(BufferListIterator, iterator_crc32c) {
 
   bl3.append(s.substr(98, 55));
   it = bl1.begin();
-  it.advance(98);
+  it.advance(98u);
   ASSERT_EQ(bl3.crc32c(0), it.crc32c(55, 0));
   ASSERT_EQ(4u, it.get_remaining());
 
   bl3.clear();
   bl3.append(s.substr(98 + 55));
   it = bl1.begin();
-  it.advance(98 + 55);
+  it.advance(98u + 55u);
   ASSERT_EQ(bl3.crc32c(0), it.crc32c(10, 0));
   ASSERT_EQ(0u, it.get_remaining());
 }
@@ -984,7 +990,7 @@ TEST(BufferListIterator, operator_star) {
   {
     bufferlist::iterator i(&bl);
     EXPECT_EQ('A', *i);
-    EXPECT_THROW(i.advance(200), buffer::end_of_buffer);
+    EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
     EXPECT_THROW(*i, buffer::end_of_buffer);
   }
 }
@@ -1076,7 +1082,7 @@ TEST(BufferListIterator, copy) {
     //
     // demonstrates that it seeks back to offset if p == ls->end()
     //
-    EXPECT_THROW(i.advance(200), buffer::end_of_buffer); 
+    EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
     i.copy(2, copy);
     EXPECT_EQ(0, ::memcmp(copy, expected, 2));
     EXPECT_EQ('X', copy[2]);
@@ -1116,7 +1122,7 @@ TEST(BufferListIterator, copy) {
     //
     // demonstrates that it seeks back to offset if p == ls->end()
     //
-    EXPECT_THROW(i.advance(200), buffer::end_of_buffer); 
+    EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
     i.copy(2, copy);
     EXPECT_EQ(0, ::memcmp(copy.c_str(), expected, 2));
     i.seek(0);
@@ -1137,7 +1143,7 @@ TEST(BufferListIterator, copy) {
     //
     // demonstrates that it seeks back to offset if p == ls->end()
     //
-    EXPECT_THROW(i.advance(200), buffer::end_of_buffer); 
+    EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
     i.copy_all(copy);
     EXPECT_EQ('A', copy[0]);
     EXPECT_EQ('B', copy[1]);
@@ -1153,7 +1159,7 @@ TEST(BufferListIterator, copy) {
     //
     // demonstrates that it seeks back to offset if p == ls->end()
     //
-    EXPECT_THROW(i.advance(200), buffer::end_of_buffer); 
+    EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
     i.copy(2, copy);
     EXPECT_EQ(0, ::memcmp(copy.c_str(), expected, 2));
     i.seek(0);
@@ -1179,7 +1185,7 @@ TEST(BufferListIterator, copy_in) {
     //
     // demonstrates that it seeks back to offset if p == ls->end()
     //
-    EXPECT_THROW(i.advance(200), buffer::end_of_buffer); 
+    EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
     const char *expected = "ABC";
     i.copy_in(3, expected);
     EXPECT_EQ(0, ::memcmp(bl.c_str(), expected, 3));
@@ -1196,7 +1202,7 @@ TEST(BufferListIterator, copy_in) {
     //
     // demonstrates that it seeks back to offset if p == ls->end()
     //
-    EXPECT_THROW(i.advance(200), buffer::end_of_buffer); 
+    EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
     bufferlist expected;
     expected.append("ABC", 3);
     i.copy_in(3, expected);
@@ -1902,10 +1908,10 @@ TEST(BufferList, begin) {
 
 TEST(BufferList, end) {
   bufferlist bl;
-  bl.append("ABC");
+  bl.append("AB");
   bufferlist::iterator i = bl.end();
-  i.advance(-1);
-  EXPECT_EQ('C', *i);
+  bl.append("C");
+  EXPECT_EQ('C', bl[i.get_off()]);
 }
 
 TEST(BufferList, copy) {


### PR DESCRIPTION
These patches remove the backward iteration facility of `ceph::bufferlist::iterator`. Its typical use case was to  prepare a gap for being filled later, when the intended value (e.g. size of serialized items) becomes available. Such scenario boils down into: 1. `append` (possibly junk) to a buffer list, 2. call `end` to get an iterator, 3. `advance` it backwardly and 4. `copy_in` the final data. This pattern is a part of our encoding macros.

To roughly estimate the cost, these specific calls have been instrumented with with `_hinst` suffixed proxies to ease differentiation. Following listing has been taken from a single `tp_osd_tp` doing 4 KB randwrites:

```
Samples: 6K of event 'cycles:pp', Event count (approx.): 2104368555                                                                                                                                           
  Children      Self  Command    Shared O  Symbol
+    1,92%     0,17%  tp_osd_tp  ceph-osd  [.] ceph::buffer::list::append_hinst
+    0,68%     0,13%  tp_osd_tp  ceph-osd  [.] ceph::buffer::list::iterator_impl<false>::advance_hinst
+    0,47%     0,07%  tp_osd_tp  ceph-osd  [.] ceph::buffer::list::iterator::copy_in_hinst
```

The changeset replaces it with `append_hole` which doesn't fill memory but returns `contiguous_filler` instead -- basically a dumb pointer with `copy_in` method to mimic the old way. The Iterator taking and decrementation are avoided entirely. The `append_hole` is cheaper as it goes with contiguous space reservation  and doesn't call the costly `buffer::ptr::append`.

```
Samples: 10K of event 'cycles:pp', Event count (approx.): 3419144900
  Children      Self  Command    Shared O  Symbol
+    1,19%     0,17%  tp_osd_tp  ceph-osd  [.] ceph::buffer::list::append_hole
```
