### PR TITLE
doc: tweak RBD iSCSI docs to point to merged tooling repo

### DIFF
--- a/doc/rbd/iscsi-target-ansible.rst
+++ b/doc/rbd/iscsi-target-ansible.rst
@@ -11,9 +11,9 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
 -  A running Ceph Luminous (12.2.x) cluster or newer
 
--  RHEL/CentOS 7.5; Linux kernel v4.16 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
+-  Red Hat Enterprise Linux/CentOS 7.5 (or newer); Linux kernel v4.16 (or newer)
 
--  The ``ceph-iscsi-config`` package installed on all the iSCSI gateway nodes
+-  The ``ceph-iscsi`` package installed on all the iSCSI gateway nodes
 
 **Installing:**
 
@@ -172,7 +172,7 @@ On the Ansible installer node, perform the following steps.
 
 **Service Management:**
 
-The ``ceph-iscsi-config`` package installs the configuration management
+The ``ceph-iscsi`` package installs the configuration management
 logic and a Systemd service called ``rbd-target-gw``. When the Systemd
 service is enabled, the ``rbd-target-gw`` will start at boot time and
 will restore the Linux IO state. The Ansible playbook disables the

--- a/doc/rbd/iscsi-target-cli-manual-install.rst
+++ b/doc/rbd/iscsi-target-cli-manual-install.rst
@@ -1,28 +1,27 @@
-==================================
-Manual ceph-iscsi-cli Installation
-==================================
+==============================
+Manual ceph-iscsi Installation
+==============================
 
 **Requirements**
 
-to complete the installation of ceph-iscsi-cli, there are 4 different steps:
+To complete the installation of ceph-iscsi, there are 4 steps:
 
 1. Install common packages from your Linux distribution's software repository
 2. Install Git to fetch the remaining packages directly from their Git repositories
-3. Ensure a compatible kernel is used or install a ceph-iscsi-test client
-4. Install all the components of ceph-iscsi-cli and start associated daemons:
+3. Ensure a compatible kernel is used
+4. Install all the components of ceph-iscsi and start associated daemons:
 
    -  tcmu-runner
    -  rtslib-fb
    -  configshell-fb
    -  targetcli-fb
-   -  ceph-iscsi-config
-   -  ceph-iscsi-cli
+   -  ceph-iscsi
 
 
 1. Install Common Packages
 ==========================
 
-The following packages will be used by ceph-iscsi-cli and target tools.
+The following packages will be used by ceph-iscsi and target tools.
 They must be installed from your Linux distribution's software repository
 on each machine that will be a iSCSI gateway:
 
@@ -37,7 +36,6 @@ on each machine that will be a iSCSI gateway:
 -  python pyparsing
 -  python rados
 -  python rbd
--  python netaddr
 -  python netifaces
 -  python crypto
 -  python requests
@@ -72,25 +70,12 @@ Ensure you use a supported kernel that contains the required Ceph iSCSI patches:
 -  all Linux distribution with a kernel v4.16 or newer, or
 -  Red Hat Enterprise Linux or CentOS 7.5 or later (in these distributions ceph-iscsi support is backported)
 
-If you are already using  on the compatible kernels, you can go to next step.
-However, if you are NOT using a compatible kernel then ceph-client ceph-iscsi-test
-branch must be used. To get the branch run:
-    
-    ::
-    
-       > git clone https://github.com/ceph/ceph-client.git
-       > git checkout ceph-iscsi-test
-    
-    .. warning::
-       ceph-iscsi-test is not for production use. It should only be used
-       for proof of concept setups and testing. The kernel is only updated
-       with Ceph iSCSI patches. General security and bug fixes from upstream
-       are not applied.
-    
-    Check your distro's docs for specific instructions on how to build a
-    kernel. The only Ceph iSCSI specific requirements are the following
-    build options must be enabled:
-    
+If you are already using a compatible kernel, you can go to next step.
+However, if you are NOT using a compatible kernel then check your distro's
+documentation for specific instructions on how to build this kernel. The only
+Ceph iSCSI specific requirements are that the following build options must be
+enabled:
+
     ::
     
        CONFIG_TARGET_CORE=m
@@ -98,7 +83,7 @@ branch must be used. To get the branch run:
        CONFIG_ISCSI_TARGET=m
 
 
-4. Install ceph-iscsi-cli
+4. Install ceph-iscsi
 ========================================================
 
 Finally, the remaining tools can be fetched directly from their Git repositories and their associated services started
@@ -176,17 +161,18 @@ targetcli-fb
       on the system. If targets have been setup and are being managed by
       targetcli the target service must be disabled.
 
-ceph-iscsi-config
+ceph-iscsi
 -----------------
 
    Installation:
 
    ::
 
-       > git clone https://github.com/ceph/ceph-iscsi-config.git
-       > cd ceph-iscsi-config
+       > git clone https://github.com/ceph/ceph-iscsi.git
+       > cd ceph-iscsi
        > python setup.py install --install-scripts=/usr/bin
        > cp usr/lib/systemd/system/rbd-target-gw.service /lib/systemd/system
+       > cp usr/lib/systemd/system/rbd-target-api.service /lib/systemd/system
 
    Enable and start the daemon:
 
@@ -195,21 +181,10 @@ ceph-iscsi-config
        > systemctl daemon-reload
        > systemctl enable rbd-target-gw
        > systemctl start rbd-target-gw
-
-ceph-iscsi-cli
---------------
-
-   Installation:
-
-   ::
-
-       > git clone https://github.com/ceph/ceph-iscsi-cli.git
-       > cd ceph-iscsi-cli
-       > python setup.py install --install-scripts=/usr/bin
-       > cp usr/lib/systemd/system/rbd-target-api.service /lib/systemd/system
-
+       > systemctl enable rbd-target-api
+       > systemctl start rbd-target-api
 
 Installation is complete. Proceed to the setup section in the
-`main ceph-iscsi-cli page`_.
+`main ceph-iscsi CLI page`_.
 
-.. _`main ceph-iscsi-cli page`: ../iscsi-target-cli
+.. _`main ceph-iscsi CLI page`: ../iscsi-target-cli

--- a/doc/rbd/iscsi-target-cli.rst
+++ b/doc/rbd/iscsi-target-cli.rst
@@ -11,7 +11,7 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
 -  A running Ceph Luminous or later storage cluster
 
--  RHEL/CentOS 7.5; Linux kernel v4.16 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
+-  Red Hat Enterprise Linux/CentOS 7.5 (or newer); Linux kernel v4.16 (or newer)
 
 -  The following packages must be installed from your Linux distribution's software repository:
 
@@ -21,9 +21,7 @@ install, and configure the Ceph iSCSI gateway for basic operation.
 
    -  ``tcmu-runner-1.3.0`` or newer package
 
-   -  ``ceph-iscsi-config-2.4`` or newer package
-
-   -  ``ceph-iscsi-cli-2.5`` or newer package
+   -  ``ceph-iscsi-2.7`` or newer package
 
      .. important::
         If previous versions of these packages exist, then they must
@@ -52,7 +50,7 @@ to the *Installing* section:
 
 **Installing:**
 
-If you are using the upstream ceph-iscsi-cli package follow the
+If you are using the upstream ceph-iscsi package follow the
 `manual install instructions`_.
 
 .. _`manual install instructions`: ../iscsi-target-cli-manual-install
@@ -65,11 +63,11 @@ If you are using the upstream ceph-iscsi-cli package follow the
 For rpm based instructions execute the following commands:
 
 #. As ``root``, on all iSCSI gateway nodes, install the
-   ``ceph-iscsi-cli`` package:
+   ``ceph-iscsi`` package:
 
    ::
 
-       # yum install ceph-iscsi-cli
+       # yum install ceph-iscsi
 
 #. As ``root``, on all iSCSI gateway nodes, install the ``tcmu-runner``
    package:

--- a/doc/rbd/iscsi-targets.rst
+++ b/doc/rbd/iscsi-targets.rst
@@ -8,7 +8,7 @@ within OpenStack environments. Starting with the Ceph Luminous release,
 block-level access is expanding to offer standard iSCSI support allowing
 wider platform usage, and potentially opening new use cases.
 
--  RHEL/CentOS 7.5; Linux kernel v4.16 or newer; or the `Ceph iSCSI client test kernel <https://shaman.ceph.com/repos/kernel/ceph-iscsi-test>`_
+-  Red Hat Enterprise Linux/CentOS 7.5 (or newer); Linux kernel v4.16 (or newer)
 
 -  A working Ceph Storage cluster, deployed with ``ceph-ansible`` or using the command-line interface
 


### PR DESCRIPTION
Also remove all references to the ceph-client test kernel since v4.16 has been
released.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

