### PR TITLE
doc/rados/operations/crush-map-edits: fix 'take' syntax

### DIFF
--- a/doc/rados/operations/crush-map-edits.rst
+++ b/doc/rados/operations/crush-map-edits.rst
@@ -377,7 +377,7 @@ A rule takes the following form::
 		min_size <min-size>
 		max_size <max-size>
 		step take <bucket-name> [class <device-class>]
-		step [choose|chooseleaf] [firstn|indep] <N> <bucket-type>
+		step [choose|chooseleaf] [firstn|indep] <N> type <bucket-type>
 		step emit
 	}
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/21496
Signed-off-by: Remy Zandwijk <remy@luckyhands.nl>
Signed-off-by: Sage Weil <sage@redhat.com>