### PR TITLE
install-deps.sh: dashboard frontend needs git

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -429,3 +429,4 @@ for interpreter in python2.7 python3 ; do
     rm -rf $top_srcdir/install-deps-$interpreter
 done
 rm -rf $XDG_CACHE_HOME
+git --version || (echo "Dashboard uses git to pull dependencies." ; false)


### PR DESCRIPTION
Running `npm install` for the dashboard pulls dependenies with git.
Under some setups, git was not installed when building the frontend.

This hit me when compiling Ceph inside a docker container.

Fixes https://tracker.ceph.com/issues/36373

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

- [x] References tracker ticket

