### PR TITLE
osdc: Change opcode size to 64bit to prevent overflow problems.

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2262,7 +2262,7 @@ void Objecter::resend_mon_ops()
 
 // read | write ---------------------------
 
-void Objecter::op_submit(Op *op, ceph_tid_t *ptid, int *ctx_budget)
+void Objecter::op_submit(Op *op, ceph_tid_t *ptid, int64_t *ctx_budget)
 {
   shunique_lock rl(rwlock, ceph::acquire_shared);
   ceph_tid_t tid = 0;
@@ -2274,7 +2274,7 @@ void Objecter::op_submit(Op *op, ceph_tid_t *ptid, int *ctx_budget)
 
 void Objecter::_op_submit_with_budget(Op *op, shunique_lock& sul,
 				      ceph_tid_t *ptid,
-				      int *ctx_budget)
+				      int64_t *ctx_budget)
 {
   ceph_assert(initialized);
 
@@ -2285,7 +2285,7 @@ void Objecter::_op_submit_with_budget(Op *op, shunique_lock& sul,
   // throttle.  before we look at any state, because
   // _take_op_budget() may drop our lock while it blocks.
   if (!op->ctx_budgeted || (ctx_budget && (*ctx_budget == -1))) {
-    int op_budget = _take_op_budget(op, sul);
+    int64_t op_budget = _take_op_budget(op, sul);
     // take and pass out the budget for the first OP
     // in the context session
     if (ctx_budget && (*ctx_budget == -1)) {
@@ -3292,9 +3292,9 @@ void Objecter::_send_op(Op *op)
   op->session->con->send_message(m);
 }
 
-int Objecter::calc_op_budget(const vector<OSDOp>& ops)
+int64_t Objecter::calc_op_budget(const vector<OSDOp>& ops)
 {
-  int op_budget = 0;
+  int64_t op_budget = 0;
   for (vector<OSDOp>::const_iterator i = ops.begin();
        i != ops.end();
        ++i) {
@@ -3314,7 +3314,7 @@ int Objecter::calc_op_budget(const vector<OSDOp>& ops)
 
 void Objecter::_throttle_op(Op *op,
 			    shunique_lock& sul,
-			    int op_budget)
+			    int64_t op_budget)
 {
   ceph_assert(sul && sul.mutex() == &rwlock);
   bool locked_for_write = sul.owns_lock();
@@ -5006,7 +5006,7 @@ struct C_EnumerateReply : public Context {
   Context *on_finish;
 
   epoch_t epoch;
-  int budget;
+  int64_t budget;
 
   C_EnumerateReply(Objecter *objecter_, hobject_t *next_,
       std::list<librados::ListObjectImpl> *result_,
@@ -5091,7 +5091,7 @@ void Objecter::_enumerate_reply(
     int r,
     const hobject_t &end,
     const int64_t pool_id,
-    int budget,
+    int64_t budget,
     epoch_t reply_epoch,
     std::list<librados::ListObjectImpl> *result,
     hobject_t *next,

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1381,7 +1381,7 @@ public:
 
     epoch_t map_dne_bound;
 
-    int budget;
+    int64_t budget;
 
     /// true if we should resend this message on failure
     bool should_resend;
@@ -1543,7 +1543,7 @@ public:
     // the budget is not get/released on OP basis, instead the budget
     // is acquired before sending the first OP and released upon receiving
     // the last op reply.
-    int ctx_budget = -1;
+    int64_t ctx_budget = -1;
 
     bool at_end() const {
       return at_end_of_pool;
@@ -1724,7 +1724,7 @@ public:
     OSDSession *session;
 
     Objecter *objecter;
-    int ctx_budget;
+    int64_t ctx_budget;
     ceph_tid_t register_tid;
     ceph_tid_t ping_tid;
     epoch_t map_dne_bound;
@@ -1996,11 +1996,11 @@ private:
    * and returned whenever an op is removed from the map
    * If throttle_op needs to throttle it will unlock client_lock.
    */
-  int calc_op_budget(const vector<OSDOp>& ops);
-  void _throttle_op(Op *op, shunique_lock& sul, int op_size = 0);
-  int _take_op_budget(Op *op, shunique_lock& sul) {
+  int64_t calc_op_budget(const vector<OSDOp>& ops);
+  void _throttle_op(Op *op, shunique_lock& sul, int64_t op_size = 0);
+  int64_t _take_op_budget(Op *op, shunique_lock& sul) {
     ceph_assert(sul && sul.mutex() == &rwlock);
-    int op_budget = calc_op_budget(op->ops);
+    int64_t op_budget = calc_op_budget(op->ops);
     if (keep_balanced_budget) {
       _throttle_op(op, sul, op_budget);
     } else { // update take_linger_budget to match this!
@@ -2012,7 +2012,7 @@ private:
   }
   int take_linger_budget(LingerOp *info);
   friend class WatchContext; // to invoke put_up_budget_bytes
-  void put_op_budget_bytes(int op_budget) {
+  void put_op_budget_bytes(int64_t op_budget) {
     ceph_assert(op_budget >= 0);
     op_throttle_bytes.put(op_budget);
     op_throttle_ops.put(1);
@@ -2154,10 +2154,10 @@ private:
   void _op_submit(Op *op, shunique_lock& lc, ceph_tid_t *ptid);
   void _op_submit_with_budget(Op *op, shunique_lock& lc,
 			      ceph_tid_t *ptid,
-			      int *ctx_budget = NULL);
+			      int64_t *ctx_budget = NULL);
   // public interface
 public:
-  void op_submit(Op *op, ceph_tid_t *ptid = NULL, int *ctx_budget = NULL);
+  void op_submit(Op *op, ceph_tid_t *ptid = NULL, int64_t *ctx_budget = NULL);
   bool is_active() {
     shared_lock l(rwlock);
     return !((!inflight_ops) && linger_ops.empty() &&
@@ -2316,7 +2316,7 @@ public:
     uint32_t hash, object_locator_t oloc,
     ObjectOperation& op, bufferlist *pbl, int flags,
     Context *onack, epoch_t *reply_epoch,
-    int *ctx_budget) {
+    int64_t *ctx_budget) {
     Op *o = new Op(object_t(), oloc,
 		   op.ops,
 		   flags | global_op_flags | CEPH_OSD_FLAG_READ |
@@ -2341,7 +2341,7 @@ public:
     uint32_t hash, object_locator_t oloc,
     ObjectOperation& op, bufferlist *pbl, int flags,
     Context *onack, epoch_t *reply_epoch,
-    int *ctx_budget) {
+    int64_t *ctx_budget) {
     Op *o = prepare_pg_read_op(hash, oloc, op, pbl, flags,
 			       onack, reply_epoch, ctx_budget);
     ceph_tid_t tid;
@@ -2913,7 +2913,7 @@ public:
       int r,
       const hobject_t &end,
       const int64_t pool_id,
-      int budget,
+      int64_t budget,
       epoch_t reply_epoch,
       std::list<librados::ListObjectImpl> *result, 
       hobject_t *next,


### PR DESCRIPTION
On a production cluster at customer side a osd crashed through an assert in
the throttling code. The underlying problem was, that calc_op_budget overflowed on
one Op and would caused negative throttling which was checked for.

I fixed the problem temporarily by setting the budget to a large number if it is negative after calc_op_budget.

Increasing the budget to int64_t should prevent the underlying problem.


ceph version 11.2.1 (e0354f9d3b1eea1d75a7dd487ba8098311be38a7)
 1: (()+0x947627) [0x55a3799fb627]
 2: (()+0xf890) [0x7efc423cc890]
 3: (gsignal()+0x37) [0x7efc401ba067]
 4: (abort()+0x148) [0x7efc401bb448]
 5: (ceph::__ceph_assert_fail(char const*, char const*, int, char
const*)+0x24f) [0x55a379bdcd1f]
 6: (Throttle::take(long)+0x2fc) [0x55a379bd327c]
 7: (Objecter::_op_submit_with_budget(Objecter::Op*,
ceph::shunique_lock<boost::shared_mutex>&, unsigned long*, int*)+0x2aa)
[0x55a379756f4a]
 8: (Objecter::op_submit(Objecter::Op*, unsigned long*, int*)+0xe3)
[0x55a3797588c3]
 9: (PrimaryLogPG::_copy_some(std::shared_ptr<ObjectContext>,
std::shared_ptr<PrimaryLogPG::CopyOp>)+0x1044) [0x55a37963bff4]
 10: (PrimaryLogPG::start_copy(PrimaryLogPG::CopyCallback*,
std::shared_ptr<ObjectContext>, hobject_t, object_locator_t, unsigned
long, unsigned int, bool, unsigned int, unsigned int)+0x684)
[0x55a37963cfb4]
 11: (PrimaryLogPG::do_osd_ops(PrimaryLogPG::OpContext*,
std::vector<OSDOp, std::allocator<OSDOp> >&)+0xbf04) [0x55a3796869f4]
 12: (PrimaryLogPG::prepare_transaction(PrimaryLogPG::OpContext*)+0xbf)
[0x55a37968c78f]
 13: (PrimaryLogPG::execute_ctx(PrimaryLogPG::OpContext*)+0x719)
[0x55a37968d4c9]
 14: (PrimaryLogPG::do_op(std::shared_ptr<OpRequest>&)+0x3da8)
[0x55a379692a68]
 15: (PrimaryLogPG::do_request(std::shared_ptr<OpRequest>&,
ThreadPool::TPHandle&)+0x727) [0x55a379650c67]
 16: (OSD::dequeue_op(boost::intrusive_ptr<PG>,
std::shared_ptr<OpRequest>, ThreadPool::TPHandle&)+0x400)
[0x55a3794f8d40]
 17: (PGQueueable::RunVis::operator()(std::shared_ptr<OpRequest>
const&)+0x6a) [0x55a3794f8f6a]
 18: (OSD::ShardedOpWQ::_process(unsigned int,
ceph::heartbeat_handle_d*)+0x72b) [0x55a379521afb]
 19: (ShardedThreadPool::shardedthreadpool_worker(unsigned int)+0x96e)
[0x55a379be28ce]
 20: (ShardedThreadPool::WorkThreadSharded::entry()+0x10)
[0x55a379be4ad0]
 21: (()+0x8064) [0x7efc423c5064]
 22: (clone()+0x6d) [0x7efc4026d62d]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is
needed to interpret this.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: Daniel Poelzleithner <poelzleithner@b1-systems.de>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

