### PR TITLE
mgr/orchestrator: Add support for "ceph orchestrator service ls"

### DIFF
--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -43,7 +43,7 @@ filtered to a particular node:
 
     orchestrator device ls [node]
 
-Query the status of a particular service (mon, osd, mds, rgw).  For OSDs
+Query the status of a particular service (mon, osd, mgr, mds, rgw).  For OSDs
 the id is the numeric OSD ID, for MDS services it is the filesystem name:
 
 ::

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -43,6 +43,15 @@ filtered to a particular node:
 
     orchestrator device ls [node]
 
+Print a list of services known to the orchestrator. The list can be limited to
+services on a particular host with the optional --host parameter and/or
+services of a particular type via optional --type parameter
+(mon, osd, mgr, mds, rgw):
+
+::
+
+    orchestrator service ls [--host=host] [--type=type]
+
 Query the status of a particular service (mon, osd, mgr, mds, rgw).  For OSDs
 the id is the numeric OSD ID, for MDS services it is the filesystem name:
 

--- a/doc/mgr/orchestrator_modules.rst
+++ b/doc/mgr/orchestrator_modules.rst
@@ -137,7 +137,6 @@ Inventory and status
 
 .. automethod:: Orchestrator.describe_service
 .. autoclass:: ServiceDescription
-.. autoclass:: ServiceLocation
 
 OSD management
 --------------

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -154,7 +154,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def describe_service(self, service_type, service_id):
+    def describe_service(self, service_type=None, service_id=None, node_name=None):
         """
         Describe a service (of any kind) that is already configured in
         the orchestrator.  For example, when viewing an OSD in the dashboard
@@ -319,6 +319,9 @@ class ServiceLocation(object):
         # This is the <foo> in mds.<foo>, the ID that will appear
         # in the FSMap/ServiceMap.
         self.daemon_name = None
+
+        # The type of service (osd, mon, mgr, etc.)
+        self.service_type = None
 
 
 class ServiceDescription(object):

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -163,6 +163,8 @@ class Orchestrator(object):
 
         When viewing a CephFS filesystem in the dashboard, we would use this
         to display the pods being currently run for MDS daemons.
+
+        Returns a list of ServiceDescription objects.
         """
         raise NotImplementedError()
 
@@ -302,9 +304,17 @@ class PlacementSpec(object):
         self.label = None
 
 
-class ServiceLocation(object):
+class ServiceDescription(object):
     """
-    See ServiceDescription
+    For responding to queries about the status of a particular service,
+    stateful or stateless.
+
+    This is not about health or performance monitoring of services: it's
+    about letting the orchestrator tell Ceph whether and where a
+    service is scheduled in the cluster.  When an orchestrator tells
+    Ceph "it's running on node123", that's not a promise that the process
+    is literally up this second, it's a description of where the orchestrator
+    has decided the service should run.
     """
     def __init__(self):
         # Node is at the same granularity as InventoryNode
@@ -322,23 +332,6 @@ class ServiceLocation(object):
 
         # The type of service (osd, mon, mgr, etc.)
         self.service_type = None
-
-
-class ServiceDescription(object):
-    """
-    For responding to queries about the status of a particular service,
-    stateful or stateless.
-
-    This is not about health or performance monitoring of services: it's
-    about letting the orchestrator tell Ceph whether and where a 
-    service is scheduled in the cluster.  When an orchestrator tells
-    Ceph "it's running on node123", that's not a promise that the process
-    is literally up this second, it's a description of where the orchestrator
-    has decided the service should run.
-    """
-
-    def __init__(self):
-        self.locations = []
 
 
 class DriveGroupSpec(object):

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -159,14 +159,13 @@ class OrchestratorCli(MgrModule):
 
         self._wait([completion])
 
-        service_description = completion.result
-        #assert isinstance(service_description, orchestrator.ServiceDescription)
+        service_list = completion.result
 
-        if len(service_description.locations) == 0:
+        if len(service_list) == 0:
             return 0, "", "No locations reported"
         else:
             lines = []
-            for l in service_description.locations:
+            for l in service_list:
                 lines.append("{0}.{1} {2} {3}".format(
                     svc_type,
                     l.daemon_name,

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -334,7 +334,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     @deferred_read
     def describe_service(self, service_type, service_id):
 
-        assert service_type in ("mds", "osd", "mon", "rgw"), service_type + " unsupported"
+        assert service_type in ("mds", "osd", "mgr", "mon", "rgw"), service_type + " unsupported"
 
         pods = self.rook_cluster.describe_pods(service_type, service_id)
 
@@ -354,9 +354,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             elif service_type == "mon":
                 sl.daemon_name = p['labels']["mon"]
             elif service_type == "mgr":
-                # FIXME: put a label on the pod to consume
-                # from here
-                raise NotImplementedError("mgr")
+                sl.daemon_name = p['labels']["mgr"]
             elif service_type == "rgw":
                 # FIXME: put a label on the pod to consume
                 # from here

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -338,26 +338,26 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         pods = self.rook_cluster.describe_pods(service_type, service_id, nodename)
 
-        result = orchestrator.ServiceDescription()
+        result = []
         for p in pods:
-            sl = orchestrator.ServiceLocation()
-            sl.nodename = p['nodename']
-            sl.container_id = p['name']
-            sl.service_type = p['labels']['app'].replace('rook-ceph-', '')
+            sd = orchestrator.ServiceDescription()
+            sd.nodename = p['nodename']
+            sd.container_id = p['name']
+            sd.service_type = p['labels']['app'].replace('rook-ceph-', '')
 
-            if sl.service_type == "osd":
-                sl.daemon_name = "%s" % p['labels']["ceph-osd-id"]
-            elif sl.service_type == "mds":
-                sl.daemon_name = p['labels']["rook_file_system"]
-            elif sl.service_type == "mon":
-                sl.daemon_name = p['labels']["mon"]
-            elif sl.service_type == "mgr":
-                sl.daemon_name = p['labels']["mgr"]
+            if sd.service_type == "osd":
+                sd.daemon_name = "%s" % p['labels']["ceph-osd-id"]
+            elif sd.service_type == "mds":
+                sd.daemon_name = p['labels']["rook_file_system"]
+            elif sd.service_type == "mon":
+                sd.daemon_name = p['labels']["mon"]
+            elif sd.service_type == "mgr":
+                sd.daemon_name = p['labels']["mgr"]
             else:
                 # Unknown type -- skip it
                 continue
 
-            result.locations.append(sl)
+            result.append(sd)
 
         return result
 

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -347,10 +347,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             if service_type == "osd":
                 sl.daemon_name = "%s" % p['labels']["ceph-osd-id"]
             elif service_type == "mds":
-                # MDS daemon names are the tail of the pod name with
-                # an 'm' prefix.
-                # TODO: Would be nice to get this out a label though.
-                sl.daemon_name = "m" + sl.container_id.split("-")[-1]
+                sl.daemon_name = p['labels']["rook_file_system"]
             elif service_type == "mon":
                 sl.daemon_name = p['labels']["mon"]
             elif service_type == "mgr":

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -154,8 +154,7 @@ class RookCluster(object):
             # label like mon=rook-ceph-mon0
             label_filter += ",mon={0}".format(service_id)
         elif service_type == "mgr":
-            # TODO: get Rook to label mgr pods
-            pass
+            label_filter += ",mgr={0}".format(service_id)
         elif service_type == "rgw":
             # TODO: rgw
             pass

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -125,7 +125,7 @@ class RookCluster(object):
 
         return nodename_to_devices
 
-    def describe_pods(self, service_type, service_id):
+    def describe_pods(self, service_type, service_id, nodename):
         # Go query the k8s API about deployment, containers related to this
         # filesystem
 
@@ -143,25 +143,32 @@ class RookCluster(object):
         # Label filter is rook_cluster=<cluster name>
         #                 rook_file_system=<self.fs_name>
 
-        label_filter = "rook_cluster={0},app=rook-ceph-{1}".format(
-            self.cluster_name, service_type)
-        if service_type == "mds":
-            label_filter += ",rook_file_system={0}".format(service_id)
-        elif service_type == "osd":
-            # Label added in https://github.com/rook/rook/pull/1698
-            label_filter += ",ceph-osd-id={0}".format(service_id)
-        elif service_type == "mon":
-            # label like mon=rook-ceph-mon0
-            label_filter += ",mon={0}".format(service_id)
-        elif service_type == "mgr":
-            label_filter += ",mgr={0}".format(service_id)
-        elif service_type == "rgw":
-            # TODO: rgw
-            pass
+        label_filter = "rook_cluster={0}".format(self.cluster_name)
+        if service_type != None:
+            label_filter += ",app=rook-ceph-{0}".format(service_type)
+            if service_id != None:
+                if service_type == "mds":
+                    label_filter += ",rook_file_system={0}".format(service_id)
+                elif service_type == "osd":
+                    # Label added in https://github.com/rook/rook/pull/1698
+                    label_filter += ",ceph-osd-id={0}".format(service_id)
+                elif service_type == "mon":
+                    # label like mon=rook-ceph-mon0
+                    label_filter += ",mon={0}".format(service_id)
+                elif service_type == "mgr":
+                    label_filter += ",mgr={0}".format(service_id)
+                elif service_type == "rgw":
+                    # TODO: rgw
+                    pass
+
+        field_filter = ""
+        if nodename != None:
+            field_filter = "spec.nodeName={0}".format(nodename);
 
         pods = self.k8s.list_namespaced_pod(
             self.rook_namespace,
-            label_selector=label_filter)
+            label_selector=label_filter,
+            field_selector=field_filter)
 
         # import json
         # print json.dumps(pods.items[0])


### PR DESCRIPTION
This starts with a couple of small bugfixes to the rook orchestrator backend, and then adds a new orchestrator_cli command and the necessary code for rook to implement it. Tested on my own test rig against some bleeding-edge rook images and they seem to do the right thing.