### PR TITLE
luminous: doc: fix broken fstab url in cephfs/fuse

### DIFF
--- a/doc/cephfs/fuse.rst
+++ b/doc/cephfs/fuse.rst
@@ -48,5 +48,5 @@ A persistent mount point can be setup via::
 	sudo systemctl enable ceph-fuse@/mnt.service
 
 .. _ceph-fuse: ../../man/8/ceph-fuse/
-.. _fstab: ./fstab
+.. _fstab: ../fstab/#fuse
 .. _CEPHX Config Reference: ../../rados/configuration/auth-config-ref


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/36312