### PR TITLE
mgr: silence GCC warning

### DIFF
--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -160,7 +160,8 @@ void ActivePyModule::config_notify()
   Gil gil(py_module->pMyThreadState, true);
   dout(20) << "Calling " << py_module->get_name() << ".config_notify..."
 	   << dendl;
-  auto remoteResult = PyObject_CallMethod(pClassInstance, "config_notify",
+  auto remoteResult = PyObject_CallMethod(pClassInstance,
+					  const_cast<char*>("config_notify"),
 					  (char*)NULL);
   if (remoteResult != nullptr) {
     Py_DECREF(remoteResult);


### PR DESCRIPTION
the signature of PyObject_CallMethod() is different in python2 and
python3:

in python2: it is

PyObject* PyObject_CallMethod(PyObject *o, char *method, char *format,
...)

while in python3, it is

PyObject* PyObject_CallMethod(PyObject *obj, const char *name, const
char *format, ...)

so, if we compile mgr with python2, we will have following warning:

warning: ISO C++ forbids converting a string constant to ‘char*’
[-Wwrite-strings]
        (char*)NULL);
                   ^

it'd be simpler if we just const_cast<> the method name string, to
silence the warning just like other places we call
PyObject_CallMethod().

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

