### PR TITLE
mimic: cmake: do not pass -B{symbolic,symbolic-functions} to linker on FreeBSD

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -702,7 +702,7 @@ target_link_libraries(ceph-common ${ceph_common_deps})
 set_target_properties(ceph-common PROPERTIES
   SOVERSION 0
   INSTALL_RPATH "")
-if(NOT APPLE)
+if(NOT APPLE AND NOT FREEBSD)
   # Apple uses Mach-O, not ELF. so this option does not apply to APPLE.
   #
   # prefer the local symbol definitions when binding references to global


### PR DESCRIPTION
http://tracker.ceph.com/issues/36751