### PR TITLE
mimic: osd/OSD: OSD::mkfs asserts when reusing disk with existing superblock.

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1750,6 +1750,9 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, const string &dev,
   }
 
 umount_store:
+  if (ch) {
+    ch.reset();
+  }
   store->umount();
 free_store:
   delete store;


### PR DESCRIPTION
http://tracker.ceph.com/issues/37496