### PR TITLE
do_cmake: warn users about slow debug builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Build instructions:
 	cd build
 	make
 
+(Note: do_cmake.sh now defaults to creating a debug build of ceph that can
+be up to 5x slower with some workloads. Please pass 
+"-DCMAKE_BUILD_TYPE=RelWithDebInfo" to do_cmake.sh to create a non-debug 
+release.)
+
 This assumes you make your build dir a subdirectory of the ceph.git
 checkout. If you put it elsewhere, just replace `..` in do_cmake.sh with a
 correct path to the checkout. Any additional CMake args can be specified

--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -48,3 +48,11 @@ erasure code dir = lib
 EOF
 
 echo done.
+cat <<EOF
+
+****
+WARNING: do_cmake.sh now creates debug builds by default. Performance
+may be severely affected. Please use -DCMAKE_BUILD_TYPE=RelWithDebInfo
+if a performance sensitive build is required.
+****
+EOF

--- a/doc/install/build-ceph.rst
+++ b/doc/install/build-ceph.rst
@@ -32,6 +32,11 @@ repository and execute the following::
     cd build
     make
 
+.. note:: By default do_cmake.sh will build a debug version of ceph that may
+   perform up to 5 times slower with certain workloads. Pass 
+   '-DCMAKE_BUILD_TYPE=RelWithDebInfo' to do_cmake.sh if you would like to
+   build a release version of the ceph executables instead.
+
 .. topic:: Hyperthreading
 
 	You can use ``make -j`` to execute multiple jobs depending upon your system. For 


### PR DESCRIPTION
Spent more time than I want to admit bisecting master over the weekend looking for a 5X random write performance regression on NVMe.  Finally I figured out that do_cmake.sh was changed to create debug builds by default in #24133. :sweat_smile:  This PR adds copious warnings so that I hopefully won't have to bisect this again in six months after I've forgotten that we changed the default behavior.

- [ ] References tracker ticket
- [X] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

