### PR TITLE
[RFC] rgw: cleanups for system object interfaces

### DIFF
--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -364,7 +364,7 @@ int read_history(RGWRados *store, RGWMetadataLogHistory *state,
   auto& pool = store->svc.zone->get_zone_params().log_pool;
   const auto& oid = RGWMetadataLogHistory::oid;
   bufferlist bl;
-  int ret = rgw_get_system_obj(store, obj_ctx, pool, oid, bl, objv_tracker, nullptr);
+  int ret = rgw_get_system_obj(obj_ctx, pool, oid, bl, objv_tracker, nullptr);
   if (ret < 0) {
     return ret;
   }
@@ -804,9 +804,8 @@ int RGWMetadataManager::prepare_mutate(RGWRados *store,
   bufferlist bl;
   real_time orig_mtime;
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
-  int ret = rgw_get_system_obj(store, obj_ctx, pool, oid,
-                               bl, objv_tracker, &orig_mtime,
-                               nullptr, nullptr);
+  int ret = rgw_get_system_obj(obj_ctx, pool, oid, bl, objv_tracker,
+                               &orig_mtime, nullptr, nullptr);
   if (ret < 0 && ret != -ENOENT) {
     return ret;
   }

--- a/src/rgw/rgw_pubsub.h
+++ b/src/rgw/rgw_pubsub.h
@@ -596,11 +596,8 @@ template <class T>
 int RGWUserPubSub::read(const rgw_raw_obj& obj, T *result, RGWObjVersionTracker *objv_tracker)
 {
   bufferlist bl;
-  int ret = rgw_get_system_obj(store, obj_ctx,
-                               obj.pool, obj.oid,
-                               bl,
-                               objv_tracker,
-                               nullptr, nullptr, nullptr);
+  int ret = rgw_get_system_obj(obj_ctx, obj.pool, obj.oid, bl,
+                               objv_tracker, nullptr, nullptr, nullptr);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8149,9 +8149,9 @@ int RGWRados::get_bucket_instance_from_oid(RGWSysObjectCtx& obj_ctx, const strin
 
   bufferlist epbl;
 
-  int ret = rgw_get_system_obj(this, obj_ctx, domain_root,
-			       oid, epbl, &info.objv_tracker, pmtime, pattrs,
-			       cache_info, refresh_version);
+  int ret = rgw_get_system_obj(obj_ctx, domain_root, oid, epbl,
+                               &info.objv_tracker, pmtime, pattrs,
+                               cache_info, refresh_version);
   if (ret < 0) {
     return ret;
   }
@@ -8181,7 +8181,7 @@ int RGWRados::get_bucket_entrypoint_info(RGWSysObjectCtx& obj_ctx,
   string bucket_entry;
 
   rgw_make_bucket_entry_name(tenant_name, bucket_name, bucket_entry);
-  int ret = rgw_get_system_obj(this, obj_ctx, svc.zone->get_zone_params().domain_root,
+  int ret = rgw_get_system_obj(obj_ctx, svc.zone->get_zone_params().domain_root,
 			       bucket_entry, bl, objv_tracker, pmtime, pattrs,
 			       cache_info, refresh_version);
   if (ret < 0) {

--- a/src/rgw/rgw_role.cc
+++ b/src/rgw/rgw_role.cc
@@ -305,7 +305,7 @@ int RGWRole::read_id(const string& role_name, const string& tenant, string& role
   bufferlist bl;
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
 
-  int ret = rgw_get_system_obj(store, obj_ctx, pool, oid, bl, NULL, NULL);
+  int ret = rgw_get_system_obj(obj_ctx, pool, oid, bl, NULL, NULL);
   if (ret < 0) {
     return ret;
   }
@@ -331,7 +331,7 @@ int RGWRole::read_info()
   bufferlist bl;
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
 
-  int ret = rgw_get_system_obj(store, obj_ctx, pool, oid, bl, NULL, NULL);
+  int ret = rgw_get_system_obj(obj_ctx, pool, oid, bl, NULL, NULL);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: failed reading role info from pool: " << pool.name <<
                   ": " << id << ": " << cpp_strerror(-ret) << dendl;
@@ -358,7 +358,7 @@ int RGWRole::read_name()
   bufferlist bl;
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
 
-  int ret = rgw_get_system_obj(store, obj_ctx, pool, oid, bl, NULL, NULL);
+  int ret = rgw_get_system_obj(obj_ctx, pool, oid, bl, NULL, NULL);
   if (ret < 0) {
     ldout(cct, 0) << "ERROR: failed reading role name from pool: " << pool.name << ": "
                   << name << ": " << cpp_strerror(-ret) << dendl;

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -145,18 +145,12 @@ int rgw_get_system_obj(RGWSysObjectCtx& obj_ctx, const rgw_pool& pool,
 
   int ret = 0;
   do {
-    auto rop = sysobj.rop();
-
-    ret = rop.set_attrs(pattrs)
-             .set_last_mod(pmtime)
-             .set_objv_tracker(objv_tracker)
-             .stat(null_yield);
-    if (ret < 0)
-      return ret;
-
-    ret = rop.set_cache_info(cache_info)
-             .set_refresh_version(refresh_version)
-             .read(&bl, null_yield);
+    ret = sysobj.rop().set_attrs(pattrs)
+                      .set_last_mod(pmtime)
+                      .set_objv_tracker(objv_tracker)
+                      .set_cache_info(cache_info)
+                      .set_refresh_version(refresh_version)
+                      .read(&bl, null_yield);
     if (ret == -ECANCELED) {
       /* raced, restart */
       if (!original_readv.empty()) {

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -24,8 +24,10 @@ int rgw_init_ioctx(librados::Rados *rados, const rgw_pool& pool,
 
 int rgw_put_system_obj(RGWRados *rgwstore, const rgw_pool& pool, const string& oid, bufferlist& data, bool exclusive,
                        RGWObjVersionTracker *objv_tracker, real_time set_mtime, map<string, bufferlist> *pattrs = NULL);
-int rgw_get_system_obj(RGWRados *rgwstore, RGWSysObjectCtx& obj_ctx, const rgw_pool& pool, const string& key, bufferlist& bl,
-                       RGWObjVersionTracker *objv_tracker, real_time *pmtime, map<string, bufferlist> *pattrs = NULL,
+int rgw_get_system_obj(RGWSysObjectCtx& obj_ctx, const rgw_pool& pool,
+                       const string& key, bufferlist& bl,
+                       RGWObjVersionTracker *objv_tracker, real_time *pmtime,
+                       map<string, bufferlist> *pattrs = NULL,
                        rgw_cache_entry_info *cache_info = NULL,
 		       boost::optional<obj_version> refresh_version = boost::none);
 int rgw_delete_system_obj(RGWRados *rgwstore, const rgw_pool& pool, const string& oid,

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -280,7 +280,7 @@ int rgw_get_user_info_from_index(RGWRados * const store,
   RGWUID uid;
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
 
-  int ret = rgw_get_system_obj(store, obj_ctx, pool, key, bl, NULL, &e.mtime);
+  int ret = rgw_get_system_obj(obj_ctx, pool, key, bl, NULL, &e.mtime);
   if (ret < 0)
     return ret;
 
@@ -326,7 +326,8 @@ int rgw_get_user_info_by_uid(RGWRados *store,
 
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
   string oid = uid.to_str();
-  int ret = rgw_get_system_obj(store, obj_ctx, store->svc.zone->get_zone_params().user_uid_pool, oid, bl, objv_tracker, pmtime, pattrs, cache_info);
+  int ret = rgw_get_system_obj(obj_ctx, store->svc.zone->get_zone_params().user_uid_pool,
+                               oid, bl, objv_tracker, pmtime, pattrs, cache_info);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/services/svc_sys_obj.cc
+++ b/src/rgw/services/svc_sys_obj.cc
@@ -42,13 +42,9 @@ int RGWSI_SysObj::Obj::ROp::read(int64_t ofs, int64_t end, bufferlist *bl,
   RGWSI_SysObj_Core *svc = source.core_svc;
   rgw_raw_obj& obj = source.get_obj();
 
-  return svc->read(source.get_ctx(), state,
-                   objv_tracker,
-                   obj, bl, ofs, end,
-                   attrs,
-		   raw_attrs,
-                   cache_info,
-                   refresh_version, y);
+  return svc->read(source.get_ctx(), state, objv_tracker,
+                   obj, obj_size, lastmod, bl, ofs, end, attrs, raw_attrs,
+                   cache_info, refresh_version, y);
 }
 
 int RGWSI_SysObj::Obj::ROp::get_attr(const char *name, bufferlist *dest,

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -337,8 +337,9 @@ int RGWSI_SysObj_Cache::write_data(const rgw_raw_obj& obj,
   return ret;
 }
 
-int RGWSI_SysObj_Cache::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *pepoch,
-                                 map<string, bufferlist> *attrs, bufferlist *first_chunk,
+int RGWSI_SysObj_Cache::raw_stat(const rgw_raw_obj& obj, uint64_t *psize,
+                                 real_time *pmtime, uint64_t *pepoch,
+                                 map<string, bufferlist> *attrs,
                                  RGWObjVersionTracker *objv_tracker,
                                  optional_yield y)
 {
@@ -368,8 +369,8 @@ int RGWSI_SysObj_Cache::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_t
       objv_tracker->read_version = info.version;
     goto done;
   }
-  r = RGWSI_SysObj_Core::raw_stat(obj, &size, &mtime, &epoch, &info.xattrs,
-                                  first_chunk, objv_tracker, y);
+  r = RGWSI_SysObj_Core::raw_stat(obj, &size, &mtime, &epoch,
+                                  &info.xattrs, objv_tracker, y);
   if (r < 0) {
     if (r == -ENOENT) {
       info.status = r;

--- a/src/rgw/services/svc_sys_obj_cache.h
+++ b/src/rgw/services/svc_sys_obj_cache.h
@@ -42,6 +42,7 @@ protected:
            GetObjState& read_state,
            RGWObjVersionTracker *objv_tracker,
            const rgw_raw_obj& obj,
+           uint64_t *psize, real_time *pmtime,
            bufferlist *bl, off_t ofs, off_t end,
            map<string, bufferlist> *attrs,
 	   bool raw_attrs,

--- a/src/rgw/services/svc_sys_obj_cache.h
+++ b/src/rgw/services/svc_sys_obj_cache.h
@@ -33,8 +33,8 @@ protected:
 
   int do_start() override;
 
-  int raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch,
-               map<string, bufferlist> *attrs, bufferlist *first_chunk,
+  int raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime,
+               uint64_t *epoch, map<string, bufferlist> *attrs,
                RGWObjVersionTracker *objv_tracker,
                optional_yield y) override;
 

--- a/src/rgw/services/svc_sys_obj_cache.h
+++ b/src/rgw/services/svc_sys_obj_cache.h
@@ -91,10 +91,9 @@ protected:
   void set_enabled(bool status);
 
 public:
-  RGWSI_SysObj_Cache(CephContext *cct) : RGWSI_SysObj_Core(cct) {
-    cache.set_ctx(cct);
-  }
-
+  RGWSI_SysObj_Cache(CephContext *cct)
+    : RGWSI_SysObj_Core(cct), cache(cct)
+  {}
   bool chain_cache_entry(std::initializer_list<rgw_cache_entry_info *> cache_info_entries,
                          RGWChainedCache::Entry *chained_entry);
   void register_chained_cache(RGWChainedCache *cc);

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -60,7 +60,7 @@ int RGWSI_SysObj_Core::get_system_obj_state_impl(RGWSysObjectCtxBase *rctx,
   }
 
   RGWSysObjState *s = rctx->get_state(obj);
-  ldout(cct, 20) << "get_system_obj_state: rctx=" << (void *)rctx << " obj=" << obj << " state=" << (void *)s << " s->prefetch_data=" << s->prefetch_data << dendl;
+  ldout(cct, 20) << "get_system_obj_state: rctx=" << (void *)rctx << " obj=" << obj << " state=" << (void *)s << dendl;
   *state = s;
   if (s->has_attrs) {
     return 0;
@@ -68,8 +68,8 @@ int RGWSI_SysObj_Core::get_system_obj_state_impl(RGWSysObjectCtxBase *rctx,
 
   s->obj = obj;
 
-  int r = raw_stat(obj, &s->size, &s->mtime, &s->epoch, &s->attrset,
-                   (s->prefetch_data ? &s->data : nullptr), objv_tracker, y);
+  int r = raw_stat(obj, &s->size, &s->mtime, &s->epoch,
+                   &s->attrset, objv_tracker, y);
   if (r == -ENOENT) {
     s->exists = false;
     s->has_attrs = true;
@@ -107,8 +107,9 @@ int RGWSI_SysObj_Core::get_system_obj_state(RGWSysObjectCtxBase *rctx,
   return ret;
 }
 
-int RGWSI_SysObj_Core::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch,
-                                map<string, bufferlist> *attrs, bufferlist *first_chunk,
+int RGWSI_SysObj_Core::raw_stat(const rgw_raw_obj& obj, uint64_t *psize,
+                                real_time *pmtime, uint64_t *epoch,
+                                map<string, bufferlist> *attrs,
                                 RGWObjVersionTracker *objv_tracker,
                                 optional_yield y)
 {
@@ -128,9 +129,6 @@ int RGWSI_SysObj_Core::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_ti
   op.getxattrs(attrs, nullptr);
   if (psize || pmtime) {
     op.stat2(&size, &mtime_ts, nullptr);
-  }
-  if (first_chunk) {
-    op.read(0, cct->_conf->rgw_max_chunk_size, first_chunk, nullptr);
   }
   bufferlist outbl;
   r = rados_obj.operate(&op, &outbl, y);

--- a/src/rgw/services/svc_sys_obj_core.h
+++ b/src/rgw/services/svc_sys_obj_core.h
@@ -20,34 +20,9 @@ struct RGWSysObjState {
   ceph::real_time mtime;
   uint64_t epoch{0};
   bufferlist obj_tag;
-  bool has_data{false};
-  bufferlist data;
-  bool prefetch_data{false};
   uint64_t pg_ver{0};
-
-  /* important! don't forget to update copy constructor */
-
   RGWObjVersionTracker objv_tracker;
-
   map<string, bufferlist> attrset;
-  RGWSysObjState() {}
-  RGWSysObjState(const RGWSysObjState& rhs) : obj (rhs.obj) {
-    has_attrs = rhs.has_attrs;
-    exists = rhs.exists;
-    size = rhs.size;
-    mtime = rhs.mtime;
-    epoch = rhs.epoch;
-    if (rhs.obj_tag.length()) {
-      obj_tag = rhs.obj_tag;
-    }
-    has_data = rhs.has_data;
-    if (rhs.data.length()) {
-      data = rhs.data;
-    }
-    prefetch_data = rhs.prefetch_data;
-    pg_ver = rhs.pg_ver;
-    objv_tracker = rhs.objv_tracker;
-  }
 };
 
 class RGWSysObjectCtxBase {
@@ -80,11 +55,6 @@ public:
     return result;
   }
 
-  void set_prefetch_data(rgw_raw_obj& obj) {
-    RWLock::WLocker wl(lock);
-    assert (!obj.empty());
-    objs_state[obj].prefetch_data = true;
-  }
   void invalidate(const rgw_raw_obj& obj) {
     RWLock::WLocker wl(lock);
     auto iter = objs_state.find(obj);
@@ -125,8 +95,9 @@ protected:
   }
   int get_rados_obj(RGWSI_Zone *zone_svc, const rgw_raw_obj& obj, RGWSI_RADOS::Obj *pobj);
 
-  virtual int raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch,
-                       map<string, bufferlist> *attrs, bufferlist *first_chunk,
+  virtual int raw_stat(const rgw_raw_obj& obj, uint64_t *psize,
+                       real_time *pmtime, uint64_t *epoch,
+                       map<string, bufferlist> *attrs,
                        RGWObjVersionTracker *objv_tracker,
                        optional_yield y);
 

--- a/src/rgw/services/svc_sys_obj_core.h
+++ b/src/rgw/services/svc_sys_obj_core.h
@@ -105,6 +105,7 @@ protected:
                    GetObjState& read_state,
                    RGWObjVersionTracker *objv_tracker,
                    const rgw_raw_obj& obj,
+                   uint64_t *psize, real_time *pmtime,
                    bufferlist *bl, off_t ofs, off_t end,
                    map<string, bufferlist> *attrs,
 		   bool raw_attrs,


### PR DESCRIPTION
* remove unused arguments and logic in rgw_get_system_obj()
* SysObj_Cache::read() can fetch size/mtime so rgw_get_system_obj() doesn't have to send a separate stat request (with potential retries if it changes in between)
* rgw_put_system_obj() doesn't need to deal with pool creation