### PR TITLE
osd: stray pg should/could not send notify anymore

### DIFF
--- a/src/osd/PeeringState.cc
+++ b/src/osd/PeeringState.cc
@@ -2610,6 +2610,7 @@ void PeeringState::fulfill_query(const MQuery& query, PeeringCtx *rctx)
   } else {
     update_history(query.query.history);
     fulfill_log(query.from, query.query, query.query_epoch);
+    send_notify = false;
   }
 }
 


### PR DESCRIPTION
let us say:

1. primary pg queried full log from stray pg
2. primary rewind the stray pg log when proc_replica_log(),and generate new peer info
3. osdmap update and did not change peering interval
4. stray pg react ActMap and send old info
5. the new peer info was replaced with older info when Primary::react(const MNotifyRec& notevt)
6. when activating, primary pg will use old peer info to search missing..

Fixes: http://tracker.ceph.com/issues/37679

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

