### PR TITLE
cmake: create WITH_MDS to fix building without MDS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,9 +294,6 @@ if(WITH_QATZIP)
   set(HAVE_QATZIP ${QATZIP_FOUND})
 endif(WITH_QATZIP)
 
-# needs mds and? XXX
-option(WITH_LIBCEPHFS "libcephfs client library" ON)
-
 # key-value store
 option(WITH_KVS "Key value store is here" ON)
 
@@ -494,6 +491,12 @@ if(WITH_RADOSGW)
     message(WARNING "ssl not found: rgw civetweb may fail to dlopen libssl libcrypto")
   endif()  # OPENSSL_FOUND
 endif (WITH_RADOSGW)
+
+#option for ceph-mds
+option(WITH_MDS "build ceph-mds daemon" ON)
+
+# building libcephfs needed for client library
+option(WITH_LIBCEPHFS "build libcephfs client library" ON)
 
 #option for CephFS
 option(WITH_CEPHFS "CephFS is enabled" ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -512,8 +512,9 @@ set_target_properties(ceph-osd PROPERTIES
   POSITION_INDEPENDENT_CODE ${EXE_LINKER_USE_PIE})
 install(TARGETS ceph-osd DESTINATION bin)
 
-if (WITH_CEPHFS)
-  add_subdirectory(mds)
+add_subdirectory(mds)
+
+if(WITH_MDS)
   set(ceph_mds_srcs
     ceph_mds.cc)
   add_executable(ceph-mds ${ceph_mds_srcs})


### PR DESCRIPTION
ceph-dencoder needs libmds, but that depends on CEPHFS
which is not really what it should be.
So include WITH_MDS to determine ceph-mds building

```
/usr/bin/ld: error: unable to find library -lmds
c++: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [src/tools/ceph-dencoder/CMakeFiles/ceph-dencoder.dir/build.make:164: bin/ceph-dencoder] Error 1
```


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug