### PR TITLE
    rgw: change the way sysobj filters raw attributes, fix bucket sync state xattrs

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1207,6 +1207,18 @@ struct RGWObjVersionTracker {
   void generate_new_write_ver(CephContext *cct);
 };
 
+inline ostream& operator<<(ostream& out, const obj_version &v)
+{
+  out << v.tag << ":" << v.ver;
+  return out;
+}
+
+inline ostream& operator<<(ostream& out, const RGWObjVersionTracker &ot)
+{
+  out << "{r=" << ot.read_version << ",w=" << ot.write_version << "}";
+  return out;
+}
+
 enum RGWBucketFlags {
   BUCKET_SUSPENDED = 0x1,
   BUCKET_VERSIONED = 0x2,

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -98,14 +98,15 @@ int RGWAsyncGetSystemObj::_send_request()
   return sysobj.rop()
                .set_objv_tracker(&objv_tracker)
                .set_attrs(pattrs)
+	       .set_raw_attrs(raw_attrs)
                .read(&bl);
 }
 
 RGWAsyncGetSystemObj::RGWAsyncGetSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWSI_SysObj *_svc,
                        RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
-                       bool want_attrs)
+                       bool want_attrs, bool raw_attrs)
   : RGWAsyncRadosRequest(caller, cn), obj_ctx(_svc),
-    obj(_obj), want_attrs(want_attrs)
+    obj(_obj), want_attrs(want_attrs), raw_attrs(raw_attrs)
 {
   if (_objv_tracker) {
     objv_tracker = *_objv_tracker;
@@ -115,7 +116,7 @@ RGWAsyncGetSystemObj::RGWAsyncGetSystemObj(RGWCoroutine *caller, RGWAioCompletio
 int RGWSimpleRadosReadAttrsCR::send_request()
 {
   req = new RGWAsyncGetSystemObj(this, stack->create_completion_notifier(),
-			         svc, nullptr, obj, true);
+			         svc, nullptr, obj, true, raw_attrs);
   async_rados->queue(req);
   return 0;
 }

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -107,12 +107,13 @@ class RGWAsyncGetSystemObj : public RGWAsyncRadosRequest {
   RGWObjVersionTracker objv_tracker;
   rgw_raw_obj obj;
   const bool want_attrs;
+  const bool raw_attrs;
 protected:
   int _send_request() override;
 public:
   RGWAsyncGetSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWSI_SysObj *_svc,
                        RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
-                       bool want_attrs);
+                       bool want_attrs, bool raw_attrs);
 
   bufferlist bl;
   map<string, bufferlist> attrs;
@@ -221,7 +222,7 @@ template <class T>
 int RGWSimpleRadosReadCR<T>::send_request()
 {
   req = new RGWAsyncGetSystemObj(this, stack->create_completion_notifier(), svc,
-			         objv_tracker, obj, false);
+			         objv_tracker, obj, false, false);
   async_rados->queue(req);
   return 0;
 }
@@ -262,15 +263,17 @@ class RGWSimpleRadosReadAttrsCR : public RGWSimpleCoroutine {
 
   rgw_raw_obj obj;
   map<string, bufferlist> *pattrs;
+  bool raw_attrs;
   RGWAsyncGetSystemObj *req;
 
 public:
   RGWSimpleRadosReadAttrsCR(RGWAsyncRadosProcessor *_async_rados, RGWSI_SysObj *_svc,
 		      const rgw_raw_obj& _obj,
-		      map<string, bufferlist> *_pattrs) : RGWSimpleCoroutine(_svc->ctx()),
+		      map<string, bufferlist> *_pattrs, bool _raw_attrs) : RGWSimpleCoroutine(_svc->ctx()),
                                                 async_rados(_async_rados), svc(_svc),
 						obj(_obj),
                                                 pattrs(_pattrs),
+						raw_attrs(_raw_attrs),
                                                 req(NULL) {}
   ~RGWSimpleRadosReadAttrsCR() override {
     request_cleanup();

--- a/src/rgw/services/svc_sys_obj.cc
+++ b/src/rgw/services/svc_sys_obj.cc
@@ -27,7 +27,8 @@ int RGWSI_SysObj::Obj::ROp::stat()
   RGWSI_SysObj_Core *svc = source.core_svc;
   rgw_raw_obj& obj = source.obj;
 
-  return svc->stat(source.get_ctx(), state, obj, attrs,
+  return svc->stat(source.get_ctx(), state, obj,
+		   attrs, raw_attrs,
                    lastmod, obj_size,
                    objv_tracker);
 }
@@ -41,6 +42,7 @@ int RGWSI_SysObj::Obj::ROp::read(int64_t ofs, int64_t end, bufferlist *bl)
                    objv_tracker,
                    obj, bl, ofs, end,
                    attrs,
+		   raw_attrs,
                    cache_info,
                    refresh_version);
 }

--- a/src/rgw/services/svc_sys_obj.h
+++ b/src/rgw/services/svc_sys_obj.h
@@ -50,6 +50,7 @@ public:
       
       RGWObjVersionTracker *objv_tracker{nullptr};
       map<string, bufferlist> *attrs{nullptr};
+      bool raw_attrs{false};
       boost::optional<obj_version> refresh_version{boost::none};
       ceph::real_time *lastmod{nullptr};
       uint64_t *obj_size{nullptr};
@@ -73,6 +74,11 @@ public:
       ROp& set_attrs(map<string, bufferlist> *_attrs) {
         attrs = _attrs;
         return *this;
+      }
+
+      ROp& set_raw_attrs(bool ra) {
+	raw_attrs = ra;
+	return *this;
       }
 
       ROp& set_refresh_version(boost::optional<obj_version>& rf) {

--- a/src/rgw/services/svc_sys_obj_cache.h
+++ b/src/rgw/services/svc_sys_obj_cache.h
@@ -43,6 +43,7 @@ protected:
            const rgw_raw_obj& obj,
            bufferlist *bl, off_t ofs, off_t end,
            map<string, bufferlist> *attrs,
+	   bool raw_attrs,
            rgw_cache_entry_info *cache_info,
            boost::optional<obj_version>) override;
 

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -105,7 +105,6 @@ int RGWSI_SysObj_Core::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_ti
     return r;
   }
 
-  map<string, bufferlist> unfiltered_attrset;
   uint64_t size = 0;
   struct timespec mtime_ts;
 
@@ -113,9 +112,7 @@ int RGWSI_SysObj_Core::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_ti
   if (objv_tracker) {
     objv_tracker->prepare_op_for_read(&op);
   }
-  if (attrs) {
-    op.getxattrs(&unfiltered_attrset, nullptr);
-  }
+  op.getxattrs(attrs, nullptr);
   if (psize || pmtime) {
     op.stat2(&size, &mtime_ts, nullptr);
   }
@@ -136,9 +133,6 @@ int RGWSI_SysObj_Core::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_ti
     *psize = size;
   if (pmtime)
     *pmtime = ceph::real_clock::from_timespec(mtime_ts);
-  if (attrs) {
-    rgw_filter_attrset(unfiltered_attrset, RGW_ATTR_PREFIX, attrs);
-  }
 
   return 0;
 }
@@ -147,6 +141,7 @@ int RGWSI_SysObj_Core::stat(RGWSysObjectCtxBase& obj_ctx,
                             GetObjState& state,
                             const rgw_raw_obj& obj,
                             map<string, bufferlist> *attrs,
+			    bool raw_attrs,
                             real_time *lastmod,
                             uint64_t *obj_size,
                             RGWObjVersionTracker *objv_tracker)
@@ -162,7 +157,11 @@ int RGWSI_SysObj_Core::stat(RGWSysObjectCtxBase& obj_ctx,
   }
 
   if (attrs) {
-    *attrs = astate->attrset;
+    if (raw_attrs) {
+      *attrs = astate->attrset;
+    } else {
+      rgw_filter_attrset(astate->attrset, RGW_ATTR_PREFIX, attrs);
+    }
     if (cct->_conf->subsys.should_gather<ceph_subsys_rgw, 20>()) {
       map<string, bufferlist>::iterator iter;
       for (iter = attrs->begin(); iter != attrs->end(); ++iter) {
@@ -185,6 +184,7 @@ int RGWSI_SysObj_Core::read(RGWSysObjectCtxBase& obj_ctx,
                             const rgw_raw_obj& obj,
                             bufferlist *bl, off_t ofs, off_t end,
                             map<string, bufferlist> *attrs,
+			    bool raw_attrs,
                             rgw_cache_entry_info *cache_info,
                             boost::optional<obj_version>)
 {
@@ -231,7 +231,11 @@ int RGWSI_SysObj_Core::read(RGWSysObjectCtxBase& obj_ctx,
   }
 
   if (attrs) {
-    rgw_filter_attrset(unfiltered_attrset, RGW_ATTR_PREFIX, attrs);
+    if (raw_attrs) {
+      attrs->swap(unfiltered_attrset);
+    } else {
+      rgw_filter_attrset(unfiltered_attrset, RGW_ATTR_PREFIX, attrs);
+    }
   }
 
   read_state.last_ver = op_ver;

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -206,7 +206,11 @@ int RGWSI_SysObj_Core::read(RGWSysObjectCtxBase& obj_ctx,
   map<string, bufferlist> unfiltered_attrset;
 
   if (attrs) {
-    op.getxattrs(&unfiltered_attrset, nullptr);
+    if (raw_attrs) {
+      op.getxattrs(attrs, nullptr);
+    } else {
+      op.getxattrs(&unfiltered_attrset, nullptr);
+    }
   }
 
   RGWSI_RADOS::Obj rados_obj;
@@ -230,12 +234,8 @@ int RGWSI_SysObj_Core::read(RGWSysObjectCtxBase& obj_ctx,
     return -ECANCELED;
   }
 
-  if (attrs) {
-    if (raw_attrs) {
-      attrs->swap(unfiltered_attrset);
-    } else {
-      rgw_filter_attrset(unfiltered_attrset, RGW_ATTR_PREFIX, attrs);
-    }
+  if (attrs && !raw_attrs) {
+    rgw_filter_attrset(unfiltered_attrset, RGW_ATTR_PREFIX, attrs);
   }
 
   read_state.last_ver = op_ver;

--- a/src/rgw/services/svc_sys_obj_core.h
+++ b/src/rgw/services/svc_sys_obj_core.h
@@ -134,6 +134,7 @@ protected:
                    const rgw_raw_obj& obj,
                    bufferlist *bl, off_t ofs, off_t end,
                    map<string, bufferlist> *attrs,
+		   bool raw_attrs,
                    rgw_cache_entry_info *cache_info,
                    boost::optional<obj_version>);
 
@@ -184,6 +185,7 @@ protected:
            GetObjState& state,
            const rgw_raw_obj& obj,
            map<string, bufferlist> *attrs,
+	   bool raw_attrs,
            real_time *lastmod,
            uint64_t *obj_size,
            RGWObjVersionTracker *objv_tracker);


### PR DESCRIPTION
   
    Fixes: http://tracker.ceph.com/issues/37281
    
    This is a regression, introduced in fc860a367bc59d4c70e7e80f021235864c5da08b.
    The problem was that the original change fixed was that we didn't filter
    out sys object attributes that needed to be filtered (e.g., ver objclass
    private attributes that were set on the object). We shouldn't know about
    these attributes. RGW mostly prefixes all its attributes with "user.rgw."
    so in most cases just filtering out everything that doesn't start with
    that is fine. However, prior to refactoring, we had multiple ways to read
    sys object, and apparently there was at least one case where we didn't
    prefix the attrs correctly (bucket sync state).
    
    This commit adds the option to read all of sys object's xattrs, and uses
    that in the case where we needed to do it. However, it also modifies the
    bucket sync state xattrs to be prefixed (in a backward compatible way).
    
    Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

