### PR TITLE
mgr/rook: fix API version and object types for recent rook changes

### DIFF
--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -19,7 +19,7 @@ except ImportError:
     ApiException = None
 
 ROOK_SYSTEM_NS = "rook-ceph-system"
-ROOK_API_VERSION = "v1beta1"
+ROOK_API_VERSION = "v1"
 ROOK_API_NAME = "ceph.rook.io/%s" % ROOK_API_VERSION
 
 log = logging.getLogger('rook')
@@ -58,7 +58,7 @@ class RookCluster(object):
 
         cluster_crd = {
             "apiVersion": ROOK_API_NAME,
-            "kind": "Cluster",
+            "kind": "CephCluster",
             "metadata": {
                 "name": self.cluster_name,
                 "namespace": self.cluster_name
@@ -69,7 +69,7 @@ class RookCluster(object):
             }
         }
 
-        self.rook_api_post("clusters", body=cluster_crd)
+        self.rook_api_post("cephclusters", body=cluster_crd)
 
     def rook_url(self, path):
         prefix = "/apis/ceph.rook.io/%s/namespaces/%s/" % (
@@ -199,7 +199,7 @@ class RookCluster(object):
 
         rook_fs = {
             "apiVersion": ROOK_API_NAME,
-            "kind": "Filesystem",
+            "kind": "CephFilesystem",
             "metadata": {
                 "name": spec.name,
                 "namespace": self.rook_namespace
@@ -216,12 +216,12 @@ class RookCluster(object):
 
         try:
             self.rook_api_post(
-                "filesystems/",
+                "cephfilesystems/",
                 body=rook_fs
             )
         except ApiException as e:
             if e.status == 409:
-                log.info("Filesystem '{0}' already exists".format(spec.name))
+                log.info("CephFilesystem '{0}' already exists".format(spec.name))
                 # Idempotent, succeed.
             else:
                 raise
@@ -230,7 +230,7 @@ class RookCluster(object):
   
         rook_os = {
             "apiVersion": ROOK_API_NAME,
-            "kind": "ObjectStore",
+            "kind": "CephObjectStore",
             "metadata": {
                 "name": spec.name,
                 "namespace": self.rook_namespace
@@ -259,12 +259,12 @@ class RookCluster(object):
         
         try:
             self.rook_api_post(
-                "objectstores/",
+                "cephobjectstores/",
                 body=rook_os
             )
         except ApiException as e:
             if e.status == 409:
-                log.info("ObjectStore '{0}' already exists".format(spec.name))
+                log.info("CephObjectStore '{0}' already exists".format(spec.name))
                 # Idempotent, succeed.                                                                                                                                                                     
             else:
                 raise
@@ -273,9 +273,9 @@ class RookCluster(object):
         assert service_type in ("mds", "rgw")
 
         if service_type == "mds":
-            rooktype = "filesystems"
+            rooktype = "cephfilesystems"
         elif service_type == "rgw":
-            rooktype = "objectstores"
+            rooktype = "cephobjectstores"
 
         objpath = "{0}/{1}".format(rooktype, service_id)
 
@@ -290,7 +290,7 @@ class RookCluster(object):
 
     def can_create_osd(self):
         current_cluster = self.rook_api_get(
-            "clusters/{0}".format(self.cluster_name))
+            "cephclusters/{0}".format(self.cluster_name))
         use_all_nodes = current_cluster['spec'].get('useAllNodes', False)
 
         # If useAllNodes is set, then Rook will not be paying attention
@@ -328,7 +328,7 @@ class RookCluster(object):
         #           storeType: bluestore
 
         current_cluster = self.rook_api_get(
-            "clusters/{0}".format(self.cluster_name))
+            "cephclusters/{0}".format(self.cluster_name))
 
         patch = []
 
@@ -381,7 +381,7 @@ class RookCluster(object):
 
         try:
             self.rook_api_patch(
-                "clusters/{0}".format(self.cluster_name),
+                "cephclusters/{0}".format(self.cluster_name),
                 body=patch)
         except ApiException as e:
             log.exception("API exception: {0}".format(e))


### PR DESCRIPTION
The rook project recently renamed these objects and promoted the version
to v1. Make the corresponding changes in the ceph rook module.

Signed-off-by: Jeff Layton <jlayton@redhat.com>