### PR TITLE
osd: fix heartbeat_reset unlock

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4961,7 +4961,6 @@ bool OSD::heartbeat_reset(Connection *con)
   auto s = con->get_priv();
   if (s) {
     if (is_stopping()) {
-      heartbeat_lock.Unlock();
       return true;
     }
     auto heartbeat_session = static_cast<HeartbeatSession*>(s.get());


### PR DESCRIPTION
Fixes 51d8e2457d73c709bfa4f706793696b3ce704ff9, which moved to lock_guard
but didn't remove the unlock call on this exit path.

Signed-off-by: Sage Weil <sage@redhat.com>