### PR TITLE
mgr/selftest: fix disabled module selection

### DIFF
--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -311,10 +311,15 @@ class Module(MgrModule):
         self.remote("influx", "handle_command", "", {"prefix": "influx self-test"})
 
         # Test calling module that exists but isn't enabled
+        # (arbitrarily pick a non-always-on module to use)
+        disabled_module = "telegraf"
         mgr_map = self.get("mgr_map")
-        all_modules = [m['name'] for m in mgr_map['available_modules']]
-        disabled_modules = set(all_modules) - set(mgr_map['modules'])
-        disabled_module = list(disabled_modules)[0]
+        assert disabled_module not in mgr_map['modules']
+
+        # (This works until the Z release in about 2027)
+        latest_release = sorted(mgr_map['always_on_modules'].keys())[-1]
+        assert disabled_module not in mgr_map['always_on_modules'][latest_release]
+
         try:
             self.remote(disabled_module, "handle_command", {"prefix": "influx self-test"})
         except ImportError:


### PR DESCRIPTION
This was broken intermittently by always on modules -- it was also
unnecessary complication, let's just pick some
hardcoded module to use.

Signed-off-by: John Spray <john.spray@redhat.com>
