### PR TITLE
[RFC] add crimson/lru

### DIFF
--- a/src/crimson/common/lru.hpp
+++ b/src/crimson/common/lru.hpp
@@ -1,0 +1,312 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include <map>
+#include <list>
+#include <boost/smart_ptr/local_shared_ptr.hpp>
+#include "common/ceph_mutex.h"
+#include "common/dout.h"
+#include "include/unordered_map.h"
+
+#include "crimson/common/config_proxy.h"
+#include "crimson/common/log.h"
+
+// re-include our assert to clobber the system one; fix dout:
+#include "include/ceph_assert.h"
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_);
+  }
+}
+
+template <class K, class V>
+class LRU {
+  using VPtr = boost::local_shared_ptr<V>;
+  using WeakVPtr = boost::weak_ptr<V>;
+  size_t max_size;
+  unsigned size;
+private:
+  using C = std::less<K>;
+  using H = std::hash<K>;
+  ceph::unordered_map<K, typename std::list<std::pair<K, VPtr> >::iterator, H> contents;
+  std::list<std::pair<K, VPtr> > lru;
+
+  std::map<K, std::pair<WeakVPtr, V*>, C> weak_refs;
+
+  void trim_cache(std::list<VPtr> *to_release) {
+    while (size > max_size) {
+      to_release->push_back(lru.back().second);
+      lru_remove(lru.back().first);
+    }
+  }
+
+  void lru_remove(const K& key) {
+    auto i = contents.find(key);
+    if (i == contents.end())
+      return;
+    lru.erase(i->second);
+    --size;
+    contents.erase(i);
+  }
+
+  void lru_add(const K& key, const VPtr& val, std::list<VPtr> *to_release) {
+    auto i = contents.find(key);
+    if (i != contents.end()) {
+      lru.splice(lru.begin(), lru, i->second);
+    } else {
+      ++size;
+      lru.push_front(make_pair(key, val));
+      contents[key] = lru.begin();
+      trim_cache(to_release);
+    }
+  }
+
+  void remove(const K& key, V *valptr) {
+    auto i = weak_refs.find(key);
+    if (i != weak_refs.end() && i->second.second == valptr) {
+      weak_refs.erase(i);
+    }
+  }
+
+  class Cleanup {
+  public:
+    LRU<K, V> *cache;
+    K key;
+    Cleanup(LRU<K, V> *cache, K key) : cache(cache), key(key) {}
+    void operator()(V *ptr) {
+      cache->remove(key, ptr);
+      delete ptr;
+    }
+  };
+
+public:
+  LRU(size_t max_size = 20)
+    : max_size(max_size),
+      size(0) {
+    contents.rehash(max_size);
+  }
+
+  ~LRU() {
+    contents.clear();
+    lru.clear();
+    if (!weak_refs.empty()) {
+      auto& conf = ceph::common::local_conf();
+      std::ostringstream _dout;
+      dump_weak_refs(_dout);
+      logger().error("leaked refs:\n", _dout.str(), "\n");
+      if (conf.get_val<bool>("debug_asserts_on_shutdown")) {
+	ceph_assert(weak_refs.empty());
+      }
+    }
+  }
+
+  int get_count() {
+    return size;
+  }
+
+  /// adjust container comparator (for purposes of get_next sort order)
+  void reset_comparator(C comp) {
+    // get_next uses weak_refs; that's the only container we need to
+    // reorder.
+    map<K, pair<WeakVPtr, V*>, C> temp;
+
+    temp.swap(weak_refs);
+
+    // reconstruct with new comparator
+    weak_refs = map<K, pair<WeakVPtr, V*>, C>(comp);
+    weak_refs.insert(temp.begin(), temp.end());
+  }
+
+  C get_comparator() {
+    return weak_refs.key_comp();
+  }
+
+  void dump_weak_refs() {
+    std::ostringstream _dout;
+    dump_weak_refs(_dout);
+    logger().error("leaked refs:\n",  _dout.str(), "\n");
+  }
+
+  void dump_weak_refs(std::ostream& out) {
+    for (const auto& [key, ref] : weak_refs) {
+      out << __func__ << " " << this << " weak_refs: "
+	  << key << " = " << ref.second
+	  << " with " << ref.first.use_count() << " refs"
+	  << std::endl;
+    }
+  }
+
+  //clear all strong reference from the lru.
+  void clear() {
+    while (true) {
+      VPtr val; // release any ref we have after we drop the lock
+      if (size == 0)
+        break;
+
+      val = lru.back().second;
+      lru_remove(lru.back().first);
+    }
+  }
+
+  void clear(const K& key) {
+    VPtr val; // release any ref we have after we drop the lock
+    {
+      typename map<K, pair<WeakVPtr, V*>, C>::iterator i = weak_refs.find(key);
+      if (i != weak_refs.end()) {
+	val = i->second.first.lock();
+      }
+      lru_remove(key);
+    }
+  }
+
+  void purge(const K &key) {
+    VPtr val; // release any ref we have after we drop the lock
+    {
+      typename map<K, pair<WeakVPtr, V*>, C>::iterator i = weak_refs.find(key);
+      if (i != weak_refs.end()) {
+	val = i->second.first.lock();
+        weak_refs.erase(i);
+      }
+      lru_remove(key);
+    }
+  }
+
+  void set_size(size_t new_size) {
+    list<VPtr> to_release;
+    {
+      max_size = new_size;
+      trim_cache(&to_release);
+    }
+  }
+
+  // Returns K key s.t. key <= k for all currently cached k,v
+  K cached_key_lower_bound() {
+    return weak_refs.begin()->first;
+  }
+
+  VPtr lower_bound(const K& key) {
+    VPtr val;
+    list<VPtr> to_release;
+
+    if (!weak_refs.empty()) {
+      auto i = weak_refs.lower_bound(key);
+      if (i == weak_refs.end()) {
+	--i;
+      }
+      val = i->second.first.lock();
+      ceph_assert(val);
+      lru_add(i->first, val, &to_release);
+    }
+    return val;
+  }
+
+  bool get_next(const K &key, std::pair<K, VPtr> *next) {
+    VPtr next_val;
+
+    typename std::map<K, std::pair<WeakVPtr, V*>, C>::iterator i = weak_refs.upper_bound(key);
+    if (i == weak_refs.end())
+      return false;
+
+    next_val = i->second.first.lock();
+    assert(next_val);
+    if (next) {
+      *next  = make_pair(i->first, next_val);
+    }
+
+    return true;
+  }
+
+  bool get_next(const K &key, std::pair<K, V> *next) {
+    std::pair<K, VPtr> r;
+    bool found = get_next(key, &r);
+    if (!found || !next)
+      return found;
+    next->first = r.first;
+    ceph_assert(r.second);
+    next->second = *(r.second);
+    return found;
+  }
+
+  VPtr lookup(const K& key) {
+    VPtr val;
+    std::list<VPtr> to_release;
+    if (auto i = weak_refs.find(key); i != weak_refs.end()) {
+      val = i->second.first.lock();
+      ceph_assert(val);
+      lru_add(key, val, &to_release);
+    }
+    return val;
+  }
+
+  VPtr lookup_or_create(const K &key) {
+    VPtr val;
+    list<VPtr> to_release;
+
+    if (auto i = weak_refs.find(key); i != weak_refs.end()) {
+      val = i->second.first.lock();
+      ceph_assert(val);
+    } else {
+      val = VPtr{new V{}, Cleanup{this, key}};
+      weak_refs.insert(make_pair(key, make_pair(val, val.get())));
+    }
+    lru_add(key, val, &to_release);
+
+    return val;
+  }
+
+  /**
+   * empty()
+   *
+   * Returns true iff there are no live references left to anything that has been
+   * in the cache.
+   */
+  bool empty() {
+    return weak_refs.empty();
+  }
+
+  /***
+   * Inserts a key if not present, or bumps it to the front of the LRU if
+   * it is, and then gives you a reference to the value. If the key already
+   * existed, you are responsible for deleting the new value you tried to
+   * insert.
+   *
+   * @param key The key to insert
+   * @param value The value that goes with the key
+   * @param existed Set to true if the value was already in the
+   * map, false otherwise
+   * @return A reference to the map's value for the given key
+   */
+  VPtr add(const K& key, V *value, bool *existed = NULL) {
+    VPtr val;
+    list<VPtr> to_release;
+
+    if (auto i = weak_refs.find(key); i != weak_refs.end()) {
+      if (existed) {
+	*existed = true;
+      }
+      val = i->second.first.lock();
+      ceph_assert(val);
+    } else {
+      if (existed) {
+	*existed = false;
+      }
+
+      val = VPtr(value, Cleanup(this, key));
+      weak_refs.insert(make_pair(key, make_pair(val, value)));
+    }
+    lru_add(key, val, &to_release);
+    return val;
+  }
+};

--- a/src/crimson/common/lru.hpp
+++ b/src/crimson/common/lru.hpp
@@ -150,45 +150,24 @@ public:
 
   //clear all strong reference from the lru.
   void clear() {
-    while (true) {
-      VPtr val; // release any ref we have after we drop the lock
-      if (size == 0)
-        break;
-
-      val = lru.back().second;
+    while (size) {
       lru_remove(lru.back().first);
     }
   }
 
   void clear(const K& key) {
-    VPtr val; // release any ref we have after we drop the lock
-    {
-      typename map<K, pair<WeakVPtr, V*>, C>::iterator i = weak_refs.find(key);
-      if (i != weak_refs.end()) {
-	val = i->second.first.lock();
-      }
       lru_remove(key);
-    }
   }
 
   void purge(const K &key) {
-    VPtr val; // release any ref we have after we drop the lock
-    {
-      typename map<K, pair<WeakVPtr, V*>, C>::iterator i = weak_refs.find(key);
-      if (i != weak_refs.end()) {
-	val = i->second.first.lock();
-        weak_refs.erase(i);
-      }
-      lru_remove(key);
-    }
+    weak_refs.erase(key);
+    lru_remove(key);
   }
 
   void set_size(size_t new_size) {
     list<VPtr> to_release;
-    {
-      max_size = new_size;
-      trim_cache(&to_release);
-    }
+    max_size = new_size;
+    trim_cache(&to_release);
   }
 
   // Returns K key s.t. key <= k for all currently cached k,v

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -34,3 +34,8 @@ add_executable(unittest_seastar_perfcounters
 add_ceph_unittest(unittest_seastar_perfcounters)
 target_link_libraries(unittest_seastar_perfcounters crimson)
 
+add_executable(unittest_seastar_lru
+  test_lru.cc)
+add_ceph_unittest(unittest_seastar_lru)
+target_link_libraries(unittest_seastar_lru crimson GTest::Main)
+

--- a/src/test/crimson/test_lru.cc
+++ b/src/test/crimson/test_lru.cc
@@ -1,0 +1,219 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2013 Cloudwatt <libre.licensing@cloudwatt.com>
+ *
+ * Author: Loic Dachary <loic@dachary.org>
+ *         Cheng Cheng <ccheng.leo@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Library Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Library Public License for more details.
+ *
+ */
+
+#include <stdio.h>
+#include "gtest/gtest.h"
+#include "crimson/common/lru.hpp"
+
+class LRUTest : public LRU<unsigned int, int> {
+};
+
+class LRU_all : public ::testing::Test {
+};
+
+TEST_F(LRU_all, add) {
+  LRUTest cache;
+  unsigned int key = 1;
+  int value1 = 2;
+  bool existed = false;
+  {
+    boost::local_shared_ptr<int> ptr = cache.add(key, new int(value1), &existed);
+    ASSERT_EQ(value1, *ptr);
+    ASSERT_FALSE(existed);
+  }
+  {
+    auto p = new int(3);
+    boost::local_shared_ptr<int> ptr = cache.add(key, p, &existed);
+    ASSERT_EQ(value1, *ptr);
+    ASSERT_TRUE(existed);
+    delete p;
+  }
+}
+
+TEST_F(LRU_all, empty) {
+  LRUTest cache;
+  unsigned int key = 1;
+  bool existed = false;
+
+  ASSERT_TRUE(cache.empty());
+  {
+    int value1 = 2;
+    boost::local_shared_ptr<int> ptr = cache.add(key, new int(value1), &existed);
+    ASSERT_EQ(value1, *ptr);
+    ASSERT_FALSE(existed);
+  }
+  ASSERT_FALSE(cache.empty());
+
+  cache.clear(key);
+  ASSERT_TRUE(cache.empty());
+}
+
+TEST_F(LRU_all, lookup) {
+  LRUTest cache;
+  unsigned int key = 1;
+  {
+    int value = 2;
+    ASSERT_TRUE(cache.add(key, new int(value)).get());
+    ASSERT_TRUE(cache.lookup(key).get());
+    ASSERT_EQ(value, *cache.lookup(key));
+  }
+  ASSERT_TRUE(cache.lookup(key).get());
+}
+TEST_F(LRU_all, lookup_or_create) {
+  LRUTest cache;
+  {
+    int value = 2;
+    unsigned int key = 1;
+    ASSERT_TRUE(cache.add(key, new int(value)).get());
+    ASSERT_TRUE(cache.lookup_or_create(key).get());
+    ASSERT_EQ(value, *cache.lookup(key));
+  }
+  {
+    unsigned int key = 2;
+    ASSERT_TRUE(cache.lookup_or_create(key).get());
+    ASSERT_EQ(0, *cache.lookup(key));
+  }
+  ASSERT_TRUE(cache.lookup(1).get());
+  ASSERT_TRUE(cache.lookup(2).get());
+}
+
+TEST_F(LRU_all, lower_bound) {
+  LRUTest cache;
+
+  {
+    unsigned int key = 1;
+    ASSERT_FALSE(cache.lower_bound(key));
+    int value = 2;
+
+    ASSERT_TRUE(cache.add(key, new int(value)).get());
+    ASSERT_TRUE(cache.lower_bound(key).get());
+    EXPECT_EQ(value, *cache.lower_bound(key));
+  }
+}
+
+TEST_F(LRU_all, get_next) {
+
+  {
+    LRUTest cache;
+    const unsigned int key = 0;
+    pair<unsigned int, int> i;
+    EXPECT_FALSE(cache.get_next(key, &i));
+  }
+  {
+    LRUTest cache;
+    const unsigned int key1 = 111;
+    boost::local_shared_ptr<int> *ptr1 = new boost::local_shared_ptr<int>(cache.lookup_or_create(key1));
+    const unsigned int key2 = 222;
+    boost::local_shared_ptr<int> ptr2 = cache.lookup_or_create(key2);
+
+    pair<unsigned int, boost::local_shared_ptr<int> > i;
+    EXPECT_TRUE(cache.get_next(i.first, &i));
+    EXPECT_EQ(key1, i.first);
+    delete ptr1;
+    EXPECT_TRUE(cache.get_next(i.first, &i));
+    EXPECT_EQ(key2, i.first);
+  }
+}
+
+TEST_F(LRU_all, clear) {
+  LRUTest cache;
+  unsigned int key = 1;
+  int value = 2;
+  {
+    boost::local_shared_ptr<int> ptr = cache.add(key, new int(value));
+    ASSERT_EQ(value, *cache.lookup(key));
+  }
+  ASSERT_TRUE(cache.lookup(key).get());
+  cache.clear(key);
+  ASSERT_FALSE(cache.lookup(key));
+
+  {
+    boost::local_shared_ptr<int> ptr = cache.add(key, new int(value));
+  }
+  ASSERT_TRUE(cache.lookup(key).get());
+  cache.clear(key);
+  ASSERT_FALSE(cache.lookup(key));
+}
+TEST_F(LRU_all, clear_all) {
+  LRUTest cache;
+  unsigned int key = 1;
+  int value = 2;
+  {
+    boost::local_shared_ptr<int> ptr = cache.add(key, new int(value));
+    ASSERT_EQ(value, *cache.lookup(key));
+  }
+  ASSERT_TRUE(cache.lookup(key).get());
+  cache.clear();
+  ASSERT_FALSE(cache.lookup(key));
+
+  boost::local_shared_ptr<int> ptr2 = cache.add(key, new int(value));
+  ASSERT_TRUE(cache.lookup(key).get());
+  cache.clear();
+  ASSERT_TRUE(cache.lookup(key).get());
+  ASSERT_FALSE(cache.empty());
+}
+
+TEST(Cache_all, add) {
+  LRU<int, int> cache;
+  unsigned int key = 1;
+  int value = 2;
+  boost::local_shared_ptr<int> ptr = cache.add(key, new int(value));
+  ASSERT_EQ(ptr, cache.lookup(key));
+  ASSERT_EQ(value, *cache.lookup(key));
+}
+
+TEST(Cache_all, lru) {
+  const size_t SIZE = 5;
+  LRU<int, int> cache(SIZE);
+
+  bool existed = false;
+  boost::local_shared_ptr<int> ptr = cache.add(0, new int(0), &existed);
+  ASSERT_FALSE(existed);
+  {
+    int *tmpint = new int(0);
+    boost::local_shared_ptr<int> ptr2 = cache.add(0, tmpint, &existed);
+    ASSERT_TRUE(existed);
+    delete tmpint;
+  }
+  for (size_t i = 1; i < 2*SIZE; ++i) {
+    cache.add(i, new int(i), &existed);
+    ASSERT_FALSE(existed);
+  }
+  ASSERT_TRUE(cache.lookup(0).get());
+  ASSERT_EQ(0, *cache.lookup(0));
+
+  ASSERT_FALSE(cache.lookup(SIZE-1));
+  ASSERT_FALSE(cache.lookup(SIZE));
+  ASSERT_TRUE(cache.lookup(SIZE+1).get());
+  ASSERT_EQ((int)SIZE+1, *cache.lookup(SIZE+1));
+
+  cache.purge(0);
+  ASSERT_FALSE(cache.lookup(0));
+  boost::local_shared_ptr<int> ptr2 = cache.add(0, new int(0), &existed);
+  ASSERT_FALSE(ptr == ptr2);
+  ptr = boost::local_shared_ptr<int>();
+  ASSERT_TRUE(cache.lookup(0).get());
+}
+
+// Local Variables:
+// compile-command: "cd ../.. ; make unittest_seastar_lru && ./unittest_seastar_lru # --gtest_filter=*.* --log-to-stderr=true"
+// End:


### PR DESCRIPTION
@tchaikov . Still keep weak_ptr is  because SharedLRU has this function, etc,
SharedLRU<int, int>(5);
add(0); ptr= lookup(0); add(1);add(2);add(4); add(5);
After add(6). 
a)If the life of ptr didn't expire, lookup(0) will return ture rather than false.
b)if the life of ptr expired, lookup(0) return false.
I think this import for OSDMap or ObjectContext,  if lookup faild, it will read from objectstore.
etc for ObjectContext, because object access is random.
the function weak_ptr in SharedLRU  is to do this. 

patch1: only remove lock and condtion_variable
patch2: do some optimization based on object of LRU allocate and destroy only on a fixed core.

