### PR TITLE
osd/PG.cc: delay calculating pg_stats till flushing

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7245,11 +7245,14 @@ MPGStats* OSD::collect_pg_stats()
     if (!pg->is_primary()) {
       continue;
     }
+    pg->lock();
+    pg->prepare_stats();
     pg->get_pg_stats([&](const pg_stat_t& s, epoch_t lec) {
 	m->pg_stat[pg->pg_id.pgid] = s;
 	min_last_epoch_clean = min(min_last_epoch_clean, lec);
 	min_last_epoch_clean_pgs.push_back(pg->pg_id.pgid);
       });
+    pg->unlock();
   }
 
   return m;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -444,6 +444,7 @@ public:
   void dump_pgstate_history(Formatter *f);
   void dump_missing(Formatter *f);
 
+  void prepare_stats();
   void get_pg_stats(std::function<void(const pg_stat_t&, epoch_t lec)> f);
   void with_heartbeat_peers(std::function<void(int)> f);
 
@@ -1293,14 +1294,12 @@ protected:
   object_stat_collection_t unstable_stats;
 
   // publish stats
-  Mutex pg_stats_publish_lock;
-  bool pg_stats_publish_valid;
+  std::atomic<bool> pg_stats_publish_valid = {false};
   pg_stat_t pg_stats_publish;
 
   void _update_calc_stats();
   void _update_blocked_by();
   void publish_stats_to_osd();
-  void clear_publish_stats();
 
   void clear_primary_state();
 


### PR DESCRIPTION
I believe this is good for performance, especially for normal
read/write paths.

See-also: https://github.com/ceph/ceph/pull/19162

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

