### PR TITLE
luminous ceph-volume util.encryption don't push stderr to terminal

### DIFF
--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -189,7 +189,8 @@ def status(device):
         'status',
         device,
     ]
-    out, err, code = process.call(command, show_command=True)
+    out, err, code = process.call(command, show_command=True, verbose_on_failure=False)
+
     metadata = {}
     if code != 0:
         logger.warning('failed to detect device mapper information')


### PR DESCRIPTION
When checking if a partition is encrypted or not, `cryptsetup` will spill stderr messages over to the terminal. Changing the setting when calling subprocess allows to mute this error in the terminal, but it is kept in the file log.

Fixes: http://tracker.ceph.com/issues/36246
Backport of: https://github.com/ceph/ceph/pull/24399