### PR TITLE
mgr/orchestrator: clarify error message about kubernetes python module

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -182,11 +182,11 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         if kubernetes_imported:
             return True, ""
         else:
-            return False, "`kubernetes` module not found"
+            return False, "`kubernetes` python module not found"
 
     def available(self):
         if not kubernetes_imported:
-            return False, "`kubernetes` module not found"
+            return False, "`kubernetes` python module not found"
         elif not self._in_cluster():
             return False, "ceph-mgr not running in Rook cluster"
 


### PR DESCRIPTION
When I saw this message, it took a bit of digging for me to understand
that it meant the _python_ module and not some missing ceph-mgr module.
Let's make that clear.

Signed-off-by: Jeff Layton <jlayton@redhat.com>