### PR TITLE
common/admin_socket: remove support for the old protocol __be32

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -300,33 +300,14 @@ bool AdminSocket::do_accept()
       retry_sys_call(::close, connection_fd);
       return false;
     }
-    if (cmd[0] == '\0') {
-      // old protocol: __be32
-      if (pos == 3 && cmd[0] == '\0') {
-	switch (cmd[3]) {
-	case 0:
-	  c = "0";
-	  break;
-	case 1:
-	  c = "perfcounters_dump";
-	  break;
-	case 2:
-	  c = "perfcounters_schema";
-	  break;
-	default:
-	  c = "foo";
-	  break;
-	}
-	break;
-      }
-    } else {
-      // new protocol: null or \n terminated string
-      if (cmd[pos] == '\n' || cmd[pos] == '\0') {
-	cmd[pos] = '\0';
-	c = cmd;
-	break;
-      }
+
+    // new protocol: null or \n terminated string
+    if (cmd[pos] == '\n' || cmd[pos] == '\0') {
+      cmd[pos] = '\0';
+      c = cmd;
+      break;
     }
+
     if (++pos >= sizeof(cmd)) {
       lderr(m_cct) << "AdminSocket: error reading request too long" << dendl;
       retry_sys_call(::close, connection_fd);


### PR DESCRIPTION
I tried to find the case for the old protocol __be32, but no results. So, It may be cleaned up.

Signed-off-by: Yao Guotao <yaoguot@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

