### PR TITLE
ceph_argparse: fix CephBool to CephChoices conversion

### DIFF
--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -93,6 +93,7 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
     f->open_object_section(string(desckv["name"]).c_str());
 
     // Compatibility for pre-nautilus clients that don't know about CephBool
+    std::string val;
     if (!HAVE_FEATURE(features, SERVER_NAUTILUS)) {
       auto i = desckv.find("type");
       if (i != desckv.end() && i->second == "CephBool") {
@@ -100,7 +101,7 @@ dump_cmd_to_json(Formatter *f, uint64_t features, const string& cmd)
         // of a 'true'/'false' value
         std::ostringstream oss;
         oss << std::string("--") << desckv["name"];
-        std::string val = oss.str();
+        val = oss.str();
         std::replace(val.begin(), val.end(), '_', '-');
 
         desckv["type"] = "CephChoices";


### PR DESCRIPTION
Commit 525623b has introduced a regression that makes Ceph clients of
versions prior to Nautilus to receive invalid unicode characters in the
commands list JSON sent by the monitors.

```
[root@node1 ~]# ceph -s 
Traceback (most recent call last):
  File "/bin/ceph", line 1212, in <module>
    retval = main()
  File "/bin/ceph", line 1136, in main
    sigdict = parse_json_funcsigs(outbuf.decode('utf-8'), 'cli')
  File "/usr/lib64/python2.7/encodings/utf_8.py", line 16, in decode
    return codecs.utf_8_decode(input, errors, True)
```

The unicode characters are caused by memory corruption in a dangling
pointer stored by a std::string_view. The dangling pointer belonged to
an std::string object that was already destructed when the
std::string_view is used.
The fix in this PR makes the std::string object to live enough time for
the std::string_view to be used safely.

Signed-off-by: Ricardo Dias <rdias@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

