### PR TITLE
osd: Fixes failure read object after a truncate+copy-from sequence

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5453,7 +5453,7 @@ int PrimaryLogPG::do_read(OpContext *ctx, OSDOp& osd_op) {
   dout(30) << __func__ << " op.extent.truncate_size: " << op.extent.truncate_size << dendl;
 
   // are we beyond truncate_size?
-  if ( (seq < op.extent.truncate_seq) &&
+  if ( seq && (seq < op.extent.truncate_seq) &&
        (op.extent.offset + op.extent.length > op.extent.truncate_size) &&
        (size > op.extent.truncate_size) )
     size = op.extent.truncate_size;


### PR DESCRIPTION
#Doing a copy-from op after truncating an object isn't working properly.
This can be easily tested using the (kernel client) copy_file_range syscall,
where a read will always fail (a read will always see 0s in the objects copied).

Writes are working, though.  And helped me finding commit e72cc233ec52
("truncate: don't write beyong truncation with old trunc seq"), where an extra
check is done -- oi.truncate_seq must be different from zero.

Fixes: https://tracker.ceph.com/issues/37378
Signed-off-by: Luis Henriques <lhenriques@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

