### PR TITLE
dashboard/mgr: Save button doesn't prevent saving an invalid form

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -101,7 +101,7 @@
         </div>
 
         <!-- Values -->
-        <div class="col-sm-12">
+        <div class="col-sm-12" formGroupName="values">
           <h2 i18n
               class="page-header">Values</h2>
           <div class="row" *ngFor="let section of availSections">

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -49,7 +49,7 @@ export class ConfigurationFormComponent implements OnInit {
     };
 
     this.availSections.forEach((section) => {
-      formControls.values.controls[section] = new FormControl(null);
+      formControls.values.addControl(section, new FormControl(null));
     });
 
     this.configForm = new CdFormGroup(formControls);


### PR DESCRIPTION
When changing a configuration value, the `Save` button will accept the user input even if it's invalid and try to save those values.

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

