### PR TITLE
doc: Fixed syntax in iscsi initiator windows docu

### DIFF
--- a/doc/rbd/iscsi-initiator-win.rst
+++ b/doc/rbd/iscsi-initiator-win.rst
@@ -97,5 +97,6 @@ Consider using the following registry settings:
        HKEY_LOCAL_MACHINE\\SYSTEM\CurrentControlSet\Control\Class\{4D36E97B-E325-11CE-BFC1-08002BE10318}\<Instance_Number>\Parameters
 
    ::
+   
        LinkDownTime = 25
        SRBTimeoutDelta = 15


### PR DESCRIPTION
Added a empty line which as its need for the correct syntax.

Signed-off-by: Michel Raabe raabe@b1-systems.de