### PR TITLE
mgr: fix daemon metadata update vs device registry

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1589,6 +1589,7 @@ bool DaemonServer::_handle_command(
     key.first = who.substr(0, dot);
     key.second = who.substr(dot + 1);
     DaemonStatePtr daemon = daemon_state.get(key);
+    std::lock_guard l(daemon->lock);
     string name;
     if (!daemon) {
       ss << "no config state for daemon " << who;
@@ -1599,7 +1600,7 @@ bool DaemonServer::_handle_command(
 	  !p->second.empty()) {
 	cmdctx->odata.append(p->second.rbegin()->second + "\n");
       } else {
-	auto& defaults = daemon->get_config_defaults();
+	auto& defaults = daemon->_get_config_defaults();
 	auto q = defaults.find(name);
 	if (q != defaults.end()) {
 	  cmdctx->odata.append(q->second + "\n");
@@ -1608,7 +1609,6 @@ bool DaemonServer::_handle_command(
 	}
       }
     } else if (daemon->config_defaults_bl.length() > 0) {
-      std::lock_guard l(daemon->lock);
       TextTable tbl;
       if (f) {
 	f->open_array_section("config");
@@ -1675,7 +1675,7 @@ bool DaemonServer::_handle_command(
 	}
       } else {
 	// show-with-defaults
-	auto& defaults = daemon->get_config_defaults();
+	auto& defaults = daemon->_get_config_defaults();
 	for (auto& i : defaults) {
 	  if (f) {
 	    f->open_object_section("value");

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -135,7 +135,11 @@ void DeviceState::print(ostream& out) const
 void DaemonStateIndex::insert(DaemonStatePtr dm)
 {
   RWLock::WLocker l(lock);
+  _insert(dm);
+}
 
+void DaemonStateIndex::_insert(DaemonStatePtr dm)
+{
   if (all.count(dm->key)) {
     _erase(dm->key);
   }
@@ -227,6 +231,11 @@ DaemonStatePtr DaemonStateIndex::get(const DaemonKey &key)
 void DaemonStateIndex::rm(const DaemonKey &key)
 {
   RWLock::WLocker l(lock);
+  _rm(key);
+}
+
+void DaemonStateIndex::_rm(const DaemonKey &key)
+{
   if (all.count(key)) {
     _erase(key);
   }

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -168,6 +168,7 @@ class DaemonState
   }
 
   void set_metadata(const std::map<std::string,std::string>& m) {
+    devices.clear();
     metadata = m;
     auto p = m.find("device_ids");
     if (p != m.end()) {

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -182,7 +182,7 @@ class DaemonState
     }
   }
 
-  const std::map<std::string,std::string>& get_config_defaults() {
+  const std::map<std::string,std::string>& _get_config_defaults() {
     if (config_defaults.empty() &&
 	config_defaults_bl.length()) {
       auto p = config_defaults_bl.cbegin();

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -268,9 +268,11 @@ public:
   PerfCounterTypes types;
 
   void insert(DaemonStatePtr dm);
+  void _insert(DaemonStatePtr dm);
   bool exists(const DaemonKey &key) const;
   DaemonStatePtr get(const DaemonKey &key);
   void rm(const DaemonKey &key);
+  void _rm(const DaemonKey &key);
 
   // Note that these return by value rather than reference to avoid
   // callers needing to stay in lock while using result.  Callers must
@@ -352,6 +354,18 @@ public:
   bool is_updating(const DaemonKey &k) {
     RWLock::RLocker l(lock);
     return updating.count(k) > 0;
+  }
+
+  void update_metadata(DaemonStatePtr state,
+		       const map<string,string>& meta) {
+    // remove and re-insert in case the device metadata changed
+    RWLock::WLocker l(lock);
+    _rm(state->key);
+    {
+      Mutex::Locker l2(state->lock);
+      state->set_metadata(meta);
+    }
+    _insert(state);
   }
 
   /**

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -94,19 +94,18 @@ void MetadataUpdate::finish(int r)
       DaemonStatePtr state;
       if (daemon_state.exists(key)) {
         state = daemon_state.get(key);
-	std::lock_guard l(state->lock);
         if (key.first == "mds" || key.first == "mgr") {
           daemon_meta.erase("name");
         } else if (key.first == "osd") {
           daemon_meta.erase("id");
         }
         daemon_meta.erase("hostname");
-        state->metadata.clear();
 	map<string,string> m;
         for (const auto &i : daemon_meta) {
           m[i.first] = i.second.get_str();
 	}
-	state->set_metadata(m);
+
+	daemon_state.update_metadata(state, m);
       } else {
         state = std::make_shared<DaemonState>(daemon_state.types);
         state->key = key;


### PR DESCRIPTION
When we update daemon metadata, we also need to adjust the DaemonState tracking for devices.