### PR TITLE
build/ops: do_cmake.sh: automate py3 build options for certain distros

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -5,6 +5,28 @@ if test -e build; then
     exit 1
 fi
 
+PYBUILD="2"
+source /etc/os-release
+case "$ID" in
+    fedora)
+        if [ "$VERSION_ID" -ge "29" ] ; then
+            PYBUILD="3"
+        fi
+        ;;
+    rhel|centos)
+        MAJOR_VER=$(echo "$VERSION_ID" | sed -e 's/\..*$//')
+        if [ "$MAJOR_VER" -ge "8" ] ; then
+            PYBUILD="3"
+        fi
+        ;;
+    opensuse*|suse|sles)
+        PYBUILD="3"
+        ;;
+esac
+if [ "$PYBUILD" = "3" ] ; then
+    ARGS="$ARGS -DWITH_PYTHON2=OFF -DWITH_PYTHON3=ON -DMGR_PYTHON_VERSION=3"
+fi
+
 if type ccache > /dev/null 2>&1 ; then
     echo "enabling ccache"
     ARGS="$ARGS -DWITH_CCACHE=ON"

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -111,9 +111,6 @@ function run() {
     test "$BUILD_MAKEOPTS" && echo "make will run with option(s) $BUILD_MAKEOPTS"
     CHECK_MAKEOPTS=${CHECK_MAKEOPTS:-$DEFAULT_MAKEOPTS}
     CMAKE_BUILD_OPTS="-DWITH_GTEST_PARALLEL=ON -DWITH_FIO=ON -DWITH_SEASTAR=ON"
-    if ! type python2 > /dev/null 2>&1 ; then
-        CMAKE_BUILD_OPTS+=" -DWITH_PYTHON2=OFF -DWITH_PYTHON3=ON -DMGR_PYTHON_VERSION=3"
-    fi
     CMAKE_BUILD_OPTS+=$(detect_ceph_dev_pkgs)
     cat <<EOM
 Note that the binaries produced by this script do not contain correct time


### PR DESCRIPTION
Before this patch, run-make-check.sh was setting the cmake options for
py3 build based only on the absence of a python2 binary in the system.
This was not sufficiently deterministic, and it didn't help folks who
run do_cmake.sh directly.

With this patch, we explicitly force the py3 build in do_cmake.sh, for 
those OS types/versions we know need it.

Fixes: https://tracker.ceph.com/issues/37330
Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

