### PR TITLE
mgr/dashboard: Fix links to external documentation

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/rgw/rgw-501/rgw-501.component.ts
@@ -27,8 +27,9 @@ export class Rgw501Component implements OnInit, OnDestroy {
       }
 
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
-      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/
-        #enabling-the-object-gateway-management-frontend`;
+      this.docsUrl =
+        `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/` +
+        `#enabling-the-object-gateway-management-frontend`;
 
       setTimeout(() => {
         subs.unsubscribe();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -55,7 +55,9 @@ export class GrafanaComponent implements OnInit, OnChanges {
       }
 
       const releaseName = this.cephReleaseNamePipe.transform(summary.version);
-      this.docsUrl = `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/`;
+      this.docsUrl =
+        `http://docs.ceph.com/docs/${releaseName}/mgr/dashboard/` +
+        `#enabling-the-embedding-of-grafana-dashboards`;
 
       setTimeout(() => {
         subs.unsubscribe();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/components/grafana/grafana.component.ts
@@ -3,9 +3,9 @@ import { Component, Input, OnChanges, OnInit } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 import { SafeUrl } from '@angular/platform-browser';
 
-import { SettingsService } from '../../../shared/api/settings.service';
-import { CephReleaseNamePipe } from '../../../shared/pipes/ceph-release-name.pipe';
-import { SummaryService } from '../../../shared/services/summary.service';
+import { SettingsService } from '../../api/settings.service';
+import { CephReleaseNamePipe } from '../../pipes/ceph-release-name.pipe';
+import { SummaryService } from '../../services/summary.service';
 
 @Component({
   selector: 'cd-grafana',


### PR DESCRIPTION
- Fix broken link to documentation for Object Gateway
- Add anchor to Grafana in `Overall Performance` documentation 

Off-topic:
- Short paths for imports