### PR TITLE
[WIP] rbd configurable worker threads

### DIFF
--- a/qa/suites/rbd/basic/tasks/rbd_api_tests_old_format.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_api_tests_old_format.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/basic/tasks/rbd_cls_tests.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_cls_tests.yaml
@@ -5,3 +5,8 @@ tasks:
         - cls/test_cls_rbd.sh
         - cls/test_cls_lock.sh
         - cls/test_cls_journal.sh
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/basic/tasks/rbd_lock_and_fence.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_lock_and_fence.yaml
@@ -3,3 +3,8 @@ tasks:
     clients:
       client.0:
         - rbd/test_lock_fence.sh
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
+++ b/qa/suites/rbd/basic/tasks/rbd_python_api_tests_old_format.yaml
@@ -3,6 +3,9 @@ overrides:
     log-whitelist:
       - \(SLOW_OPS\)
       - slow request
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/cli/features/defaults.yaml
+++ b/qa/suites/rbd/cli/features/defaults.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd default features: 61
+        rbd op threads: 8

--- a/qa/suites/rbd/cli/features/journaling.yaml
+++ b/qa/suites/rbd/cli/features/journaling.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd default features: 125
+        rbd op threads: 8

--- a/qa/suites/rbd/cli/features/layering.yaml
+++ b/qa/suites/rbd/cli/features/layering.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd default features: 1
+        rbd op threads: 8

--- a/qa/suites/rbd/cli/pool/ec-data-pool.yaml
+++ b/qa/suites/rbd/cli/pool/ec-data-pool.yaml
@@ -18,6 +18,7 @@ overrides:
     conf:
       client:
         rbd default data pool: datapool
+        rbd op threads: 8
       osd: # force bluestore since it's required for ec overwrites
         osd objectstore: bluestore
         bluestore block size: 96636764160

--- a/qa/suites/rbd/cli/pool/replicated-data-pool.yaml
+++ b/qa/suites/rbd/cli/pool/replicated-data-pool.yaml
@@ -9,3 +9,4 @@ overrides:
     conf:
       client:
         rbd default data pool: datapool
+        rbd op threads: 8

--- a/qa/suites/rbd/cli/pool/small-cache-pool.yaml
+++ b/qa/suites/rbd/cli/pool/small-cache-pool.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rbd/cli/workloads/rbd_cli_generic.yaml
+++ b/qa/suites/rbd/cli/workloads/rbd_cli_generic.yaml
@@ -3,3 +3,8 @@ tasks:
     clients:
       client.0:
         - rbd/cli_generic.sh
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/cli/workloads/rbd_cli_groups.yaml
+++ b/qa/suites/rbd/cli/workloads/rbd_cli_groups.yaml
@@ -3,3 +3,8 @@ tasks:
     clients:
       client.0:
         - rbd/rbd_groups.sh
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/cli/workloads/rbd_cli_import_export.yaml
+++ b/qa/suites/rbd/cli/workloads/rbd_cli_import_export.yaml
@@ -3,3 +3,8 @@ tasks:
     clients:
       client.0:
         - rbd/import_export.sh
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/cli_v1/features/format-1.yaml
+++ b/qa/suites/rbd/cli_v1/features/format-1.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd default format: 1
+        rbd op threads: 8

--- a/qa/suites/rbd/cli_v1/msgr-failures/few.yaml
+++ b/qa/suites/rbd/cli_v1/msgr-failures/few.yaml
@@ -4,5 +4,7 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
+      client:
+        rbd op threads: 8
     log-whitelist:
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rbd/cli_v1/pool/small-cache-pool.yaml
+++ b/qa/suites/rbd/cli_v1/pool/small-cache-pool.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rbd/cli_v1/workloads/rbd_cli_generic.yaml
+++ b/qa/suites/rbd/cli_v1/workloads/rbd_cli_generic.yaml
@@ -3,3 +3,8 @@ tasks:
     clients:
       client.0:
         - rbd/cli_generic.sh
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/cli_v1/workloads/rbd_cli_import_export.yaml
+++ b/qa/suites/rbd/cli_v1/workloads/rbd_cli_import_export.yaml
@@ -3,3 +3,8 @@ tasks:
     clients:
       client.0:
         - rbd/import_export.sh
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/cache/none.yaml
+++ b/qa/suites/rbd/librbd/cache/none.yaml
@@ -4,3 +4,8 @@ tasks:
     conf:
       client:
         rbd cache: false
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/cache/writeback.yaml
+++ b/qa/suites/rbd/librbd/cache/writeback.yaml
@@ -5,3 +5,8 @@ tasks:
       client:
         rbd cache: true
         rbd cache policy: writeback
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/cache/writethrough.yaml
+++ b/qa/suites/rbd/librbd/cache/writethrough.yaml
@@ -5,3 +5,8 @@ tasks:
       client:
         rbd cache: true
         rbd cache max dirty: 0
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/config/copy-on-read.yaml
+++ b/qa/suites/rbd/librbd/config/copy-on-read.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd clone copy on read: true
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/msgr-failures/few.yaml
+++ b/qa/suites/rbd/librbd/msgr-failures/few.yaml
@@ -4,6 +4,8 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
+      client:
+        rbd op threads: 8
     log-whitelist:
       - but it is still running
       - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rbd/librbd/pool/ec-data-pool.yaml
+++ b/qa/suites/rbd/librbd/pool/ec-data-pool.yaml
@@ -15,6 +15,7 @@ overrides:
     conf:
       client:
         rbd default data pool: datapool
+        rbd op threads: 8
       osd: # force bluestore since it's required for ec overwrites
         osd objectstore: bluestore
         bluestore block size: 96636764160

--- a/qa/suites/rbd/librbd/pool/replicated-data-pool.yaml
+++ b/qa/suites/rbd/librbd/pool/replicated-data-pool.yaml
@@ -9,3 +9,4 @@ overrides:
     conf:
       client:
         rbd default data pool: datapool
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/pool/small-cache-pool.yaml
+++ b/qa/suites/rbd/librbd/pool/small-cache-pool.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)
+    conf:
+      client:
+        rbd op threads: 8    
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rbd/librbd/workloads/c_api_tests.yaml
+++ b/qa/suites/rbd/librbd/workloads/c_api_tests.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/librbd/workloads/c_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/librbd/workloads/c_api_tests_with_defaults.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/librbd/workloads/c_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/librbd/workloads/c_api_tests_with_journaling.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/librbd/workloads/fsx.yaml
+++ b/qa/suites/rbd/librbd/workloads/fsx.yaml
@@ -2,3 +2,8 @@ tasks:
 - rbd_fsx:
     clients: [client.0]
     ops: 20000
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests.yaml
@@ -5,3 +5,8 @@ tasks:
         - rbd/test_librbd_python.sh
     env:
       RBD_FEATURES: "1"
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests_with_defaults.yaml
@@ -5,3 +5,8 @@ tasks:
         - rbd/test_librbd_python.sh
     env:
       RBD_FEATURES: "61"
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/librbd/workloads/python_api_tests_with_journaling.yaml
@@ -5,3 +5,8 @@ tasks:
         - rbd/test_librbd_python.sh
     env:
       RBD_FEATURES: "125"
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/librbd/workloads/rbd_fio.yaml
+++ b/qa/suites/rbd/librbd/workloads/rbd_fio.yaml
@@ -8,3 +8,8 @@ tasks:
       test-clone-io: 1
       rw: randrw
       runtime: 900
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8

--- a/qa/suites/rbd/maintenance/workloads/dynamic_features.yaml
+++ b/qa/suites/rbd/maintenance/workloads/dynamic_features.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 op_workload:
   sequential:
     - workunit:

--- a/qa/suites/rbd/maintenance/workloads/dynamic_features_no_cache.yaml
+++ b/qa/suites/rbd/maintenance/workloads/dynamic_features_no_cache.yaml
@@ -3,6 +3,7 @@ overrides:
     conf:
       client:
         rbd cache: false
+        rbd op threads: 8
 op_workload:
   sequential:
     - workunit:

--- a/qa/suites/rbd/maintenance/workloads/rebuild_object_map.yaml
+++ b/qa/suites/rbd/maintenance/workloads/rebuild_object_map.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 op_workload:
   sequential:
     - workunit:

--- a/qa/suites/rbd/mirror-thrash/policy/none.yaml
+++ b/qa/suites/rbd/mirror-thrash/policy/none.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd mirror image policy type: none
+        rbd op threads: 8

--- a/qa/suites/rbd/mirror-thrash/policy/simple.yaml
+++ b/qa/suites/rbd/mirror-thrash/policy/simple.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd mirror image policy type: simple
+        rbd op threads: 8

--- a/qa/suites/rbd/mirror-thrash/rbd-mirror/four-per-cluster.yaml
+++ b/qa/suites/rbd/mirror-thrash/rbd-mirror/four-per-cluster.yaml
@@ -1,5 +1,10 @@
 meta:
 - desc: run four rbd-mirror daemons per cluster
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - rbd-mirror:
     client: cluster1.client.mirror.0

--- a/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-fsx-workunit.yaml
+++ b/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-fsx-workunit.yaml
@@ -1,6 +1,11 @@
 meta:
 - desc: run multiple FSX workloads to simulate cluster load and then verify
         that the images were replicated
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-journal-workunit.yaml
+++ b/qa/suites/rbd/mirror-thrash/workloads/rbd-mirror-journal-workunit.yaml
@@ -1,5 +1,10 @@
 meta:
 - desc: run the rbd_mirror_journal.sh workunit to test the rbd-mirror daemon
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/mirror/workloads/rbd-mirror-ha-workunit.yaml
+++ b/qa/suites/rbd/mirror/workloads/rbd-mirror-ha-workunit.yaml
@@ -5,6 +5,7 @@ overrides:
     conf:
       client:
         rbd mirror image policy type: none
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/mirror/workloads/rbd-mirror-workunit-config-key.yaml
+++ b/qa/suites/rbd/mirror/workloads/rbd-mirror-workunit-config-key.yaml
@@ -1,5 +1,10 @@
 meta:
 - desc: run the rbd_mirror_journal.sh workunit to test the rbd-mirror daemon
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:
@@ -10,3 +15,4 @@ tasks:
       RBD_MIRROR_INSTANCES: '4'
       RBD_MIRROR_USE_EXISTING_CLUSTER: '1'
       RBD_MIRROR_CONFIG_KEY: '1'
+

--- a/qa/suites/rbd/mirror/workloads/rbd-mirror-workunit-policy-simple.yaml
+++ b/qa/suites/rbd/mirror/workloads/rbd-mirror-workunit-policy-simple.yaml
@@ -5,6 +5,7 @@ overrides:
     conf:
       client:
         rbd mirror image policy type: simple
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/qemu/cache/none.yaml
+++ b/qa/suites/rbd/qemu/cache/none.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rbd/qemu/cache/writeback.yaml
+++ b/qa/suites/rbd/qemu/cache/writeback.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rbd/qemu/cache/writethrough.yaml
+++ b/qa/suites/rbd/qemu/cache/writethrough.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rbd/qemu/features/defaults.yaml
+++ b/qa/suites/rbd/qemu/features/defaults.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd default features: 61
+        rbd op threads: 8

--- a/qa/suites/rbd/qemu/features/journaling.yaml
+++ b/qa/suites/rbd/qemu/features/journaling.yaml
@@ -3,3 +3,4 @@ overrides:
     conf:
       client:
         rbd default features: 125
+        rbd op threads: 8

--- a/qa/suites/rbd/qemu/msgr-failures/few.yaml
+++ b/qa/suites/rbd/qemu/msgr-failures/few.yaml
@@ -4,6 +4,8 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
+      client:
+        rbd op threads: 8
     log-whitelist:
     - but it is still running
     - \(OSD_SLOW_PING_TIME

--- a/qa/suites/rbd/qemu/pool/ec-cache-pool.yaml
+++ b/qa/suites/rbd/qemu/pool/ec-cache-pool.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rbd/qemu/pool/ec-data-pool.yaml
+++ b/qa/suites/rbd/qemu/pool/ec-data-pool.yaml
@@ -15,6 +15,7 @@ overrides:
     conf:
       client:
         rbd default data pool: datapool
+        rbd op threads: 8
       osd: # force bluestore since it's required for ec overwrites
         osd objectstore: bluestore
         bluestore block size: 96636764160

--- a/qa/suites/rbd/qemu/pool/replicated-data-pool.yaml
+++ b/qa/suites/rbd/qemu/pool/replicated-data-pool.yaml
@@ -9,3 +9,4 @@ overrides:
     conf:
       client:
         rbd default data pool: datapool
+        rbd op threads: 8

--- a/qa/suites/rbd/qemu/pool/small-cache-pool.yaml
+++ b/qa/suites/rbd/qemu/pool/small-cache-pool.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rbd/qemu/workloads/qemu_bonnie.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_bonnie.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - qemu:
     all:

--- a/qa/suites/rbd/qemu/workloads/qemu_fsstress.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_fsstress.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - qemu:
     all:

--- a/qa/suites/rbd/qemu/workloads/qemu_xfstests.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_xfstests.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - qemu:
     all:

--- a/qa/suites/rbd/singleton/all/permissions.yaml
+++ b/qa/suites/rbd/singleton/all/permissions.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:

--- a/qa/suites/rbd/singleton/all/qemu-iotests-no-cache.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-no-cache.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 exclude_arch: armv7l
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writeback.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writeback.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 exclude_arch: armv7l
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]

--- a/qa/suites/rbd/singleton/all/qemu-iotests-writethrough.yaml
+++ b/qa/suites/rbd/singleton/all/qemu-iotests-writethrough.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 exclude_arch: armv7l
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]

--- a/qa/suites/rbd/singleton/all/rbd-vs-unmanaged-snaps.yaml
+++ b/qa/suites/rbd/singleton/all/rbd-vs-unmanaged-snaps.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:

--- a/qa/suites/rbd/singleton/all/rbd_mirror.yaml
+++ b/qa/suites/rbd/singleton/all/rbd_mirror.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:

--- a/qa/suites/rbd/singleton/all/read-flags-no-cache.yaml
+++ b/qa/suites/rbd/singleton/all/read-flags-no-cache.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:

--- a/qa/suites/rbd/singleton/all/read-flags-writeback.yaml
+++ b/qa/suites/rbd/singleton/all/read-flags-writeback.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:

--- a/qa/suites/rbd/singleton/all/read-flags-writethrough.yaml
+++ b/qa/suites/rbd/singleton/all/read-flags-writethrough.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:

--- a/qa/suites/rbd/singleton/all/verify_pool.yaml
+++ b/qa/suites/rbd/singleton/all/verify_pool.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, client.0]
 tasks:

--- a/qa/suites/rbd/thrash/msgr-failures/few.yaml
+++ b/qa/suites/rbd/thrash/msgr-failures/few.yaml
@@ -4,5 +4,8 @@ overrides:
       global:
         ms inject socket failures: 5000
         mon client directed command retry: 5
+      client:
+        rbd op threads: 8
     log-whitelist:
       - \(OSD_SLOW_PING_TIME
+

--- a/qa/suites/rbd/thrash/thrashers/cache.yaml
+++ b/qa/suites/rbd/thrash/thrashers/cache.yaml
@@ -6,6 +6,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NEAR_FULL\)
       - \(CACHE_POOL_NO_HIT_SET\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - exec:
     client.0:

--- a/qa/suites/rbd/thrash/thrashers/default.yaml
+++ b/qa/suites/rbd/thrash/thrashers/default.yaml
@@ -3,6 +3,9 @@ overrides:
     log-whitelist:
     - but it is still running
     - objects unfound and apparently lost
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - thrashosds:
     timeout: 1200

--- a/qa/suites/rbd/thrash/workloads/journal.yaml
+++ b/qa/suites/rbd/thrash/workloads/journal.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/thrash/workloads/rbd_api_tests.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_api_tests.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/thrash/workloads/rbd_api_tests_copy_on_read.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_api_tests_copy_on_read.yaml
@@ -14,3 +14,4 @@ overrides:
     conf:
       client:
         rbd clone copy on read: true
+        rbd op threads: 8

--- a/qa/suites/rbd/thrash/workloads/rbd_api_tests_journaling.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_api_tests_journaling.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/thrash/workloads/rbd_api_tests_no_locking.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_api_tests_no_locking.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/thrash/workloads/rbd_fsx_cache_writeback.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_fsx_cache_writeback.yaml
@@ -8,3 +8,4 @@ overrides:
       client:
         rbd cache: true
         rbd cache policy: writeback
+        rbd op threads: 8

--- a/qa/suites/rbd/thrash/workloads/rbd_fsx_cache_writethrough.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_fsx_cache_writethrough.yaml
@@ -8,3 +8,4 @@ overrides:
       client:
         rbd cache: true
         rbd cache max dirty: 0
+        rbd op threads: 8

--- a/qa/suites/rbd/thrash/workloads/rbd_fsx_copy_on_read.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_fsx_copy_on_read.yaml
@@ -8,3 +8,4 @@ overrides:
       client:
         rbd cache: true
         rbd clone copy on read: true
+        rbd op threads: 8

--- a/qa/suites/rbd/thrash/workloads/rbd_fsx_deep_copy.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_fsx_deep_copy.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - rbd_fsx:
     clients: [client.0]

--- a/qa/suites/rbd/thrash/workloads/rbd_fsx_journal.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_fsx_journal.yaml
@@ -1,3 +1,8 @@
+overrides:
+  ceph:
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - rbd_fsx:
     clients: [client.0]

--- a/qa/suites/rbd/thrash/workloads/rbd_fsx_nocache.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_fsx_nocache.yaml
@@ -7,3 +7,4 @@ overrides:
     conf:
       client:
         rbd cache: false
+        rbd op threads: 8

--- a/qa/suites/rbd/thrash/workloads/rbd_fsx_rate_limit.yaml
+++ b/qa/suites/rbd/thrash/workloads/rbd_fsx_rate_limit.yaml
@@ -7,5 +7,6 @@ overrides:
     conf:
       client:
         rbd qos iops limit: 50
+        rbd op threads: 8
         rbd qos iops burst: 100
         rbd qos schedule tick min: 100

--- a/qa/suites/rbd/valgrind/validator/memcheck.yaml
+++ b/qa/suites/rbd/valgrind/validator/memcheck.yaml
@@ -6,6 +6,9 @@ overrides:
     ceph:
       flavor: notcmalloc
       debuginfo: true
+    conf:
+      client:
+        rbd op threads: 8
   rbd_fsx:
     valgrind: ["--tool=memcheck"]
   workunit:

--- a/qa/suites/rbd/valgrind/workloads/c_api_tests.yaml
+++ b/qa/suites/rbd/valgrind/workloads/c_api_tests.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/c_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/valgrind/workloads/c_api_tests_with_defaults.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/c_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/valgrind/workloads/c_api_tests_with_journaling.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/rbd_mirror.yaml
+++ b/qa/suites/rbd/valgrind/workloads/rbd_mirror.yaml
@@ -4,6 +4,9 @@ overrides:
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
       - \(POOL_APP_NOT_ENABLED\)
+    conf:
+      client:
+        rbd op threads: 8
 tasks:
 - workunit:
     clients:

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -59,8 +59,8 @@ public:
   ContextWQ *op_work_queue;
 
   explicit ThreadPoolSingleton(CephContext *cct)
-    : ThreadPool(cct, "librbd::thread_pool", "tp_librbd", 1,
-                 "rbd_op_threads"),
+    : ThreadPool(cct, "librbd::thread_pool", "tp_librbd",
+                 cct->_conf.get_val<uint64_t>("rbd_op_threads"), "rbd_op_threads"),
       op_work_queue(new ContextWQ("librbd::op_work_queue",
                                   cct->_conf.get_val<uint64_t>("rbd_op_thread_timeout"),
                                   this)) {

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -59,11 +59,16 @@ int main(int argc, char **argv)
 #endif // TEST_LIBRBD_INTERNALS
 
   int r = rados.conf_set("lockdep", "true");
+  int t = rados.conf_set("rbd_op_threads", "8");
+
   if (r < 0) {
     std::cerr << "failed to enable lockdep" << std::endl;
     return -r;
   }
-
+  if (t < 0) {
+    std::cerr << "failed to enable op threads" << std::endl;
+    return -t;
+  }
   int seed = getpid();
   std::cout << "seed " << seed << std::endl;
   srand(seed);

--- a/src/test/rbd_mirror/test_main.cc
+++ b/src/test/rbd_mirror/test_main.cc
@@ -45,9 +45,15 @@ int main(int argc, char **argv)
   g_ceph_context = reinterpret_cast<CephContext*>(rados.cct());
 
   int r = rados.conf_set("lockdep", "true");
+  int t = rados.conf_set("rbd_op_threads", "8");
+
   if (r < 0) {
     std::cerr << "failed to enable lockdep" << std::endl;
     return -r;
+  }
+  if (t < 0) {
+    std::cerr << "failed to enable op threads" << std::endl;
+    return -t;
   }
   return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This PR introduces refcounting for reference counting state machines and aims to support configurable worker threads (via "rbd op threads")
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

