### PR TITLE
os/bluestore/KernelDevice: Honor discard_granularity not rotational for discard

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -113,6 +113,7 @@ private:
 protected:
   uint64_t size;
   uint64_t block_size;
+  bool support_discard = false;
   bool rotational = true;
 
 public:


### PR DESCRIPTION
Kernel ABI:
A discard_granularity of 0 means
that the device does not support discard functionality.

Also discard_granularity is RO attribute, while rotational are RW.
That means what rotational can be overridden in user space if needed.

Signed-off-by: Timofey Titovets <nefelim4ag@gmail.com>
