### PR TITLE
mimic ceph-volume: fix journal and filestore data size in `lvm batch --report`

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -108,12 +108,12 @@ class SingleType(object):
                 data_percentage = data_size * 100 / device_size
                 osd = {'data': {}, 'journal': {}}
                 osd['data']['path'] = device.abspath
-                osd['data']['size'] = data_size.b
+                osd['data']['size'] = data_size.b.as_int()
                 osd['data']['parts'] = self.osds_per_device
                 osd['data']['percentage'] = int(data_percentage)
                 osd['data']['human_readable_size'] = str(data_size)
                 osd['journal']['path'] = device.abspath
-                osd['journal']['size'] = journal_size.b
+                osd['journal']['size'] = journal_size.b.as_int()
                 osd['journal']['percentage'] = int(100 - data_percentage)
                 osd['journal']['human_readable_size'] = str(journal_size)
                 osds.append(osd)

--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -73,15 +73,36 @@
   - mgrs
   gather_facts: false
   become: True
+  any_errors_fatal: true
   roles:
     - role: ceph-defaults
       tags: ['ceph_update_config']
     - role: ceph-common
-    - role: ceph-config
-      tags: ['ceph_update_config']
+  tasks:
+    - name: rsync ceph-volume to test nodes on centos
+      synchronize:
+        src: "{{ toxinidir}}/../../../../ceph_volume"
+        dest: "/usr/lib/python2.7/site-packages"
+        use_ssh_args: true
+      when:
+        - ansible_os_family == "RedHat"
+        - inventory_hostname in groups.get(osd_group_name, [])
+
+    - name: rsync ceph-volume to test nodes on ubuntu
+      synchronize:
+        src: "{{ toxinidir}}/../../../../ceph_volume"
+        dest: "/usr/lib/python2.7/dist-packages"
+        use_ssh_args: true
+      when:
+        - ansible_os_family == "Debian"
+        - inventory_hostname in groups.get(osd_group_name, [])
+
+    - import_role:
+        name: ceph-config
 
 - hosts: mons
   gather_facts: false
+  any_errors_fatal: true
   become: True
   roles:
     - role: ceph-defaults
@@ -90,6 +111,7 @@
 
 - hosts: mgrs
   gather_facts: false
+  any_errors_fatal: true
   become: True
   roles:
     - role: ceph-defaults
@@ -98,26 +120,27 @@
 
 - hosts: osds
   gather_facts: false
+  any_errors_fatal: true
   become: True
+  roles:
+    - role: ceph-defaults
+    - role: ceph-common
   tasks:
     - name: rsync ceph-volume to test nodes on centos
       synchronize:
         src: "{{ toxinidir}}/../../../../ceph_volume"
         dest: "/usr/lib/python2.7/site-packages"
         use_ssh_args: true
-      when: ansible_os_family == "RedHat"
+      when:
+        - ansible_os_family == "RedHat"
 
     - name: rsync ceph-volume to test nodes on ubuntu
       synchronize:
         src: "{{ toxinidir}}/../../../../ceph_volume"
         dest: "/usr/lib/python2.7/dist-packages"
         use_ssh_args: true
-      when: ansible_os_family == "Debian"
+      when:
+        - ansible_os_family == "Debian"
 
-- hosts: osds
-  gather_facts: false
-  become: True
-  roles:
-    - role: ceph-defaults
-    - role: ceph-common
-    - role: ceph-osd
+    - import_role:
+        name: ceph-osd

--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -97,50 +97,24 @@
         - ansible_os_family == "Debian"
         - inventory_hostname in groups.get(osd_group_name, [])
 
-    - import_role:
+    - name: run ceph-config role
+      import_role:
         name: ceph-config
 
-- hosts: mons
-  gather_facts: false
-  any_errors_fatal: true
-  become: True
-  roles:
-    - role: ceph-defaults
-    - role: ceph-common
-    - role: ceph-mon
-
-- hosts: mgrs
-  gather_facts: false
-  any_errors_fatal: true
-  become: True
-  roles:
-    - role: ceph-defaults
-    - role: ceph-common
-    - role: ceph-mgr
-
-- hosts: osds
-  gather_facts: false
-  any_errors_fatal: true
-  become: True
-  roles:
-    - role: ceph-defaults
-    - role: ceph-common
-  tasks:
-    - name: rsync ceph-volume to test nodes on centos
-      synchronize:
-        src: "{{ toxinidir}}/../../../../ceph_volume"
-        dest: "/usr/lib/python2.7/site-packages"
-        use_ssh_args: true
+    - name: run ceph-mon role
+      import_role:
+        name: ceph-mon
       when:
-        - ansible_os_family == "RedHat"
+        - inventory_hostname in groups.get(mon_group_name, [])
 
-    - name: rsync ceph-volume to test nodes on ubuntu
-      synchronize:
-        src: "{{ toxinidir}}/../../../../ceph_volume"
-        dest: "/usr/lib/python2.7/dist-packages"
-        use_ssh_args: true
+    - name: run ceph-mgr role
+      import_role:
+        name: ceph-mgr
       when:
-        - ansible_os_family == "Debian"
+        - inventory_hostname in groups.get(mgr_group_name, [])
 
-    - import_role:
+    - name: run ceph-osd role
+      import_role:
         name: ceph-osd
+      when:
+        - inventory_hostname in groups.get(osd_group_name, [])


### PR DESCRIPTION
When running ``ceph-volume lvm batch --report --filestore $devices`` the journal size and data size were being reported as the ``__repr__`` of the size class (e.g. ``"size": <FloatB(7516192768.0)>``). This was causing JSON parsing issues as well as not being friendly to the reader of the report.

This also includes some testing changes that make our functional tests fail fast and saves some time by only running the ceph-common role from ceph-ansible once during testing.

Fixes: http://tracker.ceph.com/issues/36242
Backport of: https://github.com/ceph/ceph/pull/24274