### PR TITLE
mgr/orchestrator: fix _list_services display

### DIFF
--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -162,7 +162,7 @@ class OrchestratorCli(MgrModule):
                     s.nodename,
                     s.container_id,
                     s.version,
-                    s.config_location))
+                    s.rados_config_location))
 
             return HandleCommandResult(odata="\n".join(lines))
 


### PR DESCRIPTION
```
Error EINVAL: Traceback (most recent call last):
  File "/usr/lib64/ceph/mgr/orchestrator_cli/module.py", line 318, in handle_command
    return self._handle_command(inbuf, cmd)
  File "/usr/lib64/ceph/mgr/orchestrator_cli/module.py", line 330, in _handle_command
    return self._list_services(cmd)
  File "/usr/lib64/ceph/mgr/orchestrator_cli/module.py", line 165, in _list_services
    s.config_location))
AttributeError: 'ServiceDescription' object has no attribute 'config_location'
```

The config_locations field is never set in this object and so doesn't
exist. Just remove it.

Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

