### PR TITLE
mgr: prometheus: added bluestore db and wal devices to ceph_disk_occupation metric.

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -70,7 +70,7 @@ POOL_METADATA = ('pool_id', 'name')
 
 RGW_METADATA = ('ceph_daemon', 'hostname', 'ceph_version')
 
-DISK_OCCUPATION = ( 'ceph_daemon', 'device','instance')
+DISK_OCCUPATION = ('ceph_daemon', 'device', 'db_device', 'wal_device', 'instance')
 
 NUM_OBJECTS = ['degraded', 'misplaced', 'unfound']
 
@@ -451,13 +451,24 @@ class Module(MgrModule):
             osd_metadata = self.get_metadata("osd", str(id_))
             if osd_metadata is None:
                 continue
-            dev_keys = ("backend_filestore_dev_node", "bluestore_bdev_dev_node")
-            osd_dev_node = None
-            for dev_key in dev_keys:
-                val = osd_metadata.get(dev_key, None)
-                if val and val != "unknown":
-                    osd_dev_node = val
-                    break
+
+            osd_objectstore = osd_metadata.get('osd_objectstore', None)
+            if osd_objectstore == "filestore":
+            # collect filestore backend device
+                osd_dev_node = osd_metadata.get('backend_filestore_dev_node', None)
+            # collect filestore journal device
+                osd_wal_dev_node = osd_metadata.get('osd_journal', '')
+                osd_db_dev_node = ''
+            elif osd_objectstore == "bluestore":
+            # collect bluestore backend device
+                osd_dev_node = osd_metadata.get('bluestore_bdev_dev_node', None)
+            # collect bluestore wal backend
+                osd_wal_dev_node = osd_metadata.get('bluefs_wal_dev_node', '')
+            # collect bluestore db backend
+                osd_db_dev_node = osd_metadata.get('bluefs_db_dev_node', '')
+            if osd_dev_node and osd_dev_node == "unknown":
+                osd_dev_node = None
+
             osd_hostname = osd_metadata.get('hostname', None)
             if osd_dev_node and osd_hostname:
                 self.log.debug("Got dev for osd {0}: {1}/{2}".format(
@@ -465,6 +476,8 @@ class Module(MgrModule):
                 self.metrics['disk_occupation'].set(1, (
                     "osd.{0}".format(id_),
                     osd_dev_node,
+                    osd_db_dev_node,
+                    osd_wal_dev_node,
                     osd_hostname
                 ))
             else:


### PR DESCRIPTION
With this PR possible make queries for all BlueFS devices: backend and wal/db.

osd metadata:
```
# ceph osd metadata osd.10 | jq '(.'bluestore_bdev_dev_node',.'bluefs_db_dev_node',.'bluefs_wal_dev_node')'                                                                              
"sda"
"nvme0n1"
"nvme0n1"
```
prometheus before and after:
```
$ curl -X GET -gs 'http://localhost:9090/prometheus/api/v1/series?&match[]=ceph_disk_occupation{ceph_daemon="osd.10"}' | jq
```
```json
{
  "status": "success",
  "data": [
    {
      "__name__": "ceph_disk_occupation",
      "ceph_daemon": "osd.10",
      "db_device": "nvme0n1",
      "device": "sda",
      "instance": "ceph-osd5",
      "job": "ceph",
      "wal_device": "nvme0n1"
    },
    {
      "__name__": "ceph_disk_occupation",
      "ceph_daemon": "osd.10",
      "device": "sda",
      "instance": "ceph-osd5",
      "job": "ceph"
    }
  ]
}
```

http://tracker.ceph.com/issues/36627

![selection_004](https://user-images.githubusercontent.com/7759548/47701096-50241500-dc4b-11e8-9576-41a3ede49fbf.png)
