### PR TITLE
mon: give AUTH_NONE clients a Monmap when allowed

### DIFF
--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -644,6 +644,7 @@ bool AuthMonitor::prep_auth(MonOpRequestRef op, bool paxos_writable)
       if (caps_info.allow_all) {
 	s->caps.set_allow_all();
 	s->authenticated = true;
+	finished = true;
       }
     } else {
       // request


### PR DESCRIPTION
This is a minimal fix that continues a messy interface, but we expect it
to go away with msgrv2.