### PR TITLE
Additional work on ceph-volume to add some choose_disk capabilities

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -150,6 +150,18 @@ class TestCephDiskDevice(object):
 
         assert disk.is_member is True
 
+    def test_reject_removable_device(self, device_info):
+        data = {"/dev/sdb": {"removable": 1}}
+        device_info(devices=data)
+        disk = device.Device("/dev/sdb")
+        assert not disk.is_valid
+
+    def test_accept_non_removable_device(self, device_info):
+        data = {"/dev/sdb": {"removable": 0}}
+        device_info(devices=data)
+        disk = device.Device("/dev/sdb")
+        assert disk.is_valid
+
     @pytest.mark.parametrize("label", ceph_partlabels)
     def test_is_member_lsblk(self, device_info, label):
         lsblk = {"PARTLABEL": label}

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -162,6 +162,18 @@ class TestCephDiskDevice(object):
         disk = device.Device("/dev/sdb")
         assert disk.is_valid
 
+    def test_reject_readonly_device(self, device_info):
+        data = {"/dev/cdrom": {"ro": 1}}
+        device_info(devices=data)
+        disk = device.Device("/dev/cdrom")
+        assert not disk.is_valid
+
+    def test_accept_non_readonly_device(self, device_info):
+        data = {"/dev/sda": {"ro": 0}}
+        device_info(devices=data)
+        disk = device.Device("/dev/sda")
+        assert disk.is_valid
+
     @pytest.mark.parametrize("label", ceph_partlabels)
     def test_is_member_lsblk(self, device_info, label):
         lsblk = {"PARTLABEL": label}

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -220,19 +220,6 @@ class TestGetDevices(object):
         assert result[dev_sda_path]['model'] == ''
         assert result[dev_sda_path]['partitions'] == {}
 
-    def test_sda_is_removable_gets_skipped(self, tmpfile, tmpdir):
-        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
-        dev_sda_path = os.path.join(dev_path, 'sda')
-        block_sda_path = os.path.join(block_path, 'sda')
-        os.makedirs(block_sda_path)
-        os.makedirs(dev_sda_path)
-
-        tmpfile('removable', contents='1', directory=block_sda_path)
-        result = disk.get_devices(
-            _sys_block_path=block_path,
-            _dev_path=dev_path,
-            _mapper_path=mapper_path)
-        assert result == {}
 
     def test_dm_device_is_not_used(self, monkeypatch, tmpdir):
         # the link to the mapper is used instead

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -141,6 +141,7 @@ class Device(object):
             except KeyError:
                 pass
         reject_device('removable', 1, 'removable')
+        reject_device('ro', 1, 'read-only')
 
         self._valid = len(self._rejected_reasons) == 0
         return self._valid

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -22,6 +22,7 @@ class Device(object):
         self._valid = False
         self._rejected_reasons = []
         self._parse()
+        self.is_valid
 
     def _parse(self):
         # start with lvm since it can use an absolute or relative path

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -19,6 +19,8 @@ class Device(object):
         self.sys_api = {}
         self._exists = None
         self._is_lvm_member = None
+        self._valid = False
+        self._rejected_reasons = []
         self._parse()
 
     def _parse(self):
@@ -128,6 +130,20 @@ class Device(object):
         osd_ids = [lv.tags.get("ceph.osd_id") is not None for lv in self.lvs
                    if lv.tags.get("ceph.type") in ["data", "block"]]
         return any(osd_ids)
+
+
+    @property
+    def is_valid(self):
+        def reject_device(item, value, reason):
+            try:
+                if self.sys_api[item] == value:
+                    self._rejected_reasons.append(reason)
+            except KeyError:
+                pass
+        reject_device('removable', 1, 'removable')
+
+        self._valid = len(self._rejected_reasons) == 0
+        return self._valid
 
 
 class CephDiskDevice(object):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -142,6 +142,7 @@ class Device(object):
                 pass
         reject_device('removable', 1, 'removable')
         reject_device('ro', 1, 'read-only')
+        reject_device('locked', 1, 'locked')
 
         self._valid = len(self._rejected_reasons) == 0
         return self._valid

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -694,10 +694,7 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
             if lvm.is_lv(diskname):
                 continue
 
-        # If the device reports itself as 'removable', get it excluded
         metadata['removable'] = get_file_contents(os.path.join(sysdir, 'removable'))
-        if metadata['removable'] == '1':
-            continue
 
         for key in ['vendor', 'model', 'sas_address', 'sas_device_handle']:
             metadata[key] = get_file_contents(sysdir + "/device/" + key)

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -710,7 +710,9 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
 
         metadata['partitions'] = get_partitions_facts(sysdir)
 
-        metadata['rotational'] = get_file_contents(sysdir + "/queue/rotational")
+        for key in ['rotational', 'nr_requests']:
+            metadata[key] = get_file_contents(sysdir + "/queue/" + key)
+
         metadata['scheduler_mode'] = ""
         scheduler = get_file_contents(sysdir + "/queue/scheduler")
         if scheduler is not None:

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -699,7 +699,7 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
         metadata['ro'] = get_file_contents(os.path.join(sysdir, 'ro'))
 
 
-        for key in ['vendor', 'model', 'sas_address', 'sas_device_handle']:
+        for key in ['vendor', 'model', 'rev', 'sas_address', 'sas_device_handle']:
             metadata[key] = get_file_contents(sysdir + "/device/" + key)
 
         for key in ['sectors', 'size']:

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -653,6 +653,28 @@ def is_mapper_device(device_name):
     return device_name.startswith(('/dev/mapper', '/dev/dm-'))
 
 
+def is_locked_raw_device(disk_path):
+    """
+    A device can be locked by a third party software like a database.
+    To detect that case, the device is opened in Read/Write and exclusive mode
+    """
+    open_flags = (os.O_RDWR | os.O_EXCL)
+    open_mode = 0
+    fd = None
+
+    try:
+        fd = os.open(disk_path, open_flags, open_mode)
+    except OSError:
+        return 1
+
+    try:
+        os.close(fd)
+    except OSError:
+        return 1
+
+    return 0
+
+
 def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/dev/mapper'):
     """
     Captures all available devices from /sys/block/, including its partitions,
@@ -729,6 +751,7 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
         metadata['human_readable_size'] = human_readable_size(float(size) * 512)
         metadata['size'] = float(size) * 512
         metadata['path'] = diskname
+        metadata['locked'] = is_locked_raw_device(metadata['path'])
 
         device_facts[diskname] = metadata
     return device_facts

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -695,6 +695,9 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
                 continue
 
         metadata['removable'] = get_file_contents(os.path.join(sysdir, 'removable'))
+        # Is the device read-only ?
+        metadata['ro'] = get_file_contents(os.path.join(sysdir, 'ro'))
+
 
         for key in ['vendor', 'model', 'sas_address', 'sas_device_handle']:
             metadata[key] = get_file_contents(sysdir + "/device/" + key)


### PR DESCRIPTION
This patchset is about :

- adding new filtering capabilities to allow rejecting some devices that doesn't suit ceph's expectations.
- reporting additional storage capabilities : that gives more precision on filtering devices by their capabilties

Fixes: http://tracker.ceph.com/issues/36446