### PR TITLE
ceph-volume: adds a --prepare flag to `lvm batch`

### DIFF
--- a/doc/ceph-volume/lvm/batch.rst
+++ b/doc/ceph-volume/lvm/batch.rst
@@ -12,11 +12,15 @@ devices in an efficient way?
 
 The process is similar to :ref:`ceph-volume-lvm-create`, and will do the
 preparation and activation at once, following the same workflow for each OSD.
+However, If the ``--prepare`` flag is passed then only the prepare step is taken
+and the OSDs are not activated.
 
 All the features that ``ceph-volume lvm create`` supports, like ``dmcrypt``,
 avoiding ``systemd`` units from starting, defining bluestore or filestore,
 are supported. Any fine-grained option that may affect a single OSD is not
 supported, for example: specifying where journals should be placed.
+
+
 
 
 .. _ceph-volume-lvm-batch_bluestore:

--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -58,6 +58,7 @@ Optional arguments:
 * [--bluestore]         Use the bluestore objectstore (default)
 * [--filestore]         Use the filestore objectstore
 * [--yes]               Skip the report and prompt to continue provisioning
+* [--prepare]           Only prepare OSDs, do not activate
 * [--dmcrypt]           Enable encryption for the underlying OSD devices
 * [--crush-device-class] Define a CRUSH device class to assign the OSD to
 * [--no-systemd]         Do not enable or create any systemd units

--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -263,6 +263,11 @@ class Batch(object):
             type=int,
             help='Override the "osd_journal_size" value, in megabytes'
         )
+        parser.add_argument(
+            '--prepare',
+            action='store_true',
+            help='Only prepare all OSDs, do not activate',
+        )
         args = parser.parse_args(self.argv)
 
         if not args.devices:

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -4,6 +4,7 @@ from ceph_volume.util import disk, prepare
 from ceph_volume.api import lvm
 from . import validators
 from ceph_volume.devices.lvm.create import Create
+from ceph_volume.devices.lvm.prepare import Prepare
 from ceph_volume.util import templates
 from ceph_volume.exceptions import SizeAllocationError
 
@@ -134,7 +135,10 @@ class SingleType(object):
                 if self.args.crush_device_class:
                     command.extend(['--crush-device-class', self.args.crush_device_class])
 
-                Create(command).main()
+                if self.args.prepare:
+                    Prepare(command).main()
+                else:
+                    Create(command).main()
 
 
 class MixedType(object):
@@ -310,7 +314,10 @@ class MixedType(object):
             if self.args.crush_device_class:
                 command.extend(['--crush-device-class', self.args.crush_device_class])
 
-            Create(command).main()
+            if self.args.prepare:
+                Prepare(command).main()
+            else:
+                Create(command).main()
 
     def get_common_vg(self):
         # find all the vgs associated with the current device

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -4,6 +4,7 @@ from ceph_volume.util import disk, prepare
 from ceph_volume.api import lvm
 from . import validators
 from ceph_volume.devices.lvm.create import Create
+from ceph_volume.devices.lvm.prepare import Prepare
 from ceph_volume.util import templates
 from ceph_volume.exceptions import SizeAllocationError
 
@@ -169,7 +170,10 @@ class SingleType(object):
             if self.args.crush_device_class:
                 command.extend(['--crush-device-class', self.args.crush_device_class])
 
-            Create(command).main()
+            if self.args.prepare:
+                Prepare(command).main()
+            else:
+                Create(command).main()
 
 
 class MixedType(object):
@@ -402,4 +406,7 @@ class MixedType(object):
             if self.args.crush_device_class:
                 command.extend(['--crush-device-class', self.args.crush_device_class])
 
-            Create(command).main()
+            if self.args.prepare:
+                Prepare(command).main()
+            else:
+                Create(command).main()


### PR DESCRIPTION
If you pass ``--prepare`` to ``lvm batch`` the OSDs will only be prepared and not activated.

Fixes: http://tracker.ceph.com/issues/36363