### PR TITLE
enable build ceph on ubuntu 18.04

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -48,7 +48,7 @@ function munge_ceph_spec_in {
 function ensure_decent_gcc_on_ubuntu {
     # point gcc to the one offered by g++-7 if the used one is not
     # new enough
-    local old=$(gcc -dumpversion)
+    local old=$(gcc -dumpfullversion -dumpversion)
     local new=$1
     local codename=$2
     if dpkg --compare-versions $old ge 7.0; then


### PR DESCRIPTION
CI: enable build ceph on ubuntu 18.04

Currently, ceph could be built on ubuntu 16.04(LTS) and 17.04.
The version 17.04 isn't a good option since it's not LTS version. 
This patch series support build ceph on ubuntu 18.04(LTS)

Signed-off-by: Changcheng Liu <changcheng.liu@intel.com>

