### PR TITLE
crimson/osd: crimson osd driver

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -295,6 +295,7 @@ if(WITH_SEASTAR)
   endmacro ()
   set(Seastar_HWLOC OFF CACHE BOOL "" FORCE)
   set(Seastar_STD_OPTIONAL_VARIANT_STRINGVIEW ON CACHE BOOL "" FORCE)
+  set(Seastar_CXX_FLAGS "-Wno-sign-compare;-Wno-attributes" CACHE STRING "" FORCE)
   add_subdirectory(seastar)
   # create the directory so cmake won't complain when looking at the imported
   # target: Seastar exports this directory created at build-time

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -80,6 +80,7 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/msg/msg_types.cc
   ${PROJECT_SOURCE_DIR}/src/msg/Message.cc
   ${PROJECT_SOURCE_DIR}/src/mon/MonCap.cc
+  ${PROJECT_SOURCE_DIR}/src/mon/MonMap.cc
   ${PROJECT_SOURCE_DIR}/src/osd/osd_types.cc
   ${PROJECT_SOURCE_DIR}/src/osd/ECMsgTypes.cc
   ${PROJECT_SOURCE_DIR}/src/osd/HitSet.cc
@@ -110,7 +111,6 @@ set(crimson_auth_srcs
   auth/KeyRing.cc)
 set(crimson_mon_srcs
   mon/MonClient.cc
-  ${PROJECT_SOURCE_DIR}/src/mon/MonMap.cc
   ${PROJECT_SOURCE_DIR}/src/mon/MonSub.cc)
 set(crimson_net_srcs
   net/Dispatcher.cc
@@ -134,3 +134,4 @@ target_link_libraries(crimson
     crimson-common
     crimson::cflags)
 add_subdirectory(os)
+add_subdirectory(osd)

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -133,3 +133,4 @@ target_link_libraries(crimson
   PUBLIC
     crimson-common
     crimson::cflags)
+add_subdirectory(os)

--- a/src/crimson/auth/Errors.cc
+++ b/src/crimson/auth/Errors.cc
@@ -1,0 +1,31 @@
+#include "Errors.h"
+
+namespace ceph::net {
+
+const std::error_category& auth_category()
+{
+  struct category : public std::error_category {
+    const char* name() const noexcept override {
+      return "ceph::auth";
+    }
+
+    std::string message(int ev) const override {
+      switch (static_cast<error>(ev)) {
+        case error::success:
+          return "success",
+        case error::key_not_found:
+          return "key not found";
+        case error::invalid_key:
+          return "corrupted key";
+        case error::unknown_service:
+          return "unknown service";
+        default:
+          return "unknown";
+      }
+    }
+  };
+  static category instance;
+  return instance;
+}
+
+} // namespace ceph::auth

--- a/src/crimson/auth/Errors.h
+++ b/src/crimson/auth/Errors.h
@@ -1,0 +1,37 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+namespace ceph::auth {
+
+enum class error {
+  success = 0,
+  key_not_found,
+  invalid_key,
+  unknown_service, // no ticket handler for required service
+};
+
+const std::error_category& auth_category();
+
+inline std::error_code make_error_code(error e)
+{
+  return {static_cast<int>(e), auth_category()};
+}
+
+inline std::error_condition make_error_condition(error e)
+{
+  return {static_cast<int>(e), auth_category()};
+}
+
+class auth_error : public std::runtime_error {};
+
+} // namespace ceph::auth
+
+namespace std {
+
+/// enables implicit conversion to std::error_condition
+template <>
+struct is_error_condition_enum<ceph::auth::error> : public true_type {};
+
+} // namespace std

--- a/src/crimson/common/config_proxy.cc
+++ b/src/crimson/common/config_proxy.cc
@@ -4,13 +4,15 @@
 
 namespace ceph::common {
 
-ConfigProxy::ConfigProxy()
+ConfigProxy::ConfigProxy(const EntityName& name, std::string_view cluster)
 {
   if (seastar::engine().cpu_id() != 0) {
     return;
   }
   // set the initial value on CPU#0
   values.reset(seastar::make_lw_shared<ConfigValues>());
+  values.get()->name = name;
+  values.get()->cluster = cluster;
   // and the only copy of md_config_impl<> is allocated on CPU#0
   local_config.reset(new md_config_t{*values, obs_mgr, true});
 }

--- a/src/crimson/common/config_proxy.cc
+++ b/src/crimson/common/config_proxy.cc
@@ -15,6 +15,13 @@ ConfigProxy::ConfigProxy(const EntityName& name, std::string_view cluster)
   values.get()->cluster = cluster;
   // and the only copy of md_config_impl<> is allocated on CPU#0
   local_config.reset(new md_config_t{*values, obs_mgr, true});
+  if (name.is_mds()) {
+    local_config->set_val_default(*values, obs_mgr,
+				  "keyring", "$mds_data/keyring");
+  } else if (name.is_osd()) {
+    local_config->set_val_default(*values, obs_mgr,
+				  "keyring", "$osd_data/keyring");
+  }
 }
 
 seastar::future<> ConfigProxy::start()

--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -81,7 +81,7 @@ class ConfigProxy : public seastar::peering_sharded_service<ConfigProxy>
       });
   }
 public:
-  ConfigProxy();
+  ConfigProxy(const EntityName& name, std::string_view cluster);
   const ConfigValues* operator->() const noexcept {
     return values.get();
   }

--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -458,9 +458,13 @@ std::vector<unsigned> Client::get_random_mons(unsigned n) const
     }
   }
   vector<unsigned> ranks;
-  for (const auto& m : monmap.mon_info) {
-    if (m.second.priority == min_priority) {
-      ranks.push_back(monmap.get_rank(m.first));
+  for (auto [name, info] : monmap.mon_info) {
+    // TODO: #msgr-v2
+    if (info.public_addrs.legacy_addr().is_blank_ip()) {
+      continue;
+    }
+    if (info.priority == min_priority) {
+      ranks.push_back(monmap.get_rank(name));
     }
   }
   std::random_device rd;

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -74,6 +74,12 @@ public:
   get_version_t get_version(const std::string& map);
   command_result_t run_command(const std::vector<std::string>& cmd,
 			       const bufferlist& bl);
+  seastar::future<> send_message(MessageRef);
+  bool sub_want(const std::string& what, version_t start, unsigned flags);
+  void sub_got(const std::string& what, version_t have);
+  void sub_unwant(const std::string& what);
+  bool sub_want_increment(const std::string& what, version_t start, unsigned flags);
+  seastar::future<> renew_subs();
 
 private:
   void tick();

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -37,7 +37,7 @@ namespace ceph::mon {
 class Connection;
 
 class Client : public ceph::net::Dispatcher {
-  const EntityName entity_name;
+  EntityName entity_name;
   KeyRing keyring;
   AuthMethodList auth_methods;
   const uint32_t want_keys;
@@ -65,10 +65,11 @@ class Client : public ceph::net::Dispatcher {
   MonSub sub;
 
 public:
-  Client(const EntityName& name,
-	 ceph::net::Messenger& messenger);
+  Client(ceph::net::Messenger& messenger);
   Client(Client&&);
   ~Client();
+  void set_name(const EntityName& name);
+
   seastar::future<> load_keyring();
   seastar::future<> build_initial_map();
   seastar::future<> authenticate();

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -9,7 +9,6 @@
 #include <seastar/core/lowres_clock.hh>
 #include <seastar/core/timer.hh>
 
-#include "auth/AuthMethodList.h"
 #include "auth/KeyRing.h"
 
 #include "crimson/net/Dispatcher.h"
@@ -24,6 +23,7 @@ namespace ceph::net {
   class Messenger;
 }
 
+class AuthMethodList;
 class MAuthReply;
 struct MMonMap;
 struct MMonSubscribeAck;
@@ -39,7 +39,7 @@ class Connection;
 class Client : public ceph::net::Dispatcher {
   EntityName entity_name;
   KeyRing keyring;
-  AuthMethodList auth_methods;
+  std::unique_ptr<AuthMethodList> auth_methods;
   const uint32_t want_keys;
 
   MonMap monmap;
@@ -68,12 +68,9 @@ public:
   Client(ceph::net::Messenger& messenger);
   Client(Client&&);
   ~Client();
-  void set_name(const EntityName& name);
-
-  seastar::future<> load_keyring();
-  seastar::future<> build_initial_map();
-  seastar::future<> authenticate();
+  seastar::future<> start();
   seastar::future<> stop();
+
   get_version_t get_version(const std::string& map);
   command_result_t run_command(const std::vector<std::string>& cmd,
 			       const bufferlist& bl);
@@ -96,6 +93,9 @@ private:
   seastar::future<> handle_config(Ref<MConfig> m);
 
 private:
+  seastar::future<> load_keyring();
+  seastar::future<> authenticate();
+
   bool is_hunting() const;
   seastar::future<> reopen_session(int rank);
   std::vector<unsigned> get_random_mons(unsigned n) const;

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -24,7 +24,7 @@ namespace ceph::net {
 
 class Messenger {
   entity_name_t my_name;
-  entity_addr_t my_addr;
+  entity_addrvec_t my_addrs;
   uint32_t global_seq = 0;
   uint32_t crc_flags = 0;
 
@@ -35,13 +35,14 @@ class Messenger {
   virtual ~Messenger() {}
 
   const entity_name_t& get_myname() const { return my_name; }
-  const entity_addr_t& get_myaddr() const { return my_addr; }
-  virtual void set_myaddr(const entity_addr_t& addr) {
-    my_addr = addr;
+  const entity_addrvec_t& get_myaddrs() const { return my_addrs; }
+  entity_addr_t get_myaddr() const { return my_addrs.front(); }
+  virtual void set_myaddrs(const entity_addrvec_t& addrs) {
+    my_addrs = addrs;
   }
 
   /// bind to the given address
-  virtual void bind(const entity_addr_t& addr) = 0;
+  virtual void bind(const entity_addrvec_t& addr) = 0;
 
   /// start the messenger
   virtual seastar::future<> start(Dispatcher *dispatcher) = 0;

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -230,10 +230,11 @@ bool SocketConnection::update_rx_seq(seq_num_t seq)
 seastar::future<> SocketConnection::write_message(MessageRef msg)
 {
   msg->set_seq(++out_seq);
+  auto& header = msg->get_header();
+  header.src = messenger.get_myname();
   msg->encode(features, messenger.get_crc_flags());
   bufferlist bl;
   bl.append(CEPH_MSGR_TAG_MSG);
-  auto& header = msg->get_header();
   bl.append((const char*)&header, sizeof(header));
   bl.append(msg->get_payload());
   bl.append(msg->get_middle());

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -34,21 +34,26 @@ SocketMessenger::SocketMessenger(const entity_name_t& myname,
   : Messenger{myname}, logic_name{logic_name}, nonce{nonce}
 {}
 
-void SocketMessenger::set_myaddr(const entity_addr_t& addr)
+void SocketMessenger::set_myaddrs(const entity_addrvec_t& addrs)
 {
-  entity_addr_t my_addr = addr;
-  my_addr.nonce = nonce;
+  auto my_addrs = addrs;
+  for (auto& addr : my_addrs.v) {
+    addr.nonce = nonce;
+  }
   // TODO: propagate to all the cores of the Messenger
-  Messenger::set_myaddr(my_addr);
+  Messenger::set_myaddrs(my_addrs);
 }
 
-void SocketMessenger::bind(const entity_addr_t& addr)
+void SocketMessenger::bind(const entity_addrvec_t& addrs)
 {
+  // TODO: v2: listen on multiple addresses
+  auto addr = addrs.legacy_addr();
+
   if (addr.get_family() != AF_INET) {
     throw std::system_error(EAFNOSUPPORT, std::generic_category());
   }
 
-  set_myaddr(addr);
+  set_myaddrs(addrs);
 
   seastar::socket_address address(addr.in4_addr());
   seastar::listen_options lo;
@@ -125,7 +130,7 @@ void SocketMessenger::learned_addr(const entity_addr_t &peer_addr_for_me)
   addr.u = peer_addr_for_me.u;
   addr.set_type(peer_addr_for_me.get_type());
   addr.set_port(get_myaddr().get_port());
-  set_myaddr(addr);
+  set_myaddrs(entity_addrvec_t{addr});
 }
 
 void SocketMessenger::set_default_policy(const SocketPolicy& p)

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -48,9 +48,9 @@ class SocketMessenger final : public Messenger {
                   const std::string& logic_name,
                   uint32_t nonce);
 
-  void set_myaddr(const entity_addr_t& addr) override;
+  void set_myaddrs(const entity_addrvec_t& addr) override;
 
-  void bind(const entity_addr_t& addr) override;
+  void bind(const entity_addrvec_t& addr) override;
 
   seastar::future<> start(Dispatcher *dispatcher) override;
 

--- a/src/crimson/os/CMakeLists.txt
+++ b/src/crimson/os/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(crimson-os
+  cyan_store.cc)
+target_link_libraries(crimson-os
+  fmt::fmt crimson-common)

--- a/src/crimson/os/cyan_store.cc
+++ b/src/crimson/os/cyan_store.cc
@@ -1,0 +1,31 @@
+#include "cyan_store.h"
+
+#include <fmt/format.h>
+
+#include "common/safe_io.h"
+
+void CyanStore::write_meta(const std::string& key,
+                           const std::string& value)
+{
+  std::string v = value;
+  v += "\n";
+  if (int r = safe_write_file(path.c_str(), key.c_str(),
+                              v.c_str(), v.length());
+      r < 0) {
+    throw std::runtime_error{fmt::format("unable to write_meta({})", key)};
+  }
+}
+
+std::string CyanStore::read_meta(const std::string& key)
+{
+  char buf[4096];
+  int r = safe_read_file(path.c_str(), key.c_str(),
+                         buf, sizeof(buf));
+  if (r <= 0)
+    throw std::runtime_error{fmt::format("unable to read_meta({})", key)};
+  // drop trailing newlines
+  while (r && isspace(buf[r-1])) {
+    --r;
+  }
+  return std::string(buf, r);
+}

--- a/src/crimson/os/cyan_store.h
+++ b/src/crimson/os/cyan_store.h
@@ -1,0 +1,20 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <string>
+#include "include/uuid.h"
+
+// a just-enough store for reading/writing the superblock
+class CyanStore {
+  const std::string path;
+public:
+  CyanStore(const std::string& path)
+    : path{path}
+  {}
+
+  void write_meta(const std::string& key,
+		  const std::string& value);
+  std::string read_meta(const std::string& key);
+};

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(crimson-osd
+  main.cc
+  osd.cc)
+target_link_libraries(crimson-osd
+  crimson-common crimson-os crimson)

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(crimson-osd
   main.cc
-  osd.cc)
+  osd.cc
+  chained_dispatchers.cc)
 target_link_libraries(crimson-osd
   crimson-common crimson-os crimson)

--- a/src/crimson/osd/chained_dispatchers.cc
+++ b/src/crimson/osd/chained_dispatchers.cc
@@ -1,0 +1,75 @@
+#include "chained_dispatchers.h"
+#include "crimson/net/Connection.h"
+
+
+seastar::future<>
+ChainedDispatchers::ms_dispatch(ceph::net::ConnectionRef conn,
+                                MessageRef m) {
+  return seastar::do_for_each(dispatchers, [conn, m](Dispatcher* dispatcher) {
+    return dispatcher->ms_dispatch(conn, m);
+  });
+}
+
+seastar::future<>
+ChainedDispatchers::ms_handle_accept(ceph::net::ConnectionRef conn) {
+  return seastar::do_for_each(dispatchers, [conn](Dispatcher* dispatcher) {
+    return dispatcher->ms_handle_accept(conn);
+  });
+}
+
+seastar::future<>
+ChainedDispatchers::ms_handle_connect(ceph::net::ConnectionRef conn) {
+  return seastar::do_for_each(dispatchers, [conn](Dispatcher* dispatcher) {
+    return dispatcher->ms_handle_connect(conn);
+  });
+}
+
+seastar::future<>
+ChainedDispatchers::ms_handle_reset(ceph::net::ConnectionRef conn) {
+  return seastar::do_for_each(dispatchers, [conn](Dispatcher* dispatcher) {
+    return dispatcher->ms_handle_reset(conn);
+  });
+}
+
+seastar::future<>
+ChainedDispatchers::ms_handle_remote_reset(ceph::net::ConnectionRef conn) {
+  return seastar::do_for_each(dispatchers, [conn](Dispatcher* dispatcher) {
+    return dispatcher->ms_handle_remote_reset(conn);
+  });
+}
+
+seastar::future<std::unique_ptr<AuthAuthorizer>>
+ChainedDispatchers::ms_get_authorizer(peer_type_t peer_type, bool force_new)
+{
+  // since dispatcher returns a nullptr if it does not have the authorizer,
+  // let's use the chain-of-responsibility pattern here.
+  struct Params {
+    peer_type_t peer_type;
+    bool force_new;
+    std::deque<Dispatcher*>::iterator first, last;
+  } params = {peer_type, force_new,
+              dispatchers.begin(), dispatchers.end()};
+  return seastar::do_with(Params{params}, [this] (Params& params) {
+    using result_t = std::unique_ptr<AuthAuthorizer>;
+    return seastar::repeat_until_value([&] () {
+      auto& first = params.first;
+      if (first == params.last) {
+        // just give up
+        return seastar::make_ready_future<std::optional<result_t>>(result_t{});
+      } else {
+        return (*first)->ms_get_authorizer(params.peer_type,
+                                           params.force_new)
+          .then([&] (auto&& auth)-> std::optional<result_t> {
+          if (auth) {
+            // hooray!
+            return std::move(auth);
+          } else {
+            // try next one
+            ++first;
+            return {};
+          }
+        });
+      }
+    });
+  });
+}	 

--- a/src/crimson/osd/chained_dispatchers.h
+++ b/src/crimson/osd/chained_dispatchers.h
@@ -1,0 +1,32 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*- 
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <deque>
+#include "crimson/net/Dispatcher.h"
+
+// in existing Messenger, dispatchers are put into a chain as described by
+// chain-of-responsibility pattern. we could do the same to stop processing
+// the message once any of the dispatchers claims this message, and prevent
+// other dispatchers from reading it. but this change is more involved as
+// it requires changing the ms_ methods to return a bool. so as an intermediate 
+// solution, we are using an observer dispatcher to notify all the interested
+// or unintersted parties.
+class ChainedDispatchers : public ceph::net::Dispatcher {
+  std::deque<Dispatcher*> dispatchers;
+public:
+  void push_front(Dispatcher* dispatcher) {
+    dispatchers.push_front(dispatcher);
+  }
+  void push_back(Dispatcher* dispatcher) {
+    dispatchers.push_back(dispatcher);
+  }
+  seastar::future<> ms_dispatch(ceph::net::ConnectionRef conn, MessageRef m) override;
+  seastar::future<> ms_handle_accept(ceph::net::ConnectionRef conn) override;
+  seastar::future<> ms_handle_connect(ceph::net::ConnectionRef conn) override;
+  seastar::future<> ms_handle_reset(ceph::net::ConnectionRef conn) override;
+  seastar::future<> ms_handle_remote_reset(ceph::net::ConnectionRef conn) override;
+  seastar::future<std::unique_ptr<AuthAuthorizer>>
+  ms_get_authorizer(peer_type_t peer_type, bool force_new) override;
+};

--- a/src/crimson/osd/main.cc
+++ b/src/crimson/osd/main.cc
@@ -1,0 +1,81 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:nil -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <iostream>
+
+#include <seastar/core/app-template.hh>
+#include <seastar/core/thread.hh>
+
+#include "common/ceph_argparse.h"
+#include "crimson/common/config_proxy.h"
+
+#include "osd.h"
+
+using config_t = ceph::common::ConfigProxy;
+
+void usage(const char* prog) {
+  std::cout << "usage: " << prog << " -i <ID>" << std::endl;
+  generic_server_usage();
+}
+
+int main(int argc, char* argv[])
+{
+  std::vector<const char*> args{argv + 1, argv + argc};
+  if (ceph_argparse_need_usage(args)) {
+    usage(argv[0]);
+    return EXIT_SUCCESS;
+  }
+  std::string cluster;
+  std::string conf_file_list;
+  // ceph_argparse_early_args() could _exit(), while local_conf() won't ready
+  // until it's started. so do the boilerplate-settings parsing here.
+  auto init_params = ceph_argparse_early_args(args,
+                                              CEPH_ENTITY_TYPE_OSD,
+                                              &cluster,
+                                              &conf_file_list);
+  seastar::app_template app;
+  seastar::sharded<OSD> osd;
+
+  using ceph::common::sharded_conf;
+  using ceph::common::sharded_perf_coll;
+  using ceph::common::local_conf;
+
+  args.insert(begin(args), argv[0]);
+  try {
+    return app.run_deprecated(args.size(), const_cast<char**>(args.data()), [&] {
+      seastar::engine().at_exit([] {
+        return sharded_conf().stop();
+      });
+      seastar::engine().at_exit([] {
+        return sharded_perf_coll().stop();
+      });
+      seastar::engine().at_exit([&] {
+       return osd.stop();
+      });
+      return sharded_conf().start(init_params.name, cluster).then([] {
+        return sharded_perf_coll().start();
+      }).then([&conf_file_list] {
+        return local_conf().parse_config_files(conf_file_list);
+      }).then([&] {
+        return osd.start_single(std::stoi(local_conf()->name.get_id()),
+                                static_cast<uint32_t>(getpid()));
+      }).then([&] {
+        return osd.invoke_on(0, &OSD::start);
+      });
+    });
+  } catch (...) {
+    seastar::fprint(std::cerr, "FATAL: Exception during startup, aborting: %s\n", std::current_exception());
+    return EXIT_FAILURE;
+  }
+}
+
+/*
+ * Local Variables:
+ * compile-command: "make -j4 \
+ * -C ../../../build \
+ * crimson-osd"
+ * End:
+ */

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1,5 +1,6 @@
 #include "osd.h"
 
+#include "crimson/net/Connection.h"
 #include "crimson/net/SocketMessenger.h"
 
 namespace {
@@ -26,6 +27,8 @@ OSD::OSD(int id, uint32_t nonce)
       msgr->set_crc_header();
     }
   }
+  dispatchers.push_front(this);
+  dispatchers.push_front(&monc);
 }
 
 OSD::~OSD() = default;
@@ -33,10 +36,48 @@ OSD::~OSD() = default;
 seastar::future<> OSD::start()
 {
   logger().info("start");
-  return seastar::now();
+  return client_msgr.start(&dispatchers).then([this] {
+    return monc.start();
+  }).then([this] {
+    monc.sub_want("mgrmap", 0, 0);
+    monc.sub_want("osdmap", 0, 0);
+    return monc.renew_subs();
+  });
 }
 
 seastar::future<> OSD::stop()
 {
-  return gate.close();
+  return gate.close().then([this] {
+    return monc.stop();
+  }).then([this] {
+    return client_msgr->shutdown();
+  });
+}
+
+seastar::future<> OSD::ms_dispatch(ceph::net::ConnectionRef conn, MessageRef m)
+{
+  logger().info("ms_dispatch {}", *m);
+  return seastar::now();
+}
+
+seastar::future<> OSD::ms_handle_connect(ceph::net::ConnectionRef conn)
+{
+  if (conn->get_peer_type() != CEPH_ENTITY_TYPE_MON) {
+    return seastar::now();
+  } else {
+    return seastar::now();
+  }
+}
+
+seastar::future<> OSD::ms_handle_reset(ceph::net::ConnectionRef conn)
+{
+  // TODO: cleanup the session attached to this connection
+  logger().warn("ms_handle_reset");
+  return seastar::now();
+}
+
+seastar::future<> OSD::ms_handle_remote_reset(ceph::net::ConnectionRef conn)
+{
+  logger().warn("ms_handle_remote_reset");
+  return seastar::now();
 }

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1,11 +1,19 @@
 #include "osd.h"
 
+#include "messages/MOSDBoot.h"
+#include "messages/MOSDMap.h"
 #include "crimson/net/Connection.h"
 #include "crimson/net/SocketMessenger.h"
 
 namespace {
   seastar::logger& logger() {
     return ceph::get_logger(ceph_subsys_osd);
+  }
+
+  template<typename Message, typename... Args>
+  Ref<Message> make_message(Args&&... args)
+  {
+    return {new Message{std::forward<Args>(args)...}, false};
   }
 }
 
@@ -29,6 +37,7 @@ OSD::OSD(int id, uint32_t nonce)
   }
   dispatchers.push_front(this);
   dispatchers.push_front(&monc);
+  osdmaps[0] = seastar::make_lw_shared<OSDMap>();
 }
 
 OSD::~OSD() = default;
@@ -36,17 +45,85 @@ OSD::~OSD() = default;
 seastar::future<> OSD::start()
 {
   logger().info("start");
-  return client_msgr.start(&dispatchers).then([this] {
+  auto& conf = local_conf();
+  store = std::make_unique<CyanStore>(conf.get_val<std::string>("osd_data"));
+  return read_superblock().then([this] {
+    osdmap = get_map(superblock.current_epoch);
+    return client_msgr->start(&dispatchers);
+  }).then([this] {
     return monc.start();
   }).then([this] {
+    monc.sub_want("osd_pg_creates", last_pg_create_epoch, 0);
     monc.sub_want("mgrmap", 0, 0);
     monc.sub_want("osdmap", 0, 0);
     return monc.renew_subs();
+  }).then([this] {
+    return start_boot();
   });
+}
+
+seastar::future<> OSD::start_boot()
+{
+  state.set_preboot();
+  return monc.get_version("osdmap").then([this](version_t newest, version_t oldest) {
+    return _preboot(newest, oldest);
+  });
+}
+
+seastar::future<> OSD::_preboot(version_t newest, version_t oldest)
+{
+  if (osdmap->get_epoch() == 0) {
+    logger().warn("waiting for initial osdmap");
+  } else if (osdmap->is_destroyed(whoami)) {
+    logger().warn("osdmap says I am destroyed");
+    // provide a small margin so we don't livelock seeing if we
+    // un-destroyed ourselves.
+    if (osdmap->get_epoch() > newest - 1) {
+      throw std::runtime_error("i am destroyed");
+    }
+  } else if (osdmap->test_flag(CEPH_OSDMAP_NOUP) || osdmap->is_noup(whoami)) {
+    logger().warn("osdmap NOUP flag is set, waiting for it to clear");
+  } else if (!osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE)) {
+    logger().error("osdmap SORTBITWISE OSDMap flag is NOT set; please set it");
+  } else if (osdmap->require_osd_release < CEPH_RELEASE_LUMINOUS) {
+    logger().error("osdmap require_osd_release < luminous; please upgrade to luminous");
+  } else if (false) {
+    // TODO: update mon if current fullness state is different from osdmap
+  } else if (version_t n = local_conf()->osd_map_message_max;
+             osdmap->get_epoch() >= oldest - 1 &&
+             osdmap->get_epoch() + n > newest) {
+    return _send_boot();
+  }
+  // get all the latest maps
+  if (osdmap->get_epoch() + 1 >= oldest) {
+    return osdmap_subscribe(osdmap->get_epoch() + 1, false);
+  } else {
+    return osdmap_subscribe(oldest - 1, true);
+  }
+}
+
+seastar::future<> OSD::_send_boot()
+{
+  state.set_booting();
+
+  entity_addrvec_t hb_back_addrs;
+  entity_addrvec_t hb_front_addrs;
+  entity_addrvec_t cluster_addrs;
+
+  auto m = make_message<MOSDBoot>(superblock,
+                                  osdmap->get_epoch(),
+                                  osdmap->get_epoch(),
+                                  hb_back_addrs,
+                                  hb_front_addrs,
+                                  cluster_addrs,
+                                  CEPH_FEATURES_ALL);
+  return monc.send_message(m);
 }
 
 seastar::future<> OSD::stop()
 {
+  // see also OSD::shutdown()
+  state.set_stopping();
   return gate.close().then([this] {
     return monc.stop();
   }).then([this] {
@@ -57,7 +134,16 @@ seastar::future<> OSD::stop()
 seastar::future<> OSD::ms_dispatch(ceph::net::ConnectionRef conn, MessageRef m)
 {
   logger().info("ms_dispatch {}", *m);
-  return seastar::now();
+  if (state.is_stopping()) {
+    return seastar::now();
+  }
+
+  switch (m->get_type()) {
+  case CEPH_MSG_OSD_MAP:
+    return handle_osd_map(conn, boost::static_pointer_cast<MOSDMap>(m));
+  default:
+    return seastar::now();
+  }
 }
 
 seastar::future<> OSD::ms_handle_connect(ceph::net::ConnectionRef conn)
@@ -79,5 +165,207 @@ seastar::future<> OSD::ms_handle_reset(ceph::net::ConnectionRef conn)
 seastar::future<> OSD::ms_handle_remote_reset(ceph::net::ConnectionRef conn)
 {
   logger().warn("ms_handle_remote_reset");
+  return seastar::now();
+}
+
+seastar::lw_shared_ptr<OSDMap> OSD::get_map(epoch_t e)
+{
+  // TODO: use LRU cache for managing osdmap, fallback to disk if we have to
+  return osdmaps[e];
+}
+
+void OSD::store_maps(epoch_t start, Ref<MOSDMap> m)
+{
+  for (epoch_t e = start; e <= m->get_last(); e++) {
+    seastar::lw_shared_ptr<OSDMap> o;
+    if (auto p = m->maps.find(e); p != m->maps.end()) {
+      o = seastar::make_lw_shared<OSDMap>();
+      o->decode(p->second);
+    } else if (auto p = m->incremental_maps.find(e);
+               p != m->incremental_maps.end()) {
+      o = get_map(e - 1);
+      OSDMap::Incremental inc;
+      auto i = p->second.cbegin();
+      inc.decode(i);
+      o->apply_incremental(inc);
+    } else {
+      logger().error("MOSDMap lied about what maps it had?");
+    }
+    osdmaps[e] = std::move(o);
+  }
+}
+
+seastar::future<> OSD::osdmap_subscribe(version_t epoch, bool force_request)
+{
+  if (monc.sub_want_increment("osdmap", epoch, CEPH_SUBSCRIBE_ONETIME) ||
+      force_request) {
+    return monc.renew_subs();
+  } else {
+    return seastar::now();
+  }
+}
+
+seastar::future<> OSD::read_superblock()
+{
+  // just-enough superblock so mon can ack my MOSDBoot
+  // might want to have a PurpleStore which is able to read the meta data for us.
+  string ceph_fsid = store->read_meta("ceph_fsid");
+  superblock.cluster_fsid.parse(ceph_fsid.c_str());
+  string osd_fsid = store->read_meta("fsid");
+  superblock.osd_fsid.parse(osd_fsid.c_str());
+  return seastar::now();
+}
+
+seastar::future<> OSD::handle_osd_map(ceph::net::ConnectionRef conn,
+                                      Ref<MOSDMap> m)
+{
+  logger().info("handle_osd_map {}", *m);
+  if (m->fsid != superblock.cluster_fsid) {
+    logger().warn("fsid mismatched");
+    return seastar::now();
+  }
+  if (state.is_initializing()) {
+    logger().warn("i am still initializing");
+    return seastar::now();
+  }
+
+  const auto first = m->get_first();
+  const auto last = m->get_last();
+
+  // make sure there is something new, here, before we bother flushing
+  // the queues and such
+  if (last <= superblock.newest_map) {
+    return seastar::now();
+  }
+  // missing some?
+  bool skip_maps = false;
+  epoch_t start = superblock.newest_map + 1;
+  if (first > start) {
+    logger().info("handle_osd_map message skips epochs {}..{}",
+                  start, first - 1);
+    if (m->oldest_map <= start) {
+      return osdmap_subscribe(start, false);
+    }
+    // always try to get the full range of maps--as many as we can.  this
+    //  1- is good to have
+    //  2- is at present the only way to ensure that we get a *full* map as
+    //     the first map!
+    if (m->oldest_map < first) {
+      return osdmap_subscribe(m->oldest_map - 1, true);
+    }
+    skip_maps = true;
+    start = first;
+  }
+  // TODO: store new maps: queue for disk and put in the osdmap cache
+  store_maps(start, m);
+
+  // even if this map isn't from a mon, we may have satisfied our subscription
+  monc.sub_got("osdmap", last);
+  if (!superblock.oldest_map || skip_maps) {
+    superblock.oldest_map = first;
+  }
+  superblock.newest_map = last;
+  superblock.current_epoch = last;
+
+  // note in the superblock that we were clean thru the prior epoch
+  if (boot_epoch && boot_epoch >= superblock.mounted) {
+    superblock.mounted = boot_epoch;
+    superblock.clean_thru = last;
+  }
+  // TODO: write to superblock and commit the transaction
+  return committed_osd_maps(start, last, m);
+}
+
+seastar::future<> OSD::committed_osd_maps(version_t first,
+                                          version_t last,
+                                          Ref<MOSDMap> m)
+{
+  logger().info("osd.{}: committed_osd_maps({}, {})", whoami, first, last);
+  // advance through the new maps
+  for (epoch_t cur = first; cur <= last; cur++) {
+    osdmap = get_map(cur);
+    if (up_epoch != 0 &&
+        osdmap->is_up(whoami) &&
+        osdmap->get_addrs(whoami) == client_msgr->get_myaddrs()) {
+      up_epoch = osdmap->get_epoch();
+      if (!boot_epoch) {
+        boot_epoch = osdmap->get_epoch();
+      }
+    }
+  }
+
+  if (osdmap->is_up(whoami) &&
+      osdmap->get_addrs(whoami) == client_msgr->get_myaddrs() &&
+      bind_epoch < osdmap->get_up_from(whoami)) {
+    if (state.is_booting()) {
+      logger().info("osd.{}: activating...", whoami);
+      state.set_active();
+    }
+  }
+
+  if (state.is_active()) {
+    logger().info("osd.{}: now active", whoami);
+    if (!osdmap->exists(whoami)) {
+      return shutdown();
+    }
+    if (should_restart()) {
+      return restart();
+    } else {
+      return seastar::now();
+    }
+  } else if (state.is_preboot()) {
+    logger().info("osd.{}: now preboot", whoami);
+
+    if (m->get_source().is_mon()) {
+      logger().info("osd.{}: _preboot", whoami);
+      return _preboot(m->oldest_map, m->newest_map);
+    } else {
+      logger().info("osd.{}: start_boot", whoami);
+      return start_boot();
+    }
+  } else {
+    logger().info("osd.{}: now ???", whoami);
+    // XXX
+    return seastar::now();
+  }
+}
+
+bool OSD::should_restart() const
+{
+  if (!osdmap->is_up(whoami)) {
+    logger().info("map e {} marked osd.{} down",
+                  osdmap->get_epoch(), whoami);
+    return true;
+  } else if (osdmap->get_addrs(whoami) != client_msgr->get_myaddrs()) {
+    logger().error("map e {} had wrong client addr ({} != my {})",
+                   osdmap->get_epoch(),
+                   osdmap->get_addrs(whoami),
+                   client_msgr->get_myaddrs());
+    return true;
+  } else if (osdmap->get_cluster_addrs(whoami) != cluster_msgr->get_myaddrs()) {
+    logger().error("map e {} had wrong cluster addr ({} != my {})",
+                   osdmap->get_epoch(),
+                   osdmap->get_cluster_addrs(whoami),
+                   cluster_msgr->get_myaddrs());
+    return true;
+  } else {
+    return false;
+  }
+}
+
+seastar::future<> OSD::restart()
+{
+  up_epoch = 0;
+  bind_epoch = osdmap->get_epoch();
+  // TODO: promote to shutdown if being marked down for multiple times
+  // rebind messengers
+  return start_boot();
+}
+
+seastar::future<> OSD::shutdown()
+{
+  // TODO
+  superblock.mounted = boot_epoch;
+  superblock.clean_thru = osdmap->get_epoch();
   return seastar::now();
 }

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -1,0 +1,42 @@
+#include "osd.h"
+
+#include "crimson/net/SocketMessenger.h"
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+}
+
+using ceph::common::local_conf;
+
+OSD::OSD(int id, uint32_t nonce)
+  : whoami{id},
+    cluster_msgr{new ceph::net::SocketMessenger{entity_name_t::OSD(whoami),
+                                                "cluster", nonce}},
+    client_msgr{new ceph::net::SocketMessenger{entity_name_t::OSD(whoami),
+                                               "client", nonce}},
+    monc{*client_msgr}
+{
+  for (auto msgr : {cluster_msgr.get(), client_msgr.get()}) {
+    if (local_conf()->ms_crc_data) {
+      msgr->set_crc_data();
+    }
+    if (local_conf()->ms_crc_header) {
+      msgr->set_crc_header();
+    }
+  }
+}
+
+OSD::~OSD() = default;
+
+seastar::future<> OSD::start()
+{
+  logger().info("start");
+  return seastar::now();
+}
+
+seastar::future<> OSD::stop()
+{
+  return gate.close();
+}

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -46,6 +46,17 @@ OSD::OSD(int id, uint32_t nonce)
 
 OSD::~OSD() = default;
 
+seastar::future<> OSD::mkfs(uuid_d cluster_fsid, int whoami)
+{
+  CyanStore store{local_conf().get_val<std::string>("osd_data")};
+  uuid_d osd_fsid;
+  osd_fsid.generate_random();
+  store.write_meta("fsid", osd_fsid.to_string());
+  store.write_meta("ceph_fsid", cluster_fsid.to_string());
+  store.write_meta("whoami", std::to_string(whoami));
+  return seastar::now();
+}
+
 seastar::future<> OSD::start()
 {
   logger().info("start");

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -1,11 +1,20 @@
 #pragma once
 
+#include <map>
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
+#include <seastar/core/shared_ptr.hh>
 
 #include "crimson/mon/MonClient.h"
 #include "crimson/net/Dispatcher.h"
+#include "crimson/os/cyan_store.h"
 #include "crimson/osd/chained_dispatchers.h"
+#include "crimson/osd/state.h"
+
+#include "osd/OSDMap.h"
+
+class MOSDMap;
+class OSDMap;
 
 namespace ceph::net {
   class Messenger;
@@ -21,6 +30,25 @@ class OSD : public ceph::net::Dispatcher {
   ChainedDispatchers dispatchers;
   ceph::mon::Client monc;
 
+  // TODO: use LRU cache
+  std::map<epoch_t, seastar::lw_shared_ptr<OSDMap>> osdmaps;
+  seastar::lw_shared_ptr<OSDMap> osdmap;
+  // TODO: use a wrapper for ObjectStore
+  std::unique_ptr<CyanStore> store;
+
+  OSDState state;
+
+  /// _first_ epoch we were marked up (after this process started)
+  epoch_t boot_epoch = 0;
+  /// _most_recent_ epoch we were marked up
+  epoch_t up_epoch = 0;
+  //< epoch we last did a bind to new ip:ports
+  epoch_t bind_epoch = 0;
+  //< since when there is no more pending pg creates from mon
+  epoch_t last_pg_create_epoch = 0;
+
+  OSDSuperblock superblock;
+
   // Dispatcher methods
   seastar::future<> ms_dispatch(ceph::net::ConnectionRef conn, MessageRef m) override;
   seastar::future<> ms_handle_connect(ceph::net::ConnectionRef conn) override;
@@ -33,4 +61,25 @@ public:
 
   seastar::future<> start();
   seastar::future<> stop();
+
+private:
+  seastar::future<> start_boot();
+  seastar::future<> _preboot(version_t newest_osdmap, version_t oldest_osdmap);
+  seastar::future<> _send_boot();
+
+  seastar::lw_shared_ptr<OSDMap> get_map(epoch_t e);
+  // TODO: should batch the write op along with superdisk modification as a
+  //       transaction
+  void store_maps(epoch_t start, Ref<MOSDMap> m);
+  seastar::future<> osdmap_subscribe(version_t epoch, bool force_request);
+  seastar::future<> read_superblock();
+
+  seastar::future<> handle_osd_map(ceph::net::ConnectionRef conn,
+                                   Ref<MOSDMap> m);
+  seastar::future<> committed_osd_maps(version_t first,
+                                       version_t last,
+                                       Ref<MOSDMap> m);
+  bool should_restart() const;
+  seastar::future<> restart();
+  seastar::future<> shutdown();
 };

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <seastar/core/future.hh>
+#include <seastar/core/gate.hh>
+
+#include "crimson/net/Dispatcher.h"
+
+namespace ceph::net {
+  class Messenger;
+}
+
+class OSD : public ceph::net::Dispatcher {
+  seastar::gate gate;
+  const int whoami;
+  // talk with osd
+  std::unique_ptr<ceph::net::Messenger> cluster_msgr;
+  // talk with mon/mgr
+  std::unique_ptr<ceph::net::Messenger> client_msgr;
+
+public:
+  OSD(int id, uint32_t nonce);
+  ~OSD();
+
+  seastar::future<> start();
+  seastar::future<> stop();
+};

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -61,6 +61,8 @@ public:
   OSD(int id, uint32_t nonce);
   ~OSD();
 
+  static seastar::future<> mkfs(uuid_d fsid, int whoami);
+
   seastar::future<> start();
   seastar::future<> stop();
 

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -4,6 +4,7 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 #include <seastar/core/shared_ptr.hh>
+#include <seastar/core/timer.hh>
 
 #include "crimson/mon/MonClient.h"
 #include "crimson/net/Dispatcher.h"
@@ -22,6 +23,7 @@ namespace ceph::net {
 
 class OSD : public ceph::net::Dispatcher {
   seastar::gate gate;
+  seastar::timer<seastar::lowres_clock> beacon_timer;
   const int whoami;
   // talk with osd
   std::unique_ptr<ceph::net::Messenger> cluster_msgr;
@@ -82,4 +84,6 @@ private:
   bool should_restart() const;
   seastar::future<> restart();
   seastar::future<> shutdown();
+
+  seastar::future<> send_beacon();
 };

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -3,7 +3,9 @@
 #include <seastar/core/future.hh>
 #include <seastar/core/gate.hh>
 
+#include "crimson/mon/MonClient.h"
 #include "crimson/net/Dispatcher.h"
+#include "crimson/osd/chained_dispatchers.h"
 
 namespace ceph::net {
   class Messenger;
@@ -16,6 +18,14 @@ class OSD : public ceph::net::Dispatcher {
   std::unique_ptr<ceph::net::Messenger> cluster_msgr;
   // talk with mon/mgr
   std::unique_ptr<ceph::net::Messenger> client_msgr;
+  ChainedDispatchers dispatchers;
+  ceph::mon::Client monc;
+
+  // Dispatcher methods
+  seastar::future<> ms_dispatch(ceph::net::ConnectionRef conn, MessageRef m) override;
+  seastar::future<> ms_handle_connect(ceph::net::ConnectionRef conn) override;
+  seastar::future<> ms_handle_reset(ceph::net::ConnectionRef conn) override;
+  seastar::future<> ms_handle_remote_reset(ceph::net::ConnectionRef conn) override;
 
 public:
   OSD(int id, uint32_t nonce);

--- a/src/crimson/osd/state.h
+++ b/src/crimson/osd/state.h
@@ -1,0 +1,63 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+class OSDMap;
+
+class OSDState {
+
+  enum class State {
+    INITIALIZING,
+    PREBOOT,
+    BOOTING,
+    ACTIVE,
+    STOPPING,
+    WAITING_FOR_HEALTHY,
+  };
+
+  State state = State::INITIALIZING;
+
+public:
+  bool is_initializing() const {
+    return state == State::INITIALIZING;
+  }
+  bool is_preboot() const {
+    return state == State::PREBOOT;
+  }
+  bool is_booting() const {
+    return state == State::BOOTING;
+  }
+  bool is_active() const {
+    return state == State::ACTIVE;
+  }
+  bool is_stopping() const {
+    return state == State::STOPPING;
+  }
+  bool is_waiting_for_healthy() const {
+    return state == State::WAITING_FOR_HEALTHY;
+  }
+  void set_preboot() {
+    state = State::PREBOOT;
+  }
+  void set_booting() {
+    state = State::BOOTING;
+  }
+  void set_active() {
+    state = State::ACTIVE;
+  }
+  void set_stopping() {
+    state = State::STOPPING;
+  }
+  const char* print() {
+    switch (state) {
+    case State::INITIALIZING: return "initializing";
+    case State::PREBOOT: return "preboot";
+    case State::BOOTING: return "booting";
+    case State::ACTIVE: return "active";
+    case State::STOPPING: return "stopping";
+    case State::WAITING_FOR_HEALTHY: return "waiting_for_healthy";
+    default: return "???";
+    }
+  }
+};

--- a/src/messages/MOSDBeacon.h
+++ b/src/messages/MOSDBeacon.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "PaxosServiceMessage.h"
+
 class MOSDBeacon : public MessageInstance<MOSDBeacon, PaxosServiceMessage> {
 public:
   friend factory;

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -280,7 +280,7 @@ seastar_echo(SeastarContext& sc,
         // bind the server
         server.msgr.set_policy_throttler(entity_name_t::TYPE_OSD,
                                          &server.byte_throttler);
-        server.msgr.bind(addr);
+        server.msgr.bind(entity_addrvec_t{addr});
         return server.msgr.start(&server.dispatcher)
           .then([&dispatcher=server.dispatcher, count] {
             return dispatcher.on_reply.wait([&dispatcher, count] {

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -200,7 +200,8 @@ struct Client {
       return true;
     }
     bool ping(Messenger* msgr, const entity_inst_t& peer) {
-      auto conn = msgr->get_connection(peer);
+      auto conn = msgr->connect_to(peer.name.type(),
+                                   entity_addrvec_t{peer.addr});
       replied = false;
       conn->send_message(new MPing);
       std::unique_lock lock{mutex};
@@ -335,7 +336,8 @@ static void ceph_echo(CephContext* cct,
     native_pingpong::Client client{cct};
     client.msgr->add_dispatcher_head(&client.dispatcher);
     client.msgr->start();
-    auto conn = client.msgr->get_connection(entity);
+    auto conn = client.msgr->connect_to(entity.name.type(),
+                                        entity_addrvec_t{entity.addr});
     for (unsigned i = 0; i < count; i++) {
       std::cout << "seq=" << i << std::endl;
       client.ping(entity);

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -85,7 +85,7 @@ static seastar::future<> test_echo(unsigned rounds,
       t.addr.set_family(AF_INET);
       t.addr.set_port(9010);
       t.addr.set_nonce(1);
-      t.server.messenger.bind(t.addr);
+      t.server.messenger.bind(entity_addrvec_t{t.addr});
 
       t.client.rounds = rounds;
       t.client.keepalive_dist = std::bernoulli_distribution{keepalive_ratio};
@@ -164,7 +164,7 @@ static seastar::future<> test_concurrent_dispatch()
       t.addr.set_family(AF_INET);
       t.addr.set_port(9010);
       t.addr.set_nonce(3);
-      t.server.messenger.bind(t.addr);
+      t.server.messenger.bind(entity_addrvec_t{t.addr});
 
       return t.server.messenger.start(&t.server.dispatcher)
         .then([&] {

--- a/src/test/crimson/test_monc.cc
+++ b/src/test/crimson/test_monc.cc
@@ -10,7 +10,7 @@ using MonClient = ceph::mon::Client;
 
 static seastar::future<> test_monc()
 {
-  return ceph::common::sharded_conf().start().then([] {
+  return ceph::common::sharded_conf().start(EntityName{}, string_view{"ceph"}).then([] {
     std::vector<const char*> args;
     std::string cluster;
     std::string conf_file_list;

--- a/src/test/crimson/test_monc.cc
+++ b/src/test/crimson/test_monc.cc
@@ -32,8 +32,9 @@ static seastar::future<> test_monc()
       if (conf->ms_crc_header) {
         msgr.set_crc_header();
       }
-      return seastar::do_with(MonClient{conf->name, msgr},
+      return seastar::do_with(MonClient{msgr},
                               [&msgr](auto& monc) {
+        monc.set_name(ceph::common::local_conf()->name);
         return monc.build_initial_map().then([&monc] {
           return monc.load_keyring();
         }).then([&msgr, &monc] {

--- a/src/test/crimson/test_monc.cc
+++ b/src/test/crimson/test_monc.cc
@@ -36,16 +36,11 @@ static seastar::future<> test_monc()
       }
       return seastar::do_with(MonClient{msgr},
                               [&msgr](auto& monc) {
-        monc.set_name(ceph::common::local_conf()->name);
-        return monc.build_initial_map().then([&monc] {
-          return monc.load_keyring();
-        }).then([&msgr, &monc] {
-          return msgr.start(&monc);
-        }).then([&monc] {
+        return msgr.start(&monc).then([&monc] {
           return seastar::with_timeout(
             seastar::lowres_clock::now() + std::chrono::seconds{10},
-            monc.authenticate());
-        }).finally([&monc] {
+            monc.start());
+        }).then([&monc] {
           return monc.stop();
         });
       }).finally([&msgr] {


### PR DESCRIPTION
it will connect different puzzle pieces, like `mon::Client`, osdmap cache, seastarized object store, minimal i/o path to shape the crimson-osd.

in long term, it will grow into a full-sized crimson-osd when more features are added on top of the minimal implementation. and some parts of it will be split into smaller and mergeable PRs when time elapses.

- [x] boot and join cluster
- [ ] be able to reply heartbeat from peers
- [ ] other facility to keep the OSD "visible" from monitor and its peers.
- [ ] minimal i/o path accessing replica pool