### PR TITLE
ceph-volume:  lsblk can fail to find PARTLABEL, must fallback to blkid

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/simple/scan.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/scan.py
@@ -8,6 +8,7 @@ from textwrap import dedent
 from ceph_volume import decorators, terminal, conf
 from ceph_volume.api import lvm
 from ceph_volume.util import arg_validators, system, disk, encryption
+from ceph_volume.util.device import Device
 
 
 logger = logging.getLogger(__name__)
@@ -337,10 +338,12 @@ class Scan(object):
             return
 
         args = parser.parse_args(self.argv)
-        if disk.is_partition(args.osd_path):
-            label = disk.lsblk(args.osd_path)['PARTLABEL']
-            if 'data' not in label:
-                raise RuntimeError('Device must be the data partition, but got: %s' % label)
+        device = Device(args.osd_path)
+        if device.is_partition:
+            if device.ceph_disk.type != 'data':
+                label = device.ceph_disk.partlabel
+                msg = 'Device must be the ceph data partition, but PARTLABEL reported: "%s"' % label
+                raise RuntimeError(msg)
 
         # Capture some environment status, so that it can be reused all over
         self.device_mounts = system.get_mounts(devices=True)

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -176,12 +176,14 @@ def tmpfile(tmpdir):
 
 @pytest.fixture
 def device_info(monkeypatch):
-    def apply(devices=None, lsblk=None, lv=None):
+    def apply(devices=None, lsblk=None, lv=None, blkid=None):
         devices = devices if devices else {}
         lsblk = lsblk if lsblk else {}
+        blkid = blkid if blkid else {}
         lv = Factory(**lv) if lv else None
         monkeypatch.setattr("ceph_volume.sys_info.devices", {})
         monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: devices)
         monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: lv)
         monkeypatch.setattr("ceph_volume.util.device.disk.lsblk", lambda path: lsblk)
+        monkeypatch.setattr("ceph_volume.util.device.disk.blkid", lambda path: blkid)
     return apply

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -1,3 +1,4 @@
+import pytest
 from ceph_volume.util import device
 from ceph_volume.api import lvm as api
 
@@ -55,6 +56,34 @@ class TestDevice(object):
         disk = device.Device("/dev/sda")
         assert not disk.is_mapper
 
+    def test_is_ceph_disk_member_lsblk(self, device_info):
+        lsblk = {"PARTLABEL": "ceph data"}
+        device_info(lsblk=lsblk)
+        disk = device.Device("/dev/sda")
+        assert disk.is_ceph_disk_member
+
+    def test_is_not_ceph_disk_member_lsblk(self, device_info):
+        lsblk = {"PARTLABEL": "gluster partition"}
+        device_info(lsblk=lsblk)
+        disk = device.Device("/dev/sda")
+        assert disk.is_ceph_disk_member is False
+
+    def test_is_ceph_disk_member_blkid(self, device_info):
+        # falls back to blkid
+        lsblk = {"PARTLABEL": ""}
+        blkid = {"PARTLABEL": "ceph data"}
+        device_info(lsblk=lsblk, blkid=blkid)
+        disk = device.Device("/dev/sda")
+        assert disk.is_ceph_disk_member
+
+    def test_is_not_ceph_disk_member_blkid(self, device_info):
+        # falls back to blkid
+        lsblk = {"PARTLABEL": ""}
+        blkid = {"PARTLABEL": "gluster partition"}
+        device_info(lsblk=lsblk, blkid=blkid)
+        disk = device.Device("/dev/sda")
+        assert disk.is_ceph_disk_member is False
+
     def test_pv_api(self, device_info, pvolumes, monkeypatch):
         FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", pv_tags={}, vg_name="vg")
         pvolumes.append(FooPVolume)
@@ -64,3 +93,71 @@ class TestDevice(object):
         device_info(devices=data, lsblk=lsblk)
         disk = device.Device("/dev/sda")
         assert disk.pvs_api
+
+
+ceph_partlabels = [
+    'ceph data', 'ceph journal', 'ceph block',
+    'ceph block.wal', 'ceph block.db', 'ceph lockbox'
+]
+
+
+class TestCephDiskDevice(object):
+
+    def test_partlabel_lsblk(self, device_info):
+        lsblk = {"PARTLABEL": ""}
+        device_info(lsblk=lsblk)
+        disk = device.CephDiskDevice(device.Device("/dev/sda"))
+
+        assert disk.partlabel == ''
+
+    def test_partlabel_blkid(self, device_info):
+        lsblk = {"PARTLABEL": ""}
+        blkid = {"PARTLABEL": "ceph data"}
+        device_info(lsblk=lsblk, blkid=blkid)
+        disk = device.CephDiskDevice(device.Device("/dev/sda"))
+
+        assert disk.partlabel == 'ceph data'
+
+    @pytest.mark.parametrize("label", ceph_partlabels)
+    def test_is_member_blkid(self, device_info, label):
+        lsblk = {"PARTLABEL": ""}
+        blkid = {"PARTLABEL": label}
+        device_info(lsblk=lsblk, blkid=blkid)
+        disk = device.CephDiskDevice(device.Device("/dev/sda"))
+
+        assert disk.is_member is True
+
+    @pytest.mark.parametrize("label", ceph_partlabels)
+    def test_is_member_lsblk(self, device_info, label):
+        lsblk = {"PARTLABEL": label}
+        device_info(lsblk=lsblk)
+        disk = device.CephDiskDevice(device.Device("/dev/sda"))
+
+        assert disk.is_member is True
+
+    def test_unknown_type(self, device_info):
+        lsblk = {"PARTLABEL": "gluster"}
+        device_info(lsblk=lsblk)
+        disk = device.CephDiskDevice(device.Device("/dev/sda"))
+
+        assert disk.type == 'unknown'
+
+    @pytest.mark.parametrize("label", ceph_partlabels)
+    def test_type_blkid(self, device_info, label):
+        expected = label.split()[-1].split('.')[-1]
+        lsblk = {"PARTLABEL": ""}
+        blkid = {"PARTLABEL": label}
+        device_info(lsblk=lsblk, blkid=blkid)
+        disk = device.CephDiskDevice(device.Device("/dev/sda"))
+
+        assert disk.type == expected
+
+    @pytest.mark.parametrize("label", ceph_partlabels)
+    def test_type_lsblk(self, device_info, label):
+        expected = label.split()[-1].split('.')[-1]
+        lsblk = {"PARTLABEL": label}
+        blkid = {"PARTLABEL": ''}
+        device_info(lsblk=lsblk, blkid=blkid)
+        disk = device.CephDiskDevice(device.Device("/dev/sda"))
+
+        assert disk.type == expected

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -13,6 +13,7 @@ class Device(object):
         self.lv_api = None
         self.pvs_api = []
         self.disk_api = {}
+        self.blkid_api = {}
         self.sys_api = {}
         self._exists = None
         self._is_lvm_member = None
@@ -26,6 +27,7 @@ class Device(object):
             self.abspath = lv.lv_path
         else:
             dev = disk.lsblk(self.path)
+            self.blkid_api = disk.blkid(self.path)
             self.disk_api = dev
             device_type = dev.get('TYPE', '')
             # always check is this is an lvm member
@@ -35,6 +37,8 @@ class Device(object):
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
         self.sys_api = sys_info.devices.get(self.abspath, {})
+
+        self.ceph_disk = CephDiskDevice(self)
 
     def __repr__(self):
         prefix = 'Unknown'
@@ -78,6 +82,10 @@ class Device(object):
         return self._is_lvm_member
 
     @property
+    def is_ceph_disk_member(self):
+        return self.ceph_disk.is_member
+
+    @property
     def is_mapper(self):
         return self.path.startswith('/dev/mapper')
 
@@ -96,3 +104,48 @@ class Device(object):
         if self.disk_api:
             return self.disk_api['TYPE'] == 'device'
         return False
+
+
+class CephDiskDevice(object):
+    """
+    Detect devices that have been created by ceph-disk, report their type
+    (journal, data, etc..). Requires a ``Device`` object as input.
+    """
+
+    def __init__(self, device):
+        self.device = device
+        self._is_ceph_disk_member = None
+
+    @property
+    def partlabel(self):
+        """
+        In containers, the 'PARTLABEL' attribute might not be detected
+        correctly via ``lsblk``, so we poke at the value with ``lsblk`` first,
+        falling back to ``blkid`` (which works correclty in containers).
+        """
+        lsblk_partlabel = self.device.disk_api.get('PARTLABEL')
+        if lsblk_partlabel:
+            return lsblk_partlabel
+        return self.device.blkid_api.get('PARTLABEL', '')
+
+    @property
+    def is_member(self):
+        if self._is_ceph_disk_member is None:
+            if 'ceph' in self.partlabel:
+                self._is_ceph_disk_member = True
+                return True
+            return False
+        return self._is_ceph_disk_member
+
+    @property
+    def type(self):
+        types = [
+            'data', 'wal', 'db', 'lockbox', 'journal',
+            # ceph-disk uses 'ceph block' when placing data in bluestore, but
+            # keeps the regular OSD files in 'ceph data' :( :( :( :(
+            'block',
+        ]
+        for t in types:
+            if t in self.partlabel:
+                return t
+        return 'unknown'


### PR DESCRIPTION
Specifically in containers, `PARTLABEL` might not come back with any value at all, while `blkid` will. This PR also introduces an API for ceph-disk devices which will allow better interaction with legacy OSDs.

Fixes: http://tracker.ceph.com/issues/36098