### PR TITLE
mds/MDSDaemon: hold mds_lock in ms_handle_authentication

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1304,6 +1304,7 @@ KeyStore *MDSDaemon::ms_get_auth1_authorizer_keystore()
 
 int MDSDaemon::ms_handle_authentication(Connection *con)
 {
+  std::lock_guard l(mds_lock);
   int ret = 0;
   entity_name_t n(con->get_peer_type(), con->get_peer_global_id());
 


### PR DESCRIPTION
Broken by b362ee21203f31f14ce67e8ff9a7ac66bd02836c

Fixes: http://tracker.ceph.com/issues/36573
Signed-off-by: Sage Weil <sage@redhat.com>