### PR TITLE
ceph-kvstore-tool: dump fixes

### DIFF
--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -30,6 +30,9 @@ which are as follows:
 :command:`list-crc [prefix]`
     Print CRC of all KV pairs stored with the URL encoded prefix.
 
+:command:`dump [prefix]`
+    Print key and value of all KV pairs stored with the URL encoded prefix.
+
 :command:`exists <prefix> [key]`
     Check if there is any KV pair stored with the URL encoded prefix. If key
     is also specified, check for the key with the prefix instead.

--- a/src/test/cli/ceph-kvstore-tool/help.t
+++ b/src/test/cli/ceph-kvstore-tool/help.t
@@ -4,6 +4,7 @@
   Commands:
     list [prefix]
     list-crc [prefix]
+    dump [prefix]
     exists <prefix> [key]
     get <prefix> <key> [out <file>]
     crc <prefix> <key>

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -336,6 +336,10 @@ int main(int argc, const char *argv[])
     CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
   common_init_finish(g_ceph_context);
 
+  ceph_assert((int)args.size() < argc);
+  for(size_t i=0; i<args.size(); i++)
+    argv[i+1] = args[i];
+  argc = args.size() + 1;
 
   if (args.size() < 3) {
     usage(argv[0]);

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -89,6 +89,7 @@ class StoreTool
 
   uint32_t traverse(const string &prefix,
                     const bool do_crc,
+                    const bool do_value_dump,
                     ostream *out) {
     KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
 
@@ -119,14 +120,22 @@ class StoreTool
       }
       if (out)
         *out << std::endl;
+      if (out && do_value_dump) {
+	bufferptr bp = iter->value_as_ptr();
+	bufferlist value;
+	value.append(bp);
+	ostringstream os;
+	value.hexdump(os);
+	std::cout << os.str() << std::endl;
+      }
       iter->next();
     }
 
     return crc;
   }
 
-  void list(const string &prefix, const bool do_crc) {
-    traverse(prefix, do_crc, &std::cout);
+  void list(const string &prefix, const bool do_crc, const bool do_value_dump) {
+    traverse(prefix, do_crc, do_value_dump, &std::cout);
   }
 
   bool exists(const string &prefix) {
@@ -297,6 +306,7 @@ void usage(const char *pname)
     << "Commands:\n"
     << "  list [prefix]\n"
     << "  list-crc [prefix]\n"
+    << "  dump [prefix]\n"
     << "  exists <prefix> [key]\n"
     << "  get <prefix> <key> [out <file>]\n"
     << "  crc <prefix> <key>\n"
@@ -378,8 +388,13 @@ int main(int argc, const char *argv[])
       prefix = url_unescape(argv[4]);
 
     bool do_crc = (cmd == "list-crc");
+    st.list(prefix, do_crc, false);
 
-    st.list(prefix, do_crc);
+  } else if (cmd == "dump") {
+    string prefix;
+    if (argc > 4)
+      prefix = url_unescape(argv[4]);
+    st.list(prefix, false, true);
 
   } else if (cmd == "exists") {
     string key;
@@ -580,7 +595,7 @@ int main(int argc, const char *argv[])
       return 1;
     }
     std::ofstream fs(argv[4]);
-    uint32_t crc = st.traverse(string(), true, &fs);
+    uint32_t crc = st.traverse(string(), true, false, &fs);
     std::cout << "store at '" << argv[4] << "' crc " << crc << std::endl;
 
   } else if (cmd == "compact") {


### PR DESCRIPTION
Added option dump to print both keys and values from bluestore's rocksdb.