### PR TITLE
jewel: test/librbd: not valid to have different parents between image snapshots

### DIFF
--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -596,7 +596,7 @@ TEST_F(TestClsRbd, parents)
   ASSERT_EQ(size, 10ull<<20);
 
   ASSERT_EQ(0, remove_parent(&ioctx, oid));
-  ASSERT_EQ(0, set_parent(&ioctx, oid, parent_spec(4, "parent2", 6), 5<<20));
+  ASSERT_EQ(0, set_parent(&ioctx, oid, parent_spec(1, "parent", 3), 5<<20));
   ASSERT_EQ(0, snapshot_add(&ioctx, oid, 11, "snap2"));
   ASSERT_EQ(0, get_parent(&ioctx, oid, 10, &pspec, &size));
   ASSERT_EQ(pspec.pool_id, 1);
@@ -604,9 +604,9 @@ TEST_F(TestClsRbd, parents)
   ASSERT_EQ(pspec.snap_id, snapid_t(3));
   ASSERT_EQ(size, 10ull<<20);
   ASSERT_EQ(0, get_parent(&ioctx, oid, 11, &pspec, &size));
-  ASSERT_EQ(pspec.pool_id, 4);
-  ASSERT_EQ(pspec.image_id, "parent2");
-  ASSERT_EQ(pspec.snap_id, snapid_t(6));
+  ASSERT_EQ(pspec.pool_id, 1);
+  ASSERT_EQ(pspec.image_id, "parent");
+  ASSERT_EQ(pspec.snap_id, snapid_t(3));
   ASSERT_EQ(size, 5ull<<20);
 
   ASSERT_EQ(0, remove_parent(&ioctx, oid));
@@ -617,9 +617,9 @@ TEST_F(TestClsRbd, parents)
   ASSERT_EQ(pspec.snap_id, snapid_t(3));
   ASSERT_EQ(size, 10ull<<20);
   ASSERT_EQ(0, get_parent(&ioctx, oid, 11, &pspec, &size));
-  ASSERT_EQ(pspec.pool_id, 4);
-  ASSERT_EQ(pspec.image_id, "parent2");
-  ASSERT_EQ(pspec.snap_id, snapid_t(6));
+  ASSERT_EQ(pspec.pool_id, 1);
+  ASSERT_EQ(pspec.image_id, "parent");
+  ASSERT_EQ(pspec.snap_id, snapid_t(3));
   ASSERT_EQ(size, 5ull<<20);
   ASSERT_EQ(0, get_parent(&ioctx, oid, 12, &pspec, &size));
   ASSERT_EQ(-1, pspec.pool_id);


### PR DESCRIPTION
http://tracker.ceph.com/issues/36118