### PR TITLE
mds: require w cap for cache drop

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -703,7 +703,7 @@ COMMAND("heap " \
 	"mds", "*", "cli,rest")
 COMMAND("cache drop name=timeout,type=CephInt,range=1", "trim cache and optionally "
 	"request client to release all caps and flush the journal", "mds",
-	"r", "cli,rest")
+	"rw", "cli,rest")
 };
 
 


### PR DESCRIPTION
This should be "rw" due to its potential impact on performance. Credit to John
Spray for catching the issue.

Fixes: http://tracker.ceph.com/issues/36379

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

