### PR TITLE
mgr/dashboard: Map dev 'releases' to master

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.spec.ts
@@ -7,11 +7,18 @@ describe('CephReleaseNamePipe', () => {
     expect(pipe).toBeTruthy();
   });
 
-  it('transforms with correct version format', () => {
+  it('recognizes a stable release', () => {
+    const value =
+      'ceph version 13.2.1 \
+       (5533ecdc0fda920179d7ad84e0aa65a127b20d77) mimic (stable)';
+    expect(pipe.transform(value)).toBe('mimic');
+  });
+
+  it('recognizes a development release as the master branch', () => {
     const value =
       'ceph version 13.1.0-534-g23d3751b89 \
        (23d3751b897b31d2bda57aeaf01acb5ff3c4a9cd) nautilus (dev)';
-    expect(pipe.transform(value)).toBe('nautilus');
+    expect(pipe.transform(value)).toBe('master');
   });
 
   it('transforms with wrong version format', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/pipes/ceph-release-name.pipe.ts
@@ -7,10 +7,15 @@ export class CephReleaseNamePipe implements PipeTransform {
   transform(value: any, args?: any): any {
     // Expect "ceph version 13.1.0-419-g251e2515b5
     //         (251e2515b563856349498c6caf34e7a282f62937) nautilus (dev)"
-    const result = /ceph version\s+[^ ]+\s+\(.+\)\s+(.+)\s+/.exec(value);
+    const result = /ceph version\s+[^ ]+\s+\(.+\)\s+(.+)\s+\((.+)\)/.exec(value);
     if (result) {
-      // Return the "nautilus" part
-      return result[1];
+      if (result[2] === 'dev') {
+        // Assume this is actually master
+        return 'master';
+      } else {
+        // Return the "nautilus" part
+        return result[1];
+      }
     } else {
       // Unexpected format, pass it through
       return value;


### PR DESCRIPTION
In CephReleaseNamePipe, we used to blindly return the "release name" portion of
the version string. This ends up e.g. returning 'nautilus' for master right
now, which causes us to link to nonexistent documentation on ceph.com.  This
change causes builds marked as 'dev' (as opposed to 'stable') to report
'master' as their release name.

Fixes: https://tracker.ceph.com/issues/36416

Signed-off-by: Zack Cerza <zack@redhat.com>