### PR TITLE
qa/workunits/rados/test_librados_build.sh: grab files from explicit git branch

### DIFF
--- a/qa/workunits/rados/test_librados_build.sh
+++ b/qa/workunits/rados/test_librados_build.sh
@@ -20,7 +20,7 @@ hello_world_cpp
 "
 BINARIES="${BINARIES_TO_RUN}hello_radosstriper_cpp
 "
-DL_PREFIX="http://git.ceph.com/?p=ceph.git;a=blob_plain;f=examples/librados/"
+DL_PREFIX="http://git.ceph.com/?p=ceph.git;a=blob_plain;hb=master;f=examples/librados/"
 #DL_PREFIX="https://raw.githubusercontent.com/ceph/ceph/master/examples/librados/"
 DESTDIR=$(pwd)
 


### PR DESCRIPTION
The mimic backport of this (which will obviously need to put "mimic", instead of "master", into the git.ceph.com URL) will fix https://tracker.ceph.com/issues/37392

and I will get luminous backport in as well.

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

