### PR TITLE
luminous:librbd: fix missing unblock_writes if shrink is not allowed

### DIFF
--- a/src/librbd/operation/ResizeRequest.cc
+++ b/src/librbd/operation/ResizeRequest.cc
@@ -118,6 +118,7 @@ Context *ResizeRequest<I>::send_append_op_event() {
 
   if (m_new_size < m_original_size && !m_allow_shrink) {
     ldout(cct, 1) << " shrinking the image is not permitted" << dendl;
+    image_ctx.io_work_queue->unblock_writes();
     this->async_complete(-EINVAL);
     return nullptr;
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/37363