### PR TITLE
mimic: rpm: missing dependency on python34-ceph-argparse from python34-cephfs (and others?)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -709,9 +709,7 @@ Summary:	Python 2 libraries for Ceph distributed file system
 Group:		Development/Libraries/Python
 %endif
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
-%if 0%{?suse_version}
-Recommends: python-rados = %{_epoch_prefix}%{version}-%{release}
-%endif
+Requires:	python-rados = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-ceph < %{_epoch_prefix}%{version}-%{release}
 %description -n python-cephfs
 This package contains Python 2 libraries for interacting with Cephs distributed

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -727,7 +727,6 @@ Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{relea
 This package contains Python 3 libraries for interacting with Cephs distributed
 file system.
 
-%if 0%{with python2}
 %package -n python%{python3_pkgversion}-ceph-argparse
 Summary:	Python 3 utility libraries for Ceph CLI
 %if 0%{?suse_version}
@@ -738,7 +737,6 @@ This package contains types and routines for Python 3 used by the Ceph CLI as
 well as the RESTful interface. These have to do with querying the daemons for
 command-description information, validating user command input against those
 descriptions, and submitting the command to the appropriate daemon.
-%endif
 
 %if 0%{with ceph_test_package}
 %package -n ceph-test
@@ -1194,15 +1192,8 @@ fi
 %config %{_sysconfdir}/bash_completion.d/radosgw-admin
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{_unitdir}/rbdmap.service
-%if 0%{with python2}
 %{python_sitelib}/ceph_argparse.py*
 %{python_sitelib}/ceph_daemon.py*
-%else
-%{python3_sitelib}/ceph_argparse.py
-%{python3_sitelib}/__pycache__/ceph_argparse.cpython*.py*
-%{python3_sitelib}/ceph_daemon.py
-%{python3_sitelib}/__pycache__/ceph_daemon.cpython*.py*
-%endif
 %dir %{_udevrulesdir}
 %{_udevrulesdir}/50-rbd.rules
 %attr(3770,ceph,ceph) %dir %{_localstatedir}/log/ceph/
@@ -1731,13 +1722,11 @@ fi
 %{python3_sitelib}/ceph_volume_client.py
 %{python3_sitelib}/__pycache__/ceph_volume_client.cpython*.py*
 
-%if 0%{with python2}
 %files -n python%{python3_pkgversion}-ceph-argparse
 %{python3_sitelib}/ceph_argparse.py
 %{python3_sitelib}/__pycache__/ceph_argparse.cpython*.py*
 %{python3_sitelib}/ceph_daemon.py
 %{python3_sitelib}/__pycache__/ceph_daemon.cpython*.py*
-%endif
 
 %if 0%{with ceph_test_package}
 %files -n ceph-test

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -330,6 +330,7 @@ Requires:	python%{_python_buildid}-rados = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{_python_buildid}-rbd = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{_python_buildid}-cephfs = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{_python_buildid}-rgw = %{_epoch_prefix}%{version}-%{release}
+Requires:	python%{_python_buildid}-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel}
 Requires:	python%{_python_buildid}-prettytable
 Requires:	python%{_python_buildid}-requests
@@ -710,6 +711,7 @@ Group:		Development/Libraries/Python
 %endif
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python-rados = %{_epoch_prefix}%{version}-%{release}
+Requires:	python-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	python-ceph < %{_epoch_prefix}%{version}-%{release}
 %description -n python-cephfs
 This package contains Python 2 libraries for interacting with Cephs distributed
@@ -723,9 +725,23 @@ Group:		Development/Libraries/Python
 %endif
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{_epoch_prefix}%{version}-%{release}
+Requires:	python%{python3_pkgversion}-ceph-argparse = %{_epoch_prefix}%{version}-%{release}
 %description -n python%{python3_pkgversion}-cephfs
 This package contains Python 3 libraries for interacting with Cephs distributed
 file system.
+
+%if 0%{with python2}
+%package -n python-ceph-argparse
+Summary:	Python 2 utility libraries for Ceph CLI
+%if 0%{?suse_version}
+Group:		Development/Libraries/Python
+%endif
+%description -n python-ceph-argparse
+This package contains types and routines for Python 2 used by the Ceph CLI as
+well as the RESTful interface. These have to do with querying the daemons for
+command-description information, validating user command input against those
+descriptions, and submitting the command to the appropriate daemon.
+%endif
 
 %package -n python%{python3_pkgversion}-ceph-argparse
 Summary:	Python 3 utility libraries for Ceph CLI
@@ -1192,8 +1208,6 @@ fi
 %config %{_sysconfdir}/bash_completion.d/radosgw-admin
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{_unitdir}/rbdmap.service
-%{python_sitelib}/ceph_argparse.py*
-%{python_sitelib}/ceph_daemon.py*
 %dir %{_udevrulesdir}
 %{_udevrulesdir}/50-rbd.rules
 %attr(3770,ceph,ceph) %dir %{_localstatedir}/log/ceph/
@@ -1721,6 +1735,12 @@ fi
 %{python3_sitearch}/cephfs-*.egg-info
 %{python3_sitelib}/ceph_volume_client.py
 %{python3_sitelib}/__pycache__/ceph_volume_client.cpython*.py*
+
+%if 0%{with python2}
+%files -n python-ceph-argparse
+%{python_sitelib}/ceph_argparse.py*
+%{python_sitelib}/ceph_daemon.py*
+%endif
 
 %files -n python%{python3_pkgversion}-ceph-argparse
 %{python3_sitelib}/ceph_argparse.py

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -42,5 +42,3 @@ usr/share/ceph/id_rsa_drop.ceph.com
 usr/share/ceph/id_rsa_drop.ceph.com.pub
 etc/ceph/rbdmap
 lib/udev/rules.d/50-rbd.rules
-usr/lib/python*/dist-packages/ceph_argparse.py*
-usr/lib/python*/dist-packages/ceph_daemon.py*

--- a/debian/control
+++ b/debian/control
@@ -394,6 +394,7 @@ Package: ceph-common
 Architecture: linux-any
 Depends: librbd1 (= ${binary:Version}),
          python-cephfs (= ${binary:Version}),
+         python-ceph-argparse (= ${binary:Version}),
          python-prettytable,
          python-rados (= ${binary:Version}),
          python-rbd (= ${binary:Version}),
@@ -962,6 +963,7 @@ Architecture: linux-any
 Section: python
 Depends: libcephfs2 (= ${binary:Version}),
          python-rados (= ${binary:Version}),
+         python-ceph-argparse (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
@@ -997,6 +999,7 @@ Architecture: linux-any
 Section: python
 Depends: libcephfs2 (= ${binary:Version}),
          python3-rados (= ${binary:Version}),
+         python3-ceph-argparse (= ${binary:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
@@ -1024,6 +1027,21 @@ Description: Python 3 libraries for the Ceph libcephfs library
  CephFS file system client library.
  .
  This package contains the debugging symbols for python3-cephfs.
+
+Package: python-ceph-argparse
+Architecture: linux-any
+Section: python
+Depends: ${misc:Depends},
+         ${python:Depends},
+Replaces: ceph-common (<< 14.0.0)
+Breaks: ceph-common (<< 14.0.0)
+Description: Python 2 utility libraries for Ceph CLI
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package contains types and routines for Python 2 used by the
+ Ceph CLI as well as the RESTful interface.
 
 Package: python3-ceph-argparse
 Architecture: linux-any

--- a/debian/control
+++ b/debian/control
@@ -893,6 +893,7 @@ Package: python-rgw
 Architecture: linux-any
 Section: python
 Depends: librgw2 (>= ${binary:Version}),
+         python-rados (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
@@ -927,6 +928,7 @@ Package: python3-rgw
 Architecture: linux-any
 Section: python
 Depends: librgw2 (>= ${binary:Version}),
+         python3-rados (= ${binary:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},
@@ -959,6 +961,7 @@ Package: python-cephfs
 Architecture: linux-any
 Section: python
 Depends: libcephfs2 (= ${binary:Version}),
+         python-rados (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
          ${shlibs:Depends},
@@ -993,6 +996,7 @@ Package: python3-cephfs
 Architecture: linux-any
 Section: python
 Depends: libcephfs2 (= ${binary:Version}),
+         python3-rados (= ${binary:Version}),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends},

--- a/debian/python-ceph-argparse.install
+++ b/debian/python-ceph-argparse.install
@@ -1,0 +1,2 @@
+usr/lib/python2*/dist-packages/ceph_argparse.py
+usr/lib/python2*/dist-packages/ceph_daemon.py


### PR DESCRIPTION
http://tracker.ceph.com/issues/37613