### PR TITLE
mimic: rgw_file: user info never synced since librgw init

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -119,6 +119,7 @@ namespace rgw {
 	RGWLibFS* fs = iter->first->ref();
 	uniq.unlock();
 	fs->gc();
+	fs->update_user();
 	fs->rele();
 	uniq.lock();
 	if (cur_gen != gen)

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -1206,6 +1206,13 @@ namespace rgw {
 
     RGWUserInfo* get_user() { return &user; }
 
+    void update_user() {
+      RGWUserInfo _user = user;
+      int ret = rgw_get_user_info_by_access_key(rgwlib.get_store(), key.id, user);
+      if (ret != 0)
+        user = _user;
+    }
+
     void close();
     void gc();
   }; /* RGWLibFS */


### PR DESCRIPTION
http://tracker.ceph.com/issues/37548