### PR TITLE
luminous: tests: rbd: move OpenStack devstack test to rocky release

### DIFF
--- a/qa/workunits/rbd/run_devstack_tempest.sh
+++ b/qa/workunits/rbd/run_devstack_tempest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
-STACK_BRANCH=stable/pike
-TEMPEST_BRANCH=17.2.0
+STACK_BRANCH=stable/rocky
+TEMPEST_BRANCH=19.0.0
 
 STACK_USER=${STACK_USER:-stack}
 STACK_GROUP=${STACK_GROUP:-stack}


### PR DESCRIPTION
http://tracker.ceph.com/issues/36429