### PR TITLE
ceph-kvstore-tool: rename repair -> destructive-repair

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -97,6 +97,10 @@
 
     ceph auth caps client.bad osd 'allow rwx pool foo'
 
+* The ``ceph-kvstore-tool`` ``repair`` command has been renamed
+  ``destructive-repair`` since we have discovered it can corrupt an
+  otherwise healthy rocksdb database.  It should be used only as a last-ditch
+  attempt to recover data from an otherwise corrupted store.
 
 
 

--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -72,8 +72,10 @@ which are as follows:
 :command:`compact-range <prefix> <start> <end>`
     Compact some entries specified by the URL encoded prefix and range.
 
-:command:`repair`
-    Try to repair the kvstore.
+:command:`destructive-repair`
+    Make a (potentially destructive) effort to recover a corrupted database.
+    Note that in the case of rocksdb this may corrupt an otherwise uncorrupted
+    database--use this only as a last resort!
 
 Availability
 ============

--- a/qa/workunits/cephtool/test_kvstore_tool.sh
+++ b/qa/workunits/cephtool/test_kvstore_tool.sh
@@ -59,8 +59,8 @@ function test_ceph_kvstore_tool()
   # compact
   ceph-kvstore-tool bluestore-kv ${TEMP_DIR} compact
 
-  # repair 
-  ceph-kvstore-tool bluestore-kv ${TEMP_DIR} repair 
+  # destructive-repair 
+  ceph-kvstore-tool bluestore-kv ${TEMP_DIR} destructive-repair 
 
   current_kv_nums=`ceph-kvstore-tool  bluestore-kv ${TEMP_DIR} list 2>/dev/null | wc -l`
   test ${origin_kv_nums} -eq ${current_kv_nums}

--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -16,5 +16,5 @@
     compact
     compact-prefix <prefix>
     compact-range <prefix> <start> <end>
-    repair
+    destructive-repair  (use only as last resort! may corrupt healthy data)
   

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -285,7 +285,7 @@ class StoreTool
     db->compact_range(prefix, start, end);
   }
 
-  int repair() {
+  int destructive_repair() {
     return db->repair(std::cout);
   }
 };
@@ -309,7 +309,7 @@ void usage(const char *pname)
     << "  compact\n"
     << "  compact-prefix <prefix>\n"
     << "  compact-range <prefix> <start> <end>\n"
-    << "  repair\n"
+    << "  destructive-repair  (use only as last resort! may corrupt healthy data)\n"
     << std::endl;
 }
 
@@ -355,15 +355,17 @@ int main(int argc, const char *argv[])
     return 1;
   }
 
-  bool need_open_db = (cmd != "repair");
+  bool need_open_db = (cmd != "destructive-repair");
   StoreTool st(type, path, need_open_db);
 
-  if (cmd == "repair") {
-    int ret = st.repair();
+  if (cmd == "destructive-repair") {
+    int ret = st.destructive_repair();
     if (!ret) {
-      std::cout << "repair kvstore successfully" << std::endl;
+      std::cout << "destructive-repair completed without reporting an error"
+		<< std::endl;
     } else {
-      std::cout << "repair kvstore failed" << std::endl;
+      std::cout << "destructive-repair failed with " << cpp_strerror(ret)
+		<< std::endl;
     }
     return ret;
   } else if (cmd == "list" || cmd == "list-crc") {


### PR DESCRIPTION
This is shown to corrupt otherwise healthy rocksdb databases.  Rename to
make it clear that it is generally not safe to run and shoud only be used
as a last resort.

Signed-off-by: Sage Weil <sage@redhat.com>