### PR TITLE
[RFC] os/bluestore: optimize BlueFS reads

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -939,6 +939,8 @@ OPTION(bluefs_buffered_io, OPT_BOOL)
 OPTION(bluefs_sync_write, OPT_BOOL)
 OPTION(bluefs_allocator, OPT_STR)     // stupid | bitmap
 OPTION(bluefs_preextend_wal_files, OPT_BOOL)  // this *requires* that rocksdb has recycling enabled
+OPTION(bluefs_trigger_prefetch_seq_num, OPT_U32)
+OPTION(bluefs_semi_random_max_prefetch, OPT_U64)
 
 OPTION(bluestore_bluefs, OPT_BOOL)
 OPTION(bluestore_bluefs_env_mirror, OPT_BOOL) // mirror to normal Env for debug

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4160,6 +4160,14 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("bluefs_trigger_prefetch_seq_num", Option::TYPE_UINT, Option::LEVEL_DEV)
+    .set_default(3)
+    .set_description(""),
+
+    Option("bluefs_semi_random_max_prefetch", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .set_default(65536)
+    .set_description(""),
+
     Option("bluestore_bluefs", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
     .set_flag(Option::FLAG_CREATE)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1342,8 +1342,9 @@ int BlueFS::_read_random(
 	     << std::hex << len << std::dec << dendl;
   }
   bool read_done = false;
+  auto trigger_seq_num = cct->_conf->bluefs_trigger_prefetch_seq_num;
   if (h->buf.max_prefetch >= len && h->lock.try_lock()) {
-    if (h->track_read(off, len)) {
+    if (h->track_read(off, len, trigger_seq_num)) {
       dout(5) << __func__ << " new sequence: ino "
 	      << h->file->fnode.ino << " "
 	      << h->seq_cnt_last << ","
@@ -1351,7 +1352,7 @@ int BlueFS::_read_random(
 	      << (double)h->seq_len_last / h->seq_cnt_last
 	      << dendl;
     }
-    if (h->seq_cnt > 2) { //FIXME: make configurable
+    if (h->seq_cnt >= trigger_seq_num) {
       dout(5) << __func__ << " buf read: ino "
 	      << h->file->fnode.ino
 	      << " 0x" << std::hex << off << "~" << len << std::dec
@@ -1474,11 +1475,9 @@ void BlueFS::_got_hint(FileReader* h, bool random)
   dout(5) << __func__ << " " << random << " ino "
             << h->file->fnode.ino
 	    << dendl;
-  if (random) {
-    h->buf.max_prefetch = 65536; //FIXME: make configurable
-  } else {
-    h->buf.max_prefetch = cct->_conf->bluefs_max_prefetch;
-  }
+  h->buf.max_prefetch = random ?
+   cct->_conf->bluefs_semi_random_max_prefetch :
+   cct->_conf->bluefs_max_prefetch;
 }
 
 int BlueFS::_read(
@@ -2777,7 +2776,7 @@ BlueFS::FileWriter *BlueFS::_create_writer(FileRef f)
 
 void BlueFS::close_reader(FileReader *h)
 {
-  if (h->seq_found()) {
+  if (h->seq_found(cct->_conf->bluefs_trigger_prefetch_seq_num)) {
     dout(5) << __func__ << " new sequence: ino "
             << h->file->fnode.ino << " "
             << h->seq_cnt_last << ","
@@ -2828,7 +2827,9 @@ int BlueFS::open_for_read(
   File *file = q->second.get();
 
   *h = new FileReader(file,
-		      random ? 65536 : cct->_conf->bluefs_max_prefetch, // FIXME: make configurable
+		      random ?
+		        cct->_conf->bluefs_semi_random_max_prefetch :
+		        cct->_conf->bluefs_max_prefetch,
 		      random, false);
   dout(10) << __func__ << " h " << *h << " on " << file->fnode << dendl;
   return 0;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1614,10 +1614,9 @@ void BlueFS::_rewrite_log_sync(bool allocate_with_fallback,
   uint64_t need = bl.length() + cct->_conf->bluefs_max_log_runway;
   dout(20) << __func__ << " need " << need << dendl;
 
-  mempool::bluefs::vector<bluefs_extent_t> old_extents;
-  uint64_t old_allocated = 0;
+  bluefs_fnode_t old_fnode;
   int r;
-  log_file->fnode.swap_extents(old_extents, old_allocated);
+  log_file->fnode.swap_extents(old_fnode);
   if (allocate_with_fallback) {
     r = _allocate(log_dev, need, &log_file->fnode);
     ceph_assert(r == 0);
@@ -1664,8 +1663,8 @@ void BlueFS::_rewrite_log_sync(bool allocate_with_fallback,
   _write_super(super_dev);
   flush_bdev();
 
-  dout(10) << __func__ << " release old log extents " << old_extents << dendl;
-  for (auto& r : old_extents) {
+  dout(10) << __func__ << " release old log extents " << old_fnode.extents << dendl;
+  for (auto& r : old_fnode.extents) {
     pending_release[r.bdev].insert(r.offset, r.length);
   }
 }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1381,7 +1381,7 @@ int BlueFS::_read(
       uint64_t x_off = 0;
       auto p = h->file->fnode.seek(buf->bl_off, &x_off);
       uint64_t want = round_up_to(len + (off & ~super.block_mask()),
-				  super.block_size);
+				  super.block_size) - buf->bl_off;
       want = std::max(want, buf->max_prefetch);
       uint64_t l = std::min(p->length - x_off, want);
       uint64_t eof_offset = round_up_to(h->file->fnode.size, super.block_size);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -241,8 +241,8 @@ public:
     ~FileReader() {
       --file->num_readers;
     }
-    bool seq_found() {
-      bool f = seq_cnt > 3;
+    bool seq_found(uint64_t trigger_seq_cnt) {
+      bool f = seq_cnt >= trigger_seq_cnt;
       if (f) {
 	seq_cnt_last = seq_cnt;
 	seq_len_last = seq_len;
@@ -250,13 +250,13 @@ public:
       }
       return f;
     }
-    bool track_read(uint64_t offset, uint64_t len) {
+    bool track_read(uint64_t offset, uint64_t len, uint64_t trigger_seq_cnt) {
       bool found = false;
       if (prev_offset == offset) {
 	seq_len += len;
 	++seq_cnt;
       } else {
-	found = seq_found();
+	found = seq_found(trigger_seq_cnt);
 	seq_len = len;
 	seq_cnt = 1;
      }

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -35,7 +35,7 @@ class BlueRocksSequentialFile : public rocksdb::SequentialFile {
  public:
   BlueRocksSequentialFile(BlueFS *fs, BlueFS::FileReader *h) : fs(fs), h(h) {}
   ~BlueRocksSequentialFile() override {
-    delete h;
+    fs->close_reader(h);
   }
 
   // Read up to "n" bytes from the file.  "scratch[0..n-1]" may be
@@ -81,7 +81,7 @@ class BlueRocksRandomAccessFile : public rocksdb::RandomAccessFile {
  public:
   BlueRocksRandomAccessFile(BlueFS *fs, BlueFS::FileReader *h) : fs(fs), h(h) {}
   ~BlueRocksRandomAccessFile() override {
-    delete h;
+    fs->close_reader(h);
   }
 
   // Read up to "n" bytes from the file starting at "offset".
@@ -124,10 +124,18 @@ class BlueRocksRandomAccessFile : public rocksdb::RandomAccessFile {
   //enum AccessPattern { NORMAL, RANDOM, SEQUENTIAL, WILLNEED, DONTNEED };
 
   void Hint(AccessPattern pattern) override {
-    if (pattern == RANDOM)
-      h->buf.max_prefetch = 4096;
-    else if (pattern == SEQUENTIAL)
-      h->buf.max_prefetch = fs->cct->_conf->bluefs_max_prefetch;
+    switch (pattern) {
+    case RANDOM:
+    case NORMAL:
+      fs->_got_hint(h, true);
+      break;
+    case SEQUENTIAL:
+      fs->_got_hint(h, false);
+      break;
+    default:
+      // do nothing
+      break;
+    }
   }
 
   // Remove any kind of caching of data from the offset to offset+length

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -951,6 +951,7 @@ int KernelDevice::read_random(uint64_t off, uint64_t len, char *buf,
                        bool buffered)
 {
   dout(5) << __func__ << " 0x" << std::hex << off << "~" << len << std::dec
+          << "buffered " << buffered
 	  << dendl;
   ceph_assert(len > 0);
   ceph_assert(off < size);

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <algorithm>
 #include "bluefs_types.h"
 #include "common/Formatter.h"
 #include "include/uuid.h"
@@ -86,6 +87,17 @@ mempool::bluefs::vector<bluefs_extent_t>::iterator bluefs_fnode_t::seek(
   uint64_t offset, uint64_t *x_off)
 {
   auto p = extents.begin();
+
+  if (extents_index.size() > 4) {
+    auto it = std::upper_bound(extents_index.begin(), extents_index.end(),
+      offset);
+    assert(it != extents_index.begin());
+    --it;
+    assert(offset >= *it);
+    p += it - extents_index.begin();
+    offset -= *it;
+  }
+
   while (p != extents.end()) {
     if ((int64_t) offset >= p->length) {
       offset -= p->length;

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -40,6 +40,11 @@ struct bluefs_fnode_t {
   utime_t mtime;
   uint8_t prefer_bdev;
   mempool::bluefs::vector<bluefs_extent_t> extents;
+
+  // precalculated logical offsets for extents vector entries
+  // allows fast lookup for extent index by the offset value via upper_bound()
+  mempool::bluefs::vector<uint64_t> extents_index;
+
   uint64_t allocated;
 
   bluefs_fnode_t() : ino(0), size(0), prefer_bdev(0), allocated(0) {}
@@ -50,8 +55,11 @@ struct bluefs_fnode_t {
 
   void recalc_allocated() {
     allocated = 0;
-    for (auto& p : extents)
+    extents_index.reserve(extents.size());
+    for (auto& p : extents) {
+      extents_index.emplace_back(allocated);
       allocated += p.length;
+    }
   }
 
   DENC_HELPERS
@@ -80,6 +88,7 @@ struct bluefs_fnode_t {
   }
 
   void append_extent(const bluefs_extent_t& ext) {
+    extents_index.emplace_back(allocated);
     extents.push_back(ext);
     allocated += ext.length;
   }
@@ -87,18 +96,20 @@ struct bluefs_fnode_t {
   void pop_front_extent() {
     auto it = extents.begin();
     allocated -= it->length;
+    extents_index.erase(extents_index.begin());
+    for (auto& i: extents_index) {
+      i -= it->length;
+    }
     extents.erase(it);
   }
   
   void swap_extents(bluefs_fnode_t& other) {
     other.extents.swap(extents);
+    other.extents_index.swap(extents_index);
     std::swap(allocated, other.allocated);
   }
-  void swap_extents(mempool::bluefs::vector<bluefs_extent_t>& swap_to, uint64_t& new_allocated) {
-    swap_to.swap(extents);
-    std::swap(allocated, new_allocated);
-  }
   void clear_extents() {
+    extents_index.clear();
     extents.clear();
     allocated = 0;
   }


### PR DESCRIPTION
This is an intermediate result for an attempt to improve BlueFS read performance.
It includes 2 major fixes:
1) Eliminate sequential lookup over fnode's bluefs extents. This list might be quite long (I could see 100+ items per fnode from time to time).
2) Try to do some prefetch for "semi-random" reads. Quite often one can see sequential reads using small (and unaligned to block size) chunks. This patch introduces simple sequence detection and read prefetch mechanics similar to buffered read implementation in BlueFS::_read()

Unfortunately I don't see any visible performance difference in my (quite limited) benchmark. Perhaps the reason is that BlueFS reads don't impact overall performance that much. Although these "semi-random" patterns are quite observable.

And it seems that introduced performance counters show inappropriate numbers (maybe concurrency issue?). Which I'll investigate anyway.

Wondering if this work in general deserves any prolongation?


Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

