### PR TITLE
systemd: enable ceph-rbd-mirror.target

### DIFF
--- a/systemd/50-ceph.preset
+++ b/systemd/50-ceph.preset
@@ -3,5 +3,6 @@ enable ceph-mds.target
 enable ceph-mgr.target
 enable ceph-mon.target
 enable ceph-osd.target
+enable ceph-rbd-mirror.target
 enable ceph-radosgw.target
 enable ceph-crash.service


### PR DESCRIPTION
Without this the rbd-mirror units will never start after a system
reboot. The rbd-mirror unit requires ceph-rbd-mirror.target to start
since it currently does not get enabled the daemon won't start after a
reboot.

Signed-off-by: Sébastien Han <seb@redhat.com>