### PR TITLE
luminous ceph-volume custom cluster names fail on filestore trigger

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -3,7 +3,7 @@ import argparse
 import logging
 import os
 from textwrap import dedent
-from ceph_volume import process, conf, decorators, terminal, __release__
+from ceph_volume import process, conf, decorators, terminal, __release__, configuration
 from ceph_volume.util import system, disk
 from ceph_volume.util import prepare as prepare_utils
 from ceph_volume.util import encryption as encryption_utils
@@ -24,7 +24,8 @@ def activate_filestore(lvs, no_systemd=False):
     is_vdo = osd_lv.tags.get('ceph.vdo', '0')
 
     osd_id = osd_lv.tags['ceph.osd_id']
-    conf.cluster = osd_lv.tags['ceph.cluster_name']
+    configuration.load_ceph_conf_path(osd_lv.tags['ceph.cluster_name'])
+    configuration.load()
     # it may have a volume with a journal
     osd_journal_lv = lvs.get(lv_tags={'ceph.type': 'journal'})
     # TODO: add sensible error reporting if this is ever the case

--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -76,11 +76,6 @@ Ceph Conf: {ceph_path}
         if self.plugin_help:
             self.plugin_help = '\nPlugins:\n' + self.plugin_help
 
-    def load_ceph_conf_path(self, cluster_name='ceph'):
-        abspath = '/etc/ceph/%s.conf' % cluster_name
-        conf.path = os.getenv('CEPH_CONF', abspath)
-        conf.cluster = cluster_name
-
     def load_log_path(self):
         conf.log_path = os.getenv('CEPH_VOLUME_LOG_PATH', '/var/log/ceph')
 
@@ -105,7 +100,7 @@ Ceph Conf: {ceph_path}
     def main(self, argv):
         # these need to be available for the help, which gets parsed super
         # early
-        self.load_ceph_conf_path()
+        configuration.load_ceph_conf_path()
         self.load_log_path()
         self.enable_plugins()
         main_args, subcommand_args = self._get_split_args()
@@ -143,7 +138,7 @@ Ceph Conf: {ceph_path}
         logger.info("Running command: ceph-volume %s %s", " ".join(main_args), " ".join(subcommand_args))
         # set all variables from args and load everything needed according to
         # them
-        self.load_ceph_conf_path(cluster_name=args.cluster)
+        configuration.load_ceph_conf_path(cluster_name=args.cluster)
         try:
             conf.ceph = configuration.load(conf.path)
         except exceptions.ConfigurationError as error:

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -85,6 +85,22 @@ def stub_call(monkeypatch):
     return apply
 
 
+@pytest.fixture(autouse=True)
+def reset_cluster_name(request, monkeypatch):
+    """
+    The globally available ``ceph_volume.conf.cluster`` might get mangled in
+    tests, make sure that after evert test, it gets reset, preventing pollution
+    going into other tests later.
+    """
+    def fin():
+        conf.cluster = None
+        try:
+            os.environ.pop('CEPH_CONF')
+        except KeyError:
+            pass
+    request.addfinalizer(fin)
+
+
 @pytest.fixture
 def conf_ceph(monkeypatch):
     """

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_activate.py
@@ -50,6 +50,7 @@ class TestActivate(object):
             activate.Activate([]).activate(args)
 
     def test_filestore_no_systemd(self, is_root, volumes, monkeypatch, capture):
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         fake_enable = Capture()
         fake_start_osd = Capture()
         monkeypatch.setattr('ceph_volume.util.system.device_is_mounted', lambda *a, **kw: True)
@@ -64,8 +65,8 @@ class TestActivate(object):
             lv_tags=','.join([
                 "ceph.cluster_name=ceph", "ceph.journal_device=/dev/vg/journal",
                 "ceph.journal_uuid=000", "ceph.type=journal",
-                "ceph.osd_id=0","ceph.osd_fsid=1234"])
-            )
+                "ceph.osd_id=0", "ceph.osd_fsid=1234"])
+        )
         DataVolume = api.Volume(
             lv_name='data',
             lv_path='/dev/vg/data',
@@ -81,6 +82,7 @@ class TestActivate(object):
     def test_filestore_systemd(self, is_root, volumes, monkeypatch, capture):
         fake_enable = Capture()
         fake_start_osd = Capture()
+        monkeypatch.setattr('ceph_volume.configuration.load', lambda: None)
         monkeypatch.setattr('ceph_volume.util.system.device_is_mounted', lambda *a, **kw: True)
         monkeypatch.setattr('ceph_volume.util.system.chown', lambda *a, **kw: True)
         monkeypatch.setattr('ceph_volume.process.run', lambda *a, **kw: True)

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/single-type-dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/single-type-dmcrypt/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/single-type/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/single-type/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type-dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type-dmcrypt/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/single-type-dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/single-type-dmcrypt/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/single-type/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/single-type/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/bluestore/single-type-dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/bluestore/single-type-dmcrypt/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/bluestore/single-type/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/bluestore/single-type/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/filestore/single-type-dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/filestore/single-type-dmcrypt/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/filestore/single-type/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/filestore/single-type/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
@@ -17,10 +17,10 @@
   tasks:
 
     - name: destroy osd.2
-      command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.2 --yes-i-really-mean-it"
 
     - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.0 --yes-i-really-mean-it"
 
 - hosts: osds
   become: yes
@@ -28,23 +28,23 @@
 
     # osd.2 device
     - name: zap /dev/sdd1
-      command: "ceph-volume lvm zap /dev/sdd1 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdd1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: redeploy osd.2 using /dev/sdd1
-      command: "ceph-volume lvm create --bluestore --data /dev/sdd1 --osd-id 2"
+      command: "ceph-volume --cluster {{ cluster }} lvm create --bluestore --data /dev/sdd1 --osd-id 2"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     # osd.0 lv
     - name: zap test_group/data-lv1
-      command: "ceph-volume lvm zap test_group/data-lv1"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: redeploy osd.0 using test_group/data-lv1
-      command: "ceph-volume lvm create --bluestore --data test_group/data-lv1 --osd-id 0"
+      command: "ceph-volume --cluster {{ cluster }} lvm create --bluestore --data test_group/data-lv1 --osd-id 0"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
@@ -59,7 +59,7 @@
   tasks:
 
     - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.0 --yes-i-really-mean-it"
 
 
 - hosts: osds
@@ -68,12 +68,12 @@
 
 
     - name: zap test_group/data-lv1
-      command: "ceph-volume lvm zap test_group/data-lv1"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: prepare osd.0 using test_group/data-lv1
-      command: "ceph-volume lvm prepare --bluestore --data test_group/data-lv1 --osd-id 0"
+      command: "ceph-volume --cluster {{ cluster }} lvm prepare --bluestore --data test_group/data-lv1 --osd-id 0"
       environment:
         CEPH_VOLUME_DEBUG: 1
 

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/create/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
@@ -19,10 +19,10 @@
   tasks:
 
     - name: destroy osd.2
-      command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.2 --yes-i-really-mean-it"
 
     - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.0 --yes-i-really-mean-it"
 
 
 - hosts: osds
@@ -31,33 +31,33 @@
 
     # osd.2 device
     - name: zap /dev/sdd1
-      command: "ceph-volume lvm zap /dev/sdd1 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdd1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: zap /dev/sdd2
-      command: "ceph-volume lvm zap /dev/sdd2 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdd2 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: redeploy osd.2 using /dev/sdd1
-      command: "ceph-volume lvm create --filestore --data /dev/sdd1 --journal /dev/sdd2 --osd-id 2"
+      command: "ceph-volume --cluster {{ cluster }} lvm create --filestore --data /dev/sdd1 --journal /dev/sdd2 --osd-id 2"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     # osd.0 lv
     - name: zap test_group/data-lv1
-      command: "ceph-volume lvm zap test_group/data-lv1"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: zap /dev/sdc1
-      command: "ceph-volume lvm zap /dev/sdc1 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdc1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: prepare osd.0 again using test_group/data-lv1
-      command: "ceph-volume lvm prepare --filestore --data test_group/data-lv1 --journal /dev/sdc1 --osd-id 0"
+      command: "ceph-volume --cluster {{ cluster }} lvm prepare --filestore --data test_group/data-lv1 --journal /dev/sdc1 --osd-id 0"
       environment:
         CEPH_VOLUME_DEBUG: 1
 

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
@@ -19,10 +19,10 @@
   tasks:
 
     - name: destroy osd.2
-      command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.2 --yes-i-really-mean-it"
 
     - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.0 --yes-i-really-mean-it"
 
 
 - hosts: osds
@@ -31,23 +31,23 @@
 
     # osd.2 device
     - name: zap /dev/sdd1
-      command: "ceph-volume lvm zap /dev/sdd1 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdd1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: redeploy osd.2 using /dev/sdd1
-      command: "ceph-volume lvm create --bluestore --data /dev/sdd1 --osd-id 2"
+      command: "ceph-volume --cluster {{ cluster }} lvm create --bluestore --data /dev/sdd1 --osd-id 2"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     # osd.0 device
     - name: zap test_group/data-lv1
-      command: "ceph-volume lvm zap --destroy test_group/data-lv1"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap --destroy test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: prepare osd.0 again using test_group/data-lv1
-      command: "ceph-volume lvm prepare --bluestore --data test_group/data-lv1 --osd-id 0"
+      command: "ceph-volume --cluster {{ cluster }} lvm prepare --bluestore --data test_group/data-lv1 --osd-id 0"
       environment:
         CEPH_VOLUME_DEBUG: 1
 

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
@@ -19,10 +19,10 @@
   tasks:
 
     - name: destroy osd.2
-      command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.2 --yes-i-really-mean-it"
 
     - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.0 --yes-i-really-mean-it"
 
 
 - hosts: osds
@@ -31,18 +31,18 @@
 
     # osd.2 device
     - name: zap /dev/sdd1
-      command: "ceph-volume lvm zap /dev/sdd1 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdd1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     # osd.2 journal
     - name: zap /dev/sdd2
-      command: "ceph-volume lvm zap /dev/sdd2 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdd2 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: redeploy osd.2 using /dev/sdd1
-      command: "ceph-volume lvm create --filestore --data /dev/sdd1 --journal /dev/sdd2 --osd-id 2"
+      command: "ceph-volume --cluster {{ cluster }} lvm create --filestore --data /dev/sdd1 --journal /dev/sdd2 --osd-id 2"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
@@ -50,18 +50,18 @@
     # note: we don't use --destroy here to test this works without that flag.
     # --destroy is used in the bluestore tests
     - name: zap test_group/data-lv1
-      command: "ceph-volume lvm zap test_group/data-lv1"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     # osd.0 journal device
     - name: zap /dev/sdc1
-      command: "ceph-volume lvm zap /dev/sdc1 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdc1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: prepare osd.0 again using test_group/data-lv1
-      command: "ceph-volume lvm prepare --filestore --data test_group/data-lv1 --journal /dev/sdc1 --osd-id 0"
+      command: "ceph-volume --cluster {{ cluster }} lvm prepare --filestore --data test_group/data-lv1 --journal /dev/sdc1 --osd-id 0"
       environment:
         CEPH_VOLUME_DEBUG: 1
 

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/create/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
@@ -17,10 +17,10 @@
   tasks:
 
     - name: destroy osd.2
-      command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.2 --yes-i-really-mean-it"
 
     - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.0 --yes-i-really-mean-it"
 
 
 - hosts: osds
@@ -29,23 +29,23 @@
 
     # osd.2 device
     - name: zap /dev/sdd1
-      command: "ceph-volume lvm zap /dev/sdd1 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdd1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: redeploy osd.2 using /dev/sdd1
-      command: "ceph-volume lvm create --bluestore --data /dev/sdd1 --osd-id 2"
+      command: "ceph-volume --cluster {{ cluster }} lvm create --bluestore --data /dev/sdd1 --osd-id 2"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     # osd.0 lv
     - name: zap test_group/data-lv1
-      command: "ceph-volume lvm zap test_group/data-lv1"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: redeploy osd.0 using test_group/data-lv1
-      command: "ceph-volume lvm create --bluestore --data test_group/data-lv1 --osd-id 0"
+      command: "ceph-volume --cluster {{ cluster }} lvm create --bluestore --data test_group/data-lv1 --osd-id 0"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
@@ -60,7 +60,7 @@
   tasks:
 
     - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.0 --yes-i-really-mean-it"
 
 
 - hosts: osds
@@ -68,12 +68,12 @@
   tasks:
 
     - name: zap test_group/data-lv1
-      command: "ceph-volume lvm zap test_group/data-lv1"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: prepare osd.0 using test_group/data-lv1
-      command: "ceph-volume lvm prepare --bluestore --data test_group/data-lv1 --osd-id 0"
+      command: "ceph-volume --cluster {{ cluster }} lvm prepare --bluestore --data test_group/data-lv1 --osd-id 0"
       environment:
         CEPH_VOLUME_DEBUG: 1
 

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/create/group_vars/all
@@ -1,7 +1,7 @@
 ---
 
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/group_vars/all
@@ -2,7 +2,7 @@
 
 dmcrypt: True
 ceph_dev: True
-cluster: ceph
+cluster: test
 public_network: "192.168.3.0/24"
 cluster_network: "192.168.4.0/24"
 monitor_interface: eth1

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
@@ -19,10 +19,10 @@
   tasks:
 
     - name: destroy osd.2
-      command: "ceph osd destroy osd.2 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.2 --yes-i-really-mean-it"
 
     - name: destroy osd.0
-      command: "ceph osd destroy osd.0 --yes-i-really-mean-it"
+      command: "ceph --cluster {{ cluster }} osd destroy osd.0 --yes-i-really-mean-it"
 
 
 - hosts: osds
@@ -31,33 +31,33 @@
 
     # osd.2 device
     - name: zap /dev/sdd1
-      command: "ceph-volume lvm zap /dev/sdd1 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdd1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: zap /dev/sdd2
-      command: "ceph-volume lvm zap /dev/sdd2 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdd2 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: redeploy osd.2 using /dev/sdd1
-      command: "ceph-volume lvm create --filestore --data /dev/sdd1 --journal /dev/sdd2 --osd-id 2"
+      command: "ceph-volume --cluster {{ cluster }} lvm create --filestore --data /dev/sdd1 --journal /dev/sdd2 --osd-id 2"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     # osd.0 lv
     - name: zap test_group/data-lv1
-      command: "ceph-volume lvm zap test_group/data-lv1"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap test_group/data-lv1"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: zap /dev/sdc1
-      command: "ceph-volume lvm zap /dev/sdc1 --destroy"
+      command: "ceph-volume --cluster {{ cluster }} lvm zap /dev/sdc1 --destroy"
       environment:
         CEPH_VOLUME_DEBUG: 1
 
     - name: prepare osd.0 again using test_group/data-lv1
-      command: "ceph-volume lvm prepare --filestore --data test_group/data-lv1 --journal /dev/sdc1 --osd-id 0"
+      command: "ceph-volume --cluster {{ cluster }} lvm prepare --filestore --data test_group/data-lv1 --journal /dev/sdc1 --osd-id 0"
       environment:
         CEPH_VOLUME_DEBUG: 1
 


### PR DESCRIPTION
This happens because the ceph.conf is not loaded by main.py, and later the code wants to poke in conf.ceph which is a bare property that doesn't have anything
in it.

The activate script should be aware of the custom cluster name by that time, and it should try to load the conf file. It should also try to fallback if that is
not able to be located, so that default flags for mounting don't end up preventing an OSD starting up

This PR also updates all the functional tests to use `test` as a cluster name.

Fixes: http://tracker.ceph.com/issues/27210
Backport of: https://github.com/ceph/ceph/pull/24251