### PR TITLE
mimic: qa/suites/rados/thrash-old-clients: exclude packages for hammer, jewel

### DIFF
--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -9,7 +9,7 @@ overrides:
 tasks:
 - install:
     branch: hammer
-    exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev']
+    exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev','python34-rados','python34-cephfs','python3-rados','python3-cephfs']
 - install.upgrade:
     mon.a:
     mon.b:

--- a/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/jewel.yaml
@@ -1,7 +1,7 @@
 tasks:
 - install:
     branch: jewel
-    exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev']
+    exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev','python34-rados','python34-cephfs','python3-rados','python3-cephfs']
 - install.upgrade:
     mon.a:
     mon.b:


### PR DESCRIPTION
This fix goes directly into the mimic branch since the following packages
do not need to be installed on hammer and jewel.

- python34-rados
- python34-cephfs
- python3-rados
- python3-cephfs

Fixes failures such as http://pulpito.ceph.com/teuthology-2018-11-16_02:30:01-rados-mimic-distro-basic-smithi/
Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

