### PR TITLE
ceph-volume: dmsetup can return an empty line

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -51,7 +51,7 @@ def _output_parser(output, fields):
     return report
 
 
-def _splitname_parser(line):
+def _splitname_parser(lines, dev):
     """
     Parses the output from ``dmsetup splitname``, that should contain prefixes
     (--nameprefixes) and set the separator to ";"
@@ -67,7 +67,11 @@ def _splitname_parser(line):
 
     :returns: dictionary with stripped prefixes
     """
-    parts = line[0].split(';')
+    if len(lines) != 1:
+        logger.error('Unexpected "dmsetup splitname" output for "%s"', dev)
+        return {}
+
+    parts = lines[0].split(';')
     parsed = {}
     for part in parts:
         part = part.replace("'", '')
@@ -259,7 +263,7 @@ def dmsetup_splitname(dev):
         "--separator=';'", '--nameprefixes', dev
     ]
     out, err, rc = process.call(command)
-    return _splitname_parser(out)
+    return _splitname_parser(out, dev)
 
 
 def is_lv(dev, lvs=None):

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -794,16 +794,20 @@ class TestVDOParents(object):
 class TestSplitNameParser(object):
 
     def test_keys_are_parsed_without_prefix(self):
-        line = ["DM_VG_NAME='/dev/mapper/vg';DM_LV_NAME='lv';DM_LV_LAYER=''"]
-        result = api._splitname_parser(line)
+        lines = ["DM_VG_NAME='/dev/mapper/vg';DM_LV_NAME='lv';DM_LV_LAYER=''"]
+        result = api._splitname_parser(lines, "/dev/mapper/vg")
         assert result['VG_NAME'] == 'vg'
         assert result['LV_NAME'] == 'lv'
         assert result['LV_LAYER'] == ''
 
     def test_vg_name_sans_mapper(self):
-        line = ["DM_VG_NAME='/dev/mapper/vg';DM_LV_NAME='lv';DM_LV_LAYER=''"]
-        result = api._splitname_parser(line)
+        lines = ["DM_VG_NAME='/dev/mapper/vg';DM_LV_NAME='lv';DM_LV_LAYER=''"]
+        result = api._splitname_parser(lines, "/dev/mapper/vg")
         assert '/dev/mapper' not in result['VG_NAME']
+
+    def test_empty_dmsetup(self):
+        result = api._splitname_parser([], "/dev/mapper/vg")
+        assert {} == result
 
 
 class TestIsLV(object):


### PR DESCRIPTION
dmsetup_splitname() call dmsetup but if it returns an empty line
this one fail with:

```
>       parts = line[0].split(';')
E       IndexError: list index out of range
```

This change fixes that.

Closes http://tracker.ceph.com/issues/36543

Signed-off-by: Mehdi Abaakouk <sileht@sileht.net>