### PR TITLE
doc: Clean up the snapshot consistency note

### DIFF
--- a/doc/rbd/rbd-snapshot.rst
+++ b/doc/rbd/rbd-snapshot.rst
@@ -14,15 +14,16 @@ command and many higher level interfaces, including `QEMU`_, `libvirt`_,
 
 .. important:: To use use RBD snapshots, you must have a running Ceph cluster.
 
-.. note:: If a snapshot is taken while `I/O` is still in progress in a image, the
-   snapshot might not get the exact or latest data of the image and the snapshot
-   may have to be cloned to a new image to be mountable. So, we recommend to stop
-   `I/O` before taking a snapshot of an image. If the image contains a filesystem,
-   the filesystem must be in a consistent state before taking a snapshot. To stop
-   `I/O` you can use `fsfreeze` command. See `fsfreeze(8)` man page for more details.
-   For virtual machines, `qemu-guest-agent` can be used to automatically freeze
-   filesystems when creating a snapshot.
-   
+.. note:: Because RBD does not know about the filesystem, snapshots are
+	  `crash-consistent` if they are not coordinated with the mounting
+	  computer. So, we recommend you stop `I/O` before taking a snapshot of
+	  an image. If the image contains a filesystem, the filesystem must be
+	  in a consistent state before taking a snapshot or you may have to run
+	  `fsck`. To stop `I/O` you can use `fsfreeze` command. See
+	  `fsfreeze(8)` man page for more details.
+	  For virtual machines, `qemu-guest-agent` can be used to automatically
+	  freeze filesystems when creating a snapshot.
+
 .. ditaa:: +------------+         +-------------+
            | {s}        |         | {s} c999    |
            |   Active   |<-------*|   Snapshot  |


### PR DESCRIPTION
The old note made it sound like we weren't crash-consistent, and had a
confusing section about needing to clone before mounting.
You *do* need to clone the snapshot before mounting it, but that has
nothing to do fs freezing or consistency.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

