### PR TITLE
client: fix fuse client can't read or write data due its caps is invalid

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2748,7 +2748,8 @@ void Client::send_reconnect(MetaSession *session)
       cap.issue_seq = 0;  // reset seq.
       cap.mseq = 0;  // reset seq.
       cap.issued = cap.implemented;
-
+      // cap gen should catch up with session cap_gen
+      cap.gen = cap.session->cap_gen;
       snapid_t snap_follows = 0;
       if (!in->cap_snaps.empty())
 	snap_follows = in->cap_snaps.begin()->first;


### PR DESCRIPTION
We can't do read or write if we don't have Fr or Fw.Similarly, if the
caps is invalid, we can't read or wirte either.

What's worse,the mds don't konw our cap gen is invalid and think client
inode's caps is right.Thus will lead client application hung all the time.

Fixes: http://tracker.ceph.com/issues/36189
Signed-off-by: Guan yunfei yunfei.guan@xtaotech.com