### PR TITLE
mon/MonClient: use scoped_guard instead of goto

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -103,11 +103,14 @@ int MonClient::get_monmap_and_config()
   interval.set_from_double(cct->_conf->mon_client_hunt_interval);
 
   cct->init_crypto();
+  auto shutdown_crypto = make_scope_guard([this] {
+    cct->shutdown_crypto();
+  });
 
   int r = build_initial_monmap();
   if (r < 0) {
     lderr(cct) << __func__ << " cannot identify monitors to contact" << dendl;
-    goto out;
+    return r;
   }
 
   messenger = Messenger::create_client_messenger(
@@ -115,11 +118,20 @@ int MonClient::get_monmap_and_config()
   ceph_assert(messenger);
   messenger->add_dispatcher_head(this);
   messenger->start();
+  auto shutdown_msgr = make_scope_guard([this] {
+    messenger->shutdown();
+    messenger->wait();
+    delete messenger;
+    messenger = nullptr;
+    if (!monmap.fsid.is_zero()) {
+      cct->_conf.set_val("fsid", stringify(monmap.fsid));
+    }
+  });
 
   while (tries-- > 0) {
     r = init();
     if (r < 0) {
-      goto out_msgr;
+      return r;
     }
     r = authenticate(cct->_conf->client_mount_timeout);
     if (r == -ETIMEDOUT) {
@@ -154,21 +166,7 @@ int MonClient::get_monmap_and_config()
     continue;
   }
 
-out_shutdown:
   shutdown();
-
-out_msgr:
-  messenger->shutdown();
-  messenger->wait();
-  delete messenger;
-  messenger = nullptr;
-
-  if (!monmap.fsid.is_zero()) {
-    cct->_conf.set_val("fsid", stringify(monmap.fsid));
-  }
-
-out:
-  cct->shutdown_crypto();
   return r;
 }
 


### PR DESCRIPTION
also silences the unused label warning. as "out_shutdown" is not used
anymore after f35e10f4849440f0583d021e23a83563dd3b1607 .

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

