### PR TITLE
mgr/dashboard: fix for 'Cluster >> Hosts' page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.spec.ts
@@ -1,11 +1,12 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
 import { BsDropdownModule } from 'ngx-bootstrap/dropdown';
 import { TabsModule } from 'ngx-bootstrap/tabs';
 
 import { configureTestBed } from '../../../../testing/unit-test-helper';
+import { HostService } from '../../../shared/api/host.service';
 import { Permissions } from '../../../shared/models/permissions';
 import { AuthStorageService } from '../../../shared/services/auth-storage.service';
 import { SharedModule } from '../../../shared/shared.module';
@@ -15,6 +16,7 @@ import { HostsComponent } from './hosts.component';
 describe('HostsComponent', () => {
   let component: HostsComponent;
   let fixture: ComponentFixture<HostsComponent>;
+  let hostListSpy;
 
   const fakeAuthStorageService = {
     getPermissions: () => {
@@ -37,10 +39,46 @@ describe('HostsComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(HostsComponent);
     component = fixture.componentInstance;
+    hostListSpy = spyOn(TestBed.get(HostService), 'list');
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should render hosts list even with not permission mapped services', async(() => {
+    const hostname = 'ceph.dev';
+    const payload = [
+      {
+        services: [
+          {
+            type: 'osd',
+            id: '0'
+          },
+          {
+            type: 'rgw',
+            id: 'rgw'
+          },
+          {
+            type: 'notPermissionMappedService',
+            id: '1'
+          }
+        ],
+        hostname: hostname,
+        ceph_version: 'ceph version Development'
+      }
+    ];
+
+    hostListSpy.and.returnValue(Promise.resolve(payload));
+
+    fixture.whenStable().then(() => {
+      fixture.detectChanges();
+
+      const spans = fixture.debugElement.nativeElement.querySelectorAll(
+        '.datatable-body-cell-label span'
+      );
+      expect(spans[0].textContent).toBe(hostname);
+    });
+  }));
 });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/hosts/hosts.component.ts
@@ -68,7 +68,8 @@ export class HostsComponent implements OnInit {
       osd: 'osd',
       rgw: 'rgw',
       'rbd-mirror': 'rbdMirroring',
-      mgr: 'manager'
+      mgr: 'manager',
+      'tcmu-runner': 'iscsi'
     };
     this.isLoadingHosts = true;
     this.hostService
@@ -77,8 +78,8 @@ export class HostsComponent implements OnInit {
         resp.map((host) => {
           host.services.map((service) => {
             service.cdLink = `/perf_counters/${service.type}/${service.id}`;
-            const permissionKey = typeToPermissionKey[service.type];
-            service.canRead = this.permissions[permissionKey].read;
+            const permission = this.permissions[typeToPermissionKey[service.type]];
+            service.canRead = permission ? permission.read : false;
             return service;
           });
           return host;


### PR DESCRIPTION
- Added permission mapping for 'tcmu-runner' service type.
- Avoid error caused by unmapped services' types:
  The hosts list should be visible even with not mapped services' types,
  as this mapping only decides whether the service being displayed has a link or not.

Fixes: https://tracker.ceph.com/issues/36712

Signed-off-by: Alfonso Martínez <almartin@redhat.com>