### PR TITLE
mgr/dashboard: Fix duplicate tasks

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -95,5 +95,22 @@ describe('SummaryService', () => {
         name: 'rbd/delete'
       });
     });
+
+    it('should call addRunningTask with duplicate task', () => {
+      let result = summaryService.getCurrentSummary();
+      const exec_task = new ExecutingTask('rbd/delete', {
+        pool_name: 'somePool',
+        image_name: 'someImage'
+      });
+
+      result.executing_tasks = [exec_task];
+      summaryService['summaryDataSource'].next(result);
+      result = summaryService.getCurrentSummary();
+      expect(result.executing_tasks.length).toBe(1);
+
+      summaryService.addRunningTask(exec_task);
+      result = summaryService.getCurrentSummary();
+      expect(result.executing_tasks.length).toBe(1);
+    });
   });
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
@@ -76,7 +76,12 @@ export class SummaryService {
     }
 
     if (_.isArray(current.executing_tasks)) {
-      current.executing_tasks.push(task);
+      const exists = current.executing_tasks.find((element) => {
+        return element.name === task.name && _.isEqual(element.metadata, task.metadata);
+      });
+      if (!exists) {
+        current.executing_tasks.push(task);
+      }
     } else {
       current.executing_tasks = [task];
     }


### PR DESCRIPTION
In certain situations a new task is already in the current summary before we
manually push it to the running task list.
Since we were not checking that, at the end of the operation we would have 2
entries for the same task and that would be displayed in the UI.

Signed-off-by: Tiago Melo <tmelo@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

