### PR TITLE
 mgr: generalize osd perf query and make counters accessible from modules

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -916,6 +916,48 @@ void ActivePyModules::remove_osd_perf_query(OSDPerfMetricQueryID query_id)
   }
 }
 
+PyObject *ActivePyModules::get_osd_perf_counters(OSDPerfMetricQueryID query_id)
+{
+  std::map<OSDPerfMetricKey, PerformanceCounters> counters;
+
+  int r = server.get_osd_perf_counters(query_id, &counters);
+  if (r < 0) {
+    dout(0) << "get_osd_perf_counters for query_id=" << query_id << " failed: "
+            << cpp_strerror(r) << dendl;
+    Py_RETURN_NONE;
+  }
+
+  PyFormatter f;
+
+  f.open_array_section("counters");
+  for (auto &it : counters) {
+    auto &key = it.first;
+    auto  &instance_counters = it.second;
+    f.open_object_section("i");
+    f.open_array_section("k");
+    for (auto &sub_key : key) {
+      f.open_array_section("s");
+      for (size_t i = 0; i < sub_key.size(); i++) {
+        f.dump_string(stringify(i).c_str(), sub_key[i]);
+      }
+      f.close_section(); // s
+    }
+    f.close_section(); // k
+    f.open_array_section("c");
+    for (auto &c : instance_counters) {
+      f.open_array_section("p");
+      f.dump_unsigned("0", c.first);
+      f.dump_unsigned("1", c.second);
+      f.close_section(); // p
+    }
+    f.close_section(); // c
+    f.close_section(); // i
+  }
+  f.close_section(); // counters
+
+  return f.get();
+}
+
 void ActivePyModules::cluster_log(const std::string &channel, clog_type prio,
   const std::string &message)
 {

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -94,6 +94,7 @@ public:
 
   OSDPerfMetricQueryID add_osd_perf_query(const OSDPerfMetricQuery &query);
   void remove_osd_perf_query(OSDPerfMetricQueryID query_id);
+  PyObject *get_osd_perf_counters(OSDPerfMetricQueryID query_id);
 
   bool get_store(const std::string &module_name,
       const std::string &key, std::string *val) const;

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -695,6 +695,18 @@ ceph_remove_osd_perf_query(BaseMgrModule *self, PyObject *args)
   Py_RETURN_NONE;
 }
 
+static PyObject*
+ceph_get_osd_perf_counters(BaseMgrModule *self, PyObject *args)
+{
+  OSDPerfMetricQueryID query_id;
+  if (!PyArg_ParseTuple(args, "i:ceph_get_osd_perf_counters", &query_id)) {
+    derr << "Invalid args!" << dendl;
+    return nullptr;
+  }
+
+  return self->py_modules->get_osd_perf_counters(query_id);
+}
+
 PyMethodDef BaseMgrModule_methods[] = {
   {"_ceph_get", (PyCFunction)ceph_state_get, METH_VARARGS,
    "Get a cluster object"},
@@ -774,6 +786,9 @@ PyMethodDef BaseMgrModule_methods[] = {
 
   {"_ceph_remove_osd_perf_query", (PyCFunction)ceph_remove_osd_perf_query,
     METH_VARARGS, "Remove an osd perf query"},
+
+  {"_ceph_get_osd_perf_counters", (PyCFunction)ceph_get_osd_perf_counters,
+    METH_VARARGS, "Get osd perf counters"},
 
   {NULL, NULL, 0, NULL}
 };

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -670,7 +670,14 @@ ceph_add_osd_perf_query(BaseMgrModule *self, PyObject *args)
     return nullptr;
   }
 
-  OSDPerfMetricQuery query;
+  OSDPerfMetricQuery query = {{{OSDPerfMetricSubKeyType::CLIENT_ID, "^.*$"}},
+                              {{PerformanceCounterType::WRITE_OPS},
+                               {PerformanceCounterType::READ_OPS},
+                               {PerformanceCounterType::WRITE_BYTES},
+                               {PerformanceCounterType::READ_BYTES},
+                               {PerformanceCounterType::WRITE_LATENCY},
+                               {PerformanceCounterType::READ_LATENCY}}};
+
   auto query_id = self->py_modules->add_osd_perf_query(query);
   return PyLong_FromLong(query_id);
 }

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -662,21 +662,158 @@ ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
 static PyObject*
 ceph_add_osd_perf_query(BaseMgrModule *self, PyObject *args)
 {
-  // TODO: parse args to build OSDPerfMetricQuery.
-  // For now it is ignored and can be anything.
-  PyObject *query_ = nullptr;
-  if (!PyArg_ParseTuple(args, "O:ceph_add_osd_perf_query", &query_)) {
+  static const std::string NAME_KEY_DESCRIPTOR = "key_descriptor";
+  static const std::string NAME_COUNTERS_DESCRIPTORS =
+      "performance_counter_descriptors";
+  static const std::string NAME_SUB_KEY_TYPE = "type";
+  static const std::string NAME_SUB_KEY_REGEX = "regex";
+  static const std::map<std::string, OSDPerfMetricSubKeyType> sub_key_types = {
+    {"client_id", OSDPerfMetricSubKeyType::CLIENT_ID},
+    {"pool_id", OSDPerfMetricSubKeyType::POOL_ID},
+    {"object_name", OSDPerfMetricSubKeyType::OBJECT_NAME},
+  };
+  static const std::map<std::string, PerformanceCounterType> counter_types = {
+    {"write_ops", PerformanceCounterType::WRITE_OPS},
+    {"read_ops", PerformanceCounterType::READ_OPS},
+    {"write_bytes", PerformanceCounterType::WRITE_BYTES},
+    {"read_bytes", PerformanceCounterType::READ_BYTES},
+    {"write_latency", PerformanceCounterType::WRITE_LATENCY},
+    {"read_latency", PerformanceCounterType::READ_LATENCY},
+  };
+
+  PyObject *py_query = nullptr;
+  if (!PyArg_ParseTuple(args, "O:ceph_add_osd_perf_query", &py_query)) {
     derr << "Invalid args!" << dendl;
     return nullptr;
   }
+  if (!PyDict_Check(py_query)) {
+    derr << __func__ << " arg not a dict" << dendl;
+    Py_RETURN_NONE;
+  }
 
-  OSDPerfMetricQuery query = {{{OSDPerfMetricSubKeyType::CLIENT_ID, "^.*$"}},
-                              {{PerformanceCounterType::WRITE_OPS},
-                               {PerformanceCounterType::READ_OPS},
-                               {PerformanceCounterType::WRITE_BYTES},
-                               {PerformanceCounterType::READ_BYTES},
-                               {PerformanceCounterType::WRITE_LATENCY},
-                               {PerformanceCounterType::READ_LATENCY}}};
+  PyObject *query_params = PyDict_Items(py_query);
+  OSDPerfMetricQuery query;
+
+  // {
+  //   'key_descriptor': [
+  //     {'type': subkey_type, 'regex': regex_pattern},
+  //     ...
+  //   ],
+  //   'performance_counter_descriptors': [
+  //     list, of, descriptor, types
+  //   ],
+  // }
+
+  for (int i = 0; i < PyList_Size(query_params); ++i) {
+    PyObject *kv = PyList_GET_ITEM(query_params, i);
+    char *query_param_name = nullptr;
+    PyObject *query_param_val = nullptr;
+    if (!PyArg_ParseTuple(kv, "sO:pair", &query_param_name, &query_param_val)) {
+      derr << __func__ << " dict item " << i << " not a size 2 tuple" << dendl;
+      Py_RETURN_NONE;
+    }
+    if (query_param_name == NAME_KEY_DESCRIPTOR) {
+      if (!PyList_Check(query_param_val)) {
+        derr << __func__ << " " << query_param_name << " not a list" << dendl;
+        Py_RETURN_NONE;
+      }
+      for (int j = 0; j < PyList_Size(query_param_val); j++) {
+        PyObject *sub_key = PyList_GET_ITEM(query_param_val, j);
+        if (!PyDict_Check(sub_key)) {
+          derr << __func__ << " query " << query_param_name << " item " << j
+               << " not a dict" << dendl;
+          Py_RETURN_NONE;
+        }
+        OSDPerfMetricSubKeyDescriptor d;
+        PyObject *sub_key_params = PyDict_Items(sub_key);
+        for (int k = 0; k < PyList_Size(sub_key_params); ++k) {
+          PyObject *pair = PyList_GET_ITEM(sub_key_params, k);
+          if (!PyTuple_Check(pair)) {
+            derr << __func__ << " query " << query_param_name << " item " << j
+                 << " pair " << k << " not a tuple" << dendl;
+            Py_RETURN_NONE;
+          }
+          char *param_name = nullptr;
+          PyObject *param_value = nullptr;
+          if (!PyArg_ParseTuple(pair, "sO:pair", &param_name, &param_value)) {
+            derr << __func__ << " query " << query_param_name << " item " << j
+                 << " pair " << k << " not a size 2 tuple" << dendl;
+            Py_RETURN_NONE;
+          }
+          if (param_name == NAME_SUB_KEY_TYPE) {
+            if (!PyString_Check(param_value)) {
+              derr << __func__ << " query " << query_param_name << " item " << j
+                   << " contains invalid param " << param_name << dendl;
+              Py_RETURN_NONE;
+            }
+            auto type = PyString_AsString(param_value);
+            auto it = sub_key_types.find(type);
+            if (it == sub_key_types.end()) {
+              derr << __func__ << " query " << query_param_name << " item " << j
+                   << " contains invalid type " << dendl;
+              Py_RETURN_NONE;
+            }
+            d.type = it->second;
+          } else if (param_name == NAME_SUB_KEY_REGEX) {
+            if (!PyString_Check(param_value)) {
+              derr << __func__ << " query " << query_param_name << " item " << j
+                   << " contains invalid param " << param_name << dendl;
+              Py_RETURN_NONE;
+            }
+            d.regex_str = PyString_AsString(param_value);
+            try {
+              d.regex = {d.regex_str.c_str()};
+            } catch (const std::regex_error& e) {
+              derr << __func__ << " query " << query_param_name << " item " << j
+                   << " contains invalid regex " << d.regex_str << dendl;
+              Py_RETURN_NONE;
+            }
+          } else {
+            derr << __func__ << " query " << query_param_name << " item " << j
+                 << " contains invalid param " << param_name << dendl;
+            Py_RETURN_NONE;
+          }
+        }
+        if (d.type == static_cast<OSDPerfMetricSubKeyType>(-1) ||
+            d.regex_str.empty()) {
+          derr << __func__ << " query " << query_param_name << " item " << i
+               << " invalid" << dendl;
+          Py_RETURN_NONE;
+        }
+        query.key_descriptor.push_back(d);
+      }
+    } else if (query_param_name == NAME_COUNTERS_DESCRIPTORS) {
+      if (!PyList_Check(query_param_val)) {
+        derr << __func__ << " " << query_param_name << " not a list" << dendl;
+        Py_RETURN_NONE;
+      }
+      for (int j = 0; j < PyList_Size(query_param_val); j++) {
+        PyObject *py_type = PyList_GET_ITEM(query_param_val, j);
+        if (!PyString_Check(py_type)) {
+          derr << __func__ << " query " << query_param_name << " item " << j
+               << " not a string" << dendl;
+          Py_RETURN_NONE;
+        }
+        auto type = PyString_AsString(py_type);
+        auto it = counter_types.find(type);
+        if (it == counter_types.end()) {
+          derr << __func__ << " query " << query_param_name << " item " << type
+               << " is not valid type" << dendl;
+          Py_RETURN_NONE;
+        }
+        query.performance_counter_descriptors.push_back(it->second);
+      }
+    } else {
+      derr << "unknown query param: " << query_param_name << dendl;
+      Py_RETURN_NONE;
+    }
+  }
+
+  if (query.key_descriptor.empty() ||
+      query.performance_counter_descriptors.empty()) {
+    derr << "invalid query" << dendl;
+    Py_RETURN_NONE;
+  }
 
   auto query_id = self->py_modules->add_osd_perf_query(query);
   return PyLong_FromLong(query_id);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2691,3 +2691,10 @@ int DaemonServer::remove_osd_perf_query(OSDPerfMetricQueryID query_id)
 {
   return osd_perf_metric_collector.remove_query(query_id);
 }
+
+int DaemonServer::get_osd_perf_counters(
+    OSDPerfMetricQueryID query_id,
+    std::map<OSDPerfMetricKey, PerformanceCounters> *counters)
+{
+  return osd_perf_metric_collector.get_counters(query_id, counters);
+}

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -167,6 +167,8 @@ public:
 
   OSDPerfMetricQueryID add_osd_perf_query(const OSDPerfMetricQuery &query);
   int remove_osd_perf_query(OSDPerfMetricQueryID query_id);
+  int get_osd_perf_counters(OSDPerfMetricQueryID query_id,
+                            std::map<OSDPerfMetricKey, PerformanceCounters> *c);
 
   virtual const char** get_tracked_conf_keys() const override;
   virtual void handle_conf_change(const ConfigProxy& conf,

--- a/src/mgr/OSDPerfMetricCollector.h
+++ b/src/mgr/OSDPerfMetricCollector.h
@@ -31,16 +31,22 @@ public:
   int remove_query(OSDPerfMetricQueryID query_id);
   void remove_all_queries();
 
+  int get_counters(OSDPerfMetricQueryID query_id,
+                   std::map<OSDPerfMetricKey, PerformanceCounters> *counters);
+
   void process_reports(
       const std::map<OSDPerfMetricQuery, OSDPerfMetricReport> &reports);
 
 private:
   typedef std::map<OSDPerfMetricQuery, std::set<OSDPerfMetricQueryID>> Queries;
+  typedef std::map<OSDPerfMetricQueryID,
+                   std::map<OSDPerfMetricKey, PerformanceCounters>> Counters;
 
   Listener &listener;
   mutable Mutex lock;
   OSDPerfMetricQueryID next_query_id = 0;
   Queries queries;
+  Counters counters;
 };
 
 #endif // OSD_PERF_METRIC_COLLECTOR_H_

--- a/src/mgr/PyFormatter.cc
+++ b/src/mgr/PyFormatter.cc
@@ -38,7 +38,7 @@ void PyFormatter::open_object_section(const char *name)
 
 void PyFormatter::dump_unsigned(const char *name, uint64_t u)
 {
-  PyObject *p = PyLong_FromLongLong(u);
+  PyObject *p = PyLong_FromUnsignedLong(u);
   ceph_assert(p);
   dump_pyobject(name, p);
 }

--- a/src/osd/DynamicPerfStats.h
+++ b/src/osd/DynamicPerfStats.h
@@ -19,6 +19,26 @@ public:
     }
   }
 
+  void merge(const DynamicPerfStats &dps) {
+    for (auto &query_it : dps.data) {
+      auto &query = query_it.first;
+      for (auto &key_it : query_it.second) {
+        auto &key = key_it.first;
+        auto counter_it = key_it.second.begin();
+        auto update_counter_fnc =
+            [&counter_it](const PerformanceCounterDescriptor &d,
+                          PerformanceCounter *c) {
+              c->first  += counter_it->first;
+              c->second += counter_it->second;
+              counter_it++;
+            };
+
+        ceph_assert(key_it.second.size() >= data[query][key].size());
+        query.update_counters(update_counter_fnc, &data[query][key]);
+      }
+    }
+  }
+
   void set_queries(const std::list<OSDPerfMetricQuery> &queries) {
     std::map<OSDPerfMetricQuery,
              std::map<OSDPerfMetricKey, PerformanceCounters>> new_data;

--- a/src/osd/DynamicPerfStats.h
+++ b/src/osd/DynamicPerfStats.h
@@ -4,7 +4,9 @@
 #ifndef DYNAMIC_PERF_STATS_H
 #define DYNAMIC_PERF_STATS_H
 
+#include "messages/MOSDOp.h"
 #include "mgr/OSDPerfMetricTypes.h"
+#include "osd/OpRequest.h"
 
 class DynamicPerfStats {
 public:
@@ -19,7 +21,7 @@ public:
 
   void set_queries(const std::list<OSDPerfMetricQuery> &queries) {
     std::map<OSDPerfMetricQuery,
-             std::map<std::string, PerformanceCounters>> new_data;
+             std::map<OSDPerfMetricKey, PerformanceCounters>> new_data;
     for (auto &query : queries) {
       std::swap(new_data[query], data[query]);
     }
@@ -31,12 +33,89 @@ public:
   }
 
   void add(const OpRequest& op, uint64_t inb, uint64_t outb,
-           const utime_t &now) {
+           const utime_t &latency) {
+
+    auto update_counter_fnc =
+        [&op, inb, outb, &latency](const PerformanceCounterDescriptor &d,
+                                   PerformanceCounter *c) {
+          ceph_assert(d.is_supported());
+
+          switch(d.type) {
+          case PerformanceCounterType::WRITE_OPS:
+            if (op.may_write() || op.may_cache()) {
+              c->first++;
+            }
+            return;
+          case PerformanceCounterType::READ_OPS:
+            if (op.may_read()) {
+              c->first++;
+            }
+            return;
+          case PerformanceCounterType::WRITE_BYTES:
+            if (op.may_write() || op.may_cache()) {
+              c->first += inb;
+              c->second++;
+            }
+            return;
+          case PerformanceCounterType::READ_BYTES:
+            if (op.may_read()) {
+              c->first += outb;
+              c->second++;
+            }
+            return;
+          case PerformanceCounterType::WRITE_LATENCY:
+            if (op.may_write() || op.may_cache()) {
+              c->first += latency.to_nsec();
+              c->second++;
+            }
+            return;
+          case PerformanceCounterType::READ_LATENCY:
+            if (op.may_read()) {
+              c->first += latency.to_nsec();
+              c->second++;
+            }
+            return;
+          default:
+            ceph_abort_msg("unknown counter type");
+          }
+        };
+
+    auto get_subkey_fnc =
+        [&op](const OSDPerfMetricSubKeyDescriptor &d,
+              OSDPerfMetricSubKey *sub_key) {
+          ceph_assert(d.is_supported());
+
+          auto m = static_cast<const MOSDOp*>(op.get_req());
+          std::string match_string;
+          switch(d.type) {
+          case OSDPerfMetricSubKeyType::CLIENT_ID:
+            match_string = stringify(m->get_reqid().name);
+            break;
+          case OSDPerfMetricSubKeyType::POOL_ID:
+            match_string = stringify(m->get_spg().pool());
+            break;
+          case OSDPerfMetricSubKeyType::OBJECT_NAME:
+            match_string = m->get_oid().name;
+            break;
+          default:
+            ceph_abort_msg("unknown counter type");
+          }
+
+          std::smatch match;
+          if (!std::regex_search(match_string, match, d.regex)) {
+            return false;
+          }
+          for (auto &sub_match : match) {
+            sub_key->push_back(sub_match.str());
+          }
+          return true;
+        };
+
     for (auto &it : data) {
       auto &query = it.first;
-      std::string key;
-      if (query.get_key(op, &key)) {
-        query.update_counters(op, inb, outb, now, &it.second[key]);
+      OSDPerfMetricKey key;
+      if (query.get_key(get_subkey_fnc, &key)) {
+        query.update_counters(update_counter_fnc, &it.second[key]);
       }
     }
   }
@@ -58,7 +137,8 @@ public:
   }
 
 private:
-  std::map<OSDPerfMetricQuery, std::map<std::string, PerformanceCounters>> data;
+  std::map<OSDPerfMetricQuery,
+           std::map<OSDPerfMetricKey, PerformanceCounters>> data;
 };
 
 #endif // DYNAMIC_PERF_STATS_H

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9813,12 +9813,18 @@ void OSD::get_perf_reports(
     std::map<OSDPerfMetricQuery, OSDPerfMetricReport> *reports) {
   std::vector<PGRef> pgs;
   _get_pgs(&pgs);
-  DynamicPerfStats dps(m_perf_queries);
+  DynamicPerfStats dps;
   for (auto& pg : pgs) {
     if (pg->is_primary()) {
+      // m_perf_queries can be modified only in set_perf_queries by mgr client
+      // request, and it is protected by by mgr client's lock, which is held
+      // when set_perf_queries/get_perf_reports are called, so we may not hold
+      // m_perf_queries_lock here.
+      DynamicPerfStats pg_dps(m_perf_queries);
       pg->lock();
-      pg->get_dynamic_perf_stats(&dps);
+      pg->get_dynamic_perf_stats(&pg_dps);
       pg->unlock();
+      dps.merge(pg_dps);
     }
   }
   dps.add_to_reports(reports);

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -917,7 +917,25 @@ class MgrModule(ceph_module.BaseMgrModule):
 
     def add_osd_perf_query(self, query):
         """
-        Fetch the daemon metadata for a particular service.
+        Register an OSD perf query.  Argument is a
+        dict of the query parameters, in this form:
+
+        ::
+
+           {
+             'key_descriptor': [
+               {'type': subkey_type, 'regex': regex_pattern},
+               ...
+             ],
+             'performance_counter_descriptors': [
+               list, of, descriptor, types
+             ],
+           }
+
+        Valid subkey types: 'client_id', 'pool_id', 'object_name'
+        Valid performance counter types:
+           'write_ops', 'read_ops', 'write_bytes', 'read_bytes',
+           'write_latency', 'read_latency'
 
         :param object query: query
         :rtype: int (query id)
@@ -926,8 +944,16 @@ class MgrModule(ceph_module.BaseMgrModule):
 
     def remove_osd_perf_query(self, query_id):
         """
-        Fetch the daemon metadata for a particular service.
+        Unregister an OSD perf query.
 
         :param int query_id: query ID
         """
         return self._ceph_remove_osd_perf_query(query_id)
+
+    def get_osd_perf_counters(self, query_id):
+        """
+        Get stats collected for an OSD perf query.
+
+        :param int query_id: query ID
+        """
+        return self._ceph_get_osd_perf_counters(query_id)

--- a/src/pybind/mgr/osd_perf_query/module.py
+++ b/src/pybind/mgr/osd_perf_query/module.py
@@ -3,14 +3,27 @@
 osd_perf_query module
 """
 
+from time import time
+import errno
+import prettytable
+
 from mgr_module import MgrModule
 
+def get_human_readable(bytes, precision=2):
+    suffixes = ['', 'Ki', 'Mi', 'Gi', 'Ti']
+    suffix_index = 0
+    while bytes > 1024 and suffix_index < 4:
+        # increment the index of the suffix
+        suffix_index += 1
+        # apply the division
+        bytes = bytes / 1024.0
+    return '%.*f%s' % (precision, bytes, suffixes[suffix_index])
 
 class OSDPerfQuery(MgrModule):
     COMMANDS = [
         {
             "cmd": "osd perf query add "
-                   "name=query,type=CephString,req=true",
+                   "name=query,type=CephChoices,strings=client_id|rbd_image_id",
             "desc": "add osd perf query",
             "perm": "w"
         },
@@ -20,15 +33,102 @@ class OSDPerfQuery(MgrModule):
             "desc": "remove osd perf query",
             "perm": "w"
         },
+        {
+            "cmd": "osd perf counters get "
+                   "name=query_id,type=CephInt,req=true",
+            "desc": "fetch osd perf counters",
+            "perm": "w"
+        },
     ]
+
+    CLIENT_ID_QUERY = {
+        'key_descriptor': [
+            {'type': 'client_id', 'regex': '^.+$'},
+        ],
+        'performance_counter_descriptors': [
+            'write_ops', 'read_ops', 'write_bytes', 'read_bytes',
+            'write_latency', 'read_latency',
+        ],
+    }
+
+    RBD_IMAGE_ID_QUERY = {
+        'key_descriptor': [
+            {'type': 'pool_id', 'regex': '^.+$'},
+            {'type': 'object_name', 'regex': '^rbd_data\.([^.]+)\.'},
+        ],
+        'performance_counter_descriptors': [
+            'write_ops', 'read_ops', 'write_bytes', 'read_bytes',
+            'write_latency', 'read_latency',
+        ],
+    }
+
+    queries = {}
 
     def handle_command(self, inbuf, cmd):
         if cmd['prefix'] == "osd perf query add":
-            query_id = self.add_osd_perf_query(cmd['query'])
+            if cmd['query'] == 'rbd_image_id':
+                query = self.RBD_IMAGE_ID_QUERY
+            else:
+                query = self.CLIENT_ID_QUERY
+            query_id = self.add_osd_perf_query(query)
+            if query_id is None:
+                return -errno.EINVAL, "", "Invalid query"
+            self.queries[query_id] = [query, time()]
             return 0, str(query_id), "added query " + cmd['query'] + " with id " + str(query_id)
         elif cmd['prefix'] == "osd perf query remove":
+            if cmd['query_id'] not in self.queries:
+                return -errno.ENOENT, "", "unknown query id " + str(cmd['query_id'])
             self.remove_osd_perf_query(cmd['query_id'])
+            del self.queries[cmd['query_id']]
             return 0, "", "removed query with id " + str(cmd['query_id'])
+        elif cmd['prefix'] == "osd perf counters get":
+            if cmd['query_id'] not in self.queries:
+                return -errno.ENOENT, "", "unknown query id " + str(cmd['query_id'])
+
+            query = self.queries[cmd['query_id']][0]
+            res = self.get_osd_perf_counters(cmd['query_id'])
+            now = time()
+            last_update = self.queries[cmd['query_id']][1]
+            descriptors = query['performance_counter_descriptors']
+
+            if query == self.RBD_IMAGE_ID_QUERY:
+                column_names = ["pool_id", "rbd image_id"]
+            else:
+                column_names = ["client_id"]
+            for d in descriptors:
+                desc = d
+                if d in ['write_bytes', 'read_bytes']:
+                    desc += '/sec'
+                elif d in ['write_latency', 'read_latency']:
+                    desc += '(msec)'
+                column_names.append(desc)
+
+            table = prettytable.PrettyTable(tuple(column_names),
+                                            hrules=prettytable.FRAME)
+            for c in res['counters']:
+                if query == self.RBD_IMAGE_ID_QUERY:
+                    row = [c['k'][0][0], c['k'][1][1]]
+                else:
+                    row = [c['k'][0][0]]
+                counters = c['c']
+                for i in range(len(descriptors)):
+                    if descriptors[i] in ['write_bytes', 'read_bytes']:
+                        bps = counters[i][0] / (now - last_update)
+                        row.append(get_human_readable(bps))
+                    elif descriptors[i] in ['write_latency', 'read_latency']:
+                        lat = 0
+                        if counters[i][1] > 0:
+                            lat = 1.0 * counters[i][0] / counters[i][1] / 1000000
+                        row.append("%.2f" % lat)
+                    else:
+                        row.append("%d" % counters[i][0])
+                table.add_row(row)
+
+            msg = "counters for the query id %d for the last %d sec" % \
+                (cmd['query_id'], now - last_update)
+            self.queries[cmd['query_id']][1] = now
+
+            return 0, table.get_string() + "\n", msg
         else:
             raise NotImplementedError(cmd['prefix'])
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

