### PR TITLE
qa/workunits: replace 'realpath' with 'readlink -f' in fsstress.sh

### DIFF
--- a/qa/suites/rbd/maintenance/qemu/xfstests.yaml
+++ b/qa/suites/rbd/maintenance/qemu/xfstests.yaml
@@ -10,5 +10,5 @@ io_workload:
           type: block
           disks: 3
           time_wait: 120
-          test: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/run_xfstests_qemu.sh
+          test: qa/run_xfstests_qemu.sh
 exclude_arch: armv7l

--- a/qa/suites/rbd/openstack/workloads/devstack-tempest-gate.yaml
+++ b/qa/suites/rbd/openstack/workloads/devstack-tempest-gate.yaml
@@ -7,7 +7,7 @@ tasks:
       disks:
       - image_size: 30720
       - image_size: 30720
-      test: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/workunits/rbd/run_devstack_tempest.sh
+      test: qa/workunits/rbd/run_devstack_tempest.sh
       image_url: https://cloud-images.ubuntu.com/releases/16.04/release/ubuntu-16.04-server-cloudimg-amd64-disk1.img
       cloud_config_archive:
       - type: text/cloud-config

--- a/qa/suites/rbd/qemu/workloads/qemu_bonnie.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_bonnie.yaml
@@ -2,5 +2,5 @@ tasks:
 - qemu:
     all:
       clone: true
-      test: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/workunits/suites/bonnie.sh
+      test: qa/workunits/suites/bonnie.sh
 exclude_arch: armv7l

--- a/qa/suites/rbd/qemu/workloads/qemu_fsstress.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_fsstress.yaml
@@ -2,5 +2,5 @@ tasks:
 - qemu:
     all:
       clone: true
-      test: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/workunits/suites/fsstress.sh
+      test: qa/workunits/suites/fsstress.sh
 exclude_arch: armv7l

--- a/qa/suites/rbd/qemu/workloads/qemu_iozone.yaml.disabled
+++ b/qa/suites/rbd/qemu/workloads/qemu_iozone.yaml.disabled
@@ -1,6 +1,6 @@
 tasks:
 - qemu:
     all:
-      test: http://git.ceph.com/?p={repo};a=blob_plain;h={branch};f=qa/workunits/suites/iozone.sh
+      test: qa/workunits/suites/iozone.sh
       image_size: 20480
 exclude_arch: armv7l

--- a/qa/suites/rbd/qemu/workloads/qemu_xfstests.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_xfstests.yaml
@@ -4,5 +4,5 @@ tasks:
       clone: true
       type: block
       disks: 3
-      test: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/run_xfstests_qemu.sh
+      test: qa/run_xfstests_qemu.sh
 exclude_arch: armv7l

--- a/qa/workunits/suites/fsstress.sh
+++ b/qa/workunits/suites/fsstress.sh
@@ -8,7 +8,7 @@ wget -q -O ltp-full.tgz http://download.ceph.com/qa/ltp-full-20091231.tgz
 tar xzf ltp-full.tgz
 pushd ltp-full-20091231/testcases/kernel/fs/fsstress
 make
-BIN=$(realpath fsstress)
+BIN=$(readlink -f fsstress)
 popd
 popd
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

