### PR TITLE
mgr/dashboard: Fix Python3 issue

### DIFF
--- a/qa/tasks/mgr/dashboard/test_perf_counters.py
+++ b/qa/tasks/mgr/dashboard/test_perf_counters.py
@@ -69,5 +69,5 @@ class PerfCountersControllerTest(DashboardTestCase):
             'detail': str,
             'traceback': str,
         })
-        self.assertEqual(self._resp.json()['detail'], 'osd.{} not found'.format(unused_id))
+        self.assertEqual(self._resp.json()['detail'], "'osd.{}' not found".format(unused_id))
         self.assertSchemaBody(schema)

--- a/src/pybind/mgr/dashboard/controllers/perf_counters.py
+++ b/src/pybind/mgr/dashboard/controllers/perf_counters.py
@@ -17,7 +17,7 @@ class PerfCounter(RESTController):
         try:
             schema = schema_dict["{}.{}".format(self.service_type, service_id)]
         except KeyError as e:
-            raise cherrypy.HTTPError(404, "{0} not found".format(e.message))
+            raise cherrypy.HTTPError(404, "{0} not found".format(e))
         counters = []
 
         for key, value in sorted(schema.items()):


### PR DESCRIPTION
Which results in a 500 error when trying to access the `Performance
Counter` tab on the OSD list.

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

