### PR TITLE
librados: fix unitialized timeout in wait_for_osdmap

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -581,14 +581,13 @@ int librados::RadosClient::wait_for_osdmap()
   if (need_map) {
     std::lock_guard l(lock);
 
-    ceph::timespan timeout;
+    ceph::timespan timeout{0};
     if (cct->_conf->rados_mon_op_timeout > 0) {
       timeout = ceph::make_timespan(cct->_conf->rados_mon_op_timeout);
     }
 
     if (objecter->with_osdmap(std::mem_fn(&OSDMap::get_epoch)) == 0) {
       ldout(cct, 10) << __func__ << " waiting" << dendl;
-      auto start = mono_clock::now();
       while (objecter->with_osdmap(std::mem_fn(&OSDMap::get_epoch)) == 0) {
         if (timeout == timeout.zero()) {
           cond.Wait(lock);


### PR DESCRIPTION
ceph::timespan is not zero-initialized. use std::optional for an explicit empty state

this is causing `RGW=1 vstart.sh -n` to sometimes fail in radosgw-admin commands with:
> 2018-10-23 15:13:26.107 7efe9f50e280 -1 librados: timed out waiting for first osdmap from monitors
> couldn't init storage provider