### PR TITLE
qa: use sudo to cleanup workspace

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -410,7 +410,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                 )
     finally:
         log.info('Stopping %s on %s...', tests, role)
-        args=['rm', '-rf', '--', workunits_file, clonedir]
+        args=['sudo', 'rm', '-rf', '--', workunits_file, clonedir]
         if cleanup:
             log.info("and cleaning up scratch: {}".format(scratch_tmp))
             args.append(scratch_tmp)

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -408,6 +408,9 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                     args=args,
                     label="workunit test {workunit}".format(workunit=workunit)
                 )
+                if cleanup:
+                    args=['sudo', 'rm', '-rf', '--', scratch_tmp]
+                    remote.run(logger=log.getChild(role), args=args)
     finally:
         log.info('Stopping %s on %s...', tests, role)
         args=['sudo', 'rm', '-rf', '--', workunits_file, clonedir]


### PR DESCRIPTION
Files in scratch_tmp may not be owned by ubuntu.

Fixes: http://tracker.ceph.com/issues/36165
Introduced-by: de824f74dd8ac909e47335ccd53d7a085e388e41
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>