### PR TITLE
test: fix libc++ crash in Log.GarbleRecovery

### DIFF
--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -355,7 +355,7 @@ TEST(Log, GarbleRecovery)
 
   std::string long_message(1000,'c');
   ldout(g_ceph_context, 0) << long_message << dendl;
-  ldout(g_ceph_context, 0) << "Prologue" << (char*)nullptr << long_message << dendl;
+  ldout(g_ceph_context, 0) << "Prologue" << (std::streambuf*)nullptr << long_message << dendl;
   ldout(g_ceph_context, 0) << "Epitaph" << long_message << dendl;
 
   g_ceph_context->_log = saved;


### PR DESCRIPTION
this tests whether the log recovers from operations that set the stream's badbit. writing nullptr sets badbit in libstdc++, but crashes in libc++. this was encountered previously in Log.ReuseBad and fixed in https://github.com/ceph/ceph/pull/20233. this applies the same fix to GarbleRecovery