### PR TITLE
rgw: add optional_yield to block_while_resharding()

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6216,7 +6216,8 @@ int RGWRados::Bucket::UpdateIndex::guard_reshard(BucketShard **pbs, std::functio
     }
     ldout(store->ctx(), 0) << "NOTICE: resharding operation on bucket index detected, blocking" << dendl;
     string new_bucket_id;
-    r = store->block_while_resharding(bs, &new_bucket_id, target->bucket_info);
+    r = store->block_while_resharding(bs, &new_bucket_id,
+                                      target->bucket_info, null_yield);
     if (r == -ERR_BUSY_RESHARDING) {
       continue;
     }
@@ -7091,7 +7092,7 @@ int RGWRados::guard_reshard(BucketShard *bs,
     }
     ldout(cct, 0) << "NOTICE: resharding operation on bucket index detected, blocking" << dendl;
     string new_bucket_id;
-    r = block_while_resharding(bs, &new_bucket_id, bucket_info);
+    r = block_while_resharding(bs, &new_bucket_id, bucket_info, null_yield);
     if (r == -ERR_BUSY_RESHARDING) {
       continue;
     }
@@ -7115,11 +7116,12 @@ int RGWRados::guard_reshard(BucketShard *bs,
 
 int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
 				     string *new_bucket_id,
-				     const RGWBucketInfo& bucket_info)
+                                     const RGWBucketInfo& bucket_info,
+                                     optional_yield y)
 {
   std::shared_ptr<RGWReshardWait> waiter = reshard_wait;
 
-  return waiter->block_while_resharding(bs, new_bucket_id, bucket_info);
+  return waiter->block_while_resharding(bs, new_bucket_id, bucket_info, y);
 }
 
 int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1631,7 +1631,7 @@ int RGWRados::init_complete()
     obj_tombstone_cache = new tombstone_cache_t(cct->_conf->rgw_obj_tombstone_cache_size);
   }
 
-  reshard_wait = std::make_shared<RGWReshardWait>(this);
+  reshard_wait = std::make_shared<RGWReshardWait>();
 
   reshard = new RGWReshard(this);
 
@@ -7119,9 +7119,72 @@ int RGWRados::block_while_resharding(RGWRados::BucketShard *bs,
                                      const RGWBucketInfo& bucket_info,
                                      optional_yield y)
 {
-  std::shared_ptr<RGWReshardWait> waiter = reshard_wait;
+  int ret = 0;
+  cls_rgw_bucket_instance_entry entry;
 
-  return waiter->block_while_resharding(bs, new_bucket_id, bucket_info, y);
+  const int num_retries = 10;
+  for (int i=0; i < num_retries; i++) {
+    ret = cls_rgw_get_bucket_resharding(bs->index_ctx, bs->bucket_obj, &entry);
+    if (ret < 0) {
+      ldout(cct, 0) << __func__ << " ERROR: failed to get bucket resharding :"  <<
+	cpp_strerror(-ret)<< dendl;
+      return ret;
+    }
+    if (!entry.resharding_in_progress()) {
+      *new_bucket_id = entry.new_bucket_instance_id;
+      return 0;
+    }
+    ldout(cct, 20) << "NOTICE: reshard still in progress; " << (i < num_retries - 1 ? "retrying" : "too many retries") << dendl;
+
+    if (i == num_retries - 1) {
+      break;
+    }
+
+    // If bucket is erroneously marked as resharding (e.g., crash or
+    // other error) then fix it. If we can take the bucket reshard
+    // lock then it means no other resharding should be taking place,
+    // and we're free to clear the flags.
+    {
+      // since we expect to do this rarely, we'll do our work in a
+      // block and erase our work after each try
+
+      RGWObjectCtx obj_ctx(this);
+      const rgw_bucket& b = bs->bucket;
+      std::string bucket_id = b.get_key();
+      RGWBucketReshardLock reshard_lock(this, bucket_info, true);
+      ret = reshard_lock.lock();
+      if (ret < 0) {
+	ldout(cct, 20) << __func__ <<
+	  " INFO: failed to take reshard lock for bucket " <<
+	  bucket_id << "; expected if resharding underway" << dendl;
+      } else {
+	ldout(cct, 10) << __func__ <<
+	  " INFO: was able to take reshard lock for bucket " <<
+	  bucket_id << dendl;
+	ret = RGWBucketReshard::clear_resharding(this, bucket_info);
+	if (ret < 0) {
+	  reshard_lock.unlock();
+	  ldout(cct, 0) << __func__ <<
+	    " ERROR: failed to clear resharding flags for bucket " <<
+	    bucket_id << dendl;
+	} else {
+	  reshard_lock.unlock();
+	  ldout(cct, 5) << __func__ <<
+	    " INFO: apparently successfully cleared resharding flags for "
+	    "bucket " << bucket_id << dendl;
+	  continue; // if we apparently succeed immediately test again
+	} // if clear resharding succeeded
+      } // if taking of lock succeeded
+    } // block to encapsulate recovery from incomplete reshard
+
+    ret = reshard_wait->wait(y);
+    if (ret < 0) {
+      ldout(cct, 0) << __func__ << " ERROR: bucket is still resharding, please retry" << dendl;
+      return ret;
+    }
+  }
+  ldout(cct, 0) << __func__ << " ERROR: bucket is still resharding, please retry" << dendl;
+  return -ERR_BUSY_RESHARDING;
 }
 
 int RGWRados::bucket_index_link_olh(const RGWBucketInfo& bucket_info, RGWObjState& olh_state, const rgw_obj& obj_instance,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2044,7 +2044,8 @@ public:
 		    std::function<int(BucketShard *)> call);
   int block_while_resharding(RGWRados::BucketShard *bs,
 			     string *new_bucket_id,
-			     const RGWBucketInfo& bucket_info);
+			     const RGWBucketInfo& bucket_info,
+                             optional_yield y);
 
   void bucket_index_guard_olh_op(RGWObjState& olh_state, librados::ObjectOperation& op);
   int olh_init_modification(const RGWBucketInfo& bucket_info, RGWObjState& state, const rgw_obj& olh_obj, string *op_tag);

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -862,8 +862,6 @@ int RGWReshard::clear_bucket_resharding(const string& bucket_instance_oid, cls_r
   return 0;
 }
 
-static const std::chrono::seconds default_reshard_sleep_duration(5);
-
 int RGWReshardWait::wait(optional_yield y)
 {
   std::unique_lock lock(mutex);
@@ -881,7 +879,7 @@ int RGWReshardWait::wait(optional_yield y)
     waiters.push_back(waiter);
     lock.unlock();
 
-    waiter.timer.expires_after(default_reshard_sleep_duration);
+    waiter.timer.expires_after(duration);
 
     boost::system::error_code ec;
     waiter.timer.async_wait(yield[ec]);
@@ -892,7 +890,7 @@ int RGWReshardWait::wait(optional_yield y)
   }
 #endif
 
-  cond.wait_for(lock, default_reshard_sleep_duration);
+  cond.wait_for(lock, duration);
 
   if (going_down) {
     return -ECANCELED;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -863,13 +863,13 @@ int RGWReshard::clear_bucket_resharding(const string& bucket_instance_oid, cls_r
 }
 
 const int num_retries = 10;
-const int default_reshard_sleep_duration = 5;
+static const std::chrono::seconds default_reshard_sleep_duration(5);
 
 int RGWReshardWait::do_wait()
 {
-  Mutex::Locker l(lock);
+  std::unique_lock lock(mutex);
 
-  cond.WaitInterval(lock, utime_t(default_reshard_sleep_duration, 0));
+  cond.wait_for(lock, default_reshard_sleep_duration);
 
   if (going_down) {
     return -ECANCELED;

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -173,6 +173,7 @@ public:
 };
 
 class RGWReshardWait {
+  const ceph::timespan duration;
   ceph::mutex mutex = ceph::make_mutex("RGWReshardWait::lock");
   ceph::condition_variable cond;
 
@@ -186,7 +187,8 @@ class RGWReshardWait {
   bool going_down{false};
 
 public:
-  RGWReshardWait() = default;
+  RGWReshardWait(ceph::timespan duration = std::chrono::seconds(5))
+    : duration(duration) {}
   ~RGWReshardWait() {
     ceph_assert(going_down);
   }

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -173,7 +173,6 @@ public:
 };
 
 class RGWReshardWait {
-  RGWRados *store;
   ceph::mutex mutex = ceph::make_mutex("RGWReshardWait::lock");
   ceph::condition_variable cond;
 
@@ -186,16 +185,12 @@ class RGWReshardWait {
 
   bool going_down{false};
 
-  int do_wait(optional_yield y);
 public:
-  explicit RGWReshardWait(RGWRados *_store) : store(_store) {}
+  RGWReshardWait() = default;
   ~RGWReshardWait() {
     ceph_assert(going_down);
   }
-  int block_while_resharding(RGWRados::BucketShard *bs,
-			     string *new_bucket_id,
-			     const RGWBucketInfo& bucket_info,
-                             optional_yield y);
+  int wait(optional_yield y);
   // unblock any threads waiting on reshard
   void stop();
 };

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -170,11 +170,10 @@ public:
   void stop_processor();
 };
 
-
 class RGWReshardWait {
   RGWRados *store;
-  Mutex lock{"RGWReshardWait::lock"};
-  Cond cond;
+  ceph::mutex mutex = ceph::make_mutex("RGWReshardWait::lock");
+  ceph::condition_variable cond;
 
   bool going_down{false};
 
@@ -189,9 +188,9 @@ public:
 			     const RGWBucketInfo& bucket_info);
 
   void stop() {
-    Mutex::Locker l(lock);
+    std::scoped_lock lock(mutex);
     going_down = true;
-    cond.SignalAll();
+    cond.notify_all();
   }
 };
 

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -20,6 +20,11 @@ add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager)
 target_link_libraries(unittest_http_manager rgw_a)
 
+# unitttest_rgw_reshard_wait
+add_executable(unittest_rgw_reshard_wait test_rgw_reshard_wait.cc)
+add_ceph_unittest(unittest_rgw_reshard_wait)
+target_link_libraries(unittest_rgw_reshard_wait rgw_a)
+
 set(test_rgw_a_src
   test_rgw_common.cc)
 add_library(test_rgw_a STATIC ${test_rgw_a_src})

--- a/src/test/rgw/test_rgw_reshard_wait.cc
+++ b/src/test/rgw/test_rgw_reshard_wait.cc
@@ -1,0 +1,161 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+
+#include "rgw/rgw_reshard.h"
+
+#include <gtest/gtest.h>
+
+using namespace std::chrono_literals;
+
+TEST(ReshardWait, wait_block)
+{
+  constexpr ceph::timespan wait_duration = 10ms;
+  RGWReshardWait waiter(wait_duration);
+
+  const ceph::real_time start = ceph::real_clock::now();
+  EXPECT_EQ(0, waiter.wait(null_yield));
+  const ceph::timespan elapsed = ceph::real_clock::now() - start;
+
+  EXPECT_LE(wait_duration, elapsed); // waited at least 10ms
+  waiter.stop();
+}
+
+TEST(ReshardWait, stop_block)
+{
+  constexpr ceph::timespan short_duration = 10ms;
+  constexpr ceph::timespan long_duration = 10s;
+
+  RGWReshardWait long_waiter(long_duration);
+  RGWReshardWait short_waiter(short_duration);
+
+  const ceph::real_time start = ceph::real_clock::now();
+  std::thread thread([&long_waiter] {
+    EXPECT_EQ(-ECANCELED, long_waiter.wait(null_yield));
+  });
+
+  EXPECT_EQ(0, short_waiter.wait(null_yield));
+
+  long_waiter.stop(); // cancel long waiter
+
+  thread.join();
+  const ceph::timespan elapsed = ceph::real_clock::now() - start;
+
+  EXPECT_LE(short_duration, elapsed); // waited at least 10ms
+  EXPECT_GT(long_duration, elapsed); // waited less than 10s
+  short_waiter.stop();
+}
+
+TEST(ReshardWait, wait_yield)
+{
+  constexpr ceph::timespan wait_duration = 10ms;
+  RGWReshardWait waiter(wait_duration);
+
+  boost::asio::io_context context;
+  boost::asio::spawn(context, [&] (boost::asio::yield_context yield) {
+      EXPECT_EQ(0, waiter.wait(optional_yield{context, yield}));
+    });
+
+  EXPECT_EQ(1u, context.poll()); // spawn
+  EXPECT_FALSE(context.stopped());
+
+  const ceph::real_time start = ceph::real_clock::now();
+  EXPECT_EQ(1u, context.run_one()); // timeout
+  EXPECT_TRUE(context.stopped());
+  const ceph::timespan elapsed = ceph::real_clock::now() - start;
+
+  EXPECT_LE(wait_duration, elapsed); // waited at least 10ms
+  waiter.stop();
+}
+
+TEST(ReshardWait, stop_yield)
+{
+  constexpr ceph::timespan short_duration = 10ms;
+  constexpr ceph::timespan long_duration = 10s;
+
+  RGWReshardWait long_waiter(long_duration);
+  RGWReshardWait short_waiter(short_duration);
+
+  boost::asio::io_context context;
+  boost::asio::spawn(context,
+    [&] (boost::asio::yield_context yield) {
+      EXPECT_EQ(-ECANCELED, long_waiter.wait(optional_yield{context, yield}));
+    });
+
+  EXPECT_EQ(1u, context.poll()); // spawn
+  EXPECT_FALSE(context.stopped());
+
+  const ceph::real_time start = ceph::real_clock::now();
+  EXPECT_EQ(0, short_waiter.wait(null_yield));
+
+  long_waiter.stop(); // cancel long waiter
+
+  EXPECT_EQ(1u, context.run_one_for(short_duration)); // timeout
+  EXPECT_TRUE(context.stopped());
+  const ceph::timespan elapsed = ceph::real_clock::now() - start;
+
+  EXPECT_LE(short_duration, elapsed); // waited at least 10ms
+  EXPECT_GT(long_duration, elapsed); // waited less than 10s
+  short_waiter.stop();
+}
+
+TEST(ReshardWait, stop_multiple)
+{
+  constexpr ceph::timespan short_duration = 10ms;
+  constexpr ceph::timespan long_duration = 10s;
+
+  RGWReshardWait long_waiter(long_duration);
+  RGWReshardWait short_waiter(short_duration);
+
+  // spawn 4 threads
+  std::vector<std::thread> threads;
+  {
+    auto sync_waiter([&long_waiter] {
+      EXPECT_EQ(-ECANCELED, long_waiter.wait(null_yield));
+    });
+    threads.emplace_back(sync_waiter);
+    threads.emplace_back(sync_waiter);
+    threads.emplace_back(sync_waiter);
+    threads.emplace_back(sync_waiter);
+  }
+  // spawn 4 coroutines
+  boost::asio::io_context context;
+  {
+    auto async_waiter = [&] (boost::asio::yield_context yield) {
+        EXPECT_EQ(-ECANCELED, long_waiter.wait(optional_yield{context, yield}));
+      };
+    boost::asio::spawn(context, async_waiter);
+    boost::asio::spawn(context, async_waiter);
+    boost::asio::spawn(context, async_waiter);
+    boost::asio::spawn(context, async_waiter);
+  }
+  EXPECT_EQ(4u, context.poll()); // spawn
+  EXPECT_FALSE(context.stopped());
+
+  const ceph::real_time start = ceph::real_clock::now();
+  EXPECT_EQ(0, short_waiter.wait(null_yield));
+
+  long_waiter.stop(); // cancel long waiter
+
+  EXPECT_EQ(4u, context.run_for(short_duration)); // timeout
+  EXPECT_TRUE(context.stopped());
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+  const ceph::timespan elapsed = ceph::real_clock::now() - start;
+
+  EXPECT_LE(short_duration, elapsed); // waited at least 10ms
+  EXPECT_GT(long_duration, elapsed); // waited less than 10s
+  short_waiter.stop();
+}


### PR DESCRIPTION
enables blocking waits for resharding to instead suspend/resume the coroutine when used with the beast frontend. all external callers pass null_yield, so existing behavior is unchanged