### PR TITLE
doc: Add mention of ceph osd pool stats

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -242,6 +242,10 @@ To show a pool's utilization statistics, execute::
 
 	rados df
 
+Additionally, to obtain I/O information for a specific or all pools, execute::
+
+        ceph osd pool stats [{pool-name}]
+
 
 Make a Snapshot of a Pool
 =========================


### PR DESCRIPTION

Neither  "Show Pool Statistics" nor the suggested options from `ceph osd pool` mention this command. Since I found this document when searching for this feature I think it is the right place to add it here.

Signed-off-by: Thore Kruess <thore@kruess.xyz>