### PR TITLE
client: remove redundant abort logic during dentry invalidation test

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10332,13 +10332,8 @@ int Client::test_dentry_handling(bool can_invalidate)
     r = _do_remount(false);
   }
   if (r) {
-    bool should_abort = cct->_conf.get_val<bool>("client_die_on_failed_dentry_invalidate");
-    if (should_abort) {
-      lderr(cct) << "no method to invalidate kernel dentry cache; quitting!" << dendl;
-      ceph_abort();
-    } else {
-      lderr(cct) << "no method to invalidate kernel dentry cache; expect issues!" << dendl;
-    }
+    lderr(cct) << "no method to invalidate kernel dentry cache; expect issues!"
+               << dendl;
   }
   return r;
 }


### PR DESCRIPTION
commit d1471f070c added retry logic when remounting is
used to invalidate kernel dcache. ceph-fuse performs a
dcache invalidation test during startup, thereby logging
(and continuing) or aborting as per certain configuration
settings. the abort logic is pretty much redundant and
can be cleaned up preserving the existing behavior.

Signed-off-by: Venky Shankar <vshankar@redhat.com>