### PR TITLE
common: add timestamp for perf dump

### DIFF
--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -16,6 +16,7 @@
 #include "common/perf_counters.h"
 #include "common/dout.h"
 #include "common/valgrind.h"
+#include "common/Clock.h"
 
 using std::ostringstream;
 
@@ -137,7 +138,7 @@ void PerfCountersCollection::dump_formatted_generic(
 {
   std::lock_guard<Mutex> lck(m_lock);
   f->open_object_section("perfcounter_collection");
-  
+  f->dump_stream("timestamp") << ceph_clock_now().sec();
   for (perf_counters_set_t::iterator l = m_loggers.begin();
        l != m_loggers.end(); ++l) {
     // Optionally filter on logger name, pass through counter filter


### PR DESCRIPTION
Signed-off-by: kungf <yang.wang@easystack.cn>

osd perf stats are always accumulative, add timestamp for easy to get avg,
or some other calc
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

