### PR TITLE
doc: Fix typo error on cephfs/fuse/

### DIFF
--- a/doc/cephfs/fuse.rst
+++ b/doc/cephfs/fuse.rst
@@ -26,7 +26,7 @@ For additional details on ``cephx`` configuration, see
 To mount the Ceph file system as a FUSE, you may use the ``ceph-fuse`` command.
 For example::
 
-	sudo mkdir /home/usernname/cephfs
+	sudo mkdir /home/username/cephfs
 	sudo ceph-fuse -m 192.168.0.1:6789 /home/username/cephfs
 
 If you have more than one filesystem, specify which one to mount using


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/36180
Signed-off-by: Karun Josy <kjosy@redhat.com>

