### PR TITLE
ceph-volume: Fix TypeError: join() takes exactly one argument (2 given)

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -147,6 +147,13 @@ class TestDevice(object):
         disk = device.Device("/dev/sda")
         assert not disk.used_by_ceph
 
+    def test_get_device_id(self, device_info):
+        udev = {k:k for k in ['ID_VENDOR', 'ID_MODEL', 'ID_SCSI_SERIAL']}
+        device_info(udevadm=udev)
+        disk = device.Device("/dev/sda")
+        assert disk._get_device_id() == 'ID_VENDOR_ID_MODEL_ID_SCSI_SERIAL'
+
+
 
 class TestDeviceEncryption(object):
 

--- a/src/ceph-volume/ceph_volume/util/device.py
+++ b/src/ceph-volume/ceph_volume/util/device.py
@@ -192,10 +192,10 @@ class Device(object):
                  'ID_SCSI_SERIAL']
         p = disk.udevadm_property(self.abspath, props)
         if 'ID_VENDOR' in p and 'ID_MODEL' in p and 'ID_SCSI_SERIAL' in p:
-            dev_id = '_'.join(p['ID_VENDOR'], p['ID_MODEL'],
-                              p['ID_SCSI_SERIAL'])
+            dev_id = '_'.join([p['ID_VENDOR'], p['ID_MODEL'],
+                              p['ID_SCSI_SERIAL']])
         elif 'ID_MODEL' in p and 'ID_SERIAL_SHORT' in p:
-            dev_id = '_'.join(p['ID_MODEL'], p['ID_SERIAL_SHORT'])
+            dev_id = '_'.join([p['ID_MODEL'], p['ID_SERIAL_SHORT']])
         elif 'ID_SERIAL' in p:
             dev_id = p['ID_SERIAL']
             if dev_id.startswith('MTFD'):


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>
Fixes: http://tracker.ceph.com/issues/37595


