### PR TITLE
mimic: core: rados rm --force-full is blocked when cluster is in full status

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2912,7 +2912,8 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       const string & oid = *iter;
 
     if (forcefull) {
-        ret = detail::remove(io_ctx, oid, CEPH_OSD_FLAG_FULL_FORCE, use_striper);
+        ret = detail::remove(io_ctx, oid, (CEPH_OSD_FLAG_FULL_FORCE |
+                             CEPH_OSD_FLAG_FULL_TRY), use_striper);
     } else {
         ret = detail::remove(io_ctx, oid, use_striper);
     }


### PR DESCRIPTION
http://tracker.ceph.com/issues/36435