### PR TITLE
mgr: modules CLI commands declaration using @CLICommand decorator

### DIFF
--- a/src/mgr/ActivePyModule.cc
+++ b/src/mgr/ActivePyModule.cc
@@ -193,7 +193,7 @@ int ActivePyModule::handle_command(
   inbuf.copy(0, inbuf.length(), instr);
 
   auto pResult = PyObject_CallMethod(pClassInstance,
-      const_cast<char*>("handle_command"), const_cast<char*>("s#O"),
+      const_cast<char*>("_handle_command"), const_cast<char*>("s#O"),
       instr.c_str(), instr.length(), py_cmd);
 
   Py_DECREF(py_cmd);

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -474,6 +474,16 @@ int PyModule::walk_dict_list(
 
 int PyModule::load_commands()
 {
+  PyObject *pRegCmd = PyObject_CallMethod(pClass,
+  const_cast<char*>("_register_commands"), const_cast<char*>("()"));
+  if (pRegCmd != nullptr) {
+    Py_DECREF(pRegCmd);
+  } else {
+    derr << "Exception calling _register_commands on " << get_name()
+         << dendl;
+    derr << handle_pyerror() << dendl;
+  }
+
   int r = walk_dict_list("COMMANDS", [this](PyObject *pCommand) -> int {
     ModuleCommand command;
 

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -60,8 +60,6 @@ from .controllers import generate_routes, json_error_page
 from .tools import NotificationQueue, RequestLoggingTool, TaskManager, \
                    prepare_url_prefix
 from .services.auth import AuthManager, AuthManagerTool, JwtManager
-from .services.access_control import ACCESS_CONTROL_COMMANDS, \
-                                     handle_access_control_command
 from .services.sso import SSO_COMMANDS, \
                           handle_sso_command
 from .services.exception import dashboard_exception_handler
@@ -238,7 +236,6 @@ class Module(MgrModule, CherryPyConfig):
         },
     ]
     COMMANDS.extend(options_command_list())
-    COMMANDS.extend(ACCESS_CONTROL_COMMANDS)
     COMMANDS.extend(SSO_COMMANDS)
 
     MODULE_OPTIONS = [
@@ -335,9 +332,6 @@ class Module(MgrModule, CherryPyConfig):
     def handle_command(self, inbuf, cmd):
         # pylint: disable=too-many-return-statements
         res = handle_option_command(cmd)
-        if res[0] != -errno.ENOSYS:
-            return res
-        res = handle_access_control_command(cmd)
         if res[0] != -errno.ENOSYS:
             return res
         res = handle_sso_command(cmd)

--- a/src/pybind/mgr/dashboard/services/access_control.py
+++ b/src/pybind/mgr/dashboard/services/access_control.py
@@ -10,6 +10,8 @@ import time
 
 import bcrypt
 
+from mgr_module import CLIReadCommand, CLIWriteCommand
+
 from .. import mgr, logger
 from ..security import Scope, Permission
 from ..exceptions import RoleAlreadyExists, RoleDoesNotExist, ScopeNotValid, \
@@ -358,341 +360,280 @@ def load_access_control_db():
 
 
 # CLI dashboard access control scope commands
-ACCESS_CONTROL_COMMANDS = [
-    # for backwards compatibility
-    {
-        'cmd': 'dashboard set-login-credentials '
-               'name=username,type=CephString '
-               'name=password,type=CephString',
-        'desc': 'Set the login credentials',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-role-show '
-               'name=rolename,type=CephString,req=false',
-        'desc': 'Show role info',
-        'perm': 'r'
-    },
-    {
-        'cmd': 'dashboard ac-role-create '
-               'name=rolename,type=CephString '
-               'name=description,type=CephString,req=false',
-        'desc': 'Create a new access control role',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-role-delete '
-               'name=rolename,type=CephString',
-        'desc': 'Delete an access control role',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-role-add-scope-perms '
-               'name=rolename,type=CephString '
-               'name=scopename,type=CephString '
-               'name=permissions,type=CephString,n=N',
-        'desc': 'Add the scope permissions for a role',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-role-del-scope-perms '
-               'name=rolename,type=CephString '
-               'name=scopename,type=CephString',
-        'desc': 'Delete the scope permissions for a role',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-user-show '
-               'name=username,type=CephString,req=false',
-        'desc': 'Show user info',
-        'perm': 'r'
-    },
-    {
-        'cmd': 'dashboard ac-user-create '
-               'name=username,type=CephString '
-               'name=password,type=CephString,req=false '
-               'name=rolename,type=CephString,req=false '
-               'name=name,type=CephString,req=false '
-               'name=email,type=CephString,req=false',
-        'desc': 'Create a user',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-user-delete '
-               'name=username,type=CephString',
-        'desc': 'Delete user',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-user-set-roles '
-               'name=username,type=CephString '
-               'name=roles,type=CephString,n=N',
-        'desc': 'Set user roles',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-user-add-roles '
-               'name=username,type=CephString '
-               'name=roles,type=CephString,n=N',
-        'desc': 'Add roles to user',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-user-del-roles '
-               'name=username,type=CephString '
-               'name=roles,type=CephString,n=N',
-        'desc': 'Delete roles from user',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-user-set-password '
-               'name=username,type=CephString '
-               'name=password,type=CephString',
-        'desc': 'Set user password',
-        'perm': 'w'
-    },
-    {
-        'cmd': 'dashboard ac-user-set-info '
-               'name=username,type=CephString '
-               'name=name,type=CephString '
-               'name=email,type=CephString',
-        'desc': 'Set user info',
-        'perm': 'w'
-    }
-]
 
+@CLIWriteCommand('dashboard set-login-credentials',
+                 'name=username,type=CephString '
+                 'name=password,type=CephString',
+                 'Set the login credentials')
+def set_login_credentials_cmd(_, username, password):
+    try:
+        user = ACCESS_CTRL_DB.get_user(username)
+        user.set_password(password)
+    except UserDoesNotExist:
+        user = ACCESS_CTRL_DB.create_user(username, password, None, None)
+        user.set_roles([ADMIN_ROLE])
 
-def handle_access_control_command(cmd):
-    if cmd['prefix'] == 'dashboard set-login-credentials':
-        username = cmd['username']
-        password = cmd['password']
-        try:
-            user = ACCESS_CTRL_DB.get_user(username)
-            user.set_password(password)
-        except UserDoesNotExist:
-            user = ACCESS_CTRL_DB.create_user(username, password, None, None)
-            user.set_roles([ADMIN_ROLE])
+    ACCESS_CTRL_DB.save()
 
-        ACCESS_CTRL_DB.save()
-
-        return 0, '''\
+    return 0, '''\
 ******************************************************************
 ***          WARNING: this command is deprecated.              ***
 *** Please use the ac-user-* related commands to manage users. ***
 ******************************************************************
 Username and password updated''', ''
 
-    if cmd['prefix'] == 'dashboard ac-role-show':
-        rolename = cmd['rolename'] if 'rolename' in cmd else None
-        if not rolename:
-            roles = dict(ACCESS_CTRL_DB.roles)
-            roles.update(SYSTEM_ROLES)
-            roles_list = [name for name, _ in roles.items()]
-            return 0, json.dumps(roles_list), ''
-        try:
-            role = ACCESS_CTRL_DB.get_role(rolename)
-        except RoleDoesNotExist as ex:
-            if rolename not in SYSTEM_ROLES:
-                return -errno.ENOENT, '', str(ex)
-            role = SYSTEM_ROLES[rolename]
+
+@CLIReadCommand('dashboard ac-role-show',
+                'name=rolename,type=CephString,req=false',
+                'Show role info')
+def ac_role_show_cmd(_, rolename=None):
+    if not rolename:
+        roles = dict(ACCESS_CTRL_DB.roles)
+        roles.update(SYSTEM_ROLES)
+        roles_list = [name for name, _ in roles.items()]
+        return 0, json.dumps(roles_list), ''
+    try:
+        role = ACCESS_CTRL_DB.get_role(rolename)
+    except RoleDoesNotExist as ex:
+        if rolename not in SYSTEM_ROLES:
+            return -errno.ENOENT, '', str(ex)
+        role = SYSTEM_ROLES[rolename]
+    return 0, json.dumps(role.to_dict()), ''
+
+
+@CLIWriteCommand('dashboard ac-role-create',
+                 'name=rolename,type=CephString '
+                 'name=description,type=CephString,req=false',
+                 'Create a new access control role')
+def ac_role_create_cmd(_, rolename, description=None):
+    try:
+        role = ACCESS_CTRL_DB.create_role(rolename, description)
+        ACCESS_CTRL_DB.save()
         return 0, json.dumps(role.to_dict()), ''
+    except RoleAlreadyExists as ex:
+        return -errno.EEXIST, '', str(ex)
 
-    elif cmd['prefix'] == 'dashboard ac-role-create':
-        rolename = cmd['rolename']
-        description = cmd['description'] if 'description' in cmd else None
-        try:
-            role = ACCESS_CTRL_DB.create_role(rolename, description)
-            ACCESS_CTRL_DB.save()
-            return 0, json.dumps(role.to_dict()), ''
-        except RoleAlreadyExists as ex:
-            return -errno.EEXIST, '', str(ex)
 
-    elif cmd['prefix'] == 'dashboard ac-role-delete':
-        rolename = cmd['rolename']
-        try:
-            ACCESS_CTRL_DB.delete_role(rolename)
-            ACCESS_CTRL_DB.save()
-            return 0, "Role '{}' deleted".format(rolename), ""
-        except RoleDoesNotExist as ex:
-            if rolename in SYSTEM_ROLES:
-                return -errno.EPERM, '', "Cannot delete system role '{}'" \
-                                         .format(rolename)
+@CLIWriteCommand('dashboard ac-role-delete',
+                 'name=rolename,type=CephString',
+                 'Delete an access control role')
+def ac_role_delete_cmd(_, rolename):
+    try:
+        ACCESS_CTRL_DB.delete_role(rolename)
+        ACCESS_CTRL_DB.save()
+        return 0, "Role '{}' deleted".format(rolename), ""
+    except RoleDoesNotExist as ex:
+        if rolename in SYSTEM_ROLES:
+            return -errno.EPERM, '', "Cannot delete system role '{}'" \
+                                        .format(rolename)
+        return -errno.ENOENT, '', str(ex)
+    except RoleIsAssociatedWithUser as ex:
+        return -errno.EPERM, '', str(ex)
+
+
+@CLIWriteCommand('dashboard ac-role-add-scope-perms',
+                 'name=rolename,type=CephString '
+                 'name=scopename,type=CephString '
+                 'name=permissions,type=CephString,n=N',
+                 'Add the scope permissions for a role')
+def ac_role_add_scope_perms_cmd(_, rolename, scopename, permissions):
+    try:
+        role = ACCESS_CTRL_DB.get_role(rolename)
+        perms_array = [perm.strip() for perm in permissions]
+        role.set_scope_permissions(scopename, perms_array)
+        ACCESS_CTRL_DB.update_users_with_roles(role)
+        ACCESS_CTRL_DB.save()
+        return 0, json.dumps(role.to_dict()), ''
+    except RoleDoesNotExist as ex:
+        if rolename in SYSTEM_ROLES:
+            return -errno.EPERM, '', "Cannot update system role '{}'" \
+                                        .format(rolename)
+        return -errno.ENOENT, '', str(ex)
+    except ScopeNotValid as ex:
+        return -errno.EINVAL, '', str(ex) + "\n Possible values: {}" \
+                                            .format(Scope.all_scopes())
+    except PermissionNotValid as ex:
+        return -errno.EINVAL, '', str(ex) + \
+                                    "\n Possible values: {}" \
+                                    .format(Permission.all_permissions())
+
+
+@CLIWriteCommand('dashboard ac-role-del-scope-perms',
+                 'name=rolename,type=CephString '
+                 'name=scopename,type=CephString',
+                 'Delete the scope permissions for a role')
+def ac_role_del_scope_perms_cmd(_, rolename, scopename):
+    try:
+        role = ACCESS_CTRL_DB.get_role(rolename)
+        role.del_scope_permissions(scopename)
+        ACCESS_CTRL_DB.update_users_with_roles(role)
+        ACCESS_CTRL_DB.save()
+        return 0, json.dumps(role.to_dict()), ''
+    except RoleDoesNotExist as ex:
+        if rolename in SYSTEM_ROLES:
+            return -errno.EPERM, '', "Cannot update system role '{}'" \
+                                        .format(rolename)
+        return -errno.ENOENT, '', str(ex)
+    except ScopeNotInRole as ex:
+        return -errno.ENOENT, '', str(ex)
+
+
+@CLIReadCommand('dashboard ac-user-show',
+                'name=username,type=CephString,req=false',
+                'Show user info')
+def ac_user_show_cmd(_, username=None):
+    if not username:
+        users = ACCESS_CTRL_DB.users
+        users_list = [name for name, _ in users.items()]
+        return 0, json.dumps(users_list), ''
+    try:
+        user = ACCESS_CTRL_DB.get_user(username)
+        return 0, json.dumps(user.to_dict()), ''
+    except UserDoesNotExist as ex:
+        return -errno.ENOENT, '', str(ex)
+
+
+@CLIWriteCommand('dashboard ac-user-create',
+                 'name=username,type=CephString '
+                 'name=password,type=CephString,req=false '
+                 'name=rolename,type=CephString,req=false '
+                 'name=name,type=CephString,req=false '
+                 'name=email,type=CephString,req=false',
+                 'Create a user')
+def ac_user_create_cmd(_, username, password=None, rolename=None, name=None,
+                       email=None):
+    try:
+        role = ACCESS_CTRL_DB.get_role(rolename) if rolename else None
+    except RoleDoesNotExist as ex:
+        if rolename not in SYSTEM_ROLES:
             return -errno.ENOENT, '', str(ex)
-        except RoleIsAssociatedWithUser as ex:
-            return -errno.EPERM, '', str(ex)
+        role = SYSTEM_ROLES[rolename]
 
-    elif cmd['prefix'] == 'dashboard ac-role-add-scope-perms':
-        rolename = cmd['rolename']
-        scopename = cmd['scopename']
-        permissions = cmd['permissions']
-        try:
-            role = ACCESS_CTRL_DB.get_role(rolename)
-            perms_array = [perm.strip() for perm in permissions]
-            role.set_scope_permissions(scopename, perms_array)
-            ACCESS_CTRL_DB.update_users_with_roles(role)
-            ACCESS_CTRL_DB.save()
-            return 0, json.dumps(role.to_dict()), ''
-        except RoleDoesNotExist as ex:
-            if rolename in SYSTEM_ROLES:
-                return -errno.EPERM, '', "Cannot update system role '{}'" \
-                                         .format(rolename)
-            return -errno.ENOENT, '', str(ex)
-        except ScopeNotValid as ex:
-            return -errno.EINVAL, '', str(ex) + "\n Possible values: {}" \
-                                                .format(Scope.all_scopes())
-        except PermissionNotValid as ex:
-            return -errno.EINVAL, '', str(ex) + \
-                                      "\n Possible values: {}" \
-                                      .format(Permission.all_permissions())
+    try:
+        user = ACCESS_CTRL_DB.create_user(username, password, name, email)
+    except UserAlreadyExists as ex:
+        return -errno.EEXIST, '', str(ex)
 
-    elif cmd['prefix'] == 'dashboard ac-role-del-scope-perms':
-        rolename = cmd['rolename']
-        scopename = cmd['scopename']
-        try:
-            role = ACCESS_CTRL_DB.get_role(rolename)
-            role.del_scope_permissions(scopename)
-            ACCESS_CTRL_DB.update_users_with_roles(role)
-            ACCESS_CTRL_DB.save()
-            return 0, json.dumps(role.to_dict()), ''
-        except RoleDoesNotExist as ex:
-            if rolename in SYSTEM_ROLES:
-                return -errno.EPERM, '', "Cannot update system role '{}'" \
-                                         .format(rolename)
-            return -errno.ENOENT, '', str(ex)
-        except ScopeNotInRole as ex:
-            return -errno.ENOENT, '', str(ex)
+    if role:
+        user.set_roles([role])
+    ACCESS_CTRL_DB.save()
+    return 0, json.dumps(user.to_dict()), ''
 
-    elif cmd['prefix'] == 'dashboard ac-user-show':
-        username = cmd['username'] if 'username' in cmd else None
-        if not username:
-            users = ACCESS_CTRL_DB.users
-            users_list = [name for name, _ in users.items()]
-            return 0, json.dumps(users_list), ''
-        try:
-            user = ACCESS_CTRL_DB.get_user(username)
-            return 0, json.dumps(user.to_dict()), ''
-        except UserDoesNotExist as ex:
-            return -errno.ENOENT, '', str(ex)
 
-    elif cmd['prefix'] == 'dashboard ac-user-create':
-        username = cmd['username']
-        password = cmd['password'] if 'password' in cmd else None
-        rolename = cmd['rolename'] if 'rolename' in cmd else None
-        name = cmd['name'] if 'name' in cmd else None
-        email = cmd['email'] if 'email' in cmd else None
+@CLIWriteCommand('dashboard ac-user-delete',
+                 'name=username,type=CephString',
+                 'Delete user')
+def ac_user_delete_cmd(_, username):
+    try:
+        ACCESS_CTRL_DB.delete_user(username)
+        ACCESS_CTRL_DB.save()
+        return 0, "User '{}' deleted".format(username), ""
+    except UserDoesNotExist as ex:
+        return -errno.ENOENT, '', str(ex)
+
+
+@CLIWriteCommand('dashboard ac-user-set-roles',
+                 'name=username,type=CephString '
+                 'name=roles,type=CephString,n=N',
+                 'Set user roles')
+def ac_user_set_roles_cmd(_, username, roles):
+    rolesname = roles
+    roles = []
+    for rolename in rolesname:
         try:
-            role = ACCESS_CTRL_DB.get_role(rolename) if rolename else None
+            roles.append(ACCESS_CTRL_DB.get_role(rolename))
         except RoleDoesNotExist as ex:
             if rolename not in SYSTEM_ROLES:
                 return -errno.ENOENT, '', str(ex)
-            role = SYSTEM_ROLES[rolename]
-
-        try:
-            user = ACCESS_CTRL_DB.create_user(username, password, name, email)
-        except UserAlreadyExists as ex:
-            return -errno.EEXIST, '', str(ex)
-
-        if role:
-            user.set_roles([role])
+            roles.append(SYSTEM_ROLES[rolename])
+    try:
+        user = ACCESS_CTRL_DB.get_user(username)
+        user.set_roles(roles)
         ACCESS_CTRL_DB.save()
         return 0, json.dumps(user.to_dict()), ''
+    except UserDoesNotExist as ex:
+        return -errno.ENOENT, '', str(ex)
 
-    elif cmd['prefix'] == 'dashboard ac-user-delete':
-        username = cmd['username']
+
+@CLIWriteCommand('dashboard ac-user-add-roles',
+                 'name=username,type=CephString '
+                 'name=roles,type=CephString,n=N',
+                 'Add roles to user')
+def ac_user_add_roles_cmd(_, username, roles):
+    rolesname = roles
+    roles = []
+    for rolename in rolesname:
         try:
-            ACCESS_CTRL_DB.delete_user(username)
-            ACCESS_CTRL_DB.save()
-            return 0, "User '{}' deleted".format(username), ""
-        except UserDoesNotExist as ex:
-            return -errno.ENOENT, '', str(ex)
+            roles.append(ACCESS_CTRL_DB.get_role(rolename))
+        except RoleDoesNotExist as ex:
+            if rolename not in SYSTEM_ROLES:
+                return -errno.ENOENT, '', str(ex)
+            roles.append(SYSTEM_ROLES[rolename])
+    try:
+        user = ACCESS_CTRL_DB.get_user(username)
+        user.add_roles(roles)
+        ACCESS_CTRL_DB.save()
+        return 0, json.dumps(user.to_dict()), ''
+    except UserDoesNotExist as ex:
+        return -errno.ENOENT, '', str(ex)
 
-    elif cmd['prefix'] == 'dashboard ac-user-set-roles':
-        username = cmd['username']
-        rolesname = cmd['roles']
-        roles = []
-        for rolename in rolesname:
-            try:
-                roles.append(ACCESS_CTRL_DB.get_role(rolename))
-            except RoleDoesNotExist as ex:
-                if rolename not in SYSTEM_ROLES:
-                    return -errno.ENOENT, '', str(ex)
-                roles.append(SYSTEM_ROLES[rolename])
+
+@CLIWriteCommand('dashboard ac-user-del-roles',
+                 'name=username,type=CephString '
+                 'name=roles,type=CephString,n=N',
+                 'Delete roles from user')
+def ac_user_del_roles_cmd(_, username, roles):
+    rolesname = roles
+    roles = []
+    for rolename in rolesname:
         try:
-            user = ACCESS_CTRL_DB.get_user(username)
-            user.set_roles(roles)
-            ACCESS_CTRL_DB.save()
-            return 0, json.dumps(user.to_dict()), ''
-        except UserDoesNotExist as ex:
-            return -errno.ENOENT, '', str(ex)
+            roles.append(ACCESS_CTRL_DB.get_role(rolename))
+        except RoleDoesNotExist as ex:
+            if rolename not in SYSTEM_ROLES:
+                return -errno.ENOENT, '', str(ex)
+            roles.append(SYSTEM_ROLES[rolename])
+    try:
+        user = ACCESS_CTRL_DB.get_user(username)
+        user.del_roles(roles)
+        ACCESS_CTRL_DB.save()
+        return 0, json.dumps(user.to_dict()), ''
+    except UserDoesNotExist as ex:
+        return -errno.ENOENT, '', str(ex)
+    except RoleNotInUser as ex:
+        return -errno.ENOENT, '', str(ex)
 
-    elif cmd['prefix'] == 'dashboard ac-user-add-roles':
-        username = cmd['username']
-        rolesname = cmd['roles']
-        roles = []
-        for rolename in rolesname:
-            try:
-                roles.append(ACCESS_CTRL_DB.get_role(rolename))
-            except RoleDoesNotExist as ex:
-                if rolename not in SYSTEM_ROLES:
-                    return -errno.ENOENT, '', str(ex)
-                roles.append(SYSTEM_ROLES[rolename])
-        try:
-            user = ACCESS_CTRL_DB.get_user(username)
-            user.add_roles(roles)
-            ACCESS_CTRL_DB.save()
-            return 0, json.dumps(user.to_dict()), ''
-        except UserDoesNotExist as ex:
-            return -errno.ENOENT, '', str(ex)
 
-    elif cmd['prefix'] == 'dashboard ac-user-del-roles':
-        username = cmd['username']
-        rolesname = cmd['roles']
-        roles = []
-        for rolename in rolesname:
-            try:
-                roles.append(ACCESS_CTRL_DB.get_role(rolename))
-            except RoleDoesNotExist as ex:
-                if rolename not in SYSTEM_ROLES:
-                    return -errno.ENOENT, '', str(ex)
-                roles.append(SYSTEM_ROLES[rolename])
-        try:
-            user = ACCESS_CTRL_DB.get_user(username)
-            user.del_roles(roles)
-            ACCESS_CTRL_DB.save()
-            return 0, json.dumps(user.to_dict()), ''
-        except UserDoesNotExist as ex:
-            return -errno.ENOENT, '', str(ex)
-        except RoleNotInUser as ex:
-            return -errno.ENOENT, '', str(ex)
+@CLIWriteCommand('dashboard ac-user-set-password',
+                 'name=username,type=CephString '
+                 'name=password,type=CephString',
+                 'Set user password')
+def ac_user_set_password(_, username, password):
+    try:
+        user = ACCESS_CTRL_DB.get_user(username)
+        user.set_password(password)
 
-    elif cmd['prefix'] == 'dashboard ac-user-set-password':
-        username = cmd['username']
-        password = cmd['password']
-        try:
-            user = ACCESS_CTRL_DB.get_user(username)
-            user.set_password(password)
+        ACCESS_CTRL_DB.save()
+        return 0, json.dumps(user.to_dict()), ''
+    except UserDoesNotExist as ex:
+        return -errno.ENOENT, '', str(ex)
 
-            ACCESS_CTRL_DB.save()
-            return 0, json.dumps(user.to_dict()), ''
-        except UserDoesNotExist as ex:
-            return -errno.ENOENT, '', str(ex)
 
-    elif cmd['prefix'] == 'dashboard ac-user-set-info':
-        username = cmd['username']
-        name = cmd['name']
-        email = cmd['email']
-        try:
-            user = ACCESS_CTRL_DB.get_user(username)
-            if name:
-                user.name = name
-            if email:
-                user.email = email
-            ACCESS_CTRL_DB.save()
-            return 0, json.dumps(user.to_dict()), ''
-        except UserDoesNotExist as ex:
-            return -errno.ENOENT, '', str(ex)
-
-    return -errno.ENOSYS, '', ''
+@CLIWriteCommand('dashboard ac-user-set-info',
+                 'name=username,type=CephString '
+                 'name=name,type=CephString '
+                 'name=email,type=CephString',
+                 'Set user info')
+def ac_user_set_info(_, username, name, email):
+    try:
+        user = ACCESS_CTRL_DB.get_user(username)
+        if name:
+            user.name = name
+        if email:
+            user.email = email
+        ACCESS_CTRL_DB.save()
+        return 0, json.dumps(user.to_dict()), ''
+    except UserDoesNotExist as ex:
+        return -errno.ENOENT, '', str(ex)
 
 
 class LocalAuthenticator(object):

--- a/src/pybind/mgr/dashboard/tests/__init__.py
+++ b/src/pybind/mgr/dashboard/tests/__init__.py
@@ -3,6 +3,9 @@ from __future__ import absolute_import
 
 import json
 
+from mgr_module import CLICommand, MgrModule
+from .. import mgr
+
 
 class CmdException(Exception):
     def __init__(self, retcode, message):
@@ -13,7 +16,17 @@ class CmdException(Exception):
 def exec_dashboard_cmd(command_handler, cmd, **kwargs):
     cmd_dict = {'prefix': 'dashboard {}'.format(cmd)}
     cmd_dict.update(kwargs)
-    ret, out, err = command_handler(cmd_dict)
+    if cmd_dict['prefix'] not in CLICommand.COMMANDS:
+        ret, out, err = command_handler(cmd_dict)
+        if ret < 0:
+            raise CmdException(ret, err)
+        try:
+            return json.loads(out)
+        except ValueError:
+            return out
+
+    ret, out, err = CLICommand.COMMANDS[cmd_dict['prefix']].call(mgr, cmd_dict,
+                                                                 None)
     if ret < 0:
         raise CmdException(ret, err)
     try:

--- a/src/pybind/mgr/dashboard/tests/test_access_control.py
+++ b/src/pybind/mgr/dashboard/tests/test_access_control.py
@@ -10,8 +10,7 @@ import unittest
 from . import CmdException, exec_dashboard_cmd
 from .. import mgr
 from ..security import Scope, Permission
-from ..services.access_control import handle_access_control_command, \
-                                      load_access_control_db, \
+from ..services.access_control import load_access_control_db, \
                                       password_hash, AccessControlDB, \
                                       SYSTEM_ROLES
 
@@ -41,7 +40,7 @@ class AccessControlTest(unittest.TestCase):
 
     @classmethod
     def exec_cmd(cls, cmd, **kwargs):
-        return exec_dashboard_cmd(handle_access_control_command, cmd, **kwargs)
+        return exec_dashboard_cmd(None, cmd, **kwargs)
 
     def load_persistent_db(self):
         config_key = AccessControlDB.accessdb_config_key()


### PR DESCRIPTION
This PR introduces a new backward compatible way to declare CLI commands for mgr modules.
This new way is based on a python decorator, named `@CLICommand`, that can be used to annotate a function that implements the CLI command.

Example:

```python
@CLIReadCommand("dashboard dummy command",
                "name=param,type=CephString "
                "name=opt,type=CephString,req=false",
                "Dummy command desc")
def my_dummy_command(mgr, param, opt=None):
  # ... implementation....
```

With this new approach the CLI command function can be defined anywhere in source code of the mgr module, and no need to add the boilerplate code to the `handle_command` module method.

In the PR is also included a migration of part of the dashboard CLI commands to use this new decorator:
https://github.com/ceph/ceph/pull/25543/files#diff-79afeb5577573e37cae850d2de159840

Signed-off-by: Ricardo Dias <rdias@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

