### PR TITLE
msg/async/rdma: switch QP to error state prior actual destroy

### DIFF
--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -169,7 +169,8 @@ Infiniband::QueuePair::QueuePair(
   txcq(txcq),
   rxcq(rxcq),
   initial_psn(0),
-  max_send_wr(tx_queue_len),
+  // One extra for beacon
+  max_send_wr(tx_queue_len + 1),
   max_recv_wr(rx_queue_len),
   q_key(q_key),
   dead(false)
@@ -265,14 +266,9 @@ int Infiniband::QueuePair::init()
 }
 
 /**
- * Change RC QueuePair into the ERROR state. This is necessary modify
- * the Queue Pair into the Error state and poll all of the relevant
- * Work Completions prior to destroying a Queue Pair.
- * Since destroying a Queue Pair does not guarantee that its Work
- * Completions are removed from the CQ upon destruction. Even if the
- * Work Completions are already in the CQ, it might not be possible to
- * retrieve them. If the Queue Pair is associated with an SRQ, it is
- * recommended wait for the affiliated event IBV_EVENT_QP_LAST_WQE_REACHED
+ * Switch QP to ERROR state and the post a beacon to be able to drain all
+ * WCEs and then safely destroy QP.  See RDMADispatcher::handle_tx_event()
+ * for details.
  *
  * \return
  *      -errno if the QueuePair can't switch to ERROR
@@ -282,7 +278,10 @@ int Infiniband::QueuePair::to_dead()
 {
   if (dead)
     return 0;
+
+  struct ibv_send_wr *bad_wr, beacon;
   ibv_qp_attr qpa;
+
   memset(&qpa, 0, sizeof(qpa));
   qpa.qp_state = IBV_QPS_ERR;
 
@@ -293,8 +292,21 @@ int Infiniband::QueuePair::to_dead()
                << cpp_strerror(errno) << dendl;
     return -errno;
   }
+
+  memset(&beacon, 0, sizeof(beacon));
+  beacon.wr_id = BEACON_WRID;
+  beacon.opcode = IBV_WR_SEND;
+  beacon.send_flags = IBV_SEND_SIGNALED;
+
+  ret = ibv_post_send(qp, &beacon, &bad_wr);
+  if (ret) {
+    lderr(cct) << __func__ << " failed to send a beacon: "
+               << cpp_strerror(errno) << dendl;
+    return -errno;
+  }
   dead = true;
-  return ret;
+
+  return 0;
 }
 
 int Infiniband::QueuePair::get_remote_qp_number(uint32_t *rqp) const
@@ -937,7 +949,8 @@ void Infiniband::init()
     ceph_abort();
   }
 
-  tx_queue_len = device->device_attr.max_qp_wr;
+  // Keep extra one for a beacon to indicate all WCE were consumed
+  tx_queue_len = device->device_attr.max_qp_wr - 1;
   if (tx_queue_len > cct->_conf->ms_async_rdma_send_buffers) {
     tx_queue_len = cct->_conf->ms_async_rdma_send_buffers;
     ldout(cct, 1) << __func__ << " assigning: " << tx_queue_len << " send buffers"  << dendl;

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -41,6 +41,8 @@
 #define ALIGN_TO_PAGE_SIZE(x) \
   (((x) + HUGE_PAGE_SIZE -1) / HUGE_PAGE_SIZE * HUGE_PAGE_SIZE)
 
+#define BEACON_WRID 0xDEAD
+
 struct IBSYNMsg {
   uint16_t lid;
   uint32_t qpn;
@@ -149,9 +151,6 @@ enum {
   l_msgr_rdma_rx_fin,
 
   l_msgr_rdma_handshake_errors,
-
-  l_msgr_rdma_total_async_events,
-  l_msgr_rdma_async_last_wqe_events,
 
   l_msgr_rdma_created_queue_pair,
   l_msgr_rdma_active_queue_pair,
@@ -468,9 +467,6 @@ class Infiniband {
      * Return true if the queue pair is in an error state, false otherwise.
      */
     bool is_error() const;
-    void add_tx_wr(uint32_t amt) { tx_wr_inflight += amt; }
-    void dec_tx_wr(uint32_t amt) { tx_wr_inflight -= amt; }
-    uint32_t get_tx_wr() const { return tx_wr_inflight; }
     ibv_qp* get_qp() const { return qp; }
     Infiniband::CompletionQueue* get_tx_cq() const { return txcq; }
     Infiniband::CompletionQueue* get_rx_cq() const { return rxcq; }

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -43,9 +43,7 @@ class RDMADispatcher {
   Infiniband::CompletionQueue* tx_cq = nullptr;
   Infiniband::CompletionQueue* rx_cq = nullptr;
   Infiniband::CompletionChannel *tx_cc = nullptr, *rx_cc = nullptr;
-  EventCallbackRef async_handler;
   bool done = false;
-  std::atomic<uint64_t> num_dead_queue_pair = {0};
   std::atomic<uint64_t> num_qp_conn = {0};
   // protect `qp_conns`, `dead_queue_pairs`
   ceph::mutex lock = ceph::make_mutex("RDMADispatcher::lock");
@@ -56,9 +54,9 @@ class RDMADispatcher {
   /**
    * 1. Connection call mark_down
    * 2. Move the Queue Pair into the Error state(QueuePair::to_dead)
-   * 3. Wait for the affiliated event IBV_EVENT_QP_LAST_WQE_REACHED(handle_async_event)
-   * 4. Wait for CQ to be empty(handle_tx_event)
-   * 5. Destroy the QP by calling ibv_destroy_qp()(handle_tx_event)
+   * 3. Post a beacon
+   * 4. Wait for beacon which indicates queues are drained
+   * 5. Destroy the QP by calling ibv_destroy_qp()
    *
    * @param qp The qp needed to dead
    */
@@ -79,22 +77,13 @@ class RDMADispatcher {
   std::list<RDMAWorker*> pending_workers;
   RDMAStack* stack;
 
-  class C_handle_cq_async : public EventCallback {
-    RDMADispatcher *dispatcher;
-   public:
-    explicit C_handle_cq_async(RDMADispatcher *w): dispatcher(w) {}
-    void do_request(uint64_t fd) {
-      // worker->handle_tx_event();
-      dispatcher->handle_async_event();
-    }
-  };
+  void enqueue_dead_qp(uint32_t qp);
 
  public:
   PerfCounters *perf_logger;
 
   explicit RDMADispatcher(CephContext* c, RDMAStack* s);
   virtual ~RDMADispatcher();
-  void handle_async_event();
 
   void polling_start();
   void polling_stop();
@@ -111,8 +100,7 @@ class RDMADispatcher {
   RDMAStack* get_stack() { return stack; }
   RDMAConnectedSocketImpl* get_conn_lockless(uint32_t qp);
   QueuePair* get_qp(uint32_t qp);
-  void erase_qpn_lockless(uint32_t qpn);
-  void erase_qpn(uint32_t qpn);
+  void schedule_qp_destroy(uint32_t qp);
   Infiniband::CompletionQueue* get_tx_cq() const { return tx_cq; }
   Infiniband::CompletionQueue* get_rx_cq() const { return rx_cq; }
   void notify_pending_workers();


### PR DESCRIPTION
    Before destroy QP has to be switched to error state to guarantee all
    outstanding tx WCEs are returned and SRQ is fully consumed. In this
    patch a beacon is posted to the send queue just after QP has been
    switched to error state.  Completion of a posted beacon indicates
    queues are drained and QP can be safely destroyed.
    
    This patch also removes handling of async events and accounting of tx
    WRs, just because handled beacon acts as a last event when QP can
    be destroyed.  The other reason why async events is not reliable is
    that not all uverbs providers support them (e.g. qlogic, qedr).
