### PR TITLE
luminous: rgw: Building radosgw needs librgw_a

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -177,8 +177,9 @@ endif (WITH_RADOSGW_BEAST_FRONTEND)
 
 add_library(radosgw_a STATIC ${radosgw_srcs}
   $<TARGET_OBJECTS:civetweb_common_objs>)
+target_link_libraries(radosgw_a PRIVATE rgw_a)
 if (WITH_RADOSGW_BEAST_FRONTEND AND WITH_RADOSGW_BEAST_OPENSSL)
-  target_link_libraries(radosgw_a rgw_a ${SSL_LIBRARIES})
+  target_link_libraries(radosgw_a ${SSL_LIBRARIES})
 endif()
 
 add_executable(radosgw rgw_main.cc)


### PR DESCRIPTION
On FreeBSD errors during binding are like:
```
/usr/bin/ld.lld: error: undefined symbol: rgw_tools_init(CephContext*)
>>> referenced by rgw_main.cc:302 (/home/jenkins/workspace/ceph-luminous/src/rgw/rgw_main.cc:302)
>>>               CMakeFiles/radosgw.dir/rgw_main.cc.o:(main)

/usr/bin/ld.lld: error: undefined symbol: rgw_init_resolver()
>>> referenced by rgw_main.cc:308 (/home/jenkins/workspace/ceph-luminous/src/rgw/rgw_main.cc:308)
>>>               CMakeFiles/radosgw.dir/rgw_main.cc.o:(main)
```

Not cherry-picking the changes down the chain, because the
diff is rather large, and is not 1-on-1 mergeable...
This is the minimal patch to get it working again.

