### PR TITLE
rgw: adapt AioThrottle for RGWGetObj

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -53,6 +53,7 @@ set(librgw_common_srcs
   rgw_acl.cc
   rgw_acl_s3.cc
   rgw_acl_swift.cc
+  rgw_aio_throttle.cc
   rgw_auth.cc
   rgw_auth_s3.cc
   rgw_basic_types.cc
@@ -97,7 +98,6 @@ set(librgw_common_srcs
   rgw_policy_s3.cc
   rgw_putobj.cc
   rgw_putobj_processor.cc
-  rgw_putobj_throttle.cc
   rgw_quota.cc
   rgw_rados.cc
   rgw_resolve.cc

--- a/src/rgw/rgw_aio.h
+++ b/src/rgw/rgw_aio.h
@@ -23,14 +23,14 @@ class ObjectReadOperation;
 class ObjectWriteOperation;
 }
 
-namespace rgw::putobj {
+namespace rgw {
 
-struct Result {
+struct AioResult {
   rgw_raw_obj obj;
   int result = 0;
 };
-struct ResultEntry : Result, boost::intrusive::list_base_hook<> {
-  virtual ~ResultEntry() {}
+struct AioResultEntry : AioResult, boost::intrusive::list_base_hook<> {
+  virtual ~AioResultEntry() {}
 };
 // a list of polymorphic entries that frees them on destruction
 template <typename T, typename ...Args>
@@ -42,10 +42,10 @@ struct OwningList : boost::intrusive::list<T, Args...> {
   OwningList(const OwningList&) = delete;
   OwningList& operator=(const OwningList&) = delete;
 };
-using ResultList = OwningList<ResultEntry>;
+using AioResultList = OwningList<AioResultEntry>;
 
 // returns the first error code or 0 if all succeeded
-inline int check_for_errors(const ResultList& results) {
+inline int check_for_errors(const AioResultList& results) {
   for (auto& e : results) {
     if (e.result < 0) {
       return e.result;
@@ -60,24 +60,24 @@ class Aio {
  public:
   virtual ~Aio() {}
 
-  virtual ResultList submit(RGWSI_RADOS::Obj& obj,
-                            const rgw_raw_obj& raw_obj,
-                            librados::ObjectReadOperation *op,
-                            bufferlist *data, uint64_t cost) = 0;
+  virtual AioResultList submit(RGWSI_RADOS::Obj& obj,
+                               const rgw_raw_obj& raw_obj,
+                               librados::ObjectReadOperation *op,
+                               bufferlist *data, uint64_t cost) = 0;
 
-  virtual ResultList submit(RGWSI_RADOS::Obj& obj,
-                            const rgw_raw_obj& raw_obj,
-                            librados::ObjectWriteOperation *op,
-                            uint64_t cost) = 0;
+  virtual AioResultList submit(RGWSI_RADOS::Obj& obj,
+                               const rgw_raw_obj& raw_obj,
+                               librados::ObjectWriteOperation *op,
+                               uint64_t cost) = 0;
 
   // poll for any ready completions without waiting
-  virtual ResultList poll() = 0;
+  virtual AioResultList poll() = 0;
 
   // return any ready completions. if there are none, wait for the next
-  virtual ResultList wait() = 0;
+  virtual AioResultList wait() = 0;
 
   // wait for all outstanding completions and return their results
-  virtual ResultList drain() = 0;
+  virtual AioResultList drain() = 0;
 };
 
-} // namespace rgw::putobj
+} // namespace rgw

--- a/src/rgw/rgw_aio.h
+++ b/src/rgw/rgw_aio.h
@@ -27,6 +27,7 @@ namespace rgw {
 
 struct AioResult {
   rgw_raw_obj obj;
+  uint64_t id = 0; // id allows caller to associate a result with its request
   bufferlist data; // result buffer for reads
   int result = 0;
 };
@@ -64,12 +65,12 @@ class Aio {
   virtual AioResultList submit(RGWSI_RADOS::Obj& obj,
                                const rgw_raw_obj& raw_obj,
                                librados::ObjectReadOperation *op,
-                               uint64_t cost) = 0;
+                               uint64_t cost, uint64_t id) = 0;
 
   virtual AioResultList submit(RGWSI_RADOS::Obj& obj,
                                const rgw_raw_obj& raw_obj,
                                librados::ObjectWriteOperation *op,
-                               uint64_t cost) = 0;
+                               uint64_t cost, uint64_t id) = 0;
 
   // poll for any ready completions without waiting
   virtual AioResultList poll() = 0;

--- a/src/rgw/rgw_aio.h
+++ b/src/rgw/rgw_aio.h
@@ -27,6 +27,7 @@ namespace rgw {
 
 struct AioResult {
   rgw_raw_obj obj;
+  bufferlist data; // result buffer for reads
   int result = 0;
 };
 struct AioResultEntry : AioResult, boost::intrusive::list_base_hook<> {
@@ -63,7 +64,7 @@ class Aio {
   virtual AioResultList submit(RGWSI_RADOS::Obj& obj,
                                const rgw_raw_obj& raw_obj,
                                librados::ObjectReadOperation *op,
-                               bufferlist *data, uint64_t cost) = 0;
+                               uint64_t cost) = 0;
 
   virtual AioResultList submit(RGWSI_RADOS::Obj& obj,
                                const rgw_raw_obj& raw_obj,

--- a/src/rgw/rgw_aio.h
+++ b/src/rgw/rgw_aio.h
@@ -26,7 +26,7 @@ class ObjectWriteOperation;
 namespace rgw {
 
 struct AioResult {
-  rgw_raw_obj obj;
+  RGWSI_RADOS::Obj obj;
   uint64_t id = 0; // id allows caller to associate a result with its request
   bufferlist data; // result buffer for reads
   int result = 0;
@@ -63,12 +63,10 @@ class Aio {
   virtual ~Aio() {}
 
   virtual AioResultList submit(RGWSI_RADOS::Obj& obj,
-                               const rgw_raw_obj& raw_obj,
                                librados::ObjectReadOperation *op,
                                uint64_t cost, uint64_t id) = 0;
 
   virtual AioResultList submit(RGWSI_RADOS::Obj& obj,
-                               const rgw_raw_obj& raw_obj,
                                librados::ObjectWriteOperation *op,
                                uint64_t cost, uint64_t id) = 0;
 

--- a/src/rgw/rgw_aio_throttle.cc
+++ b/src/rgw/rgw_aio_throttle.cc
@@ -37,12 +37,11 @@ bool AioThrottle::waiter_ready() const
 }
 
 AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
-                                  const rgw_raw_obj& raw_obj,
                                   librados::ObjectWriteOperation *op,
                                   uint64_t cost, uint64_t id)
 {
   auto p = std::make_unique<Pending>();
-  p->obj = raw_obj;
+  p->obj = obj;
   p->id = id;
   p->cost = cost;
 
@@ -61,12 +60,11 @@ AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
 }
 
 AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
-                                  const rgw_raw_obj& raw_obj,
                                   librados::ObjectReadOperation *op,
                                   uint64_t cost, uint64_t id)
 {
   auto p = std::make_unique<Pending>();
-  p->obj = raw_obj;
+  p->obj = obj;
   p->id = id;
   p->cost = cost;
 

--- a/src/rgw/rgw_aio_throttle.cc
+++ b/src/rgw/rgw_aio_throttle.cc
@@ -14,10 +14,10 @@
 
 #include "include/rados/librados.hpp"
 
-#include "rgw_putobj_throttle.h"
+#include "rgw_aio_throttle.h"
 #include "rgw_rados.h"
 
-namespace rgw::putobj {
+namespace rgw {
 
 void AioThrottle::aio_cb(void *cb, void *arg)
 {
@@ -36,10 +36,10 @@ bool AioThrottle::waiter_ready() const
   }
 }
 
-ResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
-                               const rgw_raw_obj& raw_obj,
-                               librados::ObjectWriteOperation *op,
-                               uint64_t cost)
+AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
+                                  const rgw_raw_obj& raw_obj,
+                                  librados::ObjectWriteOperation *op,
+                                  uint64_t cost)
 {
   auto p = std::make_unique<Pending>();
   p->obj = raw_obj;
@@ -59,10 +59,10 @@ ResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
   return std::move(completed);
 }
 
-ResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
-                               const rgw_raw_obj& raw_obj,
-                               librados::ObjectReadOperation *op,
-                               bufferlist *data, uint64_t cost)
+AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
+                                  const rgw_raw_obj& raw_obj,
+                                  librados::ObjectReadOperation *op,
+                                  bufferlist *data, uint64_t cost)
 {
   auto p = std::make_unique<Pending>();
   p->obj = raw_obj;
@@ -119,13 +119,13 @@ void AioThrottle::put(Pending& p)
   }
 }
 
-ResultList AioThrottle::poll()
+AioResultList AioThrottle::poll()
 {
   std::unique_lock lock{mutex};
   return std::move(completed);
 }
 
-ResultList AioThrottle::wait()
+AioResultList AioThrottle::wait()
 {
   std::unique_lock lock{mutex};
   if (completed.empty() && !pending.empty()) {
@@ -137,7 +137,7 @@ ResultList AioThrottle::wait()
   return std::move(completed);
 }
 
-ResultList AioThrottle::drain()
+AioResultList AioThrottle::drain()
 {
   std::unique_lock lock{mutex};
   if (!pending.empty()) {
@@ -149,4 +149,4 @@ ResultList AioThrottle::drain()
   return std::move(completed);
 }
 
-} // namespace rgw::putobj
+} // namespace rgw

--- a/src/rgw/rgw_aio_throttle.cc
+++ b/src/rgw/rgw_aio_throttle.cc
@@ -62,7 +62,7 @@ AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
 AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
                                   const rgw_raw_obj& raw_obj,
                                   librados::ObjectReadOperation *op,
-                                  bufferlist *data, uint64_t cost)
+                                  uint64_t cost)
 {
   auto p = std::make_unique<Pending>();
   p->obj = raw_obj;
@@ -73,7 +73,7 @@ AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
     completed.push_back(*p);
   } else {
     get(*p);
-    p->result = obj.aio_operate(p->completion, op, data);
+    p->result = obj.aio_operate(p->completion, op, &p->data);
     if (p->result < 0) {
       put(*p);
     }

--- a/src/rgw/rgw_aio_throttle.cc
+++ b/src/rgw/rgw_aio_throttle.cc
@@ -39,10 +39,11 @@ bool AioThrottle::waiter_ready() const
 AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
                                   const rgw_raw_obj& raw_obj,
                                   librados::ObjectWriteOperation *op,
-                                  uint64_t cost)
+                                  uint64_t cost, uint64_t id)
 {
   auto p = std::make_unique<Pending>();
   p->obj = raw_obj;
+  p->id = id;
   p->cost = cost;
 
   if (cost > window) {
@@ -62,10 +63,11 @@ AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
 AioResultList AioThrottle::submit(RGWSI_RADOS::Obj& obj,
                                   const rgw_raw_obj& raw_obj,
                                   librados::ObjectReadOperation *op,
-                                  uint64_t cost)
+                                  uint64_t cost, uint64_t id)
 {
   auto p = std::make_unique<Pending>();
   p->obj = raw_obj;
+  p->id = id;
   p->cost = cost;
 
   if (cost > window) {

--- a/src/rgw/rgw_aio_throttle.h
+++ b/src/rgw/rgw_aio_throttle.h
@@ -69,7 +69,7 @@ class AioThrottle : public Aio {
 
   AioResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
                        librados::ObjectReadOperation *op,
-                       bufferlist *data, uint64_t cost) override;
+                       uint64_t cost) override;
 
   AioResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
                        librados::ObjectWriteOperation *op,

--- a/src/rgw/rgw_aio_throttle.h
+++ b/src/rgw/rgw_aio_throttle.h
@@ -69,11 +69,11 @@ class AioThrottle : public Aio {
 
   AioResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
                        librados::ObjectReadOperation *op,
-                       uint64_t cost) override;
+                       uint64_t cost, uint64_t id) override;
 
   AioResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
                        librados::ObjectWriteOperation *op,
-                       uint64_t cost) override;
+                       uint64_t cost, uint64_t id) override;
 
   AioResultList poll() override;
 

--- a/src/rgw/rgw_aio_throttle.h
+++ b/src/rgw/rgw_aio_throttle.h
@@ -67,11 +67,11 @@ class AioThrottle : public Aio {
     ceph_assert(completed.empty());
   }
 
-  AioResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
+  AioResultList submit(RGWSI_RADOS::Obj& obj,
                        librados::ObjectReadOperation *op,
                        uint64_t cost, uint64_t id) override;
 
-  AioResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
+  AioResultList submit(RGWSI_RADOS::Obj& obj,
                        librados::ObjectWriteOperation *op,
                        uint64_t cost, uint64_t id) override;
 

--- a/src/rgw/rgw_aio_throttle.h
+++ b/src/rgw/rgw_aio_throttle.h
@@ -17,13 +17,13 @@
 #include <memory>
 #include "common/ceph_mutex.h"
 #include "services/svc_rados.h"
-#include "rgw_putobj_aio.h"
+#include "rgw_aio.h"
 
 namespace librados {
 class AioCompletion;
 }
 
-namespace rgw::putobj {
+namespace rgw {
 
 // a throttle for aio operations that enforces a maximum window on outstanding
 // bytes. only supports a single waiter, so all public functions must be called
@@ -37,13 +37,13 @@ class AioThrottle : public Aio {
   bool has_completion() const { return !completed.empty(); }
   bool is_drained() const { return pending.empty(); }
 
-  struct Pending : ResultEntry {
+  struct Pending : AioResultEntry {
     AioThrottle *parent = nullptr;
     uint64_t cost = 0;
     librados::AioCompletion *completion = nullptr;
   };
   OwningList<Pending> pending;
-  ResultList completed;
+  AioResultList completed;
 
   enum class Wait { None, Available, Completion, Drained };
   Wait waiter = Wait::None;
@@ -67,19 +67,19 @@ class AioThrottle : public Aio {
     ceph_assert(completed.empty());
   }
 
-  ResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
-                    librados::ObjectReadOperation *op,
-                    bufferlist *data, uint64_t cost) override;
+  AioResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
+                       librados::ObjectReadOperation *op,
+                       bufferlist *data, uint64_t cost) override;
 
-  ResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
-                    librados::ObjectWriteOperation *op,
-                    uint64_t cost) override;
+  AioResultList submit(RGWSI_RADOS::Obj& obj, const rgw_raw_obj& raw_obj,
+                       librados::ObjectWriteOperation *op,
+                       uint64_t cost) override;
 
-  ResultList poll() override;
+  AioResultList poll() override;
 
-  ResultList wait() override;
+  AioResultList wait() override;
 
-  ResultList drain() override;
+  AioResultList drain() override;
 };
 
-} // namespace rgw::putobj
+} // namespace rgw

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -197,7 +197,7 @@ int RGWAsyncLockSystemObj::_send_request()
   l.set_cookie(cookie);
   l.set_may_renew(true);
 
-  return l.lock_exclusive(&ref.ioctx, ref.oid);
+  return l.lock_exclusive(&ref.ioctx, ref.obj.oid);
 }
 
 RGWAsyncLockSystemObj::RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store,
@@ -223,7 +223,7 @@ int RGWAsyncUnlockSystemObj::_send_request()
 
   l.set_cookie(cookie);
 
-  return l.unlock(&ref.ioctx, ref.oid);
+  return l.unlock(&ref.ioctx, ref.obj.oid);
 }
 
 RGWAsyncUnlockSystemObj::RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store,
@@ -266,7 +266,7 @@ int RGWRadosSetOmapKeysCR::send_request()
   op.omap_set(entries);
 
   cn = stack->create_completion_notifier();
-  return ref.ioctx.aio_operate(ref.oid, cn->completion(), &op);
+  return ref.ioctx.aio_operate(ref.obj.oid, cn->completion(), &op);
 }
 
 int RGWRadosSetOmapKeysCR::request_complete()
@@ -304,7 +304,7 @@ int RGWRadosGetOmapKeysCR::send_request() {
   op.omap_get_keys2(marker, max_entries, &result->entries, &result->more, nullptr);
 
   cn = stack->create_completion_notifier(result);
-  return result->ref.ioctx.aio_operate(result->ref.oid, cn->completion(), &op, NULL);
+  return result->ref.ioctx.aio_operate(result->ref.obj.oid, cn->completion(), &op, NULL);
 }
 
 int RGWRadosGetOmapKeysCR::request_complete()
@@ -339,7 +339,7 @@ int RGWRadosRemoveOmapKeysCR::send_request() {
   op.omap_rm_keys(keys);
 
   cn = stack->create_completion_notifier();
-  return ref.ioctx.aio_operate(ref.oid, cn->completion(), &op);
+  return ref.ioctx.aio_operate(ref.obj.oid, cn->completion(), &op);
 }
 
 int RGWRadosRemoveOmapKeysCR::request_complete()
@@ -884,7 +884,7 @@ int RGWRadosNotifyCR::send_request()
   set_status() << "sending request";
 
   cn = stack->create_completion_notifier();
-  return ref.ioctx.aio_notify(ref.oid, cn->completion(), request,
+  return ref.ioctx.aio_notify(ref.obj.oid, cn->completion(), request,
                               timeout_ms, response);
 }
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -35,7 +35,7 @@
 #include "rgw_ldap.h"
 #include "rgw_token.h"
 #include "rgw_putobj_processor.h"
-#include "rgw_putobj_throttle.h"
+#include "rgw_aio_throttle.h"
 #include "rgw_compression.h"
 
 
@@ -2320,7 +2320,7 @@ public:
   const std::string& bucket_name;
   const std::string& obj_name;
   RGWFileHandle* rgw_fh;
-  std::optional<rgw::putobj::AioThrottle> aio;
+  std::optional<rgw::AioThrottle> aio;
   std::optional<rgw::putobj::AtomicObjectProcessor> processor;
   rgw::putobj::DataProcessor* filter;
   boost::optional<RGWPutObj_Compress> compressor;

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -91,7 +91,8 @@ int RadosWriter::process(bufferlist&& bl, uint64_t offset)
   } else {
     op.write(offset, data);
   }
-  auto c = aio->submit(stripe_obj, stripe_raw, &op, cost);
+  constexpr uint64_t id = 0; // unused
+  auto c = aio->submit(stripe_obj, stripe_raw, &op, cost, id);
   return process_completed(c, &written);
 }
 
@@ -103,7 +104,8 @@ int RadosWriter::write_exclusive(const bufferlist& data)
   op.create(true); // exclusive create
   op.write_full(data);
 
-  auto c = aio->submit(stripe_obj, stripe_raw, &op, cost);
+  constexpr uint64_t id = 0; // unused
+  auto c = aio->submit(stripe_obj, stripe_raw, &op, cost, id);
   auto d = aio->drain();
   c.splice(c.end(), d);
   return process_completed(c, &written);

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -63,7 +63,7 @@ static int process_completed(const AioResultList& completed, RawObjSet *written)
   std::optional<int> error;
   for (auto& r : completed) {
     if (r.result >= 0) {
-      written->insert(r.obj);
+      written->insert(r.obj.get_ref().obj);
     } else if (!error) { // record first error code
       error = r.result;
     }
@@ -71,10 +71,9 @@ static int process_completed(const AioResultList& completed, RawObjSet *written)
   return error.value_or(0);
 }
 
-int RadosWriter::set_stripe_obj(rgw_raw_obj&& raw_obj)
+int RadosWriter::set_stripe_obj(const rgw_raw_obj& raw_obj)
 {
-  stripe_raw = std::move(raw_obj);
-  stripe_obj = store->svc.rados->obj(stripe_raw);
+  stripe_obj = store->svc.rados->obj(raw_obj);
   return stripe_obj.open();
 }
 
@@ -92,7 +91,7 @@ int RadosWriter::process(bufferlist&& bl, uint64_t offset)
     op.write(offset, data);
   }
   constexpr uint64_t id = 0; // unused
-  auto c = aio->submit(stripe_obj, stripe_raw, &op, cost, id);
+  auto c = aio->submit(stripe_obj, &op, cost, id);
   return process_completed(c, &written);
 }
 
@@ -105,7 +104,7 @@ int RadosWriter::write_exclusive(const bufferlist& data)
   op.write_full(data);
 
   constexpr uint64_t id = 0; // unused
-  auto c = aio->submit(stripe_obj, stripe_raw, &op, cost, id);
+  auto c = aio->submit(stripe_obj, &op, cost, id);
   auto d = aio->drain();
   c.splice(c.end(), d);
   return process_completed(c, &written);
@@ -179,7 +178,7 @@ int ManifestObjectProcessor::next(uint64_t offset, uint64_t *pstripe_size)
   if (r < 0) {
     return r;
   }
-  r = writer.set_stripe_obj(std::move(stripe_obj));
+  r = writer.set_stripe_obj(stripe_obj);
   if (r < 0) {
     return r;
   }
@@ -223,7 +222,7 @@ int AtomicObjectProcessor::prepare()
   if (r < 0) {
     return r;
   }
-  r = writer.set_stripe_obj(std::move(stripe_obj));
+  r = writer.set_stripe_obj(stripe_obj);
   if (r < 0) {
     return r;
   }
@@ -344,7 +343,7 @@ int MultipartObjectProcessor::prepare_head()
   if (r < 0) {
     return r;
   }
-  r = writer.set_stripe_obj(std::move(stripe_obj));
+  r = writer.set_stripe_obj(stripe_obj);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -12,7 +12,7 @@
  *
  */
 
-#include "rgw_putobj_aio.h"
+#include "rgw_aio.h"
 #include "rgw_putobj_processor.h"
 #include "rgw_multi.h"
 #include "services/svc_sys_obj.h"
@@ -58,7 +58,7 @@ int HeadObjectProcessor::process(bufferlist&& data, uint64_t logical_offset)
 }
 
 
-static int process_completed(const ResultList& completed, RawObjSet *written)
+static int process_completed(const AioResultList& completed, RawObjSet *written)
 {
   std::optional<int> error;
   for (auto& r : completed) {

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -80,7 +80,6 @@ class RadosWriter : public DataProcessor {
   const RGWBucketInfo& bucket_info;
   RGWObjectCtx& obj_ctx;
   const rgw_obj& head_obj;
-  rgw_raw_obj stripe_raw;
   RGWSI_RADOS::Obj stripe_obj; // current stripe object
   RawObjSet written; // set of written objects for deletion
 
@@ -93,7 +92,7 @@ class RadosWriter : public DataProcessor {
   ~RadosWriter();
 
   // change the current stripe object
-  int set_stripe_obj(rgw_raw_obj&& obj);
+  int set_stripe_obj(const rgw_raw_obj& obj);
 
   // write the data at the given offset of the current stripe object
   int process(bufferlist&& data, uint64_t stripe_offset) override;

--- a/src/rgw/rgw_putobj_processor.h
+++ b/src/rgw/rgw_putobj_processor.h
@@ -20,7 +20,11 @@
 #include "rgw_rados.h"
 #include "services/svc_rados.h"
 
-namespace rgw::putobj {
+namespace rgw {
+
+class Aio;
+
+namespace putobj {
 
 // a data consumer that writes an object in a bucket
 class ObjectProcessor : public DataProcessor {
@@ -67,7 +71,6 @@ class HeadObjectProcessor : public ObjectProcessor {
 };
 
 
-class Aio;
 using RawObjSet = std::set<rgw_raw_obj>;
 
 // a data sink that writes to rados objects and deletes them on cancelation
@@ -210,4 +213,5 @@ class MultipartObjectProcessor : public ManifestObjectProcessor {
                rgw_zone_set *zones_trace, bool *canceled) override;
 };
 
-} // namespace rgw::putobj
+} // namespace putobj
+} // namespace rgw

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5833,10 +5833,14 @@ int RGWRados::append_atomic_test(RGWObjectCtx *rctx,
   if (r < 0)
     return r;
 
-  RGWObjState *state = *pstate;
+  return append_atomic_test(*pstate, op);
+}
 
+int RGWRados::append_atomic_test(const RGWObjState* state,
+                                 librados::ObjectOperation& op)
+{
   if (!state->is_atomic) {
-    ldout(cct, 20) << "state for obj=" << obj << " is not atomic, not appending atomic test" << dendl;
+    ldout(cct, 20) << "state for obj=" << state->obj << " is not atomic, not appending atomic test" << dendl;
     return 0;
   }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6582,7 +6582,7 @@ int RGWRados::get_obj_iterate_cb(const rgw_raw_obj& read_obj, off_t obj_ofs,
   const uint64_t cost = len;
   const uint64_t id = obj_ofs; // use logical object offset for sorting replies
 
-  auto completed = d->aio->submit(obj, read_obj, &op, cost, id);
+  auto completed = d->aio->submit(obj, &op, cost, id);
 
   return d->flush(std::move(completed));
 }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -24,12 +24,12 @@
 #include "rgw_cache.h"
 #include "rgw_acl.h"
 #include "rgw_acl_s3.h" /* for dumping s3policy in debug log */
+#include "rgw_aio_throttle.h"
 #include "rgw_bucket.h"
 #include "rgw_rest_conn.h"
 #include "rgw_cr_rados.h"
 #include "rgw_cr_rest.h"
 #include "rgw_putobj_processor.h"
-#include "rgw_putobj_throttle.h"
 
 #include "cls/rgw/cls_rgw_ops.h"
 #include "cls/rgw/cls_rgw_client.h"
@@ -4183,8 +4183,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   obj_time_weight set_mtime_weight;
   set_mtime_weight.high_precision = high_precision_time;
 
+  rgw::AioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
   using namespace rgw::putobj;
-  AioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
   AtomicObjectProcessor processor(&aio, this, dest_bucket_info, user_id,
                                   obj_ctx, dest_obj, olh_epoch, tag);
   int ret = processor.prepare();
@@ -4724,8 +4724,8 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
   string tag;
   append_rand_alpha(cct, tag, tag, 32);
 
+  rgw::AioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
   using namespace rgw::putobj;
-  AioThrottle aio(cct->_conf->rgw_put_obj_min_window_size);
   AtomicObjectProcessor processor(&aio, this, dest_bucket_info,
                                   dest_bucket_info.owner, obj_ctx,
                                   dest_obj, olh_epoch, tag);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2011,20 +2011,18 @@ public:
     return get_obj_state(rctx, bucket_info, obj, state, true);
   }
 
-  int iterate_obj(RGWObjectCtx& ctx,
-                  const RGWBucketInfo& bucket_info, const rgw_obj& obj,
-                  off_t ofs, off_t end,
-                  uint64_t max_chunk_size,
-                  int (*iterate_obj_cb)(const RGWBucketInfo& bucket_info, const rgw_obj& obj, const rgw_raw_obj&, off_t, off_t, off_t, bool, RGWObjState *, void *),
-                  void *arg);
+  using iterate_obj_cb = int (*)(const rgw_raw_obj&, off_t, off_t,
+                                 off_t, bool, RGWObjState*, void*);
+
+  int iterate_obj(RGWObjectCtx& ctx, const RGWBucketInfo& bucket_info,
+                  const rgw_obj& obj, off_t ofs, off_t end,
+                  uint64_t max_chunk_size, iterate_obj_cb cb, void *arg);
 
   int flush_read_list(struct get_obj_data *d);
 
-  int get_obj_iterate_cb(RGWObjectCtx *ctx, RGWObjState *astate,
-                         const RGWBucketInfo& bucket_info, const rgw_obj& obj,
-                         const rgw_raw_obj& read_obj,
-                         off_t obj_ofs, off_t read_ofs, off_t len,
-                         bool is_head_obj, void *arg);
+  int get_obj_iterate_cb(const rgw_raw_obj& read_obj, off_t obj_ofs,
+                         off_t read_ofs, off_t len, bool is_head_obj,
+                         RGWObjState *astate, void *arg);
 
   void get_obj_aio_completion_cb(librados::completion_t cb, void *arg);
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1255,6 +1255,7 @@ class RGWRados : public AdminSocketHook
                          bool follow_olh, bool assume_noent = false);
   int append_atomic_test(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
                          librados::ObjectOperation& op, RGWObjState **state);
+  int append_atomic_test(const RGWObjState* astate, librados::ObjectOperation& op);
 
   int update_placement_map();
   int store_bucket_info(RGWBucketInfo& info, map<string, bufferlist> *pattrs, RGWObjVersionTracker *objv_tracker, bool exclusive);

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -261,34 +261,34 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
     }
 
     // register a watch on the realm's control object
-    r = ref.ioctx.watch2(ref.oid, &handle, this);
+    r = ref.ioctx.watch2(ref.obj.oid, &handle, this);
     if (r == -ENOENT) {
       constexpr bool exclusive = true;
-      r = ref.ioctx.create(ref.oid, exclusive);
+      r = ref.ioctx.create(ref.obj.oid, exclusive);
       if (r == -EEXIST || r == 0) {
-        r = ref.ioctx.watch2(ref.oid, &handle, this);
+        r = ref.ioctx.watch2(ref.obj.oid, &handle, this);
       }
     }
     if (r < 0) {
-      lderr(store->ctx()) << "Failed to watch " << ref.oid
+      lderr(store->ctx()) << "Failed to watch " << ref.obj
           << " with " << cpp_strerror(-r) << dendl;
       ref.ioctx.close();
       return r;
     }
 
-    ldout(store->ctx(), 10) << "Watching " << ref.oid << dendl;
+    ldout(store->ctx(), 10) << "Watching " << ref.obj.oid << dendl;
     return 0;
   }
 
   int restart() {
     int r = ref.ioctx.unwatch2(handle);
     if (r < 0) {
-      lderr(store->ctx()) << "Failed to unwatch on " << ref.oid
+      lderr(store->ctx()) << "Failed to unwatch on " << ref.obj
           << " with " << cpp_strerror(-r) << dendl;
     }
-    r = ref.ioctx.watch2(ref.oid, &handle, this);
+    r = ref.ioctx.watch2(ref.obj.oid, &handle, this);
     if (r < 0) {
-      lderr(store->ctx()) << "Failed to restart watch on " << ref.oid
+      lderr(store->ctx()) << "Failed to restart watch on " << ref.obj
           << " with " << cpp_strerror(-r) << dendl;
       ref.ioctx.close();
     }
@@ -323,7 +323,7 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
     } catch (const buffer::error& e) {
       lderr(store->ctx()) << "Failed to decode notification: " << e.what() << dendl;
     }
-    ref.ioctx.notify_ack(ref.oid, notify_id, cookie, reply);
+    ref.ioctx.notify_ack(ref.obj.oid, notify_id, cookie, reply);
   }
 
   /// reestablish the watch if it gets disconnected
@@ -332,7 +332,7 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
       return;
     }
     if (err == -ENOTCONN) {
-      ldout(store->ctx(), 4) << "Disconnected watch on " << ref.oid << dendl;
+      ldout(store->ctx(), 4) << "Disconnected watch on " << ref.obj << dendl;
       restart();
     }
   }

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -357,7 +357,8 @@ int RGWSI_Notify::distribute(const string& key, bufferlist& bl)
 {
   RGWSI_RADOS::Obj notify_obj = pick_control_obj(key);
 
-  ldout(cct, 10) << "distributing notification oid=" << notify_obj.get_ref().oid << " bl.length()=" << bl.length() << dendl;
+  ldout(cct, 10) << "distributing notification oid=" << notify_obj.get_ref().obj
+      << " bl.length()=" << bl.length() << dendl;
   return robust_notify(notify_obj, bl);
 }
 

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -133,21 +133,20 @@ int RGWSI_RADOS::pool_iterate(librados::IoCtx& io_ctx,
 
   return objs.size();
 }
+
 void RGWSI_RADOS::Obj::init(const rgw_raw_obj& obj)
 {
-  ref.oid = obj.oid;
-  ref.key = obj.loc;
-  ref.pool = obj.pool;
+  ref.obj = obj;
 }
 
 int RGWSI_RADOS::Obj::open()
 {
-  int r = rados_svc->open_pool_ctx(ref.pool, ref.ioctx, rados_handle);
+  int r = rados_svc->open_pool_ctx(ref.obj.pool, ref.ioctx, rados_handle);
   if (r < 0) {
     return r;
   }
 
-  ref.ioctx.locator_set_key(ref.key);
+  ref.ioctx.locator_set_key(ref.obj.loc);
 
   return 0;
 }
@@ -155,34 +154,34 @@ int RGWSI_RADOS::Obj::open()
 int RGWSI_RADOS::Obj::operate(librados::ObjectWriteOperation *op,
                               optional_yield y)
 {
-  return rgw_rados_operate(ref.ioctx, ref.oid, op, y);
+  return rgw_rados_operate(ref.ioctx, ref.obj.oid, op, y);
 }
 
 int RGWSI_RADOS::Obj::operate(librados::ObjectReadOperation *op, bufferlist *pbl,
                               optional_yield y)
 {
-  return rgw_rados_operate(ref.ioctx, ref.oid, op, pbl, y);
+  return rgw_rados_operate(ref.ioctx, ref.obj.oid, op, pbl, y);
 }
 
 int RGWSI_RADOS::Obj::aio_operate(librados::AioCompletion *c, librados::ObjectWriteOperation *op)
 {
-  return ref.ioctx.aio_operate(ref.oid, c, op);
+  return ref.ioctx.aio_operate(ref.obj.oid, c, op);
 }
 
 int RGWSI_RADOS::Obj::aio_operate(librados::AioCompletion *c, librados::ObjectReadOperation *op,
                                   bufferlist *pbl)
 {
-  return ref.ioctx.aio_operate(ref.oid, c, op, pbl);
+  return ref.ioctx.aio_operate(ref.obj.oid, c, op, pbl);
 }
 
 int RGWSI_RADOS::Obj::watch(uint64_t *handle, librados::WatchCtx2 *ctx)
 {
-  return ref.ioctx.watch2(ref.oid, handle, ctx);
+  return ref.ioctx.watch2(ref.obj.oid, handle, ctx);
 }
 
 int RGWSI_RADOS::Obj::aio_watch(librados::AioCompletion *c, uint64_t *handle, librados::WatchCtx2 *ctx)
 {
-  return ref.ioctx.aio_watch(ref.oid, c, handle, ctx);
+  return ref.ioctx.aio_watch(ref.obj.oid, c, handle, ctx);
 }
 
 int RGWSI_RADOS::Obj::unwatch(uint64_t handle)
@@ -194,14 +193,14 @@ int RGWSI_RADOS::Obj::notify(bufferlist& bl,
                              uint64_t timeout_ms,
                              bufferlist *pbl)
 {
-  return ref.ioctx.notify2(ref.oid, bl, timeout_ms, pbl);
+  return ref.ioctx.notify2(ref.obj.oid, bl, timeout_ms, pbl);
 }
 
 void RGWSI_RADOS::Obj::notify_ack(uint64_t notify_id,
                                  uint64_t cookie,
                                  bufferlist& bl)
 {
-  ref.ioctx.notify_ack(ref.oid, notify_id, cookie, bl);
+  ref.ioctx.notify_ack(ref.obj.oid, notify_id, cookie, bl);
 }
 
 uint64_t RGWSI_RADOS::Obj::get_last_version()

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -23,9 +23,7 @@ struct RGWAccessListFilterPrefix : public RGWAccessListFilter {
 };
 
 struct rgw_rados_ref {
-  rgw_pool pool;
-  string oid;
-  string key;
+  rgw_raw_obj obj;
   librados::IoCtx ioctx;
 };
 

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -92,9 +92,8 @@ public:
 
     uint64_t get_last_version();
 
-    rgw_rados_ref& get_ref() {
-      return ref;
-    }
+    rgw_rados_ref& get_ref() { return ref; }
+    const rgw_rados_ref& get_ref() const { return ref; }
   };
 
   class Pool {

--- a/src/test/rgw/test_rgw_throttle.cc
+++ b/src/test/rgw/test_rgw_throttle.cc
@@ -44,11 +44,8 @@ auto *const rados_env = ::testing::AddGlobalTestEnvironment(new RadosEnv);
 // test fixture for global setup/teardown
 class RadosFixture : public ::testing::Test {
  protected:
-  rgw_raw_obj make_raw_obj(const std::string& oid) {
-    return {{RadosEnv::poolname}, oid};
-  }
-  RGWSI_RADOS::Obj make_obj(const rgw_raw_obj& raw) {
-    auto obj = RadosEnv::rados->obj(raw);
+  RGWSI_RADOS::Obj make_obj(const std::string& oid) {
+    auto obj = RadosEnv::rados->obj({{RadosEnv::poolname}, oid});
     ceph_assert_always(0 == obj.open());
     return obj;
   }
@@ -61,20 +58,19 @@ namespace rgw {
 TEST_F(Aio_Throttle, NoThrottleUpToMax)
 {
   AioThrottle throttle(4);
-  auto raw = make_raw_obj(__PRETTY_FUNCTION__);
-  auto obj = make_obj(raw);
+  auto obj = make_obj(__PRETTY_FUNCTION__);
   {
     librados::ObjectWriteOperation op1;
-    auto c1 = throttle.submit(obj, raw, &op1, 1, 0);
+    auto c1 = throttle.submit(obj, &op1, 1, 0);
     EXPECT_TRUE(c1.empty());
     librados::ObjectWriteOperation op2;
-    auto c2 = throttle.submit(obj, raw, &op2, 1, 0);
+    auto c2 = throttle.submit(obj, &op2, 1, 0);
     EXPECT_TRUE(c2.empty());
     librados::ObjectWriteOperation op3;
-    auto c3 = throttle.submit(obj, raw, &op3, 1, 0);
+    auto c3 = throttle.submit(obj, &op3, 1, 0);
     EXPECT_TRUE(c3.empty());
     librados::ObjectWriteOperation op4;
-    auto c4 = throttle.submit(obj, raw, &op4, 1, 0);
+    auto c4 = throttle.submit(obj, &op4, 1, 0);
     EXPECT_TRUE(c4.empty());
     // no completions because no ops had to wait
     auto c5 = throttle.poll();
@@ -89,11 +85,10 @@ TEST_F(Aio_Throttle, NoThrottleUpToMax)
 TEST_F(Aio_Throttle, CostOverWindow)
 {
   AioThrottle throttle(4);
-  auto raw = make_raw_obj(__PRETTY_FUNCTION__);
-  auto obj = make_obj(raw);
+  auto obj = make_obj(__PRETTY_FUNCTION__);
 
   librados::ObjectWriteOperation op;
-  auto c = throttle.submit(obj, raw, &op, 8, 0);
+  auto c = throttle.submit(obj, &op, 8, 0);
   ASSERT_EQ(1u, c.size());
   EXPECT_EQ(-EDEADLK, c.front().result);
 }
@@ -103,8 +98,7 @@ TEST_F(Aio_Throttle, ThrottleOverMax)
   constexpr uint64_t window = 4;
   AioThrottle throttle(window);
 
-  auto raw = make_raw_obj(__PRETTY_FUNCTION__);
-  auto obj = make_obj(raw);
+  auto obj = make_obj(__PRETTY_FUNCTION__);
 
   // issue 32 writes, and verify that max_outstanding <= window
   constexpr uint64_t total = 32;
@@ -113,7 +107,7 @@ TEST_F(Aio_Throttle, ThrottleOverMax)
 
   for (uint64_t i = 0; i < total; i++) {
     librados::ObjectWriteOperation op;
-    auto c = throttle.submit(obj, raw, &op, 1, 0);
+    auto c = throttle.submit(obj, &op, 1, 0);
     outstanding++;
     outstanding -= c.size();
     if (max_outstanding < outstanding) {


### PR DESCRIPTION
adjusts the Aio interface to better support reads, then uses the AioThrottle to reimplement `struct get_obj_data` and related logic in `RGWRados::Object::Read::iterate()`. a coroutine-yielding implementation of Aio (not included here) can be plugged in later to eliminate blocking waits on AioCompletions