### PR TITLE
build, tests: introduce compiletest_cxx11_client for C++11 conformity.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,6 +111,14 @@ if(CMAKE_VERSION VERSION_LESS "3.8")
       "The compiler ${CMAKE_CXX_COMPILER} has no C++17 support.")
   endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
+
+  # for compiletest_cxx11_client
+  CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+  if(NOT COMPILER_SUPPORTS_CXX11)
+    message(FATAL_ERROR
+      "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support.")
+  endif()
+
   include(CheckCCompilerFlag)
   CHECK_C_COMPILER_FLAG("-std=gnu99" COMPILER_SUPPORTS_GNU99)
   if(NOT COMPILER_SUPPORTS_GNU99)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -678,6 +678,28 @@ add_executable(unittest_bufferlist
 add_ceph_unittest(unittest_bufferlist)
 target_link_libraries(unittest_bufferlist global)
 
+# compiletest_cxx11_client
+add_executable(compiletest_cxx11_client
+  cxx11_client.cc
+  )
+if(CMAKE_VERSION VERSION_LESS "3.8")
+  # this is ugly as we'll end with -std=c++11 overriding the previous -std=c++17
+  # I would love to have a better way for old Cmakes
+  set_target_properties(compiletest_cxx11_client
+    PROPERTIES COMPILE_FLAGS "-std=c++11 -Werror -pedantic"
+    )
+else()
+  set_target_properties(compiletest_cxx11_client
+    PROPERTIES COMPILE_FLAGS "-Werror -pedantic"
+    CMAKE_CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON
+    )
+endif()
+add_ceph_test(compiletest_cxx11_client
+  "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/compiletest_cxx11_client"
+  )
+target_link_libraries(compiletest_cxx11_client global)
+
 # unittest_xlist
 add_executable(unittest_xlist
   test_xlist.cc

--- a/src/test/cxx11_client.cc
+++ b/src/test/cxx11_client.cc
@@ -1,0 +1,6 @@
+#include "include/buffer.h"
+
+// We might want to include here all our public headers.
+// Not any file residing in src/include has this status.
+
+int main() {}


### PR DESCRIPTION
This patch extends the usual pull request workflow with extra stage: validation of the C++11 compliance of the public headers (currently `buffers.h` only; I would love to have this broader) on `make check`.
The idea is to let the bots to detect breaking the language part of our public API early, and thus off-load reviewers and Teuthology.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>