### PR TITLE
mimic: mds: internal op missing events time 'throttled', 'all_read', 'dispatched'

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9279,10 +9279,14 @@ MDRequestRef MDCache::request_start_slave(metareqid_t ri, __u32 attempt, Message
 
 MDRequestRef MDCache::request_start_internal(int op)
 {
+  utime_t now = ceph_clock_now();
   MDRequestImpl::Params params;
   params.reqid.name = entity_name_t::MDS(mds->get_nodeid());
   params.reqid.tid = mds->issue_tid();
-  params.initiated = ceph_clock_now();
+  params.initiated = now;
+  params.throttled = now;
+  params.all_read = now;
+  params.dispatched = now;
   params.internal_op = op;
   MDRequestRef mdr =
       mds->op_tracker.create_request<MDRequestImpl,MDRequestImpl::Params*>(&params);


### PR DESCRIPTION
http://tracker.ceph.com/issues/36195