### PR TITLE
msg: clear message middle when clearing encoded message buffer

### DIFF
--- a/src/msg/async/Protocol.cc
+++ b/src/msg/async/Protocol.cc
@@ -239,7 +239,7 @@ void ProtocolV1::send_message(Message *m) {
       (can_write == WriteStatus::NOWRITE || connection->get_features() != f)) {
     // ensure the correctness of message encoding
     bl.clear();
-    m->get_payload().clear();
+    m->clear_payload();
     ldout(cct, 5) << __func__ << " clear encoded buffer previous " << f
                   << " != " << connection->get_features() << dendl;
   }


### PR DESCRIPTION
Otherwise it may trigger ceph_assert(middle.length() == 0) in
Message::encode()

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

