### PR TITLE
mgr/insights: use dedicated tox working dir

### DIFF
--- a/src/pybind/mgr/insights/tox.ini
+++ b/src/pybind/mgr/insights/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = py27,py3
 skipsdist = true
-toxworkdir = {env:CEPH_BUILD_DIR}
+toxworkdir = {env:CEPH_BUILD_DIR}/insights
 minversion = 2.8.1
 
 [testenv]


### PR DESCRIPTION
Avoids conflicting with other test environments.

Signed-off-by: Noah Watkins <nwatkins@redhat.com>