### PR TITLE
cmake: vstart target can build WITH_CEPHFS/RBD/MGR=OFF

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -512,13 +512,15 @@ set_target_properties(ceph-osd PROPERTIES
   POSITION_INDEPENDENT_CODE ${EXE_LINKER_USE_PIE})
 install(TARGETS ceph-osd DESTINATION bin)
 
-add_subdirectory(mds)
-set(ceph_mds_srcs
-  ceph_mds.cc)
-add_executable(ceph-mds ${ceph_mds_srcs})
-target_link_libraries(ceph-mds mds ${CMAKE_DL_LIBS} global-static ceph-common
-  Boost::thread)
-install(TARGETS ceph-mds DESTINATION bin)
+if (WITH_CEPHFS)
+  add_subdirectory(mds)
+  set(ceph_mds_srcs
+    ceph_mds.cc)
+  add_executable(ceph-mds ${ceph_mds_srcs})
+  target_link_libraries(ceph-mds mds ${CMAKE_DL_LIBS} global-static ceph-common
+    Boost::thread)
+  install(TARGETS ceph-mds DESTINATION bin)
+endif()
 
 add_subdirectory(erasure-code)
 
@@ -739,8 +741,10 @@ add_custom_target(vstart-base DEPENDS
 
 add_custom_target(vstart DEPENDS
     vstart-base
-    ceph-mds
     cython${PY_BINDING_INFIX}_rbd)
+if (WITH_CEPHFS)
+  add_dependencies(vstart ceph-mds)
+endif()
 if(WITH_RADOSGW)
   add_dependencies(vstart radosgw radosgw-admin)
 endif(WITH_RADOSGW)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -731,13 +731,15 @@ configure_file(
 add_custom_target(vstart-base DEPENDS
     ceph-osd
     ceph-mon
-    ceph-mgr
     ceph-authtool
     ceph-conf
     monmaptool
     crushtool
     rados
     cython${PY_BINDING_INFIX}_rados)
+if (WITH_MGR)
+  add_dependencies(vstart-base ceph-mgr)
+endif()
 
 add_custom_target(vstart DEPENDS vstart-base)
 if (WITH_RBD)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -739,9 +739,10 @@ add_custom_target(vstart-base DEPENDS
     rados
     cython${PY_BINDING_INFIX}_rados)
 
-add_custom_target(vstart DEPENDS
-    vstart-base
-    cython${PY_BINDING_INFIX}_rbd)
+add_custom_target(vstart DEPENDS vstart-base)
+if (WITH_RBD)
+  add_dependencies(vstart cython${PY_BINDING_INFIX}_rbd)
+endif()
 if (WITH_CEPHFS)
   add_dependencies(vstart ceph-mds)
 endif()

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -38,7 +38,9 @@ if(WITH_RBD)
   add_subdirectory(librbd)
 endif(WITH_RBD)
 add_subdirectory(messenger)
-add_subdirectory(mds)
+if (WITH_CEPHFS)
+  add_subdirectory(mds)
+endif()
 add_subdirectory(mon)
 add_subdirectory(mgr)
 add_subdirectory(msgr)
@@ -485,7 +487,6 @@ add_dependencies(tests
   crushtool
   ceph-conf
   rados
-  ceph-mds
   monmaptool
   ceph-osd
   ceph-dencoder
@@ -500,6 +501,9 @@ add_dependencies(tests
   ceph_erasure_code_non_regression
   ceph_erasure_code
   cython${PY_BINDING_INFIX}_modules)
+if (WITH_CEPHFS)
+  add_dependencies(tests ceph-mds)
+endif()
 if(WITH_MGR)
   add_dependencies(tests ceph-mgr)
 endif()


### PR DESCRIPTION
just trying to reduce my 'make vstart' compile times by disabling components i'm not testing locally