### PR TITLE
jewel:mon:fix Monitor::_get_moncommand

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2524,12 +2524,29 @@ void Monitor::_generate_command_map(map<string,cmd_vartype>& cmdmap,
 }
 
 const MonCommand *Monitor::_get_moncommand(const string &cmd_prefix,
-                                           MonCommand *cmds, int cmds_size)
+                                           MonCommand *cmds, int cmds_size,map<string,cmd_vartype> cmdmap)
 {
   MonCommand *this_cmd = NULL;
   for (MonCommand *cp = cmds;
        cp < &cmds[cmds_size]; cp++) {
     if (cp->cmdstring.compare(0, cmd_prefix.size(), cmd_prefix) == 0) {
+		bool found_cmd = true;
+		for(map<string,cmd_vartype>::iterator it = cmdmap.begin(); it != cmdmap.end(); it++)
+		{
+			if(it->first == "prefix" || it->first == "format")
+				continue;
+			else
+			{
+				string kvstr = "name="+it->first;
+				if(cp->cmdstring.find(kvstr) == string::npos)
+				{
+					found_cmd = false;
+					break;
+				}
+			}
+		}
+		if(!found_cmd)
+			continue;
       this_cmd = cp;
       break;
     }
@@ -2701,14 +2718,14 @@ void Monitor::handle_command(MonOpRequestRef op)
   leader_cmd = _get_moncommand(prefix,
                                // the boost underlying this isn't const for some reason
                                const_cast<MonCommand*>(leader_supported_mon_commands),
-                               leader_supported_mon_commands_size);
+                               leader_supported_mon_commands_size,cmdmap);
   if (!leader_cmd) {
     reply_command(op, -EINVAL, "command not known", 0);
     return;
   }
   // validate command is in our map & matches, or forward if it is allowed
   const MonCommand *mon_cmd = _get_moncommand(prefix, mon_commands,
-                                              ARRAY_SIZE(mon_commands));
+                                              ARRAY_SIZE(mon_commands),cmdmap);
   if (!is_leader()) {
     if (!mon_cmd) {
       if (leader_cmd->is_noforward()) {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -669,7 +669,7 @@ public:
   static void _generate_command_map(map<string,cmd_vartype>& cmdmap,
                                     map<string,string> &param_str_map);
   static const MonCommand *_get_moncommand(const string &cmd_prefix,
-                                           MonCommand *cmds, int cmds_size);
+                                           MonCommand *cmds, int cmds_size,map<string,cmd_vartype> cmdmap);
   bool _allowed_command(MonSession *s, string &module, string &prefix,
                         const map<string,cmd_vartype>& cmdmap,
                         const map<string,string>& param_str_map,


### PR DESCRIPTION
Modify Monitor::_get_moncommand.Just use prefix to locate the cmd is not appropriate.

Because some cmds have the same prefix buf not the same authority like "osd blacklist ls" and "osd blacklist add".
So I add cmdmap to locate the certain cmd.
Signed-off-by: Guang Yang Developer <pyrl247@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

