### PR TITLE
qa/suites/rados/thrash-old-clients/workloads/rbd_cls.yaml: skip parents test

### DIFF
--- a/qa/suites/rados/thrash-old-clients/workloads/rbd_cls.yaml
+++ b/qa/suites/rados/thrash-old-clients/workloads/rbd_cls.yaml
@@ -2,9 +2,6 @@ meta:
 - desc: |
    rbd object class functional tests
 tasks:
-- workunit:
-    env:
-      CLS_RBD_GTEST_FILTER: -TestClsRbd.get_features
-    clients:
-      client.2:
-        - cls/test_cls_rbd.sh
+- exec:
+    client.2:
+      - ceph_test_cls_rbd --gtest_filter=-TestClsRbd.get_features:TestClsRbd.parents


### PR DESCRIPTION
We can't (easily) build updated hammer packages, but all this sh script does
it run this one test binary with --gtest_filter arguments, so just do
it directly and skip the test explicitly here.  (Newer version of the .sh
understand the environemnt variable but the hammer version does not.)

Fixes: http://tracker.ceph.com/issues/36104
Signed-off-by: Sage Weil <sage@redhat.com>