### PR TITLE
luminous: mds: track average session uptime

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2144,6 +2144,7 @@ void MDSRankDispatcher::dump_sessions(const SessionFilter &filter, Formatter *f)
     if (s->is_open() || s->is_stale()) {
       f->dump_unsigned("request_load_avg", s->get_load_avg());
     }
+    f->dump_float("uptime", s->get_session_uptime());
     f->dump_int("replay_requests", is_clientreplay() ? s->get_request_count() : 0);
     f->dump_unsigned("completed_requests", s->get_num_completed_requests());
     f->dump_bool("reconnecting", server->waiting_for_reconnect(p->first.num()));

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -258,6 +258,9 @@ void MDSRankDispatcher::tick()
   // make sure mds log flushes, trims periodically
   mdlog->flush();
 
+  // update average session uptime
+  sessionmap.update_average_session_age();
+
   if (is_active() || is_stopping()) {
     mdcache->trim();
     mdcache->trim_client_leases();

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -62,6 +62,9 @@ void SessionMap::register_perfcounters()
               "Sessions currently stale");
   plb.add_u64(l_mdssm_total_load, "total_load", "Total Load");
   plb.add_u64(l_mdssm_avg_load, "average_load", "Average Load");
+  plb.add_u64(l_mdssm_avg_session_uptime, "avg_session_uptime",
+               "Average session uptime");
+
   logger = plb.create_perf_counters();
   g_ceph_context->get_perfcounters_collection()->add(logger);
 }
@@ -627,6 +630,8 @@ void SessionMap::add_session(Session *s)
   by_state_entry->second->push_back(&s->item_session_list);
   s->get();
 
+  update_average_birth_time(*s);
+
   logger->set(l_mdssm_session_count, session_map.size());
   logger->inc(l_mdssm_session_add);
 }
@@ -634,6 +639,8 @@ void SessionMap::add_session(Session *s)
 void SessionMap::remove_session(Session *s)
 {
   dout(10) << __func__ << " s=" << s << " name=" << s->info.inst.name << dendl;
+
+  update_average_birth_time(*s, false);
 
   s->trim_completed_requests(0);
   s->item_session_list.remove_myself();
@@ -1003,6 +1010,15 @@ void SessionMap::handle_conf_change(const struct md_config_t *conf,
       }
     }
   }
+}
+
+void SessionMap::update_average_session_age() {
+  if (!session_map.size()) {
+    return;
+  }
+
+  double avg_uptime = std::chrono::duration<double>(clock::now()-avg_birth_time).count();
+  logger->set(l_mdssm_avg_session_uptime, (uint64_t)avg_uptime);
 }
 
 int SessionFilter::parse(

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -228,6 +228,11 @@ public:
     load_avg.hit(ceph_clock_now(), load_avg_rate);
   }
 
+  double get_session_uptime() const {
+    chrono::duration<double> uptime = clock::now() - birth_time;
+    return uptime.count();
+  }
+
   time get_birth_time() const {
     return birth_time;
   }

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -45,6 +45,7 @@ enum {
   l_mdssm_session_stale,
   l_mdssm_total_load,
   l_mdssm_avg_load,
+  l_mdssm_avg_session_uptime,
   l_mdssm_last,
 };
 
@@ -111,6 +112,12 @@ private:
   // request load average for this session
   mutable DecayCounter load_avg;
   DecayRate    load_avg_rate;
+
+  // session start time -- used to track average session time
+  // note that this is initialized in the constructor rather
+  // than at the time of adding a session to the sessionmap
+  // as journal replay of sessionmap will not call add_session().
+  time birth_time;
 
 public:
 
@@ -219,6 +226,10 @@ public:
   }
   void hit_session() {
     load_avg.hit(ceph_clock_now(), load_avg_rate);
+  }
+
+  time get_birth_time() const {
+    return birth_time;
   }
 
   // -- caps --
@@ -343,8 +354,8 @@ public:
 
   Session() : 
     state(STATE_CLOSED), state_seq(0), importing_count(0),
-    recall_count(0), recall_release_count(0),
-    auth_caps(g_ceph_context),
+    birth_time(clock::now()), recall_count(0),
+    recall_release_count(0), auth_caps(g_ceph_context),
     connection(NULL), item_session_list(this),
     requests(0),  // member_offset passed to front() manually
     cap_push_seq(0),
@@ -484,6 +495,7 @@ public:
   map<int,xlist<Session*>* > by_state;
   uint64_t set_state(Session *session, int state);
   map<version_t, list<MDSInternalContextBase*> > commit_waiters;
+  void update_average_session_age();
 
   explicit SessionMap(MDSRank *m) : mds(m),
 		       projected(0), committing(0), committed(0),
@@ -699,8 +711,30 @@ public:
                      MDSGatherBuilder *gather_bld);
 
 private:
+  time avg_birth_time = time::min();
+
   uint64_t get_session_count_in_state(int state) {
     return !is_any_state(state) ? 0 : by_state[state]->size();
+  }
+
+  void update_average_birth_time(const Session &s, bool added=true) {
+    uint32_t sessions = session_map.size();
+    time birth_time = s.get_birth_time();
+
+    if (sessions == 1) {
+      avg_birth_time = added ? birth_time : time::min();
+      return;
+    }
+
+    if (added) {
+      avg_birth_time = clock::time_point(
+        ((avg_birth_time - time::min()) / sessions) * (sessions - 1) +
+        (birth_time - time::min()) / sessions);
+    } else {
+      avg_birth_time = clock::time_point(
+        ((avg_birth_time - time::min()) / (sessions - 1)) * sessions -
+        (birth_time - time::min()) / (sessions - 1));
+    }
   }
 
 public:


### PR DESCRIPTION
http://tracker.ceph.com/issues/35937 (backport https://github.com/ceph/ceph/pull/23314)