### PR TITLE
mgr/dashboard: Fix a broken ECP controller test

### DIFF
--- a/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
+++ b/qa/tasks/mgr/dashboard/test_erasure_code_profile.py
@@ -11,7 +11,7 @@ class ECPTest(DashboardTestCase):
 
     AUTH_ROLES = ['pool-manager']
 
-    @DashboardTestCase.RunAs('test', 'test', ['block-manager'])
+    @DashboardTestCase.RunAs('test', 'test', ['rgw-manager'])
     def test_read_access_permissions(self):
         self._get('/api/erasure_code_profile')
         self.assertStatus(403)


### PR DESCRIPTION
The change in b3e69a96093 broke the test's assumption that the endpoint
wouldn't be readable by block-manager. It doesn't looks as though that's
actually problematic for the ECP controller, so just update the test to
use rgw-manager instead.

Just in case I'm wrong here, I'll loop in @rjfd since he added this portion of 
the test in 01a1a1ff843b780e836e32525b2d85e864577b8a.