### PR TITLE
 denc: slightly optimize container_base::bound_encode. 

### DIFF
--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -957,7 +957,7 @@ namespace _denc {
           } else {
             denc(static_cast<const T&>(*s.begin()), elem_size);
           }
-          p += sizeof(uint32_t) + elem_size * elem_num;
+          p += elem_size * elem_num;
         }
       } else {
         for (const T& e : s) {

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -939,12 +939,16 @@ namespace _denc {
     static void bound_encode(const container& s, size_t& p, uint64_t f = 0) {
       p += sizeof(uint32_t);
       if constexpr (traits::bounded) {
-        const auto elem_num = s.size();
+#if _GLIBCXX_USE_CXX11_ABI
         // intensionally not calling container's empty() method to not prohibit
         // compiler from optimizing the check if it and the ::size() operate on
         // different memory (observed when std::list::empty() works on pointers,
         // not the size field).
-        if (elem_num) {
+        if (const auto elem_num = s.size(); elem_num > 0) {
+#else
+        if (!s.empty()) {
+	  const auto elem_num = s.size();
+#endif
           // STL containers use weird element types like std::pair<const K, V>;
           // cast to something we have denc_traits for.
           size_t elem_size = 0;

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -939,7 +939,12 @@ namespace _denc {
     static void bound_encode(const container& s, size_t& p, uint64_t f = 0) {
       p += sizeof(uint32_t);
       if constexpr (traits::bounded) {
-        if (!s.empty()) {
+        const auto elem_num = s.size();
+        // intensionally not calling container's empty() method to not prohibit
+        // compiler from optimizing the check if it and the ::size() operate on
+        // different memory (observed when std::list::empty() works on pointers,
+        // not the size field).
+        if (elem_num) {
           // STL containers use weird element types like std::pair<const K, V>;
           // cast to something we have denc_traits for.
           size_t elem_size = 0;
@@ -948,7 +953,7 @@ namespace _denc {
           } else {
             denc(static_cast<const T&>(*s.begin()), elem_size);
           }
-          p += sizeof(uint32_t) + elem_size * s.size();
+          p += sizeof(uint32_t) + elem_size * elem_num;
         }
       } else {
         for (const T& e : s) {


### PR DESCRIPTION
This cosmetics is just a side quest of poking with `bufferlist`. Sending as clean-up.