### PR TITLE
rgw: catch exceptions from librados::NObjectIterator

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -66,6 +66,9 @@
 * The `ceph` command line tool now accepts keyword arguments in
   the format "--arg=value" or "--arg value".
 
+* librados::IoCtx::nobjects_begin() and librados::NObjectIterator now communicate
+  errors by throwing a std::system_error exception instead of std::runtime_error.
+
 >=13.1.0
 --------
 

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -109,18 +109,19 @@ namespace librados
     bool operator!=(const NObjectIterator& rhs) const;
     const ListObject& operator*() const;
     const ListObject* operator->() const;
-    NObjectIterator &operator++(); // Preincrement
-    NObjectIterator operator++(int); // Postincrement
+    NObjectIterator &operator++(); //< Preincrement; errors are thrown as exceptions
+    NObjectIterator operator++(int); //< Postincrement; errors are thrown as exceptions
     friend class IoCtx;
     friend class NObjectIteratorImpl;
 
     /// get current hash position of the iterator, rounded to the current pg
     uint32_t get_pg_hash_position() const;
 
-    /// move the iterator to a given hash position.  this may (will!) be rounded to the nearest pg.
+    /// move the iterator to a given hash position. this may (will!) be rounded
+    /// to the nearest pg. errors are thrown as exceptions
     uint32_t seek(uint32_t pos);
 
-    /// move the iterator to a given cursor position
+    /// move the iterator to a given cursor position. errors are thrown as exceptions
     uint32_t seek(const ObjectCursor& cursor);
 
     /// get current cursor position
@@ -890,12 +891,14 @@ namespace librados
 		     std::list<librados::locker_t> *lockers);
 
 
-    /// Start enumerating objects for a pool
+    /// Start enumerating objects for a pool. Errors are thrown as exceptions.
     NObjectIterator nobjects_begin(const bufferlist &filter=bufferlist());
-    /// Start enumerating objects for a pool starting from a hash position
+    /// Start enumerating objects for a pool starting from a hash position.
+    /// Errors are thrown as exceptions.
     NObjectIterator nobjects_begin(uint32_t start_hash_position,
                                    const bufferlist &filter=bufferlist());
-    /// Start enumerating objects for a pool starting from cursor
+    /// Start enumerating objects for a pool starting from cursor. Errors are
+    /// thrown as exceptions.
     NObjectIterator nobjects_begin(const librados::ObjectCursor& cursor,
                                    const bufferlist &filter=bufferlist());
     /// Iterator indicating the end of a pool

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -45,7 +45,6 @@ using std::map;
 using std::set;
 using std::vector;
 using std::list;
-using std::runtime_error;
 
 #define dout_subsys ceph_subsys_rados
 #undef dout_prefix

--- a/src/librados/librados_cxx.cc
+++ b/src/librados/librados_cxx.cc
@@ -41,6 +41,7 @@
 #include <vector>
 #include <list>
 #include <stdexcept>
+#include <system_error>
 
 #ifdef WITH_LTTNG
 #define TRACEPOINT_DEFINE
@@ -57,7 +58,6 @@ using std::map;
 using std::set;
 using std::vector;
 using std::list;
-using std::runtime_error;
 
 #define dout_subsys ceph_subsys_rados
 #undef dout_prefix
@@ -761,9 +761,8 @@ void librados::NObjectIteratorImpl::get_next()
     return;
   }
   else if (ret) {
-    ostringstream oss;
-    oss << "rados returned " << cpp_strerror(ret);
-    throw std::runtime_error(oss.str());
+    throw std::system_error(-ret, std::system_category(),
+                            "rados_nobjects_list_next");
   }
 
   if (cur_obj.impl == NULL)

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8416,9 +8416,19 @@ int RGWRados::pool_iterate_begin(const rgw_pool& pool, const string& cursor, RGW
     return -EINVAL;
   }
 
-  iter = io_ctx.nobjects_begin(oc);
-
-  return 0;
+  try {
+    iter = io_ctx.nobjects_begin(oc);
+    return 0;
+  } catch (const std::system_error& e) {
+    r = -e.code().value();
+    ldout(cct, 10) << "nobjects_begin threw " << e.what()
+       << ", returning " << r << dendl;
+    return r;
+  } catch (const std::exception& e) {
+    ldout(cct, 10) << "nobjects_begin threw " << e.what()
+       << ", returning -5" << dendl;
+    return -EIO;
+  }
 }
 
 string RGWRados::pool_iterate_get_cursor(RGWPoolIterCtx& ctx)
@@ -8426,7 +8436,8 @@ string RGWRados::pool_iterate_get_cursor(RGWPoolIterCtx& ctx)
   return ctx.iter.get_cursor().to_str();
 }
 
-int RGWRados::pool_iterate(RGWPoolIterCtx& ctx, uint32_t num, vector<rgw_bucket_dir_entry>& objs,
+static int do_pool_iterate(CephContext* cct, RGWPoolIterCtx& ctx, uint32_t num,
+                           vector<rgw_bucket_dir_entry>& objs,
                            bool *is_truncated, RGWAccessListFilter *filter)
 {
   librados::IoCtx& io_ctx = ctx.io_ctx;
@@ -8455,6 +8466,24 @@ int RGWRados::pool_iterate(RGWPoolIterCtx& ctx, uint32_t num, vector<rgw_bucket_
     *is_truncated = (iter != io_ctx.nobjects_end());
 
   return objs.size();
+}
+
+int RGWRados::pool_iterate(RGWPoolIterCtx& ctx, uint32_t num, vector<rgw_bucket_dir_entry>& objs,
+                           bool *is_truncated, RGWAccessListFilter *filter)
+{
+  // catch exceptions from NObjectIterator::operator++()
+  try {
+    return do_pool_iterate(cct, ctx, num, objs, is_truncated, filter);
+  } catch (const std::system_error& e) {
+    int r = -e.code().value();
+    ldout(cct, 10) << "NObjectIterator threw exception " << e.what()
+       << ", returning " << r << dendl;
+    return r;
+  } catch (const std::exception& e) {
+    ldout(cct, 10) << "NObjectIterator threw exception " << e.what()
+       << ", returning -5" << dendl;
+    return -EIO;
+  }
 }
 
 int RGWRados::list_raw_objects_init(const rgw_pool& pool, const string& marker, RGWListRawObjsCtx *ctx)

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -17,6 +17,7 @@
 #include <boost/circular_buffer.hpp>
 #include <boost/container/flat_map.hpp>
 
+#include "include/scope_guard.h"
 #include "common/bounded_key_counter.h"
 #include "common/errno.h"
 #include "rgw_sync_log_trim.h"
@@ -580,7 +581,6 @@ class AsyncMetadataList : public RGWAsyncRadosRequest {
   const std::string section;
   const std::string start_marker;
   MetadataListCallback callback;
-  void *handle{nullptr};
 
   int _send_request() override;
  public:
@@ -591,54 +591,55 @@ class AsyncMetadataList : public RGWAsyncRadosRequest {
     : RGWAsyncRadosRequest(caller, cn), cct(cct), mgr(mgr),
       section(section), start_marker(start_marker), callback(callback)
   {}
-  ~AsyncMetadataList() override {
-    if (handle) {
-      mgr->list_keys_complete(handle);
-    }
-  }
 };
 
 int AsyncMetadataList::_send_request()
 {
-  // start a listing at the given marker
-  int r = mgr->list_keys_init(section, start_marker, &handle);
-  if (r < 0) {
-    ldout(cct, 10) << "failed to init metadata listing: "
-        << cpp_strerror(r) << dendl;
-    return r;
-  }
-  ldout(cct, 20) << "starting metadata listing at " << start_marker << dendl;
-
+  void* handle = nullptr;
   std::list<std::string> keys;
   bool truncated{false};
   std::string marker;
 
-  do {
-    // get the next key and marker
-    r = mgr->list_keys_next(handle, 1, keys, &truncated);
-    if (r < 0) {
-      ldout(cct, 10) << "failed to list metadata: "
-          << cpp_strerror(r) << dendl;
-      return r;
-    }
-    marker = mgr->get_marker(handle);
+  // start a listing at the given marker
+  int r = mgr->list_keys_init(section, start_marker, &handle);
+  if (r == -EINVAL) {
+    // restart with empty marker below
+  } else if (r < 0) {
+    ldout(cct, 10) << "failed to init metadata listing: "
+        << cpp_strerror(r) << dendl;
+    return r;
+  } else {
+    ldout(cct, 20) << "starting metadata listing at " << start_marker << dendl;
 
-    if (!keys.empty()) {
-      ceph_assert(keys.size() == 1);
-      auto& key = keys.front();
-      if (!callback(std::move(key), std::move(marker))) {
-        return 0;
+    // release the handle when scope exits
+    auto g = make_scope_guard([=] { mgr->list_keys_complete(handle); });
+
+    do {
+      // get the next key and marker
+      r = mgr->list_keys_next(handle, 1, keys, &truncated);
+      if (r < 0) {
+        ldout(cct, 10) << "failed to list metadata: "
+            << cpp_strerror(r) << dendl;
+        return r;
       }
-    }
-  } while (truncated);
+      marker = mgr->get_marker(handle);
 
-  if (start_marker.empty()) {
-    // already listed all keys
-    return 0;
+      if (!keys.empty()) {
+        ceph_assert(keys.size() == 1);
+        auto& key = keys.front();
+        if (!callback(std::move(key), std::move(marker))) {
+          return 0;
+        }
+      }
+    } while (truncated);
+
+    if (start_marker.empty()) {
+      // already listed all keys
+      return 0;
+    }
   }
 
   // restart the listing from the beginning (empty marker)
-  mgr->list_keys_complete(handle);
   handle = nullptr;
 
   r = mgr->list_keys_init(section, "", &handle);
@@ -649,6 +650,8 @@ int AsyncMetadataList::_send_request()
   }
   ldout(cct, 20) << "restarting metadata listing" << dendl;
 
+  // release the handle when scope exits
+  auto g = make_scope_guard([=] { mgr->list_keys_complete(handle); });
   do {
     // get the next key and marker
     r = mgr->list_keys_next(handle, 1, keys, &truncated);

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1438,7 +1438,7 @@ static int do_cache_flush_evict_all(IoCtx& io_ctx, bool blocking)
       }
     }
   }
-  catch (const std::runtime_error& e) {
+  catch (const std::exception& e) {
     cerr << e.what() << std::endl;
     return -1;
   }
@@ -2437,7 +2437,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 	  }
 	}
       }
-      catch (const std::runtime_error& e) {
+      catch (const std::exception& e) {
 	cerr << e.what() << std::endl;
 	ret = -1;
 	goto out;


### PR DESCRIPTION
librados::NObjectIterator::get_next() throws an exception on any error but ENOENT, which radosgw doesn't catch

the BucketTrimManager that iterates over bucket instance metadata stores its current position in a bilog.trim object - if it gets EINVAL when trying to list, it recovers by clearing the marker and starting over

Fixes: http://tracker.ceph.com/issues/37091