### PR TITLE
mgr/dashboard: Update Node.js to current LTS

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -80,10 +80,9 @@ build_dashboard_frontend() {
   TEMP_DIR=`mktemp -d`
   $CURR_DIR/src/tools/setup-virtualenv.sh --python=$(_python_autoselect) $TEMP_DIR
   $TEMP_DIR/bin/pip install nodeenv
-  $TEMP_DIR/bin/nodeenv -p --node=8.11.3
+  $TEMP_DIR/bin/nodeenv -p --node=10.13.0
   cd src/pybind/mgr/dashboard/frontend
   . $TEMP_DIR/bin/activate
-  npm i -g npm --unsafe-perm
   npm ci
   npm run build -- --prod --progress=false
   deactivate

--- a/src/pybind/mgr/dashboard/CMakeLists.txt
+++ b/src/pybind/mgr/dashboard/CMakeLists.txt
@@ -43,7 +43,7 @@ else()
     OUTPUT "${mgr-dashboard-nodeenv-dir}/bin/npm"
     COMMAND ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh --python=${MGR_PYTHON_EXECUTABLE} ${mgr-dashboard-nodeenv-dir}
     COMMAND ${mgr-dashboard-nodeenv-dir}/bin/pip install nodeenv
-    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv -p --node=8.11.3
+    COMMAND ${mgr-dashboard-nodeenv-dir}/bin/nodeenv -p --node=10.13.0
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
     COMMENT "dashboard nodeenv is being installed"
   )
@@ -59,7 +59,7 @@ endif()
 
 add_npm_command(
   OUTPUT "${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend/node_modules"
-  COMMAND npm i -g npm@6.2.0 --unsafe-perm && npm ci
+  COMMAND npm ci
   DEPENDS frontend/package.json
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/pybind/mgr/dashboard/frontend
   COMMENT "dashboard frontend dependencies are being installed"

--- a/src/pybind/mgr/dashboard/frontend/package-lock.json
+++ b/src/pybind/mgr/dashboard/frontend/package-lock.json
@@ -817,9 +817,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.10.37",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.37.tgz",
-      "integrity": "sha512-Jp39foY8Euv/PG4OGPyzxis82mnjcUtXLEMA8oFMCE4ilmuJgZPdV2nZNV1moz+99EJTtcpOSgDCgATUwABKig==",
+      "version": "10.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
+      "integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==",
       "dev": true
     },
     "@types/q": {

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -76,7 +76,7 @@
     "@types/jasminewd2": "2.0.5",
     "@types/jest": "23.3.9",
     "@types/lodash": "4.14.117",
-    "@types/node": "8.10.37",
+    "@types/node": "10.12.2",
     "babel-preset-env": "1.7.0",
     "codelyzer": "4.5.0",
     "html-linter": "1.1.0",


### PR DESCRIPTION
Removed the npm update since the current node already includes the necessary
npm version.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`
