### PR TITLE
build: mark gcc7 as minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,12 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
   FIND_PACKAGE(Threads)
 endif(CMAKE_SYSTEM_NAME MATCHES "Linux")
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 7)
+    message(FATAL_ERROR "GCC 7+ required due to C++17 requirements")
+  endif()
+endif()
+
 option(WITH_CCACHE "Build with ccache.")
 if(WITH_CCACHE)
   find_program(CCACHE_FOUND ccache)


### PR DESCRIPTION
Ceph requires C++17 support from compiler. This means gcc 7.x being minimal version supported.

This also allows to fail quick on Debian 'stretch' with it's gcc 6.3 compiler.