### PR TITLE
os/bluestore/BlueFS: reset pending_release on shutdown

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -433,6 +433,9 @@ void BlueFS::_stop_alloc()
     }
   }
   alloc.clear();
+  for (auto& i : pending_release) {
+    i.clear();
+  }
 }
 
 int BlueFS::mount()


### PR DESCRIPTION
Reported-by: Abutalib Aghayev <agayev@gmail.com>
Signed-off-by: Sage Weil <sage@redhat.com>