### PR TITLE
mgr/dashboard: Fix run-frontend-e2e-tests.sh

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -7,7 +7,7 @@ stop() {
         cd $BUILD_DIR
         ../src/stop.sh
     fi
-    exit
+    exit $1
 }
 
 BASE_URL=''
@@ -18,7 +18,10 @@ while getopts 'd:r:' flag; do
   case "${flag}" in
     d) DEVICE=$OPTARG;;
     r) REMOTE='true'
-       BASE_URL=$OPTARG;;
+       # jq is expecting a string literal, otherwise it will fail on the url ':'.
+       # We need to ensure that jq gets a json string for assignment; we achieve
+       # that by introducing literal double quotes (i.e., '"').
+       BASE_URL='"'$OPTARG'"';;
   esac
 done
 
@@ -30,7 +33,7 @@ if [ "$DEVICE" == "" ]; then
     else
         echo "ERROR: Chrome and Docker not found. You need to install one of  \
 them to run the e2e frontend tests."
-        stop
+        stop 1
     fi
 fi
 
@@ -47,19 +50,22 @@ if [ "$BASE_URL" == "" ]; then
 fi
 
 cd $DASH_DIR/frontend
-jq '.["/api/"].target'=$BASE_URL proxy.conf.json.sample | jq '.["/ui-api/"].target'=$BASE_URL > proxy.conf.json
+jq .[].target=$BASE_URL proxy.conf.json.sample > proxy.conf.json
+
 . $BUILD_DIR/src/pybind/mgr/dashboard/node-env/bin/activate
 npm ci
 
 if [ $DEVICE == "chrome" ]; then
-    npm run e2e || stop
+    npm run e2e || stop 1
+    stop 0
 elif [ $DEVICE == "docker" ]; then
-    docker run -d -v $(pwd):/workdir --net=host --name angular-e2e-container rogargon/angular-e2e || stop
-    docker exec angular-e2e-container npm run e2e
+    failed=0
+    docker run -d -v $(pwd):/workdir --net=host --name angular-e2e-container rogargon/angular-e2e || failed=1
+    docker exec angular-e2e-container npm run e2e || failed=1
     docker stop angular-e2e-container
     docker rm angular-e2e-container
+    stop $failed
 else
     echo "ERROR: Device not recognized. Valid devices are 'chrome' and 'docker'."
+    stop 1
 fi
-
-stop


### PR DESCRIPTION
e2e tests were always returning positive result, even when they failed.

Fixed problem with jq, where it was failing when it was not receiving a string.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`