### PR TITLE
ceph-volume: recognize loop device properly

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -45,6 +45,17 @@ class TestBlkid(object):
         assert result['UUID'] == '62416664-cbaf-40bd-9689-10bd337379c3'
         assert result['TYPE'] == 'xfs'
 
+class TestDeviceRecognition(object):
+
+    def test_marks_regular_disk_as_device(self, stub_call):
+        out = 'NAME="sda" TYPE="disk"',
+        stub_call((out, '', 0))
+        assert disk.is_device('/dev/sda')
+
+    def test_marks_loop_device_as_device(self, stub_call):
+        out = 'NAME="loop0" TYPE="loop"',
+        stub_call((out, '', 0))
+        assert disk.is_device('/dev/loop0')
 
 class TestDeviceFamily(object):
 

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -270,13 +270,10 @@ def is_device(dev):
     # use lsblk first, fall back to using stat
     TYPE = lsblk(dev).get('TYPE')
     if TYPE:
-        return TYPE == 'disk'
+        return TYPE in ('disk', 'loop')
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)
-    if stat.S_ISBLK(os.lstat(dev)):
-        return True
-    return False
 
 
 def is_partition(dev):


### PR DESCRIPTION
Loop device usage is a convinient way to deploy small Ceph clusters for development, however `ceph-volume lvm create` doesn't allow to use them using `lsblk` probing with exception `Cannot use device (/dev/loopX)`. The second method of device type recongnition (using python's `stat` module) works fine.

Change description:
* `is_device` helper function checks now for classic block devices or loop devices
* tests for `is_device` added

Signed-off-by: Mariusz Strzelecki <szczeles@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug