### PR TITLE
mgr/dashboard: pool stats not returned by default

### DIFF
--- a/qa/tasks/mgr/dashboard/test_pool.py
+++ b/qa/tasks/mgr/dashboard/test_pool.py
@@ -127,8 +127,8 @@ class PoolTest(DashboardTestCase):
         self.assertEqual(len(cluster_pools), len(data))
         self.assertSchemaBody(JList(self.pool_schema))
         for pool in data:
-            self.assertIn('pg_status', pool)
-            self.assertIn('stats', pool)
+            self.assertNotIn('pg_status', pool)
+            self.assertNotIn('stats', pool)
             self.assertIn(pool['pool_name'], cluster_pools)
 
     def test_pool_list_attrs(self):
@@ -146,8 +146,8 @@ class PoolTest(DashboardTestCase):
             self.assertNotIn('stats', pool)
             self.assertIn(pool['pool_name'], cluster_pools)
 
-    def test_pool_list_without_stats(self):
-        data = self._get("/api/pool?stats=false")
+    def test_pool_list_stats(self):
+        data = self._get("/api/pool?stats=true")
         self.assertStatus(200)
 
         cluster_pools = self.ceph_cluster.mon_manager.list_pools()
@@ -157,8 +157,8 @@ class PoolTest(DashboardTestCase):
             self.assertIn('type', pool)
             self.assertIn('application_metadata', pool)
             self.assertIn('flags', pool)
-            self.assertNotIn('pg_status', pool)
-            self.assertNotIn('stats', pool)
+            self.assertIn('pg_status', pool)
+            self.assertIn('stats', pool)
             self.assertIn('flags_names', pool)
             self.assertIn(pool['pool_name'], cluster_pools)
 

--- a/src/pybind/mgr/dashboard/controllers/pool.py
+++ b/src/pybind/mgr/dashboard/controllers/pool.py
@@ -54,7 +54,7 @@ class Pool(RESTController):
 
         return [self._serialize_pool(pool, attrs) for pool in pools]
 
-    def list(self, attrs=None, stats=True):
+    def list(self, attrs=None, stats=False):
         return self._pool_list(attrs, stats)
 
     def _get(self, pool_name, attrs=None, stats=False):

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.spec.ts
@@ -29,7 +29,7 @@ describe('PoolService', () => {
 
   it('should call getList', () => {
     service.getList().subscribe();
-    const req = httpTesting.expectOne(apiPath);
+    const req = httpTesting.expectOne(`${apiPath}?stats=true`);
     expect(req.request.method).toBe('GET');
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/pool.service.ts
@@ -41,7 +41,7 @@ export class PoolService {
   }
 
   getList() {
-    return this.http.get(this.apiPath);
+    return this.http.get(`${this.apiPath}?stats=true`);
   }
 
   getInfo(): Observable<PoolFormInfo> {


### PR DESCRIPTION
* All pool controller methods with same default value
for stats flag.
* Stats requested explicitly by frontend service.
* Updated API tests accordingly.

Fixes: https://tracker.ceph.com/issues/36740

Signed-off-by: Alfonso Martínez <almartin@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

