### PR TITLE
mgr/dashboard: Fix PYTHONPATH for test runner

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -115,7 +115,7 @@ run_teuthology_tests() {
 
     export PATH=$BUILD_DIR/bin:$PATH
     export LD_LIBRARY_PATH=$BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/:$BUILD_DIR/lib
-    export PYTHONPATH=$TEMP_DIR/teuthology:$BUILD_DIR/../qa:$BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/
+    export PYTHONPATH=$TEMP_DIR/teuthology:$BUILD_DIR/../qa:$BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/:$BUILD_DIR/../src/pybind
     eval python ../qa/tasks/vstart_runner.py $TEST_CASES
 
     deactivate


### PR DESCRIPTION
A new mgr module ('volumes') pulls in src/pybind/ceph_volume_client.py; the
wrapper script that we use to run backend API tests needs to include that in
PYTHONPATH, or else the cluster will be stuck in HEALTH_WARN with the message:
"Module 'volumes' has failed dependency: No module named ceph_volume_client".

Signed-off-by: Zack Cerza <zack@redhat.com>