### PR TITLE
rgw: RGWHTTP::send support send_data to fix es search

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -1197,11 +1197,11 @@ void rgw_http_client_cleanup()
 }
 
 
-int RGWHTTP::send(RGWHTTPClient *req) {
+int RGWHTTP::send(RGWHTTPClient *req, bool send_data_hint) {
   if (!req) {
     return 0;
   }
-  int r = rgw_http_manager->add_request(req);
+  int r = rgw_http_manager->add_request(req, send_data_hint);
   if (r < 0) {
     return r;
   }
@@ -1209,11 +1209,11 @@ int RGWHTTP::send(RGWHTTPClient *req) {
   return 0;
 }
 
-int RGWHTTP::process(RGWHTTPClient *req) {
+int RGWHTTP::process(RGWHTTPClient *req, bool send_data_hint) {
   if (!req) {
     return 0;
   }
-  int r = send(req);
+  int r = send(req, send_data_hint);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -355,7 +355,7 @@ public:
 class RGWHTTP
 {
 public:
-  static int send(RGWHTTPClient *req);
-  static int process(RGWHTTPClient *req);
+  static int send(RGWHTTPClient *req, bool send_data_hint = false);
+  static int process(RGWHTTPClient *req, bool send_data_hint = false);
 };
 #endif

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -785,7 +785,7 @@ int RGWRESTStreamRWRequest::send_request(RGWAccessKey *key, map<string, string>&
 int RGWRESTStreamRWRequest::send(RGWHTTPManager *mgr)
 {
   if (!mgr) {
-    return RGWHTTP::send(this);
+    return RGWHTTP::send(this, send_data_hint);
   }
 
   int r = mgr->add_request(this, send_data_hint);


### PR DESCRIPTION
es search will send query in body, need send_data_hint

Fixes: http://tracker.ceph.com/issues/36671

Signed-off-by: Tianshan Qu <tianshan@xsky.com>