### PR TITLE
osd/objectstore: change osd_objectstore default to bluestore

### DIFF
--- a/qa/standalone/mon/osd-pool-create.sh
+++ b/qa/standalone/mon/osd-pool-create.sh
@@ -213,7 +213,7 @@ function TEST_pool_create_rep_expected_num_objects() {
     setup $dir || return 1
 
     # disable pg dir merge
-    export CEPH_ARGS
+    export CEPH_ARGS="--osd-objectstore=filestore"
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
     run_osd $dir 0 || return 1

--- a/qa/standalone/special/ceph_objectstore_tool.py
+++ b/qa/standalone/special/ceph_objectstore_tool.py
@@ -72,6 +72,7 @@ def get_pool_id(name, nullfd):
 
 # return a list of unique PGS given an osd subdirectory
 def get_osd_pgs(SUBDIR, ID):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     PGS = []
     if ID:
         endhead = re.compile("{id}.*_head$".format(id=ID))
@@ -83,6 +84,7 @@ def get_osd_pgs(SUBDIR, ID):
 
 # return a sorted list of unique PGs given a directory
 def get_pgs(DIR, ID):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     OSDS = [f for f in os.listdir(DIR) if os.path.isdir(os.path.join(DIR, f)) and f.find("osd") == 0]
     PGS = []
     for d in OSDS:
@@ -93,6 +95,7 @@ def get_pgs(DIR, ID):
 
 # return a sorted list of PGS a subset of ALLPGS that contain objects with prefix specified
 def get_objs(ALLPGS, prefix, DIR, ID):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     OSDS = [f for f in os.listdir(DIR) if os.path.isdir(os.path.join(DIR, f)) and f.find("osd") == 0]
     PGS = []
     for d in OSDS:
@@ -111,6 +114,7 @@ def get_objs(ALLPGS, prefix, DIR, ID):
 
 # return a sorted list of OSDS which have data from a given PG
 def get_osds(PG, DIR):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     ALLOSDS = [f for f in os.listdir(DIR) if os.path.isdir(os.path.join(DIR, f)) and f.find("osd") == 0]
     OSDS = []
     for d in ALLOSDS:
@@ -407,6 +411,7 @@ def kill_daemons():
 
 
 def check_data(DATADIR, TMPFILE, OSDDIR, SPLIT_NAME):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     repcount = 0
     ERRORS = 0
     for rawnsfile in [f for f in os.listdir(DATADIR) if f.split('-')[1].find(SPLIT_NAME) == 0]:
@@ -598,6 +603,7 @@ def test_get_set_inc_osdmap(CFSD_PREFIX, osd_path):
 
 
 def test_removeall(CFSD_PREFIX, db, OBJREPPGS, REP_POOL, CEPH_BIN, OSDDIR, REP_NAME, NUM_CLONED_REP_OBJECTS):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     # Test removeall
     TMPFILE = r"/tmp/tmp.{pid}".format(pid=os.getpid())
     nullfd = open(os.devnull, "w")
@@ -667,6 +673,7 @@ def test_removeall(CFSD_PREFIX, db, OBJREPPGS, REP_POOL, CEPH_BIN, OSDDIR, REP_N
 
 
 def main(argv):
+    export CEPH_ARGS="--osd-objectstore=filestore"
     if sys.version_info[0] < 3:
         sys.stdout = stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
     else:

--- a/qa/suites/rados/objectstore/backends/alloc-hint.yaml
+++ b/qa/suites/rados/objectstore/backends/alloc-hint.yaml
@@ -11,6 +11,7 @@ overrides:
     conf:
       osd:
         filestore xfs extsize: true
+        osd objectstore: filestore
 
 tasks:
 - install:

--- a/qa/suites/rados/objectstore/backends/ceph_objectstore_tool.yaml
+++ b/qa/suites/rados/objectstore/backends/ceph_objectstore_tool.yaml
@@ -12,6 +12,8 @@ tasks:
       global:
         osd max object name len: 460
         osd max object namespace len: 64
+      osd:
+        osd objectstore: filestore
     log-whitelist:
       - overall HEALTH_
       - \(OSDMAP_FLAGS\)

--- a/qa/workunits/rados/test_alloc_hint.sh
+++ b/qa/workunits/rados/test_alloc_hint.sh
@@ -51,6 +51,7 @@ function setup_pgid() {
 }
 
 function expect_alloc_hint_eq() {
+    export CEPH_ARGS="--osd-objectstore=filestore"
     local expected_extsize="$1"
 
     for (( i = 0 ; i < "${NUM_OSDS}" ; i++ )); do

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3683,7 +3683,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_objectstore", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("filestore")
+    .set_default("bluestore")
     .set_enum_allowed({"bluestore", "filestore", "memstore", "kstore"})
     .set_flag(Option::FLAG_CREATE)
     .set_description("backend type for an OSD (like filestore or bluestore)"),


### PR DESCRIPTION
osd/objectstore: change osd_objectstore default to bluestore
Fixes: http://tracker.ceph.com/issues/36494

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>

