### PR TITLE
os/bluestore: check return value of _open_bluefs.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5107,6 +5107,9 @@ int BlueStore::_open_db(bool create, bool to_repair_db)
     }
 
     r = _open_bluefs(create);
+    if (r < 0) {
+      return r;
+    }
 
     if (cct->_conf->bluestore_bluefs_env_mirror) {
       rocksdb::Env *a = new BlueRocksEnv(bluefs);


### PR DESCRIPTION
With an non-existing device as db, it met the following error messages:

sceph7: 2018-12-11 04:52:28.117 7efe74b1f600 -1 bluestore(/var/lib/ceph/mnt/osd-device-0-data) _read_fsid unparsable uuid
sceph7: 2018-12-11 04:52:28.121 7efe74b1f600 -1 bluestore(/var/lib/ceph/mnt/osd-device-0-data) _open_bluefs /var/lib/ceph/mnt/osd-device-0-data/block.db symlink exists but target unusable: (2) No such file or directory
sceph7: *** Caught signal (Segmentation fault) **
sceph7:  in thread 7efe74b1f600 thread_name:ceph-osd
sceph7:  ceph version 14.0.1-1121-gfbea0e658a (fbea0e658a94c83936d2f78c42b5a8650b9700c4) nautilus (dev)
sceph7:  1: (()+0x29e7ebc) [0x564a473f8ebc]
sceph7:  2: (()+0x12890) [0x7efe7235f890]
sceph7:  3: (__pthread_mutex_trylock()+0x14) [0x7efe72357244]
sceph7:  4: (ceph::mutex_debug_detail::mutex_debug_impl<false>::try_lock_impl()+0x1f) [0x564a46ae5091]
sceph7:  5: (ceph::mutex_debug_detail::mutex_debug_impl<false>::try_lock(bool)+0x1d) [0x564a46abd3bf]
sceph7:  6: (ceph::mutex_debug_detail::mutex_debug_impl<false>::lock(bool)+0x49) [0x564a46a9b20b]
sceph7:  7: (std::lock_guard<ceph::mutex_debug_detail::mutex_debug_impl<false> >::lock_guard(ceph::mutex_debug_detail::mutex_debug_impl<false>&)+0x2f) [0x564a46a98515]
sceph7:  8: (BlueFS::mkdir(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)+0x45) [0x564a4739a7cb]
sceph7:  9: (BlueRocksEnv::CreateDir(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)+0x3a) [0x564a473b691a]
sceph7:  10: (BlueStore::_open_db(bool, bool)+0x11b3) [0x564a471ec2b7]
sceph7:  11: (BlueStore::mkfs()+0x149a) [0x564a471f4e00]
sceph7:  12: (OSD::mkfs(CephContext*, ObjectStore*, uuid_d, int)+0xc9) [0x564a46a07c2b]
sceph7:  13: (main()+0x1bf0) [0x564a469d4850]
sceph7:  14: (__libc_start_main()+0xe7) [0x7efe70ff4b97]
sceph7:  15: (_start()+0x2a) [0x564a469d1c5a]
sceph7: 2018-12-11 04:52:28.137 7efe74b1f600 -1 *** Caught signal (Segmentation fault) **

To avoid this occur, it should check return value of _open_bluefs.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

