### PR TITLE
mgr/dashboard: updated API test

### DIFF
--- a/qa/tasks/mgr/dashboard/test_health.py
+++ b/qa/tasks/mgr/dashboard/test_health.py
@@ -23,7 +23,7 @@ class HealthTest(DashboardTestCase):
                     'total_avail_bytes': int,
                     'total_bytes': int,
                     'total_objects': int,
-                    'total_used_bytes': int,
+                    'total_used_raw_bytes': int,
                 })
             }),
             'fs_map': JObj({
@@ -113,9 +113,9 @@ class HealthTest(DashboardTestCase):
                     'total_avail_bytes': int,
                     'total_bytes': int,
                     'total_objects': int,
-                    'total_percent_used': float,
                     'total_used_bytes': int,
-                    'total_used_raw_bytes': int
+                    'total_used_raw_bytes': int,
+                    'total_used_raw_ratio': float
                 })
             }),
             'fs_map': JObj({

--- a/src/pybind/mgr/dashboard/controllers/health.py
+++ b/src/pybind/mgr/dashboard/controllers/health.py
@@ -91,13 +91,16 @@ class HealthData(object):
 
     def df(self):
         df = mgr.get('df')
+
+        del df['stats_by_class']
+
         df['stats']['total_objects'] = sum(
             [p['stats']['objects'] for p in df['pools']])
         if self._minimal:
             df = dict(stats=self._partial_dict(
                 df['stats'],
                 ['total_avail_bytes', 'total_bytes', 'total_objects',
-                 'total_used_bytes']
+                 'total_used_raw_bytes']
             ))
         return df
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -61,14 +61,15 @@ export class HealthComponent implements OnInit, OnDestroy {
   prepareRawUsage(chart, data) {
     const percentAvailable = Math.round(
       100 *
-        ((data.df.stats.total_bytes - data.df.stats.total_used_bytes) / data.df.stats.total_bytes)
+        ((data.df.stats.total_bytes - data.df.stats.total_used_raw_bytes) /
+          data.df.stats.total_bytes)
     );
 
     const percentUsed = Math.round(
-      100 * (data.df.stats.total_used_bytes / data.df.stats.total_bytes)
+      100 * (data.df.stats.total_used_raw_bytes / data.df.stats.total_bytes)
     );
 
-    chart.dataset[0].data = [data.df.stats.total_used_bytes, data.df.stats.total_avail_bytes];
+    chart.dataset[0].data = [data.df.stats.total_used_raw_bytes, data.df.stats.total_avail_bytes];
     if (chart === 'doughnut') {
       chart.options.cutoutPercentage = 65;
     }


### PR DESCRIPTION
Updated health controller & test to reflect changes introduced
in 'df' payload.

Return 'total_used_raw_bytes' instead of 'total_used_bytes'
to match CLI 'bin/rados df' used/avail summary in
Landing Page (frontend component).

Do not return 'stats_by_class' to save bandwidth as they are
not needed (right now) in the dashboard.

Fixes: https://tracker.ceph.com/issues/37717

Signed-off-by: Alfonso Martínez <almartin@redhat.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

