### PR TITLE
tools/rados/rados.cc: fix object copy flags

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -497,10 +497,13 @@ static int do_copy(IoCtx& io_ctx, const char *objname,
 		   IoCtx& target_ctx, const char *target_obj)
 {
   __le32 src_fadvise_flags = LIBRADOS_OP_FLAG_FADVISE_SEQUENTIAL | LIBRADOS_OP_FLAG_FADVISE_NOCACHE;
-  __le32 dest_fadvise_flags = LIBRADOS_OP_FLAG_FADVISE_SEQUENTIAL | LIBRADOS_OP_FLAG_FADVISE_DONTNEED;
+  __le32 copy_from_flags = CEPH_OSD_COPY_FROM_FLAG_IGNORE_OVERLAY |
+    CEPH_OSD_COPY_FROM_FLAG_IGNORE_CACHE |
+    CEPH_OSD_COPY_FROM_FLAG_MAP_SNAP_CLONE |
+    CEPH_OSD_COPY_FROM_FLAG_RWORDERED;
   ObjectWriteOperation op;
   op.copy_from2(objname, io_ctx, 0, src_fadvise_flags);
-  op.set_op_flags2(dest_fadvise_flags);
+  op.set_op_flags2(copy_from_flags);
 
   return target_ctx.operate(target_obj, &op);
 }


### PR DESCRIPTION
When copying an object the copy-from Op flags should be using the CEPH_OSD_COPY_FROM_FLAG_* values, not LIBRADOS_OP_FLAG_FADVISE_*.

I can not claim that there aren't other instances where these flags are being incorrectly used -- but this was the usage that confused me when adding kernel support to the copy-from Op.  This is somewhat related with PR #24497 which clarifies these flags.
