### PR TITLE
qa/workunits/rbd: force v2 image format for namespace test

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -277,7 +277,7 @@ test_locking() {
     echo "testing locking..."
     remove_images
 
-    rbd create -s 1 test1
+    rbd create $RBD_CREATE_ARGS -s 1 test1
     rbd lock list test1 | wc -l | grep '^0$'
     rbd lock add test1 id
     rbd lock list test1 | grep ' 1 '
@@ -633,7 +633,7 @@ test_namespace() {
 
     expect_fail rbd namespace remove --pool rbd missing
 
-    rbd create rbd/test1/image1 --size 1G
+    rbd create $RBD_CREATE_ARGS --size 1G rbd/test1/image1
 
     # default test1 ns to test2 ns clone
     rbd bench --io-type write --io-pattern rand --io-total 32M --io-size 4K rbd/test1/image1
@@ -644,7 +644,7 @@ test_namespace() {
     rbd rm rbd/test2/image1
 
     # default ns to test1 ns clone
-    rbd create rbd/image2 --size 1G
+    rbd create $RBD_CREATE_ARGS --size 1G rbd/image2
     rbd bench --io-type write --io-pattern rand --io-total 32M --io-size 4K rbd/image2
     rbd snap create rbd/image2@1
     rbd clone --rbd-default-clone-format 2 rbd/image2@1 rbd/test2/image2
@@ -654,7 +654,7 @@ test_namespace() {
     rbd rm rbd/test2/image2
     rbd rm rbd/image2
 
-    rbd create --namespace test1 image2 --size 1G
+    rbd create $RBD_CREATE_ARGS --size 1G --namespace test1 image2
     expect_fail rbd namespace remove --pool rbd test1
 
     rbd group create rbd/test1/group1


### PR DESCRIPTION
While here, fix test_locking too.

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

