### PR TITLE
luminous: doc: Put command template into literal block

### DIFF
--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -124,7 +124,7 @@ configuration details, perform the following steps using ``ceph-deploy``.
      ceph-deploy mgr create node1  *Required only for luminous+ builds, i.e >= 12.x builds*
 
 #. Add three OSDs. For the purposes of these instructions, we assume you have an
-   unused disk in each node called ``/dev/vdb``.  *Be sure that the device is not currently in use and does not contain any important data.*
+   unused disk in each node called ``/dev/vdb``.  *Be sure that the device is not currently in use and does not contain any important data.* ::
 
      ceph-deploy osd create {ceph-node}:{device}
 


### PR DESCRIPTION
``ceph-deploy osd create --data {device} {ceph-node}`` command
is not displayed properly because of missing double colons. As a result, double en dash is translated to single en dash [1]

[1] http://docs.ceph.com/docs/luminous/start/quick-ceph-deploy/