### PR TITLE
osdc/Objecter: add ignore cache flag if got redirect reply

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3437,7 +3437,9 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     op->tid = 0;
     m->get_redirect().combine_with_locator(op->target.target_oloc,
 					   op->target.target_oid.name);
-    op->target.flags |= (CEPH_OSD_FLAG_REDIRECTED | CEPH_OSD_FLAG_IGNORE_OVERLAY);
+    op->target.flags |= (CEPH_OSD_FLAG_REDIRECTED |
+			 CEPH_OSD_FLAG_IGNORE_CACHE |
+			 CEPH_OSD_FLAG_IGNORE_OVERLAY);
     _op_submit(op, sul, NULL);
     m->put();
     return;


### PR DESCRIPTION
Similar to fix for https://tracker.ceph.com/issues/23296, see also #20766.

Fixes: https://tracker.ceph.com/issues/36406

Signed-off-by: Iain Buclaw iain.buclaw@sociomantic.com
