### PR TITLE
doc: add "--timeout" option to rbd-nbd

### DIFF
--- a/doc/man/8/rbd-nbd.rst
+++ b/doc/man/8/rbd-nbd.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **rbd-nbd** [-c conf] [--read-only] [--device *nbd device*] [--nbds_max *limit*] [--max_part *limit*] [--exclusive] map *image-spec* | *snap-spec*
+| **rbd-nbd** [-c conf] [--read-only] [--device *nbd device*] [--nbds_max *limit*] [--max_part *limit*] [--exclusive] [--timeout *seconds*] map *image-spec* | *snap-spec*
 | **rbd-nbd** unmap *nbd device*
 | **rbd-nbd** list-mapped
 
@@ -44,6 +44,11 @@ Options
 .. option:: --exclusive
 
    Forbid writes by other clients.
+
+.. option:: --timeout *seconds*
+
+   Override device timeout. Linux kernel will default to a 30 second request timeout.
+   Allow the user to optionally specify an alternate timeout.
 
 Image and snap specs
 ====================


### PR DESCRIPTION
add "--timeout" option to rbd-nbd documentation. The "--timeout" option was added in https://tracker.ceph.com/issues/22333.


Fixes: https://tracker.ceph.com/issues/22333

Signed-off-by: Stefan Kooman <stefan@bit.nl>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [] References tracker ticket
- [] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

