### PR TITLE
ceph-volume add new ceph-handlers role from ceph-ansible

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -77,6 +77,7 @@
   roles:
     - role: ceph-defaults
       tags: ['ceph_update_config']
+    - role: ceph-handler
     - role: ceph-common
   tasks:
     - name: rsync ceph-volume to test nodes on centos


### PR DESCRIPTION
PR https://github.com/ceph/ceph-ansible/pull/2947 added a new role which is not present in ceph-volume functional tests, this new role is needed so that we can run functional tests.

Fixes: http://tracker.ceph.com/issues/36251