### PR TITLE
doc/mgr/orchestrator: add `wal` to blink lights

### DIFF
--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -117,15 +117,16 @@ Create OSDs on a group of devices on a single host::
 See :ref:`ceph-volume-invocation… <ceph-volume-overview>` for details. E.g.
 ``ceph orchestrator osd create host1 lvm create …``
 
-..
-    Decommission an OSD
-    ^^^^^^^^^^^^^^^^^^^
-    ::
+The output of ``osd create`` is not specified and may vary between orchestrator backends.
 
-        ceph orchestrator osd rm <osd-id>
+Decommission an OSD
+^^^^^^^^^^^^^^^^^^^
+::
 
-    Removes an OSD from the cluster and the host, if the OSD is marked as
-    ``destroyed``.
+    ceph orchestrator osd rm <osd-id>
+
+Removes an OSD from the cluster and the host, if the OSD is marked as
+``destroyed``.
 
 ..
     Blink Device Lights
@@ -137,10 +138,14 @@ See :ref:`ceph-volume-invocation… <ceph-volume-overview>` for details. E.g.
         ceph orchestrator device fault-on <host> <devname>
         ceph orchestrator device fault-off <host> <devname>
 
-        ceph orchestrator osd ident-on {primary,journal,db,all} <osd-id>
-        ceph orchestrator osd ident-off {primary,journal,db,all} <osd-id>
-        ceph orchestrator osd fault-on {primary,journal,db,all} <osd-id>
-        ceph orchestrator osd fault-off {primary,journal,db,all} <osd-id>
+        ceph orchestrator osd ident-on {primary,journal,db,wal,all} <osd-id>
+        ceph orchestrator osd ident-off {primary,journal,db,wal,all} <osd-id>
+        ceph orchestrator osd fault-on {primary,journal,db,wal,all} <osd-id>
+        ceph orchestrator osd fault-off {primary,journal,db,wal,all} <osd-id>
+
+    Where ``journal`` is the filestore journal, ``wal`` is the write ahead log of
+    bluestore and ``all`` stands for all devices associated with the osd
+
 
 ..
     Monitor and manager management
@@ -208,9 +213,6 @@ Creating/growing/shrinking services::
     ceph orchestrator service add <type> <what>
 
 e.g., ``ceph orchestrator service update mds myfs 3 host1 host2 host3``
-
-Note: as with mon creation, the host list is optional, depending on the
-orchestrator backend in use.
 
 Start/stop/reload::
 


### PR DESCRIPTION
Also added: "The output of `osd create` is not specified
  any may vary between orchestrator backends."

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [X] Updates documentation if necessary

