### PR TITLE
options: set default osd_objectstore to bluestore

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3683,7 +3683,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_objectstore", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("filestore")
+    .set_default("bluestore")
     .set_enum_allowed({"bluestore", "filestore", "memstore", "kstore"})
     .set_flag(Option::FLAG_CREATE)
     .set_description("backend type for an OSD (like filestore or bluestore)"),


### PR DESCRIPTION
This will make configuration queries return the correct default.

Fixes: http://tracker.ceph.com/issues/37410
Signed-off-by: Douglas Fuller <dfuller@redhat.com>