### PR TITLE
ceph-volume: py3 - ensure correct string encoding

### DIFF
--- a/src/ceph-volume/ceph_volume/terminal.py
+++ b/src/ceph-volume/ceph_volume/terminal.py
@@ -94,7 +94,12 @@ class _Write(object):
         self.write(string)
 
     def write(self, line):
-        self._writer.write(self.prefix + line + self.suffix)
+        # Ensure compatibility of str with encoding of _writer
+        full_line = self.prefix + line + self.suffix
+        full_line = full_line.encode(encoding=self._writer.encoding,
+                                     errors="replace")
+        full_line = full_line.decode(encoding=self._writer.encoding)
+        self._writer.write(full_line)
         if self.flush:
             self._writer.flush()
 


### PR DESCRIPTION
When writing data to stdout, ensure that strings are correctly
encoded for the encoding of the stdout;  systemd is good at
generating unicode characters which get captured by the process
module and then re-logged via terminal.

If the LANG environment variable is unset in the execution
environment this results in an encoding error during the write
operation as the unicode is not compatible with the 'ascii'
encoding of stdout in this situation.

Converting the string to the target encoding using 'replace'
rather than 'strict' makes sure the content can be written.

Signed-off-by: James Page <james.page@ubuntu.com>