### PR TITLE
mgr/dashboard: consider config option default values

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-recv-speed-modal/osd-recv-speed-modal.component.spec.ts
@@ -26,10 +26,39 @@ describe('OsdRecvSpeedModalComponent', () => {
     providers: [BsModalRef, i18nProviders]
   });
 
+  let configOptions = [];
+
   beforeEach(() => {
     fixture = TestBed.createComponent(OsdRecvSpeedModalComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+
+    configOptions = [
+      {
+        name: 'osd_max_backfills',
+        desc: '',
+        type: 'uint',
+        default: 1
+      },
+      {
+        name: 'osd_recovery_max_active',
+        desc: '',
+        type: 'uint',
+        default: 3
+      },
+      {
+        name: 'osd_recovery_max_single_start',
+        desc: '',
+        type: 'uint',
+        default: 1
+      },
+      {
+        name: 'osd_recovery_sleep',
+        desc: 'Time in seconds to sleep before next recovery or backfill op',
+        type: 'float',
+        default: 0
+      }
+    ];
   });
 
   it('should create', () => {
@@ -90,7 +119,7 @@ describe('OsdRecvSpeedModalComponent', () => {
     });
   });
 
-  describe('getStoredPriority', () => {
+  describe('detectPriority', () => {
     const configOptionsLow = {
       osd_max_backfills: 1,
       osd_recovery_max_active: 1,
@@ -126,61 +155,84 @@ describe('OsdRecvSpeedModalComponent', () => {
     };
 
     it('should return priority "low" if the config option values have been set accordingly', () => {
-      component.getStoredPriority(configOptionsLow, (priority) => {
+      component.detectPriority(configOptionsLow, (priority) => {
         expect(priority.name).toBe('low');
       });
       expect(component.osdRecvSpeedForm.getValue('customizePriority')).toBeFalsy();
     });
 
     it('should return priority "default" if the config option values have been set accordingly', () => {
-      component.getStoredPriority(configOptionsDefault, (priority) => {
+      component.detectPriority(configOptionsDefault, (priority) => {
         expect(priority.name).toBe('default');
       });
       expect(component.osdRecvSpeedForm.getValue('customizePriority')).toBeFalsy();
     });
 
     it('should return priority "high" if the config option values have been set accordingly', () => {
-      component.getStoredPriority(configOptionsHigh, (priority) => {
+      component.detectPriority(configOptionsHigh, (priority) => {
         expect(priority.name).toBe('high');
       });
       expect(component.osdRecvSpeedForm.getValue('customizePriority')).toBeFalsy();
     });
 
     it('should return priority "custom" if the config option values do not match any priority', () => {
-      component.getStoredPriority(configOptionsCustom, (priority) => {
+      component.detectPriority(configOptionsCustom, (priority) => {
         expect(priority.name).toBe('custom');
       });
       expect(component.osdRecvSpeedForm.getValue('customizePriority')).toBeTruthy();
     });
 
     it('should return no priority if the config option values are incomplete', () => {
-      component.getStoredPriority(configOptionsIncomplete, (priority) => {
+      component.detectPriority(configOptionsIncomplete, (priority) => {
         expect(priority.name).toBeNull();
       });
       expect(component.osdRecvSpeedForm.getValue('customizePriority')).toBeFalsy();
     });
   });
 
-  describe('setDescription', () => {
-    const configOptions = [
-      {
-        name: 'osd_max_backfills',
-        desc: ''
-      },
-      {
-        name: 'osd_recovery_max_active',
-        desc: ''
-      },
-      {
-        name: 'osd_recovery_max_single_start',
-        desc: ''
-      },
-      {
-        name: 'osd_recovery_sleep',
-        desc: 'Time in seconds to sleep before next recovery or backfill op'
-      }
-    ];
+  describe('getCurrentValues', () => {
+    it('should return default values if no value has been set by the user', () => {
+      const currentValues = component.getCurrentValues(configOptions);
+      configOptions.forEach((configOption) => {
+        const configOptionValue = currentValues.values[configOption.name];
+        expect(configOptionValue).toBe(configOption.default);
+      });
+    });
 
+    it('should return the values set by the user if they exist', () => {
+      configOptions.forEach((configOption) => {
+        configOption['value'] = [{ section: 'osd', value: 7 }];
+      });
+
+      const currentValues = component.getCurrentValues(configOptions);
+      Object.values(currentValues.values).forEach((configValue) => {
+        expect(configValue).toBe(7);
+      });
+    });
+
+    it('should return the default value if one is missing', () => {
+      for (let i = 1; i < configOptions.length; i++) {
+        configOptions[i]['value'] = [{ section: 'osd', value: 7 }];
+      }
+
+      const currentValues = component.getCurrentValues(configOptions);
+      Object.entries(currentValues.values).forEach(([configName, configValue]) => {
+        if (configName === 'osd_max_backfills') {
+          expect(configValue).toBe(1);
+        } else {
+          expect(configValue).toBe(7);
+        }
+      });
+    });
+
+    it('should return nothing if neither value nor default value is given', () => {
+      configOptions[0].default = null;
+      const currentValues = component.getCurrentValues(configOptions);
+      expect(currentValues.values).not.toContain('osd_max_backfills');
+    });
+  });
+
+  describe('setDescription', () => {
     it('should set the description if one is given', () => {
       component.setDescription(configOptions);
       Object.keys(component.priorityAttrs).forEach((configOptionName) => {
@@ -196,25 +248,6 @@ describe('OsdRecvSpeedModalComponent', () => {
   });
 
   describe('setValidators', () => {
-    const configOptions = [
-      {
-        name: 'osd_max_backfills',
-        type: 'uint'
-      },
-      {
-        name: 'osd_recovery_max_active',
-        type: 'uint'
-      },
-      {
-        name: 'osd_recovery_max_single_start',
-        type: 'uint'
-      },
-      {
-        name: 'osd_recovery_sleep',
-        type: 'float'
-      }
-    ];
-
     it('should set needed validators for config option', () => {
       component.setValidators(configOptions);
       configOptions.forEach((configOption) => {


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

Consider the config option default values as a fallback if no values are defined by the user when detecting a profile.

Needs to be merged after #25472

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

Fixes: http://tracker.ceph.com/issues/37683
Signed-off-by: Tatjana Dehler <tdehler@suse.com>


