### PR TITLE
qa: add librados3 to exclude_packages for ugprade tests

### DIFF
--- a/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/1-ceph-install/mimic.yaml
@@ -6,6 +6,7 @@ meta:
 tasks:
 - install:
     branch: mimic
+    exclude_packages: ['librados3']
 - print: "**** done installing mimic"
 - ceph:
     log-whitelist:

--- a/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/1-ceph-install/mimic.yaml
@@ -3,6 +3,7 @@ meta:
 tasks:
 - install:
     branch: mimic
+    exclude_packages: ['librados3']
 - print: "**** done install mimic"
 - ceph:
 - exec:


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>

this should address the failures in http://pulpito.ceph.com/yuriw-2018-11-09_21:32:57-upgrade:mimic-x-master-distro-basic-smithi/