### PR TITLE
mgr: fix Clang warning on superfluous brackets

### DIFF
--- a/src/mgr/OSDPerfMetricTypes.h
+++ b/src/mgr/OSDPerfMetricTypes.h
@@ -102,7 +102,7 @@ struct denc_traits<OSDPerfMetricKeyDescriptor> {
         return;
       }
       try {
-        d.regex = {d.regex_str.c_str()};
+        d.regex = d.regex_str.c_str();
       } catch (const std::regex_error& e) {
         v.clear();
         return;


### PR DESCRIPTION
```
/home/jenkins/workspace/ceph-master/src/mgr/OSDPerfMetricTypes.h:105:19: warning: braces around scalar initializer [-Wbraced-scalar-init]
        d.regex = {d.regex_str.c_str()};
                  ^~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug