### PR TITLE
DNM: WIP: os/bluestore: invoke BlueFS rebalance on repair

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5269,7 +5269,8 @@ void BlueStore::_dump_alloc_on_rebalance_failure()
   }
 }
 
-int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
+int BlueStore::_balance_bluefs_freespace(PExtentVector *extents,
+					 KeyValueDB::Transaction synct)
 {
   int ret = 0;
   ceph_assert(bluefs);
@@ -5398,7 +5399,16 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
 
     ret = 1;
   }
-
+  if (ret > 0) {
+    for (auto& p : *extents) {
+      bluefs_extents.insert(p.offset, p.length);
+    }
+    bufferlist bl;
+    encode(bluefs_extents, bl);
+    dout(10) << __func__ << " bluefs_extents now 0x" << std::hex
+	      << bluefs_extents << std::dec << dendl;
+    synct->set(PREFIX_SUPER, "bluefs_extents", bl);
+  }
   return ret;
 }
 
@@ -6885,6 +6895,17 @@ int BlueStore::_fsck(bool deep, bool repair)
 	}
       }
       used_blocks.flip();
+    }
+  }
+  if(repair) {
+    PExtentVector bluefs_gift_extents;
+    int r = _balance_bluefs_freespace(&bluefs_gift_extents,
+                                      repairer.get_bluefs_rebalance_txn(db));
+    ceph_assert(r >= 0);
+    if (r && !bluefs_gift_extents.empty()) {
+      dout(1) << __func__ << " additional bluefs_extents allocated 0x" << std::hex
+	      << bluefs_gift_extents << std::dec << dendl;
+      _commit_bluefs_freespace(bluefs_gift_extents);
     }
   }
   if (repair) {
@@ -9380,18 +9401,8 @@ void BlueStore::_kv_sync_thread()
 	  after_flush - bluefs_last_balance >
 	  ceph::make_timespan(cct->_conf->bluestore_bluefs_balance_interval)) {
 	bluefs_last_balance = after_flush;
-	int r = _balance_bluefs_freespace(&bluefs_gift_extents);
+	int r = _balance_bluefs_freespace(&bluefs_gift_extents, synct);
 	ceph_assert(r >= 0);
-	if (r > 0) {
-	  for (auto& p : bluefs_gift_extents) {
-	    bluefs_extents.insert(p.offset, p.length);
-	  }
-	  bufferlist bl;
-	  encode(bluefs_extents, bl);
-	  dout(10) << __func__ << " bluefs_extents now 0x" << std::hex
-		   << bluefs_extents << std::dec << dendl;
-	  synct->set(PREFIX_SUPER, "bluefs_extents", bl);
-	}
       }
 
       // cleanup sync deferred keys
@@ -12777,6 +12788,10 @@ unsigned BlueStoreRepairer::apply(KeyValueDB* db)
   if (fix_statfs_txn) {
     db->submit_transaction_sync(fix_statfs_txn);
     fix_statfs_txn = nullptr;
+  }
+  if (bluefs_rebalance_txn) {
+    db->submit_transaction_sync(bluefs_rebalance_txn);
+    bluefs_rebalance_txn = nullptr;
   }
   unsigned repaired = to_repair_cnt;
   to_repair_cnt = 0;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2154,7 +2154,8 @@ private:
 
   void _dump_alloc_on_rebalance_failure();
   int _reconcile_bluefs_freespace();
-  int _balance_bluefs_freespace(PExtentVector *extents);
+  int _balance_bluefs_freespace(PExtentVector *extents,
+				KeyValueDB::Transaction synct);
   void _commit_bluefs_freespace(const PExtentVector& extents);
 
   CollectionRef _get_collection(const coll_t& cid);
@@ -2994,6 +2995,11 @@ public:
   KeyValueDB::Transaction get_fix_misreferences_txn() {
     return fix_misreferences_txn;
   }
+  KeyValueDB::Transaction get_bluefs_rebalance_txn(KeyValueDB *db) {
+    return bluefs_rebalance_txn ?
+      bluefs_rebalance_txn :
+      bluefs_rebalance_txn = db->get_transaction();
+  }
 
 private:
   unsigned to_repair_cnt = 0;
@@ -3004,6 +3010,7 @@ private:
   KeyValueDB::Transaction fix_shared_blob_txn;
 
   KeyValueDB::Transaction fix_misreferences_txn;
+  KeyValueDB::Transaction bluefs_rebalance_txn;
 
   StoreSpaceTracker space_usage_tracker;
 


### PR DESCRIPTION
This will trigger BlueFS space rebalance when repairing hence allocating
additional space immediately.

Workaround for: https://tracker.ceph.com/issues/36268

Signed-off-by: Igor Fedotov <ifedotov@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

