### PR TITLE
crimson/net: fix addresses during banner exchange

### DIFF
--- a/src/crimson/mon/MonClient.cc
+++ b/src/crimson/mon/MonClient.cc
@@ -163,7 +163,7 @@ seastar::future<bool> Connection::do_auth()
     return reply.get_future();
   }).then([this] (Ref<MAuthReply> m) {
     logger().info("mon {} => {} returns {}: {}",
-                   conn->get_my_addr(),
+                   conn->get_messenger()->get_myaddr(),
                    conn->get_peer_addr(), *m, m->result);
     reply = decltype(reply){};
     auto p = m->result_bl.cbegin();
@@ -360,7 +360,7 @@ seastar::future<> Client::handle_auth_reply(ceph::net::ConnectionRef conn,
                                                Ref<MAuthReply> m)
 {
   logger().info("mon {} => {} returns {}: {}",
-                conn->get_my_addr(),
+                conn->get_messenger()->get_myaddr(),
                 conn->get_peer_addr(), *m, m->result);
   auto found = std::find_if(pending_conns.begin(), pending_conns.end(),
                             [peer_addr = conn->get_peer_addr()](auto& mc) {

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -53,6 +53,15 @@ class Connection : public boost::intrusive_ref_counter<Connection,
 
   /// close the connection and cancel any any pending futures from read/send
   virtual seastar::future<> close() = 0;
+
+  virtual void print(ostream& out) const = 0;
 };
+
+inline ostream& operator<<(ostream& out, const Connection& conn) {
+  out << "[";
+  conn.print(out);
+  out << "]";
+  return out;
+}
 
 } // namespace ceph::net

--- a/src/crimson/net/Connection.h
+++ b/src/crimson/net/Connection.h
@@ -27,17 +27,14 @@ using seq_num_t = uint64_t;
 class Connection : public boost::intrusive_ref_counter<Connection,
 						       boost::thread_unsafe_counter> {
  protected:
-  entity_addr_t my_addr;
   entity_addr_t peer_addr;
   peer_type_t peer_type = -1;
 
  public:
-  Connection(const entity_addr_t& my_addr)
-    : my_addr(my_addr) {}
+  Connection() {}
   virtual ~Connection() {}
 
   virtual Messenger* get_messenger() const = 0;
-  const entity_addr_t& get_my_addr() const { return my_addr; }
   const entity_addr_t& get_peer_addr() const { return peer_addr; }
   virtual int get_peer_type() const = 0;
 

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -36,7 +36,7 @@ class Messenger {
 
   const entity_name_t& get_myname() const { return my_name; }
   const entity_addr_t& get_myaddr() const { return my_addr; }
-  void set_myaddr(const entity_addr_t& addr) {
+  virtual void set_myaddr(const entity_addr_t& addr) {
     my_addr = addr;
   }
 

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -71,6 +71,15 @@ class Messenger {
   void set_crc_header() {
     crc_flags |= MSG_CRC_HEADER;
   }
+
+  virtual void print(ostream& out) const = 0;
 };
+
+inline ostream& operator<<(ostream& out, const Messenger& msgr) {
+  out << "[";
+  msgr.print(out);
+  out << "]";
+  return out;
+}
 
 } // namespace ceph::net

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -40,6 +40,16 @@ class SocketConnection : public Connection {
   Dispatcher& dispatcher;
   seastar::gate pending_dispatch;
 
+  // if acceptor side, socket_port is different from peer_addr.get_port();
+  // if connector side, socket_port is different from my_addr.get_port().
+  enum class side_t {
+    none,
+    acceptor,
+    connector
+  };
+  side_t side = side_t::none;
+  uint16_t socket_port = 0;
+
   enum class state_t {
     none,
     accepting,
@@ -157,7 +167,6 @@ class SocketConnection : public Connection {
 
  public:
   SocketConnection(SocketMessenger& messenger,
-                   const entity_addr_t& my_addr,
                    Dispatcher& dispatcher);
   ~SocketConnection();
 

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -175,6 +175,8 @@ class SocketConnection : public Connection {
 
   seastar::future<> close() override;
 
+  void print(ostream& out) const override;
+
  public:
   /// start a handshake from the client's perspective,
   /// only call when SocketConnection first construct

--- a/src/crimson/net/SocketMessenger.cc
+++ b/src/crimson/net/SocketMessenger.cc
@@ -22,8 +22,9 @@
 
 using namespace ceph::net;
 
-SocketMessenger::SocketMessenger(const entity_name_t& myname)
-  : Messenger{myname}
+SocketMessenger::SocketMessenger(const entity_name_t& myname,
+                                 const std::string& logic_name)
+  : Messenger{myname}, logic_name{logic_name}
 {}
 
 void SocketMessenger::bind(const entity_addr_t& addr)

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -52,6 +52,11 @@ class SocketMessenger final : public Messenger {
 
   seastar::future<> shutdown() override;
 
+  void print(ostream& out) const override {
+    out << get_myname()
+        << " " << get_myaddr();
+  }
+
  public:
   void set_default_policy(const SocketPolicy& p);
   void set_policy(entity_type_t peer_type, const SocketPolicy& p);

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -38,13 +38,17 @@ class SocketMessenger final : public Messenger {
   ceph::net::PolicySet<Throttle> policy_set;
   // Distinguish messengers with meaningful names for debugging
   const std::string logic_name;
+  const uint32_t nonce;
 
   seastar::future<> accept(seastar::connected_socket socket,
                            seastar::socket_address paddr);
 
  public:
   SocketMessenger(const entity_name_t& myname,
-                  const std::string& logic_name);
+                  const std::string& logic_name,
+                  uint32_t nonce);
+
+  void set_myaddr(const entity_addr_t& addr) override;
 
   void bind(const entity_addr_t& addr) override;
 
@@ -62,6 +66,7 @@ class SocketMessenger final : public Messenger {
   }
 
  public:
+  void learned_addr(const entity_addr_t &peer_addr_for_me);
   void set_default_policy(const SocketPolicy& p);
   void set_policy(entity_type_t peer_type, const SocketPolicy& p);
   void set_policy_throttler(entity_type_t peer_type, Throttle* throttle);

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -36,12 +36,15 @@ class SocketMessenger final : public Messenger {
   std::set<SocketConnectionRef> accepting_conns;
   using Throttle = ceph::thread::Throttle;
   ceph::net::PolicySet<Throttle> policy_set;
+  // Distinguish messengers with meaningful names for debugging
+  const std::string logic_name;
 
   seastar::future<> accept(seastar::connected_socket socket,
                            seastar::socket_address paddr);
 
  public:
-  SocketMessenger(const entity_name_t& myname);
+  SocketMessenger(const entity_name_t& myname,
+                  const std::string& logic_name);
 
   void bind(const entity_addr_t& addr) override;
 
@@ -54,7 +57,8 @@ class SocketMessenger final : public Messenger {
 
   void print(ostream& out) const override {
     out << get_myname()
-        << " " << get_myaddr();
+        << "(" << logic_name
+        << ") " << get_myaddr();
   }
 
  public:

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -39,7 +39,7 @@ struct DummyAuthAuthorizer : public AuthAuthorizer {
 struct Server {
   ceph::thread::Throttle byte_throttler;
   static constexpr int64_t server_num = 0;
-  ceph::net::SocketMessenger msgr{entity_name_t::OSD(server_num)};
+  ceph::net::SocketMessenger msgr{entity_name_t::OSD(server_num), "server"};
   struct ServerDispatcher : ceph::net::Dispatcher {
     unsigned count = 0;
     seastar::condition_variable on_reply;
@@ -76,7 +76,7 @@ struct Server {
 struct Client {
   ceph::thread::Throttle byte_throttler;
   static constexpr int64_t client_num = 1;
-  ceph::net::SocketMessenger msgr{entity_name_t::OSD(client_num)};
+  ceph::net::SocketMessenger msgr{entity_name_t::OSD(client_num), "client"};
   struct ClientDispatcher : ceph::net::Dispatcher {
     unsigned count = 0;
     seastar::condition_variable on_reply;

--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -39,7 +39,7 @@ struct DummyAuthAuthorizer : public AuthAuthorizer {
 struct Server {
   ceph::thread::Throttle byte_throttler;
   static constexpr int64_t server_num = 0;
-  ceph::net::SocketMessenger msgr{entity_name_t::OSD(server_num), "server"};
+  ceph::net::SocketMessenger msgr{entity_name_t::OSD(server_num), "server", 0};
   struct ServerDispatcher : ceph::net::Dispatcher {
     unsigned count = 0;
     seastar::condition_variable on_reply;
@@ -76,7 +76,7 @@ struct Server {
 struct Client {
   ceph::thread::Throttle byte_throttler;
   static constexpr int64_t client_num = 1;
-  ceph::net::SocketMessenger msgr{entity_name_t::OSD(client_num), "client"};
+  ceph::net::SocketMessenger msgr{entity_name_t::OSD(client_num), "client", 0};
   struct ClientDispatcher : ceph::net::Dispatcher {
     unsigned count = 0;
     seastar::condition_variable on_reply;

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -22,7 +22,7 @@ static seastar::future<> test_echo(unsigned rounds,
     entity_addr_t addr;
 
     struct {
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1)};
+      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1), "server1"};
       struct ServerDispatcher : ceph::net::Dispatcher {
         seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
                                       MessageRef m) override {
@@ -38,7 +38,7 @@ static seastar::future<> test_echo(unsigned rounds,
     struct {
       unsigned rounds;
       std::bernoulli_distribution keepalive_dist{};
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0)};
+      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0), "client1"};
       struct ClientDispatcher : ceph::net::Dispatcher {
         seastar::promise<MessageRef> reply;
         unsigned count = 0u;
@@ -127,7 +127,7 @@ static seastar::future<> test_concurrent_dispatch()
     entity_addr_t addr;
 
     struct {
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1)};
+      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1), "server2"};
       class ServerDispatcher : public ceph::net::Dispatcher {
         int count = 0;
         seastar::promise<> on_second; // satisfied on second dispatch
@@ -151,7 +151,7 @@ static seastar::future<> test_concurrent_dispatch()
     } server;
 
     struct {
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0)};
+      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0), "client2"};
       ceph::net::Dispatcher dispatcher;
     } client;
   };

--- a/src/test/crimson/test_messenger.cc
+++ b/src/test/crimson/test_messenger.cc
@@ -22,7 +22,7 @@ static seastar::future<> test_echo(unsigned rounds,
     entity_addr_t addr;
 
     struct {
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1), "server1"};
+      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1), "server1", 1};
       struct ServerDispatcher : ceph::net::Dispatcher {
         seastar::future<> ms_dispatch(ceph::net::ConnectionRef c,
                                       MessageRef m) override {
@@ -38,7 +38,7 @@ static seastar::future<> test_echo(unsigned rounds,
     struct {
       unsigned rounds;
       std::bernoulli_distribution keepalive_dist{};
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0), "client1"};
+      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0), "client1", 2};
       struct ClientDispatcher : ceph::net::Dispatcher {
         seastar::promise<MessageRef> reply;
         unsigned count = 0u;
@@ -81,8 +81,10 @@ static seastar::future<> test_echo(unsigned rounds,
   return seastar::do_with(test_state{},
     [rounds, keepalive_ratio] (test_state& t) {
       // bind the server
+      t.addr.set_type(entity_addr_t::TYPE_LEGACY);
       t.addr.set_family(AF_INET);
       t.addr.set_port(9010);
+      t.addr.set_nonce(1);
       t.server.messenger.bind(t.addr);
 
       t.client.rounds = rounds;
@@ -127,7 +129,7 @@ static seastar::future<> test_concurrent_dispatch()
     entity_addr_t addr;
 
     struct {
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1), "server2"};
+      ceph::net::SocketMessenger messenger{entity_name_t::OSD(1), "server2", 3};
       class ServerDispatcher : public ceph::net::Dispatcher {
         int count = 0;
         seastar::promise<> on_second; // satisfied on second dispatch
@@ -151,15 +153,17 @@ static seastar::future<> test_concurrent_dispatch()
     } server;
 
     struct {
-      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0), "client2"};
+      ceph::net::SocketMessenger messenger{entity_name_t::OSD(0), "client2", 4};
       ceph::net::Dispatcher dispatcher;
     } client;
   };
   return seastar::do_with(test_state{},
     [] (test_state& t) {
       // bind the server
+      t.addr.set_type(entity_addr_t::TYPE_LEGACY);
       t.addr.set_family(AF_INET);
       t.addr.set_port(9010);
+      t.addr.set_nonce(3);
       t.server.messenger.bind(t.addr);
 
       return t.server.messenger.start(&t.server.dispatcher)

--- a/src/test/crimson/test_monc.cc
+++ b/src/test/crimson/test_monc.cc
@@ -23,7 +23,7 @@ static seastar::future<> test_monc()
     conf->cluster = cluster;
     return conf.parse_config_files(conf_file_list);
   }).then([] {
-    return seastar::do_with(ceph::net::SocketMessenger{entity_name_t::OSD(0), "monc"},
+    return seastar::do_with(ceph::net::SocketMessenger{entity_name_t::OSD(0), "monc", 0},
                             [](ceph::net::Messenger& msgr) {
       auto& conf = ceph::common::local_conf();
       if (conf->ms_crc_data) {

--- a/src/test/crimson/test_monc.cc
+++ b/src/test/crimson/test_monc.cc
@@ -23,7 +23,7 @@ static seastar::future<> test_monc()
     conf->cluster = cluster;
     return conf.parse_config_files(conf_file_list);
   }).then([] {
-    return seastar::do_with(ceph::net::SocketMessenger{entity_name_t::OSD(0)},
+    return seastar::do_with(ceph::net::SocketMessenger{entity_name_t::OSD(0), "monc"},
                             [](ceph::net::Messenger& msgr) {
       auto& conf = ceph::common::local_conf();
       if (conf->ms_crc_data) {


### PR DESCRIPTION
This PR is based on #25207, will continue to rebase until the base PR merged.

* Don't store `my_addr` in `Connection`, because the IP of `my_addr` can be learned from peer and thus changed.
* Support `nonce` in `SocketMessenger`.
* Add `learned_addr()` for `SocketMessenger`.
* Add `my_socket_port` and `peer_socket_port` to show the real connecting ports of the `SocketConnection`.
* The major fix: Fix banner exchange logic for addresses, including nonce, type, IP, port, socket_port for my_addr and peer_addr.
* Add logging prefixes for `SocketConnection` and `SocketMessenger`.