### PR TITLE
rgw: add optional_yield to SysObj service interfaces

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -888,7 +888,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
     auto sysobj = obj_ctx.get_obj(obj);
     r = sysobj.wop()
               .set_objv_tracker(&objv_tracker)
-              .write_attr(RGW_ATTR_ACL, aclbl);
+              .write_attr(RGW_ATTR_ACL, aclbl, null_yield);
     if (r < 0) {
       return r;
     }
@@ -903,7 +903,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
     auto inst_sysobj = obj_ctx.get_obj(obj_bucket_instance);
     r = inst_sysobj.wop()
                    .set_objv_tracker(&objv_tracker)
-                   .write_attr(RGW_ATTR_ACL, aclbl);
+                   .write_attr(RGW_ATTR_ACL, aclbl, null_yield);
     if (r < 0) {
       return r;
     }

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -104,7 +104,7 @@ int RGWAsyncGetSystemObj::_send_request()
                .set_objv_tracker(&objv_tracker)
                .set_attrs(pattrs)
 	       .set_raw_attrs(raw_attrs)
-               .read(&bl);
+               .read(&bl, null_yield);
 }
 
 RGWAsyncGetSystemObj::RGWAsyncGetSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWSI_SysObj *_svc,
@@ -141,7 +141,7 @@ int RGWAsyncPutSystemObj::_send_request()
   return sysobj.wop()
                .set_objv_tracker(&objv_tracker)
                .set_exclusive(exclusive)
-               .write_data(bl);
+               .write_data(bl, null_yield);
 }
 
 RGWAsyncPutSystemObj::RGWAsyncPutSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn,
@@ -164,7 +164,7 @@ int RGWAsyncPutSystemObjAttrs::_send_request()
                .set_objv_tracker(&objv_tracker)
                .set_exclusive(false)
                .set_attrs(attrs)
-               .write_attrs();
+               .write_attrs(null_yield);
 }
 
 RGWAsyncPutSystemObjAttrs::RGWAsyncPutSystemObjAttrs(RGWCoroutine *caller, RGWAioCompletionNotifier *cn,

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -372,7 +372,7 @@ int read_history(RGWRados *store, RGWMetadataLogHistory *state,
     /* bad history object, remove it */
     rgw_raw_obj obj(pool, oid);
     auto sysobj = obj_ctx.get_obj(obj);
-    ret = sysobj.wop().remove();
+    ret = sysobj.wop().remove(null_yield);
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: meta history is empty, but cannot remove it (" << cpp_strerror(-ret) << ")" << dendl;
       return ret;
@@ -1076,7 +1076,7 @@ int RGWMetadataManager::remove_from_heap(RGWMetadataHandler *handler, const stri
   rgw_raw_obj obj(heap_pool, oid);
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(obj);
-  int ret = sysobj.wop().remove();
+  int ret = sysobj.wop().remove(null_yield);
   if (ret < 0) {
     ldout(store->ctx(), 0) << "ERROR: sysobj.wop().remove() oid=" << oid << " returned ret=" << ret << dendl;
     return ret;
@@ -1146,7 +1146,7 @@ int RGWMetadataManager::remove_entry(RGWMetadataHandler *handler,
   auto sysobj = obj_ctx.get_obj(obj);
   ret = sysobj.wop()
               .set_objv_tracker(objv_tracker)
-              .remove();
+              .remove(null_yield);
   /* cascading ret into post_modify() */
 
   ret = post_modify(handler, section, key, log_data, objv_tracker, ret);

--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -136,9 +136,10 @@ int list_multipart_parts(RGWRados *store, RGWBucketInfo& bucket_info,
     snprintf(buf, sizeof(buf), "%08d", marker);
     p.append(buf);
 
-    ret = sysobj.omap().get_vals(p, num_parts + 1, &parts_map, nullptr);
+    ret = sysobj.omap().get_vals(p, num_parts + 1, &parts_map,
+                                 nullptr, null_yield);
   } else {
-    ret = sysobj.omap().get_all(&parts_map);
+    ret = sysobj.omap().get_all(&parts_map, null_yield);
   }
   if (ret < 0)
     return ret;

--- a/src/rgw/rgw_putobj_processor.cc
+++ b/src/rgw/rgw_putobj_processor.cc
@@ -485,7 +485,7 @@ int MultipartObjectProcessor::complete(size_t accounted_size,
 
   r = sysobj.omap()
       .set_must_exist(true)
-      .set(p, bl);
+      .set(p, bl, null_yield);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -47,7 +47,7 @@ int rgw_put_system_obj(RGWRados *rgwstore, const rgw_pool& pool, const string& o
                   .set_exclusive(exclusive)
                   .set_mtime(set_mtime)
                   .set_attrs(*pattrs)
-                  .write(data);
+                  .write(data, null_yield);
 
   if (ret == -ENOENT) {
     ret = rgwstore->create_pool(pool);
@@ -57,7 +57,7 @@ int rgw_put_system_obj(RGWRados *rgwstore, const rgw_pool& pool, const string& o
                   .set_exclusive(exclusive)
                   .set_mtime(set_mtime)
                   .set_attrs(*pattrs)
-                  .write(data);
+                  .write(data, null_yield);
     }
   }
 
@@ -84,13 +84,13 @@ int rgw_get_system_obj(RGWRados *rgwstore, RGWSysObjectCtx& obj_ctx, const rgw_p
     int ret = rop.set_attrs(pattrs)
                  .set_last_mod(pmtime)
                  .set_objv_tracker(objv_tracker)
-                 .stat();
+                 .stat(null_yield);
     if (ret < 0)
       return ret;
 
     ret = rop.set_cache_info(cache_info)
              .set_refresh_version(refresh_version)
-             .read(&bl);
+             .read(&bl, null_yield);
     if (ret == -ECANCELED) {
       /* raced, restart */
       if (!original_readv.empty()) {
@@ -123,7 +123,7 @@ int rgw_delete_system_obj(RGWRados *rgwstore, const rgw_pool& pool, const string
   rgw_raw_obj obj(pool, oid);
   return sysobj.wop()
                .set_objv_tracker(objv_tracker)
-               .remove();
+               .remove(null_yield);
 }
 
 thread_local bool is_asio_thread = false;

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -41,6 +41,9 @@ int rgw_rados_operate(librados::IoCtx& ioctx, const std::string& oid,
                       optional_yield y);
 int rgw_rados_operate(librados::IoCtx& ioctx, const std::string& oid,
                       librados::ObjectWriteOperation *op, optional_yield y);
+int rgw_rados_notify(librados::IoCtx& ioctx, const std::string& oid,
+                     bufferlist& bl, uint64_t timeout_ms, bufferlist* pbl,
+                     optional_yield y);
 
 int rgw_tools_init(CephContext *cct);
 void rgw_tools_cleanup();

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -250,7 +250,7 @@ int seed::save_torrent_file()
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(raw_obj);
 
-  op_ret = sysobj.omap().set(key, bl);
+  op_ret = sysobj.omap().set(key, bl, null_yield);
   if (op_ret < 0)
   {
     ldout(s->cct, 0) << "ERROR: failed to omap_set() op_ret = " << op_ret << dendl;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -401,7 +401,7 @@ int rgw_get_user_attrs_by_uid(RGWRados *store,
   return src.rop()
             .set_attrs(&attrs)
             .set_objv_tracker(objv_tracker)
-            .stat();
+            .stat(null_yield);
 }
 
 int rgw_remove_key_index(RGWRados *store, RGWAccessKey& access_key)
@@ -409,7 +409,7 @@ int rgw_remove_key_index(RGWRados *store, RGWAccessKey& access_key)
   rgw_raw_obj obj(store->svc.zone->get_zone_params().user_keys_pool, access_key.id);
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(obj);
-  return sysobj.wop().remove();
+  return sysobj.wop().remove(null_yield);
 }
 
 int rgw_remove_uid_index(RGWRados *store, rgw_user& uid)
@@ -436,7 +436,7 @@ int rgw_remove_email_index(RGWRados *store, string& email)
   rgw_raw_obj obj(store->svc.zone->get_zone_params().user_email_pool, email);
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(obj);
-  return sysobj.wop().remove();
+  return sysobj.wop().remove(null_yield);
 }
 
 int rgw_remove_swift_name_index(RGWRados *store, string& swift_name)
@@ -444,7 +444,7 @@ int rgw_remove_swift_name_index(RGWRados *store, string& swift_name)
   rgw_raw_obj obj(store->svc.zone->get_zone_params().user_swift_pool, swift_name);
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(obj);
-  return sysobj.wop().remove();
+  return sysobj.wop().remove(null_yield);
 }
 
 /**
@@ -492,7 +492,7 @@ int rgw_delete_user(RGWRados *store, RGWUserInfo& info, RGWObjVersionTracker& ob
   ldout(store->ctx(), 10) << "removing user buckets index" << dendl;
   auto obj_ctx = store->svc.sysobj->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(uid_bucks);
-  ret = sysobj.wop().remove();
+  ret = sysobj.wop().remove(null_yield);
   if (ret < 0 && ret != -ENOENT) {
     ldout(store->ctx(), 0) << "ERROR: could not remove " << info.user_id << ":" << uid_bucks << ", should be fixed (err=" << ret << ")" << dendl;
     return ret;

--- a/src/rgw/rgw_zone.cc
+++ b/src/rgw/rgw_zone.cc
@@ -392,7 +392,7 @@ int RGWSystemMetaObj::read_default(RGWDefaultSystemMetaObjInfo& default_info, co
 
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj(pool, oid));
-  int ret = sysobj.rop().read(&bl);
+  int ret = sysobj.rop().read(&bl, null_yield);
   if (ret < 0)
     return ret;
 
@@ -443,7 +443,7 @@ int RGWSystemMetaObj::set_as_default(bool exclusive)
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj(pool, oid));
   int ret = sysobj.wop()
                   .set_exclusive(exclusive)
-		  .write(bl);
+                  .write(bl, null_yield);
   if (ret < 0)
     return ret;
 
@@ -460,7 +460,7 @@ int RGWSystemMetaObj::read_id(const string& obj_name, string& object_id)
 
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj(pool, oid));
-  int ret = sysobj.rop().read(&bl);
+  int ret = sysobj.rop().read(&bl, null_yield);
   if (ret < 0) {
     return ret;
   }
@@ -492,7 +492,7 @@ int RGWSystemMetaObj::delete_obj(bool old_format)
     string oid = get_default_oid(old_format);
     rgw_raw_obj default_named_obj(pool, oid);
     auto sysobj = sysobj_svc->get_obj(obj_ctx, default_named_obj);
-    ret = sysobj.wop().remove();
+    ret = sysobj.wop().remove(null_yield);
     if (ret < 0) {
       ldout(cct, 0) << "Error delete default obj name  " << name << ": " << cpp_strerror(-ret) << dendl;
       return ret;
@@ -502,7 +502,7 @@ int RGWSystemMetaObj::delete_obj(bool old_format)
     string oid  = get_names_oid_prefix() + name;
     rgw_raw_obj object_name(pool, oid);
     auto sysobj = sysobj_svc->get_obj(obj_ctx, object_name);
-    ret = sysobj.wop().remove();
+    ret = sysobj.wop().remove(null_yield);
     if (ret < 0) {
       ldout(cct, 0) << "Error delete obj name  " << name << ": " << cpp_strerror(-ret) << dendl;
       return ret;
@@ -518,7 +518,7 @@ int RGWSystemMetaObj::delete_obj(bool old_format)
 
   rgw_raw_obj object_id(pool, oid);
   auto sysobj = sysobj_svc->get_obj(obj_ctx, object_id);
-  ret = sysobj.wop().remove();
+  ret = sysobj.wop().remove(null_yield);
   if (ret < 0) {
     ldout(cct, 0) << "Error delete object id " << id << ": " << cpp_strerror(-ret) << dendl;
   }
@@ -541,7 +541,7 @@ int RGWSystemMetaObj::store_name(bool exclusive)
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj(pool, oid));
   return sysobj.wop()
                .set_exclusive(exclusive)
-	       .write(bl);
+               .write(bl, null_yield);
 }
 
 int RGWSystemMetaObj::rename(const string& new_name)
@@ -573,7 +573,7 @@ int RGWSystemMetaObj::rename(const string& new_name)
   rgw_raw_obj old_name_obj(pool, oid);
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, old_name_obj);
-  ret = sysobj.wop().remove();
+  ret = sysobj.wop().remove(null_yield);
   if (ret < 0) {
     ldout(cct, 0) << "Error delete old obj name  " << old_name << ": " << cpp_strerror(-ret) << dendl;
     return ret;
@@ -592,7 +592,7 @@ int RGWSystemMetaObj::read_info(const string& obj_id, bool old_format)
 
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj{pool, oid});
-  int ret = sysobj.rop().read(&bl);
+  int ret = sysobj.rop().read(&bl, null_yield);
   if (ret < 0) {
     ldout(cct, 0) << "failed reading obj info from " << pool << ":" << oid << ": " << cpp_strerror(-ret) << dendl;
     return ret;
@@ -665,7 +665,7 @@ int RGWSystemMetaObj::store_info(bool exclusive)
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj{pool, oid});
   return sysobj.wop()
                .set_exclusive(exclusive)
-	       .write(bl);
+               .write(bl, null_yield);
 }
 
 int RGWSystemMetaObj::write(bool exclusive)
@@ -754,7 +754,7 @@ int RGWRealm::create_control(bool exclusive)
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj{pool, oid});
   return sysobj.wop()
                .set_exclusive(exclusive)
-	       .write(bl);
+               .write(bl, null_yield);
 }
 
 int RGWRealm::delete_control()
@@ -763,7 +763,7 @@ int RGWRealm::delete_control()
   auto obj = rgw_raw_obj{pool, get_control_oid()};
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, obj);
-  return sysobj.wop().remove();
+  return sysobj.wop().remove(null_yield);
 }
 
 rgw_pool RGWRealm::get_pool(CephContext *cct) const
@@ -835,7 +835,7 @@ int RGWRealm::notify_zone(bufferlist& bl)
   rgw_pool pool{get_pool(cct)};
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj{pool, get_control_oid()});
-  int ret = sysobj.wn().notify(bl, 0, nullptr);
+  int ret = sysobj.wn().notify(bl, 0, nullptr, null_yield);
   if (ret < 0) {
     return ret;
   }
@@ -880,7 +880,7 @@ int RGWPeriodConfig::read(RGWSI_SysObj *sysobj_svc, const std::string& realm_id)
 
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj{pool, oid});
-  int ret = sysobj.rop().read(&bl);
+  int ret = sysobj.rop().read(&bl, null_yield);
   if (ret < 0) {
     return ret;
   }
@@ -905,7 +905,7 @@ int RGWPeriodConfig::write(RGWSI_SysObj *sysobj_svc, const std::string& realm_id
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj{pool, oid});
   return sysobj.wop()
                .set_exclusive(false)
-	       .write(bl);
+               .write(bl, null_yield);
 }
 
 int RGWPeriod::init(CephContext *_cct, RGWSI_SysObj *_sysobj_svc, const string& period_realm_id,
@@ -1011,7 +1011,7 @@ int RGWPeriod::read_latest_epoch(RGWPeriodLatestEpochInfo& info,
   bufferlist bl;
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj{pool, oid});
-  int ret = sysobj.rop().read(&bl);
+  int ret = sysobj.rop().read(&bl, null_yield);
   if (ret < 0) {
     ldout(cct, 1) << "error read_lastest_epoch " << pool << ":" << oid << dendl;
     return ret;
@@ -1073,7 +1073,7 @@ int RGWPeriod::set_latest_epoch(epoch_t epoch, bool exclusive,
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj(pool, oid));
   return sysobj.wop()
                .set_exclusive(exclusive)
-               .write(bl);
+               .write(bl, null_yield);
 }
 
 int RGWPeriod::update_latest_epoch(epoch_t epoch)
@@ -1131,7 +1131,7 @@ int RGWPeriod::delete_obj()
     rgw_raw_obj oid{pool, p.get_period_oid()};
     auto obj_ctx = sysobj_svc->init_obj_ctx();
     auto sysobj = sysobj_svc->get_obj(obj_ctx, oid);
-    int ret = sysobj.wop().remove();
+    int ret = sysobj.wop().remove(null_yield);
     if (ret < 0) {
       ldout(cct, 0) << "WARNING: failed to delete period object " << oid
           << ": " << cpp_strerror(-ret) << dendl;
@@ -1142,7 +1142,7 @@ int RGWPeriod::delete_obj()
   rgw_raw_obj oid{pool, get_period_oid_prefix() + get_latest_epoch_oid()};
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, oid);
-  int ret = sysobj.wop().remove();
+  int ret = sysobj.wop().remove(null_yield);
   if (ret < 0) {
     ldout(cct, 0) << "WARNING: failed to delete period object " << oid
         << ": " << cpp_strerror(-ret) << dendl;
@@ -1158,7 +1158,7 @@ int RGWPeriod::read_info()
 
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj{pool, get_period_oid()});
-  int ret = sysobj.rop().read(&bl);
+  int ret = sysobj.rop().read(&bl, null_yield);
   if (ret < 0) {
     ldout(cct, 0) << "failed reading obj info from " << pool << ":" << get_period_oid() << ": " << cpp_strerror(-ret) << dendl;
     return ret;
@@ -1218,7 +1218,7 @@ int RGWPeriod::store_info(bool exclusive)
   auto sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj(pool, oid));
   return sysobj.wop()
                .set_exclusive(exclusive)
-               .write(bl);
+               .write(bl, null_yield);
 }
 
 rgw_pool RGWPeriod::get_pool(CephContext *cct) const
@@ -1645,7 +1645,7 @@ int RGWZoneParams::create(bool exclusive)
   rgw_raw_obj obj(domain_root, avail_pools);
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = sysobj_svc->get_obj(obj_ctx, obj);
-  int r = sysobj.rop().stat();
+  int r = sysobj.rop().stat(null_yield);
   if (r < 0) {
     ldout(cct, 10) << "couldn't find old data placement pools config, setting up new ones for the zone" << dendl;
     /* a new system, let's set new placement info */

--- a/src/rgw/services/svc_notify.cc
+++ b/src/rgw/services/svc_notify.cc
@@ -353,23 +353,25 @@ void RGWSI_Notify::_set_enabled(bool status)
   }
 }
 
-int RGWSI_Notify::distribute(const string& key, bufferlist& bl)
+int RGWSI_Notify::distribute(const string& key, bufferlist& bl,
+                             optional_yield y)
 {
   RGWSI_RADOS::Obj notify_obj = pick_control_obj(key);
 
   ldout(cct, 10) << "distributing notification oid=" << notify_obj.get_ref().obj
       << " bl.length()=" << bl.length() << dendl;
-  return robust_notify(notify_obj, bl);
+  return robust_notify(notify_obj, bl, y);
 }
 
-int RGWSI_Notify::robust_notify(RGWSI_RADOS::Obj& notify_obj, bufferlist& bl)
+int RGWSI_Notify::robust_notify(RGWSI_RADOS::Obj& notify_obj, bufferlist& bl,
+                                optional_yield y)
 {
   // The reply of every machine that acks goes in here.
   boost::container::flat_set<std::pair<uint64_t, uint64_t>> acks;
   bufferlist rbl;
 
   // First, try to send, without being fancy about it.
-  auto r = notify_obj.notify(bl, 0, &rbl);
+  auto r = notify_obj.notify(bl, 0, &rbl, y);
 
   // If that doesn't work, get serious.
   if (r < 0) {
@@ -409,7 +411,7 @@ int RGWSI_Notify::robust_notify(RGWSI_RADOS::Obj& notify_obj, bufferlist& bl)
       rbl.clear();
       // Reset the timeouts, we're only concerned with new ones.
       timeouts.clear();
-      r = notify_obj.notify(bl, 0, &rbl);
+      r = notify_obj.notify(bl, 0, &rbl, y);
       if (r < 0) {
 	ldout(cct, 1) << "robust_notify: retry " << tries << " failed: "
 		      << cpp_strerror(-r) << dendl;

--- a/src/rgw/services/svc_notify.h
+++ b/src/rgw/services/svc_notify.h
@@ -74,7 +74,8 @@ private:
   void _set_enabled(bool status);
   void set_enabled(bool status);
 
-  int robust_notify(RGWSI_RADOS::Obj& notify_obj, bufferlist& bl);
+  int robust_notify(RGWSI_RADOS::Obj& notify_obj, bufferlist& bl,
+                    optional_yield y);
 
   void schedule_context(Context *c);
 public:
@@ -91,7 +92,7 @@ public:
       virtual void set_enabled(bool status) = 0;
   };
 
-  int distribute(const string& key, bufferlist& bl);
+  int distribute(const string& key, bufferlist& bl, optional_yield y);
 
   void register_watch_cb(CB *cb);
 };

--- a/src/rgw/services/svc_rados.cc
+++ b/src/rgw/services/svc_rados.cc
@@ -157,11 +157,10 @@ int RGWSI_RADOS::Obj::unwatch(uint64_t handle)
   return ref.ioctx.unwatch2(handle);
 }
 
-int RGWSI_RADOS::Obj::notify(bufferlist& bl,
-                             uint64_t timeout_ms,
-                             bufferlist *pbl)
+int RGWSI_RADOS::Obj::notify(bufferlist& bl, uint64_t timeout_ms,
+                             bufferlist *pbl, optional_yield y)
 {
-  return ref.ioctx.notify2(ref.obj.oid, bl, timeout_ms, pbl);
+  return rgw_rados_notify(ref.ioctx, ref.obj.oid, bl, timeout_ms, pbl, y);
 }
 
 void RGWSI_RADOS::Obj::notify_ack(uint64_t notify_id,

--- a/src/rgw/services/svc_rados.h
+++ b/src/rgw/services/svc_rados.h
@@ -79,9 +79,8 @@ public:
     int watch(uint64_t *handle, librados::WatchCtx2 *ctx);
     int aio_watch(librados::AioCompletion *c, uint64_t *handle, librados::WatchCtx2 *ctx);
     int unwatch(uint64_t handle);
-    int notify(bufferlist& bl,
-               uint64_t timeout_ms,
-               bufferlist *pbl);
+    int notify(bufferlist& bl, uint64_t timeout_ms,
+               bufferlist *pbl, optional_yield y);
     void notify_ack(uint64_t notify_id,
                     uint64_t cookie,
                     bufferlist& bl);

--- a/src/rgw/services/svc_sys_obj.h
+++ b/src/rgw/services/svc_sys_obj.h
@@ -93,12 +93,12 @@ public:
 
       ROp(Obj& _source) : source(_source) {}
 
-      int stat();
-      int read(int64_t ofs, int64_t end, bufferlist *pbl);
-      int read(bufferlist *pbl) {
-        return read(0, -1, pbl);
+      int stat(optional_yield y);
+      int read(int64_t ofs, int64_t end, bufferlist *pbl, optional_yield y);
+      int read(bufferlist *pbl, optional_yield y) {
+        return read(0, -1, pbl, y);
       }
-      int get_attr(const char *name, bufferlist *dest);
+      int get_attr(const char *name, bufferlist *dest, optional_yield y);
     };
 
     struct WOp {
@@ -142,12 +142,13 @@ public:
 
       WOp(Obj& _source) : source(_source) {}
 
-      int remove();
-      int write(bufferlist& bl);
+      int remove(optional_yield y);
+      int write(bufferlist& bl, optional_yield y);
 
-      int write_data(bufferlist& bl); /* write data only */
-      int write_attrs(); /* write attrs only */
-      int write_attr(const char *name, bufferlist& bl); /* write attrs only */
+      int write_data(bufferlist& bl, optional_yield y); /* write data only */
+      int write_attrs(optional_yield y); /* write attrs only */
+      int write_attr(const char *name, bufferlist& bl,
+                     optional_yield y); /* write attrs only */
     };
 
     struct OmapOp {
@@ -162,14 +163,13 @@ public:
 
       OmapOp(Obj& _source) : source(_source) {}
 
-      int get_all(std::map<string, bufferlist> *m);
-      int get_vals(const string& marker,
-                        uint64_t count,
-                        std::map<string, bufferlist> *m,
-                        bool *pmore);
-      int set(const std::string& key, bufferlist& bl);
-      int set(const map<std::string, bufferlist>& m);
-      int del(const std::string& key);
+      int get_all(std::map<string, bufferlist> *m, optional_yield y);
+      int get_vals(const string& marker, uint64_t count,
+                   std::map<string, bufferlist> *m,
+                   bool *pmore, optional_yield y);
+      int set(const std::string& key, bufferlist& bl, optional_yield y);
+      int set(const map<std::string, bufferlist>& m, optional_yield y);
+      int del(const std::string& key, optional_yield y);
     };
 
     struct WNOp {
@@ -177,9 +177,8 @@ public:
 
       WNOp(Obj& _source) : source(_source) {}
 
-      int notify(bufferlist& bl,
-		 uint64_t timeout_ms,
-		 bufferlist *pbl);
+      int notify(bufferlist& bl, uint64_t timeout_ms, bufferlist *pbl,
+                 optional_yield y);
     };
     ROp rop() {
       return ROp(*this);

--- a/src/rgw/services/svc_sys_obj_cache.cc
+++ b/src/rgw/services/svc_sys_obj_cache.cc
@@ -66,7 +66,8 @@ void RGWSI_SysObj_Cache::normalize_pool_and_obj(const rgw_pool& src_pool, const 
 
 int RGWSI_SysObj_Cache::remove(RGWSysObjectCtxBase& obj_ctx,
                                RGWObjVersionTracker *objv_tracker,
-                               const rgw_raw_obj& obj)
+                               const rgw_raw_obj& obj,
+                               optional_yield y)
 
 {
   rgw_pool pool;
@@ -77,12 +78,12 @@ int RGWSI_SysObj_Cache::remove(RGWSysObjectCtxBase& obj_ctx,
   cache.remove(name);
 
   ObjectCacheInfo info;
-  int r = distribute_cache(name, obj, info, REMOVE_OBJ);
+  int r = distribute_cache(name, obj, info, REMOVE_OBJ, y);
   if (r < 0) {
     ldout(cct, 0) << "ERROR: " << __func__ << "(): failed to distribute cache: r=" << r << dendl;
   }
 
-  return RGWSI_SysObj_Core::remove(obj_ctx, objv_tracker, obj);
+  return RGWSI_SysObj_Core::remove(obj_ctx, objv_tracker, obj, y);
 }
 
 int RGWSI_SysObj_Cache::read(RGWSysObjectCtxBase& obj_ctx,
@@ -93,14 +94,15 @@ int RGWSI_SysObj_Cache::read(RGWSysObjectCtxBase& obj_ctx,
                              map<string, bufferlist> *attrs,
 			     bool raw_attrs,
                              rgw_cache_entry_info *cache_info,
-                             boost::optional<obj_version> refresh_version)
+                             boost::optional<obj_version> refresh_version,
+                             optional_yield y)
 {
   rgw_pool pool;
   string oid;
   if (ofs != 0) {
     return RGWSI_SysObj_Core::read(obj_ctx, read_state, objv_tracker,
-                          obj, obl, ofs, end, attrs, raw_attrs,
-                          cache_info, refresh_version);
+                                   obj, obl, ofs, end, attrs, raw_attrs,
+                                   cache_info, refresh_version, y);
   }
 
   normalize_pool_and_obj(obj.pool, obj.oid, pool, oid);
@@ -144,7 +146,7 @@ int RGWSI_SysObj_Cache::read(RGWSysObjectCtxBase& obj_ctx,
 			 (attrs ? &unfiltered_attrset : nullptr),
 			 true, /* cache unfiltered attrs */
 			 cache_info,
-                         refresh_version);
+                         refresh_version, y);
   if (r < 0) {
     if (r == -ENOENT) { // only update ENOENT, we'd rather retry other errors
       info.status = r;
@@ -182,8 +184,9 @@ int RGWSI_SysObj_Cache::read(RGWSysObjectCtxBase& obj_ctx,
 }
 
 int RGWSI_SysObj_Cache::get_attr(const rgw_raw_obj& obj,
-				 const char *attr_name,
-				 bufferlist *dest)
+                                 const char *attr_name,
+                                 bufferlist *dest,
+                                 optional_yield y)
 {
   rgw_pool pool;
   string oid;
@@ -208,13 +211,14 @@ int RGWSI_SysObj_Cache::get_attr(const rgw_raw_obj& obj,
     return dest->length();
   }
   /* don't try to cache this one */
-  return RGWSI_SysObj_Core::get_attr(obj, attr_name, dest);
+  return RGWSI_SysObj_Core::get_attr(obj, attr_name, dest, y);
 }
 
 int RGWSI_SysObj_Cache::set_attrs(const rgw_raw_obj& obj, 
                                   map<string, bufferlist>& attrs,
                                   map<string, bufferlist> *rmattrs,
-                                  RGWObjVersionTracker *objv_tracker) 
+                                  RGWObjVersionTracker *objv_tracker,
+                                  optional_yield y)
 {
   rgw_pool pool;
   string oid;
@@ -230,11 +234,11 @@ int RGWSI_SysObj_Cache::set_attrs(const rgw_raw_obj& obj,
     info.version = objv_tracker->write_version;
     info.flags |= CACHE_FLAG_OBJV;
   }
-  int ret = RGWSI_SysObj_Core::set_attrs(obj, attrs, rmattrs, objv_tracker);
+  int ret = RGWSI_SysObj_Core::set_attrs(obj, attrs, rmattrs, objv_tracker, y);
   string name = normal_name(pool, oid);
   if (ret >= 0) {
     cache.put(name, info, NULL);
-    int r = distribute_cache(name, obj, info, UPDATE_OBJ);
+    int r = distribute_cache(name, obj, info, UPDATE_OBJ, y);
     if (r < 0)
       ldout(cct, 0) << "ERROR: failed to distribute cache for " << obj << dendl;
   } else {
@@ -250,7 +254,8 @@ int RGWSI_SysObj_Cache::write(const rgw_raw_obj& obj,
                              bool exclusive,
                              const bufferlist& data,
                              RGWObjVersionTracker *objv_tracker,
-                             real_time set_mtime)
+                             real_time set_mtime,
+                             optional_yield y)
 {
   rgw_pool pool;
   string oid;
@@ -266,8 +271,8 @@ int RGWSI_SysObj_Cache::write(const rgw_raw_obj& obj,
   }
   ceph::real_time result_mtime;
   int ret = RGWSI_SysObj_Core::write(obj, &result_mtime, attrs,
-                            exclusive, data,
-                            objv_tracker, set_mtime);
+                                     exclusive, data,
+                                     objv_tracker, set_mtime, y);
   if (pmtime) {
     *pmtime = result_mtime;
   }
@@ -284,7 +289,7 @@ int RGWSI_SysObj_Cache::write(const rgw_raw_obj& obj,
     // will need that system object in the near-term and b) it
     // generates additional network traffic.
     if (!exclusive) {
-      int r = distribute_cache(name, obj, info, UPDATE_OBJ);
+      int r = distribute_cache(name, obj, info, UPDATE_OBJ, y);
       if (r < 0)
 	ldout(cct, 0) << "ERROR: failed to distribute cache for " << obj << dendl;
     }
@@ -298,7 +303,8 @@ int RGWSI_SysObj_Cache::write(const rgw_raw_obj& obj,
 int RGWSI_SysObj_Cache::write_data(const rgw_raw_obj& obj,
                                    const bufferlist& data,
                                    bool exclusive,
-                                   RGWObjVersionTracker *objv_tracker)
+                                   RGWObjVersionTracker *objv_tracker,
+                                   optional_yield y)
 {
   rgw_pool pool;
   string oid;
@@ -314,11 +320,11 @@ int RGWSI_SysObj_Cache::write_data(const rgw_raw_obj& obj,
     info.version = objv_tracker->write_version;
     info.flags |= CACHE_FLAG_OBJV;
   }
-  int ret = RGWSI_SysObj_Core::write_data(obj, data, exclusive, objv_tracker);
+  int ret = RGWSI_SysObj_Core::write_data(obj, data, exclusive, objv_tracker, y);
   string name = normal_name(pool, oid);
   if (ret >= 0) {
     cache.put(name, info, NULL);
-    int r = distribute_cache(name, obj, info, UPDATE_OBJ);
+    int r = distribute_cache(name, obj, info, UPDATE_OBJ, y);
     if (r < 0)
       ldout(cct, 0) << "ERROR: failed to distribute cache for " << obj << dendl;
   } else {
@@ -330,7 +336,8 @@ int RGWSI_SysObj_Cache::write_data(const rgw_raw_obj& obj,
 
 int RGWSI_SysObj_Cache::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *pepoch,
                                  map<string, bufferlist> *attrs, bufferlist *first_chunk,
-                                 RGWObjVersionTracker *objv_tracker)
+                                 RGWObjVersionTracker *objv_tracker,
+                                 optional_yield y)
 {
   rgw_pool pool;
   string oid;
@@ -358,7 +365,8 @@ int RGWSI_SysObj_Cache::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_t
       objv_tracker->read_version = info.version;
     goto done;
   }
-  r = RGWSI_SysObj_Core::raw_stat(obj, &size, &mtime, &epoch, &info.xattrs, first_chunk, objv_tracker);
+  r = RGWSI_SysObj_Core::raw_stat(obj, &size, &mtime, &epoch, &info.xattrs,
+                                  first_chunk, objv_tracker, y);
   if (r < 0) {
     if (r == -ENOENT) {
       info.status = r;
@@ -388,17 +396,18 @@ done:
   return 0;
 }
 
-int RGWSI_SysObj_Cache::distribute_cache(const string& normal_name, const rgw_raw_obj& obj, ObjectCacheInfo& obj_info, int op)
+int RGWSI_SysObj_Cache::distribute_cache(const string& normal_name,
+                                         const rgw_raw_obj& obj,
+                                         ObjectCacheInfo& obj_info, int op,
+                                         optional_yield y)
 {
   RGWCacheNotifyInfo info;
-
   info.op = op;
-
   info.obj_info = obj_info;
   info.obj = obj;
   bufferlist bl;
   encode(info, bl);
-  return notify_svc->distribute(normal_name, bl);
+  return notify_svc->distribute(normal_name, bl, y);
 }
 
 int RGWSI_SysObj_Cache::watch_cb(uint64_t notify_id,

--- a/src/rgw/services/svc_sys_obj_cache.h
+++ b/src/rgw/services/svc_sys_obj_cache.h
@@ -35,7 +35,8 @@ protected:
 
   int raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch,
                map<string, bufferlist> *attrs, bufferlist *first_chunk,
-               RGWObjVersionTracker *objv_tracker) override;
+               RGWObjVersionTracker *objv_tracker,
+               optional_yield y) override;
 
   int read(RGWSysObjectCtxBase& obj_ctx,
            GetObjState& read_state,
@@ -45,18 +46,22 @@ protected:
            map<string, bufferlist> *attrs,
 	   bool raw_attrs,
            rgw_cache_entry_info *cache_info,
-           boost::optional<obj_version>) override;
+           boost::optional<obj_version>,
+           optional_yield y) override;
 
-  int get_attr(const rgw_raw_obj& obj, const char *name, bufferlist *dest) override;
+  int get_attr(const rgw_raw_obj& obj, const char *name, bufferlist *dest,
+               optional_yield y) override;
 
   int set_attrs(const rgw_raw_obj& obj, 
                 map<string, bufferlist>& attrs,
                 map<string, bufferlist> *rmattrs,
-                RGWObjVersionTracker *objv_tracker);
+                RGWObjVersionTracker *objv_tracker,
+                optional_yield y);
 
   int remove(RGWSysObjectCtxBase& obj_ctx,
              RGWObjVersionTracker *objv_tracker,
-             const rgw_raw_obj& obj) override;
+             const rgw_raw_obj& obj,
+             optional_yield y) override;
 
   int write(const rgw_raw_obj& obj,
             real_time *pmtime,
@@ -64,14 +69,18 @@ protected:
             bool exclusive,
             const bufferlist& data,
             RGWObjVersionTracker *objv_tracker,
-            real_time set_mtime) override;
+            real_time set_mtime,
+            optional_yield y) override;
 
   int write_data(const rgw_raw_obj& obj,
                  const bufferlist& bl,
                  bool exclusive,
-                 RGWObjVersionTracker *objv_tracker);
+                 RGWObjVersionTracker *objv_tracker,
+                 optional_yield y);
 
-  int distribute_cache(const string& normal_name, const rgw_raw_obj& obj, ObjectCacheInfo& obj_info, int op);
+  int distribute_cache(const string& normal_name, const rgw_raw_obj& obj,
+                       ObjectCacheInfo& obj_info, int op,
+                       optional_yield y);
 
   int watch_cb(uint64_t notify_id,
                uint64_t cookie,

--- a/src/rgw/services/svc_sys_obj_core.cc
+++ b/src/rgw/services/svc_sys_obj_core.cc
@@ -46,7 +46,11 @@ int RGWSI_SysObj_Core::get_rados_obj(RGWSI_Zone *zone_svc,
   return 0;
 }
 
-int RGWSI_SysObj_Core::get_system_obj_state_impl(RGWSysObjectCtxBase *rctx, const rgw_raw_obj& obj, RGWSysObjState **state, RGWObjVersionTracker *objv_tracker)
+int RGWSI_SysObj_Core::get_system_obj_state_impl(RGWSysObjectCtxBase *rctx,
+                                                 const rgw_raw_obj& obj,
+                                                 RGWSysObjState **state,
+                                                 RGWObjVersionTracker *objv_tracker,
+                                                 optional_yield y)
 {
   if (obj.empty()) {
     return -EINVAL;
@@ -61,7 +65,8 @@ int RGWSI_SysObj_Core::get_system_obj_state_impl(RGWSysObjectCtxBase *rctx, cons
 
   s->obj = obj;
 
-  int r = raw_stat(obj, &s->size, &s->mtime, &s->epoch, &s->attrset, (s->prefetch_data ? &s->data : nullptr), objv_tracker);
+  int r = raw_stat(obj, &s->size, &s->mtime, &s->epoch, &s->attrset,
+                   (s->prefetch_data ? &s->data : nullptr), objv_tracker, y);
   if (r == -ENOENT) {
     s->exists = false;
     s->has_attrs = true;
@@ -84,12 +89,16 @@ int RGWSI_SysObj_Core::get_system_obj_state_impl(RGWSysObjectCtxBase *rctx, cons
   return 0;
 }
 
-int RGWSI_SysObj_Core::get_system_obj_state(RGWSysObjectCtxBase *rctx, const rgw_raw_obj& obj, RGWSysObjState **state, RGWObjVersionTracker *objv_tracker)
+int RGWSI_SysObj_Core::get_system_obj_state(RGWSysObjectCtxBase *rctx,
+                                            const rgw_raw_obj& obj,
+                                            RGWSysObjState **state,
+                                            RGWObjVersionTracker *objv_tracker,
+                                            optional_yield y)
 {
   int ret;
 
   do {
-    ret = get_system_obj_state_impl(rctx, obj, state, objv_tracker);
+    ret = get_system_obj_state_impl(rctx, obj, state, objv_tracker, y);
   } while (ret == -EAGAIN);
 
   return ret;
@@ -97,7 +106,8 @@ int RGWSI_SysObj_Core::get_system_obj_state(RGWSysObjectCtxBase *rctx, const rgw
 
 int RGWSI_SysObj_Core::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch,
                                 map<string, bufferlist> *attrs, bufferlist *first_chunk,
-                                RGWObjVersionTracker *objv_tracker)
+                                RGWObjVersionTracker *objv_tracker,
+                                optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -120,7 +130,7 @@ int RGWSI_SysObj_Core::raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_ti
     op.read(0, cct->_conf->rgw_max_chunk_size, first_chunk, nullptr);
   }
   bufferlist outbl;
-  r = rados_obj.operate(&op, &outbl, null_yield);
+  r = rados_obj.operate(&op, &outbl, y);
 
   if (epoch) {
     *epoch = rados_obj.get_last_version();
@@ -144,11 +154,12 @@ int RGWSI_SysObj_Core::stat(RGWSysObjectCtxBase& obj_ctx,
 			    bool raw_attrs,
                             real_time *lastmod,
                             uint64_t *obj_size,
-                            RGWObjVersionTracker *objv_tracker)
+                            RGWObjVersionTracker *objv_tracker,
+                            optional_yield y)
 {
   RGWSysObjState *astate = nullptr;
 
-  int r = get_system_obj_state(&obj_ctx, obj, &astate, objv_tracker);
+  int r = get_system_obj_state(&obj_ctx, obj, &astate, objv_tracker, y);
   if (r < 0)
     return r;
 
@@ -186,7 +197,8 @@ int RGWSI_SysObj_Core::read(RGWSysObjectCtxBase& obj_ctx,
                             map<string, bufferlist> *attrs,
 			    bool raw_attrs,
                             rgw_cache_entry_info *cache_info,
-                            boost::optional<obj_version>)
+                            boost::optional<obj_version>,
+                            optional_yield y)
 {
   uint64_t len;
   librados::ObjectReadOperation op;
@@ -219,7 +231,7 @@ int RGWSI_SysObj_Core::read(RGWSysObjectCtxBase& obj_ctx,
     ldout(cct, 20) << "get_rados_obj() on obj=" << obj << " returned " << r << dendl;
     return r;
   }
-  r = rados_obj.operate(&op, nullptr, null_yield);
+  r = rados_obj.operate(&op, nullptr, y);
   if (r < 0) {
     ldout(cct, 20) << "rados_obj.operate() r=" << r << " bl.length=" << bl->length() << dendl;
     return r;
@@ -252,7 +264,8 @@ int RGWSI_SysObj_Core::read(RGWSysObjectCtxBase& obj_ctx,
  */
 int RGWSI_SysObj_Core::get_attr(const rgw_raw_obj& obj,
                                 const char *name,
-                                bufferlist *dest)
+                                bufferlist *dest,
+                                optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -266,17 +279,18 @@ int RGWSI_SysObj_Core::get_attr(const rgw_raw_obj& obj,
   int rval;
   op.getxattr(name, dest, &rval);
   
-  r = rados_obj.operate(&op, nullptr, null_yield);
+  r = rados_obj.operate(&op, nullptr, y);
   if (r < 0)
     return r;
 
   return 0;
 }
 
-int RGWSI_SysObj_Core::set_attrs(const rgw_raw_obj& obj, 
+int RGWSI_SysObj_Core::set_attrs(const rgw_raw_obj& obj,
                                  map<string, bufferlist>& attrs,
                                  map<string, bufferlist> *rmattrs,
-                                 RGWObjVersionTracker *objv_tracker) 
+                                 RGWObjVersionTracker *objv_tracker,
+                                 optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -314,7 +328,7 @@ int RGWSI_SysObj_Core::set_attrs(const rgw_raw_obj& obj,
 
   bufferlist bl;
 
-  r = rados_obj.operate(&op, null_yield);
+  r = rados_obj.operate(&op, y);
   if (r < 0)
     return r;
 
@@ -325,7 +339,8 @@ int RGWSI_SysObj_Core::omap_get_vals(const rgw_raw_obj& obj,
                                      const string& marker,
                                      uint64_t count,
                                      std::map<string, bufferlist> *m,
-                                     bool *pmore)
+                                     bool *pmore,
+                                     optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -344,7 +359,7 @@ int RGWSI_SysObj_Core::omap_get_vals(const rgw_raw_obj& obj,
     int rval;
     op.omap_get_vals2(start_after, count, &t, &more, &rval);
   
-    r = rados_obj.operate(&op, nullptr, null_yield);
+    r = rados_obj.operate(&op, nullptr, y);
     if (r < 0) {
       return r;
     }
@@ -362,7 +377,9 @@ int RGWSI_SysObj_Core::omap_get_vals(const rgw_raw_obj& obj,
   return 0;
 }
 
-int RGWSI_SysObj_Core::omap_get_all(const rgw_raw_obj& obj, std::map<string, bufferlist> *m)
+int RGWSI_SysObj_Core::omap_get_all(const rgw_raw_obj& obj,
+                                    std::map<string, bufferlist> *m,
+                                    optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -383,7 +400,7 @@ int RGWSI_SysObj_Core::omap_get_all(const rgw_raw_obj& obj, std::map<string, buf
     int rval;
     op.omap_get_vals2(start_after, count, &t, &more, &rval);
   
-    r = rados_obj.operate(&op, nullptr, null_yield);
+    r = rados_obj.operate(&op, nullptr, y);
     if (r < 0) {
       return r;
     }
@@ -396,7 +413,9 @@ int RGWSI_SysObj_Core::omap_get_all(const rgw_raw_obj& obj, std::map<string, buf
   return 0;
 }
 
-int RGWSI_SysObj_Core::omap_set(const rgw_raw_obj& obj, const std::string& key, bufferlist& bl, bool must_exist)
+int RGWSI_SysObj_Core::omap_set(const rgw_raw_obj& obj, const std::string& key,
+                                bufferlist& bl, bool must_exist,
+                                optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -413,11 +432,13 @@ int RGWSI_SysObj_Core::omap_set(const rgw_raw_obj& obj, const std::string& key, 
   if (must_exist)
     op.assert_exists();
   op.omap_set(m);
-  r = rados_obj.operate(&op, null_yield);
+  r = rados_obj.operate(&op, y);
   return r;
 }
 
-int RGWSI_SysObj_Core::omap_set(const rgw_raw_obj& obj, const std::map<std::string, bufferlist>& m, bool must_exist)
+int RGWSI_SysObj_Core::omap_set(const rgw_raw_obj& obj,
+                                const std::map<std::string, bufferlist>& m,
+                                bool must_exist, optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -430,11 +451,12 @@ int RGWSI_SysObj_Core::omap_set(const rgw_raw_obj& obj, const std::map<std::stri
   if (must_exist)
     op.assert_exists();
   op.omap_set(m);
-  r = rados_obj.operate(&op, null_yield);
+  r = rados_obj.operate(&op, y);
   return r;
 }
 
-int RGWSI_SysObj_Core::omap_del(const rgw_raw_obj& obj, const std::string& key)
+int RGWSI_SysObj_Core::omap_del(const rgw_raw_obj& obj, const std::string& key,
+                                optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -450,14 +472,13 @@ int RGWSI_SysObj_Core::omap_del(const rgw_raw_obj& obj, const std::string& key)
 
   op.omap_rm_keys(k);
 
-  r = rados_obj.operate(&op, null_yield);
+  r = rados_obj.operate(&op, y);
   return r;
 }
 
-int RGWSI_SysObj_Core::notify(const rgw_raw_obj& obj,
-			      bufferlist& bl,
-			      uint64_t timeout_ms,
-			      bufferlist *pbl)
+int RGWSI_SysObj_Core::notify(const rgw_raw_obj& obj, bufferlist& bl,
+                              uint64_t timeout_ms, bufferlist *pbl,
+                              optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -466,13 +487,14 @@ int RGWSI_SysObj_Core::notify(const rgw_raw_obj& obj,
     return r;
   }
 
-  r = rados_obj.notify(bl, timeout_ms, pbl);
+  r = rados_obj.notify(bl, timeout_ms, pbl, y);
   return r;
 }
 
 int RGWSI_SysObj_Core::remove(RGWSysObjectCtxBase& obj_ctx,
-                         RGWObjVersionTracker *objv_tracker,
-                         const rgw_raw_obj& obj)
+                              RGWObjVersionTracker *objv_tracker,
+                              const rgw_raw_obj& obj,
+                              optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -488,7 +510,7 @@ int RGWSI_SysObj_Core::remove(RGWSysObjectCtxBase& obj_ctx,
   }
 
   op.remove();
-  r = rados_obj.operate(&op, null_yield);
+  r = rados_obj.operate(&op, y);
   if (r < 0)
     return r;
 
@@ -501,7 +523,8 @@ int RGWSI_SysObj_Core::write(const rgw_raw_obj& obj,
                              bool exclusive,
                              const bufferlist& data,
                              RGWObjVersionTracker *objv_tracker,
-                             real_time set_mtime)
+                             real_time set_mtime,
+                             optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -544,7 +567,7 @@ int RGWSI_SysObj_Core::write(const rgw_raw_obj& obj,
     op.setxattr(name.c_str(), bl);
   }
 
-  r = rados_obj.operate(&op, null_yield);
+  r = rados_obj.operate(&op, y);
   if (r < 0) {
     return r;
   }
@@ -564,7 +587,8 @@ int RGWSI_SysObj_Core::write(const rgw_raw_obj& obj,
 int RGWSI_SysObj_Core::write_data(const rgw_raw_obj& obj,
                                   const bufferlist& bl,
                                   bool exclusive,
-                                  RGWObjVersionTracker *objv_tracker)
+                                  RGWObjVersionTracker *objv_tracker,
+                                  optional_yield y)
 {
   RGWSI_RADOS::Obj rados_obj;
   int r = get_rados_obj(zone_svc, obj, &rados_obj);
@@ -583,7 +607,7 @@ int RGWSI_SysObj_Core::write_data(const rgw_raw_obj& obj,
     objv_tracker->prepare_op_for_write(&op);
   }
   op.write_full(bl);
-  r = rados_obj.operate(&op, null_yield);
+  r = rados_obj.operate(&op, y);
   if (r < 0)
     return r;
 

--- a/src/rgw/services/svc_sys_obj_core.h
+++ b/src/rgw/services/svc_sys_obj_core.h
@@ -126,7 +126,8 @@ protected:
 
   virtual int raw_stat(const rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch,
                        map<string, bufferlist> *attrs, bufferlist *first_chunk,
-                       RGWObjVersionTracker *objv_tracker);
+                       RGWObjVersionTracker *objv_tracker,
+                       optional_yield y);
 
   virtual int read(RGWSysObjectCtxBase& obj_ctx,
                    GetObjState& read_state,
@@ -136,11 +137,13 @@ protected:
                    map<string, bufferlist> *attrs,
 		   bool raw_attrs,
                    rgw_cache_entry_info *cache_info,
-                   boost::optional<obj_version>);
+                   boost::optional<obj_version>,
+                   optional_yield y);
 
   virtual int remove(RGWSysObjectCtxBase& obj_ctx,
                      RGWObjVersionTracker *objv_tracker,
-                     const rgw_raw_obj& obj);
+                     const rgw_raw_obj& obj,
+                     optional_yield y);
 
   virtual int write(const rgw_raw_obj& obj,
                     real_time *pmtime,
@@ -148,38 +151,54 @@ protected:
                     bool exclusive,
                     const bufferlist& data,
                     RGWObjVersionTracker *objv_tracker,
-                    real_time set_mtime);
+                    real_time set_mtime,
+                    optional_yield y);
 
   virtual int write_data(const rgw_raw_obj& obj,
                          const bufferlist& bl,
                          bool exclusive,
-                         RGWObjVersionTracker *objv_tracker);
+                         RGWObjVersionTracker *objv_tracker,
+                         optional_yield y);
 
-  virtual int get_attr(const rgw_raw_obj& obj, const char *name, bufferlist *dest);
+  virtual int get_attr(const rgw_raw_obj& obj, const char *name, bufferlist *dest,
+                       optional_yield y);
 
-  virtual int set_attrs(const rgw_raw_obj& obj, 
+  virtual int set_attrs(const rgw_raw_obj& obj,
                         map<string, bufferlist>& attrs,
                         map<string, bufferlist> *rmattrs,
-                        RGWObjVersionTracker *objv_tracker);
+                        RGWObjVersionTracker *objv_tracker,
+                        optional_yield y);
 
-  virtual int omap_get_all(const rgw_raw_obj& obj, std::map<string, bufferlist> *m);
+  virtual int omap_get_all(const rgw_raw_obj& obj, std::map<string, bufferlist> *m,
+                           optional_yield y);
   virtual int omap_get_vals(const rgw_raw_obj& obj,
                             const string& marker,
                             uint64_t count,
                             std::map<string, bufferlist> *m,
-                            bool *pmore);
-  virtual int omap_set(const rgw_raw_obj& obj, const std::string& key, bufferlist& bl, bool must_exist = false);
-  virtual int omap_set(const rgw_raw_obj& obj, const map<std::string, bufferlist>& m, bool must_exist = false);
-  virtual int omap_del(const rgw_raw_obj& obj, const std::string& key);
+                            bool *pmore,
+                            optional_yield y);
+  virtual int omap_set(const rgw_raw_obj& obj, const std::string& key,
+                       bufferlist& bl, bool must_exist,
+                       optional_yield y);
+  virtual int omap_set(const rgw_raw_obj& obj,
+                       const map<std::string, bufferlist>& m, bool must_exist,
+                       optional_yield y);
+  virtual int omap_del(const rgw_raw_obj& obj, const std::string& key,
+                       optional_yield y);
 
-  virtual int notify(const rgw_raw_obj& obj,
-		     bufferlist& bl,
-		     uint64_t timeout_ms,
-		     bufferlist *pbl);
+  virtual int notify(const rgw_raw_obj& obj, bufferlist& bl,
+                     uint64_t timeout_ms, bufferlist *pbl,
+                     optional_yield y);
 
   /* wrappers */
-  int get_system_obj_state_impl(RGWSysObjectCtxBase *rctx, const rgw_raw_obj& obj, RGWSysObjState **state, RGWObjVersionTracker *objv_tracker);
-  int get_system_obj_state(RGWSysObjectCtxBase *rctx, const rgw_raw_obj& obj, RGWSysObjState **state, RGWObjVersionTracker *objv_tracker);
+  int get_system_obj_state_impl(RGWSysObjectCtxBase *rctx,
+                                const rgw_raw_obj& obj, RGWSysObjState **state,
+                                RGWObjVersionTracker *objv_tracker,
+                                optional_yield y);
+  int get_system_obj_state(RGWSysObjectCtxBase *rctx, const rgw_raw_obj& obj,
+                           RGWSysObjState **state,
+                           RGWObjVersionTracker *objv_tracker,
+                           optional_yield y);
 
   int stat(RGWSysObjectCtxBase& obj_ctx,
            GetObjState& state,
@@ -188,7 +207,8 @@ protected:
 	   bool raw_attrs,
            real_time *lastmod,
            uint64_t *obj_size,
-           RGWObjVersionTracker *objv_tracker);
+           RGWObjVersionTracker *objv_tracker,
+           optional_yield y);
 
 public:
   RGWSI_SysObj_Core(CephContext *cct): RGWServiceInstance(cct) {}

--- a/src/rgw/services/svc_zone.cc
+++ b/src/rgw/services/svc_zone.cc
@@ -310,7 +310,7 @@ int RGWSI_Zone::replace_region_with_zonegroup()
   RGWSysObjectCtx obj_ctx = sysobj_svc->init_obj_ctx();
   RGWSysObj sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj(pool, oid));
 
-  int ret = sysobj.rop().read(&bl);
+  int ret = sysobj.rop().read(&bl, null_yield);
   if (ret < 0 && ret !=  -ENOENT) {
     ldout(cct, 0) << __func__ << " failed to read converted: ret "<< ret << " " << cpp_strerror(-ret)
 		  << dendl;
@@ -533,7 +533,7 @@ int RGWSI_Zone::replace_region_with_zonegroup()
   /* mark as converted */
   ret = sysobj.wop()
               .set_exclusive(true)
-              .write(bl);
+              .write(bl, null_yield);
   if (ret < 0 ) {
     ldout(cct, 0) << __func__ << " failed to mark cluster as converted: ret "<< ret << " " << cpp_strerror(-ret)
 		  << dendl;
@@ -727,7 +727,7 @@ int RGWSI_Zone::convert_regionmap()
   RGWSysObjectCtx obj_ctx = sysobj_svc->init_obj_ctx();
   RGWSysObj sysobj = sysobj_svc->get_obj(obj_ctx, rgw_raw_obj(pool, oid));
 
-  int ret = sysobj.rop().read(&bl);
+  int ret = sysobj.rop().read(&bl, null_yield);
   if (ret < 0 && ret != -ENOENT) {
     return ret;
   } else if (ret == -ENOENT) {
@@ -765,7 +765,7 @@ int RGWSI_Zone::convert_regionmap()
   current_period->set_bucket_quota(zonegroupmap.bucket_quota);
 
   // remove the region_map so we don't try to convert again
-  ret = sysobj.wop().remove();
+  ret = sysobj.wop().remove(null_yield);
   if (ret < 0) {
     ldout(cct, 0) << "Error could not remove " << sysobj.get_obj()
         << " after upgrading to zonegroup map: " << cpp_strerror(ret) << dendl;
@@ -1086,7 +1086,7 @@ int RGWSI_Zone::select_legacy_bucket_placement(RGWZonePlacementInfo *rule_info)
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(obj);
 
-  int ret = sysobj.rop().read(&map_bl);
+  int ret = sysobj.rop().read(&map_bl, null_yield);
   if (ret < 0) {
     goto read_omap;
   }
@@ -1100,7 +1100,7 @@ int RGWSI_Zone::select_legacy_bucket_placement(RGWZonePlacementInfo *rule_info)
 
 read_omap:
   if (m.empty()) {
-    ret = sysobj.omap().get_all(&m);
+    ret = sysobj.omap().get_all(&m, null_yield);
 
     write_map = true;
   }
@@ -1114,7 +1114,7 @@ read_omap:
     ret = rados_svc->pool().create(pools, &retcodes);
     if (ret < 0)
       return ret;
-    ret = sysobj.omap().set(s, bl);
+    ret = sysobj.omap().set(s, bl, null_yield);
     if (ret < 0)
       return ret;
     m[s] = bl;
@@ -1123,7 +1123,7 @@ read_omap:
   if (write_map) {
     bufferlist new_bl;
     encode(m, new_bl);
-    ret = sysobj.wop().write(new_bl);
+    ret = sysobj.wop().write(new_bl, null_yield);
     if (ret < 0) {
       ldout(cct, 0) << "WARNING: could not save avail pools map info ret=" << ret << dendl;
     }
@@ -1156,13 +1156,13 @@ int RGWSI_Zone::update_placement_map()
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(obj);
 
-  int ret = sysobj.omap().get_all(&m);
+  int ret = sysobj.omap().get_all(&m, null_yield);
   if (ret < 0)
     return ret;
 
   bufferlist new_bl;
   encode(m, new_bl);
-  ret = sysobj.wop().write(new_bl);
+  ret = sysobj.wop().write(new_bl, null_yield);
   if (ret < 0) {
     ldout(cct, 0) << "WARNING: could not save avail pools map info ret=" << ret << dendl;
   }
@@ -1182,7 +1182,7 @@ int RGWSI_Zone::add_bucket_placement(const rgw_pool& new_pool)
   auto sysobj = obj_ctx.get_obj(obj);
 
   bufferlist empty_bl;
-  ret = sysobj.omap().set(new_pool.to_str(), empty_bl);
+  ret = sysobj.omap().set(new_pool.to_str(), empty_bl, null_yield);
 
   // don't care about return value
   update_placement_map();
@@ -1196,7 +1196,7 @@ int RGWSI_Zone::remove_bucket_placement(const rgw_pool& old_pool)
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(obj);
 
-  int ret = sysobj.omap().del(old_pool.to_str());
+  int ret = sysobj.omap().del(old_pool.to_str(), null_yield);
 
   // don't care about return value
   update_placement_map();
@@ -1212,7 +1212,7 @@ int RGWSI_Zone::list_placement_set(set<rgw_pool>& names)
   rgw_raw_obj obj(zone_params->domain_root, avail_pools);
   auto obj_ctx = sysobj_svc->init_obj_ctx();
   auto sysobj = obj_ctx.get_obj(obj);
-  int ret = sysobj.omap().get_all(&m);
+  int ret = sysobj.omap().get_all(&m, null_yield);
   if (ret < 0)
     return ret;
 


### PR DESCRIPTION
followup to https://github.com/ceph/ceph/pull/25068. extends support for optional_yield through the SysObj service interface, including the watch notifications. all external callers pass `null_yield`, so existing behavior is unchanged