### PR TITLE
pybind/rbd: optimize rbd_list2

### DIFF
--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -4374,7 +4374,7 @@ cdef class ImageIterator(object):
     def __init__(self, ioctx):
         self.ioctx = convert_ioctx(ioctx)
         self.images = NULL
-        self.num_images = 32
+        self.num_images = 1024
         while True:
             self.images = <rbd_image_spec_t*>realloc_chk(
                 self.images, self.num_images * sizeof(rbd_image_spec_t))
@@ -4382,7 +4382,9 @@ cdef class ImageIterator(object):
                 ret = rbd_list2(self.ioctx, self.images, &self.num_images)
             if ret >= 0:
                 break
-            elif ret != -errno.ERANGE:
+            elif ret == -errno.ERANGE:
+                self.num_images *= 2
+            else:
                 raise make_ex(ret, 'error listing images.')
 
     def __iter__(self):


### PR DESCRIPTION
If rbd_list2 returns ERANGE, it sets num_images to the value required.
But it is better to retry with a bigger number, to avoid new retries
if images are added to the pool at that time.

Also the initial value for num_images looks too small.

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

