### PR TITLE
mds: scrub abort/pause/resume control operations

### DIFF
--- a/doc/cephfs/disaster-recovery-experts.rst
+++ b/doc/cephfs/disaster-recovery-experts.rst
@@ -259,4 +259,4 @@ run a forward scrub to repair them. Ensure you have an MDS running and issue:
 
 ::
 
-    ceph daemon mds.a scrub_path / recursive repair
+    ceph tell mds.a scrub start / recursive repair

--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -921,6 +921,10 @@ class Filesystem(MDSCluster):
         info = self.get_rank(rank=rank, status=status)
         return self.json_asok(command, 'mds', info['name'], timeout=timeout)
 
+    def rank_tell(self, command, rank=0, status=None):
+        info = self.get_rank(rank=rank, status=status)
+        return json.loads(self.mon_manager.raw_cluster_cmd("tell", 'mds.{0}'.format(info['name']), *command))
+
     def read_cache(self, path, depth=None):
         cmd = ["dump", "tree", path]
         if depth is not None:

--- a/qa/tasks/cephfs/test_damage.py
+++ b/qa/tasks/cephfs/test_damage.py
@@ -434,7 +434,7 @@ class TestDamage(CephFSTestCase):
         self.mount_a.umount_wait()
 
         # Now repair the stats
-        scrub_json = self.fs.mds_asok(["scrub_path", "/subdir", "repair"])
+        scrub_json = self.fs.rank_tell(["scrub", "start", "/subdir", "repair"])
         log.info(json.dumps(scrub_json, indent=2))
 
         self.assertEqual(scrub_json["passed_validation"], False)

--- a/qa/tasks/cephfs/test_forward_scrub.py
+++ b/qa/tasks/cephfs/test_forward_scrub.py
@@ -232,7 +232,7 @@ class TestForwardScrub(CephFSTestCase):
         self.mount_a.umount_wait()
 
         with self.assert_cluster_log("inode table repaired", invert_match=True):
-            out_json = self.fs.mds_asok(["scrub_path", "/", "repair", "recursive"])
+            out_json = self.fs.rank_tell(["scrub", "start", "/", "repair", "recursive"])
             self.assertNotEqual(out_json, None)
 
         self.mds_cluster.mds_stop()
@@ -255,7 +255,7 @@ class TestForwardScrub(CephFSTestCase):
         self.fs.wait_for_daemons()
 
         with self.assert_cluster_log("inode table repaired"):
-            out_json = self.fs.mds_asok(["scrub_path", "/", "repair", "recursive"])
+            out_json = self.fs.rank_tell(["scrub", "start", "/", "repair", "recursive"])
             self.assertNotEqual(out_json, None)
 
         self.mds_cluster.mds_stop()
@@ -286,7 +286,7 @@ class TestForwardScrub(CephFSTestCase):
                                   "oh i'm sorry did i overwrite your xattr?")
 
         with self.assert_cluster_log("bad backtrace on inode"):
-            out_json = self.fs.mds_asok(["scrub_path", "/", "repair", "recursive"])
+            out_json = self.fs.rank_tell(["scrub", "start", "/", "repair", "recursive"])
             self.assertNotEqual(out_json, None)
         self.fs.mds_asok(["flush", "journal"])
         backtrace = self.fs.read_backtrace(file_ino)

--- a/qa/tasks/cephfs/test_recovery_pool.py
+++ b/qa/tasks/cephfs/test_recovery_pool.py
@@ -186,7 +186,7 @@ class TestRecoveryPool(CephFSTestCase):
         for rank in self.recovery_fs.get_ranks(status=status):
             self.fs.mon_manager.raw_cluster_cmd('tell', "mds." + rank['name'],
                                                 'injectargs', '--debug-mds=20')
-            self.fs.rank_asok(['scrub_path', '/', 'recursive', 'repair'], rank=rank['rank'], status=status)
+            self.fs.rank_tell(['scrub', 'start', '/', 'recursive', 'repair'], rank=rank['rank'], status=status)
         log.info(str(self.mds_cluster.status()))
 
         # Mount a client

--- a/qa/tasks/cephfs/test_scrub.py
+++ b/qa/tasks/cephfs/test_scrub.py
@@ -103,7 +103,7 @@ class DupInodeWorkload(Workload):
         self._filesystem.wait_for_daemons()
 
     def validate(self):
-        out_json = self._filesystem.mds_asok(["scrub_path", "/", "recursive", "repair"])
+        out_json = self._filesystem.rank_tell(["scrub", "start", "/", "recursive", "repair"])
         self.assertNotEqual(out_json, None)
         self.assertTrue(self._filesystem.are_daemons_healthy())
         return self._errors
@@ -129,7 +129,7 @@ class TestScrub(CephFSTestCase):
         # Apply any data damage the workload wants
         workload.damage()
 
-        out_json = self.fs.mds_asok(["scrub_path", "/", "recursive", "repair"])
+        out_json = self.fs.rank_tell(["scrub", "start", "/", "recursive", "repair"])
         self.assertNotEqual(out_json, None)
 
         # See that the files are present and correct

--- a/qa/tasks/cephfs_upgrade_snap.py
+++ b/qa/tasks/cephfs_upgrade_snap.py
@@ -24,13 +24,13 @@ def task(ctx, config):
     mds_map = fs.get_mds_map()
     assert(mds_map['max_mds'] == 1)
 
-    json = fs.rank_asok(["scrub_path", "/", "force", "recursive", "repair"])
+    json = fs.rank_tell(["scrub", "start", "/", "force", "recursive", "repair"])
     if not json or json['return_code'] == 0:
         log.info("scrub / completed")
     else:
         log.info("scrub / failed: {}".format(json))
 
-    json = fs.rank_asok(["scrub_path", "~mdsdir", "force", "recursive", "repair"])
+    json = fs.rank_tell(["scrub", "start", "~mdsdir", "force", "recursive", "repair"])
     if not json or json['return_code'] == 0:
         log.info("scrub ~mdsdir completed")
     else:

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4110,7 +4110,8 @@ void CInode::validate_disk_state(CInode::validated_data *results,
     /**
      * Fetch backtrace and set tag if tag is non-empty
      */
-    void fetch_backtrace_and_tag(CInode *in, std::string_view tag,
+    void fetch_backtrace_and_tag(CInode *in,
+                                 std::string_view tag, bool is_internal,
                                  Context *fin, int *bt_r, bufferlist *bt)
     {
       const int64_t pool = in->get_backtrace_pool();
@@ -4121,8 +4122,8 @@ void CInode::validate_disk_state(CInode::validated_data *results,
       in->mdcache->mds->objecter->read(oid, object_locator_t(pool), fetch, CEPH_NOSNAP,
 				       NULL, 0, fin);
       using ceph::encode;
-      if (!tag.empty()) {
-	ObjectOperation scrub_tag;
+      if (!is_internal) {
+        ObjectOperation scrub_tag;
         bufferlist tag_bl;
         encode(tag, tag_bl);
         scrub_tag.setxattr("scrub_tag", tag_bl);
@@ -4153,10 +4154,11 @@ void CInode::validate_disk_state(CInode::validated_data *results,
 					    in->mdcache->mds->finisher);
 
       std::string_view tag = in->scrub_infop->header->get_tag();
+      bool is_internal = in->scrub_infop->header->is_internal_tag();
       // Rather than using the usual CInode::fetch_backtrace,
       // use a special variant that optionally writes a tag in the same
       // operation.
-      fetch_backtrace_and_tag(in, tag, conf, &results->backtrace.ondisk_read_retval, &bl);
+      fetch_backtrace_and_tag(in, tag, is_internal, conf, &results->backtrace.ondisk_read_retval, &bl);
       return false;
     }
 
@@ -4800,12 +4802,8 @@ void CInode::scrub_finished(MDSInternalContextBase **c) {
   if (scrub_infop->header->get_origin() == this) {
     // We are at the point that a tagging scrub was initiated
     LogChannelRef clog = mdcache->mds->clog;
-    if (scrub_infop->header->get_tag().empty()) {
-      clog->info() << "scrub complete";
-    } else {
-      clog->info() << "scrub complete with tag '"
-                   << scrub_infop->header->get_tag() << "'";
-    }
+    clog->info() << "scrub complete with tag '"
+                 << scrub_infop->header->get_tag() << "'";
   }
 }
 

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -358,6 +358,9 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
    * be complete()ed.
    */
   void scrub_finished(MDSInternalContextBase **c);
+
+  void scrub_aborted(MDSInternalContextBase **c);
+
   /**
    * Report to the CInode that alldirfrags it owns have been scrubbed.
    */

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12339,6 +12339,7 @@ public:
       formatter->open_object_section("results");
       formatter->dump_int("return_code", r);
       formatter->close_section(); // results
+      r = 0; // already dumped in formatter
     }
     if (on_finish)
       on_finish->complete(r);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12383,7 +12383,7 @@ void MDCache::enqueue_scrub_work(MDRequestRef& mdr)
   ScrubHeaderRef header = cs->header;
 
   // Cannot scrub same dentry twice at same time
-  if (in->scrub_infop && in->scrub_infop->scrub_in_progress) {
+  if (in->scrub_is_in_progress()) {
     mds->server->respond_to_request(mdr, -EBUSY);
     return;
   } else {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -12351,8 +12351,18 @@ void MDCache::enqueue_scrub(
   }
 
   C_MDS_EnqueueScrub *cs = new C_MDS_EnqueueScrub(f, fin);
+
+  bool is_internal = false;
+  std::string tag_str(tag);
+  if (tag_str.empty()) {
+    uuid_d uuid_gen;
+    uuid_gen.generate_random();
+    tag_str = uuid_gen.to_string();
+    is_internal = true;
+  }
+
   cs->header = std::make_shared<ScrubHeader>(
-      tag, force, recursive, repair, f);
+    tag_str, is_internal, force, recursive, repair, f);
 
   mdr->internal_op_finish = cs;
   enqueue_scrub_work(mdr);

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -682,6 +682,8 @@ const std::vector<MDSDaemon::MDSCommand>& MDSDaemon::get_commands()
         "name=heapcmd,type=CephChoices,strings=dump|start_profiler|stop_profiler|release|stats",
         "show heap usage info (available only if compiled with tcmalloc)"),
     MDSCommand("cache drop name=timeout,type=CephInt,range=0,req=false", "trim cache and optionally request client to release all caps and flush the journal"),
+    MDSCommand("scrub start name=path,type=CephString name=scrubops,type=CephChoices,strings=force|recursive|repair,n=N,req=false name=tag,type=CephString,req=false",
+               "scrub an inode and output results"),
   };
   return commands;
 };

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -684,6 +684,10 @@ const std::vector<MDSDaemon::MDSCommand>& MDSDaemon::get_commands()
     MDSCommand("cache drop name=timeout,type=CephInt,range=0,req=false", "trim cache and optionally request client to release all caps and flush the journal"),
     MDSCommand("scrub start name=path,type=CephString name=scrubops,type=CephChoices,strings=force|recursive|repair,n=N,req=false name=tag,type=CephString,req=false",
                "scrub an inode and output results"),
+    MDSCommand("scrub abort", "Abort in progress scrub operation(s)"),
+    MDSCommand("scrub pause", "Pause in progress scrub operation(s)"),
+    MDSCommand("scrub resume", "Resume paused scrub operation(s)"),
+    MDSCommand("scrub status", "Status of scrub operation"),
   };
   return commands;
 };

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -140,6 +140,7 @@ class MDSRank {
     friend class C_Drop_Cache;
 
     friend class C_CacheDropExecAndReply;
+    friend class C_ScrubExecAndReply;
 
     mds_rank_t get_nodeid() const { return whoami; }
     int64_t get_metadata_pool();
@@ -459,7 +460,9 @@ class MDSRank {
 
   protected:
     void dump_clientreplay_status(Formatter *f) const;
-    void command_scrub_path(Formatter *f, std::string_view path, vector<string>& scrubop_vec);
+    void command_scrub_start(Formatter *f,
+                             std::string_view path, std::string_view tag,
+                             const vector<string>& scrubop_vec, Context *on_finish);
     void command_tag_path(Formatter *f, std::string_view path,
                           std::string_view tag);
     void command_flush_path(Formatter *f, std::string_view path);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -141,6 +141,7 @@ class MDSRank {
 
     friend class C_CacheDropExecAndReply;
     friend class C_ScrubExecAndReply;
+    friend class C_ScrubControlExecAndReply;
 
     mds_rank_t get_nodeid() const { return whoami; }
     int64_t get_metadata_pool();
@@ -465,6 +466,12 @@ class MDSRank {
                              const vector<string>& scrubop_vec, Context *on_finish);
     void command_tag_path(Formatter *f, std::string_view path,
                           std::string_view tag);
+    // scrub control commands
+    void command_scrub_abort(Formatter *f, Context *on_finish);
+    void command_scrub_pause(Formatter *f, Context *on_finish);
+    void command_scrub_resume(Formatter *f);
+    void command_scrub_status(Formatter *f);
+
     void command_flush_path(Formatter *f, std::string_view path);
     void command_flush_journal(Formatter *f);
     void command_get_subtrees(Formatter *f);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -119,6 +119,7 @@ class MonClient;
 class Finisher;
 class ScrubStack;
 class C_MDS_Send_Command_Reply;
+class C_ExecAndReply;
 
 /**
  * The public part of this class's interface is what's exposed to all
@@ -137,6 +138,8 @@ class MDSRank {
 
     friend class C_Flush_Journal;
     friend class C_Drop_Cache;
+
+    friend class C_CacheDropExecAndReply;
 
     mds_rank_t get_nodeid() const { return whoami; }
     int64_t get_metadata_pool();
@@ -481,8 +484,6 @@ class MDSRank {
     void command_openfiles_ls(Formatter *f);
     void command_dump_tree(const cmdmap_t &cmdmap, std::ostream &ss, Formatter *f);
     void command_dump_inode(Formatter *f, const cmdmap_t &cmdmap, std::ostream &ss);
-
-    void cache_drop_send_reply(Formatter *f, C_MDS_Send_Command_Reply *reply, int r);
     void command_cache_drop(uint64_t timeout, Formatter *f, Context *on_finish);
 
   protected:
@@ -559,6 +560,9 @@ class MDSRank {
     void set_mdsmap_multimds_snaps_allowed();
 private:
     mono_time starttime = mono_clock::zero();
+
+protected:
+  Context *create_async_exec_context(C_ExecAndReply *ctx);
 };
 
 /* This expects to be given a reference which it is responsible for.

--- a/src/mds/ScrubHeader.h
+++ b/src/mds/ScrubHeader.h
@@ -26,10 +26,10 @@ class CInode;
  */
 class ScrubHeader {
 public:
-  ScrubHeader(std::string_view tag_, bool force_, bool recursive_,
-              bool repair_, Formatter *f_)
-      : tag(tag_), force(force_), recursive(recursive_), repair(repair_),
-        formatter(f_), origin(nullptr)
+  ScrubHeader(std::string_view tag_, bool is_tag_internal_, bool force_,
+              bool recursive_, bool repair_, Formatter *f_)
+    : tag(tag_), is_tag_internal(is_tag_internal_), force(force_),
+      recursive(recursive_), repair(repair_), formatter(f_), origin(nullptr)
   {
     ceph_assert(formatter != nullptr);
   }
@@ -41,6 +41,7 @@ public:
   bool get_recursive() const { return recursive; }
   bool get_repair() const { return repair; }
   bool get_force() const { return force; }
+  bool is_internal_tag() const { return is_tag_internal; }
   CInode *get_origin() const { return origin; }
   std::string_view get_tag() const { return tag; }
   Formatter &get_formatter() const { return *formatter; }
@@ -50,6 +51,7 @@ public:
 
 protected:
   const std::string tag;
+  bool is_tag_internal;
   const bool force;
   const bool recursive;
   const bool repair;

--- a/src/mds/ScrubStack.h
+++ b/src/mds/ScrubStack.h
@@ -44,6 +44,10 @@ protected:
     C_KickOffScrubs(MDCache *mdcache, ScrubStack *s);
     void finish(int r) override { }
     void complete(int r) override {
+      if (r == -ECANCELED) {
+        return;
+      }
+
       stack->scrubs_in_progress--;
       stack->kick_off_scrubs();
       // don't delete self
@@ -76,6 +80,7 @@ public:
   void enqueue_inode_top(CInode *in, ScrubHeaderRef& header,
 			 MDSInternalContextBase *on_finish) {
     enqueue_inode(in, header, on_finish, true);
+    scrub_origins.emplace(in);
   }
   /** Like enqueue_inode_top, but we wait for all pending scrubs before
    * starting this one.
@@ -83,9 +88,66 @@ public:
   void enqueue_inode_bottom(CInode *in, ScrubHeaderRef& header,
 			    MDSInternalContextBase *on_finish) {
     enqueue_inode(in, header, on_finish, false);
+    scrub_origins.emplace(in);
   }
 
+  /**
+   * Abort an ongoing scrub operation. The abort operation could be
+   * delayed if there are in-progress scrub operations on going. The
+   * caller should provide a context which is completed after all
+   * in-progress scrub operations are completed and pending inodes
+   * are removed from the scrub stack (with the context callbacks for
+   * inodes completed with -ECANCELED).
+   * @param on_finish Context callback to invoke after abort
+   */
+  void scrub_abort(Context *on_finish);
+
+  /**
+   * Pause scrub operations. Similar to abort, pause is delayed if
+   * there are in-progress scrub operations on going. The caller
+   * should provide a context which is completed after all in-progress
+   * scrub operations are completed. Subsequent scrub operations are
+   * queued until scrub is resumed.
+   * @param on_finish Context callback to invoke after pause
+   */
+  void scrub_pause(Context *on_finish);
+
+  /**
+   * Resume a paused scrub. Unlike abort or pause, this is instantaneous.
+   * Pending pause operations are cancelled (context callbacks are
+   * invoked with -ECANCELED).
+   * @returns 0 (success) if resumed, -EINVAL if an abort is in-progress.
+   */
+  bool scrub_resume();
+
+  /**
+   * Get the current scrub status as human readable string. Some basic
+   * information is returned such as number of inodes pending abort/pause.
+   */
+  void scrub_status(Formatter *f);
+
 private:
+  // scrub abort is _not_ a state, rather it's an operation that's
+  // performed after in-progress scrubs are finished.
+  enum State {
+    STATE_RUNNING = 0,
+    STATE_IDLE,
+    STATE_PAUSING,
+    STATE_PAUSED,
+  };
+  friend std::ostream &operator<<(std::ostream &os, const State &state);
+
+  State state = STATE_IDLE;
+  bool clear_inode_stack = false;
+
+  // list of pending context completions for asynchronous scrub
+  // control operations.
+  std::list<Context *> control_ctxs;
+
+  // list of inodes for which scrub operations are running -- used
+  // to diplay out in `scrub status`.
+  std::set<CInode *> scrub_origins;
+
   /**
    * Put the inode at either the top or bottom of the stack, with
    * the given scrub params, and then try and kick off more scrubbing.
@@ -185,6 +247,28 @@ private:
    */
   bool get_next_cdir(CInode *in, CDir **new_dir);
 
+  /**
+   * Set scrub state
+   * @param next_state State to move the scrub to.
+   */
+  void set_state(State next_state);
+
+  /**
+   * Is scrub in one of transition states (running, pausing)
+   */
+  bool scrub_in_transition_state();
+
+  /**
+   * complete queued up contexts
+   * @param r return value to complete contexts.
+   */
+  void complete_control_contexts(int r);
+
+  /**
+   * Abort pending scrubs for inodes waiting in the inode stack.
+   * Completion context is complete with -ECANCELED.
+   */
+  void abort_pending_scrubs();
 };
 
 #endif /* SCRUBSTACK_H_ */


### PR DESCRIPTION
This PR is a part of the much wider "show scrub info in ceph -s" tracker (http://tracker.ceph.com/issues/36370) and is WIP at the moment as some other operations (such as scrub progress) is in midst of being implemented w/ as part of the above tracker.