### PR TITLE
ceph-volume: make `lvm batch` idempotent

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -170,7 +170,7 @@ class Batch(object):
             if type(strategy) != type(new_strategy):
                 if not args.report:
                     mlogger.error("aborting because strategy changed from %s to %s after filtering" % (strategy, new_strategy))
-                    raise SystemExit(0)
+                    raise SystemExit(1)
             else:
                 strategy = new_strategy
         return strategy(unused_devices, args)

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -159,18 +159,18 @@ class Batch(object):
         if used_devices:
             for device in used_devices:
                 args.filtered_devices[device] = {"reasons": ["Used by ceph as a data device already"]}
-            if not args.report:
-                mlogger.info("Ignoring devices already used by ceph: %s" % ",".join(used_devices))
-        if not unused_devices and not args.report:
+            if args.yes and unused_devices:
+                mlogger.info("Ignoring devices already used by ceph: %s" % ", ".join(used_devices))
+        if not unused_devices and not args.format == 'json':
             # report nothing changed
             mlogger.info("All devices are already used by ceph. No OSDs will be created.")
             raise SystemExit(0)
         else:
             new_strategy = get_strategy(args, unused_devices)
-            if strategy != new_strategy:
+            if new_strategy and strategy != new_strategy:
                 if args.report:
                     mlogger.info("Ignoring devices already used by ceph: %s" % ",".join(used_devices))
-                mlogger.error("aborting because strategy changed from %s to %s after filtering" % (strategy.type(), new_strategy.type()))
+                mlogger.error("Aborting because strategy changed from %s to %s after filtering" % (strategy.type(), new_strategy.type()))
                 raise SystemExit(1)
 
         return strategy(unused_devices, args)

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -167,12 +167,12 @@ class Batch(object):
             raise SystemExit(0)
         else:
             new_strategy = get_strategy(args, unused_devices)
-            if type(strategy) != type(new_strategy):
-                if not args.report:
-                    mlogger.error("aborting because strategy changed from %s to %s after filtering" % (strategy, new_strategy))
-                    raise SystemExit(1)
-            else:
-                strategy = new_strategy
+            if strategy != new_strategy:
+                if args.report:
+                    mlogger.info("Ignoring devices already used by ceph: %s" % ",".join(used_devices))
+                mlogger.error("aborting because strategy changed from %s to %s after filtering" % (strategy.type(), new_strategy.type()))
+                raise SystemExit(1)
+
         return strategy(unused_devices, args)
 
     @decorators.needs_root

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -24,6 +24,10 @@ class SingleType(object):
         self.validate()
         self.compute()
 
+    @staticmethod
+    def type():
+        return "filestore.MixedType"
+
     @property
     def total_osds(self):
         if self.hdds:
@@ -143,6 +147,10 @@ class MixedType(object):
         self.dbs_needed = len(self.hdds) * self.osds_per_device
         self.validate()
         self.compute()
+
+    @staticmethod
+    def type():
+        return "bluestore.MixedType"
 
     def report_json(self):
         print(json.dumps(self.computed, indent=4, sort_keys=True))

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -77,7 +77,7 @@ class SingleType(object):
         osds = self.computed['osds']
         for device in self.hdds:
             for hdd in range(self.osds_per_device):
-                osd = {'data': {}, 'block.db': {}, 'used_by_ceph': device.used_by_ceph}
+                osd = {'data': {}, 'block.db': {}}
                 osd['data']['path'] = device.abspath
                 osd['data']['size'] = device.sys_api['size'] / self.osds_per_device
                 osd['data']['parts'] = self.osds_per_device
@@ -90,7 +90,7 @@ class SingleType(object):
         for device in self.ssds:
             extents = lvm.sizing(device.sys_api['size'], parts=self.osds_per_device)
             for ssd in range(self.osds_per_device):
-                osd = {'data': {}, 'block.db': {}, 'used_by_ceph': device.used_by_ceph}
+                osd = {'data': {}, 'block.db': {}}
                 osd['data']['path'] = device.abspath
                 osd['data']['size'] = extents['sizes']
                 osd['data']['parts'] = extents['parts']
@@ -223,7 +223,7 @@ class MixedType(object):
 
         for device in self.hdds:
             for hdd in range(self.osds_per_device):
-                osd = {'data': {}, 'block.db': {}, 'used_by_ceph': device.used_by_ceph}
+                osd = {'data': {}, 'block.db': {}}
                 osd['data']['path'] = device.abspath
                 osd['data']['size'] = device.sys_api['size'] / self.osds_per_device
                 osd['data']['percentage'] = 100 / self.osds_per_device

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -40,6 +40,8 @@ class SingleType(object):
 
     def report_pretty(self):
         string = ""
+        if self.args.filtered_devices:
+            string += templates.filtered_devices(self.args.filtered_devices)
         string += templates.total_osds.format(
             total_osds=self.total_osds,
         )
@@ -166,6 +168,8 @@ class MixedType(object):
         db_size = str(disk.Size(b=(vg_extents['sizes'])))
 
         string = ""
+        if self.args.filtered_devices:
+            string += templates.filtered_devices(self.args.filtered_devices)
         string += templates.total_osds.format(
             total_osds=len(self.hdds) * self.osds_per_device
         )

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -26,7 +26,7 @@ class SingleType(object):
 
     @staticmethod
     def type():
-        return "filestore.MixedType"
+        return "bluestore.SingleType"
 
     @property
     def total_osds(self):
@@ -209,11 +209,11 @@ class MixedType(object):
             # there isn't a common vg, so a new one must be created with all
             # the blank SSDs
             self.computed['vg'] = {
-                'devices': self.blank_ssds,
+                'devices': ", ".join([ssd.abspath for ssd in self.blank_ssds]),
                 'parts': self.dbs_needed,
                 'percentages': self.vg_extents['percentages'],
-                'sizes': self.block_db_size.b,
-                'size': int(self.total_blank_ssd_size.b),
+                'sizes': self.block_db_size.b.as_int(),
+                'size': self.total_blank_ssd_size.b.as_int(),
                 'human_readable_sizes': str(self.block_db_size),
                 'human_readable_size': str(self.total_available_db_space),
             }

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -21,8 +21,11 @@ class SingleType(object):
         self.hdds = [device for device in devices if device.sys_api['rotational'] == '1']
         self.ssds = [device for device in devices if device.sys_api['rotational'] == '0']
         self.computed = {'osds': [], 'vgs': [], 'filtered_devices': args.filtered_devices}
-        self.validate()
-        self.compute()
+        if self.devices:
+            self.validate()
+            self.compute()
+        else:
+            self.computed["changed"] = False
 
     @staticmethod
     def type():
@@ -147,8 +150,11 @@ class MixedType(object):
         self.block_db_size = self.get_block_size()
         self.system_vgs = lvm.VolumeGroups()
         self.dbs_needed = len(self.hdds) * self.osds_per_device
-        self.validate()
-        self.compute()
+        if self.devices:
+            self.validate()
+            self.compute()
+        else:
+            self.computed["changed"] = False
 
     @staticmethod
     def type():

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -106,7 +106,7 @@ class SingleType(object):
                 journal_size = self.journal_size
                 data_size = osd_size - journal_size
                 data_percentage = data_size * 100 / device_size
-                osd = {'data': {}, 'journal': {}}
+                osd = {'data': {}, 'journal': {}, 'used_by_ceph': device.used_by_ceph}
                 osd['data']['path'] = device.abspath
                 osd['data']['size'] = data_size.b.as_int()
                 osd['data']['parts'] = self.osds_per_device

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -110,7 +110,7 @@ class SingleType(object):
                 journal_size = self.journal_size
                 data_size = osd_size - journal_size
                 data_percentage = data_size * 100 / device_size
-                osd = {'data': {}, 'journal': {}, 'used_by_ceph': device.used_by_ceph}
+                osd = {'data': {}, 'journal': {}}
                 osd['data']['path'] = device.abspath
                 osd['data']['size'] = data_size.b.as_int()
                 osd['data']['parts'] = self.osds_per_device
@@ -328,7 +328,7 @@ class MixedType(object):
             for osd in range(self.osds_per_device):
                 device_size = disk.Size(b=device.sys_api['size'])
                 data_size = device_size / self.osds_per_device
-                osd = {'data': {}, 'journal': {}, 'used_by_ceph': device.used_by_ceph}
+                osd = {'data': {}, 'journal': {}}
                 osd['data']['path'] = device.path
                 osd['data']['size'] = data_size.b.as_int()
                 osd['data']['percentage'] = 100 / self.osds_per_device

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -33,8 +33,11 @@ class SingleType(object):
         self.ssds = [device for device in devices if device.sys_api['rotational'] == '0']
         self.computed = {'osds': [], 'vgs': [], 'filtered_devices': args.filtered_devices}
         self.journal_size = get_journal_size(args)
-        self.validate()
-        self.compute()
+        if self.devices:
+            self.validate()
+            self.compute()
+        else:
+            self.computed["changed"] = False
 
     @staticmethod
     def type():
@@ -189,8 +192,11 @@ class MixedType(object):
         self.journals_needed = len(self.hdds) * self.osds_per_device
         self.journal_size = get_journal_size(args)
         self.system_vgs = lvm.VolumeGroups()
-        self.validate()
-        self.compute()
+        if self.devices:
+            self.validate()
+            self.compute()
+        else:
+            self.computed["changed"] = False
 
     @staticmethod
     def type():

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -52,6 +52,8 @@ class SingleType(object):
 
     def report_pretty(self):
         string = ""
+        if self.args.filtered_devices:
+            string += templates.filtered_devices(self.args.filtered_devices)
         string += templates.total_osds.format(
             total_osds=self.total_osds
         )
@@ -206,6 +208,8 @@ class MixedType(object):
 
     def report_pretty(self):
         string = ""
+        if self.args.filtered_devices:
+            string += templates.filtered_devices(self.args.filtered_devices)
         string += templates.total_osds.format(
             total_osds=self.total_osds
         )

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -99,6 +99,7 @@ class SingleType(object):
         # chose whichever is the one group we have to compute against
         devices = self.hdds or self.ssds
         osds = self.computed['osds']
+        used_osds = []
         for device in devices:
             for osd in range(self.osds_per_device):
                 device_size = disk.Size(b=device.sys_api['size'])
@@ -106,6 +107,7 @@ class SingleType(object):
                 journal_size = self.journal_size
                 data_size = osd_size - journal_size
                 data_percentage = data_size * 100 / device_size
+                used_osds.append(device.used_by_ceph)
                 osd = {'data': {}, 'journal': {}, 'used_by_ceph': device.used_by_ceph}
                 osd['data']['path'] = device.abspath
                 osd['data']['size'] = data_size.b.as_int()
@@ -117,6 +119,8 @@ class SingleType(object):
                 osd['journal']['percentage'] = int(100 - data_percentage)
                 osd['journal']['human_readable_size'] = str(journal_size)
                 osds.append(osd)
+
+        self.computed['changed'] = not any(used_osds)
 
     def execute(self):
         """

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -36,6 +36,10 @@ class SingleType(object):
         self.validate()
         self.compute()
 
+    @staticmethod
+    def type():
+        return "filestore.SingleType"
+
     @property
     def total_osds(self):
         if self.hdds:
@@ -186,6 +190,10 @@ class MixedType(object):
         self.validate()
         self.compute()
 
+    @staticmethod
+    def type():
+        return "filestore.MixedType"
+
     def report_json(self):
         print(json.dumps(self.computed, indent=4, sort_keys=True))
 
@@ -304,11 +312,11 @@ class MixedType(object):
             # there isn't a common vg, so a new one must be created with all
             # the blank SSDs
             self.computed['vg'] = {
-                'devices': self.blank_ssds,
+                'devices': ", ".join([ssd.abspath for ssd in self.blank_ssds]),
                 'parts': self.journals_needed,
                 'percentages': self.vg_extents['percentages'],
-                'sizes': self.journal_size.b,
-                'size': int(self.total_blank_ssd_size.b),
+                'sizes': self.journal_size.b.as_int(),
+                'size': self.total_blank_ssd_size.b.as_int(),
                 'human_readable_sizes': str(self.journal_size),
                 'human_readable_size': str(self.total_available_journal_space),
             }
@@ -322,11 +330,11 @@ class MixedType(object):
                 data_size = device_size / self.osds_per_device
                 osd = {'data': {}, 'journal': {}, 'used_by_ceph': device.used_by_ceph}
                 osd['data']['path'] = device.path
-                osd['data']['size'] = data_size.b
+                osd['data']['size'] = data_size.b.as_int()
                 osd['data']['percentage'] = 100 / self.osds_per_device
                 osd['data']['human_readable_size'] = str(data_size)
                 osd['journal']['path'] = 'vg: %s' % vg_name
-                osd['journal']['size'] = self.journal_size.b
+                osd['journal']['size'] = self.journal_size.b.as_int()
                 osd['journal']['percentage'] = int(self.journal_size.gb * 100 / vg_free)
                 osd['journal']['human_readable_size'] = str(self.journal_size)
                 osds.append(osd)

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -199,7 +199,11 @@ def device_info(monkeypatch):
         lv = Factory(**lv) if lv else None
         monkeypatch.setattr("ceph_volume.sys_info.devices", {})
         monkeypatch.setattr("ceph_volume.util.device.disk.get_devices", lambda: devices)
-        monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: lv)
+        if not devices:
+            monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: lv)
+        else:
+            monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv_from_argument", lambda path: None)
+        monkeypatch.setattr("ceph_volume.util.device.lvm.get_lv", lambda vg_name, lv_uuid: lv)
         monkeypatch.setattr("ceph_volume.util.device.disk.lsblk", lambda path: lsblk)
         monkeypatch.setattr("ceph_volume.util.device.disk.blkid", lambda path: blkid)
     return apply

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_bluestore.py
@@ -5,9 +5,9 @@ from ceph_volume.devices.lvm.strategies import bluestore
 class TestSingleType(object):
 
     def test_hdd_device_is_large_enough(self, fakedevice, factory):
-        args = factory(osds_per_device=1, block_db_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
         computed_osd = bluestore.SingleType(devices, args).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 100
@@ -16,9 +16,9 @@ class TestSingleType(object):
         assert computed_osd['data']['path'] == '/dev/sda'
 
     def test_sdd_device_is_large_enough(self, fakedevice, factory):
-        args = factory(osds_per_device=1, block_db_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
         ]
         computed_osd = bluestore.SingleType(devices, args).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 100
@@ -27,18 +27,18 @@ class TestSingleType(object):
         assert computed_osd['data']['path'] == '/dev/sda'
 
     def test_device_cannot_have_many_osds_per_device(self, fakedevice, factory):
-        args = factory(osds_per_device=3, block_db_size=None)
+        args = factory(filtered_devices=[], osds_per_device=3, block_db_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             bluestore.SingleType(devices, args)
         assert 'Unable to use device 5.66 GB /dev/sda' in str(error)
 
     def test_device_is_lvm_member_fails(self, fakedevice, factory):
-        args = factory(osds_per_device=1, block_db_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
         devices = [
-            fakedevice(is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             bluestore.SingleType(devices, args)
@@ -52,9 +52,9 @@ class TestMixedTypeConfiguredSize(object):
     def test_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         # 3GB block.db in ceph.conf
         conf_ceph(get_safe=lambda *a: 3147483640)
-        args = factory(osds_per_device=1, block_db_size=None)
-        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]
 
         osd = bluestore.MixedType(devices, args).computed['osds'][0]
@@ -68,9 +68,9 @@ class TestMixedTypeConfiguredSize(object):
     def test_ssd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         # 7GB block.db in ceph.conf
         conf_ceph(get_safe=lambda *a: 7747483640)
-        args = factory(osds_per_device=1, block_db_size=None)
-        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]
 
         with pytest.raises(RuntimeError) as error:
@@ -81,9 +81,9 @@ class TestMixedTypeConfiguredSize(object):
     def test_multi_hdd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         # 3GB block.db in ceph.conf
         conf_ceph(get_safe=lambda *a: 3147483640)
-        args = factory(osds_per_device=2, block_db_size=None)
-        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
-        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        args = factory(filtered_devices=[], osds_per_device=2, block_db_size=None)
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]
 
         with pytest.raises(RuntimeError) as error:
@@ -96,9 +96,9 @@ class TestMixedTypeLargeAsPossible(object):
 
     def test_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: None)
-        args = factory(osds_per_device=1, block_db_size=None)
-        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
-        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        args = factory(filtered_devices=[], osds_per_device=1, block_db_size=None)
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]
 
         osd = bluestore.MixedType(devices, args).computed['osds'][0]
@@ -112,9 +112,9 @@ class TestMixedTypeLargeAsPossible(object):
 
     def test_multi_hdd_device_is_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: None)
-        args = factory(osds_per_device=2, block_db_size=None)
-        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=60073740000))
-        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=60073740000))
+        args = factory(filtered_devices=[], osds_per_device=2, block_db_size=None)
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=60073740000))
         devices = [ssd, hdd]
 
         osd = bluestore.MixedType(devices, args).computed['osds'][0]
@@ -128,9 +128,9 @@ class TestMixedTypeLargeAsPossible(object):
 
     def test_multi_hdd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: None)
-        args = factory(osds_per_device=2, block_db_size=None)
-        ssd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
-        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        args = factory(filtered_devices=[], osds_per_device=2, block_db_size=None)
+        ssd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=60737400000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         devices = [ssd, hdd]
 
         with pytest.raises(RuntimeError) as error:

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/strategies/test_filestore.py
@@ -7,9 +7,9 @@ class TestSingleType(object):
 
     def test_hdd_device_is_large_enough(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=12073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=12073740000))
         ]
         computed_osd = filestore.SingleType(devices, args).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 55
@@ -19,9 +19,9 @@ class TestSingleType(object):
 
     def test_hdd_device_with_large_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -30,9 +30,9 @@ class TestSingleType(object):
 
     def test_ssd_device_is_large_enough(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=12073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=12073740000))
         ]
         computed_osd = filestore.SingleType(devices, args).computed['osds'][0]
         assert computed_osd['data']['percentage'] == 55
@@ -42,9 +42,9 @@ class TestSingleType(object):
 
     def test_ssd_device_with_large_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -53,9 +53,9 @@ class TestSingleType(object):
 
     def test_ssd_device_multi_osd(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=4, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=4, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -64,9 +64,9 @@ class TestSingleType(object):
 
     def test_hdd_device_multi_osd(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=4, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=4, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -75,9 +75,9 @@ class TestSingleType(object):
 
     def test_device_is_lvm_member_fails(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=True, sys_api=dict(rotational='1', size=12073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='1', size=12073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -85,9 +85,9 @@ class TestSingleType(object):
 
     def test_hdd_device_with_small_configured_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -96,9 +96,9 @@ class TestSingleType(object):
 
     def test_ssd_device_with_small_configured_journal(self, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.SingleType(devices, args)
@@ -110,10 +110,10 @@ class TestMixedType(object):
 
     def test_minimum_size_is_not_met(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType(devices, args)
@@ -122,10 +122,10 @@ class TestMixedType(object):
 
     def test_ssd_device_is_not_large_enough(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '7120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType(devices, args)
@@ -134,10 +134,10 @@ class TestMixedType(object):
 
     def test_hdd_device_is_lvm_member_fails(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [
-            fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
-            fakedevice(is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
+            fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='0', size=6073740000)),
+            fakedevice(used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='1', size=6073740000))
         ]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType(devices, args)
@@ -147,9 +147,9 @@ class TestMixedType(object):
         # fast PV, because ssd is an LVM member
         CephPV = lvm.PVolume(vg_name='fast', pv_name='/dev/sda', pv_tags='')
         ssd = fakedevice(
-            is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV]
+            used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV]
         )
-        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         # when get_api_vgs() gets called, it will return this one VG
         stub_vgs([
             dict(
@@ -159,7 +159,7 @@ class TestMixedType(object):
         ])
 
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [ssd, hdd]
         result = filestore.MixedType(devices, args).computed['osds'][0]
         assert result['journal']['path'] == 'vg: fast'
@@ -171,12 +171,12 @@ class TestMixedType(object):
         CephPV1 = lvm.PVolume(vg_name='fast1', pv_name='/dev/sda', pv_tags='')
         CephPV2 = lvm.PVolume(vg_name='fast2', pv_name='/dev/sdb', pv_tags='')
         ssd1 = fakedevice(
-            is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV1]
+            used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV1]
         )
         ssd2 = fakedevice(
-            is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV2]
+            used_by_ceph=False, is_lvm_member=True, sys_api=dict(rotational='0', size=6073740000), pvs_api=[CephPV2]
         )
-        hdd = fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
+        hdd = fakedevice(used_by_ceph=False, is_lvm_member=False, sys_api=dict(rotational='1', size=6073740000))
         # when get_api_vgs() gets called, it will return this one VG
         stub_vgs([
             dict(
@@ -190,7 +190,7 @@ class TestMixedType(object):
         ])
 
         conf_ceph(get_safe=lambda *a: '5120')
-        args = factory(osds_per_device=1, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=1, journal_size=None)
         devices = [ssd1, ssd2, hdd]
         with pytest.raises(RuntimeError) as error:
             filestore.MixedType(devices, args)
@@ -199,7 +199,7 @@ class TestMixedType(object):
 
     def test_ssd_device_fails_multiple_osds(self, stub_vgs, fakedevice, factory, conf_ceph):
         conf_ceph(get_safe=lambda *a: '15120')
-        args = factory(osds_per_device=2, journal_size=None)
+        args = factory(filtered_devices=[], osds_per_device=2, journal_size=None)
         devices = [
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='0', size=16073740000)),
             fakedevice(is_lvm_member=False, sys_api=dict(rotational='1', size=16073740000))

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_batch.py
@@ -1,0 +1,61 @@
+from ceph_volume.devices.lvm import batch
+
+
+class TestFilterDevices(object):
+
+    def test_filter_used_device(self, factory):
+        device1 = factory(used_by_ceph=True, abspath="/dev/sda")
+        args = factory(devices=[device1], filtered_devices={})
+        result = batch.filter_devices(args)
+        assert not result
+        assert device1.abspath in args.filtered_devices
+
+    def test_has_unused_devices(self, factory):
+        device1 = factory(
+            used_by_ceph=False,
+            abspath="/dev/sda",
+            rotational=False,
+            is_lvm_member=False
+        )
+        args = factory(devices=[device1], filtered_devices={})
+        result = batch.filter_devices(args)
+        assert device1 in result
+        assert not args.filtered_devices
+
+    def test_filter_device_used_as_a_journal(self, factory):
+        hdd1 = factory(
+            used_by_ceph=True,
+            abspath="/dev/sda",
+            rotational=True,
+            is_lvm_member=True,
+        )
+        lv = factory(tags={"ceph.type": "journal"})
+        ssd1 = factory(
+            used_by_ceph=False,
+            abspath="/dev/nvme0n1",
+            rotational=False,
+            is_lvm_member=True,
+            lvs=[lv],
+        )
+        args = factory(devices=[hdd1, ssd1], filtered_devices={})
+        result = batch.filter_devices(args)
+        assert not result
+        assert ssd1.abspath in args.filtered_devices
+
+    def test_last_device_is_not_filtered(self, factory):
+        hdd1 = factory(
+            used_by_ceph=True,
+            abspath="/dev/sda",
+            rotational=True,
+            is_lvm_member=True,
+        )
+        ssd1 = factory(
+            used_by_ceph=False,
+            abspath="/dev/nvme0n1",
+            rotational=False,
+            is_lvm_member=False,
+        )
+        args = factory(devices=[hdd1, ssd1], filtered_devices={})
+        result = batch.filter_devices(args)
+        assert result
+        assert len(args.filtered_devices) == 1

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test.yml
@@ -36,17 +36,28 @@
 
     - name: ensure batch create is idempotent
       command: "ceph-volume --cluster {{ cluster }} lvm batch --yes --{{ osd_objectstore|default('bluestore') }} {{ '--dmcrypt' if dmcrypt|default(false) else '' }} {{ devices | join(' ') }}"
+      register: batch_cmd
+      failed_when: false
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: check batch idempotency
+      fail:
+        msg: "lvm batch failed idempotency check"
+      when:
+         - batch_cmd.rc != 0
+         - "'strategy changed' not in batch_cmd.stdout"
 
     - name: run batch --report to see if devices get filtered
       command: "ceph-volume --cluster {{ cluster }} lvm batch --report --format=json --{{ osd_objectstore|default('bluestore') }} {{ '--dmcrypt' if dmcrypt|default(false) else '' }} {{ devices | join(' ') }}"
       register: report_cmd
+      failed_when: false
       environment:
         CEPH_VOLUME_DEBUG: 1
 
-    - name: verify OSDs will not be created again
+    - name: check batch --report idempotency
       fail:
-        msg: "Devices were not filtered out after redeploy"
+        msg: "lvm batch --report failed idempotency check"
       when:
-        - (report_cmd.stdout | from_json).changed
+         - batch_cmd.rc != 0
+         - "'strategy changed' not in batch_cmd.stdout"

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test.yml
@@ -33,3 +33,20 @@
       command: "ceph-volume --cluster {{ cluster }} lvm batch --yes --{{ osd_objectstore|default('bluestore') }} {{ '--dmcrypt' if dmcrypt|default(false) else '' }} {{ devices | join(' ') }}"
       environment:
         CEPH_VOLUME_DEBUG: 1
+
+    - name: ensure batch create is idempotent
+      command: "ceph-volume --cluster {{ cluster }} lvm batch --yes --{{ osd_objectstore|default('bluestore') }} {{ '--dmcrypt' if dmcrypt|default(false) else '' }} {{ devices | join(' ') }}"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
+    - name: run batch --report to see if devices get filtered
+      command: "ceph-volume --cluster {{ cluster }} lvm batch --report --format=json --{{ osd_objectstore|default('bluestore') }} {{ '--dmcrypt' if dmcrypt|default(false) else '' }} {{ devices | join(' ') }}"
+      register: report_cmd
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
+    - name: verify OSDs will not be created again
+      fail:
+        msg: "Devices were not filtered out after redeploy"
+      when:
+        - (report_cmd.stdout | from_json).changed

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -94,6 +94,29 @@ class TestDevice(object):
         disk = device.Device("/dev/sda")
         assert disk.pvs_api
 
+    @pytest.mark.parametrize("ceph_type", ["data", "block"])
+    def test_used_by_ceph(self, device_info, pvolumes, monkeypatch, ceph_type):
+        FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", lv_uuid="0000", pv_tags={}, vg_name="vg")
+        pvolumes.append(FooPVolume)
+        monkeypatch.setattr(api, 'PVolumes', lambda: pvolumes)
+        data = {"/dev/sda": {"foo": "bar"}}
+        lsblk = {"TYPE": "part"}
+        lv_data = {"lv_path": "vg/lv", "vg_name": "vg", "lv_uuid": "0000", "tags": {"ceph.osd_id": 0, "ceph.type": ceph_type}}
+        device_info(devices=data, lsblk=lsblk, lv=lv_data)
+        disk = device.Device("/dev/sda")
+        assert disk.used_by_ceph
+
+    def test_not_used_by_ceph(self, device_info, pvolumes, monkeypatch):
+        FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", lv_uuid="0000", pv_tags={}, vg_name="vg")
+        pvolumes.append(FooPVolume)
+        monkeypatch.setattr(api, 'PVolumes', lambda: pvolumes)
+        data = {"/dev/sda": {"foo": "bar"}}
+        lsblk = {"TYPE": "part"}
+        lv_data = {"lv_path": "vg/lv", "vg_name": "vg", "lv_uuid": "0000", "tags": {"ceph.osd_id": 0, "ceph.type": "journal"}}
+        device_info(devices=data, lsblk=lsblk, lv=lv_data)
+        disk = device.Device("/dev/sda")
+        assert not disk.used_by_ceph
+
 
 ceph_partlabels = [
     'ceph data', 'ceph journal', 'ceph block',

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -13,7 +13,7 @@ class TestDevice(object):
         assert "foo" in disk.sys_api
 
     def test_is_lv(self, device_info):
-        data = {"lv_path": "vg/lv"}
+        data = {"lv_path": "vg/lv", "vg_name": "vg"}
         device_info(lv=data)
         disk = device.Device("vg/lv")
         assert disk.is_lv
@@ -85,7 +85,7 @@ class TestDevice(object):
         assert disk.is_ceph_disk_member is False
 
     def test_pv_api(self, device_info, pvolumes, monkeypatch):
-        FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", pv_tags={}, vg_name="vg")
+        FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", lv_uuid="0000", pv_tags={}, vg_name="vg")
         pvolumes.append(FooPVolume)
         monkeypatch.setattr(api, 'PVolumes', lambda: pvolumes)
         data = {"/dev/sda": {"foo": "bar"}}

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -120,7 +120,7 @@ class Device(object):
     def used_by_ceph(self):
         # only filter out data devices as journals could potentially be reused
         osd_ids = [lv.tags.get("ceph.osd_id") for lv in self.lvs
-                   if lv.tags.get("ceph.type") == "data"]
+                   if lv.tags.get("ceph.type") in ["data", "block"]]
         return any(osd_ids)
 
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -119,7 +119,7 @@ class Device(object):
     @property
     def used_by_ceph(self):
         # only filter out data devices as journals could potentially be reused
-        osd_ids = [lv.tags.get("ceph.osd_id") for lv in self.lvs
+        osd_ids = [lv.tags.get("ceph.osd_id") is not None for lv in self.lvs
                    if lv.tags.get("ceph.type") in ["data", "block"]]
         return any(osd_ids)
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -11,6 +11,7 @@ class Device(object):
         # LVs can have a vg/lv path, while disks will have /dev/sda
         self.abspath = path
         self.lv_api = None
+        self.vg_name = None
         self.pvs_api = []
         self.disk_api = {}
         self.blkid_api = {}
@@ -25,6 +26,7 @@ class Device(object):
         if lv:
             self.lv_api = lv
             self.abspath = lv.lv_path
+            self.vg_name = lv.vg_name
         else:
             dev = disk.lsblk(self.path)
             self.blkid_api = disk.blkid(self.path)
@@ -61,6 +63,8 @@ class Device(object):
                 return self._is_lvm_member
             has_vgs = [pv.vg_name for pv in pvs if pv.vg_name]
             if has_vgs:
+                # a pv can only be in one vg, so this should be safe
+                self.vg_name = has_vgs[0]
                 self._is_lvm_member = True
                 self.pvs_api = pvs
             else:

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -118,7 +118,9 @@ class Device(object):
 
     @property
     def used_by_ceph(self):
-        osd_ids = [lv.tags.get("ceph.osd_id") for lv in self.lvs]
+        # only filter out data devices as journals could potentially be reused
+        osd_ids = [lv.tags.get("ceph.osd_id") for lv in self.lvs
+                   if lv.tags.get("ceph.type") == "data"]
         return any(osd_ids)
 
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -116,6 +116,11 @@ class Device(object):
             return self.disk_api['TYPE'] == 'device'
         return False
 
+    @property
+    def used_by_ceph(self):
+        osd_ids = [lv.tags.get("ceph.osd_id") for lv in self.lvs]
+        return any(osd_ids)
+
 
 class CephDiskDevice(object):
     """

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -11,6 +11,7 @@ class Device(object):
         # LVs can have a vg/lv path, while disks will have /dev/sda
         self.abspath = path
         self.lv_api = None
+        self.lvs = []
         self.vg_name = None
         self.pvs_api = []
         self.disk_api = {}
@@ -25,6 +26,7 @@ class Device(object):
         lv = lvm.get_lv_from_argument(self.path)
         if lv:
             self.lv_api = lv
+            self.lvs = [lv]
             self.abspath = lv.lv_path
             self.vg_name = lv.vg_name
         else:
@@ -67,6 +69,11 @@ class Device(object):
                 self.vg_name = has_vgs[0]
                 self._is_lvm_member = True
                 self.pvs_api = pvs
+                for pv in pvs:
+                    if pv.vg_name and pv.lv_uuid:
+                        lv = lvm.get_lv(vg_name=pv.vg_name, lv_uuid=pv.lv_uuid)
+                        if lv:
+                            self.lvs.append(lv)
             else:
                 # this is contentious, if a PV is recognized by LVM but has no
                 # VGs, should we consider it as part of LVM? We choose not to

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -87,6 +87,12 @@ class Device(object):
         return os.path.exists(self.abspath)
 
     @property
+    def rotational(self):
+        if self.sys_api['rotational'] == '1':
+            return True
+        return False
+
+    @property
     def is_lvm_member(self):
         if self._is_lvm_member is None:
             self._set_lvm_membership()

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -83,7 +83,12 @@ def get_block_db_size(lv_format=True):
     .. note: Configuration values are in bytes, unlike journals which
              are defined in gigabytes
     """
-    conf_db_size = conf.ceph.get_safe('osd', 'bluestore_block_db_size', None)
+    conf_db_size = None
+    try:
+        conf_db_size = conf.ceph.get_safe('osd', 'bluestore_block_db_size', None)
+    except RuntimeError:
+        logger.debug("failed to load ceph configuration, will use defaults")
+
     if not conf_db_size:
         logger.debug(
             'block.db has no size configuration, will fallback to using as much as possible'

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -87,7 +87,7 @@ def get_block_db_size(lv_format=True):
     try:
         conf_db_size = conf.ceph.get_safe('osd', 'bluestore_block_db_size', None)
     except RuntimeError:
-        logger.debug("failed to load ceph configuration, will use defaults")
+        logger.exception("failed to load ceph configuration, will use defaults")
 
     if not conf_db_size:
         logger.debug(

--- a/src/ceph-volume/ceph_volume/util/templates.py
+++ b/src/ceph-volume/ceph_volume/util/templates.py
@@ -15,6 +15,22 @@ total_osds = """
 Total OSDs: {total_osds}
 """
 
+
+def filtered_devices(devices):
+    string = """
+Filtered Devices:"""
+    for device, info in devices.iteritems():
+        string += """
+  %s""" % device
+
+        for reason in info['reasons']:
+            string += """
+    %s""" % reason
+
+    string += "\n"
+    return string
+
+
 ssd_volume_group = """
 Solid State VG:
   Targets:   {target: <25} Total size: {total_lv_size: <25}


### PR DESCRIPTION
When run multiple times in a row with the same input ``ceph-volume lvm batch`` will no longer error and when run with ``--report`` a ``changed`` key is added to the output that will let other systems know if new OSDs will be created or not.

Fixes: http://tracker.ceph.com/issues/26864

