### PR TITLE
osd: add support for reload cls plugin through ceph tell command

### DIFF
--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -90,6 +90,17 @@ void ClassHandler::shutdown()
   classes.clear();
 }
 
+void ClassHandler::reload(string plugin){
+  for (auto& cls : classes) {
+    if (cls.second.handle && (cls.first.compare(plugin) == 0)) {
+      dlclose(cls.second.handle);
+      cls.second.status = ClassData::CLASS_MISSING;
+      ldout(cct, 0) << __func__ << " set " << cls.first << "status" << cls.second.status << dendl;
+    }
+  }
+}
+
+
 /*
  * Check if @cname is in the whitespace delimited list @list, or the @list
  * contains the wildcard "*".

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -124,6 +124,7 @@ public:
   void unregister_class(ClassData *cls);
 
   void shutdown();
+  void reload(string plugin);
 };
 
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6033,6 +6033,9 @@ COMMAND("compact",
 COMMAND("smart name=devid,type=CephString,req=False",
         "runs smartctl on this osd devices.  ",
         "osd", "rw", "cli,rest")
+COMMAND("reload plugin name=plugin,type=CephString,req=True",
+        "WARNING: reload cls plugin.",
+        "osd", "rw", "cli,rest")
 };
 
 void OSD::do_command(
@@ -6507,6 +6510,12 @@ int OSD::_do_command(
     string devid;
     cmd_getval(cct, cmdmap, "devid", devid);
     probe_smart(devid, ds);
+  }
+
+  else if (prefix == "reload plugin")   {
+    std::string plugin;
+    cmd_getval(cct, cmdmap, "plugin", plugin);
+    class_handler->reload(plugin);
   }
 
   else {


### PR DESCRIPTION
sometimes we need to reload cls plugin such as cls_rgw without restart ceph-osd process(upgrade rpm), because restart ceph-osd process some time take long time for cluster be health again, as we know ,restart osd may occur leveldb compress. so we need to support reload cls plugin when we add some feature like rgw lifecycle.

test as follow

radostest.py
```
import rados
cluster = rados.Rados(conffile='/ceph/ceph/build/ceph.conf')
cluster.connect()
ioctx = cluster.open_ioctx('test')
ret, data = ioctx.execute('foo', 'hello', 'say_hello', b"")
print data[:ret]
```
output
```
python radostest.py
Hello, world!
```

we modify say_hello function in src/cls/hello/cls_hello.cc
```
     49 static int say_hello(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     50 {
     51   // see if the input data from the client matches what this method
     52   // expects to receive.  your class can fill this buffer with what it
     53   // wants.
     54   if (in->length() > 100)
     55     return -EINVAL;
     56
     57   // we generate our reply
     58   out->append("Hello, ");
     59   if (in->length() == 0)
     60     out->append("world");
     61   else
     62     out->append(*in);
     63   out->append("! UPDATE");  //modify here for test
```

make cls_hello -j2 #replace the old  libcls_hello.so

reload cls_hello with ceph tell command
./bin/ceph -c ceph.conf tell osd.* reload plugin hello

and run radostest.py again without restart ceph-osd process
output  of py script
```
python radostest.py
Hello, world! UPDATE
```

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>
