### PR TITLE
rbd: return error code when the source and distination namespace are different

### DIFF
--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -828,6 +828,7 @@ int execute_rename(const po::variables_map &vm,
   } else if (namespace_name != dest_namespace_name) {
     std::cerr << "rbd: source and destination namespace must be the same"
               << std::endl;
+    return -EINVAL;
   } else if (image_name != dest_image_name) {
     std::cerr << "rbd: source and destination image name must be the same"
               << std::endl;


### PR DESCRIPTION
Signed-off-by: Shiyang Ruan <ruansy.fnst@cn.fujitsu.com>