### PR TITLE
credits.sh: Ignore package-lock.json and .xlf files

### DIFF
--- a/src/script/credits.sh
+++ b/src/script/credits.sh
@@ -15,8 +15,9 @@ done < $TMP
 declare -A author2lines
 declare -A organization2lines
 git log --no-merges --pretty='%ae' $range | sed -e "$remap" | sort -u > $TMP
-while read mail ; do 
-    count=$(git log --numstat --author="$mail" --pretty='%h' $range | 
+while read mail ; do
+    count=$(git log --numstat --author="$mail" --pretty='%h' $range |
+        egrep -v 'package-lock\.json|\.xlf' | # generated files that should be excluded from line counting
         perl -e 'while(<STDIN>) { if(/(\d+)\t(\d+)/) { $added += $1; $deleted += $2 } }; print $added + $deleted;')
     (( author2lines["${mail2author[$mail]}"] += $count ))
     (( organization2lines["${mail2organization[$mail]}"] += $count ))


### PR DESCRIPTION
package-lock.json: This file is modified automatically by npm any time we update
a frontend package, and can amount to large number of line changes.
For example, updating around 10 packages can result in 3k lines changed
in package-lock.json.

.xlf: They are used for the I18M of the dashboard and are automatically created
by Angular/transifex. Curretly each has around 5k lines and those lines should
not be credited to the commiter.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`