### PR TITLE
mgr/orchestrator: Add service_action method

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -31,3 +31,13 @@ class TestOrchestratorCli(MgrTestCase):
     def test_service_ls(self):
         ret = self._orch_cmd("service", "ls")
         self.assertIn("ceph-mgr", ret)
+
+    def test_service_action(self):
+        self._orch_cmd("service", "reload", "mds", "cephfs")
+        self._orch_cmd("service", "stop", "mds", "cephfs")
+        self._orch_cmd("service", "start", "mds", "cephfs")
+
+    def test_service_instance_action(self):
+        self._orch_cmd("service-instance", "reload", "mds", "a")
+        self._orch_cmd("service-instance", "stop", "mds", "a")
+        self._orch_cmd("service-instance", "start", "mds", "a")

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -186,6 +186,28 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def service_action(self, action, service_type, service_name=None, service_id=None):
+        # type: (str, str, str, str) -> WriteCompletion
+        """
+        Perform an action (start/stop/reload) on a service.
+
+        Either service_name or service_id must be specified:
+        - If using service_name, perform the action on that entire logical
+          service (i.e. all daemons providing that named service).
+        - If using service_id, perform the action on a single specific daemon
+          instance.
+
+        :param action: one of "start", "stop", "reload"
+        :param service_type: e.g. "mds", "rgw", ...
+        :param service_name: name of logical service ("cephfs", "us-east", ...)
+        :param service_id: service daemon instance (usually a short hostname)
+        :rtype: WriteCompletion
+        """
+        assert action in ["start", "stop", "reload"]
+        assert service_name or service_id
+        assert not (service_name and service_id)
+        raise NotImplementedError()
+
     def create_osds(self, osd_spec):
         """
         Create one or more OSDs within a single Drive Group.

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -90,6 +90,24 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             "perm": "rw"
         },
         {
+            'cmd': "orchestrator service "
+                   "name=action,type=CephChoices,"
+                   "strings=start|stop|reload "
+                   "name=svc_type,type=CephString "
+                   "name=svc_name,type=CephString",
+            "desc": "Start, stop or reload an entire service (i.e. all daemons)",
+            "perm": "rw"
+        },
+        {
+            'cmd': "orchestrator service-instance "
+                   "name=action,type=CephChoices,"
+                   "strings=start|stop|reload "
+                   "name=svc_type,type=CephString "
+                   "name=svc_id,type=CephString",
+            "desc": "Start, stop or reload a specific service instance",
+            "perm": "rw"
+        },
+        {
             'cmd': "orchestrator set backend "
                    "name=module,type=CephString,req=true",
             "desc": "Select orchestrator module backend",
@@ -255,6 +273,26 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
     def _nfs_rm(self, cmd):
         return self._rm_stateless_svc("nfs", cmd['svc_id'])
 
+    def _service_action(self, cmd):
+        action = cmd['action']
+        svc_type = cmd['svc_type']
+        svc_name = cmd['svc_name']
+
+        completion = self.service_action(action, svc_type, service_name=svc_name)
+        self._orchestrator_wait([completion])
+
+        return HandleCommandResult()
+
+    def _service_instance_action(self, cmd):
+        action = cmd['action']
+        svc_type = cmd['svc_type']
+        svc_id = cmd['svc_id']
+
+        completion = self.service_action(action, svc_type, service_id=svc_id)
+        self._orchestrator_wait([completion])
+
+        return HandleCommandResult()
+
     def _set_backend(self, cmd):
         """
         We implement a setter command instead of just having the user
@@ -352,6 +390,10 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             return self._nfs_add(cmd)
         elif cmd['prefix'] == "orchestrator nfs rm":
             return self._nfs_rm(cmd)
+        elif cmd['prefix'] == "orchestrator service":
+            return self._service_action(cmd)
+        elif cmd['prefix'] == "orchestrator service-instance":
+            return self._service_instance_action(cmd)
         elif cmd['prefix'] == "orchestrator set backend":
             return self._set_backend(cmd)
         elif cmd['prefix'] == "orchestrator status":

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -249,3 +249,9 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     def create_osds(self, spec):
         raise NotImplementedError(str(spec))
 
+    def service_action(self, action, service_type, service_name=None, service_id=None):
+        return TestWriteCompletion(
+            lambda: True, None,
+            "Pretending to {} service {} (name={}, id={})".format(
+                action, service_type, service_name, service_id))
+


### PR DESCRIPTION
This is to facilitate service start/stop/reload (for example,
after altering NFS Ganesha configuration, we need to trigger
a service reload).

Signed-off-by: Tim Serong <tserong@suse.com>