### PR TITLE
rgw: fix compilation after pubsub conflict

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2690,10 +2690,6 @@ static int trim_sync_error_log(int shard_id, const ceph::real_time& start_time,
   // unreachable
 }
 
-JSONFormattable& get_tier_config(RGWRados *store) {
-  return store->svc.zone->get_zone_params().tier_config;
-}
-
 const string& get_tier_type(RGWRados *store) {
   return store->svc.zone->get_zone().tier_type;
 }

--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -259,7 +259,7 @@ struct PSConfig {
     ldout(cct, 5) << "pubsub: module config (parsed representation):\n" << json_str("config", *this, true) << dendl;
   }
 
-  void init_instance(RGWRealm& realm, uint64_t instance_id) {
+  void init_instance(const RGWRealm& realm, uint64_t instance_id) {
     sync_instance = instance_id;
   }
 
@@ -426,7 +426,7 @@ struct PSEnv {
     conf->init(cct, config);
   }
 
-  void init_instance(RGWRealm& realm, uint64_t instance_id, PSManagerRef& mgr);
+  void init_instance(const RGWRealm& realm, uint64_t instance_id, PSManagerRef& mgr);
 };
 
 using PSEnvRef = std::shared_ptr<PSEnv>;
@@ -1009,7 +1009,7 @@ public:
   friend class GetSubCR;
 };
 
-void PSEnv::init_instance(RGWRealm& realm, uint64_t instance_id, PSManagerRef& mgr) {
+void PSEnv::init_instance(const RGWRealm& realm, uint64_t instance_id, PSManagerRef& mgr) {
   manager = mgr;
   conf->init_instance(realm, instance_id);
 }


### PR DESCRIPTION
github didn't detect merge conflicts between rgw pub-sub (https://github.com/ceph/ceph/pull/23298) and https://github.com/ceph/ceph/pull/25412, which changed `RGWRealm& RGWSI_Zone::get_realm()` to return `const RGWRealm&`