### PR TITLE
common/Throttle: TokenBucketThrottle: use reference to m_blockers.front()

### DIFF
--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -741,7 +741,7 @@ void TokenBucketThrottle::add_tokens() {
     // check the m_blockers from head to tail, if blocker can get
     // enough tokens, let it go.
     while (!m_blockers.empty()) {
-      Blocker blocker = m_blockers.front();
+      Blocker &blocker = m_blockers.front();
       uint64_t got = m_throttle.get(blocker.tokens_requested);
       if (got == blocker.tokens_requested) {
 	// got enough tokens for front.


### PR DESCRIPTION
…ate it

As we need to update the blocker below, then we need to use reference to front object,
rather than a new object of blocker.

Signed-off-by: Dongsheng Yang <dongsheng.yang@easystack.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

