### PR TITLE
rbd: make sure the return-value 'r' will be returned.

### DIFF
--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -132,7 +132,7 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
     }
 
     uint64_t features;
-    int r = image.features(&features);
+    r = image.features(&features);
     if (r < 0) {
       std::cerr << "rbd: failed to retrieve image features: " << cpp_strerror(r)
                 << std::endl;


### PR DESCRIPTION
The return-value `r` is declared again in the for-loop and thus the error code `-EINVAL` will not be returned successfully.

Here is the error code need to be returned:
https://github.com/ceph/ceph/blob/a7bb772e117d64844f6af5c3c5e03ca964d4f2f6/src/tools/rbd/action/DiskUsage.cc#L148

Signed-off-by: Shiyang Ruan <ruansy.fnst@cn.fujitsu.com>