### PR TITLE
test: make readable.sh fail if it doesn't run anything

### DIFF
--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -231,5 +231,11 @@ if [ $failed -gt 0 ]; then
   echo "FAILED $failed / $numtests tests."
   exit 1
 fi
+
+if [ $numtests -eq 0 ]; then
+  echo "FAILED: no tests found to run!"
+  exit 1
+fi
+
 echo "passed $numtests tests."
 


### PR DESCRIPTION
It turns out that our ceph-object-corpus tests silently PASS if you don't actually have an object corpus to test with.

That seems suboptimal to me, since I generally assume a "make check" run passing means that we haven't broken our encoders.