### PR TITLE
doc: Add mention of ceph osd pool stats

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -240,6 +240,10 @@ To show a pool's utilization statistics, execute::
 
 	rados df
 
+Additionally, to obtain I/O information for a specific pool or all, execute::
+
+        ceph osd pool stats [{pool-name}]
+
 
 Make a Snapshot of a Pool
 =========================


### PR DESCRIPTION
Neither  "Show Pool Statistics" nor the suggested options from `ceph osd pool` mention this command.
Same as #25493 just against master. 

Signed-off-by: Thore Kruess <thore@kruess.xyz>