### PR TITLE
rgw: clean-up -- use enum class for stats category

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -109,7 +109,7 @@ static int log_index_operation(cls_method_context_t hctx, cls_rgw_obj_key& obj_k
 {
   bufferlist bl;
 
-  struct rgw_bi_log_entry entry;
+  rgw_bi_log_entry entry;
 
   entry.object = obj_key.name;
   entry.instance = obj_key.instance;
@@ -221,7 +221,7 @@ static void decreasing_str(uint64_t num, string *str)
  * we'll use the second index. Note that regular objects only map to the first index anyway
  */
 
-static void get_list_index_key(struct rgw_bucket_dir_entry& entry, string *index_key)
+static void get_list_index_key(rgw_bucket_dir_entry& entry, string *index_key)
 {
   *index_key = entry.key.name;
 
@@ -371,7 +371,8 @@ static int decode_list_index_key(const string& index_key, cls_rgw_obj_key *key, 
   return 0;
 }
 
-static int read_bucket_header(cls_method_context_t hctx, struct rgw_bucket_dir_header *header)
+static int read_bucket_header(cls_method_context_t hctx,
+			      rgw_bucket_dir_header *header)
 {
   bufferlist bl;
   int rc = cls_cxx_map_read_header(hctx, &bl);
@@ -397,7 +398,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   auto iter = in->cbegin();
 
-  struct rgw_cls_list_op op;
+  rgw_cls_list_op op;
   try {
     decode(op, iter);
   } catch (buffer::error& err) {
@@ -405,8 +406,8 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     return -EINVAL;
   }
 
-  struct rgw_cls_list_ret ret;
-  struct rgw_bucket_dir& new_dir = ret.dir;
+  rgw_cls_list_ret ret;
+  rgw_bucket_dir& new_dir = ret.dir;
   int rc = read_bucket_header(hctx, &new_dir.header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: rgw_bucket_list(): failed to read header\n");
@@ -426,12 +427,12 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     if (rc < 0)
       return rc;
 
-    std::map<string, struct rgw_bucket_dir_entry>& m = new_dir.m;
+    std::map<string, rgw_bucket_dir_entry>& m = new_dir.m;
 
     done = keys.empty();
 
     for (kiter = keys.begin(); kiter != keys.end(); ++kiter) {
-      struct rgw_bucket_dir_entry entry;
+      rgw_bucket_dir_entry entry;
 
       if (!bi_is_objs_index(kiter->first)) {
         done = true;
@@ -540,7 +541,7 @@ static int check_index(cls_method_context_t hctx,
 
 int rgw_bucket_check_index(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
-  struct rgw_cls_check_index_ret ret;
+  rgw_cls_check_index_ret ret;
 
   int rc = check_index(hctx, &ret.existing_header, &ret.calculated_header);
   if (rc < 0)
@@ -551,7 +552,7 @@ int rgw_bucket_check_index(cls_method_context_t hctx, bufferlist *in, bufferlist
   return 0;
 }
 
-static int write_bucket_header(cls_method_context_t hctx, struct rgw_bucket_dir_header *header)
+static int write_bucket_header(cls_method_context_t hctx, rgw_bucket_dir_header *header)
 {
   header->ver++;
 
@@ -563,8 +564,8 @@ static int write_bucket_header(cls_method_context_t hctx, struct rgw_bucket_dir_
 
 int rgw_bucket_rebuild_index(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
-  struct rgw_bucket_dir_header existing_header;
-  struct rgw_bucket_dir_header calc_header;
+  rgw_bucket_dir_header existing_header;
+  rgw_bucket_dir_header calc_header;
   int rc = check_index(hctx, &existing_header, &calc_header);
   if (rc < 0)
     return rc;
@@ -584,7 +585,7 @@ int rgw_bucket_update_stats(cls_method_context_t hctx, bufferlist *in, bufferlis
     return -EINVAL;
   }
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: %s(): failed to read header\n", __func__);
@@ -642,7 +643,7 @@ int rgw_bucket_set_tag_timeout(cls_method_context_t hctx, bufferlist *in, buffer
     return -EINVAL;
   }
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: rgw_bucket_set_tag_timeout(): failed to read header\n");
@@ -654,7 +655,8 @@ int rgw_bucket_set_tag_timeout(cls_method_context_t hctx, bufferlist *in, buffer
   return write_bucket_header(hctx, &header);
 }
 
-static int read_key_entry(cls_method_context_t hctx, cls_rgw_obj_key& key, string *idx, struct rgw_bucket_dir_entry *entry,
+static int read_key_entry(cls_method_context_t hctx, cls_rgw_obj_key& key,
+			  string *idx, rgw_bucket_dir_entry *entry,
                           bool special_delete_marker_name = false);
 
 int rgw_bucket_prepare_op(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
@@ -680,7 +682,7 @@ int rgw_bucket_prepare_op(cls_method_context_t hctx, bufferlist *in, bufferlist 
   // get on-disk state
   string idx;
 
-  struct rgw_bucket_dir_entry entry;
+  rgw_bucket_dir_entry entry;
   int rc = read_key_entry(hctx, op.key, &idx, &entry);
   if (rc < 0 && rc != -ENOENT)
     return rc;
@@ -697,13 +699,13 @@ int rgw_bucket_prepare_op(cls_method_context_t hctx, bufferlist *in, bufferlist 
   }
 
   // fill in proper state
-  struct rgw_bucket_pending_info info;
+  rgw_bucket_pending_info info;
   info.timestamp = real_clock::now();
   info.state = CLS_RGW_STATE_PENDING_MODIFY;
   info.op = op.op;
   entry.pending_map.insert(pair<string, rgw_bucket_pending_info>(op.tag, info));
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: rgw_bucket_prepare_op(): failed to read header\n");
@@ -729,23 +731,24 @@ int rgw_bucket_prepare_op(cls_method_context_t hctx, bufferlist *in, bufferlist 
   return 0;
 }
 
-static void unaccount_entry(struct rgw_bucket_dir_header& header, struct rgw_bucket_dir_entry& entry)
+static void unaccount_entry(rgw_bucket_dir_header& header,
+			    rgw_bucket_dir_entry& entry)
 {
-  struct rgw_bucket_category_stats& stats = header.stats[entry.meta.category];
+  rgw_bucket_category_stats& stats = header.stats[entry.meta.category];
   stats.num_entries--;
   stats.total_size -= entry.meta.accounted_size;
   stats.total_size_rounded -= cls_rgw_get_rounded_size(entry.meta.accounted_size);
   stats.actual_size -= entry.meta.size;
 }
 
-static void log_entry(const char *func, const char *str, struct rgw_bucket_dir_entry *entry)
+static void log_entry(const char *func, const char *str, rgw_bucket_dir_entry *entry)
 {
   CLS_LOG(1, "%s(): %s: ver=%ld:%llu name=%s instance=%s locator=%s\n", func, str,
           (long)entry->ver.pool, (unsigned long long)entry->ver.epoch,
           entry->key.name.c_str(), entry->key.instance.c_str(), entry->locator.c_str());
 }
 
-static void log_entry(const char *func, const char *str, struct rgw_bucket_olh_entry *entry)
+static void log_entry(const char *func, const char *str, rgw_bucket_olh_entry *entry)
 {
   CLS_LOG(1, "%s(): %s: epoch=%llu name=%s instance=%s tag=%s\n", func, str,
           (unsigned long long)entry->epoch, entry->key.name.c_str(), entry->key.instance.c_str(),
@@ -773,7 +776,8 @@ static int read_index_entry(cls_method_context_t hctx, string& name, T *entry)
   return 0;
 }
 
-static int read_key_entry(cls_method_context_t hctx, cls_rgw_obj_key& key, string *idx, struct rgw_bucket_dir_entry *entry,
+static int read_key_entry(cls_method_context_t hctx, cls_rgw_obj_key& key,
+			  string *idx, rgw_bucket_dir_entry *entry,
                           bool special_delete_marker_name)
 {
   encode_obj_index_key(key, idx);
@@ -821,14 +825,14 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
           (unsigned long)op.ver.pool, (unsigned long long)op.ver.epoch,
           op.tag.c_str());
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: rgw_bucket_complete_op(): failed to read header\n");
     return -EINVAL;
   }
 
-  struct rgw_bucket_dir_entry entry;
+  rgw_bucket_dir_entry entry;
   bool ondisk = true;
 
   string idx;
@@ -847,7 +851,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
   entry.flags = (entry.key.instance.empty() ? 0 : RGW_BUCKET_DIRENT_FLAG_VER); /* resetting entry flags, entry might have been previously a delete marker */
 
   if (op.tag.size()) {
-    map<string, struct rgw_bucket_pending_info>::iterator pinter = entry.pending_map.find(op.tag);
+    map<string, rgw_bucket_pending_info>::iterator pinter = entry.pending_map.find(op.tag);
     if (pinter == entry.pending_map.end()) {
       CLS_LOG(1, "ERROR: couldn't find tag for pending operation\n");
       return -EINVAL;
@@ -917,8 +921,8 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     break;
   case CLS_RGW_OP_ADD:
     {
-      struct rgw_bucket_dir_entry_meta& meta = op.meta;
-      struct rgw_bucket_category_stats& stats = header.stats[meta.category];
+      rgw_bucket_dir_entry_meta& meta = op.meta;
+      rgw_bucket_category_stats& stats = header.stats[meta.category];
       entry.meta = meta;
       entry.key = op.key;
       entry.exists = true;
@@ -949,7 +953,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     cls_rgw_obj_key& remove_key = *remove_iter;
     CLS_LOG(1, "rgw_bucket_complete_op(): removing entries, read_index_entry name=%s instance=%s\n",
             remove_key.name.c_str(), remove_key.instance.c_str());
-    struct rgw_bucket_dir_entry remove_entry;
+    rgw_bucket_dir_entry remove_entry;
     string k;
     int ret = read_key_entry(hctx, remove_key, &k, &remove_entry);
     if (ret < 0) {
@@ -990,7 +994,7 @@ static int write_entry(cls_method_context_t hctx, T& entry, const string& key)
   return cls_cxx_map_set_val(hctx, key, &bl);
 }
 
-static int read_olh(cls_method_context_t hctx,cls_rgw_obj_key& obj_key, struct rgw_bucket_olh_entry *olh_data_entry, string *index_key, bool *found)
+static int read_olh(cls_method_context_t hctx,cls_rgw_obj_key& obj_key, rgw_bucket_olh_entry *olh_data_entry, string *index_key, bool *found)
 {
   cls_rgw_obj_key olh_key;
   olh_key.name = obj_key.name;
@@ -1007,7 +1011,7 @@ static int read_olh(cls_method_context_t hctx,cls_rgw_obj_key& obj_key, struct r
   return 0;
 }
 
-static void update_olh_log(struct rgw_bucket_olh_entry& olh_data_entry, OLHLogOp op, const string& op_tag,
+static void update_olh_log(rgw_bucket_olh_entry& olh_data_entry, OLHLogOp op, const string& op_tag,
                            cls_rgw_obj_key& key, bool delete_marker, uint64_t epoch)
 {
   vector<rgw_bucket_olh_log_entry>& log = olh_data_entry.pending_log[olh_data_entry.epoch];
@@ -1020,7 +1024,7 @@ static void update_olh_log(struct rgw_bucket_olh_entry& olh_data_entry, OLHLogOp
   log.push_back(log_entry);
 }
 
-static int write_obj_instance_entry(cls_method_context_t hctx, struct rgw_bucket_dir_entry& instance_entry, const string& instance_idx)
+static int write_obj_instance_entry(cls_method_context_t hctx, rgw_bucket_dir_entry& instance_entry, const string& instance_idx)
 {
   CLS_LOG(20, "write_entry() instance=%s idx=%s flags=%d", escape_str(instance_entry.key.instance).c_str(), instance_idx.c_str(), instance_entry.flags);
   /* write the instance entry */
@@ -1035,7 +1039,7 @@ static int write_obj_instance_entry(cls_method_context_t hctx, struct rgw_bucket
 /*
  * write object instance entry, and if needed also the list entry
  */
-static int write_obj_entries(cls_method_context_t hctx, struct rgw_bucket_dir_entry& instance_entry, const string& instance_idx)
+static int write_obj_entries(cls_method_context_t hctx, rgw_bucket_dir_entry& instance_entry, const string& instance_idx)
 {
   int ret = write_obj_instance_entry(hctx, instance_entry, instance_idx);
   if (ret < 0) {
@@ -1062,7 +1066,7 @@ class BIVerObjEntry {
   cls_rgw_obj_key key;
   string instance_idx;
 
-  struct rgw_bucket_dir_entry instance_entry;
+  rgw_bucket_dir_entry instance_entry;
 
   bool initialized;
 
@@ -1224,7 +1228,7 @@ class BIOLHEntry {
   cls_rgw_obj_key key;
 
   string olh_data_idx;
-  struct rgw_bucket_olh_entry olh_data_entry;
+  rgw_bucket_olh_entry olh_data_entry;
 
   bool initialized;
 public:
@@ -1308,7 +1312,7 @@ public:
 
 static int write_version_marker(cls_method_context_t hctx, cls_rgw_obj_key& key)
 {
-  struct rgw_bucket_dir_entry entry;
+  rgw_bucket_dir_entry entry;
   entry.key = key;
   entry.flags = RGW_BUCKET_DIRENT_FLAG_VER_MARKER;
   int ret = write_entry(hctx, entry, key.name);
@@ -1330,7 +1334,7 @@ static int convert_plain_entry_to_versioned(cls_method_context_t hctx, cls_rgw_o
     return -EINVAL;
   }
 
-  struct rgw_bucket_dir_entry entry;
+  rgw_bucket_dir_entry entry;
 
   string orig_idx;
   int ret = read_key_entry(hctx, key, &orig_idx, &entry);
@@ -1411,8 +1415,8 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
   }
 
   if (existed && !real_clock::is_zero(op.unmod_since)) {
-    struct timespec mtime = ceph::real_clock::to_timespec(obj.mtime());
-    struct timespec unmod = ceph::real_clock::to_timespec(op.unmod_since);
+    timespec mtime = ceph::real_clock::to_timespec(obj.mtime());
+    timespec unmod = ceph::real_clock::to_timespec(op.unmod_since);
     if (!op.high_precision_time) {
       mtime.tv_nsec = 0;
       unmod.tv_nsec = 0;
@@ -1531,7 +1535,7 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
     return ret;
   }
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   ret = read_bucket_header(hctx, &header);
   if (ret < 0) {
     CLS_LOG(1, "ERROR: rgw_bucket_link_olh(): failed to read header\n");
@@ -1689,7 +1693,7 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
     return ret;
   }
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   ret = read_bucket_header(hctx, &header);
   if (ret < 0) {
     CLS_LOG(1, "ERROR: rgw_bucket_unlink_instance(): failed to read header\n");
@@ -1731,7 +1735,7 @@ static int rgw_bucket_read_olh_log(cls_method_context_t hctx, bufferlist *in, bu
     return -EINVAL;
   }
 
-  struct rgw_bucket_olh_entry olh_data_entry;
+  rgw_bucket_olh_entry olh_data_entry;
   string olh_data_key;
   encode_olh_data_key(op.olh, &olh_data_key);
   int ret = read_index_entry(hctx, olh_data_key, &olh_data_entry);
@@ -1785,7 +1789,7 @@ static int rgw_bucket_trim_olh_log(cls_method_context_t hctx, bufferlist *in, bu
   }
 
   /* read olh entry */
-  struct rgw_bucket_olh_entry olh_data_entry;
+  rgw_bucket_olh_entry olh_data_entry;
   string olh_data_key;
   encode_olh_data_key(op.olh, &olh_data_key);
   int ret = read_index_entry(hctx, olh_data_key, &olh_data_entry);
@@ -1836,7 +1840,7 @@ static int rgw_bucket_clear_olh(cls_method_context_t hctx, bufferlist *in, buffe
   }
 
   /* read olh entry */
-  struct rgw_bucket_olh_entry olh_data_entry;
+  rgw_bucket_olh_entry olh_data_entry;
   string olh_data_key;
   encode_olh_data_key(op.key, &olh_data_key);
   int ret = read_index_entry(hctx, olh_data_key, &olh_data_entry);
@@ -1889,7 +1893,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
   CLS_LOG(1, "rgw_dir_suggest_changes()");
 
   bufferlist header_bl;
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   bool header_changed = false;
 
   int rc = read_bucket_header(hctx, &header);
@@ -1937,10 +1941,10 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
       }
 
       real_time cur_time = real_clock::now();
-      map<string, struct rgw_bucket_pending_info>::iterator iter =
+      map<string, rgw_bucket_pending_info>::iterator iter =
                 cur_disk.pending_map.begin();
       while(iter != cur_disk.pending_map.end()) {
-        map<string, struct rgw_bucket_pending_info>::iterator cur_iter=iter++;
+        map<string, rgw_bucket_pending_info>::iterator cur_iter=iter++;
         if (cur_time > (cur_iter->second.timestamp + timespan(tag_timeout))) {
           cur_disk.pending_map.erase(cur_iter);
         }
@@ -1953,7 +1957,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
 
     if (cur_disk.pending_map.empty()) {
       if (cur_disk.exists) {
-        struct rgw_bucket_category_stats& old_stats = header.stats[cur_disk.meta.category];
+        rgw_bucket_category_stats& old_stats = header.stats[cur_disk.meta.category];
         CLS_LOG(10, "total_entries: %" PRId64 " -> %" PRId64 "\n", old_stats.num_entries, old_stats.num_entries - 1);
         old_stats.num_entries--;
         old_stats.total_size -= cur_disk.meta.accounted_size;
@@ -1961,8 +1965,7 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx,
         old_stats.actual_size -= cur_disk.meta.size;
         header_changed = true;
       }
-      struct rgw_bucket_category_stats& stats =
-          header.stats[cur_change.meta.category];
+      rgw_bucket_category_stats& stats = header.stats[cur_change.meta.category];
       bool log_op = (op & CEPH_RGW_DIR_SUGGEST_LOG_OP) != 0;
       op &= CEPH_RGW_DIR_SUGGEST_OP_MASK;
       switch(op) {
@@ -2773,7 +2776,7 @@ static int rgw_bi_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlist
 
 static int rgw_bi_log_resync(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: rgw_bucket_complete_op(): failed to read header\n");
@@ -2782,7 +2785,7 @@ static int rgw_bi_log_resync(cls_method_context_t hctx, bufferlist *in, bufferli
 
   bufferlist bl;
 
-  struct rgw_bi_log_entry entry;
+  rgw_bi_log_entry entry;
 
   entry.timestamp = real_clock::now();
   entry.op = RGWModifyOp::CLS_RGW_OP_RESYNC;
@@ -2807,7 +2810,7 @@ static int rgw_bi_log_resync(cls_method_context_t hctx, bufferlist *in, bufferli
 
 static int rgw_bi_log_stop(cls_method_context_t hctx, bufferlist *in, bufferlist *out) 
 {
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: rgw_bucket_complete_op(): failed to read header\n");
@@ -2816,7 +2819,7 @@ static int rgw_bi_log_stop(cls_method_context_t hctx, bufferlist *in, bufferlist
 
   bufferlist bl;
 
-  struct rgw_bi_log_entry entry;
+  rgw_bi_log_entry entry;
 
   entry.timestamp = real_clock::now();
   entry.op = RGWModifyOp::CLS_RGW_OP_SYNCSTOP;
@@ -3761,7 +3764,7 @@ static int rgw_set_bucket_resharding(cls_method_context_t hctx, bufferlist *in, 
     return -EINVAL;
   }
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: %s(): failed to read header\n", __func__);
@@ -3785,7 +3788,7 @@ static int rgw_clear_bucket_resharding(cls_method_context_t hctx, bufferlist *in
     return -EINVAL;
   }
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: %s(): failed to read header\n", __func__);
@@ -3808,7 +3811,7 @@ static int rgw_guard_bucket_resharding(cls_method_context_t hctx, bufferlist *in
     return -EINVAL;
   }
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: %s(): failed to read header\n", __func__);
@@ -3822,7 +3825,8 @@ static int rgw_guard_bucket_resharding(cls_method_context_t hctx, bufferlist *in
   return 0;
 }
 
-static int rgw_get_bucket_resharding(cls_method_context_t hctx, bufferlist *in,  bufferlist *out)
+static int rgw_get_bucket_resharding(cls_method_context_t hctx,
+				     bufferlist *in, bufferlist *out)
 {
   cls_rgw_get_bucket_resharding_op op;
 
@@ -3834,7 +3838,7 @@ static int rgw_get_bucket_resharding(cls_method_context_t hctx, bufferlist *in, 
     return -EINVAL;
   }
 
-  struct rgw_bucket_dir_header header;
+  rgw_bucket_dir_header header;
   int rc = read_bucket_header(hctx, &header);
   if (rc < 0) {
     CLS_LOG(1, "ERROR: %s(): failed to read header\n", __func__);

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -484,7 +484,9 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   return 0;
 }
 
-static int check_index(cls_method_context_t hctx, struct rgw_bucket_dir_header *existing_header, struct rgw_bucket_dir_header *calc_header)
+static int check_index(cls_method_context_t hctx,
+		       rgw_bucket_dir_header *existing_header,
+		       rgw_bucket_dir_header *calc_header)
 {
   int rc = read_bucket_header(hctx, existing_header);
   if (rc < 0) {
@@ -515,7 +517,7 @@ static int check_index(cls_method_context_t hctx, struct rgw_bucket_dir_header *
         break;
       }
 
-      struct rgw_bucket_dir_entry entry;
+      rgw_bucket_dir_entry entry;
       auto eiter = kiter->second.cbegin();
       try {
         decode(entry, eiter);
@@ -523,7 +525,7 @@ static int check_index(cls_method_context_t hctx, struct rgw_bucket_dir_header *
         CLS_LOG(1, "ERROR: rgw_bucket_list(): failed to decode entry, key=%s\n", kiter->first.c_str());
         return -EIO;
       }
-      struct rgw_bucket_category_stats& stats = calc_header->stats[entry.meta.category];
+      rgw_bucket_category_stats& stats = calc_header->stats[entry.meta.category];
       stats.num_entries++;
       stats.total_size += entry.meta.accounted_size;
       stats.total_size_rounded += cls_rgw_get_rounded_size(entry.meta.accounted_size);
@@ -955,8 +957,11 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
             remove_key.name.c_str(), remove_key.instance.c_str(), ret);
       continue;
     }
-    CLS_LOG(0, "rgw_bucket_complete_op(): entry.name=%s entry.instance=%s entry.meta.category=%d\n",
-            remove_entry.key.name.c_str(), remove_entry.key.instance.c_str(), remove_entry.meta.category);
+    CLS_LOG(0,
+	    "rgw_bucket_complete_op(): entry.name=%s entry.instance=%s entry.meta.category=%d\n",
+            remove_entry.key.name.c_str(),
+	    remove_entry.key.instance.c_str(),
+	    int(remove_entry.meta.category));
     unaccount_entry(header, remove_entry);
 
     if (op.log_op && !header.syncstopped) {
@@ -2237,7 +2242,8 @@ static int rgw_bi_get_op(cls_method_context_t hctx, bufferlist *in, bufferlist *
       encode_olh_data_key(op.key, &idx);
       break;
     default:
-      CLS_LOG(10, "%s(): invalid key type encoding: %d", __func__, op.type);
+      CLS_LOG(10, "%s(): invalid key type encoding: %d",
+	      __func__, int(op.type));
       return -EINVAL;
   }
 

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -122,7 +122,7 @@ static bool issue_bucket_index_clean_op(librados::IoCtx& io_ctx,
 static bool issue_bucket_set_tag_timeout_op(librados::IoCtx& io_ctx,
     const string& oid, uint64_t timeout, BucketIndexAioManager *manager) {
   bufferlist in;
-  struct rgw_cls_tag_timeout_op call;
+  rgw_cls_tag_timeout_op call;
   call.tag_timeout = timeout;
   encode(call, in);
   ObjectWriteOperation op;
@@ -157,7 +157,7 @@ void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
 				 bool absolute,
                                  const map<RGWObjCategory, rgw_bucket_category_stats>& stats)
 {
-  struct rgw_cls_bucket_update_stats_op call;
+  rgw_cls_bucket_update_stats_op call;
   call.absolute = absolute;
   call.stats = stats;
   bufferlist in;
@@ -169,7 +169,7 @@ void cls_rgw_bucket_prepare_op(ObjectWriteOperation& o, RGWModifyOp op, string& 
                                const cls_rgw_obj_key& key, const string& locator, bool log_op,
                                uint16_t bilog_flags, rgw_zone_set& zones_trace)
 {
-  struct rgw_cls_obj_prepare_op call;
+  rgw_cls_obj_prepare_op call;
   call.op = op;
   call.tag = tag;
   call.key = key;
@@ -192,7 +192,7 @@ void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, string&
 {
 
   bufferlist in;
-  struct rgw_cls_obj_complete_op call;
+  rgw_cls_obj_complete_op call;
   call.op = op;
   call.tag = tag;
   call.key = key;
@@ -209,12 +209,14 @@ void cls_rgw_bucket_complete_op(ObjectWriteOperation& o, RGWModifyOp op, string&
   o.exec(RGW_CLASS, RGW_BUCKET_COMPLETE_OP, in);
 }
 
-static bool issue_bucket_list_op(librados::IoCtx& io_ctx,
-    const string& oid, const cls_rgw_obj_key& start_obj, const string& filter_prefix,
-    uint32_t num_entries, bool list_versions, BucketIndexAioManager *manager,
-    struct rgw_cls_list_ret *pdata) {
+static bool issue_bucket_list_op(librados::IoCtx& io_ctx, const string& oid,
+				 const cls_rgw_obj_key& start_obj,
+				 const string& filter_prefix,
+				 uint32_t num_entries, bool list_versions,
+				 BucketIndexAioManager *manager,
+				 rgw_cls_list_ret *pdata) {
   bufferlist in;
-  struct rgw_cls_list_op call;
+  rgw_cls_list_op call;
   call.start_obj = start_obj;
   call.filter_prefix = filter_prefix;
   call.num_entries = num_entries;
@@ -222,7 +224,7 @@ static bool issue_bucket_list_op(librados::IoCtx& io_ctx,
   encode(call, in);
 
   librados::ObjectReadOperation op;
-  op.exec(RGW_CLASS, RGW_BUCKET_LIST, in, new ClsBucketIndexOpCtx<struct rgw_cls_list_ret>(pdata, NULL));
+  op.exec(RGW_CLASS, RGW_BUCKET_LIST, in, new ClsBucketIndexOpCtx<rgw_cls_list_ret>(pdata, NULL));
   return manager->aio_operate(io_ctx, oid, &op);
 }
 
@@ -234,7 +236,7 @@ int CLSRGWIssueBucketList::issue_op(int shard_id, const string& oid)
 void cls_rgw_remove_obj(librados::ObjectWriteOperation& o, list<string>& keep_attr_prefixes)
 {
   bufferlist in;
-  struct rgw_cls_obj_remove_op call;
+  rgw_cls_obj_remove_op call;
   call.keep_attr_prefixes = keep_attr_prefixes;
   encode(call, in);
   o.exec(RGW_CLASS, RGW_OBJ_REMOVE, in);
@@ -243,7 +245,7 @@ void cls_rgw_remove_obj(librados::ObjectWriteOperation& o, list<string>& keep_at
 void cls_rgw_obj_store_pg_ver(librados::ObjectWriteOperation& o, const string& attr)
 {
   bufferlist in;
-  struct rgw_cls_obj_store_pg_ver_op call;
+  rgw_cls_obj_store_pg_ver_op call;
   call.attr = attr;
   encode(call, in);
   o.exec(RGW_CLASS, RGW_OBJ_STORE_PG_VER, in);
@@ -252,7 +254,7 @@ void cls_rgw_obj_store_pg_ver(librados::ObjectWriteOperation& o, const string& a
 void cls_rgw_obj_check_attrs_prefix(librados::ObjectOperation& o, const string& prefix, bool fail_if_exist)
 {
   bufferlist in;
-  struct rgw_cls_obj_check_attrs_prefix call;
+  rgw_cls_obj_check_attrs_prefix call;
   call.check_prefix = prefix;
   call.fail_if_exist = fail_if_exist;
   encode(call, in);
@@ -262,7 +264,7 @@ void cls_rgw_obj_check_attrs_prefix(librados::ObjectOperation& o, const string& 
 void cls_rgw_obj_check_mtime(librados::ObjectOperation& o, const real_time& mtime, bool high_precision_time, RGWCheckMTimeType type)
 {
   bufferlist in;
-  struct rgw_cls_obj_check_mtime call;
+  rgw_cls_obj_check_mtime call;
   call.mtime = mtime;
   call.high_precision_time = high_precision_time;
   call.type = type;
@@ -275,7 +277,7 @@ int cls_rgw_bi_get(librados::IoCtx& io_ctx, const string oid,
                    rgw_cls_bi_entry *entry)
 {
   bufferlist in, out;
-  struct rgw_cls_bi_get_op call;
+  rgw_cls_bi_get_op call;
   call.key = key;
   call.type = index_type;
   encode(call, in);
@@ -283,7 +285,7 @@ int cls_rgw_bi_get(librados::IoCtx& io_ctx, const string oid,
   if (r < 0)
     return r;
 
-  struct rgw_cls_bi_get_ret op_ret;
+  rgw_cls_bi_get_ret op_ret;
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
@@ -299,7 +301,7 @@ int cls_rgw_bi_get(librados::IoCtx& io_ctx, const string oid,
 int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, rgw_cls_bi_entry& entry)
 {
   bufferlist in, out;
-  struct rgw_cls_bi_put_op call;
+  rgw_cls_bi_put_op call;
   call.entry = entry;
   encode(call, in);
   int r = io_ctx.exec(oid, RGW_CLASS, RGW_BI_PUT, in, out);
@@ -312,7 +314,7 @@ int cls_rgw_bi_put(librados::IoCtx& io_ctx, const string oid, rgw_cls_bi_entry& 
 void cls_rgw_bi_put(ObjectWriteOperation& op, const string oid, rgw_cls_bi_entry& entry)
 {
   bufferlist in, out;
-  struct rgw_cls_bi_put_op call;
+  rgw_cls_bi_put_op call;
   call.entry = entry;
   encode(call, in);
   op.exec(RGW_CLASS, RGW_BI_PUT, in);
@@ -323,7 +325,7 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const string oid,
                    list<rgw_cls_bi_entry> *entries, bool *is_truncated)
 {
   bufferlist in, out;
-  struct rgw_cls_bi_list_op call;
+  rgw_cls_bi_list_op call;
   call.name = name;
   call.marker = marker;
   call.max = max;
@@ -332,7 +334,7 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const string oid,
   if (r < 0)
     return r;
 
-  struct rgw_cls_bi_list_ret op_ret;
+  rgw_cls_bi_list_ret op_ret;
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
@@ -348,11 +350,11 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const string oid,
 
 int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, librados::ObjectWriteOperation& op,
                             const string& oid, const cls_rgw_obj_key& key, bufferlist& olh_tag,
-                            bool delete_marker, const string& op_tag, struct rgw_bucket_dir_entry_meta *meta,
+                            bool delete_marker, const string& op_tag, rgw_bucket_dir_entry_meta *meta,
                             uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace)
 {
   bufferlist in, out;
-  struct rgw_cls_link_olh_op call;
+  rgw_cls_link_olh_op call;
   call.key = key;
   call.olh_tag = string(olh_tag.c_str(), olh_tag.length());
   call.op_tag = op_tag;
@@ -380,7 +382,7 @@ int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, librados::ObjectWrit
                                    const string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace)
 {
   bufferlist in, out;
-  struct rgw_cls_unlink_instance_op call;
+  rgw_cls_unlink_instance_op call;
   call.key = key;
   call.op_tag = op_tag;
   call.olh_epoch = olh_epoch;
@@ -398,10 +400,10 @@ int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, librados::ObjectWrit
 
 int cls_rgw_get_olh_log(IoCtx& io_ctx, string& oid, librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker,
                         const string& olh_tag,
-                        map<uint64_t, vector<struct rgw_bucket_olh_log_entry> > *log, bool *is_truncated)
+                        map<uint64_t, vector<rgw_bucket_olh_log_entry> > *log, bool *is_truncated)
 {
   bufferlist in, out;
-  struct rgw_cls_read_olh_log_op call;
+  rgw_cls_read_olh_log_op call;
   call.olh = olh;
   call.ver_marker = ver_marker;
   call.olh_tag = olh_tag;
@@ -416,7 +418,7 @@ int cls_rgw_get_olh_log(IoCtx& io_ctx, string& oid, librados::ObjectReadOperatio
     return op_ret;
   }
 
-  struct rgw_cls_read_olh_log_ret ret;
+  rgw_cls_read_olh_log_ret ret;
   try {
     auto iter = out.cbegin();
     decode(ret, iter);
@@ -437,7 +439,7 @@ int cls_rgw_get_olh_log(IoCtx& io_ctx, string& oid, librados::ObjectReadOperatio
 void cls_rgw_trim_olh_log(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, uint64_t ver, const string& olh_tag)
 {
   bufferlist in;
-  struct rgw_cls_trim_olh_log_op call;
+  rgw_cls_trim_olh_log_op call;
   call.olh = olh;
   call.ver = ver;
   call.olh_tag = olh_tag;
@@ -448,7 +450,7 @@ void cls_rgw_trim_olh_log(librados::ObjectWriteOperation& op, const cls_rgw_obj_
 int cls_rgw_clear_olh(IoCtx& io_ctx, librados::ObjectWriteOperation& op, string& oid, const cls_rgw_obj_key& olh, const string& olh_tag)
 {
   bufferlist in, out;
-  struct rgw_cls_bucket_clear_olh_op call;
+  rgw_cls_bucket_clear_olh_op call;
   call.key = olh;
   call.olh_tag = olh_tag;
   encode(call, in);
@@ -463,7 +465,7 @@ int cls_rgw_clear_olh(IoCtx& io_ctx, librados::ObjectWriteOperation& op, string&
 
 static bool issue_bi_log_list_op(librados::IoCtx& io_ctx, const string& oid, int shard_id,
                                  BucketIndexShardsManager& marker_mgr, uint32_t max, BucketIndexAioManager *manager,
-    struct cls_rgw_bi_log_list_ret *pdata) {
+    cls_rgw_bi_log_list_ret *pdata) {
   bufferlist in;
   cls_rgw_bi_log_list_op call;
   call.marker = marker_mgr.get(shard_id, "");
@@ -471,7 +473,7 @@ static bool issue_bi_log_list_op(librados::IoCtx& io_ctx, const string& oid, int
   encode(call, in);
 
   librados::ObjectReadOperation op;
-  op.exec(RGW_CLASS, RGW_BI_LOG_LIST, in, new ClsBucketIndexOpCtx<struct cls_rgw_bi_log_list_ret>(pdata, NULL));
+  op.exec(RGW_CLASS, RGW_BI_LOG_LIST, in, new ClsBucketIndexOpCtx<cls_rgw_bi_log_list_ret>(pdata, NULL));
   return manager->aio_operate(io_ctx, oid, &op);
 }
 
@@ -499,10 +501,10 @@ int CLSRGWIssueBILogTrim::issue_op(int shard_id, const string& oid)
 }
 
 static bool issue_bucket_check_index_op(IoCtx& io_ctx, const string& oid, BucketIndexAioManager *manager,
-    struct rgw_cls_check_index_ret *pdata) {
+    rgw_cls_check_index_ret *pdata) {
   bufferlist in;
   librados::ObjectReadOperation op;
-  op.exec(RGW_CLASS, RGW_BUCKET_CHECK_INDEX, in, new ClsBucketIndexOpCtx<struct rgw_cls_check_index_ret>(
+  op.exec(RGW_CLASS, RGW_BUCKET_CHECK_INDEX, in, new ClsBucketIndexOpCtx<rgw_cls_check_index_ret>(
         pdata, NULL));
   return manager->aio_operate(io_ctx, oid, &op);
 }
@@ -576,7 +578,7 @@ public:
     ret_ctx->put();
   }
   void handle_completion(int r, bufferlist& outbl) override {
-    struct rgw_cls_list_ret ret;
+    rgw_cls_list_ret ret;
     try {
       auto iter = outbl.cbegin();
       decode(ret, iter);
@@ -591,7 +593,7 @@ public:
 int cls_rgw_get_dir_header_async(IoCtx& io_ctx, string& oid, RGWGetDirHeader_CB *ctx)
 {
   bufferlist in, out;
-  struct rgw_cls_list_op call;
+  rgw_cls_list_op call;
   call.num_entries = 0;
   encode(call, in);
   ObjectReadOperation op;
@@ -848,7 +850,7 @@ int cls_rgw_lc_list(IoCtx& io_ctx, string& oid,
 void cls_rgw_reshard_add(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry)
 {
   bufferlist in;
-  struct cls_rgw_reshard_add_op call;
+  cls_rgw_reshard_add_op call;
   call.entry = entry;
   encode(call, in);
   op.exec("rgw", "reshard_add", in);
@@ -858,7 +860,7 @@ int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const string& oid, string& mar
                          list<cls_rgw_reshard_entry>& entries, bool* is_truncated)
 {
   bufferlist in, out;
-  struct cls_rgw_reshard_list_op call;
+  cls_rgw_reshard_list_op call;
   call.marker = marker;
   call.max = max;
   encode(call, in);
@@ -866,7 +868,7 @@ int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const string& oid, string& mar
   if (r < 0)
     return r;
 
-  struct cls_rgw_reshard_list_ret op_ret;
+  cls_rgw_reshard_list_ret op_ret;
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
@@ -883,14 +885,14 @@ int cls_rgw_reshard_list(librados::IoCtx& io_ctx, const string& oid, string& mar
 int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const string& oid, cls_rgw_reshard_entry& entry)
 {
   bufferlist in, out;
-  struct cls_rgw_reshard_get_op call;
+  cls_rgw_reshard_get_op call;
   call.entry = entry;
   encode(call, in);
   int r = io_ctx.exec(oid, "rgw", "reshard_get", in, out);
   if (r < 0)
     return r;
 
-  struct cls_rgw_reshard_get_ret op_ret;
+  cls_rgw_reshard_get_ret op_ret;
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
@@ -906,7 +908,7 @@ int cls_rgw_reshard_get(librados::IoCtx& io_ctx, const string& oid, cls_rgw_resh
 void cls_rgw_reshard_remove(librados::ObjectWriteOperation& op, const cls_rgw_reshard_entry& entry)
 {
   bufferlist in;
-  struct cls_rgw_reshard_remove_op call;
+  cls_rgw_reshard_remove_op call;
   call.tenant = entry.tenant;
   call.bucket_name = entry.bucket_name;
   call.bucket_id = entry.bucket_id;
@@ -918,7 +920,7 @@ int cls_rgw_set_bucket_resharding(librados::IoCtx& io_ctx, const string& oid,
 				  const cls_rgw_bucket_instance_entry& entry)
 {
   bufferlist in, out;
-  struct cls_rgw_set_bucket_resharding_op call;
+  cls_rgw_set_bucket_resharding_op call;
   call.entry = entry;
   encode(call, in);
   return io_ctx.exec(oid, "rgw", "set_bucket_resharding", in, out);
@@ -927,7 +929,7 @@ int cls_rgw_set_bucket_resharding(librados::IoCtx& io_ctx, const string& oid,
 int cls_rgw_clear_bucket_resharding(librados::IoCtx& io_ctx, const string& oid)
 {
   bufferlist in, out;
-  struct cls_rgw_clear_bucket_resharding_op call;
+  cls_rgw_clear_bucket_resharding_op call;
   encode(call, in);
   return io_ctx.exec(oid, "rgw", "clear_bucket_resharding", in, out);
 }
@@ -936,13 +938,13 @@ int cls_rgw_get_bucket_resharding(librados::IoCtx& io_ctx, const string& oid,
 				  cls_rgw_bucket_instance_entry *entry)
 {
   bufferlist in, out;
-  struct cls_rgw_get_bucket_resharding_op call;
+  cls_rgw_get_bucket_resharding_op call;
   encode(call, in);
   int r= io_ctx.exec(oid, "rgw", "get_bucket_resharding", in, out);
   if (r < 0)
     return r;
 
-  struct cls_rgw_get_bucket_resharding_ret op_ret;
+  cls_rgw_get_bucket_resharding_ret op_ret;
   auto iter = out.cbegin();
   try {
     decode(op_ret, iter);
@@ -958,7 +960,7 @@ int cls_rgw_get_bucket_resharding(librados::IoCtx& io_ctx, const string& oid,
 void cls_rgw_guard_bucket_resharding(librados::ObjectOperation& op, int ret_err)
 {
   bufferlist in, out;
-  struct cls_rgw_guard_bucket_resharding_op call;
+  cls_rgw_guard_bucket_resharding_op call;
   call.ret_err = ret_err;
   encode(call, in);
   op.exec("rgw", "guard_bucket_resharding", in);
@@ -968,7 +970,7 @@ static bool issue_set_bucket_resharding(librados::IoCtx& io_ctx, const string& o
                                         const cls_rgw_bucket_instance_entry& entry,
                                         BucketIndexAioManager *manager) {
   bufferlist in;
-  struct cls_rgw_set_bucket_resharding_op call;
+  cls_rgw_set_bucket_resharding_op call;
   call.entry = entry;
   encode(call, in);
   librados::ObjectWriteOperation op;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -153,8 +153,9 @@ int CLSRGWIssueSetTagTimeout::issue_op(int shard_id, const string& oid)
   return issue_bucket_set_tag_timeout_op(io_ctx, oid, tag_timeout, &manager);
 }
 
-void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o, bool absolute,
-                                 const map<uint8_t, rgw_bucket_category_stats>& stats)
+void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
+				 bool absolute,
+                                 const map<RGWObjCategory, rgw_bucket_category_stats>& stats)
 {
   struct rgw_cls_bucket_update_stats_op call;
   call.absolute = absolute;

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -375,14 +375,14 @@ int cls_rgw_bi_list(librados::IoCtx& io_ctx, const string oid,
 
 int cls_rgw_bucket_link_olh(librados::IoCtx& io_ctx, librados::ObjectWriteOperation& op,
                             const string& oid, const cls_rgw_obj_key& key, bufferlist& olh_tag,
-                            bool delete_marker, const string& op_tag, struct rgw_bucket_dir_entry_meta *meta,
+                            bool delete_marker, const string& op_tag, rgw_bucket_dir_entry_meta *meta,
                             uint64_t olh_epoch, ceph::real_time unmod_since, bool high_precision_time, bool log_op, rgw_zone_set& zones_trace);
 int cls_rgw_bucket_unlink_instance(librados::IoCtx& io_ctx, librados::ObjectWriteOperation& op,
                                    const string& oid, const cls_rgw_obj_key& key, const string& op_tag,
                                    const string& olh_tag, uint64_t olh_epoch, bool log_op, rgw_zone_set& zones_trace);
 int cls_rgw_get_olh_log(librados::IoCtx& io_ctx, string& oid, librados::ObjectReadOperation& op, const cls_rgw_obj_key& olh, uint64_t ver_marker,
                         const string& olh_tag,
-                        map<uint64_t, vector<struct rgw_bucket_olh_log_entry> > *log, bool *is_truncated);
+                        map<uint64_t, vector<rgw_bucket_olh_log_entry> > *log, bool *is_truncated);
 void cls_rgw_trim_olh_log(librados::ObjectWriteOperation& op, const cls_rgw_obj_key& olh, uint64_t ver, const string& olh_tag);
 int cls_rgw_clear_olh(librados::IoCtx& io_ctx, librados::ObjectWriteOperation& op, string& oid, const cls_rgw_obj_key& olh, const string& olh_tag);
 
@@ -416,14 +416,14 @@ public:
                         const string& _filter_prefix, uint32_t _num_entries,
                         bool _list_versions,
                         map<int, string>& oids,
-                        map<int, struct rgw_cls_list_ret>& list_results,
+                        map<int, rgw_cls_list_ret>& list_results,
                         uint32_t max_aio) :
   CLSRGWConcurrentIO(io_ctx, oids, max_aio),
   start_obj(_start_obj), filter_prefix(_filter_prefix), num_entries(_num_entries), list_versions(_list_versions), result(list_results) {}
 };
 
 class CLSRGWIssueBILogList : public CLSRGWConcurrentIO {
-  map<int, struct cls_rgw_bi_log_list_ret>& result;
+  map<int, cls_rgw_bi_log_list_ret>& result;
   BucketIndexShardsManager& marker_mgr;
   uint32_t max;
 protected:
@@ -431,7 +431,7 @@ protected:
 public:
   CLSRGWIssueBILogList(librados::IoCtx& io_ctx, BucketIndexShardsManager& _marker_mgr, uint32_t _max,
                        map<int, string>& oids,
-                       map<int, struct cls_rgw_bi_log_list_ret>& bi_log_lists, uint32_t max_aio) :
+                       map<int, cls_rgw_bi_log_list_ret>& bi_log_lists, uint32_t max_aio) :
     CLSRGWConcurrentIO(io_ctx, oids, max_aio), result(bi_log_lists),
     marker_mgr(_marker_mgr), max(_max) {}
 };
@@ -466,13 +466,14 @@ public:
  *
  * Return 0 on success, a failure code otherwise.
  */
-class CLSRGWIssueBucketCheck : public CLSRGWConcurrentIO /*<map<string, struct rgw_cls_check_index_ret> >*/ {
-  map<int, struct rgw_cls_check_index_ret>& result;
+class CLSRGWIssueBucketCheck : public CLSRGWConcurrentIO /*<map<string, rgw_cls_check_index_ret> >*/ {
+  map<int, rgw_cls_check_index_ret>& result;
 protected:
   int issue_op(int shard_id, const string& oid) override;
 public:
-  CLSRGWIssueBucketCheck(librados::IoCtx& ioc, map<int, string>& oids, map<int, struct rgw_cls_check_index_ret>& bucket_objs_ret,
-                     uint32_t _max_aio) :
+  CLSRGWIssueBucketCheck(librados::IoCtx& ioc, map<int, string>& oids,
+			 map<int, rgw_cls_check_index_ret>& bucket_objs_ret,
+			 uint32_t _max_aio) :
     CLSRGWConcurrentIO(ioc, oids, _max_aio), result(bucket_objs_ret) {}
 };
 

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -343,8 +343,9 @@ public:
     CLSRGWConcurrentIO(ioc, _bucket_objs, _max_aio), tag_timeout(_tag_timeout) {}
 };
 
-void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o, bool absolute,
-                                 const map<uint8_t, rgw_bucket_category_stats>& stats);
+void cls_rgw_bucket_update_stats(librados::ObjectWriteOperation& o,
+                                 bool absolute,
+                                 const map<RGWObjCategory, rgw_bucket_category_stats>& stats);
 
 void cls_rgw_bucket_prepare_op(librados::ObjectWriteOperation& o, RGWModifyOp op, string& tag,
                                const cls_rgw_obj_key& key, const string& locator, bool log_op,

--- a/src/cls/rgw/cls_rgw_ops.cc
+++ b/src/cls/rgw/cls_rgw_ops.cc
@@ -354,7 +354,7 @@ void rgw_cls_bucket_update_stats_op::generate_test_instances(list<rgw_cls_bucket
 {
   rgw_cls_bucket_update_stats_op *r = new rgw_cls_bucket_update_stats_op;
   r->absolute = true;
-  rgw_bucket_category_stats& s = r->stats[0];
+  rgw_bucket_category_stats& s = r->stats[RGWObjCategory::None];
   s.total_size = 1;
   s.total_size_rounded = 4096;
   s.num_entries = 1;

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -85,7 +85,7 @@ struct rgw_cls_obj_complete_op
   cls_rgw_obj_key key;
   string locator;
   rgw_bucket_entry_ver ver;
-  struct rgw_bucket_dir_entry_meta meta;
+  rgw_bucket_dir_entry_meta meta;
   string tag;
   bool log_op;
   uint16_t bilog_flags;
@@ -167,7 +167,7 @@ struct rgw_cls_link_olh_op {
   string olh_tag;
   bool delete_marker;
   string op_tag;
-  struct rgw_bucket_dir_entry_meta meta;
+  rgw_bucket_dir_entry_meta meta;
   uint64_t olh_epoch;
   bool log_op;
   uint16_t bilog_flags;
@@ -303,7 +303,7 @@ WRITE_CLASS_ENCODER(rgw_cls_read_olh_log_op)
 
 struct rgw_cls_read_olh_log_ret
 {
-  map<uint64_t, vector<struct rgw_bucket_olh_log_entry> > log;
+  map<uint64_t, vector<rgw_bucket_olh_log_entry> > log;
   bool is_truncated;
 
   rgw_cls_read_olh_log_ret() : is_truncated(false) {}

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -463,7 +463,7 @@ WRITE_CLASS_ENCODER(rgw_cls_check_index_ret)
 struct rgw_cls_bucket_update_stats_op
 {
   bool absolute{false};
-  map<uint8_t, rgw_bucket_category_stats> stats;
+  map<RGWObjCategory, rgw_bucket_category_stats> stats;
 
   rgw_cls_bucket_update_stats_op() {}
 

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -573,7 +573,7 @@ void rgw_bucket_dir::dump(Formatter *f) const
   f->open_object_section("header");
   header.dump(f);
   f->close_section();
-  map<string, struct rgw_bucket_dir_entry>::const_iterator iter = m.begin();
+  map<string, rgw_bucket_dir_entry>::const_iterator iter = m.begin();
   f->open_array_section("map");
   for (; iter != m.end(); ++iter) {
     f->dump_string("key", iter->first);

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -41,7 +41,7 @@ void cls_rgw_obj_key::decode_json(JSONObj *obj) {
 void rgw_bucket_dir_entry_meta::generate_test_instances(list<rgw_bucket_dir_entry_meta*>& o)
 {
   rgw_bucket_dir_entry_meta *m = new rgw_bucket_dir_entry_meta;
-  m->category = 1;
+  m->category = RGWObjCategory::Main;
   m->size = 100;
   m->etag = "etag";
   m->owner = "owner";
@@ -68,7 +68,7 @@ void rgw_bucket_dir_entry_meta::dump(Formatter *f) const
 void rgw_bucket_dir_entry_meta::decode_json(JSONObj *obj) {
   int val;
   JSONDecoder::decode_json("category", val, obj);
-  category = (uint8_t)val;
+  category = static_cast<RGWObjCategory>(val);
   JSONDecoder::decode_json("size", size, obj);
   utime_t ut;
   JSONDecoder::decode_json("mtime", ut, obj);
@@ -242,7 +242,9 @@ void rgw_cls_bi_entry::dump(Formatter *f) const
   dump_bi_entry(data, type, f);
 }
 
-bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key, uint8_t *category, rgw_bucket_category_stats *accounted_stats)
+bool rgw_cls_bi_entry::get_info(cls_rgw_obj_key *key,
+                                RGWObjCategory *category,
+                                rgw_bucket_category_stats *accounted_stats)
 {
   bool account = false;
   auto iter = data.cbegin();
@@ -509,9 +511,10 @@ void rgw_bucket_dir_header::generate_test_instances(list<rgw_bucket_dir_header*>
 
   uint8_t i;
   for (i = 0, iter = l.begin(); iter != l.end(); ++iter, ++i) {
+    RGWObjCategory c = static_cast<RGWObjCategory>(i);
     rgw_bucket_dir_header *h = new rgw_bucket_dir_header;
     rgw_bucket_category_stats *s = *iter;
-    h->stats[i] = *s;
+    h->stats[c] = *s;
 
     o.push_back(h);
 
@@ -525,10 +528,9 @@ void rgw_bucket_dir_header::dump(Formatter *f) const
 {
   f->dump_int("ver", ver);
   f->dump_int("master_ver", master_ver);
-  map<uint8_t, struct rgw_bucket_category_stats>::const_iterator iter = stats.begin();
   f->open_array_section("stats");
-  for (; iter != stats.end(); ++iter) {
-    f->dump_int("category", (int)iter->first);
+  for (auto iter = stats.begin(); iter != stats.end(); ++iter) {
+    f->dump_int("category", int(iter->first));
     f->open_object_section("category_stats");
     iter->second.dump(f);
     f->close_section();

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -326,8 +326,8 @@ struct rgw_bucket_dir_entry {
   rgw_bucket_entry_ver ver;
   std::string locator;
   bool exists;
-  struct rgw_bucket_dir_entry_meta meta;
-  multimap<string, struct rgw_bucket_pending_info> pending_map;
+  rgw_bucket_dir_entry_meta meta;
+  multimap<string, rgw_bucket_pending_info> pending_map;
   uint64_t index_ver;
   string tag;
   uint16_t flags;
@@ -760,8 +760,8 @@ struct rgw_bucket_dir_header {
 WRITE_CLASS_ENCODER(rgw_bucket_dir_header)
 
 struct rgw_bucket_dir {
-  struct rgw_bucket_dir_header header;
-  std::map<string, struct rgw_bucket_dir_entry> m;
+  rgw_bucket_dir_header header;
+  std::map<string, rgw_bucket_dir_entry> m;
 
   void encode(bufferlist &bl) const {
     ENCODE_START(2, 2, bl);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -286,13 +286,6 @@ enum RGWIntentEvent {
   DEL_DIR = 1,
 };
 
-enum RGWObjCategory {
-  RGW_OBJ_CATEGORY_NONE      = 0,
-  RGW_OBJ_CATEGORY_MAIN      = 1,
-  RGW_OBJ_CATEGORY_SHADOW    = 2,
-  RGW_OBJ_CATEGORY_MULTIMETA = 3,
-};
-
 enum HostStyle {
   PathStyle = 0,
   VirtualStyle = 1,
@@ -1472,7 +1465,7 @@ struct RGWStorageStats
   uint64_t num_objects;
 
   RGWStorageStats()
-    : category(RGW_OBJ_CATEGORY_NONE),
+    : category(RGWObjCategory::None),
       size(0),
       size_rounded(0),
       num_objects(0) {}
@@ -2257,13 +2250,13 @@ static inline void append_rand_alpha(CephContext *cct, const string& src, string
 static inline const char *rgw_obj_category_name(RGWObjCategory category)
 {
   switch (category) {
-  case RGW_OBJ_CATEGORY_NONE:
+  case RGWObjCategory::None:
     return "rgw.none";
-  case RGW_OBJ_CATEGORY_MAIN:
+  case RGWObjCategory::Main:
     return "rgw.main";
-  case RGW_OBJ_CATEGORY_SHADOW:
+  case RGWObjCategory::Shadow:
     return "rgw.shadow";
-  case RGW_OBJ_CATEGORY_MULTIMETA:
+  case RGWObjCategory::MultiMeta:
     return "rgw.multimeta";
   }
 

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -602,7 +602,7 @@ int RGWAsyncFetchRemoteObj::_send_request()
                        RGWRados::ATTRSMOD_NONE,
                        copy_if_newer,
                        attrs,
-                       RGW_OBJ_CATEGORY_MAIN,
+                       RGWObjCategory::Main,
                        versioned_epoch,
                        real_time(), /* delete_at */
                        NULL, /* string *ptag, */

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4673,7 +4673,7 @@ void RGWCopyObj::execute()
 			   if_nomatch,
 			   attrs_mod,
                            copy_if_newer,
-			   attrs, RGW_OBJ_CATEGORY_MAIN,
+			   attrs, RGWObjCategory::Main,
 			   olh_epoch,
 			   (delete_at ? *delete_at : real_time()),
 			   (version_id.empty() ? NULL : &version_id),
@@ -5358,7 +5358,7 @@ void RGWInitMultipart::execute()
     RGWRados::Object::Write obj_op(&op_target);
 
     obj_op.meta.owner = s->owner.get_id();
-    obj_op.meta.category = RGW_OBJ_CATEGORY_MULTIMETA;
+    obj_op.meta.category = RGWObjCategory::MultiMeta;
     obj_op.meta.flags = PUT_OBJ_CREATE_EXCL;
 
     op_ret = obj_op.write_meta(0, 0, attrs);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1599,7 +1599,7 @@ public:
         bool completeMultipart;
 
         MetaParams() : mtime(NULL), rmattrs(NULL), data(NULL), manifest(NULL), ptag(NULL),
-                 remove_objs(NULL), category(RGW_OBJ_CATEGORY_MAIN), flags(0),
+                 remove_objs(NULL), category(RGWObjCategory::Main), flags(0),
                  if_match(NULL), if_nomatch(NULL), canceled(false), user_data(nullptr), zones_trace(nullptr),
                  modify_tail(false),  completeMultipart(false) {}
       } meta;

--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -32,7 +32,7 @@ class BucketReshardShard {
   int num_shard;
   RGWRados::BucketShard bs;
   vector<rgw_cls_bi_entry> entries;
-  map<uint8_t, rgw_bucket_category_stats> stats;
+  map<RGWObjCategory, rgw_bucket_category_stats> stats;
   deque<librados::AioCompletion *>& aio_completions;
   uint64_t max_aio_completions;
   uint64_t reshard_shard_batch_size;
@@ -88,7 +88,7 @@ public:
     return num_shard;
   }
 
-  int add_entry(rgw_cls_bi_entry& entry, bool account, uint8_t category,
+  int add_entry(rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
                 const rgw_bucket_category_stats& entry_stats) {
     entries.push_back(entry);
     if (account) {
@@ -178,7 +178,7 @@ public:
   }
 
   int add_entry(int shard_index,
-                rgw_cls_bi_entry& entry, bool account, uint8_t category,
+                rgw_cls_bi_entry& entry, bool account, RGWObjCategory category,
                 const rgw_bucket_category_stats& entry_stats) {
     int ret = target_shards[shard_index]->add_entry(entry, account, category,
 						    entry_stats);
@@ -568,7 +568,7 @@ int RGWBucketReshard::do_reshard(int num_shards,
 
 	int target_shard_id;
 	cls_rgw_obj_key cls_key;
-	uint8_t category;
+	RGWObjCategory category;
 	rgw_bucket_category_stats stats;
 	bool account = entry.get_info(&cls_key, &category, &stats);
 	rgw_obj_key key(cls_key);

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -68,7 +68,7 @@ public:
   }
 };
 
-void test_stats(librados::IoCtx& ioctx, string& oid, int category, uint64_t num_entries, uint64_t total_size)
+void test_stats(librados::IoCtx& ioctx, string& oid, RGWObjCategory category, uint64_t num_entries, uint64_t total_size)
 {
   map<int, struct rgw_cls_list_ret> results;
   map<int, string> oids;
@@ -131,16 +131,17 @@ TEST(cls_rgw, index_basic)
 
     index_prepare(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc);
 
-    test_stats(ioctx, bucket_oid, 0, i, obj_size * i);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, i, obj_size * i);
 
     op = mgr.write_op();
     rgw_bucket_dir_entry_meta meta;
-    meta.category = 0;
+    meta.category = RGWObjCategory::None;
     meta.size = obj_size;
     index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, epoch, obj, meta);
   }
 
-  test_stats(ioctx, bucket_oid, 0, NUM_OBJS, obj_size * NUM_OBJS);
+  test_stats(ioctx, bucket_oid, RGWObjCategory::None, NUM_OBJS,
+	     obj_size * NUM_OBJS);
 }
 
 TEST(cls_rgw, index_multiple_obj_writers)
@@ -163,20 +164,21 @@ TEST(cls_rgw, index_multiple_obj_writers)
 
     index_prepare(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc);
 
-    test_stats(ioctx, bucket_oid, 0, 0, 0);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, 0, 0);
   }
 
   for (int i = NUM_OBJS; i > 0; i--) {
     string tag = str_int("tag", i - 1);
 
     rgw_bucket_dir_entry_meta meta;
-    meta.category = 0;
+    meta.category = RGWObjCategory::None;
     meta.size = obj_size * i;
 
     index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, i, obj, meta);
 
     /* verify that object size doesn't change, as we went back with epoch */
-    test_stats(ioctx, bucket_oid, 0, 1, obj_size * NUM_OBJS);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, 1,
+	       obj_size * NUM_OBJS);
   }
 }
 
@@ -203,16 +205,16 @@ TEST(cls_rgw, index_remove_object)
 
     index_prepare(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc);
 
-    test_stats(ioctx, bucket_oid, 0, i, total_size);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, i, total_size);
 
     rgw_bucket_dir_entry_meta meta;
-    meta.category = 0;
+    meta.category = RGWObjCategory::None;
     meta.size = i * obj_size;
     total_size += i * obj_size;
 
     index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, ++epoch, obj, meta);
 
-    test_stats(ioctx, bucket_oid, 0, i + 1, total_size);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, i + 1, total_size);
   }
 
   int i = NUM_OBJS / 2;
@@ -225,7 +227,7 @@ TEST(cls_rgw, index_remove_object)
   index_prepare(mgr, ioctx, bucket_oid, CLS_RGW_OP_DEL, tag_remove, obj, loc);
   index_prepare(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag_modify, obj, loc);
 
-  test_stats(ioctx, bucket_oid, 0, NUM_OBJS, total_size);
+  test_stats(ioctx, bucket_oid, RGWObjCategory::None, NUM_OBJS, total_size);
 
   rgw_bucket_dir_entry_meta meta;
 
@@ -234,17 +236,17 @@ TEST(cls_rgw, index_remove_object)
 
   /* verify stats correct */
   total_size -= i * obj_size;
-  test_stats(ioctx, bucket_oid, 0, NUM_OBJS - 1, total_size);
+  test_stats(ioctx, bucket_oid, RGWObjCategory::None, NUM_OBJS - 1, total_size);
 
   meta.size = 512;
-  meta.category = 0;
+  meta.category = RGWObjCategory::None;
 
   /* complete object modification */
   index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag_modify, ++epoch, obj, meta);
 
   /* verify stats correct */
   total_size += meta.size;
-  test_stats(ioctx, bucket_oid, 0, NUM_OBJS, total_size);
+  test_stats(ioctx, bucket_oid, RGWObjCategory::None, NUM_OBJS, total_size);
 
 
   /* prepare both removal and modification on the same object, this time we'll
@@ -255,21 +257,22 @@ TEST(cls_rgw, index_remove_object)
   /* complete modification */
   total_size -= meta.size;
   meta.size = i * obj_size * 2;
-  meta.category = 0;
+  meta.category = RGWObjCategory::None;
 
   /* complete object modification */
   index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag_modify, ++epoch, obj, meta);
 
   /* verify stats correct */
   total_size += meta.size;
-  test_stats(ioctx, bucket_oid, 0, NUM_OBJS, total_size);
+  test_stats(ioctx, bucket_oid, RGWObjCategory::None, NUM_OBJS, total_size);
 
   /* complete object removal */
   index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_DEL, tag_remove, ++epoch, obj, meta);
 
   /* verify stats correct */
   total_size -= meta.size;
-  test_stats(ioctx, bucket_oid, 0, NUM_OBJS - 1, total_size);
+  test_stats(ioctx, bucket_oid, RGWObjCategory::None, NUM_OBJS - 1,
+	     total_size);
 }
 
 TEST(cls_rgw, index_suggest)
@@ -298,16 +301,16 @@ TEST(cls_rgw, index_suggest)
 
     index_prepare(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc);
 
-    test_stats(ioctx, bucket_oid, 0, i, total_size);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, i, total_size);
 
     rgw_bucket_dir_entry_meta meta;
-    meta.category = 0;
+    meta.category = RGWObjCategory::None;
     meta.size = obj_size;
     total_size += meta.size;
 
     index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, ++epoch, obj, meta);
 
-    test_stats(ioctx, bucket_oid, 0, i + 1, total_size);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, i + 1, total_size);
   }
 
   /* prepare (without completion) some of the objects */
@@ -318,7 +321,7 @@ TEST(cls_rgw, index_suggest)
 
     index_prepare(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc);
 
-    test_stats(ioctx, bucket_oid, 0, num_objs, total_size);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, num_objs, total_size);
   }
 
   int actual_num_objs = num_objs;
@@ -330,14 +333,14 @@ TEST(cls_rgw, index_suggest)
 
     index_prepare(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc);
 
-    test_stats(ioctx, bucket_oid, 0, actual_num_objs, total_size);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, actual_num_objs, total_size);
 
     rgw_bucket_dir_entry_meta meta;
     index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_DEL, tag, ++epoch, obj, meta);
 
     total_size -= obj_size;
     actual_num_objs--;
-    test_stats(ioctx, bucket_oid, 0, actual_num_objs, total_size);
+    test_stats(ioctx, bucket_oid, RGWObjCategory::None, actual_num_objs, total_size);
   }
 
   bufferlist updates;
@@ -375,7 +378,7 @@ TEST(cls_rgw, index_suggest)
   cls_rgw_suggest_changes(*op, updates);
   ASSERT_EQ(0, ioctx.operate(bucket_oid, op));
 
-  test_stats(ioctx, bucket_oid, 0, num_objs / 2, total_size);
+  test_stats(ioctx, bucket_oid, RGWObjCategory::None, num_objs / 2, total_size);
 }
 
 /*
@@ -418,12 +421,12 @@ TEST(cls_rgw, index_list)
 
     op = mgr.write_op();
     rgw_bucket_dir_entry_meta meta;
-    meta.category = 0;
+    meta.category = RGWObjCategory::None;
     meta.size = obj_size;
     index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, epoch, obj, meta);
   }
 
-  test_stats(ioctx, bucket_oid, 0, num_objs, obj_size * num_objs);
+  test_stats(ioctx, bucket_oid, RGWObjCategory::None, num_objs, obj_size * num_objs);
 
   map<int, string> oids = { {0, bucket_oid} };
   map<int, struct rgw_cls_list_ret> list_results;
@@ -478,7 +481,7 @@ TEST(cls_rgw, bi_list)
     index_prepare(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, obj, loc, RGW_BILOG_FLAG_VERSIONED_OP);
     op = mgr.write_op();
     rgw_bucket_dir_entry_meta meta;
-    meta.category = 0;
+    meta.category = RGWObjCategory::None;
     meta.size = obj_size;
     index_complete(mgr, ioctx, bucket_oid, CLS_RGW_OP_ADD, tag, epoch, obj, meta, RGW_BILOG_FLAG_VERSIONED_OP);
   }


### PR DESCRIPTION
The stats entries for rgw buckets has a category, which used a combination of `uint8_t` and `enum RGWObjClass`. Clean this up by converting `RGWObjClass` to an `enum class` and using that throughout. This provides type safety and better code clarity.