### PR TITLE
luminous: osd/PG: avoid choose_acting picking want with > pool size items

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1356,6 +1356,9 @@ void PG::calc_replicated_acting(
       usable++;
       ss << " osd." << *i << " (up) accepted " << cur_info << std::endl;
     }
+    if (want->size() >= size) {
+      break;
+    }
   }
 
   // This no longer has backfill OSDs, but they are covered above.


### PR DESCRIPTION
http://tracker.ceph.com/issues/35962