### PR TITLE
luminous ceph-volume tests install ceph-ansible's requirements.txt dependencies

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -17,11 +17,6 @@ setenv=
   ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
-deps=
-  ansible~=2.6,<2.7
-  testinfra
-  pytest-xdist
-  notario>=0.0.13
 changedir=
   centos7-filestore-single_type: {toxinidir}/centos7/filestore/single-type
   centos7-filestore-single_type_dmcrypt: {toxinidir}/centos7/filestore/single-type-dmcrypt
@@ -37,6 +32,7 @@ changedir=
   xenial-bluestore-single_type_dmcrypt: {toxinidir}/xenial/bluestore/single-type-dmcrypt
 commands=
   git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
+  pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
 
   bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/tox.ini
@@ -18,11 +18,6 @@ setenv=
   ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
-deps=
-  ansible~=2.6,<2.7
-  testinfra
-  pytest-xdist
-  notario>=0.0.13
 changedir=
   # plain/unencrypted
   centos7-filestore-create: {toxinidir}/centos7/filestore/create
@@ -42,9 +37,7 @@ changedir=
   centos7-bluestore-prepare_activate: {toxinidir}/xenial/bluestore/prepare_activate
 commands=
   git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
-  # XXX Ideally we should be able to consume the requirements for ceph-ansible directly,
-  # but the master branch doesn't pin dependencies so we can't guarantee to work correctly
-  #pip install -r {envdir}/tmp/ceph-ansible/requirements.txt
+  pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
 
   bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}

--- a/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/simple/tox.ini
@@ -18,11 +18,6 @@ setenv=
   ANSIBLE_SSH_RETRIES = 5
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
-deps=
-  ansible~=2.6,<2.7
-  testinfra
-  pytest-xdist
-  notario>=0.0.13
 changedir=
   centos7-filestore-activate: {toxinidir}/centos7/filestore/activate
   centos7-bluestore-activate: {toxinidir}/centos7/bluestore/activate
@@ -38,9 +33,7 @@ changedir=
   centos7-filestore-dmcrypt_luks: {toxinidir}/centos7/filestore/dmcrypt-luks
 commands=
   git clone -b {env:CEPH_ANSIBLE_BRANCH:master} --single-branch https://github.com/ceph/ceph-ansible.git {envdir}/tmp/ceph-ansible
-  # XXX Ideally we should be able to consume the requirements for ceph-ansible directly,
-  # but the master branch doesn't pin dependencies so we can't guarantee to work correctly
-  #pip install -r {envdir}/tmp/ceph-ansible/requirements.txt
+  pip install -r {envdir}/tmp/ceph-ansible/tests/requirements.txt
 
   bash {toxinidir}/../scripts/vagrant_up.sh {env:VAGRANT_UP_FLAGS:"--no-provision"} {posargs:--provider=virtualbox}
   bash {toxinidir}/../scripts/generate_ssh_config.sh {changedir}


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/36672
ceph-ansible PR made it so that python-netaddr is required for ceph-volume tests https://github.com/ceph/ceph-ansible/pull/3199
Backport of: https://github.com/ceph/ceph/pull/24881