### PR TITLE
mgr/dashboard: add pytest plugin: faulthandler

### DIFF
--- a/src/pybind/mgr/dashboard/requirements.txt
+++ b/src/pybind/mgr/dashboard/requirements.txt
@@ -24,6 +24,7 @@ pylint==1.8.2
 pyopenssl==17.5.0
 pytest==3.3.2
 pytest-cov==2.5.1
+pytest-faulthandler==1.0.1
 pytz==2017.3
 requests==2.20.0
 Routes==2.4.1


### PR DESCRIPTION
- Plugin for pytest that automatically enables the faulthandler module during tests.
- Very useful when you run tests and face segmentation faults.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

