### PR TITLE
mgr: expose MODULE_OPTIONS to mon for 'config help' etc

### DIFF
--- a/src/common/options.h
+++ b/src/common/options.h
@@ -376,9 +376,10 @@ struct Option {
   {
     return
       (has_flag(FLAG_RUNTIME)
-       || type == TYPE_BOOL || type == TYPE_INT
-       || type == TYPE_UINT || type == TYPE_FLOAT
-       || type == TYPE_SIZE || type == TYPE_SECS)
+       || (!has_flag(FLAG_MGR)
+	   && (type == TYPE_BOOL || type == TYPE_INT
+	       || type == TYPE_UINT || type == TYPE_FLOAT
+	       || type == TYPE_SIZE || type == TYPE_SECS)))
       && !has_flag(FLAG_STARTUP)
       && !has_flag(FLAG_CLUSTER_CREATE)
       && !has_flag(FLAG_CREATE);

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -333,9 +333,9 @@ struct Option {
     return *this;
   }
 
-  Option& set_enum_allowed(const std::initializer_list<const char*>& allowed)
+  Option& set_enum_allowed(const std::vector<const char*>& allowed)
   {
-    enum_allowed.insert(enum_allowed.end(), allowed);
+    enum_allowed = allowed;
     return *this;
   }
 

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -116,6 +116,7 @@ struct Option {
     FLAG_STARTUP = 0x4,         ///< option can only take effect at startup
     FLAG_CLUSTER_CREATE = 0x8,  ///< option only has effect at cluster creation
     FLAG_CREATE = 0x10,         ///< option only has effect at daemon creation
+    FLAG_MGR = 0x20,            ///< option is a mgr module option
   };
 
   struct size_t {

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -13,16 +13,16 @@
 
 struct Option {
   enum type_t {
-    TYPE_UINT,
-    TYPE_INT,
-    TYPE_STR,
-    TYPE_FLOAT,
-    TYPE_BOOL,
-    TYPE_ADDR,
-    TYPE_ADDRVEC,
-    TYPE_UUID,
-    TYPE_SIZE,
-    TYPE_SECS,
+    TYPE_UINT = 0,
+    TYPE_INT = 1,
+    TYPE_STR = 2,
+    TYPE_FLOAT = 3,
+    TYPE_BOOL = 4,
+    TYPE_ADDR = 5,
+    TYPE_ADDRVEC = 6,
+    TYPE_UUID = 7,
+    TYPE_SIZE = 8,
+    TYPE_SECS = 9,
   };
 
   const char *type_to_str(type_t t) const {
@@ -47,10 +47,10 @@ struct Option {
    * Development: not for users.  May be dangerous, may not be documented.
    */
   enum level_t {
-    LEVEL_BASIC,
-    LEVEL_ADVANCED,
-    LEVEL_DEV,
-    LEVEL_UNKNOWN,
+    LEVEL_BASIC = 0,
+    LEVEL_ADVANCED = 1,
+    LEVEL_DEV = 2,
+    LEVEL_UNKNOWN = 3,
   };
 
   static const char *level_to_str(level_t l) {

--- a/src/common/options.h
+++ b/src/common/options.h
@@ -25,7 +25,7 @@ struct Option {
     TYPE_SECS = 9,
   };
 
-  const char *type_to_str(type_t t) const {
+  static const char *type_to_c_type_str(type_t t) {
     switch (t) {
     case TYPE_UINT: return "uint64_t";
     case TYPE_INT: return "int64_t";
@@ -39,6 +39,54 @@ struct Option {
     case TYPE_SECS: return "secs";
     default: return "unknown";
     }
+  }
+  static const char *type_to_str(type_t t) {
+    switch (t) {
+    case TYPE_UINT: return "uint";
+    case TYPE_INT: return "int";
+    case TYPE_STR: return "str";
+    case TYPE_FLOAT: return "float";
+    case TYPE_BOOL: return "bool";
+    case TYPE_ADDR: return "addr";
+    case TYPE_ADDRVEC: return "addrvec";
+    case TYPE_UUID: return "uuid";
+    case TYPE_SIZE: return "size";
+    case TYPE_SECS: return "secs";
+    default: return "unknown";
+    }
+  }
+  static int str_to_type(const std::string& s) {
+    if (s == "uint") {
+      return TYPE_UINT;
+    }
+    if (s == "int") {
+      return TYPE_INT;
+    }
+    if (s == "str") {
+      return TYPE_STR;
+    }
+    if (s == "float") {
+      return TYPE_FLOAT;
+    }
+    if (s == "bool") {
+      return TYPE_BOOL;
+    }
+    if (s == "addr") {
+      return TYPE_ADDR;
+    }
+    if (s == "addrvec") {
+      return TYPE_ADDRVEC;
+    }
+    if (s == "uuid") {
+      return TYPE_UUID;
+    }
+    if (s == "size") {
+      return TYPE_SIZE;
+    }
+    if (s == "secs") {
+      return TYPE_SECS;
+    }
+    return -1;
   }
 
   /**

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -399,7 +399,7 @@ ceph_get_module_option(BaseMgrModule *self, PyObject *args)
       what, &value);
   if (found) {
     dout(10) << __func__ << " " << what << " found: " << value.c_str() << dendl;
-    return PyString_FromString(value.c_str());
+    return self->this_module->py_module->get_typed_option_value(what, value);
   } else {
     dout(4) << __func__ << " " << what << " not found " << dendl;
     Py_RETURN_NONE;

--- a/src/mgr/BaseMgrStandbyModule.cc
+++ b/src/mgr/BaseMgrStandbyModule.cc
@@ -73,7 +73,7 @@ ceph_get_module_option(BaseMgrStandbyModule *self, PyObject *args)
   bool found = self->this_module->get_config(what, &value);
   if (found) {
     dout(10) << __func__ << " " << what << " found: " << value.c_str() << dendl;
-    return PyString_FromString(value.c_str());
+    return self->this_module->py_module->get_typed_option_value(what, value);
   } else {
     dout(4) << __func__ << " " << what << " not found " << dendl;
     Py_RETURN_NONE;

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -195,6 +195,7 @@ void MgrStandby::send_beacon()
     info.name = module->get_name();
     info.error_string = module->get_error_string();
     info.can_run = module->get_can_run();
+    info.module_options = module->get_options();
     module_info.push_back(std::move(info));
   }
 

--- a/src/mgr/PyModule.cc
+++ b/src/mgr/PyModule.cc
@@ -538,23 +538,31 @@ int PyModule::load_options()
       option.long_desc = PyString_AsString(p);
     }
     p = PyDict_GetItemString(pOption, "default");
-    if (p && PyObject_TypeCheck(p, &PyString_Type)) {
-      option.default_value = PyString_AsString(p);
+    if (p) {
+      auto q = PyObject_Str(p);
+      option.default_value = PyString_AsString(q);
+      Py_DECREF(q);
     }
     p = PyDict_GetItemString(pOption, "min");
-    if (p && PyObject_TypeCheck(p, &PyString_Type)) {
-      option.min = PyString_AsString(p);
+    if (p) {
+      auto q = PyObject_Str(p);
+      option.min = PyString_AsString(q);
+      Py_DECREF(q);
     }
     p = PyDict_GetItemString(pOption, "max");
-    if (p && PyObject_TypeCheck(p, &PyString_Type)) {
-      option.max = PyString_AsString(p);
+    if (p) {
+      auto q = PyObject_Str(p);
+      option.max = PyString_AsString(q);
+      Py_DECREF(q);
     }
     p = PyDict_GetItemString(pOption, "enum_allowed");
     if (p && PyObject_TypeCheck(p, &PyList_Type)) {
       for (unsigned i = 0; i < PyList_Size(p); ++i) {
 	auto q = PyList_GetItem(p, i);
-	if (q && PyObject_TypeCheck(q, &PyString_Type)) {
-	  option.enum_allowed.insert(PyString_AsString(q));
+	if (q) {
+	  auto r = PyObject_Str(q);
+	  option.enum_allowed.insert(PyString_AsString(r));
+	  Py_DECREF(r);
 	}
       }
     }

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -21,6 +21,7 @@
 #include "common/Mutex.h"
 #include "Python.h"
 #include "Gil.h"
+#include "mon/MgrMap.h"
 
 
 class MonClient;
@@ -41,15 +42,6 @@ public:
 
   // Call the ActivePyModule of this name to handle the command
   std::string module_name;
-};
-
-
-/**
- * An option declared by the python module in its configuration schema
- */
-class ModuleOption {
-  public:
-  std::string name;
 };
 
 class PyModule
@@ -90,7 +82,7 @@ private:
   std::vector<ModuleCommand> commands;
 
   int load_options();
-  std::map<std::string, ModuleOption> options;
+  std::map<std::string, MgrMap::ModuleOption> options;
 
 public:
   static std::string config_prefix;
@@ -107,6 +99,9 @@ public:
   ~PyModule();
 
   bool is_option(const std::string &option_name);
+  const std::map<std::string,MgrMap::ModuleOption>& get_options() const {
+    return options;
+  }
 
   int load(PyThreadState *pMainThreadState);
 #if PY_MAJOR_VERSION >= 3

--- a/src/mgr/PyModule.h
+++ b/src/mgr/PyModule.h
@@ -103,6 +103,10 @@ public:
     return options;
   }
 
+  PyObject *get_typed_option_value(
+    const std::string& option,
+    const std::string& value);
+
   int load(PyThreadState *pMainThreadState);
 #if PY_MAJOR_VERSION >= 3
   static PyObject* init_ceph_logger();

--- a/src/mgr/PyModuleRunner.h
+++ b/src/mgr/PyModuleRunner.h
@@ -26,10 +26,11 @@
  */
 class PyModuleRunner
 {
-protected:
+public:
   // Info about the module we're going to run
   PyModuleRef py_module;
 
+protected:
   // Populated by descendent class
   PyObject *pClassInstance = nullptr;
 

--- a/src/mgr/PythonCompat.h
+++ b/src/mgr/PythonCompat.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #pragma once
 
 #include <Python.h>
@@ -25,4 +28,11 @@ inline PyObject* PyInt_FromLong(long ival) {
 inline int PyString_Check(PyObject *o) {
   return PyUnicode_Check(o);
 }
+inline PyObject* PyFloat_FromString(PyObject *s, void *arg) {
+  return PyFloat_FromString(s);
+}
+inline PyObject* PyInt_FromString(const char *str, char **pend, int base) {
+  return PyLong_FromString(str, pend, base);
+}
+#define PyString_Type PyUnicode_Type
 #endif

--- a/src/mon/ConfigMonitor.cc
+++ b/src/mon/ConfigMonitor.cc
@@ -5,6 +5,7 @@
 
 #include "mon/Monitor.h"
 #include "mon/ConfigMonitor.h"
+#include "mon/MgrMonitor.h"
 #include "mon/OSDMonitor.h"
 #include "messages/MConfig.h"
 #include "messages/MGetConfig.h"
@@ -152,20 +153,27 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 
   bufferlist odata;
   if (prefix == "config help") {
+    stringstream ss;
     string name;
     cmd_getval(g_ceph_context, cmdmap, "key", name);
     const Option *opt = g_conf().find_option(name);
     if (!opt) {
+      opt = mon->mgrmon()->find_module_option(name);
+    }
+    if (opt) {
+      if (f) {
+	f->dump_object("option", *opt);
+      } else {
+	opt->print(&ss);
+      }
+    } else {
       ss << "configuration option '" << name << "' not recognized";
       err = -ENOENT;
       goto reply;
     }
     if (f) {
-      f->dump_object("option", *opt);
       f->flush(odata);
     } else {
-      stringstream ss;
-      opt->print(&ss);
       odata.append(ss.str());
     }
   } else if (prefix == "config dump") {
@@ -261,6 +269,9 @@ bool ConfigMonitor::preprocess_command(MonOpRequestRef op)
 	goto reply;
       }
       const Option *opt = g_conf().find_option(name);
+      if (!opt) {
+	opt = mon->mgrmon()->find_module_option(name);
+      }
       if (!opt) {
 	err = -ENOENT;
 	goto reply;
@@ -410,21 +421,22 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
     cmd_getval(g_ceph_context, cmdmap, "value", value);
 
     if (prefix == "config set") {
-      if (name.substr(0, 4) != "mgr/") {
-	const Option *opt = g_conf().find_option(name);
-	if (!opt) {
-	  ss << "unrecognized config option '" << name << "'";
-	  err = -EINVAL;
-	  goto reply;
-	}
+      const Option *opt = g_conf().find_option(name);
+      if (!opt) {
+	opt = mon->mgrmon()->find_module_option(name);
+      }
+      if (!opt) {
+	ss << "unrecognized config option '" << name << "'";
+	err = -EINVAL;
+	goto reply;
+      }
 	
-	Option::value_t real_value;
-	string errstr;
-	err = opt->parse_value(value, &real_value, &errstr, &value);
-	if (err < 0) {
-	  ss << "error parsing value: " << errstr;
-	  goto reply;
-	}
+      Option::value_t real_value;
+      string errstr;
+      err = opt->parse_value(value, &real_value, &errstr, &value);
+      if (err < 0) {
+	ss << "error parsing value: " << errstr;
+	goto reply;
       }
     }
 
@@ -513,6 +525,9 @@ bool ConfigMonitor::prepare_command(MonOpRequestRef op)
 	}
 	// a known and worthy option?
 	const Option *o = g_conf().find_option(j.key);
+	if (!o) {
+	  o = mon->mgrmon()->find_module_option(j.key);
+	}
 	if (!o ||
 	    o->flags & Option::FLAG_NO_MON_UPDATE) {
 	  goto skip;
@@ -639,58 +654,48 @@ void ConfigMonitor::load_config()
     string who;
     if (last_slash == std::string::npos) {
       name = key;
+    } else if (auto mgrpos = key.find("/mgr/"); mgrpos != std::string::npos) {
+      name = key.substr(mgrpos + 1);
+      who = key.substr(0, mgrpos);
     } else {
       name = key.substr(last_slash + 1);
       who = key.substr(0, last_slash);
     }
 
+    const Option *opt = g_conf().find_option(name);
+    if (!opt) {
+      opt = mon->mgrmon()->find_module_option(name);
+    }
+    if (!opt) {
+      dout(10) << __func__ << " unrecognized option '" << name << "'" << dendl;
+      opt = new Option(name, Option::TYPE_STR, Option::LEVEL_UNKNOWN);
+      // FIXME: this will be leaked!
+    }
+
+    string err;
+    int r = opt->pre_validate(&value, &err);
+    if (r < 0) {
+      dout(10) << __func__ << " pre-validate failed on '" << name << "' = '"
+	       << value << "' for " << name << dendl;
+    }
+    
+    MaskedOption mopt(opt);
+    mopt.raw_value = value;
     string section_name;
-    if (key.find("/mgr/") != std::string::npos) {
-      // mgr module option, "something/mgr/foo"
-      name = key.substr(key.find("/mgr/") + 1);
-      MaskedOption mopt(new Option(name, Option::TYPE_STR,
-				   Option::LEVEL_UNKNOWN));
-      mopt.raw_value = value;      
+    if (who.size() &&
+	!ConfigMap::parse_mask(who, &section_name, &mopt.mask)) {
+      derr << __func__ << " ignoring key " << key << dendl;
+    } else {
       Section *section = &config_map.global;;
-      section_name = "mgr";
-      if (section_name.find('.') != std::string::npos) {
-	section = &config_map.by_id[section_name];
-      } else {
-	section = &config_map.by_type[section_name];
+      if (section_name.size()) {
+	if (section_name.find('.') != std::string::npos) {
+	  section = &config_map.by_id[section_name];
+	} else {
+	  section = &config_map.by_type[section_name];
+	}
       }
       section->options.insert(make_pair(name, std::move(mopt)));
-      ++num;      
-    } else {
-      // normal option
-      const Option *opt = g_conf().find_option(name);
-      if (!opt) {
-	dout(10) << __func__ << " unrecognized option '" << name << "'" << dendl;
-	opt = new Option(name, Option::TYPE_STR, Option::LEVEL_UNKNOWN);
-      }
-      string err;
-      int r = opt->pre_validate(&value, &err);
-      if (r < 0) {
-	dout(10) << __func__ << " pre-validate failed on '" << name << "' = '"
-		 << value << "' for " << name << dendl;
-      }
-    
-      MaskedOption mopt(opt);
-      mopt.raw_value = value;
-      if (who.size() &&
-	  !ConfigMap::parse_mask(who, &section_name, &mopt.mask)) {
-	derr << __func__ << " ignoring key " << key << dendl;
-      } else {
-	Section *section = &config_map.global;;
-	if (section_name.size()) {
-	  if (section_name.find('.') != std::string::npos) {
-	    section = &config_map.by_id[section_name];
-	  } else {
-	    section = &config_map.by_type[section_name];
-	  }
-	}
-	section->options.insert(make_pair(name, std::move(mopt)));
-	++num;
-      }
+      ++num;
     }
     it->next();
   }

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -15,30 +15,110 @@
 #define MGR_MAP_H_
 
 #include <sstream>
+#include <set>
 
 #include "msg/msg_types.h"
 #include "common/Formatter.h"
 #include "include/encoding.h"
+#include "include/utime.h"
 #include "common/version.h"
+#include "common/options.h"
+#include "common/Clock.h"
 
 
 class MgrMap
 {
 public:
+  struct ModuleOption {
+    std::string name;
+    uint8_t type = Option::TYPE_STR;         // Option::type_t TYPE_*
+    uint8_t level = Option::LEVEL_ADVANCED;  // Option::level_t LEVEL_*
+    uint32_t flags = 0; // Option::flag_t FLAG_*
+    std::string default_value;
+    std::string min, max;
+    std::set<std::string> enum_allowed;
+    std::string desc, long_desc;
+    std::set<std::string> tags;
+    std::set<std::string> see_also;
+
+    void encode(bufferlist& bl) const {
+      ENCODE_START(1, 1, bl);
+      encode(name, bl);
+      encode(type, bl);
+      encode(level, bl);
+      encode(flags, bl);
+      encode(default_value, bl);
+      encode(min, bl);
+      encode(max, bl);
+      encode(enum_allowed, bl);
+      encode(desc, bl);
+      encode(long_desc, bl);
+      encode(tags, bl);
+      encode(see_also, bl);
+      ENCODE_FINISH(bl);
+    }
+    void decode(bufferlist::const_iterator& p) {
+      DECODE_START(1, p);
+      decode(name, p);
+      decode(type, p);
+      decode(level, p);
+      decode(flags, p);
+      decode(default_value, p);
+      decode(min, p);
+      decode(max, p);
+      decode(enum_allowed, p);
+      decode(desc, p);
+      decode(long_desc, p);
+      decode(tags, p);
+      decode(see_also, p);
+      DECODE_FINISH(p);
+    }
+    void dump(Formatter *f) const {
+      f->dump_string("name", name);
+      f->dump_string("type", Option::type_to_str(
+		       static_cast<Option::type_t>(type)));
+      f->dump_string("level", Option::level_to_str(
+		       static_cast<Option::level_t>(level)));
+      f->dump_unsigned("flags", flags);
+      f->dump_string("default_value", default_value);
+      f->dump_string("min", min);
+      f->dump_string("max", max);
+      f->open_array_section("enum_allowed");
+      for (auto& i : enum_allowed) {
+	f->dump_string("value", i);
+      }
+      f->close_section();
+      f->dump_string("desc", desc);
+      f->dump_string("long_desc", long_desc);
+      f->open_array_section("tags");
+      for (auto& i : tags) {
+	f->dump_string("tag", i);
+      }
+      f->close_section();
+      f->open_array_section("see_also");
+      for (auto& i : see_also) {
+	f->dump_string("option", i);
+      }
+      f->close_section();
+    }
+  };
+
   class ModuleInfo
   {
     public:
     std::string name;
     bool can_run = true;
     std::string error_string;
+    std::map<std::string,ModuleOption> module_options;
 
     // We do not include the module's `failed` field in the beacon,
     // because it is exposed via health checks.
     void encode(bufferlist &bl) const {
-      ENCODE_START(1, 1, bl);
+      ENCODE_START(2, 1, bl);
       encode(name, bl);
       encode(can_run, bl);
       encode(error_string, bl);
+      encode(module_options, bl);
       ENCODE_FINISH(bl);
     }
 
@@ -47,6 +127,9 @@ public:
       decode(name, bl);
       decode(can_run, bl);
       decode(error_string, bl);
+      if (struct_v >= 2) {
+	decode(module_options, bl);
+      }
       DECODE_FINISH(bl);
     }
 
@@ -60,6 +143,11 @@ public:
       f->dump_string("name", name);
       f->dump_bool("can_run", can_run);
       f->dump_string("error_string", error_string);
+      f->open_object_section("module_options");
+      for (auto& i : module_options) {
+	f->dump_object(i.first.c_str(), i.second);
+      }
+      f->close_section();
       f->close_section();
     }
   };
@@ -186,6 +274,15 @@ public:
     }
 
     return false;
+  }
+
+  const ModuleInfo *get_module_info(const std::string &module_name) const {
+    for (const auto &i : available_modules) {
+      if (i.name == module_name) {
+        return &i;
+      }
+    }
+    return nullptr;
   }
 
   bool can_run_module(const std::string &module_name, std::string *error) const
@@ -443,6 +540,7 @@ public:
 WRITE_CLASS_ENCODER_FEATURES(MgrMap)
 WRITE_CLASS_ENCODER(MgrMap::StandbyInfo)
 WRITE_CLASS_ENCODER(MgrMap::ModuleInfo);
+WRITE_CLASS_ENCODER(MgrMap::ModuleOption);
 
 #endif
 

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -173,6 +173,7 @@ void MgrMonitor::update_from_paxos(bool *need_bootstrap)
 	       static_cast<Option::level_t>(j.second.level)));
       Option& opt = p.first->second;
       opt.set_flags(static_cast<Option::flag_t>(j.second.flags));
+      opt.set_flag(Option::FLAG_MGR);
       opt.set_description(j.second.desc.c_str());
       opt.set_long_description(j.second.long_desc.c_str());
       for (auto& k : j.second.tags) {
@@ -180,11 +181,11 @@ void MgrMonitor::update_from_paxos(bool *need_bootstrap)
       }
       for (auto& k : j.second.see_also) {
 	if (i.module_options.count(k)) {
-	  // another module option
+	  // it's another module option
 	  misc_option_strings.push_back(string("mgr/") + i.name + "/" + k);
 	  opt.add_see_also(misc_option_strings.back().c_str());
 	} else {
-	  // ceph option
+	  // it's a native option
 	  opt.add_see_also(k.c_str());
 	}
       }

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -54,6 +54,32 @@ const static std::map<uint32_t, std::set<std::string>> always_on_modules = {
 // Prefix for mon store of active mgr's command descriptions
 const static std::string command_descs_prefix = "mgr_command_descs";
 
+const Option *MgrMonitor::find_module_option(const string& name)
+{
+  // we have two forms of names: "mgr/$module/$option" and
+  // localized "mgr/$module/$instance/$option".  normalize to the
+  // former by stripping out $instance.
+  string real_name;
+  if (name.substr(0, 4) != "mgr/") {
+    return nullptr;
+  }
+  auto second_slash = name.find('/', 5);
+  if (second_slash == std::string::npos) {
+    return nullptr;
+  }
+  auto third_slash = name.find('/', second_slash + 1);
+  if (third_slash != std::string::npos) {
+    // drop the $instance part between the second and third slash
+    real_name = name.substr(0, second_slash) + name.substr(third_slash);
+  } else {
+    real_name = name;
+  }
+  auto p = mgr_module_options.find(real_name);
+  if (p != mgr_module_options.end()) {
+    return &p->second;
+  }
+  return nullptr;
+}
 
 version_t MgrMonitor::get_trim_to() const
 {

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -31,6 +31,9 @@ class MgrMonitor: public PaxosService
   std::map<std::string, bufferlist> pending_metadata;
   std::set<std::string>             pending_metadata_rm;
 
+  std::map<std::string,Option> mgr_module_options;
+  std::list<std::string> misc_option_strings;
+
   utime_t first_seen_inactive;
 
   std::map<uint64_t, ceph::coarse_mono_clock::time_point> last_beacon;
@@ -77,6 +80,14 @@ public:
   void on_shutdown() override;
 
   const MgrMap &get_map() const { return map; }
+
+  const Option *find_module_option(const string& name) {
+    auto p = mgr_module_options.find(name);
+    if (p != mgr_module_options.end()) {
+      return &p->second;
+    }
+    return nullptr;
+  }
 
   bool in_use() const { return map.epoch > 0; }
 

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -81,13 +81,7 @@ public:
 
   const MgrMap &get_map() const { return map; }
 
-  const Option *find_module_option(const string& name) {
-    auto p = mgr_module_options.find(name);
-    if (p != mgr_module_options.end()) {
-      return &p->second;
-    }
-    return nullptr;
-  }
+  const Option *find_module_option(const string& name);
 
   bool in_use() const { return map.epoch > 0; }
 

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -14,10 +14,6 @@ from mgr_module import MgrModule, CommandResult
 from threading import Event
 from mgr_module import CRUSHMap
 
-# available modes: 'none', 'crush', 'crush-compat', 'upmap', 'osd_weight'
-default_mode = 'none'
-default_sleep_interval = 60   # seconds
-
 TIME_FORMAT = '%Y-%m-%d_%H:%M:%S'
 
 class MappingState:
@@ -202,17 +198,94 @@ class Eval:
 
 class Module(MgrModule):
     MODULE_OPTIONS = [
-            {'name': 'active'},
-            {'name': 'begin_time'},
-            {'name': 'crush_compat_max_iterations'},
-            {'name': 'crush_compat_metrics'},
-            {'name': 'crush_compat_step'},
-            {'name': 'end_time'},
-            {'name': 'min_score'},
-            {'name': 'mode'},
-            {'name': 'sleep_interval'},
-            {'name': 'upmap_max_iterations'},
-            {'name': 'upmap_max_deviation'},
+        {
+            'name': 'active',
+            'type': 'bool',
+            'default': False,
+            'desc': 'automatically balance PGs across cluster',
+            'runtime': True,
+        },
+        {
+            'name': 'begin_time',
+            'type': 'str',
+            'default': '0000',
+            'desc': 'beginning time of day to automatically balance',
+            'long_desc': 'This is a time of day in the format HHMM.',
+            'runtime': True,
+        },
+        {
+            'name': 'end_time',
+            'type': 'str',
+            'default': '2400',
+            'desc': 'ending time of day to automatically balance',
+            'long_desc': 'This is a time of day in the format HHMM.',
+            'runtime': True,
+        },
+        {
+            'name': 'crush_compat_max_iterations',
+            'type': 'uint',
+            'default': 25,
+            'min': '1',
+            'max': '250',
+            'desc': 'maximum number of iterations to attempt optimization',
+            'runtime': True,
+        },
+        {
+            'name': 'crush_compat_metrics',
+            'type': 'str',
+            'default': 'pgs,objects,bytes',
+            'desc': 'metrics with which to calculate OSD utilization',
+            'long_desc': 'Value is a list of one or more of "pgs", "objects", or "bytes", and indicates which metrics to use to balance utilization.',
+            'runtime': True,
+        },
+        {
+            'name': 'crush_compat_step',
+            'type': 'float',
+            'default': .5,
+            'min': '.001',
+            'max': '.999',
+            'desc': 'aggressiveness of optimization',
+            'long_desc': '.99 is very aggressive, .01 is less aggressive',
+            'runtime': True,
+        },
+        {
+            'name': 'min_score',
+            'type': 'float',
+            'default': 0,
+            'desc': 'minimum score, below which no optimization is attempted',
+            'runtime': True,
+        },
+        {
+            'name': 'mode',
+            'desc': 'Balancer mode',
+            'default': 'none',
+            'enum_allowed': ['none', 'crush-compat', 'upmap'],
+            'runtime': True,
+        },
+        {
+            'name': 'sleep_interval',
+            'type': 'secs',
+            'default': 60,
+            'desc': 'how frequently to wake up and attempt optimization',
+            'runtime': True,
+        },
+        {
+            'name': 'upmap_max_iterations',
+            'type': 'uint',
+            'default': 10,
+            'desc': 'maximum upmap optimization iterations',
+            'runtime': True,
+        },
+        {
+            'name': 'upmap_max_deviation',
+            'type': 'float',
+            'default': .01,
+            'min': 0,
+            'max': 1,
+            'desc': 'deviation below which no optimization is attempted',
+            'long_desc': 'If the ratio between the fullest and least-full OSD is below this value then we stop trying to optimize placement.',
+            'runtime': True,
+        },
     ]
 
     COMMANDS = [
@@ -297,7 +370,7 @@ class Module(MgrModule):
             s = {
                 'plans': list(self.plans.keys()),
                 'active': self.active,
-                'mode': self.get_module_option('mode', default_mode),
+                'mode': self.get_module_option('mode'),
             }
             return (0, json.dumps(s, indent=4), '')
         elif command['prefix'] == 'balancer mode':
@@ -305,13 +378,13 @@ class Module(MgrModule):
             return (0, '', '')
         elif command['prefix'] == 'balancer on':
             if not self.active:
-                self.set_module_option('active', '1')
+                self.set_module_option('active', 'true')
                 self.active = True
             self.event.set()
             return (0, '', '')
         elif command['prefix'] == 'balancer off':
             if self.active:
-                self.set_module_option('active', '')
+                self.set_module_option('active', 'false')
                 self.active = False
             self.event.set()
             return (0, '', '')
@@ -399,15 +472,14 @@ class Module(MgrModule):
     def serve(self):
         self.log.info('Starting')
         while self.run:
-            self.active = self.get_module_option('active', '') is not ''
-            begin_time = self.get_module_option('begin_time') or '0000'
-            end_time = self.get_module_option('end_time') or '2400'
+            self.active = self.get_module_option('active')
+            begin_time = self.get_module_option('begin_time')
+            end_time = self.get_module_option('end_time')
             timeofday = time.strftime('%H%M', time.localtime())
             self.log.debug('Waking up [%s, scheduled for %s-%s, now %s]',
                            "active" if self.active else "inactive",
                            begin_time, end_time, timeofday)
-            sleep_interval = float(self.get_module_option('sleep_interval',
-                                                   default_sleep_interval))
+            sleep_interval = self.get_module_option('sleep_interval')
             if self.active and self.time_in_interval(timeofday, begin_time, end_time):
                 self.log.debug('Running')
                 name = 'auto_%s' % time.strftime(TIME_FORMAT, time.gmtime())
@@ -629,7 +701,7 @@ class Module(MgrModule):
         self.log.debug('score_by_root %s' % pe.score_by_root)
 
         # get the list of score metrics, comma separated
-        metrics = self.get_module_option('crush_compat_metrics', 'pgs,objects,bytes').split(',')
+        metrics = self.get_module_option('crush_compat_metrics').split(',')
 
         # total score is just average of normalized stddevs
         pe.score = 0.0
@@ -646,7 +718,7 @@ class Module(MgrModule):
 
     def optimize(self, plan):
         self.log.info('Optimize plan %s' % plan.name)
-        plan.mode = self.get_module_option('mode', default_mode)
+        plan.mode = self.get_module_option('mode')
         max_misplaced = float(self.get_ceph_option('target_max_misplaced_ratio'))
         self.log.info('Mode %s, max misplaced %f' %
                       (plan.mode, max_misplaced))
@@ -692,8 +764,8 @@ class Module(MgrModule):
 
     def do_upmap(self, plan):
         self.log.info('do_upmap')
-        max_iterations = int(self.get_module_option('upmap_max_iterations', 10))
-        max_deviation = float(self.get_module_option('upmap_max_deviation', .01))
+        max_iterations = self.get_module_option('upmap_max_iterations')
+        max_deviation = self.get_module_option('upmap_max_deviation')
 
         ms = plan.initial
         if len(plan.pools):
@@ -725,10 +797,10 @@ class Module(MgrModule):
 
     def do_crush_compat(self, plan):
         self.log.info('do_crush_compat')
-        max_iterations = int(self.get_module_option('crush_compat_max_iterations', 25))
+        max_iterations = self.get_module_option('crush_compat_max_iterations')
         if max_iterations < 1:
             return -errno.EINVAL, '"crush_compat_max_iterations" must be >= 1'
-        step = float(self.get_module_option('crush_compat_step', .5))
+        step = self.get_module_option('crush_compat_step')
         if step <= 0 or step >= 1.0:
             return -errno.EINVAL, '"crush_compat_step" must be in (0, 1)'
         max_misplaced = float(self.get_ceph_option('target_max_misplaced_ratio'))
@@ -738,7 +810,7 @@ class Module(MgrModule):
         osdmap = ms.osdmap
         crush = osdmap.get_crush()
         pe = self.calc_eval(ms, plan.pools)
-        min_score_to_optimize = float(self.get_module_option('min_score', 0))
+        min_score_to_optimize = self.get_module_option('min_score')
         if pe.score <= min_score_to_optimize:
             if pe.score == 0:
                 detail = 'Distribution is already perfect'
@@ -781,7 +853,7 @@ class Module(MgrModule):
             return -errno.EOPNOTSUPP, detail
 
         # rebalance by pgs, objects, or bytes
-        metrics = self.get_module_option('crush_compat_metrics', 'pgs,objects,bytes').split(',')
+        metrics = self.get_module_option('crush_compat_metrics').split(',')
         key = metrics[0] # balancing using the first score metric
         if key not in ['pgs', 'bytes', 'objects']:
             self.log.warn("Invalid crush_compat balancing key %s. Using 'pgs'." % key)

--- a/src/pybind/mgr/hello/module.py
+++ b/src/pybind/mgr/hello/module.py
@@ -10,12 +10,28 @@ from threading import Event
 
 
 class Hello(MgrModule):
+    # these are CLI commands we implement
     COMMANDS = [
         {
             "cmd": "hello "
                    "name=person_name,type=CephString,req=false",
             "desc": "Prints hello world to mgr.x.log",
             "perm": "r"
+        },
+    ]
+
+    # these are module options we understand.  These can be set with
+    # 'ceph config set global mgr/hello/<name> <value>'.  e.g.,
+    # 'ceph config set global mgr/hello/place Earth'
+    MODULE_OPTIONS = [
+        {
+            'name': 'place',
+            'default': 'world',
+        },
+        {
+            'name': 'emphatic',
+            'type': 'bool',
+            'default': True,
         },
     ]
 
@@ -34,10 +50,12 @@ class Hello(MgrModule):
         status_code = 0
         output_buffer = "Output buffer is for data results"
         output_string = "Output string is for informative text"
-        message = "hello world!"
-
         if 'person_name' in cmd:
-            message = "hello, " + cmd['person_name'] + "!"
+            message = "Hello, " + cmd['person_name']
+        else:
+            message = "Hello " + self.get_module_option('place');
+        if self.get_module_option('emphatic'):
+            message += '!'
 
         return status_code, output_buffer, message + "\n" + output_string
 

--- a/src/pybind/mgr/localpool/module.py
+++ b/src/pybind/mgr/localpool/module.py
@@ -5,12 +5,47 @@ import threading
 class Module(MgrModule):
 
     MODULE_OPTIONS = [
-            {'name': 'failure_domain'},
-            {'name': 'min_size'},
-            {'name': 'num_rep'},
-            {'name': 'pg_num'},
-            {'name': 'prefix'},
-            {'name': 'subtree'},
+        {
+            'name': 'subtree',
+            'type': 'str',
+            'default': 'rack',
+            'desc': 'CRUSH level for which to create a local pool',
+            'runtime': True,
+        },
+        {
+            'name': 'failure_domain',
+            'type': 'str',
+            'default': 'host',
+            'desc': 'failure domain for any created local pool',
+            'runtime': True,
+        },
+        {
+            'name': 'min_size',
+            'type': 'int',
+            'desc': 'default min_size for any created local pool',
+            'runtime': True,
+        },
+        {
+            'name': 'num_rep',
+            'type': 'int',
+            'default': 3,
+            'desc': 'default replica count for any created local pool',
+            'runtime': True,
+        },
+        {
+            'name': 'pg_num',
+            'type': 'int',
+            'default': 128,
+            'desc': 'default pg_num for any created local pool',
+            'runtime': True,
+        },
+        {
+            'name': 'prefix',
+            'type': 'str',
+            'default': '',
+            'desc': 'name prefix for any created local pool',
+            'runtime': True,
+        },
     ]
 
     def __init__(self, *args, **kwargs):
@@ -25,10 +60,10 @@ class Module(MgrModule):
         """
         Check pools on each OSDMap change
         """
-        subtree_type = self.get_module_option('subtree') or 'rack'
-        failure_domain = self.get_module_option('failure_domain') or 'host'
-        pg_num = self.get_module_option('pg_num') or '128'
-        num_rep = self.get_module_option('num_rep') or '3'
+        subtree_type = self.get_module_option('subtree')
+        failure_domain = self.get_module_option('failure_domain')
+        pg_num = self.get_module_option('pg_num')
+        num_rep = self.get_module_option('num_rep')
         min_size = self.get_module_option('min_size')
         prefix = self.get_module_option('prefix') or 'by-' + subtree_type + '-'
 
@@ -65,7 +100,7 @@ class Module(MgrModule):
                         "pool": pool_name,
                         'rule': pool_name,
                         "pool_type": 'replicated',
-                        'pg_num': int(pg_num),
+                        'pg_num': pg_num,
                     }), "")
                     r, outb, outs = result.wait()
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -243,7 +243,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
         r = self._ceph_get_module_option(key)
         if r is None:
             final_key = key.split('/')[-1]
-            return str(self.MODULE_OPTION_DEFAULTS.get(final_key, default))
+            return self.MODULE_OPTION_DEFAULTS.get(final_key, default)
         else:
             return r
 
@@ -701,7 +701,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         r = self._ceph_get_module_option(key)
         if r is None:
             final_key = key.split('/')[-1]
-            return str(self.MODULE_OPTION_DEFAULTS.get(final_key, default))
+            return self.MODULE_OPTION_DEFAULTS.get(final_key, default)
         else:
             return r
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -323,7 +323,15 @@ class MgrModule(ceph_module.BaseMgrModule):
 
         for o in self.MODULE_OPTIONS:
             if 'default' in o:
-                self.MODULE_OPTION_DEFAULTS[o['name']] = o['default']
+                if 'type' in o:
+                    # we'll assume the declared type matches the
+                    # supplied default value's type.
+                    self.MODULE_OPTION_DEFAULTS[o['name']] = o['default']
+                else:
+                    # module not declaring it's type, so normalize the
+                    # default value to be a string for consistent behavior
+                    # with default and user-supplied option values.
+                    self.MODULE_OPTION_DEFAULTS[o['name']] = str(o['default'])
 
     def __del__(self):
         unconfigure_logger(self, self.module_name)

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -242,7 +242,8 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
         """
         r = self._ceph_get_module_option(key)
         if r is None:
-            return default
+            final_key = key.split('/')[-1]
+            return str(self.MODULE_OPTION_DEFAULTS.get(final_key, default))
         else:
             return r
 
@@ -273,6 +274,7 @@ class MgrStandbyModule(ceph_module.BaseMgrStandbyModule):
 class MgrModule(ceph_module.BaseMgrModule):
     COMMANDS = []
     MODULE_OPTIONS = []
+    MODULE_OPTION_DEFAULTS = {}
 
     # Priority definitions for perf counters
     PRIO_CRITICAL = 10
@@ -318,6 +320,10 @@ class MgrModule(ceph_module.BaseMgrModule):
 
         # Keep a librados instance for those that need it.
         self._rados = None
+
+        for o in self.MODULE_OPTIONS:
+            if 'default' in o:
+                self.MODULE_OPTION_DEFAULTS[o['name']] = o['default']
 
     def __del__(self):
         unconfigure_logger(self, self.module_name)
@@ -694,7 +700,8 @@ class MgrModule(ceph_module.BaseMgrModule):
     def _get_module_option(self, key, default):
         r = self._ceph_get_module_option(key)
         if r is None:
-            return default
+            final_key = key.split('/')[-1]
+            return str(self.MODULE_OPTION_DEFAULTS.get(final_key, default))
         else:
             return r
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -746,7 +746,7 @@ class MgrModule(ceph_module.BaseMgrModule):
         return self._get_localized(key, default, self._get_module_option)
 
     def _set_module_option(self, key, val):
-        return self._ceph_set_module_option(key, val)
+        return self._ceph_set_module_option(key, str(val))
 
     def set_module_option(self, key, val):
         """

--- a/src/pybind/mgr/telegraf/module.py
+++ b/src/pybind/mgr/telegraf/module.py
@@ -43,6 +43,7 @@ class Module(MgrModule):
         },
         {
             'name': 'interval',
+            'type': 'secs',
             'default': 15
         }
     ]

--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -38,10 +38,12 @@ class Module(MgrModule):
         },
         {
             'name': 'enabled',
+            'type': 'bool',
             'default': True
         },
         {
             'name': 'leaderboard',
+            'type': 'bool',
             'default': False
         },
         {
@@ -62,6 +64,7 @@ class Module(MgrModule):
         },
         {
             'name': 'interval',
+            'type': 'int',
             'default': 72
         }
     ]

--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -68,6 +68,7 @@ class Module(MgrModule):
             },
             {
                 'name': 'zabbix_port',
+                'type': 'int',
                 'default': 10051
             },
             {
@@ -76,6 +77,7 @@ class Module(MgrModule):
             },
             {
                 'name': 'interval',
+                'type': 'secs',
                 'default': 60
             }
     ]


### PR DESCRIPTION
Expose a more complete schema for config options.  Unify with 'config help', 'config set', 'config dump', and so on.

- [x] add the 'config set' checks
- [x] set 'runtime' field for the modules this PR cleans up
- [ ] audit those modules to make sure they tolerate typed config values
- [ ] fix up MODULE_OPTIONS for all of the other mgr modules (maybe a future PR)