### PR TITLE
mimic: core: list-inconsistent-obj output truncated, causing osd-scrub-repair.sh failure

### DIFF
--- a/src/common/scrub_types.cc
+++ b/src/common/scrub_types.cc
@@ -74,16 +74,15 @@ void shard_info_wrapper::encode(bufferlist& bl) const
   ENCODE_START(3, 3, bl);
   encode(errors, bl);
   encode(primary, bl);
-  if (has_shard_missing()) {
-    return;
+  if (!has_shard_missing()) {
+    encode(attrs, bl);
+    encode(size, bl);
+    encode(omap_digest_present, bl);
+    encode(omap_digest, bl);
+    encode(data_digest_present, bl);
+    encode(data_digest, bl);
+    encode(selected_oi, bl);
   }
-  encode(attrs, bl);
-  encode(size, bl);
-  encode(omap_digest_present, bl);
-  encode(omap_digest, bl);
-  encode(data_digest_present, bl);
-  encode(data_digest, bl);
-  encode(selected_oi, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -92,16 +91,15 @@ void shard_info_wrapper::decode(bufferlist::iterator& bp)
   DECODE_START(3, bp);
   decode(errors, bp);
   decode(primary, bp);
-  if (has_shard_missing()) {
-    return;
+  if (!has_shard_missing()) {
+    decode(attrs, bp);
+    decode(size, bp);
+    decode(omap_digest_present, bp);
+    decode(omap_digest, bp);
+    decode(data_digest_present, bp);
+    decode(data_digest, bp);
+    decode(selected_oi, bp);
   }
-  decode(attrs, bp);
-  decode(size, bp);
-  decode(omap_digest_present, bp);
-  decode(omap_digest, bp);
-  decode(data_digest_present, bp);
-  decode(data_digest, bp);
-  decode(selected_oi, bp);
   DECODE_FINISH(bp);
 }
 

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1309,7 +1309,7 @@ int librados::IoCtxImpl::get_inconsistent_objects(const pg_t& pg,
   c->io = this;
 
   ::ObjectOperation op;
-  op.scrub_ls(start_after, max_to_get, objects, interval, nullptr);
+  op.scrub_ls(start_after, max_to_get, objects, interval, &c->rval);
   object_locator_t oloc{poolid, pg.ps()};
   Objecter::Op *o = objecter->prepare_pg_read_op(
     oloc.hash, oloc, op, nullptr, CEPH_OSD_FLAG_PGOP, oncomplete,
@@ -1330,7 +1330,7 @@ int librados::IoCtxImpl::get_inconsistent_snapsets(const pg_t& pg,
   c->io = this;
 
   ::ObjectOperation op;
-  op.scrub_ls(start_after, max_to_get, snapsets, interval, nullptr);
+  op.scrub_ls(start_after, max_to_get, snapsets, interval, &c->rval);
   object_locator_t oloc{poolid, pg.ps()};
   Objecter::Op *o = objecter->prepare_pg_read_op(
     oloc.hash, oloc, op, nullptr, CEPH_OSD_FLAG_PGOP, oncomplete,
@@ -2012,7 +2012,9 @@ librados::IoCtxImpl::C_aio_Complete::C_aio_Complete(AioCompletionImpl *_c)
 void librados::IoCtxImpl::C_aio_Complete::finish(int r)
 {
   c->lock.Lock();
-  c->rval = r;
+  // Leave an existing rval unless r != 0
+  if (r)
+    c->rval = r; // This clears the error set in C_ObjectOperation_scrub_ls::finish()
   c->complete = true;
   c->cond.Signal();
 

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1791,8 +1791,6 @@ static int do_get_inconsistent_cmd(const std::vector<const char*> &nargs,
         cerr << "interval#" << interval << " expired." << std::endl;
       else if (ret == -ENOENT)
         cerr << "No scrub information available for pg " << pg << std::endl;
-      else
-        cerr << "Unknown error " << cpp_strerror(ret) << std::endl;
       break;
     }
     // It must be the same interval every time.  EAGAIN would


### PR DESCRIPTION
http://tracker.ceph.com/issues/37686