### PR TITLE
doc: add spacing to subcommand references

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1023,12 +1023,14 @@ may or may not be some processing conducted.
 Subcommand ``disable`` disables the given application on the given pool.
 
 Usage::
+
         ceph osd pool application disable <pool-name> <app> {--yes-i-really-mean-it}
 
 Subcommand ``enable`` adds an annotation to the given pool for the mentioned
 application.
 
 Usage::
+
         ceph osd pool application enable <pool-name> <app> {--yes-i-really-mean-it}
 
 Subcommand ``get`` displays the value for the given key that is assosciated
@@ -1037,18 +1039,21 @@ arguments would display all key-value pairs for all applications for all
 pools.
 
 Usage::
+
         ceph osd pool application get {<pool-name>} {<app>} {<key>}
 
 Subcommand ``rm`` removes the key-value pair for the given key in the given
 application of the given pool.
 
 Usage::
+
         ceph osd pool application rm <pool-name> <app> <key>
 
 Subcommand ``set`` assosciates or updates, if it already exists, a key-value
 pair with the given application for the given pool.
 
 Usage::
+
         ceph osd pool application set <pool-name> <app> <key> <value>
 
 Subcommand ``primary-affinity`` adjust osd primary-affinity from 0.0 <=<weight>


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

Added appropriate spacing for subcommand
code references.

Fixes: https://tracker.ceph.com/issues/36527

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>