### PR TITLE
luminous: qa: pjd test appears to require more than 3h timeout for some configurations

### DIFF
--- a/qa/suites/fs/32bits/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/fs/32bits/tasks/cfuse_workunit_suites_pjd.yaml
@@ -6,6 +6,7 @@ overrides:
         fuse default permissions: false
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/fs/basic_workload/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/fs/basic_workload/tasks/cfuse_workunit_suites_pjd.yaml
@@ -6,6 +6,7 @@ overrides:
         fuse default permissions: false
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/fs/permission/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/fs/permission/tasks/cfuse_workunit_suites_pjd.yaml
@@ -7,6 +7,7 @@ overrides:
         client acl type: posix_acl
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/fs/thrash/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/fs/thrash/tasks/cfuse_workunit_suites_pjd.yaml
@@ -6,6 +6,7 @@ overrides:
         fuse default permissions: false
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_pjd.yaml
+++ b/qa/suites/kcephfs/cephfs/tasks/kclient_workunit_suites_pjd.yaml
@@ -1,6 +1,7 @@
 tasks:
 - kclient:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh

--- a/qa/suites/multimds/basic/tasks/cfuse_workunit_suites_pjd.yaml
+++ b/qa/suites/multimds/basic/tasks/cfuse_workunit_suites_pjd.yaml
@@ -6,6 +6,7 @@ overrides:
         fuse default permissions: false
 tasks:
 - workunit:
+    timeout: 6h
     clients:
       all:
         - suites/pjd.sh


### PR DESCRIPTION
http://tracker.ceph.com/issues/37610