### PR TITLE
mgr/dashboard: Add permission validation to the  "Purge Trash" button

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -12,7 +12,7 @@ import six
 
 import rbd
 
-from . import ApiController, RESTController, Task, UpdatePermission
+from . import ApiController, RESTController, Task, UpdatePermission, DeletePermission
 from .. import mgr
 from ..security import Scope
 from ..services.ceph_service import CephService
@@ -466,7 +466,7 @@ class RbdSnapshot(RESTController):
         return _rbd_call(pool_name, _parent_clone)
 
 
-@ApiController('/block/image/trash')
+@ApiController('/block/image/trash', Scope.RBD_IMAGE)
 class RbdTrash(RESTController):
     RESOURCE_ID = "pool_name/image_id"
     rbd_inst = rbd.RBD()
@@ -506,6 +506,7 @@ class RbdTrash(RESTController):
     @handle_rados_error('pool')
     @RbdTask('trash/purge', ['{pool_name}'], 2.0)
     @RESTController.Collection('POST', query_params=['pool_name'])
+    @DeletePermission
     def purge(self, pool_name=None):
         """Remove all expired images from trash."""
         now = "{}Z".format(datetime.now().isoformat())
@@ -518,6 +519,7 @@ class RbdTrash(RESTController):
 
     @RbdTask('trash/restore', ['{pool_name}', '{image_id}', '{new_image_name}'], 2.0)
     @RESTController.Resource('POST')
+    @UpdatePermission
     def restore(self, pool_name, image_id, new_image_name):
         """Restore an image from trash."""
         return _rbd_call(pool_name, self.rbd_inst.trash_restore, image_id, new_image_name)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.html
@@ -18,7 +18,8 @@
 
     <button class="btn btn-sm btn-default btn-label"
             type="button"
-            (click)="purgeModal()">
+            (click)="purgeModal()"
+            *ngIf="permission.delete">
       <i class="fa fa-fw fa-times"
          aria-hidden="true"></i>
       <ng-container i18n>Purge Trash</ng-container>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-trash-list/rbd-trash-list.component.spec.ts
@@ -5,6 +5,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { ToastModule } from 'ng2-toastr';
 import { of } from 'rxjs';
 
+import { By } from '@angular/platform-browser';
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { RbdService } from '../../../shared/api/rbd.service';
 import { CdTableSelection } from '../../../shared/models/cd-table-selection';
@@ -100,6 +101,36 @@ describe('RbdTrashListComponent', () => {
       expect(component.images.length).toBe(2);
       expectImageTasks(component.images[0], 'Deleting');
       expectImageTasks(component.images[1], 'Restoring');
+    });
+  });
+
+  describe('display purge button', () => {
+    beforeEach(() => {});
+
+    it('should show button with delete permission', () => {
+      component.permission = {
+        read: true,
+        create: true,
+        delete: true,
+        update: true
+      };
+      fixture.detectChanges();
+
+      const purge = fixture.debugElement.query(By.css('.table-actions button .fa-times'));
+      expect(purge).not.toBeNull();
+    });
+
+    it('should remove button without delete permission', () => {
+      component.permission = {
+        read: true,
+        create: true,
+        delete: false,
+        update: true
+      };
+      fixture.detectChanges();
+
+      const purge = fixture.debugElement.query(By.css('.table-actions button .fa-times'));
+      expect(purge).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Added missing permission validations in the RBD Trash endpoints.

Fixes: http://tracker.ceph.com/issues/36272

`Signed-off-by: Tiago Melo <tmelo@suse.com>`