### PR TITLE
osd: requeue waiting peering events from deleted slots in unprime_split_children

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -10221,6 +10221,7 @@ void OSDShard::unprime_split_children(spg_t parent, unsigned old_pg_num)
 	i.first.get_ancestor(old_pg_num) == parent) {
       dout(10) << __func__ << " parent " << parent << " clearing " << i.first
 	       << dendl;
+      _wake_pg_slot(i.first, i.second.get());
       to_delete.push_back(i.first);
     }
   }


### PR DESCRIPTION
These child slots we are deleting may have queued events that should be
requeued and reexamined.  For example, a pg query may be waiting for the
split and then discarded, instead of being reexamined and processed via
handle_pg_query_nopg().

Fixes: http://tracker.ceph.com/issues/37525
Signed-off-by: Sage Weil <sage@redhat.com>