### PR TITLE
common: optimize reference counting in bufferlist

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -467,7 +467,7 @@ static ceph::spinlock debug_lock;
     _raw->nref++;
     bdout << "ptr " << this << " get " << _raw << bendl;
   }
-  buffer::ptr::ptr(const ptr& p, std::unique_ptr<raw> r)
+  buffer::ptr::ptr(const ptr& p, ceph::unique_leakable_ptr<raw> r)
     : _raw(r.release()),
       _off(p._off),
       _len(p._len)
@@ -508,7 +508,7 @@ static ceph::spinlock debug_lock;
     return *this;
   }
 
-  std::unique_ptr<buffer::raw> buffer::ptr::clone()
+  ceph::unique_leakable_ptr<buffer::raw> buffer::ptr::clone()
   {
     return _raw->clone();
   }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -539,7 +539,8 @@ static ceph::spinlock debug_lock;
   {
     if (_raw) {
       bdout << "ptr " << this << " release " << _raw << bendl;
-      if (--_raw->nref == 0) {
+      const bool last_one = (1 == _raw->nref.load(std::memory_order_acquire));
+      if (likely(last_one) || --_raw->nref == 0) {
         // BE CAREFUL: this is called also for hypercombined ptr_node. After
         // freeing underlying raw, `*this` can become inaccessible as well!
         const auto* delete_raw = _raw;

--- a/src/common/buffer_seastar.cc
+++ b/src/common/buffer_seastar.cc
@@ -27,7 +27,7 @@ class raw_seastar_foreign_ptr : public raw {
   raw_seastar_foreign_ptr(temporary_buffer&& buf)
     : raw(buf.get_write(), buf.size()), ptr(std::move(buf)) {}
   raw* clone_empty() override {
-    return create(len);
+    return create(len).release();
   }
 };
 
@@ -41,7 +41,7 @@ class raw_seastar_local_ptr : public raw {
   raw_seastar_local_ptr(temporary_buffer&& buf)
     : raw(buf.get_write(), buf.size()), buf(std::move(buf)) {}
   raw* clone_empty() override {
-    return create(len);
+    return create(len).release();
   }
 };
 
@@ -88,7 +88,7 @@ public:
   raw_seastar_local_shared_ptr(temporary_buffer& buf)
     : raw(buf.get_write(), buf.size()), buf(buf.share()) {}
   raw* clone_empty() override {
-    return ceph::buffer::create(len);
+    return ceph::buffer::create(len).release();
   }
 };
 }
@@ -103,6 +103,5 @@ buffer::ptr seastar_buffer_iterator::get_ptr(size_t len)
 
 buffer::ptr const_seastar_buffer_iterator::get_ptr(size_t len)
 {
-  buffer::raw* r = buffer::copy(get_pos_add(len), len);
-  return buffer::ptr{r};
+  return buffer::ptr{ buffer::copy(get_pos_add(len), len) };
 }

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -86,10 +86,10 @@ public:
       return data;
     }
     virtual raw* clone_empty() = 0;
-    std::unique_ptr<raw> clone() {
+    ceph::unique_leakable_ptr<raw> clone() {
       raw* const c = clone_empty();
       memcpy(c->data, data, len);
-      return std::unique_ptr<raw>(c);
+      return ceph::unique_leakable_ptr<raw>(c);
     }
     virtual bool is_shareable() const {
       // true if safe to reference/share the existing buffer copy

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -86,12 +86,12 @@ public:
       return data;
     }
     virtual raw* clone_empty() = 0;
-    raw *clone() {
-      raw *c = clone_empty();
+    std::unique_ptr<raw> clone() {
+      raw* const c = clone_empty();
       memcpy(c->data, data, len);
-      return c;
+      return std::unique_ptr<raw>(c);
     }
-    virtual bool is_shareable() {
+    virtual bool is_shareable() const {
       // true if safe to reference/share the existing buffer copy
       // false if it is not safe to share the buffer, e.g., due to special
       // and/or registered memory that is scarce

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -25,6 +25,8 @@
 #include "include/ceph_assert.h"
 #include "common/debug.h"
 #include "common/errno.h"
+#include "include/buffer.h"
+#include "include/buffer_raw.h"
 #include "include/compat.h"
 
 #define dout_context g_ceph_context
@@ -452,7 +454,7 @@ int MemDB::get(const string &prefix, const std::set<string> &keys,
 void MemDB::MDBWholeSpaceIteratorImpl::fill_current()
 {
   bufferlist bl;
-  bl.append(m_iter->second.clone());
+  bl.push_back(m_iter->second.clone());
   m_key_value = std::make_pair(m_iter->first, bl);
 }
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -69,8 +69,8 @@ namespace {
 
 TracepointProvider::Traits tracepoint_traits("librbd_tp.so", "rbd_tracing");
 
-buffer::raw* create_write_raw(librbd::ImageCtx *ictx, const char *buf,
-                              size_t len) {
+static auto create_write_raw(librbd::ImageCtx *ictx, const char *buf,
+                             size_t len) {
   // TODO: until librados can guarantee memory won't be referenced after
   // it ACKs a request, always make a copy of the user-provided memory
   return buffer::copy(buf, len);

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -24,6 +24,7 @@
 #include <sys/uio.h>
 
 #include "include/buffer.h"
+#include "include/buffer_raw.h"
 #include "include/utime.h"
 #include "include/coredumpctl.h"
 #include "include/encoding.h"


### PR DESCRIPTION
Summary
=======

A `buffer::raw` can be shared by many `bufferlist` instances from multiple threads the same time. This is possible because of managing the `buffer::raw::nref` counter in atomic manner. However, even in single-threaded workloads without cache line ping-pongs, the cost still can be significant. For instance, on x86 `lock`-prefixed instructions behave like a memory barrier serializing loads and stores.

Unfortunately, `bufferlist` makes extensive use of atomic reference counting not only when sharing `buffer::raw` between multiple `bufferlist` instances but also when:
  * using `append_buffer` (e.g. `bufferlist bl; bl.append('x');` would result in `nref == 2`; see pull request #25077).
  * mixing C-string and `buffer::ptr`-taking variants of `::append` (we might want to do deep copy if a `ptr` is small enough; investigating this is TODO), 
  * constructing first owning `buffer::ptr` for brand-new `buffer::raw` instance,
  * releasing `buffer::ptr` while being the sole user.

This pull request tries to fight with the last two issues throughout:
  * switching `buffer::raw` factories to produce a type with `std::unique_like`-like ownership indication,
  * destroying `buffer::raw` with `nref` value left to `1`.