### PR TITLE
mon: set mon_clock_drift_allowed default to 1.0

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1396,7 +1396,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_clock_drift_allowed", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(.050)
+    .set_default(1.0)
     .set_description(""),
 
     Option("mon_clock_drift_warn_backoff", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
we need to keep the time synchronized between mons since we need to have the lease valid until the next lease renewal, but if the threshold is too small it causes a lot of clock related warnings.
i think the current default setting, i.e., 0.05 is too sensitive, keep the threshold < 2.0 [1], e.g., 1.0, should be safe enough.

[1] x + `mon_lease_renew_interval_factor` * `mon_lease` < `mon_lease`
=> x < `mon_lease` * (1 - `mon_lease_renew_interval_factor`) = 5.0 * (1 - 0.6) = 2.0

Signed-off-by: runsisi <luo.runbing@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

