### PR TITLE
osd/OSD: make not_ready_to_merge override ready_to_merge

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -298,6 +298,9 @@ public:
   const PGPool& get_pool() const {
     return pool;
   }
+  unsigned get_pg_num_pending() const {
+    return pool.info.get_pg_num_pending();
+  }
   uint64_t get_last_user_version() const {
     return info.last_user_version;
   }


### PR DESCRIPTION
This is a follow-up pr of https://github.com/ceph/ceph/pull/24226.
In practice the merge sources and targets could disagree with each
other. E.g., the merge source is ready while the corresponding
merge target is not, and vice versa.
We should only merge pgs only when both of them (source and target)
are ready. Hence __not_ready_to_merge__ should always take precedence
over __ready_to_merge__.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

