### PR TITLE
rgw: user stats account for resharded buckets

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -145,6 +145,9 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
      entry = update_entry;
 
      ret = 0;
+    } else if (op.add) {
+      // bucket id may have changed (ie reshard)
+      entry.bucket.bucket_id = update_entry.bucket.bucket_id;
     }
 
     if (ret < 0) {

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -67,7 +67,8 @@ int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id)
       RGWBucketEnt& bucket_ent = i->second;
       RGWBucketInfo bucket_info;
 
-      ret = store->get_bucket_instance_info(obj_ctx, bucket_ent.bucket, bucket_info, NULL, NULL);
+      ret = store->get_bucket_info(obj_ctx, user_id.tenant, bucket_ent.bucket.name,
+                                   bucket_info, nullptr, nullptr);
       if (ret < 0) {
         ldout(cct, 0) << "ERROR: could not read bucket info: bucket=" << bucket_ent.bucket << " ret=" << ret << dendl;
         continue;


### PR DESCRIPTION
when bucket reshard completes, rgw_link_bucket() passes the new bucket instance id down to cls_user, but cls_user_set_buckets_info() does not change the instance id when it's updating an existing bucket. so when rgw_user_sync_all_stats() looks up each of the user's buckets, it uses the original bucket instance id instead of the resharded one and calculates user stats that may not match the current bucket stats

as a workaround, rgw_user_sync_all_stats() no longer relies on the bucket instance id it gets from rgw_read_user_buckets(), and instead calls get_bucket_info() to look up the current instance in the bucket entrypoint

Fixes: https://tracker.ceph.com/issues/24505

this includes two separate fixes, each of which resolve the issue independently. but the workaround in rgw_user_sync_all_stats() is the only way to handle previously-resharded buckets