### PR TITLE
erasure-code,test: silence -Wunused-variable warnings

### DIFF
--- a/src/erasure-code/clay/ErasureCodeClay.cc
+++ b/src/erasure-code/clay/ErasureCodeClay.cc
@@ -113,6 +113,7 @@ int ErasureCodeClay::decode(const set<int> &want_to_read,
   set<int> avail;
   for ([[maybe_unused]] auto& [node, bl] : chunks) {
     avail.insert(node);
+    (void)bl;  // silence -Wunused-variable
   }
 
   if (is_repair(want_to_read, avail) && 
@@ -484,6 +485,7 @@ int ErasureCodeClay::repair_one_lost_chunk(map<int, bufferlist> &recovered_data,
       // check across all erasures and aloof nodes
       for ([[maybe_unused]] auto& [node, bl] : recovered_data) {
         if (node % q == z_vec[node / q]) order++;
+        (void)bl;  // silence -Wunused-variable
       }
       for (auto node : aloof_nodes) {
         if (node % q == z_vec[node / q]) order++;
@@ -511,6 +513,7 @@ int ErasureCodeClay::repair_one_lost_chunk(map<int, bufferlist> &recovered_data,
   for ([[maybe_unused]] auto& [node, bl] : recovered_data) {
     lost_chunk = node;
     count++;
+    (void)bl;  // silence -Wunused-variable
   }
   ceph_assert(count == 1);
 
@@ -655,6 +658,7 @@ int ErasureCodeClay::decode_layered(set<int> &erased_chunks,
   for (int i = k+nu; (num_erasures < m) && (i < q*t); i++) {
     if ([[maybe_unused]] auto [it, added] = erased_chunks.emplace(i); added) {
       num_erasures++;
+      (void)it;  // silence -Wunused-variable
     }
   }
   ceph_assert(num_erasures == m);

--- a/src/test/crimson/test_perfcounters.cc
+++ b/src/test/crimson/test_perfcounters.cc
@@ -36,6 +36,7 @@ static seastar::future<> test_perfcounters(){
           if (PERF_VAL != perf_counter_ref.perf_counters->get(PERFTEST_INDEX)) {
             throw std::runtime_error("perf counter does not match");
           }
+          (void)path;           // silence -Wunused-variable
         }
       });
     });


### PR DESCRIPTION
GCC 7.3 does not support [[maybe_unused]] very well, so it emits
-Wunused-variable warnings even if the variables are marked with
maybe_unused. moreover, the C++17 standard does not forbid these
warnings:

> For an entity marked maybe_unused, implementations are encouraged not
to emit a warning that the entity is unused, or that the entity is used
despite the presence of the attribute.

see also n4659, dcl.attr.unused

so, in this change, the warnings are silenced manually.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

