### PR TITLE
crimson/net: fix compile errors in test_alien_echo.cc

### DIFF
--- a/src/common/common_init.h
+++ b/src/common/common_init.h
@@ -69,7 +69,6 @@ CephContext *common_preinit(const CephInitParameters &iparams,
 void complain_about_parse_errors(CephContext *cct,
 				 std::deque<std::string> *parse_errors);
 
-#ifndef WITH_SEASTAR
 /* This function is called after you have done your last
  * fork. When you make this call, the system will initialize everything that
  * cannot be initialized before a fork.
@@ -83,6 +82,5 @@ void complain_about_parse_errors(CephContext *cct,
  * the Ceph libraries would be destroyed by a fork().
  */
 void common_init_finish(CephContext *cct);
-#endif // #ifndef WITH_SEASTAR
 
 #endif

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -133,14 +133,6 @@ struct Server {
       }
       on_reply.notify_one();
     }
-    bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
-                              bufferlist& authorizer,
-                              bufferlist& authorizer_reply,
-                              bool& isvalid, CryptoKey& session_key,
-                              std::unique_ptr<AuthAuthorizerChallenge>*) override {
-      isvalid = true;
-      return true;
-    }
     bool ms_dispatch(Message*) override {
       ceph_abort();
     }
@@ -195,14 +187,6 @@ struct Client {
         replied = true;
       }
       on_reply.notify_one();
-    }
-    bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
-                              bufferlist& authorizer,
-                              bufferlist& authorizer_reply,
-                              bool& isvalid, CryptoKey& session_key,
-                              std::unique_ptr<AuthAuthorizerChallenge>*) override {
-      isvalid = true;
-      return true;
     }
     bool ms_dispatch(Message*) override {
       ceph_abort();


### PR DESCRIPTION
test_alien_echo.cc is using common_init_finish, but it is not available
if defined WITH_SEASTAR.

Dispatcher::ms_verify_authorizer() is removed by PR#24095.

Signed-off-by: Yingxin <yingxin.cheng@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

