### PR TITLE
fix python collections module warning for 3.7 and above

### DIFF
--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -8,7 +8,10 @@ import logging
 import os
 from textwrap import dedent
 import traceback
-from collections import namedtuple, defaultdict
+try:
+    from collections.abc import namedtuple, defaultdict
+except ImportError:
+    from collections import namedtuple, defaultdict
 
 from teuthology.orchestra.run import CommandFailedError
 from tasks.cephfs.cephfs_test_case import CephFSTestCase, for_teuthology

--- a/qa/tasks/cephfs/test_forward_scrub.py
+++ b/qa/tasks/cephfs/test_forward_scrub.py
@@ -10,7 +10,10 @@ how the functionality responds to damaged metadata.
 import json
 
 import logging
-from collections import namedtuple
+try:
+    from collections.abc import namedtuple
+except ImportError:
+    from collections import namedtuple
 from textwrap import dedent
 
 from teuthology.orchestra.run import CommandFailedError

--- a/qa/tasks/cephfs/test_recovery_pool.py
+++ b/qa/tasks/cephfs/test_recovery_pool.py
@@ -8,7 +8,10 @@ import logging
 import os
 from textwrap import dedent
 import traceback
-from collections import namedtuple, defaultdict
+try:
+    from collections.abc import namedtuple, defaultdict
+except ImportError:
+    from collections import namedtuple, defaultdict
 
 from teuthology.orchestra.run import CommandFailedError
 from tasks.cephfs.cephfs_test_case import CephFSTestCase, for_teuthology

--- a/qa/tasks/cephfs/test_scrub.py
+++ b/qa/tasks/cephfs/test_scrub.py
@@ -4,7 +4,10 @@ Test CephFS scrub (distinct from OSD scrub) functionality
 import logging
 import os
 import traceback
-from collections import namedtuple
+try:
+    from collections.abc import namedtuple
+except ImportError:
+    from collections import namedtuple
 
 from teuthology.orchestra.run import CommandFailedError
 from tasks.cephfs.cephfs_test_case import CephFSTestCase, for_teuthology

--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -4,7 +4,10 @@ from __future__ import absolute_import
 
 import json
 import logging
-from collections import namedtuple
+try:
+    from collections.abc import namedtuple
+except ImportError:
+    from collections import namedtuple
 import threading
 import time
 

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -26,7 +26,10 @@ Alternative usage:
 """
 
 from StringIO import StringIO
-from collections import defaultdict
+try:
+    from collections.abc import defaultdict
+except ImportError:
+    from collections import defaultdict
 import getpass
 import signal
 import tempfile

--- a/src/ceph-volume/ceph_volume/__init__.py
+++ b/src/ceph-volume/ceph_volume/__init__.py
@@ -1,4 +1,7 @@
-from collections import namedtuple
+try:
+    from collections.abc import namedtuple
+except ImportError:
+    from collections import namedtuple
 
 
 sys_info = namedtuple('sys_info', ['devices'])

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -15,7 +15,10 @@ import json
 import socket
 import struct
 import time
-from collections import OrderedDict
+try:
+    from collections.abc import OrderedDict
+except ImportError:
+    from collections import OrderedDict
 from fcntl import ioctl
 from fnmatch import fnmatch
 from prettytable import PrettyTable, HEADER

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -9,7 +9,10 @@ from libc.stdlib cimport malloc, realloc, free
 
 cimport rados
 
-from collections import namedtuple
+try:
+    from collections.abc import namedtuple
+except ImportError:
+    from collections import namedtuple
 from datetime import datetime
 import errno
 import os

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-from collections import defaultdict
+try:
+    from collections.abc import defaultdict
+except ImportError:
+    from collections import defaultdict
 
 import cherrypy
 

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -2,8 +2,12 @@
 from __future__ import absolute_import
 
 import time
-import collections
-from collections import defaultdict
+try:
+    import collections.abc
+    from collections.abc import defaultdict
+except ImportError:
+    import collections
+    from collections import defaultdict
 import json
 
 import rados

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -4,7 +4,10 @@ import ceph_module  # noqa
 import logging
 import six
 import threading
-from collections import defaultdict
+try:
+    from collections.abc import defaultdict
+except ImportError:
+    from collections import defaultdict
 import rados
 
 PG_STATES = [

--- a/src/pybind/mgr/restful/api/crush.py
+++ b/src/pybind/mgr/restful/api/crush.py
@@ -2,7 +2,10 @@ from pecan import expose
 from pecan.rest import RestController
 
 from restful import common, context
-from collections import defaultdict
+try:
+    from collections.abc import defaultdict
+except ImportError:
+    from collections import defaultdict
 
 from restful.decorators import auth
 

--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -3,7 +3,10 @@
 High level status display commands
 """
 
-from collections import defaultdict
+try:
+    from collections.abc import defaultdict
+except ImportError:
+    from collections import defaultdict
 from prettytable import PrettyTable
 import errno
 import fnmatch

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -12,7 +12,10 @@ import uuid
 import time
 from datetime import datetime
 from threading import Event
-from collections import defaultdict
+try:
+    from collections.abc import defaultdict
+except ImportError:
+    from collections import defaultdict
 
 from mgr_module import MgrModule
 

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -23,7 +23,10 @@ import sys
 import threading
 import time
 
-from collections import Callable
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
 from datetime import datetime
 from functools import partial, wraps
 from itertools import chain

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -23,7 +23,10 @@ from libc.stdint cimport *
 from libc.stdlib cimport realloc, free
 from libc.string cimport strdup
 
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from datetime import datetime
 
 cimport rados

--- a/src/pybind/rgw/rgw.pyx
+++ b/src/pybind/rgw/rgw.pyx
@@ -10,7 +10,10 @@ from libc.stdlib cimport malloc, realloc, free
 
 cimport rados
 
-from collections import namedtuple
+try:
+    from collections.abc import namedtuple
+except ImportError:
+    from collections import namedtuple
 from datetime import datetime
 import errno
 

--- a/src/tools/rgw/parse-cr-dump.py
+++ b/src/tools/rgw/parse-cr-dump.py
@@ -1,6 +1,9 @@
 #!/usr/bin/python
 from __future__ import print_function
-from collections import Counter
+try:
+    from collections.abc import Counter
+except ImportError:
+    from collections import Counter
 import argparse
 import json
 import re


### PR DESCRIPTION
Python 3.7 now shows a warning as below.

/usr/bin/ceph:128: DeprecationWarning: Using or importing the ABCs from
'collections' instead of from 'collections.abc' is deprecated, and in
3.8 it will stop working
  import rados

This patch addresses the that particular issue.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

