### PR TITLE
mds: log session open stats

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -813,7 +813,7 @@ int MDBalancer::mantle_prep_rebalance()
   /* execute the balancer */
   Mantle mantle;
   int ret = mantle.balance(bal_code, mds->get_nodeid(), metrics, state.targets);
-  dout(2) << " mantle decided that new targets=" << state.targets << dendl;
+  dout(5) << " mantle decided that new targets=" << state.targets << dendl;
 
   /* mantle doesn't know about cluster size, so check target len here */
   if ((int) state.targets.size() != cluster_size)

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7521,7 +7521,7 @@ void MDCache::check_memory_usage()
   if (CInode::count())
     caps_per_inode = (double)Capability::count() / (double)CInode::count();
 
-  dout(2) << "check_memory_usage"
+  dout(2) << "Memory usage: "
 	   << " total " << last.get_total()
 	   << ", rss " << last.get_rss()
 	   << ", heap " << last.get_heap()
@@ -7546,7 +7546,7 @@ void MDCache::check_memory_usage()
     // Only do this once we are back in bounds: otherwise the releases would
     // slow down whatever process caused us to exceed bounds to begin with
     if (ceph_using_tcmalloc()) {
-      dout(2) << "check_memory_usage: releasing unused space from tcmalloc" 
+      dout(5) << "check_memory_usage: releasing unused space from tcmalloc"
 	      << dendl;
       ceph_heap_release_free_memory();
     }
@@ -7596,7 +7596,7 @@ void MDCache::shutdown_check()
 
 void MDCache::shutdown_start()
 {
-  dout(2) << "shutdown_start" << dendl;
+  dout(5) << "shutdown_start" << dendl;
 
   if (g_conf()->mds_shutdown_check)
     mds->timer.add_event_after(g_conf()->mds_shutdown_check, new C_MDC_ShutdownCheck(this));
@@ -7798,7 +7798,7 @@ bool MDCache::shutdown_pass()
   }
   
   // done!
-  dout(2) << "shutdown done." << dendl;
+  dout(5) << "shutdown done." << dendl;
   return true;
 }
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1493,29 +1493,29 @@ void MDSRank::boot_start(BootStep step, int r)
 
         MDSGatherBuilder gather(g_ceph_context,
             new C_MDS_BootStart(this, MDS_BOOT_OPEN_ROOT));
-        dout(2) << "boot_start " << step << ": opening inotable" << dendl;
+        dout(2) << "Booting: " << step << ": opening inotable" << dendl;
         inotable->set_rank(whoami);
         inotable->load(gather.new_sub());
 
-        dout(2) << "boot_start " << step << ": opening sessionmap" << dendl;
+        dout(2) << "Booting: " << step << ": opening sessionmap" << dendl;
         sessionmap.set_rank(whoami);
         sessionmap.load(gather.new_sub());
 
-        dout(2) << "boot_start " << step << ": opening mds log" << dendl;
+        dout(2) << "Booting: " << step << ": opening mds log" << dendl;
         mdlog->open(gather.new_sub());
 
 	if (is_starting()) {
-	  dout(2) << "boot_start " << step << ": opening purge queue" << dendl;
+	  dout(2) << "Booting: " << step << ": opening purge queue" << dendl;
 	  purge_queue.open(new C_IO_Wrapper(this, gather.new_sub()));
 	} else if (!standby_replaying) {
-	  dout(2) << "boot_start " << step << ": opening purge queue (async)" << dendl;
+	  dout(2) << "Booting: " << step << ": opening purge queue (async)" << dendl;
 	  purge_queue.open(NULL);
-	  dout(2) << "boot_start " << step << ": loading open file table (async)" << dendl;
+	  dout(2) << "Booting: " << step << ": loading open file table (async)" << dendl;
 	  mdcache->open_file_table.load(nullptr);
 	}
 
         if (mdsmap->get_tableserver() == whoami) {
-          dout(2) << "boot_start " << step << ": opening snap table" << dendl;
+          dout(2) << "Booting: " << step << ": opening snap table" << dendl;
           snapserver->set_rank(whoami);
           snapserver->load(gather.new_sub());
         }
@@ -1525,7 +1525,7 @@ void MDSRank::boot_start(BootStep step, int r)
       break;
     case MDS_BOOT_OPEN_ROOT:
       {
-        dout(2) << "boot_start " << step << ": loading/discovering base inodes" << dendl;
+        dout(2) << "Booting: " << step << ": loading/discovering base inodes" << dendl;
 
         MDSGatherBuilder gather(g_ceph_context,
             new C_MDS_BootStart(this, MDS_BOOT_PREPARE_LOG));
@@ -1550,19 +1550,19 @@ void MDSRank::boot_start(BootStep step, int r)
       break;
     case MDS_BOOT_PREPARE_LOG:
       if (is_any_replay()) {
-	dout(2) << "boot_start " << step << ": replaying mds log" << dendl;
+	dout(2) << "Booting: " << step << ": replaying mds log" << dendl;
 	MDSGatherBuilder gather(g_ceph_context,
 	    new C_MDS_BootStart(this, MDS_BOOT_REPLAY_DONE));
 
 	if (!standby_replaying) {
-	  dout(2) << "boot_start " << step << ": waiting for purge queue recovered" << dendl;
+	  dout(2) << "Booting: " << step << ": waiting for purge queue recovered" << dendl;
 	  purge_queue.wait_for_recovery(new C_IO_Wrapper(this, gather.new_sub()));
 	}
 
 	mdlog->replay(gather.new_sub());
 	gather.activate();
       } else {
-        dout(2) << "boot_start " << step << ": positioning at end of old mds log" << dendl;
+        dout(2) << "Booting: " << step << ": positioning at end of old mds log" << dendl;
         mdlog->append();
         starting_done();
       }
@@ -2038,7 +2038,7 @@ void MDSRank::boot_create()
 
 void MDSRank::stopping_start()
 {
-  dout(2) << "stopping_start" << dendl;
+  dout(2) << "Stopping..." << dendl;
 
   if (mdsmap->get_num_in_mds() == 1 && !sessionmap.empty()) {
     std::vector<Session*> victims;
@@ -2069,7 +2069,7 @@ void MDSRank::stopping_start()
 
 void MDSRank::stopping_done()
 {
-  dout(2) << "stopping_done" << dendl;
+  dout(2) << "Finished stopping..." << dendl;
 
   // tell monitor we shut down cleanly.
   request_state(MDSMap::STATE_STOPPED);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -589,14 +589,8 @@ void Server::handle_client_session(const MClientSession::const_ref &m)
       sseq = mds->sessionmap.set_state(session, Session::STATE_OPENING);
       mds->sessionmap.touch_session(session);
       auto fin = new FunctionContext([log_session_status = std::move(log_session_status)](int r){
-        if (r == 0) {
-          log_session_status("ACCEPTED", "");
-        } else {
-          CachedStackStringStream _ss;
-          auto& ss = _ss.get_stream();
-          ss << "(internal) r = " << r;
-          log_session_status("REJECTED", ss.strv());
-        }
+        ceph_assert(r == 0);
+        log_session_status("ACCEPTED", "");
       });
       mdlog->start_submit_entry(new ESession(m->get_source_inst(), true, pv, client_metadata),
 				new C_MDS_session_finish(this, session, sseq, true, pv, fin));

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -904,7 +904,7 @@ class C_MDS_TerminatedSessions : public ServerContext {
 
 void Server::terminate_sessions()
 {
-  dout(2) << "terminate_sessions" << dendl;
+  dout(5) << "terminating all sessions..." << dendl;
 
   terminating_sessions = true;
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -473,8 +473,7 @@ void Server::handle_client_session(const MClientSession::const_ref &m)
       dout(10) << "currently open|opening|stale|killing, dropping this req" << dendl;
       return;
     }
-    ceph_assert(session->is_closed() ||
-	   session->is_closing());
+    ceph_assert(session->is_closed() || session->is_closing());
 
     if (mds->is_stopping()) {
       dout(10) << "mds is stopping, dropping open req" << dendl;
@@ -482,32 +481,56 @@ void Server::handle_client_session(const MClientSession::const_ref &m)
     }
 
     {
-      auto send_reject_message = [this, session](std::string_view err_str) {
+      auto& addr = session->info.inst.addr;
+      session->set_client_metadata(client_metadata_t(m->metadata, m->supported_features));
+      auto& client_metadata = session->info.client_metadata;
+
+      auto log_session_status = [this, m, session](std::string_view status, std::string_view err) {
+        auto now = ceph_clock_now();
+        auto throttle_elapsed = m->get_recv_complete_stamp() - m->get_throttle_stamp();
+        auto elapsed = now - m->get_recv_stamp();
+        CachedStackStringStream css;
+        *css << "New client session:"
+             << " addr=\"" <<  session->info.inst.addr << "\""
+             << ",elapsed=" << elapsed
+             << ",throttled=" << throttle_elapsed
+             << ",status=\"" << status << "\"";
+        if (!err.empty()) {
+          *css << ",error=\"" << err << "\"";
+        }
+        const auto& metadata = session->info.client_metadata;
+        if (auto it = metadata.find("root"); it != metadata.end()) {
+          *css << ",root=\"" << it->second << "\"";
+        }
+        dout(2) << css->strv() << dendl;
+      };
+
+      auto send_reject_message = [this, &session, &log_session_status](std::string_view err_str) {
 	auto m = MClientSession::create(CEPH_SESSION_REJECT);
 	if (session->info.has_feature(CEPHFS_FEATURE_MIMIC))
 	  m->metadata["error_string"] = err_str;
 	mds->send_message_client(m, session);
+        log_session_status("REJECTED", err_str);
       };
 
       bool blacklisted = mds->objecter->with_osdmap(
-	  [session](const OSDMap &osd_map) -> bool {
-	    return osd_map.is_blacklisted(session->info.inst.addr);
+	  [&addr](const OSDMap &osd_map) -> bool {
+	    return osd_map.is_blacklisted(addr);
 	  });
 
       if (blacklisted) {
-	dout(10) << "rejecting blacklisted client " << session->info.inst.addr << dendl;
+	dout(10) << "rejecting blacklisted client " << addr << dendl;
 	send_reject_message("blacklisted");
 	session->clear();
 	break;
       }
 
-      client_metadata_t client_metadata(m->metadata, m->supported_features);
       if (client_metadata.features.empty())
 	infer_supported_features(session, client_metadata);
 
       dout(20) << __func__ << " CEPH_SESSION_REQUEST_OPEN metadata entries:" << dendl;
       dout(20) << "  features: '" << client_metadata.features << dendl;
-      for (auto& p : client_metadata) {
+      for (const auto& p : client_metadata) {
 	dout(20) << "  " << p.first << ": " << p.second << dendl;
       }
 
@@ -523,11 +546,9 @@ void Server::handle_client_session(const MClientSession::const_ref &m)
 	break;
       }
 
-      client_metadata_t::iterator it;
       // Special case for the 'root' metadata path; validate that the claimed
       // root is actually within the caps of the session
-      it = client_metadata.find("root");
-      if (it != client_metadata.end()) {
+      if (auto it = client_metadata.find("root"); it != client_metadata.end()) {
 	auto claimed_root = it->second;
 	stringstream ss;
 	bool denied = false;
@@ -551,8 +572,7 @@ void Server::handle_client_session(const MClientSession::const_ref &m)
 	}
       }
 
-      it = client_metadata.find("uuid");
-      if (it != client_metadata.end()) {
+      if (auto it = client_metadata.find("uuid"); it != client_metadata.end()) {
 	if (find_session_by_uuid(it->second)) {
 	  send_reject_message("duplicated session uuid");
 	  mds->clog->warn() << "client session with duplicated session uuid '"
@@ -562,17 +582,24 @@ void Server::handle_client_session(const MClientSession::const_ref &m)
 	}
       }
 
-      session->set_client_metadata(client_metadata);
-
       if (session->is_closed())
 	mds->sessionmap.add_session(session);
 
       pv = mds->sessionmap.mark_projected(session);
       sseq = mds->sessionmap.set_state(session, Session::STATE_OPENING);
       mds->sessionmap.touch_session(session);
-      mdlog->start_submit_entry(new ESession(m->get_source_inst(), true, pv,
-					     std::move(client_metadata)),
-				new C_MDS_session_finish(this, session, sseq, true, pv));
+      auto fin = new FunctionContext([log_session_status = std::move(log_session_status)](int r){
+        if (r == 0) {
+          log_session_status("ACCEPTED", "");
+        } else {
+          CachedStackStringStream _ss;
+          auto& ss = _ss.get_stream();
+          ss << "(internal) r = " << r;
+          log_session_status("REJECTED", ss.strv());
+        }
+      });
+      mdlog->start_submit_entry(new ESession(m->get_source_inst(), true, pv, client_metadata),
+				new C_MDS_session_finish(this, session, sseq, true, pv, fin));
       mdlog->flush();
     }
     break;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -889,13 +889,6 @@ void Session::clear_recalled_at()
   recall_release_count = 0;
 }
 
-void Session::set_client_metadata(const client_metadata_t& meta)
-{
-  info.client_metadata = meta;
-
-  _update_human_name();
-}
-
 /**
  * Use client metadata to generate a somewhat-friendlier
  * name for the client than its session ID.

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -144,7 +144,13 @@ public:
     }
   }
   void decode(bufferlist::const_iterator &p);
-  void set_client_metadata(const client_metadata_t& meta);
+  template<typename T>
+  void set_client_metadata(T&& meta)
+  {
+    info.client_metadata = std::forward<T>(meta);
+    _update_human_name();
+  }
+
   const std::string& get_human_name() const {return human_name;}
 
   // Ephemeral state for tracking progress of capability recalls

--- a/src/mds/events/ESession.h
+++ b/src/mds/events/ESession.h
@@ -35,10 +35,10 @@ class ESession : public LogEvent {
  public:
   ESession() : LogEvent(EVENT_SESSION), open(false) { }
   ESession(const entity_inst_t& inst, bool o, version_t v,
-	   client_metadata_t &&cm) :
+	   const client_metadata_t& cm) :
     LogEvent(EVENT_SESSION),
     client_inst(inst), open(o), cmapv(v), inotablev(0),
-    client_metadata(std::move(cm)) { }
+    client_metadata(cm) { }
   ESession(const entity_inst_t& inst, bool o, version_t v,
 	   const interval_set<inodeno_t>& i, version_t iv) :
     LogEvent(EVENT_SESSION),


### PR DESCRIPTION
This is to assist with tracking what clients are connecting and how long it takes for them to open a session (a rough estimate of how long it takes to mount).

Example line:

        2018-12-17 17:21:31.682 7f822703c700  2 mds.0.server New client session: addr="127.0.0.1:60552/2307908923",elapsed=0.013384,throttled=0.000071,status="ACCEPTED",root="/"
    
Fixes: http://tracker.ceph.com/issues/37678