### PR TITLE
mimic: tests: make readable.sh fail if it doesn't run anything

### DIFF
--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -231,5 +231,11 @@ if [ $failed -gt 0 ]; then
   echo "FAILED $failed / $numtests tests."
   exit 1
 fi
+
+if [ $numtests -eq 0 ]; then
+  echo "FAILED: no tests found to run!"
+  exit 1
+fi
+
 echo "passed $numtests tests."
 


### PR DESCRIPTION
We want to detect if "make check" is run in an environment where some tests are skipped due to
missing data, so we now fail if we don't get a ceph object corpus.