### PR TITLE
luminous: mgr: balancer: python 3 compat fixes

### DIFF
--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -277,7 +277,7 @@ class Module(MgrModule):
         self.log.warn("Handling command: '%s'" % str(command))
         if command['prefix'] == 'balancer status':
             s = {
-                'plans': self.plans.keys(),
+                'plans': list(self.plans.keys()),
                 'active': self.active,
                 'mode': self.get_config('mode', default_mode),
             }


### PR DESCRIPTION
http://tracker.ceph.com/issues/37416

(cherry picked from commit 6dc9554)

```yaml
Conflicts:
  - path: src/pybind/mgr/crash/module.py
    comment: file does not exist in luminous: omitted
```