### PR TITLE
cephfs-shell: fixup 'str' object has no attribute 'decode'

### DIFF
--- a/src/tools/cephfs/cephfs-shell
+++ b/src/tools/cephfs/cephfs-shell
@@ -568,8 +568,7 @@ exists.')
                 items = sorted(list_items(dir_name),
                                key=lambda item: item.d_name)
             if not args.all and len(items) > 2:
-                items = [i for i in items if not i.d_name.decode(
-                    'utf-8').startswith('.')]
+                items = [i for i in items if not i.d_name.startswith('.')]
             flag = 0
             if args.S:
                 items = sorted(items, key=lambda item: cephfs.stat(
@@ -579,7 +578,7 @@ exists.')
             for item in items:
                 path = item
                 if not isinstance(item, str):
-                    path = item.d_name.decode('utf-8')
+                    path = item.d_name
                     if item.is_dir():
                         is_dir = True
                     else:


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/36368

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

