### PR TITLE
Throttle: complete all m_blockers when we set average or max to 0

### DIFF
--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -793,6 +793,8 @@ void TokenBucketThrottle::add_tokens() {
     std::lock_guard<Mutex> lock(m_lock);
     // put tokens into bucket.
     m_throttle.put(tokens_this_tick());
+    if (0 == m_avg || 0 == m_throttle.max)
+      tmp_blockers.swap(m_blockers);
     // check the m_blockers from head to tail, if blocker can get
     // enough tokens, let it go.
     while (!m_blockers.empty()) {

--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -422,9 +422,9 @@ public:
   
   template <typename T, typename I, void(T::*MF)(int, I*, uint64_t)>
   bool get(uint64_t c, T *handler, I *item, uint64_t flag) {
-    if (0 == m_avg)
+    if (0 == c)
       return false;
-  
+
     bool wait = false;
     uint64_t got = 0;
     std::lock_guard<Mutex> lock(m_lock);
@@ -432,6 +432,9 @@ public:
       // Keep the order of requests, add item after previous blocked requests.
       wait = true;
     } else {
+      if (0 == m_throttle.max || 0 == m_avg)
+        return false;
+  
       got = m_throttle.get(c);
       if (got < c) {
         // Not enough tokens, add a blocker for it.


### PR DESCRIPTION
When we change the average or max to 0, we need to complete all m_blockers
first.

Fixes: http://tracker.ceph.com/issues/36715
Signed-off-by: Dongsheng Yang <dongsheng.yang@easystack.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

