### PR TITLE
osd: WIP isolate and experiment with the outstanding i/o throttler

### DIFF
--- a/src/common/OpQueue.h
+++ b/src/common/OpQueue.h
@@ -58,6 +58,9 @@ class OpQueue {
     virtual T dequeue() = 0;
     // Formatted output of the queue
     virtual void dump(ceph::Formatter *f) const = 0;
+    // Suspend dequeue. Suspeded queue will return empty item
+    virtual void set_suspend(bool sus) {};
+    virtual bool is_suspended() { return false; }
     // Don't leak resources on destruction
     virtual ~OpQueue() {}; 
 };

--- a/src/common/WeightedPriorityQueue.h
+++ b/src/common/WeightedPriorityQueue.h
@@ -191,7 +191,8 @@ class WeightedPriorityQueue :  public OpQueue <T, K>
           f->dump_int("first_item_cost", next->get_cost());
         }
       }
-    };
+    }; // class SubQueue
+
     class Queue {
       typedef bi::rbtree<SubQueue> SubQueues;
       typedef typename SubQueues::iterator Sit;
@@ -279,6 +280,7 @@ class WeightedPriorityQueue :  public OpQueue <T, K>
 	  }
 	}
 	void dump(ceph::Formatter *f) const {
+	  f->dump_int("size", size);
 	  for (typename SubQueues::const_iterator i = queues.begin();
 	        i != queues.end(); ++i) {
 	    f->dump_int("total_priority", total_prio);
@@ -330,10 +332,13 @@ class WeightedPriorityQueue :  public OpQueue <T, K>
       return normal.pop();
     }
     void dump(ceph::Formatter *f) const override {
-      f->open_array_section("high_queues");
+      f->dump_int("size", length());
+
+      f->open_object_section("high_queues");
       strict.dump(f);
       f->close_section();
-      f->open_array_section("queues");
+
+      f->open_object_section("queues");
       normal.dump(f);
       f->close_section();
     }

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -911,6 +911,9 @@ OPTION(osdc_blkin_trace_all, OPT_BOOL) // create a blkin trace for all objecter 
 
 OPTION(osd_discard_disconnected_ops, OPT_BOOL)
 
+// TEMPORARY DEBUG
+OPTION(osd_throttle, OPT_INT)
+
 OPTION(memstore_device_bytes, OPT_U64)
 OPTION(memstore_page_set, OPT_BOOL)
 OPTION(memstore_page_size, OPT_U64)

--- a/src/common/mClockPriorityQueue.h
+++ b/src/common/mClockPriorityQueue.h
@@ -311,12 +311,6 @@ namespace ceph {
       queue.add_request(std::move(item), cl, cost);
     }
 
-#if 0
-    void set_suspend(bool sus) {
-      queue.set_suspend(sus);
-    }
-#endif
-
     void enqueue_front(K cl,
 		       unsigned priority,
 		       unsigned cost,

--- a/src/common/mClockPriorityQueue.h
+++ b/src/common/mClockPriorityQueue.h
@@ -204,7 +204,7 @@ namespace ceph {
 	f->dump_int("size", size);
 	f->dump_int("num_keys", q.size());
       }
-    };
+    }; // class SubQueue
 
     using SubQueues = std::map<priority_t, SubQueue>;
 
@@ -347,7 +347,9 @@ namespace ceph {
     }
 
     void dump(ceph::Formatter *f) const override final {
-      f->open_array_section("high_queues");
+      f->dump_int("size", length());
+
+      f->open_object_section("high_queues");
       for (typename SubQueues::const_iterator p = high_queue.begin();
 	   p != high_queue.end();
 	   ++p) {
@@ -366,6 +368,6 @@ namespace ceph {
       f->dump_int("size", queue.request_count());
       f->close_section();
     } // dump
-  };
+  }; // class mClockQueue
 
 } // namespace ceph

--- a/src/common/mClockPriorityQueue.h
+++ b/src/common/mClockPriorityQueue.h
@@ -311,6 +311,9 @@ namespace ceph {
       queue.add_request(std::move(item), cl, cost);
     }
 
+    void set_suspend(bool sus) {
+      queue.set_suspend(sus);
+    }
     void enqueue_front(K cl,
 		       unsigned priority,
 		       unsigned cost,

--- a/src/common/mClockPriorityQueue.h
+++ b/src/common/mClockPriorityQueue.h
@@ -311,9 +311,12 @@ namespace ceph {
       queue.add_request(std::move(item), cl, cost);
     }
 
+#if 0
     void set_suspend(bool sus) {
       queue.set_suspend(sus);
     }
+#endif
+
     void enqueue_front(K cl,
 		       unsigned priority,
 		       unsigned cost,

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -7346,6 +7346,11 @@ std::vector<Option> get_mds_client_options() {
     .set_default(30)
     .set_description(""),
 
+    /* TEMPORARY FOR DEBUGGING */
+    Option("osd_throttle", Option::TYPE_INT, Option::LEVEL_DEV)
+    .set_default(1)
+    .set_description("DEBUGGING ONLY; 1=CLASSIC, 2=OUTSTANDING"),
+
     Option("client_caps_release_delay", Option::TYPE_INT, Option::LEVEL_DEV)
     .set_default(5)
     .set_description(""),

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9742,7 +9742,9 @@ void BlueStore::_kv_sync_thread()
       // iteration there will already be ops awake.  otherwise, we
       // end up going to sleep, and then wake up when the very first
       // transaction is ready for commit.
+#if 0
       throttle_bytes.put(costs);
+#endif
 
       PExtentVector bluefs_gift_extents;
       if (bluefs &&
@@ -10079,7 +10081,9 @@ void BlueStore::_deferred_aio_finish(OpSequencer *osr)
 	costs += txc->cost;
       }
     }
+#if 0
     throttle_deferred_bytes.put(costs);
+#endif
     std::lock_guard l(kv_lock);
     deferred_done_queue.emplace_back(b);
   }
@@ -10195,9 +10199,12 @@ int BlueStore::queue_transactions(
     handle->suspend_tp_timeout();
 
   auto tstart = mono_clock::now();
+#if 0
   throttle_bytes.get(txc->cost);
+#endif
   if (txc->deferred_txn) {
     // ensure we do not block here because of deferred writes
+#if 0
     if (!throttle_deferred_bytes.get_or_fail(txc->cost)) {
       dout(10) << __func__ << " failed get throttle_deferred_bytes, aggressive"
 	       << dendl;
@@ -10210,7 +10217,8 @@ int BlueStore::queue_transactions(
       }
       throttle_deferred_bytes.get(txc->cost);
       --deferred_aggressive;
-   }
+    }
+#endif
   }
   auto tend = mono_clock::now();
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10207,16 +10207,14 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 
   if (2 == osd->cct->_conf->osd_throttle) { // FOR DEBUGGING
     if (sdata->is_throttled()) {
+      dout(0) << __func__ << " new throttle start waiting" << dendl;
       sdata->sdata_wait_lock.Lock();
-      if (!sdata->stop_waiting) {
-	sdata->shard_lock.Unlock();
-	sdata->sdata_cond.WaitInterval(sdata->sdata_wait_lock,
-				       std::chrono::milliseconds(40));
-	sdata->sdata_wait_lock.Unlock();
-	sdata->shard_lock.Lock();
-      } else {
-	sdata->sdata_wait_lock.Unlock();
-      }
+      sdata->shard_lock.Unlock();
+      sdata->sdata_cond.WaitInterval(sdata->sdata_wait_lock,
+				     std::chrono::milliseconds(30));
+      sdata->sdata_wait_lock.Unlock();
+      sdata->shard_lock.Lock();
+      dout(0) << __func__ << " new throttle done waiting" << dendl;
     }
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -222,6 +222,7 @@ OSDService::OSDService(OSD *osd) :
   class_handler(osd->class_handler),
   osd_max_object_size(cct->_conf, "osd_max_object_size"),
   osd_skip_data_digest(cct->_conf, "osd_skip_data_digest"),
+  oio_mon(cct),
   publish_lock("OSDService::publish_lock"),
   pre_publish_lock("OSDService::pre_publish_lock"),
   max_oldest_map(0),

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10205,16 +10205,18 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
   // peek at spg_t
   sdata->shard_lock.Lock();
 
-  if (sdata->is_throttled()) {
-    sdata->sdata_wait_lock.Lock();
-    if (!sdata->stop_waiting) {
-      sdata->shard_lock.Unlock();
-      sdata->sdata_cond.WaitInterval(sdata->sdata_wait_lock,
-				      std::chrono::milliseconds(40));
-      sdata->sdata_wait_lock.Unlock();
-      sdata->shard_lock.Lock();
-    } else {
-      sdata->sdata_wait_lock.Unlock();
+  if (2 == osd->cct->_conf->osd_throttle) { // FOR DEBUGGING
+    if (sdata->is_throttled()) {
+      sdata->sdata_wait_lock.Lock();
+      if (!sdata->stop_waiting) {
+	sdata->shard_lock.Unlock();
+	sdata->sdata_cond.WaitInterval(sdata->sdata_wait_lock,
+				       std::chrono::milliseconds(40));
+	sdata->sdata_wait_lock.Unlock();
+	sdata->shard_lock.Lock();
+      } else {
+	sdata->sdata_wait_lock.Unlock();
+      }
     }
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9936,7 +9936,7 @@ void OSDShard::consume_map(
     sdata_cond.SignalOne();
     sdata_wait_lock.Unlock();
   }
-}
+} // consume_map
 
 void OSDShard::_wake_pg_slot(
   spg_t pgid,
@@ -10332,7 +10332,7 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
 				 suicide_interval);
 
   // take next item
-  auto qi = std::move(slot->to_process.front());
+  OpQueueItem qi = std::move(slot->to_process.front());
   slot->to_process.pop_front();
   dout(20) << __func__ << " " << qi << " pg " << pg << dendl;
   set<pair<spg_t,epoch_t>> new_children;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -100,6 +100,7 @@ enum {
   l_osd_op_rw_lat_outb_hist,
   l_osd_op_rw_process_lat,
   l_osd_op_rw_prepare_lat,
+  l_osd_op_queue_size,
 
   l_osd_op_before_queue_op_lat,
   l_osd_op_before_dequeue_op_lat,

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1858,7 +1858,6 @@ protected:
 
     /// requeue an old item (at the front of the line)
     void _enqueue_front(OpQueueItem&& item) override;
-      
 
     void set_suspend(bool sus) {
       bool need_sig = false;
@@ -1869,11 +1868,13 @@ protected:
 	  need_sig = true;
 
 	suspended = sus;
-	for(uint32_t i = 0; i < num_shards; i++) {
-	  ShardData* sdata = shard_list[i];
+#if 0
+	for(uint32_t i = 0; i < osd->num_shards; i++) {
+	  OSDShard* sdata = osd->shards[i];
 	  assert (NULL != sdata); 
 	  sdata->pqueue->set_suspend(sus);
         }
+#endif
       }
 
       if (need_sig)

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -89,6 +89,7 @@ private:
   static const uint8_t flag_delayed =     1 << 2;
   static const uint8_t flag_started =     1 << 3;
   static const uint8_t flag_sub_op_sent = 1 << 4;
+  static const uint8_t flag_repop_issued =1 << 6;
   static const uint8_t flag_commit_sent = 1 << 5;
 
   std::vector<ClassInfo> classes_;
@@ -128,6 +129,7 @@ public:
     case flag_delayed: return "delayed";
     case flag_started: return "started";
     case flag_sub_op_sent: return "waiting for sub ops";
+    case flag_repop_issued: return "repop issued";
     case flag_commit_sent: return "commit sent; apply or cleanup";
     default: break;
     }
@@ -149,8 +151,15 @@ public:
   void mark_sub_op_sent(const string& s) {
     mark_flag_point_string(flag_sub_op_sent, s);
   }
+  void mark_repop_issued() {
+    mark_flag_point(flag_repop_issued, "repop_issued");
+  }
   void mark_commit_sent() {
     mark_flag_point(flag_commit_sent, "commit_sent");
+  }
+
+  bool is_repop_issued() const {
+    return hit_flag_points & flag_repop_issued;
   }
 
   utime_t get_dequeued_time() const {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3879,6 +3879,7 @@ void PrimaryLogPG::promote_object(ObjectContextRef obc,
 
 void PrimaryLogPG::oio_throttle_get(OpRequestRef op) {
   if (op->get_req()->get_type() == CEPH_MSG_OSD_OP) {
+    dout(30) << "oio_get " << op->get_reqid() << dendl;
     osd->oio_mon.get();
     double cur_load = osd->oio_mon.get_tot();
     double target_load = osd->oio_mon.get_target_load();
@@ -3887,7 +3888,7 @@ void PrimaryLogPG::oio_throttle_get(OpRequestRef op) {
     if (!is_sus && cur_load > target_load) {
       osd->osd->op_shardedwq.set_suspend(true);
 
-      dout(30) << " suspend true "
+      dout(30) << "suspend true"
       << " cur " << cur_load
       << " tar " << target_load
       << dendl;
@@ -3898,6 +3899,7 @@ void PrimaryLogPG::oio_throttle_get(OpRequestRef op) {
 void PrimaryLogPG::oio_throttle_put(OpRequestRef op) {
   if (op->get_req()->get_type() == CEPH_MSG_OSD_OP) {
     double cur_load = osd->oio_mon.get_tot();
+    dout(30) << "oio_put " << op->get_reqid() << dendl;
     osd->oio_mon.put();
     osd->oio_mon.add_load(cur_load);
     bool is_up = osd->oio_mon.update();
@@ -3906,7 +3908,7 @@ void PrimaryLogPG::oio_throttle_put(OpRequestRef op) {
 
     if (is_sus && cur_load <= target_load) {
       osd->osd->op_shardedwq.set_suspend(false);
-      dout(30) << " suspend false "
+      dout(30) << "suspend false"
 	<< " cur " << cur_load
 	<< " tar " << target_load
 	<< dendl;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3877,15 +3877,14 @@ void PrimaryLogPG::promote_object(ObjectContextRef obc,
   info.stats.stats.sum.num_promote++;
 }
 
-void PrimaryLogPG::oio_throttle_get(OpRequestRef op)
-{
+void PrimaryLogPG::oio_throttle_get(OpRequestRef op) {
   if (op->get_req()->get_type() == CEPH_MSG_OSD_OP) {
     osd->oio_mon.get();
     double cur_load = osd->oio_mon.get_tot();
     double target_load = osd->oio_mon.get_target_load();
     bool is_sus = osd->osd->op_shardedwq.is_suspended();
 
-    if (!is_sus && cur_load >= target_load) {
+    if (!is_sus && cur_load > target_load) {
       osd->osd->op_shardedwq.set_suspend(true);
 
       dout(30) << " suspend true "
@@ -3896,8 +3895,7 @@ void PrimaryLogPG::oio_throttle_get(OpRequestRef op)
   }
 }
 
-void PrimaryLogPG::oio_throttle_put(OpRequestRef op)
-{
+void PrimaryLogPG::oio_throttle_put(OpRequestRef op) {
   if (op->get_req()->get_type() == CEPH_MSG_OSD_OP) {
     double cur_load = osd->oio_mon.get_tot();
     osd->oio_mon.put();
@@ -3906,7 +3904,7 @@ void PrimaryLogPG::oio_throttle_put(OpRequestRef op)
     double target_load = osd->oio_mon.get_target_load();
     bool is_sus = osd->osd->op_shardedwq.is_suspended();
 
-    if (is_sus && cur_load < target_load) {
+    if (is_sus && cur_load <= target_load) {
       osd->osd->op_shardedwq.set_suspend(false);
       dout(30) << " suspend false "
 	<< " cur " << cur_load

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1124,6 +1124,8 @@ protected:
     object_info_t *poi);
   void execute_ctx(OpContext *ctx);
   void finish_ctx(OpContext *ctx, int log_op_type);
+  void oio_throttle_put(OpRequestRef op);
+  void oio_throttle_get(OpRequestRef op);
   void reply_ctx(OpContext *ctx, int err);
   void reply_ctx(OpContext *ctx, int err, eversion_t v, version_t uv);
   void make_writeable(OpContext *ctx);

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -563,6 +563,10 @@ $DAEMONOPTS
         bluestore block create = true
 $BLUESTORE_OPTS
 
+	; **************** eric additions ****************
+	osd op num shards = 2
+	osd op num threads per shard = 2
+
         ; kstore
         kstore fsck on mount = true
         osd objectstore = $objectstore
@@ -946,7 +950,7 @@ debug_mon = 20
 
 [osd]
 debug_ms = 1
-debug_osd = 25
+debug_osd = 30
 debug_objecter = 20
 debug_monc = 20
 debug_mgrc = 20
@@ -978,6 +982,9 @@ fi
 if [ $CEPH_NUM_OSD -gt 0 ]; then
     start_osd
 fi
+
+echo "OSDs started; press enter to continue"
+read garbage
 
 # mds
 if [ "$smallmds" -eq 1 ]; then

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -983,8 +983,8 @@ if [ $CEPH_NUM_OSD -gt 0 ]; then
     start_osd
 fi
 
-echo "OSDs started; press enter to continue"
-read garbage
+# echo "OSDs started; press enter to continue"
+# read garbage
 
 # mds
 if [ "$smallmds" -eq 1 ]; then

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -566,6 +566,7 @@ $BLUESTORE_OPTS
 	; **************** eric additions ****************
 	osd op num shards = 2
 	osd op num threads per shard = 2
+        osd throttle = 1
 
         ; kstore
         kstore fsck on mount = true


### PR DESCRIPTION
SK Telecom developed an early version of what they called the "outstanding i/o" throttler to manage the movement of ops from the OSD's op queue layer to the object store's active op layer. The challenge is we'd like to keep ops at the op queue layer so QoS algorithms, such as dmclock, have as many operations to choose from. On the other hand, we do not want to starve the object store layer to the point where it unnecessarily increases op latency.

This PR, in its current state, attempts to isolate the outstanding i/o throttler and provide some supporting code to experiment with it. At this time it's not or near a state where it's ready to merge.

The PR replaces https://github.com/ceph/ceph/pull/17450.

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

