### PR TITLE
mgr/dashboard: Enable gzip compression

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -326,6 +326,11 @@ class DashboardTestCase(MgrTestCase):
         else:
             self.assertEqual(self._resp.status_code, status)
 
+    def assertHeaders(self, headers):
+        for name, value in headers.items():
+            self.assertIn(name, self._resp.headers)
+            self.assertEqual(self._resp.headers[name], value)
+
     def assertError(self, code=None, component=None, detail=None):
         body = self._resp.json()
         if code:

--- a/qa/tasks/mgr/dashboard/test_requests.py
+++ b/qa/tasks/mgr/dashboard/test_requests.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from .helper import DashboardTestCase
+
+
+class RequestsTest(DashboardTestCase):
+    def test_gzip(self):
+        self._get('/api/summary')
+        self.assertHeaders({
+            'Content-Encoding': 'gzip',
+            'Content-Type': 'application/json',
+        })
+
+    def test_force_no_gzip(self):
+        self._get('/api/summary', params=dict(
+            headers={'Accept-Encoding': 'identity'}
+        ))
+        self.assertNotIn('Content-Encoding', self._resp.headers)
+        self.assertHeaders({
+            'Content-Type': 'application/json',
+        })

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -606,7 +606,7 @@ class LocalCephManager(CephManager):
         proc = self.controller.run([os.path.join(BIN_PREFIX, "ceph")] + list(args), **kwargs)
         return proc.exitstatus
 
-    def admin_socket(self, daemon_type, daemon_id, command, check_status=True):
+    def admin_socket(self, daemon_type, daemon_id, command, check_status=True, timeout=None):
         return self.controller.run(
             args=[os.path.join(BIN_PREFIX, "ceph"), "daemon", "{0}.{1}".format(daemon_type, daemon_id)] + command, check_status=check_status
         )

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -144,7 +144,15 @@ class CherryPyConfig(object):
             'server.socket_host': server_addr,
             'server.socket_port': int(server_port),
             'error_page.default': json_error_page,
-            'tools.request_logging.on': True
+            'tools.request_logging.on': True,
+            'tools.gzip.on': True,
+            'tools.gzip.mime_types': [
+                # text/html and text/plain are the default types to compress
+                'text/html', 'text/plain',
+                # We also want JSON and JavaScript to be compressed
+                'application/json',
+                'application/javascript',
+            ],
         }
 
         if ssl:


### PR DESCRIPTION
This is related to http://tracker.ceph.com/issues/36453. It is far from
a complete solution, but seems like a positive move.

I tested this change by first disabling my browser cache, and then used
the /docs endpoint to query /api/dashboard/health. Before compression:

    Content-Length: 60748
    Time: 615ms

After:

    Content-Length: 7505
    Time: 92ms

Then, I logged into the dashboard as normal and reloaded the page once I
was in. Some values for the reload operation before compression:

    Total page load time: 58.48s
    vendor.js Content-Length: 6486025
    vendor.js time: 48.09s

After:

    Total page load time: 14.55s
    vendor.js Content-Length: 1143178
    vendor.js time: 4.50s

Signed-off-by: Zack Cerza <zack@redhat.com>