### PR TITLE
cmake: let rbd_api depend on librbd-tp

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -139,6 +139,9 @@ add_library(rbd_internal STATIC
   ${librbd_internal_srcs}
   $<TARGET_OBJECTS:rados_snap_set_diff_obj>)
 if(WITH_LTTNG)
+  # librbd.cc includes tracing/librbd.h
+  add_dependencies(rbd_api librbd-tp)
+  # io/AioCompletion.cc includes tracing/librbd.h
   add_dependencies(rbd_internal librbd-tp)
 endif()
 if(WITH_LTTNG AND WITH_EVENTTRACE)
@@ -149,6 +152,9 @@ target_link_libraries(rbd_internal PRIVATE
 
 add_library(librbd ${CEPH_SHARED}
   librbd.cc)
+if(WITH_LTTNG)
+  add_dependencies(librbd librbd-tp)
+endif()
 
 target_link_libraries(librbd PRIVATE
   rbd_internal


### PR DESCRIPTION
whoever includes tracing/librbd.h should depends on librbd-tp.

this fix the FTBFS of:

ceph/src/librbd/librbd.cc:50:10: fatal error: tracing/librbd.h: No such
file or directory
 #include "tracing/librbd.h"
          ^~~~~~~~~~~~~~~~~~
compilation terminated.
src/librbd/CMakeFiles/rbd_api.dir/build.make:62: recipe for target
'src/librbd/CMakeFiles/rbd_api.dir/librbd.cc.o' failed

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

