### PR TITLE
cls: refcount: add obj_refcount to ceph-dencoder

### DIFF
--- a/src/cls/refcount/cls_refcount_ops.cc
+++ b/src/cls/refcount/cls_refcount_ops.cc
@@ -78,3 +78,27 @@ void cls_refcount_read_ret::generate_test_instances(list<cls_refcount_read_ret*>
   ls.back()->refs.push_back("foo");
   ls.back()->refs.push_back("bar");
 }
+
+void obj_refcount::dump(ceph::Formatter *f) const
+{
+  f->open_array_section("refs");
+  for (const auto &kv: refs) {
+    f->open_object_section("ref");
+    f->dump_string("oid", kv.first.c_str());
+    f->dump_bool("active",kv.second);
+    f->close_section();
+  }
+  f->close_section();
+
+  f->open_array_section("retired_refs");
+  for (const auto& it: retired_refs)
+    f->dump_string("ref", it.c_str());
+  f->close_section();
+}
+
+void obj_refcount::generate_test_instances(list<obj_refcount*>& ls)
+{
+  ls.push_back(new obj_refcount);
+  ls.back()->refs.emplace("foo",true);
+  ls.back()->retired_refs.emplace("bar");
+}

--- a/src/cls/refcount/cls_refcount_ops.h
+++ b/src/cls/refcount/cls_refcount_ops.h
@@ -145,6 +145,9 @@ struct obj_refcount {
     }
     DECODE_FINISH(bl);
   }
+
+  void dump(ceph::Formatter *f) const;
+  static void generate_test_instances(list<obj_refcount*>& ls);
 };
 WRITE_CLASS_ENCODER(obj_refcount)
 

--- a/src/tools/ceph-dencoder/types.h
+++ b/src/tools/ceph-dencoder/types.h
@@ -510,6 +510,7 @@ TYPE(cls_refcount_put_op)
 TYPE(cls_refcount_set_op)
 TYPE(cls_refcount_read_op)
 TYPE(cls_refcount_read_ret)
+TYPE(obj_refcount)
 
 #include "journal/Entry.h"
 TYPE(journal::Entry)


### PR DESCRIPTION
So that object reference count on disk can be directly interpreted, an example
of the current output ::
```
{
    "refs": [
        {
            "oid": "bcee12fe-501e-42be-aa8e-e2f43fa905ca.274124.79",
            "active": true
        }
    ],
    "retired_refs": [
        "bcee12fe-501e-42be-aa8e-e2f43fa905ca.274124.77"
    ]
}
```

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>

*edit* - markdown formatting