### PR TITLE
ceph-volume: test with multiple NVME drives

### DIFF
--- a/src/ceph-volume/ceph_volume/api/lvm.py
+++ b/src/ceph-volume/ceph_volume/api/lvm.py
@@ -428,6 +428,8 @@ def create_vg(devices, name=None, name_prefix=None):
         name = "ceph-%s" % str(uuid.uuid4())
     process.run([
         'vgcreate',
+        '-s',
+        '1G',
         '--force',
         '--yes',
         name] + devices

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -292,9 +292,8 @@ class MixedType(object):
         # block.db vg from before
         for osd in self.computed['osds']:
             data_path = osd['data']['path']
-            data_lv_size = disk.Size(b=osd['data']['size']).gb.as_int()
             data_vg = data_vgs[data_path]
-            data_lv_extents = data_vg.sizing(size=data_lv_size)['extents']
+            data_lv_extents = data_vg.sizing(parts=1)['extents']
             data_lv = lvm.create_lv(
                 'osd-block', data_vg.name, extents=data_lv_extents, uuid_name=True
             )

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -216,12 +216,6 @@ class MixedType(object):
     def compute(self):
         osds = self.computed['osds']
 
-        # unconfigured block db size will be 0, so set it back to using as much
-        # as possible from looking at extents
-        if self.block_db_size.b == 0:
-            self.block_db_size = disk.Size(b=self.vg_extents['sizes'])
-            self.use_large_block_db = True
-
         if not self.common_vg:
             # there isn't a common vg, so a new one must be created with all
             # the blank SSDs
@@ -396,6 +390,7 @@ class MixedType(object):
         # into the number of block.db LVs needed (i.e. "as large as possible")
         if self.block_db_size.b == 0:
             self.block_db_size = self.total_available_db_space / self.dbs_needed
+            self.use_large_block_db = True
 
         total_dbs_possible = self.total_available_db_space / self.block_db_size
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -85,16 +85,16 @@ class SingleType(object):
             for hdd in range(self.osds_per_device):
                 osd = {'data': {}, 'block.db': {}}
                 osd['data']['path'] = device.abspath
-                osd['data']['size'] = device.sys_api['size'] / self.osds_per_device
+                osd['data']['size'] = device.lvm_size.b / self.osds_per_device
                 osd['data']['parts'] = self.osds_per_device
                 osd['data']['percentage'] = 100 / self.osds_per_device
                 osd['data']['human_readable_size'] = str(
-                    disk.Size(b=device.sys_api['size']) / self.osds_per_device
+                    disk.Size(b=device.lvm_size.b) / self.osds_per_device
                 )
                 osds.append(osd)
 
         for device in self.ssds:
-            extents = lvm.sizing(device.sys_api['size'], parts=self.osds_per_device)
+            extents = lvm.sizing(device.lvm_size.b, parts=self.osds_per_device)
             for ssd in range(self.osds_per_device):
                 osd = {'data': {}, 'block.db': {}}
                 osd['data']['path'] = device.abspath
@@ -236,10 +236,10 @@ class MixedType(object):
             for hdd in range(self.osds_per_device):
                 osd = {'data': {}, 'block.db': {}}
                 osd['data']['path'] = device.abspath
-                osd['data']['size'] = device.sys_api['size'] / self.osds_per_device
+                osd['data']['size'] = device.lvm_size.b / self.osds_per_device
                 osd['data']['percentage'] = 100 / self.osds_per_device
                 osd['data']['human_readable_size'] = str(
-                    disk.Size(b=(device.sys_api['size'])) / self.osds_per_device
+                    disk.Size(b=device.lvm_size.b) / self.osds_per_device
                 )
                 osd['block.db']['path'] = 'vg: %s' % vg_name
                 osd['block.db']['size'] = int(self.block_db_size.b)
@@ -357,7 +357,7 @@ class MixedType(object):
         self.blank_ssds = set(self.ssds).difference(self.vg_ssds)
         self.total_blank_ssd_size = disk.Size(b=0)
         for blank_ssd in self.blank_ssds:
-            self.total_blank_ssd_size += disk.Size(b=blank_ssd.sys_api['size'])
+            self.total_blank_ssd_size += disk.Size(b=blank_ssd.lvm_size.b)
 
         self.total_available_db_space = self.total_blank_ssd_size + common_vg_size
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -386,9 +386,8 @@ class MixedType(object):
 
         for osd in self.computed['osds']:
             data_path = osd['data']['path']
-            data_lv_size = disk.Size(b=osd['data']['size']).gb.as_int()
             data_vg = data_vgs[data_path]
-            data_lv_extents = data_vg.sizing(size=data_lv_size)['extents']
+            data_lv_extents = data_vg.sizing(parts=1)['extents']
             data_lv = lvm.create_lv(
                 'osd-data', data_vg.name, extents=data_lv_extents, uuid_name=True
             )

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/filestore.py
@@ -111,7 +111,7 @@ class SingleType(object):
         osds = self.computed['osds']
         for device in devices:
             for osd in range(self.osds_per_device):
-                device_size = disk.Size(b=device.sys_api['size'])
+                device_size = disk.Size(b=device.lvm_size.b)
                 osd_size = device_size / self.osds_per_device
                 journal_size = self.journal_size
                 data_size = osd_size - journal_size
@@ -291,7 +291,7 @@ class MixedType(object):
         self.blank_ssds = set(self.ssds).difference(self.vg_ssds)
         self.total_blank_ssd_size = disk.Size(b=0)
         for blank_ssd in self.blank_ssds:
-            self.total_blank_ssd_size += disk.Size(b=blank_ssd.sys_api['size'])
+            self.total_blank_ssd_size += disk.Size(b=blank_ssd.lvm_size.b)
 
         self.total_available_journal_space = self.total_blank_ssd_size + common_vg_size
 
@@ -340,7 +340,7 @@ class MixedType(object):
 
         for device in self.hdds:
             for osd in range(self.osds_per_device):
-                device_size = disk.Size(b=device.sys_api['size'])
+                device_size = disk.Size(b=device.lvm_size.b)
                 data_size = device_size / self.osds_per_device
                 osd = {'data': {}, 'journal': {}}
                 osd['data']['path'] = device.path

--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/validators.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/validators.py
@@ -9,7 +9,7 @@ def minimum_device_size(devices, osds_per_device=1):
     """
     msg = 'Unable to use device %s %s, LVs would be smaller than 5GB'
     for device in devices:
-        device_size = disk.Size(b=device.sys_api['size'])
+        device_size = disk.Size(b=device.lvm_size.b)
         lv_size = device_size / osds_per_device
         if lv_size < disk.Size(gb=5):
             raise RuntimeError(msg % (device_size, device.path))
@@ -22,7 +22,7 @@ def minimum_device_collocated_size(devices, journal_size, osds_per_device=1):
     """
     msg = 'Unable to use device %s %s, LVs would be smaller than 5GB'
     for device in devices:
-        device_size = disk.Size(b=device.sys_api['size'])
+        device_size = disk.Size(b=device.lvm_size.b)
         lv_size = (device_size / osds_per_device) - journal_size
         if lv_size < disk.Size(gb=5):
             raise RuntimeError(msg % (device_size, device.path))

--- a/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
+++ b/src/ceph-volume/ceph_volume/tests/api/test_lvm.py
@@ -634,7 +634,7 @@ class TestCreateVG(object):
         monkeypatch.setattr(api, 'get_vg', lambda **kw: True)
         api.create_vg(['/dev/sda', '/dev/sdb'], name='ceph')
         result = fake_run.calls[0]['args'][0]
-        expected = ['vgcreate', '--force', '--yes', 'ceph', '/dev/sda', '/dev/sdb']
+        expected = ['vgcreate', '-s', '1G', '--force', '--yes', 'ceph', '/dev/sda', '/dev/sdb']
         assert result == expected
 
     def test_name_prefix(self, monkeypatch, fake_run):

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+from ceph_volume.util import disk
 from ceph_volume.api import lvm as lvm_api
 from ceph_volume import conf, configuration
 
@@ -66,6 +67,7 @@ def fakedevice(factory):
             is_lvm_member=True,
         )
         params.update(dict(kw))
+        params['lvm_size'] = disk.Size(b=params['sys_api'].get("size", 0))
         return factory(**params)
     return apply
 

--- a/src/ceph-volume/ceph_volume/tests/functional/Vagrantfile
+++ b/src/ceph-volume/ceph_volume/tests/functional/Vagrantfile
@@ -350,7 +350,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         (0..2).each do |d|
           vb.customize ['createhd',
                         '--filename', "disk-#{i}-#{d}",
-                        '--size', '11000'] unless File.exist?("disk-#{i}-#{d}.vdi")
+                        '--size', '12000'] unless File.exist?("disk-#{i}-#{d}.vdi")
           vb.customize ['storageattach', :id,
                         '--storagectl', 'OSD Controller',
                         '--port', 3 + d,

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type-dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type-dmcrypt/group_vars/all
@@ -16,6 +16,7 @@ devices:
   - /dev/sdb
   - /dev/sdc
   - /dev/nvme0n1
+  - /dev/nvme1n1
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type/group_vars/all
@@ -23,6 +23,8 @@ ceph_conf_overrides:
   global:
     osd_pool_default_pg_num: 8
     osd_pool_default_size: 1
+# 9GB in bytes
+block_db_size: 9663676416
 
 # The following is only needed for testing purposes and is not part of
 # ceph-ansible supported variables

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type/group_vars/all
@@ -15,6 +15,7 @@ devices:
   - /dev/sdb
   - /dev/sdc
   - /dev/nvme0n1
+  - /dev/nvme1n1
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type-dmcrypt/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type-dmcrypt/group_vars/all
@@ -16,6 +16,7 @@ devices:
   - /dev/sdb
   - /dev/sdc
   - /dev/nvme0n1
+  - /dev/nvme1n1
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type/group_vars/all
@@ -15,6 +15,7 @@ devices:
   - /dev/sdb
   - /dev/sdc
   - /dev/nvme0n1
+  - /dev/nvme1n1
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/setup_mixed_type.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/setup_mixed_type.yml
@@ -31,9 +31,11 @@
           modprobe nvme_fabrics
           modprobe loop
           losetup -v /dev/loop0 /opt/loop0_nvme0
+          losetup -v /dev/loop1 /opt/loop1_nvme1
           losetup -l
           nvmetcli restore /opt/loop.json
-          nvme connect -t loop -n testnqn -q hostnqn
+          nvme connect -t loop -n testnqn1 -q hostnqn
+          nvme connect -t loop -n testnqn2 -q hostnqn
           nvme list
         dest: "/opt/ceph-nvme.sh"
 
@@ -60,26 +62,33 @@
         - nvme_loop
         - nvme_fabrics
 
-    - name: check if the nvme file is attached to loop0
-      command: losetup -l /dev/loop0
-      register: losetup_list
+    - name: detach nvme files from loop devices
+      command: "losetup -d /dev/{{ item }}"
+      failed_when: false
+      loop:
+        - loop0
+        - loop1
 
-    - name: detach current nvme0 file
-      command: losetup -d /dev/loop0
-      when: '"loop0_nvme0" in losetup_list.stdout'
-
-    - name: remove previous nvme0 file
+    - name: remove previous nvme files
       file:
-        path: /opt/loop0_nvme0
+        path: "{{ item }}"
         state: absent
+      loop:
+        - /opt/loop0_nvme0
+        - /opt/loop1_nvme1
 
-    - name: create a 15GB sparse file for NVMe
-      command: fallocate -l 15G /opt/loop0_nvme0
+    - name: create 11GB sparse files for NVMe
+      command: "fallocate -l 11G {{ item }}"
+      loop:
+        - /opt/loop0_nvme0
+        - /opt/loop1_nvme1
 
-    - name: setup loop device with sparse file
-      command: losetup /dev/loop0 /opt/loop0_nvme0
-      when:
-        - '"loop0_nvme0" not in losetup_list.stdout'
+    - name: setup loop devices with sparse files
+      command: "losetup /dev/loop{{ item }} /opt/loop{{ item }}_nvme{{ item }}"
+      failed_when: false
+      loop:
+        - 0
+        - 1
 
     - name: create the loop.json file for nvmetcli
       copy:
@@ -102,7 +111,8 @@
                   "portid": 1,
                   "referrals": [],
                   "subsystems": [
-                    "testnqn"
+                    "testnqn1",
+                    "testnqn2"
                   ]
                 }
               ],
@@ -124,7 +134,26 @@
                       "nsid": 1
                     }
                   ],
-                  "nqn": "testnqn"
+                  "nqn": "testnqn1"
+                },
+                {
+                  "allowed_hosts": [
+                    "hostnqn"
+                  ],
+                  "attr": {
+                    "allow_any_host": "0"
+                  },
+                  "namespaces": [
+                    {
+                      "device": {
+                        "nguid": "ef90689c-6c46-d44c-89c1-4067801309a7",
+                        "path": "/dev/loop1"
+                      },
+                      "enable": 1,
+                      "nsid": 2
+                    }
+                  ],
+                  "nqn": "testnqn2"
                 }
               ]
             }
@@ -134,7 +163,10 @@
       command: nvmetcli restore /opt/loop.json
 
     - name: connect the new target as an nvme device
-      command: nvme connect -t loop -n testnqn -q hostnqn
+      command: "nvme connect -t loop -n testnqn{{ item }} -q hostnqn"
+      loop:
+        - 1
+        - 2
 
     - name: debug output for nvme list
       command: nvme list

--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -12,6 +12,20 @@ class TestDevice(object):
         assert disk.sys_api
         assert "foo" in disk.sys_api
 
+    def test_lvm_size(self, device_info):
+        # 5GB in size
+        data = {"/dev/sda": {"size": "5368709120"}}
+        device_info(devices=data)
+        disk = device.Device("/dev/sda")
+        assert disk.lvm_size.gb == 4
+
+    def test_lvm_size_rounds_down(self, device_info):
+        # 5.5GB in size
+        data = {"/dev/sda": {"size": "5905580032"}}
+        device_info(devices=data)
+        disk = device.Device("/dev/sda")
+        assert disk.lvm_size.gb == 4
+
     def test_is_lv(self, device_info):
         data = {"lv_path": "vg/lv", "vg_name": "vg", "name": "lv"}
         device_info(lv=data)

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -259,7 +259,17 @@ class Device(object):
 
     @property
     def size(self):
-            return self.sys_api['size']
+        return self.sys_api['size']
+
+    @property
+    def lvm_size(self):
+        """
+        If this device was made into a PV it would lose 1GB in total size
+        due to the 1GB physical extent size we set when creating volume groups
+        """
+        size = disk.Size(b=self.size)
+        lvm_size = disk.Size(gb=size.gb.as_int()) - disk.Size(gb=1)
+        return lvm_size
 
     @property
     def is_lvm_member(self):


### PR DESCRIPTION
The ``batch`` mixed-type tests will now test with two nvme drives. This also changes our PE size to 1G for all vgs we create. This makes sizing vgs easier as everything reports as GBs and allows for creation of larger sized lvs than the default value of 1m for PE size.

Fixes: http://tracker.ceph.com/issues/37409