### PR TITLE
rgw: fix versioned obj copy generating tags

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4639,6 +4639,12 @@ void RGWCopyObj::execute()
   rgw_obj dst_obj(dest_bucket, dest_object);
 
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
+  if ( ! version_id.empty()) {
+    dst_obj.key.set_instance(version_id);
+  } else if (dest_bucket_info.versioning_enabled()) {
+    store->gen_rand_obj_instance_name(&dst_obj);
+  }
+
   obj_ctx.set_atomic(src_obj);
   obj_ctx.set_atomic(dst_obj);
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3340,6 +3340,11 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
   }
 
   rgw_obj dest_obj(dest_bucket_info.bucket, buf);
+
+  if (dest_bucket_info.versioning_enabled()){
+    gen_rand_obj_instance_name(&dest_obj);
+  }
+
   obj_ctx.set_atomic(dest_obj);
 
   string no_zone;
@@ -3427,6 +3432,11 @@ int RGWRados::swift_versioning_restore(RGWSysObjectCtx& sysobj_ctx,
     std::map<std::string, ceph::bufferlist> no_attrs;
 
     rgw_obj archive_obj(archive_binfo.bucket, entry.key);
+
+    if (bucket_info.versioning_enabled()){
+      gen_rand_obj_instance_name(&obj);
+    }
+
     obj_ctx.set_atomic(archive_obj);
     obj_ctx.set_atomic(obj);
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4587,12 +4587,6 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
     }
   }
 
-  if (version_id && !version_id->empty()) {
-    dest_obj.key.set_instance(*version_id);
-  } else if (dest_bucket_info.versioning_enabled()) {
-    gen_rand_obj_instance_name(&dest_obj);
-  }
-
   if (copy_data) { /* refcounting tail wouldn't work here, just copy the data */
     attrs.erase(RGW_ATTR_TAIL_TAG);
     return copy_obj_data(obj_ctx, dest_bucket_info, read_op, obj_size - 1, dest_obj,


### PR DESCRIPTION
We fail to generate obj_tag and tail tags for a versioned object copy, as we
don't set the object instance until later and the atomic state hence isn't set
for this object as we call `prepare_atomic_modification` which checks for
atomicity before setting write tags. Since the tag is later used by the GC
processor for refcounting, versioned objects are not cleaned up leaving orphaned
tail instances behind. For older objects these will have to be manually cleaned
up, while this commit should fix the issues for newer versioned copy

Fixes: http://tracker.ceph.com/issues/37588
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

