### PR TITLE
monitoring/grafana: Fix OSD Capacity Utlization Grafana graph

### DIFF
--- a/monitoring/grafana/dashboards/ceph-cluster.json
+++ b/monitoring/grafana/dashboards/ceph-cluster.json
@@ -923,7 +923,7 @@
       "span": 12,
       "targets": [
         {
-          "expr": "ceph_osd_stat_bytes_used{instance='$instance'} / ceph_osd_stat_bytes{instance='$instance'}",
+          "expr": "ceph_osd_stat_bytes_used{instance=~'$instance'} / ceph_osd_stat_bytes{instance=~'$instance'}",
           "format": "time_series",
           "interval": "1m",
           "intervalFactor": 1,


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

This patch fixes the OSD Capacity utilization graph.

The `$instance` variable is always used with a `≈~` operator, but was missed in that graph

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug