### PR TITLE
test/rbd_mirror: race in TestMockImageMap.AddInstancePingPongImageTest

### DIFF
--- a/src/test/rbd_mirror/test_mock_ImageMap.cc
+++ b/src/test/rbd_mirror/test_mock_ImageMap.cc
@@ -293,8 +293,9 @@ public:
     for (auto& global_image_id : global_image_ids) {
       auto it = peer_ack_ctxs->find(global_image_id);
       ASSERT_TRUE(it != peer_ack_ctxs->end());
-      it->second->complete(ret);
+      auto ack_ctx = it->second;
       peer_ack_ctxs->erase(it);
+      ack_ctx->complete(ret);
       wait_for_scheduled_task();
     }
   }
@@ -306,8 +307,9 @@ public:
     for (auto& global_image_id : global_image_ids) {
       auto it = peer_ack_ctxs->find(global_image_id);
       ASSERT_TRUE(it != peer_ack_ctxs->end());
-      it->second->complete(ret);
+      auto ack_ctx = it->second;
       peer_ack_ctxs->erase(it);
+      ack_ctx->complete(ret);
       wait_for_scheduled_task();
       ASSERT_TRUE(wait_for_map_update(1));
     }
@@ -320,8 +322,9 @@ public:
     for (auto& global_image_id : global_image_ids) {
       auto it = peer_ack_ctxs->find(global_image_id);
       ASSERT_TRUE(it != peer_ack_ctxs->end());
-      it->second->complete(ret);
+      auto ack_ctx = it->second;
       peer_ack_ctxs->erase(it);
+      ack_ctx->complete(ret);
       ASSERT_TRUE(wait_for_map_update(1));
       ASSERT_TRUE(wait_for_listener_notify(1));
     }


### PR DESCRIPTION
Remove a context from peer_ack_ctxs before completing to avoid a race
with a listener inserting a new one.

Fixes: http://tracker.ceph.com/issues/36683
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

