### PR TITLE
mimic: client:two ceph-fuse client, one can not list out files created by an…

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3932,7 +3932,7 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
 
   unsigned old_caps = cap.issued;
   cap.cap_id = cap_id;
-  cap.issued |= issued;
+  cap.issued = issued;
   cap.implemented |= issued;
   cap.seq = seq;
   cap.issue_seq = seq;


### PR DESCRIPTION
http://tracker.ceph.com/issues/35934