### PR TITLE
qa: increase timeout for cleanup

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -410,7 +410,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                 )
                 if cleanup:
                     args=['sudo', 'rm', '-rf', '--', scratch_tmp]
-                    remote.run(logger=log.getChild(role), args=args, timeout=(15*60))
+                    remote.run(logger=log.getChild(role), args=args, timeout=(60*60))
     finally:
         log.info('Stopping %s on %s...', tests, role)
         args=['sudo', 'rm', '-rf', '--', workunits_file, clonedir]


### PR DESCRIPTION
Apparently 15m is not long enough for some workunits like fsstress.

Fixes: http://tracker.ceph.com/issues/36365

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

