### PR TITLE
luminous: tests: qa/tasks/ceph: ignore failure when chown ceph:ceph

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -793,6 +793,16 @@ def cluster(ctx, config):
                     '--monmap', monmap_path,
                 ],
             )
+            mnt_point = DATA_PATH.format(
+                type_='osd', cluster=cluster_name, id_=id_)
+            try:
+                remote.run(args=[
+                    'sudo', 'chown', '-R', 'ceph:ceph', mnt_point
+                ])
+            except run.CommandFailedError as e:
+                # hammer does not have ceph user, so ignore this error
+                log.info('ignoring error when chown ceph:ceph,'
+                         'probably installing hammer: %s', e)
 
     log.info('Reading keys from all nodes...')
     keys_fp = StringIO()
@@ -882,6 +892,14 @@ def cluster(ctx, config):
                     '--keyring', keyring_path,
                 ],
             )
+            try:
+                remote.run(args=[
+                    'sudo', 'chown', '-R', 'ceph:ceph', mnt_point
+                ])
+            except run.CommandFailedError as e:
+                # hammer does not have ceph user, so ignore this error
+                log.info('ignoring error when chown ceph:ceph,'
+                         'probably installing hammer: %s', e)
 
     run.wait(
         mons.run(


### PR DESCRIPTION
http://tracker.ceph.com/issues/37287