### PR TITLE
mgr/dashboard: Fix modified files only (frontend)

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/package.json
+++ b/src/pybind/mgr/dashboard/frontend/package.json
@@ -18,6 +18,7 @@
     "lint": "npm run lint:tslint && npm run lint:prettier && npm run lint:html",
     "fix:prettier": "prettier --write \"{src,e2e}/**/*.{ts,scss}\"",
     "fix:tslint": "npm run lint:tslint -- --fix",
+    "fixmod": "prettier --write $(git rev-parse --show-toplevel)/$(git status --porcelain | grep -E '^(\\sM|\\?\\?|A)' | sed -e 's/^...//' | grep -E '^(src|e2e).*\\.(ts|scss)$') 1>/dev/null 2>&1 && echo 'done' || echo 'no changes found'",
     "fix": "npm run fix:tslint; npm run fix:prettier"
   },
   "private": true,


### PR DESCRIPTION
Introduces a new npm command: `npm run fixmod` which, unlike `npm run fix`, only fixes modified files in the current git repository.  This is faster than the comprehensive `npm run fix` solution and can hence be
called more often with less disturbance.

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

