### PR TITLE
mds: update ctime to current time always

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2195,9 +2195,10 @@ void CInode::finish_scatter_gather_update(int type)
 	dirstat.add(pf->fragstat);
       }
       if (touched_mtime)
-	pi->mtime = pi->ctime = pi->dirstat.mtime;
+	pi->mtime = pi->dirstat.mtime;
       if (touched_chattr)
 	pi->change_attr = pi->dirstat.change_attr;
+      pi->ctime = std::max(pi->ctime, ceph_clock_now());
       dout(20) << " final dirstat " << pi->dirstat << dendl;
 
       if (dirstat_valid && !dirstat.same_sums(pi->dirstat)) {
@@ -2329,8 +2330,7 @@ void CInode::finish_scatter_gather_update(int type)
 	  }
 	  // trust the dirfrag for now
 	  version_t v = pi->rstat.version;
-	  if (pi->rstat.rctime > rstat.rctime)
-	    rstat.rctime = pi->rstat.rctime;
+          rstat.rctime = std::max(rstat.rctime, pi->rstat.rctime);
 	  pi->rstat = rstat;
 	  pi->rstat.version = v;
 	}

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -162,6 +162,8 @@ ostream& operator<<(ostream& out, const CInode& in)
       out << " nl=" << in.inode.nlink;
   }
 
+  out << " ct[" << in.inode.ctime << "]";
+
   // rstat
   out << " " << in.inode.rstat;
   if (!(in.inode.rstat == in.inode.accounted_rstat))

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -406,6 +406,8 @@ CInode::projected_inode &CInode::project_inode(bool xattr, bool snap)
     project_snaprealm();
   }
 
+  ++pi.inode.rstat.version;
+
   dout(15) << __func__ << " " << pi.inode.ino << dendl;
   return pi;
 }
@@ -1700,7 +1702,7 @@ void CInode::decode_lock_state(int type, const bufferlist& bl)
   case CEPH_LOCK_IAUTH:
     decode(inode.version, p);
     decode(tm, p);
-    if (inode.ctime < tm) inode.ctime = tm;
+    inode.ctime = std::max(inode.ctime, tm);
     decode(inode.mode, p);
     decode(inode.uid, p);
     decode(inode.gid, p);
@@ -1709,7 +1711,7 @@ void CInode::decode_lock_state(int type, const bufferlist& bl)
   case CEPH_LOCK_ILINK:
     decode(inode.version, p);
     decode(tm, p);
-    if (inode.ctime < tm) inode.ctime = tm;
+    inode.ctime = std::map(inode.ctime, tm);
     decode(inode.nlink, p);
     break;
 
@@ -1761,7 +1763,7 @@ void CInode::decode_lock_state(int type, const bufferlist& bl)
     if (!is_auth()) {
       decode(inode.version, p);
       decode(tm, p);
-      if (inode.ctime < tm) inode.ctime = tm;
+      inode.ctime = std::max(inode.ctime, tm);
       decode(inode.mtime, p);
       decode(inode.atime, p);
       decode(inode.time_warp_seq, p);
@@ -1897,7 +1899,7 @@ void CInode::decode_lock_state(int type, const bufferlist& bl)
   case CEPH_LOCK_IXATTR:
     decode(inode.version, p);
     decode(tm, p);
-    if (inode.ctime < tm) inode.ctime = tm;
+    inode.ctime = std::max(inode.ctime, tm);
     decode(xattrs, p);
     break;
 
@@ -1905,7 +1907,7 @@ void CInode::decode_lock_state(int type, const bufferlist& bl)
     {
       decode(inode.version, p);
       decode(tm, p);
-      if (inode.ctime < tm) inode.ctime = tm;
+      inode.ctime = std::max(inode.ctime, tm);
       decode_snap(p);
     }
     break;

--- a/src/mds/mdstypes.cc
+++ b/src/mds/mdstypes.cc
@@ -134,8 +134,7 @@ ostream& operator<<(ostream &out, const nest_info_t &n)
   if (n == nest_info_t())
     return out << "n()";
   out << "n(v" << n.version;
-  if (n.rctime != utime_t())
-    out << " rc" << n.rctime;
+  out << " rc" << n.rctime;
   if (n.rbytes)
     out << " b" << n.rbytes;
   if (n.rsnaps)

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -242,8 +242,7 @@ struct nest_info_t : public scatter_info_t {
     add(other, -1);
   }
   void add(const nest_info_t &other, int fac=1) {
-    if (other.rctime > rctime)
-      rctime = other.rctime;
+    rctime = std::max(rctime, other.rctime);
     rbytes += fac*other.rbytes;
     rfiles += fac*other.rfiles;
     rsubdirs += fac*other.rsubdirs;
@@ -252,8 +251,7 @@ struct nest_info_t : public scatter_info_t {
 
   // *this += cur - acc;
   void add_delta(const nest_info_t &cur, const nest_info_t &acc) {
-    if (cur.rctime > rctime)
-      rctime = cur.rctime;
+    rctime = std::max(rctime, cur.rctime);
     rbytes += cur.rbytes - acc.rbytes;
     rfiles += cur.rfiles - acc.rfiles;
     rsubdirs += cur.rsubdirs - acc.rsubdirs;

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -23,6 +23,7 @@
 #include "include/compact_map.h"
 #include "include/compact_set.h"
 #include "include/fs_types.h"
+#include "include/utime.h"
 
 #include "inode_backtrace.h"
 
@@ -232,7 +233,7 @@ struct nest_info_t : public scatter_info_t {
 
   int64_t rsnaps = 0;
 
-  nest_info_t() {}
+  nest_info_t() : rctime(ceph_clock_now()) {}
 
   void zero() {
     *this = nest_info_t();
@@ -528,7 +529,7 @@ struct inode_t {
 
   std::basic_string<char,std::char_traits<char>,Allocator<char>> stray_prior_path; //stores path before unlink
 
-  inode_t()
+  inode_t() : ctime(ceph_clock_now())
   {
     clear_layout();
     memset(&dir_layout, 0, sizeof(dir_layout));

--- a/src/messages/MClientCaps.h
+++ b/src/messages/MClientCaps.h
@@ -193,6 +193,7 @@ public:
     if (truncate_seq)
       out << " ts " << truncate_seq << "/" << truncate_size;
     out << " mtime " << mtime;
+    out << " ctime " << ctime;
     if (time_warp_seq)
       out << " tws " << time_warp_seq;
 


### PR DESCRIPTION
The MDS should update the ctime to the current time whenever any change is made
to the inode. Additionally, it should not permit the ctime to go backwards
through an update in any situation. Importantly, we should not use the mtime to
set the ctime as the client can pick arbitrary values for mtime (via utime(3))
which trickle across the file system via rctime. These values become impossible
to rollback.

Note that if the MDS system time is screwy (in the future), it's possible for a
similar situation to occur where the file system rstats become tainted with a
value in the future. This is not easily repairable and may require manual
intervention if this becomes an actual problem.

Finally, the client should maintain its own version of the ctime for inodes
during local buffered updates. The value for the ctime is ignored by the MDS
but we keep sending for backwards-compatibility. In practice, this means that a
single inode update will have two ctime updates potentially visible to a
client.

Fixes: http://tracker.ceph.com/issues/36171

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>