### PR TITLE
mimic: auth/AuthSessionHandler: no handler if no session key

### DIFF
--- a/src/auth/AuthSessionHandler.cc
+++ b/src/auth/AuthSessionHandler.cc
@@ -30,6 +30,10 @@ AuthSessionHandler *get_auth_session_handler(CephContext *cct, int protocol, Cry
  
   switch (protocol) {
   case CEPH_AUTH_CEPHX:
+    // if there is no session key, there is no session handler.
+    if (key.get_type() == CEPH_CRYPTO_NONE) {
+      return nullptr;
+    }
     return new CephxSessionHandler(cct, key, features);
   case CEPH_AUTH_NONE:
     return new AuthNoneSessionHandler(cct, key);


### PR DESCRIPTION
If there is no session key, then we should not instantiate a session
handler, or else we'll later crash with something like

     0> 2018-11-19 08:52:27.787 7f6b305e4700 -1 /home/sage/src/ceph.mimic/src/auth/Crypto.h: In function 'std::size_t CryptoKey::encrypt(CephContext*, const in_slice_t&, const out_slice_t&)' thread 7f6b305e4700 time 2018-11-19 08:52:27.784394
/home/sage/src/ceph.mimic/src/auth/Crypto.h: 164: FAILED assert(ckh)

 ceph version 13.2.2-411-g4bfd25addd (4bfd25addd77b8ea785c8b84a073cff0c477e906) mimic (stable)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x102) [0x7f6b36ad7e72]
 2: (()+0x2ab007) [0x7f6b36ad8007]
 3: (CephxSessionHandler::_calc_signature(Message*, unsigned long*)+0x297) [0x7f6b36e13007]
 4: (CephxSessionHandler::check_message_signature(Message*)+0x6b) [0x7f6b36e131ab]
 5: (AsyncConnection::process()+0x1dc5) [0x7f6b36bfbc55]
 6: (EventCenter::process_events(unsigned int, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> >*)+0x6a5) [0x7f6b36c0abb5]

The specific scenario is:

- new (nautilus) OSD connects to heartbeat port on an older OSD (<= mimic)
and sends an authorizer
- mimic osd ms_verify_authorizer succeeds, but does not set up the
session key because mimic doesn't care.. it blindly sets isvalid = true.
- mimic osd later creates a session handler
- mimic osd later tries to validate a message and crashes

The fix is to not instantiate the session handler if there is no key. Note
that this happens *after* we have authenticated the request (called
ms_verify_authorizer), which is responsible for populating the session
key while verifying the authorizer (if it is authenticating at all), so
this session_key is always set on an authenticated connection.

Fixes: http://tracker.ceph.com/issues/36443
Signed-off-by: Sage Weil <sage@redhat.com>