### PR TITLE
mgr/dashboard: Add TSLint rule "no-unused-variable"

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/rbd-snapshot-list/rbd-snapshot-list.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input, OnChanges, OnInit, TemplateRef, ViewChild } from '@angular/core';
 
-import * as _ from 'lodash';
 import * as moment from 'moment';
 import { BsModalRef, BsModalService } from 'ngx-bootstrap';
 import { of } from 'rxjs';

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
@@ -14,7 +14,6 @@ import { ConfigFormModel } from './configuration-form.model';
 describe('ConfigurationFormComponent', () => {
   let component: ConfigurationFormComponent;
   let fixture: ComponentFixture<ConfigurationFormComponent>;
-  let activatedRoute: ActivatedRoute;
 
   configureTestBed({
     imports: [
@@ -35,7 +34,6 @@ describe('ConfigurationFormComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(ConfigurationFormComponent);
     component = fixture.componentInstance;
-    activatedRoute = TestBed.get(ActivatedRoute);
   });
 
   it('should create', () => {

--- a/src/pybind/mgr/dashboard/frontend/tslint.json
+++ b/src/pybind/mgr/dashboard/frontend/tslint.json
@@ -41,6 +41,7 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
+    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
This rule is useful to catch unused variables, imports, ...
Although a warning is displayed saying that is a deprecated rule,
there is an open issue asking to remove the deprecation due to
the benefits that this rule provides:
https://github.com/palantir/tslint/issues/4100

Work done:
- TSlint no-unused-variable rule added.
- Cleanup: unused imports and variables.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>