### PR TITLE
buffer: mark the iterator traits "public"

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -687,12 +687,6 @@ namespace buffer CEPH_BUFFER_API {
       typedef typename std::conditional<is_const,
 					typename buffers_t::const_iterator,
 					typename buffers_t::iterator>::type list_iter_t;
-      using iterator_category = std::forward_iterator_tag;
-      using value_type = typename std::conditional<is_const, const char, char>::type;
-      using difference_type = std::ptrdiff_t;
-      using pointer = typename std::add_pointer<value_type>::type;
-      using reference = typename std::add_lvalue_reference<value_type>::type;
-
       bl_t* bl;
       list_t* ls;  // meh.. just here to avoid an extra pointer dereference..
       list_iter_t p;
@@ -701,6 +695,12 @@ namespace buffer CEPH_BUFFER_API {
       friend class iterator_impl<true>;
 
     public:
+      using iterator_category = std::forward_iterator_tag;
+      using value_type = typename std::conditional<is_const, const char, char>::type;
+      using difference_type = std::ptrdiff_t;
+      using pointer = typename std::add_pointer<value_type>::type;
+      using reference = typename std::add_lvalue_reference<value_type>::type;
+
       // constructor.  position.
       iterator_impl()
 	: bl(0), ls(0), off(0), p_off(0) {}


### PR DESCRIPTION
the iterator traits should be accessible from non-dervative classes.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

