### PR TITLE
 luminous: multi-site: object name should be urlencoded when we put it into ES

### DIFF
--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -149,7 +149,7 @@ struct ElasticConfig {
   }
 
   string get_obj_path(const RGWBucketInfo& bucket_info, const rgw_obj_key& key) {
-    return index_path +  "/object/" + bucket_info.bucket.bucket_id + ":" + key.name + ":" + (key.instance.empty() ? "null" : key.instance);
+    return index_path +  "/object/" + url_encode(bucket_info.bucket.bucket_id + ":" + key.name + ":" + (key.instance.empty() ? "null" : key.instance));
   }
 
   bool should_handle_operation(RGWBucketInfo& bucket_info) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/36311