### PR TITLE
test: deactivate venv after tox runs

### DIFF
--- a/src/pybind/mgr/insights/run-tox.sh
+++ b/src/pybind/mgr/insights/run-tox.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -x
 
 # run from ./ or from ../
 : ${MGR_INSIGHTS_VIRTUALENV:=/tmp/mgr-insights-virtualenv}
@@ -18,6 +19,7 @@ unset PYTHONPATH
 export CEPH_BUILD_DIR=$CEPH_BUILD_DIR
 
 source ${MGR_INSIGHTS_VIRTUALENV}/bin/activate
+trap "deactivate" EXIT
 
 if [ "$WITH_PYTHON2" = "ON" ]; then
   ENV_LIST+="py27"


### PR DESCRIPTION
Signed-off-by: Noah Watkins <nwatkins@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

