### PR TITLE
rgw: archive zone

### DIFF
--- a/doc/radosgw/archive-sync-module.rst
+++ b/doc/radosgw/archive-sync-module.rst
@@ -1,0 +1,44 @@
+===================
+Archive Sync Module
+===================
+
+.. versionadded:: Mimic
+
+This sync module leverages the versioning feature of the S3 objects in RGW to
+have an archive zone that captures the different versions of the S3 objects
+as they occur over time in the other zones.
+
+An archive zone allows to have a history of versions of S3 objects that can
+only be eliminated through the gateways associated with the archive zone.
+
+This functionality is useful to have a configuration where several
+non-versioned zones replicate their data and metadata through their zone
+gateways (mirror configuration) providing high availability to the end users,
+while the archive zone captures all the data updates and metadata for
+consolidate them as versions of S3 objects.
+
+Including an archive zone in a multizone configuration allows you to have the
+flexibility of an S3 object history in one only zone while saving the space
+that the replicas of the versioned S3 objects would consume in the rest of the
+zones.
+
+
+
+Archive Sync Tier Type Configuration
+------------------------------------
+
+How to Configure
+~~~~~~~~~~~~~~~~
+
+See `Multisite Configuration`_ for how to multisite config instructions. The
+archive sync module requires a creation of a new zone. The zone tier type needs
+to be defined as ``archive``:
+
+::
+
+    # radosgw-admin zone create --rgw-zonegroup={zone-group-name} \
+                                --rgw-zone={zone-name} \
+                                --endpoints={http://fqdn}[,{http://fqdn}]
+                                --tier-type=archive
+
+.. _Multisite Configuration: ./multisite

--- a/doc/radosgw/archive-sync-module.rst
+++ b/doc/radosgw/archive-sync-module.rst
@@ -2,7 +2,7 @@
 Archive Sync Module
 ===================
 
-.. versionadded:: Mimic
+.. versionadded:: Nautilus
 
 This sync module leverages the versioning feature of the S3 objects in RGW to
 have an archive zone that captures the different versions of the S3 objects

--- a/doc/radosgw/sync-modules.rst
+++ b/doc/radosgw/sync-modules.rst
@@ -30,6 +30,7 @@ for configuring any sync plugin
    ElasticSearch Sync Module <elastic-sync-module>
    Cloud Sync Module <cloud-sync-module>
    PubSub Module <pubsub-module>
+   Archive Sync Module <archive-sync-module>
 
 .. note ``rgw`` is the default sync plugin and there is no need to explicitly
    configure this
@@ -96,3 +97,4 @@ Now start the radosgw in the zone
 .. _`elasticsearch`: ../elastic-sync-module
 .. _`cloud sync module`: ../cloud-sync-module
 .. _`pubsub module`: ../pubsub-module
+.. _`archive sync module`: ../archive-sync-module

--- a/src/cls/version/cls_version.cc
+++ b/src/cls/version/cls_version.cc
@@ -70,6 +70,7 @@ static int read_version(cls_method_context_t hctx, obj_version *objv, bool impli
     CLS_LOG(0, "ERROR: read_version(): failed to decode version entry\n");
     return -EIO;
   }
+  CLS_LOG(20, "cls_version: read_version %s:%d", objv->tag.c_str(), (int)objv->ver);
 
   return 0;
 }
@@ -185,7 +186,6 @@ static int cls_version_check(cls_method_context_t hctx, bufferlist *in, bufferli
   int ret = read_version(hctx, &objv, false);
   if (ret < 0)
     return ret;
-  CLS_LOG(20, "cls_version: read_version %s:%d", objv.tag.c_str(), (int)objv.ver);
   
   if (!check_conds(op.conds, objv)) {
     CLS_LOG(20, "cls_version: failed condition check");

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2545,7 +2545,7 @@ WRITE_CLASS_ENCODER(archive_meta_info)
 class RGWArchiveBucketMetadataHandler : public RGWBucketMetadataHandler {
 public:
   int remove(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker) override {
-    ldout(store->ctx(), 0) << "SKIP: bucket removal is not allowed on archive zone: bucket:" << entry << " ... proceeding to rename" << dendl;
+    ldout(store->ctx(), 5) << "SKIP: bucket removal is not allowed on archive zone: bucket:" << entry << " ... proceeding to rename" << dendl;
 
     string tenant_name, bucket_name;
     parse_bucket(entry, &tenant_name, &bucket_name);

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2513,7 +2513,7 @@ struct archive_meta_info {
       return false;
     }
 
-    auto bliter = iter->second.begin();
+    auto bliter = iter->second.cbegin();
     try {
       decode(bliter);
     } catch (buffer::error& err) {
@@ -2534,7 +2534,7 @@ struct archive_meta_info {
     ENCODE_FINISH(bl);
   }
 
-  void decode(bufferlist::iterator& bl) {
+  void decode(bufferlist::const_iterator& bl) {
      DECODE_START(1, bl);
      decode(orig_bucket, bl);
      DECODE_FINISH(bl);
@@ -2555,7 +2555,7 @@ public:
     /* read original entrypoint */
 
     RGWBucketEntryPoint be;
-    RGWObjectCtx obj_ctx(store);
+    auto obj_ctx = store->svc.sysobj->init_obj_ctx();
     map<string, bufferlist> attrs;
     int ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, be, &objv_tracker, &mtime, &attrs);
     if (ret < 0) {
@@ -2598,7 +2598,6 @@ public:
 
     get_md5_digest(&new_be, md5_digest);
     new_bucket_name = ami.orig_bucket.name + "-deleted-" + md5_digest;
-ldout(store->ctx(), 0) << __FILE__ << ":" << __LINE__ << ": new_bucket_name==" << new_bucket_name << dendl;
 
     new_bi.bucket.name = new_bucket_name;
     new_bi.objv_tracker.clear();
@@ -2647,7 +2646,7 @@ ldout(store->ctx(), 0) << __FILE__ << ":" << __LINE__ << ": new_bucket_name==" <
         lderr(store->ctx()) << "could not delete bucket=" << entry << dendl;
     }
 
-    ret = rgw_delete_system_obj(store, store->get_zone_params().domain_root, RGW_BUCKET_INSTANCE_MD_PREFIX + meta_name, NULL);
+    ret = rgw_delete_system_obj(store, store->svc.zone->get_zone_params().domain_root, RGW_BUCKET_INSTANCE_MD_PREFIX + meta_name, NULL);
 
     /* idempotent */
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -163,6 +163,27 @@ public:
 WRITE_CLASS_ENCODER(RGWUserBuckets)
 
 class RGWMetadataManager;
+class RGWMetadataHandler;
+
+class RGWBucketMetaHandlerAllocator {
+public:
+  static RGWMetadataHandler *alloc();
+};
+
+class RGWBucketInstanceMetaHandlerAllocator {
+public:
+  static RGWMetadataHandler *alloc();
+};
+
+class RGWArchiveBucketMetaHandlerAllocator {
+public:
+  static RGWMetadataHandler *alloc();
+};
+
+class RGWArchiveBucketInstanceMetaHandlerAllocator {
+public:
+  static RGWMetadataHandler *alloc();
+};
 
 extern void rgw_bucket_init(RGWMetadataManager *mm);
 /**

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -582,7 +582,7 @@ int RGWAsyncFetchRemoteObj::_send_request()
 
   rgw_obj src_obj(bucket_info.bucket, key);
 
-  rgw_obj dest_obj(src_obj);
+  rgw_obj dest_obj(bucket_info.bucket, dest_key.value_or(key));
 
   int r = store->fetch_remote_obj(obj_ctx,
                        user_id,

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -854,6 +854,7 @@ class RGWAsyncFetchRemoteObj : public RGWAsyncRadosRequest {
   std::optional<rgw_placement_rule> dest_placement_rule;
 
   rgw_obj_key key;
+  std::optional<rgw_obj_key> dest_key;
   std::optional<uint64_t> versioned_epoch;
 
   real_time src_mtime;
@@ -869,12 +870,14 @@ public:
                          RGWBucketInfo& _bucket_info,
 			 std::optional<rgw_placement_rule> _dest_placement_rule,
                          const rgw_obj_key& _key,
+                         const std::optional<rgw_obj_key>& _dest_key,
                          std::optional<uint64_t> _versioned_epoch,
                          bool _if_newer, rgw_zone_set *_zones_trace) : RGWAsyncRadosRequest(caller, cn), store(_store),
                                                       source_zone(_source_zone),
                                                       bucket_info(_bucket_info),
 						      dest_placement_rule(_dest_placement_rule),
                                                       key(_key),
+                                                      dest_key(_dest_key),
                                                       versioned_epoch(_versioned_epoch),
                                                       copy_if_newer(_if_newer)
   {
@@ -894,6 +897,7 @@ class RGWFetchRemoteObjCR : public RGWSimpleCoroutine {
   std::optional<rgw_placement_rule> dest_placement_rule;
 
   rgw_obj_key key;
+  std::optional<rgw_obj_key> dest_key;
   std::optional<uint64_t> versioned_epoch;
 
   real_time src_mtime;
@@ -909,6 +913,7 @@ public:
                       RGWBucketInfo& _bucket_info,
 		      std::optional<rgw_placement_rule> _dest_placement_rule,
                       const rgw_obj_key& _key,
+                      const std::optional<rgw_obj_key>& _dest_key,
                       std::optional<uint64_t> _versioned_epoch,
                       bool _if_newer, rgw_zone_set *_zones_trace) : RGWSimpleCoroutine(_store->ctx()), cct(_store->ctx()),
                                        async_rados(_async_rados), store(_store),
@@ -916,6 +921,7 @@ public:
                                        bucket_info(_bucket_info),
 				       dest_placement_rule(_dest_placement_rule),
                                        key(_key),
+                                       dest_key(_dest_key),
                                        versioned_epoch(_versioned_epoch),
                                        copy_if_newer(_if_newer), req(NULL), zones_trace(_zones_trace) {}
 
@@ -934,7 +940,7 @@ public:
   int send_request() override {
     req = new RGWAsyncFetchRemoteObj(this, stack->create_completion_notifier(), store,
 				     source_zone, bucket_info, dest_placement_rule,
-                                     key, versioned_epoch, copy_if_newer, zones_trace);
+                                     key, dest_key, versioned_epoch, copy_if_newer, zones_trace);
     async_rados->queue(req);
     return 0;
   }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1718,8 +1718,7 @@ RGWCoroutine *RGWArchiveDataSyncModule::sync_object(RGWDataSyncEnv *sync_env, RG
   if (!bucket_info.versioned() ||
      (bucket_info.flags & BUCKET_VERSIONS_SUSPENDED)) {
       ldout(sync_env->cct, 0) << "SYNC_ARCHIVE: sync_object: enabling object versioning for archive bucket" << dendl;
-      bucket_info.flags |= BUCKET_VERSIONED;
-      bucket_info.flags &= ~BUCKET_VERSIONS_SUSPENDED;
+      bucket_info.flags = (bucket_info.flags & ~BUCKET_VERSIONS_SUSPENDED) | BUCKET_VERSIONED;
       int op_ret = sync_env->store->put_bucket_instance_info(bucket_info, false, real_time(), NULL);
       if (op_ret < 0) {
          ldout(sync_env->cct, 0) << "SYNC_ARCHIVE: sync_object: error versioning archive bucket" << dendl;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1691,6 +1691,8 @@ class RGWArchiveDataSyncModule : public RGWDefaultDataSyncModule {
 public:
   RGWArchiveDataSyncModule() {}
 
+  void init(RGWDataSyncEnv *sync_env, uint64_t instance_id) override;
+
   RGWCoroutine *sync_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
   RGWCoroutine *remove_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, real_time& mtime, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
   RGWCoroutine *create_delete_marker(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, real_time& mtime,
@@ -1710,6 +1712,20 @@ int RGWArchiveSyncModule::create_instance(CephContext *cct, const JSONFormattabl
 {
   instance->reset(new RGWArchiveSyncModuleInstance());
   return 0;
+}
+
+void RGWArchiveDataSyncModule::init(RGWDataSyncEnv *sync_env, uint64_t instance_id) {
+
+  ldout(sync_env->cct, 0) << "Switching to archive zone metadata manager" << dendl;
+
+  // FIXME: this code crashes... migrating the current state (handles, md_logs,
+  // current_log...) in meta_mgr raises errors (threads, locks ...)
+
+  //RGWMetadataManager *current_meta_mgr = sync_env->store->meta_mgr;
+  //RGWMetadataManager *new_meta_mgr = new RGWArchiveMetadataManager(sync_env->cct, sync_env->store);
+  //new_meta_mgr.update_state_from(current_meta_mgr);
+  //delete current_meta_mgr;
+  //current_meta_mgr = new_meta_mgr;
 }
 
 RGWCoroutine *RGWArchiveDataSyncModule::sync_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, uint64_t versioned_epoch, rgw_zone_set *zones_trace)

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1691,8 +1691,6 @@ class RGWArchiveDataSyncModule : public RGWDefaultDataSyncModule {
 public:
   RGWArchiveDataSyncModule() {}
 
-  void init(RGWDataSyncEnv *sync_env, uint64_t instance_id) override;
-
   RGWCoroutine *sync_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace) override;
   RGWCoroutine *remove_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, real_time& mtime, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
   RGWCoroutine *create_delete_marker(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, real_time& mtime,
@@ -1718,20 +1716,6 @@ int RGWArchiveSyncModule::create_instance(CephContext *cct, const JSONFormattabl
 {
   instance->reset(new RGWArchiveSyncModuleInstance());
   return 0;
-}
-
-void RGWArchiveDataSyncModule::init(RGWDataSyncEnv *sync_env, uint64_t instance_id) {
-
-  ldout(sync_env->cct, 0) << "Switching to archive zone metadata manager" << dendl;
-
-  // FIXME: this code crashes... migrating the current state (handles, md_logs,
-  // current_log...) in meta_mgr raises errors (threads, locks ...)
-
-  //RGWMetadataManager *current_meta_mgr = sync_env->store->meta_mgr;
-  //RGWMetadataManager *new_meta_mgr = new RGWArchiveMetadataManager(sync_env->cct, sync_env->store);
-  //new_meta_mgr.update_state_from(current_meta_mgr);
-  //delete current_meta_mgr;
-  //current_meta_mgr = new_meta_mgr;
 }
 
 RGWCoroutine *RGWArchiveDataSyncModule::sync_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace)

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1687,6 +1687,67 @@ RGWCoroutine *RGWDefaultDataSyncModule::create_delete_marker(RGWDataSyncEnv *syn
                             &owner.id, &owner.display_name, true, &mtime, zones_trace);
 }
 
+class RGWArchiveDataSyncModule : public RGWDefaultDataSyncModule {
+public:
+  RGWArchiveDataSyncModule() {}
+
+  RGWCoroutine *sync_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
+  RGWCoroutine *remove_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, real_time& mtime, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
+  RGWCoroutine *create_delete_marker(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, real_time& mtime,
+                                     rgw_bucket_entry_owner& owner, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace) override;
+};
+
+class RGWArchiveSyncModuleInstance : public RGWDefaultSyncModuleInstance {
+  RGWArchiveDataSyncModule data_handler;
+public:
+  RGWArchiveSyncModuleInstance() {}
+  RGWDataSyncModule *get_data_handler() override {
+    return &data_handler;
+  }
+};
+
+int RGWArchiveSyncModule::create_instance(CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance)
+{
+  instance->reset(new RGWArchiveSyncModuleInstance());
+  return 0;
+}
+
+RGWCoroutine *RGWArchiveDataSyncModule::sync_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, uint64_t versioned_epoch, rgw_zone_set *zones_trace)
+{
+  ldout(sync_env->cct, 0) << "SYNC_ARCHIVE: sync_object: b=" << bucket_info.bucket << " k=" << key << " versioned_epoch=" << versioned_epoch << dendl;
+  if (!bucket_info.versioned() ||
+     (bucket_info.flags & BUCKET_VERSIONS_SUSPENDED)) {
+      ldout(sync_env->cct, 0) << "SYNC_ARCHIVE: sync_object: enabling object versioning for archive bucket" << dendl;
+      bucket_info.flags |= BUCKET_VERSIONED;
+      bucket_info.flags &= ~BUCKET_VERSIONS_SUSPENDED;
+      int op_ret = sync_env->store->put_bucket_instance_info(bucket_info, false, real_time(), NULL);
+      if (op_ret < 0) {
+         ldout(sync_env->cct, 0) << "SYNC_ARCHIVE: sync_object: error versioning archive bucket" << dendl;
+         return NULL;
+      }
+  }
+  return new RGWFetchRemoteObjCR(sync_env->async_rados, sync_env->store, sync_env->source_zone, bucket_info,
+                                 key, versioned_epoch,
+                                 true, zones_trace);
+}
+
+RGWCoroutine *RGWArchiveDataSyncModule::remove_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key,
+                                                     real_time& mtime, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace)
+{
+  ldout(sync_env->cct, 0) << "SYNC_ARCHIVE: remove_object: b=" << bucket_info.bucket << " k=" << key << " versioned_epoch=" << versioned_epoch << dendl;
+  return NULL;
+}
+
+RGWCoroutine *RGWArchiveDataSyncModule::create_delete_marker(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, real_time& mtime,
+                                                            rgw_bucket_entry_owner& owner, bool versioned, uint64_t versioned_epoch, rgw_zone_set *zones_trace)
+{
+  ldout(sync_env->cct, 0) << "SYNC_ARCHIVE: create_delete_marker: b=" << bucket_info.bucket << " k=" << key << " mtime=" << mtime
+	                            << " versioned=" << versioned << " versioned_epoch=" << versioned_epoch << dendl;
+  return new RGWRemoveObjCR(sync_env->async_rados, sync_env->store, sync_env->source_zone,
+                            bucket_info, key, versioned, versioned_epoch,
+                            &owner.id, &owner.display_name, true, &mtime, zones_trace);
+}
+
 class RGWDataSyncControlCR : public RGWBackoffControlCR
 {
   RGWDataSyncEnv *sync_env;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1720,7 +1720,7 @@ int RGWArchiveSyncModule::create_instance(CephContext *cct, const JSONFormattabl
 
 RGWCoroutine *RGWArchiveDataSyncModule::sync_object(RGWDataSyncEnv *sync_env, RGWBucketInfo& bucket_info, rgw_obj_key& key, std::optional<uint64_t> versioned_epoch, rgw_zone_set *zones_trace)
 {
-  ldout(sync_env->cct, 0) << "SYNC_ARCHIVE: sync_object: b=" << bucket_info.bucket << " k=" << key << " versioned_epoch=" << versioned_epoch.value_or(0) << dendl;
+  ldout(sync_env->cct, 5) << "SYNC_ARCHIVE: sync_object: b=" << bucket_info.bucket << " k=" << key << " versioned_epoch=" << versioned_epoch.value_or(0) << dendl;
   if (!bucket_info.versioned() ||
      (bucket_info.flags & BUCKET_VERSIONS_SUSPENDED)) {
       ldout(sync_env->cct, 0) << "SYNC_ARCHIVE: sync_object: enabling object versioning for archive bucket" << dendl;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1706,6 +1706,12 @@ public:
   RGWDataSyncModule *get_data_handler() override {
     return &data_handler;
   }
+  RGWMetadataHandler *alloc_bucket_meta_handler() override {
+    return RGWArchiveBucketMetaHandlerAllocator::alloc();
+  }
+  RGWMetadataHandler *alloc_bucket_instance_meta_handler() override {
+    return RGWArchiveBucketInstanceMetaHandlerAllocator::alloc();
+  }
 };
 
 int RGWArchiveSyncModule::create_instance(CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance)

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -600,6 +600,7 @@ public:
 class RGWArchiveSyncModule : public RGWDefaultSyncModule {
 public:
   RGWArchiveSyncModule() {}
+  bool supports_writes() override { return false; }
   bool supports_data_export() override { return false; }
   int create_instance(CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
 };

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -597,6 +597,13 @@ public:
   int create_instance(CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
 };
 
+class RGWArchiveSyncModule : public RGWDefaultSyncModule {
+public:
+  RGWArchiveSyncModule() {}
+  bool supports_data_export() override { return false; }
+  int create_instance(CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
+};
+
 // DataLogTrimCR factory function
 extern RGWCoroutine* create_data_log_trim_cr(RGWRados *store,
                                              RGWHTTPManager *http,

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -600,7 +600,7 @@ public:
 class RGWArchiveSyncModule : public RGWDefaultSyncModule {
 public:
   RGWArchiveSyncModule() {}
-  bool supports_writes() override { return false; }
+  bool supports_writes() override { return true; }
   bool supports_data_export() override { return false; }
   int create_instance(CephContext *cct, const JSONFormattable& config, RGWSyncModuleInstanceRef *instance) override;
 };

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -360,6 +360,12 @@ RGWMetadataManager::RGWMetadataManager(CephContext *_cct, RGWRados *_store)
 {
 }
 
+RGWArchiveMetadataManager::RGWArchiveMetadataManager(CephContext *_cct, RGWRados *_store)
+  : RGWMetadataManager(_cct, _store)
+{
+    ldout(store->ctx(), 0) << "RGWArchiveMetadataManager() constructor check" << dendl;
+}
+
 RGWMetadataManager::~RGWMetadataManager()
 {
   map<string, RGWMetadataHandler *>::iterator iter;

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -770,16 +770,6 @@ int RGWMetadataManager::put(string& metadata_key, bufferlist& bl,
     return ret;
   }
 
-  // archive existing bucket if needed
-  if (store->get_zone().tier_type == "archive") {
-      if (handler->get_type() == "bucket") {
-          size_t found = metadata_key.find("-deleted-");
-          if(found != string::npos) {
-             remove(metadata_key);
-          }
-      }
-  }
-
   JSONParser parser;
   if (!parser.parse(bl.c_str(), bl.length())) {
     return -EINVAL;

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -342,12 +342,6 @@ RGWMetadataManager::RGWMetadataManager(CephContext *_cct, RGWRados *_store)
 {
 }
 
-RGWArchiveMetadataManager::RGWArchiveMetadataManager(CephContext *_cct, RGWRados *_store)
-  : RGWMetadataManager(_cct, _store)
-{
-    ldout(store->ctx(), 0) << "RGWArchiveMetadataManager() constructor check" << dendl;
-}
-
 RGWMetadataManager::~RGWMetadataManager()
 {
   map<string, RGWMetadataHandler *>::iterator iter;

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -80,7 +80,6 @@ public:
   virtual int put(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker,
                   real_time mtime, JSONObj *obj, sync_type_t type) = 0;
   virtual int remove(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker) = 0;
-  virtual int remove_by_metakey(RGWRados *store, string& metadata_key);
 
   virtual int list_keys_init(RGWRados *store, const string& marker, void **phandle) = 0;
   virtual int list_keys_next(void *handle, int max, list<string>& keys, bool *truncated) = 0;

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -294,8 +294,6 @@ WRITE_CLASS_ENCODER(RGWMetadataLogHistory)
 
 class RGWMetadataManager {
   map<string, RGWMetadataHandler *> handlers;
-  CephContext *cct;
-  RGWRados *store;
 
   // maintain a separate metadata log for each period
   std::map<std::string, RGWMetadataLog> md_logs;
@@ -318,6 +316,10 @@ class RGWMetadataManager {
                      const real_time& mtime,
                      RGWObjVersionTracker *objv_tracker,
                      RGWMetadataHandler::sync_type_t sync_mode);
+
+protected:
+  CephContext *cct;
+  RGWRados *store;
 
 public:
   RGWMetadataManager(CephContext *_cct, RGWRados *_store);
@@ -423,5 +425,10 @@ int RGWMetadataManager::mutate(RGWMetadataHandler *handler, const string& key,
 
   return 0;
 }
+
+class RGWArchiveMetadataManager : public RGWMetadataManager {
+public:
+  RGWArchiveMetadataManager(CephContext *_cct, RGWRados *_store);
+};
 
 #endif

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -72,6 +72,7 @@ public:
       return false;
     return true;
   }
+
   virtual ~RGWMetadataHandler() {}
   virtual string get_type() = 0;
 
@@ -79,6 +80,7 @@ public:
   virtual int put(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker,
                   real_time mtime, JSONObj *obj, sync_type_t type) = 0;
   virtual int remove(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker) = 0;
+  virtual int remove_by_metakey(RGWRados *store, string& metadata_key);
 
   virtual int list_keys_init(RGWRados *store, const string& marker, void **phandle) = 0;
   virtual int list_keys_next(void *handle, int max, list<string>& keys, bool *truncated) = 0;
@@ -300,8 +302,6 @@ class RGWMetadataManager {
   // use the current period's log for mutating operations
   RGWMetadataLog* current_log = nullptr;
 
-  void parse_metadata_key(const string& metadata_key, string& type, string& entry);
-
   int find_handler(const string& metadata_key, RGWMetadataHandler **handler, string& entry);
   int pre_modify(RGWMetadataHandler *handler, string& section, const string& key,
                  RGWMetadataLogData& log_data, RGWObjVersionTracker *objv_tracker,
@@ -322,6 +322,8 @@ class RGWMetadataManager {
 public:
   RGWMetadataManager(CephContext *_cct, RGWRados *_store);
   ~RGWMetadataManager();
+
+  RGWRados* get_store() { return store; }
 
   int init(const std::string& current_period);
 
@@ -382,6 +384,8 @@ public:
   int unlock(string& metadata_key, string& owner_id);
 
   int get_log_shard_id(const string& section, const string& key, int *shard_id);
+
+  void parse_metadata_key(const string& metadata_key, string& type, string& entry);
 };
 
 template <typename F>

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -293,6 +293,8 @@ WRITE_CLASS_ENCODER(RGWMetadataLogHistory)
 
 class RGWMetadataManager {
   map<string, RGWMetadataHandler *> handlers;
+  CephContext *cct;
+  RGWRados *store;
 
   // maintain a separate metadata log for each period
   std::map<std::string, RGWMetadataLog> md_logs;
@@ -315,10 +317,6 @@ class RGWMetadataManager {
                      const real_time& mtime,
                      RGWObjVersionTracker *objv_tracker,
                      RGWMetadataHandler::sync_type_t sync_mode);
-
-protected:
-  CephContext *cct;
-  RGWRados *store;
 
 public:
   RGWMetadataManager(CephContext *_cct, RGWRados *_store);
@@ -424,10 +422,5 @@ int RGWMetadataManager::mutate(RGWMetadataHandler *handler, const string& key,
 
   return 0;
 }
-
-class RGWArchiveMetadataManager : public RGWMetadataManager {
-public:
-  RGWArchiveMetadataManager(CephContext *_cct, RGWRados *_store);
-};
 
 #endif

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7577,7 +7577,7 @@ int RGWRados::unlink_obj_instance(RGWObjectCtx& obj_ctx, RGWBucketInfo& bucket_i
   return 0;
 }
 
-void RGWRados::gen_rand_obj_instance_name(rgw_obj *target_obj)
+void RGWRados::gen_rand_obj_instance_name(rgw_obj_key *target_key)
 {
 #define OBJ_INSTANCE_LEN 32
   char buf[OBJ_INSTANCE_LEN + 1];
@@ -7585,7 +7585,12 @@ void RGWRados::gen_rand_obj_instance_name(rgw_obj *target_obj)
   gen_rand_alphanumeric_no_underscore(cct, buf, OBJ_INSTANCE_LEN); /* don't want it to get url escaped,
                                                                       no underscore for instance name due to the way we encode the raw keys */
 
-  target_obj->key.set_instance(buf);
+  target_key->set_instance(buf);
+}
+
+void RGWRados::gen_rand_obj_instance_name(rgw_obj *target_obj)
+{
+  gen_rand_obj_instance_name(&target_obj->key);
 }
 
 int RGWRados::get_olh(const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWOLHInfo *olh)

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2097,6 +2097,7 @@ public:
   int follow_olh(const RGWBucketInfo& bucket_info, RGWObjectCtx& ctx, RGWObjState *state, const rgw_obj& olh_obj, rgw_obj *target);
   int get_olh(const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWOLHInfo *olh);
 
+  void gen_rand_obj_instance_name(rgw_obj_key *target_key);
   void gen_rand_obj_instance_name(rgw_obj *target);
 
   int update_containers_stats(map<string, RGWBucketEnt>& m);

--- a/src/rgw/rgw_sync_module.cc
+++ b/src/rgw/rgw_sync_module.cc
@@ -63,6 +63,9 @@ void rgw_register_sync_modules(RGWSyncModulesManager *modules_manager)
   RGWSyncModuleRef default_module(std::make_shared<RGWDefaultSyncModule>());
   modules_manager->register_module("rgw", default_module, true);
 
+  RGWSyncModuleRef archive_module(std::make_shared<RGWArchiveSyncModule>());
+  modules_manager->register_module("archive", archive_module);
+
   RGWSyncModuleRef log_module(std::make_shared<RGWLogSyncModule>());
   modules_manager->register_module("log", log_module);
 

--- a/src/rgw/rgw_sync_module.cc
+++ b/src/rgw/rgw_sync_module.cc
@@ -6,6 +6,7 @@
 #include "rgw_cr_rados.h"
 #include "rgw_sync_module.h"
 #include "rgw_data_sync.h"
+#include "rgw_bucket.h"
 
 #include "rgw_sync_module_log.h"
 #include "rgw_sync_module_es.h"
@@ -15,6 +16,16 @@
 #include <boost/asio/yield.hpp>
 
 #define dout_subsys ceph_subsys_rgw
+
+RGWMetadataHandler *RGWSyncModuleInstance::alloc_bucket_meta_handler()
+{
+  return RGWBucketMetaHandlerAllocator::alloc();
+}
+
+RGWMetadataHandler *RGWSyncModuleInstance::alloc_bucket_instance_meta_handler()
+{
+  return RGWBucketInstanceMetaHandlerAllocator::alloc();
+}
 
 RGWStatRemoteObjCBCR::RGWStatRemoteObjCBCR(RGWDataSyncEnv *_sync_env,
                        RGWBucketInfo& _bucket_info, rgw_obj_key& _key) : RGWCoroutine(_sync_env->cct),

--- a/src/rgw/rgw_sync_module.h
+++ b/src/rgw/rgw_sync_module.h
@@ -36,6 +36,7 @@ public:
 };
 
 class RGWRESTMgr;
+class RGWMetadataHandler;
 
 class RGWSyncModuleInstance {
 public:
@@ -48,6 +49,8 @@ public:
   virtual bool supports_user_writes() {
     return false;
   }
+  virtual RGWMetadataHandler *alloc_bucket_meta_handler();
+  virtual RGWMetadataHandler *alloc_bucket_instance_meta_handler();
 };
 
 typedef std::shared_ptr<RGWSyncModuleInstance> RGWSyncModuleInstanceRef;


### PR DESCRIPTION
Feature by @jmunhoz, rebased as original branch was based off mimic plus a few misc changes:

 - A new "archive" zone type
 - Each bucket in new zone is created as versioned
 - Synced objects are created as versioned
 - Object removals are not synced
 - Bucket are not removed but rather renamed
 - Bucket naming collision avoidance

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

