### PR TITLE
librados: support copy-less writes in librados C API

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -2214,7 +2214,30 @@ CEPH_RADOS_API int rados_aio_write(rados_ioctx_t io, const char *oid,
 		                   const char *buf, size_t len, uint64_t off);
 
 /**
- * Asynchronously append data to an object
+ * Write data to an object asynchronously
+ *
+ * Queues the write and returns. The return value of the completion
+ * will be 0 on success, negative error code on failure.
+ * 
+ * buf is assumed to not change before entire write is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior. 
+ *
+ * @param io the context in which the write will occur
+ * @param oid name of the object
+ * @param completion what to do when the write is safe and complete
+ * @param buf data to write
+ * @param len length of the data, in bytes
+ * @param off byte offset in the object to begin writing at
+ * @returns 0 on success, -EROFS if the io context specifies a snap_seq
+ * other than LIBRADOS_SNAP_HEAD
+ */
+CEPH_RADOS_API int rados_aio_write2(rados_ioctx_t io, const char *oid,
+		                   rados_completion_t completion,
+		                   char *buf, size_t len, uint64_t off);
+
+/**
+ * Asychronously append data to an object
  *
  * Queues the append and returns.
  *
@@ -2234,7 +2257,31 @@ CEPH_RADOS_API int rados_aio_append(rados_ioctx_t io, const char *oid,
 		                    const char *buf, size_t len);
 
 /**
- * Asynchronously write an entire object
+ * Asychronously append data to an object
+ *
+ * Queues the append and returns.
+ *
+ * The return value of the completion will be 0 on success, negative
+ * error code on failure.
+ * 
+ * buf is assumed to not change before entire append is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior.
+ *
+ * @param io the context to operate in
+ * @param oid the name of the object
+ * @param completion what to do when the append is safe and complete
+ * @param buf the data to append
+ * @param len length of buf (in bytes)
+ * @returns 0 on success, -EROFS if the io context specifies a snap_seq
+ * other than LIBRADOS_SNAP_HEAD
+ */
+CEPH_RADOS_API int rados_aio_append2(rados_ioctx_t io, const char *oid,
+		                    rados_completion_t completion,
+		                    char *buf, size_t len);
+
+/**
+ * Asychronously write an entire object
  *
  * The object is filled with the provided data. If the object exists,
  * it is atomically truncated and then written.
@@ -2256,7 +2303,33 @@ CEPH_RADOS_API int rados_aio_write_full(rados_ioctx_t io, const char *oid,
 			                const char *buf, size_t len);
 
 /**
- * Asynchronously write the same buffer multiple times
+ * Asychronously write an entire object
+ *
+ * The object is filled with the provided data. If the object exists,
+ * it is atomically truncated and then written.
+ * Queues the write_full and returns.
+ *
+ * The return value of the completion will be 0 on success, negative
+ * error code on failure.
+ *
+ * buf is assumed to not change before entire write is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior.
+ *
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param completion what to do when the write_full is safe and complete
+ * @param buf data to write
+ * @param len length of the data, in bytes
+ * @returns 0 on success, -EROFS if the io context specifies a snap_seq
+ * other than LIBRADOS_SNAP_HEAD
+ */
+CEPH_RADOS_API int rados_aio_write_full2(rados_ioctx_t io, const char *oid,
+			                rados_completion_t completion,
+			                char *buf, size_t len);
+
+/**
+ * Asychronously write the same buffer multiple times
  *
  * Queues the writesame and returns.
  *
@@ -2279,7 +2352,34 @@ CEPH_RADOS_API int rados_aio_writesame(rados_ioctx_t io, const char *oid,
 				       size_t write_len, uint64_t off);
 
 /**
- * Asynchronously remove an object
+ * Asychronously write the same buffer multiple times
+ *
+ * Queues the writesame and returns.
+ *
+ * The return value of the completion will be 0 on success, negative
+ * error code on failure.
+ *
+ * buf is assumed to not change before entire write is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior.
+ *
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param completion what to do when the writesame is safe and complete
+ * @param buf data to write
+ * @param data_len length of the data, in bytes
+ * @param write_len the total number of bytes to write
+ * @param off byte offset in the object to begin writing at
+ * @returns 0 on success, -EROFS if the io context specifies a snap_seq
+ * other than LIBRADOS_SNAP_HEAD
+ */
+CEPH_RADOS_API int rados_aio_writesame2(rados_ioctx_t io, const char *oid,
+			               rados_completion_t completion,
+			               char *buf, size_t data_len,
+				       size_t write_len, uint64_t off);
+
+/**
+ * Asychronously remove an object
  *
  * Queues the remove and returns.
  *
@@ -2455,6 +2555,26 @@ CEPH_RADOS_API int rados_aio_getxattr(rados_ioctx_t io, const char *o,
 CEPH_RADOS_API int rados_aio_setxattr(rados_ioctx_t io, const char *o,
 				      rados_completion_t completion,
 				      const char *name, const char *buf,
+				      size_t len);
+
+/**
+ * Asynchronously set an extended attribute on an object.
+ *
+ * buf is assumed to not change before entire operation is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior.
+ *
+ * @param io the context in which xattr is set
+ * @param o name of the object
+ * @param completion what to do when the setxattr completes
+ * @param name which extended attribute to set
+ * @param buf what to store in the xattr
+ * @param len the number of bytes in buf
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_aio_setxattr2(rados_ioctx_t io, const char *o,
+				      rados_completion_t completion,
+				      const char *name, char *buf,
 				      size_t len);
 
 /**

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1482,6 +1482,24 @@ CEPH_RADOS_API int rados_write(rados_ioctx_t io, const char *oid,
                                const char *buf, size_t len, uint64_t off);
 
 /**
+ * Write *len* bytes from *buf* into the *oid* object, starting at
+ * offset *off*. The value of *len* must be <= UINT_MAX/2.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @note This will never return a positive value not equal to len.
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param buf data to write
+ * @param len length of the data, in bytes
+ * @param off byte offset in the object to begin writing at
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_write2(rados_ioctx_t io, const char *oid,
+                                char *buf, size_t len, uint64_t off);
+
+/**
  * Write *len* bytes from *buf* into the *oid* object. The value of
  * *len* must be <= UINT_MAX/2.
  *
@@ -1496,6 +1514,25 @@ CEPH_RADOS_API int rados_write(rados_ioctx_t io, const char *oid,
  */
 CEPH_RADOS_API int rados_write_full(rados_ioctx_t io, const char *oid,
                                     const char *buf, size_t len);
+
+/**
+ * Write *len* bytes from *buf* into the *oid* object. The value of
+ * *len* must be <= UINT_MAX/2.
+ *
+ * The object is filled with the provided data. If the object exists,
+ * it is atomically truncated and then written.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param buf data to write
+ * @param len length of the data, in bytes
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_write_full2(rados_ioctx_t io, const char *oid,
+                                     char *buf, size_t len);
 
 /**
  * Write the same *data_len* bytes from *buf* multiple times into the
@@ -1516,6 +1553,49 @@ CEPH_RADOS_API int rados_writesame(rados_ioctx_t io, const char *oid,
                                    size_t write_len, uint64_t off);
 
 /**
+ * Write the same *data_len* bytes from *buf* multiple times into the
+ * *oid* object. *write_len* bytes are written in total, which must be
+ * a multiple of *data_len*. The value of *write_len* and *data_len*
+ * must be <= UINT_MAX/2.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param buf data to write
+ * @param data_len length of the data, in bytes
+ * @param write_len the total number of bytes to write
+ * @param off byte offset in the object to begin writing at
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_writesame2(rados_ioctx_t io, const char *oid,
+                                    char *buf, size_t data_len,
+                                    size_t write_len, uint64_t off);
+
+/**
+ * Efficiently copy a portion of one object to another
+ *
+ * If the underlying filesystem on the OSD supports it, this will be a
+ * copy-on-write clone.
+ *
+ * The src and dest objects must be in the same pg. To ensure this,
+ * the io context should have a locator key set (see
+ * rados_ioctx_locator_set_key()).
+ *
+ * @param io the context in which the data is cloned
+ * @param dst the name of the destination object
+ * @param dst_off the offset within the destination object (in bytes)
+ * @param src the name of the source object
+ * @param src_off the offset within the source object (in bytes)
+ * @param len how much data to copy
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_clone_range(rados_ioctx_t io, const char *dst,
+                                     uint64_t dst_off, const char *src,
+                                     uint64_t src_off, size_t len);
+
+/**
  * Append *len* bytes from *buf* into the *oid* object. The value of
  * *len* must be <= UINT_MAX/2.
  *
@@ -1527,6 +1607,22 @@ CEPH_RADOS_API int rados_writesame(rados_ioctx_t io, const char *oid,
  */
 CEPH_RADOS_API int rados_append(rados_ioctx_t io, const char *oid,
                                 const char *buf, size_t len);
+
+/**
+ * Append *len* bytes from *buf* into the *oid* object. The value of
+ * *len* must be <= UINT_MAX/2.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @param io the context to operate in
+ * @param oid the name of the object
+ * @param buf the data to append
+ * @param len length of buf (in bytes)
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_append2(rados_ioctx_t io, const char *oid,
+                                 char *buf, size_t len);
 
 /**
  * Read data from an object
@@ -1657,6 +1753,23 @@ CEPH_RADOS_API int rados_getxattr(rados_ioctx_t io, const char *o,
 CEPH_RADOS_API int rados_setxattr(rados_ioctx_t io, const char *o,
                                   const char *name, const char *buf,
                                   size_t len);
+
+/**
+ * Set an extended attribute on an object.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @param io the context in which xattr is set
+ * @param o name of the object
+ * @param name which extended attribute to set
+ * @param buf what to store in the xattr
+ * @param len the number of bytes in buf
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_setxattr2(rados_ioctx_t io, const char *o,
+                                   const char *name, char *buf,
+                                   size_t len);
 
 /**
  * Delete an extended attribute from an object.

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -2230,6 +2230,24 @@ extern "C" int rados_aio_write(rados_ioctx_t io, const char *o,
   return retval;
 }
 
+extern "C" int rados_aio_write2(rados_ioctx_t io, const char *o,
+				rados_completion_t completion,
+				char *buf, size_t len, uint64_t off)
+{
+  tracepoint(librados, rados_aio_write_enter, io, o, completion, buf, len, off);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);  
+  int retval = ctx->aio_write(oid, (librados::AioCompletionImpl*)completion,
+			bl, len, off);
+  tracepoint(librados, rados_aio_write_exit, retval);
+  return retval;
+}
+
 #ifdef WITH_BLKIN
 extern "C" int rados_aio_write_traced(rados_ioctx_t io, const char *o,
                                       rados_completion_t completion,
@@ -2267,6 +2285,24 @@ extern "C" int rados_aio_append(rados_ioctx_t io, const char *o,
   return retval;
 }
 
+extern "C" int rados_aio_append2(rados_ioctx_t io, const char *o,
+				rados_completion_t completion,
+				char *buf, size_t len)
+{
+  tracepoint(librados, rados_aio_append_enter, io, o, completion, buf, len);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);  
+  int retval = ctx->aio_append(oid, (librados::AioCompletionImpl*)completion,
+			 bl, len);
+  tracepoint(librados, rados_aio_append_exit, retval);
+  return retval;
+}
+
 extern "C" int rados_aio_write_full(rados_ioctx_t io, const char *o,
 				    rados_completion_t completion,
 				    const char *buf, size_t len)
@@ -2283,6 +2319,23 @@ extern "C" int rados_aio_write_full(rados_ioctx_t io, const char *o,
   return retval;
 }
 
+extern "C" int rados_aio_write_full2(rados_ioctx_t io, const char *o,
+				    rados_completion_t completion,
+				    char *buf, size_t len)
+{
+  tracepoint(librados, rados_aio_write_full_enter, io, o, completion, buf, len);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);  
+  int retval = ctx->aio_write_full(oid, (librados::AioCompletionImpl*)completion, bl);
+  tracepoint(librados, rados_aio_write_full_exit, retval);
+  return retval;
+}
+
 extern "C" int rados_aio_writesame(rados_ioctx_t io, const char *o,
 				   rados_completion_t completion,
 				   const char *buf, size_t data_len,
@@ -2294,6 +2347,24 @@ extern "C" int rados_aio_writesame(rados_ioctx_t io, const char *o,
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, data_len);
+  int retval = ctx->aio_writesame(o, (librados::AioCompletionImpl*)completion,
+				  bl, write_len, off);
+  tracepoint(librados, rados_aio_writesame_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_aio_writesame2(rados_ioctx_t io, const char *o,
+				   rados_completion_t completion,
+				   char *buf, size_t data_len,
+				   size_t write_len, uint64_t off)
+{
+  tracepoint(librados, rados_aio_writesame_enter, io, o, completion, buf,
+						data_len, write_len, off);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(data_len, buf);
+  bl.push_back(bp);  
   int retval = ctx->aio_writesame(o, (librados::AioCompletionImpl*)completion,
 				  bl, write_len, off);
   tracepoint(librados, rados_aio_writesame_exit, retval);
@@ -2438,6 +2509,21 @@ extern "C" int rados_aio_setxattr(rados_ioctx_t io, const char *o,
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, len);
+  int retval = ctx->aio_setxattr(oid, (librados::AioCompletionImpl*)completion, name, bl);
+  tracepoint(librados, rados_aio_setxattr_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_aio_setxattr2(rados_ioctx_t io, const char *o,
+				  rados_completion_t completion,
+				  const char *name, char *buf, size_t len)
+{
+  tracepoint(librados, rados_aio_setxattr_enter, io, o, completion, name, buf, len);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);  
   int retval = ctx->aio_setxattr(oid, (librados::AioCompletionImpl*)completion, name, bl);
   tracepoint(librados, rados_aio_setxattr_exit, retval);
   return retval;

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -1027,6 +1027,21 @@ extern "C" int rados_write(rados_ioctx_t io, const char *o, const char *buf, siz
   return retval;
 }
 
+extern "C" int rados_write2(rados_ioctx_t io, const char *o, char *buf, size_t len, uint64_t off)
+{
+  tracepoint(librados, rados_write_enter, io, o, buf, len, off);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);
+  int retval = ctx->write(oid, bl, len, off);
+  tracepoint(librados, rados_write_exit, retval);
+  return retval;
+}
+
 extern "C" int rados_append(rados_ioctx_t io, const char *o, const char *buf, size_t len)
 {
   tracepoint(librados, rados_append_enter, io, o, buf, len);
@@ -1036,6 +1051,21 @@ extern "C" int rados_append(rados_ioctx_t io, const char *o, const char *buf, si
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, len);
+  int retval = ctx->append(oid, bl, len);
+  tracepoint(librados, rados_append_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_append2(rados_ioctx_t io, const char *o, char *buf, size_t len)
+{
+  tracepoint(librados, rados_append_enter, io, o, buf, len);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);
   int retval = ctx->append(oid, bl, len);
   tracepoint(librados, rados_append_exit, retval);
   return retval;
@@ -1055,6 +1085,21 @@ extern "C" int rados_write_full(rados_ioctx_t io, const char *o, const char *buf
   return retval;
 }
 
+extern "C" int rados_write_full2(rados_ioctx_t io, const char *o, char *buf, size_t len)
+{
+  tracepoint(librados, rados_write_full_enter, io, o, buf, len);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);
+  int retval = ctx->write_full(oid, bl);
+  tracepoint(librados, rados_write_full_exit, retval);
+  return retval;
+}
+
 extern "C" int rados_writesame(rados_ioctx_t io,
 				const char *o,
 				const char *buf,
@@ -1067,6 +1112,24 @@ extern "C" int rados_writesame(rados_ioctx_t io,
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, data_len);
+  int retval = ctx->writesame(oid, bl, write_len, off);
+  tracepoint(librados, rados_writesame_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_writesame2(rados_ioctx_t io,
+				const char *o,
+				char *buf,
+				size_t data_len,
+				size_t write_len,
+				uint64_t off)
+{
+  tracepoint(librados, rados_writesame_enter, io, o, buf, data_len, write_len, off);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(data_len, buf);
+  bl.push_back(bp);
   int retval = ctx->writesame(oid, bl, write_len, off);
   tracepoint(librados, rados_writesame_exit, retval);
   return retval;
@@ -1640,6 +1703,19 @@ extern "C" int rados_setxattr(rados_ioctx_t io, const char *o, const char *name,
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, len);
+  int retval = ctx->setxattr(oid, name, bl);
+  tracepoint(librados, rados_setxattr_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_setxattr2(rados_ioctx_t io, const char *o, const char *name, char *buf, size_t len)
+{
+  tracepoint(librados, rados_setxattr_enter, io, o, name, buf, len);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);
   int retval = ctx->setxattr(oid, name, bl);
   tracepoint(librados, rados_setxattr_exit, retval);
   return retval;

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -96,7 +96,7 @@ public:
    * @return true if ready to send, or false otherwise
    */
   virtual bool is_connected() = 0;
-
+  virtual void cancel_ops(const set<ceph_tid_t> &ops) {}
   Messenger *get_messenger() {
     return msgr;
   }

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -647,6 +647,10 @@ void AsyncConnection::handle_write()
   protocol->write_event();
 }
 
+void AsyncConnection::cancel_ops(const set<ceph_tid_t> &ops) {
+    protocol->cancel_ops(ops);
+};
+
 void AsyncConnection::handle_write_callback() {
   std::lock_guard<std::mutex> l(lock);
   last_active = ceph::coarse_mono_clock::now();

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -130,10 +130,12 @@ class AsyncConnection : public Connection {
     policy.lossy = true;
   }
 
- entity_addr_t get_peer_socket_addr() const override {
-   return target_addr;
- }
+  entity_addr_t get_peer_socket_addr() const override {
+    return target_addr;
+  }
 
+  void cancel_ops(const set<ceph_tid_t> &ops) override;
+  
  private:
   enum {
     STATE_NONE,

--- a/src/msg/async/Protocol.cc
+++ b/src/msg/async/Protocol.cc
@@ -408,6 +408,39 @@ bool ProtocolV1::is_queued() {
   return !out_q.empty() || connection->is_queued();
 }
 
+void ProtocolV1::cancel_ops(const set<ceph_tid_t> &ops)
+{
+  std::lock_guard<std::mutex> l(connection->write_lock);
+  auto it = out_q.begin();
+  while (it != out_q.end()) {
+    auto lit = it->second.begin();
+    while (lit != it->second.end()) {
+      auto p = ops.find(lit->second->get_tid());
+      if (p != ops.end()) {
+        lit->second->put();
+        lit = it->second.erase(lit);
+      } else {
+        lit++;
+      }
+    }
+    if (it->second.empty()) {
+      it = out_q.erase(it);
+    } else {
+      it++;
+    }
+  }
+  auto sit = sent.begin();
+  while (sit != sent.end()) {
+    auto p = ops.find((*sit)->get_tid());
+    if (p != ops.end()) {
+      (*sit)->put();
+      sit = sent.erase(sit);
+    } else {
+      sit++;
+    }
+  }
+}
+
 void ProtocolV1::run_continuation(CtPtr continuation) {
   CONTINUATION_RUN(continuation);
 }
@@ -1078,7 +1111,9 @@ void ProtocolV1::randomize_out_seq() {
 ssize_t ProtocolV1::write_message(Message *m, bufferlist &bl, bool more) {
   FUNCTRACE(cct);
   ceph_assert(connection->center->in_thread());
-  m->set_seq(++out_seq);
+  if (m->get_seq() == 0) {
+    m->set_seq(++out_seq);
+  }
 
   if (messenger->crcflags & MSG_CRC_HEADER) {
     m->calc_header_crc();
@@ -1169,7 +1204,6 @@ void ProtocolV1::requeue_sent() {
   }
 
   list<pair<bufferlist, Message *> > &rq = out_q[CEPH_MSG_PRIO_HIGHEST];
-  out_seq -= sent.size();
   while (!sent.empty()) {
     Message *m = sent.back();
     sent.pop_back();
@@ -1179,14 +1213,13 @@ void ProtocolV1::requeue_sent() {
   }
 }
 
-uint64_t ProtocolV1::discard_requeued_up_to(uint64_t out_seq, uint64_t seq) {
+void ProtocolV1::discard_requeued_up_to(uint64_t seq) {
   ldout(cct, 10) << __func__ << " " << seq << dendl;
   std::lock_guard<std::mutex> l(connection->write_lock);
   if (out_q.count(CEPH_MSG_PRIO_HIGHEST) == 0) {
-    return seq;
+    return;
   }
   list<pair<bufferlist, Message *> > &rq = out_q[CEPH_MSG_PRIO_HIGHEST];
-  uint64_t count = out_seq;
   while (!rq.empty()) {
     pair<bufferlist, Message *> p = rq.front();
     if (p.second->get_seq() == 0 || p.second->get_seq() > seq) break;
@@ -1195,10 +1228,8 @@ uint64_t ProtocolV1::discard_requeued_up_to(uint64_t out_seq, uint64_t seq) {
                    << dendl;
     p.second->put();
     rq.pop_front();
-    count++;
   }
   if (rq.empty()) out_q.erase(CEPH_MSG_PRIO_HIGHEST);
-  return count;
 }
 
 /*
@@ -1646,7 +1677,7 @@ CtPtr ProtocolV1::handle_ack_seq(char *buffer, int r) {
   newly_acked_seq = *((uint64_t *)buffer);
   ldout(cct, 2) << __func__ << " got newly_acked_seq " << newly_acked_seq
                 << " vs out_seq " << out_seq << dendl;
-  out_seq = discard_requeued_up_to(out_seq, newly_acked_seq);
+  discard_requeued_up_to(newly_acked_seq);
 
   bufferlist bl;
   uint64_t s = in_seq;
@@ -2304,7 +2335,6 @@ CtPtr ProtocolV1::open(ceph_msg_connect_reply &reply,
   } else {
     reply.tag = CEPH_MSGR_TAG_READY;
     wait_for_seq = false;
-    out_seq = discard_requeued_up_to(out_seq, 0);
     is_reset_from_peer = false;
     in_seq = 0;
   }
@@ -2412,7 +2442,7 @@ CtPtr ProtocolV1::handle_seq(char *buffer, int r) {
   uint64_t newly_acked_seq = *(uint64_t *)buffer;
   ldout(cct, 2) << __func__ << " accept get newly_acked_seq " << newly_acked_seq
                 << dendl;
-  out_seq = discard_requeued_up_to(out_seq, newly_acked_seq);
+  discard_requeued_up_to(newly_acked_seq);
 
   return server_ready();
 }

--- a/src/msg/async/Protocol.h
+++ b/src/msg/async/Protocol.h
@@ -93,6 +93,7 @@ public:
   virtual void read_event() = 0;
   virtual void write_event() = 0;
   virtual bool is_queued() = 0;
+  virtual void cancel_ops(const set<ceph_tid_t> &ops) = 0;
 };
 
 class ProtocolV1;
@@ -291,7 +292,7 @@ protected:
   ssize_t write_message(Message *m, bufferlist &bl, bool more);
 
   void requeue_sent();
-  uint64_t discard_requeued_up_to(uint64_t out_seq, uint64_t seq);
+  void discard_requeued_up_to(uint64_t seq);
   void discard_out_queue();
 
   void reset_recv_state();
@@ -313,6 +314,7 @@ public:
   virtual void read_event() override;
   virtual void write_event() override;
   virtual bool is_queued() override;
+  virtual void cancel_ops(const set<ceph_tid_t> &ops) override;
 
   // Client Protocol
 private:

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1066,6 +1066,7 @@ void Objecter::_scan_requests(
 
   // check for changed request mappings
   map<ceph_tid_t,Op*>::iterator p = s->ops.begin();
+  map<ConnectionRef, set<ceph_tid_t> > cancel_ops;
   while (p != s->ops.end()) {
     Op *op = p->second;
     ++p;   // check_op_pool_dne() may touch ops; prevent iterator invalidation
@@ -1086,7 +1087,10 @@ void Objecter::_scan_requests(
 	break;
       // -- fall-thru --
     case RECALC_OP_TARGET_NEED_RESEND:
-      _session_op_remove(op->session, op);
+      if (op->session) {
+        cancel_ops[op->session->con].insert(op->tid);
+        _session_op_remove(op->session, op);
+      }
       need_resend[op->tid] = op;
       _op_cancel_map_check(op);
       break;
@@ -1127,6 +1131,10 @@ void Objecter::_scan_requests(
   }
 
   sl.unlock();
+
+  for (auto const& p: cancel_ops) {
+    p.first->cancel_ops(p.second);
+  }
 
   for (list<LingerOp*>::iterator iter = unregister_lingers.begin();
        iter != unregister_lingers.end();


### PR DESCRIPTION
Based on work #12216 , and fix the problem as mentioned in https://github.com/yuyuyu101/ceph/commit/794b49b#r15707924 .

* Cancel ops to the old osd when ops are redirected, so buffer will not be used when it is freed.
* out_seq is only updated for new messages, and messages from sent queue are sent using their original sequence. So even when we remove ops from sent queue, the out_seq is correct.