### PR TITLE
mgr/dashboard: npm run e2e:dev

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -153,6 +153,16 @@ Note:
   When using docker, as your device, you might need to run the script with sudo
   permissions.
 
+Writing End-to-End Tests
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+When writing e2e tests you don't want to recompile every time from scratch to
+try out if your test has succeeded. As usual you have your development server
+open (``npm start``) which already has compiled all files. To attach
+`Protractor <http://www.protractortest.org/>`__ to this process, instead of
+spinning up it's own server, you can use ``npm run e2e -- --dev-server-target``
+or just ``npm run e2e:dev`` which is equivalent.
+
 Further Help
 ~~~~~~~~~~~~
 

--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -10,6 +10,7 @@
     "test": "jest --watch",
     "test:ci": "JEST_SILENT_REPORTER_DOTS=true jest --coverage --reporters jest-silent-reporter",
     "e2e": "ng e2e",
+    "e2e:dev": "ng e2e --dev-server-target",
     "lint:tslint": "ng lint",
     "lint:prettier": "prettier --list-different \"{src,e2e}/**/*.{ts,scss}\"",
     "lint:html": "html-linter --config html-linter.config.json",


### PR DESCRIPTION
The new command introduced will make developing e2e tests faster, as
Protractor will attach to the running development server that was
perviously started running 'npm start'.

Fixes: https://tracker.ceph.com/issues/37291
Signed-off-by: Stephan Müller <smueller@suse.com>

- [x] References tracker ticket
- [x] Updates documentation if necessary

