### PR TITLE
mds: queue inodes into MDCache::export_pin_queue after setattr is journaled

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -417,7 +417,10 @@ void CInode::pop_and_dirty_projected_inode(LogSegment *ls)
   int64_t old_pool = inode.layout.pool_id;
 
   mark_dirty(front.inode.version, ls);
+  bool new_export_pin = inode.export_pin != front.inode.export_pin;
   inode = front.inode;
+  if (new_export_pin)
+    maybe_export_pin(true);
 
   if (inode.is_backtrace_updated())
     mark_dirty_parent(ls, old_pool != inode.layout.pool_id);
@@ -4857,7 +4860,6 @@ void CInode::set_export_pin(mds_rank_t rank)
   ceph_assert(is_dir());
   ceph_assert(is_projected());
   get_projected_inode()->export_pin = rank;
-  maybe_export_pin(true);
 }
 
 mds_rank_t CInode::get_export_pin(bool inherit) const
@@ -4871,15 +4873,14 @@ mds_rank_t CInode::get_export_pin(bool inherit) const
   while (true) {
     if (in->is_system())
       break;
-    const CDentry *pdn = in->get_projected_parent_dn();
+    const CDentry *pdn = in->get_parent_dn();
     if (!pdn)
       break;
-    const mempool_inode *pi = in->get_projected_inode();
     // ignore export pin for unlinked directory
-    if (pi->nlink == 0)
+    if (in->get_inode().nlink == 0)
       break;
-    if (pi->export_pin >= 0)
-      return pi->export_pin;
+    if (in->get_inode().export_pin >= 0)
+      return in->get_inode().export_pin;
 
     if (!inherit)
       break;

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -758,6 +758,7 @@ public:
   int d_type() const { return IFTODT(inode.mode); }
 
   mempool_inode& get_inode() { return inode; }
+  const mempool_inode& get_inode() const { return inode; }
   CDentry* get_parent_dn() { return parent; }
   const CDentry* get_parent_dn() const { return parent; }
   CDentry* get_projected_parent_dn() { return !projected_parent.empty() ? projected_parent.back() : parent; }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6699,8 +6699,6 @@ void Server::_unlink_local(MDRequestRef& mdr, CDentry *dn, CDentry *straydn)
   if (in->is_dir()) {
     ceph_assert(straydn);
     mdcache->project_subtree_rename(in, dn->get_dir(), straydn->get_dir());
-
-    in->maybe_export_pin(true);
   }
 
   journal_and_reply(mdr, 0, dn, le, new C_MDS_unlink_local_finish(this, mdr, dn, straydn));


### PR DESCRIPTION
Recently, when developing the rstat propagation function, we found that when pinning some directory to a specific rank, there exists chances that the directory pinned keep being replicated back and forth between exporting mds and importing mds.

After a series of debugging, we believe this is due to the fact that exporting mds put the inode into "export_pin_queue" before the journaling of "setattr" request and, during the migration, "projected inode" is not replicated. So, when the migration happens before the completion of the "setattr" request's journaling, the importing mds would receive an inode whose export_pin is -1. So, when the importing mds does MDBalancer::tick, it would find that the inode just imported should be pinned to the rank that some of its parent belongs to, which is the exporting mds by a large chance. So there goes a export back from the importing mds to the exporting mds.

This patch makes sure that, when doing inodes' migration, their "export_pin" is indeed the
mds it should be pinned to.

Fixes: http://tracker.ceph.com/issues/37368
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

