### PR TITLE
mds: answering all pending getattr/lookups targeting the same inode in one go

### DIFF
--- a/src/mds/BatchOp.cc
+++ b/src/mds/BatchOp.cc
@@ -1,0 +1,35 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2019 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/debug.h"
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_mds
+
+#include "BatchOp.h"
+
+void BatchOp::forward(mds_rank_t target)
+{
+  dout(20) << __func__ << ": forwarding batch ops to " << target << ": ";
+  print(*_dout);
+  *_dout << dendl;
+  _forward(target);
+}
+
+void BatchOp::respond(int r)
+{
+  dout(20) << __func__ << ": responding to batch ops with result=" << r << ": ";
+  print(*_dout);
+  *_dout << dendl;
+  _respond(r);
+}

--- a/src/mds/BatchOp.h
+++ b/src/mds/BatchOp.h
@@ -1,0 +1,40 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2012 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+
+#ifndef MDS_BATCHOP_H
+#define MDS_BATCHOP_H
+
+#include "common/ref.h"
+
+#include "mdstypes.h"
+
+class BatchOp {
+public:
+  virtual ~BatchOp() {}
+
+  virtual void add_request(const ceph::ref_t<class MDRequestImpl>& mdr) = 0;
+  virtual void set_request(const ceph::ref_t<class MDRequestImpl>& mdr) = 0;
+
+  virtual void print(std::ostream&) = 0;
+
+  void forward(mds_rank_t target);
+  void respond(int r);
+
+protected:
+  virtual void _forward(mds_rank_t) = 0;
+  virtual void _respond(mds_rank_t) = 0;
+};
+
+#endif

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -28,6 +28,7 @@
 #include "include/elist.h"
 #include "include/filepath.h"
 
+#include "BatchOp.h"
 #include "MDSCacheObject.h"
 #include "MDSContext.h"
 #include "SimpleLock.h"
@@ -41,7 +42,6 @@ class CDentry;
 class LogSegment;
 
 class Session;
-class BatchOp;
 
 // define an ordering
 bool operator<(const CDentry& l, const CDentry& r);
@@ -353,7 +353,7 @@ public:
   LocalLock versionlock; // FIXME referenced containers not in mempool
 
   mempool::mds_co::map<client_t,ClientLease*> client_lease_map;
-  std::map<int, BatchOp*> batch_ops;
+  std::map<int, std::unique_ptr<BatchOp>> batch_ops;
 
 
 protected:

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -41,8 +41,7 @@ class CDentry;
 class LogSegment;
 
 class Session;
-
-
+class BatchOp;
 
 // define an ordering
 bool operator<(const CDentry& l, const CDentry& r);
@@ -354,6 +353,7 @@ public:
   LocalLock versionlock; // FIXME referenced containers not in mempool
 
   mempool::mds_co::map<client_t,ClientLease*> client_lease_map;
+  std::map<int, BatchOp*> batch_ops;
 
 
 protected:

--- a/src/mds/CMakeLists.txt
+++ b/src/mds/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(mds_srcs
+  BatchOp.cc
   Capability.cc
   MDSDaemon.cc
   MDSRank.cc

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -1776,7 +1776,7 @@ uint64_t Migrator::encode_export_dir(bufferlist& exportbl,
     exportbl.append("I", 1);    // inode dentry
     
     encode_export_inode(in, exportbl, exported_client_map, exported_client_metadata_map);  // encode, and (update state for) export
-    
+
     // directory?
     auto&& dfs = in->get_dirfrags();
     for (const auto& t : dfs) {

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -357,6 +357,14 @@ bool MDRequestImpl::is_queued_for_replay() const
   return client_request ? client_request->is_queued_for_replay() : false;
 }
 
+bool MDRequestImpl::is_batch_op()
+{
+  return (client_request->get_op() == CEPH_MDS_OP_LOOKUP &&
+      client_request->get_filepath().depth() == 1) ||
+    (client_request->get_op() == CEPH_MDS_OP_GETATTR &&
+     client_request->get_filepath().depth() == 0);
+}
+
 cref_t<MClientRequest> MDRequestImpl::release_client_request()
 {
   msg_lock.lock();
@@ -378,7 +386,7 @@ void MDRequestImpl::reset_slave_request(const cref_t<MMDSSlaveRequest>& req)
 
 void MDRequestImpl::print(ostream &out) const
 {
-  out << "request(" << reqid;
+  out << "request(" << reqid << " nref=" << nref;
   //if (request) out << " " << *request;
   if (is_slave()) out << " slave_to mds." << slave_to_mds;
   if (client_request) out << " cr=" << client_request;

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -28,6 +28,7 @@
 #include "common/TrackedOp.h"
 #include "messages/MClientRequest.h"
 #include "messages/MMDSSlaveRequest.h"
+#include "messages/MClientReply.h"
 
 class LogSegment;
 class Capability;
@@ -281,6 +282,8 @@ struct MDRequestImpl : public MutationImpl {
   // indicates how may retries of request have been made
   int retry;
 
+  bool is_batch_head = false;
+
   // indicator for vxattr osdmap update
   bool waited_for_osdmap;
 
@@ -398,6 +401,7 @@ struct MDRequestImpl : public MutationImpl {
   void set_filepath(const filepath& fp);
   void set_filepath2(const filepath& fp);
   bool is_queued_for_replay() const;
+  bool is_batch_op();
 
   void print(ostream &out) const override;
   void dump(Formatter *f) const override;
@@ -407,6 +411,7 @@ struct MDRequestImpl : public MutationImpl {
 
   // TrackedOp stuff
   typedef boost::intrusive_ptr<MDRequestImpl> Ref;
+  std::vector<Ref> batch_reqs;
 protected:
   void _dump(Formatter *f) const override;
   void _dump_op_descriptor_unlocked(ostream& stream) const override;

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -77,6 +77,43 @@ class ServerContext : public MDSContext {
   }
 };
 
+class Batch_Getattr_Lookup : public BatchOp {
+protected:
+  Server* server;
+  MDRequestRef mdr;
+  MDCache* mdcache;
+  int res = 0;
+public:
+  Batch_Getattr_Lookup(Server* s, MDRequestRef& r, MDCache* mdc) : server(s), mdr(r), mdcache(mdc) {}
+  void add_request(const MDRequestRef& m) override {
+    mdr->batch_reqs.push_back(m);
+  }
+  void set_request(const MDRequestRef& m) override {
+    mdr = m;
+  }
+  void forward_all(mds_rank_t t) override {
+    mdcache->mds->forward_message_mds(mdr->release_client_request(), t);
+    mdr->set_mds_stamp(ceph_clock_now());
+    for (auto m : mdr->batch_reqs) {
+      if (!m->killed)
+	mdcache->request_forward(m, t);
+    }
+    mdr->batch_reqs.clear();
+  }
+  void respond_all(int r) {
+    mdr->set_mds_stamp(ceph_clock_now());
+    for (auto m : mdr->batch_reqs) {
+      if (!m->killed) {
+	m->tracei = mdr->tracei;
+	m->tracedn = mdr->tracedn;
+	server->respond_to_request(m, r);
+      }
+    }
+    mdr->batch_reqs.clear();
+    server->reply_client_request(mdr, make_message<MClientReply>(*mdr->client_request, r));
+  }
+};
+
 class ServerLogContext : public MDSLogContextBase {
 protected:
   Server *server;
@@ -1750,7 +1787,28 @@ void Server::submit_mdlog_entry(LogEvent *le, MDSLogContextBase *fin, MDRequestR
 void Server::respond_to_request(MDRequestRef& mdr, int r)
 {
   if (mdr->client_request) {
-    reply_client_request(mdr, make_message<MClientReply>(*mdr->client_request, r));
+    if (mdr->is_batch_op() && mdr->is_batch_head) {
+      int mask = mdr->client_request->head.args.getattr.mask;
+
+      BatchOp *fin;
+      if (mdr->client_request->get_op() == CEPH_MDS_OP_GETATTR) {
+	dout(20) << __func__ << ": respond other getattr ops. " << *mdr << dendl;
+	fin = mdr->in[0]->batch_ops[mask];
+      } else {
+	dout(20) << __func__ << ": respond other lookup ops. " << *mdr << dendl;
+	fin = mdr->dn[0].back()->batch_ops[mask];
+      }
+
+      fin->finish(r);
+
+      if (mdr->client_request->get_op() == CEPH_MDS_OP_GETATTR) {
+	mdr->in[0]->batch_ops.erase(mask);
+      } else {
+	mdr->dn[0].back()->batch_ops.erase(mask);
+      }
+    } else {
+     reply_client_request(mdr, make_message<MClientReply>(*mdr->client_request, r));
+    }
   } else if (mdr->internal_op > -1) {
     dout(10) << "respond_to_request on internal request " << mdr << dendl;
     if (!mdr->internal_op_finish)
@@ -2267,6 +2325,22 @@ void Server::handle_osd_map()
     });
 }
 
+void Server::clear_batch_ops(const MDRequestRef& mdr)
+{
+  int mask = mdr->client_request->head.args.getattr.mask;
+  if (mdr->client_request->get_op() == CEPH_MDS_OP_GETATTR && mdr->in[0]) {
+    auto it = mdr->in[0]->batch_ops.find(mask);
+    auto bocp = it->second;
+    mdr->in[0]->batch_ops.erase(it);
+    delete bocp;
+  } else if (mdr->client_request->get_op() == CEPH_MDS_OP_LOOKUP && mdr->dn[0].size()) {
+    auto it = mdr->dn[0].back()->batch_ops.find(mask);
+    auto bocp = it->second;
+    mdr->dn[0].back()->batch_ops.erase(it);
+    delete bocp;
+  }
+}
+
 void Server::dispatch_client_request(MDRequestRef& mdr)
 {
   // we shouldn't be waiting on anyone.
@@ -2274,7 +2348,44 @@ void Server::dispatch_client_request(MDRequestRef& mdr)
 
   if (mdr->killed) {
     dout(10) << "request " << *mdr << " was killed" << dendl;
-    return;
+    //if the mdr is a "batch_op" and it has followers, pick a follower as
+    //the new "head of the batch ops" and go on processing the new one.
+    if (mdr->is_batch_op() && mdr->is_batch_head ) {
+      if (!mdr->batch_reqs.empty()) {
+	MDRequestRef new_batch_head;
+	for (auto itr = mdr->batch_reqs.cbegin(); itr != mdr->batch_reqs.cend();) {
+	  auto req = *itr;
+	  itr = mdr->batch_reqs.erase(itr);
+	  if (!req->killed) {
+	    new_batch_head = req;
+	    break;
+	  }
+	}
+
+	if (!new_batch_head) {
+	  clear_batch_ops(mdr);
+	  return;
+	}
+
+	new_batch_head->batch_reqs = std::move(mdr->batch_reqs);
+
+	mdr = new_batch_head;
+	mdr->is_batch_head = true;
+	int mask = mdr->client_request->head.args.getattr.mask;
+	if (mdr->client_request->get_op() == CEPH_MDS_OP_GETATTR) {
+	  auto fin = mdr->in[0]->batch_ops[mask];
+	  fin->set_request(new_batch_head);
+	} else if (mdr->client_request->get_op() == CEPH_MDS_OP_LOOKUP) {
+	  auto fin = mdr->dn[0].back()->batch_ops[mask];
+	  fin->set_request(new_batch_head);
+	}
+      } else {
+	clear_batch_ops(mdr);
+	return;
+      }
+    } else {
+      return;
+    }
   } else if (mdr->aborted) {
     mdr->aborted = false;
     mdcache->request_kill(mdr);
@@ -3544,6 +3655,28 @@ void Server::handle_client_getattr(MDRequestRef& mdr, bool is_lookup)
   CInode *ref = rdlock_path_pin_ref(mdr, 0, lov, want_auth, false, NULL,
 				    !is_lookup);
   if (!ref) return;
+
+  mdr->getattr_caps = mask;
+
+  if (!mdr->is_batch_head && mdr->is_batch_op()) {
+    if (!is_lookup) {
+      if (ref->batch_ops.count(mask)) {
+	dout(20) << __func__ << ": GETATTR op, wait for previous same getattr ops to respond. " << *mdr << dendl;
+	ref->batch_ops[mask]->add_request(mdr);
+	return;
+      } else
+	ref->batch_ops[mask] = new Batch_Getattr_Lookup(this, mdr, mdcache);
+    } else {
+      CDentry* dn = mdr->dn[0].back();
+      if (dn->batch_ops.count(mask)) {
+	dout(20) << __func__ << ": LOOKUP op, wait for previous same getattr ops to respond. " << *mdr << dendl;
+	dn->batch_ops[mask]->add_request(mdr);
+	return;
+      } else
+	dn->batch_ops[mask] = new Batch_Getattr_Lookup(this, mdr, mdcache);
+    }
+  }
+  mdr->is_batch_head = true;
 
   /*
    * if client currently holds the EXCL cap on a field, do not rdlock

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -94,7 +94,7 @@ public:
   void forward_all(mds_rank_t t) override {
     mdcache->mds->forward_message_mds(mdr->release_client_request(), t);
     mdr->set_mds_stamp(ceph_clock_now());
-    for (auto m : mdr->batch_reqs) {
+    for (auto& m : mdr->batch_reqs) {
       if (!m->killed)
 	mdcache->request_forward(m, t);
     }
@@ -102,7 +102,7 @@ public:
   }
   void respond_all(int r) {
     mdr->set_mds_stamp(ceph_clock_now());
-    for (auto m : mdr->batch_reqs) {
+    for (auto& m : mdr->batch_reqs) {
       if (!m->killed) {
 	m->tracei = mdr->tracei;
 	m->tracedn = mdr->tracedn;

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -110,6 +110,7 @@ private:
   friend class MDSContinuation;
   friend class ServerContext;
   friend class ServerLogContext;
+  friend class Batch_Getattr_Lookup;
 
 public:
   bool terminating_sessions;
@@ -348,6 +349,7 @@ public:
 private:
   void reply_client_request(MDRequestRef& mdr, const ref_t<MClientReply> &reply);
   void flush_session(Session *session, MDSGatherBuilder *gather);
+  void clear_batch_ops(const MDRequestRef& mdr);
 
   DecayCounter recall_throttle;
   time last_recall_state;


### PR DESCRIPTION
As for now, all getattr/lookup requests get processes one by one, which
is kind of wasting CPU resources. Actually, for those getattr/lookup
requests for the same inode, only one of them needs to be processes, the
results applies all others.

Resolves: http://tracker.ceph.com/issues/36608
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

