### PR TITLE
ceph.in: write bytes to stdout in raw_write()

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -169,7 +169,7 @@ else:
 
 def raw_write(buf):
     sys.stdout.flush()
-    raw_stdout.write(buf)
+    raw_stdout.write(rados.cstr(buf, ''))
 
 
 def osdids():


### PR DESCRIPTION
in python3, sys.stdout.buffer is an io.BufferedWriter, while in python2
`sys.__stdout__` is a plain file. the former only accepts "bytes". so if
we send it a "str", it complains:

TypeError: a bytes-like object is required, not 'str'

it happens when quitting from the interactive mode of ceph CLI. in that
case, `new_style_command()` returns a tuple of `0, '\n', ''`, where the
second element is a str.

in this change, we always send `bytes` to raw_stdout.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
