### PR TITLE
mgr/dashboard: Fix renaming of pools

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.spec.ts
@@ -229,6 +229,10 @@ describe('PoolFormComponent', () => {
       formHelper.expectErrorChange('name', 'wrong format with spaces', 'pattern');
     });
 
+    it('should validate with dots in pool name', () => {
+      formHelper.expectValidChange('name', 'pool.default.bar', true);
+    });
+
     it('validates poolType', () => {
       formHelper.expectError('poolType', 'required');
       formHelper.expectValidChange('poolType', 'erasure');

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.ts
@@ -100,7 +100,7 @@ export class PoolFormComponent implements OnInit {
     this.form = new CdFormGroup(
       {
         name: new FormControl('', {
-          validators: [Validators.pattern('[A-Za-z0-9_-]+'), Validators.required]
+          validators: [Validators.pattern('[\\.A-Za-z0-9_-]+'), Validators.required]
         }),
         poolType: new FormControl('', {
           validators: [Validators.required]


### PR DESCRIPTION
The validation fails to allow dots in pool names and as such, it wasn't
allowed to create or rename pools with dots in their names.

Fixes: https://tracker.ceph.com/issues/37534

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

