### PR TITLE
client: add new routine to get fscid from a ceph_mount

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -243,7 +243,8 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
     interrupt_finisher(m->cct),
     remount_finisher(m->cct),
     objecter_finisher(m->cct),
-    m_command_hook(this)
+    m_command_hook(this),
+    fscid(0)
 {
   _reset_faked_inos();
 
@@ -5741,13 +5742,13 @@ int Client::subscribe_mdsmap(const std::string &fs_name)
     r = fetch_fsmap(true);
     if (r < 0)
       return r;
-    fs_cluster_id_t cid = fsmap_user->get_fs_cid(resolved_fs_name);
-    if (cid == FS_CLUSTER_ID_NONE) {
+    fscid = fsmap_user->get_fs_cid(resolved_fs_name);
+    if (fscid == FS_CLUSTER_ID_NONE) {
       return -ENOENT;
     }
 
     std::ostringstream oss;
-    oss << want << "." << cid;
+    oss << want << "." << fscid;
     want = oss.str();
   }
   ldout(cct, 10) << "Subscribing to map '" << want << "'" << dendl;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -303,6 +303,10 @@ public:
 		    const std::string& fs_name);
   void finish_reclaim();
 
+  fs_cluster_id_t get_fs_cid() {
+    return fscid;
+  }
+
   int mds_command(
     const std::string &mds_spec,
     const std::vector<std::string>& cmd,
@@ -1237,6 +1241,9 @@ private:
   CommandTable<MDSCommandOp> command_table;
 
   bool _use_faked_inos;
+
+  // Cluster fsid
+  fs_cluster_id_t fscid;
 
   // file handles, etc.
   interval_set<int> free_fd_set;  // unused fds

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -279,6 +279,15 @@ int ceph_select_filesystem(struct ceph_mount_info *cmount, const char *fs_name);
 int ceph_mount(struct ceph_mount_info *cmount, const char *root);
 
 /**
+ * Return cluster ID for a mounted ceph filesystem
+ *
+ * Every ceph filesystem has a filesystem ID associated with it. This
+ * function returns that value. If the ceph_mount_info does not refer to a
+ * mounted filesystem, this returns a negative error code.
+ */
+int64_t ceph_get_fs_cid(struct ceph_mount_info *cmount);
+
+/**
  * Execute a management command remotely on an MDS.
  *
  * Must have called ceph_init or ceph_mount before calling this.

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -538,6 +538,13 @@ extern "C" struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount)
   return &cmount->default_perms;
 }
 
+extern "C" int64_t ceph_get_fs_cid(struct ceph_mount_info *cmount)
+{
+  if (!cmount->is_mounted())
+    return -ENOTCONN;
+  return cmount->get_client()->get_fs_cid();
+}
+
 extern "C" int ceph_mount_perms_set(struct ceph_mount_info *cmount,
 				    struct UserPerm *perms)
 {


### PR DESCRIPTION
Ceph recently gained the ability to create alternate named filesystems
within a cluster. We want to allow nfs-ganesha to export them, but it
currently generates filehandles using a inode number+snapid tuple, and
that will not be unique across multiple filesystems.

Add a new field to hold the fscid in the Client, as that is generated
on a per-filesystem basis via monotonic counter. When we mount, fetch
the fscid and store it in that field. Add a new Client accessor, and a
libcephfs function that returns that value.

Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

