### PR TITLE
ceph-volume tests.functional fix typo when stopping osd.0 in filestore

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/strategies/bluestore.py
@@ -1,5 +1,4 @@
 from __future__ import print_function
-import json
 from ceph_volume.util import disk, prepare, str_to_int
 from ceph_volume.api import lvm
 from . import validators

--- a/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/lvm/playbooks/test_filestore.yml
@@ -111,7 +111,7 @@
 
     - name: stop ceph-osd@1 daemon
       service:
-        name: ceph-osd@0
+        name: ceph-osd@1
         state: stopped
 
     - name: activate all to start the previously prepared osd.0


### PR DESCRIPTION
A typo in the functional test was preventing an OSD to come up (detection was correct). The OSD needs to be stopped in order for `activate --all` to not skip it

Fixes: http://tracker.ceph.com/issues/37675