### PR TITLE
mimic: qa: wrong setting for msgr failures

### DIFF
--- a/qa/suites/fs/thrash/msgr-failures/osd-mds-delay.yaml
+++ b/qa/suites/fs/thrash/msgr-failures/osd-mds-delay.yaml
@@ -3,6 +3,6 @@ overrides:
     conf:
       global:
         ms inject socket failures: 2500
-        mds inject delay type: osd mds
+        ms inject delay type: osd mds
         ms inject delay probability: .005
         ms inject delay max: 1


### PR DESCRIPTION
http://tracker.ceph.com/issues/37424