### PR TITLE
mimic: ceph fs add_data_pool applies pool application metadata incorrectly

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -614,7 +614,7 @@ class AddDataPoolHandler : public FileSystemCommandHandler
     }
     mon->osdmon()->do_application_enable(poolid,
 					 pg_pool_t::APPLICATION_NAME_CEPHFS,
-					 "data", poolname);
+					 "data", fs_name);
     mon->osdmon()->propose_pending();
 
     fsmap.modify_filesystem(


### PR DESCRIPTION
http://tracker.ceph.com/issues/36203