### PR TITLE
DNM: ceph-volume-zfs: add the prepare command

### DIFF
--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -162,7 +162,7 @@ def _load_library_extensions():
 
     `plugin_name` will be used to load it as a sub command.
     """
-    logger = logging.getLogger('ceph_volume.plugins')
+    logger = logging.getLogger(__name__ + ".plugins")
     group = 'ceph_volume_handlers'
     entry_points = pkg_resources.iter_entry_points(group=group)
     plugins = []

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/__init__.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/__init__.py
@@ -4,3 +4,8 @@
 
 __author__ = """Willem Jan Withagen"""
 __email__ = 'wjw@digiware.nl'
+
+from collections import namedtuple
+
+sys_info = namedtuple('sys_info', ['devices'])
+sys_info.devices = dict()

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/api/zfs.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/api/zfs.py
@@ -1,0 +1,652 @@
+# vim: expandtab smarttab shiftwidth=4 softtabstop=4
+
+"""
+    API for zpool or zfs volume tag operations.
+    Follows the Ceph ZFS tag naming convention
+    that prefixes tags with ``ceph:`` and use
+    ``=`` for assignment, and provides
+    set of utilities for interacting with ZFS.
+"""
+
+import logging
+import os
+import uuid
+import string
+from ceph_volume import process
+from ceph_volume import exceptions
+from ceph_volume_zfs.exceptions import (
+    MultipleZFSError, MultipleZPoolsError,
+)
+
+TAG = "ceph"
+TAGEND = ":"
+TAGPREFIX = TAG + TAGEND
+TAGASSIGN = "="
+CEPHTAGS = TAGPREFIX + "tags"
+
+logger = logging.getLogger(__name__)
+
+
+def create_osd_path(device, osd_id):
+    """ 
+    """ 
+    return
+
+def _zfs_parser(output, deleteTags=None):
+    """
+    Loading all output of a ZFS/zpool list command.
+    First line contains the field names in CAPS
+    remainder are the zpools/zvols per line
+
+    :param output: The CLI output from the ZFS call
+    """
+    report = []
+    field_items = output[0].lower().split()
+    if deleteTags is not None:
+        # delete the mlslabel tag, since it has no value
+        for k in deleteTags:
+            if k in field_items:
+                field_items.remove(k)
+    for line in output[1:]:
+        line = line.strip()
+        output_items = [i.strip() for i in line.split()]
+        # map the output to the fields
+        report.append(
+            dict(zip(field_items, output_items))
+        )
+    return report
+
+
+def parse_tags(zfs_tags):
+    """
+    Return a dictionary mapping of all the tags associated with
+    a Volume from the ZFS API
+
+    Input looks like::
+
+       "ceph:osd_fsid=aaa-fff-bbbb,ceph:osd_id=0"
+
+    For the above example, the expected return value would be::
+
+        {
+            "osd_fsid": "aaa-fff-bbbb",
+            "osd_id": "0"
+        }
+    """
+    if not zfs_tags:
+        return {}
+    tag_mapping = {}
+    tags = zfs_tags.split(MULTITAGSEP)
+    for ceph_tag in tags:
+        if not ceph_tag.startswith(TAGPREFIX):
+            continue
+        cephpref, tag_assignment = ceph_tag.split(TAGEND, 1)
+        key, value = tag_assignment.split(TAGASSIGN, 1)
+        tag_mapping[key] = value
+    return tag_mapping
+
+
+def is_zfs(dev, zfsfs=None):
+    """
+    Boolean to detect if a device is a ZFS FS or not.
+    """
+    # Allowing to optionally pass `zfsfs` can help reduce repetitive checks for
+    # multiple devices at once.
+    zfsfs = zfsfs if zfsfs is not None else ZVolumes()
+    if splitname.get('ZFS_NAME'):
+        zfsfs.filter(name=splitname['ZFS_NAME'],
+                     zpool_name=splitname['POOL_NAME'])
+        return len(zfsfs) > 0
+    return False
+
+
+def get_zfsname_from_argument(argument):
+    """
+    Helper proxy function that consumes a possible logical volume passed
+    in from the CLI in the form of `zpool/zfsvol`, but with some validation
+    so that an argument that is a full path to a device can be ignored
+    """
+    if argument.startswith('/'):
+        zfs = get_zfs(mountpoint=argument)
+        return zfs
+    try:
+        zpool_name, zfs_name = argument.split('/')
+    except (ValueError, AttributeError):
+        return None
+    return get_zfs(zfs_name=zfs_name, zpool_name=zpool_name)
+
+
+def get_zfs(name=None, zpool_name=None, mountpoint=None, guid=None,
+            zfs_tags=None):
+    """
+    Return a matching zfs for the current system, requiring ``name``,
+    ``zpool_name``, ``mountpoint`` or ``tags``.
+    Raises an error if more than one zfsvol is found.
+
+    It is useful to use ``tags`` when trying to find a specific logical volume
+    but it can also lead to multiple zfs being found, since a lot of metadata
+    is shared between lvs of a distinct OSD.
+    """
+    if not any([name, zpool_name, mountpoint, guid, zfs_tags]):
+        return None
+    zfss = ZVolumes()
+    return zfss.get(
+        name=name, zpool_name=zpool_name, mountpoint=mountpoint, guid=guid,
+        zfs_tags=zfs_tags
+    )
+
+
+def get_api_zfs_list():
+    """
+    Return the list of logical volumes available in the system using flags to
+    include common metadata associated with them
+    """
+    stdout, stderr, returncode = process.call(
+        ['zfs', 'list', '-p', '-o', 'all']
+    )
+    return _zfs_parser(stdout, ['mlslabel'])
+
+
+def get_api_zpool_list():
+    """
+    Return the list of physical volumes configured for zpool
+
+    """
+    stdout, stderr, returncode = process.call(
+        ['zpool', 'list', '-p', '-o', 'all']
+    )
+    return _zfs_parser(stdout)
+
+
+def get_zfs_from_argument(argument):
+    """
+    Helper proxy function that consumes a possible zfs directory path passed in
+    from the CLI in the form of `zfs`, but with some validation so that an
+    argument that is a full path to a device can be ignored
+    """
+    if argument.startswith('/'):
+        zfs = get_zfs(mountpoint=argument)
+        return zfs
+    try:
+        pool_name, name = argument.split('/')
+    except (ValueError, AttributeError):
+        return None
+    return get_zfs(name=name, pool_name=pool_name)
+
+
+def get_zfs(name=None, zpool_name=None, mountpoint=None, guid=None,
+            zfs_tags=None):
+    """
+    Return a matching zfs for the current system, requiring ``name``,
+    ``zpool_name``, ``mountpoint`` or ``tags``.
+    Raises an error if more than one zfs is found.
+
+    It is useful to use ``tags`` when trying to find a specific logical volume
+    """
+    if not any([name, zpool_name, mountpoint, guid, zfs_tags]):
+        return None
+    zfss = ZVolumes()
+    zfs = zfss.get(
+        name=name, zpool_name=zpool_name, mountpoint=mountpoint, guid=guid,
+        zfs_tags=zfs_tags
+    )
+    return zfs
+
+
+def get_zpool(zpool_name=None):
+    """
+    Return a matching zpool (physical volume) for the current system,
+    requiring ``zpool_name``. Raises an error if more than one
+    zpool is found.
+    """
+    if not any([zpool_name]):
+        return None
+    zpools = ZVolumes()
+    return zpools.get(zpool_name=zpool_name)
+
+
+def create_zpool(device, osd_id):
+    """
+    Create a physical volume from a device, useful when devices need
+    to be later mapped to journals.
+    Return the path of the pool created.
+    """
+    fail_msg = "Unable to create zpool osd.%s on %s" % (osd_id, device)
+    osdpool = 'osd.%s' % osd_id
+
+    # gpart create -s GPT da0
+    process.run(['gpart', 'create', '-s', 'GPT', device])
+
+    # Create a partition aligned on 1M boundary, for the full size of
+    # the remainder of the disk
+    # gpart add -a 1M -t freebsd-zfs -l osd1 da0
+    process.run(['gpart', 'add',
+                 '-a', '1M',
+                 '-t', 'freebsd-zfs',
+                 '-l', osdpool,
+                 device],
+                )
+    # Then create the ZFS filesystem on the partion using the label
+    # but hide it from the regular tools
+    process.run(['zpool', 'create',
+                 '-m', 'none',
+                 osdpool,
+                 '/dev/gpt/%s' % osdpool],
+                )
+    zpools = ZPools()
+    return zpools.get(name=osdpool)
+
+
+def remove_zpool(zpool_name):
+    """
+    Removes a physical volume.
+    """
+    fail_msg = "Unable to remove zpool %s" % zpool_name
+    process.run([
+        'zpool', 'remove',
+        '-f',  # force it
+        zpool_name
+        ],
+        show_command=True,
+        fail_msg=fail_msg,
+    )
+
+
+def create_zfsvol(device, osd_id, tags=None):
+    """
+    Create a Zpool and  Volume
+
+    Tags are an optional dictionary and is expected to
+    conform to the convention of prefixing them with "ceph:" like::
+
+        {"ceph:block_device": "/dev/ceph/osd-1"}
+    """
+    type_path_tag = {
+        'journal': 'journal_device',
+        'data': 'data_device',
+        'block': 'block_device',
+        'wal': 'wal_device',
+        'db': 'db_device',
+    }
+    fail_msg = "zfs create has failed"
+    osdpool = 'osd.%s' % osd_id
+    osdname = 'ceph-%s' % osd_id
+    process.run([
+        'zfs', 'create',
+        '-o', 'mountpoint=/var/lib/ceph/osd/%s' % osdname,
+        '-o', 'compression=on',
+        '-o', 'checksum=off',
+        '-o', 'atime=off',
+        '-o', 'devices=off',
+        '-o', 'exec=off',
+        '-o', 'setuid=off',
+        '%s/osd' % osdpool,
+        ],
+        fail_msg=fail_msg,
+    )
+    zfs = get_zfs(name='%s/osd' % osdpool)
+    zfs.set_tags(tags)
+
+    # when creating a distinct type, the caller doesn't know what the path will
+    # be so this function will set it after creation using the mapping
+    path_tag = type_path_tag.get(tags.get('type'))
+    if path_tag:
+        zfs.set_tags(
+            {mountpoint: zfs.mountpoint}
+        )
+    return zfs
+
+
+def remove_zfs(path):
+    """
+    Removes a logical volume given it's absolute path.
+
+    Will return True if the lv is successfully removed or
+    raises a RuntimeError if the removal fails.
+    """
+    stdout, stderr, returncode = process.call([
+        'zfs', 'remove',
+        '-v',  # verbose
+        '-f',  # force it
+        path
+        ],
+        show_command=True,
+        terminal_verbose=True,
+    )
+    if returncode != 0:
+        raise RuntimeError("Unable to remove %s" % path)
+    return True
+
+
+def create_zfs(zpool, parts=None, size=None, name_prefix='ceph-zfs'):
+    """
+    Create Logical ZVolume from a ZPool by calculating the
+    proper extents from ``parts`` or ``size``. A custom prefix can be used
+    (defaults to ``ceph-zfs``), these names are always suffixed with a uuid.
+
+    ZV creation in ceph-volume will require tags, this is expected to be
+    pre-computed by callers who know Ceph metadata like OSD IDs and FSIDs. It
+    will probably not be the case when mass-creating ZVs, so common/default
+    tags will be set to ``"null"``.
+
+    .. note:: ZVs that are not in use can be detected by querying ZFS for tags
+              that are set to ``"null"``.
+
+    :param zpool: The zpool to use for zfs creation
+    :type group: ``ZPool()`` object
+    :param parts: Number of ZVs to create *instead of* ``size``.
+    :type parts: int
+    :param size: Size (in gigabytes) of ZVs to create,
+                 e.g. "as many 10gb ZVs as possible"
+    :type size: int
+    """
+    if parts is None and size is None:
+        # fallback to just one part (using 100% of the vg)
+        parts = 1
+    zfs = []
+    tags = {
+        "ceph:osd_id": "null",
+        "ceph:type": "null",
+        "ceph:cluster_fsid": "null",
+        "ceph:osd_fsid": "null",
+    }
+    sizing = zpool.sizing(parts=parts, size=size)
+    for part in range(0, sizing['parts']):
+        size = sizing['sizes']
+        name = '%s-%s' % (name_prefix, uuid.uuid4())
+        zfs.append(
+            create_zfs(name, zpool.name, size="%sg" % size, tags=tags)
+        )
+    return zfs
+
+
+def get_pool(pool_name=None, pool_tags=None):
+    """
+    Return a matching pool for the current system, requires ``pool_name`` or
+    ``tags``. Raises an error if more than one vg is found.
+
+    It is useful to use ``tags`` when trying to find a specific volume group,
+    but it can also lead to multiple vgs being found.
+    """
+    if not any([pool_name, pool_tags]):
+        return None
+    pools = ZPools()
+    return pools.get(name=pool_name, pool_tags=pool_tags)
+
+
+class ZPools(list):
+    """
+    A list of all disks in the system
+    """
+
+    def __init__(self):
+        self._populate()
+
+    def _populate(self):
+        # get all the zpools in the current system
+        for zp_item in get_api_zpool_list():
+            self.append(ZPool(**zp_item))
+
+    def get(self, name=None, guid=None, zpool_tags=None):
+        """
+        fields = 'name,guid,size,comment'
+
+        This is a bit expensive, since it will try to filter out all the
+        matching items in the list, filter them out applying anything that was
+        added and return the matching item.
+
+        This method does *not* alter the list, and it will raise an error if
+        multiple ZPools are matched
+
+        It is useful to use ``tags`` when trying to find a specific logical
+        volume, but it can also lead to multiple zfs being found, since a
+        lot of metadata is shared between zfs of a distinct OSD.
+        """
+        if not any([name, guid, zpool_tags]):
+            return None
+        zpool = self._filter(
+            name=name,
+            guid=guid,
+            zpool_tags=zpool_tags
+        )
+        if not zpool:
+            return None
+        if len(zpool) > 1:
+            raise MultipleZPoolError(name)
+        return zpool[0]
+
+    def _filter(self, name=None, guid=None, zpool_tags=None):
+        """
+        The actual method that filters using a new list. Useful so that other
+        methods that do not want to alter the contents of the list (e.g.
+        ``self.find``) can operate safely.
+        """
+        filtered = [i for i in self]
+        if name:
+            filtered = [i for i in filtered if i.tags['name'] == name]
+
+        if guid:
+            filtered = [i for i in filtered if i.tags['guid'] == guid]
+
+        # at this point, `filtered` has either all the zpool in self or is an
+        # actual filtered list if any filters were applied
+        if zpool_tags:
+            tag_filtered = []
+            for zpool in filtered:
+                # all the tags we got need to match on the pool
+                matches = all(zpool.tags.get(k) == str(v)
+                              for k, v in zpool_tags.items())
+                if matches:
+                    tag_filtered.append(zpool)
+            return tag_filtered
+
+        return filtered
+
+
+class ZVolumes(list):
+    """
+    A list of all known (logical) volumes for the current system,
+    with the ability to filter them via keyword arguments.
+    """
+
+    def __init__(self):
+        self._populate()
+
+    def _populate(self):
+        # get all the zfs volumes in the current system
+        for zfs_item in get_api_zfs_list():
+            self.append(ZVolume(**zfs_item))
+
+    def _purge(self):
+        """
+        Delete all the items in the list, used internally only so that we can
+        dynamically allocate the items when filtering without the concern of
+        messing up the contents
+        """
+        self[:] = []
+
+    def _filter(self, name=None, zpool_name=None, mountpoint=None, guid=None,
+                zfs_tags=None):
+        """
+        The actual method that filters using a new list. Useful so that other
+        methods that do not want to alter the contents of the list (e.g.
+        ``self.find``) can operate safely.
+        """
+        filtered = [i for i in self]
+        if name:
+            filtered = [i for i in filtered if i.name == name]
+
+        if zpool_name:
+            filtered = [i for i in filtered if i.zpool_name == zpool_name]
+
+        if guid:
+            filtered = [i for i in filtered if i.guid == guid]
+
+        if mountpoint:
+            filtered = [i for i in filtered if i.mountpoint == mountpoint]
+
+        # at this point, `filtered` has either all the volumes in self or is an
+        # actual filtered list if any filters were applied
+        if zfs_tags:
+            tag_filtered = []
+            for zfs in filtered:
+                # all the tags we got need to match on the volume
+                matches = all(getattr(zfs, k) == str(v)
+                              for k, v in zfs_tags.items())
+                if matches:
+                    tag_filtered.append(zfs)
+            return tag_filtered
+
+        return filtered
+
+    def filter(self, name=None, zpool_name=None, mountpoint=None,
+               guid=None, zfs_tags=None):
+        """
+        Filter out volumes on top level attributes like ``name`` or by
+        ``zfs_tags`` where a dict is required. For example, to find a volume
+        that has an OSD ID of 0, the filter would look like::
+
+            zfs_tags={'ceph:osd_id': '0'}
+
+        """
+        if not any([name, zpool_name, mountpoint, guid, zfs_tags]):
+            raise TypeError('.filter() requires name, pool_name, mountpoint, '
+                            ' guid, or tags (none given)')
+        # first find the filtered volumes with the values in self
+        filtered_zfs = self._filter(
+            name=name,
+            zpool_name=zpool_name,
+            mountpoint=mountpoint,
+            guid=guid,
+            zfs_tags=zfs_tags
+        )
+        # then purge everything
+        self._purge()
+        # and add the filtered items
+        self.extend(filtered_zfs)
+
+    def get(self, name=None, zpool_name=None, mountpoint=None, guid=None,
+            zfs_tags=None):
+        """
+        This is a bit expensive, since it will try to filter out all the
+        matching items in the list, filter them out applying anything that was
+        added and return the matching item.
+
+        This method does *not* alter the list, and it will raise an error if
+        multiple ZVs are matched
+
+        It is useful to use ``tags`` when trying to find a specific logical
+        volume, but it can also lead to multiple zfs being found, since a
+        lot of metadata is shared between zfs of a distinct OSD.
+        """
+        if not any([name, mountpoint, guid, zfs_tags]):
+            return None
+        zfs = self._filter(
+            name=name,
+            zpool_name=zpool_name,
+            mountpoint=mountpoint,
+            guid=guid,
+            zfs_tags=zfs_tags
+        )
+        if not zfs:
+            return None
+        if len(zfs) > 1:
+            raise MultipleZFSError(name, mountpoint)
+        return zfs[0]
+
+
+class ZPool(object):
+    """
+    Represents a ZPool on the system, with some top-level attributes like
+    name and path
+    """
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+        self.tags = kw
+        self.name = kw['name']
+
+    def __str__(self):
+        return '<%s>' % (self.name)
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class ZVolume(object):
+    """
+    Represents a Logical Volume from ZFS, with some top-level attributes like
+    name and parsed tags as a dictionary of key/value pairs.
+    """
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+        self.tags = kw
+        self.name = kw['name']
+
+    def __str__(self):
+        return '<%s,%s>' % (self.name, self.tags['mountpoint'])
+
+    def __repr__(self):
+        return self.__str__()
+
+    def as_dict(self):
+        obj = {}
+        obj.update(self.tags)
+        obj['tags'] = self.tags
+        obj['zpool_name'] = self.zpool_name
+        obj['type'] = self.tags['type']
+        obj['path'] = self.mountpoint
+        return obj
+
+    def clear_tags(self):
+        """
+        Removes all tags from the Logical Volume.
+        """
+        for k, v in self.tags.items():
+            clear_tag(key)
+
+    def clear_tag(self, key):
+        """
+        :param key: the attrribute to delete from the zfs volume
+        Only delete ceph:xxxxx tags.
+        """
+        if TAGPREFIX in key:
+            tag = "%s" % k
+            process.run(['zfs', 'inherit', tag, self.name])
+
+    def set_tags(self, newtags):
+        """
+        :param newtags: A dictionary of tag names and values, like::
+
+            {
+                "ceph:osd_fsid": "aaa-fff-bbbb",
+                "ceph:osd_id": "0"
+            }
+
+        At the end of all modifications, the tags are refreshed to reflect
+        ZFS's most current view.
+        """
+        for k, v in newtags.items():
+            self.set_tag(k, v)
+
+        # after setting all the tags, refresh them for the current object,
+        # use the zfs_* identifiers to filter because those shouldn't change
+        zfs_object = get_zfs(name=self.name, mountpoint=self.mountpoint)
+        self.tags = zfs_object.tags
+
+    def set_tag(self, key, value):
+        """
+        Set the key/value pair as an ZFS tag. Does not "refresh" the values of
+        the current object for its tags. Meant to be a "fire and forget" type
+        of modification.
+
+        Only set ceph:xxxxx tags.
+        """
+        if TAGPREFIX in key:
+            process.call([
+                'zfs',
+                'set', '%s=%s' % (key, value), self.name
+            ])

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/__init__.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/__init__.py
@@ -1,2 +1,7 @@
 # -*- coding: utf-8 -*-
 from .main import ZFS
+import logging
+from math import floor
+from ceph_volume import terminal
+
+logger = logging.getLogger(__name__)

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/common.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/common.py
@@ -1,0 +1,100 @@
+# vim: expandtab smarttab shiftwidth=4 softtabstop=4
+
+from ceph_volume_zfs.util import arg_validators
+from ceph_volume import process
+from ceph_volume import terminal
+import argparse
+
+
+def rollback_osd(args, osd_id):
+    """
+    When the process of creating or preparing fails, the OSD needs to be either
+    purged (ID fully removed) or destroyed (ID persists). This is important
+    because otherwise it would leave the ID around, which can cause confusion
+    if relying on the automatic (OSD.N + 1) behavior.
+
+    When the OSD id is specified in the command line explicitly (with
+    ``--osd-id``) , the the ID is then preserved with a soft removal (``ceph
+    osd destroy``), otherwise it is fully removed with ``purge``.
+    """
+    if not osd_id:
+        # it means that it wasn't generated
+        # nothing to rollback here
+        return
+
+    # once here, this is an error condition that needs to be rolled back
+    terminal.error('Was unable to complete a new OSD, will rollback changes')
+    osd_name = 'osd.%s'
+    if args.osd_id is None:
+        terminal.error('OSD will be fully purged from the cluster, '
+                       'because the ID was generated')
+        # the ID wasn't passed in explicitly, so make sure it is fully removed
+        process.call([
+            'ceph', 'osd', 'purge',
+            osd_name % osd_id,
+            '--yes-i-really-mean-it'])
+    else:
+        terminal.error('OSD will be destroyed, '
+                       'keeping the ID because it was provided with --osd-id')
+        # the ID was passed explicitly, so allow to re-use by using `destroy`
+        process.call([
+            'ceph', 'osd', 'destroy',
+            osd_name % args.osd_id,
+            '--yes-i-really-mean-it'])
+
+
+def common_parser(prog, description):
+    """
+    Both prepare and create share the same parser, those are defined here to
+    avoid duplication
+    """
+    parser = argparse.ArgumentParser(
+        prog=prog,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=description,
+    )
+
+    required_group = parser.add_argument_group('required arguments')
+    filestore_group = parser.add_argument_group('filestore')
+
+    required_group.add_argument(
+        '--data',
+        required=True,
+        type=arg_validators.ZFSPath(),
+        help='OSD data path. A physical device or ZVOL or zfs filesystem',
+    )
+
+    filestore_group.add_argument(
+        '--filestore',
+        action='store_true',
+        help='Use the filestore objectstore',
+    )
+
+    filestore_group.add_argument(
+        '--journal',
+        help='A ZVOL or zfs filesystem (zpool/volume), or path to a device',
+    )
+
+    parser.add_argument(
+        '--osd-id',
+        help='Reuse an existing OSD id',
+    )
+
+    parser.add_argument(
+        '--osd-fsid',
+        help='Reuse an existing OSD fsid',
+    )
+
+    parser.add_argument(
+        '--crush-device-class',
+        dest='crush_device_class',
+        help='Crush device class to assign this OSD to',
+    )
+
+    # Do not parse args, so that consumers can do something before the args get
+    # parsed triggering argparse behavior
+    return parser
+
+
+create_parser = common_parser  # noqa
+prepare_parser = common_parser  # noqa

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/main.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/main.py
@@ -1,6 +1,10 @@
+# vim: expandtab smarttab shiftwidth=4 softtabstop=4
+
 import argparse
 from textwrap import dedent
 from ceph_volume import terminal
+
+from . import prepare
 
 
 class ZFS(object):
@@ -8,12 +12,13 @@ class ZFS(object):
     help = 'Use ZFS to deploy OSDs'
 
     _help = dedent("""
-    Use ZFS to deploy OSDs
+        Use ZFS to deploy OSDs
 
-    {sub_help}
+        {sub_help}
     """)
 
     mapper = {
+        'prepare':  prepare.Prepare,
     }
 
     def __init__(self, argv):

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/prepare.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/devices/zfs/prepare.py
@@ -1,0 +1,218 @@
+# vim: expandtab smarttab shiftwidth=4 softtabstop=4
+
+from __future__ import print_function
+import os
+import json
+import logging
+from textwrap import dedent
+
+from ceph_volume import conf, decorators, terminal
+from ceph_volume.util import prepare as prepare_utils
+from ceph_volume.util import system
+from ceph_volume.util.arg_validators import exclude_group_options
+
+from ceph_volume_zfs.api import zfs as api
+from ceph_volume_zfs.util import disk
+from ceph_volume_zfs.util import prepare as prepare_zfs
+
+from .common import prepare_parser, rollback_osd
+
+logger = logging.getLogger(__name__)
+
+
+def prepare_filestore(device, journal, secrets, tags, osd_id, fsid):
+    """
+    :param device: The name of the logical volume to work with
+    :param journal: similar to device but can also be a regular/plain disk
+    :param secrets: A dict with secrets needed to create the osd (e.g. cephx)
+    :param id_: The OSD id
+    :param fsid: The OSD fsid, also known as the OSD UUID
+    """
+    cephx_secret = secrets.get('cephx_secret', prepare_utils.create_key())
+
+    # create the directory
+    api.create_osd_path(device, osd_id)
+    if journal is not None:
+        prepare_utils.link_journal(journal, osd_id)
+
+    # get the latest monmap
+    prepare_utils.get_monmap(osd_id)
+    # prepare the osd filesystem
+    prepare_zfs.osd_mkfs_filestore(osd_id, fsid, cephx_secret)
+    # write the OSD keyring if it doesn't exist already
+    prepare_utils.write_keyring(osd_id, cephx_secret)
+
+
+class Prepare(object):
+
+    help = 'Format an ZFS volume and associate it with an OSD'
+
+    def __init__(self, argv):
+        self.argv = argv
+        self.osd_id = None
+
+    def get_zfsvol(self, argument):
+        """
+        Perform some parsing of the command-line value so that the process
+        can determine correctly if it got a device path or an zfsvol
+
+        :param argument: The command-line value that will need to be split to
+                         retrieve the actual zfsvol
+        """
+        try:
+            zp_name, zv_name = argument.split('/')
+        except (ValueError, AttributeError):
+            return None
+        return api.get_zfsvol(zv_name=zv_name, zp_name=zp_name)
+
+    def setup_device(self, device_type, device_name, tags):
+        """
+        Check if ``device`` is an zfsvol, if so, set the tags, making sure to
+        update the tags with the zfsvol_uuid and zfsvol_path which the
+        incoming tags will not have.
+        """
+        if device_name is None:
+            return '', '', tags
+        tags['ceph:type'] = device_type
+        zfsvol = self.get_zfsvol(device_name)
+        if zfsvol:
+            uuid = zfsvol.zv_uuid
+            path = zfsvol.zv_path
+            tags['ceph:%s_uuid' % device_type] = uuid
+            tags['ceph:%s_device' % device_type] = path
+            zfsvol.set_tags(tags)
+        else:
+            # otherwise assume this is a regular disk partition
+            path = device_name
+            tags['ceph:%s_uuid' % device_type] = uuid
+            tags['ceph:%s_device' % device_type] = path
+        return path, uuid, tags
+
+    def prepare_device(self, arg, device_type, cluster_fsid, osd_fsid, osd_id):
+        """
+        Check if ``arg`` is a device or partition to create an zfsvol out of it
+        with a distinct volume group name, assigning zfs tags on it and
+        ultimately, returning the logical volume object.  Failing to detect
+        a device or partition will result in error.
+
+        :param arg: The value of ``--data`` when parsing args
+        :param device_type: Usually, either ``data`` or ``block``
+                            (filestore vs. bluestore)
+        :param cluster_fsid: The cluster fsid/uuid
+        :param osd_fsid: The OSD fsid/uuid
+        :param osd_id: The OSD id
+        return a zfs volume object just created.
+        """
+        # we must create a zpool, and then a single zfsvol
+        zp = api.create_zpool(arg, osd_id)
+        self.zv_name = "osd.%s" % osd_id
+        self.zv_path = "osd.%s" % osd_id
+        return api.create_zfsvol(
+            zp.name,  # the zpool to create the OSD on
+            osd_id,
+            tags={'ceph:type': device_type})
+
+    def safe_prepare(self, args):
+        """
+        An intermediate step between `main()` and `prepare()` so that we can
+        capture the `self.osd_id` in case we need to rollback
+        """
+        try:
+            self.prepare(args)
+        except Exception:
+            logger.exception('zfs prepare was unable to complete')
+            logger.info('will rollback OSD ID: %s creation' % self.osd_id)
+            rollback_osd(args, self.osd_id)
+            raise
+        terminal.success("ceph-volume zfs prepare successful for: %s"
+                         % args.data)
+
+    @decorators.needs_root
+    def prepare(self, args):
+        if not (disk.is_partition(args.data) or disk.is_device(args.data)):
+            error = [
+                'Cannot use device (%s).' % args.data,
+                'A zfsvol path or an existing device is needed']
+            raise RuntimeError(' '.join(error))
+
+        # FIXME we don't allow re-using a keyring, we always generate one for
+        # the OSD, this needs to be fixed.
+        # This could either be a file (!)
+        # or a string (!!)
+        # or some flags that we would need to compound into a dict so that we
+        # can convert to JSON (!!!)
+        secrets = {'cephx_secret': prepare_utils.create_key()}
+
+        cluster_fsid = conf.ceph.get('global', 'fsid')
+        osd_fsid = args.osd_fsid or system.generate_uuid()
+        crush_device_class = args.crush_device_class
+        if crush_device_class:
+            secrets['crush_device_class'] = crush_device_class
+        # reuse a given ID if it exists, otherwise create a new ID
+        self.osd_id = prepare_utils.create_id(
+                osd_fsid,
+                json.dumps(secrets),
+                osd_id=args.osd_id)
+        tags = {
+            'ceph:osd_fsid': osd_fsid,
+            'ceph:osd_id': self.osd_id,
+            'ceph:cluster_fsid': cluster_fsid,
+            'ceph:cluster_name': conf.cluster,
+            'ceph:crush_device_class': crush_device_class,
+        }
+        if args.filestore:
+            data_zfs = self.get_zfsvol(args.data)
+            if not data_zfs:
+                data_zfs = self.prepare_device(args.data,
+                                               'data',
+                                               cluster_fsid,
+                                               osd_fsid,
+                                               self.osd_id)
+            tags['ceph:data_device'] = 'osd.%s' % self.osd_id
+
+            journal_device = None
+            # journal_device, journal_uuid, tags =
+            #     self.setup_device('journal', args.journal, tags)
+
+            tags['ceph:type'] = 'data'
+            data_zfs.set_tags(tags)
+
+            prepare_filestore(
+                data_zfs.mountpoint,
+                journal_device,
+                secrets,
+                tags,
+                self.osd_id,
+                osd_fsid,
+            )
+
+    def main(self):
+        sub_command_help = dedent("""
+            Prepare an OSD by assigning an ID and FSID, registering them with
+            the cluster with an ID and FSID, formatting and mounting the
+            volume, and finally by adding all the metadata to the logical
+            volumes using ZFS tags, so that it can later be discovered.
+
+            Existing logical volume (zfs volume):
+
+                ceph-volume zfs prepare --data {zfsvol}
+
+            Existing device, that will be made a pool and volume:
+
+                ceph-volume zfs prepare --data /path/to/device
+
+        """)
+        parser = prepare_parser(
+            prog='ceph-volume zfs prepare',
+            description=sub_command_help,
+        )
+        if len(self.argv) == 0:
+            print(sub_command_help)
+            return
+        exclude_group_options(parser, argv=self.argv,
+                              groups=['filestore', 'bluestore'])
+        args = parser.parse_args(self.argv)
+        # Default to filestore here since defaulting it in add_argument may
+        # cause both to be True
+        args.filestore = True
+        self.safe_prepare(args)

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/exceptions.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/exceptions.py
@@ -1,0 +1,22 @@
+import os
+
+
+class MultipleZPoolsError(Exception):
+
+    def __init__(self, zp_name):
+        self.pv_name = zp_name
+
+    def __str__(self):
+        msg = "Got more than 1 result looking for zpool: %s" % self.zp_name
+        return msg
+
+
+class MultipleZFSError(Exception):
+
+    def __init__(self, zv_name, zv_path):
+        self.zv_name = zv_name
+        self.zv_path = zv_path
+
+    def __str__(self):
+        msg = "Got more than 1 result looking for %s with path: %s" % (self.zv_name, self.zv_path)
+        return msg

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/__init__.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/__init__.py
@@ -1,1 +1,85 @@
-# -*- coding: utf-8 -*-
+import logging
+from math import floor
+from ceph_volume import terminal
+
+
+logger = logging.getLogger(__name__)
+
+
+def as_string(string):
+    """
+    Ensure that whatever type of string is incoming, it is returned as an
+    actual string, versus 'bytes' which Python 3 likes to use.
+    """
+    if isinstance(string, bytes):
+        # we really ignore here if we can't properly decode with utf-8
+        return string.decode('utf-8', 'ignore')
+    return string
+
+
+def as_bytes(string):
+    """
+    Ensure that whatever type of string is incoming, it is returned as bytes,
+    encoding to utf-8 otherwise
+    """
+    if isinstance(string, bytes):
+        return string
+    return string.encode('utf-8', errors='ignore')
+
+
+def str_to_int(string, round_down=True):
+    """
+    Parses a string number into an integer, optionally converting to a float
+    and rounding down.
+    """
+    error_msg = "Unable to convert to integer: '%s'" % str(string)
+    try:
+        integer = float(string)
+    except (TypeError, ValueError):
+        logger.exception(error_msg)
+        raise RuntimeError(error_msg)
+
+    if round_down:
+        integer = floor(integer)
+    else:
+        integer = round(integer)
+    return int(integer)
+
+
+def str_to_bool(val):
+    """
+    Convert a string representation of truth to True or False
+
+    True values are 'y', 'yes', or ''; case-insensitive
+    False values are 'n', or 'no'; case-insensitive
+    Raises ValueError if 'val' is anything else.
+    """
+    true_vals = ['yes', 'y', '']
+    false_vals = ['no', 'n']
+    try:
+        val = val.lower()
+    except AttributeError:
+        val = str(val).lower()
+    if val in true_vals:
+        return True
+    elif val in false_vals:
+        return False
+    else:
+        raise ValueError("Invalid input value: %s" % val)
+
+
+def prompt_bool(question, _raw_input=None):
+    """
+    Interface to prompt a boolean (or boolean-like) response from a user.
+    Usually a confirmation.
+    """
+    input_prompt = _raw_input or raw_input
+    prompt_format = '--> {question} '.format(question=question)
+    response = input_prompt(prompt_format)
+    try:
+        return str_to_bool(response)
+    except ValueError:
+        terminal.error('Valid true responses are: y, yes, <Enter>')
+        terminal.error('Valid false responses are: n, no')
+        terminal.error('That response was invalid, please try again')
+        return prompt_bool(question, _raw_input=input_prompt)

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/arg_validators.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/arg_validators.py
@@ -1,0 +1,140 @@
+# vim: expandtab smarttab shiftwidth=4 softtabstop=4
+
+import argparse
+import os
+from ceph_volume import terminal
+from ceph_volume import decorators
+from ceph_volume_zfs.util import disk
+
+
+class ZFSPath(object):
+    """
+    A simple validator to ensure that a logical volume is specified like:
+
+        <zpool>/<zfsvol>
+
+    Or a full path to a device, like ``/dev/sda``
+
+    """
+
+    def __call__(self, string):
+        error = None
+        path = string
+        if ':' in string:
+            disk, path = string.split(':')
+        if path.startswith('/'):
+            if not os.path.exists(string):
+                error = "Argument (device) does not exist: %s" % string
+                raise argparse.ArgumentError(None, error)
+            else:
+                return string
+        try:
+            zpool, zfsvol = string.split('/')
+        except ValueError:
+            error = "Logical volume must be specified as 'zpool/zfsvol' "
+            " but got: %s" % string
+            raise argparse.ArgumentError(None, error)
+
+        if not zpool:
+            error = "Didn't specify a zpool like 'zpool/zfsvol', "
+            "got: %s" % string
+        if not zfs:
+            error = "Didn't specify a zfs volume like 'zpool/zfsvol', "
+            "got: %s" % string
+        if error:
+            raise argparse.ArgumentError(None, error)
+        return string
+
+
+class OSDPath(object):
+    """
+    Validate path exists and it looks like an OSD directory.
+    """
+
+    @decorators.needs_root
+    def __call__(self, string):
+        if not os.path.exists(string):
+            error = "Path does not exist: %s" % string
+            raise argparse.ArgumentError(None, error)
+
+        arg_is_partition = disk.is_partition(string)
+        if arg_is_partition:
+            return os.path.abspath(string)
+        absolute_path = os.path.abspath(string)
+        if not os.path.isdir(absolute_path):
+            error = "Argument is not a directory or device which is required to scan"
+            raise argparse.ArgumentError(None, error)
+        key_files = ['ceph_fsid', 'fsid', 'keyring', 'ready', 'type', 'whoami']
+        dir_files = os.listdir(absolute_path)
+        for key_file in key_files:
+            if key_file not in dir_files:
+                terminal.error('All following files must exist in path: %s'
+                               % ' '.join(key_files))
+                error = "Required file (%s) was not found in OSD dir path: %s" % (key_file, absolute_path)
+                raise argparse.ArgumentError(None, error)
+
+        return os.path.abspath(string)
+
+
+def exclude_group_options(parser, groups, argv=None):
+    """
+    ``argparse`` has the ability to check for mutually exclusive options, but
+    it only allows a basic XOR behavior: only one flag can be used from
+    a defined group of options. This doesn't help when two groups of options
+    need to be separated. For example, with filestore and bluestore, neither
+    set can be used in conjunction with the other set.
+
+    This helper validator will consume the parser to inspect the group flags,
+    and it will group them together from ``groups``. This allows proper error
+    reporting, matching each incompatible flag with its group name.
+
+    :param parser: The argparse object, once it has configured all flags. It is
+                   required to contain the group names being used to validate.
+    :param groups: A list of group names (at least two), with the same used for
+                  ``add_argument_group``
+    :param argv: Consume the args (sys.argv) directly from this argument
+
+    .. note: **Unfortunately** this will not be able to validate correctly when
+    using default flags. In the case of filestore vs. bluestore, ceph-volume
+    defaults to --bluestore, but we can't check that programmatically, we can
+    only parse the flags seen via argv
+    """
+    # Reduce the parser groups to only the groups we need to intersect
+    parser_groups = [g for g in parser._action_groups if g.title in groups]
+    # A mapping of the group name to flags/options
+    group_flags = {}
+    flags_to_verify = []
+    for group in parser_groups:
+        # option groups may have more than one item in ``option_strings``, this
+        # will loop over ``_group_actions`` which contains the
+        # ``option_strings``, like ``['--filestore']``
+        group_flags[group.title] = [
+            option for group_action in group._group_actions
+            for option in group_action.option_strings
+        ]
+
+    # Gather all the flags present in the groups so that we only check on those
+    for flags in group_flags.values():
+        flags_to_verify.extend(flags)
+
+    seen = []
+    last_flag = None
+    last_group = None
+    for flag in argv:
+        if flag not in flags_to_verify:
+            continue
+        for group_name, flags in group_flags.items():
+            if flag in flags:
+                seen.append(group_name)
+                # We are mutually excluding groups, so having more than 1 group
+                # in ``seen`` means we must raise an error
+                if len(set(seen)) == len(groups):
+                    terminal.warning(
+                        'Incompatible flags found, some values may get ignored'
+                    )
+                    msg = 'Cannot use %s (%s) with %s (%s)' % (
+                        last_flag, last_group, flag, group_name
+                    )
+                    terminal.warning(msg)
+            last_group = group_name
+        last_flag = flag

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/disk.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/disk.py
@@ -1,0 +1,122 @@
+# vim: expandtab smarttab shiftwidth=4 softtabstop=4
+
+import logging
+import os
+import re
+import stat
+from ceph_volume import process
+from ceph_volume_zfs.api import zfs
+from ceph_volume_zfs.util.system import get_file_contents
+
+logger = logging.getLogger(__name__)
+
+class Disk(object):
+    """
+    Represents a disk on the system, with some top-level attributes like
+    name and path
+    """
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class Disks(list):
+    """
+    A list of all disks in the system
+    """
+
+    def __init__(self):
+        self._populate()
+
+    def _populate(self):
+        # get all the disks in the current system
+        for disk_item in get_api_geom_list():
+            self.append(Disk(**disk_item))
+
+
+def _output_geom_parser(output):
+    """
+    kern.geom.conftxt contains DISK, PART and LABEL lines
+    filter on those properties and only return those
+    rank, class, name, size sectorsize, 'hd' heads, 'sc' sectors
+    0 DISK vtbd1 268435456000 512 hd 16 sc 63
+    0 DISK vtbd0 536870912000 512 hd 16 sc 63
+    rank, class, name, size, 'i' index, 'o' offset, 'ty' type,
+        'xs' scheme, 'xt' rawtype,
+    1 PART vtbd0p2 536870805504 512 i 2 o 86016 ty freebsd-ufs \
+        xs GPT xt 516e7cb6-6ecf-11d6-8ff8-00022d09712b
+    1 PART vtbd0p1 65536 512 i 1 o 20480 ty freebsd-boot \
+        xs GPT xt 83bd6b9d-7f41-11dc-be0b-001560b84f0f
+    ank, class, name, size, secorsize, 'i' index, 'o' offset
+    2 LABEL gptid/2481ea40-dbb8-11e5-b242-dd112b2c50de 65536 512 i 0 o 0
+
+    :param fields: A string, possibly using ',' to group many items, as it
+                   would be used on the CLI
+    :param output: The CLI output from the sysctl kern.geom.conftxt call
+    """
+    report = []
+    fields = ['rank', 'class', 'name', 'size', 'rest']
+    for line in output:
+        # clear the leading/trailing whitespace
+        line = line.strip()
+        # prevent moving forward with empty contents
+        if not line:
+            continue
+
+        output_items = [i.strip() for i in line.split(None, 4)]
+        # map the output to the fields
+        report.append(
+            dict(zip(fields, output_items))
+        )
+    return report
+
+
+def get_api_geom_list():
+    stdout, stderr, returncode = process.call(
+        ['sysctl', '-n', 'kern.geom.conftxt']
+    )
+    return _output_geom_parser(stdout)
+
+
+def _stat_is_device(stat_obj):
+    """
+    Helper function that will interpret ``os.stat`` output directly,
+    so that other functions can call ``os.stat`` once and interpret
+    that result several times
+    """
+    return stat.S_ISBLK(stat_obj)
+
+
+def is_device(dev):
+    """
+    Boolean to determine if a given device is a disk device
+    (**not** a partition!)
+    param dev: should start with '/dev/'
+    return:    True if it is the raw disk device
+    """
+    if not os.path.exists(dev):
+        return False
+    dev = dev[5:]
+    stdout, stderr, returncode = process.call(
+        ['sysctl', '-n', 'kern.disks']
+    )
+    disks = stdout[0].split()
+    if dev in disks:
+        return True
+    return False
+
+def is_partition(dev):
+    """
+    Boolean to determine if a given device is a partition, like /dev/sda1
+    """
+    if not os.path.exists(dev):
+        return False
+
+    # fallback to stat
+    stat_obj = os.stat(dev)
+    if _stat_is_device(stat_obj.st_mode):
+        return False
+
+    return True
+

--- a/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/system.py
+++ b/src/ceph-volume/plugin/zfs/ceph_volume_zfs/util/system.py
@@ -1,0 +1,187 @@
+import errno
+import logging
+import os
+import platform
+import tempfile
+import uuid
+from ceph_volume import process, terminal
+from . import as_string
+
+logger = logging.getLogger(__name__)
+mlogger = terminal.MultiLogger(__name__)
+
+# TODO: get these out of here and into a common area for others to consume
+if platform.system() == 'FreeBSD':
+    FREEBSD = True
+    DEFAULT_FS_TYPE = 'zfs'
+    PROCDIR = '/compat/linux/proc'
+    # FreeBSD does not have blockdevices any more
+    BLOCKDIR = '/dev'
+    ROOTGROUP = 'wheel'
+else:
+    FREEBSD = False
+    DEFAULT_FS_TYPE = 'xfs'
+    PROCDIR = '/proc'
+    BLOCKDIR = '/sys/block'
+    ROOTGROUP = 'root'
+
+
+def generate_uuid():
+    return str(uuid.uuid4())
+
+
+def which(executable):
+    """find the location of an executable"""
+    locations = (
+        '/usr/local/bin',
+        '/bin',
+        '/usr/bin',
+        '/usr/local/sbin',
+        '/usr/sbin',
+        '/sbin',
+    )
+
+    for location in locations:
+        executable_path = os.path.join(location, executable)
+        if os.path.exists(executable_path) and os.path.isfile(executable_path):
+            return executable_path
+    mlogger.warning('Absolute path not found for executable: %s', executable)
+    mlogger.warning('Ensure $PATH environment variable contains '
+                    'common executable locations')
+    # fallback to just returning the argument as-is, to prevent a hard fail,
+    # and hoping that the system might have the executable somewhere custom
+    return executable
+
+
+def get_ceph_user_ids():
+    """
+    Return the id and gid of the ceph user
+    """
+    try:
+        user = pwd.getpwnam('ceph')
+    except KeyError:
+        # is this even possible?
+        raise RuntimeError('"ceph" user is not available in the system')
+    return user[2], user[3]
+
+
+def get_file_contents(path, default=''):
+    contents = default
+    if not os.path.exists(path):
+        return contents
+    try:
+        with open(path, 'r') as open_file:
+            contents = open_file.read().strip()
+    except Exception:
+        logger.exception('Failed to read contents from: %s' % path)
+
+    return contents
+
+
+def mkdir_p(path, chown=True):
+    """
+    A `mkdir -p` that defaults to chown the path to the ceph user
+    """
+    try:
+        os.mkdir(path)
+    except OSError as e:
+        if e.errno == errno.EEXIST:
+            pass
+        else:
+            raise
+    if chown:
+        uid, gid = get_ceph_user_ids()
+        os.chown(path, uid, gid)
+
+
+def chown(path, recursive=True):
+    """
+    ``chown`` a path to the ceph user (uid and guid fetched at runtime)
+    """
+    uid, gid = get_ceph_user_ids()
+    if os.path.islink(path):
+        process.run(['chown', '-h', 'ceph:ceph', path])
+        path = os.path.realpath(path)
+    if recursive:
+        process.run(['chown', '-R', 'ceph:ceph', path])
+    else:
+        os.chown(path, uid, gid)
+
+
+def is_binary(path):
+    """
+    Detect if a file path is a binary or not. Will falsely report as binary
+    when utf-16 encoded. In the ceph universe there is no such risk (yet)
+    """
+    with open(path, 'rb') as fp:
+        contents = fp.read(8192)
+    if b'\x00' in contents:  # a null byte may signal binary
+        return True
+    return False
+
+
+def path_is_mounted(path, destination=None):
+    """
+    Check if the given path is mounted
+    """
+    mounts = get_mounts(paths=True)
+    realpath = os.path.realpath(path)
+    mounted_locations = mounts.get(realpath, [])
+
+    if destination:
+        return destination in mounted_locations
+    return mounted_locations != []
+
+
+def get_mounts(devices=False, paths=False):
+    """
+    Create a mapping of all available system mounts so that other helpers can
+    detect nicely what path or device is mounted
+
+    It ignores (most of) non existing devices, but since some setups might need
+    some extra device information, it will make an exception for:
+
+    - tmpfs
+    - devtmpfs
+
+    If ``devices`` is set to ``True`` the mapping will be a device-to-path(s),
+    if ``paths`` is set to ``True`` the mapping will be a path-to-device(s)
+    for zfs mount the zpool part will also be considered a device.
+
+    """
+    devices_mounted = {}
+    paths_mounted = {}
+    do_not_skip = ['tmpfs', 'devtmpfs']
+    type_not_skip = ['zfs']
+    default_to_devices = not devices and not paths
+
+    with open(PROCDIR + '/mounts', 'rb') as mounts:
+        proc_mounts = mounts.readlines()
+
+    for line in proc_mounts:
+        fields = [as_string(f) for f in line.split()]
+        if len(fields) < 3:
+            continue
+        device = str(fields[0])
+        path = os.path.realpath(str(fields[1]))
+        devtype = str(fields[2])
+
+        # only care about actual existing devices
+        if not os.path.exists(device) or not device.startswith('/'):
+            if not (device in do_not_skip or devtype in type_not_skip):
+                continue
+        if device in devices_mounted.keys():
+            devices_mounted[device].append(path)
+        else:
+            devices_mounted[device] = [path]
+        if path in paths_mounted.keys():
+            paths_mounted[path].append(device)
+        else:
+            paths_mounted[path] = [device]
+
+    # Default to returning information for devices if
+    if devices is True or default_to_devices:
+        return devices_mounted
+    else:
+        return paths_mounted
+# vim: expandtab smarttab shiftwidth=4 softtabstop=4

--- a/src/ceph-volume/plugin/zfs/setup.py
+++ b/src/ceph-volume/plugin/zfs/setup.py
@@ -5,9 +5,9 @@
 
 from setuptools import setup, find_packages
 
-requirements = [ ]
+requirements = []
 
-setup_requirements = [ ]
+setup_requirements = []
 
 setup(
     author="Willem Jan Withagen",
@@ -39,8 +39,8 @@ setup(
     url='https://github.com/ceph/ceph/src/ceph-volume/plugin/zfs',
     version='0.1.0',
     zip_safe=False,
-    entry_points = dict(
-        ceph_volume_handlers = [
+    entry_points=dict(
+        ceph_volume_handlers=[
             'zfs = ceph_volume_zfs.main:ZFSVOL',
         ],
     ),


### PR DESCRIPTION
```
usage: ceph-volume zfs prepare [-h] --data DATA [--filestore]
                               [--journal JOURNAL] [--osd-id OSD_ID]
                               [--osd-fsid OSD_FSID]
                               [--crush-device-class CRUSH_DEVICE_CLASS]

Prepare an OSD by assigning an ID and FSID, registering them with the
cluster with an ID and FSID, formatting and mounting the volume, and
finally by adding all the metadata to the logical volumes using ZFS
tags, so that it can later be discovered.

Existing logical volume (zfs volume):

    ceph-volume zfs prepare --data {zfsvol}

Existing device, that will be made a pool and volume:

    ceph-volume zfs prepare --data /path/to/device

optional arguments:
  -h, --help            show this help message and exit
  --osd-id OSD_ID       Reuse an existing OSD id
  --osd-fsid OSD_FSID   Reuse an existing OSD fsid
  --crush-device-class  CRUSH_DEVICE_CLASS
                        Crush device class to assign this OSD to

required arguments:
  --data DATA           OSD data path. A physical device or ZVOL or zfs
                        filesystem

filestore:
  --filestore           Use the filestore objectstore
  --journal JOURNAL     A ZVOL or zfs filesystem (zpool/volume), or path to a
                        device
```



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug