### PR TITLE
rgw: data sync accepts ERR_PRECONDITION_FAILED on remove_object()

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2583,6 +2583,10 @@ public:
             }
             tn->log(10, SSTR("removing obj: " << sync_env->source_zone << "/" << bucket_info->bucket << "/" << key << "[" << versioned_epoch.value_or(0) << "]"));
             call(data_sync_module->remove_object(sync_env, *bucket_info, key, timestamp, versioned, versioned_epoch.value_or(0), &zones_trace));
+            // our copy of the object is more recent, continue as if it succeeded
+            if (retcode == -ERR_PRECONDITION_FAILED) {
+              retcode = 0;
+            }
           } else if (op == CLS_RGW_OP_LINK_OLH_DM) {
             set_status("creating delete marker");
             tn->log(10, SSTR("creating delete marker: obj: " << sync_env->source_zone << "/" << bucket_info->bucket << "/" << key << "[" << versioned_epoch.value_or(0) << "]"));


### PR DESCRIPTION
sync of deletes uses an If-UnModified-Since precondition, but does not handle the corresponding ERR_PRECONDITION_FAILED error. treating this as a failure means that we'll keep retrying the delete which will never succeed. break this loop by treating ERR_PRECONDITION_FAILED as a success

Fixes: http://tracker.ceph.com/issues/37448