### PR TITLE
qa/rgw: add cls_lock/log/refcount/version tests to verify suite

### DIFF
--- a/qa/suites/rgw/verify/tasks/cls.yaml
+++ b/qa/suites/rgw/verify/tasks/cls.yaml
@@ -1,0 +1,8 @@
+tasks:
+- workunit:
+    clients:
+      client.0:
+        - cls/test_cls_lock.sh
+        - cls/test_cls_log.sh
+        - cls/test_cls_refcount.sh
+        - cls/test_cls_rgw.sh

--- a/qa/suites/rgw/verify/tasks/cls_rgw.yaml
+++ b/qa/suites/rgw/verify/tasks/cls_rgw.yaml
@@ -1,5 +1,0 @@
-tasks:
-- workunit:
-    clients:
-      client.0:
-        - cls/test_cls_rgw.sh


### PR DESCRIPTION
run the other ceph_test_cls_* tests that radosgw depends on