### PR TITLE
rgw: RADOS::Obj::operate takes optional_yield

### DIFF
--- a/src/common/async/yield_context.h
+++ b/src/common/async/yield_context.h
@@ -1,0 +1,64 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat, Inc
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <boost/asio/io_context.hpp>
+
+#include "acconfig.h"
+
+#ifndef HAVE_BOOST_CONTEXT
+
+// hide the dependencies on boost::context and boost::coroutines
+namespace boost::asio {
+struct yield_context;
+}
+
+#else // HAVE_BOOST_CONTEXT
+
+#define BOOST_COROUTINES_NO_DEPRECATION_WARNING
+#include <boost/asio/spawn.hpp>
+
+#endif // HAVE_BOOST_CONTEXT
+
+
+/// optional-like wrapper for a boost::asio::yield_context and its associated
+/// boost::asio::io_context. operations that take an optional_yield argument
+/// will, when passed a non-empty yield context, suspend this coroutine instead
+/// of the blocking the thread of execution
+class optional_yield {
+  boost::asio::io_context *c = nullptr;
+  boost::asio::yield_context *y = nullptr;
+ public:
+  /// construct with a valid io and yield_context
+  explicit optional_yield(boost::asio::io_context& c,
+                          boost::asio::yield_context& y) noexcept
+    : c(&c), y(&y) {}
+
+  /// type tag to construct an empty object
+  struct empty_t {};
+  optional_yield(empty_t) noexcept {}
+
+  /// implicit conversion to bool, returns true if non-empty
+  operator bool() const noexcept { return y; }
+
+  /// return a reference to the associated io_context. only valid if non-empty
+  boost::asio::io_context& get_io_context() const noexcept { return *c; }
+
+  /// return a reference to the yield_context. only valid if non-empty
+  boost::asio::yield_context& get_yield_context() const noexcept { return *y; }
+};
+
+// type tag object to construct an empty optional_yield
+static constexpr optional_yield::empty_t null_yield{};

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -196,8 +196,7 @@ if(WITH_CURL_OPENSSL)
   target_link_libraries(rgw_a PRIVATE OpenSSL::Crypto)
 endif()
 
-if(WITH_RADOSGW_BEAST_FRONTEND)
-  target_compile_definitions(rgw_a PUBLIC BOOST_COROUTINES_NO_DEPRECATION_WARNING)
+if(WITH_BOOST_CONTEXT)
   target_link_libraries(rgw_a PRIVATE Boost::coroutine Boost::context)
 endif()
 
@@ -327,3 +326,6 @@ target_link_libraries(rgw_admin_user PRIVATE
 set_target_properties(rgw_admin_user PROPERTIES OUTPUT_NAME rgw_admin_user VERSION 1.0.0
   SOVERSION 0)
 install(TARGETS rgw_admin_user DESTINATION ${CMAKE_INSTALL_LIBDIR})
+if(WITH_BOOST_CONTEXT)
+  target_link_libraries(rgw_admin_user PRIVATE Boost::coroutine Boost::context)
+endif()

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include <boost/asio.hpp>
+#define BOOST_COROUTINES_NO_DEPRECATION_WARNING
 #include <boost/asio/spawn.hpp>
 #include <boost/intrusive/list.hpp>
 

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -558,6 +558,8 @@ int AsioFrontend::run()
 
   for (int i = 0; i < thread_count; i++) {
     threads.emplace_back([=] {
+      // request warnings on synchronous librados calls in this thread
+      is_asio_thread = true;
       boost::system::error_code ec;
       context.run(ec);
     });

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -13,6 +13,7 @@
 class RGWRados;
 class RGWSysObjectCtx;
 struct RGWObjVersionTracker;
+class optional_yield;
 
 struct obj_version;
 
@@ -29,6 +30,13 @@ const char *rgw_find_mime_by_ext(string& ext);
 
 void rgw_filter_attrset(map<string, bufferlist>& unfiltered_attrset, const string& check_prefix,
                         map<string, bufferlist> *attrset);
+
+/// perform the rados operation, using the yield context when given
+int rgw_rados_operate(librados::IoCtx& ioctx, const std::string& oid,
+                      librados::ObjectReadOperation *op, bufferlist* pbl,
+                      optional_yield y);
+int rgw_rados_operate(librados::IoCtx& ioctx, const std::string& oid,
+                      librados::ObjectWriteOperation *op, optional_yield y);
 
 int rgw_tools_init(CephContext *cct);
 void rgw_tools_cleanup();

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -31,6 +31,10 @@ const char *rgw_find_mime_by_ext(string& ext);
 void rgw_filter_attrset(map<string, bufferlist>& unfiltered_attrset, const string& check_prefix,
                         map<string, bufferlist> *attrset);
 
+/// indicates whether the current thread is in boost::asio::io_context::run(),
+/// used to log warnings if synchronous librados calls are made
+extern thread_local bool is_asio_thread;
+
 /// perform the rados operation, using the yield context when given
 int rgw_rados_operate(librados::IoCtx& ioctx, const std::string& oid,
                       librados::ObjectReadOperation *op, bufferlist* pbl,

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -190,7 +190,7 @@ int RGWSI_Notify::init_watch()
 
     librados::ObjectWriteOperation op;
     op.create(false);
-    r = notify_obj.operate(&op);
+    r = notify_obj.operate(&op, null_yield);
     if (r < 0 && r != -EEXIST) {
       ldout(cct, 0) << "ERROR: notify_obj.operate() returned r=" << r << dendl;
       return r;

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -3,6 +3,7 @@
 #include "include/rados/librados.hpp"
 #include "common/errno.h"
 #include "osd/osd_types.h"
+#include "rgw/rgw_tools.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -151,14 +152,16 @@ int RGWSI_RADOS::Obj::open()
   return 0;
 }
 
-int RGWSI_RADOS::Obj::operate(librados::ObjectWriteOperation *op)
+int RGWSI_RADOS::Obj::operate(librados::ObjectWriteOperation *op,
+                              optional_yield y)
 {
-  return ref.ioctx.operate(ref.oid, op);
+  return rgw_rados_operate(ref.ioctx, ref.oid, op, y);
 }
 
-int RGWSI_RADOS::Obj::operate(librados::ObjectReadOperation *op, bufferlist *pbl)
+int RGWSI_RADOS::Obj::operate(librados::ObjectReadOperation *op, bufferlist *pbl,
+                              optional_yield y)
 {
-  return ref.ioctx.operate(ref.oid, op, pbl);
+  return rgw_rados_operate(ref.ioctx, ref.oid, op, pbl, y);
 }
 
 int RGWSI_RADOS::Obj::aio_operate(librados::AioCompletion *c, librados::ObjectWriteOperation *op)

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -5,6 +5,7 @@
 #include "rgw/rgw_service.h"
 
 #include "include/rados/librados.hpp"
+#include "common/async/yield_context.h"
 
 class RGWAccessListFilter {
 public:
@@ -74,8 +75,9 @@ public:
 
     int open();
 
-    int operate(librados::ObjectWriteOperation *op);
-    int operate(librados::ObjectReadOperation *op, bufferlist *pbl);
+    int operate(librados::ObjectWriteOperation *op, optional_yield y);
+    int operate(librados::ObjectReadOperation *op, bufferlist *pbl,
+                optional_yield y);
     int aio_operate(librados::AioCompletion *c, librados::ObjectWriteOperation *op);
     int aio_operate(librados::AioCompletion *c, librados::ObjectReadOperation *op,
                     bufferlist *pbl);

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -123,7 +123,7 @@ int RGWSI_SysObj_Core::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_ti
     op.read(0, cct->_conf->rgw_max_chunk_size, first_chunk, nullptr);
   }
   bufferlist outbl;
-  r = rados_obj.operate(&op, &outbl);
+  r = rados_obj.operate(&op, &outbl, null_yield);
 
   if (epoch) {
     *epoch = rados_obj.get_last_version();
@@ -215,7 +215,7 @@ int RGWSI_SysObj_Core::read(RGWSysObjectCtxBase& obj_ctx,
     ldout(cct, 20) << "get_rados_obj() on obj=" << obj << " returned " << r << dendl;
     return r;
   }
-  r = rados_obj.operate(&op, nullptr);
+  r = rados_obj.operate(&op, nullptr, null_yield);
   if (r < 0) {
     ldout(cct, 20) << "rados_obj.operate() r=" << r << " bl.length=" << bl->length() << dendl;
     return r;
@@ -262,7 +262,7 @@ int RGWSI_SysObj_Core::get_attr(const rgw_raw_obj& obj,
   int rval;
   op.getxattr(name, dest, &rval);
   
-  r = rados_obj.operate(&op, nullptr);
+  r = rados_obj.operate(&op, nullptr, null_yield);
   if (r < 0)
     return r;
 
@@ -310,7 +310,7 @@ int RGWSI_SysObj_Core::set_attrs(const rgw_raw_obj& obj,
 
   bufferlist bl;
 
-  r = rados_obj.operate(&op);
+  r = rados_obj.operate(&op, null_yield);
   if (r < 0)
     return r;
 
@@ -340,7 +340,7 @@ int RGWSI_SysObj_Core::omap_get_vals(const rgw_raw_obj& obj,
     int rval;
     op.omap_get_vals2(start_after, count, &t, &more, &rval);
   
-    r = rados_obj.operate(&op, nullptr);
+    r = rados_obj.operate(&op, nullptr, null_yield);
     if (r < 0) {
       return r;
     }
@@ -379,7 +379,7 @@ int RGWSI_SysObj_Core::omap_get_all(const rgw_raw_obj& obj, std::map<string, buf
     int rval;
     op.omap_get_vals2(start_after, count, &t, &more, &rval);
   
-    r = rados_obj.operate(&op, nullptr);
+    r = rados_obj.operate(&op, nullptr, null_yield);
     if (r < 0) {
       return r;
     }
@@ -409,7 +409,7 @@ int RGWSI_SysObj_Core::omap_set(const rgw_raw_obj& obj, const std::string& key, 
   if (must_exist)
     op.assert_exists();
   op.omap_set(m);
-  r = rados_obj.operate(&op);
+  r = rados_obj.operate(&op, null_yield);
   return r;
 }
 
@@ -426,7 +426,7 @@ int RGWSI_SysObj_Core::omap_set(const rgw_raw_obj& obj, const std::map<std::stri
   if (must_exist)
     op.assert_exists();
   op.omap_set(m);
-  r = rados_obj.operate(&op);
+  r = rados_obj.operate(&op, null_yield);
   return r;
 }
 
@@ -446,7 +446,7 @@ int RGWSI_SysObj_Core::omap_del(const rgw_raw_obj& obj, const std::string& key)
 
   op.omap_rm_keys(k);
 
-  r = rados_obj.operate(&op);
+  r = rados_obj.operate(&op, null_yield);
   return r;
 }
 
@@ -484,7 +484,7 @@ int RGWSI_SysObj_Core::remove(RGWSysObjectCtxBase& obj_ctx,
   }
 
   op.remove();
-  r = rados_obj.operate(&op);
+  r = rados_obj.operate(&op, null_yield);
   if (r < 0)
     return r;
 
@@ -540,7 +540,7 @@ int RGWSI_SysObj_Core::write(const rgw_raw_obj& obj,
     op.setxattr(name.c_str(), bl);
   }
 
-  r = rados_obj.operate(&op);
+  r = rados_obj.operate(&op, null_yield);
   if (r < 0) {
     return r;
   }
@@ -579,7 +579,7 @@ int RGWSI_SysObj_Core::write_data(const rgw_raw_obj& obj,
     objv_tracker->prepare_op_for_write(&op);
   }
   op.write_full(bl);
-  r = rados_obj.operate(&op);
+  r = rados_obj.operate(&op, null_yield);
   if (r < 0)
     return r;
 


### PR DESCRIPTION
introduces a `class optional_yield` that wraps the coroutine context from the beast frontend, a helper function `rgw_rados_operate()` that acts like a synchronous function (but suspends/resumes instead of blocking when given a yield_context), and adds an optional_yield argument to `RADOS::Obj::operate()`. all callers currently pass `null_yield`, but this lays the groundwork for further integration