### PR TITLE
crimson/net: enable connections on all cores

### DIFF
--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -125,8 +125,7 @@ set(crimson_thread_srcs
   thread/Throttle.cc)
 add_library(crimson STATIC
   ${crimson_auth_srcs}
-  # TODO: fix crimson_mon_client with the new design
-  # ${crimson_mon_srcs}
+  ${crimson_mon_srcs}
   ${crimson_net_srcs}
   ${crimson_thread_srcs}
   ${CMAKE_SOURCE_DIR}/src/common/buffer_seastar.cc)

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -116,6 +116,7 @@ set(crimson_mon_srcs
 set(crimson_net_srcs
   net/Dispatcher.cc
   net/Errors.cc
+  net/Messenger.cc
   net/SocketConnection.cc
   net/SocketMessenger.cc
   net/Socket.cc)
@@ -124,7 +125,8 @@ set(crimson_thread_srcs
   thread/Throttle.cc)
 add_library(crimson STATIC
   ${crimson_auth_srcs}
-  ${crimson_mon_srcs}
+  # TODO: fix crimson_mon_client with the new design
+  # ${crimson_mon_srcs}
   ${crimson_net_srcs}
   ${crimson_thread_srcs}
   ${CMAKE_SOURCE_DIR}/src/common/buffer_seastar.cc)

--- a/src/crimson/net/Dispatcher.h
+++ b/src/crimson/net/Dispatcher.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <seastar/core/future.hh>
+#include <seastar/core/sharded.hh>
 
 #include "Fwd.h"
 
@@ -54,6 +55,11 @@ class Dispatcher {
   }
   virtual seastar::future<std::unique_ptr<AuthAuthorizer>>
   ms_get_authorizer(peer_type_t);
+
+  // get the local dispatcher shard if it is accessed by another core
+  virtual Dispatcher* get_local_shard() {
+    return this;
+  }
 };
 
 } // namespace ceph::net

--- a/src/crimson/net/Fwd.h
+++ b/src/crimson/net/Fwd.h
@@ -14,7 +14,8 @@
 
 #pragma once
 
-#include <boost/intrusive_ptr.hpp>
+#include <seastar/core/shared_ptr.hh>
+#include <seastar/core/sharded.hh>
 
 #include "msg/msg_types.h"
 #include "msg/Message.h"
@@ -27,10 +28,25 @@ namespace ceph::net {
 using msgr_tag_t = uint8_t;
 
 class Connection;
-using ConnectionRef = boost::intrusive_ptr<Connection>;
+using ConnectionRef = seastar::shared_ptr<Connection>;
+// NOTE: ConnectionXRef should only be used in seastar world, because
+// lw_shared_ptr<> is not safe to be accessed by unpinned alien threads.
+using ConnectionXRef = seastar::lw_shared_ptr<seastar::foreign_ptr<ConnectionRef>>;
 
 class Dispatcher;
 
 class Messenger;
+
+template <typename T, typename... Args>
+seastar::future<T*> create_sharded(Args... args) {
+  auto sharded_obj = seastar::make_lw_shared<seastar::sharded<T>>();
+  return sharded_obj->start(args...).then([sharded_obj]() {
+      auto ret = &sharded_obj->local();
+      seastar::engine().at_exit([sharded_obj]() {
+          return sharded_obj->stop().finally([sharded_obj] {});
+        });
+      return ret;
+    });
+}
 
 } // namespace ceph::net

--- a/src/crimson/net/Messenger.cc
+++ b/src/crimson/net/Messenger.cc
@@ -1,0 +1,20 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "Messenger.h"
+#include "SocketMessenger.h"
+
+namespace ceph::net {
+
+seastar::future<Messenger*>
+Messenger::create(const entity_name_t& name,
+                  const std::string& lname,
+                  const uint64_t nonce)
+{
+  return create_sharded<SocketMessenger>(name, lname, nonce)
+    .then([](Messenger *msgr) {
+      return msgr;
+    });
+}
+
+} // namespace ceph::net

--- a/src/crimson/net/Messenger.cc
+++ b/src/crimson/net/Messenger.cc
@@ -9,9 +9,10 @@ namespace ceph::net {
 seastar::future<Messenger*>
 Messenger::create(const entity_name_t& name,
                   const std::string& lname,
-                  const uint64_t nonce)
+                  const uint64_t nonce,
+                  const int master_sid)
 {
-  return create_sharded<SocketMessenger>(name, lname, nonce)
+  return create_sharded<SocketMessenger>(name, lname, nonce, master_sid)
     .then([](Messenger *msgr) {
       return msgr;
     });

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -17,10 +17,15 @@
 #include <seastar/core/future.hh>
 
 #include "Fwd.h"
+#include "crimson/thread/Throttle.h"
+#include "msg/Policy.h"
 
 class AuthAuthorizer;
 
 namespace ceph::net {
+
+using Throttle = ceph::thread::Throttle;
+using SocketPolicy = ceph::net::Policy<Throttle>;
 
 class Messenger {
   entity_name_t my_name;
@@ -88,6 +93,12 @@ class Messenger {
   }
 
   virtual void print(ostream& out) const = 0;
+
+  virtual void set_default_policy(const SocketPolicy& p) = 0;
+
+  virtual void set_policy(entity_type_t peer_type, const SocketPolicy& p) = 0;
+
+  virtual void set_policy_throttler(entity_type_t peer_type, Throttle* throttle) = 0;
 
   static seastar::future<Messenger*>
   create(const entity_name_t& name,

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -90,7 +90,10 @@ class Messenger {
   virtual void print(ostream& out) const = 0;
 
   static seastar::future<Messenger*>
-  create(const entity_name_t& name, const std::string& lname, const uint64_t nonce);
+  create(const entity_name_t& name,
+         const std::string& lname,
+         const uint64_t nonce,
+         const int master_sid=-1);
 };
 
 inline ostream& operator<<(ostream& out, const Messenger& msgr) {

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -572,7 +572,7 @@ SocketConnection::handle_keepalive2()
     .then([this] (auto buf) {
       k.ack.stamp = *reinterpret_cast<const ceph_timespec*>(buf.get());
       seastar::shared_future<> f = send_ready.then([this] {
-          logger().info("{} keepalive2 {}", *this, k.ack.stamp.tv_sec);
+          logger().debug("{} keepalive2 {}", *this, k.ack.stamp.tv_sec);
           return socket->write_flush(make_static_packet(k.ack));
         });
       send_ready = f.get_future();
@@ -587,7 +587,7 @@ SocketConnection::handle_keepalive2_ack()
     .then([this] (auto buf) {
       auto t = reinterpret_cast<const ceph_timespec*>(buf.get());
       k.ack_stamp = *t;
-      logger().info("{} keepalive2 ack {}", *this, t->tv_sec);
+      logger().debug("{} keepalive2 ack {}", *this, t->tv_sec);
     });
 }
 

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -49,6 +49,7 @@ SocketConnection::SocketConnection(SocketMessenger& messenger,
     dispatcher(dispatcher),
     send_ready(h.promise.get_future())
 {
+  ceph_assert(&messenger.container().local() == &messenger);
 }
 
 SocketConnection::~SocketConnection()
@@ -61,34 +62,47 @@ SocketConnection::get_messenger() const {
   return &messenger;
 }
 
-bool SocketConnection::is_connected()
+seastar::future<bool> SocketConnection::is_connected()
 {
-  return !send_ready.failed();
+  return seastar::smp::submit_to(shard_id(), [this] {
+      return !send_ready.failed();
+    });
 }
 
 seastar::future<> SocketConnection::send(MessageRef msg)
 {
-  if (state == state_t::closing)
-    return seastar::now();
-  return seastar::with_gate(pending_dispatch, [this, msg=std::move(msg)] {
-      return do_send(std::move(msg))
-        .handle_exception([this] (std::exception_ptr eptr) {
-          logger().warn("{} send fault: {}", *this, eptr);
-          close();
+  return seastar::smp::submit_to(shard_id(), [this, msg=std::move(msg)] {
+      if (state == state_t::closing)
+        return seastar::now();
+      return seastar::with_gate(pending_dispatch, [this, msg=std::move(msg)] {
+          return do_send(std::move(msg))
+            .handle_exception([this] (std::exception_ptr eptr) {
+              logger().warn("{} send fault: {}", *this, eptr);
+              close();
+            });
         });
     });
 }
 
 seastar::future<> SocketConnection::keepalive()
 {
-  if (state == state_t::closing)
-    return seastar::now();
-  return seastar::with_gate(pending_dispatch, [this] {
-      return do_keepalive()
-        .handle_exception([this] (std::exception_ptr eptr) {
-          logger().warn("{} keepalive fault: {}", *this, eptr);
-          close();
+  return seastar::smp::submit_to(shard_id(), [this] {
+      if (state == state_t::closing)
+        return seastar::now();
+      return seastar::with_gate(pending_dispatch, [this] {
+          return do_keepalive()
+            .handle_exception([this] (std::exception_ptr eptr) {
+              logger().warn("{} keepalive fault: {}", *this, eptr);
+              close();
+            });
         });
+    });
+}
+
+seastar::future<> SocketConnection::close()
+{
+  return seastar::smp::submit_to(shard_id(), [this] {
+      return do_close();
     });
 }
 
@@ -196,10 +210,13 @@ seastar::future<> SocketConnection::read_message()
       }
 
       constexpr bool add_ref = false; // Message starts with 1 ref
+      // TODO: change MessageRef with foreign_ptr
       auto msg_ref = MessageRef{msg, add_ref};
       // start dispatch, ignoring exceptions from the application layer
       seastar::with_gate(pending_dispatch, [this, msg = std::move(msg_ref)] {
-          return dispatcher.ms_dispatch(this, std::move(msg))
+          return dispatcher.ms_dispatch(
+              seastar::static_pointer_cast<SocketConnection>(shared_from_this()),
+              std::move(msg))
             .handle_exception([this] (std::exception_ptr eptr) {
               logger().error("{} ms_dispatch caught exception: {}", *this, eptr);
               ceph_assert(false);
@@ -298,7 +315,7 @@ seastar::future<> SocketConnection::do_keepalive()
   return f.get_future();
 }
 
-seastar::future<> SocketConnection::close()
+seastar::future<> SocketConnection::do_close()
 {
   if (state == state_t::closing) {
     // already closing
@@ -307,12 +324,14 @@ seastar::future<> SocketConnection::close()
   }
 
   // unregister_conn() drops a reference, so hold another until completion
-  auto cleanup = [conn = SocketConnectionRef(this)] {};
+  auto cleanup = [conn_ref = shared_from_this(), this] {
+      logger().debug("{} closed!", *this);
+    };
 
   if (state == state_t::accepting) {
-    messenger.unaccept_conn(this);
+    messenger.unaccept_conn(seastar::static_pointer_cast<SocketConnection>(shared_from_this()));
   } else if (state >= state_t::connecting && state < state_t::closing) {
-    messenger.unregister_conn(this);
+    messenger.unregister_conn(seastar::static_pointer_cast<SocketConnection>(shared_from_this()));
   } else {
     // cannot happen
     ceph_assert(false);
@@ -785,7 +804,7 @@ SocketConnection::start_connect(const entity_addr_t& _peer_addr,
   ceph_assert(!socket);
   peer_addr = _peer_addr;
   peer_type = _peer_type;
-  messenger.register_conn(this);
+  messenger.register_conn(seastar::static_pointer_cast<SocketConnection>(shared_from_this()));
   logger().debug("{} trigger connecting, was {}", *this, static_cast<int>(state));
   state = state_t::connecting;
   seastar::with_gate(pending_dispatch, [this] {
@@ -796,7 +815,7 @@ SocketConnection::start_connect(const entity_addr_t& _peer_addr,
             fd.shutdown_output();
             throw std::system_error(make_error_code(error::connection_aborted));
           }
-          socket.emplace(std::move(fd));
+          socket = seastar::make_foreign(std::make_unique<Socket>(std::move(fd)));
           // read server's handshake header
           return socket->read(server_header_size);
         }).then([this] (bufferlist headerbl) {
@@ -810,8 +829,8 @@ SocketConnection::start_connect(const entity_addr_t& _peer_addr,
 
           side = side_t::connector;
           socket_port = caddr.get_port();
-          messenger.learned_addr(caddr);
-
+          return messenger.learned_addr(caddr);
+        }).then([this] {
           // encode/send client's handshake header
           bufferlist bl;
           bl.append(buffer::create_static(banner_size, banner));
@@ -824,7 +843,7 @@ SocketConnection::start_connect(const entity_addr_t& _peer_addr,
           });
         }).then([this] {
           // notify the dispatcher and allow them to reject the connection
-          return dispatcher.ms_handle_connect(this);
+          return dispatcher.ms_handle_connect(seastar::static_pointer_cast<SocketConnection>(shared_from_this()));
         }).then([this] {
           execute_open();
         }).handle_exception([this] (std::exception_ptr eptr) {
@@ -837,7 +856,7 @@ SocketConnection::start_connect(const entity_addr_t& _peer_addr,
 }
 
 void
-SocketConnection::start_accept(seastar::connected_socket&& fd,
+SocketConnection::start_accept(seastar::foreign_ptr<std::unique_ptr<Socket>>&& sock,
                                const entity_addr_t& _peer_addr)
 {
   ceph_assert(state == state_t::none);
@@ -846,8 +865,8 @@ SocketConnection::start_accept(seastar::connected_socket&& fd,
   peer_addr.set_port(0);
   side = side_t::acceptor;
   socket_port = _peer_addr.get_port();
-  socket.emplace(std::move(fd));
-  messenger.accept_conn(this);
+  socket = std::move(sock);
+  messenger.accept_conn(seastar::static_pointer_cast<SocketConnection>(shared_from_this()));
   logger().debug("{} trigger accepting, was {}", *this, static_cast<int>(state));
   state = state_t::accepting;
   seastar::with_gate(pending_dispatch, [this, _peer_addr] {
@@ -874,10 +893,10 @@ SocketConnection::start_accept(seastar::connected_socket&& fd,
           });
         }).then([this] {
           // notify the dispatcher and allow them to reject the connection
-          return dispatcher.ms_handle_accept(this);
+          return dispatcher.ms_handle_accept(seastar::static_pointer_cast<SocketConnection>(shared_from_this()));
         }).then([this] {
-          messenger.register_conn(this);
-          messenger.unaccept_conn(this);
+          messenger.register_conn(seastar::static_pointer_cast<SocketConnection>(shared_from_this()));
+          messenger.unaccept_conn(seastar::static_pointer_cast<SocketConnection>(shared_from_this()));
           execute_open();
         }).handle_exception([this] (std::exception_ptr eptr) {
           // TODO: handle fault in the accepting state
@@ -902,12 +921,12 @@ SocketConnection::execute_open()
           logger().warn("{} open fault: {}", *this, e);
           if (e.code() == error::connection_aborted ||
               e.code() == error::connection_reset) {
-            return dispatcher.ms_handle_reset(this)
+            return dispatcher.ms_handle_reset(seastar::static_pointer_cast<SocketConnection>(shared_from_this()))
               .then([this] {
                 close();
               });
           } else if (e.code() == error::read_eof) {
-            return dispatcher.ms_handle_remote_reset(this)
+            return dispatcher.ms_handle_remote_reset(seastar::static_pointer_cast<SocketConnection>(shared_from_this()))
               .then([this] {
                 close();
               });
@@ -925,7 +944,7 @@ SocketConnection::execute_open()
 seastar::future<> SocketConnection::fault()
 {
   if (policy.lossy) {
-    messenger.unregister_conn(this);
+    messenger.unregister_conn(seastar::static_pointer_cast<SocketConnection>(shared_from_this()));
   }
   if (h.backoff.count()) {
     h.backoff += h.backoff;
@@ -936,6 +955,10 @@ seastar::future<> SocketConnection::fault()
     h.backoff = conf.ms_max_backoff;
   }
   return seastar::sleep(h.backoff);
+}
+
+seastar::shard_id SocketConnection::shard_id() const {
+  return messenger.shard_id();
 }
 
 void SocketConnection::print(ostream& out) const {

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -21,14 +21,10 @@
 #include <seastar/core/reactor.hh>
 #include <seastar/core/sharded.hh>
 
-#include "msg/Policy.h"
 #include "Messenger.h"
 #include "SocketConnection.h"
-#include "crimson/thread/Throttle.h"
 
 namespace ceph::net {
-
-using SocketPolicy = ceph::net::Policy<ceph::thread::Throttle>;
 
 class SocketMessenger final : public Messenger, public seastar::peering_sharded_service<SocketMessenger> {
   const int master_sid;
@@ -39,7 +35,6 @@ class SocketMessenger final : public Messenger, public seastar::peering_sharded_
   Dispatcher *dispatcher = nullptr;
   std::map<entity_addr_t, SocketConnectionRef> connections;
   std::set<SocketConnectionRef> accepting_conns;
-  using Throttle = ceph::thread::Throttle;
   ceph::net::PolicySet<Throttle> policy_set;
   // Distinguish messengers with meaningful names for debugging
   const std::string logic_name;
@@ -96,11 +91,14 @@ class SocketMessenger final : public Messenger, public seastar::peering_sharded_
         << ") " << get_myaddr();
   }
 
+  void set_default_policy(const SocketPolicy& p) override;
+
+  void set_policy(entity_type_t peer_type, const SocketPolicy& p) override;
+
+  void set_policy_throttler(entity_type_t peer_type, Throttle* throttle) override;
+
  public:
   seastar::future<> learned_addr(const entity_addr_t &peer_addr_for_me);
-  void set_default_policy(const SocketPolicy& p);
-  void set_policy(entity_type_t peer_type, const SocketPolicy& p);
-  void set_policy_throttler(entity_type_t peer_type, Throttle* throttle);
 
   SocketConnectionRef lookup_conn(const entity_addr_t& addr);
   void accept_conn(SocketConnectionRef);

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -31,7 +31,7 @@ public:
 			  entity_addrvec_t back);
   seastar::future<> stop();
 
-  void add_peer(osd_id_t peer, epoch_t epoch);
+  seastar::future<> add_peer(osd_id_t peer, epoch_t epoch);
   seastar::future<> update_peers(int whoami);
   seastar::future<> remove_peer(osd_id_t peer);
 
@@ -64,8 +64,10 @@ private:
   void add_reporter_peers(int whoami);
 
 private:
-  std::unique_ptr<ceph::net::Messenger> front_msgr;
-  std::unique_ptr<ceph::net::Messenger> back_msgr;
+  const int whoami;
+  const uint32_t nonce;
+  ceph::net::Messenger* front_msgr = nullptr;
+  ceph::net::Messenger* back_msgr = nullptr;
   const OSDMapService& service;
   ceph::mon::Client& monc;
 

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -40,12 +40,13 @@ class OSD : public ceph::net::Dispatcher,
   seastar::gate gate;
   seastar::timer<seastar::lowres_clock> beacon_timer;
   const int whoami;
+  const uint32_t nonce;
   // talk with osd
-  std::unique_ptr<ceph::net::Messenger> cluster_msgr;
+  ceph::net::Messenger* cluster_msgr = nullptr;
   // talk with client/mon/mgr
-  std::unique_ptr<ceph::net::Messenger> public_msgr;
+  ceph::net::Messenger* public_msgr = nullptr;
   ChainedDispatchers dispatchers;
-  ceph::mon::Client monc;
+  std::unique_ptr<ceph::mon::Client> monc;
 
   std::unique_ptr<Heartbeat> heartbeat;
   seastar::timer<seastar::lowres_clock> heartbeat_timer;

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -9,12 +9,13 @@ add_ceph_unittest(unittest_seastar_denc)
 target_link_libraries(unittest_seastar_denc crimson GTest::Main)
 
 add_executable(unittest_seastar_messenger test_messenger.cc)
-#add_ceph_unittest(unittest_seastar_messenger)
+add_ceph_unittest(unittest_seastar_messenger)
 target_link_libraries(unittest_seastar_messenger ceph-common crimson)
 
-add_executable(unittest_seastar_echo
-  test_alien_echo.cc)
-target_link_libraries(unittest_seastar_echo ceph-common global crimson)
+# TODO: fix unittest_seastar_echo with the new design
+#add_executable(unittest_seastar_echo
+#  test_alien_echo.cc)
+#target_link_libraries(unittest_seastar_echo ceph-common global crimson)
 
 add_executable(unittest_seastar_thread_pool
   test_thread_pool.cc)
@@ -25,9 +26,10 @@ add_executable(unittest_seastar_config
   test_config.cc)
 target_link_libraries(unittest_seastar_config crimson)
 
-add_executable(unittest_seastar_monc
-  test_monc.cc)
-target_link_libraries(unittest_seastar_monc crimson)
+# TODO: fix unittest_seastar_monc with the new design
+#add_executable(unittest_seastar_monc
+#  test_monc.cc)
+#target_link_libraries(unittest_seastar_monc crimson)
 
 add_executable(unittest_seastar_perfcounters
   test_perfcounters.cc)

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -12,10 +12,9 @@ add_executable(unittest_seastar_messenger test_messenger.cc)
 add_ceph_unittest(unittest_seastar_messenger)
 target_link_libraries(unittest_seastar_messenger ceph-common crimson)
 
-# TODO: fix unittest_seastar_echo with the new design
-#add_executable(unittest_seastar_echo
-#  test_alien_echo.cc)
-#target_link_libraries(unittest_seastar_echo ceph-common global crimson)
+add_executable(unittest_seastar_echo
+  test_alien_echo.cc)
+target_link_libraries(unittest_seastar_echo ceph-common global crimson)
 
 add_executable(unittest_seastar_thread_pool
   test_thread_pool.cc)
@@ -26,10 +25,9 @@ add_executable(unittest_seastar_config
   test_config.cc)
 target_link_libraries(unittest_seastar_config crimson)
 
-# TODO: fix unittest_seastar_monc with the new design
-#add_executable(unittest_seastar_monc
-#  test_monc.cc)
-#target_link_libraries(unittest_seastar_monc crimson)
+add_executable(unittest_seastar_monc
+  test_monc.cc)
+target_link_libraries(unittest_seastar_monc crimson)
 
 add_executable(unittest_seastar_perfcounters
   test_perfcounters.cc)

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -1,15 +1,25 @@
 #include "messages/MPing.h"
+#include "crimson/common/log.h"
 #include "crimson/net/Connection.h"
 #include "crimson/net/Dispatcher.h"
-#include "crimson/net/SocketMessenger.h"
+#include "crimson/net/Messenger.h"
 
+#include <map>
 #include <random>
 #include <boost/program_options.hpp>
 #include <seastar/core/app-template.hh>
+#include <seastar/core/do_with.hh>
 #include <seastar/core/future-util.hh>
 #include <seastar/core/reactor.hh>
+#include <seastar/core/sleep.hh>
 
 namespace bpo = boost::program_options;
+
+namespace {
+
+seastar::logger& logger() {
+  return ceph::get_logger(ceph_subsys_ms);
+}
 
 static std::random_device rd;
 static std::default_random_engine rng{rd()};
@@ -19,106 +29,226 @@ static seastar::future<> test_echo(unsigned rounds,
                                    double keepalive_ratio)
 {
   struct test_state {
-    entity_addr_t addr;
+    struct Server final
+        : public ceph::net::Dispatcher,
+          public seastar::peering_sharded_service<Server> {
+      ceph::net::Messenger *msgr = nullptr;
 
-    struct {
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1), "server1", 1};
-      struct ServerDispatcher : ceph::net::Dispatcher {
-        seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
-                                      MessageRef m) override {
-          if (verbose) {
-            std::cout << "server got " << *m << std::endl;
-          }
-          // reply with a pong
-          return c->send(MessageRef{new MPing(), false});
+      Dispatcher* get_local_shard() override {
+        return &(container().local());
+      }
+      seastar::future<> stop() {
+        return seastar::make_ready_future<>();
+      }
+      seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
+                                    MessageRef m) override {
+        if (verbose) {
+          logger().info("server got {}", *m);
         }
-      } dispatcher;
-    } server;
+        // reply with a pong
+        return c->send(MessageRef{new MPing(), false});
+      }
 
-    struct {
-      unsigned rounds;
-      std::bernoulli_distribution keepalive_dist{};
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0), "client1", 2};
-      struct ClientDispatcher : ceph::net::Dispatcher {
-        seastar::promise<MessageRef> reply;
+      seastar::future<> init(const entity_name_t& name,
+                             const std::string& lname,
+                             const uint64_t nonce,
+                             const entity_addr_t& addr) {
+        auto&& fut = ceph::net::Messenger::create(name, lname, nonce);
+        return fut.then([this, addr](ceph::net::Messenger *messenger) {
+            return container().invoke_on_all([messenger](auto& server) {
+                server.msgr = messenger->get_local_shard();
+              }).then([messenger, addr] {
+                return messenger->bind(entity_addrvec_t{addr});
+              }).then([this, messenger] {
+                return messenger->start(this);
+              });
+          });
+      }
+      seastar::future<> shutdown() {
+        ceph_assert(msgr);
+        return msgr->shutdown();
+      }
+    };
+
+    struct Client final
+        : public ceph::net::Dispatcher,
+          public seastar::peering_sharded_service<Client> {
+
+      struct PingSession : public seastar::enable_shared_from_this<PingSession> {
         unsigned count = 0u;
-        seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
-                                      MessageRef m) override {
-          ++count;
-          if (verbose) {
-            std::cout << "client ms_dispatch " << count << std::endl;
-          }
-          reply.set_value(std::move(m));
+      };
+      using PingSessionRef = seastar::shared_ptr<PingSession>;
+
+      unsigned rounds;
+      std::bernoulli_distribution keepalive_dist;
+      ceph::net::Messenger *msgr = nullptr;
+      std::map<ceph::net::Connection*, seastar::promise<>> pending_conns;
+      std::map<ceph::net::ConnectionRef, PingSessionRef> sessions;
+
+      Client(unsigned rounds, double keepalive_ratio)
+        : rounds(rounds),
+          keepalive_dist(std::bernoulli_distribution{keepalive_ratio}) {}
+      Dispatcher* get_local_shard() override {
+        return &(container().local());
+      }
+      seastar::future<> stop() {
+        return seastar::now();
+      }
+      seastar::future<> ms_handle_connect(ceph::net::ConnectionRef conn) override {
+        logger().info("{}: connected to {}", *conn, conn->get_peer_addr());
+        auto session = seastar::make_shared<PingSession>();
+        auto [i, added] = sessions.emplace(conn, session);
+        std::ignore = i;
+        ceph_assert(added);
+        return container().invoke_on_all([conn = conn.get()](auto& client) {
+            auto [i, added] = client.pending_conns.emplace(conn, seastar::promise<>());
+            std::ignore = i;
+            ceph_assert(added);
+          });
+      }
+      seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
+                                    MessageRef m) override {
+        auto found = sessions.find(c);
+        if (found == sessions.end()) {
+          ceph_assert(false);
+        }
+        auto session = found->second;
+        ++(session->count);
+        if (verbose) {
+          logger().info("client ms_dispatch {}", session->count);
+        }
+
+        if (session->count == rounds) {
+          logger().info("{}: finished receiving {} pongs", *c.get(), session->count);
+          return container().invoke_on_all([conn = c.get()](auto &client) {
+              auto found = client.pending_conns.find(conn);
+              ceph_assert(found != client.pending_conns.end());
+              found->second.set_value();
+            });
+        } else {
           return seastar::now();
         }
-      } dispatcher;
-      seastar::future<> pingpong(ceph::net::ConnectionRef c) {
-        return seastar::repeat([conn=std::move(c), this] {
-          if (keepalive_dist(rng)) {
-            return conn->keepalive().then([] {
-              return seastar::make_ready_future<seastar::stop_iteration>(
-                seastar::stop_iteration::no);
+      }
+
+      seastar::future<> init(const entity_name_t& name,
+                             const std::string& lname,
+                             const uint64_t nonce) {
+        return ceph::net::Messenger::create(name, lname, nonce)
+          .then([this](ceph::net::Messenger *messenger) {
+            return container().invoke_on_all([messenger](auto& client) {
+                client.msgr = messenger->get_local_shard();
+              }).then([this, messenger] {
+                return messenger->start(this);
               });
-          } else {
-            return conn->send(MessageRef{new MPing(), false}).then([&] {
-              return dispatcher.reply.get_future();
-            }).then([&] (MessageRef msg) {
-              dispatcher.reply = seastar::promise<MessageRef>{};
-              if (verbose) {
-                std::cout << "client got reply " << *msg << std::endl;
-              }
-              return seastar::make_ready_future<seastar::stop_iteration>(
-                  seastar::stop_iteration::yes);
-            });
-          };
-        });
+          });
       }
-      bool done() const {
-        return dispatcher.count >= rounds;
+
+      seastar::future<> shutdown() {
+        ceph_assert(msgr);
+        return msgr->shutdown();
       }
-    } client;
+
+      seastar::future<> dispatch_pingpong(const entity_addr_t& peer_addr, bool foreign_dispatch=true) {
+        return msgr->connect(peer_addr, entity_name_t::TYPE_OSD)
+          .then([this, foreign_dispatch](auto conn) {
+            if (foreign_dispatch) {
+              return do_dispatch_pingpong(&**conn)
+                .finally([this, conn] {});
+            } else {
+              // NOTE: this could be faster if we don't switch cores in do_dispatch_pingpong().
+              return container().invoke_on(conn->get()->shard_id(), [conn = &**conn](auto &client) {
+                  return client.do_dispatch_pingpong(conn);
+                }).finally([this, conn] {});
+            }
+          });
+      }
+
+     private:
+      seastar::future<> do_dispatch_pingpong(ceph::net::Connection* conn) {
+        return seastar::do_with(0u, 0u,
+                                [this, conn](auto &count_ping, auto &count_keepalive) {
+            return seastar::do_until(
+              [this, conn, &count_ping, &count_keepalive] {
+                bool stop = (count_ping == rounds);
+                if (stop) {
+                  logger().info("{}: finished sending {} pings with {} keepalives",
+                                *conn, count_ping, count_keepalive);
+                }
+                return stop;
+              },
+              [this, conn, &count_ping, &count_keepalive] {
+                return seastar::repeat([this, conn, &count_ping, &count_keepalive] {
+                    if (keepalive_dist(rng)) {
+                      count_keepalive += 1;
+                      return conn->keepalive()
+                        .then([&count_keepalive] {
+                          return seastar::make_ready_future<seastar::stop_iteration>(
+                            seastar::stop_iteration::no);
+                        });
+                    } else {
+                      count_ping += 1;
+                      return conn->send(MessageRef{new MPing(), false})
+                        .then([] {
+                          return seastar::make_ready_future<seastar::stop_iteration>(
+                            seastar::stop_iteration::yes);
+                        });
+                    }
+                  });
+              }).then([this, conn] {
+                auto found = pending_conns.find(conn);
+                if (found == pending_conns.end())
+                  throw std::runtime_error{"Not connected."};
+                return found->second.get_future();
+              });
+          });
+      }
+    };
   };
-  return seastar::do_with(test_state{},
-    [rounds, keepalive_ratio] (test_state& t) {
-      // bind the server
-      t.addr.set_type(entity_addr_t::TYPE_LEGACY);
-      t.addr.set_family(AF_INET);
-      t.addr.set_port(9010);
-      t.addr.set_nonce(1);
-      t.server.messenger.bind(entity_addrvec_t{t.addr});
 
-      t.client.rounds = rounds;
-      t.client.keepalive_dist = std::bernoulli_distribution{keepalive_ratio};
-
-      return t.server.messenger.start(&t.server.dispatcher)
-        .then([&] {
-          return t.client.messenger.start(&t.client.dispatcher)
-            .then([&] {
-              return t.client.messenger.connect(t.addr,
-                                                entity_name_t::TYPE_OSD);
-            }).then([&client=t.client] (ceph::net::ConnectionRef conn) {
-              if (verbose) {
-                std::cout << "client connected" << std::endl;
-              }
-              return seastar::repeat([&client,conn=std::move(conn)] {
-                return client.pingpong(conn).then([&client] {
-                  return seastar::make_ready_future<seastar::stop_iteration>(
-                    client.done() ?
-                    seastar::stop_iteration::yes :
-                    seastar::stop_iteration::no);
-                });
-              });
-            }).finally([&] {
-              if (verbose) {
-                std::cout << "client shutting down" << std::endl;
-              }
-              return t.client.messenger.shutdown();
-            });
-        }).finally([&] {
-          if (verbose) {
-            std::cout << "server shutting down" << std::endl;
-          }
-          return t.server.messenger.shutdown();
+  logger().info("test_echo():");
+  return seastar::when_all_succeed(
+      ceph::net::create_sharded<test_state::Server>(),
+      ceph::net::create_sharded<test_state::Server>(),
+      ceph::net::create_sharded<test_state::Client>(rounds, keepalive_ratio),
+      ceph::net::create_sharded<test_state::Client>(rounds, keepalive_ratio))
+    .then([rounds, keepalive_ratio](test_state::Server *server1,
+                                    test_state::Server *server2,
+                                    test_state::Client *client1,
+                                    test_state::Client *client2) {
+      // start servers and clients
+      entity_addr_t addr1;
+      addr1.parse("127.0.0.1:9010", nullptr);
+      addr1.set_type(entity_addr_t::TYPE_LEGACY);
+      entity_addr_t addr2;
+      addr2.parse("127.0.0.1:9011", nullptr);
+      addr2.set_type(entity_addr_t::TYPE_LEGACY);
+      return seastar::when_all_succeed(
+          server1->init(entity_name_t::OSD(0), "server1", 1, addr1),
+          server2->init(entity_name_t::OSD(1), "server2", 2, addr2),
+          client1->init(entity_name_t::OSD(2), "client1", 3),
+          client2->init(entity_name_t::OSD(3), "client2", 4))
+      // dispatch pingpoing
+        .then([client1, client2, server1, server2] {
+          return seastar::when_all_succeed(
+              // test connecting in parallel, accepting in parallel,
+              // and operating the connection reference from a foreign/local core
+              client1->dispatch_pingpong(server1->msgr->get_myaddr(), true),
+              client1->dispatch_pingpong(server2->msgr->get_myaddr(), false),
+              client2->dispatch_pingpong(server1->msgr->get_myaddr(), false),
+              client2->dispatch_pingpong(server2->msgr->get_myaddr(), true));
+      // shutdown
+        }).finally([client1] {
+          logger().info("client1 shutdown...");
+          return client1->shutdown();
+        }).finally([client2] {
+          logger().info("client2 shutdown...");
+          return client2->shutdown();
+        }).finally([server1] {
+          logger().info("server1 shutdown...");
+          return server1->shutdown();
+        }).finally([server2] {
+          logger().info("server2 shutdown...");
+          return server2->shutdown();
         });
     });
 }
@@ -126,66 +256,118 @@ static seastar::future<> test_echo(unsigned rounds,
 static seastar::future<> test_concurrent_dispatch()
 {
   struct test_state {
-    entity_addr_t addr;
+    struct Server final
+      : public ceph::net::Dispatcher,
+        public seastar::peering_sharded_service<Server> {
+      ceph::net::Messenger *msgr = nullptr;
+      int count = 0;
+      seastar::promise<> on_second; // satisfied on second dispatch
+      seastar::promise<> on_done; // satisfied when first dispatch unblocks
 
-    struct {
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1), "server2", 3};
-      class ServerDispatcher : public ceph::net::Dispatcher {
-        int count = 0;
-        seastar::promise<> on_second; // satisfied on second dispatch
-        seastar::promise<> on_done; // satisfied when first dispatch unblocks
-       public:
-        seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
-                                      MessageRef m) override {
-          switch (++count) {
-          case 1:
-            // block on the first request until we reenter with the second
-            return on_second.get_future().then([=] { on_done.set_value(); });
-          case 2:
-            on_second.set_value();
-            return seastar::now();
-          default:
-            throw std::runtime_error("unexpected count");
-          }
-        }
-        seastar::future<> wait() { return on_done.get_future(); }
-      } dispatcher;
-    } server;
-
-    struct {
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0), "client2", 4};
-      ceph::net::Dispatcher dispatcher;
-    } client;
-  };
-  return seastar::do_with(test_state{},
-    [] (test_state& t) {
-      // bind the server
-      t.addr.set_type(entity_addr_t::TYPE_LEGACY);
-      t.addr.set_family(AF_INET);
-      t.addr.set_port(9010);
-      t.addr.set_nonce(3);
-      t.server.messenger.bind(entity_addrvec_t{t.addr});
-
-      return t.server.messenger.start(&t.server.dispatcher)
-        .then([&] {
-          return t.client.messenger.start(&t.client.dispatcher)
-            .then([&] {
-              return t.client.messenger.connect(t.addr,
-                                                entity_name_t::TYPE_OSD);
-            }).then([] (ceph::net::ConnectionRef conn) {
-              // send two messages
-              conn->send(MessageRef{new MPing, false});
-              conn->send(MessageRef{new MPing, false});
-            }).then([&] {
-              // wait for the server to get both
-              return t.server.dispatcher.wait();
-            }).finally([&] {
-              return t.client.messenger.shutdown();
+      seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
+                                    MessageRef m) override {
+        switch (++count) {
+        case 1:
+          // block on the first request until we reenter with the second
+          return on_second.get_future()
+            .then([this] {
+              return container().invoke_on_all([](Server& server) {
+                  server.on_done.set_value();
+                });
             });
-        }).finally([&] {
-          return t.server.messenger.shutdown();
+        case 2:
+          on_second.set_value();
+          return seastar::now();
+        default:
+          throw std::runtime_error("unexpected count");
+        }
+      }
+
+      seastar::future<> wait() { return on_done.get_future(); }
+
+      seastar::future<> init(const entity_name_t& name,
+                             const std::string& lname,
+                             const uint64_t nonce,
+                             const entity_addr_t& addr) {
+        return ceph::net::Messenger::create(name, lname, nonce)
+          .then([this, addr](ceph::net::Messenger *messenger) {
+            return container().invoke_on_all([messenger](auto& server) {
+                server.msgr = messenger->get_local_shard();
+              }).then([messenger, addr] {
+                return messenger->bind(entity_addrvec_t{addr});
+              }).then([this, messenger] {
+                return messenger->start(this);
+              });
+          });
+      }
+
+      Dispatcher* get_local_shard() override {
+        return &(container().local());
+      }
+      seastar::future<> stop() {
+        return seastar::make_ready_future<>();
+      }
+    };
+
+    struct Client final
+      : public ceph::net::Dispatcher,
+        public seastar::peering_sharded_service<Client> {
+      ceph::net::Messenger *msgr = nullptr;
+
+      seastar::future<> init(const entity_name_t& name,
+                             const std::string& lname,
+                             const uint64_t nonce) {
+        return ceph::net::Messenger::create(name, lname, nonce)
+          .then([this](ceph::net::Messenger *messenger) {
+            return container().invoke_on_all([messenger](auto& client) {
+                client.msgr = messenger->get_local_shard();
+              }).then([this, messenger] {
+                return messenger->start(this);
+              });
+          });
+      }
+
+      Dispatcher* get_local_shard() override {
+        return &(container().local());
+      }
+      seastar::future<> stop() {
+        return seastar::make_ready_future<>();
+      }
+    };
+  };
+
+  logger().info("test_concurrent_dispatch():");
+  return seastar::when_all_succeed(
+      ceph::net::create_sharded<test_state::Server>(),
+      ceph::net::create_sharded<test_state::Client>())
+    .then([](test_state::Server *server,
+             test_state::Client *client) {
+      entity_addr_t addr;
+      addr.parse("127.0.0.1:9010", nullptr);
+      addr.set_type(entity_addr_t::TYPE_LEGACY);
+      addr.set_family(AF_INET);
+      return seastar::when_all_succeed(
+          server->init(entity_name_t::OSD(4), "server3", 5, addr),
+          client->init(entity_name_t::OSD(5), "client3", 6))
+        .then([server, client] {
+          return client->msgr->connect(server->msgr->get_myaddr(),
+                                      entity_name_t::TYPE_OSD);
+        }).then([](ceph::net::ConnectionXRef conn) {
+          // send two messages
+          (*conn)->send(MessageRef{new MPing, false});
+          (*conn)->send(MessageRef{new MPing, false});
+        }).then([server] {
+          server->wait();
+        }).finally([client] {
+          logger().info("client shutdown...");
+          return client->msgr->shutdown();
+        }).finally([server] {
+          logger().info("server shutdown...");
+          return server->msgr->shutdown();
         });
     });
+}
+
 }
 
 int main(int argc, char** argv)
@@ -198,7 +380,7 @@ int main(int argc, char** argv)
      "number of pingpong rounds")
     ("keepalive-ratio", bpo::value<double>()->default_value(0.1),
      "ratio of keepalive in ping messages");
-  return app.run(argc, argv, [&] {
+  return app.run(argc, argv, [&app] {
     auto&& config = app.configuration();
     verbose = config["verbose"].as<bool>();
     auto rounds = config["rounds"].as<unsigned>();


### PR DESCRIPTION
~~This is a PoC implementation towards true sharded seastar-messenger for
interface discussion purposes.~~
Implement the sharded crimson-messenger:
* Sharded Messenger: provides shared-nothing Messenger for each shard,
  it's interfaces are symmetric to be called, any modifications will be
  applied to all shards.
* Sharded/non-sharded Dispatcher interface: allow connections to be
  dispatched, and related resources (such as Session) to be managed in
  its own shard or not.
* Sharded Connection: A connection only lives at one dedicated core
  during its lifecycle. It's sharded by its peer_IP in this PoC, because
  peer port and nonce are not available when a socket is accepted. While
  its interfaces are safe to be called from all shards.
* Replace `boost::intrusive_ptr` by seastar native smart ptrs for
  `Connection` and `SocketConnection`, because they need to be
  destructed from its original core.
* Unit test: establish multiple connections on both client and server
  sides, they runs concurrently and creates sessions that are also
  following shared-nothing design.