### PR TITLE
[RFC] ceph-volume: initial propose plugin

### DIFF
--- a/src/ceph-volume/plugin/propose/CMakeLists.txt
+++ b/src/ceph-volume/plugin/propose/CMakeLists.txt
@@ -1,0 +1,3 @@
+
+distutils_install_module(ceph_volume_propose
+  INSTALL_SCRIPT ${CMAKE_INSTALL_FULL_SBINDIR})

--- a/src/ceph-volume/plugin/propose/MANIFEST.in
+++ b/src/ceph-volume/plugin/propose/MANIFEST.in
@@ -1,0 +1,5 @@
+recursive-include ceph_volume_propose *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]
+
+recursive-include *.rst conf.py Makefile *.jpg *.png *.gif

--- a/src/ceph-volume/plugin/propose/ceph_volume_propose/__init__.py
+++ b/src/ceph-volume/plugin/propose/ceph_volume_propose/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+"""Top-level package for Ceph volume hardware proposal."""
+
+__author__ = """Jan Fajerski"""
+__email__ = 'jfajerski@suse.com'

--- a/src/ceph-volume/plugin/propose/ceph_volume_propose/devices.py
+++ b/src/ceph-volume/plugin/propose/ceph_volume_propose/devices.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+
+from ceph_volume.util import disk
+from ceph_volume.util.system import get_mounts
+
+block_device_template = """
+{dev:<25} {size:<12} {rot:<7} {model}"""
+
+
+class Devices(object):
+
+    def __init__(self, devices=None):
+        if not devices:
+            devices = disk.get_devices()
+        self.devices = [Device(k, v) for k, v in
+                        self._annotate_devices(devices).items()]
+
+    def items(self):
+        for device in self.devices:
+            yield device
+
+    def _annotate_devices(self, devices):
+        """
+        adds some extra info the the devices structure
+        """
+        mounts = get_mounts()
+        mounted_devs = mounts.keys()
+        for device in devices:
+            devices[device]['mounted'] = '0' if device in mounted_devs else '1'
+        return devices
+
+    def pretty_report(self, all=True):
+        output = [
+            block_device_template.format(
+                dev='Device Path',
+                size='Size',
+                rot='rotates',
+                model='Model name',
+            )]
+        for device in self.devices:
+            if device.available or all:
+                output.append(
+                    block_device_template.format(
+                        dev=device.device,
+                        size=device.attrs['human_readable_size'],
+                        rot='true' if device.attrs['rotational'] == 0
+                            else 'false',
+                        model=device.attrs['model'],
+                    )
+                )
+        return ''.join(output)
+
+
+class Device(object):
+
+    def __init__(self, device, attrs):
+        self.device = device
+        self.attrs = attrs
+
+    def __repr__(self):
+        return self.device
+
+    def __str_(self):
+        return self.device
+
+    @property
+    def available(self):
+        return self.attrs['mounted'] != '0' and self.attrs['partitions'] == {}
+
+    @property
+    def rotates(self):
+        return self.attrs['rotational'] == 1

--- a/src/ceph-volume/plugin/propose/ceph_volume_propose/drive_groups.py
+++ b/src/ceph-volume/plugin/propose/ceph_volume_propose/drive_groups.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+import argparse
+
+from . import devices
+
+
+class DriveGroups(object):
+
+    help = "Generate Drive Groups from the local disc inventory"
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def main(self):
+        self.devices = devices.Devices()
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume-propose',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.help,
+        )
+        parser.add_argument(
+            '--standalone',
+            action='store_true',
+            help='Standalone OSDs only',
+        )
+        self.args = parser.parse_args(self.argv)
+        if self.args.standalone:
+            self._standalone()
+        else:
+            self._default()
+
+    def _standalone(self):
+        ret = {
+            'data_devices': [],
+            'shared_devices': [],
+        }
+        for dev in self.devices.items():
+            if dev.available:
+                ret['data_devices'].append(dev)
+        print(ret)
+
+    def _default(self):
+        ret = {
+            'data_devices': [],
+            'shared_devices': [],
+        }
+        for dev in self.devices.items():
+            if dev.available:
+                if dev.rotates:
+                    ret['data_devices'].append(dev)
+                else:
+                    ret['shared_devices'].append(dev)
+        if not ret['data_devices']:
+            ret['data_devices'] = ret['shared_devices']
+            ret['shared_devices'] = []
+        print(ret)

--- a/src/ceph-volume/plugin/propose/ceph_volume_propose/inventory.py
+++ b/src/ceph-volume/plugin/propose/ceph_volume_propose/inventory.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import argparse
+
+from . import devices
+
+
+class Inventory(object):
+
+    help = "Get this nodes available disk inventory"
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def main(self):
+        self.devices = devices.Devices()
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume-propose',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.help,
+        )
+        parser.add_argument(
+            '--all',
+            action='store_true',
+            help='Show all devices',
+        )
+        self.args = parser.parse_args(self.argv)
+        print(self.devices.pretty_report(self.args.all))

--- a/src/ceph-volume/plugin/propose/ceph_volume_propose/main.py
+++ b/src/ceph-volume/plugin/propose/ceph_volume_propose/main.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function
+import argparse
+
+from ceph_volume import terminal
+from . import inventory
+from . import drive_groups
+
+
+class Proposal(object):
+
+    help_menu = "Get disk inventory and propose Drive Groups"
+    _help = """
+Get a nodes disk inventory and generate Drive Group proposals
+
+{sub_help}
+    """
+    name = "propose"
+
+    mapper = {
+        'inventory': inventory.Inventory,
+        'drive_groups': drive_groups.DriveGroups,
+    }
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    def main(self):
+        terminal.dispatch(self.mapper, self.argv)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume propose',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=self.print_help(terminal.subhelp(self.mapper)),
+        )
+        parser.parse_args(self.argv)
+        if len(self.argv) <= 1:
+            return parser.print_help()
+
+    def print_help(self, sub_help):
+        return self._help.format(sub_help=sub_help)

--- a/src/ceph-volume/plugin/propose/requirements_dev.txt
+++ b/src/ceph-volume/plugin/propose/requirements_dev.txt
@@ -1,0 +1,5 @@
+pip==9.0.1
+wheel==0.30.0
+flake8==3.5.0
+tox==2.9.1
+coverage==4.5.1

--- a/src/ceph-volume/plugin/propose/setup.py
+++ b/src/ceph-volume/plugin/propose/setup.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""The setup script."""
+
+from setuptools import setup, find_packages
+
+requirements = [ ]
+
+setup_requirements = [ ]
+
+setup(
+    author="Jan Fajerski",
+    author_email='jfajerski@suse.com',
+    classifiers=[
+        'Development Status :: 1 - Pre-Alpha',
+        'Environment :: Console',
+        'Intended Audience :: Information Technology',
+        'Intended Audience :: System Administrators',
+        'Operating System :: POSIX :: FreeBSD',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+    ],
+    description="Scan a nodes block storage hardware and propose OSD deployment groups",
+    install_requires=requirements,
+    license="BSD license",
+    include_package_data=True,
+    keywords='ceph-volume-propose',
+    name='ceph-volume-propose',
+    packages=find_packages(include=['ceph_volume_propose']),
+    # scripts=['bin/ceph-volume-propose'],
+    setup_requires=setup_requirements,
+    url='https://github.com/ceph/ceph/src/ceph-volume/plugin/propose',
+    version='0.1.0',
+    zip_safe=False,
+    entry_points = dict(
+        ceph_volume_handlers = [
+            'propose = ceph_volume_propose.main:Proposal',
+        ],
+    ),
+)


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

This ceph-volume plugin implements a simple node device inventory and can propose (for now trivial) Drive Groups. This hopefully advances the Drive Group discussion and the orchestrator work.

This plugin adds two commands ```ceph-volume propose inventory``` and ```ceph-volume propose drive_groups```. See both commands help for details.

##### ```ceph-volume propose drive_groups```
This will print a Drive Group structure with rotating drives as data devices and non-rotating drives as shared devices (to be used to wal/db/journals) unless there are no rotating drives. the ```--standalone``` flag will propose all drives as data devices.

If this PR receives positive feedback more command line flags and arguments would be added to give more control about the Drive Group proposal. This proposal could then be used as input to another layer that does drive formatting or LVM management (could be ```ceph-volume``` itself, orchestrator implementations or other deployment tools).

The first thing to add would a to filter devices by regex on drive attributes (model name, size, ...) for example.

I'm interested in the communities feedback regarding the Drive Groups structure itself (see also the [previous discussion](https://docs.google.com/document/d/1iwTnQc8d9W3BpQHgGYTMZSKvN6J7s0z8kQaYNxYvLho/edit#heading=h.70ln4hrkito3)), the implementation as a ```ceph-volume``` plugin and how that would fit into the various workflows of existing deployment tools and the orchestrator work (not limited to this of course).
