### PR TITLE
rgw: fix obj can still be deleted even if deleteobject policy is set

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4285,7 +4285,7 @@ int RGWDeleteObj::verify_permission()
     if (r == Effect::Allow)
       return true;
     else if (r == Effect::Deny)
-      return false;
+      return -EACCES;
     else if (usr_policy_res == Effect::Allow)
       return true;
   }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4275,7 +4275,7 @@ int RGWDeleteObj::verify_permission()
                                               rgw::IAM::s3DeleteObjectVersion,
                                               ARN(s->bucket, s->object.name));
     if (usr_policy_res == Effect::Deny) {
-      return false;
+      return -EACCES;
     }
     auto r = s->iam_policy->eval(s->env, *s->auth.identity,
 				 s->object.instance.empty() ?
@@ -4283,11 +4283,11 @@ int RGWDeleteObj::verify_permission()
 				 rgw::IAM::s3DeleteObjectVersion,
 				 ARN(s->bucket, s->object.name));
     if (r == Effect::Allow)
-      return true;
+      return 0;
     else if (r == Effect::Deny)
       return -EACCES;
     else if (usr_policy_res == Effect::Allow)
-      return true;
+      return 0;
   }
 
   if (!verify_bucket_permission_no_policy(this, s, RGW_PERM_WRITE)) {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/37403

Signed-off-by: Enming.Zhang <zvampirem77@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

