### PR TITLE
mimic: rbd: [rbd-mirror] periodic mirror status timer might fail to be scheduled

### DIFF
--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1484,9 +1484,8 @@ void ImageReplayer<I>::reschedule_update_status_task(int new_interval) {
       m_update_status_interval = new_interval;
     }
 
-    bool restarting = (new_interval == 0 || canceled_task);
     if (new_interval >= 0 && is_running_() &&
-        start_mirror_image_status_update(false, restarting)) {
+        start_mirror_image_status_update(true, false)) {
       m_update_status_task = new FunctionContext(
         [this](int r) {
           assert(m_threads->timer_lock.is_locked());
@@ -1502,6 +1501,7 @@ void ImageReplayer<I>::reschedule_update_status_task(int new_interval) {
   }
 
   if (canceled_task) {
+    // decrement in-flight status update counter for canceled task
     finish_mirror_image_status_update();
   }
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/36555