### PR TITLE
mon/OSDMonitor: do not no_reply on ready_to_merge message

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3326,7 +3326,6 @@ bool OSDMonitor::prepare_pg_ready_to_merge(MonOpRequestRef op)
   } else {
     wait_for_finished_proposal(op, new C_ReplyMap(this, op, m->version));
   }
-  mon->no_reply(op);
   return true;
 }
 


### PR DESCRIPTION
The C_ReplyMap will reply to this op.  Do not no_reply, or else an
ill-timed mon election will mean we do nothing for this request.

Fixes: http://tracker.ceph.com/issues/37512
Signed-off-by: Sage Weil <sage@redhat.com>