### PR TITLE
include/buffer: make static_assert c++11-safe

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -654,7 +654,8 @@ namespace buffer CEPH_BUFFER_API {
     };
     // The contiguous_filler is supposed to be not costlier than a single
     // pointer. Keep it dumb, please.
-    static_assert(sizeof(contiguous_filler) == sizeof(char*));
+    static_assert(sizeof(contiguous_filler) == sizeof(char*),
+		  "contiguous_filler should be no costlier than pointer");
 
     class page_aligned_appender {
       bufferlist *pbl;


### PR DESCRIPTION
The variant with only one arg was added in c++17.

Signed-off-by: Sage Weil <sage@redhat.com>