### PR TITLE
mgr/rook: Fix Rook cluster name detection

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -187,7 +187,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     def available(self):
         if not kubernetes_imported:
             return False, "`kubernetes` module not found"
-        elif not self._in_cluster():
+        elif not self._in_cluster_name:
             return False, "ceph-mgr not running in Rook cluster"
 
         try:
@@ -219,23 +219,27 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         self._initialized.wait()
         return self._rook_cluster
 
-    def _in_cluster(self):
+    @property
+    def _in_cluster_name(self):
         """
         Check if we appear to be running inside a Kubernetes/Rook
         cluster
 
-        :return: bool
+        :return: str
         """
-        return 'ROOK_CLUSTER_NAME' in os.environ
+        if 'POD_NAMESPACE' in os.environ:
+            return os.environ['POD_NAMESPACE']
+        if 'ROOK_CLUSTER_NAME' in os.environ:
+            return os.environ['ROOK_CLUSTER_NAME']
 
     def serve(self):
         # For deployed clusters, we should always be running inside
         # a Rook cluster.  For development convenience, also support
         # running outside (reading ~/.kube config)
 
-        if self._in_cluster():
+        if self._in_cluster_name:
             config.load_incluster_config()
-            cluster_name = os.environ['ROOK_CLUSTER_NAME']
+            cluster_name = self._in_cluster_name
         else:
             self.log.warning("DEVELOPMENT ONLY: Reading kube config from ~")
             config.load_kube_config()


### PR DESCRIPTION
`ROOK_CLUSTER_NAME` vanished from environment. Change to
'POD_NAMESPACE'.

@BlaineEXE could you review this PR?

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>
