### PR TITLE
mimic: qa: install dependencies for rbd_workunit_kernel_untar_build

### DIFF
--- a/qa/suites/krbd/rbd/tasks/rbd_workunit_kernel_untar_build.yaml
+++ b/qa/suites/krbd/rbd/tasks/rbd_workunit_kernel_untar_build.yaml
@@ -1,5 +1,8 @@
 tasks:
 - install:
+    extra_system_packages:
+      deb: ['bison', 'flex', 'libelf-dev', 'libssl-dev']
+      rpm: ['bison', 'flex', 'elfutils-libelf-devel', 'openssl-devel']
 - ceph:
 - rbd:
     all:


### PR DESCRIPTION
http://tracker.ceph.com/issues/35077