### PR TITLE
luminous: ceph-volume lvm.prepare update help to indicate partitions are needed, not devices

### DIFF
--- a/doc/ceph-volume/lvm/prepare.rst
+++ b/doc/ceph-volume/lvm/prepare.rst
@@ -201,6 +201,33 @@ work for both bluestore and filestore OSDs::
     ceph-volume lvm prepare --bluestore --data vg/lv --crush-device-class foo
 
 
+.. _ceph-volume-lvm-multipath:
+
+``multipath`` support
+---------------------
+Devices that come from ``multipath`` are not supported as-is. The tool will
+refuse to consume a raw multipath device and will report a message like::
+
+    -->  RuntimeError: Cannot use device (/dev/mapper/<name>). A vg/lv path or an existing device is needed
+
+The reason for not supporting multipath is that depending on the type of the
+multipath setup, if using an active/passive array as the underlying physical
+devices, filters are required in ``lvm.conf`` to exclude the disks that are part of
+those underlying devices.
+
+It is unfeasible for ceph-volume to understand what type of configuration is
+needed for LVM to be able to work in various different multipath scenarios. The
+functionality to create the LV for you is merely a (naive) convenience,
+anything that involves different settings or configuration must be provided by
+a config management system which can then provide VGs and LVs for ceph-volume
+to consume.
+
+This situation will only arise when trying to use the ceph-volume functionality
+that creates a volume group and logical volume from a device. If a multipath
+device is already a logical volume it *should* work, given that the LVM
+configuration is done correctly to avoid issues.
+
+
 Storing metadata
 ----------------
 The following tags will get applied as part of the preparation process

--- a/src/ceph-volume/ceph_volume/devices/lvm/create.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/create.py
@@ -44,18 +44,13 @@ class Create(object):
         all the metadata to the logical volumes using LVM tags, and starting
         the OSD daemon.
 
-        Example calls for supported scenarios:
+        Existing logical volume (lv) or device:
 
-        Filestore
-        ---------
+            ceph-volume lvm create --data {vg name/lv name} --journal /path/to/device
 
-          Existing logical volume (lv) or device:
+        Or:
 
-              ceph-volume lvm create --filestore --data {vg name/lv name} --journal /path/to/device
-
-          Or:
-
-              ceph-volume lvm create --filestore --data {vg name/lv name} --journal {vg name/lv name}
+            ceph-volume lvm create --data {vg name/lv name} --journal {vg name/lv name}
 
         """)
         parser = create_parser(

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -318,37 +318,17 @@ class Prepare(object):
 
         Encryption is supported via dmcrypt and the --dmcrypt flag.
 
-        Example calls for supported scenarios:
+        Existing logical volume (lv):
 
-        Dedicated volume group for Journal(s)
-        -------------------------------------
+            ceph-volume lvm prepare --data {vg/lv}
 
-          Existing logical volume (lv) or device:
+        Existing block device, that will be made a group and logical volume:
 
-              ceph-volume lvm prepare --filestore --data {vg/lv} --journal /path/to/device
+            ceph-volume lvm prepare --data /path/to/device
 
-          Or:
+        Optionally, can consume db and wal devices or logical volumes:
 
-              ceph-volume lvm prepare --filestore --data {vg/lv} --journal {vg/lv}
-
-          Existing block device, that will be made a group and logical volume:
-
-              ceph-volume lvm prepare --filestore --data /path/to/device --journal {vg/lv}
-
-        Bluestore
-        ---------
-
-          Existing logical volume (lv):
-
-              ceph-volume lvm prepare --bluestore --data {vg/lv}
-
-          Existing block device, that will be made a group and logical volume:
-
-              ceph-volume lvm prepare --bluestore --data /path/to/device
-
-          Optionally, can consume db and wal devices or logical volumes:
-
-              ceph-volume lvm prepare --bluestore --data {vg/lv} --block.wal {device} --block-db {vg/lv}
+            ceph-volume lvm prepare --data {vg/lv} --block.wal {device} --block-db {vg/lv}
         """)
         parser = prepare_parser(
             prog='ceph-volume lvm prepare',

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -328,7 +328,7 @@ class Prepare(object):
 
         Optionally, can consume db and wal devices or logical volumes:
 
-            ceph-volume lvm prepare --data {vg/lv} --block.wal {device} --block-db {vg/lv}
+            ceph-volume lvm prepare --data {vg/lv} --block.wal {device} --block.db {vg/lv}
         """)
         parser = prepare_parser(
             prog='ceph-volume lvm prepare',

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -312,10 +312,6 @@ class Prepare(object):
         Once the OSD is ready, an ad-hoc systemd unit will be enabled so that
         it can later get activated and the OSD daemon can get started.
 
-        Most basic Usage looks like (journal will be collocated from the same volume group):
-
-            ceph-volume lvm prepare --data {volume group name}
-
         Encryption is supported via dmcrypt and the --dmcrypt flag.
 
         Existing logical volume (lv):

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -326,9 +326,9 @@ class Prepare(object):
 
             ceph-volume lvm prepare --data /path/to/device
 
-        Optionally, can consume db and wal devices or logical volumes:
+        Optionally, can consume db and wal partitions or logical volumes:
 
-            ceph-volume lvm prepare --data {vg/lv} --block.wal {device} --block.db {vg/lv}
+            ceph-volume lvm prepare --data {vg/lv} --block.wal {partition} --block.db {vg/lv}
         """)
         parser = prepare_parser(
             prog='ceph-volume lvm prepare',


### PR DESCRIPTION
cherry-picks additional commits that were missing in luminous, and adds a new commit that removed conflicts caused by a missing backport commit from pr https://github.com/ceph/ceph/pull/20878

Backport of: https://github.com/ceph/ceph/pull/24394

Fixes:  http://tracker.ceph.com/issues/24795