### PR TITLE
mimic ceph-volume: use console_scripts

### DIFF
--- a/src/ceph-volume/bin/ceph-volume
+++ b/src/ceph-volume/bin/ceph-volume
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from ceph_volume import main
-
-if __name__ == '__main__':
-    main.Volume()

--- a/src/ceph-volume/bin/ceph-volume-systemd
+++ b/src/ceph-volume/bin/ceph-volume-systemd
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-
-from ceph_volume.systemd import main
-
-if __name__ == '__main__':
-    main.main()

--- a/src/ceph-volume/setup.py
+++ b/src/ceph-volume/setup.py
@@ -17,7 +17,12 @@ setup(
         'pytest >=2.1.3',
         'tox',
     ],
-    scripts = ['bin/ceph-volume', 'bin/ceph-volume-systemd'],
+    entry_points = dict(
+        console_scripts = [
+            'ceph-volume = ceph_volume.main:Volume',
+            'ceph-volume-systemd = ceph_volume.systemd:main',
+        ],
+    ),
     classifiers = [
         'Environment :: Console',
         'Intended Audience :: Information Technology',
@@ -29,5 +34,4 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
     ]
-
 )


### PR DESCRIPTION
Using "#!/usr/bin/env python" is not recommended as it's not portable.

setuptools provides an console_scripts entry_point that generates
scripts that always have the good sheban whatever the target operating
system and python version/distribution.

http://tracker.ceph.com/issues/36601

Signed-off-by: Mehdi Abaakouk <sileht@sileht.net>
Backport of: https://github.com/ceph/ceph/pull/24773