### PR TITLE
cls/rgw: update rgw_cls_usage_log_trim_op encode version

### DIFF
--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -767,7 +767,7 @@ struct rgw_cls_usage_log_trim_op {
   string bucket;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 2, bl);
+    ENCODE_START(3, 2, bl);
     encode(start_epoch, bl);
     encode(end_epoch, bl);
     encode(user, bl);
@@ -776,11 +776,11 @@ struct rgw_cls_usage_log_trim_op {
   }
 
   void decode(bufferlist::const_iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     decode(start_epoch, bl);
     decode(end_epoch, bl);
     decode(user, bl);
-    if (struct_v >= 2) {
+    if (struct_v >= 3) {
       decode(bucket, bl);
     }
     DECODE_FINISH(bl);


### PR DESCRIPTION
commit 7b17da691f3bee8118ac69a7419519017030a4c9 added a 'bucket' field to this op without bumping the encode version, and is causing failures on upgrade

Fixes: http://tracker.ceph.com/issues/37703