### PR TITLE
mon: cancel the lease timer when cancel lease

### DIFF
--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -989,6 +989,9 @@ private:
   /// restart the lease timeout timer
   void reset_lease_timeout();
 
+  /// cancel the lease timeout timer
+  void cancel_lease_timeout();
+
   /**
    * Cancel all of Paxos' timeout/renew events. 
    */


### PR DESCRIPTION
If we only cancel lease by set lease_expire = utime_t(), but not
cancel the lease timer, the lease may also timeout during proposing.

i have see many times in my cluster, if the disk of mon store is busy and used
by other programs, the mon store transaction will used too much time, then
the lease may timeout, mon will election, and may be down temporarily!

if we cancel lease when proposing,  i think lease timeout in proposing may not 
behavior we want, so i make this change.

Signed-off-by: kungf <yang.wang@easystack.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

