### PR TITLE
mgr/dashboard: Confirmation modal doesn't close

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
@@ -1,4 +1,4 @@
-<cd-modal>
+<cd-modal (hide)="cancel()">
   <ng-container class="modal-title">{{ titleText }}</ng-container>
   <ng-container class="modal-content">
     <form name="confirmationForm"

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.html
@@ -5,7 +5,7 @@
   <button type="button"
           class="close pull-right"
           aria-label="Close"
-          (click)="modalRef.hide()">
+          (click)="close()">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ModalModule } from 'ngx-bootstrap/modal';
+import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { ModalComponent } from './modal.component';
@@ -22,5 +23,21 @@ describe('ModalComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should call the hide callback function', () => {
+    spyOn(component.hide, 'emit');
+    const nativeElement = fixture.nativeElement;
+    const button = nativeElement.querySelector('button');
+    button.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    expect(component.hide.emit).toHaveBeenCalled();
+  });
+
+  it('should hide the modal', () => {
+    component.modalRef = new BsModalRef();
+    spyOn(component.modalRef, 'hide');
+    component.close();
+    expect(component.modalRef.hide).toHaveBeenCalled();
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/modal/modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 
 import { BsModalRef } from 'ngx-bootstrap/modal/bs-modal-ref.service';
 
@@ -11,5 +11,18 @@ export class ModalComponent {
   @Input()
   modalRef: BsModalRef;
 
+  /**
+   * Should be a function that is triggered when the modal is hidden.
+   */
+  @Output()
+  hide = new EventEmitter();
+
   constructor() {}
+
+  close() {
+    if (this.modalRef) {
+      this.modalRef.hide();
+    }
+    this.hide.emit();
+  }
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/24729

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

