### PR TITLE
osd: add required cls_* libraries as dependencies of osd

### DIFF
--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -57,3 +57,16 @@ endif()
 if(WITH_OSD_INSTRUMENT_FUNCTIONS)
   add_dependencies(osd cyg_profile_tp)
 endif()
+
+# libcls_* are runtime dependencies
+add_dependencies(osd cls_journal cls_hello cls_lock cls_log cls_numops
+  cls_refcount cls_timeindex cls_user cls_version cls_cas)
+if(WITH_CEPHFS)
+  add_dependencies(osd cls_cephfs)
+endif()
+if(WITH_RBD)
+  add_dependencies(osd cls_rbd)
+endif()
+if(WITH_RADOSGW)
+  add_dependencies(osd cls_otp cls_rgw)
+endif()

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -205,10 +205,6 @@ target_link_libraries(radosgw radosgw_a librados
   global ${FCGI_LIBRARY} ${LIB_RESOLV}
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
   ${ALLOC_LIBS})
-# radosgw depends on cls libraries at runtime, but not as link dependencies
-add_dependencies(radosgw cls_rgw cls_lock cls_refcount
-  cls_log cls_timeindex
-  cls_version cls_user cls_otp)
 install(TARGETS radosgw DESTINATION bin)
 
 set(radosgw_admin_srcs


### PR DESCRIPTION
The libcls_*.so libraries are runtime dependencies of the OSD. Building
the vstart target doesn't build these libraries, rendering some
functionalities unusable. This goes unnoticed when building the entire
source tree.

Signed-off-by: Mohamad Gebai <mgebai@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

