### PR TITLE
multipath too device

### DIFF
--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -270,7 +270,7 @@ def is_device(dev):
     # use lsblk first, fall back to using stat
     TYPE = lsblk(dev).get('TYPE')
     if TYPE:
-        return TYPE == 'disk'
+        return TYPE == 'disk' or 'mpath'
 
     # fallback to stat
     return _stat_is_device(os.lstat(dev).st_mode)


### PR DESCRIPTION
ceph-volume do not like the multipath devices.
But in fact it is the same block device as a regular disk.
Signed-off-by: Andrey Groshev <greenx@yandex.ru>

