### PR TITLE
mgr/dashboard: Add left padding to helper icon

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/helper/helper.component.scss
@@ -3,4 +3,5 @@
 i {
   color: $color-helper-bg;
   cursor: pointer;
+  padding-left: 4px;
 }


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/36466
Signed-off-by: Stephan Müller <smueller@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

This pull request is needed in [#24627](https://github.com/ceph/ceph/pull/24627)