### PR TITLE
common: Fix Alpine compatability for TEMP_FAILURE_RETRY and ACCESSPERMS

### DIFF
--- a/src/client/posix_acl.cc
+++ b/src/client/posix_acl.cc
@@ -1,11 +1,8 @@
+#include "include/compat.h"
 #include "include/types.h"
 #include <sys/stat.h>
 #include "posix_acl.h"
 #include "UserPerm.h"
-
-#ifndef ACCESSPERMS
-#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
-#endif
 
 int posix_acl_check(const void *xattr, size_t size)
 {

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -12,6 +12,8 @@
  *
  */
 
+#include "include/compat.h"
+
 #ifdef __FreeBSD__
 #include <sys/param.h>
 #include <geom/geom_disk.h>

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "common/common_init.h"
 #include "common/admin_socket.h"
 #include "common/ceph_argparse.h"

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -19,6 +19,11 @@
 #define PROCPREFIX
 #endif
 
+#include <sys/stat.h>
+#ifndef ACCESSPERMS
+#define ACCESSPERMS (S_IRWXU|S_IRWXG|S_IRWXO)
+#endif
+
 #if defined(__FreeBSD__)
 
 // FreeBSD supports Linux procfs with its compatibility module


### PR DESCRIPTION
Compiler output:
/ceph/src/common/blkdev.cc: In function 'int64_t get_vdo_stat(int, const char*)':
/ceph/src/common/blkdev.cc:337:3: error: 'TEMP_FAILURE_RETRY' was not declared in this scope
   TEMP_FAILURE_RETRY(::close(fd));

And

/ceph/src/common/common_init.cc: In function 'void common_init_finish(CephContext*)':
/ceph/src/common/common_init.cc:124:21: error: 'ACCESSPERMS' was not declared in this scope
       if (!(ret & (~ACCESSPERMS))) {
                     ^~~~~~~~~~~-

Reported-by: Beierl, Mark <Mark.Beierl@dell.com>



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug