### PR TITLE
rgw: es: fix doc dump etag

### DIFF
--- a/src/rgw/rgw_sync_module_es.cc
+++ b/src/rgw/rgw_sync_module_es.cc
@@ -312,6 +312,8 @@ struct es_obj_metadata {
         auto vals_bl = val.cbegin();
         decode(cs_info, vals_bl);
         out_attrs[name] = cs_info.compression_type;
+      } else if (name == "etag") {
+        out_attrs[name] = string(val.c_str(), val.length());
       } else {
         if (name != "pg_ver" &&
             name != "source_zone" &&


### PR DESCRIPTION
etag store without last '\0', es doc dump should change also

Fixes: http://tracker.ceph.com/issues/36670

Signed-off-by: Tianshan Qu <tianshan@xsky.com>