### PR TITLE
mgr/orchestrator: use result property in Completion classes

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -7,7 +7,8 @@ Please see the ceph-mgr module developer's guide for more information.
 
 
 class _Completion(object):
-    def get_result(self):
+    @property
+    def result(self):
         """
         Return the result of the operation that we were waited
         for.  Only valid after calling Orchestrator.wait() on this

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -33,7 +33,7 @@ class RookReadCompletion(orchestrator.ReadCompletion):
     def __init__(self, cb):
         super(RookReadCompletion, self).__init__()
         self.cb = cb
-        self.result = None
+        self._result = None
         self._complete = False
 
         self.message = "<read op>"
@@ -43,11 +43,15 @@ class RookReadCompletion(orchestrator.ReadCompletion):
         all_completions.append(self)
 
     @property
+    def result(self):
+        return self._result
+
+    @property
     def is_complete(self):
         return self._complete
 
     def execute(self):
-        self.result = self.cb()
+        self._result = self.cb()
         self._complete = True
 
 


### PR DESCRIPTION
The _Completion class defined a get_result() method, but the orchestrator
CLI and Rook module both just expected a result property, so let's run with
the property version.

Signed-off-by: Tim Serong <tserong@suse.com>