### PR TITLE
mgr/dashboard: tasks.mgr.dashboard.test_osd.OsdTest failures

### DIFF
--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -162,10 +162,8 @@ class DashboardTestCase(MgrTestCase):
     @classmethod
     def _request(cls, url, method, data=None, params=None):
         url = "{}{}".format(cls._base_uri, url)
-        log.info("request %s to %s", method, url)
-        headers = {
-            'Content-Type': 'application/json'
-        }
+        log.info("Request %s to %s", method, url)
+        headers = {}
         if cls._token:
             headers['Authorization'] = "Bearer {}".format(cls._token)
 
@@ -184,6 +182,9 @@ class DashboardTestCase(MgrTestCase):
         else:
             assert False
         try:
+            if not cls._resp.ok:
+                # Output response for easier debugging.
+                log.error("Request response: %s", cls._resp.text)
             content_type = cls._resp.headers['content-type']
             if content_type == 'application/json' and cls._resp.text and cls._resp.text != "":
                 return cls._resp.json()

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -133,10 +133,10 @@ class Osd(RESTController):
         :return:
         """
         result = CephService.send_command(
-            'mon', 'osd create', id=svc_id, uuid=uuid)
+            'mon', 'osd create', id=int(svc_id), uuid=uuid)
         return {
             'result': result,
-            'svc_id': svc_id,
+            'svc_id': int(svc_id),
             'uuid': uuid,
         }
 

--- a/src/pybind/mgr/dashboard/tools.py
+++ b/src/pybind/mgr/dashboard/tools.py
@@ -47,8 +47,7 @@ class RequestLoggingTool(cherrypy.Tool):
             msg = '[DASHBOARD] from=\'{}\' path=\'{}\' method=\'{}\' ' \
                 'user=\'{}\''.format(url, req.path_info, req.method, user)
             if Settings.AUDIT_API_LOG_PAYLOAD:
-                params = req.params if req.params else {}
-                params.update(get_request_body_params(req))
+                params = dict(req.params or {}, **get_request_body_params(req))
                 # Hide sensitive data like passwords, secret keys, ...
                 # Extend the list of patterns to search for if necessary.
                 # Currently parameters like this are processed:


### PR DESCRIPTION
- Fix bug in Dashboard QA unit test framework. Don't set the application type header manually, this is done by the requests library if required.
- Enhance QA unit test helper: Print the response of the API request if it fails. This should help to identify the problem more easily.
- Fix bug in the OSD controller. A parameter needs to be converted to integer.
- Take care that the params of the request object are not modified.

The issue was introduced by PR https://github.com/ceph/ceph/pull/24475. The CherryPy json_in plugin disclosed the errorneous unit test helper implementation.

Fixes: https://tracker.ceph.com/issues/36708

Signed-off-by: Volker Theile <vtheile@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

