### PR TITLE
crimson/net: encapsulate protocol implementations with states (remaining part)

### DIFF
--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -62,15 +62,6 @@ class Messenger {
     return ++global_seq;
   }
 
-  // @returns a tuple of <is_valid, auth_reply, session_key>
-  virtual seastar::future<msgr_tag_t,    /// tag for error, 0 if authorized
-                          bufferlist>    /// auth_reply
-  verify_authorizer(peer_type_t peer_type,
-		    auth_proto_t protocol,
-		    bufferlist& auth) = 0;
-  virtual seastar::future<std::unique_ptr<AuthAuthorizer>>
-  get_authorizer(peer_type_t peer_type,
-		 bool force_new) = 0;
   uint32_t get_crc_flags() const {
     return crc_flags;
   }

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -533,8 +533,6 @@ SocketConnection::send_connect_reply_ready(msgr_tag_t tag,
         return socket->flush();
       }
     }).then([this] {
-      messenger.register_conn(this);
-      messenger.unaccept_conn(this);
       return stop_t::yes;
     });
 }
@@ -889,6 +887,8 @@ SocketConnection::accept(seastar::connected_socket&& fd,
               return dispatcher.ms_handle_accept(this);
             });
         }).then([this] {
+          messenger.register_conn(this);
+          messenger.unaccept_conn(this);
           execute_open();
         }).handle_exception([this] (std::exception_ptr eptr) {
           // TODO: handle fault in the accepting state

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -460,9 +460,9 @@ SocketConnection::repeat_handle_connect()
         return seastar::make_ready_future<msgr_tag_t, bufferlist>(
             CEPH_MSGR_TAG_FEATURES, bufferlist{});
       }
-      return messenger.verify_authorizer(peer_type,
-                                         h.connect.authorizer_protocol,
-                                         authorizer);
+      return dispatcher.ms_verify_authorizer(peer_type,
+                                             h.connect.authorizer_protocol,
+                                             authorizer);
     }).then([this] (ceph::net::msgr_tag_t tag, bufferlist&& authorizer_reply) {
       memset(&h.reply, 0, sizeof(h.reply));
       if (tag) {
@@ -642,7 +642,7 @@ SocketConnection::handle_connect_reply(msgr_tag_t tag)
     }
     h.got_bad_auth = true;
     // try harder
-    return messenger.get_authorizer(peer_type, true)
+    return dispatcher.ms_get_authorizer(peer_type, true)
       .then([this](auto&& auth) {
         h.authorizer = std::move(auth);
         return stop_t::no;
@@ -734,7 +734,7 @@ SocketConnection::repeat_connect()
   // this is fyi, actually, server decides!
   h.connect.flags = policy.lossy ? CEPH_MSG_CONNECT_LOSSY : 0;
 
-  return messenger.get_authorizer(peer_type, false)
+  return dispatcher.ms_get_authorizer(peer_type, false)
     .then([this](auto&& auth) {
       h.authorizer = std::move(auth);
       bufferlist bl;

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -153,7 +153,7 @@ class SocketConnection : public Connection {
 
   seastar::future<> fault();
 
-  void dispatch();
+  void execute_open();
 
   /// start a handshake from the client's perspective,
   /// only call when SocketConnection first construct

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -155,13 +155,6 @@ class SocketConnection : public Connection {
 
   void execute_open();
 
-  /// start a handshake from the client's perspective,
-  /// only call when SocketConnection first construct
-  seastar::future<> start_connect();
-  /// start a handshake from the server's perspective,
-  /// only call when SocketConnection first construct
-  seastar::future<> start_accept();
-
  public:
   SocketConnection(SocketMessenger& messenger,
                    const entity_addr_t& my_addr,
@@ -183,10 +176,14 @@ class SocketConnection : public Connection {
   seastar::future<> close() override;
 
  public:
-  void connect(const entity_addr_t& peer_addr,
-               const entity_type_t& peer_type);
-  void accept(seastar::connected_socket&& socket,
-              const entity_addr_t& peer_addr);
+  /// start a handshake from the client's perspective,
+  /// only call when SocketConnection first construct
+  void start_connect(const entity_addr_t& peer_addr,
+                     const entity_type_t& peer_type);
+  /// start a handshake from the server's perspective,
+  /// only call when SocketConnection first construct
+  void start_accept(seastar::connected_socket&& socket,
+                    const entity_addr_t& peer_addr);
 
   /// read a message from a connection that has completed its handshake
   seastar::future<MessageRef> read_message();

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <seastar/core/gate.hh>
 #include <seastar/core/reactor.hh>
 #include <seastar/core/shared_future.hh>
 
@@ -36,6 +37,8 @@ using SocketConnectionRef = boost::intrusive_ptr<SocketConnection>;
 class SocketConnection : public Connection {
   SocketMessenger& messenger;
   std::optional<Socket> socket;
+  Dispatcher& dispatcher;
+  seastar::gate pending_dispatch;
 
   enum class state_t {
     none,
@@ -150,9 +153,19 @@ class SocketConnection : public Connection {
 
   seastar::future<> fault();
 
+  seastar::future<> dispatch();
+
+  /// start a handshake from the client's perspective,
+  /// only call when SocketConnection first construct
+  seastar::future<> start_connect();
+  /// start a handshake from the server's perspective,
+  /// only call when SocketConnection first construct
+  seastar::future<> start_accept();
+
  public:
   SocketConnection(SocketMessenger& messenger,
-                   const entity_addr_t& my_addr);
+                   const entity_addr_t& my_addr,
+                   Dispatcher& dispatcher);
   ~SocketConnection();
 
   Messenger* get_messenger() const override;
@@ -170,13 +183,10 @@ class SocketConnection : public Connection {
   seastar::future<> close() override;
 
  public:
-  /// complete a handshake from the client's perspective
-  seastar::future<> start_connect(const entity_addr_t& peer_addr,
-                                  const entity_type_t& peer_type);
-
-  /// complete a handshake from the server's perspective
-  seastar::future<> start_accept(seastar::connected_socket&& socket,
-                                 const entity_addr_t& peer_addr);
+  void connect(const entity_addr_t& peer_addr,
+               const entity_type_t& peer_type);
+  seastar::future<> accept(seastar::connected_socket&& socket,
+                           const entity_addr_t& peer_addr);
 
   /// read a message from a connection that has completed its handshake
   seastar::future<MessageRef> read_message();

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -153,7 +153,7 @@ class SocketConnection : public Connection {
 
   seastar::future<> fault();
 
-  seastar::future<> dispatch();
+  void dispatch();
 
   /// start a handshake from the client's perspective,
   /// only call when SocketConnection first construct
@@ -185,8 +185,8 @@ class SocketConnection : public Connection {
  public:
   void connect(const entity_addr_t& peer_addr,
                const entity_type_t& peer_type);
-  seastar::future<> accept(seastar::connected_socket&& socket,
-                           const entity_addr_t& peer_addr);
+  void accept(seastar::connected_socket&& socket,
+              const entity_addr_t& peer_addr);
 
   /// read a message from a connection that has completed its handshake
   seastar::future<MessageRef> read_message();

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -40,35 +40,6 @@ void SocketMessenger::bind(const entity_addr_t& addr)
   listener = seastar::listen(address, lo);
 }
 
-seastar::future<> SocketMessenger::dispatch(SocketConnectionRef conn)
-{
-  return seastar::keep_doing([=] {
-      return conn->read_message()
-        .then([=] (MessageRef msg) {
-          // start dispatch, ignoring exceptions from the application layer
-          seastar::with_gate(pending_dispatch, [=, msg = std::move(msg)] {
-              return dispatcher->ms_dispatch(conn, std::move(msg))
-                .handle_exception([] (std::exception_ptr eptr) {});
-            });
-          // return immediately to start on the next message
-          return seastar::now();
-        });
-    }).handle_exception_type([=] (const std::system_error& e) {
-      if (e.code() == error::connection_aborted ||
-          e.code() == error::connection_reset) {
-        return seastar::with_gate(pending_dispatch, [=] {
-            return dispatcher->ms_handle_reset(conn);
-          });
-      } else if (e.code() == error::read_eof) {
-        return seastar::with_gate(pending_dispatch, [=] {
-            return dispatcher->ms_handle_remote_reset(conn);
-          });
-      } else {
-        throw e;
-      }
-    });
-}
-
 seastar::future<> SocketMessenger::accept(seastar::connected_socket socket,
                                           seastar::socket_address paddr)
 {
@@ -76,23 +47,9 @@ seastar::future<> SocketMessenger::accept(seastar::connected_socket socket,
   entity_addr_t peer_addr;
   peer_addr.set_type(entity_addr_t::TYPE_DEFAULT);
   peer_addr.set_sockaddr(&paddr.as_posix_sockaddr());
-  SocketConnectionRef conn = new SocketConnection(*this, get_myaddr());
+  SocketConnectionRef conn = new SocketConnection(*this, get_myaddr(), *dispatcher);
   // initiate the handshake
-  return conn->start_accept(std::move(socket), peer_addr)
-    .then([this, conn] {
-      // notify the dispatcher and allow them to reject the connection
-      return seastar::with_gate(pending_dispatch, [=] {
-          return dispatcher->ms_handle_accept(conn);
-        });
-    }).handle_exception([conn] (std::exception_ptr eptr) {
-      // close the connection before returning errors
-      return seastar::make_exception_future<>(eptr)
-        .finally([conn] { return conn->close(); });
-    }).then([this, conn] {
-      // dispatch messages until the connection closes or the dispatch
-      // queue shuts down
-      return dispatch(std::move(conn));
-    });
+  return conn->accept(std::move(socket), peer_addr);
 }
 
 seastar::future<> SocketMessenger::start(Dispatcher *disp)
@@ -127,23 +84,8 @@ SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_type_t& pe
   if (auto found = lookup_conn(peer_addr); found) {
     return found;
   }
-  SocketConnectionRef conn = new SocketConnection(*this, get_myaddr());
-  conn->start_connect(peer_addr, peer_type)
-    .then([this, conn] {
-      // notify the dispatcher and allow them to reject the connection
-      return seastar::with_gate(pending_dispatch, [this, conn] {
-        return dispatcher->ms_handle_connect(conn);
-      });
-    }).handle_exception([conn] (std::exception_ptr eptr) {
-      // close the connection before returning errors
-      return seastar::make_exception_future<>(eptr)
-        .finally([conn] { return conn->close(); });
-      // TODO: retry on fault
-    }).then([this, conn] {
-      // dispatch replies on this connection
-      dispatch(conn)
-        .handle_exception([] (std::exception_ptr eptr) {});
-    });
+  SocketConnectionRef conn = new SocketConnection(*this, get_myaddr(), *dispatcher);
+  conn->connect(peer_addr, peer_type);
   return conn;
 }
 

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -151,17 +151,3 @@ void SocketMessenger::unregister_conn(SocketConnectionRef conn)
   ceph_assert(found->second == conn);
   connections.erase(found);
 }
-
-seastar::future<msgr_tag_t, bufferlist>
-SocketMessenger::verify_authorizer(peer_type_t peer_type,
-				   auth_proto_t protocol,
-				   bufferlist& auth)
-{
-  return dispatcher->ms_verify_authorizer(peer_type, protocol, auth);
-}
-
-seastar::future<std::unique_ptr<AuthAuthorizer>>
-SocketMessenger::get_authorizer(peer_type_t peer_type, bool force_new)
-{
-  return dispatcher->ms_get_authorizer(peer_type, force_new);
-}

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -56,7 +56,7 @@ seastar::future<> SocketMessenger::start(Dispatcher *disp)
             peer_addr.set_sockaddr(&paddr.as_posix_sockaddr());
             SocketConnectionRef conn = new SocketConnection(*this, get_myaddr(), *dispatcher);
             // don't wait before accepting another
-            conn->accept(std::move(socket), peer_addr);
+            conn->start_accept(std::move(socket), peer_addr);
           });
       }).handle_exception_type([this] (const std::system_error& e) {
         // stop gracefully on connection_aborted
@@ -76,7 +76,7 @@ SocketMessenger::connect(const entity_addr_t& peer_addr, const entity_type_t& pe
     return found;
   }
   SocketConnectionRef conn = new SocketConnection(*this, get_myaddr(), *dispatcher);
-  conn->connect(peer_addr, peer_type);
+  conn->start_connect(peer_addr, peer_type);
   return conn;
 }
 

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -52,15 +52,6 @@ class SocketMessenger final : public Messenger {
 
   seastar::future<> shutdown() override;
 
-  seastar::future<msgr_tag_t, bufferlist>
-  verify_authorizer(peer_type_t peer_type,
-		    auth_proto_t protocol,
-		    bufferlist& auth) override;
-
-  seastar::future<std::unique_ptr<AuthAuthorizer>>
-  get_authorizer(peer_type_t peer_type,
-		 bool force_new) override;
-
  public:
   void set_default_policy(const SocketPolicy& p);
   void set_policy(entity_type_t peer_type, const SocketPolicy& p);

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -62,9 +62,6 @@ class SocketMessenger final : public Messenger {
 		 bool force_new) override;
 
  public:
-  // TODO: change to per-connection messenger gate
-  seastar::gate pending_dispatch;
-
   void set_default_policy(const SocketPolicy& p);
   void set_policy(entity_type_t peer_type, const SocketPolicy& p);
   void set_policy_throttler(entity_type_t peer_type, Throttle* throttle);

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -36,9 +36,6 @@ class SocketMessenger final : public Messenger {
   std::set<SocketConnectionRef> accepting_conns;
   using Throttle = ceph::thread::Throttle;
   ceph::net::PolicySet<Throttle> policy_set;
-  seastar::gate pending_dispatch;
-
-  seastar::future<> dispatch(SocketConnectionRef conn);
 
   seastar::future<> accept(seastar::connected_socket socket,
                            seastar::socket_address paddr);
@@ -65,6 +62,9 @@ class SocketMessenger final : public Messenger {
 		 bool force_new) override;
 
  public:
+  // TODO: change to per-connection messenger gate
+  seastar::gate pending_dispatch;
+
   void set_default_policy(const SocketPolicy& p);
   void set_policy(entity_type_t peer_type, const SocketPolicy& p);
   void set_policy_throttler(entity_type_t peer_type, Throttle* throttle);


### PR DESCRIPTION
This PR is to split #24142 into smaller digestible pieces, and further split #24656 for the remaining parts.
Major progress:
- [x] (merged) Clean seastar-msgr interfaces.
- [x] (merged) Add connecting/accepting states, and let `Messenger::connect()` return a `ConnectionRef` instead of future.
- [x] (merged) Centralize error handling so it's easier to make decisions of lossless policy
- [x] Report changes according to connection state via `Dispatcher` (ms_handle_reset etc).
- [x] Change to per-connection seastar-gates.
- [ ] Let reconnect/replace happen transparently inside `SocketConnection`.
- [ ] Formalize a connection state machine.
- [ ] Add v1/v2 protocol abstractions that act on the state machine.