### PR TITLE
mgr/dashboard: Fix failing QA test: test_safe_to_destroy

### DIFF
--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -102,12 +102,18 @@ class OsdTest(DashboardTestCase):
         unused_osd_id = max(map(lambda e: e['osd'], osd_dump['osds'])) + 10
         self._get('/api/osd/{}/safe_to_destroy'.format(unused_osd_id))
         self.assertStatus(200)
-        self.assertJsonBody({'safe-to-destroy': True})
+        self.assertJsonBody({
+            'is_safe_to_destroy': True,
+            'active': [],
+            'missing_stats': [],
+            'safe_to_destroy': [unused_osd_id],
+            'stored_pgs': [],
+        })
 
         def get_destroy_status():
             self._get('/api/osd/0/safe_to_destroy')
-            if 'safe-to-destroy' in self.jsonBody():
-                return self.jsonBody()['safe-to-destroy']
+            if 'is_safe_to_destroy' in self.jsonBody():
+                return self.jsonBody()['is_safe_to_destroy']
             return None
         self.wait_until_equal(get_destroy_status, False, 10)
         self.assertStatus(200)

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -168,13 +168,15 @@ class Osd(RESTController):
             svc_id = [svc_id]
         svc_id = list(map(str, svc_id))
         try:
-            CephService.send_command(
+            result = CephService.send_command(
                 'mon', 'osd safe-to-destroy', ids=svc_id, target=('mgr', ''))
-            return {'safe-to-destroy': True}
+            result['is_safe_to_destroy'] = set(result['safe_to_destroy']) == set(map(int, svc_id))
+            return result
+
         except SendCommandError as e:
             return {
                 'message': str(e),
-                'safe-to-destroy': False,
+                'is_safe_to_destroy': False,
             }
 
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -68,10 +68,10 @@
 <ng-template #criticalConfirmationTpl
              let-safeToDestroyResult="result"
              let-actionDescription="actionDescription">
-  <div *ngIf="!safeToDestroyResult['safe-to-destroy']"
+  <div *ngIf="!safeToDestroyResult['is_safe_to_destroy']"
        class="danger">
-    <cd-warning-panel>
-      {{ safeToDestroyResult.message }}
+    <cd-warning-panel i18n>
+      The OSD is not safe to destroy!
     </cd-warning-panel>
   </div>
   <ng-container i18n><strong>OSD {{ selection.first().id }}</strong> will be


### PR DESCRIPTION
The behavior of `safe-to-destroy` has changed in
432f19435523d455ecd4f386e58ee1f033cf97e2 (PR#24799) and the backend
needs to be adapted accordingly.

Fixes: http://tracker.ceph.com/issues/37290

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket


