### PR TITLE
ceph-volume: remove useless main.Volume() args

### DIFF
--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -23,18 +23,14 @@ Ceph Conf: {ceph_path}
 {warning}
     """
 
-    def __init__(self, argv=None, parse=True):
+    def __init__(self):
         self.mapper = {
             'lvm': devices.lvm.LVM,
             'simple': devices.simple.Simple,
         }
         self.plugin_help = "No plugins found/loaded"
-        if argv is None:
-            self.argv = sys.argv
-        else:
-            self.argv = argv
-        if parse:
-            self.main(self.argv)
+        self.argv = sys.argv
+        self.main()
 
     def help(self, warning=False):
         warning = 'See "ceph-volume --help" for full list of options.' if warning else ''
@@ -93,7 +89,7 @@ Ceph Conf: {ceph_path}
         return pruned_args[:slice_on_index], pruned_args[slice_on_index:]
 
     @catches()
-    def main(self, argv):
+    def main(self):
         # these need to be available for the help, which gets parsed super
         # early
         configuration.load_ceph_conf_path()
@@ -102,7 +98,7 @@ Ceph Conf: {ceph_path}
         main_args, subcommand_args = self._get_split_args()
         # no flags where passed in, return the help menu instead of waiting for
         # argparse which will end up complaning that there are no args
-        if len(argv) <= 1:
+        if len(self.argv) <= 1:
             print(self.help(warning=True))
             return
         parser = argparse.ArgumentParser(

--- a/src/ceph-volume/ceph_volume/tests/test_main.py
+++ b/src/ceph-volume/ceph_volume/tests/test_main.py
@@ -1,48 +1,53 @@
 import os
+import sys
 import pytest
 from ceph_volume import main
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 
 class TestVolume(object):
 
+    @mock.patch.object(sys, 'argv', [])
     def test_main_spits_help_with_no_arguments(self, capsys):
-        main.Volume(argv=[])
+        main.Volume()
         stdout, stderr = capsys.readouterr()
         assert 'Log Path' in stdout
 
+    @mock.patch.object(sys, 'argv', [])
     def test_warn_about_using_help_for_full_options(self, capsys):
-        main.Volume(argv=[])
+        main.Volume()
         stdout, stderr = capsys.readouterr()
         assert 'See "ceph-volume --help" for full list' in stdout
 
+    @mock.patch.object(sys, 'argv', [])
     def test_environ_vars_show_up(self, capsys):
         os.environ['CEPH_CONF'] = '/opt/ceph.conf'
-        main.Volume(argv=[])
+        main.Volume()
         stdout, stderr = capsys.readouterr()
         assert 'CEPH_CONF' in stdout
         assert '/opt/ceph.conf' in stdout
 
+    @mock.patch.object(sys, 'argv', ['ceph-volume', '--help'])
     def test_flags_are_parsed_with_help(self, capsys):
         with pytest.raises(SystemExit):
-            main.Volume(argv=['ceph-volume', '--help'])
+            main.Volume()
         stdout, stderr = capsys.readouterr()
         assert '--cluster' in stdout
         assert '--log-path' in stdout
 
+    @mock.patch.object(sys, 'argv', ['ceph-volume', '--cluster', 'barnacle', 'lvm', '--help'])
     def test_log_ignoring_missing_ceph_conf(self, caplog):
         with pytest.raises(SystemExit) as error:
-            main.Volume(argv=['ceph-volume', '--cluster', 'barnacle', 'lvm', '--help'])
-        # make sure we aren't causing an actual error
-        assert error.value.code == 0
-        log = caplog.records[1]
-        assert log.message == 'ignoring inability to load ceph.conf'
-        assert log.levelname == 'ERROR'
-
-    def test_logs_current_command(self, caplog):
-        with pytest.raises(SystemExit) as error:
-            main.Volume(argv=['ceph-volume', '--cluster', 'barnacle', 'lvm', '--help'])
+            main.Volume()
         # make sure we aren't causing an actual error
         assert error.value.code == 0
         log = caplog.records[0]
         assert log.message == 'Running command: ceph-volume --cluster barnacle lvm --help'
         assert log.levelname == 'INFO'
+        log = caplog.records[1]
+        assert log.message == 'ignoring inability to load ceph.conf'
+        assert log.levelname == 'ERROR'

--- a/src/ceph-volume/setup.py
+++ b/src/ceph-volume/setup.py
@@ -15,6 +15,7 @@ setup(
     zip_safe = False,
     tests_require=[
         'pytest >=2.1.3',
+        "mock; python_version < '3.4'",
         'tox',
     ],
     scripts = ['bin/ceph-volume', 'bin/ceph-volume-systemd'],


### PR DESCRIPTION
main.Volume__init__() parse argument is never used.
main.Volume__init__() args argument is used in test only.

So there is no need to have them in main.Volume.__init__()

This change removes parse and args arguments. Tests are
updated to mock sys.argv correctly.

Signed-off-by: Mehdi Abaakouk <sileht@sileht.net>