### PR TITLE
rgw: add missing explicit placement to bucket info.

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6068,6 +6068,10 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     if (ret < 0)
       return ret;
 
+    bucket.explicit_placement.data_pool = rule_info.data_pool;
+    bucket.explicit_placement.data_extra_pool = rule_info.data_extra_pool;
+    bucket.explicit_placement.index_pool = rule_info.index_pool;
+
     if (!pmaster_bucket) {
       create_bucket_id(&bucket.marker);
       bucket.bucket_id = bucket.marker;


### PR DESCRIPTION
Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->



