### PR TITLE
client: support getfattr ceph.dir.pin extended attribute

### DIFF
--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -103,9 +103,22 @@ class TestExports(CephFSTestCase):
         self.mount_a.run_shell(["mkdir", "-p", "a/b", "aa/bb"])
         self.mount_a.setfattr("a", "ceph.dir.pin", "1")
         self.mount_a.setfattr("aa/bb", "ceph.dir.pin", "0")
-        self._wait_subtrees(status, 0, [('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2), ('/a', 1), ('/aa/bb', 0)])
+        if (len(self.fs.get_active_names()) > 2):
+            self._wait_subtrees(status, 0, [('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2), ('/a', 1), ('/aa/bb', 0)])
+        else:
+            self._wait_subtrees(status, 0, [('/1', 0), ('/1/4/5', 1), ('/a', 1), ('/aa/bb', 0)])
         self.mount_a.run_shell(["mv", "aa", "a/b/"])
-        self._wait_subtrees(status, 0, [('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2), ('/a', 1), ('/a/b/aa/bb', 0)])
+        if (len(self.fs.get_active_names()) > 2):
+            self._wait_subtrees(status, 0, [('/1', 0), ('/1/4/5', 1), ('/1/2/3', 2), ('/a', 1), ('/a/b/aa/bb', 0)])
+        else:
+            self._wait_subtrees(status, 0, [('/1', 0), ('/1/4/5', 1), ('/a', 1), ('/a/b/aa/bb', 0)])
+
+        # Test getfattr
+        self.assertTrue(self.mount_a.getfattr("1", "ceph.dir.pin") == "0")
+        self.assertTrue(self.mount_a.getfattr("1/4", "ceph.dir.pin") == "-1")
+        self.assertTrue(self.mount_a.getfattr("1/4/5", "ceph.dir.pin") == "1")
+        if (len(self.fs.get_active_names()) > 2):
+            self.assertTrue(self.mount_a.getfattr("1/2/3", "ceph.dir.pin") == "2")
 
     def test_session_race(self):
         """

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -1167,6 +1167,10 @@ private:
   size_t _vxattrcb_dir_rsubdirs(Inode *in, char *val, size_t size);
   size_t _vxattrcb_dir_rbytes(Inode *in, char *val, size_t size);
   size_t _vxattrcb_dir_rctime(Inode *in, char *val, size_t size);
+
+  bool _vxattrcb_dir_pin_exists(Inode *in);
+  size_t _vxattrcb_dir_pin(Inode *in, char *val, size_t size);
+
   size_t _vxattrs_calcu_name_size(const VXattr *vxattrs);
 
   static const VXattr *_get_vxattrs(Inode *in);

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -263,6 +263,8 @@ struct Inode {
 
   std::set<Fh*> fhs;
 
+  mds_rank_t dir_pin;
+
   Inode(Client *c, vinodeno_t vino, file_layout_t *newlayout)
     : client(c), ino(vino.ino), snapid(vino.snapid), faked_ino(0),
       rdev(0), mode(0), uid(0), gid(0), nlink(0),
@@ -278,7 +280,7 @@ struct Inode {
       snaprealm(0), snaprealm_item(this),
       oset((void *)this, newlayout->pool_id, this->ino),
       reported_size(0), wanted_max_size(0), requested_max_size(0),
-      _ref(0), ll_ref(0)
+      _ref(0), ll_ref(0), dir_pin(MDS_RANK_NONE)
   {
     memset(&dir_layout, 0, sizeof(dir_layout));
   }

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3576,7 +3576,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
    * note: encoding matches MClientReply::InodeStat
    */
   if (session->info.has_feature(CEPHFS_FEATURE_REPLY_ENCODING)) {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     encode(oi->ino, bl);
     encode(snapid, bl);
     encode(oi->rdev, bl);
@@ -3617,6 +3617,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
     encode(layout.pool_ns, bl);
     encode(any_i->btime, bl);
     encode(any_i->change_attr, bl);
+    encode(file_i->export_pin, bl);
     ENCODE_FINISH(bl);
   }
   else {

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -134,6 +134,8 @@ struct InodeStat {
 
   quota_info_t quota;
 
+  mds_rank_t dir_pin;
+
  public:
   InodeStat() {}
   InodeStat(bufferlist::const_iterator& p, const uint64_t features) {
@@ -143,7 +145,7 @@ struct InodeStat {
   void decode(bufferlist::const_iterator &p, const uint64_t features) {
     using ceph::decode;
     if (features == (uint64_t)-1) {
-      DECODE_START(1, p);
+      DECODE_START(2, p);
       decode(vino.ino, p);
       decode(vino.snapid, p);
       decode(rdev, p);
@@ -183,6 +185,11 @@ struct InodeStat {
       decode(layout.pool_ns, p);
       decode(btime, p);
       decode(change_attr, p);
+      if (struct_v > 1) {
+        decode(dir_pin, p);
+      } else {
+        dir_pin = -ENODATA;
+      }
       DECODE_FINISH(p);
     }
     else {


### PR DESCRIPTION
In Multi-MDSes, we can set ceph.dir.pin on client to bind a directory to a specific MDS. But we can't get this attribute on client. So it is not convenient to check which directory is pinned on which MDS since we have multiple active MDSes running in a cluster and many user direcotires pinned to different MDS.

Fixes: http://tracker.ceph.com/issues/36707

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

