### PR TITLE
luminous: rgw: set default objecter_inflight_ops = 24576

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -200,6 +200,7 @@ int main(int argc, const char **argv)
   vector<const char *> def_args;
   def_args.push_back("--debug-rgw=1/5");
   def_args.push_back("--keyring=$rgw_data/keyring");
+  def_args.push_back("--objecter_inflight_ops=24576");
 
   vector<const char*> args;
   argv_to_vec(argc, argv, args);


### PR DESCRIPTION
http://tracker.ceph.com/issues/36570

---

Backport of https://github.com/ceph/ceph/pull/23242 for luminous
Tracked at: http://tracker.ceph.com/issues/36570

I just adapted the new parameter to the vector, as there is no map there yet, as in master.
