### PR TITLE
build/ops: rpm: Package grafana dashboards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -707,6 +707,11 @@ if(LINUX)
   add_subdirectory(etc/sysctl)
 endif()
 
+option(WITH_GRAFANA "install grafana dashboards" OFF)
+if(WITH_GRAFANA)
+  add_subdirectory(monitoring/grafana/dashboards)
+endif()
+
 include(CTags)
 option(CTAG_EXCLUDES "Exclude files/directories when running ctag.")
 add_tags(ctags

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -908,6 +908,19 @@ depending on python-ceph should be fixed to depend on python-rados,
 python-rbd, python-rgw or python-cephfs instead.
 %endif
 
+%package grafana-dashboards
+Summary:	The set of Grafana dashboards for monitoring purposes
+BuildArch:	noarch
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
+%description grafana-dashboards
+This package provides a set of Grafana dashboards for monitoring of
+Ceph clusters. The dashboards require a Prometheus server setup
+collecting data from Ceph Manager "prometheus" module and Prometheus
+project "node_exporter" module. The dashboards are designed to be
+integrated with the Ceph Manager Dashboard web UI.
+
 #################################################################################
 # common
 #################################################################################
@@ -1022,7 +1035,8 @@ ${CMAKE} .. \
 %else
     -DWITH_LIBRADOSSTRIPER=OFF \
 %endif
-    -DBOOST_J=$CEPH_SMP_NCPUS
+    -DBOOST_J=$CEPH_SMP_NCPUS \
+    -DWITH_GRAFANA=ON
 
 make "$CEPH_MFLAGS_JOBS"
 
@@ -1944,6 +1958,12 @@ exit 0
 # We need an empty %%files list for python-ceph-compat, to tell rpmbuild to
 # actually build this meta package.
 %endif
+
+%files grafana-dashboards
+%attr(0755,root,root) %dir %{_sysconfdir}/grafana/dashboards/ceph-dashboard
+%config %{_sysconfdir}/grafana/dashboards/ceph-dashboard/*
+%doc monitoring/grafana/dashboards/README
+%doc monitoring/grafana/README.md
 
 
 %changelog

--- a/monitoring/grafana/dashboards/CMakeLists.txt
+++ b/monitoring/grafana/dashboards/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(CEPH_GRAFANA_DASHBOARDS_DIR "${CMAKE_INSTALL_SYSCONFDIR}/grafana/dashboards/ceph-dashboard"
+  CACHE PATH "Location for grafana dashboards")
+
+FILE(GLOB CEPH_GRAFANA_DASHBOARDS "*.json")
+
+install(FILES
+  ${CEPH_GRAFANA_DASHBOARDS}
+  DESTINATION ${CEPH_GRAFANA_DASHBOARDS_DIR})


### PR DESCRIPTION
This PR packages the grafana dashboards in a separate rpm package ceph-grafana-dashboards so that they could be later used by grafana server integrated with ceph-dashboard and they would get automatically updated on package upgrade. This also adds cmake support for installing the dashboards.

I have a test build repo with this branch, here:

https://1.chacra.ceph.com/r/ceph/wip-rpm-dashboards/a45d0ef99c9afd04e1eacd99de8710c6419b8318/centos/7/flavors/notcmalloc/

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

