### PR TITLE
ceph-volume: skip processing devices that don't exist when scanning system disks

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -197,6 +197,15 @@ class TestGetDevices(object):
             _mapper_path=str(tmpdir))
         assert result == {}
 
+    def test_no_devices_are_found_errors(self, tmpdir):
+        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
+        os.makedirs(os.path.join(block_path, 'sda'))
+        result = disk.get_devices(
+            _sys_block_path=block_path, # has 1 device
+            _dev_path=str(tmpdir), # exists but no devices
+            _mapper_path='/does/not/exist/path') # does not exist
+        assert result == {}
+
     def test_sda_block_is_found(self, tmpfile, tmpdir):
         block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
         dev_sda_path = os.path.join(dev_path, 'sda')

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -686,6 +686,8 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
         # Ensure that the diskname is an absolute path and that it never points
         # to a /dev/dm-* device
         diskname = mapper_devs.get(block) or dev_devs.get(block)
+        if not diskname:
+            continue
 
         # If the mapper device is a logical volume it gets excluded
         if is_mapper_device(diskname):


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/36247