### PR TITLE
tslint 'no-unused-variable' option is deprecated since v5.11.0

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/tslint.json
+++ b/src/pybind/mgr/dashboard/frontend/tslint.json
@@ -41,7 +41,6 @@
     "no-trailing-whitespace": true,
     "no-unnecessary-initializer": true,
     "no-unused-expression": true,
-    "no-unused-variable": true,
     "no-use-before-declare": true,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,


### PR DESCRIPTION
See https://github.com/palantir/tslint/pull/3919 and https://github.com/palantir/tslint/blob/master/CHANGELOG.md#warning-deprecations.

```
=============================== Coverage summary ===============================
Statements   : 81.15% ( 5253/6473 )
Branches     : 71.01% ( 1844/2597 )
Functions    : 73.15% ( 1114/1523 )
Lines        : 80.38% ( 4675/5816 )
================================================================================
no-unused-variable is deprecated. Since TypeScript 2.9. Please use the built-in compiler checks instead.


All files pass linting.
All files pass linting
```

Signed-off-by: Volker Theile <vtheile@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

