### PR TITLE
compressor: Fix build of Brotli Compressor

### DIFF
--- a/src/compressor/brotli/BrotliCompressor.cc
+++ b/src/compressor/brotli/BrotliCompressor.cc
@@ -90,6 +90,6 @@ int BrotliCompressor::decompress(bufferlist::const_iterator &p,
 
 int BrotliCompressor::decompress(const bufferlist &in, bufferlist &out) 
 {  
-  bufferlist::iterator i = const_cast<bufferlist&>(in).begin();
+  auto i = std::cbegin(in);
   return decompress(i, in.length(), out);
 }

--- a/src/compressor/brotli/CMakeLists.txt
+++ b/src/compressor/brotli/CMakeLists.txt
@@ -8,7 +8,7 @@ include(ExternalProject)
 ExternalProject_Add(brotli_ext
   DOWNLOAD_DIR ${CMAKE_BINARY_DIR}/src/
   GIT_REPOSITORY "https://github.com/google/brotli.git"
-  GIT_TAG "master"
+  GIT_TAG "v1.0.7"
   SOURCE_DIR ${CMAKE_BINARY_DIR}/src/brotli
   CONFIGURE_COMMAND ./configure-cmake --disable-debug 
   INSTALL_COMMAND ""
@@ -23,6 +23,7 @@ ExternalProject_Add_Step(brotli_ext forcebuild
   ALWAYS 1)
 
 set(bortli_libs enc dec common)
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/src/brotli/c/include")
 foreach(lib ${bortli_libs})
   add_library(brotli::${lib} STATIC IMPORTED)
   add_dependencies(brotli::${lib} brotli_ext)

--- a/src/compressor/brotli/CompressionPluginBrotli.cc
+++ b/src/compressor/brotli/CompressionPluginBrotli.cc
@@ -1,6 +1,8 @@
 #include "acconfig.h"
 #include "ceph_ver.h"
 #include "CompressionPluginBrotli.h"
+#include "common/ceph_context.h"
+
 
 const char *__ceph_plugin_version()
 {


### PR DESCRIPTION
Using stable brotli version
Add common/ceph_context.h header file for brotli compression plugin

Signed-off-by: BI SHUN KE <aionshun@livemail.tw>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

