### PR TITLE
luminous: osd: cast 'whoami' to unsigned so it can be used as the seed for RNG

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2055,7 +2055,7 @@ double OSD::get_tick_interval() const
 {
   // vary +/- 5% to avoid scrub scheduling livelocks
   constexpr auto delta = 0.05;
-  std::default_random_engine rng{whoami};
+  std::default_random_engine rng{static_cast<unsigned>(whoami)};
   return (OSD_TICK_INTERVAL *
           std::uniform_real_distribution<>{1.0 - delta, 1.0 + delta}(rng));
 }


### PR DESCRIPTION
default_random_engine's result_type is `unsigned int`, so we need to
pass an `unsigned int` as its seed.

Fixes: http://tracker.ceph.com/issues/26890
Signed-off-by: Kefu Chai <kchai@redhat.com>

Conflicts:
	src/osd/OSD.cc: this breaks the build with clang. and in master
we are not using std::default_random_engine for setting the scrub
interval. so this change is not cherry-picked from master.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

