### PR TITLE
qa/rgw: fix invalid syntax error in radosgw_admin_rest.py

### DIFF
--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -203,7 +203,7 @@ def task(ctx, config):
     assert ret == 200
 
     # TESTCASE 'list-no-user','user','list','list user keys','user list object'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'max-entries' : 0})
+    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 0})
     assert ret == 200
     assert out['count'] == 0
     assert out['truncated'] == True
@@ -211,7 +211,7 @@ def task(ctx, config):
     assert len(out['marker']) > 0
 
     # TESTCASE 'list-user-without-marker','user','list','list user keys','user list object'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'max-entries' : 1})
+    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 1})
     assert ret == 200
     assert out['count'] == 1
     assert out['truncated'] == True
@@ -220,7 +220,7 @@ def task(ctx, config):
     marker = out['marker']
 
     # TESTCASE 'list-user-with-marker','user','list','list user keys','user list object'
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'max-entries' : 1, 'marker': marker})
+    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'list' : '', 'max-entries' : 1, 'marker': marker})
     assert ret == 200
     assert out['count'] == 1
     assert out['truncated'] == False

--- a/qa/tasks/radosgw_admin_rest.py
+++ b/qa/tasks/radosgw_admin_rest.py
@@ -226,9 +226,6 @@ def task(ctx, config):
     assert out['truncated'] == False
     assert len(out['keys']) == 1
 
-    (ret, out) = rgwadmin_rest(admin_conn, ['user', 'list'], {'max-entries' : 1,
-        'marker': })
-
     # TESTCASE 'info-existing','user','info','existing user','returns correct info'
     (ret, out) = rgwadmin_rest(admin_conn, ['user', 'info'], {'uid' : user1})
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/37440