### PR TITLE
osd: Remove old bft= which has been superceded by backfill=

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6327,8 +6327,6 @@ ostream& operator<<(ostream& out, const PG& pg)
     }
   }
 
-  if (!pg.backfill_targets.empty())
-    out << " bft=" << pg.backfill_targets;
   out << " crt=" << pg.pg_log.get_can_rollback_to();
 
   if (pg.last_complete_ondisk != pg.info.last_complete)


### PR DESCRIPTION
We could remove the backfill=[] instead because that was added more recently and it is possible some are use to looking for bft= in the log.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [X] References tracker ticket
- N/A Updates documentation if necessary
- N/A Includes tests for new functionality or reproducer for bug
