### PR TITLE
mgr/orchestrator: added useful attributes to ServiceDescription

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -333,6 +333,17 @@ class ServiceDescription(object):
         # The type of service (osd, mon, mgr, etc.)
         self.service_type = None
 
+        # Service version that was deployed
+        self.version = None
+
+        # Location of the service configuration when stored in rados
+        # object. Format: "rados://<pool>/[<namespace/>]<object>"
+        self.rados_config_location = None
+
+        # If the service exposes REST-like API, this attribute should hold
+        # the URL.
+        self.service_url = None
+
 
 class DriveGroupSpec(object):
     """

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -344,6 +344,12 @@ class ServiceDescription(object):
         # the URL.
         self.service_url = None
 
+        # Service status: -1 error, 0 stopped, 1 running
+        self.status = None
+
+        # Service status description when status == -1.
+        self.status_desc = None
+
 
 class DriveGroupSpec(object):
     """

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -171,11 +171,13 @@ class OrchestratorCli(MgrModule):
             services.sort(key = lambda s: (s.service_type, s.nodename, s.daemon_name))
             lines = []
             for s in services:
-                lines.append("{0}.{1} {2} {3}".format(
+                lines.append("{0}.{1} {2} {3} {4} {5}".format(
                     s.service_type,
                     s.daemon_name,
                     s.nodename,
-                    s.container_id))
+                    s.container_id,
+                    s.version,
+                    s.config_location))
 
             return HandleCommandResult(odata="\n".join(lines))
 


### PR DESCRIPTION
Adds the `version`, `config_location`, and `service_url` to the description of a service.

These attributes are needed for services like NFS, or iSCSI, so that orchestrator clients can query the orchestrator about its services and then use the above information to manage the services.

Signed-off-by: Ricardo Dias <rdias@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

