### PR TITLE
luminous: osd: potential deadlock in PG::_scan_snaps when repairing snap mapper

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4347,7 +4347,7 @@ void PG::_scan_snaps(ScrubMap &smap)
 	  bool done;
 	  t.register_on_applied_sync(
 	    new C_SafeCond(&my_lock, &my_cond, &done, &r));
-	  r = osd->store->apply_transaction(osr.get(), std::move(t));
+	  r = osd->store->queue_transaction(osr.get(), std::move(t), nullptr);
 	  if (r != 0) {
 	    derr << __func__ << ": apply_transaction got " << cpp_strerror(r)
 		 << dendl;


### PR DESCRIPTION
http://tracker.ceph.com/issues/36630

---

Using apply_transaction when holding the pg lock is not safe.

Fixes: http://tracker.ceph.com/issues/36630
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

