### PR TITLE
luminous ceph-volume: patch Device when testing

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/test_inventory.py
+++ b/src/ceph-volume/ceph_volume/tests/test_inventory.py
@@ -2,24 +2,11 @@
 
 import pytest
 from ceph_volume.util.device import Devices
-from ceph_volume import sys_info
+
 
 @pytest.fixture
-def device_report_keys():
-    report = Devices().json_report()[0]
-    return list(report.keys())
-
-@pytest.fixture
-def device_sys_api_keys():
-    report = Devices().json_report()[0]
-    return list(report['sys_api'].keys())
-
-
-class TestInventory(object):
-
-    # populate sys_info with something; creating a Device instance will use
-    # this data
-    sys_info.devices = {
+def device_report_keys(device_info):
+    device_info(devices={
         # example output of disk.get_devices()
         '/dev/sdb': {'human_readable_size': '1.82 TB',
                      'locked': 0,
@@ -40,6 +27,39 @@ class TestInventory(object):
                      'support_discard': '',
                      'vendor': 'DELL'}
     }
+ )
+    report = Devices().json_report()[0]
+    return list(report.keys())
+
+@pytest.fixture
+def device_sys_api_keys(device_info):
+    device_info(devices={
+        # example output of disk.get_devices()
+        '/dev/sdb': {'human_readable_size': '1.82 TB',
+                     'locked': 0,
+                     'model': 'PERC H700',
+                     'nr_requests': '128',
+                     'partitions': {},
+                     'path': '/dev/sdb',
+                     'removable': '0',
+                     'rev': '2.10',
+                     'ro': '0',
+                     'rotational': '1',
+                     'sas_address': '',
+                     'sas_device_handle': '',
+                     'scheduler_mode': 'cfq',
+                     'sectors': 0,
+                     'sectorsize': '512',
+                     'size': 1999844147200.0,
+                     'support_discard': '',
+                     'vendor': 'DELL'}
+    }
+ )
+    report = Devices().json_report()[0]
+    return list(report['sys_api'].keys())
+
+
+class TestInventory(object):
 
     expected_keys = [
         'path',


### PR DESCRIPTION
PR https://github.com/ceph/ceph/pull/24859 introduced unit tests that cause failures on systems without LVM.

Fixes: http://tracker.ceph.com/issues/36768
Backport of: https://github.com/ceph/ceph/pull/25063