### PR TITLE
mds: remove MonClient reconnect

### DIFF
--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -260,14 +260,6 @@ bool Beacon::is_laggy()
 	      << "s since last acked beacon" << dendl;
     }
     laggy = true;
-    auto last_reconnect = std::chrono::duration<double>(now-last_mon_reconnect).count();
-    if (since > (g_conf()->mds_beacon_grace*2) && last_reconnect > g_conf()->mds_beacon_interval) {
-      // maybe it's not us?
-      dout(1) << "initiating monitor reconnect; maybe we're not the slow one"
-              << dendl;
-      last_mon_reconnect = now;
-      monc->reopen_session();
-    }
     return true;
   }
   return false;

--- a/src/mds/Beacon.h
+++ b/src/mds/Beacon.h
@@ -108,7 +108,6 @@ private:
   version_t last_seq = 0; // last seq sent to monitor
   std::map<version_t,time>  seq_stamp;    // seq # -> time sent
   time last_acked_stamp = clock::zero();  // last time we sent a beacon that got acked
-  time last_mon_reconnect = clock::zero();
   bool laggy = false;
   time last_laggy = clock::zero();
 


### PR DESCRIPTION
We should instead rely on the keepalives and automatic reconnects by the
MonClient.

Fixes: http://tracker.ceph.com/issues/36493

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

