### PR TITLE
ceph-dencoder: add RGWRealm and RGWPeriod  support.

### DIFF
--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -456,6 +456,20 @@ void RGWZone::generate_test_instances(list<RGWZone*> &o)
   o.push_back(new RGWZone);
 }
 
+void RGWRealm::generate_test_instances(list<RGWRealm*> &o)
+{
+  RGWRealm *z = new RGWRealm;
+  o.push_back(z);
+  o.push_back(new RGWRealm);
+}
+
+void RGWPeriod::generate_test_instances(list<RGWPeriod*> &o)
+{
+  RGWPeriod *z = new RGWPeriod;
+  o.push_back(z);
+  o.push_back(new RGWPeriod);
+}
+
 void RGWZoneParams::generate_test_instances(list<RGWZoneParams*> &o)
 {
   o.push_back(new RGWZoneParams);

--- a/src/rgw/rgw_zone.h
+++ b/src/rgw/rgw_zone.h
@@ -773,6 +773,7 @@ public:
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(list<RGWRealm*>& o);
 
   const std::string& get_current_period() const {
     return current_period;
@@ -971,6 +972,7 @@ public:
   }
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(list<RGWPeriod*>& o);
 
   static std::string get_staging_id(const std::string& realm_id) {
     return realm_id + ":staging";

--- a/src/tools/ceph-dencoder/types.h
+++ b/src/tools/ceph-dencoder/types.h
@@ -346,6 +346,8 @@ TYPE(RGWObjManifest)
 TYPE(RGWZoneParams)
 TYPE(RGWZone)
 TYPE(RGWZoneGroup)
+TYPE(RGWRealm)
+TYPE(RGWPeriod)
 
 #include "rgw/rgw_acl.h"
 TYPE(ACLPermission)


### PR DESCRIPTION
```
./bin/rados -p .rgw.root get realms.f267f99c-7795-4570-b4f5-869a9b49c4da realms.f267f99c-7795-4570-b4f5-869a9b49c4da  -c m1/ceph.conf

./bin/ceph-dencoder import realms.f267f99c-7795-4570-b4f5-869a9b49c4da type  RGWRealm decode dump_json
{
    "id": "f267f99c-7795-4570-b4f5-869a9b49c4da",
    "name": "realm_abc",
    "current_period": "c756c41e-50d0-4481-bb5b-f61fad7dd3aa",
    "epoch": 1
}


./bin/rados -p .rgw.root get periods.c756c41e-50d0-4481-bb5b-f61fad7dd3aa.1 periods.c756c41e-50d0-4481-bb5b-f61fad7dd3aa.1 -c m1/ceph.conf

./bin/ceph-dencoder import periods.c756c41e-50d0-4481-bb5b-f61fad7dd3aa.1 type  RGWPeriod  decode dump_json
{
    "id": "c756c41e-50d0-4481-bb5b-f61fad7dd3aa",
    "epoch": 1,
    "predecessor_uuid": "",
    "sync_status": [],
    "period_map": {
        "id": "c756c41e-50d0-4481-bb5b-f61fad7dd3aa",
        "zonegroups": [],
        "short_zone_ids": []
    },
    "master_zonegroup": "",
    "master_zone": "",
    "period_config": {
        "bucket_quota": {
            "enabled": false,
            "check_on_raw": false,
            "max_size": -1,
            "max_size_kb": -1,
            "max_objects": -1
        },
        "user_quota": {
            "enabled": false,
            "check_on_raw": false,
            "max_size": -1,
            "max_size_kb": -1,
            "max_objects": -1
        }
    },
    "realm_id": "f267f99c-7795-4570-b4f5-869a9b49c4da",
    "realm_name": "realm_abc",
    "realm_epoch": 1
}
```

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>
