### PR TITLE
ceph-volume: extract flake8 config

### DIFF
--- a/src/ceph-volume/tox.ini
+++ b/src/ceph-volume/tox.ini
@@ -8,7 +8,10 @@ commands=py.test -v {posargs:ceph_volume/tests}
 
 [testenv:flake8]
 deps=flake8
-commands=flake8 --select=F,E9 {posargs:ceph_volume}
+commands=flake8 {posargs:ceph_volume}
 
 [tool:pytest]
 norecursedirs = .* _* virtualenv
+
+[flake8]
+select=F,E9


### PR DESCRIPTION
It's preferable to use [flake8] section to configure flake8.

So external tools/editor can read the configuration.