### PR TITLE
rpm: Install python3-tox on >= fedora 29

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -189,7 +189,11 @@ BuildRequires:	python%{_python_buildid}-nose
 BuildRequires:	python%{_python_buildid}-pecan
 BuildRequires:	python%{_python_buildid}-requests
 BuildRequires:	python%{_python_buildid}-six
+%if 0%{?fedora} >= 29
+BuildRequires:	python3-tox
+%else
 BuildRequires:	python%{_python_buildid}-tox
+%endif
 BuildRequires:	python%{_python_buildid}-virtualenv
 BuildRequires:	socat
 %endif


### PR DESCRIPTION
Fix the error "No matching package to install: 'python-tox'"

Fixes: http://tracker.ceph.com/issues/37301

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

