### PR TITLE
cmake: do not pass unnecessary param to setup.py

### DIFF
--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -20,14 +20,16 @@ function(distutils_install_module name)
       if(EXISTS /etc/debian_version)
         list(APPEND options --install-layout=deb)
       endif()
-      list(APPEND options --root=\$ENV{DESTDIR})
+      list(APPEND options
+        --root=\$ENV{DESTDIR}
+        --single-version-externally-managed)
       if(NOT \"${DU_INSTALL_SCRIPT}\" STREQUAL \"\")
         list(APPEND options --install-script=${DU_INSTALL_SCRIPT})
       endif()
     endif()
     execute_process(
     COMMAND ${PYTHON${PYTHON_VERSION}_EXECUTABLE}
-        setup.py install \${options} --single-version-externally-managed
+        setup.py install \${options}
     WORKING_DIRECTORY \"${CMAKE_CURRENT_BINARY_DIR}\")")
 endfunction(distutils_install_module)
 


### PR DESCRIPTION
--single-version-externally-managed is used for packaging python eggs
to deb. so the metadata can be stored in the egg, and can be accessed
by user if necessary, see [1]. but this does not apply to users who
just want to "make install" without packaging Ceph.

the problem is, if we pass --single-version-externally-managed to
setup.py, we need to pass --record or --root also. otherwise setuptools
complains:

error: You must specify --record or --root when building system packages

so in this change, we choose not to pass
"--single-version-externally-managed", unless $DESTDIR is set.

both "ceph.spec.in" and "debian/rules" set $DESTDIR when running "make
install". so we can always check $DESTDIR to tell if current "make
install" is launched by the packaging script or not. this might not be
accurate, but good enough. assuming enduser does not use DESTDIR when
running plain "make install".

--
[1] https://wiki.debian.org/Python/FAQ#How_should_we_package_Python_eggs.3F

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

