### PR TITLE
luminous: client: explicitly show blacklisted state via asok status command

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -456,6 +456,7 @@ void Client::dump_status(Formatter *f)
     f->dump_int("mds_epoch", mdsmap->get_epoch());
     f->dump_int("osd_epoch", osd_epoch);
     f->dump_int("osd_epoch_barrier", cap_epoch_barrier);
+    f->dump_bool("blacklisted", blacklisted);
   }
 }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/36456