### PR TITLE
mgr/dashboard: Small improvements for running teuthology tests

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -74,7 +74,7 @@ EOF
     pip install -r $CURR_DIR/requirements.txt
     deactivate
 
-    git clone https://github.com/ceph/teuthology.git
+    git clone --depth 1 https://github.com/ceph/teuthology.git
 
     cd $BUILD_DIR
 

--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -99,6 +99,7 @@ EOF
 
 run_teuthology_tests() {
     cd "$BUILD_DIR"
+    find ../src/pybind/mgr/dashboard/ -name '*.pyc' -exec rm -f {} \;
     source $TEMP_DIR/venv/bin/activate
 
 


### PR DESCRIPTION
Part of this PR addresses the reason why failures described in https://github.com/ceph/ceph/pull/24900#issuecomment-439143240 were missed; the other part should just save a few seconds whenever that test runner is invoked.