### PR TITLE
luminous: rgw: list bucket can not show the object uploaded by RGWPostObj when enable bucket versioning

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3794,6 +3794,7 @@ void RGWPostObj::execute()
                                         s->cct->_conf->rgw_obj_stripe_size,
                                         s->req_id,
                                         s->bucket_info.versioning_enabled());
+    processor.set_olh_epoch(0);
     /* No filters by default. */
     filter = &processor;
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/36423