### PR TITLE
msg/async: truly use first addr if multiple incoming addrs provided

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -578,6 +578,7 @@ AsyncConnectionRef AsyncMessenger::create_connect(
     // FIXME: for ipv4 vs ipv6, check whether local host can handle ipv6 before
     // trying it?  for now, just pick whichever is listed first.
     target = a;
+    break;
   }
 
   // create connection


### PR DESCRIPTION
For incoming IPv4 and IPv6 dual stack support, there might be
multiple addresses provided in entity's addrvec.
The comment says we'll just pick whichever is listed first for now
to accept, whereas the implementation does quite the opposite.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

