### PR TITLE
common: assert if buffer advance length overflow

### DIFF
--- a/src/msg/async/Protocol.cc
+++ b/src/msg/async/Protocol.cc
@@ -827,6 +827,7 @@ void ProtocolV1::handle_message_data(char *buffer, int r) {
 
   bufferptr bp = data_blp.get_current_ptr();
   unsigned read_len = std::min(bp.length(), msg_left);
+  ceph_assert(read_len < std::numeric_limits<int>::max());
   data_blp.advance(read_len);
   data.append(bp, 0, read_len);
   msg_left -= read_len;


### PR DESCRIPTION
Buffer advance length was defined as int, but in async msg, the real
length of data buffer was defined as unsigned, so this overflow caused
MDS crash.

Fixes: http://tracker.ceph.com/issues/36340

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

