### PR TITLE
librbd: disallow trash restoring when image being migrated

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -743,6 +743,14 @@ test_migration() {
     rbd migration execute test1
     rbd migration commit test1
 
+    # testing trash
+    rbd migration prepare test1
+    expect_fail rbd trash mv test1
+    ID=`rbd trash ls -a | cut -d ' ' -f 1`
+    expect_fail rbd trash rm $ID
+    expect_fail rbd trash restore $ID
+    rbd migration abort test1
+
     for format in 1 2; do
         # Abort migration after successful prepare
         rbd create -s 128M --image-format ${format} test2

--- a/src/librbd/api/Migration.cc
+++ b/src/librbd/api/Migration.cc
@@ -1109,8 +1109,8 @@ template <typename I>
 int Migration<I>::v2_relink_src_image() {
   ldout(m_cct, 10) << dendl;
 
-  int r = Trash<I>::restore(m_src_io_ctx, m_src_image_ctx->id,
-                            m_src_image_ctx->name);
+  int r = Trash<I>::restore(m_src_io_ctx, RBD_TRASH_IMAGE_SOURCE_MIGRATION,
+                            m_src_image_ctx->id, m_src_image_ctx->name);
   if (r < 0) {
     lderr(m_cct) << "failed restoring image from trash: " << cpp_strerror(r)
                  << dendl;

--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -243,7 +243,8 @@ int Trash<I>::remove(IoCtx &io_ctx, const std::string &image_id, bool force,
 }
 
 template <typename I>
-int Trash<I>::restore(librados::IoCtx &io_ctx, const std::string &image_id,
+int Trash<I>::restore(librados::IoCtx &io_ctx, rbd_trash_image_source_t source,
+                      const std::string &image_id,
                       const std::string &image_new_name) {
   CephContext *cct((CephContext *)io_ctx.cct());
   ldout(cct, 20) << "trash_restore " << &io_ctx << " " << image_id << " "
@@ -255,6 +256,13 @@ int Trash<I>::restore(librados::IoCtx &io_ctx, const std::string &image_id,
     lderr(cct) << "error getting image id " << image_id
                << " info from trash: " << cpp_strerror(r) << dendl;
     return r;
+  }
+
+  if (trash_spec.source !=  static_cast<cls::rbd::TrashImageSource>(source)) {
+    lderr(cct) << "Current trash source: " << trash_spec.source
+               << " does not match expected: "
+               << static_cast<cls::rbd::TrashImageSource>(source) << dendl;
+    return -EINVAL;
   }
 
   std::string image_name = image_new_name;

--- a/src/librbd/api/Trash.h
+++ b/src/librbd/api/Trash.h
@@ -29,7 +29,8 @@ struct Trash {
                   std::vector<trash_image_info_t> &entries);
   static int remove(librados::IoCtx &io_ctx, const std::string &image_id,
                     bool force, ProgressContext& prog_ctx);
-  static int restore(librados::IoCtx &io_ctx, const std::string &image_id,
+  static int restore(librados::IoCtx &io_ctx, rbd_trash_image_source_t source,
+                     const std::string &image_id,
                      const std::string &image_new_name);
 
 };

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -643,7 +643,8 @@ namespace librbd {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, trash_undelete_enter, io_ctx.get_pool_name().c_str(),
                io_ctx.get_id(), id, name);
-    int r = librbd::api::Trash<>::restore(io_ctx, id, name);
+    int r = librbd::api::Trash<>::restore(io_ctx, RBD_TRASH_IMAGE_SOURCE_USER,
+                                          id, name);
     tracepoint(librbd, trash_undelete_exit, r);
     return r;
   }
@@ -3216,7 +3217,8 @@ extern "C" int rbd_trash_restore(rados_ioctx_t p, const char *id,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, trash_undelete_enter, io_ctx.get_pool_name().c_str(),
              io_ctx.get_id(), id, name);
-  int r = librbd::api::Trash<>::restore(io_ctx, id, name);
+  int r = librbd::api::Trash<>::restore(io_ctx, RBD_TRASH_IMAGE_SOURCE_USER,
+                                        id, name);
   tracepoint(librbd, trash_undelete_exit, r);
   return r;
 }

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -6920,6 +6920,8 @@ TEST_F(TestLibRBD, Migration) {
     ASSERT_EQ(status.source_image_id, string());
   } else {
     ASSERT_NE(status.source_image_id, string());
+    ASSERT_EQ(-EROFS, rbd_trash_remove(ioctx, status.source_image_id, false));
+    ASSERT_EQ(-EINVAL, rbd_trash_restore(ioctx, status.source_image_id, name.c_str()));
   }
   ASSERT_EQ(status.dest_pool_id, rados_ioctx_get_id(ioctx));
   ASSERT_EQ(status.dest_image_name, name);
@@ -6928,6 +6930,7 @@ TEST_F(TestLibRBD, Migration) {
   rbd_migration_status_cleanup(&status);
 
   ASSERT_EQ(-EBUSY, rbd_remove(ioctx, name.c_str()));
+  ASSERT_EQ(-EINVAL, rbd_trash_move(ioctx, name.c_str(), 0));
 
   ASSERT_EQ(0, rbd_migration_execute(ioctx, name.c_str()));
 
@@ -6944,6 +6947,7 @@ TEST_F(TestLibRBD, Migration) {
                                      new_name.c_str(), image_options));
 
   ASSERT_EQ(-EBUSY, rbd_remove(ioctx, new_name.c_str()));
+  ASSERT_EQ(-EINVAL, rbd_trash_move(ioctx, new_name.c_str(), 0));
 
   ASSERT_EQ(0, rbd_migration_abort(ioctx, name.c_str()));
 
@@ -6980,6 +6984,8 @@ TEST_F(TestLibRBD, MigrationPP) {
     ASSERT_EQ(status.source_image_id, "");
   } else {
     ASSERT_NE(status.source_image_id, "");
+    ASSERT_EQ(-EROFS, rbd.trash_remove(ioctx, status.source_image_id.c_str(), false));
+    ASSERT_EQ(-EINVAL, rbd.trash_restore(ioctx, status.source_image_id.c_str(), name.c_str()));
   }
   ASSERT_EQ(status.dest_pool_id, ioctx.get_id());
   ASSERT_EQ(status.dest_image_name, name);
@@ -6987,6 +6993,7 @@ TEST_F(TestLibRBD, MigrationPP) {
   ASSERT_EQ(status.state, RBD_IMAGE_MIGRATION_STATE_PREPARED);
 
   ASSERT_EQ(-EBUSY, rbd.remove(ioctx, name.c_str()));
+  ASSERT_EQ(-EINVAL, rbd.trash_move(ioctx, name.c_str(), 0));
 
   ASSERT_EQ(0, rbd.migration_execute(ioctx, name.c_str()));
 
@@ -7002,6 +7009,7 @@ TEST_F(TestLibRBD, MigrationPP) {
                                      new_name.c_str(), image_options));
 
   ASSERT_EQ(-EBUSY, rbd.remove(ioctx, new_name.c_str()));
+  ASSERT_EQ(-EINVAL, rbd.trash_move(ioctx, new_name.c_str(), 0));
 
   ASSERT_EQ(0, rbd.migration_abort(ioctx, name.c_str()));
 


### PR DESCRIPTION
Signed-off-by: songweibin <song.weibin@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

