### PR TITLE
test/crimson: fix FTBFS of unittest_seastar_perfcounters on arm64

### DIFF
--- a/src/test/crimson/test_perfcounters.cc
+++ b/src/test/crimson/test_perfcounters.cc
@@ -31,12 +31,11 @@ static seastar::future<> test_perfcounters(){
   }).then([]{
     return ceph::common::sharded_perf_coll().invoke_on_all([] (auto& s){
       auto pcc = s.get_perf_collection();
-      pcc->with_counters([=](auto& by_path){
-        for (const auto &[path, perf_counter_ref] : by_path) {
-          if (PERF_VAL != perf_counter_ref.perf_counters->get(PERFTEST_INDEX)) {
-            throw std::runtime_error("perf counter does not match");
-          }
-          (void)path;           // silence -Wunused-variable
+      pcc->with_counters([](auto& by_path){
+        for (auto& perf_counter : by_path) {
+          if (PERF_VAL != perf_counter.second.perf_counters->get(PERFTEST_INDEX)) {
+             throw std::runtime_error("perf counter does not match");
+           }
         }
       });
     });


### PR DESCRIPTION
this should address the GCC bug which causes following failure:

/home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/test/crimson/test_perfcounters.cc:35:9:
internal compiler error: in tsubst_decomp_names, at cp/pt.c:16537
         for (const auto &[path, perf_counter_ref] : by_path) {
         ^~~

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

