### PR TITLE
mimic: librbd: object copy state machine might dereference a deleted object

### DIFF
--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -460,13 +460,16 @@ void ObjectCopyRequest<I>::send_update_object_map() {
       finish_op_ctx->complete(0);
     });
 
-  m_dst_image_ctx->object_map_lock.get_write();
-  bool sent = m_dst_image_ctx->object_map->template aio_update<
+  auto dst_image_ctx = m_dst_image_ctx;
+  dst_image_ctx->object_map_lock.get_write();
+  bool sent = dst_image_ctx->object_map->template aio_update<
     Context, &Context::complete>(dst_snap_id, m_dst_object_number, object_state,
                                  {}, {}, ctx);
-  m_dst_image_ctx->object_map_lock.put_write();
-  m_dst_image_ctx->snap_lock.put_read();
-  m_dst_image_ctx->owner_lock.put_read();
+
+  // NOTE: state machine might complete before we reach here
+  dst_image_ctx->object_map_lock.put_write();
+  dst_image_ctx->snap_lock.put_read();
+  dst_image_ctx->owner_lock.put_read();
   if (!sent) {
     assert(dst_snap_id == CEPH_NOSNAP);
     ctx->complete(0);


### PR DESCRIPTION
http://tracker.ceph.com/issues/36238