### PR TITLE
luminous: gperftools-libs-2.6.1-1 or newer required for binaries linked against corresponding version at build time

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -254,6 +254,7 @@ Requires:      grep
 Requires:      xfsprogs
 Requires:      e2fsprogs
 Requires:      logrotate
+Requires:      parted
 Requires:      util-linux
 Requires:      cryptsetup
 Requires:      findutils
@@ -432,7 +433,6 @@ Summary:	Ceph Object Storage Daemon
 Group:		System/Filesystems
 %endif
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
-Requires:	parted
 Requires:	lvm2
 %description osd
 ceph-osd is the object storage daemon for the Ceph distributed file

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -262,6 +262,11 @@ Requires:      psmisc
 Requires:      which
 %if 0%{?fedora} || 0%{?rhel}
 Requires:      gdisk
+# The following is necessary due to tracker 36508 and can be removed once the
+# associated upstream bugs are resolved.
+%if 0%{with tcmalloc}
+Requires:      gperftools-libs >= 2.6.1
+%endif
 %endif
 %if 0%{?suse_version}
 Recommends:    ntp-daemon

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -259,8 +259,12 @@ Requires:      cryptsetup
 Requires:      findutils
 Requires:      psmisc
 Requires:      which
+%if 0%{?fedora} || 0%{?rhel}
+Requires:      gdisk
+%endif
 %if 0%{?suse_version}
 Recommends:    ntp-daemon
+Requires:      gptfdisk
 %endif
 %description base
 Base is the package that includes all the files shared amongst ceph servers
@@ -428,13 +432,6 @@ Summary:	Ceph Object Storage Daemon
 Group:		System/Filesystems
 %endif
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
-# for sgdisk, used by ceph-disk
-%if 0%{?fedora} || 0%{?rhel}
-Requires:	gdisk
-%endif
-%if 0%{?suse_version}
-Requires:	gptfdisk
-%endif
 Requires:	parted
 Requires:	lvm2
 %description osd

--- a/debian/control
+++ b/debian/control
@@ -93,6 +93,7 @@ Depends: binutils,
          gdisk,
          grep,
          logrotate,
+         parted,
          psmisc,
          xfsprogs,
          ${misc:Depends},
@@ -236,7 +237,6 @@ Description: debugging symbols for ceph-mon
 Package: ceph-osd
 Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
-         parted,
          lvm2,
          ${misc:Depends},
          ${python:Depends},


### PR DESCRIPTION
http://tracker.ceph.com/issues/36552
http://tracker.ceph.com/issues/36558