### PR TITLE
os/bluestore: implement on-demand BlueFS space allocation at slow dev

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -958,6 +958,10 @@ OPTION(bluestore_bluefs_balance_interval, OPT_FLOAT) // how often (sec) to balan
 // how often (sec) to dump allocator on allocation failure
 OPTION(bluestore_bluefs_alloc_failure_dump_interval, OPT_FLOAT)
 
+// Enforces db sync with legacy bluefs extents information on close.
+// Enables downgrades to pre-nautilus releases
+OPTION(bluestore_bluefs_db_compatibility, OPT_BOOL)
+
 // If you want to use spdk driver, you need to specify NVMe serial number here
 // with "spdk:" prefix.
 // Users can use 'lspci -vvv -d 8086:0953 | grep "Device Serial Number"' to

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -955,8 +955,8 @@ OPTION(bluestore_bluefs_max_ratio, OPT_FLOAT)  // max fs free / total free
 OPTION(bluestore_bluefs_gift_ratio, OPT_FLOAT) // how much to add at a time
 OPTION(bluestore_bluefs_reclaim_ratio, OPT_FLOAT) // how much to reclaim at a time
 OPTION(bluestore_bluefs_balance_interval, OPT_FLOAT) // how often (sec) to balance free space between bluefs and bluestore
-// how often (sec) to dump allocation failure happened during bluefs rebalance
-OPTION(bluestore_bluefs_balance_failure_dump_interval, OPT_FLOAT)
+// how often (sec) to dump allocator on allocation failure
+OPTION(bluestore_bluefs_alloc_failure_dump_interval, OPT_FLOAT)
 
 // If you want to use spdk driver, you need to specify NVMe serial number here
 // with "spdk:" prefix.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4107,10 +4107,10 @@ std::vector<Option> get_global_options() {
     .set_default(1)
     .set_description("How frequently (in seconds) to balance free space between BlueFS and BlueStore"),
 
-    Option("bluestore_bluefs_balance_failure_dump_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    Option("bluestore_bluefs_alloc_failure_dump_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
-    .set_description("How frequently (in seconds) to dump information on "
-      "allocation failure occurred during BlueFS space rebalance"),
+    .set_description("How frequently (in seconds) to dump allocator on"
+      "BlueFS space allocation failure"),
 
     Option("bluestore_spdk_mem", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(512)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4112,6 +4112,12 @@ std::vector<Option> get_global_options() {
     .set_description("How frequently (in seconds) to dump allocator on"
       "BlueFS space allocation failure"),
 
+    Option("bluestore_bluefs_db_compatibility", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(true)
+    .set_description("Sync db with legacy bluefs extents info")
+    .set_long_description("Enforces db sync with legacy bluefs extents information on close."
+                          " Enables downgrades to pre-nautilus releases"),
+
     Option("bluestore_spdk_mem", Option::TYPE_SIZE, Option::LEVEL_DEV)
     .set_default(512)
     .set_description("Amount of dpdk memory size in MB")

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -161,6 +161,11 @@ public:
   // vector cfs contains column families to be created when db is created.
   virtual int create_and_open(std::ostream &out,
 			      const vector<ColumnFamily>& cfs = {}) = 0;
+
+  virtual int open_read_only(ostream &out, const vector<ColumnFamily>& cfs = {}) {
+    return -ENOTSUP;
+  }
+
   virtual void close() { }
 
   /// Try to repair K/V database. leveldb and rocksdb require that database must be not opened.

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -318,9 +318,9 @@ int RocksDBStore::create_and_open(ostream &out,
   if (r < 0)
     return r;
   if (cfs.empty()) {
-    return do_open(out, true, nullptr);
+    return do_open(out, true, false, nullptr);
   } else {
-    return do_open(out, true, &cfs);
+    return do_open(out, true, false, &cfs);
   }
 }
 
@@ -463,9 +463,12 @@ int RocksDBStore::load_rocksdb_options(bool create_if_missing, rocksdb::Options&
   return 0;
 }
 
-int RocksDBStore::do_open(ostream &out, bool create_if_missing,
+int RocksDBStore::do_open(ostream &out,
+			  bool create_if_missing,
+			  bool open_readonly,
 			  const vector<ColumnFamily>* cfs)
 {
+  ceph_assert(!(create_if_missing && open_readonly));
   rocksdb::Options opt;
   int r = load_rocksdb_options(create_if_missing, opt);
   if (r) {
@@ -515,7 +518,11 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing,
     dout(1) << __func__ << " column families: " << existing_cfs << dendl;
     if (existing_cfs.empty()) {
       // no column families
-      status = rocksdb::DB::Open(opt, path, &db);
+      if (open_readonly) {
+	status = rocksdb::DB::Open(opt, path, &db);
+      } else {
+	status = rocksdb::DB::OpenForReadOnly(opt, path, &db);
+      }
       if (!status.ok()) {
 	derr << status.ToString() << dendl;
 	return -EINVAL;
@@ -554,8 +561,14 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing,
 	}
       }
       std::vector<rocksdb::ColumnFamilyHandle*> handles;
-      status = rocksdb::DB::Open(rocksdb::DBOptions(opt),
-				 path, column_families, &handles, &db);
+      if (open_readonly) {
+        status = rocksdb::DB::OpenForReadOnly(rocksdb::DBOptions(opt),
+				              path, column_families,
+					      &handles, &db);
+      } else {
+        status = rocksdb::DB::Open(rocksdb::DBOptions(opt),
+				   path, column_families, &handles, &db);
+      }
       if (!status.ok()) {
 	derr << status.ToString() << dendl;
 	return -EINVAL;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -89,7 +89,7 @@ class RocksDBStore : public KeyValueDB {
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);
   int install_cf_mergeop(const string &cf_name, rocksdb::ColumnFamilyOptions *cf_opt);
   int create_db_dir();
-  int do_open(ostream &out, bool create_if_missing,
+  int do_open(ostream &out, bool create_if_missing, bool open_readonly,
 	      const vector<ColumnFamily>* cfs = nullptr);
   int load_rocksdb_options(bool create_if_missing, rocksdb::Options& opt);
 
@@ -168,11 +168,15 @@ public:
   static bool check_omap_dir(string &omap_dir);
   /// Opens underlying db
   int open(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
-    return do_open(out, false, &cfs);
+    return do_open(out, false, false, &cfs);
   }
   /// Creates underlying db if missing and opens it
   int create_and_open(ostream &out,
 		      const vector<ColumnFamily>& cfs = {}) override;
+
+  int open_read_only(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
+    return do_open(out, false, true, &cfs);
+  }
 
   void close() override;
 

--- a/src/os/bluestore/BitmapFreelistManager.h
+++ b/src/os/bluestore/BitmapFreelistManager.h
@@ -15,7 +15,6 @@
 
 class BitmapFreelistManager : public FreelistManager {
   std::string meta_prefix, bitmap_prefix;
-  KeyValueDB *kvdb;
   std::shared_ptr<KeyValueDB::MergeOperator> merge_op;
   ceph::mutex lock = ceph::make_mutex("BitmapFreelistManager::lock");
 
@@ -41,13 +40,14 @@ class BitmapFreelistManager : public FreelistManager {
 
   void _init_misc();
 
-  void _verify_range(uint64_t offset, uint64_t length, int val);
+  void _verify_range(KeyValueDB *kvdb,
+    uint64_t offset, uint64_t length, int val);
   void _xor(
     uint64_t offset, uint64_t length,
     KeyValueDB::Transaction txn);
 
 public:
-  BitmapFreelistManager(CephContext* cct, KeyValueDB *db, string meta_prefix,
+  BitmapFreelistManager(CephContext* cct, string meta_prefix,
 			string bitmap_prefix);
 
   static void setup_merge_operator(KeyValueDB *db, string prefix);
@@ -58,14 +58,13 @@ public:
   int expand(uint64_t new_size,
              KeyValueDB::Transaction txn) override;
 
-
-  int init() override;
+  int init(KeyValueDB *kvdb) override;
   void shutdown() override;
 
-  void dump() override;
+  void dump(KeyValueDB *kvdb) override;
 
   void enumerate_reset() override;
-  bool enumerate_next(uint64_t *offset, uint64_t *length) override;
+  bool enumerate_next(KeyValueDB *kvdb, uint64_t *offset, uint64_t *length) override;
 
   void allocate(
     uint64_t offset, uint64_t length,

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -193,12 +193,12 @@ uint64_t BlueFS::get_block_device_size(unsigned id)
   return 0;
 }
 
-void BlueFS::add_block_extent(unsigned id, uint64_t offset, uint64_t length)
+void BlueFS::_add_block_extent(unsigned id, uint64_t offset, uint64_t length)
 {
-  std::unique_lock l(lock);
   dout(1) << __func__ << " bdev " << id
-          << " 0x" << std::hex << offset << "~" << length << std::dec
+	  << " 0x" << std::hex << offset << "~" << length << std::dec
 	  << dendl;
+
   ceph_assert(id < bdev.size());
   ceph_assert(bdev[id]);
   ceph_assert(bdev[id]->get_size() >= offset + length);
@@ -206,8 +206,6 @@ void BlueFS::add_block_extent(unsigned id, uint64_t offset, uint64_t length)
 
   if (id < alloc.size() && alloc[id]) {
     log_t.op_alloc_add(id, offset, length);
-    int r = _flush_and_sync_log(l);
-    ceph_assert(r == 0);
     alloc[id]->init_add_free(offset, length);
   }
 
@@ -1738,6 +1736,14 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
                                 cct->_conf->bluefs_alloc_size);
   t.op_jump(log_seq, new_log_jump_to);
 
+  // allocate
+  r = _allocate(BlueFS::BDEV_DB, new_log_jump_to,
+                    &new_log->fnode);
+  ceph_assert(r == 0);
+
+  // we might have some more ops in log_t due to _allocate call
+  t.claim_ops(log_t);
+
   bufferlist bl;
   encode(t, bl);
   _pad_bl(bl);
@@ -1745,10 +1751,6 @@ void BlueFS::_compact_log_async(std::unique_lock<ceph::mutex>& l)
   dout(10) << __func__ << " new_log_jump_to 0x" << std::hex << new_log_jump_to
 	   << std::dec << dendl;
 
-  // allocate
-  r = _allocate(BlueFS::BDEV_DB, new_log_jump_to,
-                    &new_log->fnode);
-  ceph_assert(r == 0);
   new_log_writer = _create_writer(new_log);
   new_log_writer->append(bl);
 
@@ -2352,6 +2354,22 @@ void BlueFS::flush_bdev()
   }
 }
 
+int BlueFS::_expand_slow_device(uint64_t min_size, PExtentVector& extents)
+{
+  int r = -ENOSPC;
+  if (slow_dev_expander) {
+    uint64_t need = std::min(
+      min_size, (uint64_t)cct->_conf.get_val<Option::size_t>("bluestore_bluefs_min_free"));
+    auto min_alloc_size = cct->_conf->bluefs_alloc_size;
+    need = round_up_to(need, min_alloc_size);
+    dout(10) << __func__ << " expanding slow device by 0x"
+             << std::hex << need << std::dec
+	     << dendl;
+    r = slow_dev_expander->allocate_freespace(need, extents);
+  }
+  return r;
+}
+
 int BlueFS::_allocate_without_fallback(uint8_t id, uint64_t len,
 		      PExtentVector* extents)
 {
@@ -2398,8 +2416,8 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   int64_t alloc_len = 0;
   PExtentVector extents;
   
+  uint64_t hint = 0;
   if (alloc[id]) {
-    uint64_t hint = 0;
     if (!node->extents.empty() && node->extents.back().bdev == id) {
       hint = node->extents.back().end();
     }   
@@ -2407,7 +2425,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
     alloc_len = alloc[id]->allocate(left, min_alloc_size, hint, &extents);
   }
   if (alloc_len < (int64_t)left) {
-    if (alloc_len != 0) {
+    if (alloc_len > 0) {
       alloc[id]->release(extents);
     }
     if (id != BDEV_SLOW) {
@@ -2420,16 +2438,37 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
       }
       return _allocate(id + 1, len, node);
     }
-    if (bdev[id])
-      derr << __func__ << " failed to allocate 0x" << std::hex << left
-	   << " on bdev " << (int)id
-	   << ", free 0x" << alloc[id]->get_free() << std::dec << dendl;
-    else
-      derr << __func__ << " failed to allocate 0x" << std::hex << left
-	   << " on bdev " << (int)id << ", dne" << std::dec << dendl;
-    if (alloc[id]) 
-      alloc[id]->dump();    
-    return -ENOSPC;
+    dout(1) << __func__ << " unable to allocate 0x" << std::hex << left
+	    << " on bdev " << (int)id << ", free 0x"
+	    << (alloc[id] ? alloc[id]->get_free() : (uint64_t)-1)
+	    << "; fallback to slow device expander "
+	    << std::dec << dendl;
+    extents.clear();
+    if (_expand_slow_device(left, extents) == 0) {
+      id = alloc[BDEV_SLOW] ? BDEV_SLOW : BDEV_DB;
+      for (auto& e : extents) {
+	_add_block_extent(id, e.offset, e.length);
+      }
+      extents.clear();
+      auto* last_alloc = alloc[id];
+      ceph_assert(last_alloc);
+      // try again
+      alloc_len = last_alloc->allocate(left, min_alloc_size, hint, &extents);
+      if (alloc_len < (int64_t)left) {
+	if (alloc_len > 0) {
+	  last_alloc->release(extents);
+	}
+	derr << __func__ << " failed to allocate 0x" << std::hex << left
+	      << " on bdev " << (int)id
+	      << ", free 0x" << last_alloc->get_free() << std::dec << dendl;
+        return -ENOSPC;
+      }
+    } else {
+      derr << __func__ << " failed to expand slow device to fit +0x"
+	   << std::hex << left << std::dec
+	   << dendl;
+      return -ENOSPC;
+    }
   } else {
     uint64_t total_allocated =
       block_all[id].size() - alloc[id]->get_free();

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -46,6 +46,8 @@ class BlueFSDeviceExpander {
 protected:
   ~BlueFSDeviceExpander() {}
 public:
+  virtual uint64_t get_recommended_expansion_delta(uint64_t bluefs_free,
+    uint64_t bluefs_total) = 0;
   virtual int allocate_freespace(uint64_t size, PExtentVector& extents) = 0;
 };
 
@@ -296,6 +298,7 @@ private:
   FileRef _get_file(uint64_t ino);
   void _drop_link(FileRef f);
 
+  int _get_slow_device_id() { return bdev[BDEV_SLOW] ? BDEV_SLOW : BDEV_DB; }
   int _expand_slow_device(uint64_t min_size, PExtentVector& extents);
   int _allocate(uint8_t bdev, uint64_t len,
 		bluefs_fnode_t* node);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -42,6 +42,13 @@ enum {
   l_bluefs_last,
 };
 
+class BlueFSDeviceExpander {
+protected:
+  ~BlueFSDeviceExpander() {}
+public:
+  virtual int allocate_freespace(uint64_t size, PExtentVector& extents) = 0;
+};
+
 class BlueFS {
 public:
   CephContext* cct;
@@ -275,6 +282,8 @@ private:
 
   BlockDevice::aio_callback_t discard_cb[3]; //discard callbacks for each dev
 
+  BlueFSDeviceExpander* slow_dev_expander = nullptr;
+
   void _init_logger();
   void _shutdown_logger();
   void _update_logger_stats();
@@ -287,6 +296,7 @@ private:
   FileRef _get_file(uint64_t ino);
   void _drop_link(FileRef f);
 
+  int _expand_slow_device(uint64_t min_size, PExtentVector& extents);
   int _allocate(uint8_t bdev, uint64_t len,
 		bluefs_fnode_t* node);
   int _allocate_without_fallback(uint8_t id, uint64_t len,
@@ -364,6 +374,8 @@ private:
     return 4096;
   }
 
+  void _add_block_extent(unsigned bdev, uint64_t offset, uint64_t len);
+
 public:
   BlueFS(CephContext* cct);
   ~BlueFS();
@@ -440,12 +452,20 @@ public:
   /// sync any uncommitted state to disk
   void sync_metadata();
 
+  void set_slow_device_expander(BlueFSDeviceExpander* a) {
+    slow_dev_expander = a;
+  }
   int add_block_device(unsigned bdev, const string& path, bool trim);
   bool bdev_support_label(unsigned id);
   uint64_t get_block_device_size(unsigned bdev);
 
   /// gift more block space
-  void add_block_extent(unsigned bdev, uint64_t offset, uint64_t len);
+  void add_block_extent(unsigned bdev, uint64_t offset, uint64_t len) {
+    std::unique_lock l(lock);
+    _add_block_extent(bdev, offset, len);
+    int r = _flush_and_sync_log(l);
+    ceph_assert(r == 0);
+  }
 
   /// reclaim block space
   int reclaim_blocks(unsigned bdev, uint64_t want,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5291,15 +5291,15 @@ void BlueStore::_close_db()
   }
 }
 
-void BlueStore::_dump_alloc_on_rebalance_failure()
+void BlueStore::_dump_alloc_on_failure()
 {
   auto dump_interval =
-    cct->_conf->bluestore_bluefs_balance_failure_dump_interval;
+    cct->_conf->bluestore_bluefs_alloc_failure_dump_interval;
   if (dump_interval > 0 &&
-    next_dump_on_bluefs_balance_failure <= ceph_clock_now()) {
+    next_dump_on_bluefs_alloc_failure <= ceph_clock_now()) {
     alloc->dump();
-    next_dump_on_bluefs_balance_failure = ceph_clock_now();
-    next_dump_on_bluefs_balance_failure += dump_interval;
+    next_dump_on_bluefs_alloc_failure = ceph_clock_now();
+    next_dump_on_bluefs_alloc_failure += dump_interval;
   }
 }
 
@@ -5442,7 +5442,7 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
 	      << " allocated 0x" << alloc_len
 	      << " available 0x " << alloc->get_free()
 	      << std::dec << dendl;
-      _dump_alloc_on_rebalance_failure();
+      _dump_alloc_on_failure();
     }
     for (auto& e : *extents) {
       dout(1) << __func__ << " gifting " << e << " to bluefs" << dendl;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2933,6 +2933,11 @@ private:
 private:
   // --------------------------------------------------------
   // BlueFSDeviceExpander implementation
+  uint64_t get_recommended_expansion_delta(uint64_t bluefs_free,
+    uint64_t bluefs_total) override {
+    auto delta = _get_bluefs_size_delta(bluefs_free, bluefs_total);
+    return delta > 0 ? delta : 0;
+  }
   int allocate_freespace(uint64_t size, PExtentVector& extents) override {
     return allocate_bluefs_freespace(size, &extents);
   };

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2180,13 +2180,23 @@ private:
   void _umount_for_bluefs();
 
 
+  int _is_bluefs(bool create, bool* ret);
+  /*
+  * opens both DB and dependant super_meta, FreelistManager and allocator
+  * in the proper order
+  */
+  int _open_db_and_around(bool read_only);
+  void _close_db_and_around();
+
   /*
    * @warning to_repair_db means that we open this db to repair it, will not
    * hold the rocksdb's file lock.
    */
-  int _open_db(bool create, bool to_repair_db=false);
+  int _open_db(bool create,
+	       bool to_repair_db=false,
+	       bool read_only = false);
   void _close_db();
-  int _open_fm(bool create);
+  int _open_fm(KeyValueDB::Transaction t);
   void _close_fm();
   int _open_alloc();
   void _close_alloc();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1881,7 +1881,7 @@ private:
   unsigned bluefs_shared_bdev = 0;  ///< which bluefs bdev we are sharing
   bool bluefs_single_shared_device = true;
   mono_time bluefs_last_balance;
-  utime_t next_dump_on_bluefs_balance_failure;
+  utime_t next_dump_on_bluefs_alloc_failure;
 
   KeyValueDB *db = nullptr;
   BlockDevice *bdev = nullptr;
@@ -2209,7 +2209,7 @@ private:
   void _open_statfs();
   void _get_statfs_overall(struct store_statfs_t *buf);
 
-  void _dump_alloc_on_rebalance_failure();
+  void _dump_alloc_on_failure();
   int _balance_bluefs_freespace(PExtentVector *extents);
   void _commit_bluefs_freespace(const PExtentVector& extents);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2210,7 +2210,6 @@ private:
   void _get_statfs_overall(struct store_statfs_t *buf);
 
   void _dump_alloc_on_rebalance_failure();
-  int _reconcile_bluefs_freespace();
   int _balance_bluefs_freespace(PExtentVector *extents);
   void _commit_bluefs_freespace(const PExtentVector& extents);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2221,8 +2221,9 @@ private:
   void _get_statfs_overall(struct store_statfs_t *buf);
 
   void _dump_alloc_on_failure();
-  int _balance_bluefs_freespace(PExtentVector *extents);
-  void _commit_bluefs_freespace(const PExtentVector& extents);
+
+  int64_t _get_bluefs_size_delta(uint64_t bluefs_free, uint64_t bluefs_total);
+  int _balance_bluefs_freespace();
 
   CollectionRef _get_collection(const coll_t& cid);
   void _queue_reap_collection(CollectionRef& c);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2188,6 +2188,10 @@ private:
   int _open_db_and_around(bool read_only);
   void _close_db_and_around();
 
+  // updates legacy bluefs related recs in DB to a state valid for
+  // downgrades from nautilus.
+  void _sync_bluefs_and_fm();
+
   /*
    * @warning to_repair_db means that we open this db to repair it, will not
    * hold the rocksdb's file lock.
@@ -2931,6 +2935,7 @@ private:
 			unsigned bits);
 
 private:
+  std::atomic<uint64_t> out_of_sync_fm = {0};
   // --------------------------------------------------------
   // BlueFSDeviceExpander implementation
   uint64_t get_recommended_expansion_delta(uint64_t bluefs_free,
@@ -3114,6 +3119,7 @@ public:
   bool fix_false_free(KeyValueDB *db,
 		      FreelistManager* fm,
 		      uint64_t offset, uint64_t len);
+  bool fix_bluefs_extents(std::atomic<uint64_t>& out_of_sync_flag);
 
   void init(uint64_t total_space, uint64_t lres_tracking_unit_size);
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -42,11 +42,11 @@
 
 #include "bluestore_types.h"
 #include "BlockDevice.h"
+#include "BlueFS.h"
 #include "common/EventTrace.h"
 
 class Allocator;
 class FreelistManager;
-class BlueFS;
 class BlueStoreRepairer;
 
 //#define DEBUG_CACHE
@@ -129,6 +129,7 @@ enum {
 #define META_POOL_ID ((uint64_t)-1ull)
 
 class BlueStore : public ObjectStore,
+		  public BlueFSDeviceExpander,
 		  public md_config_obs_t {
   // -----------------------------------------------------
   // types
@@ -2626,7 +2627,12 @@ public:
     return true;
   }
 
-  int allocate_bluefs_freespace(uint64_t size);
+  /*
+  Allocate space for BlueFS from slow device.
+  Either automatically applies allocated extents to underlying 
+  BlueFS (extents == nullptr) or just return them (non-null extents) provided
+  */
+  int allocate_bluefs_freespace(uint64_t size, PExtentVector* extents);
 
 private:
   bool _debug_data_eio(const ghobject_t& o) {
@@ -2912,6 +2918,13 @@ private:
 			CollectionRef *c,
 			CollectionRef& d,
 			unsigned bits);
+
+private:
+  // --------------------------------------------------------
+  // BlueFSDeviceExpander implementation
+  int allocate_freespace(uint64_t size, PExtentVector& extents) override {
+    return allocate_bluefs_freespace(size, &extents);
+  };
 };
 
 inline ostream& operator<<(ostream& out, const BlueStore::volatile_statfs& s) {
@@ -3125,5 +3138,4 @@ private:
   fsck_interval misreferenced_extents;
 
 };
-
 #endif

--- a/src/os/bluestore/FreelistManager.cc
+++ b/src/os/bluestore/FreelistManager.cc
@@ -7,7 +7,6 @@
 FreelistManager *FreelistManager::create(
   CephContext* cct,
   string type,
-  KeyValueDB *kvdb,
   string prefix)
 {
   // a bit of a hack... we hard-code the prefixes here.  we need to
@@ -16,7 +15,7 @@ FreelistManager *FreelistManager::create(
   // freelist type until after we open the db.
   ceph_assert(prefix == "B");
   if (type == "bitmap")
-    return new BitmapFreelistManager(cct, kvdb, "B", "b");
+    return new BitmapFreelistManager(cct, "B", "b");
   return NULL;
 }
 

--- a/src/os/bluestore/FreelistManager.h
+++ b/src/os/bluestore/FreelistManager.h
@@ -19,7 +19,6 @@ public:
   static FreelistManager *create(
     CephContext* cct,
     string type,
-    KeyValueDB *db,
     string prefix);
 
   static void setup_merge_operators(KeyValueDB *db);
@@ -30,13 +29,13 @@ public:
   virtual int expand(uint64_t new_size,
 		     KeyValueDB::Transaction txn) = 0;
 
-  virtual int init() = 0;
+  virtual int init(KeyValueDB *kvdb) = 0;
   virtual void shutdown() = 0;
 
-  virtual void dump() = 0;
+  virtual void dump(KeyValueDB *kvdb) = 0;
 
   virtual void enumerate_reset() = 0;
-  virtual bool enumerate_next(uint64_t *offset, uint64_t *length) = 0;
+  virtual bool enumerate_next(KeyValueDB *kvdb, uint64_t *offset, uint64_t *length) = 0;
 
   virtual void allocate(
     uint64_t offset, uint64_t length,

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -232,6 +232,9 @@ struct bluefs_transaction_t {
     encode((__u8)OP_JUMP_SEQ, op_bl);
     encode(next_seq, op_bl);
   }
+  void claim_ops(bluefs_transaction_t& from) {
+    op_bl.claim_append(from.op_bl);
+  }
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::const_iterator& p);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -4576,6 +4576,25 @@ TEST_P(StoreTest, Synthetic) {
   doSyntheticTest(10000, 400*1024, 40*1024, 0);
 }
 
+TEST_P(StoreTestSpecificAUSize, BlueFSExtenderTest) {
+  if(string(GetParam()) != "bluestore")
+    return;
+
+  SetVal(g_conf(), "bluestore_block_db_size", "0");
+  SetVal(g_conf(), "bluestore_block_wal_size", "0");
+  SetVal(g_conf(), "bluestore_bluefs_min", "12582912");
+  SetVal(g_conf(), "bluestore_bluefs_min_free", "4194304");
+  SetVal(g_conf(), "bluestore_bluefs_gift_ratio", "0");
+  SetVal(g_conf(), "bluestore_bluefs_min_ratio", "0");
+  SetVal(g_conf(), "bluestore_bluefs_balance_interval", "100000");
+
+  g_conf().apply_changes(nullptr);
+
+  StartDeferred(4096);
+
+  doSyntheticTest(10000, 400*1024, 40*1024, 0);
+}
+
 #if defined(WITH_BLUESTORE)
 TEST_P(StoreTestSpecificAUSize, SyntheticMatrixSharding) {
   if (string(GetParam()) != "bluestore")

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -7603,11 +7603,11 @@ TEST_P(StoreTest, allocateBlueFSTest) {
 
   uint64_t to_alloc = g_conf().get_val<Option::size_t>("bluefs_alloc_size");
 
-  int r = bstore->allocate_bluefs_freespace(to_alloc);
+  int r = bstore->allocate_bluefs_freespace(to_alloc, nullptr);
   ASSERT_EQ(r, 0);
-  r = bstore->allocate_bluefs_freespace(statfs.total);
+  r = bstore->allocate_bluefs_freespace(statfs.total, nullptr);
   ASSERT_EQ(r, -ENOSPC);
-  r = bstore->allocate_bluefs_freespace(to_alloc * 16);
+  r = bstore->allocate_bluefs_freespace(to_alloc * 16, nullptr);
   ASSERT_EQ(r, 0);
   store->umount();
   ASSERT_EQ(store->fsck(false), 0); // do fsck explicitly


### PR DESCRIPTION
Hence BlueFS can request the space explicitly when needed rather than rely on the background rebalancing. 
Fixes: https://tracker.ceph.com/issues/36268

Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

