### PR TITLE
qa/suites/rados/upgrade/jewel-x-singleton: exclude python3-rados, python3-cephfs

### DIFF
--- a/qa/suites/rados/upgrade/jewel-x-singleton/1-jewel-install/jewel.yaml
+++ b/qa/suites/rados/upgrade/jewel-x-singleton/1-jewel-install/jewel.yaml
@@ -3,7 +3,7 @@ meta:
 tasks:
 - install:
     branch: jewel
-    exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev']
+    exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev', 'python3-rados', 'python3-cephfs']
 - print: "**** done install jewel"
 - ceph:
     skip_mgr_daemons: true


### PR DESCRIPTION
This fix goes directly into the luminous branch since these packages do not need
to be installed on jewel, when upgrading to luminous.

Fixes: https://tracker.ceph.com/issues/36347
Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

