### PR TITLE
doc: install build-doc deps without git clone

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,3 +1,3 @@
 Sphinx == 1.6.3
--e git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
--e git+https://github.com/michaeljones/breathe#egg=breathe
+git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
+git+https://github.com/michaeljones/breathe#egg=breathe


### PR DESCRIPTION
With `-e` the repository is cloned, leading to `git clean` skipping
the cloned dependencies due to the `.git` directory, and forcing manual
removal.

[nwatkins@daq ceph]$ git clean -dxf
Skipping repository build-doc/virtualenv/src/breathe
Skipping repository build-doc/virtualenv/src/sphinx-ditaa

Signed-off-by: Noah Watkins <nwatkins@redhat.com>
