### PR TITLE
common/util.cc: add CONTAINER_NAME processing for metadata

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -154,15 +154,24 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   }
 
   // but wait, am i in a container?
+  bool in_container = false;
+
   if (const char *pod_name = getenv("POD_NAME")) {
     (*m)["pod_name"] = pod_name;
+    in_container = true;
+  }
+  if (const char *container_name = getenv("CONTAINER_NAME")) {
+    (*m)["container_name"] = container_name;
+    in_container = true;
+  }
+  if (in_container) {
     if (const char *node_name = getenv("NODE_NAME")) {
       (*m)["container_hostname"] = u.nodename;
       (*m)["hostname"] = node_name;
     }
-  }
-  if (const char *ns = getenv("POD_NAMESPACE")) {
-    (*m)["pod_namespace"] = ns;
+    if (const char *ns = getenv("POD_NAMESPACE")) {
+      (*m)["pod_namespace"] = ns;
+    }
   }
 
 #ifdef __APPLE__


### PR DESCRIPTION
Kubernetes clusters use POD_NAME; simple containers should be
distinguishable and don't have 'pods'.

Signed-off-by: Dan Mick <dan.mick@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

