### PR TITLE
mimic: osd: Remove old bft= which has been superceded by backfill=

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6140,8 +6140,6 @@ ostream& operator<<(ostream& out, const PG& pg)
     }
   }
 
-  if (!pg.backfill_targets.empty())
-    out << " bft=" << pg.backfill_targets;
   out << " crt=" << pg.pg_log.get_can_rollback_to();
 
   if (pg.last_complete_ondisk != pg.info.last_complete)


### PR DESCRIPTION
http://tracker.ceph.com/issues/36292