### PR TITLE
mimic: librados application's symbol could conflict with the libceph-common

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -701,6 +701,20 @@ target_link_libraries(ceph-common ${ceph_common_deps})
 set_target_properties(ceph-common PROPERTIES
   SOVERSION 0
   INSTALL_RPATH "")
+if(NOT APPLE)
+  # Apple uses Mach-O, not ELF. so this option does not apply to APPLE.
+  #
+  # prefer the local symbol definitions when binding references to global
+  # symbols. otherwise we could reference the symbols defined by the application
+  # with the same name, instead of using the one defined in libceph-common.
+  # in other words, we require libceph-common to use local symbols, even if redefined
+  # in application".
+  set_property(
+    TARGET ceph-common
+    APPEND APPEND_STRING
+    PROPERTY LINK_FLAGS "-Wl,-Bsymbolic -Wl,-Bsymbolic-functions")
+endif()
+
 install(TARGETS ceph-common DESTINATION ${CMAKE_INSTALL_PKGLIBDIR})
 
 add_library(common_utf8 STATIC common/utf8.c)

--- a/src/test/common/test_mutex.cc
+++ b/src/test/common/test_mutex.cc
@@ -11,19 +11,6 @@
 #include "common/config.h"
 #include "include/coredumpctl.h"
 
-/*
- * Override normal ceph assert.
- * It is needed to prevent hang when we assert() and THEN still wait on lock().
- */
-namespace ceph
-{
-  void __ceph_assert_fail(const char *assertion, const char *file, int line,
-        const char *func)
-  {
-    throw 0;
-  }
-}
-
 static CephContext* cct;
 
 static void do_init() {
@@ -44,7 +31,8 @@ static void disable_lockdep() {
 TEST(Mutex, NormalAsserts) {
   Mutex* m = new Mutex("Normal",false);
   m->Lock();
-  EXPECT_THROW(m->Lock(), int);
+  testing::GTEST_FLAG(death_test_style) = "threadsafe";
+  EXPECT_DEATH(m->Lock(), ".*");
 }
 
 TEST(Mutex, RecursiveWithLockdep) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/26839