### PR TITLE
Wip kv iterator hierarchy 2

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -208,7 +208,7 @@ public:
     virtual int upper_bound(const std::string &after) = 0;
     virtual int lower_bound(const std::string &to) = 0;
     virtual bool valid() = 0;
-    virtual int next(bool validate=true) = 0;
+    virtual int next() = 0;
     virtual std::string key() = 0;
     virtual bufferlist value() = 0;
     virtual int status() = 0;
@@ -219,7 +219,7 @@ public:
   public:
     virtual ~IteratorImpl() {}
     virtual int seek_to_last() = 0;
-    virtual int prev(bool validate=true) = 0;
+    virtual int prev() = 0;
     virtual std::pair<std::string, std::string> raw_key() = 0;
     virtual bufferptr value_as_ptr() {
       bufferlist bl = value();
@@ -299,26 +299,11 @@ private:
 	return false;
       return generic_iter->raw_key_is_prefixed(prefix);
     }
-    // Note that next() and prev() shouldn't validate iters,
-    // it's responsibility of caller to ensure they're valid.
-    int next(bool validate=true) override {
-      if (validate) {
-        if (valid())
-          return generic_iter->next();
-        return status();
-      } else {
-        return generic_iter->next();  
-      }      
+    int next() override {
+      return generic_iter->next();
     }
-    
-    int prev(bool validate=true) override {
-      if (validate) {
-        if (valid())
-          return generic_iter->prev();
-        return status();
-      } else {
-        return generic_iter->prev();  
-      }      
+    int prev() override {
+      return generic_iter->prev();
     }
     std::string key() override {
       return generic_iter->key();

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -199,28 +199,13 @@ public:
     return get(prefix, string(key, keylen), value);
   }
 
-  // This superclass is used both by kv iterators *and* by the ObjectMap
-  // omap iterator.  The class hierarchies are unfortunately tied together
-  // by the legacy DBOjectMap implementation :(.
-  class SimplestIteratorImpl {
+  class ForwardIterator {
   public:
     virtual int seek_to_first() = 0;
-    virtual int upper_bound(const std::string &after) = 0;
-    virtual int lower_bound(const std::string &to) = 0;
     virtual bool valid() = 0;
     virtual int next() = 0;
     virtual std::string key() = 0;
     virtual bufferlist value() = 0;
-    virtual int status() = 0;
-    virtual ~SimplestIteratorImpl() {}
-  };
-
-  class IteratorImpl : public SimplestIteratorImpl {
-  public:
-    virtual ~IteratorImpl() {}
-    virtual int seek_to_last() = 0;
-    virtual int prev() = 0;
-    virtual std::pair<std::string, std::string> raw_key() = 0;
     virtual bufferptr value_as_ptr() {
       bufferlist bl = value();
       if (bl.length() == 1) {
@@ -228,42 +213,58 @@ public:
       } else if (bl.length() == 0) {
         return bufferptr();
       } else {
-	ceph_abort();
+        ceph_abort();
       }
     }
+    virtual int status() = 0;
+    virtual ~ForwardIterator() {}
+  };
+
+  // This superclass is used both by kv iterators *and* by the ObjectMap
+  // omap iterator.  The class hierarchies are unfortunately tied together
+  // by the legacy DBOjectMap implementation :(.
+  class SimplestIteratorImpl : public ForwardIterator {
+  public:
+    virtual int upper_bound(const std::string &after) = 0;
+    virtual int lower_bound(const std::string &to) = 0;
+    virtual ~SimplestIteratorImpl() {}
+  };
+
+  class BackwardIterator {
+  public:
+    virtual int seek_to_last() = 0;
+    virtual int prev() = 0;
+    virtual std::pair<std::string, std::string> raw_key() = 0;
+    virtual ~BackwardIterator() {}
+  };
+  class IteratorImpl : public SimplestIteratorImpl, public BackwardIterator {
+  public:
+    virtual ~IteratorImpl() {}
   };
   typedef std::shared_ptr< IteratorImpl > Iterator;
 
   // This is the low-level iterator implemented by the underlying KV store.
-  class WholeSpaceIteratorImpl {
+  class WholeSpaceIteratorImpl : public ForwardIterator, public BackwardIterator {
   public:
-    virtual int seek_to_first() = 0;
+    using ForwardIterator::seek_to_first;
+    using BackwardIterator::seek_to_last;
+    using ForwardIterator::valid;
+    using ForwardIterator::next;
+    using BackwardIterator::prev;
+    using ForwardIterator::key;
+    using ForwardIterator::value;
+    using ForwardIterator::value_as_ptr;
+    using ForwardIterator::status;
     virtual int seek_to_first(const std::string &prefix) = 0;
-    virtual int seek_to_last() = 0;
     virtual int seek_to_last(const std::string &prefix) = 0;
     virtual int upper_bound(const std::string &prefix, const std::string &after) = 0;
     virtual int lower_bound(const std::string &prefix, const std::string &to) = 0;
-    virtual bool valid() = 0;
-    virtual int next() = 0;
-    virtual int prev() = 0;
-    virtual std::string key() = 0;
-    virtual std::pair<std::string,std::string> raw_key() = 0;
     virtual bool raw_key_is_prefixed(const std::string &prefix) = 0;
-    virtual bufferlist value() = 0;
-    virtual bufferptr value_as_ptr() {
-      bufferlist bl = value();
-      if (bl.length()) {
-        return *bl.buffers().begin();
-      } else {
-        return bufferptr();
-      }
-    }
-    virtual int status() = 0;
     virtual size_t key_size() {
-      return 0;
+      return key().size();
     }
     virtual size_t value_size() {
-      return 0;
+      return value().length();
     }
     virtual ~WholeSpaceIteratorImpl() { }
   };

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -199,7 +199,7 @@ public:
     return get(prefix, string(key, keylen), value);
   }
 
-  class ForwardIterator {
+  class IteratorBase {
   public:
     virtual int seek_to_first() = 0;
     virtual bool valid() = 0;
@@ -216,45 +216,46 @@ public:
         ceph_abort();
       }
     }
+    virtual std::pair<std::string, std::string> raw_key() {
+      return std::make_pair(key(), value().c_str());
+    }
     virtual int status() = 0;
-    virtual ~ForwardIterator() {}
+    virtual int seek_to_last() { ceph_abort(); return 0; }
+    virtual int prev() { ceph_abort(); return 0; }
+    virtual ~IteratorBase() {}
   };
 
   // This superclass is used both by kv iterators *and* by the ObjectMap
   // omap iterator.  The class hierarchies are unfortunately tied together
   // by the legacy DBOjectMap implementation :(.
-  class SimplestIteratorImpl : public ForwardIterator {
+  class ObjectMapIteratorImpl : public IteratorBase {
   public:
     virtual int upper_bound(const std::string &after) = 0;
     virtual int lower_bound(const std::string &to) = 0;
-    virtual ~SimplestIteratorImpl() {}
+    virtual ~ObjectMapIteratorImpl() {}
   };
 
-  class BackwardIterator {
+
+  class IteratorImpl : public ObjectMapIteratorImpl {
   public:
-    virtual int seek_to_last() = 0;
-    virtual int prev() = 0;
-    virtual std::pair<std::string, std::string> raw_key() = 0;
-    virtual ~BackwardIterator() {}
-  };
-  class IteratorImpl : public SimplestIteratorImpl, public BackwardIterator {
-  public:
+    int seek_to_last() override = 0;
+    int prev() override = 0;
     virtual ~IteratorImpl() {}
   };
   typedef std::shared_ptr< IteratorImpl > Iterator;
 
   // This is the low-level iterator implemented by the underlying KV store.
-  class WholeSpaceIteratorImpl : public ForwardIterator, public BackwardIterator {
+  class WholeSpaceIteratorImpl : public IteratorBase {
   public:
-    using ForwardIterator::seek_to_first;
-    using BackwardIterator::seek_to_last;
-    using ForwardIterator::valid;
-    using ForwardIterator::next;
-    using BackwardIterator::prev;
-    using ForwardIterator::key;
-    using ForwardIterator::value;
-    using ForwardIterator::value_as_ptr;
-    using ForwardIterator::status;
+    using IteratorBase::seek_to_first;
+    int seek_to_last() override = 0;
+    using IteratorBase::valid;
+    using IteratorBase::next;
+    int prev() override = 0;
+    using IteratorBase::key;
+    using IteratorBase::value;
+    using IteratorBase::value_as_ptr;
+    using IteratorBase::status;
     virtual int seek_to_first(const std::string &prefix) = 0;
     virtual int seek_to_last(const std::string &prefix) = 0;
     virtual int upper_bound(const std::string &prefix, const std::string &after) = 0;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1504,13 +1504,13 @@ public:
     dbiter->Seek(slice_bound);
     return dbiter->status().ok() ? 0 : -1;
   }
-  int next(bool validate=true) override {
+  int next() override {
     if (valid()) {
       dbiter->Next();
     }
     return dbiter->status().ok() ? 0 : -1;
   }
-  int prev(bool validate=true) override {
+  int prev() override {
     if (valid()) {
       dbiter->Prev();
     }

--- a/src/os/ObjectMap.h
+++ b/src/os/ObjectMap.h
@@ -157,7 +157,7 @@ public:
 
   virtual void compact() {}
 
-  typedef KeyValueDB::SimplestIteratorImpl ObjectMapIteratorImpl;
+  typedef KeyValueDB::ObjectMapIteratorImpl ObjectMapIteratorImpl;
   typedef std::shared_ptr<ObjectMapIteratorImpl> ObjectMapIterator;
   virtual ObjectMapIterator get_iterator(const ghobject_t &oid) {
     return ObjectMapIterator();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3780,7 +3780,7 @@ bool BlueStore::OmapIteratorImpl::valid()
   return r;
 }
 
-int BlueStore::OmapIteratorImpl::next(bool validate)
+int BlueStore::OmapIteratorImpl::next()
 {
   RWLock::RLocker l(c->lock);
   if (o->onode.has_omap()) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1434,7 +1434,7 @@ public:
     int upper_bound(const string &after) override;
     int lower_bound(const string &to) override;
     bool valid() override;
-    int next(bool validate=true) override;
+    int next() override;
     string key() override;
     bufferlist value() override;
     int status() override {

--- a/src/os/filestore/DBObjectMap.cc
+++ b/src/os/filestore/DBObjectMap.cc
@@ -402,7 +402,7 @@ bool DBObjectMap::DBObjectMapIteratorImpl::valid_parent()
   return false;
 }
 
-int DBObjectMap::DBObjectMapIteratorImpl::next(bool validate)
+int DBObjectMap::DBObjectMapIteratorImpl::next()
 {
   ceph_assert(cur_iter->valid());
   ceph_assert(valid());

--- a/src/os/filestore/DBObjectMap.h
+++ b/src/os/filestore/DBObjectMap.h
@@ -387,7 +387,7 @@ private:
     int upper_bound(const string &after) override { return 0; }
     int lower_bound(const string &to) override { return 0; }
     bool valid() override { return false; }
-    int next(bool validate=true) override { ceph_abort(); return 0; }
+    int next() override { ceph_abort(); return 0; }
     string key() override { ceph_abort(); return ""; }
     bufferlist value() override { ceph_abort(); return bufferlist(); }
     int status() override { return 0; }
@@ -425,7 +425,7 @@ private:
     int upper_bound(const string &after) override;
     int lower_bound(const string &to) override;
     bool valid() override;
-    int next(bool validate=true) override;
+    int next() override;
     string key() override;
     bufferlist value() override;
     int status() override;

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1636,7 +1636,7 @@ bool KStore::OmapIteratorImpl::valid()
   }
 }
 
-int KStore::OmapIteratorImpl::next(bool validate)
+int KStore::OmapIteratorImpl::next()
 {
   RWLock::RLocker l(c->lock);
   if (o->onode.omap_head) {

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -175,7 +175,7 @@ public:
     int upper_bound(const string &after) override;
     int lower_bound(const string &to) override;
     bool valid() override;
-    int next(bool validate=true) override;
+    int next() override;
     string key() override;
     bufferlist value() override;
     int status() override {

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -583,7 +583,7 @@ public:
     std::lock_guard<std::mutex> lock(o->omap_mutex);
     return it != o->omap.end();
   }
-  int next(bool validate=true) override {
+  int next() override {
     std::lock_guard<std::mutex> lock(o->omap_mutex);
     ++it;
     return 0;

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -1339,7 +1339,7 @@ public:
     list<pg_log_entry_t> entries;
     list<pg_log_dup_t> dups;
     if (p) {
-      for (p->seek_to_first(); p->valid() ; p->next(false)) {
+      for (p->seek_to_first(); p->valid() ; p->next()) {
 	// non-log pgmeta_oid keys are prefixed with _; skip those
 	if (p->key()[0] == '_')
 	  continue;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7302,7 +7302,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	    );
 	  ceph_assert(iter);
 	  iter->upper_bound(start_after);
-	  for (num = 0; iter->valid(); ++num, iter->next(false)) {
+	  for (num = 0; iter->valid(); ++num, iter->next()) {
 	    if (num >= max_return ||
 		bl.length() >= cct->_conf->osd_max_omap_bytes_per_request) {
 	      truncated = true;
@@ -7356,7 +7356,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  for (num = 0;
 	       iter->valid() &&
 		 iter->key().substr(0, filter_prefix.size()) == filter_prefix;
-	       ++num, iter->next(false)) {
+	       ++num, iter->next()) {
 	    dout(20) << "Found key " << iter->key() << dendl;
 	    if (num >= max_return ||
 		bl.length() >= cct->_conf->osd_max_omap_bytes_per_request) {
@@ -8762,7 +8762,7 @@ int PrimaryLogPG::do_copy_get(OpContext *ctx, bufferlist::const_iterator& bp,
 	osd->store->get_omap_iterator(ch, ghobject_t(oi.soid));
       ceph_assert(iter);
       iter->upper_bound(cursor.omap_offset);
-      for (; iter->valid(); iter->next(false)) {
+      for (; iter->valid(); iter->next()) {
 	++omap_keys;
 	encode(iter->key(), omap_data);
 	encode(iter->value(), omap_data);

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1877,7 +1877,7 @@ int ReplicatedBackend::build_push_op(const ObjectRecoveryInfo &recovery_info,
     ceph_assert(iter);
     for (iter->lower_bound(progress.omap_recovered_to);
 	 iter->valid();
-	 iter->next(false)) {
+	 iter->next()) {
       if (!out_op->omap_entries.empty() &&
 	  ((cct->_conf->osd_recovery_max_omap_entries_per_chunk > 0 &&
 	    out_op->omap_entries.size() >= cct->_conf->osd_recovery_max_omap_entries_per_chunk) ||

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -3010,7 +3010,7 @@ TEST_P(StoreTest, OmapSimple) {
   {
     map<string,bufferlist> r;
     ObjectMap::ObjectMapIterator iter = store->get_omap_iterator(ch, hoid);
-    for (iter->seek_to_first(); iter->valid(); iter->next(false)) {
+    for (iter->seek_to_first(); iter->valid(); iter->next()) {
       r[iter->key()] = iter->value();
     }
     cout << "r: " << r << std::endl;
@@ -3020,7 +3020,7 @@ TEST_P(StoreTest, OmapSimple) {
   {
     map<string,bufferlist> r;
     ObjectMap::ObjectMapIterator iter = store->get_omap_iterator(ch, hoid);
-    for (iter->lower_bound(string()); iter->valid(); iter->next(false)) {
+    for (iter->lower_bound(string()); iter->valid(); iter->next()) {
       r[iter->key()] = iter->value();
     }
     cout << "r: " << r << std::endl;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -534,7 +534,7 @@ int do_trim_pg_log(ObjectStore *store, const coll_t &coll,
     ObjectMap::ObjectMapIterator p = store->get_omap_iterator(ch, oid);
     if (!p)
       break;
-    for (p->seek_to_first(); p->valid(); p->next(false)) {
+    for (p->seek_to_first(); p->valid(); p->next()) {
       if (p->key()[0] == '_')
 	continue;
       if (p->key() == "can_rollback_to")


### PR DESCRIPTION
This is a variant of new K-V database iterator hierarchy that moves both forward and backward iterator into single `IteratorBase`. Branch that is base of ObjectMap hierarchy has `prev()` and `seek_to_last()` implementations that do `ceph_abort()`.
