### PR TITLE
mimic: osd/PG: avoid choose_acting picking want with > pool size items

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1359,6 +1359,9 @@ void PG::calc_replicated_acting(
       usable++;
       ss << " osd." << *i << " (up) accepted " << cur_info << std::endl;
     }
+    if (want->size() >= size) {
+      break;
+    }
   }
 
   if (usable >= size) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/35963