### PR TITLE
ceph-volume: don't change behavior of python exception

### DIFF
--- a/src/ceph-volume/ceph_volume/exceptions.py
+++ b/src/ceph-volume/ceph_volume/exceptions.py
@@ -7,18 +7,18 @@ class ConfigurationError(Exception):
         self.cluster_name = cluster_name
         self.path = path
         self.abspath = abspath or "%s.conf" % os.path.join(self.path, self.cluster_name)
-
-    def __str__(self):
-        return 'Unable to load expected Ceph config at: %s' % self.abspath
+        super(ConfigurationError, self).__init__(
+            'Unable to load expected Ceph config at: %s' % self.abspath
+        )
 
 
 class ConfigurationSectionError(Exception):
 
     def __init__(self, section):
         self.section = section
-
-    def __str__(self):
-        return 'Unable to find expected configuration section: "%s"' % self.section
+        super(ConfigurationSectionError, self).__init__(
+            'Unable to find expected configuration section: "%s"' % self.section
+        )
 
 
 class ConfigurationKeyError(Exception):
@@ -26,12 +26,11 @@ class ConfigurationKeyError(Exception):
     def __init__(self, section, key):
         self.section = section
         self.key = key
-
-    def __str__(self):
-        return 'Unable to find expected configuration key: "%s" from section "%s"' % (
-            self.key,
-            self.section
-        )
+        super(ConfigurationKeyError, self).__init__(
+            'Unable to find expected configuration key: "%s" from section "%s"' % (
+                self.key,
+                self.section
+        ))
 
 
 class SuffixParsingError(Exception):
@@ -39,25 +38,26 @@ class SuffixParsingError(Exception):
     def __init__(self, suffix, part=None):
         self.suffix = suffix
         self.part = part
-
-    def __str__(self):
-        return 'Unable to parse the %s from systemd suffix: %s' % (self.part, self.suffix)
+        super(SuffixParsingError, self).__init__(
+            'Unable to parse the %s from systemd suffix: %s' % (self.part, self.suffix)
+        )
 
 
 class SuperUserError(Exception):
 
-    def __str__(self):
-        return 'This command needs to be executed with sudo or as root'
+    def __init__(self):
+        super(SuffixParsingError, self).__init__(
+            'This command needs to be executed with sudo or as root'
+        )
 
 
 class MultiplePVsError(Exception):
 
     def __init__(self, pv_name):
         self.pv_name = pv_name
-
-    def __str__(self):
-        msg = "Got more than 1 result looking for physical volume: %s" % self.pv_name
-        return msg
+        super(MultiplePVsError, self).__init__(
+            "Got more than 1 result looking for physical volume: %s" % self.pv_name
+        )
 
 
 class MultipleLVsError(Exception):
@@ -65,20 +65,18 @@ class MultipleLVsError(Exception):
     def __init__(self, lv_name, lv_path):
         self.lv_name = lv_name
         self.lv_path = lv_path
-
-    def __str__(self):
-        msg = "Got more than 1 result looking for %s with path: %s" % (self.lv_name, self.lv_path)
-        return msg
+        super(MultipleLVsError, self).__init__(
+            "Got more than 1 result looking for %s with path: %s" % (self.lv_name, self.lv_path)
+        )
 
 
 class MultipleVGsError(Exception):
 
     def __init__(self, vg_name):
         self.vg_name = vg_name
-
-    def __str__(self):
-        msg = "Got more than 1 result looking for volume group: %s" % self.vg_name
-        return msg
+        super(MultipleVGsError, self).__init__(
+            "Got more than 1 result looking for volume group: %s" % self.vg_name
+        )
 
 
 class SizeAllocationError(Exception):
@@ -86,9 +84,8 @@ class SizeAllocationError(Exception):
     def __init__(self, requested, available):
         self.requested = requested
         self.available = available
-
-    def __str__(self):
-        msg = 'Unable to allocate size (%s), not enough free space (%s)' % (
-            self.requested, self.available
+        super(SizeAllocationError, self).__init__(
+            'Unable to allocate size (%s), not enough free space (%s)' % (
+                self.requested, self.available
+            )
         )
-        return msg


### PR DESCRIPTION
Exception message should be passed to Exception.__init__()

Then the Exception class will automatically implement all magic methods
(__str__, __repr__) with this message.

Signed-off-by: Mehdi Abaakouk <sileht@sileht.net>