### PR TITLE
osd: reduce debug-related string processing on the write path

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -595,7 +595,7 @@ void PGLog::write_log_and_missing(
   bool require_rollback)
 {
   if (is_dirty()) {
-    dout(5) << "write_log_and_missing with: "
+    dout(6) << "write_log_and_missing with: "
 	     << "dirty_to: " << dirty_to
 	     << ", dirty_from: " << dirty_from
 	     << ", writeout_from: " << writeout_from

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -567,9 +567,7 @@ void ReplicatedBackend::do_repop_reply(OpRequestRef op)
       ceph_assert(ip_op.waiting_for_commit.count(from));
       ip_op.waiting_for_commit.erase(from);
       if (ip_op.op) {
-        ostringstream ss;
-        ss << "sub_op_commit_rec from " << from;
-	ip_op.op->mark_event_string(ss.str());
+	ip_op.op->mark_event_string("sub_op_commit_rec");
 	ip_op.op->pg_trace.event("sub_op_commit_rec");
       }
     } else {


### PR DESCRIPTION
Profiling an OSD during 4 KB randwrites shows we do pretty costly string processing on hot paths. It happens in:
* `PGLog::write_log_and_missing` while running on default `debug_osd` levels (`1/5`) because of the `dout` the method has,
* `ReplicatedBackend::do_repop_reply` for the sake of op tracking.

These patches deal with the issues in the simplest way: 1) by bumping up the local `dout` level and 2) just killing the dynamically generated part of the event tracking message. However, I'm not sure whether we actually can do that, and thus I treat this PR rather as a requests for comments.

Before
--------

### `PGLog::write_log_and_missing`
```
Samples: 11K of event 'cycles:pp', Event count (approx.): 3947658588                                                                                                                                          
  Children      Self  Command    Shared O  Symbol                                                                                                                                                            ▒
-    4,32%     0,12%  tp_osd_tp  ceph-osd  [.] PGLog::write_log_and_missing                                                                                                                                  ▒
   - 4,20% PGLog::write_log_and_missing                                                                                                                                                                      ▒
      + 2,62% PGLog::_write_log_and_missing                                                                                                                                                                  ▒
      + 0,34% operator<<                                                                                                                                                                                     ▒
      + 0,22% std::__ostream_insert<char, std::char_traits<char> >                                                                                                                                           ◆
      + 0,22% ceph::logging::Log::submit_entry                                                                                                                                                               ▒
      + 0,21% ceph::logging::Log::create_entry                                                                                                                                                               ▒
      + 0,19% std::ostream::_M_insert<unsigned long>                                                                                                                                                         ▒
        0,11% __strlen_sse42                                                                                                                                                                                 ▒
      + 0,11% pthread_mutex_unlock                                                                                                                                                                           ▒
      + 0,10% std::ostream::_M_insert<bool>                                                                                                                                                                  ▒
        0,03% std::_Rb_tree_increment                                                                                                                                                                        ▒
      + 0,02% std::ostream::flush                                                                                                                                                                            ▒
        0,01% _ZNSo5flushEv@plt                                                                                                                                                                              ▒
   + 0,08% __clone                                                                                                                                                                                           ▒
```

### `ReplicatedBackend::do_repop_reply`
```
Samples: 11K of event 'cycles:pp', Event count (approx.): 3947658588                                                                                                                                          
  Children      Self  Command    Shared O  Symbol                                                                                                                                                            ▒
-    6,98%     0,25%  tp_osd_tp  ceph-osd  [.] ReplicatedBackend::do_repop_reply                                                                                                                             ▒
   - 6,73% ReplicatedBackend::do_repop_reply                                                                                                                                                                 ▒
      + 2,59% Context::complete                                                                                                                                                                              ◆
      + 0,98% std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >::basic_ostringstream                                                                                             ▒
      + 0,78% operator<<                                                                                                                                                                                     ▒
      + 0,73% std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::intrusive_ptr<ReplicatedBackend::InProgressOp> >, std::_Select1st<std::pair<unsigned long const, boost::intrusive_ptr<Replic▒
      + 0,34% std::__ostream_insert<char, std::char_traits<char> >                                                                                                                                           ▒
      + 0,21% ceph::buffer::list::iterator_impl<true>::copy                                                                                                                                                  ▒
      + 0,19% std::basic_stringbuf<char, std::char_traits<char>, std::allocator<char> >::str                                                                                                                 ▒
      + 0,18% std::basic_ostringstream<char, std::char_traits<char>, std::allocator<char> >::~basic_ostringstream                                                                                            ▒
      + 0,15% std::_Rb_tree<pg_shard_t, pg_shard_t, std::_Identity<pg_shard_t>, std::less<pg_shard_t>, std::allocator<pg_shard_t> >::erase                                                                   ▒
        0,10% non-virtual thunk to PrimaryLogPG::update_peer_last_complete_ondisk(pg_shard_t, eversion_t)                                                                                                    ▒
      + 0,09% TrackedOp::mark_event_string                                                                                                                                                                   ▒
        0,08% std::_Rb_tree<pg_shard_t, pg_shard_t, std::_Identity<pg_shard_t>, std::less<pg_shard_t>, std::allocator<pg_shard_t> >::find                                                                    ▒
        0,07% __strlen_sse42                                                                                                                                                                                 ▒
      + 0,06% C_OSD_RepopCommit::~C_OSD_RepopCommit                                                                                                                                                          ▒
      + 0,06% pg_shard_t::decode                                                                                                                                                                             ▒
        0,03% std::string::_Rep::_M_dispose                                                                                                                                                                  ▒
      + 0,02% OpRequest::mark_flag_point                                                                                                                                                                     ▒
        0,02% _ZSt16__ostream_insertIcSt11char_traitsIcEERSt13basic_ostreamIT_T0_ES6_PKS3_l@plt                                                                                                              ▒
        0,02% __clock_gettime                                                                                                                                                                                ▒
        0,02% strlen@plt                                                                                                                                                                                     ▒
```

After
------

### `PGLog::write_log_and_missing`
```
Samples: 14K of event 'cycles:pp', Event count (approx.): 4898080077                                                                                                                                          
  Children      Self  Command    Shared O  Symbol                                                                                                                                                            ▒
-    2,54%     0,10%  tp_osd_tp  ceph-osd  [.] PGLog::write_log_and_missing                                                                                                                                  ▒
   - 2,45% PGLog::write_log_and_missing                                                                                                                                                                      ▒
      + 2,42% PGLog::_write_log_and_missing                                                                                                                                                                  ▒
        0,01% std::_Rb_tree<hobject_t, hobject_t, std::_Identity<hobject_t>, std::less<hobject_t>, std::allocator<hobject_t> >::_M_erase                                                                     ◆
   + 0,04% __clone                                                                                                                                                                                           ▒
```
### `ReplicatedBackend::do_repop_reply`
```
Samples: 14K of event 'cycles:pp', Event count (approx.): 4898080077                                                                                                                                          
  Children      Self  Command    Shared O  Symbol                                                                                                                                                            ▒
-    5,12%     0,34%  tp_osd_tp  ceph-osd  [.] ReplicatedBackend::do_repop_reply                                                                                                                             ▒
   - 4,78% ReplicatedBackend::do_repop_reply                                                                                                                                                                 ◆
      + 2,66% Context::complete                                                                                                                                                                              ▒
      + 0,92% std::_Rb_tree<unsigned long, std::pair<unsigned long const, boost::intrusive_ptr<ReplicatedBackend::InProgressOp> >, std::_Select1st<std::pair<unsigned long const, boost::intrusive_ptr<Replic▒
      + 0,27% ceph::buffer::list::iterator_impl<true>::copy                                                                                                                                                  ▒
      + 0,21% TrackedOp::mark_event_string                                                                                                                                                                   ▒
        0,17% non-virtual thunk to PrimaryLogPG::update_peer_last_complete_ondisk(pg_shard_t, eversion_t)                                                                                                    ▒
      + 0,15% std::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string                                                                                                           ▒
      + 0,13% std::_Rb_tree<pg_shard_t, pg_shard_t, std::_Identity<pg_shard_t>, std::less<pg_shard_t>, std::allocator<pg_shard_t> >::erase                                                                   ▒
        0,07% std::_Rb_tree<pg_shard_t, pg_shard_t, std::_Identity<pg_shard_t>, std::less<pg_shard_t>, std::allocator<pg_shard_t> >::find                                                                    ▒
      + 0,07% pg_shard_t::decode                                                                                                                                                                             ▒
      + 0,06% C_OSD_RepopCommit::~C_OSD_RepopCommit                                                                                                                                                          ▒
      + 0,06% OpRequest::mark_flag_point                                                                                                                                                                     ▒
   + 0,31% __clone                                                                                                                                                                                           ▒
```