### PR TITLE
jewel: librbd: protect against race condition for back-to-back failures when rewatching images

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -85,7 +85,8 @@ ImageWatcher<I>::ImageWatcher(I &image_ctx)
     m_task_finisher(new TaskFinisher<Task>(*m_image_ctx.cct)),
     m_async_request_lock(util::unique_lock_name("librbd::ImageWatcher::m_async_request_lock", this)),
     m_owner_client_id_lock(util::unique_lock_name("librbd::ImageWatcher::m_owner_client_id_lock", this)),
-    m_notifier(image_ctx)
+    m_notifier(image_ctx),
+    m_watch_error_count(0)
 {
 }
 
@@ -1014,9 +1015,11 @@ void ImageWatcher<I>::handle_error(uint64_t handle, int err) {
   }
 
   RWLock::WLocker l(m_watch_lock);
+  m_watch_error_count += 1;
+  lderr(m_image_ctx.cct) << this << " handle_error count= " << m_watch_error_count << dendl;
   if (m_watch_state == WATCH_STATE_REGISTERED) {
     m_watch_state = WATCH_STATE_ERROR;
-
+    lderr(m_image_ctx.cct) << this << " handle_error transition to STATE_ERROR, trigger rewatch " << dendl;
     FunctionContext *ctx = new FunctionContext(
       boost::bind(&ImageWatcher<I>::rewatch, this));
     m_task_finisher->queue(TASK_CODE_REREGISTER_WATCH, ctx);
@@ -1035,9 +1038,11 @@ void ImageWatcher<I>::rewatch() {
 
   RWLock::WLocker l(m_watch_lock);
   if (m_watch_state != WATCH_STATE_ERROR) {
+    ldout(m_image_ctx.cct, 10) << this << " rewatch: not in STATE_ERROR" << dendl;
     return;
   }
   m_watch_state = WATCH_STATE_REWATCHING;
+  ldout(m_image_ctx.cct, 10) << this << " rewatch: transition to STATE_REWATCHING" << dendl;
 
   Context *ctx = create_context_callback<
     ImageWatcher<I>, &ImageWatcher<I>::handle_rewatch>(this);
@@ -1050,29 +1055,56 @@ void ImageWatcher<I>::rewatch() {
 template <typename I>
 void ImageWatcher<I>::handle_rewatch(int r) {
   CephContext *cct = m_image_ctx.cct;
+  Context *unregister_watch_ctx = nullptr;
+
   ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
 
-  WatchState next_watch_state = WATCH_STATE_REGISTERED;
-  if (r < 0) {
-    // only EBLACKLISTED or ENOENT can be returned
-    assert(r == -EBLACKLISTED || r == -ENOENT);
-    next_watch_state = WATCH_STATE_UNREGISTERED;
-  }
-
-  Context *unregister_watch_ctx = nullptr;
-  {
+  { // scope to hold the lock
     RWLock::WLocker watch_locker(m_watch_lock);
-    assert(m_watch_state == WATCH_STATE_REWATCHING);
-    m_watch_state = next_watch_state;
 
-    std::swap(unregister_watch_ctx, m_unregister_watch_ctx);
+    ldout(m_image_ctx.cct, 10) << this << " handle_rewatch error_count=" << m_watch_error_count << dendl;
+    ldout(m_image_ctx.cct, 10) << this << " handle_rewatch unregister_watch_ctx=" << m_unregister_watch_ctx << dendl;
 
-    // image might have been updated while we didn't have active watch
-    handle_payload(HeaderUpdatePayload(), nullptr);
+    bool retry_rewatch = (m_watch_error_count > 1 &&
+                          m_unregister_watch_ctx == nullptr);
+
+    ldout(m_image_ctx.cct, 10) << this << " handle_rewatch retry=" << retry_rewatch << dendl;
+
+    if (retry_rewatch) {
+      // We have accumulated more errors while rewatching. Don't finalize this
+      // rewatch attempt and start another one.
+      m_watch_error_count = 1;
+      ldout(m_image_ctx.cct, 10) << this << " handle_rewatch transitioning to STATE_ERROR " << dendl;
+      m_watch_state = WATCH_STATE_ERROR;
+      FunctionContext *ctx = new FunctionContext(
+        boost::bind(&ImageWatcher<I>::rewatch, this));
+      m_task_finisher->queue(TASK_CODE_REREGISTER_WATCH, ctx);
+      return;
+    }
+
+    m_watch_error_count = 0;
+    ldout(m_image_ctx.cct, 10) << this << " handle_rewatch transitioning to STATE_REGISTERED " << dendl;
+    WatchState next_watch_state = WATCH_STATE_REGISTERED;
+    if (r < 0) {
+      // only EBLACKLISTED or ENOENT can be returned
+      assert(r == -EBLACKLISTED || r == -ENOENT);
+      next_watch_state = WATCH_STATE_UNREGISTERED;
+    }
+
+    {
+      assert(m_watch_state == WATCH_STATE_REWATCHING);
+      m_watch_state = next_watch_state;
+
+      std::swap(unregister_watch_ctx, m_unregister_watch_ctx);
+
+      // image might have been updated while we didn't have active watch
+      handle_payload(HeaderUpdatePayload(), nullptr);
+    }
   }
 
   // wake up pending unregister request
   if (unregister_watch_ctx != nullptr) {
+    ldout(m_image_ctx.cct, 10) << this << " handle_rewatch unregistering watch " << dendl;
     unregister_watch_ctx->complete(0);
   }
 }

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -227,6 +227,8 @@ private:
   WatchCtx m_watch_ctx;
   uint64_t m_watch_handle;
   WatchState m_watch_state;
+  uint64_t m_watch_error_count;
+
   Context *m_unregister_watch_ctx = nullptr;
 
   TaskFinisher<Task> *m_task_finisher;


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
rbd: fix race condition for back-to-back failures while re-watching an image

This is a draft/RFC for a fix to jewel that protects against a race condition for
multiple failures while rewatching an RBD image.

Fixes: [http://tracker.ceph.com/issues/36580]
Signed-off-by: Christian Theune <ct@flyingcircus.io>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

Talked to @dillaman on IRC and the tracker about coming up with a fix for this issue which has been handled in Luminous already but blocks us from upgrading to Jewel intermediately at the moment.

This is purely a draft at the moment - I didn't even compile this but need to get some discussion about how to approach this out there. 