### PR TITLE
osd/osd_types: fix notify-ack string rendering

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -6021,7 +6021,6 @@ ostream& operator<<(ostream& out, const OSDOp& op)
 	out << " gen " << op.op.watch.gen;
       break;
     case CEPH_OSD_OP_NOTIFY:
-    case CEPH_OSD_OP_NOTIFY_ACK:
       out << " cookie " << op.op.notify.cookie;
       break;
     case CEPH_OSD_OP_COPY_GET:


### PR DESCRIPTION
The notify id argument is encoded, not in the args structure (sadly).  See Objecter.h notify_ack() method
