### PR TITLE
mimic ceph-volume: reject devices that have existing GPT headers

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -52,7 +52,7 @@ def common_parser(prog, description):
     required_group.add_argument(
         '--data',
         required=True,
-        type=arg_validators.LVPath(),
+        type=arg_validators.ValidDevice(as_string=True),
         help='OSD data path. A physical device or logical volume',
     )
 

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_create.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_create.py
@@ -17,14 +17,16 @@ class TestCreate(object):
         assert 'Use the bluestore objectstore' in stdout
         assert 'A physical device or logical' in stdout
 
-    def test_excludes_filestore_bluestore_flags(self, capsys):
+    def test_excludes_filestore_bluestore_flags(self, capsys, device_info):
+        device_info()
         with pytest.raises(SystemExit):
             lvm.create.Create(argv=['--data', '/dev/sdfoo', '--filestore', '--bluestore']).main()
         stdout, sterr = capsys.readouterr()
         expected = 'Cannot use --filestore (filestore) with --bluestore (bluestore)'
         assert expected in stdout
 
-    def test_excludes_other_filestore_bluestore_flags(self, capsys):
+    def test_excludes_other_filestore_bluestore_flags(self, capsys, device_info):
+        device_info()
         with pytest.raises(SystemExit):
             lvm.create.Create(argv=[
                 '--bluestore', '--data', '/dev/sdfoo',
@@ -34,7 +36,8 @@ class TestCreate(object):
         expected = 'Cannot use --bluestore (bluestore) with --journal (filestore)'
         assert expected in stdout
 
-    def test_excludes_block_and_journal_flags(self, capsys):
+    def test_excludes_block_and_journal_flags(self, capsys, device_info):
+        device_info()
         with pytest.raises(SystemExit):
             lvm.create.Create(argv=[
                 '--bluestore', '--data', '/dev/sdfoo', '--block.db', 'vg/ceph1',

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_prepare.py
@@ -47,14 +47,16 @@ class TestPrepare(object):
         assert 'Use the bluestore objectstore' in stdout
         assert 'A physical device or logical' in stdout
 
-    def test_excludes_filestore_bluestore_flags(self, capsys):
+    def test_excludes_filestore_bluestore_flags(self, capsys, device_info):
+        device_info()
         with pytest.raises(SystemExit):
             lvm.prepare.Prepare(argv=['--data', '/dev/sdfoo', '--filestore', '--bluestore']).main()
         stdout, stderr = capsys.readouterr()
         expected = 'Cannot use --filestore (filestore) with --bluestore (bluestore)'
         assert expected in stdout
 
-    def test_excludes_other_filestore_bluestore_flags(self, capsys):
+    def test_excludes_other_filestore_bluestore_flags(self, capsys, device_info):
+        device_info()
         with pytest.raises(SystemExit):
             lvm.prepare.Prepare(argv=[
                 '--bluestore', '--data', '/dev/sdfoo',
@@ -64,7 +66,8 @@ class TestPrepare(object):
         expected = 'Cannot use --bluestore (bluestore) with --journal (filestore)'
         assert expected in stdout
 
-    def test_excludes_block_and_journal_flags(self, capsys):
+    def test_excludes_block_and_journal_flags(self, capsys, device_info):
+        device_info()
         with pytest.raises(SystemExit):
             lvm.prepare.Prepare(argv=[
                 '--bluestore', '--data', '/dev/sdfoo', '--block.db', 'vg/ceph1',
@@ -74,8 +77,9 @@ class TestPrepare(object):
         expected = 'Cannot use --block.db (bluestore) with --journal (filestore)'
         assert expected in stdout
 
-    def test_journal_is_required_with_filestore(self, is_root, monkeypatch):
-        monkeypatch.setattr('os.path.exists', lambda x: True)
+    def test_journal_is_required_with_filestore(self, is_root, monkeypatch, device_info):
+        monkeypatch.setattr("os.path.exists", lambda path: True)
+        device_info()
         with pytest.raises(SystemExit) as error:
             lvm.prepare.Prepare(argv=['--filestore', '--data', '/dev/sdfoo']).main()
         expected = '--journal is required when using --filestore'

--- a/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_arg_validators.py
@@ -4,31 +4,6 @@ from ceph_volume import exceptions
 from ceph_volume.util import arg_validators
 
 
-invalid_lv_paths = [
-    '', 'lv_name', '/lv_name', 'lv_name/',
-    '/dev/lv_group/lv_name'
-]
-
-
-class TestLVPath(object):
-
-    def setup(self):
-        self.validator = arg_validators.LVPath()
-
-    @pytest.mark.parametrize('path', invalid_lv_paths)
-    def test_no_slash_is_an_error(self, path):
-        with pytest.raises(argparse.ArgumentError):
-            self.validator(path)
-
-    def test_is_valid(self):
-        path = 'vg/lv'
-        assert self.validator(path) == path
-
-    def test_abspath_is_valid(self):
-        path = '/'
-        assert self.validator(path) == path
-
-
 class TestOSDPath(object):
 
     def setup(self):

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -13,7 +13,7 @@ class TestDevice(object):
         assert "foo" in disk.sys_api
 
     def test_is_lv(self, device_info):
-        data = {"lv_path": "vg/lv", "vg_name": "vg"}
+        data = {"lv_path": "vg/lv", "vg_name": "vg", "name": "lv"}
         device_info(lv=data)
         disk = device.Device("vg/lv")
         assert disk.is_lv

--- a/src/ceph-volume/ceph_volume/util/arg_validators.py
+++ b/src/ceph-volume/ceph_volume/util/arg_validators.py
@@ -23,6 +23,9 @@ class ValidDevice(object):
             raise argparse.ArgumentError(None, error)
 
         if self.as_string:
+            if device.is_lv:
+                # all codepaths expect an lv path to be returned in this format
+                return "{}/{}".format(device.vg_name, device.lv_name)
             return string
         return device
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -212,6 +212,10 @@ class Device(object):
         return os.path.exists(self.abspath)
 
     @property
+    def has_gpt_headers(self):
+        return self.blkid_api.get("PTTYPE") == "gpt"
+
+    @property
     def rotational(self):
         return self.sys_api['rotational'] == '1'
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -70,6 +70,7 @@ class Device(object):
         self.lv_api = None
         self.lvs = []
         self.vg_name = None
+        self.lv_name = None
         self.pvs_api = []
         self.disk_api = {}
         self.blkid_api = {}
@@ -108,6 +109,7 @@ class Device(object):
             self.lvs = [lv]
             self.abspath = lv.lv_path
             self.vg_name = lv.vg_name
+            self.lv_name = lv.name
         else:
             dev = disk.lsblk(self.path)
             self.blkid_api = disk.blkid(self.path)

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -51,6 +51,7 @@ def _blkid_parser(output):
         'TYPE': 'TYPE',
         'PART_ENTRY_NAME': 'PARTLABEL',
         'PART_ENTRY_UUID': 'PARTUUID',
+        'PTTYPE': 'PTTYPE',
     }
 
     for pair in pairs:


### PR DESCRIPTION
This also combines the LVPath and ValidDevice arg validators so now all subcommands are using the same validator for devices.

Fixes: http://tracker.ceph.com/issues/27062
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1644321
Backport of: https://github.com/ceph/ceph/pull/25098