### PR TITLE
os/tests: should read size_t options using get_val<Option::size_t>()

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -7325,7 +7325,7 @@ TEST_P(StoreTest, allocateBlueFSTest) {
   struct store_statfs_t statfs;
   store->statfs(&statfs);
 
-  uint64_t to_alloc = g_conf().get_val<uint64_t>("bluefs_alloc_size");
+  uint64_t to_alloc = g_conf().get_val<Option::size_t>("bluefs_alloc_size");
 
   int r = bstore->allocate_bluefs_freespace(to_alloc);
   ASSERT_EQ(r, 0);


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

