### PR TITLE
common: avoid bl::get_current_ptr()-driven ref counting in denc.h.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -898,6 +898,15 @@ using namespace ceph;
     return ptr(*p, p_off, p->length() - p_off);
   }
 
+  template<bool is_const>
+  bool buffer::list::iterator_impl<is_const>::is_pointing_same_raw(
+    const ptr& other) const
+  {
+    if (p == ls->end())
+      throw end_of_buffer();
+    return p->get_raw() == other.get_raw();
+  }
+
   // copy data out.
   // note that these all _append_ to dest!
   template<bool is_const>

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -728,6 +728,7 @@ namespace buffer CEPH_BUFFER_API {
       char operator*() const;
       iterator_impl& operator++();
       ptr get_current_ptr() const;
+      bool is_pointing_same_raw(const ptr& other) const;
 
       bl_t& get_bl() const { return *bl; }
 

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -1523,8 +1523,7 @@ inline std::enable_if_t<traits::supported && !traits::need_contiguous> decode(
   const auto& bl = p.get_bl();
   const auto remaining = bl.length() - p.get_off();
   // it is expensive to rebuild a contigous buffer and drop it, so avoid this.
-  if (p.get_current_ptr().get_raw() != bl.back().get_raw() &&
-      remaining > CEPH_PAGE_SIZE) {
+  if (!p.is_pointing_same_raw(bl.back()) && remaining > CEPH_PAGE_SIZE) {
     traits::decode(o, p);
   } else {
     // ensure we get a contigous buffer... until the end of the


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>