### PR TITLE
 osd: support more dynamic perf query subkey types

### DIFF
--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -685,8 +685,13 @@ ceph_add_osd_perf_query(BaseMgrModule *self, PyObject *args)
   static const std::string NAME_SUB_KEY_REGEX = "regex";
   static const std::map<std::string, OSDPerfMetricSubKeyType> sub_key_types = {
     {"client_id", OSDPerfMetricSubKeyType::CLIENT_ID},
+    {"client_address", OSDPerfMetricSubKeyType::CLIENT_ADDRESS},
     {"pool_id", OSDPerfMetricSubKeyType::POOL_ID},
+    {"namespace", OSDPerfMetricSubKeyType::NAMESPACE},
+    {"osd_id", OSDPerfMetricSubKeyType::OSD_ID},
+    {"pg_id", OSDPerfMetricSubKeyType::PG_ID},
     {"object_name", OSDPerfMetricSubKeyType::OBJECT_NAME},
+    {"snap_id", OSDPerfMetricSubKeyType::SNAP_ID},
   };
   static const std::map<std::string, PerformanceCounterType> counter_types = {
     {"write_ops", PerformanceCounterType::WRITE_OPS},

--- a/src/mgr/OSDPerfMetricTypes.cc
+++ b/src/mgr/OSDPerfMetricTypes.cc
@@ -11,11 +11,26 @@ std::ostream& operator<<(std::ostream& os,
   case OSDPerfMetricSubKeyType::CLIENT_ID:
     os << "client_id";
     break;
+  case OSDPerfMetricSubKeyType::CLIENT_ADDRESS:
+    os << "client_address";
+    break;
   case OSDPerfMetricSubKeyType::POOL_ID:
     os << "pool_id";
     break;
+  case OSDPerfMetricSubKeyType::NAMESPACE:
+    os << "namespace";
+    break;
+  case OSDPerfMetricSubKeyType::OSD_ID:
+    os << "osd_id";
+    break;
+  case OSDPerfMetricSubKeyType::PG_ID:
+    os << "pg_id";
+    break;
   case OSDPerfMetricSubKeyType::OBJECT_NAME:
     os << "object_name";
+    break;
+  case OSDPerfMetricSubKeyType::SNAP_ID:
+    os << "snap_id";
     break;
   default:
     os << "unknown (" << static_cast<int>(d.type) << ")";

--- a/src/mgr/OSDPerfMetricTypes.h
+++ b/src/mgr/OSDPerfMetricTypes.h
@@ -14,8 +14,13 @@ typedef std::vector<OSDPerfMetricSubKey> OSDPerfMetricKey;
 
 enum class OSDPerfMetricSubKeyType : uint8_t {
   CLIENT_ID = 0,
-  POOL_ID = 1,
-  OBJECT_NAME = 2,
+  CLIENT_ADDRESS = 1,
+  POOL_ID = 2,
+  NAMESPACE = 3,
+  OSD_ID = 4,
+  PG_ID = 5,
+  OBJECT_NAME = 6,
+  SNAP_ID = 7,
 };
 
 struct OSDPerfMetricSubKeyDescriptor {
@@ -26,8 +31,13 @@ struct OSDPerfMetricSubKeyDescriptor {
   bool is_supported() const {
     switch (type) {
     case OSDPerfMetricSubKeyType::CLIENT_ID:
+    case OSDPerfMetricSubKeyType::CLIENT_ADDRESS:
     case OSDPerfMetricSubKeyType::POOL_ID:
+    case OSDPerfMetricSubKeyType::NAMESPACE:
+    case OSDPerfMetricSubKeyType::OSD_ID:
+    case OSDPerfMetricSubKeyType::PG_ID:
     case OSDPerfMetricSubKeyType::OBJECT_NAME:
+    case OSDPerfMetricSubKeyType::SNAP_ID:
       return true;
     default:
       return false;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4141,7 +4141,7 @@ void PrimaryLogPG::log_op_stats(const OpRequest& op,
 	   << " lat " << latency << dendl;
 
   if (m_dynamic_perf_stats.is_enabled()) {
-    m_dynamic_perf_stats.add(op, inb, outb, latency);
+    m_dynamic_perf_stats.add(osd, info, op, inb, outb, latency);
   }
 }
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -969,7 +969,9 @@ class MgrModule(ceph_module.BaseMgrModule):
              ],
            }
 
-        Valid subkey types: 'client_id', 'pool_id', 'object_name'
+        Valid subkey types:
+           'client_id', 'client_address', 'pool_id', 'namespace', 'osd_id',
+           'pg_id', 'object_name', 'snap_id'
         Valid performance counter types:
            'write_ops', 'read_ops', 'write_bytes', 'read_bytes',
            'write_latency', 'read_latency'

--- a/src/pybind/mgr/osd_perf_query/module.py
+++ b/src/pybind/mgr/osd_perf_query/module.py
@@ -23,7 +23,8 @@ class OSDPerfQuery(MgrModule):
     COMMANDS = [
         {
             "cmd": "osd perf query add "
-                   "name=query,type=CephChoices,strings=client_id|rbd_image_id",
+                   "name=query,type=CephChoices,"
+                   "strings=client_id|rbd_image_id|all_subkeys",
             "desc": "add osd perf query",
             "perm": "w"
         },
@@ -62,14 +63,32 @@ class OSDPerfQuery(MgrModule):
         ],
     }
 
+    ALL_SUBKEYS_QUERY = {
+        'key_descriptor': [
+            {'type': 'client_id', 'regex': '^.*$'},
+            {'type': 'client_address', 'regex': '^.*$'},
+            {'type': 'pool_id', 'regex': '^.*$'},
+            {'type': 'namespace', 'regex': '^.*$'},
+            {'type': 'osd_id', 'regex': '^.*$'},
+            {'type': 'pg_id', 'regex': '^.*$'},
+            {'type': 'object_name', 'regex': '^.*$'},
+            {'type': 'snap_id', 'regex': '^.*$'},
+        ],
+        'performance_counter_descriptors': [
+            'write_ops', 'read_ops',
+        ],
+    }
+
     queries = {}
 
     def handle_command(self, inbuf, cmd):
         if cmd['prefix'] == "osd perf query add":
             if cmd['query'] == 'rbd_image_id':
                 query = self.RBD_IMAGE_ID_QUERY
-            else:
+            elif cmd['query'] == 'rbd_image_id':
                 query = self.CLIENT_ID_QUERY
+            else:
+                query = self.ALL_SUBKEYS_QUERY
             query_id = self.add_osd_perf_query(query)
             if query_id is None:
                 return -errno.EINVAL, "", "Invalid query"
@@ -94,7 +113,7 @@ class OSDPerfQuery(MgrModule):
             if query == self.RBD_IMAGE_ID_QUERY:
                 column_names = ["pool_id", "rbd image_id"]
             else:
-                column_names = ["client_id"]
+                column_names = [sk['type'] for sk in query['key_descriptor']]
             for d in descriptors:
                 desc = d
                 if d in ['write_bytes', 'read_bytes']:
@@ -109,7 +128,7 @@ class OSDPerfQuery(MgrModule):
                 if query == self.RBD_IMAGE_ID_QUERY:
                     row = [c['k'][0][0], c['k'][1][1]]
                 else:
-                    row = [c['k'][0][0]]
+                    row = [sk[0] for sk in c['k']]
                 counters = c['c']
                 for i in range(len(descriptors)):
                     if descriptors[i] in ['write_bytes', 'read_bytes']:

--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -462,8 +462,8 @@ int bench_execute(const po::variables_map &vm, io_type_t bench_io_type) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, namespace_name, image_name, "", "",
-                                 false, &rados, &io_ctx, &image);
+  r = utils::init_and_open_image(pool_name, namespace_name, image_name, "",
+                                 snap_name, false, &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
   }


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

