### PR TITLE
mds: throttle client messages

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -189,6 +189,19 @@ int main(int argc, const char **argv)
   msgr->set_policy(entity_name_t::TYPE_CLIENT,
                    Messenger::Policy::stateful_server(0));
 
+  // throttle client-mds traffic
+  {
+    auto limit = cct->_conf.get_val<Option::size_t>("mds_msg_client_throttle_bytes");
+    auto client_throttler = new Throttle(g_ceph_context, "mds_msg_client_throttle_bytes", limit);
+    msgr->set_policy_throttlers(entity_name_t::TYPE_CLIENT, client_throttler, NULL);
+  }
+  // throttle mds-mds traffic
+  {
+    auto limit = cct->_conf.get_val<Option::size_t>("mds_msg_mds_throttle_bytes");
+    auto mds_throttler = new Throttle(g_ceph_context, "mds_msg_mds_throttle_bytes", limit);
+    msgr->set_policy_throttlers(entity_name_t::TYPE_MDS, mds_throttler, NULL);
+  }
+
   int r = msgr->bindv(addrs);
   if (r < 0)
     forker.exit(1);

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -886,7 +886,7 @@ std::vector<Option> get_global_options() {
     .set_description("Induce a daemon crash/exit if sender skips a message sequence number"),
 
     Option("ms_dispatch_throttle_bytes", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
-    .set_default(100_M)
+    .set_default(128_M)
     .set_description("Limit messages that are read off the network but still being processed"),
 
     Option("ms_bind_ipv4", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
@@ -7191,6 +7191,20 @@ std::vector<Option> get_mds_options() {
     Option("mds_scatter_nudge_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(5)
     .set_description("minimum interval between scatter lock updates"),
+
+    Option("mds_msg_client_throttle_bytes", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .add_see_also("ms_dispatch_throttle_bytes")
+    .add_see_also("mds_msg_mds_throttle_bytes")
+    .set_default(64_M)
+    .set_description("number of bytes client messages can consume in memory before being throttled")
+    .set_long_description("The number of bytes client messages, for all clients, may consume in memory before the MDS begins throttling reads from the client sockets. This value should be smaller than the global throttle ms_dispatch_throttle_bytes so messages from other MDSs and Monitors may still be processed."),
+
+    Option("mds_msg_mds_throttle_bytes", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
+    .add_see_also("ms_dispatch_throttle_bytes")
+    .add_see_also("mds_msg_client_throttle_bytes")
+    .set_default(32_M)
+    .set_description("number of bytes mds-mds messages can consume in memory before being throttled")
+    .set_long_description("The number of bytes MDS messages, for all MDS, may consume in memory before the MDS begins throttling reads from the MDS sockets. This value should be smaller than the global throttle ms_dispatch_throttle_bytes so messages from clients and Monitors may still be processed."),
 
     Option("mds_client_prealloc_inos", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1000)


### PR DESCRIPTION
Currently client messages are not throttled except by the global
DispatchQueue::dispatch_throttler which is applied to all message types. If the
MDS receives too many messages from clients, this may cause other important
messages to be delayed being read off the wire like critical MDSBeacon ACKs
from the Monitors.  This will cause the MDS to falsely think its connection
with the Mons is laggy. Note that fast dispatch does not work around the
dispatch_throttler.

Fixes: http://tracker.ceph.com/issues/36730

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

