### PR TITLE
luminous: ceph-volume tests.systemd update imports for systemd module

### DIFF
--- a/src/ceph-volume/ceph_volume/systemd/__init__.py
+++ b/src/ceph-volume/ceph_volume/systemd/__init__.py
@@ -1,1 +1,1 @@
-from .main import main
+from .main import main # noqa

--- a/src/ceph-volume/ceph_volume/tests/systemd/test_main.py
+++ b/src/ceph-volume/ceph_volume/tests/systemd/test_main.py
@@ -1,16 +1,16 @@
 import pytest
 from ceph_volume import exceptions, conf
-from ceph_volume.systemd import main
+from ceph_volume.systemd.main import parse_subcommand, main, process
 
 
 class TestParseSubcommand(object):
 
     def test_no_subcommand_found(self):
         with pytest.raises(exceptions.SuffixParsingError):
-            main.parse_subcommand('')
+            parse_subcommand('')
 
     def test_sub_command_is_found(self):
-        result = main.parse_subcommand('lvm-1-sha-1-something-0')
+        result = parse_subcommand('lvm-1-sha-1-something-0')
         assert result == 'lvm'
 
 
@@ -33,16 +33,16 @@ class TestMain(object):
 
     def test_no_arguments_parsing_error(self):
         with pytest.raises(RuntimeError):
-            main.main(args=[])
+            main(args=[])
 
     def test_parsing_suffix_error(self):
         with pytest.raises(exceptions.SuffixParsingError):
-            main.main(args=['asdf'])
+            main(args=['asdf'])
 
     def test_correct_command(self, monkeypatch):
         run = Capture()
-        monkeypatch.setattr(main.process, 'run', run)
-        main.main(args=['ceph-volume-systemd', 'lvm-8715BEB4-15C5-49DE-BA6F-401086EC7B41-0' ])
+        monkeypatch.setattr(process, 'run', run)
+        main(args=['ceph-volume-systemd', 'lvm-8715BEB4-15C5-49DE-BA6F-401086EC7B41-0' ])
         command = run.calls[0][0]
         assert command == [
             'ceph-volume',


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/36704
Backport of: #24937