### PR TITLE
librbd: not return the migration source as the parent

### DIFF
--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -172,6 +172,10 @@ int Image<I>::get_parent(I *ictx,
     return -ENOENT;
   }
 
+  if ((ictx->features & RBD_FEATURE_MIGRATING) != 0) {
+    return -ENOENT;
+  }
+
   cls::rbd::ParentImageSpec parent_spec;
   if (ictx->snap_id == CEPH_NOSNAP) {
     parent_spec = ictx->parent_md.spec;

--- a/src/tools/rbd/action/Info.cc
+++ b/src/tools/rbd/action/Info.cc
@@ -324,9 +324,6 @@ static int do_show_info(librados::IoCtx &io_ctx, librbd::Image& image,
       f->dump_string("id", parent_image_spec.image_id);
       f->dump_string("snapshot", parent_snap_spec.name);
       f->dump_bool("trash", parent_image_spec.trash);
-      if ((features & RBD_FEATURE_MIGRATING) != 0) {
-        f->dump_bool("migration_source", true);
-      }
       f->dump_unsigned("overlap", overlap);
       f->close_section();
     } else {
@@ -338,9 +335,6 @@ static int do_show_info(librados::IoCtx &io_ctx, librbd::Image& image,
                 << parent_snap_spec.name;
       if (parent_image_spec.trash) {
         std::cout << " (trash " << parent_image_spec.image_id << ")";
-      }
-      if ((features & RBD_FEATURE_MIGRATING) != 0) {
-        std::cout << " (migration source)";
       }
       std::cout << std::endl;
       std::cout << "\toverlap: " << byte_u_t(overlap) << std::endl;


### PR DESCRIPTION
```
[swb@ ~/ceph/ceph-dev/build]$ rbd migration prepare img1 img2
[swb@ ~/ceph/ceph-dev/build]$ rbd ls -l
NAME  SIZE   PARENT    FMT PROT LOCK
img2  10 MiB rbd/img1@   2
```

Signed-off-by: songweibin <song.weibin@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

