### PR TITLE
rbd: add 'config global' command to get/store overrides in mon config db

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -197,10 +197,22 @@ Commands
   The parent snapshot must be protected (see `rbd snap protect`).
   This requires image format 2.
 
+:command:`config global get` *config-entity* *key*
+  Get a global-level configuration override.
+
+:command:`config global list` [--format plain | json | xml] [--pretty-format] *config-entity*
+  List global-level configuration overrides.
+
+:command:`config global set` *config-entity* *key* *value*
+  Set a global-level configuration override.
+
+:command:`config global remove` *config-entity* *key*
+  Remove a global-level configuration override.
+
 :command:`config image get` *image-spec* *key*
   Get an image-level configuration override.
 
-:command:`config image list` [--format plain | json | xml] [--pretty-format] *image-spec* *key*
+:command:`config image list` [--format plain | json | xml] [--pretty-format] *image-spec*
   List image-level configuration overrides.
 
 :command:`config image set` *image-spec* *key* *value*

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -772,6 +772,27 @@ test_config() {
     echo "testing config..."
     remove_images
 
+    expect_fail rbd config global set osd rbd_cache true
+    expect_fail rbd config global set global debug_ms 10
+    expect_fail rbd config global set global rbd_UNKNOWN false
+    expect_fail rbd config global set global rbd_cache INVALID
+    rbd config global set global rbd_cache false
+    rbd config global set client rbd_cache true
+    rbd config global set client.123 rbd_cache false
+    rbd config global get global rbd_cache | grep '^false$'
+    rbd config global get client rbd_cache | grep '^true$'
+    rbd config global get client.123 rbd_cache | grep '^false$'
+    expect_fail rbd config global get client.UNKNOWN rbd_cache
+    rbd config global list global | grep '^rbd_cache * false * global *$'
+    rbd config global list client | grep '^rbd_cache * true * client *$'
+    rbd config global list client.123 | grep '^rbd_cache * false * client.123 *$'
+    rbd config global list client.UNKNOWN | grep '^rbd_cache * true * client *$'
+    rbd config global rm client rbd_cache
+    expect_fail rbd config global get client rbd_cache
+    rbd config global list client | grep '^rbd_cache * false * global *$'
+    rbd config global rm client.123 rbd_cache
+    rbd config global rm global rbd_cache
+
     rbd config pool set rbd rbd_cache true
     rbd config pool list rbd | grep '^rbd_cache * true * pool *$'
     rbd config pool get rbd rbd_cache | grep '^true$'

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -8,6 +8,11 @@
       bench                             Simple benchmark.
       children                          Display children of snapshot.
       clone                             Clone a snapshot into a CoW child image.
+      config global get                 Get a global-level configuration override.
+      config global list (... ls)       List global-level configuration overrides.
+      config global remove (... rm)     Remove a global-level configuration
+                                        override.
+      config global set                 Set a global-level configuration override.
       config image get                  Get an image-level configuration override.
       config image list (... ls)        List image-level configuration overrides.
       config image remove (... rm)      Remove an image-level configuration
@@ -233,6 +238,47 @@
     (*) supports enabling/disabling on existing images
     (-) supports disabling-only on existing images
     (+) enabled by default for new images if features not specified
+  
+  rbd help config global get
+  usage: rbd config global get <config-entity> <key> 
+  
+  Get a global-level configuration override.
+  
+  Positional arguments
+    <config-entity>      config entity (global, client, client.<id>)
+    <key>                config key
+  
+  rbd help config global list
+  usage: rbd config global list [--format <format>] [--pretty-format] 
+                                <config-entity> 
+  
+  List global-level configuration overrides.
+  
+  Positional arguments
+    <config-entity>      config entity (global, client, client.<id>)
+  
+  Optional arguments
+    --format arg         output format (plain, json, or xml) [default: plain]
+    --pretty-format      pretty formatting (json and xml)
+  
+  rbd help config global remove
+  usage: rbd config global remove <config-entity> <key> 
+  
+  Remove a global-level configuration override.
+  
+  Positional arguments
+    <config-entity>      config entity (global, client, client.<id>)
+    <key>                config key
+  
+  rbd help config global set
+  usage: rbd config global set <config-entity> <key> <value> 
+  
+  Set a global-level configuration override.
+  
+  Positional arguments
+    <config-entity>      config entity (global, client, client.<id>)
+    <key>                config key
+    <value>              config value
   
   rbd help config image get
   usage: rbd config image get [--pool <pool>] [--namespace <namespace>] 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -5,132 +5,123 @@
   
   Positional arguments:
     <command>
-      bench                                 Simple benchmark.
-      children                              Display children of snapshot.
-      clone                                 Clone a snapshot into a CoW child
-                                            image.
-      config image get                      Get an image-level configuration
-                                            override.
-      config image list (config image ls)   List image-level configuration
-                                            overrides.
-      config image remove (config image rm) Remove an image-level configuration
-                                            override.
-      config image set                      Set an image-level configuration
-                                            override.
-      config pool get                       Get a pool-level configuration
-                                            override.
-      config pool list (config pool ls)     List pool-level configuration
-                                            overrides.
-      config pool remove (config pool rm)   Remove a pool-level configuration
-                                            override.
-      config pool set                       Set a pool-level configuration
-                                            override.
-      copy (cp)                             Copy src image to dest.
-      create                                Create an empty image.
-      deep copy (deep cp)                   Deep copy src image to dest.
-      device list (showmapped)              List mapped rbd images.
-      device map (map)                      Map an image to a block device.
-      device unmap (unmap)                  Unmap a rbd device.
-      diff                                  Print extents that differ since a
-                                            previous snap, or image creation.
-      disk-usage (du)                       Show disk usage stats for pool, image
-                                            or snapshot.
-      export                                Export image to file.
-      export-diff                           Export incremental diff to file.
-      feature disable                       Disable the specified image feature.
-      feature enable                        Enable the specified image feature.
-      flatten                               Fill clone with parent data (make it
-                                            independent).
-      group create                          Create a group.
-      group image add                       Add an image to a group.
-      group image list (group image ls)     List images in a group.
-      group image remove (group image rm)   Remove an image from a group.
-      group list (group ls)                 List rbd groups.
-      group remove (group rm)               Delete a group.
-      group rename                          Rename a group within pool.
-      group snap create                     Make a snapshot of a group.
-      group snap list (group snap ls)       List snapshots of a group.
-      group snap remove (group snap rm)     Remove a snapshot from a group.
-      group snap rename                     Rename group's snapshot.
-      group snap rollback                   Rollback group to snapshot.
-      image-meta get                        Image metadata get the value
-                                            associated with the key.
-      image-meta list (image-meta ls)       Image metadata list keys with values.
-      image-meta remove (image-meta rm)     Image metadata remove the key and
-                                            value associated.
-      image-meta set                        Image metadata set key with value.
-      import                                Import image from file.
-      import-diff                           Import an incremental diff.
-      info                                  Show information about image size,
-                                            striping, etc.
-      journal client disconnect             Flag image journal client as
-                                            disconnected.
-      journal export                        Export image journal.
-      journal import                        Import image journal.
-      journal info                          Show information about image journal.
-      journal inspect                       Inspect image journal for structural
-                                            errors.
-      journal reset                         Reset image journal.
-      journal status                        Show status of image journal.
-      list (ls)                             List rbd images.
-      lock add                              Take a lock on an image.
-      lock list (lock ls)                   Show locks held on an image.
-      lock remove (lock rm)                 Release a lock on an image.
-      merge-diff                            Merge two diff exports together.
-      migration abort                       Cancel interrupted image migration.
-      migration commit                      Commit image migration.
-      migration execute                     Execute image migration.
-      migration prepare                     Prepare image migration.
-      mirror image demote                   Demote an image to non-primary for
-                                            RBD mirroring.
-      mirror image disable                  Disable RBD mirroring for an image.
-      mirror image enable                   Enable RBD mirroring for an image.
-      mirror image promote                  Promote an image to primary for RBD
-                                            mirroring.
-      mirror image resync                   Force resync to primary image for RBD
-                                            mirroring.
-      mirror image status                   Show RBD mirroring status for an
-                                            image.
-      mirror pool demote                    Demote all primary images in the pool.
-      mirror pool disable                   Disable RBD mirroring by default
-                                            within a pool.
-      mirror pool enable                    Enable RBD mirroring by default
-                                            within a pool.
-      mirror pool info                      Show information about the pool
-                                            mirroring configuration.
-      mirror pool peer add                  Add a mirroring peer to a pool.
-      mirror pool peer remove               Remove a mirroring peer from a pool.
-      mirror pool peer set                  Update mirroring peer settings.
-      mirror pool promote                   Promote all non-primary images in the
-                                            pool.
-      mirror pool status                    Show status for all mirrored images
-                                            in the pool.
-      namespace create                      Create an RBD image namespace.
-      namespace list (namespace ls)         List RBD image namespaces.
-      namespace remove (namespace rm)       Remove an RBD image namespace.
-      object-map check                      Verify the object map is correct.
-      object-map rebuild                    Rebuild an invalid object map.
-      pool init                             Initialize pool for use by RBD.
-      remove (rm)                           Delete an image.
-      rename (mv)                           Rename image within pool.
-      resize                                Resize (expand or shrink) image.
-      snap create (snap add)                Create a snapshot.
-      snap limit clear                      Remove snapshot limit.
-      snap limit set                        Limit the number of snapshots.
-      snap list (snap ls)                   Dump list of image snapshots.
-      snap protect                          Prevent a snapshot from being deleted.
-      snap purge                            Delete all unprotected snapshots.
-      snap remove (snap rm)                 Delete a snapshot.
-      snap rename                           Rename a snapshot.
-      snap rollback (snap revert)           Rollback image to snapshot.
-      snap unprotect                        Allow a snapshot to be deleted.
-      status                                Show the status of this image.
-      trash list (trash ls)                 List trash images.
-      trash move (trash mv)                 Move an image to the trash.
-      trash purge                           Remove all expired images from trash.
-      trash remove (trash rm)               Remove an image from trash.
-      trash restore                         Restore an image from trash.
-      watch                                 Watch events on image.
+      bench                             Simple benchmark.
+      children                          Display children of snapshot.
+      clone                             Clone a snapshot into a CoW child image.
+      config image get                  Get an image-level configuration override.
+      config image list (... ls)        List image-level configuration overrides.
+      config image remove (... rm)      Remove an image-level configuration
+                                        override.
+      config image set                  Set an image-level configuration override.
+      config pool get                   Get a pool-level configuration override.
+      config pool list (... ls)         List pool-level configuration overrides.
+      config pool remove (... rm)       Remove a pool-level configuration
+                                        override.
+      config pool set                   Set a pool-level configuration override.
+      copy (cp)                         Copy src image to dest.
+      create                            Create an empty image.
+      deep copy (deep cp)               Deep copy src image to dest.
+      device list (showmapped)          List mapped rbd images.
+      device map (map)                  Map an image to a block device.
+      device unmap (unmap)              Unmap a rbd device.
+      diff                              Print extents that differ since a
+                                        previous snap, or image creation.
+      disk-usage (du)                   Show disk usage stats for pool, image or
+                                        snapshot.
+      export                            Export image to file.
+      export-diff                       Export incremental diff to file.
+      feature disable                   Disable the specified image feature.
+      feature enable                    Enable the specified image feature.
+      flatten                           Fill clone with parent data (make it
+                                        independent).
+      group create                      Create a group.
+      group image add                   Add an image to a group.
+      group image list (... ls)         List images in a group.
+      group image remove (... rm)       Remove an image from a group.
+      group list (group ls)             List rbd groups.
+      group remove (group rm)           Delete a group.
+      group rename                      Rename a group within pool.
+      group snap create                 Make a snapshot of a group.
+      group snap list (... ls)          List snapshots of a group.
+      group snap remove (... rm)        Remove a snapshot from a group.
+      group snap rename                 Rename group's snapshot.
+      group snap rollback               Rollback group to snapshot.
+      image-meta get                    Image metadata get the value associated
+                                        with the key.
+      image-meta list (image-meta ls)   Image metadata list keys with values.
+      image-meta remove (image-meta rm) Image metadata remove the key and value
+                                        associated.
+      image-meta set                    Image metadata set key with value.
+      import                            Import image from file.
+      import-diff                       Import an incremental diff.
+      info                              Show information about image size,
+                                        striping, etc.
+      journal client disconnect         Flag image journal client as disconnected.
+      journal export                    Export image journal.
+      journal import                    Import image journal.
+      journal info                      Show information about image journal.
+      journal inspect                   Inspect image journal for structural
+                                        errors.
+      journal reset                     Reset image journal.
+      journal status                    Show status of image journal.
+      list (ls)                         List rbd images.
+      lock add                          Take a lock on an image.
+      lock list (lock ls)               Show locks held on an image.
+      lock remove (lock rm)             Release a lock on an image.
+      merge-diff                        Merge two diff exports together.
+      migration abort                   Cancel interrupted image migration.
+      migration commit                  Commit image migration.
+      migration execute                 Execute image migration.
+      migration prepare                 Prepare image migration.
+      mirror image demote               Demote an image to non-primary for RBD
+                                        mirroring.
+      mirror image disable              Disable RBD mirroring for an image.
+      mirror image enable               Enable RBD mirroring for an image.
+      mirror image promote              Promote an image to primary for RBD
+                                        mirroring.
+      mirror image resync               Force resync to primary image for RBD
+                                        mirroring.
+      mirror image status               Show RBD mirroring status for an image.
+      mirror pool demote                Demote all primary images in the pool.
+      mirror pool disable               Disable RBD mirroring by default within a
+                                        pool.
+      mirror pool enable                Enable RBD mirroring by default within a
+                                        pool.
+      mirror pool info                  Show information about the pool mirroring
+                                        configuration.
+      mirror pool peer add              Add a mirroring peer to a pool.
+      mirror pool peer remove           Remove a mirroring peer from a pool.
+      mirror pool peer set              Update mirroring peer settings.
+      mirror pool promote               Promote all non-primary images in the
+                                        pool.
+      mirror pool status                Show status for all mirrored images in
+                                        the pool.
+      namespace create                  Create an RBD image namespace.
+      namespace list (namespace ls)     List RBD image namespaces.
+      namespace remove (namespace rm)   Remove an RBD image namespace.
+      object-map check                  Verify the object map is correct.
+      object-map rebuild                Rebuild an invalid object map.
+      pool init                         Initialize pool for use by RBD.
+      remove (rm)                       Delete an image.
+      rename (mv)                       Rename image within pool.
+      resize                            Resize (expand or shrink) image.
+      snap create (snap add)            Create a snapshot.
+      snap limit clear                  Remove snapshot limit.
+      snap limit set                    Limit the number of snapshots.
+      snap list (snap ls)               Dump list of image snapshots.
+      snap protect                      Prevent a snapshot from being deleted.
+      snap purge                        Delete all unprotected snapshots.
+      snap remove (snap rm)             Delete a snapshot.
+      snap rename                       Rename a snapshot.
+      snap rollback (snap revert)       Rollback image to snapshot.
+      snap unprotect                    Allow a snapshot to be deleted.
+      status                            Show the status of this image.
+      trash list (trash ls)             List trash images.
+      trash move (trash mv)             Move an image to the trash.
+      trash purge                       Remove all expired images from trash.
+      trash remove (trash rm)           Remove an image from trash.
+      trash restore                     Restore an image from trash.
+      watch                             Watch events on image.
   
   Optional arguments:
     -c [ --conf ] arg     path to cluster configuration

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -306,8 +306,7 @@
     --image arg          image name
   
   rbd help config pool get
-  usage: rbd config pool get 
-                             <pool-name> <key> 
+  usage: rbd config pool get <pool-name> <key> 
   
   Get a pool-level configuration override.
   
@@ -329,8 +328,7 @@
     --pretty-format      pretty formatting (json and xml)
   
   rbd help config pool remove
-  usage: rbd config pool remove 
-                                <pool-name> <key> 
+  usage: rbd config pool remove <pool-name> <key> 
   
   Remove a pool-level configuration override.
   
@@ -339,8 +337,7 @@
     <key>                config key
   
   rbd help config pool set
-  usage: rbd config pool set 
-                             <pool-name> <key> <value> 
+  usage: rbd config pool set <pool-name> <key> <value> 
   
   Set a pool-level configuration override.
   

--- a/src/tools/rbd/OptionPrinter.cc
+++ b/src/tools/rbd/OptionPrinter.cc
@@ -37,7 +37,10 @@ void OptionPrinter::print_short(std::ostream &os, size_t initial_offset) {
     }
     indent_stream << " ";
   }
-  indent_stream << std::endl;
+
+  if (m_optional.options().size() > 0 || m_positional.options().size() == 0) {
+    indent_stream << std::endl;
+  }
 
   if (m_positional.options().size() > 0) {
     indent_stream.set_delimiter(" ");

--- a/src/tools/rbd/OptionPrinter.h
+++ b/src/tools/rbd/OptionPrinter.h
@@ -20,7 +20,7 @@ public:
 
   static const size_t LINE_WIDTH = 80;
   static const size_t MIN_NAME_WIDTH = 20;
-  static const size_t MAX_DESCRIPTION_OFFSET = LINE_WIDTH / 2 + 2;
+  static const size_t MAX_DESCRIPTION_OFFSET = LINE_WIDTH / 2;
 
   OptionPrinter(const OptionsDescription &positional,
                 const OptionsDescription &optional);

--- a/src/tools/rbd/Shell.cc
+++ b/src/tools/rbd/Shell.cc
@@ -63,11 +63,31 @@ std::string format_command_spec(const Shell::CommandSpec &spec) {
   return joinify<std::string>(spec.begin(), spec.end(), " ");
 }
 
+std::string format_alias_spec(const Shell::CommandSpec &spec,
+                              const Shell::CommandSpec &alias_spec) {
+    auto spec_it = spec.begin();
+    auto alias_it = alias_spec.begin();
+    int level = 0;
+    while (spec_it != spec.end() && alias_it != alias_spec.end() &&
+           *spec_it == *alias_it) {
+      spec_it++;
+      alias_it++;
+      level++;
+    }
+    ceph_assert(spec_it != spec.end() && alias_it != alias_spec.end());
+
+    if (level < 2) {
+      return joinify<std::string>(alias_spec.begin(), alias_spec.end(), " ");
+    } else {
+      return "... " + joinify<std::string>(alias_it, alias_spec.end(), " ");
+    }
+}
+
 std::string format_command_name(const Shell::CommandSpec &spec,
                                 const Shell::CommandSpec &alias_spec) {
   std::string name = format_command_spec(spec);
   if (!alias_spec.empty()) {
-    name += " (" + format_command_spec(alias_spec) + ")";
+    name += " (" + format_alias_spec(spec, alias_spec) + ")";
   }
   return name;
 }

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -626,8 +626,7 @@ void init_context() {
   common_init_finish(g_ceph_context);
 }
 
-int init(const std::string &pool_name, const std::string& namespace_name,
-         librados::Rados *rados, librados::IoCtx *io_ctx) {
+int init_rados(librados::Rados *rados) {
   init_context();
 
   int r = rados->init_with_context(g_ceph_context);
@@ -639,6 +638,18 @@ int init(const std::string &pool_name, const std::string& namespace_name,
   r = rados->connect();
   if (r < 0) {
     std::cerr << "rbd: couldn't connect to the cluster!" << std::endl;
+    return r;
+  }
+
+  return 0;
+}
+
+int init(const std::string &pool_name, const std::string& namespace_name,
+         librados::Rados *rados, librados::IoCtx *io_ctx) {
+  init_context();
+
+  int r = init_rados(rados);
+  if (r < 0) {
     return r;
   }
 

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -151,6 +151,8 @@ int get_formatter(const boost::program_options::variables_map &vm,
 
 void init_context();
 
+int init_rados(librados::Rados *rados);
+
 int init(const std::string &pool_name, const std::string& namespace_name,
          librados::Rados *rados, librados::IoCtx *io_ctx);
 int init_io_ctx(librados::Rados &rados, const std::string &pool_name,


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

