### PR TITLE
mon: disable health warning on misplaced objects by default

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -138,6 +138,10 @@
   option, you will need to adjust your config to set the new global option
   or revert to the default of .05 (5%).
 
+* By default, Ceph no longer issues a health warning when there are
+  misplaced objects (objects that are fully replicated but not stored
+  on the intended OSDs).  You can reenable the old warning by setting
+  ``mon_warn_on_misplaced`` to ``true``.
 
 Upgrading from Luminous
 -----------------------

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -257,6 +257,7 @@ OPTION(mon_crush_min_required_version, OPT_STR)
 OPTION(mon_warn_on_crush_straw_calc_version_zero, OPT_BOOL) // warn if crush straw_calc_version==0
 OPTION(mon_warn_on_osd_down_out_interval_zero, OPT_BOOL) // warn if 'mon_osd_down_out_interval == 0'
 OPTION(mon_warn_on_cache_pools_without_hit_sets, OPT_BOOL)
+OPTION(mon_warn_on_misplaced, OPT_BOOL)
 OPTION(mon_min_osdmap_epochs, OPT_INT)
 OPTION(mon_max_pgmap_epochs, OPT_INT)
 OPTION(mon_max_log_epochs, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1523,6 +1523,10 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description("Enable POOL_APP_NOT_ENABLED health check"),
 
+    Option("mon_warn_on_misplaced", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("Issue a health warning if there are misplaced objects"),
+
     Option("mon_max_snap_prune_per_epoch", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(100)
     .set_description("Max number of pruned snaps we will process in a single OSDMap epoch"),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1524,7 +1524,7 @@ std::vector<Option> get_global_options() {
     .set_description("Enable POOL_APP_NOT_ENABLED health check"),
 
     Option("mon_warn_on_misplaced", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description("Issue a health warning if there are misplaced objects"),
 
     Option("mon_max_snap_prune_per_epoch", Option::TYPE_UINT, Option::LEVEL_ADVANCED)

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2732,7 +2732,8 @@ void PGMap::get_health_checks(
 
   // OBJECT_MISPLACED
   if (pg_sum.stats.sum.num_objects_misplaced &&
-      pg_sum.stats.sum.num_object_copies > 0) {
+      pg_sum.stats.sum.num_object_copies > 0 &&
+      cct->_conf->mon_warn_on_misplaced) {
     double pc = (double)pg_sum.stats.sum.num_objects_misplaced /
       (double)pg_sum.stats.sum.num_object_copies * (double)100.0;
     char b[20];


### PR DESCRIPTION
Misplaced is a pretty normal thing and shouldn't keep an operator on edge.  Don't raise health warn by default.  Add a config option to reenable the warning for legacy behavior if they operator wants it.



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug