### PR TITLE
doc: admin/build-doc to check distros

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -6,45 +6,52 @@ TOPDIR=`pwd`
 
 install -d -m0755 build-doc
 
-if command -v dpkg >/dev/null; then
-    packages=`cat ${TOPDIR}/doc_deps.deb.txt`
-    for package in $packages; do
-    if [ "$(dpkg --status -- $package 2>&1 | sed -n 's/^Status: //p')" != "install ok installed" ]; then
-        # add a space after old values
-        missing="${missing:+$missing }$package"
-    fi
-    done
-    if [ -n "$missing" ]; then
-        echo "$0: missing required packages, please install them:" 1>&2
-        echo "sudo apt-get install -o APT::Install-Recommends=true $missing" 1>&2
-        exit 1
-    fi
-elif command -v yum >/dev/null; then
-    for package in python-devel python-pip python-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel Cython graphviz; do
-	if ! rpm -q --whatprovides $package >/dev/null ; then
-		missing="${missing:+$missing }$package"
-	fi
-    done
-    if [ -n "$missing" ]; then
-        echo "$0: missing required packages, please install them:" 1>&2
-        echo "yum install $missing"
-        exit 1
-    fi
-else
-    for command in virtualenv doxygen ant ditaa cython; do
-	command -v "$command" > /dev/null;
-	ret_code=$?
-	if [ $ret_code -ne 0 ]; then
-            # add a space after old values
-	    missing="${missing:+$missing }$command"
-	fi
-    done
-    if [ -n "$missing" ]; then
-	echo "$0: missing required command, please install them:" 1>&2
-	echo "$missing"
-	exit 1
-    fi
-fi
+source /etc/os-release
+case $ID in
+    debian|ubuntu|devuan)
+        packages=`cat ${TOPDIR}/doc_deps.deb.txt`
+        for package in $packages; do
+            if [ "$(dpkg --status -- $package 2>&1 | sed -n 's/^Status: //p')" != "install ok installed" ]; then
+                # add a space after old values
+                missing="${missing:+$missing }$package"
+            fi
+        done
+        if [ -n "$missing" ]; then
+            echo "$0: missing required packages, please install them:" 1>&2
+            echo "sudo apt-get install -o APT::Install-Recommends=true $missing" 1>&2
+            exit 1
+        fi
+    ;;
+
+    centos|fedora|rhel|ol|virtuozzo)
+        for package in python-devel python-pip python-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel Cython graphviz; do
+	        if ! rpm -q --whatprovides $package >/dev/null ; then
+		        missing="${missing:+$missing }$package"
+	        fi
+        done
+        if [ -n "$missing" ]; then
+            echo "$0: missing required packages, please install them:" 1>&2
+            echo "yum install $missing"
+            exit 1
+        fi
+    ;;
+
+    *)
+        for command in virtualenv doxygen ant ditaa cython; do
+            command -v "$command" > /dev/null;
+            ret_code=$?
+            if [ $ret_code -ne 0 ]; then
+                # add a space after old values
+                missing="${missing:+$missing }$command"
+            fi
+        done
+        if [ -n "$missing" ]; then
+	        echo "$0: missing required command, please install them:" 1>&2
+	        echo "$missing"
+	        exit 1
+        fi
+    ;;
+esac
 
 # Don't enable -e until after running all the potentially-erroring checks
 # for availability of commands


### PR DESCRIPTION
This allows the admin/build-doc script to check for the Linux distro, instead of the existence of tools such as: dpkg, yum. 

There is a possibility of using distros that use yum/rpm, however a dpkg tool been installed (which may or may not be fully compatible with the original 'dpkg tool' or yet just happens to have the same name). 

Also, checking by distros gives us more granularity should we need a few more/different steps depending on the distro/version. 
