### PR TITLE
luminous: msg/async: clean up local buffers on dispatch

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -798,6 +798,12 @@ void AsyncConnection::process()
             dispatch_queue->enqueue(message, message->get_priority(), conn_id);
           }
 
+	  // clean up local buffer references
+          data_buf.clear();
+          front.clear();
+          middle.clear();
+          data.clear();
+
           break;
         }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/36126