### PR TITLE
ceph.in: reinstate interactive mode output

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -625,7 +625,17 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
                     print('Can not use \'tell\' in interactive mode.',
                           file=sys.stderr)
                     continue
-                do_command(parsed_args, target, cmdargs, sigdict, inbuf, verbose)
+                ret, outbuf, outs = do_command(parsed_args, target, cmdargs,
+                                               sigdict, inbuf, verbose)
+                if ret < 0:
+                    ret = -ret
+                    errstr = errno.errorcode.get(ret, 'Unknown')
+                    print(u'Error {0}: {1}'.format(errstr, outs), file=sys.stderr)
+                else:
+                    if outs:
+                        print(outs, file=sys.stderr)
+                    if outbuf:
+                        print(outbuf)
 
     return ret, outbuf, outs
 


### PR DESCRIPTION
This was broken in the following commit:
"""
commit 474c94b81efad1b954ab789bf8a97d93cd0e74f3
Author: Mohamad Gebai <mgebai@suse.com>
Date:   Wed Feb 28 18:12:19 2018 -0500

ceph.in: handle polling commands

Signed-off-by: Mohamad Gebai <mgebai@suse.com>
"""

Fixes: http://tracker.ceph.com/issues/36358

Signed-off-by: John Spray <john.spray@redhat.com>