### PR TITLE
common/blkdev: refactor to add block_device_get_metrics returning json

### DIFF
--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -1,8 +1,12 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef __CEPH_COMMON_BLKDEV_H
 #define __CEPH_COMMON_BLKDEV_H
 
 #include <set>
 #include <string>
+#include "json_spirit/json_spirit_value.h"
 
 enum blkdev_prop_t {
   BLKDEV_PROP_DEV,
@@ -21,6 +25,8 @@ extern std::string get_device_id(const std::string& devname);
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
 extern int block_device_run_smartctl(const char *device, int timeout,
 				     std::string *result);
+extern int block_device_get_metrics(const char *device, int timeout,
+				    json_spirit::mValue *result);
 
 // for VDO
 /// return an op fd for the sysfs stats dir, if this is a VDO device

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3646,17 +3646,9 @@ void Monitor::handle_command(MonOpRequestRef op)
 	"mon_smart_report_timeout");
       json_spirit::mObject json_map;
       json_spirit::mValue smart_json;
-      std::string result;
-      if (block_device_run_smartctl(("/dev/" + dev).c_str(), smart_timeout,
-				    &result)) {
-	dout(10) << "probe_smart_device failed for /dev/" << dev << dendl;
-	result = "{\"error\": \"smartctl failed\", \"dev\": \"" + dev +
-	  "\", \"smartctl_error\": \"" + result + "\"}";
-      }
-
-      if (!json_spirit::read(result, smart_json)) {
-	derr << "smartctl JSON output of /dev/" + dev + " is invalid"
-	     << dendl;
+      if (block_device_get_metrics(("/dev/" + dev).c_str(), smart_timeout,
+				    &smart_json)) {
+	dout(10) << "block_device_get_metrics failed for /dev/" << dev << dendl;
       } else {
 	json_map[devid] = smart_json;
       }


### PR DESCRIPTION
Refactor block_device_run_smartctl into a helper that returns JSON.

Signed-off-by: Sage Weil <sage@redhat.com>