### PR TITLE
handle gcc older than 7 (-fno-new-ttp-matching)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,7 +37,9 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-pragmas")
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -rdynamic")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-null-sentinel -Woverloaded-virtual")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-new-ttp-matching")
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0.0)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-new-ttp-matching")
+  endif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0.0)
   # cmake does not add '-pie' for executables even if
   # CMAKE_POSITION_INDEPENDENT_CODE is TRUE.
   if(EXE_LINKER_USE_PIE)


### PR DESCRIPTION
I am building Mimic under Debian 'stretch' so all I have is gcc 6.3 version:

cd /home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/obj-aarch64-linux-gnu/src/osdc && /usr/bin/c++  -DCEPH_LIBDIR=\"/usr/lib\" -DCEPH_PKGLIBDIR=\"/usr/lib/ceph\" -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE -D__linux__ -isystem /home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/obj-aarch64-linux-gnu/boost/include -I/home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/obj-aarch64-linux-gnu/src/include -I/home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/src -isystem /home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/obj-aarch64-linux-gnu/include -I/usr/include/nss -I/usr/include/nspr -isystem /home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/src/xxHash -isystem /home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/src/rapidjson/include -I/home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/src/dmclock/src -I/home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/src/dmclock/support/src -isystem /home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/src/googletest/googletest/include  -g -O2 -fdebug-prefix-map=/home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -Wall -Wtype-limits -Wignored-qualifiers -Winit-self -Wpointer-arith -Werror=format-security -fno-strict-aliasing -fsigned-char -Wno-unknown-pragmas -rdynamic -g -O2 -fdebug-prefix-map=/home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -ftemplate-depth-1024 -Wnon-virtual-dtor -Wno-unknown-pragmas -Wstrict-null-sentinel -Woverloaded-virtual -fno-new-ttp-matching -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector-strong -fdiagnostics-color=auto -I/usr/include -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fPIC   -DHAVE_CONFIG_H -D__CEPH__ -D_REENTRANT -D_THREAD_SAFE -D__STDC_FORMAT_MACROS -std=c++1z -o CMakeFiles/osdc.dir/Filer.cc.o -c /home/hrw/devel/ceph-ansible/packages/mimic/ceph-13.2.2/src/osdc/Filer.cc
c++: error: unrecognized command line option ‘-fno-new-ttp-matching’; did you mean ‘-fno-var-tracking’?

Simple check for GCC version handles problem.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

