### PR TITLE
jewel: librbd: snapshots should be created/removed against data pool

### DIFF
--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -34,7 +34,7 @@ struct C_CreateSnapId: public Context {
   }
 
   virtual void finish(int r) {
-    r = image_ctx.md_ctx.selfmanaged_snap_create(snap_id);
+    r = image_ctx.data_ctx.selfmanaged_snap_create(snap_id);
     on_finish->complete(r);
   }
 };
@@ -50,7 +50,7 @@ struct C_RemoveSnapId: public Context {
   }
 
   virtual void finish(int r) {
-    r = image_ctx.md_ctx.selfmanaged_snap_remove(snap_id);
+    r = image_ctx.data_ctx.selfmanaged_snap_remove(snap_id);
     on_finish->complete(r);
   }
 };

--- a/src/librbd/operation/SnapshotRemoveRequest.cc
+++ b/src/librbd/operation/SnapshotRemoveRequest.cc
@@ -202,7 +202,7 @@ void SnapshotRemoveRequest<I>::send_release_snap_id() {
   m_state = STATE_RELEASE_SNAP_ID;
 
   // TODO add async version of selfmanaged_snap_remove
-  int r = image_ctx.md_ctx.selfmanaged_snap_remove(m_snap_id);
+  int r = image_ctx.data_ctx.selfmanaged_snap_remove(m_snap_id);
   this->async_complete(r);
 }
 

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -43,7 +43,7 @@ public:
   }
 
   void expect_allocate_snap_id(MockImageCtx &mock_image_ctx, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
                                selfmanaged_snap_create(_));
     if (r < 0 && r != -ESTALE) {
       expect.WillOnce(Return(r));
@@ -53,7 +53,7 @@ public:
   }
 
   void expect_release_snap_id(MockImageCtx &mock_image_ctx, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
                                selfmanaged_snap_remove(_));
     if (r < 0) {
       expect.WillOnce(Return(r));

--- a/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
@@ -110,7 +110,7 @@ public:
   }
 
   void expect_release_snap_id(MockImageCtx &mock_image_ctx) {
-    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
                                 selfmanaged_snap_remove(_))
                                   .WillOnce(DoDefault());
   }


### PR DESCRIPTION

http://tracker.ceph.com/issues/36476

---
Fixes: http://tracker.ceph.com/issues/21567
Signed-off-by: Jason Dillaman <dillaman@redhat.com>
(cherry picked from commit 5a3baf1bd852d6c5d0de10a33839658789edc4eb)

Conflicts:
	src/librbd/operation/SnapshotCreateRequest.cc:
          the original PR was targeting. so this change is adapted
          to jewel.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
