### PR TITLE
mgr/dashboard: Object Gateway user configuration

### DIFF
--- a/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
+++ b/src/pybind/mgr/dashboard/run-frontend-e2e-tests.sh
@@ -46,6 +46,16 @@ if [ "$BASE_URL" == "" ]; then
     MGR=2 RGW=1 ../src/vstart.sh -n -d
     sleep 10
 
+    # Create an Object Gateway User
+    ./bin/radosgw-admin user create --uid=dev --display-name=Developer --system
+    # Set the user-id
+    ./bin/ceph dashboard set-rgw-api-user-id dev
+    # Obtain and set access and secret key for the previously created user
+    ./bin/ceph dashboard set-rgw-api-access-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].access_key | sed -e 's/^"//' -e 's/"$//'`
+    ./bin/ceph dashboard set-rgw-api-secret-key `./bin/radosgw-admin user info --uid=dev | jq .keys[0].secret_key | sed -e 's/^"//' -e 's/"$//'`
+    # Set SSL verify to False
+    ./bin/ceph dashboard set-rgw-api-ssl-verify False
+
     BASE_URL=`./bin/ceph mgr services | jq .dashboard`
 fi
 


### PR DESCRIPTION
In order to be able to access and test the Object Gateway
within our end-to-end tests it needs to be configured properly.
This script will now take care of creating and configuring
a user and will set the corresponding credentials for the user.

Signed-off-by: Laura Paduano <lpaduano@suse.com>
