### PR TITLE
osd/OSDMap: Incorrect upmap remove

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1786,8 +1786,7 @@ void OSDMap::maybe_remove_pg_upmaps(CephContext *cct,
                    << " failure-domain-type " << type
                    << dendl;
     vector<int> raw;
-    int primary;
-    nextmap.pg_to_raw_up(pg, &raw, &primary);
+    nextmap.pg_to_raw_upmap(pg, &raw);
     set<int> parents;
     for (auto osd : raw) {
       if (type > 0) {
@@ -2414,6 +2413,18 @@ void OSDMap::pg_to_raw_up(pg_t pg, vector<int> *up, int *primary) const
   _raw_to_up_osds(*pool, raw, up);
   *primary = _pick_primary(raw);
   _apply_primary_affinity(pps, *pool, up, primary);
+}
+
+void OSDMap::pg_to_raw_upmap(pg_t pg, vector<int> *raw) const
+{
+  const pg_pool_t *pool = get_pg_pool(pg.pool());
+  if (!pool) {
+    raw->clear();
+    return;
+  }
+  ps_t pps;
+  _pg_to_raw_osds(*pool, pg, raw, &pps);
+  _apply_upmap(*pool, pg, raw);
 }
 
 void OSDMap::_pg_to_up_acting_osds(

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1165,6 +1165,7 @@ public:
    * by anybody for data mapping purposes. Specify both pointers.
    */
   void pg_to_raw_up(pg_t pg, vector<int> *up, int *primary) const;
+  void pg_to_raw_upmap(pg_t pg, vector<int> *raw) const;
   /**
    * map a pg to its acting set as well as its up set. You must use
    * the acting set for data mapping purposes, but some users will


### PR DESCRIPTION
There is no need to check OSD state in the function pg_to_raw_up, and checks are made in the maybe_remove_pg_upmaps process,
which might result in unreasonable deletion of the pg_upmap_items member, see https://tracker.ceph.com/issues/37493

Signed-off-by: ningtao <ningtao@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

