### PR TITLE
qa: fix delay type config name

### DIFF
--- a/qa/suites/fs/thrash/msgr-failures/osd-mds-delay.yaml
+++ b/qa/suites/fs/thrash/msgr-failures/osd-mds-delay.yaml
@@ -3,6 +3,6 @@ overrides:
     conf:
       global:
         ms inject socket failures: 2500
-        mds inject delay type: osd mds
+        ms inject delay type: osd mds
         ms inject delay probability: .005
         ms inject delay max: 1


### PR DESCRIPTION
Setting as-is is a no-op.

Fixes: http://tracker.ceph.com/issues/36676

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

