### PR TITLE
cmake: remove checking for GCC 5.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,17 +138,6 @@ int main() {
 }
 " HAVE_STDLIB_MAP_SPLICING)
 
-if(CMAKE_COMPILER_IS_GNUCXX AND
-    CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1)
-  # this is not always correct, as one can use clang with libstdc++ or
-  # use old gcc with new libstdc++, but it covers the most cases.
-  #
-  # libstdc++ 4.9 has O(n) list::size(), and its regex is buggy
-  message(SEND_ERROR "performance regression is expected due to an O(n) "
-    "implementation of 'std::list::size()' in libstdc++ older than 5.1.0, "
-    "Please use GCC 5.1 and up.")
-endif()
-
 ## Handle diagnostics color if compiler supports them.
 CHECK_C_COMPILER_FLAG("-fdiagnostics-color=always"
   COMPILER_SUPPORTS_DIAGNOSTICS_COLOR)


### PR DESCRIPTION
this reverts bcc0511d3b857a8810493ca3d3f17ba053651af2,

because

* we already check for C++17 support in the same cmake list
* it's non trivial to check the O(1) std::list::size().
* we always build using the GCC 7.3 from SCLs on CentOS and RHEL. so the
  error message is always printed if we could have detected the O(1)
  std::list::size(). and we cannot fail the build if we are using an
  standard library with O(1) std::list::size().

so, this check is pointless.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

