### PR TITLE
pybind/mgr: Unified bits of volumes and orchestrator

### DIFF
--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -861,7 +861,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         Set the value of a persistent configuration setting
 
         :param str key:
-        :param str val:
+        :type val: str | None
         """
         self._validate_module_option(key)
         return self._set_module_option(key, val)


### PR DESCRIPTION
* Created a common class `OrchestratorClientMixin`
* Added a metaclass `OrchestratorClientMixinMeta` that redirects all calls to the current orchestrator
* `s/self._oremote("meth"...),/self.meth(...)/g`

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Testing depends on #25236 :disappointed: 

