### PR TITLE
qa/workunits/rbd: fix cli generic namespace test

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -10,12 +10,8 @@ rbd ls | wc -l | grep -v '^0$' && echo "nonempty rbd pool, aborting!  run this s
 
 IMGS="testimg1 testimg2 testimg3 testimg4 testimg5 testimg6 testimg-diff1 testimg-diff2 testimg-diff3 foo foo2 bar bar2 test1 test2 test3 test4 clone2"
 
-expect_fail()
-{
-  set -x
-  set +e
-  "$@"
-  if [ $? == 0 ]; then return 1; else return 0; fi
+expect_fail() {
+    "$@" && return 1 || return 0
 }
 
 tiered=0
@@ -644,7 +640,7 @@ test_namespace() {
     rbd snap create rbd/test1/image1@1
     rbd clone --rbd-default-clone-format 2 rbd/test1/image1@1 rbd/test2/image1
     rbd snap rm rbd/test1/image1@1
-    cmp <(rbd export rbd/test1/image1@1 -) <(rbd export rbd/test2/image1 -)
+    cmp <(rbd export rbd/test1/image1 -) <(rbd export rbd/test2/image1 -)
     rbd rm rbd/test2/image1
 
     # default ns to test1 ns clone
@@ -653,7 +649,7 @@ test_namespace() {
     rbd snap create rbd/image2@1
     rbd clone --rbd-default-clone-format 2 rbd/image2@1 rbd/test2/image2
     rbd snap rm rbd/image2@1
-    cmp <(rbd export rbd/image2@1 -) <(rbd export rbd/test2/image2 -)
+    cmp <(rbd export rbd/image2 -) <(rbd export rbd/test2/image2 -)
     expect_fail rbd rm rbd/image2
     rbd rm rbd/test2/image2
     rbd rm rbd/image2


### PR DESCRIPTION
expect_fail incorrectly unset '-e' option and if a consequent test
failed it did not abort the execution. And two typos in the namespace
tests were not detected due to this.

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

