### PR TITLE
osdc/Objecter: update op_target_t::paused in _calc_target

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2884,10 +2884,12 @@ int Objecter::_calc_target(op_target_t *t, Connection *con, bool any_change)
     force_resend = true;
   }
 
-  bool unpaused = false;
-  if (t->paused && !target_should_be_paused(t)) {
+  bool unpaused = !target_should_be_paused(t);
+  if (t->paused && unpaused) {
     t->paused = false;
-    unpaused = true;
+  } else {
+    t->paused = !unpaused;
+    unpaused = false;
   }
 
   bool legacy_change =


### PR DESCRIPTION
`LingerOp::target.paused` has no chance to be touched by anyone (see `Objecter::_send_linger`),
then the following bug exists:

1. ceph osd pause
2. rados watch -p pool oid
3. ceph osd unpause
3. the linger op will be in a lost state, i.e., osd op cancelled and the linger
   op will not be resent

Signed-off-by: runsisi <luo.runbing@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

