### PR TITLE
rgw: thread DoutPrefixProvider into RGW::Auth_S3::authorize

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -253,7 +253,7 @@ namespace rgw {
     /* XXX authorize does less here then in the REST path, e.g.,
      * the user's info is cached, but still incomplete */
     ldpp_dout(s, 2) << "authorizing" << dendl;
-    ret = req->authorize();
+    ret = req->authorize(op);
     if (ret < 0) {
       dout(10) << "failed to authorize request" << dendl;
       abort_req(s, op, ret);
@@ -368,7 +368,7 @@ namespace rgw {
     /* XXX authorize does less here then in the REST path, e.g.,
      * the user's info is cached, but still incomplete */
     ldpp_dout(s, 2) << "authorizing" << dendl;
-    ret = req->authorize();
+    ret = req->authorize(op);
     if (ret < 0) {
       dout(10) << "failed to authorize request" << dendl;
       abort_req(s, op, ret);
@@ -645,7 +645,7 @@ namespace rgw {
     return ret;
   } /* RGWLibRequest::read_permissions */
 
-  int RGWHandler_Lib::authorize()
+  int RGWHandler_Lib::authorize(const DoutPrefixProvider *dpp)
   {
     /* TODO: handle
      *  1. subusers

--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -52,13 +52,14 @@ void RGWAccessControlList::add_grant(ACLGrant *grant)
   _add_grant(grant);
 }
 
-uint32_t RGWAccessControlList::get_perm(const rgw::auth::Identity& auth_identity,
+uint32_t RGWAccessControlList::get_perm(const DoutPrefixProvider* dpp, 
+                                        const rgw::auth::Identity& auth_identity,
                                         const uint32_t perm_mask)
 {
-  ldout(cct, 5) << "Searching permissions for identity=" << auth_identity
+  ldpp_dout(dpp, 5) << "Searching permissions for identity=" << auth_identity
                 << " mask=" << perm_mask << dendl;
 
-  return perm_mask & auth_identity.get_perms_from_aclspec(acl_user_map);
+  return perm_mask & auth_identity.get_perms_from_aclspec(dpp, acl_user_map);
 }
 
 uint32_t RGWAccessControlList::get_group_perm(ACLGroupTypeEnum group,
@@ -98,14 +99,15 @@ uint32_t RGWAccessControlList::get_referer_perm(const uint32_t current_perm,
   return referer_perm & perm_mask;
 }
 
-uint32_t RGWAccessControlPolicy::get_perm(const rgw::auth::Identity& auth_identity,
+uint32_t RGWAccessControlPolicy::get_perm(const DoutPrefixProvider* dpp,
+                                          const rgw::auth::Identity& auth_identity,
                                           const uint32_t perm_mask,
                                           const char * const http_referer)
 {
-  ldout(cct, 20) << "-- Getting permissions begin with perm_mask=" << perm_mask
+  ldpp_dout(dpp, 20) << "-- Getting permissions begin with perm_mask=" << perm_mask
                  << dendl;
 
-  uint32_t perm = acl.get_perm(auth_identity, perm_mask);
+  uint32_t perm = acl.get_perm(dpp, auth_identity, perm_mask);
 
   if (auth_identity.is_owner_of(owner.get_id())) {
     perm |= perm_mask & (RGW_PERM_READ_ACP | RGW_PERM_WRITE_ACP);
@@ -130,21 +132,22 @@ uint32_t RGWAccessControlPolicy::get_perm(const rgw::auth::Identity& auth_identi
     perm = acl.get_referer_perm(perm, http_referer, perm_mask);
   }
 
-  ldout(cct, 5) << "-- Getting permissions done for identity=" << auth_identity
+  ldpp_dout(dpp, 5) << "-- Getting permissions done for identity=" << auth_identity
                 << ", owner=" << owner.get_id()
                 << ", perm=" << perm << dendl;
 
   return perm;
 }
 
-bool RGWAccessControlPolicy::verify_permission(const rgw::auth::Identity& auth_identity,
+bool RGWAccessControlPolicy::verify_permission(const DoutPrefixProvider* dpp,
+                                               const rgw::auth::Identity& auth_identity,
                                                const uint32_t user_perm_mask,
                                                const uint32_t perm,
                                                const char * const http_referer)
 {
   uint32_t test_perm = perm | RGW_PERM_READ_OBJS | RGW_PERM_WRITE_OBJS;
 
-  uint32_t policy_perm = get_perm(auth_identity, test_perm, http_referer);
+  uint32_t policy_perm = get_perm(dpp, auth_identity, test_perm, http_referer);
 
   /* the swift WRITE_OBJS perm is equivalent to the WRITE obj, just
      convert those bits. Note that these bits will only be set on
@@ -159,7 +162,7 @@ bool RGWAccessControlPolicy::verify_permission(const rgw::auth::Identity& auth_i
    
   uint32_t acl_perm = policy_perm & perm & user_perm_mask;
 
-  ldout(cct, 10) << " identity=" << auth_identity
+  ldpp_dout(dpp, 10) << " identity=" << auth_identity
                  << " requested perm (type)=" << perm
                  << ", policy perm=" << policy_perm
                  << ", user_perm_mask=" << user_perm_mask

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -303,7 +303,8 @@ public:
 
   virtual ~RGWAccessControlList() {}
 
-  uint32_t get_perm(const rgw::auth::Identity& auth_identity,
+  uint32_t get_perm(const DoutPrefixProvider* dpp,
+                    const rgw::auth::Identity& auth_identity,
                     uint32_t perm_mask);
   uint32_t get_group_perm(ACLGroupTypeEnum group, uint32_t perm_mask);
   uint32_t get_referer_perm(uint32_t current_perm,
@@ -413,11 +414,13 @@ public:
     acl.set_ctx(ctx);
   }
 
-  uint32_t get_perm(const rgw::auth::Identity& auth_identity,
+  uint32_t get_perm(const DoutPrefixProvider* dpp,
+                    const rgw::auth::Identity& auth_identity,
                     uint32_t perm_mask,
                     const char * http_referer);
   uint32_t get_group_perm(ACLGroupTypeEnum group, uint32_t perm_mask);
-  bool verify_permission(const rgw::auth::Identity& auth_identity,
+  bool verify_permission(const DoutPrefixProvider* dpp,
+                         const rgw::auth::Identity& auth_identity,
                          uint32_t user_perm_mask,
                          uint32_t perm,
                          const char * http_referer = nullptr);

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -266,7 +266,7 @@ rgw::auth::Strategy::authenticate(const req_state* const s) const
 }
 
 int
-rgw::auth::Strategy::apply(const rgw::auth::Strategy& auth_strategy,
+rgw::auth::Strategy::apply(const DoutPrefixProvider *dpp, const rgw::auth::Strategy& auth_strategy,
                            req_state* const s) noexcept
 {
   try {
@@ -274,7 +274,7 @@ rgw::auth::Strategy::apply(const rgw::auth::Strategy& auth_strategy,
     if (result.get_status() != decltype(result)::Status::GRANTED) {
       /* Access denied is acknowledged by returning a std::unique_ptr with
        * nullptr inside. */
-      ldout(s->cct, 5) << "Failed the auth strategy, reason="
+      ldpp_dout(dpp, 5) << "Failed the auth strategy, reason="
                        << result.get_reason() << dendl;
       return result.get_reason();
     }
@@ -301,11 +301,11 @@ rgw::auth::Strategy::apply(const rgw::auth::Strategy& auth_strategy,
 
       return 0;
     } catch (const int err) {
-      ldout(s->cct, 5) << "applier throwed err=" << err << dendl;
+      ldpp_dout(dpp, 5) << "applier throwed err=" << err << dendl;
       return err;
     }
   } catch (const int err) {
-    ldout(s->cct, 5) << "auth engine throwed err=" << err << dendl;
+    ldpp_dout(dpp, 5) << "auth engine throwed err=" << err << dendl;
     return err;
   }
 

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -38,7 +38,7 @@ public:
    * NOTE: an implementation is responsible for giving the real semantic to
    * the items in @aclspec. That is, their meaning may depend on particular
    * applier that is being used. */
-  virtual uint32_t get_perms_from_aclspec(const aclspec_t& aclspec) const = 0;
+  virtual uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const = 0;
 
   /* Verify whether a given identity *can be treated as* an admin of rgw_user
   * (account in Swift's terminology) specified in @uid. On error throws
@@ -106,11 +106,11 @@ public:
    *
    * XXX: be aware that the "account" term refers to rgw_user. The naming
    * is legacy. */
-  virtual void load_acct_info(RGWUserInfo& user_info) const = 0; /* out */
+  virtual void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const = 0; /* out */
 
   /* Apply any changes to request state. This method will be most useful for
    * TempURL of Swift API. */
-  virtual void modify_request_state(req_state* s) const {}      /* in/out */
+  virtual void modify_request_state(const DoutPrefixProvider* dpp, req_state* s) const {}      /* in/out */
 };
 
 
@@ -146,7 +146,7 @@ public:
 
   /* Apply any changes to request state. The initial use case was injecting
    * the AWSv4 filter over rgw::io::RestfulClient in req_state. */
-  virtual void modify_request_state(req_state* s) = 0;     /* in/out */
+  virtual void modify_request_state(const DoutPrefixProvider* dpp, req_state* s) = 0;     /* in/out */
 };
 
 
@@ -404,7 +404,8 @@ protected:
   const AuthInfo info;
   const bool implicit_tenants;
 
-  virtual void create_account(const rgw_user& acct_user,
+  virtual void create_account(const DoutPrefixProvider* dpp,
+                              const rgw_user& acct_user,
                               RGWUserInfo& user_info) const;          /* out */
 
 public:
@@ -420,14 +421,14 @@ public:
       implicit_tenants(implicit_tenants) {
   }
 
-  uint32_t get_perms_from_aclspec(const aclspec_t& aclspec) const override;
+  uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override;
   bool is_admin_of(const rgw_user& uid) const override;
   bool is_owner_of(const rgw_user& uid) const override;
   bool is_identity(const idset_t& ids) const override;
 
   uint32_t get_perm_mask() const override { return info.perm_mask; }
   void to_str(std::ostream& out) const override;
-  void load_acct_info(RGWUserInfo& user_info) const override; /* out */
+  void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const override; /* out */
   uint32_t get_identity_type() const override { return info.acct_type; }
   string get_acct_name() const override { return info.acct_name; }
 
@@ -481,7 +482,7 @@ public:
   }
 
 
-  uint32_t get_perms_from_aclspec(const aclspec_t& aclspec) const override;
+  uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override;
   bool is_admin_of(const rgw_user& uid) const override;
   bool is_owner_of(const rgw_user& uid) const override;
   bool is_identity(const idset_t& ids) const override;
@@ -493,10 +494,10 @@ public:
     }
   }
   void to_str(std::ostream& out) const override;
-  void load_acct_info(RGWUserInfo& user_info) const override; /* out */
+  void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const override; /* out */
   uint32_t get_identity_type() const override { return TYPE_RGW; }
   string get_acct_name() const override { return {}; }
-  void modify_request_state(req_state* s) const override;
+  void modify_request_state(const DoutPrefixProvider* dpp, req_state* s) const override;
 
   struct Factory {
     virtual ~Factory() {}

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -219,7 +219,7 @@ public:
       /* Engine doesn't grant the access but also doesn't reject it. */
       DENIED,
 
-      /* Engine successfully authenticated requester. */
+      /* Engine successfully authenicated requester. */
       GRANTED,
 
       /* Engine strictly indicates that a request should be rejected
@@ -329,7 +329,7 @@ public:
     return auth_stack.empty();
   }
 
-  static int apply(const Strategy& auth_strategy, req_state* s) noexcept;
+  static int apply(const DoutPrefixProvider* dpp, const Strategy& auth_strategy, req_state* s) noexcept;
 
 private:
   /* Using the reference wrapper here to explicitly point out we are not

--- a/src/rgw/rgw_auth.h
+++ b/src/rgw/rgw_auth.h
@@ -280,7 +280,7 @@ public:
    *    interface.
    *
    * On error throws rgw::auth::Exception containing the reason. */
-  virtual result_t authenticate(const req_state* s) const = 0;
+  virtual result_t authenticate(const DoutPrefixProvider* dpp, const req_state* s) const = 0;
 };
 
 
@@ -323,7 +323,7 @@ public:
     FALLBACK,
   };
 
-  Engine::result_t authenticate(const req_state* s) const override final;
+  Engine::result_t authenticate(const DoutPrefixProvider* dpp, const req_state* s) const override final;
 
   bool is_empty() const {
     return auth_stack.empty();
@@ -526,7 +526,7 @@ public:
     return "rgw::auth::AnonymousEngine";
   }
 
-  Engine::result_t authenticate(const req_state* s) const override final;
+  Engine::result_t authenticate(const DoutPrefixProvider* dpp, const req_state* s) const override final;
 
 protected:
   virtual bool is_applicable(const req_state*) const noexcept {

--- a/src/rgw/rgw_auth_filters.h
+++ b/src/rgw/rgw_auth_filters.h
@@ -64,8 +64,8 @@ public:
     : decoratee(std::forward<DecorateeT>(decoratee)) {
   }
 
-  uint32_t get_perms_from_aclspec(const aclspec_t& aclspec) const override {
-    return get_decoratee().get_perms_from_aclspec(aclspec);
+  uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
+    return get_decoratee().get_perms_from_aclspec(dpp, aclspec);
   }
 
   bool is_admin_of(const rgw_user& uid) const override {
@@ -97,12 +97,12 @@ public:
     get_decoratee().to_str(out);
   }
 
-  void load_acct_info(RGWUserInfo& user_info) const override {  /* out */
-    return get_decoratee().load_acct_info(user_info);
+  void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const override {  /* out */
+    return get_decoratee().load_acct_info(dpp, user_info);
   }
 
-  void modify_request_state(req_state * s) const override {     /* in/out */
-    return get_decoratee().modify_request_state(s);
+  void modify_request_state(const DoutPrefixProvider* dpp, req_state * s) const override {     /* in/out */
+    return get_decoratee().modify_request_state(dpp, s);
   }
 };
 
@@ -128,7 +128,7 @@ public:
   }
 
   void to_str(std::ostream& out) const override;
-  void load_acct_info(RGWUserInfo& user_info) const override;   /* out */
+  void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const override;   /* out */
 };
 
 /* static declaration: UNKNOWN_ACCT will be an empty rgw_user that is a result
@@ -145,16 +145,16 @@ void ThirdPartyAccountApplier<T>::to_str(std::ostream& out) const
 }
 
 template <typename T>
-void ThirdPartyAccountApplier<T>::load_acct_info(RGWUserInfo& user_info) const
+void ThirdPartyAccountApplier<T>::load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const
 {
   if (UNKNOWN_ACCT == acct_user_override) {
     /* There is no override specified by the upper layer. This means that we'll
      * load the account owned by the authenticated identity (aka auth_user). */
-    DecoratedApplier<T>::load_acct_info(user_info);
+    DecoratedApplier<T>::load_acct_info(dpp, user_info);
   } else if (DecoratedApplier<T>::is_owner_of(acct_user_override)) {
     /* The override has been specified but the account belongs to the authenticated
      * identity. We may safely forward the call to a next stage. */
-    DecoratedApplier<T>::load_acct_info(user_info);
+    DecoratedApplier<T>::load_acct_info(dpp, user_info);
   } else {
     /* Compatibility mechanism for multi-tenancy. For more details refer to
      * load_acct_info method of rgw::auth::RemoteApplier. */
@@ -211,8 +211,8 @@ public:
   }
 
   void to_str(std::ostream& out) const override;
-  void load_acct_info(RGWUserInfo& user_info) const override;   /* out */
-  void modify_request_state(req_state* s) const override;       /* in/out */
+  void load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const override;   /* out */
+  void modify_request_state(const DoutPrefixProvider* dpp, req_state* s) const override;       /* in/out */
 };
 
 template <typename T>
@@ -223,13 +223,13 @@ void SysReqApplier<T>::to_str(std::ostream& out) const
 }
 
 template <typename T>
-void SysReqApplier<T>::load_acct_info(RGWUserInfo& user_info) const
+void SysReqApplier<T>::load_acct_info(const DoutPrefixProvider* dpp, RGWUserInfo& user_info) const
 {
-  DecoratedApplier<T>::load_acct_info(user_info);
+  DecoratedApplier<T>::load_acct_info(dpp, user_info);
   is_system = user_info.system;
 
   if (is_system) {
-    //dout(20) << "system request" << dendl;
+    //ldpp_dout(dpp, 20) << "system request" << dendl;
 
     rgw_user effective_uid(args.sys_get(RGW_SYS_PARAM_PREFIX "uid"));
     if (! effective_uid.empty()) {
@@ -238,7 +238,7 @@ void SysReqApplier<T>::load_acct_info(RGWUserInfo& user_info) const
        * calls ::decode instead. */
       RGWUserInfo euser_info;
       if (rgw_get_user_info_by_uid(store, effective_uid, euser_info) < 0) {
-        //ldout(s->cct, 0) << "User lookup failed!" << dendl;
+        //ldpp_dout(dpp, 0) << "User lookup failed!" << dendl;
         throw -EACCES;
       }
       user_info = euser_info;
@@ -247,18 +247,18 @@ void SysReqApplier<T>::load_acct_info(RGWUserInfo& user_info) const
 }
 
 template <typename T>
-void SysReqApplier<T>::modify_request_state(req_state* const s) const
+void SysReqApplier<T>::modify_request_state(const DoutPrefixProvider* dpp, req_state* const s) const
 {
   if (boost::logic::indeterminate(is_system)) {
     RGWUserInfo unused_info;
-    load_acct_info(unused_info);
+    load_acct_info(dpp, unused_info);
   }
 
   if (is_system) {
     s->info.args.set_system();
     s->system_request = true;
   }
-  DecoratedApplier<T>::modify_request_state(s);
+  DecoratedApplier<T>::modify_request_state(dpp, s);
 }
 
 template <typename T> static inline

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -37,10 +37,10 @@ class TokenEngine : public rgw::auth::Engine {
 
   /* Helper methods. */
   bool is_applicable(const std::string& token) const noexcept;
-  token_envelope_t decode_pki_token(const std::string& token) const;
+  token_envelope_t decode_pki_token(const DoutPrefixProvider* dpp, const std::string& token) const;
 
   boost::optional<token_envelope_t>
-  get_from_keystone(const std::string& token) const;
+  get_from_keystone(const DoutPrefixProvider* dpp, const std::string& token) const;
 
   acl_strategy_t get_acl_strategy(const token_envelope_t& token) const;
   auth_info_t get_creds_info(const token_envelope_t& token,
@@ -89,7 +89,7 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
                              const std::vector<std::string>& admin_roles
                             ) const noexcept;
   std::pair<boost::optional<token_envelope_t>, int>
-  get_from_keystone(const boost::string_view& access_key_id,
+  get_from_keystone(const DoutPrefixProvider* dpp, const boost::string_view& access_key_id,
                     const std::string& string_to_sign,
                     const boost::string_view& signature) const;
   result_t authenticate(const DoutPrefixProvider* dpp,

--- a/src/rgw/rgw_auth_keystone.h
+++ b/src/rgw/rgw_auth_keystone.h
@@ -46,7 +46,8 @@ class TokenEngine : public rgw::auth::Engine {
   auth_info_t get_creds_info(const token_envelope_t& token,
                              const std::vector<std::string>& admin_roles
                             ) const noexcept;
-  result_t authenticate(const std::string& token,
+  result_t authenticate(const DoutPrefixProvider* dpp,
+                        const std::string& token,
                         const req_state* s) const;
 
 public:
@@ -66,8 +67,8 @@ public:
     return "rgw::auth::keystone::TokenEngine";
   }
 
-  result_t authenticate(const req_state* const s) const override {
-    return authenticate(extractor->get_token(s), s);
+  result_t authenticate(const DoutPrefixProvider* dpp, const req_state* const s) const override {
+    return authenticate(dpp, extractor->get_token(s), s);
   }
 }; /* class TokenEngine */
 
@@ -91,7 +92,8 @@ class EC2Engine : public rgw::auth::s3::AWSEngine {
   get_from_keystone(const boost::string_view& access_key_id,
                     const std::string& string_to_sign,
                     const boost::string_view& signature) const;
-  result_t authenticate(const boost::string_view& access_key_id,
+  result_t authenticate(const DoutPrefixProvider* dpp,
+                        const boost::string_view& access_key_id,
                         const boost::string_view& signature,
                         const boost::string_view& session_token,
                         const string_to_sign_t& string_to_sign,

--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -1009,7 +1009,7 @@ size_t AWSv4ComplMulti::recv_body(char* const buf, const size_t buf_max)
   return buf_pos;
 }
 
-void AWSv4ComplMulti::modify_request_state(req_state* const s_rw)
+void AWSv4ComplMulti::modify_request_state(const DoutPrefixProvider* dpp, req_state* const s_rw)
 {
   const char* const decoded_length = \
     s_rw->info.env->get("HTTP_X_AMZ_DECODED_CONTENT_LENGTH");
@@ -1021,7 +1021,7 @@ void AWSv4ComplMulti::modify_request_state(req_state* const s_rw)
     s_rw->content_length = parse_content_length(decoded_length);
 
     if (s_rw->content_length < 0) {
-      ldout(cct, 10) << "negative AWSv4's content length, aborting" << dendl;
+      ldpp_dout(dpp, 10) << "negative AWSv4's content length, aborting" << dendl;
       throw -EINVAL;
     }
   }
@@ -1075,7 +1075,7 @@ size_t AWSv4ComplSingle::recv_body(char* const buf, const size_t max)
   return received;
 }
 
-void AWSv4ComplSingle::modify_request_state(req_state* const s_rw)
+void AWSv4ComplSingle::modify_request_state(const DoutPrefixProvider* dpp, req_state* const s_rw)
 {
   /* Install the filter over rgw::io::RestfulClient. */
   AWS_AUTHv4_IO(s_rw)->add_filter(

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -348,7 +348,7 @@ public:
   size_t recv_body(char* buf, size_t max) override;
 
   /* rgw::auth::Completer. */
-  void modify_request_state(req_state* s_rw) override;
+  void modify_request_state(const DoutPrefixProvider* dpp, req_state* s_rw) override;
   bool complete() override;
 
   /* Factories. */
@@ -385,7 +385,7 @@ public:
   size_t recv_body(char* buf, size_t max) override;
 
   /* rgw::auth::Completer. */
-  void modify_request_state(req_state* s_rw) override;
+  void modify_request_state(const DoutPrefixProvider* dpp, req_state* s_rw) override;
   bool complete() override;
 
   /* Factories. */

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2294,20 +2294,25 @@ rgw::IAM::Effect eval_user_policies(const vector<rgw::IAM::Policy>& user_policie
                           boost::optional<const rgw::auth::Identity&> id,
                           const uint64_t op,
                           const rgw::IAM::ARN& arn);
-bool verify_user_permission(struct req_state * const s,
+bool verify_user_permission(const DoutPrefixProvider* dpp,
+                            struct req_state * const s,
                             RGWAccessControlPolicy * const user_acl,
                             const vector<rgw::IAM::Policy>& user_policies,
                             const rgw::IAM::ARN& res,
                             const uint64_t op);
-bool verify_user_permission_no_policy(struct req_state * const s,
+bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
+                                      struct req_state * const s,
                                       RGWAccessControlPolicy * const user_acl,
                                       const int perm);
-bool verify_user_permission(struct req_state * const s,
+bool verify_user_permission(const DoutPrefixProvider* dpp,
+                            struct req_state * const s,
                             const rgw::IAM::ARN& res,
                             const uint64_t op);
-bool verify_user_permission_no_policy(struct req_state * const s,
+bool verify_user_permission_no_policy(const DoutPrefixProvider* dpp,
+                                      struct req_state * const s,
                                       int perm);
 bool verify_bucket_permission(
+  const DoutPrefixProvider* dpp,
   struct req_state * const s,
   const rgw_bucket& bucket,
   RGWAccessControlPolicy * const user_acl,
@@ -2315,17 +2320,20 @@ bool verify_bucket_permission(
   const boost::optional<rgw::IAM::Policy>& bucket_policy,
   const vector<rgw::IAM::Policy>& user_policies,
   const uint64_t op);
-bool verify_bucket_permission(struct req_state * const s, const uint64_t op);
+bool verify_bucket_permission(const DoutPrefixProvider* dpp, struct req_state * const s, const uint64_t op);
 bool verify_bucket_permission_no_policy(
+  const DoutPrefixProvider* dpp,
   struct req_state * const s,
   RGWAccessControlPolicy * const user_acl,
   RGWAccessControlPolicy * const bucket_acl,
   const int perm);
-bool verify_bucket_permission_no_policy(struct req_state * const s,
+bool verify_bucket_permission_no_policy(const DoutPrefixProvider* dpp,
+                                        struct req_state * const s,
 					const int perm);
 int verify_bucket_owner_or_policy(struct req_state* const s,
 				  const uint64_t op);
 extern bool verify_object_permission(
+  const DoutPrefixProvider* dpp,
   struct req_state * const s,
   const rgw_obj& obj,
   RGWAccessControlPolicy * const user_acl,
@@ -2334,14 +2342,15 @@ extern bool verify_object_permission(
   const boost::optional<rgw::IAM::Policy>& bucket_policy,
   const vector<rgw::IAM::Policy>& user_policies,
   const uint64_t op);
-extern bool verify_object_permission(struct req_state *s, uint64_t op);
+extern bool verify_object_permission(const DoutPrefixProvider* dpp, struct req_state *s, uint64_t op);
 extern bool verify_object_permission_no_policy(
+  const DoutPrefixProvider* dpp,
   struct req_state * const s,
   RGWAccessControlPolicy * const user_acl,
   RGWAccessControlPolicy * const bucket_acl,
   RGWAccessControlPolicy * const object_acl,
   int perm);
-extern bool verify_object_permission_no_policy(struct req_state *s,
+extern bool verify_object_permission_no_policy(const DoutPrefixProvider* dpp, struct req_state *s,
 					       int perm);
 /** Convert an input URL into a sane object name
  * by converting %-escaped strings into characters, etc*/

--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -115,7 +115,7 @@ namespace rgw {
     friend class RGWRESTMgr_Lib;
   public:
 
-    int authorize() override;
+    int authorize(const DoutPrefixProvider *dpp) override;
 
     RGWHandler_Lib() {}
     ~RGWHandler_Lib() override {}

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -92,7 +92,7 @@ public:
   }
 
   virtual int read_permissions(RGWOp* op) = 0;
-  virtual int authorize() = 0;
+  virtual int authorize(const DoutPrefixProvider* dpp) = 0;
   virtual int postauth_init() = 0;
   virtual int error_handler(int err_no, std::string* error_content);
   virtual void dump(const string& code, const string& message) const {}
@@ -162,7 +162,7 @@ public:
    * of special cases. */
   virtual int verify_requester(const rgw::auth::StrategyRegistry& auth_registry) {
     /* TODO(rzarzynski): rename RGWHandler::authorize to generic_authenticate. */
-    return dialect_handler->authorize();
+    return dialect_handler->authorize(this);
   }
   virtual int verify_permission() = 0;
   virtual int verify_op_mask();

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -404,6 +404,7 @@ public:
 
   class Deleter {
   protected:
+    const DoutPrefixProvider * dpp;
     unsigned int num_deleted;
     unsigned int num_unfound;
     std::list<fail_desc_t> failures;
@@ -412,8 +413,9 @@ public:
     req_state * const s;
 
   public:
-    Deleter(RGWRados * const str, req_state * const s)
-      : num_deleted(0),
+    Deleter(const DoutPrefixProvider* dpp, RGWRados * const str, req_state * const s)
+      : dpp(dpp),
+        num_deleted(0),
         num_unfound(0),
         store(str),
         s(s) {

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -39,7 +39,8 @@ int RGWRestRole::verify_permission()
 
   string resource_name = role.get_path() + role_name;
   uint64_t op = get_op();
-  if (!verify_user_permission(s,
+  if (!verify_user_permission(this,
+                              s,
                               rgw::IAM::ARN(resource_name,
                                             "role",
                                              s->user->user_id.tenant, true),
@@ -85,7 +86,8 @@ int RGWCreateRole::verify_permission()
   string role_path = s->info.args.get("Path");
 
   string resource_name = role_path + role_name;
-  if (!verify_user_permission(s,
+  if (!verify_user_permission(this,
+                              s,
                               rgw::IAM::ARN(resource_name,
                                             "role",
                                              s->user->user_id.tenant, true),
@@ -183,7 +185,8 @@ int RGWGetRole::_verify_permission(const RGWRole& role)
   }
 
   string resource_name = role.get_path() + role.get_name();
-  if (!verify_user_permission(s,
+  if (!verify_user_permission(this,
+                              s,
                               rgw::IAM::ARN(resource_name,
                                             "role",
                                              s->user->user_id.tenant, true),
@@ -268,7 +271,8 @@ int RGWListRoles::verify_permission()
     return ret;
   }
 
-  if (!verify_user_permission(s,
+  if (!verify_user_permission(this, 
+                              s,
                               rgw::IAM::ARN(),
                               get_op())) {
     return -EACCES;

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -754,7 +754,8 @@ protected:
   /* TODO(rzarzynski): clean up. We've too many input parameter hee. Also
    * the signature get_auth_data() of VersionAbstractor is too complicated.
    * Replace these thing with a simple, dedicated structure. */
-  virtual result_t authenticate(const boost::string_view& access_key_id,
+  virtual result_t authenticate(const DoutPrefixProvider* dpp,
+                                const boost::string_view& access_key_id,
                                 const boost::string_view& signature,
                                 const boost::string_view& session_token,
                                 const string_to_sign_t& string_to_sign,
@@ -763,7 +764,7 @@ protected:
                                 const req_state* s) const = 0;
 
 public:
-  result_t authenticate(const req_state* const s) const final;
+  result_t authenticate(const DoutPrefixProvider* dpp, const req_state* const s) const final;
 };
 
 
@@ -830,7 +831,8 @@ protected:
   acl_strategy_t get_acl_strategy() const;
   auth_info_t get_creds_info(const rgw::RGWToken& token) const noexcept;
 
-  result_t authenticate(const boost::string_view& access_key_id,
+  result_t authenticate(const DoutPrefixProvider* dpp,
+                        const boost::string_view& access_key_id,
                         const boost::string_view& signature,
                         const boost::string_view& session_token,
                         const string_to_sign_t& string_to_sign,
@@ -861,7 +863,8 @@ class LocalEngine : public AWSEngine {
   RGWRados* const store;
   const rgw::auth::LocalApplier::Factory* const apl_factory;
 
-  result_t authenticate(const boost::string_view& access_key_id,
+  result_t authenticate(const DoutPrefixProvider* dpp,
+                        const boost::string_view& access_key_id,
                         const boost::string_view& signature,
                         const boost::string_view& session_token,
                         const string_to_sign_t& string_to_sign,

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -902,7 +902,8 @@ class STSEngine : public AWSEngine {
   int get_session_token(const boost::string_view& session_token,
                         STS::SessionToken& token) const;
 
-  result_t authenticate(const boost::string_view& access_key_id,
+  result_t authenticate(const DoutPrefixProvider* dpp, 
+                        const boost::string_view& access_key_id,
                         const boost::string_view& signature,
                         const boost::string_view& session_token,
                         const string_to_sign_t& string_to_sign,

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -468,7 +468,8 @@ public:
 
 class RGW_Auth_S3 {
 public:
-  static int authorize(RGWRados *store,
+  static int authorize(const DoutPrefixProvider *dpp,
+                       RGWRados *store,
                        const rgw::auth::StrategyRegistry& auth_registry,
                        struct req_state *s);
 };
@@ -491,8 +492,8 @@ public:
   int init(RGWRados *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
-  int authorize() override {
-    return RGW_Auth_S3::authorize(store, auth_registry, s);
+  int authorize(const DoutPrefixProvider *dpp) override {
+    return RGW_Auth_S3::authorize(dpp, store, auth_registry, s);
   }
   int postauth_init() override { return 0; }
 };
@@ -513,8 +514,8 @@ public:
   int init(RGWRados *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
-  int authorize() override {
-    return RGW_Auth_S3::authorize(store, auth_registry, s);
+  int authorize(const DoutPrefixProvider *dpp) override {
+    return RGW_Auth_S3::authorize(dpp, store, auth_registry, s);
   }
   int postauth_init() override;
 };

--- a/src/rgw/rgw_rest_sts.h
+++ b/src/rgw/rgw_rest_sts.h
@@ -57,8 +57,8 @@ public:
   int init(RGWRados *store,
            struct req_state *s,
            rgw::io::BasicClient *cio) override;
-  int authorize() override {
-    return RGW_Auth_S3::authorize(store, auth_registry, s);
+  int authorize(const DoutPrefixProvider* dpp) override {
+    return RGW_Auth_S3::authorize(dpp, store, auth_registry, s);
   }
   int postauth_init() override { return 0; }
 };

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2772,9 +2772,9 @@ RGWOp *RGWHandler_REST_Obj_SWIFT::op_options()
 }
 
 
-int RGWHandler_REST_SWIFT::authorize()
+int RGWHandler_REST_SWIFT::authorize(const DoutPrefixProvider *dpp)
 {
-  return rgw::auth::Strategy::apply(auth_strategy, s);
+  return rgw::auth::Strategy::apply(dpp, auth_strategy, s);
 }
 
 int RGWHandler_REST_SWIFT::postauth_init()

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -395,7 +395,7 @@ public:
   int validate_bucket_name(const string& bucket);
 
   int init(RGWRados *store, struct req_state *s, rgw::io::BasicClient *cio) override;
-  int authorize() override;
+  int authorize(const DoutPrefixProvider *dpp) override;
   int postauth_init() override;
 
   RGWAccessControlPolicy *alloc_policy() { return nullptr; /* return new RGWAccessControlPolicy_SWIFT; */ }
@@ -543,7 +543,7 @@ public:
     return RGWHandler::init(store, state, cio);
   }
 
-  int authorize() override {
+  int authorize(const DoutPrefixProvider *dpp) override {
     return 0;
   }
 
@@ -599,7 +599,7 @@ public:
     return RGWHandler::init(store, state, cio);
   }
 
-  int authorize() override {
+  int authorize(const DoutPrefixProvider *dpp) override {
     return 0;
   }
 
@@ -655,7 +655,7 @@ public:
     return RGWHandler::init(store, state, cio);
   }
 
-  int authorize() override {
+  int authorize(const DoutPrefixProvider *dpp) override {
     return 0;
   }
 

--- a/src/rgw/rgw_rest_user_policy.cc
+++ b/src/rgw/rgw_rest_user_policy.cc
@@ -48,7 +48,7 @@ int RGWRestUserPolicy::verify_permission()
   uint64_t op = get_op();
   string user_name = s->info.args.get("UserName");
   rgw_user user_id(user_name);
-  if (! verify_user_permission(s, rgw::IAM::ARN(rgw::IAM::ARN(user_id.id,
+  if (! verify_user_permission(this, s, rgw::IAM::ARN(rgw::IAM::ARN(user_id.id,
                                                 "user",
                                                  user_id.tenant)), op)) {
     return -EACCES;

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -244,7 +244,7 @@ public:
 }; /* TempURLEngine::PrefixableSignatureHelper */
 
 TempURLEngine::result_t
-TempURLEngine::authenticate(const req_state* const s) const
+TempURLEngine::authenticate(const DoutPrefixProvider* dpp, const req_state* const s) const
 {
   if (! is_applicable(s)) {
     return result_t::deny();
@@ -270,17 +270,17 @@ TempURLEngine::authenticate(const req_state* const s) const
   try {
     get_owner_info(s, owner_info);
   } catch (...) {
-    ldout(cct, 5) << "cannot get user_info of account's owner" << dendl;
+    ldpp_dout(dpp, 5) << "cannot get user_info of account's owner" << dendl;
     return result_t::reject();
   }
 
   if (owner_info.temp_url_keys.empty()) {
-    ldout(cct, 5) << "user does not have temp url key set, aborting" << dendl;
+    ldpp_dout(dpp, 5) << "user does not have temp url key set, aborting" << dendl;
     return result_t::reject();
   }
 
   if (is_expired(temp_url_expires)) {
-    ldout(cct, 5) << "temp url link expired" << dendl;
+    ldpp_dout(dpp, 5) << "temp url link expired" << dendl;
     return result_t::reject(-EPERM);
   }
 
@@ -331,7 +331,7 @@ TempURLEngine::authenticate(const req_state* const s) const
         const char* const local_sig = sig_helper.calc(temp_url_key, method,
                                                       path, temp_url_expires);
 
-        ldout(s->cct, 20) << "temp url signature [" << temp_url_key_num
+        ldpp_dout(dpp, 20) << "temp url signature [" << temp_url_key_num
                           << "] (calculated): " << local_sig
                           << dendl;
 
@@ -339,7 +339,7 @@ TempURLEngine::authenticate(const req_state* const s) const
           auto apl = apl_factory->create_apl_turl(cct, s, owner_info);
           return result_t::grant(std::move(apl));
         } else {
-          ldout(s->cct,  5) << "temp url signature mismatch: " << local_sig
+          ldpp_dout(dpp,  5) << "temp url signature mismatch: " << local_sig
                             << " != " << temp_url_sig  << dendl;
         }
       }
@@ -363,7 +363,8 @@ bool ExternalTokenEngine::is_applicable(const std::string& token) const noexcept
 }
 
 ExternalTokenEngine::result_t
-ExternalTokenEngine::authenticate(const std::string& token,
+ExternalTokenEngine::authenticate(const DoutPrefixProvider* dpp,
+                                  const std::string& token,
                                   const req_state* const s) const
 {
   if (! is_applicable(token)) {
@@ -381,7 +382,7 @@ ExternalTokenEngine::authenticate(const std::string& token,
 
   RGWHTTPHeadersCollector validator(cct, "GET", url_buf, { "X-Auth-Groups", "X-Auth-Ttl" });
 
-  ldout(cct, 10) << "rgw_swift_validate_token url=" << url_buf << dendl;
+  ldpp_dout(dpp, 10) << "rgw_swift_validate_token url=" << url_buf << dendl;
 
   int ret = validator.process();
   if (ret < 0) {
@@ -408,12 +409,12 @@ ExternalTokenEngine::authenticate(const std::string& token,
     return result_t::deny(-EPERM);
   }
 
-  ldout(cct, 10) << "swift user=" << swift_user << dendl;
+  ldpp_dout(dpp, 10) << "swift user=" << swift_user << dendl;
 
   RGWUserInfo tmp_uinfo;
   ret = rgw_get_user_info_by_swift(store, swift_user, tmp_uinfo);
   if (ret < 0) {
-    ldout(cct, 0) << "NOTICE: couldn't map swift user" << dendl;
+    ldpp_dout(dpp, 0) << "NOTICE: couldn't map swift user" << dendl;
     throw ret;
   }
 
@@ -477,7 +478,8 @@ bool SignedTokenEngine::is_applicable(const std::string& token) const noexcept
 }
 
 SignedTokenEngine::result_t
-SignedTokenEngine::authenticate(const std::string& token,
+SignedTokenEngine::authenticate(const DoutPrefixProvider* dpp,
+                                const std::string& token,
                                 const req_state* const s) const
 {
   if (! is_applicable(token)) {
@@ -489,7 +491,7 @@ SignedTokenEngine::authenticate(const std::string& token,
   const size_t etoken_len = etoken.length();
 
   if (etoken_len & 1) {
-    ldout(cct, 0) << "NOTICE: failed to verify token: odd token length="
+    ldpp_dout(dpp, 0) << "NOTICE: failed to verify token: odd token length="
 	          << etoken_len << dendl;
     throw -EINVAL;
   }
@@ -515,13 +517,13 @@ SignedTokenEngine::authenticate(const std::string& token,
     decode(nonce, iter);
     decode(expiration, iter);
   } catch (buffer::error& err) {
-    ldout(cct, 0) << "NOTICE: failed to decode token" << dendl;
+    ldpp_dout(dpp, 0) << "NOTICE: failed to decode token" << dendl;
     throw -EINVAL;
   }
 
   const utime_t now = ceph_clock_now();
   if (expiration < now) {
-    ldout(cct, 0) << "NOTICE: old timed out token was used now=" << now
+    ldpp_dout(dpp, 0) << "NOTICE: old timed out token was used now=" << now
 	          << " token.expiration=" << expiration
                   << dendl;
     return result_t::deny(-EPERM);
@@ -533,7 +535,7 @@ SignedTokenEngine::authenticate(const std::string& token,
     throw ret;
   }
 
-  ldout(cct, 10) << "swift_user=" << swift_user << dendl;
+  ldpp_dout(dpp, 10) << "swift_user=" << swift_user << dendl;
 
   const auto siter = user_info.swift_keys.find(swift_user);
   if (siter == std::end(user_info.swift_keys)) {
@@ -549,7 +551,7 @@ SignedTokenEngine::authenticate(const std::string& token,
   }
 
   if (local_tok_bl.length() != tok_bl.length()) {
-    ldout(cct, 0) << "NOTICE: tokens length mismatch:"
+    ldpp_dout(dpp, 0) << "NOTICE: tokens length mismatch:"
                   << " tok_bl.length()=" << tok_bl.length()
 	          << " local_tok_bl.length()=" << local_tok_bl.length()
                   << dendl;
@@ -563,7 +565,7 @@ SignedTokenEngine::authenticate(const std::string& token,
     buf_to_hex(reinterpret_cast<const unsigned char *>(local_tok_bl.c_str()),
                local_tok_bl.length(), buf);
 
-    ldout(cct, 0) << "NOTICE: tokens mismatch tok=" << buf << dendl;
+    ldpp_dout(dpp, 0) << "NOTICE: tokens mismatch tok=" << buf << dendl;
     return result_t::deny(-EPERM);
   }
 

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -709,7 +709,7 @@ int RGWHandler_SWIFT_Auth::init(RGWRados *store, struct req_state *state,
   return RGWHandler::init(store, state, cio);
 }
 
-int RGWHandler_SWIFT_Auth::authorize()
+int RGWHandler_SWIFT_Auth::authorize(const DoutPrefixProvider *dpp)
 {
   return 0;
 }

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -33,7 +33,7 @@ namespace auth {
 namespace swift {
 
 /* TempURL: applier */
-void TempURLApplier::modify_request_state(req_state* s) const       /* in/out */
+void TempURLApplier::modify_request_state(const DoutPrefixProvider* dpp, req_state* s) const       /* in/out */
 {
   bool inline_exists = false;
   const std::string& filename = s->info.args.get("filename");
@@ -51,7 +51,7 @@ void TempURLApplier::modify_request_state(req_state* s) const       /* in/out */
     s->content_disp.fallback = "attachment; filename=\"" + fenc + "\"";
   }
 
-  ldout(s->cct, 20) << "finished applying changes to req_state for TempURL: "
+  ldpp_dout(dpp, 20) << "finished applying changes to req_state for TempURL: "
                     << " content_disp override " << s->content_disp.override
                     << " content_disp fallback " << s->content_disp.fallback
                     << dendl;

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -65,7 +65,7 @@ bool TempURLEngine::is_applicable(const req_state* const s) const noexcept
          s->info.args.exists("temp_url_expires");
 }
 
-void TempURLEngine::get_owner_info(const req_state* const s,
+void TempURLEngine::get_owner_info(const DoutPrefixProvider* dpp, const req_state* const s,
                                    RGWUserInfo& owner_info) const
 {
   /* We cannot use req_state::bucket_name because it isn't available
@@ -113,7 +113,7 @@ void TempURLEngine::get_owner_info(const req_state* const s,
     throw ret;
   }
 
-  ldout(cct, 20) << "temp url user (bucket owner): " << bucket_info.owner
+  ldpp_dout(dpp, 20) << "temp url user (bucket owner): " << bucket_info.owner
                  << dendl;
 
   if (rgw_get_user_info_by_uid(store, bucket_info.owner, owner_info) < 0) {
@@ -268,7 +268,7 @@ TempURLEngine::authenticate(const DoutPrefixProvider* dpp, const req_state* cons
 
   RGWUserInfo owner_info;
   try {
-    get_owner_info(s, owner_info);
+    get_owner_info(dpp, s, owner_info);
   } catch (...) {
     ldpp_dout(dpp, 5) << "cannot get user_info of account's owner" << dendl;
     return result_t::reject();

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -43,7 +43,8 @@ class TempURLEngine : public rgw::auth::Engine {
   const TempURLApplier::Factory* const apl_factory;
 
   /* Helper methods. */
-  void get_owner_info(const req_state* s,
+  void get_owner_info(const DoutPrefixProvider* dpp, 
+                      const req_state* s,
                       RGWUserInfo& owner_info) const;
   bool is_applicable(const req_state* s) const noexcept;
   bool is_expired(const std::string& expires) const;

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -24,7 +24,7 @@ public:
     : LocalApplier(cct, user_info, LocalApplier::NO_SUBUSER, boost::none, boost::none) {
   };
 
-  void modify_request_state(req_state * s) const override; /* in/out */
+  void modify_request_state(const DoutPrefixProvider* dpp, req_state * s) const override; /* in/out */
 
   struct Factory {
     virtual ~Factory() {}

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -65,7 +65,7 @@ public:
     return "rgw::auth::swift::TempURLEngine";
   }
 
-  result_t authenticate(const req_state* const s) const override;
+  result_t authenticate(const DoutPrefixProvider* dpp, const req_state* const s) const override;
 };
 
 
@@ -79,7 +79,8 @@ class SignedTokenEngine : public rgw::auth::Engine {
   const rgw::auth::LocalApplier::Factory* const apl_factory;
 
   bool is_applicable(const std::string& token) const noexcept;
-  result_t authenticate(const std::string& token,
+  result_t authenticate(const DoutPrefixProvider* dpp,
+                        const std::string& token,
                         const req_state* s) const;
 
 public:
@@ -97,8 +98,8 @@ public:
     return "rgw::auth::swift::SignedTokenEngine";
   }
 
-  result_t authenticate(const req_state* const s) const override {
-    return authenticate(extractor->get_token(s), s);
+  result_t authenticate(const DoutPrefixProvider* dpp, const req_state* const s) const override {
+    return authenticate(dpp, extractor->get_token(s), s);
   }
 };
 
@@ -113,7 +114,8 @@ class ExternalTokenEngine : public rgw::auth::Engine {
   const rgw::auth::LocalApplier::Factory* const apl_factory;
 
   bool is_applicable(const std::string& token) const noexcept;
-  result_t authenticate(const std::string& token,
+  result_t authenticate(const DoutPrefixProvider* dpp,
+                        const std::string& token,
                         const req_state* s) const;
 
 public:
@@ -131,8 +133,8 @@ public:
     return "rgw::auth::swift::ExternalTokenEngine";
   }
 
-  result_t authenticate(const req_state* const s) const override {
-    return authenticate(extractor->get_token(s), s);
+  result_t authenticate(const DoutPrefixProvider* dpp, const req_state* const s) const override {
+    return authenticate(dpp, extractor->get_token(s), s);
   }
 };
 

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -290,7 +290,7 @@ public:
   RGWOp *op_get() override;
 
   int init(RGWRados *store, struct req_state *state, rgw::io::BasicClient *cio) override;
-  int authorize() override;
+  int authorize(const DoutPrefixProvider *dpp) override;
   int postauth_init() override { return 0; }
   int read_permissions(RGWOp *op) override { return 0; }
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -91,7 +91,7 @@ class FakeIdentity : public Identity {
 public:
 
   explicit FakeIdentity(Principal&& id) : id(std::move(id)) {}
-  uint32_t get_perms_from_aclspec(const aclspec_t& aclspec) const override {
+  uint32_t get_perms_from_aclspec(const DoutPrefixProvider* dpp, const aclspec_t& aclspec) const override {
     ceph_abort();
     return 0;
   };


### PR DESCRIPTION
Pass a DPP into RGWOp::verify_request that leads
through RGWHandler -> RGWHandler_REST->
RGW::Auth_S3::authorize().

Changing the logging in the auth engines is next

Signed-off-by: Ali Maredia <amaredia@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

