### PR TITLE
qa/osd: fixup osd-rep-recov-eio.sh fails to parse pg dump

### DIFF
--- a/qa/standalone/erasure-code/test-erasure-eio.sh
+++ b/qa/standalone/erasure-code/test-erasure-eio.sh
@@ -60,7 +60,7 @@ function get_state() {
     local pgid=$1
     local sname=state
     ceph --format json pg dump pgs 2>/dev/null | \
-        jq -r ".[] | select(.pgid==\"$pgid\") | .$sname"
+        jq -r ".pg_stats | .[] | select(.pgid==\"$pgid\") | .$sname"
 }
 
 function create_erasure_coded_pool() {

--- a/qa/standalone/osd/osd-backfill-stats.sh
+++ b/qa/standalone/osd/osd-backfill-stats.sh
@@ -648,7 +648,7 @@ function TEST_backfill_ec_down_all_out() {
     while(true)
     do
       if test "$(ceph --format json pg dump pgs |
-         jq '[.[] | .state | select(. == "incomplete")] | length')" -ne "0"
+         jq '.pg_stats | [.[] | .state | select(. == "incomplete")] | length')" -ne "0"
       then
         sleep 2
         continue

--- a/qa/standalone/osd/osd-rep-recov-eio.sh
+++ b/qa/standalone/osd/osd-rep-recov-eio.sh
@@ -54,7 +54,7 @@ function get_state() {
     local pgid=$1
     local sname=state
     ceph --format json pg dump pgs 2>/dev/null | \
-        jq -r ".[] | select(.pgid==\"$pgid\") | .$sname"
+        jq -r ".pg_stats | .[] | select(.pgid==\"$pgid\") | .$sname"
 }
 
 function rados_put() {
@@ -323,7 +323,7 @@ function TEST_rep_read_unfound() {
 
     ceph --format=json pg dump pgs | jq '.'
 
-    if ! ceph --format=json pg dump pgs | jq '.[0].state' | grep -q recovery_unfound
+    if ! ceph --format=json pg dump pgs | jq '.pg_stats | .[0].state' | grep -q recovery_unfound
     then
       echo "Failure to get to recovery_unfound state"
       return 1


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/36418
Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

