### PR TITLE
doc: give pool name if default pool rbd is not created

### DIFF
--- a/doc/start/quick-rbd.rst
+++ b/doc/start/quick-rbd.rst
@@ -62,23 +62,23 @@ Configure a Block Device
 
 #. On the ``ceph-client`` node, create a block device image. :: 
 
-	rbd create foo --size 4096 --image-feature layering [-m {mon-IP}] [-k /path/to/ceph.client.admin.keyring]
+	rbd create foo --size 4096 --image-feature layering [-m {mon-IP}] [-k /path/to/ceph.client.admin.keyring] [-p {pool-name}]
 
 #. On the ``ceph-client`` node, map the image to a block device. :: 
 
-	sudo rbd map foo --name client.admin [-m {mon-IP}] [-k /path/to/ceph.client.admin.keyring]
+	sudo rbd map foo --name client.admin [-m {mon-IP}] [-k /path/to/ceph.client.admin.keyring] [-p {pool-name}]
 	
 #. Use the block device by creating a file system on the ``ceph-client`` 
    node. :: 
 
-	sudo mkfs.ext4 -m0 /dev/rbd/rbd/foo
+	sudo mkfs.ext4 -m0 /dev/rbd/{pool-name}/foo
 	
 	This may take a few moments.
 	
 #. Mount the file system on the ``ceph-client`` node. ::
 
 	sudo mkdir /mnt/ceph-block-device
-	sudo mount /dev/rbd/rbd/foo /mnt/ceph-block-device
+	sudo mount /dev/rbd/{pool-name}/foo /mnt/ceph-block-device
 	cd /mnt/ceph-block-device
 
 #. Optionally configure the block device to be automatically mapped and mounted


### PR DESCRIPTION
unless creating the default pool named to be "rgb",
it will fail without pointing the pool name when
using rbd command.

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>

