### PR TITLE
crimson: crimson/mon: remove timeout support from mon::Client::authenticate()

### DIFF
--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -12,10 +12,8 @@ set(crimson_common_srcs
 #  - the logging is sent to Seastar backend
 #  - and the template parameter of lock_policy is SINGLE
 add_library(crimson-common STATIC
-  ${PROJECT_SOURCE_DIR}/src/common/addr_parsing.c
   ${PROJECT_SOURCE_DIR}/src/common/admin_socket.cc
   ${PROJECT_SOURCE_DIR}/src/common/admin_socket_client.cc
-  ${PROJECT_SOURCE_DIR}/src/common/armor.c
   ${PROJECT_SOURCE_DIR}/src/common/bit_str.cc
   ${PROJECT_SOURCE_DIR}/src/common/bloom_filter.cc
   ${PROJECT_SOURCE_DIR}/src/common/ceph_argparse.cc
@@ -50,7 +48,6 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/common/perf_histogram.cc
   ${PROJECT_SOURCE_DIR}/src/common/page.cc
   ${PROJECT_SOURCE_DIR}/src/common/snap_types.cc
-  ${PROJECT_SOURCE_DIR}/src/common/safe_io.c
   ${PROJECT_SOURCE_DIR}/src/common/signal.cc
   ${PROJECT_SOURCE_DIR}/src/common/str_list.cc
   ${PROJECT_SOURCE_DIR}/src/common/str_map.cc
@@ -91,6 +88,7 @@ add_library(crimson-common STATIC
   ${crimson_common_srcs}
   $<TARGET_OBJECTS:crimson-auth>
   $<TARGET_OBJECTS:common_buffer_obj>
+  $<TARGET_OBJECTS:common_mountcephfs_objs>
   $<TARGET_OBJECTS:crimson-crush>
   $<TARGET_OBJECTS:global_common_objs>)
 

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -466,11 +466,9 @@ seastar::future<> Client::build_initial_map()
   return monmap.build_initial(ceph::common::local_conf());
 }
 
-seastar::future<> Client::authenticate(std::chrono::seconds seconds)
+seastar::future<> Client::authenticate()
 {
-  return seastar::with_timeout(
-    seastar::lowres_clock::now() + seconds,
-    reopen_session(-1));
+  return reopen_session(-1);
 }
 
 seastar::future<> Client::stop()

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -71,7 +71,7 @@ public:
   ~Client();
   seastar::future<> load_keyring();
   seastar::future<> build_initial_map();
-  seastar::future<> authenticate(std::chrono::seconds seconds);
+  seastar::future<> authenticate();
   seastar::future<> stop();
   get_version_t get_version(const std::string& map);
   command_result_t run_command(const std::vector<std::string>& cmd,

--- a/src/test/crimson/test_monc.cc
+++ b/src/test/crimson/test_monc.cc
@@ -39,7 +39,9 @@ static seastar::future<> test_monc()
         }).then([&msgr, &monc] {
           return msgr.start(&monc);
         }).then([&monc] {
-          return monc.authenticate(std::chrono::seconds{10});
+          return seastar::with_timeout(
+            seastar::lowres_clock::now() + std::chrono::seconds{10},
+            monc.authenticate());
         }).finally([&monc] {
           return monc.stop();
         });


### PR DESCRIPTION
and cmake cleanup