### PR TITLE
pybind/mgr/status: fix ceph fs status in py3 environments.

### DIFF
--- a/src/pybind/mgr/status/module.py
+++ b/src/pybind/mgr/status/module.py
@@ -246,7 +246,7 @@ class Module(MgrModule):
         output += "\n" + standby_table.get_string() + "\n"
 
         if len(mds_versions) == 1:
-            output += "MDS version: {0}".format(mds_versions.keys()[0])
+            output += "MDS version: {0}".format(list(mds_versions)[0])
         else:
             version_table = PrettyTable(["version", "daemons"])
             for version, daemons in six.iteritems(mds_versions):


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/37573

Signed-off-by: Jan Fajerski <jfajerski@suse.com>

