### PR TITLE
common/options: fix bad default

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -875,8 +875,9 @@ std::vector<Option> get_global_options() {
     .set_description("Frequency of internal heartbeat checks (seconds)"),
 
     Option("heartbeat_file", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("File to touch on successful internal heartbeat")
-    .set_description("If set, this file will be touched every time an internal heartbeat check succeeds")
+    .set_default("")
+    .set_description("File to touch on successful internal heartbeat")
+    .set_long_description("If set, this file will be touched every time an internal heartbeat check succeeds.")
     .add_see_also("heartbeat_interval"),
 
     Option("heartbeat_inject_failure", Option::TYPE_INT, Option::LEVEL_DEV)


### PR DESCRIPTION
Got the fields wrong.

Fixes ff75a0b4f21eb14b11702ab2df82ed594f650fcd

Signed-off-by: Sage Weil <sage@redhat.com>