### PR TITLE
mgr/dashboard/qa: Fix ECP creation test

### DIFF
--- a/qa/suites/rados/mgr/tasks/dashboard.yaml
+++ b/qa/suites/rados/mgr/tasks/dashboard.yaml
@@ -44,3 +44,4 @@ tasks:
         - tasks.mgr.dashboard.test_role
         - tasks.mgr.dashboard.test_settings
         - tasks.mgr.dashboard.test_user
+        - tasks.mgr.dashboard.test_erasure_code_profile

--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -319,9 +319,16 @@ class DashboardTestCase(MgrTestCase):
     def reset_session(cls):
         cls._session = requests.Session()
 
+    def assertSubset(self, data, biggerData):
+        for key, value in data.items():
+            self.assertEqual(biggerData[key], value)
+
     def assertJsonBody(self, data):
         body = self._resp.json()
         self.assertEqual(body, data)
+
+    def assertJsonSubset(self, data):
+        self.assertSubset(data, self._resp.json())
 
     def assertSchema(self, data, schema):
         try:

--- a/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
+++ b/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
@@ -47,7 +47,7 @@ class ECPTest(DashboardTestCase):
             }
             if 'crush-failure-domain' in default[0]:
                 default_ecp['crush-failure-domain'] = default[0]['crush-failure-domain']
-            self.assertEqual(default[0], default_ecp)
+            self.assertSubset(default_ecp, default[0])
             get_data = self._get('/api/erasure_code_profile/default')
             self.assertEqual(get_data, default[0])
 
@@ -58,7 +58,7 @@ class ECPTest(DashboardTestCase):
         self.assertStatus(201)
 
         self._get('/api/erasure_code_profile/ecp32')
-        self.assertJsonBody({
+        self.assertJsonSubset({
             'crush-device-class': '',
             'crush-failure-domain': 'osd',
             'crush-root': 'default',
@@ -68,7 +68,6 @@ class ECPTest(DashboardTestCase):
             'name': 'ecp32',
             'plugin': 'jerasure',
             'technique': 'reed_sol_van',
-            'w': '8'
         })
 
         self.assertStatus(200)


### PR DESCRIPTION
The current solution fails on our CI-system as the parameter 'w' can have
different values in different environments. 'w' is returned from the backend
during the creation of a jerasure based erasure code profile.

As this was only tested before in a vstart cluster environment it worked.

Through this commit this dynamic set parameter will be ignored in order
to pass in different environments.

Fixes: https://tracker.ceph.com/issues/37275
Signed-off-by: Stephan Müller <smueller@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

