### PR TITLE
osd,mon: keep last_epoch_started along with last_epoch_clean premerge

### DIFF
--- a/src/messages/MOSDPGReadyToMerge.h
+++ b/src/messages/MOSDPGReadyToMerge.h
@@ -7,15 +7,17 @@ class MOSDPGReadyToMerge
   : public MessageInstance<MOSDPGReadyToMerge, PaxosServiceMessage> {
 public:
   pg_t pgid;
+  epoch_t last_epoch_started = 0;
   epoch_t last_epoch_clean = 0;
   bool ready = true;
 
   MOSDPGReadyToMerge()
     : MessageInstance(MSG_OSD_PG_READY_TO_MERGE, 0)
   {}
-  MOSDPGReadyToMerge(pg_t p, epoch_t lec, bool r, epoch_t v)
+  MOSDPGReadyToMerge(pg_t p, epoch_t les, epoch_t lec, bool r, epoch_t v)
     : MessageInstance(MSG_OSD_PG_READY_TO_MERGE, v),
       pgid(p),
+      last_epoch_started(les),
       last_epoch_clean(lec),
       ready(r)
   {}
@@ -23,6 +25,7 @@ public:
     using ceph::encode;
     paxos_encode();
     encode(pgid, payload);
+    encode(last_epoch_started, payload);
     encode(last_epoch_clean, payload);
     encode(ready, payload);
   }
@@ -30,13 +33,15 @@ public:
     bufferlist::const_iterator p = payload.begin();
     paxos_decode(p);
     decode(pgid, p);
+    decode(last_epoch_started, p);
     decode(last_epoch_clean, p);
     decode(ready, p);
   }
   const char *get_type_name() const override { return "osd_pg_ready_to_merge"; }
   void print(ostream &out) const {
     out << get_type_name()
-        << "(" << pgid << " lec " << last_epoch_clean
+        << "(" << pgid
+	<< " les/c " << last_epoch_started << "/" << last_epoch_clean
 	<< (ready ? " ready" : " NOT READY")
         << " v" << version << ")";
   }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3296,7 +3296,7 @@ bool OSDMonitor::prepare_pg_ready_to_merge(MonOpRequestRef op)
   }
 
   if (m->ready) {
-    p.dec_pg_num(m->last_epoch_clean);
+    p.dec_pg_num(m->last_epoch_started, m->last_epoch_clean);
     p.last_change = pending_inc.epoch;
   } else {
     // back off the merge attempt!

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -717,13 +717,15 @@ public:
   // -- pg merge --
   Mutex merge_lock = {"OSD::merge_lock"};
   set<pg_t> ready_to_merge_source;
-  map<pg_t,epoch_t> ready_to_merge_target;  // pg -> last_epoch_clean
+  map<pg_t,pair<epoch_t,epoch_t>> ready_to_merge_target;  // pg -> (les,lec)
   set<pg_t> not_ready_to_merge_source;
   map<pg_t,pg_t> not_ready_to_merge_target;
   set<pg_t> sent_ready_to_merge_source;
 
   void set_ready_to_merge_source(PG *pg);
-  void set_ready_to_merge_target(PG *pg, epoch_t last_epoch_clean);
+  void set_ready_to_merge_target(PG *pg,
+				 epoch_t last_epoch_started,
+				 epoch_t last_epoch_clean);
   void set_not_ready_to_merge_source(pg_t source);
   void set_not_ready_to_merge_target(pg_t target, pg_t source);
   void clear_ready_to_merge(PG *pg);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -400,6 +400,7 @@ public:
   void split_into(pg_t child_pgid, PG *child, unsigned split_bits);
   void merge_from(map<spg_t,PGRef>& sources, RecoveryCtx *rctx,
 		  unsigned split_bits,
+		  epoch_t dec_last_epoch_started,
 		  epoch_t dec_last_epoch_clean);
   void finish_split_stats(const object_stat_sum_t& stats, ObjectStore::Transaction *t);
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1231,6 +1231,8 @@ void pg_pool_t::dump(Formatter *f) const
   f->dump_unsigned("pg_placement_num_target", get_pgp_num_target());
   f->dump_unsigned("pg_num_target", get_pg_num_target());
   f->dump_unsigned("pg_num_pending", get_pg_num_pending());
+  f->dump_unsigned("pg_num_dec_last_epoch_started",
+		   get_pg_num_dec_last_epoch_started());
   f->dump_unsigned("pg_num_dec_last_epoch_clean",
 		   get_pg_num_dec_last_epoch_clean());
   f->dump_stream("last_change") << get_last_change();
@@ -1734,6 +1736,7 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
     encode(pg_num_target, bl);
     encode(pgp_num_target, bl);
     encode(pg_num_pending, bl);
+    encode(pg_num_dec_last_epoch_started, bl);
     encode(pg_num_dec_last_epoch_clean, bl);
     encode(last_force_op_resend, bl);
   }
@@ -1899,6 +1902,7 @@ void pg_pool_t::decode(bufferlist::const_iterator& bl)
     decode(pg_num_target, bl);
     decode(pgp_num_target, bl);
     decode(pg_num_pending, bl);
+    decode(pg_num_dec_last_epoch_started, bl);
     decode(pg_num_dec_last_epoch_clean, bl);
     decode(last_force_op_resend, bl);
   } else {
@@ -1927,7 +1931,8 @@ void pg_pool_t::generate_test_instances(list<pg_pool_t*>& o)
   a.pgp_num_target = 4;
   a.pg_num_target = 5;
   a.pg_num_pending = 5;
-  a.pg_num_dec_last_epoch_clean = 2;
+  a.pg_num_dec_last_epoch_started = 2;
+  a.pg_num_dec_last_epoch_clean = 3;
   a.last_change = 9;
   a.last_force_op_resend = 123823;
   a.last_force_op_resend_preluminous = 123824;
@@ -1998,8 +2003,10 @@ ostream& operator<<(ostream& out, const pg_pool_t& p)
   }
   if (p.get_pg_num_pending() != p.get_pg_num()) {
     out << " pg_num_pending " << p.get_pg_num_pending();
-    if (p.get_pg_num_dec_last_epoch_clean())
-      out << " dlec " << p.get_pg_num_dec_last_epoch_clean();
+    if (p.get_pg_num_dec_last_epoch_started() ||
+	p.get_pg_num_dec_last_epoch_clean())
+      out << " dles/c " << p.get_pg_num_dec_last_epoch_started()
+	  << "/" << p.get_pg_num_dec_last_epoch_clean();
   }
   out << " last_change " << p.get_last_change();
   if (p.get_last_force_op_resend() ||

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1361,6 +1361,8 @@ public:
   /// last epoch that forced clients to resend (pre-luminous clients only)
   epoch_t last_force_op_resend_preluminous = 0;
 
+  ///< last_epoch_started preceding pg_num decrement request
+  epoch_t pg_num_dec_last_epoch_started = 0;
   ///< last_epoch_clean preceding pg_num decrement request
   epoch_t pg_num_dec_last_epoch_clean = 0;
   snapid_t snap_seq;        ///< seq for per-pool snapshot
@@ -1618,6 +1620,9 @@ public:
   // pool size that it represents.
   unsigned get_pg_num_divisor(pg_t pgid) const;
 
+  epoch_t get_pg_num_dec_last_epoch_started() const {
+    return pg_num_dec_last_epoch_started;
+  }
   epoch_t get_pg_num_dec_last_epoch_clean() const {
     return pg_num_dec_last_epoch_clean;
   }
@@ -1643,8 +1648,10 @@ public:
   void set_pgp_num_target(int p) {
     pgp_num_target = p;
   }
-  void dec_pg_num(epoch_t last_epoch_clean) {
+  void dec_pg_num(epoch_t last_epoch_started,
+		  epoch_t last_epoch_clean) {
     --pg_num;
+    pg_num_dec_last_epoch_started = last_epoch_started;
     pg_num_dec_last_epoch_clean = last_epoch_clean;
     calc_pg_masks();
   }


### PR DESCRIPTION
We need to populate both the last_epoch_clean and last_epoch_started
accurately when fabricating a pg merge target.  In the case where the
premerge PG peers, recovers (e.g., backfill), then becomes ready to
merge, the last_epoch_clean may be > the last_epoch_started, and using
the later last_epoch_clean will prevent the PG from subsequently
peering (it'll go to incomplete state instead).

Fix by keeping both values, separately.

Signed-off-by: Sage Weil <sage@redhat.com>