### PR TITLE
mds: fix bug filelock stuck at LOCK_XSYN leading client can't read data

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -4892,7 +4892,7 @@ void Locker::file_eval(ScatterLock *lock, bool *need_issue)
   else if (lock->get_state() != LOCK_SYNC &&
 	   !lock->is_wrlocked() &&   // drain wrlocks first!
 	   !lock->is_waiter_for(SimpleLock::WAIT_WR) &&
-	   !(wanted & (CEPH_CAP_GWR|CEPH_CAP_GBUFFER)) &&
+	   !(wanted & CEPH_CAP_GWR) &&
 	   !((lock->get_state() == LOCK_MIX) &&
 	     in->is_dir() && in->has_subtree_or_exporting_dirfrag())  // if we are a delegation point, stay where we are
 	   //((wanted & CEPH_CAP_RD) || 


### PR DESCRIPTION
The file's wanted_loner_cap will be -1 when more than one client open
it.Sometimes the loner can't be dropped successfully which will leading
filelock stuck at LOCK_XSYN.However,this state doesn't allow others any
caps so the client open the file by O_RDONLY can't read data all the time
untill someone else open it by O_RDWR or O_WRONLY.We should change the
state to LOCK_MIX or LOCK_SYNC instead of stucking all the time.

Fixes: http://tracker.ceph.com/issues/37333
Signed-off-by: Guan yunfei <yunfei.guan@xtaotech.com>