### PR TITLE
mgr/dashboard: Reduce Jest logs in CI

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package-lock.json
+++ b/src/pybind/mgr/dashboard/frontend/package-lock.json
@@ -6879,6 +6879,29 @@
       "integrity": "sha1-o3dq6zEekP6D+rnlM+hRAr0WQWU=",
       "dev": true
     },
+    "jest-silent-reporter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jest-silent-reporter/-/jest-silent-reporter-0.1.1.tgz",
+      "integrity": "sha512-nrRzOV4151hG354tnVWfyZbFGJdylpadRWYWWPSD+WeOz2hQOjUGxvIFODnaY9cKQ7JWCtG+5LgSss22ccRhBg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.1",
+        "jest-util": "^23.0.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        }
+      }
+    },
     "jest-snapshot": {
       "version": "23.4.2",
       "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-23.4.2.tgz",

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve --host 0.0.0.0",
     "build": "ng build",
     "test": "jest --watch",
-    "test:ci": "jest --coverage",
+    "test:ci": "JEST_SILENT_REPORTER_DOTS=true jest --coverage --reporters jest-silent-reporter",
     "e2e": "ng e2e",
     "lint:tslint": "ng lint ceph-dashboard ceph-dashboard-e2e",
     "lint:prettier": "prettier --list-different \"{src,e2e}/**/*.{ts,scss}\"",
@@ -16,7 +16,6 @@
     "fix:prettier": "prettier --write \"{src,e2e}/**/*.{ts,scss}\"",
     "fix:tslint": "npm run lint:tslint -- --fix",
     "fix": "npm run fix:tslint; npm run fix:prettier"
-
   },
   "private": true,
   "jest": {
@@ -33,7 +32,6 @@
       "jest-canvas-mock"
     ],
     "coverageReporters": [
-      "text",
       "cobertura",
       "html"
     ],
@@ -85,6 +83,7 @@
     "jest": "23.4.2",
     "jest-canvas-mock": "1.1.0",
     "jest-preset-angular": "6.0.0",
+    "jest-silent-reporter": "0.1.1",
     "prettier": "1.14.0",
     "protractor": "5.4.0",
     "ts-node": "7.0.0",


### PR DESCRIPTION
With the current number of unit tests we have for the frontend the output from
Jest is too big, and is exceeding the limit from jenkins.
This is resulting in the omission of linting results.

With this change, Jest will only output the results of failing tests and will no
longer show the coverage in the logs.
Jenkins will keep tracking the coverage via the generated cobertura file.

Signed-off-by: Tiago Melo <tmelo@suse.com>