### PR TITLE
[RFC] denc: add rvalue overloads for bufferlist/ptr encode

### DIFF
--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -1524,6 +1524,18 @@ inline std::enable_if_t<traits::supported && !traits::featured> encode(
 }
 
 template<typename T, typename traits=denc_traits<T>>
+inline std::enable_if_t<traits::supported && !traits::featured> encode(
+  T&& o,
+  bufferlist& bl,
+  uint64_t features_unused=0)
+{
+  size_t len = 0;
+  traits::bound_encode(o, len);
+  auto a = bl.get_contiguous_appender(len);
+  traits::encode(std::move(o), a);
+}
+
+template<typename T, typename traits=denc_traits<T>>
 inline std::enable_if_t<traits::supported && traits::featured> encode(
   const T& o, bufferlist& bl,
   uint64_t features)
@@ -1532,6 +1544,17 @@ inline std::enable_if_t<traits::supported && traits::featured> encode(
   traits::bound_encode(o, len, features);
   auto a = bl.get_contiguous_appender(len);
   traits::encode(o, a, features);
+}
+
+template<typename T, typename traits=denc_traits<T>>
+inline std::enable_if_t<traits::supported && traits::featured> encode(
+  T&& o, bufferlist& bl,
+  uint64_t features)
+{
+  size_t len = 0;
+  traits::bound_encode(o, len, features);
+  auto a = bl.get_contiguous_appender(len);
+  traits::encode(std::move(o), a, features);
 }
 
 template<typename T,
@@ -1593,6 +1616,18 @@ inline std::enable_if_t<traits::supported &&
   traits::bound_encode(o, len);
   auto a = bl.get_contiguous_appender(len);
   traits::encode_nohead(o, a);
+}
+
+template<typename T, typename traits=denc_traits<T>>
+inline std::enable_if_t<traits::supported &&
+			!traits::featured> encode_nohead(
+  T&& o,
+  bufferlist& bl)
+{
+  size_t len = 0;
+  traits::bound_encode(o, len);
+  auto a = bl.get_contiguous_appender(len);
+  traits::encode_nohead(std::move(o), a);
 }
 
 template<typename T, typename traits=denc_traits<T>>

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -629,6 +629,19 @@ denc(const T& o,
 }
 
 template<typename T, class It, typename traits=denc_traits<T>>
+inline std::enable_if_t<traits::supported && !is_const_iterator_v<It>>
+denc(T&& o,
+     It& p,
+     uint64_t features=0)
+{
+  if constexpr (traits::featured) {
+    traits::encode(std::move(o), p, features);
+  } else {
+    traits::encode(std::move(o), p);
+  }
+}
+
+template<typename T, class It, typename traits=denc_traits<T>>
 inline std::enable_if_t<traits::supported && is_const_iterator_v<It>>
 denc(T& o,
      It& p,

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -222,12 +222,19 @@ inline void encode(const char *s, bufferlist& bl)
 // buffers
 
 // bufferptr (encapsulated)
-inline void encode(const buffer::ptr& bp, bufferlist& bl) 
+inline void encode(const buffer::ptr& bp, bufferlist& bl)
 {
   __u32 len = bp.length();
   encode(len, bl);
   if (len)
     bl.append(bp);
+}
+inline void encode(buffer::ptr&& bp, bufferlist& bl)
+{
+  __u32 len = bp.length();
+  encode(len, bl);
+  if (len)
+    bl.append(std::move(bp));
 }
 inline void decode(buffer::ptr& bp, bufferlist::const_iterator& p)
 {
@@ -246,13 +253,13 @@ inline void decode(buffer::ptr& bp, bufferlist::const_iterator& p)
 }
 
 // bufferlist (encapsulated)
-inline void encode(const bufferlist& s, bufferlist& bl) 
+inline void encode(const bufferlist& s, bufferlist& bl)
 {
   __u32 len = s.length();
   encode(len, bl);
   bl.append(s);
 }
-inline void encode_destructively(bufferlist& s, bufferlist& bl) 
+inline void encode(bufferlist&& s, bufferlist& bl)
 {
   __u32 len = s.length();
   encode(len, bl);
@@ -266,9 +273,13 @@ inline void decode(bufferlist& s, bufferlist::const_iterator& p)
   p.copy(len, s);
 }
 
-inline void encode_nohead(const bufferlist& s, bufferlist& bl) 
+inline void encode_nohead(const bufferlist& s, bufferlist& bl)
 {
   bl.append(s);
+}
+inline void encode_nohead(bufferlist&& s, bufferlist& bl)
+{
+  bl.claim_append(s);
 }
 inline void decode_nohead(int len, bufferlist& s, bufferlist::const_iterator& p)
 {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5051,7 +5051,7 @@ struct ToSparseReadResult : public Context {
     bufferlist outdata;
     map<uint64_t, uint64_t> extents = {{data_offset, r}};
     encode(extents, outdata);
-    ::encode_destructively(*data_bl, outdata);
+    encode(std::move(*data_bl), outdata);
     data_bl->swap(outdata);
   }
 };
@@ -5665,7 +5665,7 @@ int PrimaryLogPG::do_sparse_read(OpContext *ctx, OSDOp& osd_op) {
     op.extent.length = total_read;
 
     encode(m, osd_op.outdata); // re-encode since it might be modified
-    ::encode_destructively(data_bl, osd_op.outdata);
+    encode(std::move(data_bl), osd_op.outdata);
 
     dout(10) << " sparse_read got " << total_read << " bytes from object "
 	     << soid << dendl;


### PR DESCRIPTION
adds denc() and ceph::encode() overloads taking `bufferlist&&` and `bufferptr&&` so that buffer segments can be moved directly into the destination bufferlist without the atomic reference counting associated with sharing the buffers between the source and destination

this is mainly only useful for manual encoding, though composite types (like map<string, bufferlist> or structs that contain buffers) could also add rvalue overloads to take advantage of this