### PR TITLE
luminous: cmake: link unittest_compression against gtest

### DIFF
--- a/src/test/compressor/CMakeLists.txt
+++ b/src/test/compressor/CMakeLists.txt
@@ -6,5 +6,5 @@ add_executable(unittest_compression
   $<TARGET_OBJECTS:unit-main>
   )
 add_ceph_unittest(unittest_compression ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_compression)
-target_link_libraries(unittest_compression global)
+target_link_libraries(unittest_compression global gtest)
 add_dependencies(unittest_compression ceph_example)


### PR DESCRIPTION
During linking the error is:
```
/usr/bin/ld.lld: error: undefined symbol: testing::Message::Message()
>>> referenced by test_compression.cc:78 (/home/jenkins/workspace/ceph-luminous/src/test/compressor/test_compression.cc:78)
>>>               CMakeFiles/unittest_compression.dir/test_compression.cc.o:(CompressorTest_small_round_trip_Test::TestBody())

/usr/bin/ld.lld: error: undefined symbol: testing::internal::AssertHelper::AssertHelper(testing::TestPartResult::Type, char const*, int, char const*)
```
This can probably be fixed by backporting
    https://github.com/ceph/ceph/pull/23628
and friendsr. But that needs a lot of fixing.

So instead of backporting, is this PR a lot easier

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

