### PR TITLE
osd/OSDMap: add pool blacklist

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -921,6 +921,15 @@ COMMAND("osd blacklist " \
 	"osd", "rw")
 COMMAND("osd blacklist ls", "show blacklisted clients", "osd", "r")
 COMMAND("osd blacklist clear", "clear all blacklisted clients", "osd", "rw")
+COMMAND("osd blacklist pool " \
+	"name=pool,type=CephPoolname " \
+	"name=blacklistop,type=CephChoices,strings=add|rm " \
+	"name=addr,type=CephEntityAddr " \
+	"name=expire,type=CephFloat,range=0.0,req=false", \
+	"<pool name> add (optionally until <expire> seconds from now) or remove <addr> from blacklist", \
+	"osd", "rw")
+COMMAND("osd blacklist pool ls", "show blacklisted pools for clients", "osd", "r")
+COMMAND("osd blacklist pool clear", "clear all blacklisted pools for clients", "osd", "rw")
 COMMAND("osd pool mksnap " \
 	"name=pool,type=CephPoolname " \
 	"name=snap,type=CephString", \

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -390,6 +390,10 @@ public:
 
     mempool::osdmap::map<entity_addr_t,utime_t> new_blacklist;
     mempool::osdmap::vector<entity_addr_t> old_blacklist;
+
+    mempool::osdmap::map<string,mempool::osdmap::unordered_map<entity_addr_t,utime_t>> new_pool_blacklist;
+    mempool::osdmap::map<string,mempool::osdmap::set<entity_addr_t>> old_pool_blacklist;
+
     mempool::osdmap::map<int32_t, entity_addrvec_t> new_hb_back_up;
     mempool::osdmap::map<int32_t, entity_addrvec_t> new_hb_front_up;
 
@@ -559,6 +563,7 @@ private:
   mempool::osdmap::vector<osd_xinfo_t> osd_xinfo;
 
   mempool::osdmap::unordered_map<entity_addr_t,utime_t> blacklist;
+  mempool::osdmap::unordered_map<string,mempool::osdmap::unordered_map<entity_addr_t,utime_t>> pool_blacklist;
 
   /// queue of snaps to remove
   mempool::osdmap::map<int64_t, snap_interval_set_t> removed_snaps_queue;
@@ -664,8 +669,10 @@ public:
 
   bool is_blacklisted(const entity_addr_t& a) const;
   bool is_blacklisted(const entity_addrvec_t& a) const;
+  bool is_pool_blacklisted(string pool_name, const entity_addr_t& a) const;
   void get_blacklist(list<pair<entity_addr_t,utime_t > > *bl) const;
   void get_blacklist(std::set<entity_addr_t> *bl) const;
+  void get_pool_blacklist(map<string,set<entity_addr_t>> *bl) const;
 
   string get_cluster_snapshot() const {
     if (cluster_snapshot_epoch == epoch)

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2026,6 +2026,14 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     return;
   }
 
+  // pool blacklisted?
+  string pool_name = get_osdmap()->get_pool_name(get_pgid().pool());
+  if (get_osdmap()->is_pool_blacklisted(pool_name, m->get_source_addr())) {
+    dout(10) << "do_op " << pool_name << " " << m->get_source_addr() << " is blacklisted" << dendl;
+    osd->reply_op_error(op, -EBLACKLISTED);
+    return;
+  }
+
   // order this op as a write?
   bool write_ordered = op->rwordered();
 


### PR DESCRIPTION
implement blacklist against pools。
sometime we only want client can not access data plane pool, but he can still access
controller plane pool, this may useful for this purpose。

Signed-off-by: kungf <yang.wang@easystack.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

