### PR TITLE
mon: use dout to take the place of audit_clog in admin socket

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -304,9 +304,11 @@ void Monitor::do_admin_command(std::string_view command, const cmdmap_t& cmdmap,
                     command == "ops" ||
                     command == "sessions");
 
-  (read_only ? audit_clog->debug() : audit_clog->info())
+  int log_level = read_only ? 5 : 0;
+
+  dout(log_level)
     << "from='admin socket' entity='admin socket' "
-    << "cmd='" << command << "' args=" << args << ": dispatch";
+    << "cmd='" << command << "' args=" << args << ": dispatch" << dendl;
 
   if (command == "mon_status") {
     get_mon_status(f.get(), ss);
@@ -375,19 +377,19 @@ void Monitor::do_admin_command(std::string_view command, const cmdmap_t& cmdmap,
   } else {
     ceph_abort_msg("bad AdminSocket command binding");
   }
-  (read_only ? audit_clog->debug() : audit_clog->info())
+  dout(log_level)
     << "from='admin socket' "
     << "entity='admin socket' "
-    << "cmd=" << command << " "
-    << "args=" << args << ": finished";
+    << "cmd='" << command << "' "
+    << "args=" << args << ": finished" << dendl;
   return;
 
 abort:
-  (read_only ? audit_clog->debug() : audit_clog->info())
+  dout(log_level)
     << "from='admin socket' "
     << "entity='admin socket' "
-    << "cmd=" << command << " "
-    << "args=" << args << ": aborted";
+    << "cmd='" << command << "' "
+    << "args=" << args << ": aborted" << dendl;
 }
 
 void Monitor::handle_signal(int signum)


### PR DESCRIPTION
Use dout to print log in admin socket. Set log level to 5 for
former debug-level and set log level to 0 for former info-level

Signed-off-by: ArchieZh <zhang.chi85@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

