### PR TITLE
ceph-volume: revert partition as disk

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/dmcrypt/test.yml
@@ -93,6 +93,11 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
+    - name: node inventory
+      command: "ceph-volume inventory"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
     - name: list all OSDs
       command: "ceph-volume lvm list"
       environment:

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/filestore/dmcrypt/test.yml
@@ -97,6 +97,11 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
+    - name: node inventory
+      command: "ceph-volume inventory"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
     - name: list all OSDs
       command: "ceph-volume lvm list"
       environment:

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_bluestore.yml
@@ -67,6 +67,11 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
+    - name: node inventory
+      command: "ceph-volume inventory"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
     - name: list all OSDs
       command: "ceph-volume lvm list"
       environment:

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
@@ -91,6 +91,11 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
+    - name: node inventory
+      command: "ceph-volume inventory"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
     - name: list all OSDs
       command: "ceph-volume lvm list"
       environment:

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/bluestore/dmcrypt/test.yml
@@ -93,6 +93,11 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
+    - name: node inventory
+      command: "ceph-volume inventory"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
     - name: list all OSDs
       command: "ceph-volume lvm list"
       environment:

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/xenial/filestore/dmcrypt/test.yml
@@ -97,6 +97,11 @@
       environment:
         CEPH_VOLUME_DEBUG: 1
 
+    - name: node inventory
+      command: "ceph-volume inventory"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+
     - name: list all OSDs
       command: "ceph-volume lvm list"
       environment:

--- a/src/ceph-volume/ceph_volume/tests/util/test_disk.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_disk.py
@@ -267,28 +267,6 @@ class TestGetDevices(object):
         assert len(result) == 1
         assert result == [ceph_data_path]
 
-    def test_sda1_partition(self, tmpfile, tmpdir):
-        block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
-        block_sda_path = os.path.join(block_path, 'sda')
-        block_sda1_path = os.path.join(block_sda_path, 'sda1')
-        block_sda1_holders = os.path.join(block_sda1_path, 'holders')
-        dev_sda_path = os.path.join(dev_path, 'sda')
-        dev_sda1_path = os.path.join(dev_path, 'sda1')
-        os.makedirs(block_sda_path)
-        os.makedirs(block_sda1_path)
-        os.makedirs(dev_sda1_path)
-        os.makedirs(block_sda1_holders)
-        os.makedirs(dev_sda_path)
-        tmpfile('size', '1024', directory=block_sda_path)
-        tmpfile('partition', '1', directory=block_sda1_path)
-        result = disk.get_devices(
-            _sys_block_path=block_path,
-            _dev_path=dev_path,
-            _mapper_path=mapper_path)
-        assert dev_sda_path in list(result.keys())
-        assert '/dev/sda1' in list(result.keys())
-        assert result['/dev/sda1']['holders'] == []
-
     def test_sda_size(self, tmpfile, tmpdir):
         block_path, dev_path, mapper_path = self.setup_paths(tmpdir)
         block_sda_path = os.path.join(block_path, 'sda')

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -110,6 +110,14 @@ class Device(object):
         if not sys_info.devices:
             sys_info.devices = disk.get_devices()
         self.sys_api = sys_info.devices.get(self.abspath, {})
+        if not self.sys_api:
+            # if no device was found check if we are a partition
+            partname = self.abspath.split('/')[-1]
+            for device, info in sys_info.devices.items():
+                part = info['partitions'].get(partname, {})
+                if part:
+                    self.sys_api = part
+                    break
 
         # start with lvm since it can use an absolute or relative path
         lv = lvm.get_lv_from_argument(self.path)

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -815,9 +815,5 @@ def get_devices(_sys_block_path='/sys/block', _dev_path='/dev', _mapper_path='/d
         metadata['path'] = diskname
         metadata['locked'] = is_locked_raw_device(metadata['path'])
 
-        for part_name, part_metadata in metadata['partitions'].items():
-            part_abspath = '/dev/%s' % part_name
-            device_facts[part_abspath] = part_metadata
-
         device_facts[diskname] = metadata
     return device_facts


### PR DESCRIPTION
This reverts two commits from PR #25330. Really sorry I didn't catch this in the review. The main reason for this revert is, that it breaks `ceph-volume inventory` as it is not prepared to deal with partitions being reported as disks (and the dict carrying a different set of keys...see example output below).

Fixes: http://tracker.ceph.com/issues/37506

Furthermore I think there're other arguments to be made against this change:
- It dramatically changes what `disk.get_devices()` has done in the past and is very different from what the name suggests.
- It simply duplicates the information. As illustrated in the output below, the exact same partition information is already part of the device itself. Why does it need to be duplicated?
- So far I could not find where this additional data is used? Other then the test case (also reverted here) this new functionality seems not used. I'm sure I just didn't look closely enough but I'm certain, that the same functionality can be implemented based on the existing partition reporting done by `disk.get_devices()`

```
{'/dev/vda': {'human_readable_size': '40.00 GB',
              'locked': 1,
              'model': '',
              'nr_requests': '256',
              'partitions': {'vda1': {'holders': [],
                                      'sectors': '83884032',
                                      'sectorsize': 512,
                                      'size': '40.00 GB',
                                      'start': '2048'}},
              'path': '/dev/vda',
              'removable': '0',
              'rev': '',
              'ro': '0',
              'rotational': '1',
              'sas_address': '',
              'sas_device_handle': '',
              'scheduler_mode': 'mq-deadline',
              'sectors': 0,
              'sectorsize': '512',
              'size': 42949672960.0,
              'support_discard': '',
              'vendor': '0x1af4'},
 '/dev/vda1': {'holders': [],
               'sectors': '83884032',
               'sectorsize': 512,
               'size': '40.00 GB',
               'start': '2048'},
}
```