### PR TITLE
msg/async: fix is_queued() semantics

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -551,7 +551,7 @@ void AsyncConnection::_stop() {
 }
 
 bool AsyncConnection::is_queued() const {
-  return protocol->is_queued() || outcoming_bl.length();
+  return outcoming_bl.length();
 }
 
 void AsyncConnection::shutdown_socket() {


### PR DESCRIPTION
Before AsyncConnection was split into two classes as part of the
multi-protocol refactor, we only had AsyncConnection::is_queued().
It checked both out_q and outcoming_bl because out_q was part of
AsyncConnection.

out_q is now part of ProtocolV1.  AsyncConnection should no longer be
concerned with out_q, only with outcoming_bl.  Checking whether out_q
is empty in _try_send() is particuarly wrong because if the write is
fininished (i.e. outcoming_bl is empty) but out_q has something in it,
the write callback isn't invoked.

Although probably not strictly necessary, this commit preserves the
semantics of connection->is_queued() in Protocol.cc.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

