### PR TITLE
mimic: qa: increase rm timeout for workunit cleanup

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -480,7 +480,7 @@ def _run_tests(ctx, refspec, role, tests, env, basedir,
                 )
                 if cleanup:
                     args=['sudo', 'rm', '-rf', '--', scratch_tmp]
-                    remote.run(logger=log.getChild(role), args=args, timeout=(15*60))
+                    remote.run(logger=log.getChild(role), args=args, timeout=(60*60))
     finally:
         log.info('Stopping %s on %s...', tests, role)
         args=['sudo', 'rm', '-rf', '--', workunits_file, clonedir]


### PR DESCRIPTION
http://tracker.ceph.com/issues/36501