### PR TITLE
spec: requires ceph base instead of common

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -479,7 +479,7 @@ Summary:	Ceph daemon for mirroring RBD images
 %if 0%{?suse_version}
 Group:		System/Filesystems
 %endif
-Requires:	ceph-common = %{_epoch_prefix}%{version}-%{release}
+Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 Requires:	libradospp1 = %{_epoch_prefix}%{version}-%{release}
 %description -n rbd-mirror
 Daemon for mirroring RBD images between Ceph clusters, streaming
@@ -500,7 +500,7 @@ Summary:	Rados REST gateway
 %if 0%{?suse_version}
 Group:		System/Filesystems
 %endif
-Requires:	ceph-common = %{_epoch_prefix}%{version}-%{release}
+Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 %if 0%{with selinux}
 Requires:	ceph-selinux = %{_epoch_prefix}%{version}-%{release}
 %endif


### PR DESCRIPTION
Currently rbd-mirror and radosgw packages installation won't create the
Ceph directories in /var/lib/ceph since they depend on ceph-common
only. ceph-base is responsible for creating these directories.

Since ceph-base requires ceph-common then let's use ceph-base as a
dependency.

Closes: http://tracker.ceph.com/issues/37620
Signed-off-by: Sébastien Han <seb@redhat.com>