### PR TITLE
rgw: feature -- log successful bucket resharding events

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -741,6 +741,11 @@ int RGWBucketReshard::execute(int num_shards, int max_op_entries,
       "\"created after successful resharding with error " << ret << dendl;
   }
 
+  ldout(store->ctx(), 1) << __func__ <<
+    " INFO: reshard of bucket \"" << bucket_info.bucket.name << "\" from \"" <<
+    bucket_info.bucket.get_key() << "\" to \"" <<
+    new_bucket_info.bucket.get_key() << "\" completed successfully" << dendl;
+
   return 0;
 
 error_out:


### PR DESCRIPTION
This change adds a single log entry at level 10 to indicate when a bucket resharding successfully completes.

Note: this change is minimal and does not require run-time QA.