### PR TITLE
mimic: [restful] deep_scrub is not a valid OSD command

### DIFF
--- a/src/pybind/mgr/restful/common.py
+++ b/src/pybind/mgr/restful/common.py
@@ -6,7 +6,7 @@ OSD_FLAGS = [
 
 # Implemented osd commands
 OSD_IMPLEMENTED_COMMANDS = [
-    'scrub', 'deep_scrub', 'repair'
+    'scrub', 'deep-scrub', 'repair'
 ]
 
 # Valid values for the 'var' argument to 'ceph osd pool set'


### PR DESCRIPTION
http://tracker.ceph.com/issues/36749