### PR TITLE
mimic: rgw: set default objecter_inflight_ops = 24576

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -178,7 +178,8 @@ int main(int argc, const char **argv)
   /* alternative default for module */
   map<string,string> defaults = {
     { "debug_rgw", "1/5" },
-    { "keyring", "$rgw_data/keyring" }
+    { "keyring", "$rgw_data/keyring" },
+    { "objecter_inflight_ops", "24576" }
   };
 
   vector<const char*> args;


### PR DESCRIPTION
http://tracker.ceph.com/issues/36571

---

Backport of https://github.com/ceph/ceph/pull/23242 for mimic
Tracked at: http://tracker.ceph.com/issues/36571
