### PR TITLE
mgr/diskprediction_cloud: Remove needless library in the requirements file

### DIFF
--- a/src/pybind/mgr/diskprediction_cloud/requirements.txt
+++ b/src/pybind/mgr/diskprediction_cloud/requirements.txt
@@ -1,8 +1,6 @@
-google==2.0.1
 google-api-python-client==1.7.3
 google-auth==1.5.0
 google-auth-httplib2==0.0.3
-google-gax==0.12.5
 googleapis-common-protos==1.5.3
 grpc==0.3.post19
 grpc-google-logging-v2==0.8.1


### PR DESCRIPTION
Remove needless library in the requirements file.
Fixes: http://tracker.ceph.com/issues/37533

Signed-off-by: Rick Chen <rick.chen@prophetstor.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

