### PR TITLE
mgr/dashboard: Fix error when clicking on newly created OSD

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -25,8 +25,8 @@ class DashboardTestCase(MgrTestCase):
     CLIENTS_REQUIRED = 1
     CEPHFS = False
 
-    _session = None
-    _resp = None
+    _session = None  # type: requests.sessions.Session
+    _resp = None  # type: requests.models.Response
     _loggedin = False
     _base_uri = None
 

--- a/src/pybind/mgr/dashboard/controllers/perf_counters.py
+++ b/src/pybind/mgr/dashboard/controllers/perf_counters.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
+import cherrypy
+
 from . import ApiController, RESTController
 from .. import mgr
 from ..security import Scope
@@ -12,7 +14,10 @@ class PerfCounter(RESTController):
 
     def get(self, service_id):
         schema_dict = mgr.get_perf_schema(self.service_type, str(service_id))
-        schema = schema_dict["{}.{}".format(self.service_type, service_id)]
+        try:
+            schema = schema_dict["{}.{}".format(self.service_type, service_id)]
+        except KeyError as e:
+            raise cherrypy.HTTPError(404, "{0} not found".format(e.message))
         counters = []
 
         for key, value in sorted(schema.items()):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.html
@@ -5,10 +5,15 @@
     </cd-table-key-value>
   </tab>
   <tab heading="Metadata">
-    <cd-table-key-value *ngIf="osd.loaded"
+    <cd-table-key-value *ngIf="osd.loaded && osd.details.osd_metadata; else noMetaData"
                         (fetchData)="osd.autoRefresh()"
                         [data]="osd.details.osd_metadata">
     </cd-table-key-value>
+    <ng-template #noMetaData>
+      <cd-warning-panel i18n>
+        Metadata not available
+      </cd-warning-panel>
+    </ng-template>
   </tab>
   <tab heading="Performance counter">
     <cd-table-performance-counter *ngIf="osd.loaded"

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-details/osd-details.component.ts
@@ -32,7 +32,7 @@ export class OsdDetailsComponent implements OnChanges {
   }
 
   refresh() {
-    this.osdService.getDetails(this.osd.tree.id).subscribe((data: any) => {
+    this.osdService.getDetails(this.osd.id).subscribe((data: any) => {
       this.osd.details = data;
       this.osd.histogram_failed = '';
       if (!_.isObject(data.histogram)) {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.html
@@ -1,4 +1,5 @@
-<cd-table [data]="counters"
+<cd-table *ngIf="counters; else warning"
+          [data]="counters"
           [columns]="columns"
           columnMode="flex"
           [autoSave]="false"
@@ -7,3 +8,8 @@
     {{ row.value | dimless }} {{ row.unit }}
   </ng-template>
 </cd-table>
+<ng-template #warning>
+  <cd-warning-panel i18n>
+    Performance counters not available
+  </cd-warning-panel>
+</ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
@@ -53,10 +53,16 @@ export class TablePerformanceCounterComponent implements OnInit {
   }
 
   getCounters() {
-    this.performanceCounterService
-      .get(this.serviceType, this.serviceId)
-      .subscribe((resp: object[]) => {
+    this.performanceCounterService.get(this.serviceType, this.serviceId).subscribe(
+      (resp: object[]) => {
         this.counters = resp;
-      });
+      },
+      (error) => {
+        if (error.status === 404) {
+          error.preventDefault();
+          this.counters = null;
+        }
+      }
+    );
   }
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
@@ -82,16 +82,6 @@ describe('ApiInterceptorService', () => {
     );
   });
 
-  it('should redirect 404', (done) => {
-    runRouterTest(
-      {
-        status: 404
-      },
-      [['/404']],
-      done
-    );
-  });
-
   it('should show notification (error string)', function(done) {
     runNotificationTest(
       'foobar',

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.ts
@@ -59,9 +59,6 @@ export class ApiInterceptorService implements HttpInterceptor {
             case 403:
               this.router.navigate(['/403']);
               break;
-            case 404:
-              this.router.navigate(['/404']);
-              break;
           }
 
           let timeoutId;


### PR DESCRIPTION
Fix for errors which occur when the user clicks on an OSD on the OSD page which has just been created and has not been attached to the CRUSH map before. Fetching data for the details (usually shown below the OSD table) fails for that OSD. A warning will be displayed on those tabs where no data could be fetched.

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

Steps to reproduce:
- Create an OSD using the command line: `ceph osd create`
- Click on the OSD on the OSD page 

Only the `Metadata` and `Performance Counter` tabs are affected. The `Histogram` tab has already been fixed and the `Attributes` tab does also work with a newly created OSD.

I wonder if a warning is appropriate here but implemented it as it has already been done for the histogram. Do we want to keep the warning or switch to a (blue) information panel instead?

![screen-metadata](https://user-images.githubusercontent.com/9606095/46353015-71e5a880-c65b-11e8-9522-9c8c825d0a12.png)
![screen-perf-counter](https://user-images.githubusercontent.com/9606095/46353021-75792f80-c65b-11e8-9d4c-45b2a92c430e.png)

By the way:

This PR removes the redirect of the frontend to a 404 Not Found page if a non user visible request of the frontend returns a 404 HTTP status code. I don't see the reason for that redirect, if you do, please let me know. It'll still show a notification with a 404 error, but the user won't automatically be redirected to another page. The notification is not shown for the click on a newly created OSD.