### PR TITLE
ceph-volume: allow ceph-volume use for 'vstart'-ed cluster

### DIFF
--- a/src/ceph-volume/ceph_volume/__init__.py
+++ b/src/ceph-volume/ceph_volume/__init__.py
@@ -14,7 +14,8 @@ class UnloadedConfig(object):
     def __getattr__(self, *a):
         raise RuntimeError("No valid ceph configuration file was loaded.")
 
-conf = namedtuple('config', ['ceph', 'cluster', 'verbosity', 'path', 'log_path'])
+conf = namedtuple('config', ['ceph', 'cluster', 'verbosity', 'path', 'log_path',
+                             'osd_root'])
 conf.ceph = UnloadedConfig()
 
 __version__ = "1.0.0"

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -59,7 +59,7 @@ def activate_filestore(lvs, no_systemd=False):
         source = osd_lv.lv_path
 
     # mount the osd
-    destination = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
+    destination = os.path.join(conf.osd_root, '%s-%s' % (conf.cluster, osd_id))
     if not system.device_is_mounted(source, destination=destination):
         prepare_utils.mount_osd(source, osd_id, is_vdo=is_vdo)
 
@@ -68,7 +68,7 @@ def activate_filestore(lvs, no_systemd=False):
 
     # always re-do the symlink regardless if it exists, so that the journal
     # device path that may have changed can be mapped correctly every time
-    destination = '/var/lib/ceph/osd/%s-%s/journal' % (conf.cluster, osd_id)
+    destination = os.path.join(conf.osd_root, '%s-%s/journal' % (conf.cluster, osd_id))
     process.run(['ln', '-snf', osd_journal, destination])
 
     # make sure that the journal has proper permissions
@@ -131,7 +131,7 @@ def activate_bluestore(lvs, no_systemd=False):
     osd_fsid = osd_lv.tags['ceph.osd_fsid']
 
     # mount on tmpfs the osd directory
-    osd_path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
+    osd_path = os.path.join(conf.osd_root, '%s-%s' % (conf.cluster, osd_id))
     if not system.path_is_mounted(osd_path):
         # mkdir -p and mount as tmpfs
         prepare_utils.create_osd_path(osd_id, tmpfs=True)

--- a/src/ceph-volume/ceph_volume/devices/lvm/common.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/common.py
@@ -4,7 +4,7 @@ from ceph_volume import terminal
 import argparse
 
 
-def rollback_osd(args, osd_id=None):
+def rollback_osd(args, keyring, osd_id=None):
     """
     When the process of creating or preparing fails, the OSD needs to be
     destroyed so that the ID cane be reused.  This is prevents leaving the ID
@@ -21,12 +21,11 @@ def rollback_osd(args, osd_id=None):
     # once here, this is an error condition that needs to be rolled back
     terminal.error('Was unable to complete a new OSD, will rollback changes')
     osd_name = 'osd.%s'
-    bootstrap_keyring = '/var/lib/ceph/bootstrap-osd/%s.keyring' % conf.cluster
     cmd = [
         'ceph',
         '--cluster', conf.cluster,
         '--name', 'client.bootstrap-osd',
-        '--keyring', bootstrap_keyring,
+        '--keyring', keyring,
         'osd', 'purge-new', osd_name % osd_id,
         '--yes-i-really-mean-it',
     ]
@@ -117,6 +116,11 @@ def common_parser(prog, description):
         dest='no_systemd',
         action='store_true',
         help='Skip creating and enabling systemd units and starting OSD services when activating',
+    )
+    parser.add_argument(
+        '--bootstrap-keyring',
+        default='/var/lib/ceph/bootstrap-osd/%s.keyring',
+        help='Change the bootstrap keyring path (defaults to /var/lib/ceph/bootstrap-osd)',
     )
 
     # Do not parse args, so that consumers can do something before the args get

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -4,7 +4,7 @@ import logging
 
 from textwrap import dedent
 
-from ceph_volume import decorators, terminal, process
+from ceph_volume import decorators, terminal, process, conf
 from ceph_volume.api import lvm as api
 from ceph_volume.util import system, encryption, disk, arg_validators
 from ceph_volume.util.device import Device
@@ -124,7 +124,8 @@ class Zap(object):
 
     def unmount_lv(self, lv):
         if lv.tags.get('ceph.cluster_name') and lv.tags.get('ceph.osd_id'):
-            lv_path = "/var/lib/ceph/osd/{}-{}".format(lv.tags['ceph.cluster_name'], lv.tags['ceph.osd_id'])
+            lv_path = os.path.join(conf.osd_root, "{}-{}").format(
+              lv.tags['ceph.cluster_name'], lv.tags['ceph.osd_id'])
         else:
             lv_path = lv.lv_path
         dmcrypt_uuid = lv.lv_uuid

--- a/src/ceph-volume/ceph_volume/devices/simple/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/simple/activate.py
@@ -156,7 +156,7 @@ class Activate(object):
             self.dmcrypt_secret = base64.b64decode(raw_dmcrypt_secret)
 
         cluster_name = osd_metadata.get('cluster_name', 'ceph')
-        osd_dir = '/var/lib/ceph/osd/%s-%s' % (cluster_name, osd_id)
+        osd_dir = os.path.join(conf.osd_root, '%s-%s' % (cluster_name, osd_id))
 
         # XXX there is no support for LVM here
         data_device = self.get_device(data_uuid)

--- a/src/ceph-volume/ceph_volume/main.py
+++ b/src/ceph-volume/ceph_volume/main.py
@@ -126,8 +126,14 @@ Ceph Conf: {ceph_path}
             default='/var/log/ceph/',
             help='Change the log path (defaults to /var/log/ceph)',
         )
+        parser.add_argument(
+            '--osd-root',
+            default='/var/lib/ceph/osd',
+            help='Change the osd mount point location (defaults to /var/lib/ceph/osd)',
+        )
         args = parser.parse_args(main_args)
         conf.log_path = args.log_path
+        conf.osd_root = args.osd_root
         if os.path.isdir(conf.log_path):
             conf.log_path = os.path.join(args.log_path, 'ceph-volume.log')
         log.setup()

--- a/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_prepare.py
@@ -10,12 +10,12 @@ from ceph_volume.tests.conftest import Factory
 class TestOSDIDAvailable(object):
 
     def test_false_if_id_is_none(self):
-        assert not prepare.osd_id_available(None)
+        assert not prepare.osd_id_available('somekeyring', None)
 
     def test_returncode_is_not_zero(self, monkeypatch):
         monkeypatch.setattr('ceph_volume.process.call', lambda *a, **kw: ('', '', 1))
         with pytest.raises(RuntimeError):
-            prepare.osd_id_available(1)
+            prepare.osd_id_available('somekeyring', 1)
 
     def test_id_does_exist_but_not_available(self, monkeypatch):
         stdout = dict(nodes=[
@@ -23,7 +23,7 @@ class TestOSDIDAvailable(object):
         ])
         stdout = ['', json.dumps(stdout)]
         monkeypatch.setattr('ceph_volume.process.call', lambda *a, **kw: (stdout, '', 0))
-        result = prepare.osd_id_available(0)
+        result = prepare.osd_id_available('somekeyring', 0)
         assert not result
 
     def test_id_does_not_exist(self, monkeypatch):
@@ -32,7 +32,7 @@ class TestOSDIDAvailable(object):
         ])
         stdout = ['', json.dumps(stdout)]
         monkeypatch.setattr('ceph_volume.process.call', lambda *a, **kw: (stdout, '', 0))
-        result = prepare.osd_id_available(1)
+        result = prepare.osd_id_available('somekeyring', 1)
         assert not result
 
     def test_invalid_osd_id(self, monkeypatch):
@@ -41,7 +41,7 @@ class TestOSDIDAvailable(object):
         ])
         stdout = ['', json.dumps(stdout)]
         monkeypatch.setattr('ceph_volume.process.call', lambda *a, **kw: (stdout, '', 0))
-        result = prepare.osd_id_available("foo")
+        result = prepare.osd_id_available('somekeyring', "foo")
         assert not result
 
     def test_returns_true_when_id_is_destroyed(self, monkeypatch):
@@ -50,7 +50,7 @@ class TestOSDIDAvailable(object):
         ])
         stdout = ['', json.dumps(stdout)]
         monkeypatch.setattr('ceph_volume.process.call', lambda *a, **kw: (stdout, '', 0))
-        result = prepare.osd_id_available(0)
+        result = prepare.osd_id_available('somekeyring', 0)
         assert result
 
 

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -116,7 +116,8 @@ def get_dmcrypt_key(osd_id, osd_fsid, lockbox_keyring=None):
     (e.g. inside a lockbox partition mounted in a temporary location)
     """
     if lockbox_keyring is None:
-        lockbox_keyring = '/var/lib/ceph/osd/%s-%s/lockbox.keyring' % (conf.cluster, osd_id)
+        lockbox_keyring = os.path.join(conf.osd_root,
+                                       '%s-%s/lockbox.keyring' % (conf.cluster, osd_id))
     name = 'client.osd-lockbox.%s' % osd_fsid
     config_key = 'dm-crypt/osd/%s/luks' % osd_fsid
 
@@ -151,7 +152,7 @@ def write_lockbox_keyring(osd_id, osd_fsid, secret):
     then the data device is mounted on that directory, making the keyring
     "disappear".
     """
-    if os.path.exists('/var/lib/ceph/osd/%s-%s/lockbox.keyring' % (conf.cluster, osd_id)):
+    if os.path.exists(os.path.join(conf.osd_root,'%s-%s/lockbox.keyring' % (conf.cluster, osd_id))):
         return
 
     name = 'client.osd-lockbox.%s' % osd_fsid

--- a/src/ceph-volume/ceph_volume/util/prepare.py
+++ b/src/ceph-volume/ceph_volume/util/prepare.py
@@ -36,7 +36,8 @@ def write_keyring(osd_id, secret, keyring_name='keyring', name=None):
     :param keyring_name: Alternative keyring name, for supporting other
                          types of keys like for lockbox
     """
-    osd_keyring = '/var/lib/ceph/osd/%s-%s/%s' % (conf.cluster, osd_id, keyring_name)
+    osd_keyring = os.path.join(conf.osd_root,
+                               '%s-%s/%s' % (conf.cluster, osd_id, keyring_name))
     name = name or 'osd.%s' % str(osd_id)
     process.run(
         [
@@ -181,8 +182,9 @@ def mount_tmpfs(path):
 
 
 def create_osd_path(osd_id, tmpfs=False):
-    path = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
-    system.mkdir_p('/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id))
+    path = os.path.join(conf.osd_root,'%s-%s' % (conf.cluster, osd_id))
+    system.mkdir_p(os.path.join(conf.osd_root,
+                                '%s-%s' % (conf.cluster, osd_id)))
     if tmpfs:
         mount_tmpfs(path)
 
@@ -263,7 +265,7 @@ def mount_osd(device, osd_id, **kw):
     is_vdo = kw.get('is_vdo', '0')
     if is_vdo == '1':
         extras = ['discard']
-    destination = '/var/lib/ceph/osd/%s-%s' % (conf.cluster, osd_id)
+    destination = os.path.join(conf.osd_root,'%s-%s' % (conf.cluster, osd_id))
     command = ['mount', '-t', 'xfs', '-o']
     flags = conf.ceph.get_list(
         'osd',
@@ -288,11 +290,11 @@ def _link_device(device, device_type, osd_id):
     source, with an absolute path and ``device_type`` will be the destination
     name, like 'journal', or 'block'
     """
-    device_path = '/var/lib/ceph/osd/%s-%s/%s' % (
+    device_path = os.path.join(conf.osd_root,'%s-%s/%s' % (
         conf.cluster,
         osd_id,
         device_type
-    )
+    ))
     command = ['ln', '-s', device, device_path]
     system.chown(device)
 
@@ -324,7 +326,7 @@ def get_monmap(keyring, osd_id):
              --keyring /var/lib/ceph/bootstrap-osd/ceph.keyring \
              mon getmap -o /var/lib/ceph/osd/ceph-0/activate.monmap
     """
-    path = '/var/lib/ceph/osd/%s-%s/' % (conf.cluster, osd_id)
+    path = os.path.join(conf.osd_root, '%s-%s/' % (conf.cluster, osd_id))
     monmap_destination = os.path.join(path, 'activate.monmap')
 
     process.run([
@@ -350,7 +352,7 @@ def osd_mkfs_bluestore(osd_id, fsid, keyring=None, wal=False, db=False):
     In some cases it is required to use the keyring, when it is passed in as
     a keyword argument it is used as part of the ceph-osd command
     """
-    path = '/var/lib/ceph/osd/%s-%s/' % (conf.cluster, osd_id)
+    path = os.path.join(conf.osd_root,'%s-%s/' % (conf.cluster, osd_id))
     monmap = os.path.join(path, 'activate.monmap')
 
     system.chown(path)
@@ -406,7 +408,7 @@ def osd_mkfs_filestore(osd_id, fsid, keyring):
                    --setuser ceph --setgroup ceph
 
     """
-    path = '/var/lib/ceph/osd/%s-%s/' % (conf.cluster, osd_id)
+    path = os.path.join(conf.osd_root, '%s-%s/' % (conf.cluster, osd_id))
     monmap = os.path.join(path, 'activate.monmap')
     journal = os.path.join(path, 'journal')
 


### PR DESCRIPTION
--osd-root and --bstrap-keyring command options have been added for that.

Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

