### PR TITLE
ceph.in: Add support for python 3

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -109,7 +109,7 @@ def get_cmake_variables(names):
             if line.startswith("{}:".format(name)):
                 vars[name] = line.split("=")[1].strip()
                 break
-        if all(vars.itervalues()):
+        if all(vars.values()):
             break
     return vars
 


### PR DESCRIPTION
This will allow the usage of the itervalues
method in both python 2 and 3 environments.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`
