### PR TITLE
common: encode for std::list<T> doesn't use the costly bl::copy_in() anymore.

### DIFF
--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -617,30 +617,18 @@ inline std::enable_if_t<!traits::supported>
 {
   __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
   encode(n, bl);
-  for (auto p = ls.begin(); p != ls.end(); ++p)
-    encode(*p, bl);
+  for (auto& elem : ls) {
+    encode(elem, bl);
+  }
 }
 template<class T, class Alloc, typename traits>
 inline std::enable_if_t<!traits::supported>
   encode(const std::list<T,Alloc>& ls, bufferlist& bl, uint64_t features)
 {
-  // should i pre- or post- count?
-  if (!ls.empty()) {
-    unsigned pos = bl.length();
-    unsigned n = 0;
-    encode(n, bl);
-    for (auto p = ls.begin(); p != ls.end(); ++p) {
-      n++;
-      encode(*p, bl, features);
-    }
-    ceph_le32 en;
-    en = n;
-    bl.copy_in(pos, sizeof(en), (char*)&en);
-  } else {
-    __u32 n = (__u32)(ls.size());    // FIXME: this is slow on a list.
-    encode(n, bl);
-    for (auto p = ls.begin(); p != ls.end(); ++p)
-      encode(*p, bl, features);
+  __u32 n = (__u32)(ls.size());  // c++11 std::list::size() is O(1)
+  encode(n, bl);
+  for (auto& elem : ls) {
+    encode(elem, bl, features);
   }
 }
 template<class T, class Alloc, typename traits>


### PR DESCRIPTION
In `buffer.h` we do have:
```cpp
    // crope lookalikes.
    // **** WARNING: this are horribly inefficient for large bufferlists. ****
    void copy(unsigned off, unsigned len, char *dest) const;
    void copy(unsigned off, unsigned len, list &dest) const;
    void copy(unsigned off, unsigned len, std::string& dest) const;
    void copy_in(unsigned off, unsigned len, const char *src);
    void copy_in(unsigned off, unsigned len, const char *src, bool crc_reset); 
    void copy_in(unsigned off, unsigned len, const list& src);

    // ...
```

The comment is very old (dating on 2007; see b1fe02e403d1d6f3e19155320de58ff892962378) but is also the same that introduced the `last_p` likely as a countermeasure for to save extensive `::seek`. Still, I think it's better to use e.g. `::copy_in` only when really necessary.
