### PR TITLE
common: parse time strings like "2h" or "1w2h3m23s"

### DIFF
--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -181,4 +181,54 @@ namespace ceph {
     ss << yr << "y";
     return ss.str();
   }
+
+  std::string exact_timespan_str(timespan t)
+  {
+    uint64_t nsec = std::chrono::nanoseconds(t).count();
+    uint64_t sec = nsec / 1000000000;
+    nsec %= 1000000000;
+    uint64_t yr = sec / (60 * 60 * 24 * 365);
+    ostringstream ss;
+    if (yr) {
+      ss << yr << "y";
+      sec -= yr * (60 * 60 * 24 * 365);
+    }
+    /* I don't like the capital M -sage
+    uint64_t mn = sec / (60 * 60 * 24 * 30);
+    if (mn >= 3) {
+      ss << mn << "M";
+      sec -= mn * (60 * 60 * 24 * 30);
+    }
+    */
+    uint64_t wk = sec / (60 * 60 * 24 * 7);
+    if (wk >= 2) {
+      ss << wk << "w";
+      sec -= wk * (60 * 60 * 24 * 7);
+    }
+    uint64_t day = sec / (60 * 60 * 24);
+    if (day >= 2) {
+      ss << day << "d";
+      sec -= day * (60 * 60 * 24);
+    }
+    uint64_t hr = sec / (60 * 60);
+    if (hr >= 2) {
+      ss << hr << "h";
+      sec -= hr * (60 * 60);
+    }
+    uint64_t min = sec / 60;
+    if (min >= 2) {
+      ss << min << "m";
+      sec -= min * 60;
+    }
+    if (sec) {
+      ss << sec;
+    }
+    if (nsec) {
+      ss << ((float)nsec / 1000000000);
+    }
+    if (sec || nsec) {
+      ss << "s";
+    }
+    return ss.str();
+  }
 }

--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -194,13 +194,11 @@ namespace ceph {
       ss << yr << "y";
       sec -= yr * (60 * 60 * 24 * 365);
     }
-    /* I don't like the capital M -sage
     uint64_t mn = sec / (60 * 60 * 24 * 30);
     if (mn >= 3) {
-      ss << mn << "M";
+      ss << mn << "mo";
       sec -= mn * (60 * 60 * 24 * 30);
     }
-    */
     uint64_t wk = sec / (60 * 60 * 24 * 7);
     if (wk >= 2) {
       ss << wk << "w";
@@ -255,7 +253,7 @@ namespace ceph {
       { "wk", 7*24*60*60 },
       { "week", 7*24*60*60 },
       { "weeks", 7*24*60*60 },
-      { "M", 30*24*60*60 },
+      { "mo", 30*24*60*60 },
       { "month", 30*24*60*60 },
       { "months", 30*24*60*60 },
       { "y", 365*24*60*60 },

--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -487,6 +487,7 @@ inline timespan to_timespan(signedspan z) {
 }
 
 std::string timespan_str(timespan t);
+std::string exact_timespan_str(timespan t);
 
 // detects presence of Clock::to_timespec() and from_timespec()
 template <typename Clock, typename = std::void_t<>>

--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -488,6 +488,7 @@ inline timespan to_timespan(signedspan z) {
 
 std::string timespan_str(timespan t);
 std::string exact_timespan_str(timespan t);
+std::chrono::seconds parse_timespan(const std::string& s);
 
 // detects presence of Clock::to_timespec() and from_timespec()
 template <typename Clock, typename = std::void_t<>>

--- a/src/common/config_proxy.h
+++ b/src/common/config_proxy.h
@@ -172,7 +172,7 @@ public:
   int set_val(const std::string& key, const std::string& s,
               std::stringstream* err_ss=nullptr) {
     std::lock_guard l{lock};
-    return config.set_val(values, obs_mgr, key, s);
+    return config.set_val(values, obs_mgr, key, s, err_ss);
   }
   void set_val_default(const std::string& key, const std::string& val) {
     std::lock_guard l{lock};

--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -195,7 +195,7 @@ TEST(md_config_t, set_val)
     { "1weeks"s, duration_cast<seconds>(seconds{3600*24*7}) },
     { "1month"s, duration_cast<seconds>(seconds{3600*24*30}) },
     { "1months"s, duration_cast<seconds>(seconds{3600*24*30}) },
-    { "1M"s, duration_cast<seconds>(seconds{3600*24*30}) },
+    { "1mo"s, duration_cast<seconds>(seconds{3600*24*30}) },
     { "1y"s, duration_cast<seconds>(seconds{3600*24*365}) },
     { "1yr"s, duration_cast<seconds>(seconds{3600*24*365}) },
     { "1year"s, duration_cast<seconds>(seconds{3600*24*365}) },

--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -167,6 +167,14 @@ TEST(md_config_t, set_val)
     EXPECT_EQ(-EINVAL, conf.set_val("mgr_tick_period", "21 centuries", nullptr));
     EXPECT_EQ(expected.count(), conf.get_val<seconds>("mgr_tick_period").count());
   }
+
+  for (int i = 0; i < 100; ++i) {
+    std::chrono::seconds j = std::chrono::seconds(rand());
+    string s = exact_timespan_str(j);
+    std::chrono::seconds k = parse_timespan(s);
+    cout << "rt: " << j.count() << " -> " << s << " -> " << k.count() << std::endl;
+    EXPECT_EQ(j.count(), k.count());
+  }
 }
 
 TEST(Option, validation)

--- a/src/test/common/test_config.cc
+++ b/src/test/common/test_config.cc
@@ -159,13 +159,75 @@ TEST(md_config_t, set_val)
     const string s{"1 days 2 hours 4 minutes"};
     using days_t = duration<int, std::ratio<3600 * 24>>;
     auto expected = (duration_cast<seconds>(days_t{1}) +
-		     duration_cast<seconds>(hours{2}) +
-		     duration_cast<seconds>(minutes{4}));
+                    duration_cast<seconds>(hours{2}) +
+                    duration_cast<seconds>(minutes{4}));
     EXPECT_EQ(0, conf.set_val("mgr_tick_period",
-			      "1 days 2 hours 4 minutes", nullptr));
+                             "1 days 2 hours 4 minutes", nullptr));
     EXPECT_EQ(expected.count(), conf.get_val<seconds>("mgr_tick_period").count());
     EXPECT_EQ(-EINVAL, conf.set_val("mgr_tick_period", "21 centuries", nullptr));
     EXPECT_EQ(expected.count(), conf.get_val<seconds>("mgr_tick_period").count());
+  }
+
+  using namespace std::chrono;
+
+  using days_t = duration<int, std::ratio<3600 * 24>>;
+
+  struct testcase {
+    std::string s;
+    std::chrono::seconds r;
+  };
+  std::vector<testcase> good = {
+    { "23"s, duration_cast<seconds>(seconds{23}) },
+    { " 23 "s, duration_cast<seconds>(seconds{23}) },
+    { " 23s "s, duration_cast<seconds>(seconds{23}) },
+    { " 23 s "s, duration_cast<seconds>(seconds{23}) },
+    { " 23 sec "s, duration_cast<seconds>(seconds{23}) },
+    { "23 second "s, duration_cast<seconds>(seconds{23}) },
+    { "23 seconds"s, duration_cast<seconds>(seconds{23}) },
+    { "2m5s"s,  duration_cast<seconds>(seconds{2*60+5}) },
+    { "2 m 5 s "s,  duration_cast<seconds>(seconds{2*60+5}) },
+    { "2 m5"s,  duration_cast<seconds>(seconds{2*60+5}) },
+    { "2 min5"s,  duration_cast<seconds>(seconds{2*60+5}) },
+    { "2 minutes  5"s,  duration_cast<seconds>(seconds{2*60+5}) },
+    { "1w"s, duration_cast<seconds>(seconds{3600*24*7}) },
+    { "1wk"s, duration_cast<seconds>(seconds{3600*24*7}) },
+    { "1week"s, duration_cast<seconds>(seconds{3600*24*7}) },
+    { "1weeks"s, duration_cast<seconds>(seconds{3600*24*7}) },
+    { "1month"s, duration_cast<seconds>(seconds{3600*24*30}) },
+    { "1months"s, duration_cast<seconds>(seconds{3600*24*30}) },
+    { "1M"s, duration_cast<seconds>(seconds{3600*24*30}) },
+    { "1y"s, duration_cast<seconds>(seconds{3600*24*365}) },
+    { "1yr"s, duration_cast<seconds>(seconds{3600*24*365}) },
+    { "1year"s, duration_cast<seconds>(seconds{3600*24*365}) },
+    { "1years"s, duration_cast<seconds>(seconds{3600*24*365}) },
+    { "1d2h3m4s"s,
+      duration_cast<seconds>(days_t{1}) +
+      duration_cast<seconds>(hours{2}) +
+      duration_cast<seconds>(minutes{3}) +
+      duration_cast<seconds>(seconds{4}) },
+    { "1 days 2 hours 4 minutes"s,
+      duration_cast<seconds>(days_t{1}) +
+      duration_cast<seconds>(hours{2}) +
+      duration_cast<seconds>(minutes{4}) },
+  };
+
+  for (auto& i : good) {
+    cout << "good: " << i.s << " -> " << i.r.count() << std::endl;
+    EXPECT_EQ(0, conf.set_val("mgr_tick_period", i.s, nullptr));
+    EXPECT_EQ(i.r.count(), conf.get_val<seconds>("mgr_tick_period").count());
+  }
+
+  std::vector<std::string> bad = {
+    "12x",
+    "_ 12",
+    "1 2",
+    "21 centuries",
+    "1 y m",
+  };
+  for (auto& i : bad) {
+    std::stringstream err;
+    EXPECT_EQ(-EINVAL, conf.set_val("mgr_tick_period", i, &err));
+    cout << "bad: " << i << " -> " << err.str() << std::endl;
   }
 
   for (int i = 0; i < 100; ++i) {


### PR DESCRIPTION
- [ ] move the time parse function into ceph_time
- [ ] make 'config dump' etc show TYPE_SECS options with exact_timespan_str