### PR TITLE
rgw: Return tenant field in bucket_stats function

### DIFF
--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -382,6 +382,7 @@ def task(ctx, config):
 
     assert ret == 200
     assert out['owner'] == user1
+    assert out['tenant'] == ''
     bucket_id = out['id']
 
     # TESTCASE 'bucket-stats4','bucket','stats','new empty bucket','succeeds, expected bucket ID'

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1420,6 +1420,7 @@ static int bucket_stats(RGWRados *store, const std::string& tenant_name, std::st
 
   formatter->open_object_section("stats");
   formatter->dump_string("bucket", bucket.name);
+  formatter->dump_string("tenant", bucket.tenant);
   formatter->dump_string("zonegroup", bucket_info.zonegroup);
   formatter->dump_string("placement_rule", bucket_info.placement_rule);
   ::encode_json("explicit_placement", bucket.explicit_placement, formatter);


### PR DESCRIPTION
This PR is required by a dashboard related bug, see https://github.com/ceph/ceph/pull/24757.

Fixes: https://tracker.ceph.com/issues/36681

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

