### PR TITLE
os/bluestore: fixup access a destroy cond cause deadlock or undefine behaviors.

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -95,13 +95,14 @@ public:
 
   void try_aio_wake() {
     assert(num_running >= 1);
+
+    std::lock_guard l(lock);
     if (num_running.fetch_sub(1) == 1) {
 
       // we might have some pending IOs submitted after the check
       // as there is no lock protection for aio_submit.
       // Hence we might have false conditional trigger.
       // aio_wait has to handle that hence do not care here.
-      std::lock_guard l(lock);
       cond.notify_all();
     }
   }


### PR DESCRIPTION
    
  bluestore using temp IOContex to call aio_read, and when _do_read complete, IOContext will be reclaim, means that IOContext::cond will be destroy(pthread_cond_destory). when access a destory cond will cause dedalock or undefined behavior. this bug reproduce in bluestore _do_read, as follow desc:
  
1. read thread has call aio_submit, and before she call aio_wait
2. aio_read has  complete, and take num_running to 0
3. io_complete thread  lose the mutex lock, read thread win the mutex lock 
4. read thread found num_running is 0, so read thread will not call aio_wait and return,
5. complete thread got the mutex lock, if IOContext has been reclaim, then acces the IOContext::cond will case deadlock or undefined behaviors. else nothing happened.


Fixes: <https://tracker.ceph.com/issues/37733>
Signed-off-by: linbing <linbing@t2cloud.net>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

