### PR TITLE
mgr/dashboard: Check content-type before decode json response

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -169,7 +169,8 @@ class DashboardTestCase(MgrTestCase):
         else:
             assert False
         try:
-            if cls._resp.text and cls._resp.text != "":
+            content_type = cls._resp.headers['content-type']
+            if content_type == 'application/json' and cls._resp.text and cls._resp.text != "":
                 return cls._resp.json()
             return cls._resp.text
         except ValueError as ex:


### PR DESCRIPTION
Ceph dashboard should check the content-type before trying to decode a JSON response, otherwise it will fail for responses that are not JSON (e.g. XML responses).

Signed-off-by: Ricardo Marques <rimarques@suse.com>