### PR TITLE
test/dashboard: fix segfault when importing dm.xmlsec.binding

### DIFF
--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -10,6 +10,7 @@ deps =
     py27: -r{toxinidir}/requirements-py27.txt
     py3: -r{toxinidir}/requirements-py3.txt
 setenv=
+    CFLAGS = -DXMLSEC_NO_SIZE_T
     UNITTEST = true
     WEBTEST_INTERACTIVE = false
     LD_LIBRARY_PATH = {toxinidir}/../../../../build/lib


### PR DESCRIPTION
python-saml depends on dm.xmlsec.binding which is a python binding of
xmlsec C library. but without -DXMLSEC_NO_SIZE_T the compiled
dm.xmlsec.binding segfaults when `import dm.xmlsec.binding`. see
https://github.com/onelogin/python-saml/issues/30 and
https://github.com/4teamwork/ftw.saml2auth/issues/3 .

in long term, we might want to switch to python-pysaml2, see
http://tracker.ceph.com/issues/37081

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

