### PR TITLE
common: fix missing include boost/noncopyable.hpp

### DIFF
--- a/src/common/inline_variant.h
+++ b/src/common/inline_variant.h
@@ -14,6 +14,7 @@
 #include <boost/mpl/map.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/range_c.hpp>
+#include <boost/noncopyable.hpp>
 
 #include "function_signature.h"
 


### PR DESCRIPTION
Clang complains:
```
In file included from /home/jenkins/workspace/ceph-master/src/osd/ReplicatedBackend.cc:15:
In file included from /home/jenkins/workspace/ceph-master/src/osd/ReplicatedBackend.h:18:
In file included from /home/jenkins/workspace/ceph-master/src/osd/PGBackend.h:27:
In file included from /home/jenkins/workspace/ceph-master/src/osd/PGTransaction.h:25:
/home/jenkins/workspace/ceph-master/src/common/inline_variant.h:88:64: error: expected class name
struct generic_visitor : boost::static_visitor<Result>, boost::noncopyable
                                                               ^
1 error generated.
gmake[2]: *** [src/osd/CMakeFiles/osd.dir/build.make:141: src/osd/CMakeFiles/osd.dir/ReplicatedBackend.cc.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
```




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug