### PR TITLE
luminous: rgw: Fix log level of bi_log_iterate_entries" src/cls/rgw/cls_rgw.cc

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2617,7 +2617,7 @@ static int bi_log_iterate_entries(cls_method_context_t hctx, const string& marke
     end_key.append(end_marker);
   }
 
-  CLS_LOG(0, "bi_log_iterate_entries start_key=%s end_key=%s\n", start_key.c_str(), end_key.c_str());
+  CLS_LOG(10, "bi_log_iterate_entries start_key=%s end_key=%s\n", start_key.c_str(), end_key.c_str());
 
   string filter;
 


### PR DESCRIPTION
Hi,

Like this [pull request](https://github.com/ceph/ceph/pull/23665), maybe it's wrong log level for this line. 

What do you think ?

