### PR TITLE
rgw: fix set user_data when list bucket

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -80,6 +80,7 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_PG_VER 	RGW_ATTR_PREFIX "pg_ver"
 #define RGW_ATTR_SOURCE_ZONE    RGW_ATTR_PREFIX "source_zone"
 #define RGW_ATTR_TAGS           RGW_ATTR_PREFIX RGW_AMZ_PREFIX "tagging"
+#define RGW_ATTR_USER_DATA  RGW_ATTR_PREFIX "user_data"
 
 #define RGW_ATTR_TEMPURL_KEY1   RGW_ATTR_META_PREFIX "temp-url-key"
 #define RGW_ATTR_TEMPURL_KEY2   RGW_ATTR_META_PREFIX "temp-url-key-2"

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9321,6 +9321,7 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
   string etag;
   string content_type;
   ACLOwner owner;
+  string user_data;
 
   object.meta.size = astate->size;
   object.meta.accounted_size = astate->accounted_size;
@@ -9340,6 +9341,10 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
     if (r < 0) {
       dout(0) << "WARNING: could not decode policy for object: " << obj << dendl;
     }
+  }
+  iter = astate->attrset.find(RGW_ATTR_USER_DATA);
+  if (iter != astate->attrset.end()) {
+    user_data = iter->second.to_str();
   }
 
   if (astate->has_manifest) {
@@ -9364,6 +9369,7 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
   object.meta.content_type = content_type;
   object.meta.owner = owner.get_id().to_str();
   object.meta.owner_display_name = owner.get_display_name();
+  object.meta.user_data = user_data;
 
   // encode suggested updates
   list_state.ver.pool = io_ctx.get_id();
@@ -9378,6 +9384,7 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
     list_state.tag = astate->obj_tag.c_str();
   list_state.meta.owner = owner.get_id().to_str();
   list_state.meta.owner_display_name = owner.get_display_name();
+  list_state.meta.user_data = object.meta.user_data;
 
   list_state.exists = true;
   cls_rgw_encode_suggestion(CEPH_RGW_UPDATE | suggest_flag, list_state, suggested_updates);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -952,6 +952,7 @@ int RGWPutObj_ObjStore_SWIFT::get_params()
     string custom_header = s->cct->_conf->rgw_swift_custom_header;
     if (s->info.env->exists(custom_header.c_str())) {
       user_data = s->info.env->get(custom_header.c_str());
+      s->generic_attrs[RGW_ATTR_USER_DATA] = user_data;
     }
   }
 


### PR DESCRIPTION
when set custom header in swift (put object op) concurrent and at the same time list the bucket, it will result some object failed to set the custom header


```
set rgw_swift_custom_header = HTTP_ONESTSWIFT in ceph.conf and restart rgw
```

```
run list bucket before put object in 200 concurrent
# -*- coding: utf-8 -*-
import sys
import swiftclient
user = 'user1:swift'
key = 'liBTeMBGAINgJFIsNOm9yLL4PhbXgQ2R2MExhPIG'
endpoint = 'http://127.0.0.1:7480'
conn = swiftclient.Connection(
        user=user,
        key=key,
        authurl=endpoint+'/auth',
)
container_name = 'test1'
for data in conn.get_container(container_name)[1]:
  try:
    print '{0}\t{1}\t{2}\t{3}'.format(data['name'], data['bytes'], data['last_modified'], data['user_custom_data'])
  except:
    print 'user_custom_data header not found for obj'

seq 1 1000  | xargs -I{} -P 200  python listswift.py
```

```
run put object 200 concurrent  before list op finish
putswift.py
# -*- coding: utf-8 -*-
import sys
import swiftclient
user = 'user1:swift'
key = 'liBTeMBGAINgJFIsNOm9yLL4PhbXgQ2R2MExhPIG'
endpoint = 'http://127.0.0.1:7480'
conn = swiftclient.Connection(
        user=user,
        key=key,
        authurl=endpoint+'/auth',
)
container_name = 'test1'
conn.put_object(container="test1",obj=sys.argv[1],headers={'onestswift':'red'},contents="xxxxxxxxxxxxxxx")

seq 1 200  | xargs -I{} -P 200  python putswift.py  {}
```

result:
```
    {
        "bytes": 15,
        "hash": "de59bd9061c93855e3fdd416e26f27a6",
        "last_modified": "2018-11-26T14:46:59.882Z",
        "name": "104",
        "user_custom_data": "red"     <= this object set custom header success
    },
    {
        "bytes": 15,
        "hash": "de59bd9061c93855e3fdd416e26f27a6",
        "last_modified": "2018-11-26T14:47:00.067Z",
        "name": "105"        <= this object set custom header failed
    },
    {
        "bytes": 15,
        "hash": "de59bd9061c93855e3fdd416e26f27a6",
        "last_modified": "2018-11-26T14:46:59.930Z",
        "name": "106",
        "user_custom_data": "red"
    },


```



Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>
