### PR TITLE
mgr/dashboard: Performance counter progress bar keeps infinitely looping

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.html
@@ -3,7 +3,7 @@
           [columns]="columns"
           columnMode="flex"
           [autoSave]="false"
-          (fetchData)="getCounters()">
+          (fetchData)="getCounters($event)">
   <ng-template #valueTpl let-row="row">
     {{ row.value | dimless }} {{ row.unit }}
   </ng-template>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/performance-counter/table-performance-counter/table-performance-counter.component.ts
@@ -2,6 +2,7 @@ import { Component, Input, OnInit, TemplateRef, ViewChild } from '@angular/core'
 
 import { PerformanceCounterService } from '../../../shared/api/performance-counter.service';
 import { CdTableColumn } from '../../../shared/models/cd-table-column';
+import { CdTableFetchDataContext } from '../../../shared/models/cd-table-fetch-data-context';
 
 /**
  * Display the specified performance counters in a datatable.
@@ -52,7 +53,7 @@ export class TablePerformanceCounterComponent implements OnInit {
     ];
   }
 
-  getCounters() {
+  getCounters(context: CdTableFetchDataContext) {
     this.performanceCounterService.get(this.serviceType, this.serviceId).subscribe(
       (resp: object[]) => {
         this.counters = resp;
@@ -61,6 +62,8 @@ export class TablePerformanceCounterComponent implements OnInit {
         if (error.status === 404) {
           error.preventDefault();
           this.counters = null;
+        } else {
+          context.error();
         }
       }
     );

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/api-interceptor.service.spec.ts
@@ -1,4 +1,4 @@
-import { HTTP_INTERCEPTORS, HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';


### PR DESCRIPTION
If there is an HTTP error other than 404 the performance counter progress bar keeps looping infinitively. The PR will fix that by implementing the CdTableFetchDataContext interface correctly.

Previous behaviour:
![loop](https://user-images.githubusercontent.com/1897962/46535732-95ebf880-c8ac-11e8-9946-d6bd6ae83f5d.gif)

Fixes: https://tracker.ceph.com/issues/36325

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

