### PR TITLE
osd: Extreme conditions cause ignore peer missing

### DIFF
--- a/qa/standalone/osd/osd-peering.sh
+++ b/qa/standalone/osd/osd-peering.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7155" # git grep '\<7155\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON"
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        $func $dir || return 1
+    done
+}
+
+function TEST_peer_missing() {
+    local dir=$1
+
+    setup $dir || return 1
+    run_mon $dir a --osd_pool_default_size=3 || return 1
+    run_mgr $dir x || return 1
+    run_osd $dir 0 || return 1
+    run_osd $dir 1 || return 1
+    run_osd $dir 2 || return 1
+
+    wait_for_clean || return 1
+
+    ceph osd pool create rep 1 || return 1
+    ceph osd pool set rep min_size 2 || return 1
+
+    ceph osd primary-affinity 1 10	# let osd.1 be primary
+    ceph osd primary-affinity 0 0
+    ceph osd primary-affinity 2 0
+
+    rados -p rep put test /etc/hosts || return 1
+
+    ceph daemon osd.2 config set osd_debug_repop_crash true || return 1
+
+    rados -p rep put test /etc/hosts || return 1
+
+    kill_daemons $dir TERM osd.1 || return 1
+    ceph daemon osd.0 injectdataerr rep test || return 1
+    ceph daemon osd.0 config set bluestore_debug_inject_read_err true || return 1
+    activate_osd $dir 2 || return 1
+
+    sleep 10 # wait for pgs to go active
+
+    kill_daemons $dir KILL osd.0 || return 1
+    kill_daemons $dir KILL osd.2 || return 1
+
+    activate_osd $dir 1 || return 1
+    ceph daemon osd.1 injectdataerr rep test || return 1
+    ceph daemon osd.1 config set bluestore_debug_inject_read_err true || return 1
+
+    activate_osd $dir 2 || return 1
+
+    sleep 10
+
+    kill_daemons $dir KILL osd.2 || return 1
+
+    activate_osd $dir 0 || return 1
+
+    sleep 10
+
+    rados -p rep put test /etc/hosts || return 1
+
+    wait_for_clean || return 1
+}
+
+
+
+main osd-peering "$@"
+
+# Local Variables:
+# compile-command: "cd ../.. ; make -j4 && test/osd/pg-split-merge.sh"
+# End:

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -749,6 +749,7 @@ OPTION(osd_backoff_on_peering, OPT_BOOL)  // [debug] pg peering
 OPTION(osd_debug_crash_on_ignored_backoff, OPT_BOOL) // crash osd if client ignores a backoff; useful for debugging
 OPTION(osd_debug_inject_dispatch_delay_probability, OPT_DOUBLE)
 OPTION(osd_debug_inject_dispatch_delay_duration, OPT_DOUBLE)
+OPTION(osd_debug_repop_crash, OPT_BOOL) 
 OPTION(osd_debug_drop_ping_probability, OPT_DOUBLE)
 OPTION(osd_debug_drop_ping_duration, OPT_INT)
 OPTION(osd_debug_op_order, OPT_BOOL)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3559,6 +3559,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description("Turn up debug levels during shutdown"),
 
+    Option("osd_debug_repop_crash", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("Turn up to simulate repop submit crash"),
+
     Option("osd_debug_crash_on_ignored_backoff", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description(""),

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1052,9 +1052,12 @@ public:
     }
 
     void send_notify(pg_shard_t to,
-		     const pg_notify_t &info, const PastIntervals &pi) {
+		     const pg_notify_t &info,
+		     const PastIntervals &pi,
+		     const bool has_missing) {
       ceph_assert(notify_list);
       (*notify_list)[to.osd].emplace_back(info, pi);
+      (*notify_list)[to.osd].back().first.info.have_missing = has_missing;
     }
   };
 protected:
@@ -2132,7 +2135,7 @@ protected:
       void send_notify(pg_shard_t to,
 		       const pg_notify_t &info, const PastIntervals &pi) {
 	ceph_assert(state->rctx);
-	state->rctx->send_notify(to, info, pi);
+	state->rctx->send_notify(to, info, pi, pg->pg_log.get_missing().have_missing());
       }
     };
     friend class RecoveryMachine;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1010,6 +1010,10 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
 	   << " " << m->logbl.length()
 	   << dendl;
 
+  if (cct->_conf->osd_debug_repop_crash) {
+    assert(0 == "debuging... crash before repop submit");
+  }
+
   // sanity checks
   ceph_assert(m->map_epoch >= get_info().history.same_interval_since);
 
@@ -1065,6 +1069,10 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   pg_missing_tracker_t pmissing = get_parent()->get_local_missing();
   if (pmissing.is_missing(soid)) {
     async = true;
+
+    // sanity checks
+    ceph_assert(!rm->opt.get_num_ops());
+
     dout(30) << __func__ << " is_missing " << pmissing.is_missing(soid) << dendl;
     for (auto &&e: log) {
       dout(30) << " add_next_event entry " << e << dendl;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3207,7 +3207,7 @@ void pg_history_t::generate_test_instances(list<pg_history_t*>& o)
 
 void pg_info_t::encode(ceph::buffer::list &bl) const
 {
-  ENCODE_START(32, 26, bl);
+  ENCODE_START(33, 26, bl);
   encode(pgid.pgid, bl);
   encode(last_update, bl);
   encode(last_complete, bl);
@@ -3227,12 +3227,13 @@ void pg_info_t::encode(ceph::buffer::list &bl) const
   encode(last_backfill, bl);
   encode(last_backfill_bitwise, bl);
   encode(last_interval_started, bl);
+  encode(have_missing, bl);
   ENCODE_FINISH(bl);
 }
 
 void pg_info_t::decode(ceph::buffer::list::const_iterator &bl)
 {
-  DECODE_START(32, bl);
+  DECODE_START(33, bl);
   decode(pgid.pgid, bl);
   decode(last_update, bl);
   decode(last_complete, bl);
@@ -3255,6 +3256,9 @@ void pg_info_t::decode(ceph::buffer::list::const_iterator &bl)
   } else {
     last_interval_started = last_epoch_started;
   }
+  if (struct_v >= 33) {
+    decode(have_missing, bl);
+  }
   DECODE_FINISH(bl);
 }
 
@@ -3269,6 +3273,7 @@ void pg_info_t::dump(Formatter *f) const
   f->dump_int("last_user_version", last_user_version);
   f->dump_stream("last_backfill") << last_backfill;
   f->dump_int("last_backfill_bitwise", (int)last_backfill_bitwise);
+  f->dump_bool("have_missing", have_missing);
   f->open_array_section("purged_snaps");
   for (interval_set<snapid_t>::const_iterator i=purged_snaps.begin();
        i != purged_snaps.end();
@@ -3310,6 +3315,7 @@ void pg_info_t::generate_test_instances(list<pg_info_t*>& o)
   o.back()->log_tail = eversion_t(7, 8);
   o.back()->last_backfill = hobject_t(object_t("objname"), "key", 123, 456, -1, "");
   o.back()->last_backfill_bitwise = true;
+  o.back()->have_missing = false;
   {
     list<pg_stat_t*> s;
     pg_stat_t::generate_test_instances(s);


### PR DESCRIPTION
the analysis of circumstance:

<epoch 16259 [23,13,12,5]/p23>
calc_acting osd.5 14.1a( v 16253'3749 (7924'2167,16253'3749] local-lis/les=16255/16256 n=1 ec=2558/2558 lis/c 16255/16248 les/c/f 16256/16249/0 16259/16259/16259)
calc_acting osd.12 14.1a( v 16253'3749 (7924'2167,16253'3749] local-lis/les=16255/16256 n=1 ec=2558/2558 lis/c 16255/16248 les/c/f 16256/16249/0 16259/16259/16259)
calc_acting osd.13 14.1a( v 16253'3749 (7924'2167,16253'3749] local-lis/les=16255/16256 n=1 ec=2558/2558 lis/c 16255/16248 les/c/f 16256/16249/0 16259/16259/16259)
calc_acting osd.23 14.1a( v 16253'3750 (7924'2167,16253'3750] local-lis/les=16248/16249 n=0 ec=2558/2558 lis/c 16255/16248 les/c/f 16256/16249/0 16259/16259/16259)

when osd.23 do peering as primary, he choose osd.5 as auth log(because his les is smaller).
so he rewind 16253'3750, and mark the obj as missing. then he notify the monitor to update up_thru, and persist his pg_info.
then new osdmap change up set, new peering begin.

<epoch  16260 [26,23,13,12,5]/p26>
calc_acting osd.5 14.1a( v 16253'3749 (7924'2167,16253'3749] local-lis/les=16255/16256 n=1 ec=2558/2558 lis/c 16255/16248 les/c/f 16256/16249/0 16259/16259/16259)
calc_acting osd.12 14.1a( v 16253'3749 (7924'2167,16253'3749] local-lis/les=16255/16256 n=1 ec=2558/2558 lis/c 16255/16248 les/c/f 16256/16249/0 16259/16259/16259)
calc_acting osd.13 14.1a( v 16253'3749 (7924'2167,16253'3749] local-lis/les=16255/16256 n=1 ec=2558/2558 lis/c 16255/16248 les/c/f 16256/16249/0 16259/16259/16259)
calc_acting osd.23 14.1a( v 16253'3750 (7924'2167,16253'3750] local-lis/les=16248/16249 n=0 ec=2558/2558 lis/c 16255/16248 les/c/f 16256/16249/0 16259/16259/16259)
calc_acting osd.26 14.1a( v 16253'3750 (7924'2167,16253'3750] local-lis/les=16248/16249 n=0 ec=2558/2558 lis/c 16255/16248 les/c/f 16256/16249/0 16259/16259/16259)

now osd.26 choose osd.5 as auth log again, and rewind 16253'3750, but in get_missing stage,
he think osd.23's info identical to his ,so skip get_log from osd.23, and mark osd.23 *has no missing*(wrong place).

when pg go active and write the missing object, rep pg will hit "assert(!parent->get_log().get_missing().is_missing(soid))" in ReplicatedBackend::do_repop()

tracker: https://tracker.ceph.com/issues/23031

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

