### PR TITLE
mgr/devicehealth: fix is_valid_daemon_name typo error

### DIFF
--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -115,7 +115,7 @@ class Module(MgrModule):
         self.event = Event()
 
     def is_valid_daemon_name(self, who):
-        l = cmd.get('who', '').split('.')
+        l = who.split('.')
         if len(l) != 2:
             return False
         if l[0] not in ('osd', 'mon'):


### PR DESCRIPTION
Apparently `cmd.get('who', '')` should be replaced by `who`

Signed-off-by: Lan Liu <liulan@umcloud.com>
