### PR TITLE
[RFC] ceph-volume: Make c-v invocable without installing it

### DIFF
--- a/src/ceph-volume/ceph_volume/__main__.py
+++ b/src/ceph-volume/ceph_volume/__main__.py
@@ -1,0 +1,4 @@
+from .main import Volume
+
+if __name__ == "__main__":
+    Volume()


### PR DESCRIPTION
With this change, you can execute c-v like so:

```
$ cd /src/ceph-volume
$ python3 -m ceph_volume inventory --format json
```

My use case is #25236: It would be nice to run `c-v inventory` in a pure vstart environment. Sorry for my ignorance: Is there a better way to do this?

See also: #24775

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>
