### PR TITLE
crimson: test memstore running in posix thread.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -276,36 +276,6 @@ add_subdirectory(json_spirit)
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/xxHash")
 include_directories(SYSTEM "${CMAKE_SOURCE_DIR}/src/rapidjson/include")
 
-if(WITH_SEASTAR)
-  find_package(fmt 4.0.0 QUIET)
-  if(NOT fmt_FOUND)
-    message(STATUS "Could not find fmt, will build it")
-    add_subdirectory(fmt)
-  elseif(fmt_VERSION VERSION_GREATER_EQUAL 5.0.0)
-    message(WARNING "Could NOT find fmt: "
-      "Found unsuitable version \"${fmt_VERSION}\", "
-      "but required is at most \"5.0.0\" (found ${fmt_INCLUDE_DIR}). "
-      "Will build it")
-    add_subdirectory(fmt)
-  endif()
-  find_package(c-ares 1.13.0 QUIET)
-  if(NOT c-ares_FOUND)
-    message(STATUS "Could not find c-ares, will build it")
-    include(Buildc-ares)
-    build_c_ares()
-  endif()
-  macro(find_package name)
-    if(NOT TARGET ${name})
-      _find_package(${ARGV})
-    endif()
-  endmacro ()
-  set(Seastar_HWLOC OFF CACHE BOOL "" FORCE)
-  add_subdirectory(seastar)
-  # create the directory so cmake won't complain when looking at the imported
-  # target: Seastar exports this directory created at build-time
-  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/seastar/gen")
-  add_subdirectory(crimson)
-endif()
 
 set(libcommon_files
   ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h
@@ -522,6 +492,36 @@ install(TARGETS ceph-mds DESTINATION bin)
 
 add_subdirectory(erasure-code)
 
+if(WITH_SEASTAR)
+  find_package(fmt 4.0.0 QUIET)
+  if(NOT fmt_FOUND)
+    message(STATUS "Could not find fmt, will build it")
+    add_subdirectory(fmt)
+  elseif(fmt_VERSION VERSION_GREATER_EQUAL 5.0.0)
+    message(WARNING "Could NOT find fmt: "
+      "Found unsuitable version \"${fmt_VERSION}\", "
+      "but required is at most \"5.0.0\" (found ${fmt_INCLUDE_DIR}). "
+      "Will build it")
+    add_subdirectory(fmt)
+  endif()
+  find_package(c-ares 1.13.0 QUIET)
+  if(NOT c-ares_FOUND)
+    message(STATUS "Could not find c-ares, will build it")
+    include(Buildc-ares)
+    build_c_ares()
+  endif()
+  macro(find_package name)
+    if(NOT TARGET ${name})
+      _find_package(${ARGV})
+    endif()
+  endmacro ()
+  set(Seastar_HWLOC OFF CACHE BOOL "" FORCE)
+  add_subdirectory(seastar)
+  # create the directory so cmake won't complain when looking at the imported
+  # target: Seastar exports this directory created at build-time
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/seastar/gen")
+  add_subdirectory(crimson)
+endif()
 # Support/Tools
 if(WITH_TESTS)
   option(WITH_SYSTEM_GTEST "require and build with system gtest and gmock" OFF)

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -133,3 +133,5 @@ target_link_libraries(crimson
   PUBLIC
     crimson-common
     crimson::cflags)
+
+add_subdirectory(os)

--- a/src/crimson/os/CMakeLists.txt
+++ b/src/crimson/os/CMakeLists.txt
@@ -1,0 +1,73 @@
+set(libcrimsonos_srcs
+  memstore/MemStore.cc
+  Finisher.cc
+  ${PROJECT_SOURCE_DIR}/src/os/ObjectStore.cc
+  ${PROJECT_SOURCE_DIR}/src/os/Transaction.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/chain_xattr.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/BtrfsFileStoreBackend.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/DBObjectMap.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/FileJournal.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/FileStore.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/JournalThrottle.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/GenericFileStoreBackend.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/JournalingObjectStore.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/HashIndex.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/IndexManager.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/LFNIndex.cc
+  ${PROJECT_SOURCE_DIR}/src/os/filestore/WBThrottle.cc
+  ${PROJECT_SOURCE_DIR}/src/os/kstore/KStore.cc
+  ${PROJECT_SOURCE_DIR}/src/os/kstore/kstore_types.cc
+  ${PROJECT_SOURCE_DIR}/src/os/fs/FS.cc)
+
+if(WITH_BLUESTORE)
+  list(APPEND libcrimsonos_srcs
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/Allocator.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/BitmapFreelistManager.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlockDevice.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueFS.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/bluefs_types.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueRocksEnv.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/BlueStore.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/bluestore_types.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/fastbmap_allocator_impl.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/FreelistManager.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/StupidAllocator.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/BitmapAllocator.cc
+  )
+endif(WITH_BLUESTORE)
+
+if(HAVE_LIBAIO)
+  list(APPEND libcrimsonos_srcs
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/KernelDevice.cc
+    ${PROJECT_SOURCE_DIR}/src/os/bluestore/aio.cc)
+endif()
+
+if(WITH_SPDK)
+  list(APPEND libcrimsonos_srcs
+     ${PROJECT_SOURCE_DIR}/src/os/bluestore/NVMEDevice.cc)
+endif()
+
+
+if(HAVE_LIBXFS)
+  list(APPEND libcrimsonos_srcs
+    ${PROJECT_SOURCE_DIR}/src/os/filestore/XfsFileStoreBackend.cc
+    ${PROJECT_SOURCE_DIR}/src/os/fs/XFS.cc)
+endif()
+
+add_library(crimsonos STATIC ${libcrimsonos_srcs}
+  $<TARGET_OBJECTS:kv_objs>)
+target_link_libraries(crimsonos heap_profiler seastar)
+
+if(HAVE_LIBAIO)
+  target_link_libraries(crimsonos ${AIO_LIBRARIES})
+endif(HAVE_LIBAIO)
+if(WITH_SPDK)
+  target_link_libraries(crimsonos
+    ${SPDK_LIBRARIES})
+endif()
+
+target_link_libraries(crimsonos kv)
+
+
+
+

--- a/src/crimson/os/ConfigObs.h
+++ b/src/crimson/os/ConfigObs.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "common/config_obs.h"
+#include "common/config_values.h"
+#include "crimson/common/config_proxy.h"
+#include "common/options.h"
+
+using Config = ceph::common::ConfigProxy;
+const uint64_t INVALID_VALUE = (uint64_t)(-1);
+const std::string memstore_device_bytes ="memstore_device_bytes";
+const std::string memstore_page_set = "memstore_page_set";
+const std::string memstore_page_size = "memstore_page_size";
+
+
+class ConfigObs : public ceph::md_config_obs_impl<Config> {
+  uint64_t total = 0;
+  bool page_set = false;
+  uint64_t page_size = 0;
+private:
+  const char** get_tracked_conf_keys() const override {
+    static const char* keys[] = {
+      memstore_device_bytes.c_str(),
+      memstore_page_set.c_str(),
+      memstore_page_size.c_str(),
+      nullptr,
+    };
+    return keys;
+  }
+  void handle_conf_change(const Config& conf,
+                          const std::set <std::string> &changes) override{
+    if (changes.count(memstore_device_bytes)) {
+      Option::size_t bytes = conf.get_val<Option::size_t>(memstore_device_bytes);
+      total = static_cast<uint64_t>(bytes.value);
+    }
+    if (changes.count(memstore_page_set)) {
+      page_set = conf.get_val<bool>(memstore_page_set);
+    }
+    if (changes.count(memstore_page_size)) {
+      Option::size_t size = conf.get_val<Option::size_t>(memstore_page_size);
+      page_size = static_cast<uint64_t>(size.value);
+    }
+  }
+public:
+  ConfigObs() {
+  }
+  uint64_t get_device_bytes() const {return total;}
+  bool get_page_set() const {return page_set;}
+  uint64_t get_page_size() const {return page_size;}
+};
+

--- a/src/crimson/os/Finisher.cc
+++ b/src/crimson/os/Finisher.cc
@@ -1,0 +1,97 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "Finisher.h"
+
+#define dout_subsys ceph_subsys_finisher
+#undef dout_prefix
+#define dout_prefix *_dout << "finisher(" << this << ") "
+#include "crimson/os/out.h"
+
+void Finisher::start()
+{
+  ldout(cct, 10) << __func__ << dendl;
+  finisher_thread.create(thread_name.c_str());
+}
+
+void Finisher::stop()
+{
+  ldout(cct, 10) << __func__ << dendl;
+  finisher_lock.lock();
+  finisher_stop = true;
+  // we don't have any new work to do, but we want the worker to wake up anyway
+  // to process the stop condition.
+  finisher_cond.notify_all();
+  finisher_lock.unlock();
+  finisher_thread.join(); // wait until the worker exits completely
+  ldout(cct, 10) << __func__ << " finish" << dendl;
+}
+
+void Finisher::wait_for_empty()
+{
+  std::unique_lock ul(finisher_lock);
+  while (!finisher_queue.empty() || finisher_running) {
+    ldout(cct, 10) << "wait_for_empty waiting" << dendl;
+    finisher_empty_wait = true;
+    finisher_empty_cond.wait(ul);
+  }
+  ldout(cct, 10) << "wait_for_empty empty" << dendl;
+  finisher_empty_wait = false;
+}
+
+void *Finisher::finisher_thread_entry()
+{
+  std::unique_lock ul(finisher_lock);
+  ldout(cct, 10) << "finisher_thread start" << dendl;
+
+  utime_t start;
+  uint64_t count = 0;
+  while (!finisher_stop) {
+    /// Every time we are woken up, we process the queue until it is empty.
+    while (!finisher_queue.empty()) {
+      // To reduce lock contention, we swap out the queue to process.
+      // This way other threads can submit new contexts to complete
+      // while we are working.
+      vector<pair<Context*,int>> ls;
+      ls.swap(finisher_queue);
+      finisher_running = true;
+      ul.unlock();
+      ldout(cct, 10) << "finisher_thread doing " << ls << dendl;
+
+      if (logger) {
+	start = ceph_clock_now();
+	count = ls.size();
+      }
+
+      // Now actually process the contexts.
+      for (auto p : ls) {
+	p.first->complete(p.second);
+      }
+      ldout(cct, 10) << "finisher_thread done with " << ls << dendl;
+      ls.clear();
+      if (logger) {
+	logger->dec(l_finisher_queue_len, count);
+	logger->tinc(l_finisher_complete_lat, ceph_clock_now() - start);
+      }
+
+      ul.lock();
+      finisher_running = false;
+    }
+    ldout(cct, 10) << "finisher_thread empty" << dendl;
+    if (unlikely(finisher_empty_wait))
+      finisher_empty_cond.notify_all();
+    if (finisher_stop)
+      break;
+    
+    ldout(cct, 10) << "finisher_thread sleeping" << dendl;
+    finisher_cond.wait(ul);
+  }
+  // If we are exiting, we signal the thread waiting in stop(),
+  // otherwise it would never unblock
+  finisher_empty_cond.notify_all();
+
+  ldout(cct, 10) << "finisher_thread stop" << dendl;
+  finisher_stop = false;
+  return 0;
+}
+

--- a/src/crimson/os/Finisher.h
+++ b/src/crimson/os/Finisher.h
@@ -1,0 +1,231 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#ifndef CEPH_FINISHER_H
+#define CEPH_FINISHER_H
+
+#include "common/Thread.h"
+#include "common/perf_counters.h"
+#include "common/Cond.h"
+#include "crimson/os/store_context.h"
+
+/// Finisher queue length performance counter ID.
+enum {
+  l_finisher_first = 997082,
+  l_finisher_queue_len,
+  l_finisher_complete_lat,
+  l_finisher_last
+};
+
+/** @brief Asynchronous cleanup class.
+ * Finisher asynchronously completes Contexts, which are simple classes
+ * representing callbacks, in a dedicated worker thread. Enqueuing
+ * contexts to complete is thread-safe.
+ */
+class Finisher {
+  StoreContext *scct;
+  std::mutex finisher_lock; ///< Protects access to queues and finisher_running.
+  std::condition_variable finisher_cond; ///< Signaled when there is something to process.
+  std::condition_variable finisher_empty_cond; ///< Signaled when the finisher has nothing more to process.
+  bool         finisher_stop; ///< Set when the finisher should stop.
+  bool         finisher_running; ///< True when the finisher is currently executing contexts.
+  bool	       finisher_empty_wait; ///< True mean someone wait finisher empty.
+
+  /// Queue for contexts for which complete(0) will be called.
+  vector<pair<Context*,int>> finisher_queue;
+
+  string thread_name;
+
+  /// Performance counter for the finisher's queue length.
+  /// Only active for named finishers.
+  PerfCounters *logger;
+  
+  void *finisher_thread_entry();
+
+  struct FinisherThread : public Thread {
+    Finisher *fin;    
+    explicit FinisherThread(Finisher *f) : fin(f) {}
+    void* entry() override { return fin->finisher_thread_entry(); }
+  } finisher_thread;
+
+ public:
+  /// Add a context to complete, optionally specifying a parameter for the complete function.
+  void queue(Context *c, int r = 0) {
+    std::unique_lock ul(finisher_lock);
+    if (finisher_queue.empty()) {
+      finisher_cond.notify_all();
+    }
+    finisher_queue.push_back(make_pair(c, r));
+    if (logger)
+      logger->inc(l_finisher_queue_len);
+  }
+
+  void queue(list<Context*>& ls) {
+    {
+      std::unique_lock ul(finisher_lock);
+      if (finisher_queue.empty()) {
+	finisher_cond.notify_all();
+      }
+      for (auto i : ls) {
+	finisher_queue.push_back(make_pair(i, 0));
+      }
+      if (logger)
+	logger->inc(l_finisher_queue_len, ls.size());
+    }
+    ls.clear();
+  }
+  void queue(deque<Context*>& ls) {
+    {
+      std::unique_lock ul(finisher_lock);
+      if (finisher_queue.empty()) {
+	finisher_cond.notify_all();
+      }
+      for (auto i : ls) {
+	finisher_queue.push_back(make_pair(i, 0));
+      }
+      if (logger)
+	logger->inc(l_finisher_queue_len, ls.size());
+    }
+    ls.clear();
+  }
+  void queue(vector<Context*>& ls) {
+    {
+      std::unique_lock ul(finisher_lock);
+      if (finisher_queue.empty()) {
+	finisher_cond.notify_all();
+      }
+      for (auto i : ls) {
+	finisher_queue.push_back(make_pair(i, 0));
+      }
+      if (logger)
+	logger->inc(l_finisher_queue_len, ls.size());
+    }
+    ls.clear();
+  }
+
+  /// Start the worker thread.
+  void start();
+
+  /** @brief Stop the worker thread.
+   *
+   * Does not wait until all outstanding contexts are completed.
+   * To ensure that everything finishes, you should first shut down
+   * all sources that can add contexts to this finisher and call
+   * wait_for_empty() before calling stop(). */
+  void stop();
+
+  /** @brief Blocks until the finisher has nothing left to process.
+   * This function will also return when a concurrent call to stop()
+   * finishes, but this class should never be used in this way. */
+  void wait_for_empty();
+
+  /// Construct an anonymous Finisher.
+  /// Anonymous finishers do not log their queue length.
+  explicit Finisher(StoreContext *cct_) :
+    scct(cct_), finisher_lock(),
+    finisher_stop(false), finisher_running(false), finisher_empty_wait(false),
+    thread_name("fn_anonymous"), logger(0),
+    finisher_thread(this) {}
+
+  /// Construct a named Finisher that logs its queue length.
+  Finisher(StoreContext *cct_, string name, string tn) :
+    scct(cct_), finisher_lock(),
+    finisher_stop(false), finisher_running(false), finisher_empty_wait(false),
+    thread_name(tn), logger(0),
+    finisher_thread(this) {
+    PerfCountersBuilder b(NULL, string("finisher-") + name,
+			  l_finisher_first, l_finisher_last);
+    b.add_u64(l_finisher_queue_len, "queue_len");
+    b.add_time_avg(l_finisher_complete_lat, "complete_latency");
+    logger = b.create_perf_counters();
+    scct->get_perfcounters_collection()->add(logger);
+    logger->set(l_finisher_queue_len, 0);
+    logger->set(l_finisher_complete_lat, 0);
+  }
+
+  ~Finisher() {
+    if (logger && scct) {
+      scct->get_perfcounters_collection()->remove(logger);
+      delete logger;
+    }
+  }
+};
+
+/// Context that is completed asynchronously on the supplied finisher.
+class C_OnFinisher : public Context {
+  Context *con;
+  Finisher *fin;
+public:
+  C_OnFinisher(Context *c, Finisher *f) : con(c), fin(f) {
+    ceph_assert(fin != NULL);
+  //  ceph_assert(con != NULL);
+  }
+
+  ~C_OnFinisher() override {
+    if (con != nullptr) {
+      delete con;
+      con = nullptr;
+    }
+  }
+
+  void finish(int r) override {
+    fin->queue(con, r);
+    con = nullptr;
+  }
+};
+
+class ContextQueue {
+  list<Context *> q;
+  std::mutex q_mutex;
+  Mutex& mutex;
+  Cond& cond;
+public:
+  ContextQueue(Mutex& mut, Cond& con) : mutex(mut), cond(con) {}
+
+  void queue(list<Context *>& ls) {
+    bool empty = false;
+    {
+      std::scoped_lock l(q_mutex);
+      if (q.empty()) {
+	q.swap(ls);
+	empty = true;
+      } else {
+	q.insert(q.end(), ls.begin(), ls.end());
+      }
+    }
+
+    if (empty) {
+      mutex.Lock();
+      cond.Signal();
+      mutex.Unlock();
+    }
+
+    ls.clear();
+  }
+
+  void swap(list<Context *>& ls) {
+    ls.clear();
+    std::scoped_lock l(q_mutex);
+    if (!q.empty()) {
+      q.swap(ls);
+    }
+  }
+
+  bool empty() {
+    std::scoped_lock l(q_mutex);
+    return q.empty();
+  }
+};
+
+#endif

--- a/src/crimson/os/memstore/MemStore.cc
+++ b/src/crimson/os/memstore/MemStore.cc
@@ -1,0 +1,1795 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2013 Inktank
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include "acconfig.h"
+
+#ifdef HAVE_SYS_MOUNT_H
+#include <sys/mount.h>
+#endif
+
+#ifdef HAVE_SYS_PARAM_H
+#include <sys/param.h>
+#endif
+#include "include/types.h"
+#include "include/stringify.h"
+#include "include/unordered_map.h"
+#include "common/errno.h"
+#include "MemStore.h"
+#include "include/compat.h"
+
+#define dout_context cct
+#define dout_subsys ceph_subsys_filestore
+#undef dout_prefix
+#define dout_prefix *_dout << "memstore(" << path << ") "
+
+
+#include "crimson/os/out.h"
+
+// for comparing collections for lock ordering
+bool operator>(const MemStore::CollectionRef& l,
+	       const MemStore::CollectionRef& r)
+{
+  return (unsigned long)l.get() > (unsigned long)r.get();
+}
+
+
+int MemStore::mount()
+{
+  int r = _load();
+  if (r < 0)
+    return r;
+  finisher.start();
+  return 0;
+}
+
+int MemStore::umount()
+{
+  finisher.wait_for_empty();
+  finisher.stop();
+  return _save();
+}
+
+int MemStore::_save()
+{
+  dout(10) << __func__ << dendl;
+  dump_all();
+  set<coll_t> collections;
+  for (ceph::unordered_map<coll_t,CollectionRef>::iterator p = coll_map.begin();
+       p != coll_map.end();
+       ++p) {
+    dout(20) << __func__ << " coll " << p->first << " " << p->second << dendl;
+    collections.insert(p->first);
+    bufferlist bl;
+    ceph_assert(p->second);
+    p->second->encode(bl);
+    string fn = path + "/" + stringify(p->first);
+    int r = bl.write_file(fn.c_str());
+    if (r < 0)
+      return r;
+  }
+
+  string fn = path + "/collections";
+  bufferlist bl;
+  encode(collections, bl);
+  int r = bl.write_file(fn.c_str());
+  if (r < 0)
+    return r;
+
+  return 0;
+}
+
+void MemStore::dump_all()
+{
+  Formatter *f = Formatter::create("json-pretty");
+  f->open_object_section("store");
+  dump(f);
+  f->close_section();
+  dout(0) << "dump:";
+  f->flush(*_dout);
+  *_dout << dendl;
+  delete f;
+}
+
+void MemStore::dump(Formatter *f)
+{
+  f->open_array_section("collections");
+  for (ceph::unordered_map<coll_t,CollectionRef>::iterator p = coll_map.begin();
+       p != coll_map.end();
+       ++p) {
+    f->open_object_section("collection");
+    f->dump_string("name", stringify(p->first));
+
+    f->open_array_section("xattrs");
+    for (map<string,bufferptr>::iterator q = p->second->xattr.begin();
+	 q != p->second->xattr.end();
+	 ++q) {
+      f->open_object_section("xattr");
+      f->dump_string("name", q->first);
+      f->dump_int("length", q->second.length());
+      f->close_section();
+    }
+    f->close_section();
+
+    f->open_array_section("objects");
+    for (map<ghobject_t,ObjectRef>::iterator q = p->second->object_map.begin();
+	 q != p->second->object_map.end();
+	 ++q) {
+      f->open_object_section("object");
+      f->dump_string("name", stringify(q->first));
+      if (q->second)
+	q->second->dump(f);
+      f->close_section();
+    }
+    f->close_section();
+
+    f->close_section();
+  }
+  f->close_section();
+}
+
+int MemStore::_load()
+{
+  dout(10) << __func__ << dendl;
+  bufferlist bl;
+  string fn = path + "/collections";
+  string err;
+  int r = bl.read_file(fn.c_str(), &err);
+  if (r < 0)
+    return r;
+
+  set<coll_t> collections;
+  auto p = bl.cbegin();
+  decode(collections, p);
+
+  for (set<coll_t>::iterator q = collections.begin();
+       q != collections.end();
+       ++q) {
+    string fn = path + "/" + stringify(*q);
+    bufferlist cbl;
+    int r = cbl.read_file(fn.c_str(), &err);
+    if (r < 0)
+      return r;
+    CollectionRef c(new Collection(scct, *q));
+    auto p = cbl.cbegin();
+    c->decode(p);
+    coll_map[*q] = c;
+    used_bytes += c->used_bytes();
+  }
+
+  dump_all();
+
+  return 0;
+}
+
+void MemStore::set_fsid(uuid_d u)
+{
+  int r = write_meta("fsid", stringify(u));
+  ceph_assert(r >= 0);
+}
+
+uuid_d MemStore::get_fsid()
+{
+  string fsid_str;
+  int r = read_meta("fsid", &fsid_str);
+  ceph_assert(r >= 0);
+  uuid_d uuid;
+  bool b = uuid.parse(fsid_str.c_str());
+  ceph_assert(b);
+  return uuid;
+}
+
+int MemStore::mkfs()
+{
+  string fsid_str;
+  int r = read_meta("fsid", &fsid_str);
+  if (r == -ENOENT) {
+    uuid_d fsid;
+    fsid.generate_random();
+    fsid_str = stringify(fsid);
+    r = write_meta("fsid", fsid_str);
+    if (r < 0)
+      return r;
+    dout(1) << __func__ << " new fsid " << fsid_str << dendl;
+  } else if (r < 0) {
+    return r;
+  } else {  
+    dout(1) << __func__ << " had fsid " << fsid_str << dendl;
+  }
+
+  string fn = path + "/collections";
+  derr << path << dendl;
+  bufferlist bl;
+  set<coll_t> collections;
+  encode(collections, bl);
+  r = bl.write_file(fn.c_str());
+  if (r < 0)
+    return r;
+
+  r = write_meta("type", "memstore");
+  if (r < 0)
+    return r;
+
+  return 0;
+}
+
+int MemStore::statfs(struct store_statfs_t *st)
+{
+   dout(10) << __func__ << dendl;
+  st->reset();
+  st->total = scct->get_cobs()->get_device_bytes();
+  st->available = std::max<int64_t>(st->total - used_bytes, 0);
+  dout(10) << __func__ << ": used_bytes: " << used_bytes
+	   << "/" << scct->get_cobs()->get_device_bytes() << dendl;
+  return 0;
+}
+
+objectstore_perf_stat_t MemStore::get_cur_stats()
+{
+  // fixme
+  return objectstore_perf_stat_t();
+}
+
+MemStore::CollectionRef MemStore::get_collection(const coll_t& cid)
+{
+  RWLock::RLocker l(coll_lock);
+  ceph::unordered_map<coll_t,CollectionRef>::iterator cp = coll_map.find(cid);
+  if (cp == coll_map.end())
+    return CollectionRef();
+  return cp->second;
+}
+
+ObjectStore::CollectionHandle MemStore::create_new_collection(const coll_t& cid)
+{
+  RWLock::WLocker l(coll_lock);
+  Collection *c = new Collection(scct, cid);
+  new_coll_map[cid] = c;
+  return c;
+}
+
+
+// ---------------
+// read operations
+
+bool MemStore::exists(CollectionHandle &c_, const ghobject_t& oid)
+{
+  Collection *c = static_cast<Collection*>(c_.get());
+  dout(10) << __func__ << " " << c->get_cid() << " " << oid << dendl;
+  if (!c->exists)
+    return false;
+
+  // Perform equivalent of c->get_object_(oid) != NULL. In C++11 the
+  // shared_ptr needs to be compared to nullptr.
+  return (bool)c->get_object(oid);
+}
+
+int MemStore::stat(
+  CollectionHandle &c_,
+  const ghobject_t& oid,
+  struct stat *st,
+  bool allow_eio)
+{
+  Collection *c = static_cast<Collection*>(c_.get());
+  dout(10) << __func__ << " " << c->cid << " " << oid << dendl;
+  if (!c->exists)
+    return -ENOENT;
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  st->st_size = o->get_size();
+  st->st_blksize = 4096;
+  st->st_blocks = (st->st_size + st->st_blksize - 1) / st->st_blksize;
+  st->st_nlink = 1;
+  return 0;
+}
+
+int MemStore::set_collection_opts(
+  CollectionHandle& ch,
+  const pool_opts_t& opts)
+{
+  return -EOPNOTSUPP;
+}
+
+int MemStore::read(
+  CollectionHandle &c_,
+  const ghobject_t& oid,
+  uint64_t offset,
+  size_t len,
+  bufferlist& bl,
+  uint32_t op_flags)
+{
+  Collection *c = static_cast<Collection*>(c_.get());
+  dout(10) << __func__ << " " << c->cid << " " << oid << " "
+	   << offset << "~" << len << dendl;
+  if (!c->exists)
+    return -ENOENT;
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  if (offset >= o->get_size())
+    return 0;
+  size_t l = len;
+  if (l == 0 && offset == 0)  // note: len == 0 means read the entire object
+    l = o->get_size();
+  else if (offset + l > o->get_size())
+    l = o->get_size() - offset;
+  bl.clear();
+  return o->read(offset, l, bl);
+}
+
+int MemStore::fiemap(CollectionHandle& ch, const ghobject_t& oid,
+		     uint64_t offset, size_t len, bufferlist& bl)
+{
+  map<uint64_t, uint64_t> destmap;
+  int r = fiemap(ch, oid, offset, len, destmap);
+  if (r >= 0)
+    encode(destmap, bl);
+  return r;
+}
+
+int MemStore::fiemap(CollectionHandle& ch, const ghobject_t& oid,
+		     uint64_t offset, size_t len, map<uint64_t, uint64_t>& destmap)
+{
+  dout(10) << __func__ << " " << ch->cid << " " << oid << " " << offset << "~"
+	   << len << dendl;
+  Collection *c = static_cast<Collection*>(ch.get());
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  size_t l = len;
+  if (offset + l > o->get_size())
+    l = o->get_size() - offset;
+  if (offset >= o->get_size())
+    goto out;
+  destmap[offset] = l;
+ out:
+  return 0;
+}
+
+int MemStore::getattr(CollectionHandle &c_, const ghobject_t& oid,
+		      const char *name, bufferptr& value)
+{
+  Collection *c = static_cast<Collection*>(c_.get());
+  dout(10) << __func__ << " " << c->cid << " " << oid << " " << name << dendl;
+  if (!c->exists)
+    return -ENOENT;
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  string k(name);
+  std::lock_guard<std::mutex> lock(o->xattr_mutex);
+  if (!o->xattr.count(k)) {
+    return -ENODATA;
+  }
+  value = o->xattr[k];
+  return 0;
+}
+
+int MemStore::getattrs(CollectionHandle &c_, const ghobject_t& oid,
+		       map<string,bufferptr>& aset)
+{
+  Collection *c = static_cast<Collection*>(c_.get());
+  dout(10) << __func__ << " " << c->cid << " " << oid << dendl;
+  if (!c->exists)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->xattr_mutex);
+  aset = o->xattr;
+  return 0;
+}
+
+int MemStore::list_collections(vector<coll_t>& ls)
+{
+  dout(10) << __func__ << dendl;
+  RWLock::RLocker l(coll_lock);
+  for (ceph::unordered_map<coll_t,CollectionRef>::iterator p = coll_map.begin();
+       p != coll_map.end();
+       ++p) {
+    ls.push_back(p->first);
+  }
+  return 0;
+}
+
+bool MemStore::collection_exists(const coll_t& cid)
+{
+  dout(10) << __func__ << " " << cid << dendl;
+  RWLock::RLocker l(coll_lock);
+  return coll_map.count(cid);
+}
+
+int MemStore::collection_empty(CollectionHandle& ch, bool *empty)
+{
+  dout(10) << __func__ << " " << ch->cid << dendl;
+  CollectionRef c = static_cast<Collection*>(ch.get());
+  RWLock::RLocker l(c->lock);
+  *empty = c->object_map.empty();
+  return 0;
+}
+
+int MemStore::collection_bits(CollectionHandle& ch)
+{
+  dout(10) << __func__ << " " << ch->cid << dendl;
+  Collection *c = static_cast<Collection*>(ch.get());
+  RWLock::RLocker l(c->lock);
+  return c->bits;
+}
+
+int MemStore::collection_list(CollectionHandle& ch,
+			      const ghobject_t& start,
+			      const ghobject_t& end,
+			      int max,
+			      vector<ghobject_t> *ls, ghobject_t *next)
+{
+  Collection *c = static_cast<Collection*>(ch.get());
+  RWLock::RLocker l(c->lock);
+
+  dout(10) << __func__ << " cid " << ch->cid << " start " << start
+	   << " end " << end << dendl;
+  map<ghobject_t,ObjectRef>::iterator p = c->object_map.lower_bound(start);
+  while (p != c->object_map.end() &&
+	 ls->size() < (unsigned)max &&
+	 p->first < end) {
+    ls->push_back(p->first);
+    ++p;
+  }
+  if (next != NULL) {
+    if (p == c->object_map.end())
+      *next = ghobject_t::get_max();
+    else
+      *next = p->first;
+  }
+  dout(10) << __func__ << " cid " << ch->cid << " got " << ls->size() << dendl;
+  return 0;
+}
+
+int MemStore::omap_get(
+  CollectionHandle& ch,                ///< [in] Collection containing oid
+  const ghobject_t &oid,   ///< [in] Object containing omap
+  bufferlist *header,      ///< [out] omap header
+  map<string, bufferlist> *out /// < [out] Key to value map
+  )
+{
+  dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
+  Collection *c = static_cast<Collection*>(ch.get());
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  *header = o->omap_header;
+  *out = o->omap;
+  return 0;
+}
+
+int MemStore::omap_get_header(
+  CollectionHandle& ch,                ///< [in] Collection containing oid
+  const ghobject_t &oid,   ///< [in] Object containing omap
+  bufferlist *header,      ///< [out] omap header
+  bool allow_eio ///< [in] don't assert on eio
+  )
+{
+  dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
+  Collection *c = static_cast<Collection*>(ch.get());
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  *header = o->omap_header;
+  return 0;
+}
+
+int MemStore::omap_get_keys(
+  CollectionHandle& ch,              ///< [in] Collection containing oid
+  const ghobject_t &oid, ///< [in] Object containing omap
+  set<string> *keys      ///< [out] Keys defined on oid
+  )
+{
+  dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
+  Collection *c = static_cast<Collection*>(ch.get());
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  for (map<string,bufferlist>::iterator p = o->omap.begin();
+       p != o->omap.end();
+       ++p)
+    keys->insert(p->first);
+  return 0;
+}
+
+int MemStore::omap_get_values(
+  CollectionHandle& ch,                    ///< [in] Collection containing oid
+  const ghobject_t &oid,       ///< [in] Object containing omap
+  const set<string> &keys,     ///< [in] Keys to get
+  map<string, bufferlist> *out ///< [out] Returned keys and values
+  )
+{
+  dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
+  Collection *c = static_cast<Collection*>(ch.get());
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  for (set<string>::const_iterator p = keys.begin();
+       p != keys.end();
+       ++p) {
+    map<string,bufferlist>::iterator q = o->omap.find(*p);
+    if (q != o->omap.end())
+      out->insert(*q);
+  }
+  return 0;
+}
+
+int MemStore::omap_check_keys(
+  CollectionHandle& ch,                ///< [in] Collection containing oid
+  const ghobject_t &oid,   ///< [in] Object containing omap
+  const set<string> &keys, ///< [in] Keys to check
+  set<string> *out         ///< [out] Subset of keys defined on oid
+  )
+{
+  dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
+  Collection *c = static_cast<Collection*>(ch.get());
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  for (set<string>::const_iterator p = keys.begin();
+       p != keys.end();
+       ++p) {
+    map<string,bufferlist>::iterator q = o->omap.find(*p);
+    if (q != o->omap.end())
+      out->insert(*p);
+  }
+  return 0;
+}
+
+class MemStore::OmapIteratorImpl : public ObjectMap::ObjectMapIteratorImpl {
+  CollectionRef c;
+  ObjectRef o;
+  map<string,bufferlist>::iterator it;
+public:
+  OmapIteratorImpl(CollectionRef c, ObjectRef o)
+    : c(c), o(o), it(o->omap.begin()) {}
+
+  int seek_to_first() override {
+    std::lock_guard<std::mutex> lock(o->omap_mutex);
+    it = o->omap.begin();
+    return 0;
+  }
+  int upper_bound(const string &after) override {
+    std::lock_guard<std::mutex> lock(o->omap_mutex);
+    it = o->omap.upper_bound(after);
+    return 0;
+  }
+  int lower_bound(const string &to) override {
+    std::lock_guard<std::mutex> lock(o->omap_mutex);
+    it = o->omap.lower_bound(to);
+    return 0;
+  }
+  bool valid() override {
+    std::lock_guard<std::mutex> lock(o->omap_mutex);
+    return it != o->omap.end();
+  }
+  int next(bool validate=true) override {
+    std::lock_guard<std::mutex> lock(o->omap_mutex);
+    ++it;
+    return 0;
+  }
+  string key() override {
+    std::lock_guard<std::mutex> lock(o->omap_mutex);
+    return it->first;
+  }
+  bufferlist value() override {
+    std::lock_guard<std::mutex> lock(o->omap_mutex);
+    return it->second;
+  }
+  int status() override {
+    return 0;
+  }
+};
+
+ObjectMap::ObjectMapIterator MemStore::get_omap_iterator(
+  CollectionHandle& ch,
+  const ghobject_t& oid)
+{
+  dout(10) << __func__ << " " << ch->cid << " " << oid << dendl;
+  Collection *c = static_cast<Collection*>(ch.get());
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return ObjectMap::ObjectMapIterator();
+  return ObjectMap::ObjectMapIterator(new OmapIteratorImpl(c, o));
+}
+
+
+// ---------------
+// write operations
+
+int MemStore::queue_transactions(
+  CollectionHandle& ch,
+  vector<Transaction>& tls,
+  TrackedOpRef op,
+  ThreadPool::TPHandle *handle)
+{
+  // because memstore operations are synchronous, we can implement the
+  // Sequencer with a mutex. this guarantees ordering on a given sequencer,
+  // while allowing operations on different sequencers to happen in parallel
+  Collection *c = static_cast<Collection*>(ch.get());
+  std::unique_lock<std::mutex> lock;
+  lock = std::unique_lock<std::mutex>(c->sequencer_mutex);
+
+  for (vector<Transaction>::iterator p = tls.begin(); p != tls.end(); ++p) {
+    // poke the TPHandle heartbeat just to exercise that code path
+    if (handle)
+      handle->reset_tp_timeout();
+
+    _do_transaction(*p);
+  }
+
+  Context *on_apply = NULL, *on_apply_sync = NULL, *on_commit = NULL;
+  ObjectStore::Transaction::collect_contexts(tls, &on_apply, &on_commit,
+					     &on_apply_sync);
+  if (on_apply_sync)
+    on_apply_sync->complete(0);
+  if (on_apply)
+    finisher.queue(on_apply);
+  if (on_commit)
+    finisher.queue(on_commit);
+  return 0;
+}
+
+void MemStore::_do_transaction(Transaction& t)
+{
+  Transaction::iterator i = t.begin();
+  int pos = 0;
+
+  while (i.have_op()) {
+    Transaction::Op *op = i.decode_op();
+    int r = 0;
+
+    switch (op->op) {
+    case Transaction::OP_NOP:
+      break;
+    case Transaction::OP_TOUCH:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+	r = _touch(cid, oid);
+      }
+      break;
+
+    case Transaction::OP_WRITE:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        uint64_t off = op->off;
+        uint64_t len = op->len;
+	uint32_t fadvise_flags = i.get_fadvise_flags();
+        bufferlist bl;
+        i.decode_bl(bl);
+	r = _write(cid, oid, off, len, bl, fadvise_flags);
+      }
+      break;
+
+    case Transaction::OP_ZERO:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        uint64_t off = op->off;
+        uint64_t len = op->len;
+	r = _zero(cid, oid, off, len);
+      }
+      break;
+
+    case Transaction::OP_TRIMCACHE:
+      {
+        // deprecated, no-op
+      }
+      break;
+
+    case Transaction::OP_TRUNCATE:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        uint64_t off = op->off;
+	r = _truncate(cid, oid, off);
+      }
+      break;
+
+    case Transaction::OP_REMOVE:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+	r = _remove(cid, oid);
+      }
+      break;
+
+    case Transaction::OP_SETATTR:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        string name = i.decode_string();
+        bufferlist bl;
+        i.decode_bl(bl);
+	map<string, bufferptr> to_set;
+	to_set[name] = bufferptr(bl.c_str(), bl.length());
+	r = _setattrs(cid, oid, to_set);
+      }
+      break;
+
+    case Transaction::OP_SETATTRS:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        map<string, bufferptr> aset;
+        i.decode_attrset(aset);
+	r = _setattrs(cid, oid, aset);
+      }
+      break;
+
+    case Transaction::OP_RMATTR:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        string name = i.decode_string();
+	r = _rmattr(cid, oid, name.c_str());
+      }
+      break;
+
+    case Transaction::OP_RMATTRS:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+	r = _rmattrs(cid, oid);
+      }
+      break;
+
+    case Transaction::OP_CLONE:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        ghobject_t noid = i.get_oid(op->dest_oid);
+	r = _clone(cid, oid, noid);
+      }
+      break;
+
+    case Transaction::OP_CLONERANGE:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        ghobject_t noid = i.get_oid(op->dest_oid);
+        uint64_t off = op->off;
+        uint64_t len = op->len;
+	r = _clone_range(cid, oid, noid, off, len, off);
+      }
+      break;
+
+    case Transaction::OP_CLONERANGE2:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        ghobject_t noid = i.get_oid(op->dest_oid);
+        uint64_t srcoff = op->off;
+        uint64_t len = op->len;
+        uint64_t dstoff = op->dest_off;
+	r = _clone_range(cid, oid, noid, srcoff, len, dstoff);
+      }
+      break;
+
+    case Transaction::OP_MKCOLL:
+      {
+        coll_t cid = i.get_cid(op->cid);
+	r = _create_collection(cid, op->split_bits);
+      }
+      break;
+
+    case Transaction::OP_COLL_HINT:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        uint32_t type = op->hint_type;
+        bufferlist hint;
+        i.decode_bl(hint);
+        auto hiter = hint.cbegin();
+        if (type == Transaction::COLL_HINT_EXPECTED_NUM_OBJECTS) {
+          uint32_t pg_num;
+          uint64_t num_objs;
+          decode(pg_num, hiter);
+          decode(num_objs, hiter);
+          r = _collection_hint_expected_num_objs(cid, pg_num, num_objs);
+        } else {
+          // Ignore the hint
+          dout(10) << "Unrecognized collection hint type: " << type << dendl;
+        }
+      }
+      break;
+
+    case Transaction::OP_RMCOLL:
+      {
+        coll_t cid = i.get_cid(op->cid);
+	r = _destroy_collection(cid);
+      }
+      break;
+
+    case Transaction::OP_COLL_ADD:
+      {
+        coll_t ocid = i.get_cid(op->cid);
+        coll_t ncid = i.get_cid(op->dest_cid);
+        ghobject_t oid = i.get_oid(op->oid);
+	r = _collection_add(ncid, ocid, oid);
+      }
+      break;
+
+    case Transaction::OP_COLL_REMOVE:
+       {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+	r = _remove(cid, oid);
+       }
+      break;
+
+    case Transaction::OP_COLL_MOVE:
+      ceph_abort_msg("deprecated");
+      break;
+
+    case Transaction::OP_COLL_MOVE_RENAME:
+      {
+        coll_t oldcid = i.get_cid(op->cid);
+        ghobject_t oldoid = i.get_oid(op->oid);
+        coll_t newcid = i.get_cid(op->dest_cid);
+        ghobject_t newoid = i.get_oid(op->dest_oid);
+	r = _collection_move_rename(oldcid, oldoid, newcid, newoid);
+	if (r == -ENOENT)
+	  r = 0;
+      }
+      break;
+
+    case Transaction::OP_TRY_RENAME:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oldoid = i.get_oid(op->oid);
+        ghobject_t newoid = i.get_oid(op->dest_oid);
+	r = _collection_move_rename(cid, oldoid, cid, newoid);
+	if (r == -ENOENT)
+	  r = 0;
+      }
+      break;
+
+    case Transaction::OP_COLL_SETATTR:
+      {
+	ceph_abort_msg("not implemented");
+      }
+      break;
+
+    case Transaction::OP_COLL_RMATTR:
+      {
+	ceph_abort_msg("not implemented");
+      }
+      break;
+
+    case Transaction::OP_COLL_RENAME:
+      {
+	ceph_abort_msg("not implemented");
+      }
+      break;
+
+    case Transaction::OP_OMAP_CLEAR:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+	r = _omap_clear(cid, oid);
+      }
+      break;
+    case Transaction::OP_OMAP_SETKEYS:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        bufferlist aset_bl;
+        i.decode_attrset_bl(&aset_bl);
+	r = _omap_setkeys(cid, oid, aset_bl);
+      }
+      break;
+    case Transaction::OP_OMAP_RMKEYS:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        bufferlist keys_bl;
+        i.decode_keyset_bl(&keys_bl);
+	r = _omap_rmkeys(cid, oid, keys_bl);
+      }
+      break;
+    case Transaction::OP_OMAP_RMKEYRANGE:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        string first, last;
+        first = i.decode_string();
+        last = i.decode_string();
+	r = _omap_rmkeyrange(cid, oid, first, last);
+      }
+      break;
+    case Transaction::OP_OMAP_SETHEADER:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        ghobject_t oid = i.get_oid(op->oid);
+        bufferlist bl;
+        i.decode_bl(bl);
+	r = _omap_setheader(cid, oid, bl);
+      }
+      break;
+    case Transaction::OP_SPLIT_COLLECTION:
+      ceph_abort_msg("deprecated");
+      break;
+    case Transaction::OP_SPLIT_COLLECTION2:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        uint32_t bits = op->split_bits;
+        uint32_t rem = op->split_rem;
+        coll_t dest = i.get_cid(op->dest_cid);
+	r = _split_collection(cid, bits, rem, dest);
+      }
+      break;
+    case Transaction::OP_MERGE_COLLECTION:
+      {
+        coll_t cid = i.get_cid(op->cid);
+        uint32_t bits = op->split_bits;
+        coll_t dest = i.get_cid(op->dest_cid);
+	r = _merge_collection(cid, bits, dest);
+      }
+      break;
+
+    case Transaction::OP_SETALLOCHINT:
+      {
+        r = 0;
+      }
+      break;
+
+    default:
+      derr << "bad op " << op->op << dendl;
+      ceph_abort();
+    }
+
+    if (r < 0) {
+      bool ok = false;
+
+      if (r == -ENOENT && !(op->op == Transaction::OP_CLONERANGE ||
+			    op->op == Transaction::OP_CLONE ||
+			    op->op == Transaction::OP_CLONERANGE2 ||
+			    op->op == Transaction::OP_COLL_ADD))
+	// -ENOENT is usually okay
+	ok = true;
+      if (r == -ENODATA)
+	ok = true;
+
+      if (!ok) {
+	const char *msg = "unexpected error code";
+
+	if (r == -ENOENT && (op->op == Transaction::OP_CLONERANGE ||
+			     op->op == Transaction::OP_CLONE ||
+			     op->op == Transaction::OP_CLONERANGE2))
+	  msg = "ENOENT on clone suggests osd bug";
+
+	if (r == -ENOSPC)
+	  // For now, if we hit _any_ ENOSPC, crash, before we do any damage
+	  // by partially applying transactions.
+	  msg = "ENOSPC from MemStore, misconfigured cluster or insufficient memory";
+
+	if (r == -ENOTEMPTY) {
+	  msg = "ENOTEMPTY suggests garbage data in osd data dir";
+	  dump_all();
+	}
+
+	derr    << " error " << cpp_strerror(r) << " not handled on operation " << op->op
+		<< " (op " << pos << ", counting from 0)" << dendl;
+	dout(0) << msg << dendl;
+	dout(0) << " transaction dump:\n";
+	JSONFormatter f(true);
+	f.open_object_section("transaction");
+	t.dump(&f);
+	f.close_section();
+	f.flush(*_dout);
+	*_dout << dendl;
+	ceph_abort_msg("unexpected error");
+      }
+    }
+
+    ++pos;
+  }
+}
+
+int MemStore::_touch(const coll_t& cid, const ghobject_t& oid)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  c->get_or_create_object(oid);
+  return 0;
+}
+
+int MemStore::_write(const coll_t& cid, const ghobject_t& oid,
+		     uint64_t offset, size_t len, const bufferlist& bl,
+		     uint32_t fadvise_flags)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << " "
+	   << offset << "~" << len << dendl;
+  ceph_assert(len == bl.length());
+
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_or_create_object(oid);
+  if (len > 0) {
+    const ssize_t old_size = o->get_size();
+    o->write(offset, bl);
+    used_bytes += (o->get_size() - old_size);
+  }
+
+  return 0;
+}
+
+int MemStore::_zero(const coll_t& cid, const ghobject_t& oid,
+		    uint64_t offset, size_t len)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << " " << offset << "~"
+	   << len << dendl;
+  bufferlist bl;
+  bl.append_zero(len);
+  return _write(cid, oid, offset, len, bl);
+}
+
+int MemStore::_truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << " " << size << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  const ssize_t old_size = o->get_size();
+  int r = o->truncate(size);
+  used_bytes += (o->get_size() - old_size);
+  return r;
+}
+
+int MemStore::_remove(const coll_t& cid, const ghobject_t& oid)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+  RWLock::WLocker l(c->lock);
+
+  auto i = c->object_hash.find(oid);
+  if (i == c->object_hash.end())
+    return -ENOENT;
+  used_bytes -= i->second->get_size();
+  c->object_hash.erase(i);
+  c->object_map.erase(oid);
+
+  return 0;
+}
+
+int MemStore::_setattrs(const coll_t& cid, const ghobject_t& oid,
+			map<string,bufferptr>& aset)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->xattr_mutex);
+  for (map<string,bufferptr>::const_iterator p = aset.begin(); p != aset.end(); ++p)
+    o->xattr[p->first] = p->second;
+  return 0;
+}
+
+int MemStore::_rmattr(const coll_t& cid, const ghobject_t& oid, const char *name)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << " " << name << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->xattr_mutex);
+  auto i = o->xattr.find(name);
+  if (i == o->xattr.end())
+    return -ENODATA;
+  o->xattr.erase(i);
+  return 0;
+}
+
+int MemStore::_rmattrs(const coll_t& cid, const ghobject_t& oid)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->xattr_mutex);
+  o->xattr.clear();
+  return 0;
+}
+
+int MemStore::_clone(const coll_t& cid, const ghobject_t& oldoid,
+		     const ghobject_t& newoid)
+{
+  dout(10) << __func__ << " " << cid << " " << oldoid
+	   << " -> " << newoid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef oo = c->get_object(oldoid);
+  if (!oo)
+    return -ENOENT;
+  ObjectRef no = c->get_or_create_object(newoid);
+  used_bytes += oo->get_size() - no->get_size();
+  no->clone(oo.get(), 0, oo->get_size(), 0);
+
+  // take xattr and omap locks with std::lock()
+  std::unique_lock<std::mutex>
+      ox_lock(oo->xattr_mutex, std::defer_lock),
+      nx_lock(no->xattr_mutex, std::defer_lock),
+      oo_lock(oo->omap_mutex, std::defer_lock),
+      no_lock(no->omap_mutex, std::defer_lock);
+  std::lock(ox_lock, nx_lock, oo_lock, no_lock);
+
+  no->omap_header = oo->omap_header;
+  no->omap = oo->omap;
+  no->xattr = oo->xattr;
+  return 0;
+}
+
+int MemStore::_clone_range(const coll_t& cid, const ghobject_t& oldoid,
+			   const ghobject_t& newoid,
+			   uint64_t srcoff, uint64_t len, uint64_t dstoff)
+{
+  dout(10) << __func__ << " " << cid << " "
+	   << oldoid << " " << srcoff << "~" << len << " -> "
+	   << newoid << " " << dstoff << "~" << len
+	   << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef oo = c->get_object(oldoid);
+  if (!oo)
+    return -ENOENT;
+  ObjectRef no = c->get_or_create_object(newoid);
+  if (srcoff >= oo->get_size())
+    return 0;
+  if (srcoff + len >= oo->get_size())
+    len = oo->get_size() - srcoff;
+
+  const ssize_t old_size = no->get_size();
+  no->clone(oo.get(), srcoff, len, dstoff);
+  used_bytes += (no->get_size() - old_size);
+
+  return len;
+}
+
+int MemStore::_omap_clear(const coll_t& cid, const ghobject_t &oid)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  o->omap.clear();
+  o->omap_header.clear();
+  return 0;
+}
+
+int MemStore::_omap_setkeys(const coll_t& cid, const ghobject_t &oid,
+			    bufferlist& aset_bl)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  auto p = aset_bl.cbegin();
+  __u32 num;
+  decode(num, p);
+  while (num--) {
+    string key;
+    decode(key, p);
+    decode(o->omap[key], p);
+  }
+  return 0;
+}
+
+int MemStore::_omap_rmkeys(const coll_t& cid, const ghobject_t &oid,
+			   bufferlist& keys_bl)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  auto p = keys_bl.cbegin();
+  __u32 num;
+  decode(num, p);
+  while (num--) {
+    string key;
+    decode(key, p);
+    o->omap.erase(key);
+  }
+  return 0;
+}
+
+int MemStore::_omap_rmkeyrange(const coll_t& cid, const ghobject_t &oid,
+			       const string& first, const string& last)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << " " << first
+	   << " " << last << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  map<string,bufferlist>::iterator p = o->omap.lower_bound(first);
+  map<string,bufferlist>::iterator e = o->omap.lower_bound(last);
+  o->omap.erase(p, e);
+  return 0;
+}
+
+int MemStore::_omap_setheader(const coll_t& cid, const ghobject_t &oid,
+			      const bufferlist &bl)
+{
+  dout(10) << __func__ << " " << cid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+
+  ObjectRef o = c->get_object(oid);
+  if (!o)
+    return -ENOENT;
+  std::lock_guard<std::mutex> lock(o->omap_mutex);
+  o->omap_header = bl;
+  return 0;
+}
+
+int MemStore::_create_collection(const coll_t& cid, int bits)
+{
+  dout(10) << __func__ << " " << cid << dendl;
+  RWLock::WLocker l(coll_lock);
+  auto result = coll_map.insert(std::make_pair(cid, CollectionRef()));
+  if (!result.second)
+    return -EEXIST;
+  auto p = new_coll_map.find(cid);
+  ceph_assert(p != new_coll_map.end());
+  result.first->second = p->second;
+  result.first->second->bits = bits;
+  new_coll_map.erase(p);
+  return 0;
+}
+
+int MemStore::_destroy_collection(const coll_t& cid)
+{
+  dout(10) << __func__ << " " << cid << dendl;
+  RWLock::WLocker l(coll_lock);
+  ceph::unordered_map<coll_t,CollectionRef>::iterator cp = coll_map.find(cid);
+  if (cp == coll_map.end())
+    return -ENOENT;
+  {
+    RWLock::RLocker l2(cp->second->lock);
+    if (!cp->second->object_map.empty())
+      return -ENOTEMPTY;
+    cp->second->exists = false;
+  }
+  used_bytes -= cp->second->used_bytes();
+  coll_map.erase(cp);
+  return 0;
+}
+
+int MemStore::_collection_add(const coll_t& cid, const coll_t& ocid, const ghobject_t& oid)
+{
+  dout(10) << __func__ << " " << cid << " " << ocid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+  CollectionRef oc = get_collection(ocid);
+  if (!oc)
+    return -ENOENT;
+  RWLock::WLocker l1(std::min(&(*c), &(*oc))->lock);
+  RWLock::WLocker l2(std::max(&(*c), &(*oc))->lock);
+
+  if (c->object_hash.count(oid))
+    return -EEXIST;
+  if (oc->object_hash.count(oid) == 0)
+    return -ENOENT;
+  ObjectRef o = oc->object_hash[oid];
+  c->object_map[oid] = o;
+  c->object_hash[oid] = o;
+  return 0;
+}
+
+int MemStore::_collection_move_rename(const coll_t& oldcid, const ghobject_t& oldoid,
+				      coll_t cid, const ghobject_t& oid)
+{
+  dout(10) << __func__ << " " << oldcid << " " << oldoid << " -> "
+	   << cid << " " << oid << dendl;
+  CollectionRef c = get_collection(cid);
+  if (!c)
+    return -ENOENT;
+  CollectionRef oc = get_collection(oldcid);
+  if (!oc)
+    return -ENOENT;
+
+  // note: c and oc may be the same
+  ceph_assert(&(*c) == &(*oc));
+  c->lock.get_write();
+
+  int r = -EEXIST;
+  if (c->object_hash.count(oid))
+    goto out;
+  r = -ENOENT;
+  if (oc->object_hash.count(oldoid) == 0)
+    goto out;
+  {
+    ObjectRef o = oc->object_hash[oldoid];
+    c->object_map[oid] = o;
+    c->object_hash[oid] = o;
+    oc->object_map.erase(oldoid);
+    oc->object_hash.erase(oldoid);
+  }
+  r = 0;
+ out:
+  c->lock.put_write();
+  return r;
+}
+
+int MemStore::_split_collection(const coll_t& cid, uint32_t bits, uint32_t match,
+				coll_t dest)
+{
+  dout(10) << __func__ << " " << cid << " " << bits << " " << match << " "
+	   << dest << dendl;
+  CollectionRef sc = get_collection(cid);
+  if (!sc)
+    return -ENOENT;
+  CollectionRef dc = get_collection(dest);
+  if (!dc)
+    return -ENOENT;
+  RWLock::WLocker l1(std::min(&(*sc), &(*dc))->lock);
+  RWLock::WLocker l2(std::max(&(*sc), &(*dc))->lock);
+
+  map<ghobject_t,ObjectRef>::iterator p = sc->object_map.begin();
+  while (p != sc->object_map.end()) {
+    if (p->first.match(bits, match)) {
+      dout(20) << " moving " << p->first << dendl;
+      dc->object_map.insert(make_pair(p->first, p->second));
+      dc->object_hash.insert(make_pair(p->first, p->second));
+      sc->object_hash.erase(p->first);
+      sc->object_map.erase(p++);
+    } else {
+      ++p;
+    }
+  }
+
+  sc->bits = bits;
+  ceph_assert(dc->bits == (int)bits);
+
+  return 0;
+}
+
+int MemStore::_merge_collection(const coll_t& cid, uint32_t bits, coll_t dest)
+{
+  dout(10) << __func__ << " " << cid << " " << bits << " "
+	   << dest << dendl;
+  CollectionRef sc = get_collection(cid);
+  if (!sc)
+    return -ENOENT;
+  CollectionRef dc = get_collection(dest);
+  if (!dc)
+    return -ENOENT;
+  {
+    RWLock::WLocker l1(std::min(&(*sc), &(*dc))->lock);
+    RWLock::WLocker l2(std::max(&(*sc), &(*dc))->lock);
+
+    map<ghobject_t,ObjectRef>::iterator p = sc->object_map.begin();
+    while (p != sc->object_map.end()) {
+      dout(20) << " moving " << p->first << dendl;
+      dc->object_map.insert(make_pair(p->first, p->second));
+      dc->object_hash.insert(make_pair(p->first, p->second));
+      sc->object_hash.erase(p->first);
+      sc->object_map.erase(p++);
+    }
+
+    dc->bits = bits;
+  }
+
+  {
+    RWLock::WLocker l(coll_lock);
+    ceph::unordered_map<coll_t,CollectionRef>::iterator cp = coll_map.find(cid);
+    ceph_assert(cp != coll_map.end());
+    used_bytes -= cp->second->used_bytes();
+    coll_map.erase(cp);
+  }
+
+  return 0;
+}
+
+namespace {
+struct BufferlistObject : public MemStore::Object {
+  ceph::spinlock mutex;
+  bufferlist data;
+
+  size_t get_size() const override { return data.length(); }
+
+  int read(uint64_t offset, uint64_t len, bufferlist &bl) override;
+  int write(uint64_t offset, const bufferlist &bl) override;
+  int clone(Object *src, uint64_t srcoff, uint64_t len,
+            uint64_t dstoff) override;
+  int truncate(uint64_t offset) override;
+
+  void encode(bufferlist& bl) const override {
+    ENCODE_START(1, 1, bl);
+    encode(data, bl);
+    encode_base(bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator& p) override {
+    DECODE_START(1, p);
+    decode(data, p);
+    decode_base(p);
+    DECODE_FINISH(p);
+  }
+};
+}
+// BufferlistObject
+int BufferlistObject::read(uint64_t offset, uint64_t len,
+                                     bufferlist &bl)
+{
+  std::lock_guard<decltype(mutex)> lock(mutex);
+  bl.substr_of(data, offset, len);
+  return bl.length();
+}
+
+int BufferlistObject::write(uint64_t offset, const bufferlist &src)
+{
+  unsigned len = src.length();
+
+  std::lock_guard<decltype(mutex)> lock(mutex);
+
+  // before
+  bufferlist newdata;
+  if (get_size() >= offset) {
+    newdata.substr_of(data, 0, offset);
+  } else {
+    if (get_size()) {
+      newdata.substr_of(data, 0, get_size());
+    }
+    newdata.append_zero(offset - get_size());
+  }
+
+  newdata.append(src);
+
+  // after
+  if (get_size() > offset + len) {
+    bufferlist tail;
+    tail.substr_of(data, offset + len, get_size() - (offset + len));
+    newdata.append(tail);
+  }
+
+  data.claim(newdata);
+  return 0;
+}
+
+int BufferlistObject::clone(Object *src, uint64_t srcoff,
+                                      uint64_t len, uint64_t dstoff)
+{
+  auto srcbl = dynamic_cast<BufferlistObject*>(src);
+  if (srcbl == nullptr)
+    return -ENOTSUP;
+
+  bufferlist bl;
+  {
+    std::lock_guard<decltype(srcbl->mutex)> lock(srcbl->mutex);
+    if (srcoff == dstoff && len == src->get_size()) {
+      data = srcbl->data;
+      return 0;
+    }
+    bl.substr_of(srcbl->data, srcoff, len);
+  }
+  return write(dstoff, bl);
+}
+
+int BufferlistObject::truncate(uint64_t size)
+{
+  std::lock_guard<decltype(mutex)> lock(mutex);
+  if (get_size() > size) {
+    bufferlist bl;
+    bl.substr_of(data, 0, size);
+    data.claim(bl);
+  } else if (get_size() == size) {
+    // do nothing
+  } else {
+    data.append_zero(size - get_size());
+  }
+  return 0;
+}
+
+// PageSetObject
+
+struct MemStore::PageSetObject : public Object {
+  PageSet data;
+  uint64_t data_len;
+#if defined(__GLIBCXX__)
+  // use a thread-local vector for the pages returned by PageSet, so we
+  // can avoid allocations in read/write()
+  static thread_local PageSet::page_vector tls_pages;
+#endif
+
+  explicit PageSetObject(size_t page_size) : data(page_size), data_len(0) {}
+
+  size_t get_size() const override { return data_len; }
+
+  int read(uint64_t offset, uint64_t len, bufferlist &bl) override;
+  int write(uint64_t offset, const bufferlist &bl) override;
+  int clone(Object *src, uint64_t srcoff, uint64_t len,
+            uint64_t dstoff) override;
+  int truncate(uint64_t offset) override;
+
+  void encode(bufferlist& bl) const override {
+    ENCODE_START(1, 1, bl);
+    encode(data_len, bl);
+    data.encode(bl);
+    encode_base(bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator& p) override {
+    DECODE_START(1, p);
+    decode(data_len, p);
+    data.decode(p);
+    decode_base(p);
+    DECODE_FINISH(p);
+  }
+};
+
+#if defined(__GLIBCXX__)
+// use a thread-local vector for the pages returned by PageSet, so we
+// can avoid allocations in read/write()
+thread_local PageSet::page_vector MemStore::PageSetObject::tls_pages;
+#define DEFINE_PAGE_VECTOR(name)
+#else
+#define DEFINE_PAGE_VECTOR(name) PageSet::page_vector name;
+#endif
+
+int MemStore::PageSetObject::read(uint64_t offset, uint64_t len, bufferlist& bl)
+{
+  const auto start = offset;
+  const auto end = offset + len;
+  auto remaining = len;
+
+  DEFINE_PAGE_VECTOR(tls_pages);
+  data.get_range(offset, len, tls_pages);
+
+  // allocate a buffer for the data
+  buffer::ptr buf(len);
+
+  auto p = tls_pages.begin();
+  while (remaining) {
+    // no more pages in range
+    if (p == tls_pages.end() || (*p)->offset >= end) {
+      buf.zero(offset - start, remaining);
+      break;
+    }
+    auto page = *p;
+
+    // fill any holes between pages with zeroes
+    if (page->offset > offset) {
+      const auto count = std::min(remaining, page->offset - offset);
+      buf.zero(offset - start, count);
+      remaining -= count;
+      offset = page->offset;
+      if (!remaining)
+        break;
+    }
+
+    // read from page
+    const auto page_offset = offset - page->offset;
+    const auto count = min(remaining, data.get_page_size() - page_offset);
+
+    buf.copy_in(offset - start, count, page->data + page_offset);
+
+    remaining -= count;
+    offset += count;
+
+    ++p;
+  }
+
+  tls_pages.clear(); // drop page refs
+
+  bl.append(std::move(buf));
+  return len;
+}
+
+int MemStore::PageSetObject::write(uint64_t offset, const bufferlist &src)
+{
+  unsigned len = src.length();
+
+  DEFINE_PAGE_VECTOR(tls_pages);
+  // make sure the page range is allocated
+  data.alloc_range(offset, src.length(), tls_pages);
+
+  auto page = tls_pages.begin();
+
+  auto p = src.begin();
+  while (len > 0) {
+    unsigned page_offset = offset - (*page)->offset;
+    unsigned pageoff = data.get_page_size() - page_offset;
+    unsigned count = min(len, pageoff);
+    p.copy(count, (*page)->data + page_offset);
+    offset += count;
+    len -= count;
+    if (count == pageoff)
+      ++page;
+  }
+  if (data_len < offset)
+    data_len = offset;
+  tls_pages.clear(); // drop page refs
+  return 0;
+}
+
+int MemStore::PageSetObject::clone(Object *src, uint64_t srcoff,
+                                   uint64_t len, uint64_t dstoff)
+{
+  const int64_t delta = dstoff - srcoff;
+
+  auto &src_data = static_cast<PageSetObject*>(src)->data;
+  const uint64_t src_page_size = src_data.get_page_size();
+
+  auto &dst_data = data;
+  const auto dst_page_size = dst_data.get_page_size();
+
+  DEFINE_PAGE_VECTOR(tls_pages);
+  PageSet::page_vector dst_pages;
+
+  while (len) {
+    // limit to 16 pages at a time so tls_pages doesn't balloon in size
+    auto count = std::min(len, (uint64_t)src_page_size * 16);
+    src_data.get_range(srcoff, count, tls_pages);
+
+    // allocate the destination range
+    // TODO: avoid allocating pages for holes in the source range
+    dst_data.alloc_range(srcoff + delta, count, dst_pages);
+    auto dst_iter = dst_pages.begin();
+
+    for (auto &src_page : tls_pages) {
+      auto sbegin = std::max(srcoff, src_page->offset);
+      auto send = std::min(srcoff + count, src_page->offset + src_page_size);
+
+      // zero-fill holes before src_page
+      if (srcoff < sbegin) {
+        while (dst_iter != dst_pages.end()) {
+          auto &dst_page = *dst_iter;
+          auto dbegin = std::max(srcoff + delta, dst_page->offset);
+          auto dend = std::min(sbegin + delta, dst_page->offset + dst_page_size);
+          std::fill(dst_page->data + dbegin - dst_page->offset,
+                    dst_page->data + dend - dst_page->offset, 0);
+          if (dend < dst_page->offset + dst_page_size)
+            break;
+          ++dst_iter;
+        }
+        const auto c = sbegin - srcoff;
+        count -= c;
+        len -= c;
+      }
+
+      // copy data from src page to dst pages
+      while (dst_iter != dst_pages.end()) {
+        auto &dst_page = *dst_iter;
+        auto dbegin = std::max(sbegin + delta, dst_page->offset);
+        auto dend = std::min(send + delta, dst_page->offset + dst_page_size);
+
+        std::copy(src_page->data + (dbegin - delta) - src_page->offset,
+                  src_page->data + (dend - delta) - src_page->offset,
+                  dst_page->data + dbegin - dst_page->offset);
+        if (dend < dst_page->offset + dst_page_size)
+          break;
+        ++dst_iter;
+      }
+
+      const auto c = send - sbegin;
+      count -= c;
+      len -= c;
+      srcoff = send;
+      dstoff = send + delta;
+    }
+    tls_pages.clear(); // drop page refs
+
+    // zero-fill holes after the last src_page
+    if (count > 0) {
+      while (dst_iter != dst_pages.end()) {
+        auto &dst_page = *dst_iter;
+        auto dbegin = std::max(dstoff, dst_page->offset);
+        auto dend = std::min(dstoff + count, dst_page->offset + dst_page_size);
+        std::fill(dst_page->data + dbegin - dst_page->offset,
+                  dst_page->data + dend - dst_page->offset, 0);
+        ++dst_iter;
+      }
+      srcoff += count;
+      dstoff += count;
+      len -= count;
+    }
+    dst_pages.clear(); // drop page refs
+  }
+
+  // update object size
+  if (data_len < dstoff)
+    data_len = dstoff;
+  return 0;
+}
+
+int MemStore::PageSetObject::truncate(uint64_t size)
+{
+  data.free_pages_after(size);
+  data_len = size;
+
+  const auto page_size = data.get_page_size();
+  const auto page_offset = size & ~(page_size-1);
+  if (page_offset == size)
+    return 0;
+
+  DEFINE_PAGE_VECTOR(tls_pages);
+  // write zeroes to the rest of the last page
+  data.get_range(page_offset, page_size, tls_pages);
+  if (tls_pages.empty())
+    return 0;
+
+  auto page = tls_pages.begin();
+  auto data = (*page)->data;
+  std::fill(data + (size - page_offset), data + page_size, 0);
+  tls_pages.clear(); // drop page ref
+  return 0;
+}
+
+
+MemStore::ObjectRef MemStore::Collection::create_object() const {
+  if (use_page_set)
+    return new PageSetObject(scct->get_cobs()->get_page_size());
+  return new BufferlistObject();
+}

--- a/src/crimson/os/memstore/MemStore.h
+++ b/src/crimson/os/memstore/MemStore.h
@@ -1,0 +1,412 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2013- Sage Weil <sage@inktank.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+
+#ifndef CEPH_MEMSTORE_H
+#define CEPH_MEMSTORE_H
+
+#include <mutex>
+#include <boost/intrusive_ptr.hpp>
+
+#include "include/unordered_map.h"
+#include "crimson/os/Finisher.h"
+#include "common/RefCountedObj.h"
+#include "common/RWLock.h"
+#include "os/ObjectStore.h"
+#include "os/memstore/PageSet.h"
+#include "include/ceph_assert.h"
+#include "crimson/os/ConfigObs.h"
+#include "crimson/os/store_context.h"
+
+class MemStore : public ObjectStore {
+public:
+  struct Object : public RefCountedObject {
+    std::mutex xattr_mutex;
+    std::mutex omap_mutex;
+    map<string,bufferptr> xattr;
+    bufferlist omap_header;
+    map<string,bufferlist> omap;
+    typedef boost::intrusive_ptr<Object> Ref;
+    friend void intrusive_ptr_add_ref(Object *o) { o->get(); }
+    friend void intrusive_ptr_release(Object *o) { o->put(); }
+
+    Object() : RefCountedObject(nullptr, 0) {}
+    // interface for object data
+    virtual size_t get_size() const = 0;
+    virtual int read(uint64_t offset, uint64_t len, bufferlist &bl) = 0;
+    virtual int write(uint64_t offset, const bufferlist &bl) = 0;
+    virtual int clone(Object *src, uint64_t srcoff, uint64_t len,
+                      uint64_t dstoff) = 0;
+    virtual int truncate(uint64_t offset) = 0;
+    virtual void encode(bufferlist& bl) const = 0;
+    virtual void decode(bufferlist::const_iterator& p) = 0;
+
+    void encode_base(bufferlist& bl) const {
+      using ceph::encode;
+      encode(xattr, bl);
+      encode(omap_header, bl);
+      encode(omap, bl);
+    }
+    void decode_base(bufferlist::const_iterator& p) {
+      using ceph::decode;
+      decode(xattr, p);
+      decode(omap_header, p);
+      decode(omap, p);
+    }
+
+    void dump(Formatter *f) const {
+      f->dump_int("data_len", get_size());
+      f->dump_int("omap_header_len", omap_header.length());
+
+      f->open_array_section("xattrs");
+      for (map<string,bufferptr>::const_iterator p = xattr.begin();
+	   p != xattr.end();
+	   ++p) {
+	f->open_object_section("xattr");
+	f->dump_string("name", p->first);
+	f->dump_int("length", p->second.length());
+	f->close_section();
+      }
+      f->close_section();
+
+      f->open_array_section("omap");
+      for (map<string,bufferlist>::const_iterator p = omap.begin();
+	   p != omap.end();
+	   ++p) {
+	f->open_object_section("pair");
+	f->dump_string("key", p->first);
+	f->dump_int("length", p->second.length());
+	f->close_section();
+      }
+      f->close_section();
+    }
+  };
+  typedef Object::Ref ObjectRef;
+  StoreContext *scct;
+
+  struct PageSetObject;
+  struct Collection : public CollectionImpl {
+    int bits = 0;
+    StoreContext *scct;
+    bool use_page_set;
+    ceph::unordered_map<ghobject_t, ObjectRef> object_hash;  ///< for lookup
+    map<ghobject_t, ObjectRef> object_map;        ///< for iteration
+    map<string,bufferptr> xattr;
+    RWLock lock;   ///< for object_{map,hash}
+    bool exists;
+    std::mutex sequencer_mutex;
+
+    typedef boost::intrusive_ptr<Collection> Ref;
+    friend void intrusive_ptr_add_ref(Collection *c) { c->get(); }
+    friend void intrusive_ptr_release(Collection *c) { c->put(); }
+
+    ObjectRef create_object() const;
+
+    // NOTE: The lock only needs to protect the object_map/hash, not the
+    // contents of individual objects.  The osd is already sequencing
+    // reads and writes, so we will never see them concurrently at this
+    // level.
+
+    ObjectRef get_object(ghobject_t oid) {
+      RWLock::RLocker l(lock);
+      auto o = object_hash.find(oid);
+      if (o == object_hash.end())
+	return ObjectRef();
+      return o->second;
+    }
+
+    ObjectRef get_or_create_object(ghobject_t oid) {
+      RWLock::WLocker l(lock);
+      auto result = object_hash.emplace(oid, ObjectRef());
+      if (result.second)
+        object_map[oid] = result.first->second = create_object();
+      return result.first->second;
+    }
+
+    void encode(bufferlist& bl) const {
+      ENCODE_START(1, 1, bl);
+      encode(xattr, bl);
+      encode(use_page_set, bl);
+      uint32_t s = object_map.size();
+      encode(s, bl);
+      for (map<ghobject_t, ObjectRef>::const_iterator p = object_map.begin();
+	   p != object_map.end();
+	   ++p) {
+	encode(p->first, bl);
+	p->second->encode(bl);
+      }
+      ENCODE_FINISH(bl);
+    }
+    void decode(bufferlist::const_iterator& p) {
+      DECODE_START(1, p);
+      decode(xattr, p);
+      decode(use_page_set, p);
+      uint32_t s;
+      decode(s, p);
+      while (s--) {
+	ghobject_t k;
+	decode(k, p);
+	auto o = create_object();
+	o->decode(p);
+	object_map.insert(make_pair(k, o));
+	object_hash.insert(make_pair(k, o));
+      }
+      DECODE_FINISH(p);
+    }
+
+    uint64_t used_bytes() const {
+      uint64_t result = 0;
+      for (map<ghobject_t, ObjectRef>::const_iterator p = object_map.begin();
+	   p != object_map.end();
+	   ++p) {
+        result += p->second->get_size();
+      }
+
+      return result;
+    }
+
+    void flush() override {
+    }
+    bool flush_commit(Context *c) override {
+      return true;
+    }
+
+    explicit Collection(StoreContext *scct, coll_t c)
+      : CollectionImpl(c),
+	scct(scct),
+	use_page_set(scct->get_cobs()->get_page_set()),
+        lock("MemStore::Collection::lock", true, false),
+	exists(true) {}
+  };
+  typedef Collection::Ref CollectionRef;
+
+private:
+  class OmapIteratorImpl;
+
+
+  ceph::unordered_map<coll_t, CollectionRef> coll_map;
+  RWLock coll_lock;    ///< rwlock to protect coll_map
+  map<coll_t,CollectionRef> new_coll_map;
+
+  CollectionRef get_collection(const coll_t& cid);
+
+  Finisher finisher;
+
+  uint64_t used_bytes;
+
+  void _do_transaction(Transaction& t);
+
+  int _touch(const coll_t& cid, const ghobject_t& oid);
+  int _write(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len,
+	      const bufferlist& bl, uint32_t fadvise_flags = 0);
+  int _zero(const coll_t& cid, const ghobject_t& oid, uint64_t offset, size_t len);
+  int _truncate(const coll_t& cid, const ghobject_t& oid, uint64_t size);
+  int _remove(const coll_t& cid, const ghobject_t& oid);
+  int _setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& aset);
+  int _rmattr(const coll_t& cid, const ghobject_t& oid, const char *name);
+  int _rmattrs(const coll_t& cid, const ghobject_t& oid);
+  int _clone(const coll_t& cid, const ghobject_t& oldoid, const ghobject_t& newoid);
+  int _clone_range(const coll_t& cid, const ghobject_t& oldoid,
+		   const ghobject_t& newoid,
+		   uint64_t srcoff, uint64_t len, uint64_t dstoff);
+  int _omap_clear(const coll_t& cid, const ghobject_t &oid);
+  int _omap_setkeys(const coll_t& cid, const ghobject_t &oid, bufferlist& aset_bl);
+  int _omap_rmkeys(const coll_t& cid, const ghobject_t &oid, bufferlist& keys_bl);
+  int _omap_rmkeyrange(const coll_t& cid, const ghobject_t &oid,
+		       const string& first, const string& last);
+  int _omap_setheader(const coll_t& cid, const ghobject_t &oid, const bufferlist &bl);
+
+  int _collection_hint_expected_num_objs(const coll_t& cid, uint32_t pg_num,
+      uint64_t num_objs) const { return 0; }
+  int _create_collection(const coll_t& c, int bits);
+  int _destroy_collection(const coll_t& c);
+  int _collection_add(const coll_t& cid, const coll_t& ocid, const ghobject_t& oid);
+  int _collection_move_rename(const coll_t& oldcid, const ghobject_t& oldoid,
+			      coll_t cid, const ghobject_t& o);
+  int _split_collection(const coll_t& cid, uint32_t bits, uint32_t rem, coll_t dest);
+  int _merge_collection(const coll_t& cid, uint32_t bits, coll_t dest);
+
+  int _save();
+  int _load();
+
+  void dump(Formatter *f);
+  void dump_all();
+
+public:
+  MemStore(StoreContext *scct, const string& path)
+    : ObjectStore(NULL, path),
+      scct(scct),
+      coll_lock("MemStore::coll_lock"),
+      finisher(scct),
+      used_bytes(0) {}
+  ~MemStore() override {} 
+
+  string get_type() override {
+    return "memstore";
+  }
+
+  bool test_mount_in_use() override {
+    return false;
+  }
+
+  int mount() override;
+  int umount() override;
+
+  int fsck(bool deep) override {
+    return 0;
+  }
+
+  int validate_hobject_key(const hobject_t &obj) const override {
+    return 0;
+  }
+  unsigned get_max_attr_name_length() override {
+    return 256;  // arbitrary; there is no real limit internally
+  }
+
+  int mkfs() override;
+  int mkjournal() override {
+    return 0;
+  }
+  bool wants_journal() override {
+    return false;
+  }
+  bool allows_journal() override {
+    return false;
+  }
+  bool needs_journal() override {
+    return false;
+  }
+
+  int get_devices(set<string> *ls) override {
+    // no devices for us!
+    return 0;
+  }
+
+  int statfs(struct store_statfs_t *buf) override;
+
+  bool exists(CollectionHandle &c, const ghobject_t& oid) override;
+  int stat(CollectionHandle &c, const ghobject_t& oid,
+	   struct stat *st, bool allow_eio = false) override;
+  int set_collection_opts(
+    CollectionHandle& c,
+    const pool_opts_t& opts) override;
+  int read(
+    CollectionHandle &c,
+    const ghobject_t& oid,
+    uint64_t offset,
+    size_t len,
+    bufferlist& bl,
+    uint32_t op_flags = 0) override;
+  using ObjectStore::fiemap;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid,
+	     uint64_t offset, size_t len, bufferlist& bl) override;
+  int fiemap(CollectionHandle& c, const ghobject_t& oid, uint64_t offset,
+	     size_t len, map<uint64_t, uint64_t>& destmap) override;
+  int getattr(CollectionHandle &c, const ghobject_t& oid, const char *name,
+	      bufferptr& value) override;
+  int getattrs(CollectionHandle &c, const ghobject_t& oid,
+	       map<string,bufferptr>& aset) override;
+
+  int list_collections(vector<coll_t>& ls) override;
+
+  CollectionHandle open_collection(const coll_t& c) override {
+    return get_collection(c);
+  }
+  CollectionHandle create_new_collection(const coll_t& c) override;
+
+  void set_collection_commit_queue(const coll_t& cid,
+				   ContextQueue *commit_queue) override {
+  }
+
+  bool collection_exists(const coll_t& c) override;
+  int collection_empty(CollectionHandle& c, bool *empty) override;
+  int collection_bits(CollectionHandle& c) override;
+  int collection_list(CollectionHandle& cid,
+		      const ghobject_t& start, const ghobject_t& end, int max,
+		      vector<ghobject_t> *ls, ghobject_t *next) override;
+
+  using ObjectStore::omap_get;
+  int omap_get(
+    CollectionHandle& c,                ///< [in] Collection containing oid
+    const ghobject_t &oid,   ///< [in] Object containing omap
+    bufferlist *header,      ///< [out] omap header
+    map<string, bufferlist> *out /// < [out] Key to value map
+    ) override;
+
+  using ObjectStore::omap_get_header;
+  /// Get omap header
+  int omap_get_header(
+    CollectionHandle& c,                ///< [in] Collection containing oid
+    const ghobject_t &oid,   ///< [in] Object containing omap
+    bufferlist *header,      ///< [out] omap header
+    bool allow_eio = false ///< [in] don't assert on eio
+    ) override;
+
+  using ObjectStore::omap_get_keys;
+  /// Get keys defined on oid
+  int omap_get_keys(
+    CollectionHandle& c,              ///< [in] Collection containing oid
+    const ghobject_t &oid, ///< [in] Object containing omap
+    set<string> *keys      ///< [out] Keys defined on oid
+    ) override;
+
+  using ObjectStore::omap_get_values;
+  /// Get key values
+  int omap_get_values(
+    CollectionHandle& c,                    ///< [in] Collection containing oid
+    const ghobject_t &oid,       ///< [in] Object containing omap
+    const set<string> &keys,     ///< [in] Keys to get
+    map<string, bufferlist> *out ///< [out] Returned keys and values
+    ) override;
+
+  using ObjectStore::omap_check_keys;
+  /// Filters keys into out which are defined on oid
+  int omap_check_keys(
+    CollectionHandle& c,                ///< [in] Collection containing oid
+    const ghobject_t &oid,   ///< [in] Object containing omap
+    const set<string> &keys, ///< [in] Keys to check
+    set<string> *out         ///< [out] Subset of keys defined on oid
+    ) override;
+
+  using ObjectStore::get_omap_iterator;
+  ObjectMap::ObjectMapIterator get_omap_iterator(
+    CollectionHandle& c,              ///< [in] collection
+    const ghobject_t &oid  ///< [in] object
+    ) override;
+
+  void set_fsid(uuid_d u) override;
+  uuid_d get_fsid() override;
+
+  uint64_t estimate_objects_overhead(uint64_t num_objects) override {
+    return 0; //do not care
+  }
+
+  objectstore_perf_stat_t get_cur_stats() override;
+
+  const PerfCounters* get_perf_counters() const override {
+    return nullptr;
+  }
+
+
+  int queue_transactions(
+    CollectionHandle& ch,
+    vector<Transaction>& tls,
+    TrackedOpRef op = TrackedOpRef(),
+    ThreadPool::TPHandle *handle = NULL) override;
+};
+
+
+
+
+#endif

--- a/src/crimson/os/out.h
+++ b/src/crimson/os/out.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <iostream>
+#undef dout
+#undef ldout
+#undef dendl
+#undef derr
+#undef dout_impl
+#define dout_impl(v)                                          \
+  do {                                                                  \
+      std::ostringstream _out;                                          \
+      std::ostream* _dout = &_out;
+#define dendl                              \
+     "";                                        \
+      const std::string _s = _out.str();        \
+      std::ostream & objOstream = std::cout;    \
+      objOstream <<_s.c_str()<<"\n";                 \
+  } while (0)
+#define dout(v)  dout_impl(v) dout_prefix
+#define ldout(cct,v) dout(v)
+#define derr dout(-1)
+

--- a/src/crimson/os/store_context.h
+++ b/src/crimson/os/store_context.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "common/perf_counters_collection.h"
+#include "ConfigObs.h"
+
+class StoreContext {
+  std::unique_ptr<ConfigObs> cobs;
+  std::unique_ptr<PerfCountersCollection> perf_counters_collection;
+public:
+  StoreContext(): cobs(nullptr),perf_counters_collection(nullptr) {
+     cobs = std::unique_ptr<ConfigObs>(new ConfigObs);
+     perf_counters_collection = std::unique_ptr<PerfCountersCollection>(new PerfCountersCollection(nullptr));
+  }
+  ~StoreContext(){
+   if (perf_counters_collection){
+     perf_counters_collection->clear();
+   }
+  }
+  ConfigObs* get_cobs(){ return cobs.get();}
+  PerfCountersCollection* get_perfcounters_collection() {
+    return perf_counters_collection.get();
+  }
+
+};
+

--- a/src/test/crimson/CMakeLists.txt
+++ b/src/test/crimson/CMakeLists.txt
@@ -34,3 +34,8 @@ add_executable(unittest_seastar_perfcounters
 add_ceph_unittest(unittest_seastar_perfcounters)
 target_link_libraries(unittest_seastar_perfcounters crimson)
 
+add_executable(unittest_seastar_memstore
+  test_memstore.cc)
+add_ceph_unittest(unittest_seastar_memstore)
+target_link_libraries(unittest_seastar_memstore crimson crimsonos common)
+

--- a/src/test/crimson/test_memstore.cc
+++ b/src/test/crimson/test_memstore.cc
@@ -1,0 +1,240 @@
+#include <chrono>
+#include <cstring>
+#include <numeric>
+#include <fstream>
+#include <seastar/core/app-template.hh>
+#include <seastar/core/alien.hh>
+#include <seastar/core/sharded.hh>
+#include "crimson/thread/ThreadPool.h"
+#include <gtest/gtest.h>
+#include "include/ceph_assert.h"
+#include "common/errno.h"
+#include "crimson/os/ConfigObs.h"
+#include "crimson/os/memstore/MemStore.h"
+#include "crimson/os/store_context.h"
+
+class C_MEM_OnCommit : public Context {
+  int cpuid;
+public:
+  C_MEM_OnCommit(int id): cpuid(id) {}
+  void finish(int) override {
+    std::cout << "posix thread cpuid is "<<sched_getcpu()<<std::endl;
+    auto fut = seastar::alien::submit_to(cpuid,[this]{
+      std::cout<<"seastar cpuid is "<<cpuid<<" ; return to shard #"<<seastar::engine().cpu_id()<<std::endl;
+      return seastar::make_ready_future<>(); 
+    });
+    fut.wait();
+  }
+};
+
+static seastar::future<> test_config(ConfigObs* cobs)
+{
+  return ceph::common::sharded_conf().start().then([cobs] {
+    return ceph::common::sharded_conf().invoke_on(0, &Config::start);
+  }).then([cobs] {
+    return ceph::common::sharded_conf().invoke_on(0,[cobs](Config& config) {
+      config.add_observer(cobs);
+      return config.set_val(memstore_device_bytes,
+                            "1073741824"); //1_G
+    });
+  }).then([cobs] {
+    return ceph::common::sharded_conf().invoke_on(0,[cobs](Config& config) {
+      return config.set_val(memstore_page_set,"false");
+    });
+  }).then([cobs] {
+    return ceph::common::sharded_conf().invoke_on(0,[cobs](Config& config) {
+      return config.set_val(memstore_page_size,"65536");
+    });
+  });
+}
+
+namespace {
+ghobject_t make_ghobject(const char *oid)
+{
+  return ghobject_t{hobject_t{oid, "", CEPH_NOSNAP, 0, 0, ""}};
+}
+
+} // anonymous namespace
+
+static void rm_r(const string& path)
+{
+  string cmd = string("rm -r ") + path;
+  cout << "==> " << cmd << std::endl;
+  int r = ::system(cmd.c_str());
+  if (r) {
+    if (r == -1) {
+      r = errno;
+      cout << "system() failed to fork() " << cpp_strerror(r)
+           << ", continuing anyway" << std::endl;
+    } else {
+      cout << "failed with exit code " << r
+           << ", continuing anyway" << std::endl;
+    }
+  }
+}
+
+class MemStoreTest{
+  const std::string type;
+  const std::string data_dir;
+public:
+  std::unique_ptr<MemStore> store;
+  ObjectStore::CollectionHandle ch;
+  const coll_t cid;
+  StoreContext* scct;
+
+public:
+  explicit MemStoreTest(const std::string& type)
+    : type(type), data_dir(type + ".test_temp_dir")
+  { 
+    scct = new StoreContext();
+  }
+  ~MemStoreTest(){
+    if (scct)
+      delete scct;
+  }
+  void SetUp () {
+    ifstream ifile(data_dir.c_str());
+    if (!ifile) {
+      int r = ::mkdir(data_dir.c_str(), 0777);
+      if (r < 0) {
+        r = -errno;
+        std::cout << __func__ << ": unable to create " << data_dir << ": " << cpp_strerror(r) << std::endl;
+      }
+      ASSERT_EQ(0, r);
+    }
+    store.reset(new (std::nothrow) MemStore(scct, data_dir));
+    if (!store) {
+      std::cout << __func__ << ": objectstore type " << type << " doesn't exist yet!" << std::endl;
+    }  
+    ASSERT_TRUE(store);
+    ASSERT_EQ(0, store->mkfs());
+    ASSERT_EQ(0, store->mount());
+  }
+  void TearDown() {
+    ch.reset();
+    if (store) {
+      int r = store->umount();
+      EXPECT_EQ(0, r);
+      rm_r(data_dir);
+    }
+  }
+
+};
+
+
+seastar::future<> test_newcollection(ceph::thread::ThreadPool& tp, std::shared_ptr<MemStoreTest> st)
+{
+  static int cpuid = seastar::engine().cpu_id();
+  auto alien_exec = [&tp, st]() mutable{
+    return tp.submit([=]() {
+      ObjectStore::Transaction t;
+      st->ch = st->store->create_new_collection(st->cid);
+      t.create_collection(st->cid, 4);
+      t.register_on_applied(new C_MEM_OnCommit(cpuid));
+
+      unsigned r = st->store->queue_transaction(st->ch, std::move(t));
+      //std::this_thread::sleep_for(10ns);
+      return r; 
+    });
+  };
+  return alien_exec().then([] (unsigned r) {
+      ASSERT_EQ(0U, r);
+      //return seastar::make_ready_future<>();
+    });
+}
+
+seastar::future<> test_memstoreclone(ceph::thread::ThreadPool& tp, std::shared_ptr<MemStoreTest> st)
+{
+  static const auto src = make_ghobject("src1");
+  static const auto dst = make_ghobject("dst1");
+  static bufferlist srcbl, dstbl, result, expected;
+  int cpuid = seastar::engine().cpu_id();
+
+  auto alien_exec = [&tp, st, cpuid]() mutable{
+    return tp.submit([=]() {
+      unsigned r;
+      srcbl.append("111111111111");
+      dstbl.append("222222222222");
+      expected.append("221111111122");
+
+      ObjectStore::Transaction t;
+      t.write(st->cid, src, 0, 12, srcbl);
+      t.write(st->cid, dst, 0, 12, dstbl);
+      t.clone_range(st->cid, src, dst, 2, 8, 2);
+      t.register_on_applied(new C_MEM_OnCommit(cpuid));
+      r = st->store->queue_transaction(st->ch, std::move(t));
+      ceph_assert(r==0);
+      r = st->store->read(st->ch, dst, 0, 12, result);
+      ceph_assert(r==12);     
+      return result;
+    });
+  };
+  
+  return alien_exec().then([=] (bufferlist re) {
+      ASSERT_EQ(expected, re); 
+  }); 
+}
+
+seastar::future<> test_clonerangehole(ceph::thread::ThreadPool& tp, std::shared_ptr<MemStoreTest> st)
+{
+  static const auto src = make_ghobject("src2");
+  static const auto dst = make_ghobject("dst2");
+  static bufferlist srcbl, dstbl, result, expected;
+  int cpuid = seastar::engine().cpu_id();
+ 
+  auto alien_exec = [&tp, st, cpuid]() mutable{
+    return tp.submit([=]() {
+      unsigned r;
+      srcbl.append("1111");
+      dstbl.append("222222222222");
+      expected.append("22\000\000\000\000\000\000\000\00022", 12);
+ 
+      ObjectStore::Transaction t;
+      t.write(st->cid, src, 12, 4, srcbl);
+      t.write(st->cid, dst, 0, 12, dstbl);
+      t.clone_range(st->cid, src, dst, 2, 8, 2);
+      t.register_on_applied(new C_MEM_OnCommit(cpuid));
+      r = st->store->queue_transaction(st->ch, std::move(t));
+      ceph_assert(r==0);
+      r = st->store->read(st->ch, dst, 0, 12, result);
+      ceph_assert(r==12);     
+      return result;
+    });
+  };
+  return alien_exec().then([=] (bufferlist re) {
+      ASSERT_EQ(expected, re);
+  });
+
+}
+
+int main(int argc, char** argv)
+{
+  ceph::thread::ThreadPool tp{2, 128, 20};
+  seastar::app_template app;
+  auto st = std::shared_ptr<MemStoreTest>(new MemStoreTest("memstore"));     
+  st->SetUp(); 
+  return app.run(argc, argv, [&tp,st] {
+    return test_config(st->scct->get_cobs()).then([&tp,st]{
+      return tp.start().then([&tp,st] {
+          return test_newcollection(tp,st).then([&tp,st]{
+            return test_memstoreclone(tp,st).then([&tp,st]{
+              return test_clonerangehole(tp,st);
+            });
+          });
+      }).then([&tp,st] {
+        return tp.stop();
+      }).then([st] {
+        return ceph::common::sharded_conf().invoke_on(0,[st](Config& config){
+          config.remove_observer(st->scct->get_cobs());
+        });
+      }).finally([st] {
+      //  asm volatile("int $3");
+        return ceph::common::sharded_conf().stop();
+      });
+    }).finally([st] {
+      st->TearDown();
+      std::cout << "All tests succeeded" << std::endl;
+    });
+  });
+}
+


### PR DESCRIPTION
in seastar osd framework, object store will run in posix thread.
This patch implement a test case to use posix thread to run memstore function and finisher thread will return to seastar environment. 
Signed-off-by: chunmei Liu <chunmei.liu@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

