### PR TITLE
rgw: fix warning about class redeclaration

### DIFF
--- a/src/rgw/rgw_sync_module_pubsub.cc
+++ b/src/rgw/rgw_sync_module_pubsub.cc
@@ -564,7 +564,6 @@ class PSSubscription {
     string path;
   } push;
 
-  class InitCR;
   InitCR *init_cr{nullptr};
 
   class InitBucketLifecycleCR : public RGWCoroutine {


### PR DESCRIPTION
```
/home/jenkins/workspace/ceph-master/src/rgw/rgw_sync_module_pubsub.cc:567:9: warning: class member cannot be redeclared [-Wredeclared-class-member]
  class InitCR;
        ^
/home/jenkins/workspace/ceph-master/src/rgw/rgw_sync_module_pubsub.cc:549:9: note: previous declaration is here
  class InitCR;
        ^
1 warning generated.
```

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug