### PR TITLE
ec: lrc doesn't depend on crosstalks between bufferlists anymore.

### DIFF
--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -754,16 +754,18 @@ int ErasureCodeLrc::encode_chunks(const set<int> &want_to_encode,
     set<int> layer_want_to_encode;
     map<int, bufferlist> layer_encoded;
     int j = 0;
-    for (vector<int>::const_iterator c = layer.chunks.begin();
-	 c != layer.chunks.end();
-	 ++c) {
-      layer_encoded[j] = (*encoded)[*c];
-      if (want_to_encode.find(*c) != want_to_encode.end())
+    for (const auto& c : layer.chunks) {
+      std::swap(layer_encoded[j], (*encoded)[c]);
+      if (want_to_encode.find(c) != want_to_encode.end())
 	layer_want_to_encode.insert(j);
       j++;
     }
     int err = layer.erasure_code->encode_chunks(layer_want_to_encode,
 						&layer_encoded);
+    j = 0;
+    for (const auto& c : layer.chunks) {
+      std::swap(layer_encoded[j++], (*encoded)[c]);
+    }
     if (err) {
       derr << __func__ << " layer " << layer.chunks_map
 	   << " failed with " << err << " trying to encode "


### PR DESCRIPTION
This patch tries to remove the dependency on crosstalk between `bufferlist` instances `ErasureCodeLrc` currently exhibits. The general problem is that `bufferlist::c_str()` returns non-const `char*`, fully usable as e.g. destination of `memcpy`, while the pointer's value **can be the same across different `bufferlist` instances**. Whether it actually is depends on the number of `buffer::ptr` stored inside particular instances which - on itself - can be quite hard to control.

The crosstalk problem [is illustrated](
https://gist.github.com/rzarzynski/aed18372e88aed392101adac3bd87bbc) with an unit test  that will be proposed together with the second part the bl rework.

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>