### PR TITLE
mgr/dashboard: Audit REST API calls

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -514,3 +514,29 @@ to use hyperlinks that include your prefix, you can set the
   ceph config set mgr mgr/dashboard/url_prefix $PREFIX
 
 so you can access the dashboard at ``http://$IP:$PORT/$PREFIX/``.
+
+
+Auditing
+--------
+
+The REST API is capable of logging PUT, POST and DELETE requests to the Ceph
+audit log. This feature is disabled by default, but can be enabled with the
+following command::
+
+  $ ceph dashboard set-audit-api-enabled <true|false>
+
+If enabled, the following parameters are logged per each request:
+
+* from - The origin of the request, e.g. https://[::1]:44410
+* path - The REST API path, e.g. /api/auth
+* method - e.g. PUT, POST or DELETE
+* user - The name of the user, otherwise 'None'
+
+The logging of the request payload (the arguments and their values) is enabled
+by default. Execute the following command to disable this behaviour::
+
+  $ ceph dashboard set-audit-api-log-payload <true|false>
+
+A log entry may look like this::
+
+  2018-10-22 15:27:01.302514 mgr.x [INF] [DASHBOARD] from='https://[::ffff:127.0.0.1]:37022' path='/api/rgw/user/klaus' method='PUT' user='admin' params='{"max_buckets": "1000", "display_name": "Klaus Mustermann", "uid": "klaus", "suspended": "0", "email": "klaus.mustermann@ceph.com"}'

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -151,6 +151,8 @@ class CherryPyConfig(object):
                 'application/json',
                 'application/javascript',
             ],
+            'tools.json_in.on': True,
+            'tools.json_in.force': False
         }
 
         if ssl:

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -21,6 +21,10 @@ class Options(object):
     ENABLE_BROWSABLE_API = (True, bool)
     REST_REQUESTS_TIMEOUT = (45, int)
 
+    # API auditing
+    AUDIT_API_ENABLED = (False, bool)
+    AUDIT_API_LOG_PAYLOAD = (True, bool)
+
     # RGW settings
     RGW_API_HOST = ('', str)
     RGW_API_PORT = (80, int)

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -40,7 +40,11 @@ class ControllerTestCase(helper.CPWebCase):
         cherrypy.tools.authenticate = AuthManagerTool()
         cherrypy.tools.dashboard_exception_handler = HandlerWrapperTool(dashboard_exception_handler,
                                                                         priority=31)
-        cherrypy.config.update({'error_page.default': json_error_page})
+        cherrypy.config.update({
+            'error_page.default': json_error_page,
+            'tools.json_in.on': True,
+            'tools.json_in.force': False
+        })
         super(ControllerTestCase, self).__init__(*args, **kwargs)
 
     def _request(self, url, method, data=None):

--- a/src/pybind/mgr/dashboard/tests/test_api_auditing.py
+++ b/src/pybind/mgr/dashboard/tests/test_api_auditing.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
+import re
+import json
+import cherrypy
+import mock
+
+from .helper import ControllerTestCase
+from ..controllers import RESTController, Controller
+from ..tools import RequestLoggingTool
+from .. import mgr
+
+
+# pylint: disable=W0613
+@Controller('/foo', secure=False)
+class FooResource(RESTController):
+    def create(self, password):
+        pass
+
+    def get(self, key):
+        pass
+
+    def delete(self, key):
+        pass
+
+    def set(self, key, password, secret_key=None):
+        pass
+
+
+class ApiAuditingTest(ControllerTestCase):
+    settings = {}
+
+    def __init__(self, *args, **kwargs):
+        cherrypy.tools.request_logging = RequestLoggingTool()
+        cherrypy.config.update({'tools.request_logging.on': True})
+        super(ApiAuditingTest, self).__init__(*args, **kwargs)
+
+    @classmethod
+    def mock_set_config(cls, key, val):
+        cls.settings[key] = val
+
+    @classmethod
+    def mock_get_config(cls, key, default=None):
+        return cls.settings.get(key, default)
+
+    @classmethod
+    def setUpClass(cls):
+        mgr.get_config.side_effect = cls.mock_get_config
+        mgr.set_config.side_effect = cls.mock_set_config
+
+    @classmethod
+    def setup_server(cls):
+        cls.setup_controllers([FooResource])
+
+    def setUp(self):
+        mgr.cluster_log = mock.Mock()
+        mgr.set_config('AUDIT_API_ENABLED', True)
+        mgr.set_config('AUDIT_API_LOG_PAYLOAD', True)
+
+    def _validate_cluster_log_msg(self, path, method, user, params):
+        channel, _, msg = mgr.cluster_log.call_args_list[0][0]
+        self.assertEqual(channel, 'audit')
+        pattern = r'^\[DASHBOARD\] from=\'(.+)\' path=\'(.+)\' ' \
+                  'method=\'(.+)\' user=\'(.+)\' params=\'(.+)\'$'
+        m = re.match(pattern, msg)
+        self.assertEqual(m.group(2), path)
+        self.assertEqual(m.group(3), method)
+        self.assertEqual(m.group(4), user)
+        self.assertDictEqual(json.loads(m.group(5)), params)
+
+    def test_no_audit(self):
+        mgr.set_config('AUDIT_API_ENABLED', False)
+        self._delete('/foo/test1')
+        mgr.cluster_log.assert_not_called()
+
+    def test_no_payload(self):
+        mgr.set_config('AUDIT_API_LOG_PAYLOAD', False)
+        self._delete('/foo/test1')
+        _, _, msg = mgr.cluster_log.call_args_list[0][0]
+        self.assertNotIn('params=', msg)
+
+    def test_no_audit_get(self):
+        self._get('/foo/test1')
+        mgr.cluster_log.assert_not_called()
+
+    def test_audit_put(self):
+        self._put('/foo/test1', {'password': 'y', 'secret_key': 1234})
+        mgr.cluster_log.assert_called_once()
+        self._validate_cluster_log_msg('/foo/test1', 'PUT', 'None',
+                                       {'key': 'test1',
+                                        'password': '***',
+                                        'secret_key': '***'})
+
+    def test_audit_post(self):
+        with mock.patch('dashboard.services.auth.JwtManager.get_username',
+                        return_value='hugo'):
+            self._post('/foo?password=1234')
+            mgr.cluster_log.assert_called_once()
+            self._validate_cluster_log_msg('/foo', 'POST', 'hugo',
+                                           {'password': '***'})
+
+    def test_audit_delete(self):
+        self._delete('/foo/test1')
+        mgr.cluster_log.assert_called_once()
+        self._validate_cluster_log_msg('/foo/test1', 'DELETE',
+                                       'None', {'key': 'test1'})


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/36193

Enable API auditing with ``ceph dashboard set-audit-api-enabled true`` (default is false). If you do not want to log the request payload, then disable it via ``set-audit-api-log-payload false`` (default is true).

Example output:
```
2018-10-08 10:25:21.850994 mgr.x [INF] [DASHBOARD] from='https://[::1]:44410' path='/api/auth' method='POST' user='None' params='{"username": "admin", "password": "***", "stay_signed_in": false}'
```

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

