### PR TITLE
qa,pybind,tools: Correct usage of collections.abc

### DIFF
--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -8,10 +8,7 @@ import logging
 import os
 from textwrap import dedent
 import traceback
-try:
-    from collections.abc import namedtuple, defaultdict
-except ImportError:
-    from collections import namedtuple, defaultdict
+from collections import namedtuple, defaultdict
 
 from teuthology.orchestra.run import CommandFailedError
 from tasks.cephfs.cephfs_test_case import CephFSTestCase, for_teuthology

--- a/qa/tasks/cephfs/test_forward_scrub.py
+++ b/qa/tasks/cephfs/test_forward_scrub.py
@@ -10,10 +10,7 @@ how the functionality responds to damaged metadata.
 import json
 
 import logging
-try:
-    from collections.abc import namedtuple
-except ImportError:
-    from collections import namedtuple
+from collections import namedtuple
 from textwrap import dedent
 
 from teuthology.orchestra.run import CommandFailedError

--- a/qa/tasks/cephfs/test_recovery_pool.py
+++ b/qa/tasks/cephfs/test_recovery_pool.py
@@ -8,10 +8,7 @@ import logging
 import os
 from textwrap import dedent
 import traceback
-try:
-    from collections.abc import namedtuple, defaultdict
-except ImportError:
-    from collections import namedtuple, defaultdict
+from collections import namedtuple, defaultdict
 
 from teuthology.orchestra.run import CommandFailedError
 from tasks.cephfs.cephfs_test_case import CephFSTestCase, for_teuthology

--- a/qa/tasks/cephfs/test_scrub.py
+++ b/qa/tasks/cephfs/test_scrub.py
@@ -4,10 +4,7 @@ Test CephFS scrub (distinct from OSD scrub) functionality
 import logging
 import os
 import traceback
-try:
-    from collections.abc import namedtuple
-except ImportError:
-    from collections import namedtuple
+from collections import namedtuple
 
 from teuthology.orchestra.run import CommandFailedError
 from tasks.cephfs.cephfs_test_case import CephFSTestCase, for_teuthology

--- a/qa/tasks/mgr/dashboard/helper.py
+++ b/qa/tasks/mgr/dashboard/helper.py
@@ -4,10 +4,7 @@ from __future__ import absolute_import
 
 import json
 import logging
-try:
-    from collections.abc import namedtuple
-except ImportError:
-    from collections import namedtuple
+from collections import namedtuple
 import time
 
 import requests

--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -26,10 +26,7 @@ Alternative usage:
 """
 
 from StringIO import StringIO
-try:
-    from collections.abc import defaultdict
-except ImportError:
-    from collections import defaultdict
+from collections import defaultdict
 import getpass
 import signal
 import tempfile

--- a/src/ceph-volume/ceph_volume/__init__.py
+++ b/src/ceph-volume/ceph_volume/__init__.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import namedtuple
-except ImportError:
-    from collections import namedtuple
+from collections import namedtuple
 
 
 sys_info = namedtuple('sys_info', ['devices'])

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -9,10 +9,7 @@ from libc.stdlib cimport malloc, realloc, free
 
 cimport rados
 
-try:
-    from collections.abc import namedtuple
-except ImportError:
-    from collections import namedtuple
+from collections import namedtuple
 from datetime import datetime
 import errno
 import os

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -1,10 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 
-try:
-    from collections.abc import defaultdict
-except ImportError:
-    from collections import defaultdict
+from collections import defaultdict
 
 import cherrypy
 

--- a/src/pybind/mgr/dashboard/services/ceph_service.py
+++ b/src/pybind/mgr/dashboard/services/ceph_service.py
@@ -2,12 +2,8 @@
 from __future__ import absolute_import
 
 import time
-try:
-    import collections.abc
-    from collections.abc import defaultdict
-except ImportError:
-    import collections
-    from collections import defaultdict
+import collections
+from collections import defaultdict
 import json
 
 import rados

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -5,10 +5,7 @@ import logging
 import json
 import six
 import threading
-try:
-    from collections.abc import defaultdict, namedtuple
-except ImportError:
-    from collections import defaultdict, namedtuple
+from collections import defaultdict, namedtuple
 import rados
 import time
 

--- a/src/pybind/mgr/restful/api/crush.py
+++ b/src/pybind/mgr/restful/api/crush.py
@@ -2,10 +2,7 @@ from pecan import expose
 from pecan.rest import RestController
 
 from restful import common, context
-try:
-    from collections.abc import defaultdict
-except ImportError:
-    from collections import defaultdict
+from collections import defaultdict
 
 from restful.decorators import auth
 

--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -3,10 +3,7 @@
 High level status display commands
 """
 
-try:
-    from collections.abc import defaultdict
-except ImportError:
-    from collections import defaultdict
+from collections import defaultdict
 from prettytable import PrettyTable
 import errno
 import fnmatch

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -12,10 +12,7 @@ import uuid
 import time
 from datetime import datetime
 from threading import Event
-try:
-    from collections.abc import defaultdict
-except ImportError:
-    from collections import defaultdict
+from collections import defaultdict
 
 from mgr_module import MgrModule
 

--- a/src/pybind/rgw/rgw.pyx
+++ b/src/pybind/rgw/rgw.pyx
@@ -10,10 +10,7 @@ from libc.stdlib cimport malloc, realloc, free
 
 cimport rados
 
-try:
-    from collections.abc import namedtuple
-except ImportError:
-    from collections import namedtuple
+from collections import namedtuple
 from datetime import datetime
 import errno
 

--- a/src/tools/rgw/parse-cr-dump.py
+++ b/src/tools/rgw/parse-cr-dump.py
@@ -1,9 +1,6 @@
 #!/usr/bin/python
 from __future__ import print_function
-try:
-    from collections.abc import Counter
-except ImportError:
-    from collections import Counter
+from collections import Counter
 import argparse
 import json
 import re


### PR DESCRIPTION
Some classes should still be imported directly from collections;
only OrderedDict, Iterable and Callable (in the context of the
ceph codebase) are found in collections.abc.

The current code works due to the fallback support for Python 2.

Signed-off-by: James Page <james.page@ubuntu.com>