### PR TITLE
rgw: fix vector index out of range in RGWReadDataSyncRecoveringShardsCR

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -113,7 +113,7 @@ class RGWReadDataSyncRecoveringShardsCR : public RGWShardCollectCR {
 
 bool RGWReadDataSyncRecoveringShardsCR::spawn_next()
 {
-  if (shard_id > num_shards)
+  if (shard_id >= num_shards)
     return false;
  
   string error_oid = RGWDataSyncStatusManager::shard_obj_name(env->source_zone, shard_id) + ".retry";


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/36537