### PR TITLE
osd: set lower bound+docs on osd_max_write_size

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2102,8 +2102,13 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_max_write_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .set_min(4)
     .set_default(90)
-    .set_description(""),
+    .set_description("Maximum size of a RADOS write operation in megabytes")
+    .set_long_description("This setting prevents clients from doing "
+        "very large writes to RADOS.  If you set this to a value "
+        "below what clients expect, they will receive an error "
+        "when attempting to write to the cluster."),
 
     Option("osd_max_pgls", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(1024)


### PR DESCRIPTION
(inspired by thread "[ceph-users] Should OSD write error result in damaged filesystem?")

It never makes sense to set this below 4 megabytes (no
sane OSD backend would have a problem with writes of
that size), and doing so is a quick way to break your
cluster.

Also fill out doc fields.

Signed-off-by: John Spray <john.spray@redhat.com>

