### PR TITLE
[DNM] Wip bufferlist iterator refactor

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -861,8 +861,10 @@ using namespace ceph;
       return;
     }
     while (p_off > 0) {
-      if (p == ls->end())
+      if (p == ls->end()) {
+	seek(off);
         throw end_of_buffer();
+      }
       if (p_off >= p->length()) {
         // skip this buffer
         p_off -= p->length();
@@ -914,7 +916,6 @@ using namespace ceph;
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy(unsigned len, char *dest)
   {
-    if (p == ls->end()) seek(off);
     while (len > 0) {
       if (p == ls->end())
 	throw end_of_buffer();
@@ -971,8 +972,6 @@ using namespace ceph;
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy(unsigned len, list &dest)
   {
-    if (p == ls->end())
-      seek(off);
     while (len > 0) {
       if (p == ls->end())
 	throw end_of_buffer();
@@ -990,8 +989,6 @@ using namespace ceph;
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy(unsigned len, std::string &dest)
   {
-    if (p == ls->end())
-      seek(off);
     while (len > 0) {
       if (p == ls->end())
 	throw end_of_buffer();
@@ -1010,8 +1007,6 @@ using namespace ceph;
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy_all(list &dest)
   {
-    if (p == ls->end())
-      seek(off);
     while (1) {
       if (p == ls->end())
 	return;
@@ -1550,7 +1545,7 @@ using namespace ceph;
   {
     if (off + len > length())
       throw end_of_buffer();
-    if (last_p.get_off() != off) 
+    if (last_p.end() || last_p.get_off() != off)
       last_p.seek(off);
     last_p.copy(len, dest);
   }
@@ -1559,14 +1554,16 @@ using namespace ceph;
   {
     if (off + len > length())
       throw end_of_buffer();
-    if (last_p.get_off() != off) 
+    if (last_p.end() || last_p.get_off() != off)
       last_p.seek(off);
     last_p.copy(len, dest);
   }
 
   void buffer::list::copy(unsigned off, unsigned len, std::string& dest) const
   {
-    if (last_p.get_off() != off) 
+    if (off + len > length())
+      throw end_of_buffer();
+    if (last_p.end() || last_p.get_off() != off)
       last_p.seek(off);
     return last_p.copy(len, dest);
   }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -839,96 +839,205 @@ using namespace ceph;
 
   template<bool is_const>
   buffer::list::iterator_impl<is_const>::iterator_impl(bl_t *l, unsigned o)
-    : bl(l), ls(&bl->_buffers), off(0), p(ls->begin()), p_off(0)
-  {
+    : bl(l), ls(&bl->_buffers), p(ls->begin()), current(nullptr), limit(nullptr), off_anchor(0) {
+    if (p == ls->end()) {
+      if (o > 0)
+        throw end_of_buffer();
+    } else {
+      if (p->have_raw()) {
+        off_anchor = p->length();
+        current = p->c_str();
+        limit = p->end_c_str();
+      }
+    }
     advance(o);
   }
 
   template<bool is_const>
   buffer::list::iterator_impl<is_const>::iterator_impl(const buffer::list::iterator& i)
-    : iterator_impl<is_const>(i.bl, i.off, i.p, i.p_off) {}
+    : bl(i.bl), ls(&bl->_buffers), p(i.p), current(i.current), limit(i.limit), off_anchor(i.off_anchor) {
+  }
+
+  template<bool is_const>
+  bool buffer::list::iterator_impl<is_const>::end() const {
+    if (unlikely(current >= limit)) {
+      normalize();
+    }
+    bool b = current == limit;
+    if (b) {
+      b = p == ls->end();
+    }
+    return b;
+  }
+
+  /*
+   * As a rule, it should fulfill (current < limit),
+   * however, if end reached (p == ls->end()) then (current == limit).
+   */
+  template<bool is_const>
+  inline void buffer::list::iterator_impl<is_const>::normalize() const
+  {
+    if (likely(current == limit)) {
+      if (p != ls->end()) {
+        //p is already set to new buffer::ptr
+        off_anchor += p->length();
+        current = p->c_str();
+        limit = current + p->length();
+      }
+    }
+  }
+
+  /*
+   Fixes current, limit and p so current < limit.
+   If less then _needed_ bytes are available, throws end_of_buffer.
+   Needs to be invoked in stable state.
+   */
+  template<bool is_const>
+  inline void buffer::list::iterator_impl<is_const>::require(unsigned needed) const {
+    if (current >= limit)
+      normalize();
+
+    if (unlikely(get_off() + needed > bl->length())) {
+      throw end_of_buffer();
+    }
+  }
+
+  template<bool is_const>
+  inline void buffer::list::iterator_impl<is_const>::next()
+  {
+    if (current == limit) {
+      p++;
+      if (p != ls->end()) {
+        off_anchor += p->length();
+        current = p->c_str();
+        limit = current + p->length();
+      }
+    }
+  }
+
+
+   /*
+    * Contract on p, current, limit and off_anchor
+    * 1. Generally, current < limit.
+    * If reading from current had to make current == limit, then p is to go ahead.
+    * So, when current == limit it means that p is already on next buffer::ptr,
+    * and reload current:=p->c_str(), limit:=p->end_c_str(), and off_anchor fixed.
+    *
+    * 2. END
+    * When p == ls->end() then current == limit; ofs = off_anchor.
+    *
+    * 3. Reading exactly last cnt bytes, e.g. current+cnt == limit,
+    * p is to be moved ahead on prepare step, including fixing of off_anchor.
+    * So, in case that (p != ls->end() && current == limit) values of current and limit
+    * must be loaded from p.
+    *
+    */
 
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::advance(unsigned o)
   {
-    //cout << this << " advance " << o << " from " << off
-    //     << " (p_off " << p_off << " in " << p->length() << ")"
-    //     << std::endl;
-
-    p_off += o;
-
-    if (!o) {
-      return;
+    if (likely(current + o < limit)) {
+      current +=o;
+    } else {
+      if (o > 0)
+        advance_internal(o);
     }
-    while (p_off > 0) {
-      if (p == ls->end()) {
-	seek(off);
-        throw end_of_buffer();
-      }
-      if (p_off >= p->length()) {
-        // skip this buffer
-        p_off -= p->length();
+  }
+
+  //this is intended for cases when current+o>limit
+  template<bool is_const>
+  void buffer::list::iterator_impl<is_const>::advance_internal(unsigned o)
+  {
+    require(o);
+    current += o;
+    if (o > 0) {
+      while (current > limit) {
         p++;
-      } else {
-        // somewhere in this buffer!
-        break;
+        ceph_assert(p != ls->end());
+        off_anchor += p->length();
+        current = p->c_str() + (current - limit);
+        limit = p->end_c_str();
+      }
+      if (current == limit) {
+        p++;
+        if (p != ls->end()) {
+          off_anchor += p->length();
+          current = p->c_str();
+          limit = p->end_c_str();
+        }
       }
     }
-    off += o;
   }
 
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::seek(unsigned o)
   {
     p = ls->begin();
-    off = p_off = 0;
+    off_anchor = 0;
+    current = limit = nullptr;
     advance(o);
   }
 
   template<bool is_const>
   char buffer::list::iterator_impl<is_const>::operator*() const
   {
-    if (p == ls->end())
-      throw end_of_buffer();
-    return (*p)[p_off];
+    if (unlikely(current >= limit)) {
+      require(1);
+    }
+    return *current;
   }
 
   template<bool is_const>
   buffer::list::iterator_impl<is_const>&
   buffer::list::iterator_impl<is_const>::operator++()
   {
-    if (p == ls->end())
-      throw end_of_buffer();
-    advance(1u);
+    if (likely(current + 1 < limit)) {
+      current++;
+    } else {
+      advance(1u);
+    }
     return *this;
   }
 
   template<bool is_const>
   buffer::ptr buffer::list::iterator_impl<is_const>::get_current_ptr() const
   {
-    if (p == ls->end())
-      throw end_of_buffer();
-    return ptr(*p, p_off, p->length() - p_off);
+    if (unlikely(current >= limit)) {
+      normalize();
+      if (p == ls->end()) {
+        throw end_of_buffer();
+      }
+    }
+    return ptr(*p, current - p->c_str(), limit - current);
   }
 
   // copy data out.
   // note that these all _append_ to dest!
   template<bool is_const>
-  void buffer::list::iterator_impl<is_const>::copy(unsigned len, char *dest)
+  void buffer::list::iterator_impl<is_const>::copy_(unsigned len, char *dest)
   {
-    while (len > 0) {
-      if (p == ls->end())
-	throw end_of_buffer();
-      ceph_assert(p->length() > 0);
+    if (likely(current + len < limit)) {
+      memcpy(dest, current, len);
+      current += len;
+    } else {
+      require(len);
 
-      unsigned howmuch = p->length() - p_off;
-      if (len < howmuch) howmuch = len;
-      p->copy_out(p_off, howmuch, dest);
-      dest += howmuch;
-
-      len -= howmuch;
-      advance(howmuch);
+      while (current + len > limit) {
+        memcpy(dest, current, limit - current);
+        dest += (limit - current);
+        len -= (limit - current);
+        p++;
+        off_anchor += p->length();
+        current = p->c_str();
+        limit = current + p->length();
+        }
+      if (len > 0) {
+        memcpy(dest, current, len);
+        current += len;
+        next();
+      }
     }
+    return;
   }
 
   template<bool is_const>
@@ -940,31 +1049,32 @@ using namespace ceph;
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy_deep(unsigned len, ptr &dest)
   {
-    if (!len) {
-      return;
+    if (unlikely(current >= limit))
+      normalize();
+    if (len > 0) {
+      dest = create(len);
+      copy(len, dest.c_str());
     }
-    if (p == ls->end())
-      throw end_of_buffer();
-    ceph_assert(p->length() > 0);
-    dest = create(len);
-    copy(len, dest.c_str());
   }
+
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy_shallow(unsigned len,
 							   ptr &dest)
   {
+    if (unlikely(current >= limit))
+      normalize();
     if (!len) {
       return;
     }
     if (p == ls->end())
       throw end_of_buffer();
     ceph_assert(p->length() > 0);
-    unsigned howmuch = p->length() - p_off;
+    unsigned howmuch = limit - current;
     if (howmuch < len) {
       dest = create(len);
       copy(len, dest.c_str());
     } else {
-      dest = ptr(*p, p_off, len);
+      dest = ptr(*p, current - p->c_str(), len);
       advance(len);
     }
   }
@@ -972,15 +1082,10 @@ using namespace ceph;
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy(unsigned len, list &dest)
   {
+    require(len);
     while (len > 0) {
-      if (p == ls->end())
-	throw end_of_buffer();
-
-      unsigned howmuch = p->length() - p_off;
-      if (len < howmuch)
-	howmuch = len;
-      dest.append(*p, p_off, howmuch);
-
+      unsigned howmuch = std::min<unsigned>(limit - current, len);
+      dest.append(*p, current - p->c_str(), howmuch);
       len -= howmuch;
       advance(howmuch);
     }
@@ -989,34 +1094,32 @@ using namespace ceph;
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy(unsigned len, std::string &dest)
   {
-    while (len > 0) {
-      if (p == ls->end())
-	throw end_of_buffer();
-
-      unsigned howmuch = p->length() - p_off;
-      const char *c_str = p->c_str();
-      if (len < howmuch)
-	howmuch = len;
-      dest.append(c_str + p_off, howmuch);
-
-      len -= howmuch;
-      advance(howmuch);
-    }
+    if (len > 0) {
+      require(len);
+      while(current + len > limit) {
+        dest.append(current, limit - current);
+        len -= (limit - current);
+        p++;
+        ceph_assert(p != ls->end());
+        off_anchor += p->length();
+        current = p->c_str();
+        limit = current + p->length();
+        }
+      ceph_assert(len <= limit - current);
+      dest.append(current, len);
+      current += len;
+      next();
+      }
   }
 
   template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy_all(list &dest)
   {
-    while (1) {
-      if (p == ls->end())
-	return;
-      ceph_assert(p->length() > 0);
-
-      unsigned howmuch = p->length() - p_off;
-      const char *c_str = p->c_str();
-      dest.append(c_str + p_off, howmuch);
-
-      advance(howmuch);
+    if (current >= limit)
+      normalize();
+    while (p != ls->end()) {
+      dest.append(current, limit - current);
+      advance((unsigned)(limit - current));
     }
   }
 
@@ -1024,20 +1127,22 @@ using namespace ceph;
   size_t buffer::list::iterator_impl<is_const>::get_ptr_and_advance(
     size_t want, const char **data)
   {
+    normalize();
     if (p == ls->end()) {
-      seek(off);
-      if (p == ls->end()) {
-	return 0;
-      }
+      seek(get_off());
+      if (p == ls->end())
+        return 0;
     }
-    *data = p->c_str() + p_off;
-    size_t l = std::min<size_t>(p->length() - p_off, want);
-    p_off += l;
-    if (p_off == p->length()) {
-      ++p;
-      p_off = 0;
+
+    *data = current;
+    size_t l = want;
+    if (current + want >= limit) {
+      l = limit - current;
+      current += l;
+      next();
+      } else {
+      current += l;
     }
-    off += l;
     return l;
   }
 
@@ -1064,28 +1169,9 @@ using namespace ceph;
   buffer::list::iterator::iterator(bl_t *l, unsigned o)
     : iterator_impl(l, o)
   {}
-
-  buffer::list::iterator::iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po)
-    : iterator_impl(l, o, ip, po)
+  buffer::list::iterator::iterator(bl_t *l, seek_end)
+      : iterator_impl(l, seek_end{})
   {}
-
-  void buffer::list::iterator::advance(unsigned o)
-  {
-    buffer::list::iterator_impl<false>::advance(o);
-  }
-
-  void buffer::list::iterator::seek(unsigned o)
-  {
-    buffer::list::iterator_impl<false>::seek(o);
-  }
-
-  char buffer::list::iterator::operator*()
-  {
-    if (p == ls->end()) {
-      throw end_of_buffer();
-    }
-    return (*p)[p_off];
-  }
 
   buffer::list::iterator& buffer::list::iterator::operator++()
   {
@@ -1093,49 +1179,10 @@ using namespace ceph;
     return *this;
   }
 
-  buffer::ptr buffer::list::iterator::get_current_ptr()
+  buffer::ptr buffer::list::iterator::get_current_ptr() const
   {
-    if (p == ls->end()) {
-      throw end_of_buffer();
-    }
-    return ptr(*p, p_off, p->length() - p_off);
+    return buffer::list::iterator_impl<false>::get_current_ptr();
   }
-
-  void buffer::list::iterator::copy(unsigned len, char *dest)
-  {
-    return buffer::list::iterator_impl<false>::copy(len, dest);
-  }
-
-  void buffer::list::iterator::copy(unsigned len, ptr &dest)
-  {
-    return buffer::list::iterator_impl<false>::copy_deep(len, dest);
-  }
-
-  void buffer::list::iterator::copy_deep(unsigned len, ptr &dest)
-  {
-    buffer::list::iterator_impl<false>::copy_deep(len, dest);
-  }
-
-  void buffer::list::iterator::copy_shallow(unsigned len, ptr &dest)
-  {
-    buffer::list::iterator_impl<false>::copy_shallow(len, dest);
-  }
-
-  void buffer::list::iterator::copy(unsigned len, list &dest)
-  {
-    buffer::list::iterator_impl<false>::copy(len, dest);
-  }
-
-  void buffer::list::iterator::copy(unsigned len, std::string &dest)
-  {
-    buffer::list::iterator_impl<false>::copy(len, dest);
-  }
-
-  void buffer::list::iterator::copy_all(list &dest)
-  {
-    buffer::list::iterator_impl<false>::copy_all(dest);
-  }
-
   void buffer::list::iterator::copy_in(unsigned len, const char *src)
   {
     copy_in(len, src, true);
@@ -1145,17 +1192,15 @@ using namespace ceph;
   void buffer::list::iterator::copy_in(unsigned len, const char *src, bool crc_reset)
   {
     // copy
-    if (p == ls->end())
-      seek(off);
+    if (p == ls->end()) {
+      seek(get_off());
+    }
+    require(len);
     while (len > 0) {
-      if (p == ls->end())
-	throw end_of_buffer();
-      
-      unsigned howmuch = p->length() - p_off;
+      unsigned howmuch = limit - current;
       if (len < howmuch)
-	howmuch = len;
-      p->copy_in(p_off, howmuch, src, crc_reset);
-	
+        howmuch = len;
+      p->copy_in(current - p->c_str(), howmuch, src, crc_reset);
       src += howmuch;
       len -= howmuch;
       advance(howmuch);
@@ -1165,7 +1210,7 @@ using namespace ceph;
   void buffer::list::iterator::copy_in(unsigned len, const list& otherl)
   {
     if (p == ls->end())
-      seek(off);
+      seek(get_off());
     unsigned left = len;
     for (std::list<ptr>::const_iterator i = otherl._buffers.begin();
 	 i != otherl._buffers.end();
@@ -1578,14 +1623,14 @@ using namespace ceph;
     if (off + len > length())
       throw end_of_buffer();
     
-    if (last_p.get_off() != off) 
+    if (last_p.end() || last_p.get_off() != off)
       last_p.seek(off);
     last_p.copy_in(len, src, crc_reset);
   }
 
   void buffer::list::copy_in(unsigned off, unsigned len, const list& src)
   {
-    if (last_p.get_off() != off) 
+    if (last_p.end() || last_p.get_off() != off)
       last_p.seek(off);
     last_p.copy_in(len, src);
   }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -61,6 +61,7 @@
 #endif
 
 #include "inline_memory.h"
+#include "common/likely.h"
 
 #if __GNUC__ >= 4
   #define CEPH_BUFFER_API  __attribute__ ((visibility ("default")))
@@ -397,6 +398,7 @@ namespace buffer CEPH_BUFFER_API {
     class iterator;
 
   private:
+    class seek_end{};
     template <bool is_const>
     class CEPH_BUFFER_API iterator_impl
       : public std::iterator<std::forward_iterator_tag, char> {
@@ -412,34 +414,41 @@ namespace buffer CEPH_BUFFER_API {
 					typename std::list<ptr>::iterator>::type list_iter_t;
       bl_t* bl;
       list_t* ls;  // meh.. just here to avoid an extra pointer dereference..
-      unsigned off; // in bl
       list_iter_t p;
-      unsigned p_off;   // in *p
+      mutable const char* current;
+      mutable const char* limit;
+      mutable unsigned off_anchor;
       friend class iterator_impl<true>;
 
     public:
       // constructor.  position.
       iterator_impl()
-	: bl(0), ls(0), off(0), p_off(0) {}
+	: bl(0), ls(0) , current(nullptr), limit(nullptr), off_anchor(0)
+      {}
       iterator_impl(bl_t *l, unsigned o=0);
-      iterator_impl(bl_t *l, unsigned o, list_iter_t ip, unsigned po)
-	: bl(l), ls(&bl->_buffers), off(o), p(ip), p_off(po) {}
+      iterator_impl(bl_t *l, seek_end)
+        : bl(l), ls(&bl->_buffers), p(ls->end()), current(nullptr), limit(nullptr), off_anchor(bl->_len)
+      {}
       iterator_impl(const list::iterator& i);
 
       /// get current iterator offset in buffer::list
-      unsigned get_off() const { return off; }
+      unsigned get_off() const {
+        return off_anchor - (limit - current);
+      }
       
       /// get number of bytes remaining from iterator position to the end of the buffer::list
-      unsigned get_remaining() const { return bl->length() - off; }
+      unsigned get_remaining() const { return bl->length() - get_off(); }
 
       /// true if iterator is at the end of the buffer::list
-      bool end() const {
-	return p == ls->end();
-	//return off == bl->length();
-      }
-
+      bool end() const;
       void advance(int o) = delete;
       void advance(unsigned o);
+    protected:
+      void normalize() const;
+      void require(unsigned s) const;
+      void advance_internal(unsigned o);
+      void next();
+    public:
       void advance(size_t o) { advance(static_cast<unsigned>(o)); }
       void seek(unsigned o);
       char operator*() const;
@@ -450,7 +459,15 @@ namespace buffer CEPH_BUFFER_API {
 
       // copy data out.
       // note that these all _append_ to dest!
-      void copy(unsigned len, char *dest);
+      void copy(unsigned len, char *dest) {
+        if (likely(current + len < limit)) {
+          memcpy(dest, current, len);
+          current += len;
+        } else {
+          copy_(len, dest);
+        }
+      }
+      void copy_(unsigned len, char *dest);
       // deprecated, use copy_deep()
       void copy(unsigned len, ptr &dest) __attribute__((deprecated));
       void copy_deep(unsigned len, ptr &dest);
@@ -459,6 +476,7 @@ namespace buffer CEPH_BUFFER_API {
       void copy(unsigned len, std::string &dest);
       void copy_all(list &dest);
 
+    public:
       // get a pointer to the currenet iterator position, return the
       // number of bytes we can read from that position (up to want),
       // and advance the iterator by that amount.
@@ -484,27 +502,10 @@ namespace buffer CEPH_BUFFER_API {
     public:
       iterator() = default;
       iterator(bl_t *l, unsigned o=0);
-      iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po);
+      iterator(bl_t *l, seek_end);
 
-      void advance(int o) = delete;
-      void advance(unsigned o);
-      void advance(size_t o) { advance(static_cast<unsigned>(o)); }
-
-      void seek(unsigned o);
-      using iterator_impl<false>::operator*;
-      char operator*();
       iterator& operator++();
-      ptr get_current_ptr();
-
-      // copy data out
-      void copy(unsigned len, char *dest);
-      // deprecated, use copy_deep()
-      void copy(unsigned len, ptr &dest) __attribute__((deprecated));
-      void copy_deep(unsigned len, ptr &dest);
-      void copy_shallow(unsigned len, ptr &dest);
-      void copy(unsigned len, list &dest);
-      void copy(unsigned len, std::string &dest);
-      void copy_all(list &dest);
+      ptr get_current_ptr() const;
 
       // copy data in
       void copy_in(unsigned len, const char *src);
@@ -512,10 +513,10 @@ namespace buffer CEPH_BUFFER_API {
       void copy_in(unsigned len, const list& otherl);
 
       bool operator==(const iterator& rhs) const {
-	return bl == rhs.bl && off == rhs.off;
+	return bl == rhs.bl && get_off() == rhs.get_off();
       }
       bool operator!=(const iterator& rhs) const {
-	return bl != rhs.bl || off != rhs.off;
+	return bl != rhs.bl || get_off() != rhs.get_off();
       }
     };
 
@@ -874,7 +875,7 @@ namespace buffer CEPH_BUFFER_API {
       return iterator(this, 0);
     }
     iterator end() {
-      return iterator(this, _len, _buffers.end(), 0);
+      return iterator(this, seek_end{});
     }
 
     const_iterator begin() const {
@@ -884,7 +885,7 @@ namespace buffer CEPH_BUFFER_API {
       return begin();
     }
     const_iterator end() const {
-      return const_iterator(this, _len, _buffers.end(), 0);
+      return const_iterator(this, seek_end{});
     }
 
     // crope lookalikes.

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -459,7 +459,7 @@ namespace buffer CEPH_BUFFER_API {
 
       // copy data out.
       // note that these all _append_ to dest!
-      void copy(unsigned len, char *dest) {
+      void copy(unsigned len, char *dest) __attribute__((always_inline)) {
         if (likely(current + len < limit)) {
           memcpy(dest, current, len);
           current += len;

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -76,9 +76,12 @@ inline void decode_raw(T& t, bufferlist::const_iterator &p)
 {
   p.copy(sizeof(t), (char*)&t);
 }
+template<class T>
+inline void decode_raw(T& t, bufferlist::const_iterator &p) __attribute__((always_inline));
 
 #define WRITE_RAW_ENCODER(type)						\
   inline void encode(const type &v, ::ceph::bufferlist& bl, uint64_t features=0) { ::ceph::encode_raw(v, bl); } \
+  inline void decode(type &v, ::ceph::bufferlist::const_iterator& p)  __attribute__((always_inline)); \
   inline void decode(type &v, ::ceph::bufferlist::const_iterator& p) { ::ceph::decode_raw(v, p); }
 
 WRITE_RAW_ENCODER(__u8)
@@ -114,6 +117,7 @@ inline void decode(bool &v, bufferlist::const_iterator& p) {
     e = v;                                                              \
     ::ceph::encode_raw(e, bl);						\
   }									\
+  inline void decode(type &v, ::ceph::bufferlist::const_iterator& p) __attribute__((always_inline)); \
   inline void decode(type &v, ::ceph::bufferlist::const_iterator& p) {	\
     ceph_##etype e;							\
     ::ceph::decode_raw(e, p);						\

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1008,7 +1008,10 @@ TEST(BufferListIterator, operator_star) {
     bufferlist::iterator i(&bl);
     EXPECT_EQ('A', *i);
     EXPECT_THROW(i.advance(200u), buffer::end_of_buffer);
-    EXPECT_THROW(*i, buffer::end_of_buffer);
+    //
+    // demonstrates that it seeks back to offset if p == ls->end()
+    //
+    EXPECT_EQ('A', *i);
   }
 }
 


### PR DESCRIPTION
Refactor of bufferlist::iterator to speed up paths related to decode() of primitive types.
Unsuccessful, does not yield speed improvements.