### PR TITLE
ceph-volume add device_id to inventory listing

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -45,6 +45,34 @@ class TestBlkid(object):
         assert result['UUID'] == '62416664-cbaf-40bd-9689-10bd337379c3'
         assert result['TYPE'] == 'xfs'
 
+class TestUdevadmProperty(object):
+
+    def test_good_output(self, stub_call):
+        output = """ID_MODEL=SK_hynix_SC311_SATA_512GB
+ID_PART_TABLE_TYPE=gpt
+ID_SERIAL_SHORT=MS83N71801150416A""".split()
+        stub_call((output, [], 0))
+        result = disk.udevadm_property('dev/sda')
+        assert result['ID_MODEL'] == 'SK_hynix_SC311_SATA_512GB'
+        assert result['ID_PART_TABLE_TYPE'] == 'gpt'
+        assert result['ID_SERIAL_SHORT'] == 'MS83N71801150416A'
+
+    def test_property_filter(self, stub_call):
+        output = """ID_MODEL=SK_hynix_SC311_SATA_512GB
+ID_PART_TABLE_TYPE=gpt
+ID_SERIAL_SHORT=MS83N71801150416A""".split()
+        stub_call((output, [], 0))
+        result = disk.udevadm_property('dev/sda', ['ID_MODEL',
+                                                   'ID_SERIAL_SHORT'])
+        assert result['ID_MODEL'] == 'SK_hynix_SC311_SATA_512GB'
+        assert 'ID_PART_TABLE_TYPE' not in result
+
+    def test_fail_on_broken_output(self, stub_call):
+        output = ["ID_MODEL:SK_hynix_SC311_SATA_512GB"]
+        stub_call((output, [], 0))
+        with pytest.raises(ValueError):
+            disk.udevadm_property('dev/sda')
+
 
 class TestDeviceFamily(object):
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -79,6 +79,7 @@ class Device(object):
         self._is_lvm_member = None
         self._parse()
         self.available, self.rejected_reasons = self._check_reject_reasons()
+        self.device_id = self._get_device_id()
 
     def __lt__(self, other):
         '''
@@ -171,6 +172,22 @@ class Device(object):
                   self.report_fields}
         output['lvs'] = [lv.report() for lv in self.lvs]
         return output
+
+    def _get_device_id(self):
+        props = ['ID_MODEL','ID_SERIAL_SHORT']
+        dev_id = disk.udevadm_property(self.abspath, props)
+        if all([prop in dev_id and dev_id[prop] for prop in props]):
+            values = [dev_id[prop].replace(' ', '_') for prop in props]
+            return '_'.join(values)
+        else:
+            # the else branch should fallback to using sysfs and ioctl to
+            # retrieve device_id on FreeBSD. Still figuring out if/how the
+            # python ioctl implementation does that on FreeBSD
+            return ''
+        return ''
+
+
+
 
     def _set_lvm_membership(self):
         if self._is_lvm_member is None:

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -170,6 +170,47 @@ def device_family(device):
     return devices
 
 
+def udevadm_property(device, properties=[]):
+    """
+    Query udevadm for information about device properties.
+    Optionally pass a list of properties to return. A requested property might
+    not be returned if not present.
+
+    Expected output format::
+        # udevadm info --query=property --name=/dev/sda                                  :(
+        DEVNAME=/dev/sda
+        DEVTYPE=disk
+        ID_ATA=1
+        ID_BUS=ata
+        ID_MODEL=SK_hynix_SC311_SATA_512GB
+        ID_PART_TABLE_TYPE=gpt
+        ID_PART_TABLE_UUID=c8f91d57-b26c-4de1-8884-0c9541da288c
+        ID_PATH=pci-0000:00:17.0-ata-3
+        ID_PATH_TAG=pci-0000_00_17_0-ata-3
+        ID_REVISION=70000P10
+        ID_SERIAL=SK_hynix_SC311_SATA_512GB_MS83N71801150416A
+        TAGS=:systemd:
+        USEC_INITIALIZED=16117769
+        ...
+    """
+    out = _udevadm_info(device)
+    ret = {}
+    for line in out:
+        p, v = line.split('=', 1)
+        if not properties or p in properties:
+            ret[p] = v
+    return ret
+
+
+def _udevadm_info(device):
+    """
+    Call udevadm and return the output
+    """
+    cmd = ['udevadm', 'info', '--query=property', device]
+    out, _err, _rc = process.call(cmd)
+    return out
+
+
 def lsblk(device, columns=None, abspath=False):
     """
     Create a dictionary of identifying values for a device using ``lsblk``.

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -397,6 +397,7 @@ std::string get_device_id(const std::string& devname)
   struct udev_device *dev;
   static struct udev *udev;
   const char *data;
+  std::string device_model;
   std::string device_id;
 
   udev = udev_new();
@@ -409,9 +410,14 @@ std::string get_device_id(const std::string& devname)
     return {};
   }
 
+  data = udev_device_get_property_value(dev, "ID_MODEL");
+  if (data) {
+    device_model = data;
+  }
+
   // "ID_SERIAL_SHORT" returns only the serial number;
-  // "ID_SERIAL" returns vendor model_serial.
-  data = udev_device_get_property_value(dev, "ID_SERIAL");
+  // "ID_SERIAL" returns vendor model_serial but can be unreliable and return.
+  data = udev_device_get_property_value(dev, "ID_SERIAL_SHORT");
   if (data) {
     device_id = data;
   }
@@ -419,9 +425,10 @@ std::string get_device_id(const std::string& devname)
   udev_device_unref(dev);
   udev_unref(udev);
 
-  if (!device_id.empty()) {
+  if (!device_id.empty() and !device_model.empty()) {
+    std::replace(device_model.begin(), device_model.end(), ' ', '_');
     std::replace(device_id.begin(), device_id.end(), ' ', '_');
-    return device_id;
+    return device_model + '_' + device_id;
   }
 
   // either udev_device_get_property_value() failed, or succeeded but


### PR DESCRIPTION
This PR changes the device_id implementation from using ```ID_SERIAL``` to ```ID_MODEL + _ + ID_SERIAL_SHORT``` (1) and adds an equivalent python implementation to ceph-volume (2).

1) The reasoning is that the new implementation seem more reliable. ```ID_SERIAL``` often contains the model and serial, but sometimes only the serial.

2) The python implementation is not equivalent yet for the FreeBSD case. In C++ this uses sysfs and ```ioctl``` with a (Free?)BSD specific constant. I'm not sure yet of the same call can be made with python's ```ioctl``` implementation. If so this should also be a RFC if we should move this to python/ceph-volume and call it from C++ to avoid the duplicate implementation.

Fixes: https://tracker.ceph.com/issues/37083