### PR TITLE
mgr/dashboard: Give `test_safe_to_destroy` more time to recover

### DIFF
--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -109,7 +109,7 @@ class OsdTest(DashboardTestCase):
             if 'safe-to-destroy' in self.jsonBody():
                 return self.jsonBody()['safe-to-destroy']
             return None
-        self.wait_until_equal(get_destroy_status, False, 10)
+        self.wait_until_equal(get_destroy_status, False, 30)
         self.assertStatus(200)
 
 


### PR DESCRIPTION
Signed-off-by: Patrick Nawracay <pnawracay@suse.com>

