### PR TITLE
qa/suites/rados/upgrade: set require-osd-release to nautilus

### DIFF
--- a/qa/releases/nautilus.yaml
+++ b/qa/releases/nautilus.yaml
@@ -1,0 +1,6 @@
+tasks:
+- exec:
+    osd.0:
+      - ceph osd require-osd-release nautilus
+      - ceph osd set-require-min-compat-client nautilus
+- ceph.healthy:

--- a/qa/suites/rados/upgrade/luminous-x-singleton/7-mimic.yaml
+++ b/qa/suites/rados/upgrade/luminous-x-singleton/7-mimic.yaml
@@ -1,1 +1,0 @@
-.qa/releases/mimic.yaml

--- a/qa/suites/rados/upgrade/luminous-x-singleton/7-nautilus.yaml
+++ b/qa/suites/rados/upgrade/luminous-x-singleton/7-nautilus.yaml
@@ -1,0 +1,1 @@
+.qa/releases/nautilus.yaml


### PR DESCRIPTION
* add qa/releases/nautilus.yaml so it can be reused.
* use releases/nautilus.yaml in luminous-x upgrade test, so
  test_librbd_python.sh is able to use the feature introduced in
  nautilus.

Fixes: http://tracker.ceph.com/issues/37432
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

