### PR TITLE
mgr/selftest: handle_command takes 3 args

### DIFF
--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -316,7 +316,7 @@ class Module(MgrModule):
         disabled_modules = set(all_modules) - set(mgr_map['modules'])
         disabled_module = list(disabled_modules)[0]
         try:
-            self.remote(disabled_module, "handle_command", {"prefix": "influx self-test"})
+            self.remote(disabled_module, "handle_command", "", {"prefix": "influx self-test"})
         except ImportError:
             pass
         else:
@@ -324,7 +324,7 @@ class Module(MgrModule):
 
         # Test calling module that doesn't exist
         try:
-            self.remote("idontexist", "handle_command", {"prefix": "influx self-test"})
+            self.remote("idontexist", "handle_command", "", {"prefix": "influx self-test"})
         except ImportError:
             pass
         else:


### PR DESCRIPTION
This is only a partial fix, though... the fact that we are getting

```
2018-10-11T15:06:12.799 INFO:tasks.ceph.mgr.z.smithi159.stderr:2018-10-11 15:06:12.793 7faef18fc700 -1 mgr handle_command module 'selftest' command handler threw exception: Remote method threw exception: TypeError: handle_command() takes exactly 3 arguments (2 given)
2018-10-11T15:06:12.799 INFO:tasks.ceph.mgr.z.smithi159.stderr:
2018-10-11T15:06:12.799 INFO:tasks.ceph.mgr.z.smithi159.stderr:2018-10-11 15:06:12.793 7faef18fc700 -1 mgr.server reply reply (22) Invalid argument Traceback (most recent call last):
2018-10-11T15:06:12.799 INFO:tasks.ceph.mgr.z.smithi159.stderr:  File "/usr/lib/ceph/mgr/selftest/module.py", line 131, in handle_command
2018-10-11T15:06:12.799 INFO:tasks.ceph.mgr.z.smithi159.stderr:    self._test_remote_calls()
2018-10-11T15:06:12.799 INFO:tasks.ceph.mgr.z.smithi159.stderr:  File "/usr/lib/ceph/mgr/selftest/module.py", line 319, in _test_remote_calls
2018-10-11T15:06:12.799 INFO:tasks.ceph.mgr.z.smithi159.stderr:    self.remote(disabled_module, "handle_command", {"prefix": "influx self-test"})
2018-10-11T15:06:12.799 INFO:tasks.ceph.mgr.z.smithi159.stderr:  File "/usr/lib/ceph/mgr/mgr_module.py", line 905, in remote
2018-10-11T15:06:12.800 INFO:tasks.ceph.mgr.z.smithi159.stderr:    args, kwargs)
```

suggests that this test will still fail because we're not throwing ImportError?