### PR TITLE
mgr/dashboard: configs textarea disallow horizontal resize

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.html
@@ -33,7 +33,7 @@
                  class="control-label col-sm-3">Description
           </label>
           <div class="col-sm-9">
-            <textarea class="form-control"
+            <textarea class="form-control resize-vertical"
                       id="desc"
                       formControlName="desc"
                       readonly>
@@ -48,7 +48,7 @@
                  class="control-label col-sm-3">Long description
           </label>
           <div class="col-sm-9">
-            <textarea class="form-control"
+            <textarea class="form-control resize-vertical"
                       id="long_desc"
                       formControlName="long_desc"
                       readonly>

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.scss
@@ -6,3 +6,7 @@
     margin-top: 7px;
   }
 }
+
+.resize-vertical {
+  resize: vertical;
+}


### PR DESCRIPTION
The textarea allows horizontal and vertical resize by default. Only the vertical resize is appropriate for this form.

Fixes: http://tracker.ceph.com/issues/36452
Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket

