### PR TITLE
kv/rocksdb_cache/BinnedLRUCache: Remove pre-C99 style struct hack

### DIFF
--- a/src/kv/rocksdb_cache/BinnedLRUCache.h
+++ b/src/kv/rocksdb_cache/BinnedLRUCache.h
@@ -71,7 +71,7 @@ struct BinnedLRUHandle {
 
   uint32_t hash;     // Hash of key(); used for fast sharding and comparisons
 
-  char key_data[1];  // Beginning of key
+  char* key_data = nullptr;  // Beginning of key
 
   rocksdb::Slice key() const {
     // For cheaper lookups, we allow a temporary Handle object
@@ -119,7 +119,8 @@ struct BinnedLRUHandle {
     if (deleter) {
       (*deleter)(key(), value);
     }
-    delete[] reinterpret_cast<char*>(this);
+    delete[] key_data;
+    delete this;
   }
 };
 


### PR DESCRIPTION
This removes the "struct hack" from the BinnedLRUCache.  This was presumably done for performance reasons at some point early in the LevelDB development cycle, but makes the LRUHandle brittle and potentially break in various ways when modified (not only modifications at the end of the struct, but also in other circumstances regarding POD and alignment).  Very specifically, this PR is necessary for upcoming changes in the BinnedLRUCache.

Performance tests on incerta (1 NVMe backed OSD) show no obvious impact during 1 hour of 4k random writes to a 256GB pre-allocated RBD volume:

master test1: 77.6MiB/s (19.9k IOPS)
master test2: 77.1MiB/s (19.7k IOPS)
wip-remove-struct-hack test1: 77.3MiB/s (19.8K IOPS)
wip-remove-struct-hack test2: 77.5MiB/s (19.8K IOPS)

The same test on my CPU-limited Ryzen development box were more variable, but also showed no obvious regression:

master test1: 74.5MiB/s (19.1k IOPS)
master test2: 65.7MiB/s (16.8k IOPS)
wip-remove-struct-hack test1: 73.7MiB/s (18.9K IOPS)
wip-remove-struct-hack test2: 74.5MiB/s (19.1K IOPS)

Alternatively we may be able to perform an up-front malloc like in the existing code but use placement new instead of going out of bounds in key_data.  This would retain the single contiguous allocation and avoid the extra delete, but still require the pointer.  Until we see evidence that would result in a significant performance gain, I think we should keep this code as simple and straightforward as possible.

For more background on this, see:

http://www.open-std.org/jtc1/sc22/wg14/www/docs/dr_051.html
http://c-faq.com/struct/structhack.html
https://stackoverflow.com/questions/3711233/is-the-struct-hack-technically-undefined-behavior/

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

