### PR TITLE
rgw: fix stats for versioned buckets after reshard

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2225,13 +2225,13 @@ static int rgw_bi_get_op(cls_method_context_t hctx, bufferlist *in, bufferlist *
   string idx;
 
   switch (op.type) {
-    case PlainIdx:
+    case BIIndexType::Plain:
       idx = op.key.name;
       break;
-    case InstanceIdx:
+    case BIIndexType::Instance:
       encode_obj_index_key(op.key, &idx);
       break;
-    case OLHIdx:
+    case BIIndexType::OLH:
       encode_olh_data_key(op.key, &idx);
       break;
     default:
@@ -2306,7 +2306,7 @@ static int list_plain_entries(cls_method_context_t hctx, const string& name, con
     }
 
     rgw_cls_bi_entry entry;
-    entry.type = PlainIdx;
+    entry.type = BIIndexType::Plain;
     entry.idx = iter->first;
     entry.data = iter->second;
 
@@ -2384,7 +2384,7 @@ static int list_instance_entries(cls_method_context_t hctx, const string& name, 
   map<string, bufferlist>::iterator iter;
   for (iter = keys.begin(); iter != keys.end(); ++iter) {
     rgw_cls_bi_entry entry;
-    entry.type = InstanceIdx;
+    entry.type = BIIndexType::Instance;
     entry.idx = iter->first;
     entry.data = iter->second;
 
@@ -2469,7 +2469,7 @@ static int list_olh_entries(cls_method_context_t hctx, const string& name, const
   map<string, bufferlist>::iterator iter;
   for (iter = keys.begin(); iter != keys.end(); ++iter) {
     rgw_cls_bi_entry entry;
-    entry.type = OLHIdx;
+    entry.type = BIIndexType::OLH;
     entry.idx = iter->first;
     entry.data = iter->second;
 

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -597,7 +597,7 @@ struct rgw_cls_bi_get_op {
   cls_rgw_obj_key key;
   BIIndexType type; /* namespace: plain, instance, olh */
 
-  rgw_cls_bi_get_op() : type(PlainIdx) {}
+  rgw_cls_bi_get_op() : type(BIIndexType::Plain) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -247,6 +247,8 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key, uint8_t *category, rgw_buc
   using ceph::decode;
   switch (type) {
     case PlainIdx:
+        account = true;
+        // NO BREAK; falls through to case InstanceIdx:
     case InstanceIdx:
       {
         rgw_bucket_dir_entry entry;
@@ -257,7 +259,6 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key, uint8_t *category, rgw_buc
         accounted_stats->total_size += entry.meta.accounted_size;
         accounted_stats->total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
         accounted_stats->actual_size += entry.meta.size;
-        account = true;
       }
       break;
     case OLHIdx:

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
 
 #include "cls/rgw/cls_rgw_types.h"
 #include "common/ceph_json.h"
@@ -156,15 +158,15 @@ static void dump_bi_entry(bufferlist bl, BIIndexType index_type, Formatter *form
 {
   auto iter = bl.cbegin();
   switch (index_type) {
-    case PlainIdx:
-    case InstanceIdx:
+    case BIIndexType::Plain:
+    case BIIndexType::Instance:
       {
         rgw_bucket_dir_entry entry;
         decode(entry, iter);
         encode_json("entry", entry, formatter);
       }
       break;
-    case OLHIdx:
+    case BIIndexType::OLH:
       {
         rgw_bucket_olh_entry entry;
         decode(entry, iter);
@@ -181,18 +183,18 @@ void rgw_cls_bi_entry::decode_json(JSONObj *obj, cls_rgw_obj_key *effective_key)
   string s;
   JSONDecoder::decode_json("type", s, obj);
   if (s == "plain") {
-    type = PlainIdx;
+    type = BIIndexType::Plain;
   } else if (s == "instance") {
-    type = InstanceIdx;
+    type = BIIndexType::Instance;
   } else if (s == "olh") {
-    type = OLHIdx;
+    type = BIIndexType::OLH;
   } else {
-    type = InvalidIdx;
+    type = BIIndexType::Invalid;
   }
   using ceph::encode;
   switch (type) {
-    case PlainIdx:
-    case InstanceIdx:
+    case BIIndexType::Plain:
+    case BIIndexType::Instance:
       {
         rgw_bucket_dir_entry entry;
         JSONDecoder::decode_json("entry", entry, obj);
@@ -203,7 +205,7 @@ void rgw_cls_bi_entry::decode_json(JSONObj *obj, cls_rgw_obj_key *effective_key)
         }
       }
       break;
-    case OLHIdx:
+    case BIIndexType::OLH:
       {
         rgw_bucket_olh_entry entry;
         JSONDecoder::decode_json("entry", entry, obj);
@@ -223,17 +225,17 @@ void rgw_cls_bi_entry::dump(Formatter *f) const
 {
   string type_str;
   switch (type) {
-    case PlainIdx:
-      type_str = "plain";
-      break;
-    case InstanceIdx:
-      type_str = "instance";
-      break;
-    case OLHIdx:
-      type_str = "olh";
-      break;
-    default:
-      type_str = "invalid";
+  case BIIndexType::Plain:
+    type_str = "plain";
+    break;
+  case BIIndexType::Instance:
+    type_str = "instance";
+    break;
+  case BIIndexType::OLH:
+    type_str = "olh";
+    break;
+  default:
+    type_str = "invalid";
   }
   encode_json("type", type_str, f);
   encode_json("idx", idx, f);
@@ -246,10 +248,10 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key, uint8_t *category, rgw_buc
   auto iter = data.cbegin();
   using ceph::decode;
   switch (type) {
-    case PlainIdx:
+    case BIIndexType::Plain:
         account = true;
         // NO BREAK; falls through to case InstanceIdx:
-    case InstanceIdx:
+    case BIIndexType::Instance:
       {
         rgw_bucket_dir_entry entry;
         decode(entry, iter);
@@ -261,7 +263,7 @@ bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key, uint8_t *category, rgw_buc
         accounted_stats->actual_size += entry.meta.size;
       }
       break;
-    case OLHIdx:
+    case BIIndexType::OLH:
       {
         rgw_bucket_olh_entry entry;
         decode(entry, iter);

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -382,11 +382,11 @@ struct rgw_bucket_dir_entry {
 };
 WRITE_CLASS_ENCODER(rgw_bucket_dir_entry)
 
-enum BIIndexType {
-  InvalidIdx    = 0,
-  PlainIdx      = 1,
-  InstanceIdx   = 2,
-  OLHIdx        = 3,
+enum class BIIndexType : uint8_t {
+  Invalid    = 0,
+  Plain      = 1,
+  Instance   = 2,
+  OLH        = 3,
 };
 
 struct rgw_bucket_category_stats;
@@ -396,11 +396,11 @@ struct rgw_cls_bi_entry {
   string idx;
   bufferlist data;
 
-  rgw_cls_bi_entry() : type(InvalidIdx) {}
+  rgw_cls_bi_entry() : type(BIIndexType::Invalid) {}
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
-    encode((uint8_t)type, bl);
+    encode(type, bl);
     encode(idx, bl);
     encode(data, bl);
     ENCODE_FINISH(bl);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -984,28 +984,28 @@ static int get_cmd(const char *cmd, const char *prev_cmd, const char *prev_prev_
 
 BIIndexType get_bi_index_type(const string& type_str) {
   if (type_str == "plain")
-    return PlainIdx;
+    return BIIndexType::Plain;
   if (type_str == "instance")
-    return InstanceIdx;
+    return BIIndexType::Instance;
   if (type_str == "olh")
-    return OLHIdx;
+    return BIIndexType::OLH;
 
-  return InvalidIdx;
+  return BIIndexType::Invalid;
 }
 
 void dump_bi_entry(bufferlist& bl, BIIndexType index_type, Formatter *formatter)
 {
   auto iter = bl.cbegin();
   switch (index_type) {
-    case PlainIdx:
-    case InstanceIdx:
+    case BIIndexType::Plain:
+    case BIIndexType::Instance:
       {
         rgw_bucket_dir_entry entry;
         decode(entry, iter);
         encode_json("entry", entry, formatter);
       }
       break;
-    case OLHIdx:
+    case BIIndexType::OLH:
       {
         rgw_bucket_olh_entry entry;
         decode(entry, iter);
@@ -2754,7 +2754,7 @@ int main(int argc, const char **argv)
   uint64_t max_rewrite_size = ULLONG_MAX;
   uint64_t min_rewrite_stripe_size = 0;
 
-  BIIndexType bi_index_type = PlainIdx;
+  BIIndexType bi_index_type = BIIndexType::Plain;
 
   string job_id;
   int num_shards = 0;
@@ -2999,7 +2999,7 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--index-type", (char*)NULL)) {
       string index_type_str = val;
       bi_index_type = get_bi_index_type(index_type_str);
-      if (bi_index_type == InvalidIdx) {
+      if (bi_index_type == BIIndexType::Invalid) {
         cerr << "ERROR: invalid bucket index entry type" << std::endl;
         return EINVAL;
       }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8669,7 +8669,7 @@ int RGWRados::bi_get_instance(const RGWBucketInfo& bucket_info, rgw_obj& obj, rg
   }
 
   rgw_cls_bi_entry bi_entry;
-  r = bi_get(obj.bucket, obj, InstanceIdx, &bi_entry);
+  r = bi_get(obj.bucket, obj, BIIndexType::Instance, &bi_entry);
   if (r < 0 && r != -ENOENT) {
     ldout(cct, 0) << "ERROR: bi_get() returned r=" << r << dendl;
   }


### PR DESCRIPTION
When a versioned bucket is resharded, the stats for bucket index entries of type PlainIdx and InstanceIdx were both accumulated to determine the bucket stats. This caused a doubling of some stats, such as bytes used. This fix makes certain that only PlainIdx entries are accumulated. This works for unversioned buckets as well, as they only have Plain Idx entries.

Also, do a little cleanup by converting enum BIIndexType to an enum class.

Tracker: https://tracker.ceph.com/issues/37473

