### PR TITLE
Add nfs gateway support to the orchestrator

### DIFF
--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -211,6 +211,8 @@ Creating/growing/shrinking services::
 
     ceph orchestrator {mds,rgw} update <name> <size> [host…]
     ceph orchestrator {mds,rgw} add <name>
+    ceph orchestrator nfs update <name> <size> [host…]
+    ceph orchestrator nfs add <name> <pool> [--namespace=<namespace>]
 
 e.g., ``ceph orchestrator mds update myfs 3 host1 host2 host3``
 

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -209,10 +209,10 @@ Sizing: the ``size`` parameter gives the number of daemons in the cluster
 
 Creating/growing/shrinking services::
 
-    ceph orchestrator service update <type> <name> <size> [host…]
-    ceph orchestrator service add <type> <what>
+    ceph orchestrator {mds,rgw} update <name> <size> [host…]
+    ceph orchestrator {mds,rgw} add <name>
 
-e.g., ``ceph orchestrator service update mds myfs 3 host1 host2 host3``
+e.g., ``ceph orchestrator mds update myfs 3 host1 host2 host3``
 
 Start/stop/reload::
 
@@ -223,5 +223,5 @@ Start/stop/reload::
 
 Removing services::
 
-    ceph orchestrator service rm <type> <name>
+    ceph orchestrator {mds,rgw} rm <name>
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -76,6 +76,20 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             "perm": "rw"
         },
         {
+            'cmd': "orchestrator nfs add "
+                   "name=svc_arg,type=CephString "
+                   "name=pool,type=CephString "
+                   "name=namespace,type=CephString,req=false ",
+            "desc": "Create an NFS service",
+            "perm": "rw"
+        },
+        {
+            'cmd': "orchestrator nfs rm "
+                   "name=svc_id,type=CephString ",
+            "desc": "Remove an NFS service",
+            "perm": "rw"
+        },
+        {
             'cmd': "orchestrator set backend "
                    "name=module,type=CephString,req=true",
             "desc": "Select orchestrator module backend",
@@ -212,6 +226,18 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         spec.name = cmd['svc_arg']
         return self._add_stateless_svc("rgw", spec)
 
+    def _nfs_add(self, cmd):
+        cluster_name = cmd['svc_arg']
+        pool = cmd['pool']
+        ns = cmd.get('namespace', None)
+
+        spec = orchestrator.StatelessServiceSpec()
+        spec.name = cluster_name
+        spec.extended = { "pool":pool }
+        if ns != None:
+            spec.extended["namespace"] = ns
+        return self._add_stateless_svc("nfs", spec)
+
     def _rm_stateless_svc(self, svc_type, svc_id):
         completion = self.remove_stateless_service(svc_type, svc_id)
         self._orchestrator_wait([completion])
@@ -225,6 +251,9 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def _rgw_rm(self, cmd):
         return self._rm_stateless_svc("rgw", cmd['svc_id'])
+
+    def _nfs_rm(self, cmd):
+        return self._rm_stateless_svc("nfs", cmd['svc_id'])
 
     def _set_backend(self, cmd):
         """
@@ -319,6 +348,10 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             return self._rgw_add(cmd)
         elif cmd['prefix'] == "orchestrator rgw rm":
             return self._rgw_rm(cmd)
+        elif cmd['prefix'] == "orchestrator nfs add":
+            return self._nfs_add(cmd)
+        elif cmd['prefix'] == "orchestrator nfs rm":
+            return self._nfs_rm(cmd)
         elif cmd['prefix'] == "orchestrator set backend":
             return self._set_backend(cmd)
         elif cmd['prefix'] == "orchestrator status":

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -361,19 +361,19 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
 
         return result
 
+    def _service_add_decorate(self, typename, spec, func):
+        return RookWriteCompletion(lambda: func(spec), None,
+                    "Creating {0} services for {1}".format(typename, spec.name))
+
     def add_stateless_service(self, service_type, spec):
         # assert isinstance(spec, orchestrator.StatelessServiceSpec)
-
         if service_type == "mds":
-            return RookWriteCompletion(
-                lambda: self.rook_cluster.add_filesystem(spec), None,
-                "Creating Filesystem services for {0}".format(spec.name))
+            return self._service_add_decorate("Filesystem", spec,
+                                         self.rook_cluster.add_filesystem)
         elif service_type == "rgw" :
-            return RookWriteCompletion(
-                lambda: self.rook_cluster.add_objectstore(spec), None,
-                "Creating RGW services for {0}".format(spec.name))
+            return self._service_add_decorate("RGW", spec,
+                                         self.rook_cluster.add_objectstore)
         else:
-            # TODO: RGW, NFS
             raise NotImplementedError(service_type)
 
     def remove_stateless_service(self, service_type, service_id):

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -373,6 +373,9 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
         elif service_type == "rgw" :
             return self._service_add_decorate("RGW", spec,
                                          self.rook_cluster.add_objectstore)
+        elif service_type == "nfs" :
+            return self._service_add_decorate("NFS", spec,
+                                         self.rook_cluster.add_nfsgw)
         else:
             raise NotImplementedError(service_type)
 

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -334,7 +334,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
     @deferred_read
     def describe_service(self, service_type, service_id, nodename):
 
-        assert service_type in ("mds", "osd", "mgr", "mon", None), service_type + " unsupported"
+        assert service_type in ("mds", "osd", "mgr", "mon", "nfs", None), service_type + " unsupported"
 
         pods = self.rook_cluster.describe_pods(service_type, service_id, nodename)
 
@@ -353,6 +353,8 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                 sd.daemon_name = p['labels']["mon"]
             elif sd.service_type == "mgr":
                 sd.daemon_name = p['labels']["mgr"]
+            elif sd.service_type == "nfs":
+                sd.daemon_name = p['labels']["ceph_nfs"]
             else:
                 # Unknown type -- skip it
                 continue

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -161,6 +161,8 @@ class RookCluster(object):
                     label_filter += ",mon={0}".format(service_id)
                 elif service_type == "mgr":
                     label_filter += ",mgr={0}".format(service_id)
+                elif service_type == "nfs":
+                    label_filter += ",ceph_nfs={0}".format(service_id)
                 elif service_type == "rgw":
                     # TODO: rgw
                     pass


### PR DESCRIPTION
These patches add support to the orchestrator for NFS services, as well as the backend machinery for the rook orchestrator. Note that this PR depends on the rook nfs-ganesha CRD being merged:

https://github.com/rook/rook/pull/2099

...so I've added the DNM tag until that is done.