### PR TITLE
ceph.in: clean up and enable --foo=bar style arguments

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -63,6 +63,9 @@
   or reclaim state held by a previous incarnation. These functions are for NFS
   servers.
 
+* The `ceph` command line tool now accepts keyword arguments in
+  the format "--arg=value" or "--arg value".
+
 >=13.1.0
 --------
 

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -24,7 +24,6 @@ from time import sleep
 import codecs
 import os
 import sys
-import subprocess
 import time
 import platform
 
@@ -147,7 +146,7 @@ import subprocess
 
 from ceph_argparse import \
     concise_sig, descsort_key, parse_json_funcsigs, \
-    matchnum, validate_command, find_cmd_target, \
+    validate_command, find_cmd_target, \
     json_command, run_in_thread
 
 from ceph_daemon import admin_socket, DaemonWatcher, Termsize
@@ -615,9 +614,9 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
             ret, outbuf, outs = do_command(parsed_args, target, cmdargs, sigdict, inbuf, verbose)
         else:
             # Interactive mode (ceph cli)
-            if sys.stdin.isatty():
-                # do the command-interpreter looping
-                # for input to do readline cmd editing
+            if sys.stdin.isatty():  
+                # do the command-interpreter looping    
+                # for input to do readline cmd editing    
                 import readline  # noqa
 
             while True:
@@ -661,8 +660,6 @@ def complete(sigdict, args, target):
     Return exitcode.
     """
     # XXX this looks a lot like the front of validate_command().  Refactor?
-
-    complete_verbose = 'COMPVERBOSE' in os.environ
 
     # Repulsive hack to handle tell: lop off 'tell' and target
     # and validate the rest of the command.  'target' is already
@@ -929,8 +926,6 @@ def main():
     # For now, --admin-daemon is handled as usual.  Try it
     # first in case we can't connect() to the cluster
 
-    format = parsed_args.output_format
-
     done, ret = maybe_daemon_command(parsed_args, childargs)
     if done:
         return ret
@@ -1164,7 +1159,7 @@ def main():
         if ret:
             where = '{0}.{1}'.format(*target)
             if ret > 0:
-                raise RuntimeError('Unexpeceted return code from {0}: {1}'.
+                raise RuntimeError('Unexpected return code from {0}: {1}'.
                                    format(where, ret))
             outs = 'problem getting command descriptions from {0}'.format(where)
         else:

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -268,6 +268,14 @@ GLOBAL_ARGS = {
 
 
 def parse_cmdargs(args=None, target=''):
+    """
+    Consume generic arguments from the start of the ``args``
+    list.  Call this first to handle arguments that are not
+    handled by a command description provided by the server.
+
+    :returns: three tuple of ArgumentParser instance, Namespace instance
+              containing parsed values, and list of un-handled arguments
+    """
     # alias: let the line-wrapping be sane
     AP = argparse.ArgumentParser
 

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -566,6 +566,7 @@ public:
       ostringstream secname;
       secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
       dump_cmd_and_help_to_json(&jf,
+                                CEPH_FEATURES_ALL,
 				secname.str().c_str(),
 				info.desc,
 				info.help);

--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -120,7 +120,6 @@ dump_cmddesc_to_json(Formatter *jf,
 		     const string& helptext,
 		     const string& module,
 		     const string& perm,
-		     const string& avail,
 		     uint64_t flags)
 {
       jf->open_object_section(secname.c_str());
@@ -130,7 +129,6 @@ dump_cmddesc_to_json(Formatter *jf,
       jf->dump_string("help", helptext.c_str());
       jf->dump_string("module", module.c_str());
       jf->dump_string("perm", perm.c_str());
-      jf->dump_string("avail", avail.c_str());
       jf->dump_int("flags", flags);
       jf->close_section(); // cmd
 }

--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -23,12 +23,15 @@ typedef boost::variant<std::string,
 typedef std::map<std::string, cmd_vartype, std::less<>> cmdmap_t;
 
 std::string cmddesc_get_prefix(const std::string &cmddesc);
-void dump_cmd_to_json(ceph::Formatter *f, const std::string& cmd);
+void dump_cmd_to_json(ceph::Formatter *f, uint64_t features,
+                      const std::string& cmd);
 void dump_cmd_and_help_to_json(ceph::Formatter *f,
+			       uint64_t features,
 			       const std::string& secname,
 			       const std::string& cmd,
 			       const std::string& helptext);
 void dump_cmddesc_to_json(ceph::Formatter *jf,
+		          uint64_t features,
 		          const std::string& secname,
 		          const std::string& cmdsig,
 		          const std::string& helptext,
@@ -51,6 +54,9 @@ struct bad_cmd_get : public std::exception {
     return desc.c_str();
   }
 };
+
+bool cmd_getval(CephContext *cct, const cmdmap_t& cmdmap,
+		const std::string& k, bool& val);
 
 template <typename T>
 bool cmd_getval(CephContext *cct, const cmdmap_t& cmdmap,

--- a/src/common/cmdparse.h
+++ b/src/common/cmdparse.h
@@ -34,7 +34,6 @@ void dump_cmddesc_to_json(ceph::Formatter *jf,
 		          const std::string& helptext,
 		          const std::string& module,
 		          const std::string& perm,
-		          const std::string& avail,
 		          uint64_t flags);
 bool cmdmap_from_json(std::vector<std::string> cmd, cmdmap_t *mapp,
 		      std::stringstream &ss);

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -2092,7 +2092,7 @@ void librados::IoCtxImpl::application_enable_async(const std::string& app_name,
       << "\"pool\": \"" << get_cached_pool_name() << "\","
       << "\"app\": \"" << app_name << "\"";
   if (force) {
-    cmd << ",\"force\":\"--yes-i-really-mean-it\"";
+    cmd << ",\"yes_i_really_mean_it\": true";
   }
   cmd << "}";
 

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -728,7 +728,7 @@ int MDSDaemon::_handle_command(
       ostringstream secname;
       secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
       dump_cmddesc_to_json(f.get(), secname.str(), c.cmdstring, c.helpstring,
-			   c.module, "*", c.availability, 0);
+			   c.module, "*", 0);
       cmdnum++;
     }
     f->close_section();	// command_descriptions

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -727,7 +727,8 @@ int MDSDaemon::_handle_command(
     for (auto& c : get_commands()) {
       ostringstream secname;
       secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
-      dump_cmddesc_to_json(f.get(), secname.str(), c.cmdstring, c.helpstring,
+      dump_cmddesc_to_json(f.get(), m->get_connection()->get_features(),
+                           secname.str(), c.cmdstring, c.helpstring,
 			   c.module, "*", 0);
       cmdnum++;
     }

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -174,7 +174,6 @@ private:
     std::string cmdstring;
     std::string helpstring;
     std::string module = "mds";
-    std::string availability = "cli,rest";
   };
 
   static const std::vector<MDSCommand>& get_commands();

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -834,7 +834,7 @@ bool DaemonServer::_handle_command(
       ostringstream secname;
       secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
       dump_cmddesc_to_json(&f, secname.str(), mc.cmdstring, mc.helpstring,
-                           mc.module, mc.req_perms, mc.availability, 0);
+                           mc.module, mc.req_perms, 0);
       cmdnum++;
     };
 
@@ -858,7 +858,7 @@ bool DaemonServer::_handle_command(
 
   bool is_allowed;
   if (!mgr_cmd) {
-    MonCommand py_command = {"", "", "py", "rw", "cli"};
+    MonCommand py_command = {"", "", "py", "rw"};
     is_allowed = _allowed_command(session, py_command.module,
       prefix, cmdctx->cmdmap, param_str_map, &py_command);
   } else {

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -830,10 +830,11 @@ bool DaemonServer::_handle_command(
     JSONFormatter f;
     f.open_object_section("command_descriptions");
 
-    auto dump_cmd = [&cmdnum, &f](const MonCommand &mc){
+    auto dump_cmd = [&cmdnum, &f, m](const MonCommand &mc){
       ostringstream secname;
       secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
-      dump_cmddesc_to_json(&f, secname.str(), mc.cmdstring, mc.helpstring,
+      dump_cmddesc_to_json(&f, m->get_connection()->get_features(),
+                           secname.str(), mc.cmdstring, mc.helpstring,
                            mc.module, mc.req_perms, 0);
       cmdnum++;
     };

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -6,106 +6,105 @@
 // see MonCommands.h
 
 COMMAND("pg stat", "show placement group status.",
-	"pg", "r", "cli,rest")
-COMMAND("pg getmap", "get binary pg map to -o/stdout", "pg", "r", "cli,rest")
+	"pg", "r")
+COMMAND("pg getmap", "get binary pg map to -o/stdout", "pg", "r")
 
 COMMAND("pg dump "							\
 	"name=dumpcontents,type=CephChoices,strings=all|summary|sum|delta|pools|osds|pgs|pgs_brief,n=N,req=false", \
-	"show human-readable versions of pg map (only 'all' valid with plain)", "pg", "r", "cli,rest")
+	"show human-readable versions of pg map (only 'all' valid with plain)", "pg", "r")
 COMMAND("pg dump_json "							\
 	"name=dumpcontents,type=CephChoices,strings=all|summary|sum|pools|osds|pgs,n=N,req=false", \
 	"show human-readable version of pg map in json only",\
-	"pg", "r", "cli,rest")
+	"pg", "r")
 COMMAND("pg dump_pools_json", "show pg pools info in json only",\
-	"pg", "r", "cli,rest")
+	"pg", "r")
 
 COMMAND("pg ls-by-pool "		\
         "name=poolstr,type=CephString " \
 	"name=states,type=CephString,n=N,req=false", \
-	"list pg with pool = [poolname]", "pg", "r", "cli,rest")
+	"list pg with pool = [poolname]", "pg", "r")
 COMMAND("pg ls-by-primary " \
         "name=osd,type=CephOsdName " \
         "name=pool,type=CephInt,req=false " \
 	"name=states,type=CephString,n=N,req=false", \
-	"list pg with primary = [osd]", "pg", "r", "cli,rest")
+	"list pg with primary = [osd]", "pg", "r")
 COMMAND("pg ls-by-osd " \
         "name=osd,type=CephOsdName " \
         "name=pool,type=CephInt,req=false " \
 	"name=states,type=CephString,n=N,req=false", \
-	"list pg on osd [osd]", "pg", "r", "cli,rest")
+	"list pg on osd [osd]", "pg", "r")
 COMMAND("pg ls " \
         "name=pool,type=CephInt,req=false " \
 	"name=states,type=CephString,n=N,req=false", \
-	"list pg with specific pool, osd, state", "pg", "r", "cli,rest")
+	"list pg with specific pool, osd, state", "pg", "r")
 COMMAND("pg dump_stuck " \
 	"name=stuckops,type=CephChoices,strings=inactive|unclean|stale|undersized|degraded,n=N,req=false " \
 	"name=threshold,type=CephInt,req=false",
 	"show information about stuck pgs",\
-	"pg", "r", "cli,rest")
+	"pg", "r")
 COMMAND("pg debug " \
 	"name=debugop,type=CephChoices,strings=unfound_objects_exist|degraded_pgs_exist", \
-	"show debug info about pgs", "pg", "r", "cli,rest")
+	"show debug info about pgs", "pg", "r")
 
 COMMAND("pg scrub name=pgid,type=CephPgid", "start scrub on <pgid>", \
-	"pg", "rw", "cli,rest")
+	"pg", "rw")
 COMMAND("pg deep-scrub name=pgid,type=CephPgid", "start deep-scrub on <pgid>", \
-	"pg", "rw", "cli,rest")
+	"pg", "rw")
 COMMAND("pg repair name=pgid,type=CephPgid", "start repair on <pgid>", \
-	"pg", "rw", "cli,rest")
+	"pg", "rw")
 
 COMMAND("pg force-recovery name=pgid,type=CephPgid,n=N", "force recovery of <pgid> first", \
-	"pg", "rw", "cli,rest")
+	"pg", "rw")
 COMMAND("pg force-backfill name=pgid,type=CephPgid,n=N", "force backfill of <pgid> first", \
-	"pg", "rw", "cli,rest")
+	"pg", "rw")
 COMMAND("pg cancel-force-recovery name=pgid,type=CephPgid,n=N", "restore normal recovery priority of <pgid>", \
-	"pg", "rw", "cli,rest")
+	"pg", "rw")
 COMMAND("pg cancel-force-backfill name=pgid,type=CephPgid,n=N", "restore normal backfill priority of <pgid>", \
-	"pg", "rw", "cli,rest")
+	"pg", "rw")
 
 // stuff in osd namespace
 COMMAND("osd perf", \
         "print dump of OSD perf summary stats", \
         "osd", \
-        "r", \
-        "cli,rest")
+        "r")
 COMMAND("osd df " \
 	"name=output_method,type=CephChoices,strings=plain|tree,req=false", \
-	"show OSD utilization", "osd", "r", "cli,rest")
+	"show OSD utilization", "osd", "r")
 COMMAND("osd blocked-by", \
 	"print histogram of which OSDs are blocking their peers", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd pool stats " \
         "name=pool_name,type=CephPoolname,req=false",
         "obtain stats from all pools, or from specified pool",
-        "osd", "r", "cli,rest")
+        "osd", "r")
 COMMAND("osd reweight-by-utilization " \
 	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
 	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
 	"reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd test-reweight-by-utilization " \
 	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
 	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
 	"dry run of reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd reweight-by-pg " \
 	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
 	"name=pools,type=CephPoolname,n=N,req=false",			\
 	"reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd test-reweight-by-pg " \
 	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
 	"name=pools,type=CephPoolname,n=N,req=false",			\
 	"dry run of reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 
 COMMAND("osd destroy "	    \
         "name=id,type=CephOsdName " \
@@ -113,65 +112,65 @@ COMMAND("osd destroy "	    \
         "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \
         "but removes cephx keys, config-key data and lockbox keys, "\
         "rendering data permanently unreadable.", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd purge " \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephString,req=false",			     \
         "purge all osd data from the monitors including the OSD id " \
 	"and CRUSH position",					     \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 
 COMMAND("osd safe-to-destroy name=ids,type=CephString,n=N",
 	"check whether osd(s) can be safely destroyed without reducing data durability",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd ok-to-stop name=ids,type=CephString,n=N",
 	"check whether osd(s) can be safely stopped without reducing immediate"\
-	" data availability", "osd", "r", "cli,rest")
+	" data availability", "osd", "r")
 
 COMMAND("osd scrub " \
 	"name=who,type=CephString", \
 	"initiate scrub on osd <who>, or use <all|any> to scrub all", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd deep-scrub " \
 	"name=who,type=CephString", \
 	"initiate deep scrub on osd <who>, or use <all|any> to deep scrub all", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd repair " \
 	"name=who,type=CephString", \
 	"initiate repair on osd <who>, or use <all|any> to repair all", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 
 COMMAND("service dump",
-        "dump service map", "service", "r", "cli,rest")
+        "dump service map", "service", "r")
 COMMAND("service status",
-        "dump service state", "service", "r", "cli,rest")
+        "dump service state", "service", "r")
 
 COMMAND("config show " \
 	"name=who,type=CephString name=key,type=CephString,req=False",
 	"Show running configuration",
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 COMMAND("config show-with-defaults " \
 	"name=who,type=CephString",
 	"Show running configuration (including compiled-in defaults)",
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 
 COMMAND("device ls",
 	"Show devices",
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 COMMAND("device info name=devid,type=CephString",
 	"Show information about a device",
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 COMMAND("device ls-by-daemon name=who,type=CephString",
 	"Show devices associated with a daemon",
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 COMMAND("device ls-by-host name=host,type=CephString",
 	"Show devices on a host",
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 COMMAND("device set-life-expectancy name=devid,type=CephString "\
 	"name=from,type=CephString "\
 	"name=to,type=CephString,req=False",
 	"Set predicted device life expectancy",
-	"mgr", "rw", "cli,rest")
+	"mgr", "rw")
 COMMAND("device rm-life-expectancy name=devid,type=CephString",
 	"Clear predicted device life expectancy",
-	"mgr", "rw", "cli,rest")
+	"mgr", "rw")

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -108,14 +108,14 @@ COMMAND("osd test-reweight-by-pg " \
 
 COMMAND("osd destroy "	    \
         "name=id,type=CephOsdName " \
-        "name=sure,type=CephString,req=False",
+	"name=sure,type=CephChoices,strings=--force|--yes-i-really-mean-it,req=false", \
         "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \
         "but removes cephx keys, config-key data and lockbox keys, "\
         "rendering data permanently unreadable.", \
         "osd", "rw")
 COMMAND("osd purge " \
         "name=id,type=CephOsdName " \
-        "name=sure,type=CephString,req=false",			     \
+	"name=sure,type=CephChoices,strings=--force|--yes-i-really-mean-it,req=false", \
         "purge all osd data from the monitors including the OSD id " \
 	"and CRUSH position",					     \
 	"osd", "rw")

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -88,7 +88,7 @@ COMMAND("osd test-reweight-by-utilization " \
 	"name=oload,type=CephInt,req=false " \
 	"name=max_change,type=CephFloat,req=false "			\
 	"name=max_osds,type=CephInt,req=false "			\
-	"name=no_increasing,type=CephChoices,strings=--no-increasing,req=false",\
+	"name=no_increasing,type=CephBool,req=false",\
 	"dry run of reweight OSDs by utilization [overload-percentage-for-consideration, default 120]", \
 	"osd", "r")
 COMMAND("osd reweight-by-pg " \
@@ -108,14 +108,18 @@ COMMAND("osd test-reweight-by-pg " \
 
 COMMAND("osd destroy "	    \
         "name=id,type=CephOsdName " \
-	"name=sure,type=CephChoices,strings=--force|--yes-i-really-mean-it,req=false", \
+	"name=force,type=CephBool,req=false "
+        // backward compat synonym for --force
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
         "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \
         "but removes cephx keys, config-key data and lockbox keys, "\
         "rendering data permanently unreadable.", \
         "osd", "rw")
 COMMAND("osd purge " \
         "name=id,type=CephOsdName " \
-	"name=sure,type=CephChoices,strings=--force|--yes-i-really-mean-it,req=false", \
+	"name=force,type=CephBool,req=false "
+        // backward compat synonym for --force
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
         "purge all osd data from the monitors including the OSD id " \
 	"and CRUSH position",					     \
 	"osd", "rw")

--- a/src/mgr/PyModuleRegistry.cc
+++ b/src/mgr/PyModuleRegistry.cc
@@ -331,7 +331,7 @@ std::vector<MonCommand> PyModuleRegistry::get_commands() const
       flags |= MonCommand::FLAG_POLL;
     }
     result.push_back({pyc.cmdstring, pyc.helpstring, "mgr",
-                        pyc.perm, "cli", flags});
+                        pyc.perm, flags});
   }
   return result;
 }

--- a/src/mgr/mgr_commands.cc
+++ b/src/mgr/mgr_commands.cc
@@ -7,8 +7,8 @@
  * does not include the Python-defined commands, which are loaded
  * in PyModules */
 const std::vector<MonCommand> mgr_commands = {
-#define COMMAND(parsesig, helptext, module, perm, availability) \
-  {parsesig, helptext, module, perm, availability, 0},
+#define COMMAND(parsesig, helptext, module, perm) \
+  {parsesig, helptext, module, perm, 0},
 #include "MgrCommands.h"
 #undef COMMAND
 };

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1360,9 +1360,9 @@ int MDSMonitor::filesystem_command(
       }
     }
   } else if (prefix == "mds rmfailed") {
-    string confirm;
-    if (!cmd_getval(g_ceph_context, cmdmap, "confirm", confirm) ||
-       confirm != "--yes-i-really-mean-it") {
+    bool confirm = false;
+    cmd_getval(g_ceph_context, cmdmap, "yes_i_really_mean_it", confirm);
+    if (!confirm) {
          ss << "WARNING: this can make your filesystem inaccessible! "
                "Add --yes-i-really-mean-it if you are sure you wish to continue.";
          return -EPERM;

--- a/src/mon/MonCommand.h
+++ b/src/mon/MonCommand.h
@@ -21,7 +21,6 @@ struct MonCommand {
   std::string helpstring;
   std::string module;
   std::string req_perms;
-  std::string availability;
   uint64_t flags;
 
   // MonCommand flags
@@ -60,6 +59,7 @@ struct MonCommand {
     encode(helpstring, bl);
     encode(module, bl);
     encode(req_perms, bl);
+    std::string availability;  // Removed field, for backward compat
     encode(availability, bl);
   }
   void decode_bare(bufferlist::const_iterator &bl) {
@@ -68,12 +68,12 @@ struct MonCommand {
     decode(helpstring, bl);
     decode(module, bl);
     decode(req_perms, bl);
+    std::string availability;  // Removed field, for backward compat
     decode(availability, bl);
   }
   bool is_compat(const MonCommand* o) const {
     return cmdstring == o->cmdstring &&
-	module == o->module && req_perms == o->req_perms &&
-	availability == o->availability;
+	module == o->module && req_perms == o->req_perms;
   }
 
   bool is_noforward() const {

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -942,14 +942,16 @@ COMMAND("osd pool create " \
 COMMAND_WITH_FLAG("osd pool delete " \
 	"name=pool,type=CephPoolname " \
 	"name=pool2,type=CephPoolname,req=false " \
-	"name=sure,type=CephString,req=false", \
+	"name=sure,type=CephChoices,strings=--yes-i-really-really-mean-it|" \
+        "--yes-i-really-really-mean-it-not-faking,req=false", \
 	"delete pool", \
 	"osd", "rw", \
     FLAG(DEPRECATED))
 COMMAND("osd pool rm " \
 	"name=pool,type=CephPoolname " \
 	"name=pool2,type=CephPoolname,req=false " \
-	"name=sure,type=CephString,req=false", \
+	"name=sure,type=CephChoices,strings=--yes-i-really-really-mean-it|" \
+        "--yes-i-really-really-mean-it-not-faking,req=false", \
 	"remove pool", \
 	"osd", "rw")
 COMMAND("osd pool rename " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -764,8 +764,6 @@ COMMAND("osd require-osd-release "\
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"set the minimum allowed OSD release to participate in the cluster",
 	"osd", "rw")
-COMMAND("osd cluster_snap", "take cluster snapshot (disabled)", \
-	"osd", "r")
 COMMAND("osd down " \
 	"type=CephString,name=ids,n=N", \
 	"set osd(s) <id> [<id>...] down, " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -652,7 +652,7 @@ COMMAND("osd crush rule create-replicated " \
 	"name=root,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=type,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=class,type=CephString,goodchars=[A-Za-z0-9-_.],req=false",
-	"create crush rule <name> for replicated pool to start from <root>, replicate across buckets of type <type>, using a choose mode of <firstn|indep> (default firstn; indep best for erasure pools)", \
+	"create crush rule <name> for replicated pool to start from <root>, replicate across buckets of type <type>, use devices of type <class> (ssd or hdd)", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd crush rule create-erasure " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -32,7 +32,6 @@
  *             mds, osd, pg (osd), mon, auth, log, config-key, mgr
  * req perms:  required permission in that modulename space to execute command
  *             this also controls what type of REST command is accepted
- * availability: cli, rest, or both
  *
  * The commands describe themselves completely enough for the separate
  * frontend(s) to be able to accept user input and validate it against
@@ -122,12 +121,12 @@
  */
 
 COMMAND("pg map name=pgid,type=CephPgid", "show mapping of pg to osds", \
-	"pg", "r", "cli,rest")
+	"pg", "r")
 COMMAND("pg repeer name=pgid,type=CephPgid", "force a PG to repeer",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd last-stat-seq name=id,type=CephOsdName", \
 	"get the last pg stats sequence number reported for this osd", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 
 /*
  * auth commands AuthMonitor.cc
@@ -135,147 +134,147 @@ COMMAND("osd last-stat-seq name=id,type=CephOsdName", \
 
 COMMAND("auth export name=entity,type=CephString,req=false", \
        	"write keyring for requested entity, or master keyring if none given", \
-	"auth", "rx", "cli,rest")
+	"auth", "rx")
 COMMAND("auth get name=entity,type=CephString", \
-	"write keyring file with requested key", "auth", "rx", "cli,rest")
+	"write keyring file with requested key", "auth", "rx")
 COMMAND("auth get-key name=entity,type=CephString", "display requested key", \
-	"auth", "rx", "cli,rest")
+	"auth", "rx")
 COMMAND("auth print-key name=entity,type=CephString", "display requested key", \
-	"auth", "rx", "cli,rest")
+	"auth", "rx")
 COMMAND("auth print_key name=entity,type=CephString", "display requested key", \
-	"auth", "rx", "cli,rest")
-COMMAND_WITH_FLAG("auth list", "list authentication state", "auth", "rx", "cli,rest",
+	"auth", "rx")
+COMMAND_WITH_FLAG("auth list", "list authentication state", "auth", "rx",
 		  FLAG(DEPRECATED))
-COMMAND("auth ls", "list authentication state", "auth", "rx", "cli,rest")
+COMMAND("auth ls", "list authentication state", "auth", "rx")
 COMMAND("auth import", "auth import: read keyring file from -i <file>", \
-	"auth", "rwx", "cli,rest")
+	"auth", "rwx")
 COMMAND("auth add " \
 	"name=entity,type=CephString " \
 	"name=caps,type=CephString,n=N,req=false", \
 	"add auth info for <entity> from input file, or random key if no " \
         "input is given, and/or any caps specified in the command",
-	"auth", "rwx", "cli,rest")
+	"auth", "rwx")
 COMMAND("auth get-or-create-key " \
 	"name=entity,type=CephString " \
 	"name=caps,type=CephString,n=N,req=false", \
 	"get, or add, key for <name> from system/caps pairs specified in the command.  If key already exists, any given caps must match the existing caps for that key.", \
-	"auth", "rwx", "cli,rest")
+	"auth", "rwx")
 COMMAND("auth get-or-create " \
 	"name=entity,type=CephString " \
 	"name=caps,type=CephString,n=N,req=false", \
 	"add auth info for <entity> from input file, or random key if no input given, and/or any caps specified in the command", \
-	"auth", "rwx", "cli,rest")
+	"auth", "rwx")
 COMMAND("fs authorize " \
    "name=filesystem,type=CephString " \
    "name=entity,type=CephString " \
 	"name=caps,type=CephString,n=N", \
 	"add auth for <entity> to access file system <filesystem> based on following directory and permissions pairs", \
-	"auth", "rwx", "cli,rest")
+	"auth", "rwx")
 COMMAND("auth caps " \
 	"name=entity,type=CephString " \
 	"name=caps,type=CephString,n=N", \
 	"update caps for <name> from caps specified in the command", \
-	"auth", "rwx", "cli,rest")
+	"auth", "rwx")
 COMMAND_WITH_FLAG("auth del " \
 	"name=entity,type=CephString", \
 	"delete all caps for <name>", \
-	"auth", "rwx", "cli,rest", \
+	"auth", "rwx", \
     FLAG(DEPRECATED))
 COMMAND("auth rm " \
 	"name=entity,type=CephString", \
 	"remove all caps for <name>", \
-	"auth", "rwx", "cli,rest")
+	"auth", "rwx")
 
 /*
  * Monitor commands (Monitor.cc)
  */
 COMMAND_WITH_FLAG("compact", "cause compaction of monitor's leveldb/rocksdb storage", \
-	     "mon", "rw", "cli,rest", \
+	     "mon", "rw", \
              FLAG(NOFORWARD)|FLAG(DEPRECATED))
 COMMAND_WITH_FLAG("scrub", "scrub the monitor stores", \
-             "mon", "rw", "cli,rest", \
+             "mon", "rw", \
              FLAG(DEPRECATED))
-COMMAND("fsid", "show cluster FSID/UUID", "mon", "r", "cli,rest")
+COMMAND("fsid", "show cluster FSID/UUID", "mon", "r")
 COMMAND("log name=logtext,type=CephString,n=N", \
-	"log supplied text to the monitor log", "mon", "rw", "cli,rest")
+	"log supplied text to the monitor log", "mon", "rw")
 COMMAND("log last "
         "name=num,type=CephInt,range=1,req=false "
         "name=level,type=CephChoices,strings=debug|info|sec|warn|error,req=false "
         "name=channel,type=CephChoices,strings=*|cluster|audit,req=false", \
 	"print last few lines of the cluster log", \
-	"mon", "r", "cli,rest")
+	"mon", "r")
 COMMAND_WITH_FLAG("injectargs " \
 	     "name=injected_args,type=CephString,n=N",			\
-	     "inject config arguments into monitor", "mon", "rw", "cli,rest",
+	     "inject config arguments into monitor", "mon", "rw",
 	     FLAG(NOFORWARD))
 
-COMMAND("status", "show cluster status", "mon", "r", "cli,rest")
+COMMAND("status", "show cluster status", "mon", "r")
 COMMAND("health name=detail,type=CephChoices,strings=detail,req=false", \
-	"show cluster health", "mon", "r", "cli,rest")
-COMMAND("time-sync-status", "show time sync status", "mon", "r", "cli,rest")
+	"show cluster health", "mon", "r")
+COMMAND("time-sync-status", "show time sync status", "mon", "r")
 COMMAND("df name=detail,type=CephChoices,strings=detail,req=false", \
-	"show cluster free space stats", "mon", "r", "cli,rest")
+	"show cluster free space stats", "mon", "r")
 COMMAND("report name=tags,type=CephString,n=N,req=false", \
 	"report full status of cluster, optional title tag strings", \
-	"mon", "r", "cli,rest")
+	"mon", "r")
 COMMAND("features", "report of connected features", \
-        "mon", "r", "cli,rest")
+        "mon", "r")
 COMMAND("quorum_status", "report status of monitor quorum", \
-	"mon", "r", "cli,rest")
+	"mon", "r")
 
-COMMAND_WITH_FLAG("mon_status", "report status of monitors", "mon", "r", "cli,rest",
+COMMAND_WITH_FLAG("mon_status", "report status of monitors", "mon", "r",
 	     FLAG(NOFORWARD))
 COMMAND_WITH_FLAG("sync force " \
 	"name=validate1,type=CephChoices,strings=--yes-i-really-mean-it,req=false " \
 	"name=validate2,type=CephChoices,strings=--i-know-what-i-am-doing,req=false", \
 	"force sync of and clear monitor store", \
-        "mon", "rw", "cli,rest", \
+        "mon", "rw", \
         FLAG(NOFORWARD)|FLAG(DEPRECATED))
 COMMAND_WITH_FLAG("heap " \
 	     "name=heapcmd,type=CephChoices,strings=dump|start_profiler|stop_profiler|release|stats", \
 	     "show heap usage info (available only if compiled with tcmalloc)", \
-	     "mon", "rw", "cli,rest", FLAG(NOFORWARD))
+	     "mon", "rw", FLAG(NOFORWARD))
 COMMAND("quorum name=quorumcmd,type=CephChoices,strings=enter|exit,n=1", \
-	"enter or exit quorum", "mon", "rw", "cli,rest")
+	"enter or exit quorum", "mon", "rw")
 COMMAND("tell " \
 	"name=target,type=CephName " \
 	"name=args,type=CephString,n=N", \
-	"send a command to a specific daemon", "mon", "rw", "cli,rest")
-COMMAND_WITH_FLAG("version", "show mon daemon version", "mon", "r", "cli,rest",
+	"send a command to a specific daemon", "mon", "rw")
+COMMAND_WITH_FLAG("version", "show mon daemon version", "mon", "r",
                   FLAG(NOFORWARD))
 
 COMMAND("node ls " \
 	"name=type,type=CephChoices,strings=all|osd|mon|mds|mgr,req=false",
-	"list all nodes in cluster [type]", "mon", "r", "cli,rest")
+	"list all nodes in cluster [type]", "mon", "r")
 /*
  * Monitor-specific commands under module 'mon'
  */
 COMMAND_WITH_FLAG("mon compact", \
     "cause compaction of monitor's leveldb/rocksdb storage", \
-    "mon", "rw", "cli,rest", \
+    "mon", "rw", \
     FLAG(NOFORWARD))
 COMMAND_WITH_FLAG("mon scrub",
     "scrub the monitor stores", \
-    "mon", "rw", "cli,rest", \
+    "mon", "rw", \
     FLAG(NONE))
 COMMAND_WITH_FLAG("mon sync force " \
     "name=validate1,type=CephChoices,strings=--yes-i-really-mean-it,req=false " \
     "name=validate2,type=CephChoices,strings=--i-know-what-i-am-doing,req=false", \
     "force sync of and clear monitor store", \
-    "mon", "rw", "cli,rest", \
+    "mon", "rw", \
     FLAG(NOFORWARD))
 COMMAND("mon metadata name=id,type=CephString,req=false",
 	"fetch metadata for mon <id>",
-	"mon", "r", "cli,rest")
+	"mon", "r")
 COMMAND("mon count-metadata name=property,type=CephString",
 	"count mons by metadata field property",
-	"mon", "r", "cli,rest")
+	"mon", "r")
 COMMAND("mon versions",
 	"check running versions of monitors",
-	"mon", "r", "cli,rest")
+	"mon", "r")
 COMMAND("versions",
 	"check running versions of ceph daemons",
-	"mon", "r", "cli,rest")
+	"mon", "r")
 
 
 
@@ -283,86 +282,86 @@ COMMAND("versions",
  * MDS commands (MDSMonitor.cc)
  */
 
-COMMAND("mds stat", "show MDS status", "mds", "r", "cli,rest")
+COMMAND("mds stat", "show MDS status", "mds", "r")
 COMMAND_WITH_FLAG("mds dump "
 	"name=epoch,type=CephInt,req=false,range=0", \
 	"dump legacy MDS cluster info, optionally from epoch",
-        "mds", "r", "cli,rest", FLAG(OBSOLETE))
+        "mds", "r", FLAG(OBSOLETE))
 COMMAND("fs dump "
 	"name=epoch,type=CephInt,req=false,range=0", \
-	"dump all CephFS status, optionally from epoch", "mds", "r", "cli,rest")
+	"dump all CephFS status, optionally from epoch", "mds", "r")
 COMMAND_WITH_FLAG("mds getmap " \
 	"name=epoch,type=CephInt,req=false,range=0", \
-	"get MDS map, optionally from epoch", "mds", "r", "cli,rest", FLAG(OBSOLETE))
+	"get MDS map, optionally from epoch", "mds", "r", FLAG(OBSOLETE))
 COMMAND("mds metadata name=who,type=CephString,req=false",
 	"fetch metadata for mds <role>",
-	"mds", "r", "cli,rest")
+	"mds", "r")
 COMMAND("mds count-metadata name=property,type=CephString",
 	"count MDSs by metadata field property",
-	"mds", "r", "cli,rest")
+	"mds", "r")
 COMMAND("mds versions",
 	"check running versions of MDSs",
-	"mds", "r", "cli,rest")
+	"mds", "r")
 COMMAND_WITH_FLAG("mds tell " \
 	"name=who,type=CephString " \
 	"name=args,type=CephString,n=N", \
-	"send command to particular mds", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"send command to particular mds", "mds", "rw", FLAG(OBSOLETE))
 COMMAND("mds compat show", "show mds compatibility settings", \
-	"mds", "r", "cli,rest")
+	"mds", "r")
 COMMAND_WITH_FLAG("mds stop name=role,type=CephString", "stop mds", \
-	"mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"mds", "rw", FLAG(OBSOLETE))
 COMMAND_WITH_FLAG("mds deactivate name=role,type=CephString",
         "clean up specified MDS rank (use with `set max_mds` to shrink cluster)", \
-	"mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"mds", "rw", FLAG(OBSOLETE))
 COMMAND_WITH_FLAG("mds set_max_mds " \
 	"name=maxmds,type=CephInt,range=0", \
-	"set max MDS index", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"set max MDS index", "mds", "rw", FLAG(OBSOLETE))
 COMMAND_WITH_FLAG("mds set " \
 	"name=var,type=CephChoices,strings=max_mds|max_file_size|inline_data|"
 	"allow_new_snaps|allow_multimds|allow_multimds_snaps|allow_dirfrags " \
 	"name=val,type=CephString "					\
 	"name=confirm,type=CephString,req=false",			\
-	"set mds parameter <var> to <val>", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"set mds parameter <var> to <val>", "mds", "rw", FLAG(OBSOLETE))
 // arbitrary limit 0-20 below; worth standing on head to make it
 // relate to actual state definitions?
 // #include "include/ceph_fs.h"
 COMMAND("mds set_state " \
 	"name=gid,type=CephInt,range=0 " \
 	"name=state,type=CephInt,range=0|20", \
-	"set mds state of <gid> to <numeric-state>", "mds", "rw", "cli,rest")
+	"set mds state of <gid> to <numeric-state>", "mds", "rw")
 COMMAND("mds fail name=role_or_gid,type=CephString", \
 	"Mark MDS failed: trigger a failover if a standby is available",
-        "mds", "rw", "cli,rest")
+        "mds", "rw")
 COMMAND("mds repaired name=role,type=CephString", \
-	"mark a damaged MDS rank as no longer damaged", "mds", "rw", "cli,rest")
+	"mark a damaged MDS rank as no longer damaged", "mds", "rw")
 COMMAND("mds rm " \
 	"name=gid,type=CephInt,range=0", \
-	"remove nonactive mds", "mds", "rw", "cli,rest")
+	"remove nonactive mds", "mds", "rw")
 COMMAND("mds rmfailed name=role,type=CephString name=confirm,type=CephString,req=false", \
-	"remove failed mds", "mds", "rw", "cli,rest")
-COMMAND_WITH_FLAG("mds cluster_down", "take MDS cluster down", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
-COMMAND_WITH_FLAG("mds cluster_up", "bring MDS cluster up", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"remove failed mds", "mds", "rw")
+COMMAND_WITH_FLAG("mds cluster_down", "take MDS cluster down", "mds", "rw", FLAG(OBSOLETE))
+COMMAND_WITH_FLAG("mds cluster_up", "bring MDS cluster up", "mds", "rw", FLAG(OBSOLETE))
 COMMAND("mds compat rm_compat " \
 	"name=feature,type=CephInt,range=0", \
-	"remove compatible feature", "mds", "rw", "cli,rest")
+	"remove compatible feature", "mds", "rw")
 COMMAND("mds compat rm_incompat " \
 	"name=feature,type=CephInt,range=0", \
-	"remove incompatible feature", "mds", "rw", "cli,rest")
+	"remove incompatible feature", "mds", "rw")
 COMMAND_WITH_FLAG("mds add_data_pool " \
 	"name=pool,type=CephString", \
-	"add data pool <pool>", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"add data pool <pool>", "mds", "rw", FLAG(OBSOLETE))
 COMMAND_WITH_FLAG("mds rm_data_pool " \
 	"name=pool,type=CephString", \
-	"remove data pool <pool>", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"remove data pool <pool>", "mds", "rw", FLAG(OBSOLETE))
 COMMAND_WITH_FLAG("mds remove_data_pool " \
 	"name=pool,type=CephString", \
-	"remove data pool <pool>", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"remove data pool <pool>", "mds", "rw", FLAG(OBSOLETE))
 COMMAND_WITH_FLAG("mds newfs " \
 	"name=metadata,type=CephInt,range=0 " \
 	"name=data,type=CephInt,range=0 " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"make new filesystem using pools <metadata> and <data>", \
-	"mds", "rw", "cli,rest", FLAG(OBSOLETE))
+	"mds", "rw", FLAG(OBSOLETE))
 COMMAND("fs new " \
 	"name=fs_name,type=CephString " \
 	"name=metadata,type=CephString " \
@@ -370,23 +369,23 @@ COMMAND("fs new " \
 	"name=force,type=CephChoices,strings=--force,req=false " \
 	"name=sure,type=CephChoices,strings=--allow-dangerous-metadata-overlay,req=false", \
 	"make new filesystem using named pools <metadata> and <data>", \
-	"fs", "rw", "cli,rest")
+	"fs", "rw")
 COMMAND("fs rm " \
 	"name=fs_name,type=CephString " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"disable the named filesystem", \
-	"fs", "rw", "cli,rest")
+	"fs", "rw")
 COMMAND("fs reset " \
 	"name=fs_name,type=CephString " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"disaster recovery only: reset to a single-MDS map", \
-	"fs", "rw", "cli,rest")
+	"fs", "rw")
 COMMAND("fs ls ", \
 	"list filesystems", \
-	"fs", "r", "cli,rest")
+	"fs", "r")
 COMMAND("fs get name=fs_name,type=CephString", \
 	"get info about one filesystem", \
-	"fs", "r", "cli,rest")
+	"fs", "r")
 COMMAND("fs set " \
 	"name=fs_name,type=CephString " \
 	"name=var,type=CephChoices,strings=max_mds|max_file_size"
@@ -395,25 +394,25 @@ COMMAND("fs set " \
         "|down|joinable|min_compat_client " \
 	"name=val,type=CephString "					\
 	"name=confirm,type=CephString,req=false",			\
-	"set fs parameter <var> to <val>", "mds", "rw", "cli,rest")
+	"set fs parameter <var> to <val>", "mds", "rw")
 COMMAND("fs flag set name=flag_name,type=CephChoices,strings=enable_multiple "
         "name=val,type=CephString " \
 	"name=confirm,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"Set a global CephFS flag", \
-	"fs", "rw", "cli,rest")
+	"fs", "rw")
 COMMAND("fs add_data_pool name=fs_name,type=CephString " \
 	"name=pool,type=CephString", \
-	"add data pool <pool>", "mds", "rw", "cli,rest")
+	"add data pool <pool>", "mds", "rw")
 COMMAND("fs rm_data_pool name=fs_name,type=CephString " \
 	"name=pool,type=CephString", \
-	"remove data pool <pool>", "mds", "rw", "cli,rest")
+	"remove data pool <pool>", "mds", "rw")
 COMMAND_WITH_FLAG("fs set_default name=fs_name,type=CephString",	\
 		  "set the default to the named filesystem",		\
-		  "fs", "rw", "cli,rest",				\
+		  "fs", "rw",				\
 		  FLAG(DEPRECATED))
 COMMAND("fs set-default name=fs_name,type=CephString", \
 	"set the default to the named filesystem", \
-	"fs", "rw", "cli,rest")
+	"fs", "rw")
 
 /*
  * Monmap commands
@@ -421,491 +420,491 @@ COMMAND("fs set-default name=fs_name,type=CephString", \
 COMMAND("mon dump " \
 	"name=epoch,type=CephInt,range=0,req=false", \
 	"dump formatted monmap (optionally from epoch)", \
-	"mon", "r", "cli,rest")
-COMMAND("mon stat", "summarize monitor status", "mon", "r", "cli,rest")
+	"mon", "r")
+COMMAND("mon stat", "summarize monitor status", "mon", "r")
 COMMAND("mon getmap " \
 	"name=epoch,type=CephInt,range=0,req=false", \
-	"get monmap", "mon", "r", "cli,rest")
+	"get monmap", "mon", "r")
 COMMAND("mon add " \
 	"name=name,type=CephString " \
 	"name=addr,type=CephIPAddr", \
-	"add new monitor named <name> at <addr>", "mon", "rw", "cli,rest")
+	"add new monitor named <name> at <addr>", "mon", "rw")
 COMMAND("mon rm " \
 	"name=name,type=CephString", \
-	"remove monitor named <name>", "mon", "rw", "cli,rest")
+	"remove monitor named <name>", "mon", "rw")
 COMMAND_WITH_FLAG("mon remove " \
 	"name=name,type=CephString", \
-	"remove monitor named <name>", "mon", "rw", "cli,rest", \
+	"remove monitor named <name>", "mon", "rw", \
     FLAG(DEPRECATED))
 COMMAND("mon feature ls " \
         "name=with_value,type=CephChoices,strings=--with-value,req=false", \
         "list available mon map features to be set/unset", \
-        "mon", "r", "cli,rest")
+        "mon", "r")
 COMMAND("mon feature set " \
         "name=feature_name,type=CephString " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
         "set provided feature on mon map", \
-        "mon", "rw", "cli,rest")
+        "mon", "rw")
 COMMAND("mon set-rank " \
 	"name=name,type=CephString " \
 	"name=rank,type=CephInt",
 	"set the rank for the specified mon",
-	"mon", "rw", "cli,rest")
+	"mon", "rw")
 
 /*
  * OSD commands
  */
-COMMAND("osd stat", "print summary of OSD map", "osd", "r", "cli,rest")
+COMMAND("osd stat", "print summary of OSD map", "osd", "r")
 COMMAND("osd dump " \
 	"name=epoch,type=CephInt,range=0,req=false",
-	"print summary of OSD map", "osd", "r", "cli,rest")
+	"print summary of OSD map", "osd", "r")
 COMMAND("osd tree " \
 	"name=epoch,type=CephInt,range=0,req=false " \
 	"name=states,type=CephChoices,strings=up|down|in|out|destroyed,n=N,req=false", \
-	"print OSD tree", "osd", "r", "cli,rest")
+	"print OSD tree", "osd", "r")
 COMMAND("osd tree-from " \
 	"name=epoch,type=CephInt,range=0,req=false " \
 	"name=bucket,type=CephString " \
 	"name=states,type=CephChoices,strings=up|down|in|out|destroyed,n=N,req=false", \
-	"print OSD tree in bucket", "osd", "r", "cli,rest")
+	"print OSD tree in bucket", "osd", "r")
 COMMAND("osd ls " \
 	"name=epoch,type=CephInt,range=0,req=false", \
-	"show all OSD ids", "osd", "r", "cli,rest")
+	"show all OSD ids", "osd", "r")
 COMMAND("osd getmap " \
 	"name=epoch,type=CephInt,range=0,req=false", \
-	"get OSD map", "osd", "r", "cli,rest")
+	"get OSD map", "osd", "r")
 COMMAND("osd getcrushmap " \
 	"name=epoch,type=CephInt,range=0,req=false", \
-	"get CRUSH map", "osd", "r", "cli,rest")
-COMMAND("osd getmaxosd", "show largest OSD id", "osd", "r", "cli,rest")
+	"get CRUSH map", "osd", "r")
+COMMAND("osd getmaxosd", "show largest OSD id", "osd", "r")
 COMMAND("osd ls-tree " \
         "name=epoch,type=CephInt,range=0,req=false "
         "name=name,type=CephString,req=true", \
         "show OSD ids under bucket <name> in the CRUSH map", \
-        "osd", "r", "cli,rest")
+        "osd", "r")
 COMMAND("osd find " \
 	"name=id,type=CephOsdName", \
 	"find osd <id> in the CRUSH map and show its location", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd metadata " \
 	"name=id,type=CephOsdName,req=false", \
 	"fetch metadata for osd {id} (default all)", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd count-metadata name=property,type=CephString",
 	"count OSDs by metadata field property",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd versions", \
 	"check running versions of OSDs",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd map " \
 	"name=pool,type=CephPoolname " \
 	"name=object,type=CephObjectname " \
 	"name=nspace,type=CephString,req=false", \
-	"find pg for <object> in <pool> with [namespace]", "osd", "r", "cli,rest")
+	"find pg for <object> in <pool> with [namespace]", "osd", "r")
 COMMAND_WITH_FLAG("osd lspools",		\
-		  "list pools", "osd", "r", "cli,rest", FLAG(DEPRECATED))
-COMMAND_WITH_FLAG("osd crush rule list", "list crush rules", "osd", "r", "cli,rest",
+		  "list pools", "osd", "r", FLAG(DEPRECATED))
+COMMAND_WITH_FLAG("osd crush rule list", "list crush rules", "osd", "r",
 		  FLAG(DEPRECATED))
-COMMAND("osd crush rule ls", "list crush rules", "osd", "r", "cli,rest")
+COMMAND("osd crush rule ls", "list crush rules", "osd", "r")
 COMMAND("osd crush rule ls-by-class " \
         "name=class,type=CephString,goodchars=[A-Za-z0-9-_.]", \
         "list all crush rules that reference the same <class>", \
-        "osd", "r", "cli,rest")
+        "osd", "r")
 COMMAND("osd crush rule dump " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.],req=false", \
 	"dump crush rule <name> (default all)", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd crush dump", \
 	"dump crush map", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd setcrushmap name=prior_version,type=CephInt,req=false", \
 	"set crush map from input file",	\
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush set name=prior_version,type=CephInt,req=false", \
 	"set crush map from input file",	\
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush add-bucket " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
         "name=type,type=CephString " \
         "name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=],req=false", \
 	"add no-parent (probably root) crush bucket <name> of type <type> " \
         "to location <args>", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush rename-bucket " \
 	"name=srcname,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=dstname,type=CephString,goodchars=[A-Za-z0-9-_.]", \
 	"rename bucket <srcname> to <dstname>", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush set " \
 	"name=id,type=CephOsdName " \
 	"name=weight,type=CephFloat,range=0.0 " \
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]", \
 	"update crushmap position and weight for <name> to <weight> with location <args>", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush add " \
 	"name=id,type=CephOsdName " \
 	"name=weight,type=CephFloat,range=0.0 " \
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]", \
 	"add or update crushmap position and weight for <name> with <weight> and location <args>", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush set-all-straw-buckets-to-straw2",
         "convert all CRUSH current straw buckets to use the straw2 algorithm",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush class create " \
         "name=class,type=CephString,goodchars=[A-Za-z0-9-_]", \
         "create crush device class <class>", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd crush class rm " \
         "name=class,type=CephString,goodchars=[A-Za-z0-9-_]", \
         "remove crush device class <class>", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd crush set-device-class " \
         "name=class,type=CephString " \
 	"name=ids,type=CephString,n=N", \
 	"set the <class> of the osd(s) <id> [<id>...]," \
         "or use <all|any> to set all.", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush rm-device-class " \
         "name=ids,type=CephString,n=N", \
         "remove class of the osd(s) <id> [<id>...]," \
         "or use <all|any> to remove all.", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd crush class rename " \
         "name=srcname,type=CephString,goodchars=[A-Za-z0-9-_] " \
         "name=dstname,type=CephString,goodchars=[A-Za-z0-9-_]", \
         "rename crush device class <srcname> to <dstname>", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd crush create-or-move " \
 	"name=id,type=CephOsdName " \
 	"name=weight,type=CephFloat,range=0.0 " \
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]", \
 	"create entry or move existing entry for <name> <weight> at/to location <args>", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush move " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]", \
 	"move existing entry for <name> to location <args>", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush swap-bucket " \
 	"name=source,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=dest,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"swap existing bucket contents from (orphan) bucket <source> and <target>", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush link " \
 	"name=name,type=CephString " \
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]", \
 	"link existing entry for <name> under location <args>", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush rm " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=ancestor,type=CephString,req=false,goodchars=[A-Za-z0-9-_.]", \
 	"remove <name> from crush map (everywhere, or just at <ancestor>)",\
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND_WITH_FLAG("osd crush remove " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=ancestor,type=CephString,req=false,goodchars=[A-Za-z0-9-_.]", \
 	"remove <name> from crush map (everywhere, or just at <ancestor>)", \
-	"osd", "rw", "cli,rest", \
+	"osd", "rw", \
     FLAG(DEPRECATED))
 COMMAND("osd crush unlink " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=ancestor,type=CephString,req=false,goodchars=[A-Za-z0-9-_.]", \
 	"unlink <name> from crush map (everywhere, or just at <ancestor>)", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush reweight-all",
 	"recalculate the weights for the tree to ensure they sum correctly",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush reweight " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=weight,type=CephFloat,range=0.0", \
 	"change <name>'s weight to <weight> in crush map", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush reweight-subtree " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=weight,type=CephFloat,range=0.0", \
 	"change all leaf items beneath <name> to <weight> in crush map", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush tunables " \
 	"name=profile,type=CephChoices,strings=legacy|argonaut|bobtail|firefly|hammer|jewel|optimal|default", \
-	"set crush tunables values to <profile>", "osd", "rw", "cli,rest")
+	"set crush tunables values to <profile>", "osd", "rw")
 COMMAND("osd crush set-tunable "				    \
 	"name=tunable,type=CephChoices,strings=straw_calc_version " \
 	"name=value,type=CephInt",
 	"set crush tunable <tunable> to <value>",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush get-tunable "			      \
 	"name=tunable,type=CephChoices,strings=straw_calc_version",
 	"get crush tunable <tunable>",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd crush show-tunables", \
-	"show current crush tunables", "osd", "r", "cli,rest")
+	"show current crush tunables", "osd", "r")
 COMMAND("osd crush rule create-simple " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=root,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=type,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=mode,type=CephChoices,strings=firstn|indep,req=false",
 	"create crush rule <name> to start from <root>, replicate across buckets of type <type>, using a choose mode of <firstn|indep> (default firstn; indep best for erasure pools)", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush rule create-replicated " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=root,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=type,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=class,type=CephString,goodchars=[A-Za-z0-9-_.],req=false",
 	"create crush rule <name> for replicated pool to start from <root>, replicate across buckets of type <type>, use devices of type <class> (ssd or hdd)", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush rule create-erasure " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=profile,type=CephString,req=false,goodchars=[A-Za-z0-9-_.=]", \
 	"create crush rule <name> for erasure coded pool created with <profile> (default default)", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush rule rm " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] ",	\
-	"remove crush rule <name>", "osd", "rw", "cli,rest")
+	"remove crush rule <name>", "osd", "rw")
 COMMAND("osd crush rule rename " \
         "name=srcname,type=CephString,goodchars=[A-Za-z0-9-_.] "  \
         "name=dstname,type=CephString,goodchars=[A-Za-z0-9-_.]",  \
         "rename crush rule <srcname> to <dstname>",
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd crush tree "
         "name=shadow,type=CephChoices,strings=--show-shadow,req=false", \
 	"dump crush buckets and items in a tree view",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd crush ls name=node,type=CephString,goodchars=[A-Za-z0-9-_.]",
 	"list items beneath a node in the CRUSH tree",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd crush class ls", \
 	"list all crush device classes", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd crush class ls-osd " \
         "name=class,type=CephString,goodchars=[A-Za-z0-9-_]", \
         "list all osds belonging to the specific <class>", \
-        "osd", "r", "cli,rest")
+        "osd", "r")
 COMMAND("osd crush weight-set ls",
 	"list crush weight sets",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd crush weight-set dump",
 	"dump crush weight sets",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd crush weight-set create-compat",
 	"create a default backward-compatible weight-set",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush weight-set create "		\
         "name=pool,type=CephPoolname "\
         "name=mode,type=CephChoices,strings=flat|positional",
 	"create a weight-set for a given pool",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush weight-set rm name=pool,type=CephPoolname",
 	"remove the weight-set for a given pool",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush weight-set rm-compat",
 	"remove the backward-compatible weight-set",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush weight-set reweight "		\
         "name=pool,type=CephPoolname "			\
 	"name=item,type=CephString "			\
         "name=weight,type=CephFloat,range=0.0,n=N",
 	"set weight for an item (bucket or osd) in a pool's weight-set",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd crush weight-set reweight-compat "		\
 	"name=item,type=CephString "			\
         "name=weight,type=CephFloat,range=0.0,n=N",
 	"set weight for an item (bucket or osd) in the backward-compatible weight-set",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd setmaxosd " \
 	"name=newmax,type=CephInt,range=0", \
-	"set new maximum osd value", "osd", "rw", "cli,rest")
+	"set new maximum osd value", "osd", "rw")
 COMMAND("osd set-full-ratio " \
 	"name=ratio,type=CephFloat,range=0.0|1.0", \
 	"set usage ratio at which OSDs are marked full",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd set-backfillfull-ratio " \
 	"name=ratio,type=CephFloat,range=0.0|1.0", \
 	"set usage ratio at which OSDs are marked too full to backfill",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd set-nearfull-ratio " \
 	"name=ratio,type=CephFloat,range=0.0|1.0", \
 	"set usage ratio at which OSDs are marked near-full",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd get-require-min-compat-client",
         "get the minimum client version we will maintain compatibility with",
-        "osd", "r", "cli,rest")
+        "osd", "r")
 COMMAND("osd set-require-min-compat-client " \
 	"name=version,type=CephString " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"set the minimum client version we will maintain compatibility with",
-	"osd", "rw", "cli,rest")
-COMMAND("osd pause", "pause osd", "osd", "rw", "cli,rest")
-COMMAND("osd unpause", "unpause osd", "osd", "rw", "cli,rest")
+	"osd", "rw")
+COMMAND("osd pause", "pause osd", "osd", "rw")
+COMMAND("osd unpause", "unpause osd", "osd", "rw")
 COMMAND("osd erasure-code-profile set " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=profile,type=CephString,n=N,req=false", \
 	"create erasure code profile <name> with [<key[=value]> ...] pairs. Add a --force at the end to override an existing profile (VERY DANGEROUS)", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd erasure-code-profile get " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.]", \
 	"get erasure code profile <name>", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd erasure-code-profile rm " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.]", \
 	"remove erasure code profile <name>", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd erasure-code-profile ls", \
 	"list all erasure code profiles", \
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("osd set " \
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim|sortbitwise|recovery_deletes|require_jewel_osds|require_kraken_osds " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
-	"set <key>", "osd", "rw", "cli,rest")
+	"set <key>", "osd", "rw")
 COMMAND("osd unset " \
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim", \
-	"unset <key>", "osd", "rw", "cli,rest")
+	"unset <key>", "osd", "rw")
 COMMAND("osd require-osd-release "\
 	"name=release,type=CephChoices,strings=luminous|mimic|nautilus " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"set the minimum allowed OSD release to participate in the cluster",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd cluster_snap", "take cluster snapshot (disabled)", \
-	"osd", "r", "")
+	"osd", "r")
 COMMAND("osd down " \
 	"type=CephString,name=ids,n=N", \
 	"set osd(s) <id> [<id>...] down, " \
         "or use <any|all> to set all osds down", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd out " \
 	"name=ids,type=CephString,n=N", \
 	"set osd(s) <id> [<id>...] out, " \
         "or use <any|all> to set all osds out", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd in " \
 	"name=ids,type=CephString,n=N", \
 	"set osd(s) <id> [<id>...] in, "
         "can use <any|all> to automatically set all previously out osds in", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND_WITH_FLAG("osd rm " \
 	"name=ids,type=CephString,n=N", \
 	"remove osd(s) <id> [<id>...], "
         "or use <any|all> to remove all osds", \
-	"osd", "rw", "cli,rest",
+	"osd", "rw",
 	FLAG(DEPRECATED))
 COMMAND("osd add-noup " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noup, " \
         "or use <all|any> to mark all osds as noup", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd add-nodown " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as nodown, " \
         "or use <all|any> to mark all osds as nodown", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd add-noin " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noin, " \
         "or use <all|any> to mark all osds as noin", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd add-noout " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noout, " \
         "or use <all|any> to mark all osds as noout", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd rm-noup " \
         "name=ids,type=CephString,n=N", \
         "allow osd(s) <id> [<id>...] to be marked up " \
         "(if they are currently marked as noup), " \
         "can use <all|any> to automatically filter out all noup osds", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd rm-nodown " \
         "name=ids,type=CephString,n=N", \
         "allow osd(s) <id> [<id>...] to be marked down " \
         "(if they are currently marked as nodown), " \
         "can use <all|any> to automatically filter out all nodown osds", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd rm-noin " \
         "name=ids,type=CephString,n=N", \
         "allow osd(s) <id> [<id>...] to be marked in " \
         "(if they are currently marked as noin), " \
         "can use <all|any> to automatically filter out all noin osds", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd rm-noout " \
         "name=ids,type=CephString,n=N", \
         "allow osd(s) <id> [<id>...] to be marked out " \
         "(if they are currently marked as noout), " \
         "can use <all|any> to automatically filter out all noout osds", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd reweight " \
 	"name=id,type=CephOsdName " \
 	"type=CephFloat,name=weight,range=0.0|1.0", \
-	"reweight osd to 0.0 < <weight> < 1.0", "osd", "rw", "cli,rest")
+	"reweight osd to 0.0 < <weight> < 1.0", "osd", "rw")
 COMMAND("osd reweightn " \
 	"name=weights,type=CephString",
 	"reweight osds with {<id>: <weight>,...})",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd force-create-pg " \
 	"name=pgid,type=CephPgid "\
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"force creation of pg <pgid>",
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd pg-temp " \
 	"name=pgid,type=CephPgid " \
 	"name=id,type=CephOsdName,n=N,req=false", \
 	"set pg_temp mapping pgid:[<id> [<id>...]] (developers only)", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd pg-upmap " \
 	"name=pgid,type=CephPgid " \
 	"name=id,type=CephOsdName,n=N", \
 	"set pg_upmap mapping <pgid>:[<id> [<id>...]] (developers only)", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd rm-pg-upmap " \
 	"name=pgid,type=CephPgid",					\
 	"clear pg_upmap mapping for <pgid> (developers only)", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd pg-upmap-items " \
 	"name=pgid,type=CephPgid " \
 	"name=id,type=CephOsdName,n=N", \
 	"set pg_upmap_items mapping <pgid>:{<id> to <id>, [...]} (developers only)", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd rm-pg-upmap-items " \
 	"name=pgid,type=CephPgid",		  \
 	"clear pg_upmap_items mapping for <pgid> (developers only)", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd primary-temp " \
 	"name=pgid,type=CephPgid " \
 	"name=id,type=CephOsdName", \
         "set primary_temp mapping pgid:<id>|-1 (developers only)", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd primary-affinity " \
 	"name=id,type=CephOsdName " \
 	"type=CephFloat,name=weight,range=0.0|1.0", \
 	"adjust osd primary-affinity from 0.0 <= <weight> <= 1.0", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND_WITH_FLAG("osd destroy-actual "	    \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
         "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \
         "but removes cephx keys, config-key data and lockbox keys, "\
         "rendering data permanently unreadable.", \
-		  "osd", "rw", "cli,rest", FLAG(HIDDEN))
+		  "osd", "rw", FLAG(HIDDEN))
 COMMAND("osd purge-new " \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
         "purge all traces of an OSD that was partially created but never " \
 	"started", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND_WITH_FLAG("osd purge-actual " \
         "name=id,type=CephOsdName " \
         "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
         "purge all osd data from the monitors. Combines `osd destroy`, " \
         "`osd rm`, and `osd crush rm`.", \
-		  "osd", "rw", "cli,rest", FLAG(HIDDEN))
+		  "osd", "rw", FLAG(HIDDEN))
 COMMAND("osd lost " \
 	"name=id,type=CephOsdName " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"mark osd as permanently lost. THIS DESTROYS DATA IF NO MORE REPLICAS EXIST, BE CAREFUL", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND_WITH_FLAG("osd create " \
 	"name=uuid,type=CephUUID,req=false " \
 	"name=id,type=CephOsdName,req=false", \
-	"create new osd (with optional UUID and ID)", "osd", "rw", "cli,rest",
+	"create new osd (with optional UUID and ID)", "osd", "rw",
 	FLAG(DEPRECATED))
 COMMAND("osd new " \
         "name=uuid,type=CephUUID,req=true " \
@@ -913,27 +912,26 @@ COMMAND("osd new " \
         "Create a new OSD. If supplied, the `id` to be replaced needs to " \
         "exist and have been previously destroyed. " \
         "Reads secrets from JSON file via `-i <file>` (see man page).", \
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd blacklist " \
 	"name=blacklistop,type=CephChoices,strings=add|rm " \
 	"name=addr,type=CephEntityAddr " \
 	"name=expire,type=CephFloat,range=0.0,req=false", \
 	"add (optionally until <expire> seconds from now) or remove <addr> from blacklist", \
-	"osd", "rw", "cli,rest")
-COMMAND("osd blacklist ls", "show blacklisted clients", "osd", "r", "cli,rest")
-COMMAND("osd blacklist clear", "clear all blacklisted clients", "osd", "rw",
-        "cli,rest")
+	"osd", "rw")
+COMMAND("osd blacklist ls", "show blacklisted clients", "osd", "r")
+COMMAND("osd blacklist clear", "clear all blacklisted clients", "osd", "rw")
 COMMAND("osd pool mksnap " \
 	"name=pool,type=CephPoolname " \
 	"name=snap,type=CephString", \
-	"make snapshot <snap> in <pool>", "osd", "rw", "cli,rest")
+	"make snapshot <snap> in <pool>", "osd", "rw")
 COMMAND("osd pool rmsnap " \
 	"name=pool,type=CephPoolname " \
 	"name=snap,type=CephString", \
-	"remove snapshot <snap> from <pool>", "osd", "rw", "cli,rest")
+	"remove snapshot <snap> from <pool>", "osd", "rw")
 COMMAND("osd pool ls " \
 	"name=detail,type=CephChoices,strings=detail,req=false", \
-	"list pools", "osd", "r", "cli,rest")
+	"list pools", "osd", "r")
 COMMAND("osd pool create " \
 	"name=pool,type=CephPoolname " \
 	"name=pg_num,type=CephInt,range=0 " \
@@ -942,34 +940,34 @@ COMMAND("osd pool create " \
 	"name=erasure_code_profile,type=CephString,req=false,goodchars=[A-Za-z0-9-_.] " \
 	"name=rule,type=CephString,req=false " \
         "name=expected_num_objects,type=CephInt,req=false", \
-	"create pool", "osd", "rw", "cli,rest")
+	"create pool", "osd", "rw")
 COMMAND_WITH_FLAG("osd pool delete " \
 	"name=pool,type=CephPoolname " \
 	"name=pool2,type=CephPoolname,req=false " \
 	"name=sure,type=CephString,req=false", \
 	"delete pool", \
-	"osd", "rw", "cli,rest", \
+	"osd", "rw", \
     FLAG(DEPRECATED))
 COMMAND("osd pool rm " \
 	"name=pool,type=CephPoolname " \
 	"name=pool2,type=CephPoolname,req=false " \
 	"name=sure,type=CephString,req=false", \
 	"remove pool", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd pool rename " \
 	"name=srcpool,type=CephPoolname " \
 	"name=destpool,type=CephPoolname", \
-	"rename <srcpool> to <destpool>", "osd", "rw", "cli,rest")
+	"rename <srcpool> to <destpool>", "osd", "rw")
 COMMAND("osd pool get " \
 	"name=pool,type=CephPoolname " \
 	"name=var,type=CephChoices,strings=size|min_size|pg_num|pgp_num|crush_rule|hashpspool|nodelete|nopgchange|nosizechange|write_fadvise_dontneed|noscrub|nodeep-scrub|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|use_gmt_hitset|target_max_objects|target_max_bytes|cache_target_dirty_ratio|cache_target_dirty_high_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age|erasure_code_profile|min_read_recency_for_promote|all|min_write_recency_for_promote|fast_read|hit_set_grade_decay_rate|hit_set_search_last_n|scrub_min_interval|scrub_max_interval|deep_scrub_interval|recovery_priority|recovery_op_priority|scrub_priority|compression_mode|compression_algorithm|compression_required_ratio|compression_max_blob_size|compression_min_blob_size|csum_type|csum_min_block|csum_max_block|allow_ec_overwrites|fingerprint_algorithm", \
-	"get pool parameter <var>", "osd", "r", "cli,rest")
+	"get pool parameter <var>", "osd", "r")
 COMMAND("osd pool set " \
 	"name=pool,type=CephPoolname " \
 	"name=var,type=CephChoices,strings=size|min_size|pg_num|pgp_num|crush_rule|hashpspool|nodelete|nopgchange|nosizechange|write_fadvise_dontneed|noscrub|nodeep-scrub|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|use_gmt_hitset|target_max_bytes|target_max_objects|cache_target_dirty_ratio|cache_target_dirty_high_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age|min_read_recency_for_promote|min_write_recency_for_promote|fast_read|hit_set_grade_decay_rate|hit_set_search_last_n|scrub_min_interval|scrub_max_interval|deep_scrub_interval|recovery_priority|recovery_op_priority|scrub_priority|compression_mode|compression_algorithm|compression_required_ratio|compression_max_blob_size|compression_min_blob_size|csum_type|csum_min_block|csum_max_block|allow_ec_overwrites|fingerprint_algorithm " \
 	"name=val,type=CephString " \
 	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
-	"set pool parameter <var> to <val>", "osd", "rw", "cli,rest")
+	"set pool parameter <var> to <val>", "osd", "rw")
 // 'val' is a CephString because it can include a unit.  Perhaps
 // there should be a Python type for validation/conversion of strings
 // with units.
@@ -977,45 +975,45 @@ COMMAND("osd pool set-quota " \
 	"name=pool,type=CephPoolname " \
 	"name=field,type=CephChoices,strings=max_objects|max_bytes " \
 	"name=val,type=CephString",
-	"set object or byte limit on pool", "osd", "rw", "cli,rest")
+	"set object or byte limit on pool", "osd", "rw")
 COMMAND("osd pool get-quota " \
         "name=pool,type=CephPoolname ",
         "obtain object or byte limits for pool",
-        "osd", "r", "cli,rest")
+        "osd", "r")
 COMMAND("osd pool application enable " \
         "name=pool,type=CephPoolname " \
         "name=app,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
         "enable use of an application <app> [cephfs,rbd,rgw] on pool <poolname>",
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd pool application disable " \
         "name=pool,type=CephPoolname " \
         "name=app,type=CephString " \
 	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
         "disables use of an application <app> on pool <poolname>",
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd pool application set " \
         "name=pool,type=CephPoolname " \
         "name=app,type=CephString " \
         "name=key,type=CephString,goodchars=[A-Za-z0-9-_.] " \
         "name=value,type=CephString,goodchars=[A-Za-z0-9-_.=]",
         "sets application <app> metadata key <key> to <value> on pool <poolname>",
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd pool application rm " \
         "name=pool,type=CephPoolname " \
         "name=app,type=CephString " \
         "name=key,type=CephString",
         "removes application <app> metadata key <key> on pool <poolname>",
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("osd pool application get " \
         "name=pool,type=CephPoolname,req=fasle " \
         "name=app,type=CephString,req=false " \
         "name=key,type=CephString,req=false",
         "get value of key <key> of application <app> on pool <poolname>",
-        "osd", "r", "cli,rest")
+        "osd", "r")
 COMMAND("osd utilization",
 	"get basic pg distribution stats",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 
 // tiering
 COMMAND("osd tier add " \
@@ -1023,33 +1021,33 @@ COMMAND("osd tier add " \
 	"name=tierpool,type=CephPoolname " \
 	"name=force_nonempty,type=CephChoices,strings=--force-nonempty,req=false",
 	"add the tier <tierpool> (the second one) to base pool <pool> (the first one)", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("osd tier rm " \
 	"name=pool,type=CephPoolname " \
 	"name=tierpool,type=CephPoolname",
 	"remove the tier <tierpool> (the second one) from base pool <pool> (the first one)", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND_WITH_FLAG("osd tier remove " \
 	"name=pool,type=CephPoolname " \
 	"name=tierpool,type=CephPoolname",
 	"remove the tier <tierpool> (the second one) from base pool <pool> (the first one)", \
-	"osd", "rw", "cli,rest", \
+	"osd", "rw", \
     FLAG(DEPRECATED))
 COMMAND("osd tier cache-mode " \
 	"name=pool,type=CephPoolname " \
 	"name=mode,type=CephChoices,strings=none|writeback|forward|readonly|readforward|proxy|readproxy " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
-	"specify the caching mode for cache tier <pool>", "osd", "rw", "cli,rest")
+	"specify the caching mode for cache tier <pool>", "osd", "rw")
 COMMAND("osd tier set-overlay " \
 	"name=pool,type=CephPoolname " \
 	"name=overlaypool,type=CephPoolname", \
-	"set the overlay pool for base pool <pool> to be <overlaypool>", "osd", "rw", "cli,rest")
+	"set the overlay pool for base pool <pool> to be <overlaypool>", "osd", "rw")
 COMMAND("osd tier rm-overlay " \
 	"name=pool,type=CephPoolname ", \
-	"remove the overlay pool for base pool <pool>", "osd", "rw", "cli,rest")
+	"remove the overlay pool for base pool <pool>", "osd", "rw")
 COMMAND_WITH_FLAG("osd tier remove-overlay " \
 	"name=pool,type=CephPoolname ", \
-	"remove the overlay pool for base pool <pool>", "osd", "rw", "cli,rest", \
+	"remove the overlay pool for base pool <pool>", "osd", "rw", \
     FLAG(DEPRECATED))
 
 COMMAND("osd tier add-cache " \
@@ -1057,7 +1055,7 @@ COMMAND("osd tier add-cache " \
 	"name=tierpool,type=CephPoolname " \
 	"name=size,type=CephInt,range=0", \
 	"add a cache <tierpool> (the second one) of size <size> to existing pool <pool> (the first one)", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 
 /*
  * mon/ConfigKeyService.cc
@@ -1065,31 +1063,31 @@ COMMAND("osd tier add-cache " \
 
 COMMAND("config-key get " \
 	"name=key,type=CephString", \
-	"get <key>", "config-key", "r", "cli,rest")
+	"get <key>", "config-key", "r")
 COMMAND("config-key set " \
 	"name=key,type=CephString " \
 	"name=val,type=CephString,req=false", \
-	"set <key> to value <val>", "config-key", "rw", "cli,rest")
+	"set <key> to value <val>", "config-key", "rw")
 COMMAND_WITH_FLAG("config-key put " \
 		  "name=key,type=CephString " \
 		  "name=val,type=CephString,req=false",			\
-		  "put <key>, value <val>", "config-key", "rw", "cli,rest",
+		  "put <key>, value <val>", "config-key", "rw",
 		  FLAG(DEPRECATED))
 COMMAND_WITH_FLAG("config-key del " \
 	"name=key,type=CephString", \
-	"delete <key>", "config-key", "rw", "cli,rest", \
+	"delete <key>", "config-key", "rw", \
     FLAG(DEPRECATED))
 COMMAND("config-key rm " \
 	"name=key,type=CephString", \
-	"rm <key>", "config-key", "rw", "cli,rest")
+	"rm <key>", "config-key", "rw")
 COMMAND("config-key exists " \
 	"name=key,type=CephString", \
-	"check for <key>'s existence", "config-key", "r", "cli,rest")
-COMMAND_WITH_FLAG("config-key list ", "list keys", "config-key", "r", "cli,rest",
+	"check for <key>'s existence", "config-key", "r")
+COMMAND_WITH_FLAG("config-key list ", "list keys", "config-key", "r",
 		  FLAG(DEPRECATED))
-COMMAND("config-key ls ", "list keys", "config-key", "r", "cli,rest")
+COMMAND("config-key ls ", "list keys", "config-key", "r")
 COMMAND("config-key dump " \
-	"name=key,type=CephString,req=false", "dump keys and values (with optional prefix)", "config-key", "r", "cli,rest")
+	"name=key,type=CephString,req=false", "dump keys and values (with optional prefix)", "config-key", "r")
 
 
 /*
@@ -1098,30 +1096,30 @@ COMMAND("config-key dump " \
 COMMAND("mgr dump "				     \
 	"name=epoch,type=CephInt,range=0,req=false", \
 	"dump the latest MgrMap",		     \
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 COMMAND("mgr fail name=who,type=CephString", \
-	"treat the named manager daemon as failed", "mgr", "rw", "cli,rest")
+	"treat the named manager daemon as failed", "mgr", "rw")
 COMMAND("mgr module ls",
-	"list active mgr modules", "mgr", "r", "cli,rest")
+	"list active mgr modules", "mgr", "r")
 COMMAND("mgr services",
 	"list service endpoints provided by mgr modules",
-        "mgr", "r", "cli,rest")
+        "mgr", "r")
 COMMAND("mgr module enable "						\
 	"name=module,type=CephString "					\
 	"name=force,type=CephChoices,strings=--force,req=false",
-	"enable mgr module", "mgr", "rw", "cli,rest")
+	"enable mgr module", "mgr", "rw")
 COMMAND("mgr module disable "						\
 	"name=module,type=CephString",
-	"disable mgr module", "mgr", "rw", "cli,rest")
+	"disable mgr module", "mgr", "rw")
 COMMAND("mgr metadata name=who,type=CephString,req=false",
 	"dump metadata for all daemons or a specific daemon",
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 COMMAND("mgr count-metadata name=property,type=CephString",
 	"count ceph-mgr daemons by metadata field property",
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 COMMAND("mgr versions", \
 	"check running versions of ceph-mgr daemons",
-	"mgr", "r", "cli,rest")
+	"mgr", "r")
 
 // ConfigMonitor
 COMMAND("config set" \
@@ -1129,36 +1127,35 @@ COMMAND("config set" \
 	" name=name,type=CephString" \
 	" name=value,type=CephString", \
 	"Set a configuration option for one or more entities",
-	"config", "rw", "cli,rest")
+	"config", "rw")
 COMMAND("config rm"						\
 	" name=who,type=CephString" \
 	" name=name,type=CephString",
 	"Clear a configuration option for one or more entities",
-	"config", "rw", "cli,rest")
+	"config", "rw")
 COMMAND("config get " \
 	"name=who,type=CephString " \
 	"name=key,type=CephString,req=False",
 	"Show configuration option(s) for an entity",
-	"config", "r", "cli,rest")
+	"config", "r")
 COMMAND("config dump",
 	"Show all configuration option(s)",
-	"mon", "r", "cli,rest")
+	"mon", "r")
 COMMAND("config help " \
 	"name=key,type=CephString",
 	"Describe a configuration option",
-	"config", "r", "cli,rest")
+	"config", "r")
 COMMAND("config assimilate-conf",
 	"Assimilate options from a conf, and return a new, minimal conf file",
-	"config", "rw", "cli,rest")
+	"config", "rw")
 COMMAND("config log name=num,type=CephInt,req=False",
 	"Show recent history of config changes",
-	"config", "r", "cli,rest")
+	"config", "r")
 COMMAND("config reset" \
 	" name=num,type=CephInt",
 	"Revert configuration to previous state",
-	"config", "rw", "cli,rest")
+	"config", "rw")
 
 COMMAND_WITH_FLAG("smart name=devid,type=CephString,req=false",
 		  "Query health metrics for underlying device",
-		  "mon", "rw", "cli,rest",
-		  FLAG(HIDDEN))
+		  "mon", "rw", FLAG(HIDDEN))

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -738,7 +738,8 @@ COMMAND("osd pause", "pause osd", "osd", "rw")
 COMMAND("osd unpause", "unpause osd", "osd", "rw")
 COMMAND("osd erasure-code-profile set " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
-	"name=profile,type=CephString,n=N,req=false", \
+	"name=profile,type=CephString,n=N,req=false " \
+	"name=force,type=CephBool,req=false", \
 	"create erasure code profile <name> with [<key[=value]> ...] pairs. Add a --force at the end to override an existing profile (VERY DANGEROUS)", \
 	"osd", "rw")
 COMMAND("osd erasure-code-profile get " \
@@ -942,16 +943,16 @@ COMMAND("osd pool create " \
 COMMAND_WITH_FLAG("osd pool delete " \
 	"name=pool,type=CephPoolname " \
 	"name=pool2,type=CephPoolname,req=false " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-really-mean-it|" \
-        "--yes-i-really-really-mean-it-not-faking,req=false", \
+	"name=yes_i_really_really_mean_it,type=CephBool,req=false "
+	"name=yes_i_really_really_mean_it_not_faking,type=CephBool,req=false ", \
 	"delete pool", \
 	"osd", "rw", \
     FLAG(DEPRECATED))
 COMMAND("osd pool rm " \
 	"name=pool,type=CephPoolname " \
 	"name=pool2,type=CephPoolname,req=false " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-really-mean-it|" \
-        "--yes-i-really-really-mean-it-not-faking,req=false", \
+	"name=yes_i_really_really_mean_it,type=CephBool,req=false "
+	"name=yes_i_really_really_mean_it_not_faking,type=CephBool,req=false ", \
 	"remove pool", \
 	"osd", "rw")
 COMMAND("osd pool rename " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -225,8 +225,8 @@ COMMAND("quorum_status", "report status of monitor quorum", \
 COMMAND_WITH_FLAG("mon_status", "report status of monitors", "mon", "r",
 	     FLAG(NOFORWARD))
 COMMAND_WITH_FLAG("sync force " \
-	"name=validate1,type=CephChoices,strings=--yes-i-really-mean-it,req=false " \
-	"name=validate2,type=CephChoices,strings=--i-know-what-i-am-doing,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false " \
+	"name=i_know_what_i_am_doing,type=CephBool,req=false", \
 	"force sync of and clear monitor store", \
         "mon", "rw", \
         FLAG(NOFORWARD)|FLAG(DEPRECATED))
@@ -258,8 +258,8 @@ COMMAND_WITH_FLAG("mon scrub",
     "mon", "rw", \
     FLAG(NONE))
 COMMAND_WITH_FLAG("mon sync force " \
-    "name=validate1,type=CephChoices,strings=--yes-i-really-mean-it,req=false " \
-    "name=validate2,type=CephChoices,strings=--i-know-what-i-am-doing,req=false", \
+    "name=yes_i_really_mean_it,type=CephBool,req=false " \
+    "name=i_know_what_i_am_doing,type=CephBool,req=false", \
     "force sync of and clear monitor store", \
     "mon", "rw", \
     FLAG(NOFORWARD))
@@ -320,7 +320,7 @@ COMMAND_WITH_FLAG("mds set " \
 	"name=var,type=CephChoices,strings=max_mds|max_file_size|inline_data|"
 	"allow_new_snaps|allow_multimds|allow_multimds_snaps|allow_dirfrags " \
 	"name=val,type=CephString "					\
-	"name=confirm,type=CephString,req=false",			\
+	"name=yes_i_really_mean_it,type=CephBool,req=false",			\
 	"set mds parameter <var> to <val>", "mds", "rw", FLAG(OBSOLETE))
 // arbitrary limit 0-20 below; worth standing on head to make it
 // relate to actual state definitions?
@@ -337,7 +337,8 @@ COMMAND("mds repaired name=role,type=CephString", \
 COMMAND("mds rm " \
 	"name=gid,type=CephInt,range=0", \
 	"remove nonactive mds", "mds", "rw")
-COMMAND("mds rmfailed name=role,type=CephString name=confirm,type=CephString,req=false", \
+COMMAND("mds rmfailed name=role,type=CephString " \
+        "name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"remove failed mds", "mds", "rw")
 COMMAND_WITH_FLAG("mds cluster_down", "take MDS cluster down", "mds", "rw", FLAG(OBSOLETE))
 COMMAND_WITH_FLAG("mds cluster_up", "bring MDS cluster up", "mds", "rw", FLAG(OBSOLETE))
@@ -359,25 +360,25 @@ COMMAND_WITH_FLAG("mds remove_data_pool " \
 COMMAND_WITH_FLAG("mds newfs " \
 	"name=metadata,type=CephInt,range=0 " \
 	"name=data,type=CephInt,range=0 " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"make new filesystem using pools <metadata> and <data>", \
 	"mds", "rw", FLAG(OBSOLETE))
 COMMAND("fs new " \
 	"name=fs_name,type=CephString " \
 	"name=metadata,type=CephString " \
 	"name=data,type=CephString " \
-	"name=force,type=CephChoices,strings=--force,req=false " \
-	"name=sure,type=CephChoices,strings=--allow-dangerous-metadata-overlay,req=false", \
+	"name=force,type=CephBool,req=false " \
+	"name=allow_dangerous_metadata_overlay,type=CephBool,req=false", \
 	"make new filesystem using named pools <metadata> and <data>", \
 	"fs", "rw")
 COMMAND("fs rm " \
 	"name=fs_name,type=CephString " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"disable the named filesystem", \
 	"fs", "rw")
 COMMAND("fs reset " \
 	"name=fs_name,type=CephString " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"disaster recovery only: reset to a single-MDS map", \
 	"fs", "rw")
 COMMAND("fs ls ", \
@@ -393,11 +394,11 @@ COMMAND("fs set " \
         "|standby_count_wanted|session_timeout|session_autoclose" \
         "|down|joinable|min_compat_client " \
 	"name=val,type=CephString "					\
-	"name=confirm,type=CephString,req=false",			\
+	"name=yes_i_really_mean_it,type=CephBool,req=false",			\
 	"set fs parameter <var> to <val>", "mds", "rw")
 COMMAND("fs flag set name=flag_name,type=CephChoices,strings=enable_multiple "
         "name=val,type=CephString " \
-	"name=confirm,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"Set a global CephFS flag", \
 	"fs", "rw")
 COMMAND("fs add_data_pool name=fs_name,type=CephString " \
@@ -442,7 +443,7 @@ COMMAND("mon feature ls " \
         "mon", "r")
 COMMAND("mon feature set " \
         "name=feature_name,type=CephString " \
-        "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
         "set provided feature on mon map", \
         "mon", "rw")
 COMMAND("mon set-rank " \
@@ -588,7 +589,7 @@ COMMAND("osd crush move " \
 COMMAND("osd crush swap-bucket " \
 	"name=source,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=dest,type=CephString,goodchars=[A-Za-z0-9-_.] " \
-	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"swap existing bucket contents from (orphan) bucket <source> and <target>", \
 	"osd", "rw")
 COMMAND("osd crush link " \
@@ -731,7 +732,7 @@ COMMAND("osd get-require-min-compat-client",
         "osd", "r")
 COMMAND("osd set-require-min-compat-client " \
 	"name=version,type=CephString " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+        "name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"set the minimum client version we will maintain compatibility with",
 	"osd", "rw")
 COMMAND("osd pause", "pause osd", "osd", "rw")
@@ -755,14 +756,14 @@ COMMAND("osd erasure-code-profile ls", \
 	"osd", "r")
 COMMAND("osd set " \
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim|sortbitwise|recovery_deletes|require_jewel_osds|require_kraken_osds " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+        "name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"set <key>", "osd", "rw")
 COMMAND("osd unset " \
 	"name=key,type=CephChoices,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|nosnaptrim", \
 	"unset <key>", "osd", "rw")
 COMMAND("osd require-osd-release "\
 	"name=release,type=CephChoices,strings=luminous|mimic|nautilus " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+        "name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"set the minimum allowed OSD release to participate in the cluster",
 	"osd", "rw")
 COMMAND("osd down " \
@@ -840,7 +841,7 @@ COMMAND("osd reweightn " \
 	"osd", "rw")
 COMMAND("osd force-create-pg " \
 	"name=pgid,type=CephPgid "\
-        "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"force creation of pg <pgid>",
         "osd", "rw")
 COMMAND("osd pg-temp " \
@@ -878,26 +879,26 @@ COMMAND("osd primary-affinity " \
 	"osd", "rw")
 COMMAND_WITH_FLAG("osd destroy-actual "	    \
         "name=id,type=CephOsdName " \
-        "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+        "name=yes_i_really_mean_it,type=CephBool,req=false", \
         "mark osd as being destroyed. Keeps the ID intact (allowing reuse), " \
         "but removes cephx keys, config-key data and lockbox keys, "\
         "rendering data permanently unreadable.", \
 		  "osd", "rw", FLAG(HIDDEN))
 COMMAND("osd purge-new " \
         "name=id,type=CephOsdName " \
-        "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+        "name=yes_i_really_mean_it,type=CephBool,req=false", \
         "purge all traces of an OSD that was partially created but never " \
 	"started", \
         "osd", "rw")
 COMMAND_WITH_FLAG("osd purge-actual " \
         "name=id,type=CephOsdName " \
-        "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+        "name=yes_i_really_mean_it,type=CephBool,req=false", \
         "purge all osd data from the monitors. Combines `osd destroy`, " \
         "`osd rm`, and `osd crush rm`.", \
 		  "osd", "rw", FLAG(HIDDEN))
 COMMAND("osd lost " \
 	"name=id,type=CephOsdName " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"mark osd as permanently lost. THIS DESTROYS DATA IF NO MORE REPLICAS EXIST, BE CAREFUL", \
 	"osd", "rw")
 COMMAND_WITH_FLAG("osd create " \
@@ -967,7 +968,7 @@ COMMAND("osd pool set " \
 	"name=pool,type=CephPoolname " \
 	"name=var,type=CephChoices,strings=size|min_size|pg_num|pgp_num|crush_rule|hashpspool|nodelete|nopgchange|nosizechange|write_fadvise_dontneed|noscrub|nodeep-scrub|hit_set_type|hit_set_period|hit_set_count|hit_set_fpp|use_gmt_hitset|target_max_bytes|target_max_objects|cache_target_dirty_ratio|cache_target_dirty_high_ratio|cache_target_full_ratio|cache_min_flush_age|cache_min_evict_age|min_read_recency_for_promote|min_write_recency_for_promote|fast_read|hit_set_grade_decay_rate|hit_set_search_last_n|scrub_min_interval|scrub_max_interval|deep_scrub_interval|recovery_priority|recovery_op_priority|scrub_priority|compression_mode|compression_algorithm|compression_required_ratio|compression_max_blob_size|compression_min_blob_size|csum_type|csum_min_block|csum_max_block|allow_ec_overwrites|fingerprint_algorithm " \
 	"name=val,type=CephString " \
-	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"set pool parameter <var> to <val>", "osd", "rw")
 // 'val' is a CephString because it can include a unit.  Perhaps
 // there should be a Python type for validation/conversion of strings
@@ -984,13 +985,13 @@ COMMAND("osd pool get-quota " \
 COMMAND("osd pool application enable " \
         "name=pool,type=CephPoolname " \
         "name=app,type=CephString,goodchars=[A-Za-z0-9-_.] " \
-	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
         "enable use of an application <app> [cephfs,rbd,rgw] on pool <poolname>",
         "osd", "rw")
 COMMAND("osd pool application disable " \
         "name=pool,type=CephPoolname " \
         "name=app,type=CephString " \
-	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
         "disables use of an application <app> on pool <poolname>",
         "osd", "rw")
 COMMAND("osd pool application set " \
@@ -1037,7 +1038,7 @@ COMMAND_WITH_FLAG("osd tier remove " \
 COMMAND("osd tier cache-mode " \
 	"name=pool,type=CephPoolname " \
 	"name=mode,type=CephChoices,strings=none|writeback|forward|readonly|readforward|proxy|readproxy " \
-	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"name=yes_i_really_mean_it,type=CephBool,req=false", \
 	"specify the caching mode for cache tier <pool>", "osd", "rw")
 COMMAND("osd tier set-overlay " \
 	"name=pool,type=CephPoolname " \

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2869,6 +2869,7 @@ bool Monitor::_allowed_command(MonSession *s, const string &module,
 
 void Monitor::format_command_descriptions(const std::vector<MonCommand> &commands,
 					  Formatter *f,
+					  uint64_t features,
 					  bufferlist *rdata)
 {
   int cmdnum = 0;
@@ -2877,7 +2878,7 @@ void Monitor::format_command_descriptions(const std::vector<MonCommand> &command
     unsigned flags = cmd.flags;
     ostringstream secname;
     secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
-    dump_cmddesc_to_json(f, secname.str(),
+    dump_cmddesc_to_json(f, features, secname.str(),
 			 cmd.cmdstring, cmd.helpstring, cmd.module,
 			 cmd.req_perms, flags);
     cmdnum++;
@@ -2979,7 +2980,8 @@ void Monitor::handle_command(MonOpRequestRef op)
       }
     }
 
-    format_command_descriptions(commands, f, &rdata);
+    auto features = m->get_connection()->get_features();
+    format_command_descriptions(commands, f, features, &rdata);
     delete f;
     reply_command(op, 0, "", rdata, 0);
     return;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3490,11 +3490,12 @@ void Monitor::handle_command(MonOpRequestRef op)
     r = 0;
   } else if (prefix == "sync force" ||
              prefix == "mon sync force") {
-    string validate1, validate2;
-    cmd_getval(g_ceph_context, cmdmap, "validate1", validate1);
-    cmd_getval(g_ceph_context, cmdmap, "validate2", validate2);
-    if (validate1 != "--yes-i-really-mean-it" ||
-	validate2 != "--i-know-what-i-am-doing") {
+    bool validate1 = false;
+    cmd_getval(g_ceph_context, cmdmap, "yes_i_really_mean_it", validate1);
+    bool validate2 = false;
+    cmd_getval(g_ceph_context, cmdmap, "i_know_what_i_am_doing", validate2);
+
+    if (!validate1 || !validate2) {
       r = -EINVAL;
       rs = "are you SURE? this will mean the monitor store will be "
 	   "erased.  pass '--yes-i-really-mean-it "

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -108,10 +108,10 @@ const string Monitor::MONITOR_STORE_PREFIX = "monitor_store";
 #undef COMMAND
 #undef COMMAND_WITH_FLAG
 #define FLAG(f) (MonCommand::FLAG_##f)
-#define COMMAND(parsesig, helptext, modulename, req_perms, avail)	\
-  {parsesig, helptext, modulename, req_perms, avail, FLAG(NONE)},
-#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, avail, flags) \
-  {parsesig, helptext, modulename, req_perms, avail, flags},
+#define COMMAND(parsesig, helptext, modulename, req_perms)	\
+  {parsesig, helptext, modulename, req_perms, FLAG(NONE)},
+#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, flags) \
+  {parsesig, helptext, modulename, req_perms, flags},
 MonCommand mon_commands[] = {
 #include <mon/MonCommands.h>
 };
@@ -2879,7 +2879,7 @@ void Monitor::format_command_descriptions(const std::vector<MonCommand> &command
     secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
     dump_cmddesc_to_json(f, secname.str(),
 			 cmd.cmdstring, cmd.helpstring, cmd.module,
-			 cmd.req_perms, cmd.availability, flags);
+			 cmd.req_perms, flags);
     cmdnum++;
   }
   f->close_section();	// command_descriptions

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -963,6 +963,7 @@ private:
 public:
   static void format_command_descriptions(const std::vector<MonCommand> &commands,
 					  Formatter *f,
+					  uint64_t features,
 					  bufferlist *rdata);
 
   const std::vector<MonCommand> &get_local_commands(mon_feature_t f) {

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -654,9 +654,9 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
       goto reply;
     }
 
-    string sure;
-    if (!cmd_getval(g_ceph_context, cmdmap, "sure", sure) ||
-        sure != "--yes-i-really-mean-it") {
+    bool sure = false;
+    cmd_getval(g_ceph_context, cmdmap, "yes_i_really_mean_it", sure);
+    if (!sure) {
       ss << "please specify '--yes-i-really-mean-it' if you "
          << "really, **really** want to set feature '"
          << feature << "' in the monmap.";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9589,13 +9589,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     cmd_getval(cct, cmdmap, "name", name);
     vector<string> profile;
     cmd_getval(cct, cmdmap, "profile", profile);
-    bool force;
-    if (profile.size() > 0 && profile.back() == "--force") {
-      profile.pop_back();
-      force = true;
-    } else {
-      force = false;
-    }
+
+    bool force = false;
+    cmd_getval(cct, cmdmap, "force", force);
+
     map<string,string> profile_map;
     err = parse_erasure_code_profile(profile, &profile_map, &ss);
     if (err)
@@ -11591,7 +11588,6 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     string poolstr, poolstr2, sure;
     cmd_getval(cct, cmdmap, "pool", poolstr);
     cmd_getval(cct, cmdmap, "pool2", poolstr2);
-    cmd_getval(cct, cmdmap, "sure", sure);
     int64_t pool = osdmap.lookup_pg_pool_name(poolstr.c_str());
     if (pool < 0) {
       ss << "pool '" << poolstr << "' does not exist";
@@ -11599,9 +11595,12 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       goto reply;
     }
 
-    bool force_no_fake = sure == "--yes-i-really-really-mean-it-not-faking";
+    bool force_no_fake = false;
+    cmd_getval(cct, cmdmap, "yes_i_really_really_mean_it", force_no_fake);
+    bool force = false;
+    cmd_getval(cct, cmdmap, "yes_i_really_really_mean_it_not_faking", force);
     if (poolstr2 != poolstr ||
-	(sure != "--yes-i-really-really-mean-it" && !force_no_fake)) {
+	(!force && !force_no_fake)) {
       ss << "WARNING: this will *PERMANENTLY DESTROY* all data stored in pool " << poolstr
 	 << ".  If you are *ABSOLUTELY CERTAIN* that is what you want, pass the pool name *twice*, "
 	 << "followed by --yes-i-really-really-mean-it.";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -10118,11 +10118,6 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     }
     pending_inc.new_require_osd_release = rel;
     goto update;
-  } else if (prefix == "osd cluster_snap") {
-    // ** DISABLE THIS FOR NOW **
-    ss << "cluster snapshot currently disabled (broken implementation)";
-    // ** DISABLE THIS FOR NOW **
-
   } else if (prefix == "osd down" ||
 	     prefix == "osd out" ||
 	     prefix == "osd in" ||

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6092,7 +6092,8 @@ int OSD::_do_command(
 
       ostringstream secname;
       secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
-      dump_cmddesc_to_json(f, secname.str(), cp->cmdstring, cp->helpstring,
+      dump_cmddesc_to_json(f, con->get_features(),
+                           secname.str(), cp->cmdstring, cp->helpstring,
 			   cp->module, cp->perm, 0);
       cmdnum++;
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5921,11 +5921,10 @@ struct OSDCommand {
   string helpstring;
   string module;
   string perm;
-  string availability;
 } osd_commands[] = {
 
-#define COMMAND(parsesig, helptext, module, perm, availability) \
-  {parsesig, helptext, module, perm, availability},
+#define COMMAND(parsesig, helptext, module, perm) \
+  {parsesig, helptext, module, perm},
 
 // yes, these are really pg commands, but there's a limit to how
 // much work it's worth.  The OSD returns all of them.  Make this
@@ -5935,62 +5934,62 @@ struct OSDCommand {
 COMMAND("pg " \
 	"name=pgid,type=CephPgid " \
 	"name=cmd,type=CephChoices,strings=query", \
-	"show details of a specific pg", "osd", "r", "cli")
+	"show details of a specific pg", "osd", "r")
 COMMAND("pg " \
 	"name=pgid,type=CephPgid " \
 	"name=cmd,type=CephChoices,strings=mark_unfound_lost " \
 	"name=mulcmd,type=CephChoices,strings=revert|delete", \
 	"mark all unfound objects in this pg as lost, either removing or reverting to a prior version if one is available",
-	"osd", "rw", "cli")
+	"osd", "rw")
 COMMAND("pg " \
 	"name=pgid,type=CephPgid " \
 	"name=cmd,type=CephChoices,strings=list_unfound " \
 	"name=offset,type=CephString,req=false",
 	"list unfound objects on this pg, perhaps starting at an offset given in JSON",
-	"osd", "r", "cli")
+	"osd", "r")
 
 // new form: tell <pgid> <cmd> for both cli and rest
 
 COMMAND("query",
-	"show details of a specific pg", "osd", "r", "cli,rest")
+	"show details of a specific pg", "osd", "r")
 COMMAND("mark_unfound_lost " \
 	"name=mulcmd,type=CephChoices,strings=revert|delete", \
 	"mark all unfound objects in this pg as lost, either removing or reverting to a prior version if one is available",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("list_unfound " \
 	"name=offset,type=CephString,req=false",
 	"list unfound objects on this pg, perhaps starting at an offset given in JSON",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("perf histogram dump "
         "name=logger,type=CephString,req=false "
         "name=counter,type=CephString,req=false",
 	"Get histogram data",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 
 // tell <osd.n> commands.  Validation of osd.n must be special-cased in client
-COMMAND("version", "report version of OSD", "osd", "r", "cli,rest")
-COMMAND("get_command_descriptions", "list commands descriptions", "osd", "r", "cli,rest")
+COMMAND("version", "report version of OSD", "osd", "r")
+COMMAND("get_command_descriptions", "list commands descriptions", "osd", "r")
 COMMAND("injectargs " \
 	"name=injected_args,type=CephString,n=N",
 	"inject configuration arguments into running OSD",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("config set " \
 	"name=key,type=CephString name=value,type=CephString",
 	"Set a configuration option at runtime (not persistent)",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("config get " \
 	"name=key,type=CephString",
 	"Get a configuration option at runtime",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("config unset " \
 	"name=key,type=CephString",
 	"Unset a configuration option at runtime (not persistent)",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("cluster_log " \
 	"name=level,type=CephChoices,strings=error,warning,info,debug " \
 	"name=message,type=CephString,n=N",
 	"log a message to the cluster log",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("bench " \
 	"name=count,type=CephInt,req=false " \
 	"name=size,type=CephInt,req=false " \
@@ -5998,38 +5997,38 @@ COMMAND("bench " \
 	"name=object_num,type=CephInt,req=false ", \
 	"OSD benchmark: write <count> <size>-byte objects, " \
 	"(default 1G size 4MB). Results in log.",
-	"osd", "rw", "cli,rest")
-COMMAND("flush_pg_stats", "flush pg stats", "osd", "rw", "cli,rest")
+	"osd", "rw")
+COMMAND("flush_pg_stats", "flush pg stats", "osd", "rw")
 COMMAND("heap " \
 	"name=heapcmd,type=CephChoices,strings=dump|start_profiler|stop_profiler|release|stats", \
 	"show heap usage info (available only if compiled with tcmalloc)", \
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("debug dump_missing " \
 	"name=filename,type=CephFilepath",
-	"dump missing objects to a named file", "osd", "r", "cli,rest")
+	"dump missing objects to a named file", "osd", "r")
 COMMAND("debug kick_recovery_wq " \
 	"name=delay,type=CephInt,range=0",
-	"set osd_recovery_delay_start to <val>", "osd", "rw", "cli,rest")
+	"set osd_recovery_delay_start to <val>", "osd", "rw")
 COMMAND("cpu_profiler " \
 	"name=arg,type=CephChoices,strings=status|flush",
-	"run cpu profiling on daemon", "osd", "rw", "cli,rest")
+	"run cpu profiling on daemon", "osd", "rw")
 COMMAND("dump_pg_recovery_stats", "dump pg recovery statistics",
-	"osd", "r", "cli,rest")
+	"osd", "r")
 COMMAND("reset_pg_recovery_stats", "reset pg recovery statistics",
-	"osd", "rw", "cli,rest")
+	"osd", "rw")
 COMMAND("compact",
         "compact object store's omap. "
         "WARNING: Compaction probably slows your requests",
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("smart name=devid,type=CephString,req=False",
         "runs smartctl on this osd devices.  ",
-        "osd", "rw", "cli,rest")
+        "osd", "rw")
 COMMAND("cache drop",
         "Drop all OSD caches",
-        "osd", "rwx", "cli,rest")
+        "osd", "rwx")
 COMMAND("cache status",
         "Get OSD caches statistics",
-        "osd", "r", "cli,rest")
+        "osd", "r")
 };
 
 void OSD::do_command(
@@ -6094,7 +6093,7 @@ int OSD::_do_command(
       ostringstream secname;
       secname << "cmd" << setfill('0') << std::setw(3) << cmdnum;
       dump_cmddesc_to_json(f, secname.str(), cp->cmdstring, cp->helpstring,
-			   cp->module, cp->perm, cp->availability, 0);
+			   cp->module, cp->perm, 0);
       cmdnum++;
     }
     f->close_section();	// command_descriptions

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -755,7 +755,7 @@ class CephFSVolumeClient(object):
                                 {
                                     "pool": pool_name,
                                     "pool2": pool_name,
-                                    "sure": "--yes-i-really-really-mean-it"
+                                    "yes_i_really_really_mean_it": True
                                 })
 
     def _get_ancestor_xattr(self, path, attr):

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -124,7 +124,7 @@ class Osd(RESTController):
             'mon',
             'osd lost',
             id=int(svc_id),
-            sure='--yes-i-really-mean-it')
+            yes_i_really_mean_it=True)
 
     def create(self, uuid=None, svc_id=None):
         """
@@ -157,7 +157,7 @@ class Osd(RESTController):
         The osd must be marked down before being destroyed.
         """
         CephService.send_command(
-            'mon', 'osd destroy-actual', id=int(svc_id), sure='--yes-i-really-mean-it')
+            'mon', 'osd destroy-actual', id=int(svc_id), yes_i_really_mean_it=True)
 
     @RESTController.Resource('GET')
     def safe_to_destroy(self, svc_id):

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -74,7 +74,7 @@ class Pool(RESTController):
     @handle_send_command_error('pool')
     def delete(self, pool_name):
         return CephService.send_command('mon', 'osd pool delete', pool=pool_name, pool2=pool_name,
-                                        sure='--yes-i-really-really-mean-it')
+                                        yes_i_really_really_mean_it=True)
 
     @pool_task('edit', ['{pool_name}'])
     def set(self, pool_name, flags=None, application_metadata=None, **kwargs):
@@ -101,7 +101,7 @@ class Pool(RESTController):
         if application_metadata is not None:
             def set_app(what, app):
                 CephService.send_command('mon', 'osd pool application ' + what, pool=pool, app=app,
-                                         force='--yes-i-really-mean-it')
+                                         yes_i_really_mean_it=True)
             if update_existing:
                 original_app_metadata = set(
                     current_pool.get('application_metadata'))

--- a/src/pybind/mgr/restful/api/pool.py
+++ b/src/pybind/mgr/restful/api/pool.py
@@ -72,7 +72,7 @@ class PoolId(RestController):
             'prefix': 'osd pool delete',
             'pool': pool['pool_name'],
             'pool2': pool['pool_name'],
-            'sure': '--yes-i-really-really-mean-it'
+            'yes_i_really_really_mean_it': True
         }]], **kwargs)
 
 

--- a/src/test/common/get_command_descriptions.cc
+++ b/src/test/common/get_command_descriptions.cc
@@ -58,18 +58,18 @@ static void all()
 #undef COMMAND_WITH_FLAG
   std::vector<MonCommand> mon_commands = {
 #define FLAG(f) (MonCommand::FLAG_##f)
-#define COMMAND(parsesig, helptext, modulename, req_perms, avail)	\
-    {parsesig, helptext, modulename, req_perms, avail, 0},
-#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, avail, flags) \
-    {parsesig, helptext, modulename, req_perms, avail, flags},
+#define COMMAND(parsesig, helptext, modulename, req_perms)	\
+    {parsesig, helptext, modulename, req_perms, 0},
+#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, flags) \
+    {parsesig, helptext, modulename, req_perms, flags},
 #include <mon/MonCommands.h>
 #undef COMMAND
 #undef COMMAND_WITH_FLAG
 
-#define COMMAND(parsesig, helptext, modulename, req_perms, avail)	\
-  {parsesig, helptext, modulename, req_perms, avail, FLAG(MGR)},
-#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, avail, flags) \
-  {parsesig, helptext, modulename, req_perms, avail, flags | FLAG(MGR)},
+#define COMMAND(parsesig, helptext, modulename, req_perms)	\
+  {parsesig, helptext, modulename, req_perms, FLAG(MGR)},
+#define COMMAND_WITH_FLAG(parsesig, helptext, modulename, req_perms, flags) \
+  {parsesig, helptext, modulename, req_perms, flags | FLAG(MGR)},
 #include <mgr/MgrCommands.h>
  #undef COMMAND
 #undef COMMAND_WITH_FLAG
@@ -87,7 +87,7 @@ static void pull585()
       "name=pg_num,type=CephInt,range=0 " 
       "name=pgp_num,type=CephInt,range=0,req=false" // !!! missing trailing space
       "name=properties,type=CephString,n=N,req=false,goodchars=[A-Za-z0-9-_.=]", 
-      "create pool", "osd", "rw", "cli,rest" }
+      "create pool", "osd", "rw" }
   };
 
   json_print(mon_commands);

--- a/src/test/common/get_command_descriptions.cc
+++ b/src/test/common/get_command_descriptions.cc
@@ -45,7 +45,8 @@ static void json_print(const std::vector<MonCommand> &mon_commands)
 {
   bufferlist rdata;
   Formatter *f = Formatter::create("json");
-  Monitor::format_command_descriptions(mon_commands, f, &rdata);
+  Monitor::format_command_descriptions(mon_commands, f,
+                                       CEPH_FEATURES_ALL, &rdata);
   delete f;
   string data(rdata.c_str(), rdata.length());
   cout << data << std::endl;

--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -385,7 +385,7 @@ TEST_F(LibRadosListNP, ListObjectsError) {
     size_t buflen, stlen;
     string c = "{\"prefix\":\"osd pool rm\",\"pool\": \"" + pool_name +
       "\",\"pool2\":\"" + pool_name +
-      "\",\"sure\": \"--yes-i-really-really-mean-it-not-faking\"}";
+      "\",\"yes_i_really_really_mean_it_not_faking\": true}";
     const char *cmd[2] = { c.c_str(), 0 };
     ASSERT_EQ(0, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, &buf, &buflen, &st, &stlen));
     ASSERT_EQ(0, rados_wait_for_latest_osdmap(cluster));

--- a/src/test/librados/pool.cc
+++ b/src/test/librados/pool.cc
@@ -125,8 +125,8 @@ TEST(LibRadosPools, PoolGetBaseTier) {
   ASSERT_EQ(0, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0));
 
   cmdstr = "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" +
-     tier_pool_name + "\", \"mode\":\"readonly\", \"sure\": " +
-    "\"--yes-i-really-mean-it\"}";
+     tier_pool_name + "\", \"mode\":\"readonly\"," +
+    " \"yes_i_really_mean_it\": true}";
   cmd[0] = (char *)cmdstr.c_str();
   ASSERT_EQ(0, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0));
 

--- a/src/test/librados/testcase_cxx.cc
+++ b/src/test/librados/testcase_cxx.cc
@@ -91,7 +91,7 @@ void RadosTestParamPPNS::TearDownTestCase()
       inbl, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd pool delete\", \"pool\": \"" + cache_pool_name +
-      "\", \"pool2\": \"" + cache_pool_name + "\", \"sure\": \"--yes-i-really-really-mean-it\"}",
+      "\", \"pool2\": \"" + cache_pool_name + "\", \"yes_i_really_really_mean_it\": true}",
       inbl, NULL, NULL));
     cache_pool_name = "";
   }
@@ -286,7 +286,7 @@ void RadosTestParamPP::TearDownTestCase()
       inbl, NULL, NULL));
     ASSERT_EQ(0, s_cluster.mon_command(
       "{\"prefix\": \"osd pool delete\", \"pool\": \"" + cache_pool_name +
-      "\", \"pool2\": \"" + cache_pool_name + "\", \"sure\": \"--yes-i-really-really-mean-it\"}",
+      "\", \"pool2\": \"" + cache_pool_name + "\", \"yes_i_really_really_mean_it\": true}",
       inbl, NULL, NULL));
     cache_pool_name = "";
   }

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -859,9 +859,6 @@ class TestOSD(TestArgparse):
             assert_equal({}, validate_command(sigdict, ['osd', action,
                                                         'pause', 'toomany']))
 
-    def test_cluster_snap(self):
-        assert_equal({}, validate_command(sigdict, ['osd', 'cluster_snap']))
-
     def test_down(self):
         self.check_1_or_more_string_args('osd', 'down')
 

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -955,6 +955,50 @@ class TestOSD(TestArgparse):
                                                     'poolname', 'snapname',
                                                     'toomany']))
 
+    def test_pool_kwargs(self):
+        """
+        Use the pool creation command to exercise keyword-style arguments
+        since it has lots of parameters
+        """
+        # Simply use a keyword arg instead of a positional arg, in its
+        # normal order (pgp_num after pg_num)
+        assert_equal(
+            {
+                "prefix": "osd pool create",
+                "pool": "foo",
+                "pg_num": 8,
+                "pgp_num": 16
+            }, validate_command(sigdict, [
+                'osd', 'pool', 'create', "foo", "8", "--pgp_num", "16"]))
+
+        # Again, but using the "--foo=bar" style
+        assert_equal(
+            {
+                "prefix": "osd pool create",
+                "pool": "foo",
+                "pg_num": 8,
+                "pgp_num": 16
+            }, validate_command(sigdict, [
+                'osd', 'pool', 'create', "foo", "8", "--pgp_num=16"]))
+
+        # Specify keyword args in a different order than their definitions
+        # (pgp_num after pool_type)
+        assert_equal(
+            {
+                "prefix": "osd pool create",
+                "pool": "foo",
+                "pg_num": 8,
+                "pgp_num": 16,
+                "pool_type": "replicated"
+            }, validate_command(sigdict, [
+                'osd', 'pool', 'create', "foo", "8",
+                "--pool_type", "replicated",
+                "--pgp_num", "16"]))
+
+        # Use a keyword argument that doesn't exist, should fail validation
+        assert_equal({}, validate_command(sigdict,
+            ['osd', 'pool', 'create', "foo", "8", "--foo=bar"]))
+
     def test_pool_create(self):
         self.assert_valid_command(['osd', 'pool', 'create',
                                    'poolname', '128'])

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1123,7 +1123,6 @@ class TestOSD(TestArgparse):
         self.assert_valid_command(['osd', 'reweight-by-utilization'])
         self.assert_valid_command(['osd', 'reweight-by-utilization', '100'])
         self.assert_valid_command(['osd', 'reweight-by-utilization', '100', '.1'])
-        self.assert_valid_command(['osd', 'reweight-by-utilization', '--no-increasing'])
         assert_equal({}, validate_command(sigdict, ['osd',
                                                     'reweight-by-utilization',
                                                     '100',

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -999,6 +999,62 @@ class TestOSD(TestArgparse):
         assert_equal({}, validate_command(sigdict,
             ['osd', 'pool', 'create', "foo", "8", "--foo=bar"]))
 
+    def test_foo(self):
+        # Long form of a boolean argument (--foo=true)
+        assert_equal(
+            {
+                "prefix": "osd pool delete",
+                "pool": "foo",
+                "pool2": "foo",
+                "yes_i_really_really_mean_it": True
+            }, validate_command(sigdict, [
+                'osd', 'pool', 'delete', "foo", "foo",
+                "--yes-i-really-really-mean-it=true"]))
+
+    def test_pool_bool_args(self):
+        """
+        Use pool deletion to exercise boolean arguments since it has
+        the --yes-i-really-really-mean-it flags
+        """
+
+        # Short form of a boolean argument (--foo)
+        assert_equal(
+            {
+                "prefix": "osd pool delete",
+                "pool": "foo",
+                "pool2": "foo",
+                "yes_i_really_really_mean_it": True
+            }, validate_command(sigdict, [
+                'osd', 'pool', 'delete', "foo", "foo",
+                "--yes-i-really-really-mean-it"]))
+
+        # Long form of a boolean argument (--foo=true)
+        assert_equal(
+            {
+                "prefix": "osd pool delete",
+                "pool": "foo",
+                "pool2": "foo",
+                "yes_i_really_really_mean_it": True
+            }, validate_command(sigdict, [
+                'osd', 'pool', 'delete', "foo", "foo",
+                "--yes-i-really-really-mean-it=true"]))
+
+        # Negative form of a boolean argument (--foo=false)
+        assert_equal(
+            {
+                "prefix": "osd pool delete",
+                "pool": "foo",
+                "pool2": "foo",
+                "yes_i_really_really_mean_it": False
+            }, validate_command(sigdict, [
+                'osd', 'pool', 'delete', "foo", "foo",
+                "--yes-i-really-really-mean-it=false"]))
+
+        # Invalid value boolean argument (--foo=somethingelse)
+        assert_equal({}, validate_command(sigdict, [
+                'osd', 'pool', 'delete', "foo", "foo",
+                "--yes-i-really-really-mean-it=rhubarb"]))
+
     def test_pool_create(self):
         self.assert_valid_command(['osd', 'pool', 'create',
                                    'poolname', '128'])

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -221,7 +221,7 @@ class TestRados(object):
                 eq(ret, 0)
 
                 try:
-                    cmd = {"prefix":"osd tier cache-mode", "pool":"foo-cache", "tierpool":"foo-cache", "mode":"readonly", "sure":"--yes-i-really-mean-it"}
+                    cmd = {"prefix":"osd tier cache-mode", "pool":"foo-cache", "tierpool":"foo-cache", "mode":"readonly", "yes_i_really_mean_it": True}
                     ret, buf, errs = self.rados.mon_command(json.dumps(cmd), b'', timeout=30)
                     eq(ret, 0)
 


### PR DESCRIPTION
Currently, our CLI only provides positional arguments -- if there are lots of optional fields for an operation, we can only specify a field by specifying all the optional fields before it too.  That's awkward, and it's hard to be sure you've got all your values in the order you intended.

For example, specifying "pool_type" on a created pool, previously we had to know the right order of args, and also specify the pgp_num field (because it comes before pool type in the command definition):
```
ceph osd pool create mypool 8 8 replicated
```

With this change, we can use a simpler form without extra unnecessary args:
```
ceph osd pool create mypool 8 --pool_type=replicated
```

In general, I would expect most people to continue using positional arguments for the mandatory arguments, and switch to keyword arguments for optional arguments.

- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

