### PR TITLE
test: allow ceph_kvstorebench to be built on FreeBSD

### DIFF
--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -11,6 +11,7 @@
  * Foundation.  See file COPYING.
  */
 
+#include "include/compat.h"
 #include "key_value_store/key_value_structure.h"
 #include "key_value_store/kv_flat_btree_async.h"
 #include "key_value_store/kvs_arg_types.h"


### PR DESCRIPTION
Add `compat.h` to fix missing error codes
```
/home/srcs/Ceph/bluestore/ceph/src/key_value_store/kv_flat_btree_async.cc:448:15: error: use of undeclared identifier 'EUCLEAN'
      return -EUCLEAN;
              ^
/home/srcs/Ceph/bluestore/ceph/src/key_value_store/kv_flat_btree_async.cc:1434:11: error: use of undeclared identifier 'EKEYREJECTED'
    case -EKEYREJECTED: {
          ^
/home/srcs/Ceph/bluestore/ceph/src/key_value_store/kv_flat_btree_async.cc:1554:11: error: use of undeclared identifier 'EKEYREJECTED'
    case -EKEYREJECTED: {
          ^
/home/srcs/Ceph/bluestore/ceph/src/key_value_store/kv_flat_btree_async.cc:1583:17: error: use of undeclared identifier 'EUCLEAN'
          case -EUCLEAN:
                ^
/home/srcs/Ceph/bluestore/ceph/src/key_value_store/kv_flat_btree_async.cc:1661:18: error: use of undeclared identifier 'EUCLEAN'
      && err != -EUCLEAN){
                 ^
```
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug