### PR TITLE
doc: correct rbytes description

### DIFF
--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -114,7 +114,7 @@ Options
 
 :command:`rbytes`
   Report the recursive size of the directory contents for st_size on
-  directories.  Default: on
+  directories.  Default: off
 
 :command:`norbytes`
   Do not report the recursive size of the directory contents for


### PR DESCRIPTION
The option rbytes is off as default indeed:
```
[root@test root]# mount -t ceph 192.168.0.24:/ /mnt -o name=admin,secretfile=/etc/ceph/admin.secret
[root@test root]# cd /mnt
[root@test mnt]# ls -ld mongo
drwxr-xr-x 4 polkitd root 29 11月  6 16:33 mongo
[root@test root]# cd
[root@test root]# mount -t ceph 192.168.0.24:/ /mnt -o name=admin,secretfile=/etc/ceph/admin.secret,rbytes
[root@test root]# cd /mnt
[root@test mnt]# ls -ld mongo
drwxr-xr-x 4 polkitd root 392021518 11月  6 16:33 mongo
```

Signed-off-by: Xiang Dai 764524258@qq.com