### PR TITLE
bluestore/stupidallocator: Raise logging level of dump()

### DIFF
--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -277,12 +277,12 @@ void StupidAllocator::dump()
 {
   std::lock_guard<std::mutex> l(lock);
   for (unsigned bin = 0; bin < free.size(); ++bin) {
-    ldout(cct, 0) << __func__ << " free bin " << bin << ": "
+    ldout(cct, 10) << __func__ << " free bin " << bin << ": "
 	    	  << free[bin].num_intervals() << " extents" << dendl;
     for (auto p = free[bin].begin();
 	 p != free[bin].end();
 	 ++p) {
-      ldout(cct, 0) << __func__ << "  0x" << std::hex << p.get_start() << "~"
+      ldout(cct, 10) << __func__ << "  0x" << std::hex << p.get_start() << "~"
 	      	    << p.get_len() << std::dec << dendl;
     }
   }


### PR DESCRIPTION
When BlueFS tries to reclaim free space it can dump many of these
lines in the logfile at a high rate which can cause a system to
lock up due to the amount of logging:

  7f90c2f0f700  0 stupidalloc 0x0x55828ae047d0 dump  0x15cd2078000~34000
  7f90c2f0f700  0 stupidalloc 0x0x55828ae047d0 dump  0x15cd22cc000~24000
  7f90c2f0f700  0 stupidalloc 0x0x55828ae047d0 dump  0x15cd2300000~20000

By setting to loglevel to 10 we prevent the logs from being filled
with these messages when running with a stock configuration.

Signed-off-by: Wido den Hollander <wido@42on.com>

