### PR TITLE
qa: add timeout to fs workunits

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/cfuse_workunit_quota.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cfuse_workunit_quota.yaml
@@ -1,6 +1,5 @@
 tasks:
 - workunit:
-    timeout: 6h
     clients:
       all:
         - fs/quota

--- a/qa/suites/fs/basic_workload/tasks/cfuse_workunit_misc.yaml
+++ b/qa/suites/fs/basic_workload/tasks/cfuse_workunit_misc.yaml
@@ -4,7 +4,6 @@ tasks:
       mds:
         - "mds.dir_split"
 - workunit:
-    timeout: 6h
     clients:
       all:
         - fs/misc

--- a/qa/suites/fs/basic_workload/tasks/cfuse_workunit_norstats.yaml
+++ b/qa/suites/fs/basic_workload/tasks/cfuse_workunit_norstats.yaml
@@ -4,7 +4,6 @@ tasks:
       mds:
         - "mds.dir_split"
 - workunit:
-    timeout: 6h
     clients:
       all:
         - fs/norstats

--- a/qa/suites/multimds/basic/tasks/cfuse_workunit_misc.yaml
+++ b/qa/suites/multimds/basic/tasks/cfuse_workunit_misc.yaml
@@ -1,6 +1,5 @@
 tasks:
 - workunit:
-    timeout: 6h
     clients:
       all:
         - fs/misc

--- a/qa/suites/multimds/basic/tasks/cfuse_workunit_norstats.yaml
+++ b/qa/suites/multimds/basic/tasks/cfuse_workunit_norstats.yaml
@@ -1,6 +1,5 @@
 tasks:
 - workunit:
-    timeout: 6h
     clients:
       all:
         - fs/norstats

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -101,7 +101,7 @@ class KernelMount(CephFSMount):
             cmd.append('-f')
 
         try:
-            self.client_remote.run(args=cmd)
+            self.client_remote.run(args=cmd, timeout=(5*60))
         except Exception as e:
             self.client_remote.run(args=[
                 'sudo',

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -410,7 +410,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                 )
                 if cleanup:
                     args=['sudo', 'rm', '-rf', '--', scratch_tmp]
-                    remote.run(logger=log.getChild(role), args=args)
+                    remote.run(logger=log.getChild(role), args=args, timeout=(15*60))
     finally:
         log.info('Stopping %s on %s...', tests, role)
         args=['sudo', 'rm', '-rf', '--', workunits_file, clonedir]

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -414,9 +414,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
     finally:
         log.info('Stopping %s on %s...', tests, role)
         args=['sudo', 'rm', '-rf', '--', workunits_file, clonedir]
-        if cleanup:
-            log.info("and cleaning up scratch: {}".format(scratch_tmp))
-            args.append(scratch_tmp)
+        # N.B. don't cleanup scratch_tmp! If the mount is broken then rm will hang.
         remote.run(
             logger=log.getChild(role),
             args=args,


### PR DESCRIPTION
This avoids tests timing out when there is a bug in the osd/mds that causes the
workunit to hang.

Fixes: http://tracker.ceph.com/issues/36184

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>