### PR TITLE
qa/distros: add openSUSE Leap 42.3 and 15.0

### DIFF
--- a/qa/distros/all/opensuse_15.0.yaml
+++ b/qa/distros/all/opensuse_15.0.yaml
@@ -1,0 +1,2 @@
+os_type: opensuse
+os_version: "15.0"

--- a/qa/distros/all/opensuse_42.3.yaml
+++ b/qa/distros/all/opensuse_42.3.yaml
@@ -1,0 +1,2 @@
+os_type: opensuse
+os_version: "42.3"


### PR DESCRIPTION
References: https://tracker.ceph.com/issues/35927
Signed-off-by: Nathan Cutler <ncutler@suse.com>
