### PR TITLE
mimic ceph-volume: rename Device property valid to available

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/test_inventory.py
+++ b/src/ceph-volume/ceph_volume/tests/test_inventory.py
@@ -65,7 +65,7 @@ class TestInventory(object):
         'path',
         'rejected_reasons',
         'sys_api',
-        'valid',
+        'available',
         'lvs',
     ]
 

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -189,25 +189,25 @@ class TestCephDiskDevice(object):
         data = {"/dev/sdb": {"removable": 1}}
         device_info(devices=data)
         disk = device.Device("/dev/sdb")
-        assert not disk.is_valid
+        assert not disk.available
 
     def test_accept_non_removable_device(self, device_info):
         data = {"/dev/sdb": {"removable": 0}}
         device_info(devices=data)
         disk = device.Device("/dev/sdb")
-        assert disk.is_valid
+        assert disk.available
 
     def test_reject_readonly_device(self, device_info):
         data = {"/dev/cdrom": {"ro": 1}}
         device_info(devices=data)
         disk = device.Device("/dev/cdrom")
-        assert not disk.is_valid
+        assert not disk.available
 
     def test_accept_non_readonly_device(self, device_info):
         data = {"/dev/sda": {"ro": 0}}
         device_info(devices=data)
         disk = device.Device("/dev/sda")
-        assert disk.is_valid
+        assert disk.available
 
     @pytest.mark.parametrize("label", ceph_partlabels)
     def test_is_member_lsblk(self, device_info, label):

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -7,7 +7,7 @@ from ceph_volume.api import lvm
 from ceph_volume.util import disk
 
 report_template = """
-{dev:<25} {size:<12} {rot!s:<7} {valid!s:<7} {model}"""
+{dev:<25} {size:<12} {rot!s:<7} {available!s:<9} {model}"""
 
 
 class Devices(object):
@@ -28,7 +28,7 @@ class Devices(object):
                 size='Size',
                 rot='rotates',
                 model='Model name',
-                valid='valid',
+                available='available',
             )]
         for device in sorted(self.devices):
             output.append(device.report())
@@ -47,8 +47,8 @@ class Device(object):
      {attr:<25} {value}"""
 
     report_fields = [
-        '_rejected_reasons',
-        '_valid',
+        'rejected_reasons',
+        'available',
         'path',
         'sys_api',
     ]
@@ -76,22 +76,20 @@ class Device(object):
         self.sys_api = {}
         self._exists = None
         self._is_lvm_member = None
-        self._valid = False
-        self._rejected_reasons = []
         self._parse()
-        self.is_valid
+        self.available, self.rejected_reasons = self._check_reject_reasons()
 
     def __lt__(self, other):
         '''
         Implementing this method and __eq__ allows the @total_ordering
         decorator to turn the Device class into a totally ordered type.
         This can slower then implementing all comparison operations.
-        This sorting should put valid devices before invalid devices and sort
-        on the path otherwise (str sorting).
+        This sorting should put available devices before unavailable devices
+        and sort on the path otherwise (str sorting).
         '''
-        if self._valid == other._valid:
+        if self.available == other.available:
             return self.path < other.path
-        return self._valid and not other._valid
+        return self.available and not other.available
 
     def __eq__(self, other):
         return self.path == other.path
@@ -162,7 +160,7 @@ class Device(object):
             dev=self.abspath,
             size=self.size_human,
             rot=self.rotational,
-            valid=self.is_valid,
+            available=self.available,
             model=self.model,
         )
 
@@ -264,21 +262,21 @@ class Device(object):
                    if lv.tags.get("ceph.type") in ["data", "block"]]
         return any(osd_ids)
 
-
-    @property
-    def is_valid(self):
-        def reject_device(item, value, reason):
-            try:
-                if self.sys_api[item] == value:
-                    self._rejected_reasons.append(reason)
-            except KeyError:
-                pass
-        reject_device('removable', 1, 'removable')
-        reject_device('ro', 1, 'read-only')
-        reject_device('locked', 1, 'locked')
-
-        self._valid = len(self._rejected_reasons) == 0
-        return self._valid
+    def _check_reject_reasons(self):
+        """
+        This checks a number of potential reject reasons for a drive and
+        returns a tuple (boolean, list). The first element denotes whether a
+        drive is available or not, the second element lists reasons in case a
+        drive is not available.
+        """
+        reasons = [
+            ('removable', 1, 'removable'),
+            ('ro', 1, 'read-only'),
+            ('locked', 1, 'locked'),
+        ]
+        rejected = [reason for (k, v, reason) in reasons if
+                    self.sys_api.get(k, '') == v]
+        return len(rejected) == 0, rejected
 
 
 class CephDiskDevice(object):


### PR DESCRIPTION
This flag is used in the inventory reporting and available is deemed more
appropriate. Furthermore this fixes a bug where rejected_reasons
accumulated duplicate entries.

Fixes: http://tracker.ceph.com/issues/36701
Signed-off-by: Jan Fajerski <jfajerski@suse.com>



Backport of: https://github.com/ceph/ceph/pull/25007