### PR TITLE
test/librados: fix unordered manifest-unset op

### DIFF
--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -3378,13 +3378,29 @@ TEST_F(LibRadosTwoPoolsPP, ManifestUnset) {
   {
     bufferlist in, out;
     cache_ioctx.exec("bar", "cas", "chunk_read", in, out);
-    ASSERT_EQ(0U, out.length());
+    if (out.length() != 0U) {
+      ObjectWriteOperation op;
+      op.unset_manifest();
+      librados::AioCompletion *completion = cluster.aio_create_completion();
+      ASSERT_EQ(0, ioctx.aio_operate("foo", completion, &op));
+      completion->wait_for_safe();
+      ASSERT_EQ(-EOPNOTSUPP, completion->get_return_value());
+      completion->release();
+    }
   }
   // chunk's refcount 
   {
     bufferlist in, out;
     cache_ioctx.exec("bar-chunk", "cas", "chunk_read", in, out);
-    ASSERT_EQ(0u, out.length());
+    if (out.length() != 0U) {
+      ObjectWriteOperation op;
+      op.unset_manifest();
+      librados::AioCompletion *completion = cluster.aio_create_completion();
+      ASSERT_EQ(0, ioctx.aio_operate("foo-chunk", completion, &op));
+      completion->wait_for_safe();
+      ASSERT_EQ(-EOPNOTSUPP, completion->get_return_value());
+      completion->release();
+    }
   }
 
   // wait for maps to settle before next test


### PR DESCRIPTION
- manifest unset op to foo-chunk object
 -- remove manifest flag
 -- commit
 -- send an ack to a client
 -- send decrement mesages ("chunk_put") to old chunks (bar-chunk)

Current unit test(ManifestUnset) send "chunk_read" command (to bar-chunk)
in order to see whether chunk's reference count is decreased.
But, as described above, "chunk_read" event can be triggered after a client
(test application) receives an ack. Therefore, there is a corner case
such as bar-chunk (in chunk pool) receives "chunk_read" first instead of "chunk_put"

Reference count model of dedup/tiering is based on false-positive (#24230).
So decreasing reference count is not guaranteed. If reference mismatch occur,
chunk-scrub(this is WIP) will fix it.
One guaranteed thing is that existing manifest flag is removed.

So, the solution of this commit is just re-send unset op, and then
chenk that return value is -EOPNOTSUPP (this means manifest flags is removed).

Fixes: http://tracker.ceph.com/issues/24485
Signed-off-by: Myoungwon Oh <omwmw@sk.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->



