### PR TITLE
 mgr/dashboard: Notification queue

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/models/cd-notification.ts
@@ -1,16 +1,23 @@
+import { ToastOptions } from 'ng2-toastr';
 import { NotificationType } from '../enum/notification-type.enum';
 
+export class CdNotificationConfig {
+  constructor(
+    public type: NotificationType,
+    public title: string,
+    public message?: string, // Use this for error notifications only
+    public options?: any | ToastOptions
+  ) {}
+}
+
 export class CdNotification {
-  message: string;
   timestamp: string;
-  title: string;
-  type: NotificationType;
 
-  constructor(type: NotificationType = NotificationType.info, title?: string, message?: string) {
-    this.type = type;
-    this.title = title;
-    this.message = message;
-
+  constructor(
+    public type: NotificationType = NotificationType.info,
+    public title?: string,
+    public message?: string
+  ) {
     /* string representation of the Date object so it can be directly compared
     with the timestamps parsed from localStorage */
     this.timestamp = new Date().toJSON();

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.spec.ts
@@ -5,6 +5,7 @@ import { ToastsManager } from 'ng2-toastr';
 
 import { configureTestBed, i18nProviders } from '../../../testing/unit-test-helper';
 import { NotificationType } from '../enum/notification-type.enum';
+import { CdNotificationConfig } from '../models/cd-notification';
 import { FinishedTask } from '../models/finished-task';
 import { NotificationService } from './notification.service';
 import { TaskMessageService } from './task-message.service';
@@ -57,7 +58,7 @@ describe('NotificationService', () => {
   }));
 
   it('should create a success notification and save it', fakeAsync(() => {
-    notificationService.show(NotificationType.success, 'Simple test');
+    notificationService.show(new CdNotificationConfig(NotificationType.success, 'Simple test'));
     tick(100);
     expect(notificationService['dataSource'].getValue().length).toBe(1);
     expect(notificationService['dataSource'].getValue()[0].type).toBe(NotificationType.success);
@@ -71,7 +72,7 @@ describe('NotificationService', () => {
   }));
 
   it('should create an info notification and save it', fakeAsync(() => {
-    notificationService.show(NotificationType.info, 'Simple test');
+    notificationService.show(new CdNotificationConfig(NotificationType.info, 'Simple test'));
     tick(100);
     expect(notificationService['dataSource'].getValue().length).toBe(1);
     const notification = notificationService['dataSource'].getValue()[0];

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/notification.service.ts
@@ -5,7 +5,7 @@ import { ToastsManager } from 'ng2-toastr';
 import { BehaviorSubject } from 'rxjs';
 
 import { NotificationType } from '../enum/notification-type.enum';
-import { CdNotification } from '../models/cd-notification';
+import { CdNotification, CdNotificationConfig } from '../models/cd-notification';
 import { FinishedTask } from '../models/finished-task';
 import { ServicesModule } from './services.module';
 import { TaskMessageService } from './task-message.service';
@@ -70,10 +70,22 @@ export class NotificationService {
    * @param {string} [message] The message to be displayed. Note, use this field
    *   for error notifications only.
    * @param {*} [options] toastr compatible options, used when creating a toastr
-   * @memberof NotificationService
    * @returns The timeout ID that is set to be able to cancel the notification.
    */
-  show(type: NotificationType, title: string, message?: string, options?: any) {
+  show(type: NotificationType, title: string, message?: string, options?: any): number;
+  show(config: CdNotificationConfig): number;
+  show(
+    arg: NotificationType | CdNotificationConfig,
+    title?: string,
+    message?: string,
+    options?: any
+  ): number {
+    let type;
+    if (_.isObject(arg)) {
+      ({ message, type, title, options } = <CdNotificationConfig>arg);
+    } else {
+      type = arg;
+    }
     return setTimeout(() => {
       this.save(type, title, message);
       if (!message) {
@@ -94,15 +106,20 @@ export class NotificationService {
   }
 
   notifyTask(finishedTask: FinishedTask, success: boolean = true) {
+    let notification: CdNotificationConfig;
     if (finishedTask.success && success) {
-      this.show(NotificationType.success, this.taskMessageService.getSuccessTitle(finishedTask));
+      notification = new CdNotificationConfig(
+        NotificationType.success,
+        this.taskMessageService.getSuccessTitle(finishedTask)
+      );
     } else {
-      this.show(
+      notification = new CdNotificationConfig(
         NotificationType.error,
         this.taskMessageService.getErrorTitle(finishedTask),
         this.taskMessageService.getErrorMessage(finishedTask)
       );
     }
+    this.show(notification);
   }
 
   /**


### PR DESCRIPTION
It's now possible to send an array of notification configs to the notification
service. These array is cached for, by default 500ms, before this array
is unified and than converted to full notifications that are seen by the
user.

Useful if different service can come to the same conclusions regarding
the notification. This is the case for the Prometheus notification service
and the Prometheus alert service.

Fixes: https://tracker.ceph.com/issues/37469
Signed-off-by: Stephan Müller <smueller@suse.com>

- [x] References tracker ticket
- [x] Includes tests for new functionality or reproducer for bug

