### PR TITLE
DNM: common: fix up "ceph releases"

### DIFF
--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -183,6 +183,10 @@ uint64_t ceph_release_features(int r)
 	if (r <= CEPH_RELEASE_LUMINOUS)
 		return req;
 
+	req |= CEPH_FEATUREMASK_SERVER_MIMIC;
+	if (r <= CEPH_RELEASE_MIMIC)
+	  return req;
+
 	return req;
 }
 

--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -187,6 +187,10 @@ uint64_t ceph_release_features(int r)
 	if (r <= CEPH_RELEASE_MIMIC)
 	  return req;
 
+	req |= CEPH_FEATUREMASK_SERVER_NAUTILUS;
+	if (r<= CEPH_RELEASE_NAUTILUS)
+	  return req;
+	
 	return req;
 }
 


### PR DESCRIPTION
Users are being confused because they still see "luminous" after upgrading to mimic. Fix that!