### PR TITLE
librbd: add support for dynamically adjusting rbd qos parameters.

### DIFF
--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -62,7 +62,7 @@ namespace librbd {
   template <typename> class ResizeRequest;
   }
 
-  struct ImageCtx {
+  struct ImageCtx : public md_config_obs_t {
     static const string METADATA_CONF_PREFIX;
 
     CephContext *cct;
@@ -324,6 +324,11 @@ namespace librbd {
                                          ContextWQ **op_work_queue);
     static void get_timer_instance(CephContext *cct, SafeTimer **timer,
                                    Mutex **timer_lock);
+
+    // config observer bits
+    const char** get_tracked_conf_keys() const override;
+    void handle_conf_change(const ConfigProxy& conf,
+                          const std::set <std::string> &changed) override;
   };
 }
 


### PR DESCRIPTION
In some scenarios, not all RBD images use the same qos limitation, and each image may need its own individual limit value, so I think we can add dynamic modification of qos parameters to achieve.

Signed-off-by: Yao Guotao <yaoguot@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

