### PR TITLE
[DNM] mgr/dashboard: Feature toggles

### DIFF
--- a/doc/mgr/dashboard.rst
+++ b/doc/mgr/dashboard.rst
@@ -72,6 +72,10 @@ various aspects of your Ceph cluster:
   counters. Display and manage (add/edit/delete) object gateway users and their
   details (e.g. quotas) as well as the users' buckets and their details (e.g.
   owner, quotas).
+* **Feature toggles**: regardless of any existing Role-Based Authorization
+  defined, certain features can be disabled from the Dashboard, as well as the
+  corresponding REST API functionality. See :ref:`dashboard-feature-toggles`
+  for details.
 
 Enabling
 --------
@@ -525,7 +529,7 @@ To associate roles to users, the following CLI commands are available:
 
   $ ceph dashboard ac-user-del-roles <username> <rolename> [<rolename>...]
 
-
+ 
 Example of user and custom role creation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -546,6 +550,49 @@ view and create Ceph pools, and have read-only access to any other scopes.
 3. *Associate roles to user*::
 
    $ ceph dashboard ac-user-set-roles bob rbd/pool-manager read-only
+
+.. _dashboard-feature-toggles:
+
+Feature toggles
+---------------
+
+If some Ceph or Dashboard functionality is not being used (e.g.: RBD Mirroring)
+it can be disabled and hidden from the Web User Interface, as well as from the REST
+API (501 "Not Implemented" error will be returned). Features can be disabled or
+enabled without the need of restarting Ceph Manager.
+
+Currently the following features can be disabled:
+
+- *RBD (Images, Mirroring and iSCSI)*::
+
+  $ ceph dashboard set-enable-rbd-images <true|false>
+  $ ceph dashboard set-enable-rbd-mirroring <true|false>
+  $ ceph dashboard set-enable-rbd-iscsi <true|false>
+
+- *CephFS*::
+
+  $ ceph dashboard set-enable-cephfs <true|false>
+
+- *Rados GW*::
+
+  $ ceph dashboard set-enable-rgw <true|false>
+
+Debug mode
+----------
+
+While not recommended for production deployments, under certain circumstances,
+it can be helpful to obtain extra information from Dashboard errors.
+
+This can be achieved with the following command:
+
+::
+
+  $ ceph dashboard set-debug-mode <false|true>
+
+The list of changes that `DEBUG_MODE` brings in is the following:
+
+- CherryPy environment changes from `production` to `test_suite`. As a result of this:
+  - Back-end HTTP Error responses include Python traceback.
 
 
 Reverse proxies

--- a/src/pybind/mgr/dashboard/controllers/__init__.py
+++ b/src/pybind/mgr/dashboard/controllers/__init__.py
@@ -27,7 +27,8 @@ from ..services.auth import AuthManager, JwtManager
 
 
 class Controller(object):
-    def __init__(self, path, base_url=None, security_scope=None, secure=True):
+    def __init__(self, path, base_url=None, security_scope=None, secure=True,
+                 feature_enable_option=None):
         if security_scope and not Scope.valid_scope(security_scope):
             logger.debug("Invalid security scope name: %s\n Possible values: "
                          "%s", security_scope, Scope.all_scopes())
@@ -36,6 +37,7 @@ class Controller(object):
         self.base_url = base_url
         self.security_scope = security_scope
         self.secure = secure
+        self.feature_enable_option = feature_enable_option
 
         if self.path and self.path[0] != "/":
             self.path = "/" + self.path
@@ -52,10 +54,12 @@ class Controller(object):
         cls._cp_controller_ = True
         cls._cp_path_ = "{}{}".format(self.base_url, self.path)
         cls._security_scope = self.security_scope
+        cls._feature_enable_option = self.feature_enable_option
 
         config = {
             'tools.dashboard_exception_handler.on': True,
             'tools.authenticate.on': self.secure,
+            'tools.feature_toggle.on': True,
         }
         if not hasattr(cls, '_cp_config'):
             cls._cp_config = {}
@@ -64,10 +68,11 @@ class Controller(object):
 
 
 class ApiController(Controller):
-    def __init__(self, path, security_scope=None, secure=True):
+    def __init__(self, path, security_scope=None, secure=True, feature_enable_option=None):
         super(ApiController, self).__init__(path, base_url="/api",
                                             security_scope=security_scope,
-                                            secure=secure)
+                                            secure=secure,
+                                            feature_enable_option=feature_enable_option)
 
     def __call__(self, cls):
         cls = super(ApiController, self).__call__(cls)

--- a/src/pybind/mgr/dashboard/controllers/cephfs.py
+++ b/src/pybind/mgr/dashboard/controllers/cephfs.py
@@ -13,7 +13,8 @@ from ..services.ceph_service import CephService
 from ..tools import ViewCache
 
 
-@ApiController('/cephfs', Scope.CEPHFS)
+@ApiController('/cephfs', Scope.CEPHFS,
+               feature_enable_option='ENABLE_CEPHFS')
 class CephFS(RESTController):
     def __init__(self):
         super(CephFS, self).__init__()

--- a/src/pybind/mgr/dashboard/controllers/rbd.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd.py
@@ -114,7 +114,8 @@ def _sort_features(features, enable=True):
     features.sort(key=key_func, reverse=not enable)
 
 
-@ApiController('/block/image', Scope.RBD_IMAGE)
+@ApiController('/block/image', Scope.RBD_IMAGE,
+               feature_enable_option='ENABLE_RBD_IMAGES')
 class Rbd(RESTController):
 
     RESOURCE_ID = "pool_name/image_name"
@@ -386,7 +387,8 @@ class Rbd(RESTController):
         return _rbd_call(pool_name, rbd_inst.trash_move, image_name, delay)
 
 
-@ApiController('/block/image/{pool_name}/{image_name}/snap', Scope.RBD_IMAGE)
+@ApiController('/block/image/{pool_name}/{image_name}/snap', Scope.RBD_IMAGE,
+               feature_enable_option='ENABLE_RBD_IMAGES')
 class RbdSnapshot(RESTController):
 
     RESOURCE_ID = "snapshot_name"
@@ -466,7 +468,8 @@ class RbdSnapshot(RESTController):
         return _rbd_call(pool_name, _parent_clone)
 
 
-@ApiController('/block/image/trash', Scope.RBD_IMAGE)
+@ApiController('/block/image/trash', Scope.RBD_IMAGE,
+               feature_enable_option='ENABLE_RBD_IMAGES')
 class RbdTrash(RESTController):
     RESOURCE_ID = "pool_name/image_id"
     rbd_inst = rbd.RBD()

--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -328,7 +328,7 @@ def _reset_view_cache():
     _get_content_data.reset()
 
 
-@ApiController('/block/mirroring/summary', Scope.RBD_MIRRORING)
+@ApiController('/block/mirroring/summary', Scope.RBD_MIRRORING, feature_enable_option='ENABLE_RBD_MIRRORING')
 class RbdMirroringSummary(BaseController):
 
     @Endpoint()
@@ -339,7 +339,7 @@ class RbdMirroringSummary(BaseController):
         return {'status': status, 'content_data': content_data}
 
 
-@ApiController('/block/mirroring/pool', Scope.RBD_MIRRORING)
+@ApiController('/block/mirroring/pool', Scope.RBD_MIRRORING, feature_enable_option='ENABLE_RBD_MIRRORING')
 class RbdMirroringPoolMode(RESTController):
 
     RESOURCE_ID = "pool_name"
@@ -375,7 +375,7 @@ class RbdMirroringPoolMode(RESTController):
         return _rbd_call(pool_name, _edit, mirror_mode)
 
 
-@ApiController('/block/mirroring/pool/{pool_name}/peer', Scope.RBD_MIRRORING)
+@ApiController('/block/mirroring/pool/{pool_name}/peer', Scope.RBD_MIRRORING, feature_enable_option='ENABLE_RBD_MIRRORING')
 class RbdMirroringPoolPeer(RESTController):
 
     RESOURCE_ID = "peer_uuid"

--- a/src/pybind/mgr/dashboard/controllers/rgw.py
+++ b/src/pybind/mgr/dashboard/controllers/rgw.py
@@ -14,7 +14,7 @@ from ..rest_client import RequestException
 from ..exceptions import DashboardException
 
 
-@ApiController('/rgw', Scope.RGW)
+@ApiController('/rgw', Scope.RGW, feature_enable_option='ENABLE_RGW')
 class Rgw(BaseController):
 
     @Endpoint()
@@ -43,7 +43,7 @@ class Rgw(BaseController):
         return status
 
 
-@ApiController('/rgw/daemon', Scope.RGW)
+@ApiController('/rgw/daemon', Scope.RGW, feature_enable_option='ENABLE_RGW')
 class RgwDaemon(RESTController):
 
     def list(self):
@@ -102,7 +102,7 @@ class RgwRESTController(RESTController):
             raise DashboardException(e, http_status_code=500, component='rgw')
 
 
-@ApiController('/rgw/bucket', Scope.RGW)
+@ApiController('/rgw/bucket', Scope.RGW, feature_enable_option='ENABLE_RGW')
 class RgwBucket(RgwRESTController):
 
     def _append_bid(self, bucket):
@@ -149,7 +149,7 @@ class RgwBucket(RgwRESTController):
         }, json_response=False)
 
 
-@ApiController('/rgw/user', Scope.RGW)
+@ApiController('/rgw/user', Scope.RGW, feature_enable_option='ENABLE_RGW')
 class RgwUser(RgwRESTController):
 
     def _append_uid(self, user):

--- a/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
+++ b/src/pybind/mgr/dashboard/controllers/tcmu_iscsi.py
@@ -6,7 +6,8 @@ from ..security import Scope
 from ..services.tcmu_service import TcmuService
 
 
-@ApiController('/tcmuiscsi', Scope.ISCSI)
+@ApiController('/tcmuiscsi', Scope.ISCSI,
+               feature_enable_option='ENABLE_RBD_ISCSI')
 class TcmuIscsi(RESTController):
 
     def list(self):

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -58,6 +58,7 @@ from .controllers import generate_routes, json_error_page
 from .tools import NotificationQueue, RequestLoggingTool, TaskManager, \
                    prepare_url_prefix
 from .services.auth import AuthManager, AuthManagerTool, JwtManager
+from .services.feature_toggle import FeatureToggleTool
 from .services.access_control import ACCESS_CONTROL_COMMANDS, \
                                      handle_access_control_command
 from .services.sso import SSO_COMMANDS, \
@@ -122,6 +123,7 @@ class CherryPyConfig(object):
                       server_port)
 
         # Initialize custom handlers.
+        cherrypy.tools.feature_toggle = FeatureToggleTool()
         cherrypy.tools.authenticate = AuthManagerTool()
         cherrypy.tools.request_logging = RequestLoggingTool()
         cherrypy.tools.dashboard_exception_handler = HandlerWrapperTool(dashboard_exception_handler,
@@ -143,7 +145,7 @@ class CherryPyConfig(object):
                 'application/javascript',
             ],
             'tools.json_in.on': True,
-            'tools.json_in.force': False
+            'tools.json_in.force': False,
         }
 
         if ssl:

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -54,6 +54,7 @@ if 'COVERAGE_ENABLED' in os.environ:
 
 # pylint: disable=wrong-import-position
 from . import logger, mgr
+from .settings import Settings
 from .controllers import generate_routes, json_error_page
 from .tools import NotificationQueue, RequestLoggingTool, TaskManager, \
                    prepare_url_prefix
@@ -131,7 +132,7 @@ class CherryPyConfig(object):
 
         # Apply the 'global' CherryPy configuration.
         config = {
-            'engine.autoreload.on': False,
+            'environment': 'production' if not Settings.DEBUG_MODE else 'test_suite',
             'server.socket_host': server_addr,
             'server.socket_port': int(server_port),
             'error_page.default': json_error_page,

--- a/src/pybind/mgr/dashboard/services/feature_toggle.py
+++ b/src/pybind/mgr/dashboard/services/feature_toggle.py
@@ -1,15 +1,30 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import
 import cherrypy
+import json
 
 from .. import logger
 from ..settings import Settings
 
 
 class FeatureToggleTool(cherrypy.Tool):
+    FEATURE_TOGGLES = [
+        'ENABLE_RBD_IMAGES',
+        'ENABLE_RBD_MIRRORING',
+        'ENABLE_RBD_ISCSI',
+        'ENABLE_CEPHFS',
+        'ENABLE_RGW'
+    ]
+
     def __init__(self):
         super(FeatureToggleTool, self).__init__(
             'before_handler', self.is_disabled, priority=10)
+
+    def _setup(self):
+        super(FeatureToggleTool, self)._setup()
+        cherrypy.request.hooks.attach('before_finalize',
+                                      self.announce_feature_toggles,
+                                      priority=10)
 
     def is_disabled(self):
         controller = cherrypy.request.handler.callable.__self__
@@ -20,3 +35,8 @@ class FeatureToggleTool(cherrypy.Tool):
                         type(controller).__name__, feature_enable_option)
             raise cherrypy.HTTPError(501, "Feature disabled by option '{}'".format(
                 feature_enable_option))
+
+    def announce_feature_toggles(self):
+        cherrypy.response.headers["X-Dashboard-FeatureToggles"] = {
+            feature_enable_option: getattr(Settings, feature_enable_option, True) for
+            feature_enable_option in self.FEATURE_TOGGLES}

--- a/src/pybind/mgr/dashboard/services/feature_toggle.py
+++ b/src/pybind/mgr/dashboard/services/feature_toggle.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+import cherrypy
+
+from .. import logger
+from ..settings import Settings
+
+
+class FeatureToggleTool(cherrypy.Tool):
+    def __init__(self):
+        super(FeatureToggleTool, self).__init__(
+            'before_handler', self.is_disabled, priority=10)
+
+    def is_disabled(self):
+        controller = cherrypy.request.handler.callable.__self__
+        feature_enable_option = getattr(controller, '_feature_enable_option', None)
+
+        if feature_enable_option and getattr(Settings, feature_enable_option, True) is False:
+            logger.info("[FeatureToggle] Disabled: class: '%s', option: '%s'",
+                        type(controller).__name__, feature_enable_option)
+            raise cherrypy.HTTPError(501, "Feature disabled by option '{}'".format(
+                feature_enable_option))

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -40,6 +40,15 @@ class Options(object):
     GRAFANA_API_USERNAME = ('admin', str)
     GRAFANA_API_PASSWORD = ('admin', str)
 
+    # Feature Toggles
+    ENABLE_RBD_IMAGES = (True, bool)
+    ENABLE_RBD_MIRRORING = (True, bool)
+    ENABLE_RBD_ISCSI = (True, bool)
+
+    ENABLE_CEPHFS = (True, bool)
+
+    ENABLE_RGW = (True, bool)
+
     @staticmethod
     def has_default_value(name):
         return getattr(Settings, name, None) is None or \

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -18,6 +18,7 @@ class Options(object):
         GRAFANA_API_HOST = ('localhost', str)
         GRAFANA_API_PORT = (3000, int)
     """
+    DEBUG_MODE = (False, bool)
     ENABLE_BROWSABLE_API = (True, bool)
     REST_REQUESTS_TIMEOUT = (45, int)
 

--- a/src/pybind/mgr/dashboard/tests/helper.py
+++ b/src/pybind/mgr/dashboard/tests/helper.py
@@ -13,6 +13,7 @@ from cherrypy.test import helper
 from .. import logger
 from ..controllers import json_error_page, generate_controller_routes
 from ..services.auth import AuthManagerTool
+from ..services.feature_toggle import FeatureToggleTool
 from ..services.exception import dashboard_exception_handler
 
 
@@ -38,6 +39,7 @@ class ControllerTestCase(helper.CPWebCase):
 
     def __init__(self, *args, **kwargs):
         cherrypy.tools.authenticate = AuthManagerTool()
+        cherrypy.tools.feature_toggle = FeatureToggleTool()
         cherrypy.tools.dashboard_exception_handler = HandlerWrapperTool(dashboard_exception_handler,
                                                                         priority=31)
         cherrypy.config.update({


### PR DESCRIPTION
This PR brings to Ceph Dashboard Feature Toggles (aka Feature Flags, Switches, etc.), which will allow an Admin to disable specific features (e.g.: RBD iSCSI, CephFS, etc). Features may be enabled/disabled live, with no need of reloading Ceph Dashboard.

Feature Toggle has been implemented following the same approach as Role Base Authorization: extending the `Controller` initializator with a new optional argument `feature_enable_option`, which expects a string with the name of the option (it might be expanded later to support lists), and using a new `cherrypy.tool` for checking disabled Controllers.

Details:
- Initial set of Feature Toggles (all set by default to `True`):
  - `ENABLE_RBD_IMAGES`
  - `ENABLE_RBD_MIRRORING`
  - `ENABLE_RBD_ISCSI`
  - `ENABLE_CEPHFS`
  - `ENABLE_RGW`
- New `DEBUG_MODE` (default: `False`) Ceph Dashboard option. This has been added as the HTTP error responses when a Feature was disabled (501 Not Implemented) showed the Python traceback, which exposes sensitive information (file locations, python version, etc).

Reference:
- [Feature Toggles, by Martin Fowler](https://martinfowler.com/articles/feature-toggles.html)

Fixes: http://tracker.ceph.com/issues/37530

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

