### PR TITLE
qa: use 6h timeout for pjd test

### DIFF
--- a/qa/suites/fs/32bits/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/fs/32bits/tasks/cfuse_workunit_suites_pjd.yaml
@@ -6,6 +6,7 @@ overrides:
         fuse default permissions: false
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/fs/basic_workload/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/fs/basic_workload/tasks/cfuse_workunit_suites_pjd.yaml
@@ -6,6 +6,7 @@ overrides:
         fuse default permissions: false
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/fs/permission/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/fs/permission/tasks/cfuse_workunit_suites_pjd.yaml
@@ -7,6 +7,7 @@ overrides:
         client acl type: posix_acl
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/fs/thrash/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/fs/thrash/tasks/cfuse_workunit_suites_pjd.yaml
@@ -6,6 +6,7 @@ overrides:
         fuse default permissions: false
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_pjd.yaml
+++ b/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_pjd.yaml
@@ -1,5 +1,6 @@
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/multimds/basic/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/multimds/basic/tasks/cfuse_workunit_suites_pjd.yaml
@@ -6,6 +6,7 @@ overrides:
         fuse default permissions: false
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh


### PR DESCRIPTION
Apparently needs this long for some configurations.

Fixes: https://tracker.ceph.com/issues/36594
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

