### PR TITLE
mgr/dashboard: Remove _filterValue from CdFormGroup

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -53,9 +53,6 @@ export class ConfigurationFormComponent implements OnInit {
     });
 
     this.configForm = new CdFormGroup(formControls);
-    this.configForm._filterValue = (value) => {
-      return value;
-    };
   }
 
   ngOnInit() {

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-user-form/rgw-user-form.component.spec.ts
@@ -15,6 +15,8 @@ import { RgwUserFormComponent } from './rgw-user-form.component';
 describe('RgwUserFormComponent', () => {
   let component: RgwUserFormComponent;
   let fixture: ComponentFixture<RgwUserFormComponent>;
+  let rgwUserService: RgwUserService;
+  let formHelper: FormHelper;
 
   configureTestBed({
     declarations: [RgwUserFormComponent],
@@ -26,6 +28,8 @@ describe('RgwUserFormComponent', () => {
     fixture = TestBed.createComponent(RgwUserFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+    rgwUserService = TestBed.get(RgwUserService);
+    formHelper = new FormHelper(component.userForm);
   });
 
   it('should create', () => {
@@ -33,10 +37,7 @@ describe('RgwUserFormComponent', () => {
   });
 
   describe('s3 key management', () => {
-    let rgwUserService: RgwUserService;
-
     beforeEach(() => {
-      rgwUserService = TestBed.get(RgwUserService);
       spyOn(rgwUserService, 'addS3Key').and.stub();
     });
 
@@ -113,13 +114,8 @@ describe('RgwUserFormComponent', () => {
   });
 
   describe('username validation', () => {
-    let rgwUserService: RgwUserService;
-    let formHelper: FormHelper;
-
     beforeEach(() => {
-      rgwUserService = TestBed.get(RgwUserService);
       spyOn(rgwUserService, 'enumerate').and.returnValue(observableOf(['abc', 'xyz']));
-      formHelper = new FormHelper(component.userForm);
     });
 
     it('should validate that username is required', () => {
@@ -143,5 +139,20 @@ describe('RgwUserFormComponent', () => {
         formHelper.expectError('user_id', 'notUnique');
       })
     );
+  });
+
+  describe('onSubmit', () => {
+    it('should be able to clear the mail field on update', () => {
+      spyOn(rgwUserService, 'update');
+      component.editing = true;
+      formHelper.setValue('email', '', true);
+      component.onSubmit();
+      expect(rgwUserService.update).toHaveBeenCalledWith(null, {
+        display_name: null,
+        email: '',
+        max_buckets: 1000,
+        suspended: false
+      });
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-group.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-group.spec.ts
@@ -118,7 +118,8 @@ describe('CdFormGroup', () => {
       expect(form.getValue('floating')).toBe(0.1);
     });
 
-    it('returns strings that are not empty', () => {
+    it('returns strings', () => {
+      expect(form.getValue('emptyString')).toBe('');
       expect(form.getValue('someString1')).toBe('s');
       expect(form.getValue('someString2')).toBe('sth');
     });
@@ -132,18 +133,10 @@ describe('CdFormGroup', () => {
       expect(form.getValue('undefined')).toBe(null);
     });
 
-    it('returns a falsy value for empty string, null, undefined, false and 0', () => {
-      expect(form.getValue('emptyString')).toBe(false);
+    it('returns a falsy value for null, undefined, false and 0', () => {
       expect(form.getValue('false')).toBeFalsy();
       expect(form.getValue('null')).toBeFalsy();
       expect(form.getValue('number0')).toBeFalsy();
-    });
-
-    it('test _filterValue', () => {
-      expect(form._filterValue(0)).toBe(true);
-      expect(form._filterValue(null)).toBe(true);
-      expect(form._filterValue(false)).toBe(true);
-      expect(form._filterValue('')).toBe(false);
     });
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-group.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/forms/cd-form-group.ts
@@ -21,9 +21,6 @@ export class CdFormGroup extends FormGroup {
 
   /**
    * Get a control out of any control even if its nested in other CdFormGroups or a FormGroup
-   *
-   * @param {string} controlName
-   * @returns {AbstractControl}
    */
   get(controlName: string): AbstractControl {
     const control = this._get(controlName);
@@ -49,19 +46,10 @@ export class CdFormGroup extends FormGroup {
   }
 
   /**
-   * Get the value of a control if it has none it will return false
-   *
-   * @param {string} controlName
-   * @returns {any} false or the value of the control
+   * Get the value of a control
    */
   getValue(controlName: string): any {
-    const value = this.get(controlName).value;
-    return this._filterValue(value) && value;
-  }
-
-  // Overwrite this if needed.
-  _filterValue(value) {
-    return value !== '';
+    return this.get(controlName).value;
   }
 
   /**
@@ -69,9 +57,6 @@ export class CdFormGroup extends FormGroup {
    *
    * Very useful if a function is called through a value changes event but the value
    * should be changed within the call.
-   *
-   * @param {string} controlName
-   * @param value
    */
   silentSet(controlName: string, value: any) {
     this.get(controlName).setValue(value, { emitEvent: false });
@@ -79,13 +64,8 @@ export class CdFormGroup extends FormGroup {
 
   /**
    * Indicates errors of the control in templates
-   *
-   * @param {string} controlName
-   * @param {NgForm} form
-   * @param {string} errorName
-   * @returns {boolean}
    */
-  showError(controlName: string, form: NgForm, errorName?: string) {
+  showError(controlName: string, form: NgForm, errorName?: string): boolean {
     const control = this.get(controlName);
     return (
       (form.submitted || control.dirty) &&


### PR DESCRIPTION
The current behavior when submitting an empty mail field in the RGW user form
that was previously filled was to replace it with "false".

This was a regression introduced through the use of "CdFormGroup" which had
a "_filterValue" method which converted empty strings into false, but it was
removed now.

Fixes: http://tracker.ceph.com/issues/26861
Signed-off-by: Stephan Müller <smueller@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

