### PR TITLE
common: hint bufferlist's buffer_track_c_str accordingly.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -676,25 +676,25 @@ using namespace ceph;
 
   const char *buffer::ptr::c_str() const {
     ceph_assert(_raw);
-    if (buffer_track_c_str)
+    if (unlikely(buffer_track_c_str))
       buffer_c_str_accesses++;
     return _raw->get_data() + _off;
   }
   char *buffer::ptr::c_str() {
     ceph_assert(_raw);
-    if (buffer_track_c_str)
+    if (unlikely(buffer_track_c_str))
       buffer_c_str_accesses++;
     return _raw->get_data() + _off;
   }
   const char *buffer::ptr::end_c_str() const {
     ceph_assert(_raw);
-    if (buffer_track_c_str)
+    if (unlikely(buffer_track_c_str))
       buffer_c_str_accesses++;
     return _raw->get_data() + _off + _len;
   }
   char *buffer::ptr::end_c_str() {
     ceph_assert(_raw);
-    if (buffer_track_c_str)
+    if (unlikely(buffer_track_c_str))
       buffer_c_str_accesses++;
     return _raw->get_data() + _off + _len;
   }

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -107,17 +107,6 @@ using namespace ceph;
     return buffer_missed_crc;
   }
 
-  static std::atomic<unsigned> buffer_c_str_accesses { 0 };
-
-  static bool buffer_track_c_str = get_env_bool("CEPH_BUFFER_TRACK");
-
-  void buffer::track_c_str(bool b) {
-    buffer_track_c_str = b;
-  }
-  int buffer::get_c_str_accesses() {
-    return buffer_c_str_accesses;
-  }
-
 #ifdef CEPH_HAVE_SETPIPE_SZ
   static std::atomic<unsigned> buffer_max_pipe_size { 0 };
   int update_max_pipe_size() {
@@ -676,26 +665,18 @@ using namespace ceph;
 
   const char *buffer::ptr::c_str() const {
     ceph_assert(_raw);
-    if (unlikely(buffer_track_c_str))
-      buffer_c_str_accesses++;
     return _raw->get_data() + _off;
   }
   char *buffer::ptr::c_str() {
     ceph_assert(_raw);
-    if (unlikely(buffer_track_c_str))
-      buffer_c_str_accesses++;
     return _raw->get_data() + _off;
   }
   const char *buffer::ptr::end_c_str() const {
     ceph_assert(_raw);
-    if (unlikely(buffer_track_c_str))
-      buffer_c_str_accesses++;
     return _raw->get_data() + _off + _len;
   }
   char *buffer::ptr::end_c_str() {
     ceph_assert(_raw);
-    if (unlikely(buffer_track_c_str))
-      buffer_c_str_accesses++;
     return _raw->get_data() + _off + _len;
   }
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -134,11 +134,6 @@ namespace buffer CEPH_BUFFER_API {
   /// enable/disable tracking of cached crcs
   void track_cached_crc(bool b);
 
-  /// count of calls to buffer::ptr::c_str()
-  int get_c_str_accesses();
-  /// enable/disable tracking of buffer::ptr::c_str() calls
-  void track_c_str(bool b);
-
   /*
    * an abstract raw buffer.  with a reference count.
    */


### PR DESCRIPTION
Before
---------
```
Samples: 5K of event 'cycles', Event count (approx.): 942571342                                                                                                                                               
  Children      Self  Command    Shared O  Symbol                                                                                                                                                            ◆
+    1,00%     0,65%  tp_osd_tp  ceph-osd  [.] ceph::buffer::ptr::c_str                                                                                                                                      ▒
```

```
ceph::buffer::ptr::c_str  /work/ceph-rzarzynski-2/build/bin/ceph-osd                                                                                                                                          
       │                                                                                                                                                                                                     ◆
       │                                                                                                                                                                                                     ▒
       │                                                                                                                                                                                                     ▒
       │    Disassembly of section .text:                                                                                                                                                                    ▒
       │                                                                                                                                                                                                     ▒
       │    0000000000d6de10 <ceph::buffer::ptr::c_str() const>:                                                                                                                                             ▒
       │    _ZNK4ceph6buffer3ptr5c_strEv():                                                                                                                                                                  ▒
       │          _raw->try_assign_to_mempool(pool);                                                                                                                                                         ▒
       │        }                                                                                                                                                                                            ▒
       │      }                                                                                                                                                                                              ▒
       │                                                                                                                                                                                                     ▒
       │      const char *buffer::ptr::c_str() const {                                                                                                                                                       ▒
       │        ceph_assert(_raw);                                                                                                                                                                           ▒
 32,26 │      mov    (%rdi),%rdx                                                                                                                                                                             ▒
       │      test   %rdx,%rdx                                                                                                                                                                               ▒
       │    ↓ je     24                                                                                                                                                                                      ▒
       │        if (buffer_track_c_str)                                                                                                                                                                      ▒
  3,23 │      cmpb   $0x0,buffer_track_c_str                                                                                                                                                                 ▒
 22,58 │    ↓ je     1c                                                                                                                                                                                      ▒
       │    _ZNSt13__atomic_baseIjE9fetch_addEjSt12memory_order():                                                                                                                                           ▒
       │          }                                                                                                                                                                                          ▒
       │                                                                                                                                                                                                     ▒
       │          _GLIBCXX_ALWAYS_INLINE __int_type                                                                                                                                                          ▒
       │          fetch_add(__int_type __i,                                                                                                                                                                  ▒
       │                    memory_order __m = memory_order_seq_cst) noexcept                                                                                                                                ▒
       │          { return __atomic_fetch_add(&_M_i, __i, __m); }                                                                                                                                            ▒
       │      lock   addl   $0x1,buffer_c_str_accesses                                                                                                                                                       ▒
       │      mov    (%rdi),%rdx                                                                                                                                                                             ▒
       │    _ZNK4ceph6buffer3ptr5c_strEv():                                                                                                                                                                  ▒
       │          buffer_c_str_accesses++;                                                                                                                                                                   ▒
       │        return _raw->get_data() + _off;                                                                                                                                                              ▒
       │1c:   mov    0x8(%rdi),%eax                                                                                                                                                                          ▒
       │      add    0x20(%rdx),%rax                                                                                                                                                                         ▒
       │      }                                                                                                                                                                                              ▒
 41,94 │    ← retq                                                                                                                                                                                           ▒
       │          _raw->try_assign_to_mempool(pool);                                                                                                                                                         ▒
       │        }                                                                                                                                                                                            ▒
       │      }                                                                                                                                                                                              ▒
       │                                                                                                                                                                                                     ▒
       │      const char *buffer::ptr::c_str() const {                                                                                                                                                       ▒
       │        ceph_assert(_raw);                                                                                                                                                                           ▒
       │24:   lea    ceph::buffer::ptr::c_str() const::assert_data_ctx,%rdi                                                                                                                                  ▒
       │        if (_raw) {                                                                                                                                                                                  ▒
       │          _raw->try_assign_to_mempool(pool);                                                                                                                                                         ▒
       │        }                                                                                                                                                                                            ▒
       │      }                                                                                                                                                                                              ▒
       │                                                                                                                                                                                                     ▒
       │      const char *buffer::ptr::c_str() const {                                                                                                                                                       ▒
       │      sub    $0x8,%rsp                                                                                                                                                                               ▒
       │        ceph_assert(_raw);                                                                                                                                                                           ▒
       │    → callq  ceph::__ceph_assert_fail(ceph::assert_data const&)                                                                                                                                      ▒
                                                                                                                                                                                                             ▒
```
After
-------
```
Samples: 6K of event 'cycles', Event count (approx.): 1286978390                                                                                                                                              
  Children      Self  Command    Shared O  Symbol                                                                                                                                                            ◆
+    0,59%     0,34%  tp_osd_tp  ceph-osd  [.] ceph::buffer::ptr::c_str                                                                                                                                      ▒
```

```
ceph::buffer::ptr::c_str  /work/ceph-rzarzynski-2/build/bin/ceph-osd                                                                                                                                          
       │                                                                                                                                                                                                     ◆
       │                                                                                                                                                                                                     ▒
       │                                                                                                                                                                                                     ▒
       │    Disassembly of section .text:                                                                                                                                                                    ▒
       │                                                                                                                                                                                                     ▒
       │    0000000000d6de10 <ceph::buffer::ptr::c_str() const>:                                                                                                                                             ▒
       │    _ZNK4ceph6buffer3ptr5c_strEv():                                                                                                                                                                  ▒
       │          _raw->try_assign_to_mempool(pool);                                                                                                                                                         ▒
       │        }                                                                                                                                                                                            ▒
       │      }                                                                                                                                                                                              ▒
       │                                                                                                                                                                                                     ▒
       │      const char *buffer::ptr::c_str() const {                                                                                                                                                       ▒
       │        ceph_assert(_raw);                                                                                                                                                                           ▒
  8,70 │      mov    (%rdi),%rdx                                                                                                                                                                             ▒
 13,04 │      test   %rdx,%rdx                                                                                                                                                                               ▒
       │    ↓ je     33                                                                                                                                                                                      ▒
       │        if (unlikely(buffer_track_c_str))                                                                                                                                                            ▒
       │      cmpb   $0x0,buffer_track_c_str                                                                                                                                                                 ▒
 43,48 │    ↓ jne    20                                                                                                                                                                                      ▒
       │          buffer_c_str_accesses++;                                                                                                                                                                   ▒
       │        return _raw->get_data() + _off;                                                                                                                                                              ▒
  4,35 │      mov    0x8(%rdi),%eax                                                                                                                                                                          ▒
       │      add    0x20(%rdx),%rax                                                                                                                                                                         ▒
       │      }                                                                                                                                                                                              ▒
 30,43 │    ← retq                                                                                                                                                                                           ▒
       │      nop                                                                                                                                                                                            ▒
       │    _ZNSt13__atomic_baseIjE9fetch_addEjSt12memory_order():                                                                                                                                           ▒
       │          }                                                                                                                                                                                          ▒
       │                                                                                                                                                                                                     ▒
       │          _GLIBCXX_ALWAYS_INLINE __int_type                                                                                                                                                          ▒
       │          fetch_add(__int_type __i,                                                                                                                                                                  ▒
       │                    memory_order __m = memory_order_seq_cst) noexcept                                                                                                                                ▒
       │          { return __atomic_fetch_add(&_M_i, __i, __m); }                                                                                                                                            ▒
       │20:   lock   addl   $0x1,buffer_c_str_accesses                                                                                                                                                       ▒
       │      mov    (%rdi),%rdx                                                                                                                                                                             ▒
       │    _ZNK4ceph6buffer3ptr5c_strEv():                                                                                                                                                                  ▒
       │                                                                                                                                                                                                     ▒
       │      const char *buffer::ptr::c_str() const {                                                                                                                                                       ▒
       │        ceph_assert(_raw);                                                                                                                                                                           ▒
       │        if (unlikely(buffer_track_c_str))                                                                                                                                                            ▒
       │          buffer_c_str_accesses++;                                                                                                                                                                   ▒
       │        return _raw->get_data() + _off;                                                                                                                                                              ▒
       │      mov    0x8(%rdi),%eax                                                                                                                                                                          ▒
       │      add    0x20(%rdx),%rax                                                                                                                                                                         ▒
       │      }                                                                                                                                                                                              ▒
       │    ← retq                                                                                                                                                                                           ▒
       │          _raw->try_assign_to_mempool(pool);                                                                                                                                                         ▒
       │        }                                                                                                                                                                                            ▒
       │      }                                                                                                                                                                                              ▒
       │                                                                                                                                                                                                     ▒
       │      const char *buffer::ptr::c_str() const {                                                                                                                                                       ▒
       │        ceph_assert(_raw);                                                                                                                                                                           ▒
       │33:   lea    ceph::buffer::ptr::c_str() const::assert_data_ctx,%rdi                                                                                                                                  ▒
       │        if (_raw) {                                                                                                                                                                                  ▒
       │          _raw->try_assign_to_mempool(pool);                                                                                                                                                         ▒
       │        }                                                                                                                                                                                            ▒
       │      }                                                                                                                                                                                              ▒
       │                                                                                                                                                                                                     ▒                                                                                                                                                                               ▒
       │      const char *buffer::ptr::c_str() const {                                                                                                                                                       ▒
       │      sub    $0x8,%rsp                                                                                                                                                                               ▒
       │        ceph_assert(_raw);                                                                                                                                                                           ▒
```