### PR TITLE
os/bluestore: reduce the number of bluefs space allocations

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5432,7 +5432,7 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
   uint64_t min_free = cct->_conf.get_val<Option::size_t>("bluestore_bluefs_min_free");
   if (bluefs_free < min_free &&
       min_free < free_cap) {
-    uint64_t g = min_free - bluefs_free;
+    uint64_t g = std::max<uint64_t>(min_free - bluefs_free, cct->_conf->bluestore_bluefs_gift_ratio * total_free);
     dout(10) << __func__ << " bluefs_free " << bluefs_free
 	     << " < min " << min_free
 	     << ", should gift " << byte_u_t(g) << dendl;


### PR DESCRIPTION
when the bluefs free space is smaller than min_free, the space is allocated continuously, and the allocation space is very small each time.

Signed-off-by: Gabe.Lee <ligangbin117@163.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

