### PR TITLE
mgr/rook: fix urljoin import

### DIFF
--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -7,7 +7,7 @@ call methods.
 This module is runnable outside of ceph-mgr, useful for testing.
 """
 
-from six.moves.urllib import parse
+from six.moves.urllib.parse import urljoin  # pylint: disable=import-error
 import logging
 import json
 
@@ -74,7 +74,7 @@ class RookCluster(object):
     def rook_url(self, path):
         prefix = "/apis/ceph.rook.io/%s/namespaces/%s/" % (
             ROOK_API_VERSION, self.rook_namespace)
-        return urlparse.urljoin(prefix, path)
+        return urljoin(prefix, path)
 
     def rook_api_call(self, verb, path, **kwargs):
         full_path = self.rook_url(path)


### PR DESCRIPTION
This is the correct syntax to ensure that we get urljoin, no matter
the python version.

Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

