### PR TITLE
mgr/diskprediction: Add diskprediction local plugin dependencies

### DIFF
--- a/src/pybind/mgr/diskprediction_cloud/requirements.txt
+++ b/src/pybind/mgr/diskprediction_cloud/requirements.txt
@@ -2,11 +2,7 @@ google-api-python-client==1.7.3
 google-auth==1.5.0
 google-auth-httplib2==0.0.3
 googleapis-common-protos==1.5.3
-grpc==0.3.post19
-grpc-google-logging-v2==0.8.1
-grpc-google-pubsub-v1==0.8.1
-grpcio==1.14.1
-mock==2.0.0
-numpy==1.15.1
-scikit-learn==0.19.2
-scipy==1.1.0
+grpc-google-logging-v2>=0.8.1
+grpc-google-pubsub-v1>=0.8.1
+grpcio>=1.14.1
+

--- a/src/pybind/mgr/diskprediction_local/requirements.txt
+++ b/src/pybind/mgr/diskprediction_local/requirements.txt
@@ -1,0 +1,3 @@
+numpy==1.15.1
+scikit-learn==0.19.2
+scipy==1.1.0


### PR DESCRIPTION
Separate diskprediction local plugin dependencies from the diskprediction clould plugin dependencies requirements.txt.

Signed-off-by: Rick Chen <rick.chen@prophetstor.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

