### PR TITLE
mgr/dashboard: Fix ts error on iSCSI page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.spec.ts
@@ -1,6 +1,8 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { of } from 'rxjs';
+
 import { configureTestBed } from '../../../../testing/unit-test-helper';
 import { TcmuIscsiService } from '../../../shared/api/tcmu-iscsi.service';
 import { CephShortVersionPipe } from '../../../shared/pipes/ceph-short-version.pipe';
@@ -13,6 +15,8 @@ import { IscsiComponent } from './iscsi.component';
 describe('IscsiComponent', () => {
   let component: IscsiComponent;
   let fixture: ComponentFixture<IscsiComponent>;
+  let tcmuIscsiService: TcmuIscsiService;
+  let tcmuiscsiData;
 
   const fakeService = {
     tcmuiscsi: () => {
@@ -39,10 +43,33 @@ describe('IscsiComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(IscsiComponent);
     component = fixture.componentInstance;
+    tcmuIscsiService = TestBed.get(TcmuIscsiService);
     fixture.detectChanges();
+    tcmuiscsiData = {
+      images: []
+    };
+    spyOn(tcmuIscsiService, 'tcmuiscsi').and.callFake(() => of(tcmuiscsiData));
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should refresh without stats available', () => {
+    tcmuiscsiData.images.push({});
+    component.refresh();
+    expect(component.images[0].cdIsBinary).toBe(true);
+  });
+
+  it('should refresh with stats', () => {
+    tcmuiscsiData.images.push({
+      stats_history: {
+        rd_bytes: [[1540551220, 0.0], [1540551225, 0.0], [1540551230, 0.0]],
+        wr_bytes: [[1540551220, 0.0], [1540551225, 0.0], [1540551230, 0.0]]
+      }
+    });
+    component.refresh();
+    expect(component.images[0].stats_history).toEqual({ rd_bytes: [0, 0, 0], wr_bytes: [0, 0, 0] });
+    expect(component.images[0].cdIsBinary).toBe(true);
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/block/iscsi/iscsi.component.ts
@@ -94,12 +94,14 @@ export class IscsiComponent {
   }
 
   refresh() {
-    this.tcmuIscsiService.tcmuiscsi().then((resp) => {
+    this.tcmuIscsiService.tcmuiscsi().subscribe((resp: any) => {
       this.daemons = resp.daemons;
       this.images = resp.images;
       this.images.map((image) => {
-        image.stats_history.rd_bytes = image.stats_history.rd_bytes.map((i) => i[1]);
-        image.stats_history.wr_bytes = image.stats_history.wr_bytes.map((i) => i[1]);
+        if (image.stats_history) {
+          image.stats_history.rd_bytes = image.stats_history.rd_bytes.map((i) => i[1]);
+          image.stats_history.wr_bytes = image.stats_history.wr_bytes.map((i) => i[1]);
+        }
         image.cdIsBinary = true;
         return image;
       });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/tcmu-iscsi.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/tcmu-iscsi.service.spec.ts
@@ -30,7 +30,7 @@ describe('TcmuIscsiService', () => {
     'should call tcmuiscsi',
     fakeAsync(() => {
       let result;
-      service.tcmuiscsi().then((resp) => {
+      service.tcmuiscsi().subscribe((resp) => {
         result = resp;
       });
       const req = httpTesting.expectOne('api/tcmuiscsi');

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/tcmu-iscsi.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/tcmu-iscsi.service.ts
@@ -10,11 +10,6 @@ export class TcmuIscsiService {
   constructor(private http: HttpClient) {}
 
   tcmuiscsi() {
-    return this.http
-      .get('api/tcmuiscsi')
-      .toPromise()
-      .then((resp: any) => {
-        return resp;
-      });
+    return this.http.get('api/tcmuiscsi');
   }
 }


### PR DESCRIPTION
This error only happens until an initiator is connected to the target.

Fixes: https://tracker.ceph.com/issues/36564

Signed-off-by: Ricardo Marques <rimarques@suse.com>

