### PR TITLE
qa: downgrade librados2,librbd1 for thrash-old-clients tests

### DIFF
--- a/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
+++ b/qa/suites/rados/thrash-old-clients/1-install/hammer.yaml
@@ -9,6 +9,7 @@ overrides:
 tasks:
 - install:
     branch: hammer
+    downgrade_packages: ['librbd1', 'librados2']
     exclude_packages: ['ceph-mgr','libcephfs2','libcephfs-devel','libcephfs-dev', 'librados3', 'libradospp-devel']
     extra_packages: ['librados2']
 - install.upgrade:


### PR DESCRIPTION
librados2 and librbd1 are installed as a dependency of qemu-kvm.
qemu-kvm is installed by ceph-cm-ansible, see [1].

in thrash-old-clients, jewel packages are installed, but yum does
not allow downgrade unless it's required explicitly. in this change,
we downgrade librbd1 and librados2 to address this issue.

this change should address failures like

Command failed on smithi136 with status 1: '\n sudo yum -y install
rbd-fuse\n '

found in rados/thrash-old-clients tests.

this change depends on https://github.com/ceph/teuthology/pull/1244

---
[1]
ceph/ceph-cm-ansible@3db1cbd#diff-f2b05d775fedff6c5c6689f564b32f1c
