### PR TITLE
common: hypercombined bufferlist

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9255,9 +9255,9 @@ int Client::_read_sync(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
 	int64_t some = in->size - pos;
 	if (some > left)
 	  some = left;
-	auto& z = buffer::ptr_node::create(some);
-	z.zero();
-	bl->push_back(z);
+	auto z = buffer::ptr_node::create(some);
+	z->zero();
+	bl->push_back(std::move(z));
 	read += some;
 	pos += some;
 	left -= some;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9255,7 +9255,7 @@ int Client::_read_sync(Fh *f, uint64_t off, uint64_t len, bufferlist *bl,
 	int64_t some = in->size - pos;
 	if (some > left)
 	  some = left;
-	bufferptr z(some);
+	auto& z = buffer::ptr_node::create(some);
 	z.zero();
 	bl->push_back(z);
 	read += some;
@@ -13174,10 +13174,10 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
   }
   object_t oid = file_object_t(vino.ino, blockid);
   SnapContext fakesnap;
-  bufferptr bp;
-  if (length > 0) bp = buffer::copy(buf, length);
-  bufferlist bl;
-  bl.push_back(bp);
+  ceph::bufferlist bl;
+  if (length > 0) {
+    bl.push_back(buffer::copy(buf, length));
+  }
 
   ldout(cct, 1) << "ll_block_write for " << vino.ino << "." << blockid
 		<< dendl;

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1085,7 +1085,7 @@ using namespace ceph;
     if (p == ls->end())
       seek(off);
     unsigned left = len;
-    for (std::list<ptr>::const_iterator i = otherl._buffers.begin();
+    for (buffers_t::const_iterator i = otherl._buffers.begin();
 	 i != otherl._buffers.end();
 	 ++i) {
       unsigned l = (*i).length();
@@ -1127,8 +1127,8 @@ using namespace ceph;
 
     // buffer-wise comparison
     if (true) {
-      std::list<ptr>::const_iterator a = _buffers.begin();
-      std::list<ptr>::const_iterator b = other._buffers.begin();
+      buffers_t::const_iterator a = _buffers.begin();
+      buffers_t::const_iterator b = other._buffers.begin();
       unsigned aoff = 0, boff = 0;
       while (a != _buffers.end()) {
 	unsigned len = a->length() - aoff;
@@ -1174,7 +1174,7 @@ using namespace ceph;
 
   bool buffer::list::is_aligned(unsigned align) const
   {
-    for (std::list<ptr>::const_iterator it = _buffers.begin();
+    for (buffers_t::const_iterator it = _buffers.begin();
 	 it != _buffers.end();
 	 ++it) 
       if (!it->is_aligned(align))
@@ -1184,7 +1184,7 @@ using namespace ceph;
 
   bool buffer::list::is_n_align_sized(unsigned align) const
   {
-    for (std::list<ptr>::const_iterator it = _buffers.begin();
+    for (buffers_t::const_iterator it = _buffers.begin();
 	 it != _buffers.end();
 	 ++it) 
       if (!it->is_n_align_sized(align))
@@ -1195,7 +1195,7 @@ using namespace ceph;
   bool buffer::list::is_aligned_size_and_memory(unsigned align_size,
 						  unsigned align_memory) const
   {
-    for (std::list<ptr>::const_iterator it = _buffers.begin();
+    for (buffers_t::const_iterator it = _buffers.begin();
 	 it != _buffers.end();
 	 ++it) {
       if (!it->is_aligned(align_memory) || !it->is_n_align_sized(align_size))
@@ -1205,7 +1205,7 @@ using namespace ceph;
   }
 
   bool buffer::list::is_zero() const {
-    for (std::list<ptr>::const_iterator it = _buffers.begin();
+    for (buffers_t::const_iterator it = _buffers.begin();
 	 it != _buffers.end();
 	 ++it) {
       if (!it->is_zero()) {
@@ -1217,7 +1217,7 @@ using namespace ceph;
 
   void buffer::list::zero()
   {
-    for (std::list<ptr>::iterator it = _buffers.begin();
+    for (buffers_t::iterator it = _buffers.begin();
 	 it != _buffers.end();
 	 ++it)
       it->zero();
@@ -1227,7 +1227,7 @@ using namespace ceph;
   {
     ceph_assert(o+l <= _len);
     unsigned p = 0;
-    for (std::list<ptr>::iterator it = _buffers.begin();
+    for (buffers_t::iterator it = _buffers.begin();
 	 it != _buffers.end();
 	 ++it) {
       if (p + it->length() > o) {
@@ -1341,7 +1341,7 @@ using namespace ceph;
   void buffer::list::rebuild(ptr& nb)
   {
     unsigned pos = 0;
-    for (std::list<ptr>::iterator it = _buffers.begin();
+    for (buffers_t::iterator it = _buffers.begin();
 	 it != _buffers.end();
 	 ++it) {
       nb.copy_in(pos, it->length(), it->c_str(), false);
@@ -1370,7 +1370,7 @@ using namespace ceph;
 	&& _len > (max_buffers * align_size)) {
       align_size = round_up_to(round_up_to(_len, max_buffers) / max_buffers, align_size);
     }
-    std::list<ptr>::iterator p = _buffers.begin();
+    buffers_t::iterator p = _buffers.begin();
     while (p != _buffers.end()) {
       // keep anything that's already align and sized aligned
       if (p->is_aligned(align_memory) && p->is_n_align_sized(align_size)) {
@@ -1395,7 +1395,7 @@ using namespace ceph;
         */
         offset += p->length();
         unaligned.push_back(*p);
-        _buffers.erase(p++);
+        p = _buffers.erase(p);
       } while (p != _buffers.end() &&
   	     (!p->is_aligned(align_memory) ||
   	      !p->is_n_align_sized(align_size) ||
@@ -1439,7 +1439,9 @@ using namespace ceph;
     _len += bl._len;
     if (!(flags & CLAIM_ALLOW_NONSHAREABLE))
       bl.make_shareable();
-    _buffers.splice(_buffers.end(), bl._buffers );
+    std::move(bl._buffers.begin(), bl._buffers.end(),
+      std::back_inserter(_buffers));
+    bl._buffers.clear();
     bl._len = 0;
     bl.last_p = bl.begin();
   }
@@ -1447,7 +1449,7 @@ using namespace ceph;
   void buffer::list::claim_append_piecewise(list& bl)
   {
     // steal the other guy's buffers
-    for (std::list<buffer::ptr>::const_iterator i = bl.buffers().begin();
+    for (buffers_t::const_iterator i = bl.buffers().begin();
         i != bl.buffers().end(); ++i) {
       append(*i, 0, i->length());
     }
@@ -1567,7 +1569,7 @@ using namespace ceph;
   void buffer::list::append(const list& bl)
   {
     _len += bl._len;
-    for (std::list<ptr>::const_iterator p = bl._buffers.begin();
+    for (buffers_t::const_iterator p = bl._buffers.begin();
 	 p != bl._buffers.end();
 	 ++p) 
       _buffers.push_back(*p);
@@ -1635,7 +1637,7 @@ using namespace ceph;
     if (n >= _len)
       throw end_of_buffer();
     
-    for (std::list<ptr>::const_iterator p = _buffers.begin();
+    for (buffers_t::const_iterator p = _buffers.begin();
 	 p != _buffers.end();
 	 ++p) {
       if (n >= p->length()) {
@@ -1655,7 +1657,7 @@ using namespace ceph;
     if (_buffers.empty())
       return 0;                         // no buffers
 
-    std::list<ptr>::const_iterator iter = _buffers.begin();
+    buffers_t::const_iterator iter = _buffers.begin();
     ++iter;
 
     if (iter != _buffers.end())
@@ -1666,7 +1668,7 @@ using namespace ceph;
   string buffer::list::to_str() const {
     string s;
     s.reserve(length());
-    for (std::list<ptr>::const_iterator p = _buffers.begin();
+    for (buffers_t::const_iterator p = _buffers.begin();
 	 p != _buffers.end();
 	 ++p) {
       if (p->length()) {
@@ -1684,7 +1686,7 @@ using namespace ceph;
     clear();
 
     // skip off
-    std::list<ptr>::const_iterator curbuf = other._buffers.begin();
+    buffers_t::const_iterator curbuf = other._buffers.begin();
     while (off > 0 &&
 	   off >= curbuf->length()) {
       // skip this buffer
@@ -1727,7 +1729,7 @@ using namespace ceph;
     //cout << "splice off " << off << " len " << len << " ... mylen = " << length() << std::endl;
       
     // skip off
-    std::list<ptr>::iterator curbuf = _buffers.begin();
+    buffers_t::iterator curbuf = _buffers.begin();
     while (off > 0) {
       ceph_assert(curbuf != _buffers.end());
       if (off >= (*curbuf).length()) {
@@ -1769,7 +1771,7 @@ using namespace ceph;
       if (claim_by) 
 	claim_by->append( *curbuf, off, howmuch );
       _len -= (*curbuf).length();
-      _buffers.erase( curbuf++ );
+      curbuf = _buffers.erase( curbuf );
       len -= howmuch;
       off = 0;
     }
@@ -1783,7 +1785,7 @@ using namespace ceph;
   {
     list s;
     s.substr_of(*this, off, len);
-    for (std::list<ptr>::const_iterator it = s._buffers.begin(); 
+    for (buffers_t::const_iterator it = s._buffers.begin(); 
 	 it != s._buffers.end(); 
 	 ++it)
       if (it->length())
@@ -1949,7 +1951,7 @@ int buffer::list::write_fd(int fd) const
   int iovlen = 0;
   ssize_t bytes = 0;
 
-  std::list<ptr>::const_iterator p = _buffers.begin();
+  buffers_t::const_iterator p = _buffers.begin();
   while (p != _buffers.end()) {
     if (p->length() > 0) {
       iov[iovlen].iov_base = (void *)p->c_str();
@@ -1998,7 +2000,7 @@ int buffer::list::write_fd(int fd, uint64_t offset) const
 {
   iovec iov[IOV_MAX];
 
-  std::list<ptr>::const_iterator p = _buffers.begin();
+  buffers_t::const_iterator p = _buffers.begin();
   uint64_t left_pbrs = _buffers.size();
   while (left_pbrs) {
     ssize_t bytes = 0;
@@ -2028,7 +2030,7 @@ __u32 buffer::list::crc32c(__u32 crc) const
   int cache_hits = 0;
   int cache_adjusts = 0;
 
-  for (std::list<ptr>::const_iterator it = _buffers.begin();
+  for (buffers_t::const_iterator it = _buffers.begin();
        it != _buffers.end();
        ++it) {
     if (it->length()) {
@@ -2075,7 +2077,7 @@ __u32 buffer::list::crc32c(__u32 crc) const
 
 void buffer::list::invalidate_crc()
 {
-  for (std::list<ptr>::const_iterator p = _buffers.begin(); p != _buffers.end(); ++p) {
+  for (buffers_t::const_iterator p = _buffers.begin(); p != _buffers.end(); ++p) {
     raw *r = p->get_raw();
     if (r) {
       r->invalidate_crc();
@@ -2102,7 +2104,7 @@ sha1_digest_t buffer::list::sha1()
  */
 void buffer::list::write_stream(std::ostream &out) const
 {
-  for (std::list<ptr>::const_iterator p = _buffers.begin(); p != _buffers.end(); ++p) {
+  for (buffers_t::const_iterator p = _buffers.begin(); p != _buffers.end(); ++p) {
     if (p->length() > 0) {
       out.write(p->c_str(), p->length());
     }
@@ -2219,7 +2221,7 @@ std::ostream& buffer::operator<<(std::ostream& out, const buffer::ptr& bp) {
 std::ostream& buffer::operator<<(std::ostream& out, const buffer::list& bl) {
   out << "buffer::list(len=" << bl.length() << "," << std::endl;
 
-  std::list<buffer::ptr>::const_iterator it = bl.buffers().begin();
+  buffer::list::buffers_t::const_iterator it = bl.buffers().begin();
   while (it != bl.buffers().end()) {
     out << "\t" << *it;
     if (++it == bl.buffers().end()) break;

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1599,7 +1599,7 @@ using namespace ceph;
     append_buffer.set_length(append_buffer.length() + len);
     append(append_buffer, append_buffer.length() - len, len);
 
-    return { std::prev(std::end(_buffers))->end_c_str() - len };
+    return { _buffers.back().end_c_str() - len };
   }
 
   void buffer::list::prepend_zero(unsigned len)

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1256,7 +1256,7 @@ using namespace ceph;
 
   bool buffer::list::is_contiguous() const
   {
-    return &(*_buffers.begin()) == &(*_buffers.rbegin());
+    return _buffers.size() <= 1;
   }
 
   bool buffer::list::is_n_page_sized() const
@@ -1326,7 +1326,7 @@ using namespace ceph;
   void buffer::list::rebuild()
   {
     if (_len == 0) {
-      _buffers.clear_and_dispose(ptr_node::disposer());
+      _buffers.clear_and_dispose();
       return;
     }
     if ((_len & ~CEPH_PAGE_MASK) == 0)
@@ -1344,7 +1344,7 @@ using namespace ceph;
       pos += node.length();
     }
     _memcopy_count += pos;
-    _buffers.clear_and_dispose(ptr_node::disposer());
+    _buffers.clear_and_dispose();
     if (likely(nb->length())) {
       _buffers.push_back(*nb.release());
     }
@@ -1764,7 +1764,7 @@ using namespace ceph;
       if (claim_by) 
 	claim_by->append( *curbuf, off, howmuch );
       _len -= (*curbuf).length();
-      curbuf = _buffers.erase_and_dispose( curbuf, ptr_node::disposer() );
+      curbuf = _buffers.erase_and_dispose(curbuf);
       len -= howmuch;
       off = 0;
     }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1335,19 +1335,18 @@ using namespace ceph;
       rebuild(ptr_node::create(buffer::create(_len)));
   }
 
-  void buffer::list::rebuild(ptr_node& nb)
+  void buffer::list::rebuild(
+    std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer> nb)
   {
     unsigned pos = 0;
     for (auto& node : _buffers) {
-      nb.copy_in(pos, node.length(), node.c_str(), false);
+      nb->copy_in(pos, node.length(), node.c_str(), false);
       pos += node.length();
     }
     _memcopy_count += pos;
     _buffers.clear_and_dispose(ptr_node::disposer());
-    if (likely(nb.length())) {
-      _buffers.push_back(nb);
-    } else {
-      ptr_node::disposer()(&nb);
+    if (likely(nb->length())) {
+      _buffers.push_back(*nb.release());
     }
     invalidate_crc();
     last_p = begin();
@@ -1407,7 +1406,7 @@ using namespace ceph;
             buffer::create_aligned(unaligned._len, align_memory)));
         _memcopy_count += unaligned._len;
       }
-      _buffers.insert(p, ptr_node::create(unaligned._buffers.front()));
+      _buffers.insert(p, *ptr_node::create(unaligned._buffers.front()).release());
     }
     last_p = begin();
 
@@ -1569,7 +1568,7 @@ using namespace ceph;
   {
     _len += bl._len;
     for (const auto& node : bl._buffers) {
-      _buffers.push_back(ptr_node::create(node));
+      _buffers.push_back(*ptr_node::create(node).release());
     }
   }
 
@@ -1605,10 +1604,10 @@ using namespace ceph;
 
   void buffer::list::prepend_zero(unsigned len)
   {
-    auto& bp = ptr_node::create(len);
-    bp.zero(false);
+    auto bp = ptr_node::create(len);
+    bp->zero(false);
     _len += len;
-    _buffers.push_front(bp);
+    _buffers.push_front(*bp.release());
   }
   
   void buffer::list::append_zero(unsigned len)
@@ -1620,10 +1619,9 @@ using namespace ceph;
       len -= need;
     }
     if (len) {
-      auto& bp = ptr_node::create(buffer::create_page_aligned(len));
-      bp.zero(false);
-      _len += bp.length();
-      _buffers.push_back(bp);
+      auto bp = ptr_node::create(buffer::create_page_aligned(len));
+      bp->zero(false);
+      push_back(std::move(bp));
     }
   }
 
@@ -1695,7 +1693,7 @@ using namespace ceph;
       // partial?
       if (off + len < curbuf->length()) {
 	//cout << "copying partial of " << *curbuf << std::endl;
-	_buffers.push_back( ptr_node::create( *curbuf, off, len ) );
+	_buffers.push_back(*ptr_node::create( *curbuf, off, len ).release());
 	_len += len;
 	break;
       }
@@ -1703,7 +1701,7 @@ using namespace ceph;
       // through end
       //cout << "copying end (all?) of " << *curbuf << std::endl;
       unsigned howmuch = curbuf->length() - off;
-      _buffers.push_back( ptr_node::create( *curbuf, off, howmuch ) );
+      _buffers.push_back(*ptr_node::create( *curbuf, off, howmuch ).release());
       _len += howmuch;
       len -= howmuch;
       off = 0;
@@ -1743,7 +1741,7 @@ using namespace ceph;
       // add a reference to the front bit
       //  insert it before curbuf (which we'll hose)
       //cout << "keeping front " << off << " of " << *curbuf << std::endl;
-      _buffers.insert( curbuf, ptr_node::create( *curbuf, 0, off ) );
+      _buffers.insert( curbuf, *ptr_node::create( *curbuf, 0, off ).release());
       _len += off;
     }
     
@@ -1858,11 +1856,11 @@ int buffer::list::read_file(const char *fn, std::string *error)
 
 ssize_t buffer::list::read_fd(int fd, size_t len)
 {
-  auto& bp = ptr_node::create(buffer::create(len));
-  ssize_t ret = safe_read(fd, (void*)bp.c_str(), len);
+  auto bp = ptr_node::create(buffer::create(len));
+  ssize_t ret = safe_read(fd, (void*)bp->c_str(), len);
   if (ret >= 0) {
-    bp.set_length(ret);
-    push_back(bp);
+    bp->set_length(ret);
+    push_back(std::move(bp));
   }
   return ret;
 }
@@ -2198,13 +2196,15 @@ bool buffer::ptr_node::dispose_if_hypercombined(
   return is_hypercombined;
 }
 
-buffer::ptr_node& buffer::ptr_node::create_hypercombined(
-  buffer::raw* const r)
+std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>
+buffer::ptr_node::create_hypercombined(buffer::raw* const r)
 {
   if (likely(r->nref == 0)) {
-    return *new (&r->bptr_storage) ptr_node(r);
+    return std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>(
+      new (&r->bptr_storage) ptr_node(r));
   } else {
-    return *new ptr_node(r);
+    return std::unique_ptr<buffer::ptr_node, buffer::ptr_node::disposer>(
+      new ptr_node(r));
   }
 }
 

--- a/src/compressor/zlib/ZlibCompressor.cc
+++ b/src/compressor/zlib/ZlibCompressor.cc
@@ -66,7 +66,7 @@ int ZlibCompressor::zlib_compress(const bufferlist &in, bufferlist &out)
     return -1;
   }
 
-  for (std::list<buffer::ptr>::const_iterator i = in.buffers().begin();
+  for (ceph::bufferlist::buffers_t::const_iterator i = in.buffers().begin();
       i != in.buffers().end();) {
 
     c_in = (unsigned char*) (*i).c_str();
@@ -120,7 +120,7 @@ int ZlibCompressor::isal_compress(const bufferlist &in, bufferlist &out)
   isal_deflate_init(&strm);
   strm.end_of_stream = 0;
 
-  for (std::list<buffer::ptr>::const_iterator i = in.buffers().begin();
+  for (ceph::bufferlist::buffers_t::const_iterator i = in.buffers().begin();
       i != in.buffers().end();) {
 
     c_in = (unsigned char*) (*i).c_str();

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -384,16 +384,17 @@ namespace buffer CEPH_BUFFER_API {
    */
 
   class CEPH_BUFFER_API list {
+  public:
+    typedef std::list<ptr> buffers_t;
+    class iterator;
+
+  private:
     // my private bits
-    std::list<ptr> _buffers;
+    buffers_t _buffers;
     unsigned _len;
     unsigned _memcopy_count; //the total of memcopy using rebuild().
     ptr append_buffer;  // where i put small appends.
 
-  public:
-    class iterator;
-
-  private:
     template <bool is_const>
     class CEPH_BUFFER_API iterator_impl {
     protected:
@@ -401,11 +402,11 @@ namespace buffer CEPH_BUFFER_API {
 					const list,
 					list>::type bl_t;
       typedef typename std::conditional<is_const,
-					const std::list<ptr>,
-					std::list<ptr> >::type list_t;
+					const buffers_t,
+					buffers_t >::type list_t;
       typedef typename std::conditional<is_const,
-					typename std::list<ptr>::const_iterator,
-					typename std::list<ptr>::iterator>::type list_iter_t;
+					typename buffers_t::const_iterator,
+					typename buffers_t::iterator>::type list_iter_t;
       using iterator_category = std::forward_iterator_tag;
       using value_type = typename std::conditional<is_const, const char, char>::type;
       using difference_type = std::ptrdiff_t;
@@ -740,7 +741,7 @@ namespace buffer CEPH_BUFFER_API {
     }
 
     unsigned get_memcopy_count() const {return _memcopy_count; }
-    const std::list<ptr>& buffers() const { return _buffers; }
+    const buffers_t& buffers() const { return _buffers; }
     void swap(list& other) noexcept;
     unsigned length() const {
 #if 0
@@ -823,7 +824,7 @@ namespace buffer CEPH_BUFFER_API {
 
     // clone non-shareable buffers (make shareable)
     void make_shareable() {
-      std::list<buffer::ptr>::iterator pb;
+      decltype(_buffers)::iterator pb;
       for (pb = _buffers.begin(); pb != _buffers.end(); ++pb) {
         (void) pb->make_shareable();
       }
@@ -834,7 +835,7 @@ namespace buffer CEPH_BUFFER_API {
     {
       if (this != &bl) {
         clear();
-        std::list<buffer::ptr>::const_iterator pb;
+        decltype(_buffers)::const_iterator pb;
         for (pb = bl._buffers.begin(); pb != bl._buffers.end(); ++pb) {
           push_back(*pb);
         }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -828,6 +828,12 @@ namespace buffer CEPH_BUFFER_API {
       _len += bp.length();
       _buffers.push_back(ptr_node::create(std::move(bp)));
     }
+    void push_back(ptr_node& bp) {
+      if (bp.length() == 0)
+	return;
+      _len += bp.length();
+      _buffers.push_back(bp);
+    }
     void push_back(raw *r) {
       _buffers.push_back(ptr_node::create(r));
       _len += _buffers.back().length();
@@ -838,7 +844,7 @@ namespace buffer CEPH_BUFFER_API {
 
     bool is_contiguous() const;
     void rebuild();
-    void rebuild(ptr& nb);
+    void rebuild(ptr_node& nb);
     bool rebuild_aligned(unsigned align);
     // max_buffers = 0 mean don't care _buffers.size(), other
     // must make _buffers.size() <= max_buffers after rebuilding.

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -384,35 +384,7 @@ namespace buffer CEPH_BUFFER_API {
 
 
   class ptr_node : public ptr, public boost::intrusive::list_base_hook<> {
-    template <class... Args>
-    ptr_node(Args&&... args) : ptr(std::forward<Args>(args)...) {
-    }
-    ptr_node(const ptr_node&) = default;
-
-    ptr& operator= (const ptr& p) = delete;
-    ptr& operator= (ptr&& p) noexcept = delete;
-    ptr_node& operator= (const ptr_node& p) = delete;
-    ptr_node& operator= (ptr_node&& p) noexcept = delete;
-    void swap(ptr& other) noexcept = delete;
-    void swap(ptr_node& other) noexcept = delete;
-
   public:
-    ~ptr_node() = default;
-
-    static bool dispose_if_hypercombined(ptr_node* delete_this);
-    static ptr_node& create_hypercombined(raw* r);
-
-    static ptr_node& create(raw* const r) {
-      return create_hypercombined(r);
-    }
-    static ptr_node& create(const unsigned l) {
-      return create_hypercombined(buffer::create(l));
-    }
-    template <class... Args>
-    static ptr_node& create(Args&&... args) {
-      return *new ptr_node(std::forward<Args>(args)...);
-    }
-
     struct cloner {
       ptr_node* operator()(const ptr_node& clone_this) {
 	return new ptr_node(clone_this);
@@ -425,6 +397,36 @@ namespace buffer CEPH_BUFFER_API {
 	}
       }
     };
+
+    ~ptr_node() = default;
+
+    static std::unique_ptr<ptr_node, disposer> create(raw* const r) {
+      return create_hypercombined(r);
+    }
+    static std::unique_ptr<ptr_node, disposer> create(const unsigned l) {
+      return create_hypercombined(buffer::create(l));
+    }
+    template <class... Args>
+    static std::unique_ptr<ptr_node, disposer> create(Args&&... args) {
+      return std::unique_ptr<ptr_node, disposer>(
+	new ptr_node(std::forward<Args>(args)...));
+    }
+
+  private:
+    template <class... Args>
+    ptr_node(Args&&... args) : ptr(std::forward<Args>(args)...) {
+    }
+    ptr_node(const ptr_node&) = default;
+
+    ptr& operator= (const ptr& p) = delete;
+    ptr& operator= (ptr&& p) noexcept = delete;
+    ptr_node& operator= (const ptr_node& p) = delete;
+    ptr_node& operator= (ptr_node&& p) noexcept = delete;
+    void swap(ptr& other) noexcept = delete;
+    void swap(ptr_node& other) noexcept = delete;
+
+    static bool dispose_if_hypercombined(ptr_node* delete_this);
+    static std::unique_ptr<ptr_node, disposer> create_hypercombined(raw* r);
   };
   /*
    * list - the useful bit!
@@ -838,23 +840,26 @@ namespace buffer CEPH_BUFFER_API {
     void push_back(const ptr& bp) {
       if (bp.length() == 0)
 	return;
-      _buffers.push_back(ptr_node::create(bp));
+      _buffers.push_back(*ptr_node::create(bp).release());
       _len += bp.length();
     }
     void push_back(ptr&& bp) {
       if (bp.length() == 0)
 	return;
       _len += bp.length();
-      _buffers.push_back(ptr_node::create(std::move(bp)));
+      _buffers.push_back(*ptr_node::create(std::move(bp)).release());
     }
-    void push_back(ptr_node& bp) {
-      if (bp.length() == 0)
+    void push_back(const ptr_node&) = delete;
+    void push_back(ptr_node&) = delete;
+    void push_back(ptr_node&&) = delete;
+    void push_back(std::unique_ptr<ptr_node, ptr_node::disposer> bp) {
+      if (bp->length() == 0)
 	return;
-      _len += bp.length();
-      _buffers.push_back(bp);
+      _len += bp->length();
+      _buffers.push_back(*bp.release());
     }
     void push_back(raw* const r) {
-      _buffers.push_back(ptr_node::create(r));
+      _buffers.push_back(*ptr_node::create(r).release());
       _len += _buffers.back().length();
     }
 
@@ -863,7 +868,7 @@ namespace buffer CEPH_BUFFER_API {
 
     bool is_contiguous() const;
     void rebuild();
-    void rebuild(ptr_node& nb);
+    void rebuild(std::unique_ptr<ptr_node, ptr_node::disposer> nb);
     bool rebuild_aligned(unsigned align);
     // max_buffers = 0 mean don't care _buffers.size(), other
     // must make _buffers.size() <= max_buffers after rebuilding.
@@ -896,9 +901,8 @@ namespace buffer CEPH_BUFFER_API {
     {
       if (this != &bl) {
         clear();
-        decltype(_buffers)::const_iterator pb;
-        for (pb = bl._buffers.begin(); pb != bl._buffers.end(); ++pb) {
-          push_back(*pb);
+	for (const auto& pb : bl._buffers) {
+          push_back(static_cast<const ptr&>(pb));
         }
       }
     }

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -28,7 +28,8 @@ namespace ceph::buffer {
   public:
     // In the future we might want to have a slab allocator here with few
     // embedded slots. This would allow to avoid the "if" in dtor of ptr_node.
-    std::aligned_storage_t<sizeof(ptr_node), alignof(ptr_node)> bptr_storage;
+    std::aligned_storage<sizeof(ptr_node),
+			 alignof(ptr_node)>::type bptr_storage;
     char *data;
     unsigned len;
     std::atomic<unsigned> nref { 0 };

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <map>
 #include <utility>
+#include <type_traits>
 #include "include/buffer.h"
 #include "include/mempool.h"
 #include "include/spinlock.h"
@@ -25,6 +26,9 @@
 namespace ceph::buffer {
   class raw {
   public:
+    // In the future we might want to have a slab allocator here with few
+    // embedded slots. This would allow to avoid the "if" in dtor of ptr_node.
+    std::aligned_storage_t<sizeof(ptr_node), alignof(ptr_node)> bptr_storage;
     char *data;
     unsigned len;
     std::atomic<unsigned> nref { 0 };
@@ -36,7 +40,7 @@ namespace ceph::buffer {
     mutable ceph::spinlock crc_spinlock;
 
     explicit raw(unsigned l, int mempool=mempool::mempool_buffer_anon)
-      : data(NULL), len(l), nref(0), mempool(mempool) {
+      : data(nullptr), len(l), nref(0), mempool(mempool) {
       mempool::get_pool(mempool::pool_index_t(mempool)).adjust_count(1, len);
     }
     raw(char *c, unsigned l, int mempool=mempool::mempool_buffer_anon)

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -255,10 +255,9 @@ void LevelDBStore::LevelDBTransactionImpl::set(
     // make sure the buffer isn't too large or we might crash here...    
     char* slicebuf = (char*) alloca(bllen);
     leveldb::Slice newslice(slicebuf, bllen);
-    ceph::bufferlist::buffers_t::const_iterator pb;
-    for (pb = to_set_bl.buffers().begin(); pb != to_set_bl.buffers().end(); ++pb) {
-      size_t ptrlen = (*pb).length();
-      memcpy((void*)slicebuf, (*pb).c_str(), ptrlen);
+    for (const auto& node : to_set_bl.buffers()) {
+      const size_t ptrlen = node.length();
+      memcpy(static_cast<void*>(slicebuf), node.c_str(), ptrlen);
       slicebuf += ptrlen;
     } 
     bat.Put(leveldb::Slice(key), newslice);

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -255,7 +255,7 @@ void LevelDBStore::LevelDBTransactionImpl::set(
     // make sure the buffer isn't too large or we might crash here...    
     char* slicebuf = (char*) alloca(bllen);
     leveldb::Slice newslice(slicebuf, bllen);
-    std::list<buffer::ptr>::const_iterator pb;
+    ceph::bufferlist::buffers_t::const_iterator pb;
     for (pb = to_set_bl.buffers().begin(); pb != to_set_bl.buffers().end(); ++pb) {
       size_t ptrlen = (*pb).length();
       memcpy((void*)slicebuf, (*pb).c_str(), ptrlen);

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1427,7 +1427,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       });
       auto gather_ctx = new C_Gather(m_dest->cct, end_op_ctx);
 
-      bufferptr m_ptr(m_bl->length());
+      auto& m_ptr = buffer::ptr_node::create(m_bl->length());
       m_bl->rebuild(m_ptr);
       size_t write_offset = 0;
       size_t write_length = 0;
@@ -1440,7 +1440,8 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
 				     &write_offset,
 				     &write_length,
 				     &offset)) {
-	  bufferptr write_ptr(m_ptr, write_offset, write_length);
+	  auto& write_ptr = \
+	    buffer::ptr_node::create(m_ptr, write_offset, write_length);
 	  bufferlist *write_bl = new bufferlist();
 	  write_bl->push_back(write_ptr);
 	  Context *ctx = new C_CopyWrite(write_bl, gather_ctx->new_sub());

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1427,12 +1427,12 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       });
       auto gather_ctx = new C_Gather(m_dest->cct, end_op_ctx);
 
-      auto& m_ptr = buffer::ptr_node::create(m_bl->length());
-      m_bl->rebuild(m_ptr);
+      m_bl->rebuild(buffer::ptr_node::create(m_bl->length()));
       size_t write_offset = 0;
       size_t write_length = 0;
       size_t offset = 0;
       size_t length = m_bl->length();
+      const auto& m_ptr = m_bl->front();
       while (offset < length) {
 	if (util::calc_sparse_extent(m_ptr,
 				     m_sparse_size,
@@ -1440,10 +1440,9 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
 				     &write_offset,
 				     &write_length,
 				     &offset)) {
-	  auto& write_ptr = \
-	    buffer::ptr_node::create(m_ptr, write_offset, write_length);
 	  bufferlist *write_bl = new bufferlist();
-	  write_bl->push_back(write_ptr);
+	  write_bl->push_back(
+	    buffer::ptr_node::create(m_ptr, write_offset, write_length));
 	  Context *ctx = new C_CopyWrite(write_bl, gather_ctx->new_sub());
 	  auto comp = io::AioCompletion::create(ctx);
 

--- a/src/messages/MDataPing.h
+++ b/src/messages/MDataPing.h
@@ -64,8 +64,8 @@ private:
 	mdata_hook(&mp);
 
       if (free_data)  {
-	const std::list<buffer::ptr>& buffers = data.buffers();
-	list<bufferptr>::const_iterator pb;
+	const ceph::bufferlist::buffers_t& buffers = data.buffers();
+	ceph::bufferlist::buffers_t::const_iterator pb;
 	for (pb = buffers.begin(); pb != buffers.end(); ++pb) {
 	  free((void*) pb->c_str());
 	}

--- a/src/messages/MDataPing.h
+++ b/src/messages/MDataPing.h
@@ -64,10 +64,8 @@ private:
 	mdata_hook(&mp);
 
       if (free_data)  {
-	const ceph::bufferlist::buffers_t& buffers = data.buffers();
-	ceph::bufferlist::buffers_t::const_iterator pb;
-	for (pb = buffers.begin(); pb != buffers.end(); ++pb) {
-	  free((void*) pb->c_str());
+	for (const auto& node : data.buffers()) {
+	  free(const_cast<void*>(static_cast<const void*>(node.c_str())));
 	}
       }
     }

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -112,7 +112,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
 
   ssize_t send(bufferlist &bl, bool more) override {
     size_t sent_bytes = 0;
-    std::list<bufferptr>::const_iterator pb = bl.buffers().begin();
+    ceph::bufferlist::buffers_t::const_iterator pb = bl.buffers().begin();
     uint64_t left_pbrs = bl.buffers().size();
     while (left_pbrs) {
       struct msghdr msg;

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -112,8 +112,8 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
 
   ssize_t send(bufferlist &bl, bool more) override {
     size_t sent_bytes = 0;
-    ceph::bufferlist::buffers_t::const_iterator pb = bl.buffers().begin();
-    uint64_t left_pbrs = bl.buffers().size();
+    auto pb = std::cbegin(bl.buffers());
+    uint64_t left_pbrs = std::size(bl.buffers());
     while (left_pbrs) {
       struct msghdr msg;
       struct iovec msgvec[IOV_MAX];

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -447,8 +447,8 @@ ssize_t RDMAConnectedSocketImpl::submit(bool more)
     return 0;
 
   auto fill_tx_via_copy = [this](std::vector<Chunk*> &tx_buffers, unsigned bytes,
-                                 std::list<bufferptr>::const_iterator &start,
-                                 std::list<bufferptr>::const_iterator &end) -> unsigned {
+                                 ceph::bufferlist::buffers_t::const_iterator &start,
+                                 ceph::bufferlist::buffers_t::const_iterator &end) -> unsigned {
     ceph_assert(start != end);
     auto chunk_idx = tx_buffers.size();
     int ret = worker->get_reged_mem(this, tx_buffers, bytes);
@@ -481,8 +481,8 @@ ssize_t RDMAConnectedSocketImpl::submit(bool more)
   };
 
   std::vector<Chunk*> tx_buffers;
-  std::list<bufferptr>::const_iterator it = pending_bl.buffers().begin();
-  std::list<bufferptr>::const_iterator copy_it = it;
+  ceph::bufferlist::buffers_t::const_iterator it = pending_bl.buffers().begin();
+  ceph::bufferlist::buffers_t::const_iterator copy_it = it;
   unsigned total = 0;
   unsigned need_reserve_bytes = 0;
   while (it != pending_bl.buffers().end()) {

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -446,9 +446,10 @@ ssize_t RDMAConnectedSocketImpl::submit(bool more)
   if (!bytes)
     return 0;
 
-  auto fill_tx_via_copy = [this](std::vector<Chunk*> &tx_buffers, unsigned bytes,
-                                 ceph::bufferlist::buffers_t::const_iterator &start,
-                                 ceph::bufferlist::buffers_t::const_iterator &end) -> unsigned {
+  auto fill_tx_via_copy = [this](std::vector<Chunk*> &tx_buffers,
+                                 unsigned bytes,
+                                 auto& start,
+                                 const auto& end) -> unsigned {
     ceph_assert(start != end);
     auto chunk_idx = tx_buffers.size();
     int ret = worker->get_reged_mem(this, tx_buffers, bytes);
@@ -481,8 +482,8 @@ ssize_t RDMAConnectedSocketImpl::submit(bool more)
   };
 
   std::vector<Chunk*> tx_buffers;
-  ceph::bufferlist::buffers_t::const_iterator it = pending_bl.buffers().begin();
-  ceph::bufferlist::buffers_t::const_iterator copy_it = it;
+  auto it = std::cbegin(pending_bl.buffers());
+  auto copy_it = it;
   unsigned total = 0;
   unsigned need_reserve_bytes = 0;
   while (it != pending_bl.buffers().end()) {

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2408,7 +2408,7 @@ int Pipe::write_message(const ceph_msg_header& header, const ceph_msg_footer& fo
   msg.msg_iovlen++;
 
   // payload (front+data)
-  ceph::bufferlist::buffers_t::const_iterator pb = blist.buffers().begin();
+  auto pb = std::cbegin(blist.buffers());
   unsigned b_off = 0;  // carry-over buffer offset, if any
   unsigned bl_pos = 0; // blist pos
   unsigned left = blist.length();

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2408,7 +2408,7 @@ int Pipe::write_message(const ceph_msg_header& header, const ceph_msg_footer& fo
   msg.msg_iovlen++;
 
   // payload (front+data)
-  list<bufferptr>::const_iterator pb = blist.buffers().begin();
+  ceph::bufferlist::buffers_t::const_iterator pb = blist.buffers().begin();
   unsigned b_off = 0;  // carry-over buffer offset, if any
   unsigned bl_pos = 0; // blist pos
   unsigned left = blist.length();

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -695,15 +695,11 @@ public:
       bufferlist& bl,
       vector<__le32> &cm,
       vector<__le32> &om) {
+      for (auto& bp : bl.buffers()) {
+        ceph_assert(bp.length() % sizeof(Op) == 0);
 
-      ceph::bufferlist::buffers_t list = bl.buffers();
-      ceph::bufferlist::buffers_t::iterator p;
-
-      for(p = list.begin(); p != list.end(); ++p) {
-        ceph_assert(p->length() % sizeof(Op) == 0);
-
-        char* raw_p = p->c_str();
-        char* raw_end = raw_p + p->length();
+        char* raw_p = const_cast<char*>(bp.c_str());
+        char* raw_end = raw_p + bp.length();
         while (raw_p < raw_end) {
           _update_op(reinterpret_cast<Op*>(raw_p), cm, om);
           raw_p += sizeof(Op);

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -696,8 +696,8 @@ public:
       vector<__le32> &cm,
       vector<__le32> &om) {
 
-      list<bufferptr> list = bl.buffers();
-      std::list<bufferptr>::iterator p;
+      ceph::bufferlist::buffers_t list = bl.buffers();
+      ceph::bufferlist::buffers_t::iterator p;
 
       for(p = list.begin(); p != list.end(); ++p) {
         ceph_assert(p->length() % sizeof(Op) == 0);

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -847,9 +847,9 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
 
   _aio_log_start(ioc, off, len);
 
-  auto& p = buffer::ptr_node::create(buffer::create_small_page_aligned(len));
+  auto p = buffer::ptr_node::create(buffer::create_small_page_aligned(len));
   int r = ::pread(buffered ? fd_buffereds[WRITE_LIFE_NOT_SET] : fd_directs[WRITE_LIFE_NOT_SET],
-		  p.c_str(), len, off);
+		  p->c_str(), len, off);
   if (r < 0) {
     r = -errno;
     goto out;

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -847,7 +847,7 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
 
   _aio_log_start(ioc, off, len);
 
-  bufferptr p = buffer::create_small_page_aligned(len);
+  auto& p = buffer::ptr_node::create(buffer::create_small_page_aligned(len));
   int r = ::pread(buffered ? fd_buffereds[WRITE_LIFE_NOT_SET] : fd_directs[WRITE_LIFE_NOT_SET],
 		  p.c_str(), len, off);
   if (r < 0) {

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1372,7 +1372,7 @@ int FileJournal::write_aio_bl(off64_t& pos, bufferlist& bl, uint64_t seq)
     iovec *iov = new iovec[max];
     int n = 0;
     unsigned len = 0;
-    for (std::list<buffer::ptr>::const_iterator p = bl.buffers().begin();
+    for (ceph::bufferlist::buffers_t::const_iterator p = bl.buffers().begin();
 	 n < max;
 	 ++p, ++n) {
       ceph_assert(p != bl.buffers().end());

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1372,11 +1372,9 @@ int FileJournal::write_aio_bl(off64_t& pos, bufferlist& bl, uint64_t seq)
     iovec *iov = new iovec[max];
     int n = 0;
     unsigned len = 0;
-    for (ceph::bufferlist::buffers_t::const_iterator p = bl.buffers().begin();
-	 n < max;
-	 ++p, ++n) {
-      ceph_assert(p != bl.buffers().end());
-      iov[n].iov_base = (void *)p->c_str();
+    for (auto p = std::cbegin(bl.buffers()); n < max; ++p, ++n) {
+      ceph_assert(p != std::cend(bl.buffers()));
+      iov[n].iov_base = const_cast<void*>(static_cast<const void*>(p->c_str()));
       iov[n].iov_len = p->length();
       len += p->length();
     }

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -2186,7 +2186,7 @@ public:
 
   struct rgw_vio* get_vio() { return vio; }
 
-  const buffer::list::buffers_t& buffers() { return bl.buffers(); }
+  const auto& buffers() { return bl.buffers(); }
 
   unsigned /* XXX */ length() { return bl.length(); }
 

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -2186,7 +2186,7 @@ public:
 
   struct rgw_vio* get_vio() { return vio; }
 
-  const std::list<buffer::ptr>& buffers() { return bl.buffers(); }
+  const buffer::list::buffers_t& buffers() { return bl.buffers(); }
 
   unsigned /* XXX */ length() { return bl.length(); }
 

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1294,7 +1294,7 @@ void bench_bufferlist_alloc(int size, int num, int per)
   for (int i=0; i<num; ++i) {
     bufferlist bl;
     for (int j=0; j<per; ++j)
-      bl.append(buffer::create(size));
+      bl.push_back(buffer::ptr_node::create(buffer::create(size)));
   }
   utime_t end = ceph_clock_now();
   cout << num << " alloc of size " << size

--- a/src/test/rgw/test_rgw_compression.cc
+++ b/src/test/rgw/test_rgw_compression.cc
@@ -12,7 +12,7 @@ public:
 
   int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) override
   {
-    auto bl_buffers = bl.buffers();
+    auto& bl_buffers = bl.buffers();
     auto i = bl_buffers.begin();
     while (bl_len > 0)
     {


### PR DESCRIPTION
Summary
=======
`bufferlist` offers `buffer::raw_combined` concept. It's basically a `buffer::raw` control structure allocated with its underlying data buffer in one go. This reduces pressure on memory allocator while improving memory locality. The pull requests extends the idea throughout following changes:
* `bufferlist::_buffers` container has been switched to ~~`boost::intrusive::list`~~  a plain, C-style list to gain control over memory management of its nodes.
* `buffer::ptr` has been combined with the intrusive hooks to form `ptr_node`. The extra benefit is avoidance of memcpy/moving in some cases. 
* `buffer::raw` got `std::aligned_storage` to hold one `ptr_node` that points to it. Of course, as these instances live on the same memory, their life-times must be controlled - `ptr` can never outlive `raw`. That's the exact reason why `ptr_node` is not re-assignable.

As a result data buffer, `buffer::raw`, `buffer::ptr` and the container's hook can be allocated together.

UPDATE: additionally the memory footprint of `buffer::ptr` has been minimized from 32 bytes to 24 thanks to the singly linked list.

Microbenchmarking
===============
For the 4 KB allocation size `bufferlist::append` typically work on, around 40% time reduction has been observed  (`1 - 0.226191 / 0.371490`).

Before: 1b57df1d514588b1c8232fe0c348b21fcc90c4ee
--------
```
$ ./bin/unittest_bufferlist --gtest_filter=BufferList.BenchAlloc
Note: Google Test filter = BufferList.BenchAlloc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from BufferList
[ RUN      ] BufferList.BenchAlloc
100000 alloc of size 32768 in 0.701351
100000 alloc of size 25000 in 0.678349
100000 alloc of size 16384 in 0.670223
100000 alloc of size 10000 in 0.643028
100000 alloc of size 8192 in 0.640630
100000 alloc of size 6000 in 0.421637
100000 alloc of size 4096 in 0.371490
100000 alloc of size 1024 in 0.357983
100000 alloc of size 256 in 0.328453
100000 alloc of size 32 in 0.320399
100000 alloc of size 4 in 0.321341
[       OK ] BufferList.BenchAlloc (5455 ms)
[----------] 1 test from BufferList (5455 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (5455 ms total)
[  PASSED  ] 1 test.
```

After: 58e3a9ab470620a0f704e2c79908810b19e03c89
-----
```
$ ./bin/unittest_bufferlist --gtest_filter=BufferList.BenchAlloc
Note: Google Test filter = BufferList.BenchAlloc
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from BufferList
[ RUN      ] BufferList.BenchAlloc
100000 alloc of size 32768 in 0.614499
100000 alloc of size 25000 in 0.598030
100000 alloc of size 16384 in 0.589918
100000 alloc of size 10000 in 0.557164
100000 alloc of size 8192 in 0.547145
100000 alloc of size 6000 in 0.222730
100000 alloc of size 4096 in 0.226191
100000 alloc of size 1024 in 0.225212
100000 alloc of size 256 in 0.225188
100000 alloc of size 32 in 0.223975
100000 alloc of size 4 in 0.217744
[       OK ] BufferList.BenchAlloc (4248 ms)
[----------] 1 test from BufferList (4248 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (4248 ms total)
[  PASSED  ] 1 test.
```