### PR TITLE
mgr/prometheus: collect pg inconsistent info

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -720,6 +720,17 @@ CEPH_RADOS_API int rados_inconsistent_pg_list(rados_t cluster, int64_t pool,
 					      char *buf, size_t len);
 
 /**
+ * List inconsistent objects of the given placement group
+ * @param cluster cluster handle
+ * @param pg_str pg ID
+ * @param buf output buffer
+ * @param len output buffer length
+ * @returns length of the buffer we would need to list all inconsistent objects
+ */
+CEPH_RADOS_API int rados_inconsistent_obj_list(rados_t cluster, const char* pg_str,
+                                               char* buf, size_t len);
+
+/**
  * Get a configuration handle for a rados cluster handle
  *
  * This handle is valid only as long as the cluster handle is valid.

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -3945,3 +3945,23 @@ TRACEPOINT_EVENT(librados, rados_inconsistent_pg_list_exit,
         ctf_integer(int, retval, retval)
     )
 )
+
+TRACEPOINT_EVENT(librados, rados_inconsistent_obj_list_enter,
+    TP_ARGS(
+        rados_t, cluster,
+        const char*, pg_str,
+        size_t, size),
+    TP_FIELDS(
+        ctf_integer_hex(rados_t, cluster, cluster)
+        ceph_ctf_string(pg_str, pg_str)
+        ctf_integer(size_t, size, size)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_inconsistent_obj_list_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

Collect pgs inconsistent info in prometheus.

Example:

No inconsistent pgs in cluster, prometheus:

```
# HELP ceph_pg_inconsistent_info PG Inconsistent Info
# TYPE ceph_pg_inconsistent_info untyped
ceph_pg_inconsistent_info{pg_id="",object="",primary_osd="",errors=""} 0.0
```

If there's pgs are inconsistent and the scrub happened, prometheus will collect the inconsistent pgs info:

```
# HELP ceph_pg_inconsistent_info PG Inconsistent Info
# TYPE ceph_pg_inconsistent_info untyped
ceph_pg_inconsistent_info{pg_id="5.4",object="ceph.doc",primary_osd="0",errors="[u'data_digest_mismatch', u'size_mismatch']"} 1.0
ceph_pg_inconsistent_info{pg_id="5.9",object="make",primary_osd="1",errors="[u'size_mismatch']"} 1.0
```

Repair the inconsistent pg using `pg_id` or `primary_osd`:

```
ceph pg repair 5.9
ceph osd repair 0
```

prometheus:

```
# HELP ceph_pg_inconsistent_info PG Inconsistent Info
# TYPE ceph_pg_inconsistent_info untyped
ceph_pg_inconsistent_info{pg_id="",object="",primary_osd="",errors=""} 0.0
```

Signed-off-by: Lan Liu <liulan@umcloud.com>