### PR TITLE
 doc: purge subcommand link broken

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -510,6 +510,7 @@ Usage::
 
   ceph mgr count-metadata <field>
 
+.. _ceph-admin-osd:
 
 osd
 ---

--- a/doc/rados/operations/add-or-rm-osds.rst
+++ b/doc/rados/operations/add-or-rm-osds.rst
@@ -287,7 +287,7 @@ OSD for each drive by repeating this procedure.
 
 #. Let the cluster forget the OSD first. This step removes the OSD from the CRUSH
    map, removes its authentication key. And it is removed from the OSD map as
-   well. Please note the `purge subcommand`_ is introduced in Luminous, for older
+   well. Please note the :ref:`purge subcommand <ceph-admin-osd>` is introduced in Luminous, for older
    versions, please see below ::
 
     ceph osd purge {id} --yes-i-really-mean-it
@@ -335,4 +335,3 @@ you need to perform this step manually:
 
 
 .. _Remove an OSD: ../crush-map#removeosd
-.. _purge subcommand: /man/8/ceph#osd


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

This PR fixes a broken link on ```rados/operations/add-or-rm-osds.rst```. I added a ```:ref:``` label for ```ceph osd``` commands (under ceph administration tools). Due to the unique nature of these commands, I wonder if we could add ```:ref:``` labels for all command references (unless I'm missing something and the command references can be cross-referenced without ```:ref:```). In the future, the Ceph documentation structure may change. If all of the command references are labeled, the link integrity will remain. 

I would be more than happy to work on this project, as there are many Ceph commands and reference pages. 

Fixes: https://tracker.ceph.com/issues/36605

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>
