### PR TITLE
osd: pg merge fixes

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2765,6 +2765,17 @@ void PG::merge_from(map<spg_t,PGRef>& sources, RecoveryCtx *rctx,
     // remapped in concert with each other...
     info.history = sources.begin()->second->info.history;
 
+    // if the past_intervals start is later than last_epoch_clean, it implies
+    // the source repeered again but the target didn't.  avoid the discrepancy
+    // but adjusting the interval start backwards to match.
+    auto pib = past_intervals.get_bounds();
+    if (info.history.last_epoch_clean < pib.first) {
+      dout(10) << __func__ << " last_epoch_clean "
+	       << info.history.last_epoch_clean << " < past_interval start "
+	       << pib.first << ", adjusting start backwards" << dendl;
+      past_intervals.adjust_start_backwards(info.history.last_epoch_clean);
+    }
+
     // we use the pg_num_dec_last_epoch_clean we got from the caller, which is
     // the epoch that was clean according to the target pg whe it requested
     // the mon decrement pg_num.

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3403,6 +3403,10 @@ public:
   pair<epoch_t, epoch_t> get_bounds() const override {
     return make_pair(first, last + 1);
   }
+  void adjust_start_backwards(epoch_t last_epoch_clean) {
+    first = last_epoch_clean;
+  }
+
   set<pg_shard_t> get_all_participants(
     bool ec_pool) const override {
     return all_participants;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2935,6 +2935,7 @@ public:
       ceph_assert(!has_full_intervals());
       ceph_abort_msg("not valid for this implementation");
     }
+    virtual void adjust_start_backwards(epoch_t last_epoch_clean) = 0;
 
     virtual ~interval_rep() {}
   };
@@ -3099,6 +3100,11 @@ public:
   pair<epoch_t, epoch_t> get_bounds() const {
     ceph_assert(past_intervals);
     return past_intervals->get_bounds();
+  }
+
+  void adjust_start_backwards(epoch_t last_epoch_clean) {
+    ceph_assert(past_intervals);
+    past_intervals->adjust_start_backwards(last_epoch_clean);
   }
 
   enum osd_state_t {


### PR DESCRIPTION
The first patch addresses past_intervals for fabricate dmerge targets.  FIxes http://tracker.ceph.com/issues/37511.

The second patch ensures we don't get new upmaps racing with PGs that are merging.  The mgr cocntroller already clears out pg_upmaps before proposing a merge, so the new safety check just deals with the race cases.