### PR TITLE
ceph-volume: Use $PATH instead of hard-coded file system locations.

### DIFF
--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -33,14 +33,7 @@ def generate_uuid():
 
 def which(executable):
     """find the location of an executable"""
-    locations = (
-        '/usr/local/bin',
-        '/bin',
-        '/usr/bin',
-        '/usr/local/sbin',
-        '/usr/sbin',
-        '/sbin',
-    )
+    locations = os.getenv('PATH').split(':')
 
     for location in locations:
         executable_path = os.path.join(location, executable)


### PR DESCRIPTION
Hello!

This tiny change makes it easier to run `ceph-volume` on "weird" distributions that do not use standard file system locations.