### PR TITLE
rgw: move all reshard config options out of legacy_config_options

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1537,13 +1537,6 @@ OPTION(rgw_swift_custom_header, OPT_STR) // option to enable swift custom header
 
 OPTION(rgw_swift_need_stats, OPT_BOOL) // option to enable stats on bucket listing for swift
 
-/* resharding tunables */
-OPTION(rgw_reshard_num_logs, OPT_INT)
-OPTION(rgw_reshard_bucket_lock_duration, OPT_INT) // duration of lock on bucket obj during resharding
-OPTION(rgw_dynamic_resharding, OPT_BOOL)
-OPTION(rgw_max_objs_per_shard, OPT_INT)
-OPTION(rgw_reshard_thread_interval, OPT_U32) // maximum time between rounds of reshard thread processing
-
 OPTION(rgw_acl_grants_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html), An ACL can have up to 100 grants.
 OPTION(rgw_cors_rules_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html), An cors can have up to 100 rules.
 OPTION(rgw_delete_multi_obj_max_num, OPT_INT) // According to AWS S3(https://docs.aws.amazon.com/AmazonS3/latest/dev/DeletingObjects.html), Amazon S3 also provides the Multi-Object Delete API that you can use to delete up to 1000 objects in a single HTTP request.

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6375,7 +6375,7 @@ std::vector<Option> get_rgw_options() {
         "a high number of objects per shard.")
     .add_see_also("rgw_max_objs_per_shard"),
 
-    Option("rgw_max_objs_per_shard", Option::TYPE_INT, Option::LEVEL_BASIC)
+    Option("rgw_max_objs_per_shard", Option::TYPE_UINT, Option::LEVEL_BASIC)
     .set_default(100000)
     .set_description("Max objects per shard for dynamic resharding")
     .set_long_description(

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -499,7 +499,7 @@ namespace rgw {
 					 g_conf()->rgw_enable_lc_threads,
 					 g_conf()->rgw_enable_quota_threads,
 					 g_conf()->rgw_run_sync_thread,
-					 g_conf()->rgw_dynamic_resharding);
+					 g_conf().get_val<bool>("rgw_dynamic_resharding"));
 
     if (!store) {
       mutex.Lock();

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6106,7 +6106,8 @@ next:
       max_entries = 1000;
     }
 
-    int num_logshards = store->ctx()->_conf->rgw_reshard_num_logs;
+    int num_logshards =
+      store->ctx()->_conf.get_val<uint64_t>("rgw_reshard_num_logs");
 
     RGWReshard reshard(store);
 
@@ -6196,11 +6197,13 @@ next:
     int ret = br.cancel();
     if (ret < 0) {
       if (ret == -EBUSY) {
-	cerr << "There is ongoing resharding, please retry after " << g_conf()->rgw_reshard_bucket_lock_duration <<
-	     " seconds " << std::endl;
+	cerr << "There is ongoing resharding, please retry after " <<
+	  store->ctx()->_conf.get_val<uint64_t>(
+	    "rgw_reshard_bucket_lock_duration") <<
+	  " seconds " << std::endl;
       } else {
-	cerr << "Error canceling bucket " << bucket_name << " resharding: " << cpp_strerror(-ret) <<
-	  std::endl;
+	cerr << "Error canceling bucket " << bucket_name <<
+	  " resharding: " << cpp_strerror(-ret) << std::endl;
       }
       return ret;
     }

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -298,9 +298,14 @@ int main(int argc, const char **argv)
   FCGX_Init();
 #endif
 
-  RGWRados *store = RGWStoreManager::get_storage(g_ceph_context,
-      g_conf()->rgw_enable_gc_threads, g_conf()->rgw_enable_lc_threads, g_conf()->rgw_enable_quota_threads,
-      g_conf()->rgw_run_sync_thread, g_conf()->rgw_dynamic_resharding, g_conf()->rgw_cache_enabled);
+  RGWRados *store =
+    RGWStoreManager::get_storage(g_ceph_context,
+				 g_conf()->rgw_enable_gc_threads,
+				 g_conf()->rgw_enable_lc_threads,
+				 g_conf()->rgw_enable_quota_threads,
+				 g_conf()->rgw_run_sync_thread,
+				 g_conf().get_val<bool>("rgw_dynamic_resharding"),
+				 g_conf()->rgw_cache_enabled);
   if (!store) {
     mutex.Lock();
     init_timer.cancel_all_events();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9637,7 +9637,7 @@ int RGWRados::cls_user_remove_bucket(rgw_raw_obj& obj, const cls_user_bucket& bu
 int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info, const rgw_bucket& bucket,
 				  RGWQuotaInfo& bucket_quota)
 {
-  if (!cct->_conf->rgw_dynamic_resharding) {
+  if (! cct->_conf.get_val<bool>("rgw_dynamic_resharding")) {
       return 0;
   }
 
@@ -9645,9 +9645,12 @@ int RGWRados::check_bucket_shards(const RGWBucketInfo& bucket_info, const rgw_bu
   int num_source_shards = (bucket_info.num_shards > 0 ? bucket_info.num_shards : 1);
   uint32_t suggested_num_shards;
 
-  int ret =  quota_handler->check_bucket_shards((uint64_t)cct->_conf->rgw_max_objs_per_shard,
-						num_source_shards,  bucket_info.owner, bucket, bucket_quota,
-						1, need_resharding, &suggested_num_shards);
+  const uint64_t max_objs_per_shard =
+    cct->_conf.get_val<uint64_t>("rgw_max_objs_per_shard");
+  int ret =
+    quota_handler->check_bucket_shards(max_objs_per_shard, num_source_shards,
+				       bucket_info.owner, bucket, bucket_quota,
+				       1, need_resharding, &suggested_num_shards);
   if (ret < 0) {
     return ret;
   }

--- a/src/rgw/rgw_realm_reloader.cc
+++ b/src/rgw/rgw_realm_reloader.cc
@@ -102,14 +102,14 @@ void RGWRealmReloader::reload()
 
   while (!store) {
     // recreate and initialize a new store
-    store = RGWStoreManager::get_storage(cct,
-                                         cct->_conf->rgw_enable_gc_threads,
-                                         cct->_conf->rgw_enable_lc_threads,
-                                         cct->_conf->rgw_enable_quota_threads,
-                                         cct->_conf->rgw_run_sync_thread,
-                                         cct->_conf->rgw_dynamic_resharding,
-					 cct->_conf->rgw_cache_enabled
-      );
+    store =
+      RGWStoreManager::get_storage(cct,
+				   cct->_conf->rgw_enable_gc_threads,
+				   cct->_conf->rgw_enable_lc_threads,
+				   cct->_conf->rgw_enable_quota_threads,
+				   cct->_conf->rgw_run_sync_thread,
+				   cct->_conf.get_val<bool>("rgw_dynamic_resharding"),
+				   cct->_conf->rgw_cache_enabled);
 
     ldout(cct, 1) << "Creating new store" << dendl;
 

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -725,10 +725,11 @@ RGWReshard::RGWReshard(RGWRados* _store, bool _verbose, ostream *_out,
   store(_store), instance_lock(bucket_instance_lock_name),
   verbose(_verbose), out(_out), formatter(_formatter)
 {
-  num_logshards = store->ctx()->_conf->rgw_reshard_num_logs;
+  num_logshards = store->ctx()->_conf.get_val<uint64_t>("rgw_reshard_num_logs");
 }
 
-string RGWReshard::get_logshard_key(const string& tenant, const string& bucket_name)
+string RGWReshard::get_logshard_key(const string& tenant,
+				    const string& bucket_name)
 {
   return tenant + ":" + bucket_name;
 }


### PR DESCRIPTION
With commit b713bb77a1d some rgw reshard config options were updated, but corresponding changes were not made to legacy_config_options. Since accesses to these config options were mixed (both modern and legacy) it led to some inconsistencies. So we remove the legacy options and made sure all accesses uses the modern convention/coding.

Tracker: https://tracker.ceph.com/issues/37491