### PR TITLE
crimson/net: seastar-msgr refactoring

### DIFF
--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -27,34 +27,22 @@ using seq_num_t = uint64_t;
 class Connection : public boost::intrusive_ref_counter<Connection,
 						       boost::thread_unsafe_counter> {
  protected:
-  Messenger *const messenger;
   entity_addr_t my_addr;
   entity_addr_t peer_addr;
 
  public:
-  Connection(Messenger *messenger, const entity_addr_t& my_addr,
+  Connection(const entity_addr_t& my_addr,
              const entity_addr_t& peer_addr)
-    : messenger(messenger), my_addr(my_addr), peer_addr(peer_addr) {}
+    : my_addr(my_addr), peer_addr(peer_addr) {}
   virtual ~Connection() {}
 
-  Messenger* get_messenger() const { return messenger; }
-
+  virtual Messenger* get_messenger() const = 0;
   const entity_addr_t& get_my_addr() const { return my_addr; }
   const entity_addr_t& get_peer_addr() const { return peer_addr; }
   virtual int get_peer_type() const = 0;
 
   /// true if the handshake has completed and no errors have been encountered
   virtual bool is_connected() = 0;
-
-  /// complete a handshake from the client's perspective
-  virtual seastar::future<> client_handshake(entity_type_t peer_type,
-					     entity_type_t host_type) = 0;
-
-  /// complete a handshake from the server's perspective
-  virtual seastar::future<> server_handshake() = 0;
-
-  /// read a message from a connection that has completed its handshake
-  virtual seastar::future<MessageRef> read_message() = 0;
 
   /// send a message over a connection that has completed its handshake
   virtual seastar::future<> send(MessageRef msg) = 0;
@@ -65,35 +53,6 @@ class Connection : public boost::intrusive_ref_counter<Connection,
 
   /// close the connection and cancel any any pending futures from read/send
   virtual seastar::future<> close() = 0;
-
-  /// move all messages in the sent list back into the queue
-  virtual void requeue_sent() = 0;
-
-  /// get all messages in the out queue
-  virtual std::tuple<seq_num_t, std::queue<MessageRef>> get_out_queue() = 0;
-
-public:
-  enum class state_t {
-    none,
-    open,
-    standby,
-    closed,
-    wait
-  };
-  /// the number of connections initiated in this session, increment when a
-  /// new connection is established
-  virtual uint32_t connect_seq() const = 0;
-
-  /// the client side should connect us with a gseq. it will be reset with a
-  /// the one of exsting connection if it's greater.
-  virtual uint32_t peer_global_seq() const = 0;
-
-  virtual seq_num_t rx_seq_num() const = 0;
-
-  /// current state of connection
-  virtual state_t get_state() const = 0;
-  virtual bool is_server_side() const = 0;
-  virtual bool is_lossy() const = 0;
 };
 
 } // namespace ceph::net

--- a/src/crimson/net/Fwd.h
+++ b/src/crimson/net/Fwd.h
@@ -16,15 +16,11 @@
 
 #include <boost/intrusive_ptr.hpp>
 
-#include "Errors.h"
 #include "msg/msg_types.h"
 #include "msg/Message.h"
 
 using peer_type_t = int;
 using auth_proto_t = int;
-
-class Message;
-using MessageRef = boost::intrusive_ptr<Message>;
 
 namespace ceph::net {
 
@@ -38,4 +34,3 @@ class Dispatcher;
 class Messenger;
 
 } // namespace ceph::net
-

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -60,8 +60,6 @@ class Messenger {
     }
     return ++global_seq;
   }
-  virtual ConnectionRef lookup_conn(const entity_addr_t&) = 0;
-  virtual void unregister_conn(ConnectionRef) = 0;
 
   // @returns a tuple of <is_valid, auth_reply, session_key>
   virtual seastar::future<msgr_tag_t,    /// tag for error, 0 if authorized

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -21,15 +21,28 @@
 #include "Connection.h"
 #include "crimson/thread/Throttle.h"
 
+class AuthAuthorizer;
 class AuthSessionHandler;
 
 namespace ceph::net {
 
+class SocketMessenger;
+class SocketConnection;
+using SocketConnectionRef = boost::intrusive_ptr<SocketConnection>;
+
 class SocketConnection : public Connection {
+  SocketMessenger& messenger;
   seastar::connected_socket socket;
   seastar::input_stream<char> in;
   seastar::output_stream<char> out;
 
+  enum class state_t {
+    none,
+    open,
+    standby,
+    closed,
+    wait
+  };
   state_t state = state_t::none;
 
   /// become valid only when state is state_t::closed
@@ -60,9 +73,9 @@ class SocketConnection : public Connection {
 
   /// server side of handshake negotiation
   seastar::future<> handle_connect();
-  seastar::future<> handle_connect_with_existing(ConnectionRef existing,
+  seastar::future<> handle_connect_with_existing(SocketConnectionRef existing,
 						 bufferlist&& authorizer_reply);
-  seastar::future<> replace_existing(ConnectionRef existing,
+  seastar::future<> replace_existing(SocketConnectionRef existing,
 				     bufferlist&& authorizer_reply,
 				     bool is_reset_from_peer = false);
   seastar::future<> send_connect_reply(ceph::net::msgr_tag_t tag,
@@ -74,9 +87,6 @@ class SocketConnection : public Connection {
   seastar::future<> handle_keepalive2_ack();
 
   bool require_auth_feature() const;
-  int get_peer_type() const override {
-    return h.connect.host_type;
-  }
   uint32_t get_proto_version(entity_type_t peer_type, bool connec) const;
   /// client side of handshake negotiation
   seastar::future<> connect(entity_type_t peer_type, entity_type_t host_type);
@@ -148,20 +158,19 @@ class SocketConnection : public Connection {
   seastar::future<> fault();
 
  public:
-  SocketConnection(Messenger *messenger,
+  SocketConnection(SocketMessenger& messenger,
                    const entity_addr_t& my_addr,
                    const entity_addr_t& peer_addr,
                    seastar::connected_socket&& socket);
   ~SocketConnection();
 
+  Messenger* get_messenger() const override;
+
+  int get_peer_type() const override {
+    return h.connect.host_type;
+  }
+
   bool is_connected() override;
-
-  seastar::future<> client_handshake(entity_type_t peer_type,
-				     entity_type_t host_type) override;
-
-  seastar::future<> server_handshake() override;
-
-  seastar::future<MessageRef> read_message() override;
 
   seastar::future<> send(MessageRef msg) override;
 
@@ -169,31 +178,49 @@ class SocketConnection : public Connection {
 
   seastar::future<> close() override;
 
-  uint32_t connect_seq() const override {
+ public:
+  /// complete a handshake from the client's perspective
+  seastar::future<> client_handshake(entity_type_t peer_type,
+				     entity_type_t host_type);
+
+  /// complete a handshake from the server's perspective
+  seastar::future<> server_handshake();
+
+  /// read a message from a connection that has completed its handshake
+  seastar::future<MessageRef> read_message();
+
+  /// the number of connections initiated in this session, increment when a
+  /// new connection is established
+  uint32_t connect_seq() const {
     return h.connect_seq;
   }
-  uint32_t peer_global_seq() const override {
+
+  /// the client side should connect us with a gseq. it will be reset with
+  /// the one of exsting connection if it's greater.
+  uint32_t peer_global_seq() const {
     return h.peer_global_seq;
   }
   seq_num_t rx_seq_num() const {
     return in_seq;
   }
-  state_t get_state() const override {
+
+  /// current state of connection
+  state_t get_state() const {
     return state;
   }
-  bool is_server_side() const override {
+  bool is_server_side() const {
     return policy.server;
   }
-  bool is_lossy() const override {
+  bool is_lossy() const {
     return policy.lossy;
   }
 
-private:
-  void requeue_sent() override;
-  std::tuple<seq_num_t, std::queue<MessageRef>> get_out_queue() override {
+  /// move all messages in the sent list back into the queue
+  void requeue_sent();
+
+  std::tuple<seq_num_t, std::queue<MessageRef>> get_out_queue() {
     return {out_seq, std::move(out_q)};
   }
-
 };
 
 } // namespace ceph::net


### PR DESCRIPTION
This PR is to split #24142 into smaller digestible pieces.
Most probably will contain the following steps/commits:

- [x] Clean seastar-msgr interfaces.
- [ ] Add connecting/accepting states so `Messenger::connect()` can return a `ConnectionRef` instead of future.
- [ ] Let reconnect/replace happen transparently inside `SocketConnection`.
- [ ] Centralize error handling so it's easier to a) make decisions based on policy (lossy/lossless) and b) report changes to connection state via `Dispatcher` (ms_handle_reset etc).
- [ ] Change to per-connection seastar-gates.
- [ ] Formalize a connection state machine.
- [ ] Add v1/v2 protocol abstractions that act on the state machine.