### PR TITLE
osd: keep using cache even if op will invalid cache

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1838,13 +1838,12 @@ bool ECBackend::try_state_to_reads()
     return false;
   }
 
+  op->using_cache = pipeline_state.caching_enabled();
+
   if (op->invalidates_cache()) {
     dout(20) << __func__ << ": invalidating cache after this op"
 	     << dendl;
     pipeline_state.invalidate();
-    op->using_cache = false;
-  } else {
-    op->using_cache = pipeline_state.caching_enabled();
   }
 
   waiting_state.pop_front();


### PR DESCRIPTION
the current wrong process on same obj in ec 4+2 pool with 16K stripe:

obj has 16K\~16K with content-0
new op1 will write 8K\~32K (16K\~16K content-1)
op1 reserve 0K\~48K in cache
op1 read 0\~16K & 32K\~48K from disk
new op2 will write 20K\~24K (20K\~4K content-2) *** (invalid_cache due to clone)
op2 read 16K\~32K from disk (content-0) ***** due to not using_cache
op1 write 0\~48K to disk (content-1)
op1 present 0\~48K to cache (content-1)
op2 write 16\~32K to disk (content-0 + content-2) *** here we drop the content1

even if the op will invalid cache, it should do that *after* itself,
the op should use the cache by itself.

Fixes: https://tracker.ceph.com/issues/37593

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

