### PR TITLE
common: drop get_contiguous() from ceph::bufferlist.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1740,48 +1740,6 @@ using namespace ceph;
     return s;
   }
 
-  char *buffer::list::get_contiguous(unsigned orig_off, unsigned len)
-  {
-    if (orig_off + len > length())
-      throw end_of_buffer();
-
-    if (len == 0) {
-      return 0;
-    }
-
-    unsigned off = orig_off;
-    std::list<ptr>::iterator curbuf = _buffers.begin();
-    while (off > 0 && off >= curbuf->length()) {
-      off -= curbuf->length();
-      ++curbuf;
-    }
-
-    if (off + len > curbuf->length()) {
-      bufferlist tmp;
-      unsigned l = off + len;
-
-      do {
-	if (l >= curbuf->length())
-	  l -= curbuf->length();
-	else
-	  l = 0;
-	tmp.append(*curbuf);
-	curbuf = _buffers.erase(curbuf);
-
-      } while (curbuf != _buffers.end() && l > 0);
-
-      ceph_assert(l == 0);
-
-      tmp.rebuild();
-      _buffers.insert(curbuf, tmp._buffers.front());
-      return tmp.c_str() + off;
-    }
-
-    last_p = begin();  // we modified _buffers
-
-    return curbuf->c_str() + off;
-  }
-
   void buffer::list::substr_of(const list& other, unsigned off, unsigned len)
   {
     if (off + len > other.length())

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -910,11 +910,6 @@ namespace buffer CEPH_BUFFER_API {
 
     void substr_of(const list& other, unsigned off, unsigned len);
 
-    /// return a pointer to a contiguous extent of the buffer,
-    /// reallocating as needed
-    char *get_contiguous(unsigned off,  ///< offset
-			 unsigned len); ///< length
-
     // funky modifer
     void splice(unsigned off, unsigned len, list *claim_by=0 /*, bufferlist& replace_with */);
     void write(int off, int len, std::ostream& out) const;

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -868,7 +868,7 @@ public:
           objects(t->object_index.size()) {
 
         ops = t->data.ops;
-        op_buffer_p = t->op_bl.get_contiguous(0, t->data.ops * sizeof(Op));
+        op_buffer_p = t->op_bl.c_str();
 
         map<coll_t, __le32>::iterator coll_index_p;
         for (coll_index_p = t->coll_index.begin();

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1348,55 +1348,6 @@ TEST(BufferList, to_str) {
   }
 }
 
-TEST(BufferList, get_contiguous) {
-  {
-    bufferptr a("foobarbaz", 9);
-    bufferptr b("123456789", 9);
-    bufferptr c("ABCDEFGHI", 9);
-    bufferlist bl;
-    ASSERT_EQ(0, bl.get_contiguous(0, 0));
-
-    bl.append(a);
-    bl.append(b);
-    bl.append(c);
-    ASSERT_EQ(3u, bl.get_num_buffers());
-    ASSERT_EQ(0, memcmp("bar", bl.get_contiguous(3, 3), 3));
-    ASSERT_EQ(0, memcmp("456", bl.get_contiguous(12, 3), 3));
-    ASSERT_EQ(0, memcmp("ABC", bl.get_contiguous(18, 3), 3));
-    ASSERT_EQ(3u, bl.get_num_buffers());
-    ASSERT_EQ(0, memcmp("789ABC", bl.get_contiguous(15, 6), 6));
-    ASSERT_EQ(2u, bl.get_num_buffers());
-  }
-
-  {
-    bufferptr a("foobarbaz", 9);
-    bufferptr b("123456789", 9);
-    bufferptr c("ABCDEFGHI", 9);
-    bufferlist bl;
-
-    bl.append(a);
-    bl.append(b);
-    bl.append(c);
-
-    ASSERT_EQ(0, memcmp("789ABCDEFGHI", bl.get_contiguous(15, 12), 12));
-    ASSERT_EQ(2u, bl.get_num_buffers());
-  }
-
-  {
-    bufferptr a("foobarbaz", 9);
-    bufferptr b("123456789", 9);
-    bufferptr c("ABCDEFGHI", 9);
-    bufferlist bl;
-
-    bl.append(a);
-    bl.append(b);
-    bl.append(c);
-
-    ASSERT_EQ(0, memcmp("z123456789AB", bl.get_contiguous(8, 12), 12));
-    ASSERT_EQ(1u, bl.get_num_buffers());
-  }
-}
-
 TEST(BufferList, swap) {
   bufferlist b1;
   b1.append('A');

--- a/src/test/perf_local.cc
+++ b/src/test/perf_local.cc
@@ -278,22 +278,6 @@ double buffer_encode()
   return Cycles::to_seconds(total)/(count*10);
 }
 
-// Measure the cost of retrieving an object from the beginning of a buffer.
-double buffer_get_contiguous()
-{
-  int count = 1000000;
-  int value = 11;
-  bufferlist b;
-  b.append((char*)&value, sizeof(value));
-  int sum = 0;
-  uint64_t start = Cycles::rdtsc();
-  for (int i = 0; i < count; i++) {
-    sum += *reinterpret_cast<int*>(b.get_contiguous(0, sizeof(value)));
-  }
-  uint64_t stop = Cycles::rdtsc();
-  return Cycles::to_seconds(stop - start)/count;
-}
-
 // Measure the cost of creating an iterator and iterating over 10
 // chunks in a buffer.
 double buffer_iterator()
@@ -930,8 +914,6 @@ TestInfo tests[] = {
     "copy out 2 small ptrs from buffer"},
   {"buffer_encode10", buffer_encode,
     "buffer encoding 10 structures onto existing ptr"},
-  {"buffer_get_contiguous", buffer_get_contiguous,
-    "Buffer::get_contiguous"},
   {"buffer_iterator", buffer_iterator,
     "iterate over buffer with 5 ptrs"},
   {"cond_ping_pong", cond_ping_pong,


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>