### PR TITLE
mon/config-key: increase max key entry size

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1655,8 +1655,9 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_config_key_max_entry_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
-    .set_default(4_K)
-    .set_description(""),
+    .set_default(64_K)
+    .set_description("Defines the number of bytes allowed to be held in a "
+		     "single config-key entry"),
 
     Option("mon_sync_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(60.0)


### PR DESCRIPTION
Turns out the dashboard requires more than 4K bytes on occasion. Instead
of forcing them to split entries, we can afford them a bit more of extra
size. We could go higher, but they tell us they don't need it.

Signed-off-by: Joao Eduardo Luis <joao@suse.de>