### PR TITLE
os/bluestore: only switch to per-pool statfs on repair

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6797,8 +6797,9 @@ int BlueStore::_fsck(bool deep, bool repair)
   actual_statfs.omap_allocated = 0;
 
   // switch to per-pool stats if not explicitly prohibited
-  if (!per_pool_stat_collection &&
-        !cct->_conf->bluestore_debug_no_per_pool_stats) {
+  if (repair &&
+      !per_pool_stat_collection &&
+      !cct->_conf->bluestore_debug_no_per_pool_stats) {
     per_pool_stat_collection = true;
   }
 


### PR DESCRIPTION
Otherwise, an upgrade + fsck will error out with something like

2018-12-17 22:35:52.362 7f12f79208c0 -1 bluestore(/var/lib/ceph/osd/ceph-1) fsck error: missing Pool StatFS record for pool ffffffffffffffff

or similar.

Signed-off-by: Sage Weil <sage@redhat.com>