### PR TITLE
rgw: admin command to cleanup stale bucket indexes from reshard

### DIFF
--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -148,6 +148,7 @@
     reshard status             read bucket resharding status
     reshard process            process of scheduled reshard jobs
     reshard cancel             cancel resharding a bucket
+    reshard cleanup            cleanup old index objects from a resharded bucket
     sync error list            list sync error
     sync error trim            trim sync error
     mfa create                 create a new MFA TOTP token


### PR DESCRIPTION
`radosgw-admin reshard cleanup --bucket={}`
This currently processes only a single bucket, it starts to reshard if the
marker differs from the bucket id, indicating a resharded bucket. Since a bucket
may have been resharded multiple times, we loop through the next bucket id and
confirm that it is not the current and continue to purge bucket indices until we
reach the original bucket id.

Fixes: http://tracker.ceph.com/issues/24082
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [X] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

