### PR TITLE
pybind/mgr: clean up module vs ceph options naming, helpers

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -274,6 +274,7 @@ BuildRequires:	python%{_python_buildid}-jwt
 BuildRequires:	python%{_python_buildid}-routes
 BuildRequires:	python%{_python_buildid}-werkzeug
 BuildRequires:	python%{_python_buildid}-bcrypt
+BuildRequires:  xmlsec1
 %endif
 %if 0%{?suse_version}
 BuildRequires:	python%{_python_buildid}-CherryPy
@@ -282,6 +283,7 @@ BuildRequires:	python%{_python_buildid}-Routes
 BuildRequires:	python%{_python_buildid}-Werkzeug
 BuildRequires:	python%{_python_buildid}-numpy-devel
 BuildRequires:	python%{_python_buildid}-bcrypt
+BuildRequires:  libxmlsec1-1
 %endif
 %endif
 # lttng and babeltrace for rbd-replay-prep

--- a/doc/mgr/plugins.rst
+++ b/doc/mgr/plugins.rst
@@ -96,38 +96,38 @@ Configuration options
 ---------------------
 
 Modules can load and store configuration options using the
-``set_config`` and ``get_config`` methods.
+``set_module_option`` and ``get_module_option`` methods.
 
-.. note:: Use ``set_config`` and ``get_config`` to manage user-visible
-   configuration options that are not blobs (like certificates). If you want to
-   persist module-internal data or binary configuration data consider using
-   the `KV store`_.
+.. note:: Use ``set_module_option`` and ``get_module_option`` to
+   manage user-visible configuration options that are not blobs (like
+   certificates). If you want to persist module-internal data or
+   binary configuration data consider using the `KV store`_.
 
 You must declare your available configuration options in the
-``OPTIONS`` class attribute, like this:
+``MODULE_OPTIONS`` class attribute, like this:
 
 ::
 
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {
             "name": "my_option"
         }
     ]
 
-If you try to use set_config or get_config on options not declared
-in ``OPTIONS``, an exception will be raised.
+If you try to use set_module_option or get_module_option on options not declared
+in ``MODULE_OPTIONS``, an exception will be raised.
 
 You may choose to provide setter commands in your module to perform
 high level validation.  Users can also modify configuration using
 the normal `ceph config set` command, where the configuration options
 for a mgr module are named like `mgr/<module name>/<option>`.
 
-If a configuration option is different depending on which node
-the mgr is running on, then use *localized* configuration (
-``get_localized_config``, ``set_localized_config``).  This may be necessary
-for options such as what address to listen on.  Localized options may
-also be set externally with ``ceph config set``, where they key name
-is like ``mgr/<module name>/<mgr id>/<option>``
+If a configuration option is different depending on which node the mgr
+is running on, then use *localized* configuration (
+``get_localized_module_option``, ``set_localized_module_option``).
+This may be necessary for options such as what address to listen on.
+Localized options may also be set externally with ``ceph config set``,
+where they key name is like ``mgr/<module name>/<mgr id>/<option>``
 
 If you need to load and store data (e.g. something larger, binary, or multiline),
 use the KV store instead of configuration options (see next section).
@@ -135,21 +135,21 @@ use the KV store instead of configuration options (see next section).
 Hints for using config options:
 
 * Reads are fast: ceph-mgr keeps a local in-memory copy, so in many cases
-  you can just do a get_config every time you use a option, rather than
+  you can just do a get_module_option every time you use a option, rather than
   copying it out into a variable.
 * Writes block until the value is persisted (i.e. round trip to the monitor),
   but reads from another thread will see the new value immediately.
 * If a user has used `config set` from the command line, then the new
-  value will become visible to `get_config` immediately, although the
+  value will become visible to `get_module_option` immediately, although the
   mon->mgr update is asynchronous, so `config set` will return a fraction
   of a second before the new value is visible on the mgr.
 * To delete a config value (i.e. revert to default), just pass ``None`` to
-  set_config.
+  set_module_option.
 
-.. automethod:: MgrModule.get_config
-.. automethod:: MgrModule.set_config
-.. automethod:: MgrModule.get_localized_config
-.. automethod:: MgrModule.set_localized_config
+.. automethod:: MgrModule.get_module_option
+.. automethod:: MgrModule.set_module_option
+.. automethod:: MgrModule.get_localized_module_option
+.. automethod:: MgrModule.set_localized_module_option
 
 KV store
 --------
@@ -373,7 +373,7 @@ Limitations
 -----------
 
 It is not possible to call back into C++ code from a module's
-``__init__()`` method.  For example calling ``self.get_config()`` at
+``__init__()`` method.  For example calling ``self.get_module_option()`` at
 this point will result in an assertion failure in ceph-mgr.  For modules
 that implement the ``serve()`` method, it usually makes sense to do most
 initialization inside that method instead.

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -420,11 +420,11 @@ ceph_store_get_prefix(BaseMgrModule *self, PyObject *args)
 }
 
 static PyObject*
-ceph_config_set(BaseMgrModule *self, PyObject *args)
+ceph_set_module_option(BaseMgrModule *self, PyObject *args)
 {
   char *key = nullptr;
   char *value = nullptr;
-  if (!PyArg_ParseTuple(args, "sz:ceph_config_set", &key, &value)) {
+  if (!PyArg_ParseTuple(args, "sz:ceph_set_module_option", &key, &value)) {
     return nullptr;
   }
   boost::optional<string> val;
@@ -967,8 +967,8 @@ PyMethodDef BaseMgrModule_methods[] = {
   {"_ceph_get_store_prefix", (PyCFunction)ceph_store_get_prefix, METH_VARARGS,
    "Get all KV store values with a given prefix"},
 
-  {"_ceph_set_config", (PyCFunction)ceph_config_set, METH_VARARGS,
-   "Set a configuration value"},
+  {"_ceph_set_module_option", (PyCFunction)ceph_set_module_option, METH_VARARGS,
+   "Set a module configuration option value"},
 
   {"_ceph_get_store", (PyCFunction)ceph_store_get, METH_VARARGS,
    "Get a stored field"},

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -380,16 +380,16 @@ ceph_option_get(BaseMgrModule *self, PyObject *args)
     dout(10) << "ceph_option_get " << what << " found: " << value << dendl;
     return PyString_FromString(value.c_str());
   } else {
-    dout(4) << "ceph_config_get " << what << " not found " << dendl;
+    dout(4) << "ceph_option_get " << what << " not found " << dendl;
     Py_RETURN_NONE;
   }
 }
 
 static PyObject*
-ceph_config_get(BaseMgrModule *self, PyObject *args)
+ceph_get_module_option(BaseMgrModule *self, PyObject *args)
 {
   char *what = nullptr;
-  if (!PyArg_ParseTuple(args, "s:ceph_config_get", &what)) {
+  if (!PyArg_ParseTuple(args, "s:ceph_get_module_option", &what)) {
     derr << "Invalid args!" << dendl;
     return nullptr;
   }
@@ -398,10 +398,10 @@ ceph_config_get(BaseMgrModule *self, PyObject *args)
   bool found = self->py_modules->get_config(self->this_module->get_name(),
       what, &value);
   if (found) {
-    dout(10) << "ceph_config_get " << what << " found: " << value.c_str() << dendl;
+    dout(10) << __func__ << " " << what << " found: " << value.c_str() << dendl;
     return PyString_FromString(value.c_str());
   } else {
-    dout(4) << "ceph_config_get " << what << " not found " << dendl;
+    dout(4) << __func__ << " " << what << " not found " << dendl;
     Py_RETURN_NONE;
   }
 }
@@ -959,10 +959,10 @@ PyMethodDef BaseMgrModule_methods[] = {
    "Get the name of the Mgr daemon where we are running"},
 
   {"_ceph_get_option", (PyCFunction)ceph_option_get, METH_VARARGS,
-   "Get a configuration option value"},
+   "Get a native configuration option value"},
 
-  {"_ceph_get_config", (PyCFunction)ceph_config_get, METH_VARARGS,
-   "Get a configuration value"},
+  {"_ceph_get_module_option", (PyCFunction)ceph_get_module_option, METH_VARARGS,
+   "Get a module configuration option value"},
 
   {"_ceph_get_store_prefix", (PyCFunction)ceph_store_get_prefix, METH_VARARGS,
    "Get all KV store values with a given prefix"},

--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -61,10 +61,10 @@ ceph_get_mgr_id(BaseMgrStandbyModule *self, PyObject *args)
 }
 
 static PyObject*
-ceph_config_get(BaseMgrStandbyModule *self, PyObject *args)
+ceph_get_module_option(BaseMgrStandbyModule *self, PyObject *args)
 {
   char *what = nullptr;
-  if (!PyArg_ParseTuple(args, "s:ceph_config_get", &what)) {
+  if (!PyArg_ParseTuple(args, "s:ceph_get_module_option", &what)) {
     derr << "Invalid args!" << dendl;
     return nullptr;
   }
@@ -72,10 +72,10 @@ ceph_config_get(BaseMgrStandbyModule *self, PyObject *args)
   std::string value;
   bool found = self->this_module->get_config(what, &value);
   if (found) {
-    dout(10) << "ceph_config_get " << what << " found: " << value.c_str() << dendl;
+    dout(10) << __func__ << " " << what << " found: " << value.c_str() << dendl;
     return PyString_FromString(value.c_str());
   } else {
-    dout(4) << "ceph_config_get " << what << " not found " << dendl;
+    dout(4) << __func__ << " " << what << " not found " << dendl;
     Py_RETURN_NONE;
   }
 }
@@ -133,7 +133,7 @@ PyMethodDef BaseMgrStandbyModule_methods[] = {
   {"_ceph_get_mgr_id", (PyCFunction)ceph_get_mgr_id, METH_NOARGS,
    "Get the name of the Mgr daemon where we are running"},
 
-  {"_ceph_get_config", (PyCFunction)ceph_config_get, METH_VARARGS,
+  {"_ceph_get_module_option", (PyCFunction)ceph_get_module_option, METH_VARARGS,
    "Get a configuration value"},
 
   {"_ceph_get_store", (PyCFunction)ceph_store_get, METH_VARARGS,

--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -134,7 +134,7 @@ PyMethodDef BaseMgrStandbyModule_methods[] = {
    "Get the name of the Mgr daemon where we are running"},
 
   {"_ceph_get_module_option", (PyCFunction)ceph_get_module_option, METH_VARARGS,
-   "Get a configuration value"},
+   "Get a module configuration option value"},
 
   {"_ceph_get_store", (PyCFunction)ceph_store_get, METH_VARARGS,
    "Get a KV store value"},

--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -81,6 +81,26 @@ ceph_get_module_option(BaseMgrStandbyModule *self, PyObject *args)
 }
 
 static PyObject*
+ceph_option_get(BaseMgrStandbyModule *self, PyObject *args)
+{
+  char *what = nullptr;
+  if (!PyArg_ParseTuple(args, "s:ceph_option_get", &what)) {
+    derr << "Invalid args!" << dendl;
+    return nullptr;
+  }
+
+  std::string value;
+  int r = g_conf().get_val(string(what), &value);
+  if (r >= 0) {
+    dout(10) << "ceph_option_get " << what << " found: " << value << dendl;
+    return PyString_FromString(value.c_str());
+  } else {
+    dout(4) << "ceph_option_get " << what << " not found " << dendl;
+    Py_RETURN_NONE;
+  }
+}
+
+static PyObject*
 ceph_store_get(BaseMgrStandbyModule *self, PyObject *args)
 {
   char *what = nullptr;
@@ -135,6 +155,9 @@ PyMethodDef BaseMgrStandbyModule_methods[] = {
 
   {"_ceph_get_module_option", (PyCFunction)ceph_get_module_option, METH_VARARGS,
    "Get a module configuration option value"},
+
+  {"_ceph_get_option", (PyCFunction)ceph_option_get, METH_VARARGS,
+   "Get a native configuration option value"},
 
   {"_ceph_get_store", (PyCFunction)ceph_store_get, METH_VARARGS,
    "Get a KV store value"},

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -372,9 +372,9 @@ int PyModule::load(PyThreadState *pMainThreadState)
 
     r = load_options();
     if (r != 0) {
-      derr << "Missing or invalid OPTIONS attribute in module '"
+      derr << "Missing or invalid MODULE_OPTIONS attribute in module '"
           << module_name << "'" << dendl;
-      error_string = "Missing or invalid OPTIONS attribute";
+      error_string = "Missing or invalid MODULE_OPTIONS attribute";
       return r;
     }
 
@@ -514,13 +514,13 @@ int PyModule::load_commands()
 
 int PyModule::load_options()
 {
-  int r = walk_dict_list("OPTIONS", [this](PyObject *pOption) -> int {
+  int r = walk_dict_list("MODULE_OPTIONS", [this](PyObject *pOption) -> int {
     PyObject *pName = PyDict_GetItemString(pOption, "name");
     ceph_assert(pName != nullptr);
 
     ModuleOption option;
     option.name = PyString_AsString(pName);
-    dout(20) << "loaded option " << option.name << dendl;
+    dout(20) << "loaded module option " << option.name << dendl;
 
     options[option.name] = std::move(option);
 

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -81,7 +81,7 @@ private:
   // Populated if loaded, can_run or failed indicates a problem
   std::string error_string;
 
-  // Helper for loading OPTIONS and COMMANDS members
+  // Helper for loading MODULE_OPTIONS and COMMANDS members
   int walk_dict_list(
       const std::string &attr_name,
       std::function<int(PyObject*)> fn);

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -297,7 +297,7 @@ class Module(MgrModule):
             s = {
                 'plans': list(self.plans.keys()),
                 'active': self.active,
-                'mode': self.get_config('mode', default_mode),
+                'mode': self.get_module_option('mode', default_mode),
             }
             return (0, json.dumps(s, indent=4), '')
         elif command['prefix'] == 'balancer mode':
@@ -399,14 +399,14 @@ class Module(MgrModule):
     def serve(self):
         self.log.info('Starting')
         while self.run:
-            self.active = self.get_config('active', '') is not ''
-            begin_time = self.get_config('begin_time') or '0000'
-            end_time = self.get_config('end_time') or '2400'
+            self.active = self.get_module_option('active', '') is not ''
+            begin_time = self.get_module_option('begin_time') or '0000'
+            end_time = self.get_module_option('end_time') or '2400'
             timeofday = time.strftime('%H%M', time.localtime())
             self.log.debug('Waking up [%s, scheduled for %s-%s, now %s]',
                            "active" if self.active else "inactive",
                            begin_time, end_time, timeofday)
-            sleep_interval = float(self.get_config('sleep_interval',
+            sleep_interval = float(self.get_module_option('sleep_interval',
                                                    default_sleep_interval))
             if self.active and self.time_in_interval(timeofday, begin_time, end_time):
                 self.log.debug('Running')
@@ -629,7 +629,7 @@ class Module(MgrModule):
         self.log.debug('score_by_root %s' % pe.score_by_root)
 
         # get the list of score metrics, comma separated
-        metrics = self.get_config('crush_compat_metrics', 'pgs,objects,bytes').split(',')
+        metrics = self.get_module_option('crush_compat_metrics', 'pgs,objects,bytes').split(',')
 
         # total score is just average of normalized stddevs
         pe.score = 0.0
@@ -646,7 +646,7 @@ class Module(MgrModule):
 
     def optimize(self, plan):
         self.log.info('Optimize plan %s' % plan.name)
-        plan.mode = self.get_config('mode', default_mode)
+        plan.mode = self.get_module_option('mode', default_mode)
         max_misplaced = float(self.get_option('target_max_misplaced_ratio'))
         self.log.info('Mode %s, max misplaced %f' %
                       (plan.mode, max_misplaced))
@@ -692,8 +692,8 @@ class Module(MgrModule):
 
     def do_upmap(self, plan):
         self.log.info('do_upmap')
-        max_iterations = int(self.get_config('upmap_max_iterations', 10))
-        max_deviation = float(self.get_config('upmap_max_deviation', .01))
+        max_iterations = int(self.get_module_option('upmap_max_iterations', 10))
+        max_deviation = float(self.get_module_option('upmap_max_deviation', .01))
 
         ms = plan.initial
         if len(plan.pools):
@@ -725,10 +725,10 @@ class Module(MgrModule):
 
     def do_crush_compat(self, plan):
         self.log.info('do_crush_compat')
-        max_iterations = int(self.get_config('crush_compat_max_iterations', 25))
+        max_iterations = int(self.get_module_option('crush_compat_max_iterations', 25))
         if max_iterations < 1:
             return -errno.EINVAL, '"crush_compat_max_iterations" must be >= 1'
-        step = float(self.get_config('crush_compat_step', .5))
+        step = float(self.get_module_option('crush_compat_step', .5))
         if step <= 0 or step >= 1.0:
             return -errno.EINVAL, '"crush_compat_step" must be in (0, 1)'
         max_misplaced = float(self.get_option('target_max_misplaced_ratio'))
@@ -738,7 +738,7 @@ class Module(MgrModule):
         osdmap = ms.osdmap
         crush = osdmap.get_crush()
         pe = self.calc_eval(ms, plan.pools)
-        min_score_to_optimize = float(self.get_config('min_score', 0))
+        min_score_to_optimize = float(self.get_module_option('min_score', 0))
         if pe.score <= min_score_to_optimize:
             if pe.score == 0:
                 detail = 'Distribution is already perfect'
@@ -781,7 +781,7 @@ class Module(MgrModule):
             return -errno.EOPNOTSUPP, detail
 
         # rebalance by pgs, objects, or bytes
-        metrics = self.get_config('crush_compat_metrics', 'pgs,objects,bytes').split(',')
+        metrics = self.get_module_option('crush_compat_metrics', 'pgs,objects,bytes').split(',')
         key = metrics[0] # balancing using the first score metric
         if key not in ['pgs', 'bytes', 'objects']:
             self.log.warn("Invalid crush_compat balancing key %s. Using 'pgs'." % key)

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -201,7 +201,7 @@ class Eval:
         return r
 
 class Module(MgrModule):
-    OPTIONS = [
+    MODULE_OPTIONS = [
             {'name': 'active'},
             {'name': 'begin_time'},
             {'name': 'crush_compat_max_iterations'},

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -301,17 +301,17 @@ class Module(MgrModule):
             }
             return (0, json.dumps(s, indent=4), '')
         elif command['prefix'] == 'balancer mode':
-            self.set_config('mode', command['mode'])
+            self.set_module_option('mode', command['mode'])
             return (0, '', '')
         elif command['prefix'] == 'balancer on':
             if not self.active:
-                self.set_config('active', '1')
+                self.set_module_option('active', '1')
                 self.active = True
             self.event.set()
             return (0, '', '')
         elif command['prefix'] == 'balancer off':
             if self.active:
-                self.set_config('active', '')
+                self.set_module_option('active', '')
                 self.active = False
             self.event.set()
             return (0, '', '')

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -647,7 +647,7 @@ class Module(MgrModule):
     def optimize(self, plan):
         self.log.info('Optimize plan %s' % plan.name)
         plan.mode = self.get_module_option('mode', default_mode)
-        max_misplaced = float(self.get_option('target_max_misplaced_ratio'))
+        max_misplaced = float(self.get_ceph_option('target_max_misplaced_ratio'))
         self.log.info('Mode %s, max misplaced %f' %
                       (plan.mode, max_misplaced))
 
@@ -731,7 +731,7 @@ class Module(MgrModule):
         step = float(self.get_module_option('crush_compat_step', .5))
         if step <= 0 or step >= 1.0:
             return -errno.EINVAL, '"crush_compat_step" must be in (0, 1)'
-        max_misplaced = float(self.get_option('target_max_misplaced_ratio'))
+        max_misplaced = float(self.get_ceph_option('target_max_misplaced_ratio'))
         min_pg_per_osd = 2
 
         ms = plan.initial

--- a/src/pybind/mgr/dashboard/controllers/docs.py
+++ b/src/pybind/mgr/dashboard/controllers/docs.py
@@ -180,7 +180,7 @@ class Docs(BaseController):
             baseUrl = "/"
 
         scheme = 'https'
-        ssl = strtobool(mgr.get_localized_config('ssl', 'True'))
+        ssl = strtobool(mgr.get_localized_module_option('ssl', 'True'))
         if not ssl:
             scheme = 'http'
 

--- a/src/pybind/mgr/dashboard/controllers/saml2.py
+++ b/src/pybind/mgr/dashboard/controllers/saml2.py
@@ -77,7 +77,7 @@ class Saml2(BaseController):
             JwtManager.set_user(JwtManager.decode_token(token))
             token = token.decode('utf-8')
             logger.debug("JWT Token: %s", token)
-            url_prefix = prepare_url_prefix(mgr.get_config('url_prefix', default=''))
+            url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
             raise cherrypy.HTTPRedirect("{}/#/login?access_token={}".format(url_prefix, token))
         else:
             return {
@@ -111,5 +111,5 @@ class Saml2(BaseController):
         # pylint: disable=unused-argument
         Saml2._check_python_saml()
         JwtManager.reset_user()
-        url_prefix = prepare_url_prefix(mgr.get_config('url_prefix', default=''))
+        url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
         raise cherrypy.HTTPRedirect("{}/#/login".format(url_prefix))

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -339,7 +339,7 @@ class Module(MgrModule, CherryPyConfig):
         if res[0] != -errno.ENOSYS:
             return res
         elif cmd['prefix'] == 'dashboard set-jwt-token-ttl':
-            self.set_config('jwt_token_ttl', str(cmd['seconds']))
+            self.set_module_option('jwt_token_ttl', str(cmd['seconds']))
             return 0, 'JWT token TTL updated', ''
         elif cmd['prefix'] == 'dashboard get-jwt-token-ttl':
             ttl = self.get_module_option('jwt_token_ttl', JwtManager.JWT_TOKEN_TTL)

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -106,13 +106,13 @@ class CherryPyConfig(object):
 
         :returns our URI
         """
-        server_addr = self.get_localized_config('server_addr', '::')
-        ssl = strtobool(self.get_localized_config('ssl', 'True'))
+        server_addr = self.get_localized_module_option('server_addr', '::')
+        ssl = strtobool(self.get_localized_module_option('ssl', 'True'))
         def_server_port = 8443
         if not ssl:
             def_server_port = 8080
 
-        server_port = self.get_localized_config('server_port', def_server_port)
+        server_port = self.get_localized_module_option('server_port', def_server_port)
         if server_addr is None:
             raise ServerConfigException(
                 'no server_addr configured; '
@@ -155,7 +155,7 @@ class CherryPyConfig(object):
                 self.cert_tmp.flush()  # cert_tmp must not be gc'ed
                 cert_fname = self.cert_tmp.name
             else:
-                cert_fname = self.get_localized_config('crt_file')
+                cert_fname = self.get_localized_module_option('crt_file')
 
             pkey = self.get_store("key")
             if pkey is not None:
@@ -164,7 +164,7 @@ class CherryPyConfig(object):
                 self.pkey_tmp.flush()  # pkey_tmp must not be gc'ed
                 pkey_fname = self.pkey_tmp.name
             else:
-                pkey_fname = self.get_localized_config('key_file')
+                pkey_fname = self.get_localized_module_option('key_file')
 
             if not cert_fname or not pkey_fname:
                 raise ServerConfigException('no certificate configured')
@@ -179,7 +179,7 @@ class CherryPyConfig(object):
 
         cherrypy.config.update(config)
 
-        self._url_prefix = prepare_url_prefix(self.get_config('url_prefix',
+        self._url_prefix = prepare_url_prefix(self.get_module_option('url_prefix',
                                                               default=''))
 
         uri = "{0}://{1}:{2}{3}/".format(
@@ -342,7 +342,7 @@ class Module(MgrModule, CherryPyConfig):
             self.set_config('jwt_token_ttl', str(cmd['seconds']))
             return 0, 'JWT token TTL updated', ''
         elif cmd['prefix'] == 'dashboard get-jwt-token-ttl':
-            ttl = self.get_config('jwt_token_ttl', JwtManager.JWT_TOKEN_TTL)
+            ttl = self.get_module_option('jwt_token_ttl', JwtManager.JWT_TOKEN_TTL)
             return 0, str(ttl), ''
         elif cmd['prefix'] == 'dashboard create-self-signed-cert':
             self.create_self_signed_cert()

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -180,7 +180,7 @@ class CherryPyConfig(object):
         cherrypy.config.update(config)
 
         self._url_prefix = prepare_url_prefix(self.get_module_option('url_prefix',
-                                                              default=''))
+                                                                     default=''))
 
         uri = "{0}://{1}:{2}{3}/".format(
             'https' if ssl else 'http',

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -239,7 +239,7 @@ class Module(MgrModule, CherryPyConfig):
     COMMANDS.extend(ACCESS_CONTROL_COMMANDS)
     COMMANDS.extend(SSO_COMMANDS)
 
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {'name': 'server_addr'},
         {'name': 'server_port'},
         {'name': 'jwt_token_ttl'},
@@ -250,7 +250,7 @@ class Module(MgrModule, CherryPyConfig):
         {'name': 'crt_file'},
         {'name': 'ssl'}
     ]
-    OPTIONS.extend(options_schema_list())
+    MODULE_OPTIONS.extend(options_schema_list())
 
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -314,8 +314,8 @@ class AccessControlDB(object):
         logger.debug("AC: Checking for previews DB versions")
         if self.VERSION == 1:  # current version
             # check if there is username/password from previous version
-            username = mgr.get_config('username', None)
-            password = mgr.get_config('password', None)
+            username = mgr.get_module_option('username', None)
+            password = mgr.get_module_option('password', None)
             if username and password:
                 logger.debug("AC: Found single user credentials: user=%s",
                              username)

--- a/src/pybind/mgr/dashboard/services/auth.py
+++ b/src/pybind/mgr/dashboard/services/auth.py
@@ -41,7 +41,7 @@ class JwtManager(object):
     def gen_token(cls, username):
         if not cls._secret:
             cls.init()
-        ttl = mgr.get_config('jwt_token_ttl', cls.JWT_TOKEN_TTL)
+        ttl = mgr.get_module_option('jwt_token_ttl', cls.JWT_TOKEN_TTL)
         ttl = int(ttl)
         now = int(time.mktime(time.gmtime()))
         payload = {

--- a/src/pybind/mgr/dashboard/services/sso.py
+++ b/src/pybind/mgr/dashboard/services/sso.py
@@ -221,7 +221,7 @@ def handle_sso_command(cmd):
             except Exception:
                 return -errno.EINVAL, '', 'Invalid parameter `idp_metadata`.'
 
-        url_prefix = prepare_url_prefix(mgr.get_config('url_prefix', default=''))
+        url_prefix = prepare_url_prefix(mgr.get_module_option('url_prefix', default=''))
         settings = {
             'sp': {
                 'entityId': '{}{}/auth/saml2/metadata'.format(ceph_dashboard_base_url, url_prefix),

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -49,11 +49,11 @@ class Options(object):
 class SettingsMeta(type):
     def __getattr__(cls, attr):
         default, stype = getattr(Options, attr)
-        if stype == bool and str(mgr.get_config(attr,
+        if stype == bool and str(mgr.get_module_option(attr,
                                                 default)).lower() == 'false':
             value = False
         else:
-            value = stype(mgr.get_config(attr, default))
+            value = stype(mgr.get_module_option(attr, default))
         return value
 
     def __setattr__(cls, attr, value):

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -58,13 +58,13 @@ class SettingsMeta(type):
 
     def __setattr__(cls, attr, value):
         if not attr.startswith('_') and hasattr(Options, attr):
-            mgr.set_config(attr, str(value))
+            mgr.set_module_option(attr, str(value))
         else:
             setattr(SettingsMeta, attr, value)
 
     def __delattr__(self, attr):
         if not attr.startswith('_') and hasattr(Options, attr):
-            mgr.set_config(attr, None)
+            mgr.set_module_option(attr, None)
 
 
 # pylint: disable=no-init

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -49,8 +49,9 @@ class Options(object):
 class SettingsMeta(type):
     def __getattr__(cls, attr):
         default, stype = getattr(Options, attr)
-        if stype == bool and str(mgr.get_module_option(attr,
-                                                default)).lower() == 'false':
+        if stype == bool and str(mgr.get_module_option(
+                attr,
+                default)).lower() == 'false':
             value = False
         else:
             value = stype(mgr.get_module_option(attr, default))

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -20,19 +20,20 @@ class AccessControlTest(unittest.TestCase):
     CONFIG_KEY_DICT = {}
 
     @classmethod
-    def mock_set_config(cls, attr, val):
+    def mock_set_module_option(cls, attr, val):
         cls.CONFIG_KEY_DICT[attr] = val
 
     @classmethod
-    def mock_get_config(cls, attr, default=None):
+    def mock_get_module_option(cls, attr, default=None):
         return cls.CONFIG_KEY_DICT.get(attr, default)
 
     @classmethod
     def setUpClass(cls):
-        mgr.set_config.side_effect = cls.mock_set_config
-        mgr.get_config.side_effect = cls.mock_get_config
-        mgr.set_store.side_effect = cls.mock_set_config
-        mgr.get_store.side_effect = cls.mock_get_config
+        mgr.set_module_option.side_effect = cls.mock_set_module_option
+        mgr.get_module_option.side_effect = cls.mock_get_module_option
+        # kludge below
+        mgr.set_store.side_effect = cls.mock_set_module_option
+        mgr.get_store.side_effect = cls.mock_get_module_option
 
     def setUp(self):
         self.CONFIG_KEY_DICT.clear()

--- a/src/pybind/mgr/dashboard/tests/test_api_auditing.py
+++ b/src/pybind/mgr/dashboard/tests/test_api_auditing.py
@@ -37,17 +37,17 @@ class ApiAuditingTest(ControllerTestCase):
         super(ApiAuditingTest, self).__init__(*args, **kwargs)
 
     @classmethod
-    def mock_set_config(cls, key, val):
+    def mock_set_module_option(cls, key, val):
         cls.settings[key] = val
 
     @classmethod
-    def mock_get_config(cls, key, default=None):
+    def mock_get_module_option(cls, key, default=None):
         return cls.settings.get(key, default)
 
     @classmethod
     def setUpClass(cls):
-        mgr.get_config.side_effect = cls.mock_get_config
-        mgr.set_config.side_effect = cls.mock_set_config
+        mgr.get_module_option.side_effect = cls.mock_get_module_option
+        mgr.set_module_option.side_effect = cls.mock_set_module_option
 
     @classmethod
     def setup_server(cls):
@@ -55,8 +55,8 @@ class ApiAuditingTest(ControllerTestCase):
 
     def setUp(self):
         mgr.cluster_log = mock.Mock()
-        mgr.set_config('AUDIT_API_ENABLED', True)
-        mgr.set_config('AUDIT_API_LOG_PAYLOAD', True)
+        mgr.set_module_option('AUDIT_API_ENABLED', True)
+        mgr.set_module_option('AUDIT_API_LOG_PAYLOAD', True)
 
     def _validate_cluster_log_msg(self, path, method, user, params):
         channel, _, msg = mgr.cluster_log.call_args_list[0][0]
@@ -70,12 +70,12 @@ class ApiAuditingTest(ControllerTestCase):
         self.assertDictEqual(json.loads(m.group(5)), params)
 
     def test_no_audit(self):
-        mgr.set_config('AUDIT_API_ENABLED', False)
+        mgr.set_module_option('AUDIT_API_ENABLED', False)
         self._delete('/foo/test1')
         mgr.cluster_log.assert_not_called()
 
     def test_no_payload(self):
-        mgr.set_config('AUDIT_API_LOG_PAYLOAD', False)
+        mgr.set_module_option('AUDIT_API_LOG_PAYLOAD', False)
         self._delete('/foo/test1')
         _, _, msg = mgr.cluster_log.call_args_list[0][0]
         self.assertNotIn('params=', msg)

--- a/src/pybind/mgr/dashboard/tests/test_grafana.py
+++ b/src/pybind/mgr/dashboard/tests/test_grafana.py
@@ -35,7 +35,7 @@ class GrafanaControllerTestCase(ControllerTestCase):
             'GRAFANA_API_USERNAME': 'admin',
             'GRAFANA_API_PASSWORD': 'admin'
         }
-        mgr.get_config.side_effect = settings.get
+        mgr.get_module_option.side_effect = settings.get
         GrafanaProxy._cp_config['tools.authenticate.on'] = False  # pylint: disable=protected-access
 
         cls.setup_controllers([GrafanaProxy, GrafanaMockInstance])

--- a/src/pybind/mgr/dashboard/tests/test_rest_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_rest_client.py
@@ -11,7 +11,7 @@ from ..rest_client import RequestException, RestClient
 class RestClientTest(unittest.TestCase):
     def setUp(self):
         settings = {'REST_REQUESTS_TIMEOUT': 45}
-        mgr.get_config.side_effect = settings.get
+        mgr.get_module_option.side_effect = settings.get
 
     def test_timeout_auto_set(self):
         with patch('requests.Session.request') as mock_request:

--- a/src/pybind/mgr/dashboard/tests/test_rgw_client.py
+++ b/src/pybind/mgr/dashboard/tests/test_rgw_client.py
@@ -14,27 +14,27 @@ class RgwClientTest(unittest.TestCase):
     }
 
     @classmethod
-    def mock_set_config(cls, key, val):
+    def mock_set_module_option(cls, key, val):
         cls.settings[key] = val
 
     @classmethod
-    def mock_get_config(cls, key, default):
+    def mock_get_module_option(cls, key, default):
         return cls.settings.get(key, default)
 
     @classmethod
     def setUpClass(cls):
-        mgr.get_config.side_effect = cls.mock_get_config
-        mgr.set_config.side_effect = cls.mock_set_config
+        mgr.get_module_option.side_effect = cls.mock_get_module_option
+        mgr.set_module_option.side_effect = cls.mock_set_module_option
 
     def setUp(self):
         RgwClient._user_instances.clear()  # pylint: disable=protected-access
 
     def test_ssl_verify(self):
-        mgr.set_config('RGW_API_SSL_VERIFY', True)
+        mgr.set_module_option('RGW_API_SSL_VERIFY', True)
         instance = RgwClient.admin_instance()
         self.assertTrue(instance.session.verify)
 
     def test_no_ssl_verify(self):
-        mgr.set_config('RGW_API_SSL_VERIFY', False)
+        mgr.set_module_option('RGW_API_SSL_VERIFY', False)
         instance = RgwClient.admin_instance()
         self.assertFalse(instance.session.verify)

--- a/src/pybind/mgr/dashboard/tests/test_settings.py
+++ b/src/pybind/mgr/dashboard/tests/test_settings.py
@@ -22,17 +22,17 @@ class SettingsTest(unittest.TestCase):
         settings._OPTIONS_COMMAND_MAP = settings._options_command_map()
 
     @classmethod
-    def mock_set_config(cls, attr, val):
+    def mock_set_module_option(cls, attr, val):
         cls.CONFIG_KEY_DICT[attr] = val
 
     @classmethod
-    def mock_get_config(cls, attr, default):
+    def mock_get_module_option(cls, attr, default):
         return cls.CONFIG_KEY_DICT.get(attr, default)
 
     def setUp(self):
         self.CONFIG_KEY_DICT.clear()
-        mgr.set_config.side_effect = self.mock_set_config
-        mgr.get_config.side_effect = self.mock_get_config
+        mgr.set_module_option.side_effect = self.mock_set_module_option
+        mgr.get_module_option.side_effect = self.mock_get_module_option
         if Settings.GRAFANA_API_HOST != 'localhost':
             Settings.GRAFANA_API_HOST = 'localhost'
         if Settings.GRAFANA_API_PORT != 3000:
@@ -119,17 +119,17 @@ class SettingsControllerTest(ControllerTestCase):
         cls.setup_controllers([SettingsController])
 
     @classmethod
-    def mock_set_config(cls, attr, val):
+    def mock_set_module_option(cls, attr, val):
         cls.config_values[attr] = val
 
     @classmethod
-    def mock_get_config(cls, attr, default):
+    def mock_get_module_option(cls, attr, default):
         return cls.config_values.get(attr, default)
 
     def setUp(self):
         self.config_values.clear()
-        mgr.set_config.side_effect = self.mock_set_config
-        mgr.get_config.side_effect = self.mock_get_config
+        mgr.set_module_option.side_effect = self.mock_set_module_option
+        mgr.get_module_option.side_effect = self.mock_get_module_option
 
     def test_settings_list(self):
         self._get('/api/settings')

--- a/src/pybind/mgr/dashboard/tests/test_sso.py
+++ b/src/pybind/mgr/dashboard/tests/test_sso.py
@@ -14,11 +14,11 @@ class AccessControlTest(unittest.TestCase):
     CONFIG_KEY_DICT = {}
 
     @classmethod
-    def mock_set_config(cls, attr, val):
+    def mock_set_module_option(cls, attr, val):
         cls.CONFIG_KEY_DICT[attr] = val
 
     @classmethod
-    def mock_get_config(cls, attr, default):
+    def mock_get_module_option(cls, attr, default):
         return cls.CONFIG_KEY_DICT.get(attr, default)
 
     IDP_METADATA = '''<?xml version="1.0"?>
@@ -71,10 +71,11 @@ class AccessControlTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        mgr.set_config.side_effect = cls.mock_set_config
-        mgr.get_config.side_effect = cls.mock_get_config
-        mgr.set_store.side_effect = cls.mock_set_config
-        mgr.get_store.side_effect = cls.mock_get_config
+        mgr.set_module_option.side_effect = cls.mock_set_module_option
+        mgr.get_module_option.side_effect = cls.mock_get_module_option
+        # kludge below
+        mgr.set_store.side_effect = cls.mock_set_module_option
+        mgr.get_store.side_effect = cls.mock_get_module_option
 
     def setUp(self):
         self.CONFIG_KEY_DICT.clear()

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -44,7 +44,7 @@ class DeepSeaReadCompletion(orchestrator.ReadCompletion):
 
 
 class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {
             'name': 'salt_api_url',
             'default': None
@@ -81,7 +81,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     @property
     def config_keys(self):
-        return dict((o['name'], o.get('default', None)) for o in self.OPTIONS)
+        return dict((o['name'], o.get('default', None)) for o in self.MODULE_OPTIONS)
 
 
     def get_config(self, key, default=None):

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -240,7 +240,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
                 return (-errno.EINVAL, '',
                         "Unknown configuration option '{0}'".format(cmd['key']))
 
-            self.set_config(cmd['key'], cmd['value'])
+            self.set_module_option(cmd['key'], cmd['value'])
             self._event.set();
             return 0, "Configuration option '{0}' updated".format(cmd['key']), ''
 

--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -84,17 +84,17 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
         return dict((o['name'], o.get('default', None)) for o in self.MODULE_OPTIONS)
 
 
-    def get_config(self, key, default=None):
+    def get_module_option(self, key, default=None):
         """
-        Overrides the default MgrModule get_config() method to pull in defaults
+        Overrides the default MgrModule get_module_option() method to pull in defaults
         specific to this module
         """
-        return super(DeepSeaOrchestrator, self).get_config(key, default=self.config_keys[key])
+        return super(DeepSeaOrchestrator, self).get_module_option(key, default=self.config_keys[key])
 
 
     def _config_valid(self):
         for key in self.config_keys.keys():
-            if not self.get_config(key, self.config_keys[key]):
+            if not self.get_module_option(key, self.config_keys[key]):
                 return False
         return True
 
@@ -233,7 +233,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     def handle_command(self, inbuf, cmd):
         if cmd['prefix'] == 'deepsea config-show':
-            return 0, json.dumps(dict([(key, self.get_config(key)) for key in self.config_keys.keys()])), ''
+            return 0, json.dumps(dict([(key, self.get_module_option(key)) for key in self.config_keys.keys()])), ''
 
         elif cmd['prefix'] == 'deepsea config-set':
             if cmd['key'] not in self.config_keys.keys():
@@ -414,7 +414,7 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
         """
         returns the response, which the caller then has to read
         """
-        url = "{0}/{1}".format(self.get_config('salt_api_url'), path)
+        url = "{0}/{1}".format(self.get_module_option('salt_api_url'), path)
         try:
             if method.lower() == 'get':
                 resp = requests.get(url, headers = { "X-Auth-Token": self._token },
@@ -440,9 +440,9 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     def _login(self):
         resp = self._do_request('POST', 'login', data = {
-            "eauth": self.get_config('salt_api_eauth'),
-            "sharedsecret" if self.get_config('salt_api_eauth') == 'sharedsecret' else 'password': self.get_config('salt_api_password'),
-            "username": self.get_config('salt_api_username')
+            "eauth": self.get_module_option('salt_api_eauth'),
+            "sharedsecret" if self.get_module_option('salt_api_eauth') == 'sharedsecret' else 'password': self.get_module_option('salt_api_password'),
+            "username": self.get_module_option('salt_api_username')
         })
         self._token = resp.json()['return'][0]['token']
         self.log.info("Salt API login successful")

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -158,11 +158,11 @@ class Module(MgrModule):
         elif cmd['prefix'] == 'device check-health':
             return self.check_health()
         elif cmd['prefix'] == 'device monitoring on':
-            self.set_config('enable_monitoring', 'true')
+            self.set_module_option('enable_monitoring', 'true')
             self.event.set()
             return 0, '', ''
         elif cmd['prefix'] == 'device monitoring off':
-            self.set_config('enable_monitoring', 'false')
+            self.set_module_option('enable_monitoring', 'false')
             self.set_health_checks({})  # avoid stuck health alerts
             return 0, '', ''
         elif cmd['prefix'] == 'device predict-life-expectancy':

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -24,7 +24,7 @@ HEALTH_MESSAGES = {
 
 
 class Module(MgrModule):
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {
             'name': 'enable_monitoring',
             'default': str(False),
@@ -113,7 +113,7 @@ class Module(MgrModule):
         super(Module, self).__init__(*args, **kwargs)
 
         # options
-        for opt in self.OPTIONS:
+        for opt in self.MODULE_OPTIONS:
             setattr(self, opt['name'], opt['default'])
 
         # other
@@ -189,7 +189,7 @@ class Module(MgrModule):
             assert before != after
 
     def config_notify(self):
-        for opt in self.OPTIONS:
+        for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
                     self.get_config(opt['name']) or opt['default'])

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -577,7 +577,7 @@ class Module(MgrModule):
 
     def predict_lift_expectancy(self, devid):
         plugin_name = ''
-        model = self.get_option('device_failure_prediction_mode')
+        model = self.get_ceph_option('device_failure_prediction_mode')
         if model and model.lower() == 'cloud':
             plugin_name = 'diskprediction_cloud'
         elif model and model.lower() == 'local':
@@ -593,7 +593,7 @@ class Module(MgrModule):
 
     def predict_all_devices(self):
         plugin_name = ''
-        model = self.get_option('device_failure_prediction_mode')
+        model = self.get_ceph_option('device_failure_prediction_mode')
         if model and model.lower() == 'cloud':
             plugin_name = 'diskprediction_cloud'
         elif model and model.lower() == 'local':

--- a/src/pybind/mgr/devicehealth/module.py
+++ b/src/pybind/mgr/devicehealth/module.py
@@ -192,7 +192,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_config(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']) or opt['default'])
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
 
     def serve(self):

--- a/src/pybind/mgr/diskprediction_cloud/module.py
+++ b/src/pybind/mgr/diskprediction_cloud/module.py
@@ -36,7 +36,7 @@ def decode_string(value):
 
 class Module(MgrModule):
 
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {
             'name': 'diskprediction_server',
             'default': ''
@@ -128,7 +128,7 @@ class Module(MgrModule):
         self._run = True
 
     def config_notify(self):
-        for opt in self.OPTIONS:
+        for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
                     self.get_config(opt['name']) or opt['default'])
@@ -140,7 +140,7 @@ class Module(MgrModule):
 
     @property
     def config_keys(self):
-        return dict((o['name'], o.get('default', None)) for o in self.OPTIONS)
+        return dict((o['name'], o.get('default', None)) for o in self.MODULE_OPTIONS)
 
     def set_config_option(self, option, value):
         if option not in self.config_keys.keys():
@@ -232,7 +232,7 @@ class Module(MgrModule):
         return 0, msg, ''
 
     def refresh_config(self):
-        for opt in self.OPTIONS:
+        for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
                     self.get_config(opt['name']) or opt['default'])

--- a/src/pybind/mgr/diskprediction_cloud/module.py
+++ b/src/pybind/mgr/diskprediction_cloud/module.py
@@ -131,7 +131,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_config(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']) or opt['default'])
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
         if not self._activated_cloud and self.get_option('device_failure_prediction_mode') == 'cloud':
             self._event.set()
@@ -163,7 +163,7 @@ class Module(MgrModule):
         return True
 
     def get_configuration(self, key):
-        return self.get_config(key, self.config_keys[key])
+        return self.get_module_option(key, self.config_keys[key])
 
     @staticmethod
     def _convert_timestamp(predicted_timestamp, life_expectancy_day):
@@ -235,7 +235,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_config(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']) or opt['default'])
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
 
     def _status(self,  cmd):
@@ -361,7 +361,7 @@ class Module(MgrModule):
 
     def show_module_config(self):
         for key, default in self.config_keys.items():
-            self.set_config_option(key, self.get_config(key, default))
+            self.set_config_option(key, self.get_module_option(key, default))
 
     def serve(self):
         self.log.info('Starting diskprediction module')

--- a/src/pybind/mgr/diskprediction_cloud/module.py
+++ b/src/pybind/mgr/diskprediction_cloud/module.py
@@ -157,7 +157,7 @@ class Module(MgrModule):
 
         self.log.debug('Setting in-memory config option %s to: %s', option,
                        value)
-        self.set_config(option, value)
+        self.set_module_option(option, value)
         self.config[option] = value
 
         return True
@@ -183,7 +183,7 @@ class Module(MgrModule):
     def _set_ssl_target_name(self, cmd):
         str_ssl_target = cmd.get('ssl_target_name', '')
         try:
-            self.set_config('diskprediction_ssl_target_name_override', str_ssl_target)
+            self.set_module_option('diskprediction_ssl_target_name_override', str_ssl_target)
             return (0,
                     'success to config ssl target name', 0)
         except Exception as e:
@@ -192,7 +192,7 @@ class Module(MgrModule):
     def _set_ssl_default_authority(self, cmd):
         str_ssl_authority = cmd.get('ssl_authority', '')
         try:
-            self.set_config('diskprediction_default_authority', str_ssl_authority)
+            self.set_module_option('diskprediction_default_authority', str_ssl_authority)
             return 0, 'success to config ssl default authority', 0
         except Exception as e:
             return -errno.EINVAL, '', str(e)
@@ -206,11 +206,11 @@ class Module(MgrModule):
                 'diskprediction_cert_context', trusted_certs)
             for _agent in self._agents:
                 _agent.event.set()
-            self.set_config('diskprediction_server', cmd['server'])
-            self.set_config('diskprediction_user', cmd['user'])
-            self.set_config('diskprediction_password', encode_string(cmd['password']))
+            self.set_module_option('diskprediction_server', cmd['server'])
+            self.set_module_option('diskprediction_user', cmd['user'])
+            self.set_module_option('diskprediction_password', encode_string(cmd['password']))
             if cmd.get('port'):
-                self.set_config('diskprediction_port', cmd['port'])
+                self.set_module_option('diskprediction_port', cmd['port'])
             return 0, 'succeed to config cloud mode connection', ''
         else:
             return -errno.EINVAL, '', 'certification file not existed'

--- a/src/pybind/mgr/diskprediction_cloud/module.py
+++ b/src/pybind/mgr/diskprediction_cloud/module.py
@@ -133,9 +133,9 @@ class Module(MgrModule):
                     opt['name'],
                     self.get_module_option(opt['name']) or opt['default'])
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
-        if not self._activated_cloud and self.get_option('device_failure_prediction_mode') == 'cloud':
+        if not self._activated_cloud and self.get_ceph_option('device_failure_prediction_mode') == 'cloud':
             self._event.set()
-        if self._activated_cloud and self.get_option('device_failure_prediction_mode') != 'cloud':
+        if self._activated_cloud and self.get_ceph_option('device_failure_prediction_mode') != 'cloud':
             self._event.set()
 
     @property
@@ -370,7 +370,7 @@ class Module(MgrModule):
 
         while self._run:
             self.refresh_config()
-            mode = self.get_option('device_failure_prediction_mode')
+            mode = self.get_ceph_option('device_failure_prediction_mode')
             if mode == 'cloud':
                 if not self._activated_cloud:
                     self.start_cloud_disk_prediction()

--- a/src/pybind/mgr/diskprediction_local/module.py
+++ b/src/pybind/mgr/diskprediction_local/module.py
@@ -44,7 +44,7 @@ class Module(MgrModule):
                     opt['name'],
                     self.get_module_option(opt['name']) or opt['default'])
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
-        if self.get_option('device_failure_prediction_mode') == 'local':
+        if self.get_ceph_option('device_failure_prediction_mode') == 'local':
             self._event.set()
 
     def refresh_config(self):
@@ -77,7 +77,7 @@ class Module(MgrModule):
 
         while self._run:
             self.refresh_config()
-            mode = self.get_option('device_failure_prediction_mode')
+            mode = self.get_ceph_option('device_failure_prediction_mode')
             if mode == 'local':
                 now = datetime.datetime.utcnow()
                 if not last_predicted:

--- a/src/pybind/mgr/diskprediction_local/module.py
+++ b/src/pybind/mgr/diskprediction_local/module.py
@@ -16,7 +16,7 @@ TIME_WEEK = TIME_DAYS * 7
 
 
 class Module(MgrModule):
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {
             'name': 'sleep_interval',
             'default': str(600),
@@ -32,14 +32,14 @@ class Module(MgrModule):
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)
         # options
-        for opt in self.OPTIONS:
+        for opt in self.MODULE_OPTIONS:
             setattr(self, opt['name'], opt['default'])
         # other
         self._run = True
         self._event = Event()
 
     def config_notify(self):
-        for opt in self.OPTIONS:
+        for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
                     self.get_config(opt['name']) or opt['default'])
@@ -48,7 +48,7 @@ class Module(MgrModule):
             self._event.set()
 
     def refresh_config(self):
-        for opt in self.OPTIONS:
+        for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
                     self.get_config(opt['name']) or opt['default'])

--- a/src/pybind/mgr/diskprediction_local/module.py
+++ b/src/pybind/mgr/diskprediction_local/module.py
@@ -42,7 +42,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_config(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']) or opt['default'])
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
         if self.get_option('device_failure_prediction_mode') == 'local':
             self._event.set()
@@ -51,7 +51,7 @@ class Module(MgrModule):
         for opt in self.MODULE_OPTIONS:
             setattr(self,
                     opt['name'],
-                    self.get_config(opt['name']) or opt['default'])
+                    self.get_module_option(opt['name']) or opt['default'])
             self.log.debug(' %s = %s', opt['name'], getattr(self, opt['name']))
 
     def handle_command(self, _, cmd):

--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 class Module(MgrModule):
-    OPTIONS = [
+    MODULE_OPTIONS = [
             {
                 'name': 'hostname',
                 'default': None
@@ -66,7 +66,7 @@ class Module(MgrModule):
     @property
     def config_keys(self):
         return dict((o['name'], o.get('default', None))
-                for o in self.OPTIONS)
+                for o in self.MODULE_OPTIONS)
 
     COMMANDS = [
         {

--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -301,28 +301,28 @@ class Module(MgrModule):
 
     def init_module_config(self):
         self.config['hostname'] = \
-            self.get_config("hostname", default=self.config_keys['hostname'])
+            self.get_module_option("hostname", default=self.config_keys['hostname'])
         self.config['port'] = \
-            int(self.get_config("port", default=self.config_keys['port']))
+            int(self.get_module_option("port", default=self.config_keys['port']))
         self.config['database'] = \
-            self.get_config("database", default=self.config_keys['database'])
+            self.get_module_option("database", default=self.config_keys['database'])
         self.config['username'] = \
-            self.get_config("username", default=self.config_keys['username'])
+            self.get_module_option("username", default=self.config_keys['username'])
         self.config['password'] = \
-            self.get_config("password", default=self.config_keys['password'])
+            self.get_module_option("password", default=self.config_keys['password'])
         self.config['interval'] = \
-            int(self.get_config("interval",
+            int(self.get_module_option("interval",
                                 default=self.config_keys['interval']))
         self.config['threads'] = \
-            int(self.get_config("threads",
+            int(self.get_module_option("threads",
                                 default=self.config_keys['threads']))
         self.config['batch_size'] = \
-            int(self.get_config("batch_size",
+            int(self.get_module_option("batch_size",
                                 default=self.config_keys['batch_size']))
-        ssl = self.get_config("ssl", default=self.config_keys['ssl'])
+        ssl = self.get_module_option("ssl", default=self.config_keys['ssl'])
         self.config['ssl'] = ssl.lower() == 'true'
         verify_ssl = \
-            self.get_config("verify_ssl", default=self.config_keys['verify_ssl'])
+            self.get_module_option("verify_ssl", default=self.config_keys['verify_ssl'])
         self.config['verify_ssl'] = verify_ssl.lower() == 'true'
 
     def gather_statistics(self):

--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -444,7 +444,7 @@ class Module(MgrModule):
 
             self.log.debug('Setting configuration option %s to %s', key, value)
             self.set_config_option(key, value)
-            self.set_config(key, value)
+            self.set_module_option(key, value)
             return 0, 'Configuration option {0} updated'.format(key), ''
         elif cmd['prefix'] == 'influx send':
             self.send_to_influx()

--- a/src/pybind/mgr/localpool/module.py
+++ b/src/pybind/mgr/localpool/module.py
@@ -4,7 +4,7 @@ import threading
 
 class Module(MgrModule):
 
-    OPTIONS = [
+    MODULE_OPTIONS = [
             {'name': 'failure_domain'},
             {'name': 'min_size'},
             {'name': 'num_rep'},

--- a/src/pybind/mgr/localpool/module.py
+++ b/src/pybind/mgr/localpool/module.py
@@ -25,12 +25,12 @@ class Module(MgrModule):
         """
         Check pools on each OSDMap change
         """
-        subtree_type = self.get_config('subtree') or 'rack'
-        failure_domain = self.get_config('failure_domain') or 'host'
-        pg_num = self.get_config('pg_num') or '128'
-        num_rep = self.get_config('num_rep') or '3'
-        min_size = self.get_config('min_size')
-        prefix = self.get_config('prefix') or 'by-' + subtree_type + '-'
+        subtree_type = self.get_module_option('subtree') or 'rack'
+        failure_domain = self.get_module_option('failure_domain') or 'host'
+        pg_num = self.get_module_option('pg_num') or '128'
+        num_rep = self.get_module_option('num_rep') or '3'
+        min_size = self.get_module_option('min_size')
+        prefix = self.get_module_option('prefix') or 'by-' + subtree_type + '-'
 
         osdmap = self.get("osd_map")
         lpools = []

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -736,7 +736,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         return self._get_localized(key, default, self._get_module_option)
 
     def _set_module_option(self, key, val):
-        return self._ceph_set_config(key, val)
+        return self._ceph_set_module_option(key, val)
 
     def set_module_option(self, key, val):
         """

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -735,10 +735,10 @@ class MgrModule(ceph_module.BaseMgrModule):
         self._validate_module_option(key)
         return self._get_localized(key, default, self._get_module_option)
 
-    def _set_config(self, key, val):
+    def _set_module_option(self, key, val):
         return self._ceph_set_config(key, val)
 
-    def set_config(self, key, val):
+    def set_module_option(self, key, val):
         """
         Set the value of a persistent configuration setting
 
@@ -746,9 +746,9 @@ class MgrModule(ceph_module.BaseMgrModule):
         :param str val:
         """
         self._validate_module_option(key)
-        return self._set_config(key, val)
+        return self._set_module_option(key, val)
 
-    def set_localized_config(self, key, val):
+    def set_localized_module_option(self, key, val):
         """
         Set localized configuration for this ceph-mgr instance
         :param str key:
@@ -756,7 +756,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         :return: str
         """
         self._validate_module_option(key)
-        return self._set_localized(key, val, self._set_config)
+        return self._set_localized(key, val, self._set_module_option)
 
     def set_store(self, key, val):
         """

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -246,6 +246,9 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
         else:
             return r
 
+    def get_ceph_option(self, key):
+        return self._ceph_get_option(key)
+
     def get_store(self, key):
         """
         Retrieve the value of a persistent KV store entry

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -232,7 +232,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
     def get_mgr_id(self):
         return self._ceph_get_mgr_id()
 
-    def get_config(self, key, default=None):
+    def get_module_option(self, key, default=None):
         """
         Retrieve the value of a persistent configuration setting
 
@@ -258,10 +258,10 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
     def get_active_uri(self):
         return self._ceph_get_active_uri()
 
-    def get_localized_config(self, key, default=None):
-        r = self.get_config(self.get_mgr_id() + '/' + key)
+    def get_localized_module_option(self, key, default=None):
+        r = self.get_module_option(self.get_mgr_id() + '/' + key)
         if r is None:
-            r = self.get_config(key)
+            r = self.get_module_option(key)
 
         if r is None:
             r = default
@@ -695,7 +695,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         else:
             return r
 
-    def get_config(self, key, default=None):
+    def get_module_option(self, key, default=None):
         """
         Retrieve the value of a persistent configuration setting
 
@@ -725,7 +725,7 @@ class MgrModule(ceph_module.BaseMgrModule):
     def _set_localized(self, key, val, setter):
         return setter(self.get_mgr_id() + '/' + key, val)
 
-    def get_localized_config(self, key, default=None):
+    def get_localized_module_option(self, key, default=None):
         """
         Retrieve localized configuration for this ceph-mgr instance
         :param str key:

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -678,7 +678,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         """
         return self._ceph_get_mgr_id()
 
-    def get_option(self, key):
+    def get_ceph_option(self, key):
         return self._ceph_get_option(key)
 
     def _validate_module_option(self, key):

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -269,7 +269,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
 
 class MgrModule(ceph_module.BaseMgrModule):
     COMMANDS = []
-    OPTIONS = []
+    MODULE_OPTIONS = []
 
     # Priority definitions for perf counters
     PRIO_CRITICAL = 10
@@ -684,8 +684,8 @@ class MgrModule(ceph_module.BaseMgrModule):
         access config options that they didn't declare
         in their schema.
         """
-        if key not in [o['name'] for o in self.OPTIONS]:
-            raise RuntimeError("Config option '{0}' is not in {1}.OPTIONS".\
+        if key not in [o['name'] for o in self.MODULE_OPTIONS]:
+            raise RuntimeError("Config option '{0}' is not in {1}.MODULE_OPTIONS".\
                     format(key, self.__class__.__name__))
 
     def _get_config(self, key, default):

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -240,7 +240,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
         :param default: the default value of the config if it is not found
         :return: str
         """
-        r = self._ceph_get_config(key)
+        r = self._ceph_get_module_option(key)
         if r is None:
             return default
         else:
@@ -678,7 +678,7 @@ class MgrModule(ceph_module.BaseMgrModule):
     def get_option(self, key):
         return self._ceph_get_option(key)
 
-    def _validate_option(self, key):
+    def _validate_module_option(self, key):
         """
         Helper: don't allow get/set config callers to 
         access config options that they didn't declare
@@ -688,8 +688,8 @@ class MgrModule(ceph_module.BaseMgrModule):
             raise RuntimeError("Config option '{0}' is not in {1}.MODULE_OPTIONS".\
                     format(key, self.__class__.__name__))
 
-    def _get_config(self, key, default):
-        r = self._ceph_get_config(key)
+    def _get_module_option(self, key, default):
+        r = self._ceph_get_module_option(key)
         if r is None:
             return default
         else:
@@ -702,8 +702,8 @@ class MgrModule(ceph_module.BaseMgrModule):
         :param str key:
         :return: str
         """
-        self._validate_option(key)
-        return self._get_config(key, default)
+        self._validate_module_option(key)
+        return self._get_module_option(key, default)
 
     def get_store_prefix(self, key_prefix):
         """
@@ -732,8 +732,8 @@ class MgrModule(ceph_module.BaseMgrModule):
         :param str default:
         :return: str
         """
-        self._validate_option(key)
-        return self._get_localized(key, default, self._get_config)
+        self._validate_module_option(key)
+        return self._get_localized(key, default, self._get_module_option)
 
     def _set_config(self, key, val):
         return self._ceph_set_config(key, val)
@@ -745,7 +745,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         :param str key:
         :param str val:
         """
-        self._validate_option(key)
+        self._validate_module_option(key)
         return self._set_config(key, val)
 
     def set_localized_config(self, key, val):
@@ -755,7 +755,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         :param str default:
         :return: str
         """
-        self._validate_option(key)
+        self._validate_module_option(key)
         return self._set_localized(key, val, self._set_config)
 
     def set_store(self, key, val):

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -62,7 +62,7 @@ class OrchestratorCli(MgrModule):
     ]
 
     def _select_orchestrator(self):
-        o = self.get_config("orchestrator")
+        o = self.get_module_option("orchestrator")
         if o is None:
             raise NoOrchestrator()
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -10,7 +10,7 @@ class NoOrchestrator(Exception):
 
 
 class OrchestratorCli(MgrModule):
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {'name': 'orchestrator'}
     ]
     COMMANDS = [

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -278,7 +278,7 @@ class OrchestratorCli(MgrModule):
         module_name = cmd['module']
 
         if module_name == "":
-            self.set_config("orchestrator", None)
+            self.set_module_option("orchestrator", None)
             return HandleCommandResult()
 
         for module in mgr_map['available_modules']:
@@ -303,7 +303,7 @@ class OrchestratorCli(MgrModule):
                 return HandleCommandResult(-errno.EINVAL,
                                            rs="'{0}' is not an orchestrator module".format(module_name))
 
-            self.set_config("orchestrator", module_name)
+            self.set_module_option("orchestrator", module_name)
 
             return HandleCommandResult()
 

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -153,7 +153,7 @@ class Module(MgrModule):
         },
     ]
 
-    OPTIONS = [
+    MODULE_OPTIONS = [
             {'name': 'server_addr'},
             {'name': 'server_port'},
             {'name': 'scrape_interval'},

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -670,10 +670,10 @@ class Module(MgrModule):
                     raise cherrypy.HTTPError(503, 'No MON connection')
 
         # Make the cache timeout for collecting configurable
-        self.collect_timeout = self.get_localized_config('scrape_interval', 5.0)
+        self.collect_timeout = self.get_localized_module_option('scrape_interval', 5.0)
 
-        server_addr = self.get_localized_config('server_addr', DEFAULT_ADDR)
-        server_port = self.get_localized_config('server_port', DEFAULT_PORT)
+        server_addr = self.get_localized_module_option('server_addr', DEFAULT_ADDR)
+        server_port = self.get_localized_module_option('server_port', DEFAULT_PORT)
         self.log.info(
             "server_addr: %s server_port: %s" %
             (server_addr, server_port)
@@ -712,8 +712,8 @@ class StandbyModule(MgrStandbyModule):
         self.shutdown_event = threading.Event()
 
     def serve(self):
-        server_addr = self.get_localized_config('server_addr', '::')
-        server_port = self.get_localized_config('server_port', DEFAULT_PORT)
+        server_addr = self.get_localized_module_option('server_addr', '::')
+        server_port = self.get_localized_module_option('server_port', DEFAULT_PORT)
         self.log.info("server_addr: %s server_port: %s" % (server_addr, server_port))
         cherrypy.config.update({
             'server.socket_host': server_addr,

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -199,7 +199,7 @@ class CommandsRequest(object):
 
 
 class Module(MgrModule):
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {'name': 'server_addr'},
         {'name': 'server_port'},
         {'name': 'key_file'},

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -279,11 +279,11 @@ class Module(MgrModule):
             separators=(',', ': '),
         )
 
-        server_addr = self.get_localized_config('server_addr', '::')
+        server_addr = self.get_localized_module_option('server_addr', '::')
         if server_addr is None:
             raise CannotServe('no server_addr configured; try "ceph config-key set mgr/restful/server_addr <ip>"')
 
-        server_port = int(self.get_localized_config('server_port', '8003'))
+        server_port = int(self.get_localized_module_option('server_port', '8003'))
         self.log.info('server_addr: %s server_port: %d',
                       server_addr, server_port)
 
@@ -303,7 +303,7 @@ class Module(MgrModule):
             pkey_tmp.flush()
             pkey_fname = pkey_tmp.name
         else:
-            pkey_fname = self.get_localized_config('key_file')
+            pkey_fname = self.get_localized_module_option('key_file')
 
         if not cert_fname or not pkey_fname:
             raise CannotServe('no certificate configured')

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -128,7 +128,7 @@ def deferred_read(f):
 
 
 class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
-    OPTIONS = [
+    MODULE_OPTIONS = [
         # TODO: configure k8s API addr instead of assuming local
     ]
 

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -124,9 +124,9 @@ class Module(MgrModule):
             else:
                 return 0, '', 'No background workload was running'
         elif command['prefix'] == 'mgr self-test config get':
-            return 0, str(self.get_config(command['key'])), ''
+            return 0, str(self.get_module_option(command['key'])), ''
         elif command['prefix'] == 'mgr self-test config get_localized':
-            return 0, str(self.get_localized_config(command['key'])), ''
+            return 0, str(self.get_localized_module_option(command['key'])), ''
         elif command['prefix'] == 'mgr self-test remote':
             self._test_remote_calls()
             return 0, '', 'Successfully called'
@@ -255,10 +255,10 @@ class Module(MgrModule):
         # persisted), it's just for the python interface bit.
 
         self.set_config("testkey", "testvalue")
-        assert self.get_config("testkey") == "testvalue"
+        assert self.get_module_option("testkey") == "testvalue"
 
         self.set_localized_config("testkey", "testvalue")
-        assert self.get_localized_config("testkey") == "testvalue"
+        assert self.get_localized_module_option("testkey") == "testvalue"
 
     def _self_test_store(self):
         existing_keys = set(self.get_store_prefix("test").keys())

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -254,10 +254,10 @@ class Module(MgrModule):
         # This is not a strong test (can't tell if values really
         # persisted), it's just for the python interface bit.
 
-        self.set_config("testkey", "testvalue")
+        self.set_module_option("testkey", "testvalue")
         assert self.get_module_option("testkey") == "testvalue"
 
-        self.set_localized_config("testkey", "testvalue")
+        self.set_localized_module_option("testkey", "testvalue")
         assert self.get_localized_module_option("testkey") == "testvalue"
 
     def _self_test_store(self):

--- a/src/pybind/mgr/selftest/module.py
+++ b/src/pybind/mgr/selftest/module.py
@@ -28,7 +28,7 @@ class Module(MgrModule):
 
     # The test code in qa/ relies on these options existing -- they
     # are of course not really used for anything in the module
-    OPTIONS = [
+    MODULE_OPTIONS = [
             {'name': 'testkey'},
             {'name': 'testlkey'},
             {'name': 'testnewline'}

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -218,9 +218,9 @@ class Module(MgrModule):
 
     def init_module_config(self):
         self.config['address'] = \
-            self.get_config("address", default=self.config_keys['address'])
+            self.get_module_option("address", default=self.config_keys['address'])
         self.config['interval'] = \
-            int(self.get_config("interval",
+            int(self.get_module_option("interval",
                                 default=self.config_keys['interval']))
 
     def now(self):

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -36,7 +36,7 @@ class Module(MgrModule):
         },
     ]
 
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {
             'name': 'address',
             'default': 'unixgram:///tmp/telegraf.sock',
@@ -51,7 +51,7 @@ class Module(MgrModule):
 
     @property
     def config_keys(self):
-        return dict((o['name'], o.get('default', None)) for o in self.OPTIONS)
+        return dict((o['name'], o.get('default', None)) for o in self.MODULE_OPTIONS)
 
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -267,7 +267,7 @@ class Module(MgrModule):
 
             self.log.debug('Setting configuration option %s to %s', key, value)
             self.set_config_option(key, value)
-            self.set_config(key, value)
+            self.set_module_option(key, value)
             return 0, 'Configuration option {0} updated'.format(key), ''
         elif cmd['prefix'] == 'telegraf send':
             self.send_to_telegraf()

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -31,7 +31,7 @@ class Module(MgrModule):
             "distro"
     ]
 
-    OPTIONS = [
+    MODULE_OPTIONS = [
         {
             'name': 'url',
             'default': 'https://telemetry.ceph.com/report'
@@ -92,7 +92,7 @@ class Module(MgrModule):
 
     @property
     def config_keys(self):
-        return dict((o['name'], o.get('default', None)) for o in self.OPTIONS)
+        return dict((o['name'], o.get('default', None)) for o in self.MODULE_OPTIONS)
 
     def __init__(self, *args, **kwargs):
         super(Module, self).__init__(*args, **kwargs)

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -308,7 +308,7 @@ class Module(MgrModule):
 
             self.log.debug('Setting configuration option %s to %s', key, value)
             self.set_config_option(key, value)
-            self.set_config(key, value)
+            self.set_module_option(key, value)
             return 0, 'Configuration option {0} updated'.format(key), ''
         elif command['prefix'] == 'telemetry send':
             self.last_report = self.compile_report()

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -159,7 +159,7 @@ class Module(MgrModule):
 
     def init_module_config(self):
         for key, default in self.config_keys.items():
-            self.set_config_option(key, self.get_config(key, default))
+            self.set_config_option(key, self.get_module_option(key, default))
 
         self.last_upload = self.get_store('last_upload', None)
         if self.last_upload is not None:

--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -108,7 +108,7 @@ class Module(MgrModule):
         self.log.debug('Found Ceph fsid %s', self.fsid)
 
         for key, default in self.config_keys.items():
-            self.set_config_option(key, self.get_config(key, default))
+            self.set_config_option(key, self.get_module_option(key, default))
 
     def set_config_option(self, option, value):
         if option not in self.config_keys.keys():

--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -304,7 +304,7 @@ class Module(MgrModule):
 
             self.log.debug('Setting configuration option %s to %s', key, value)
             if self.set_config_option(key, value):
-                self.set_config(key, value)
+                self.set_module_option(key, value)
                 return 0, 'Configuration option {0} updated'.format(key), ''
 
             return 1,\

--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -55,9 +55,9 @@ class Module(MgrModule):
     @property
     def config_keys(self):
         return dict((o['name'], o.get('default', None))
-                for o in self.OPTIONS)
+                for o in self.MODULE_OPTIONS)
 
-    OPTIONS = [
+    MODULE_OPTIONS = [
             {
                 'name': 'zabbix_sender',
                 'default': '/usr/bin/zabbix_sender'


### PR DESCRIPTION
High level goal:
- "module options" are the "mgr/$module/foo" options that are scoped to mgr modules
- "ceph options" are the common/options.cc compiled-in options.

This PR changes:
- rename OPTIONS -> MODULE_OPTIONS
- rename get_config -> get_module_option, set_config -> set_module_option
- rename get_option -> get_ceph_option
- clean up some of the intenral names for mgr_module.py <-> BaseMgr[Standby]Module
- add get_ceph_option to the standby module parent