### PR TITLE
ptl-tool.py: move githubmap update into merge commit

### DIFF
--- a/src/script/ptl-tool.py
+++ b/src/script/ptl-tool.py
@@ -295,22 +295,16 @@ def build_branch(args):
         for indication in indications:
             message = message + indication + "\n"
 
+        G.git.merge(tip.hexsha, '--no-ff', m=message)
+
         if new_new_contributors:
             # Check out the PR, add a commit adding to .githubmap
-            HEAD = G.head.commit
-            log.info("adding new contributors to githubmap on top of PR #%s" % pr)
-            G.head.reset(commit=tip, index=True, working_tree=True)
+            log.info("adding new contributors to githubmap in merge commit")
             with open(".githubmap", "a") as f:
                 for c in new_new_contributors:
                     f.write("%s %s\n" % (c, new_new_contributors[c]))
             G.index.add([".githubmap"])
-            G.git.commit("-s", "-m", "githubmap: update contributors")
-            c = G.head.commit
-            G.head.reset(HEAD, index=True, working_tree=True)
-        else:
-            c = tip
-
-        G.git.merge(c.hexsha, '--no-ff', m=message)
+            G.git.commit("--amend", "--no-edit")
 
         if label:
             req = requests.post("https://api.github.com/repos/{project}/{repo}/issues/{pr}/labels".format(pr=pr, project=BASE_PROJECT, repo=BASE_REPO), data=json.dumps([label]), auth=(USER, PASSWORD))


### PR DESCRIPTION
Otherwise Github will reject the push because one commit is not part of the PR
(and "untested").

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

