### PR TITLE
luminous: qa/ceph-ansible: Specify stable-3.2 branch

### DIFF
--- a/qa/suites/ceph-ansible/smoke/basic/2-ceph/ceph_ansible.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/2-ceph/ceph_ansible.yaml
@@ -4,6 +4,7 @@ meta:
 overrides:
    ceph_ansible:
      vars:
+        branch: stable-3.2
         ceph_conf_overrides:
           global:
             osd default pool size: 2

--- a/qa/suites/ceph-ansible/smoke/basic/3-config/bluestore_with_dmcrypt.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/3-config/bluestore_with_dmcrypt.yaml
@@ -3,6 +3,7 @@ meta:
 
 overrides:
    ceph_ansible:
+     branch: stable-3.2
      vars:
         osd_objectstore: bluestore
         dmcrypt: True

--- a/qa/suites/ceph-ansible/smoke/basic/3-config/dmcrypt_off.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/3-config/dmcrypt_off.yaml
@@ -3,5 +3,6 @@ meta:
 
 overrides:
    ceph_ansible:
+     branch: stable-3.2
      vars:
         dmcrypt: False

--- a/qa/suites/ceph-ansible/smoke/basic/3-config/dmcrypt_on.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/3-config/dmcrypt_on.yaml
@@ -3,5 +3,6 @@ meta:
 
 overrides:
    ceph_ansible:
+     branch: stable-3.2
      vars:
         dmcrypt: True


### PR DESCRIPTION
Ceph-ansible no longer supports luminous post stable-3.2.

Fixes: https://tracker.ceph.com/issues/37331

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

