### PR TITLE
ceph-volume:  activate option --auto-detect-objectstore respects --no-systemd

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -250,9 +250,9 @@ class Activate(object):
                 has_journal = lv.tags.get('ceph.journal_uuid')
                 if has_journal:
                     logger.info('found a journal associated with the OSD, assuming filestore')
-                    return activate_filestore(lvs)
+                    return activate_filestore(lvs, no_systemd=args.no_systemd)
             logger.info('unable to find a journal associated with the OSD, assuming bluestore')
-            return activate_bluestore(lvs)
+            return activate_bluestore(lvs, no_systemd=args.no_systemd)
         if args.bluestore:
             activate_bluestore(lvs, no_systemd=args.no_systemd)
         elif args.filestore:


### PR DESCRIPTION
The `--auto-detect-objectstore` flag was meant to make it easier for systemd to load/activate OSDs, which is why it was omitted when the `--no-systemd` flag was added. This PR fixes that omission and adds a few tests to ensure its new optional behavior. 

Fixes: http://tracker.ceph.com/issues/36249