### PR TITLE
crimson/net: encapsulate protocol implementations with states (splitted)

### DIFF
--- a/src/crimson/net/Socket.cc
+++ b/src/crimson/net/Socket.cc
@@ -67,4 +67,15 @@ seastar::future<bufferlist> Socket::read(size_t bytes)
     });
 }
 
+seastar::future<seastar::temporary_buffer<char>>
+Socket::read_exactly(size_t bytes) {
+  return in.read_exactly(bytes)
+    .then([this](auto buf) {
+      if (buf.empty()) {
+        throw std::system_error(make_error_code(error::read_eof));
+      }
+      return seastar::make_ready_future<tmp_buf>(std::move(buf));
+    });
+}
+
 } // namespace ceph::net

--- a/src/crimson/net/Socket.h
+++ b/src/crimson/net/Socket.h
@@ -33,9 +33,7 @@ class Socket
   seastar::future<bufferlist> read(size_t bytes);
   using tmp_buf = seastar::temporary_buffer<char>;
   using packet = seastar::net::packet;
-  seastar::future<tmp_buf> read_exactly(size_t bytes) {
-    return in.read_exactly(bytes);
-  }
+  seastar::future<tmp_buf> read_exactly(size_t bytes);
 
   seastar::future<> write(packet&& buf) {
     return out.write(std::move(buf));

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -679,7 +679,6 @@ SocketConnection::handle_connect_reply(msgr_tag_t tag)
     // hooray!
     h.peer_global_seq = h.reply.global_seq;
     policy.lossy = h.reply.flags & CEPH_MSG_CONNECT_LOSSY;
-    state = state_t::open;
     h.connect_seq++;
     h.backoff = 0ms;
     set_features(h.reply.features & h.connect.features);
@@ -809,6 +808,7 @@ SocketConnection::start_connect(const entity_addr_t& _peer_addr,
       return seastar::repeat([this] {
         return repeat_connect();
       });
+      // TODO: handle errors for state_t::connecting
     }).then([this] {
       state = state_t::open;
       // start background processing of tags
@@ -851,6 +851,7 @@ SocketConnection::start_accept(seastar::connected_socket&& fd,
       return seastar::repeat([this] {
         return repeat_handle_connect();
       });
+      // TODO: handle errors for state_t::accepting
     }).then([this] {
       state = state_t::open;
       // start background processing of tags

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -79,24 +79,22 @@ void SocketConnection::read_tags_until_next_message()
           switch (buf[0]) {
           case CEPH_MSGR_TAG_MSG:
             // stop looping and notify read_header()
-            return seastar::make_ready_future<seastar::stop_iteration>(
-                seastar::stop_iteration::yes);
+            return seastar::make_ready_future<stop_t>(stop_t::yes);
           case CEPH_MSGR_TAG_ACK:
             return handle_ack();
           case CEPH_MSGR_TAG_KEEPALIVE:
             break;
           case CEPH_MSGR_TAG_KEEPALIVE2:
             return handle_keepalive2()
-              .then([this] { return seastar::stop_iteration::no; });
+              .then([this] { return stop_t::no; });
           case CEPH_MSGR_TAG_KEEPALIVE2_ACK:
             return handle_keepalive2_ack()
-              .then([this] { return seastar::stop_iteration::no; });
+              .then([this] { return stop_t::no; });
           case CEPH_MSGR_TAG_CLOSE:
             std::cout << "close" << std::endl;
             break;
           }
-          return seastar::make_ready_future<seastar::stop_iteration>(
-              seastar::stop_iteration::no);
+          return seastar::make_ready_future<stop_t>(stop_t::no);
         });
     }).handle_exception_type([this] (const std::system_error& e) {
       if (e.code() == error::read_eof) {
@@ -115,7 +113,7 @@ seastar::future<seastar::stop_iteration> SocketConnection::handle_ack()
     .then([this] (auto buf) {
       auto seq = reinterpret_cast<const ceph_le64*>(buf.get());
       discard_up_to(&sent, *seq);
-      return seastar::stop_iteration::no;
+      return stop_t::no;
     });
 }
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -27,6 +27,8 @@ class AuthSessionHandler;
 
 namespace ceph::net {
 
+using stop_t = seastar::stop_iteration;
+
 class SocketMessenger;
 class SocketConnection;
 using SocketConnectionRef = boost::intrusive_ptr<SocketConnection>;
@@ -99,7 +101,7 @@ class SocketConnection : public Connection {
 
   seastar::future<> maybe_throttle();
   void read_tags_until_next_message();
-  seastar::future<seastar::stop_iteration> handle_ack();
+  seastar::future<stop_t> handle_ack();
 
   /// becomes available when handshake completes, and when all previous messages
   /// have been sent to the output stream. send() chains new messages as

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -65,16 +65,16 @@ class SocketConnection : public Connection {
   } h;
 
   /// server side of handshake negotiation
-  seastar::future<> repeat_handle_connect();
-  seastar::future<> handle_connect_with_existing(SocketConnectionRef existing,
-						 bufferlist&& authorizer_reply);
-  seastar::future<> replace_existing(SocketConnectionRef existing,
-				     bufferlist&& authorizer_reply,
-				     bool is_reset_from_peer = false);
-  seastar::future<> send_connect_reply(ceph::net::msgr_tag_t tag,
-				       bufferlist&& authorizer_reply = {});
-  seastar::future<> send_connect_reply_ready(ceph::net::msgr_tag_t tag,
-					     bufferlist&& authorizer_reply);
+  seastar::future<stop_t> repeat_handle_connect();
+  seastar::future<stop_t> handle_connect_with_existing(SocketConnectionRef existing,
+                                                        bufferlist&& authorizer_reply);
+  seastar::future<stop_t> replace_existing(SocketConnectionRef existing,
+                                            bufferlist&& authorizer_reply,
+                                            bool is_reset_from_peer = false);
+  seastar::future<stop_t> send_connect_reply(ceph::net::msgr_tag_t tag,
+                                              bufferlist&& authorizer_reply = {});
+  seastar::future<stop_t> send_connect_reply_ready(ceph::net::msgr_tag_t tag,
+                                                    bufferlist&& authorizer_reply);
 
   seastar::future<> handle_keepalive2();
   seastar::future<> handle_keepalive2_ack();
@@ -82,8 +82,8 @@ class SocketConnection : public Connection {
   bool require_auth_feature() const;
   uint32_t get_proto_version(entity_type_t peer_type, bool connec) const;
   /// client side of handshake negotiation
-  seastar::future<> repeat_connect();
-  seastar::future<> handle_connect_reply(ceph::net::msgr_tag_t tag);
+  seastar::future<stop_t> repeat_connect();
+  seastar::future<stop_t> handle_connect_reply(ceph::net::msgr_tag_t tag);
   void reset_session();
 
   /// state for an incoming message


### PR DESCRIPTION
This PR is to split #24142 into smaller digestible pieces, and further split #24656 by collecting its agreeable pieces.
Major progress:
- [x] (merged) Clean seastar-msgr interfaces.
- [x] (merged) Add connecting/accepting states, and let `Messenger::connect()` return a `ConnectionRef` instead of future.
- [x] Centralize error handling so it's easier to make decisions of lossless policy
- [ ] Report changes according to connection state via `Dispatcher` (ms_handle_reset etc).
- [ ] Change to per-connection seastar-gates.
- [ ] Let reconnect/replace happen transparently inside `SocketConnection`.
- [ ] Formalize a connection state machine.
- [ ] Add v1/v2 protocol abstractions that act on the state machine.