### PR TITLE
common: avoid the overhead of ANNOTATE_HAPPENS_* in NDEBUG builds.

### DIFF
--- a/src/common/valgrind.h
+++ b/src/common/valgrind.h
@@ -6,7 +6,7 @@
 
 #include "acconfig.h"
 
-#ifdef HAVE_VALGRIND_HELGRIND_H
+#if defined(HAVE_VALGRIND_HELGRIND_H) && !defined(NDEBUG)
   #include <valgrind/helgrind.h>
 #else
   #define ANNOTATE_HAPPENS_AFTER(x)             (void)0


### PR DESCRIPTION
Occurrences
-----------------
* `buffer::ptr::release`,
* `RefCountedObject::put`,
* `buffer::ptr::make_shareable`,
* `CephContext::put`.

Before
--------
```
$ objdump -dC bin/ceph-osd

...

0000000000d8db70 <ceph::buffer::ptr::release()>:
  d8db70:       48 81 ec c8 00 00 00    sub    $0xc8,%rsp
  d8db77:       64 48 8b 04 25 28 00    mov    %fs:0x28,%rax
  d8db7e:       00 00 
  d8db80:       48 89 84 24 b8 00 00    mov    %rax,0xb8(%rsp)
  d8db87:       00 
  d8db88:       31 c0                   xor    %eax,%eax
  d8db8a:       48 8b 07                mov    (%rdi),%rax
  d8db8d:       48 85 c0                test   %rax,%rax
  d8db90:       0f 84 02 01 00 00       je     d8dc98 <ceph::buffer::ptr::release()+0x128>
  d8db96:       ba 01 00 00 00          mov    $0x1,%edx
  d8db9b:       b9 ff ff ff ff          mov    $0xffffffff,%ecx
  d8dba0:       f0 0f c1 48 34          lock xadd %ecx,0x34(%rax)
  d8dba5:       29 d1                   sub    %edx,%ecx
  d8dba7:       0f 85 0b 01 00 00       jne    d8dcb8 <ceph::buffer::ptr::release()+0x148>
  d8dbad:       48 c7 44 24 50 22 01    movq   $0x48470122,0x50(%rsp)
  d8dbb4:       47 48 
  d8dbb6:       48 8b 37                mov    (%rdi),%rsi
  d8dbb9:       48 8d 44 24 50          lea    0x50(%rsp),%rax
  d8dbbe:       48 c7 44 24 58 34 00    movq   $0x34,0x58(%rsp)
  d8dbc5:       00 00 
  d8dbc7:       48 c7 07 00 00 00 00    movq   $0x0,(%rdi)
  d8dbce:       89 ca                   mov    %ecx,%edx
  d8dbd0:       48 c7 44 24 60 00 00    movq   $0x0,0x60(%rsp)
  d8dbd7:       00 00 
  d8dbd9:       48 c7 44 24 68 00 00    movq   $0x0,0x68(%rsp)
  d8dbe0:       00 00 
  d8dbe2:       48 c7 44 24 70 00 00    movq   $0x0,0x70(%rsp)
  d8dbe9:       00 00 
  d8dbeb:       48 c7 44 24 78 00 00    movq   $0x0,0x78(%rsp)
  d8dbf2:       00 00 
  d8dbf4:       48 c1 c7 03             rol    $0x3,%rdi
  d8dbf8:       48 c1 c7 0d             rol    $0xd,%rdi
  d8dbfc:       48 c1 c7 3d             rol    $0x3d,%rdi
  d8dc00:       48 c1 c7 33             rol    $0x33,%rdi
  d8dc04:       48 87 db                xchg   %rbx,%rbx
  d8dc07:       48 89 54 24 10          mov    %rdx,0x10(%rsp)
  d8dc0c:       48 8b 44 24 10          mov    0x10(%rsp),%rax
  d8dc11:       89 ca                   mov    %ecx,%edx
  d8dc13:       48 8b 07                mov    (%rdi),%rax
  d8dc16:       48 c7 84 24 80 00 00    movq   $0x48470123,0x80(%rsp)
  d8dc1d:       00 23 01 47 48 
  d8dc22:       48 83 c0 34             add    $0x34,%rax
  d8dc26:       48 89 84 24 88 00 00    mov    %rax,0x88(%rsp)
  d8dc2d:       00 
  d8dc2e:       48 c7 84 24 90 00 00    movq   $0x0,0x90(%rsp)
  d8dc35:       00 00 00 00 00 
  d8dc3a:       48 8d 84 24 80 00 00    lea    0x80(%rsp),%rax
  d8dc41:       00 
  d8dc42:       48 c7 84 24 98 00 00    movq   $0x0,0x98(%rsp)
  d8dc49:       00 00 00 00 00 
  d8dc4e:       48 c7 84 24 a0 00 00    movq   $0x0,0xa0(%rsp)
  d8dc55:       00 00 00 00 00 
  d8dc5a:       48 c7 84 24 a8 00 00    movq   $0x0,0xa8(%rsp)
  d8dc61:       00 00 00 00 00 
  d8dc61:       00 00 00 00 00 
  d8dc66:       48 c1 c7 03             rol    $0x3,%rdi
  d8dc6a:       48 c1 c7 0d             rol    $0xd,%rdi
  d8dc6e:       48 c1 c7 3d             rol    $0x3d,%rdi
  d8dc72:       48 c1 c7 33             rol    $0x33,%rdi
  d8dc76:       48 87 db                xchg   %rbx,%rbx
  d8dc79:       48 85 f6                test   %rsi,%rsi
  d8dc7c:       48 89 54 24 18          mov    %rdx,0x18(%rsp)
  d8dc81:       48 8b 44 24 18          mov    0x18(%rsp),%rax
  d8dc86:       74 10                   je     d8dc98 <ceph::buffer::ptr::release()+0x128>
  d8dc88:       48 8b 06                mov    (%rsi),%rax
  d8dc8b:       48 89 f7                mov    %rsi,%rdi
  d8dc8e:       ff 50 08                callq  *0x8(%rax)
  d8dc91:       0f 1f 80 00 00 00 00    nopl   0x0(%rax)
  d8dc98:       48 8b 84 24 b8 00 00    mov    0xb8(%rsp),%rax
  d8dc9f:       00 
  d8dca0:       64 48 33 04 25 28 00    xor    %fs:0x28,%rax
  d8dca7:       00 00 
  d8dca9:       75 76                   jne    d8dd21 <ceph::buffer::ptr::release()+0x1b1>
  d8dcab:       48 81 c4 c8 00 00 00    add    $0xc8,%rsp
  d8dcb2:       c3                      retq   
  d8dcb3:       0f 1f 44 00 00          nopl   0x0(%rax,%rax,1)
  d8dcb8:       48 8b 07                mov    (%rdi),%rax
  d8dcbb:       48 c7 44 24 20 21 01    movq   $0x48470121,0x20(%rsp)
  d8dcc2:       47 48 
  d8dcc4:       31 d2                   xor    %edx,%edx
  d8dcc6:       48 83 c0 34             add    $0x34,%rax
  d8dcca:       48 89 44 24 28          mov    %rax,0x28(%rsp)
  d8dccf:       48 c7 44 24 30 00 00    movq   $0x0,0x30(%rsp)
  d8dcd6:       00 00 
  d8dcd8:       48 8d 44 24 20          lea    0x20(%rsp),%rax
  d8dcdd:       48 c7 44 24 38 00 00    movq   $0x0,0x38(%rsp)
  d8dce4:       00 00 
  d8dce6:       48 c7 44 24 40 00 00    movq   $0x0,0x40(%rsp)
  d8dced:       00 00 
  d8dcef:       48 c7 44 24 48 00 00    movq   $0x0,0x48(%rsp)
  d8dcf6:       00 00 
  d8dcf8:       48 c1 c7 03             rol    $0x3,%rdi
  d8dcfc:       48 c1 c7 0d             rol    $0xd,%rdi
  d8dd00:       48 c1 c7 3d             rol    $0x3d,%rdi
  d8dd04:       48 c1 c7 33             rol    $0x33,%rdi
  d8dd08:       48 87 db                xchg   %rbx,%rbx
  d8dd0b:       48 89 54 24 08          mov    %rdx,0x8(%rsp)
  d8dd10:       48 c7 07 00 00 00 00    movq   $0x0,(%rdi)
  d8dd17:       48 8b 44 24 08          mov    0x8(%rsp),%rax
  d8dd1c:       e9 77 ff ff ff          jmpq   d8dc98 <ceph::buffer::ptr::release()+0x128>
  d8dd21:       e8 1a 0f 6c ff          callq  44ec40 <__stack_chk_fail@plt>
  d8dd26:       66 2e 0f 1f 84 00 00    nopw   %cs:0x0(%rax,%rax,1)
  d8dd2d:       00 00 00 
```

After
------
```
$ grep -r BUILD_TYPE CMakeCache.txt 
CMAKE_BUILD_TYPE:STRING=RelWithDebInfo
```
```
$ objdump -dC bin/ceph-osd

...

0000000000d89eb0 <ceph::buffer::ptr::release()>:
  d89eb0:       48 8b 07                mov    (%rdi),%rax
  d89eb3:       48 85 c0                test   %rax,%rax
  d89eb6:       74 2f                   je     d89ee7 <ceph::buffer::ptr::release()+0x37>
  d89eb8:       f0 83 68 34 01          lock subl $0x1,0x34(%rax)
  d89ebd:       75 21                   jne    d89ee0 <ceph::buffer::ptr::release()+0x30>
  d89ebf:       48 8b 07                mov    (%rdi),%rax
  d89ec2:       48 c7 07 00 00 00 00    movq   $0x0,(%rdi)
  d89ec9:       48 85 c0                test   %rax,%rax
  d89ecc:       74 19                   je     d89ee7 <ceph::buffer::ptr::release()+0x37>
  d89ece:       48 8b 10                mov    (%rax),%rdx
  d89ed1:       48 89 c7                mov    %rax,%rdi
  d89ed4:       48 8b 52 08             mov    0x8(%rdx),%rdx
  d89ed8:       ff e2                   jmpq   *%rdx
  d89eda:       66 0f 1f 44 00 00       nopw   0x0(%rax,%rax,1)
  d89ee0:       48 c7 07 00 00 00 00    movq   $0x0,(%rdi)
  d89ee7:       f3 c3                   repz retq 
  d89ee9:       90                      nop
  d89eea:       66 0f 1f 44 00 00       nopw   0x0(%rax,%rax,1)
```