### PR TITLE
mgr/prometheus: Adjusted standby manager prometheus module behavior to redirect to active mgr

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -706,19 +706,16 @@ class StandbyModule(MgrStandbyModule):
             @cherrypy.expose
             def index(self):
                 active_uri = module.get_active_uri()
-                return '''<!DOCTYPE html>
-<html>
-	<head><title>Ceph Exporter</title></head>
-	<body>
-		<h1>Ceph Exporter</h1>
-        <p><a href='{}metrics'>Metrics</a></p>
-	</body>
-</html>'''.format(active_uri)
+                if active_uri:
+                    module.log.info("Redirecting to active '%s'", active_uri)
+                    raise cherrypy.HTTPRedirect(active_uri)
 
             @cherrypy.expose
             def metrics(self):
-                cherrypy.response.headers['Content-Type'] = 'text/plain'
-                return ''
+                active_uri = module.get_active_uri()
+                if active_uri:
+                    module.log.info("Redirecting to active '%s/metrics'", active_uri)
+                    raise cherrypy.HTTPRedirect('{}/metrics'.format(active_uri))
 
         cherrypy.tree.mount(Root(), '/', {})
         self.log.info('Starting engine...')


### PR DESCRIPTION
mgr/prometheus: Adjusted standby manager prometheus module behavior to redirect to active mgr

When prometheus manager module is enabled and queried on the non-active manager instance, the response is as follows:

```
$ curl http://standby-mgr:9283/metrics
$
```
Without the /metrics path:
```
$ curl http://standby-mgr:9283/
<!DOCTYPE html>
<html>
        <head><title>Ceph Exporter</title></head>
        <body>
                <h1>Ceph Exporter</h1>
        <p><a href='http://active-mgr:9283/metrics'>Metrics</a></p>
        </body>
</html>
```
This patch adjusts the behavior to produce a redirect to the active module both with, or without the /metrics path.  This behavior mimics that of the mgr/dashboard module.

Signed-off-by: Michael J. Kidd <linuxkidd@gmail.com>