### PR TITLE
common/blkdev: a few fixes to device name mapping

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -310,6 +310,28 @@ void get_dm_parents(const std::string& dev, std::set<std::string> *ls)
   }
 }
 
+void get_raw_devices(const std::string& in,
+		     std::set<std::string> *ls)
+{
+  if (in.substr(0, 3) == "dm-") {
+    std::set<std::string> o;
+    get_dm_parents(in, &o);
+    for (auto& d : o) {
+      get_raw_devices(d, ls);
+    }
+  } else {
+    BlkDev d(in);
+    std::string wholedisk;
+    if (d.wholedisk(&wholedisk) == 0) {
+      std::cout << " wholedisk of " << in << " is " << wholedisk << std::endl;
+      ls->insert(wholedisk);
+    } else {
+      std::cout << " wholedisk of " << in << " failed" << std::endl;
+      ls->insert(in);
+    }
+  }
+}
+
 int _get_vdo_stats_handle(const char *devname, std::string *vdo_name)
 {
   int vdo_fd = -1;
@@ -641,6 +663,11 @@ void get_dm_parents(const std::string& dev, std::set<std::string> *ls)
 {
 }
 
+void get_raw_devices(const std::string& in,
+		     std::set<std::string> *ls)
+{
+}
+
 int get_vdo_stats_handle(const char *devname, std::string *vdo_name)
 {
   return -1;
@@ -791,6 +818,11 @@ void get_dm_parents(const std::string& dev, std::set<std::string> *ls)
 {
 }
 
+void get_raw_devices(const std::string& in,
+		     std::set<std::string> *ls)
+{
+}
+
 int get_vdo_stats_handle(const char *devname, std::string *vdo_name)
 {
   return -1;
@@ -919,6 +951,11 @@ int BlkDev::wholedisk(char *wd, size_t max) const
 }
 
 void get_dm_parents(const std::string& dev, std::set<std::string> *ls)
+{
+}
+
+void get_raw_devices(const std::string& in,
+		     std::set<std::string> *ls)
 {
 }
 

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -522,32 +522,121 @@ std::string get_device_id(const std::string& devname,
   return device_id;
 }
 
-int block_device_get_metrics(const char *device, int timeout,
-			     json_spirit::mValue *result)
+static std::string get_device_vendor(const std::string& devname)
 {
-  std::string s;
-  if (int r = block_device_run_smartctl(device, timeout, &s); r != 0) {
-    s = "{\"error\": \"smartctl failed\", \"dev\": \"";
-    s += device;
-    s += "\", \"smartctl_error_code\": " + stringify(r);
-    s += "\", \"smartctl_output\": \"" + s;
-    s += + "\"}";
+  struct udev_device *dev;
+  static struct udev *udev;
+  const char *data;
+
+  udev = udev_new();
+  if (!udev) {
+    return {};
   }
-  if (json_spirit::read(s, *result)) {
-    return 0;
+  dev = udev_device_new_from_subsystem_sysname(udev, "block", devname.c_str());
+  if (!dev) {
+    udev_unref(udev);
+    return {};
   }
-  s = "{\"error\": \"smartctl returned invalid JSON\", \"dev\": \"";
-  s += device;
-  s += "\"}";
-  if (json_spirit::read(s, *result)) {
-    return 0;
+
+  std::string id_vendor, id_model;
+  data = udev_device_get_property_value(dev, "ID_VENDOR");
+  if (data) {
+    id_vendor = data;
   }
-  return -EINVAL;
+  data = udev_device_get_property_value(dev, "ID_MODEL");
+  if (data) {
+    id_model = data;
+  }
+  udev_device_unref(dev);
+  udev_unref(udev);
+
+  std::transform(id_vendor.begin(), id_vendor.end(), id_vendor.begin(),
+		 ::tolower);
+  std::transform(id_model.begin(), id_model.end(), id_model.begin(),
+		 ::tolower);
+
+  if (id_vendor.size()) {
+    return id_vendor;
+  }
+  if (id_model.size()) {
+    int pos = id_model.find(" ");
+    if (pos > 0) {
+      return id_model.substr(0, pos);
+    } else {
+      return id_model;
+    }
+  }
+
+  std::string vendor, model;
+  char buf[1024] = {0};
+  BlkDev blkdev(devname);
+  if (!blkdev.vendor(buf, sizeof(buf))) {
+    vendor = buf;
+  }
+  if (!blkdev.model(buf, sizeof(buf))) {
+    model = buf;
+  }
+  if (vendor.size()) {
+    return vendor;
+  }
+  if (model.size()) {
+     int pos = model.find(" ");
+    if (pos > 0) {
+      return model.substr(0, pos);
+    } else {
+      return model;
+    }
+  }
+
+  return {};
 }
 
-int block_device_run_smartctl(const char *device, int timeout,
-			      std::string *result)
+static int block_device_run_vendor_nvme(
+  const string& devname, const string& vendor, int timeout,
+  std::string *result)
 {
+  string device = "/dev/" + devname;
+
+  SubProcessTimed nvmecli(
+    "sudo", SubProcess::CLOSE, SubProcess::PIPE, SubProcess::CLOSE,
+    timeout);
+  nvmecli.add_cmd_args(
+    "nvme",
+    vendor.c_str(),
+    "smart-log-add",
+    "--json",
+    device.c_str(),
+    NULL);
+  int ret = nvmecli.spawn();
+  if (ret != 0) {
+    *result = std::string("error spawning nvme command: ") + nvmecli.err();
+    return ret;
+  }
+
+  bufferlist output;
+  ret = output.read_fd(nvmecli.get_stdout(), 100*1024);
+  if (ret < 0) {
+    bufferlist err;
+    err.read_fd(nvmecli.get_stderr(), 100 * 1024);
+    *result = std::string("failed to execute nvme: ") + err.to_str();
+  } else {
+    ret = 0;
+    *result = output.to_str();
+  }
+
+  if (nvmecli.join() != 0) {
+    *result = std::string("nvme returned an error: ") + nvmecli.err();
+    return -EINVAL;
+  }
+
+  return ret;
+}
+
+static int block_device_run_smartctl(const string& devname, int timeout,
+				     std::string *result)
+{
+  string device = "/dev/" + devname;
+
   // when using --json, smartctl will report its errors in JSON format to stdout 
   SubProcessTimed smartctl(
     "sudo", SubProcess::CLOSE, SubProcess::PIPE, SubProcess::CLOSE,
@@ -557,7 +646,7 @@ int block_device_run_smartctl(const char *device, int timeout,
     "-a",
     //"-x",
     "--json",
-    device,
+    device.c_str(),
     NULL);
 
   int ret = smartctl.spawn();
@@ -583,6 +672,53 @@ int block_device_run_smartctl(const char *device, int timeout,
   return ret;
 }
 
+int block_device_get_metrics(const string& devname, int timeout,
+			     json_spirit::mValue *result)
+{
+  std::string s;
+
+  // smartctl
+  if (int r = block_device_run_smartctl(devname, timeout, &s);
+      r != 0) {
+    s = "{\"error\": \"smartctl failed\", \"dev\": \"/dev/";
+    s += devname;
+    s += "\", \"smartctl_error_code\": " + stringify(r);
+    s += "\", \"smartctl_output\": \"" + s;
+    s += + "\"}";
+  }
+  if (!json_spirit::read(s, *result)) {
+    s = "{\"error\": \"smartctl returned invalid JSON\", \"dev\": \"/dev/";
+    s += devname;
+    s += "\"}";
+  }
+  if (!json_spirit::read(s, *result)) {
+    return -EINVAL;
+  }
+
+  json_spirit::mObject& base = result->get_obj();
+  string vendor = get_device_vendor(devname);
+  if (vendor.size()) {
+    base["nvme_vendor"] = vendor;
+    s.clear();
+    json_spirit::mValue nvme_json;
+    if (int r = block_device_run_vendor_nvme(devname, vendor, timeout, &s);
+	r == 0) {
+      if (json_spirit::read(s, nvme_json) != 0) {
+	base["nvme_smart_health_information_add_log"] = nvme_json;
+      } else {
+	base["nvme_smart_health_information_add_log_error"] = "bad json output: "
+	  + s;
+      }
+    } else {
+      base["nvme_smart_health_information_add_log_error_code"] = r;
+      base["nvme_smart_health_information_add_log_error"] = s;
+    }
+  } else {
+    base["nvme_vendor"] = "unknown";
+  }
+
+  return 0;
+}
 
 #elif defined(__APPLE__)
 #include <sys/disk.h>
@@ -865,6 +1001,12 @@ int block_device_run_smartctl(const char *device, int timeout,
   return -EOPNOTSUPP;  
 }
 
+int block_device_run_nvme(const char *device, const char *vendor, int timeout,
+             std::string *result)
+{
+  return -EOPNOTSUPP;
+}
+
 static int block_device_devname(int fd, char *devname, size_t max)
 {
   struct fiodgname_arg arg;
@@ -996,6 +1138,12 @@ std::string get_device_id(const std::string& devname,
 
 int block_device_run_smartctl(const char *device, int timeout,
 			      std::string *result)
+{
+  return -EOPNOTSUPP;
+}
+
+int block_device_run_nvme(const char *device, const char *vendor, int timeout,
+            std::string *result)
 {
   return -EOPNOTSUPP;
 }

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -82,14 +82,20 @@ BlkDev::BlkDev(const std::string& devname)
   : devname(devname)
 {}
 
-int BlkDev::get_devid(dev_t *id) const {
+int BlkDev::get_devid(dev_t *id) const
+{
   struct stat st;
-
-  int r = fstat(fd, &st);
-
-  if (r < 0)
+  int r;
+  if (fd >= 0) {
+    r = fstat(fd, &st);
+  } else {
+    char path[PATH_MAX];
+    snprintf(path, sizeof(path), "/dev/%s", devname.c_str());
+    stat(path, &st);
+  }
+  if (r < 0) {
     return -errno;
-
+  }
   *id = S_ISBLK(st.st_mode) ? st.st_rdev : st.st_dev;
   return 0;
 }

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -395,7 +395,8 @@ bool get_vdo_utilization(int fd, uint64_t *total, uint64_t *avail)
 
 // trying to use udev first, and if it doesn't work, we fall back to 
 // reading /sys/block/$devname/device/(vendor/model/serial).
-std::string get_device_id(const std::string& devname)
+std::string get_device_id(const std::string& devname,
+			  std::string *err)
 {
   struct udev_device *dev;
   static struct udev *udev;
@@ -403,10 +404,17 @@ std::string get_device_id(const std::string& devname)
 
   udev = udev_new();
   if (!udev) {
+    if (err) {
+      *err = "udev_new failed";
+    }
     return {};
   }
   dev = udev_device_new_from_subsystem_sysname(udev, "block", devname.c_str());
   if (!dev) {
+    if (err) {
+      *err = std::string("udev_device_new_from_subsystem_sysname failed on '")
+	+ devname + "'";
+    }
     udev_unref(udev);
     return {};
   }
@@ -474,6 +482,10 @@ std::string get_device_id(const std::string& devname)
     serial = buf;
   }
   if (!model.size() || serial.size()) {
+    if (err) {
+      *err = std::string("fallback method has serial '") + serial
+	+ "'but no model";
+    }
     return {};
   }
 
@@ -788,9 +800,13 @@ bool get_vdo_utilization(int fd, uint64_t *total, uint64_t *avail)
   return false;
 }
 
-std::string get_device_id(const std::string& devname)
+std::string get_device_id(const std::string& devname,
+			  std::string *err)
 {
   // FIXME: implement me for freebsd
+  if (err) {
+    *err = "not implemented for FreeBSD";
+  }
   return std::string();
 }
 
@@ -915,9 +931,13 @@ bool get_vdo_utilization(int fd, uint64_t *total, uint64_t *avail)
   return false;
 }
 
-std::string get_device_id(const std::string& devname)
+std::string get_device_id(const std::string& devname,
+			  std::string *err)
 {
   // not implemented
+  if (err) {
+    *err = "not implemented";
+  }
   return std::string();
 }
 

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -683,6 +683,16 @@ bool get_vdo_utilization(int fd, uint64_t *total, uint64_t *avail)
   return false;
 }
 
+std::string get_device_id(const std::string& devname,
+			  std::string *err)
+{
+  // FIXME: implement me
+  if (err) {
+    *err = "not implemented";
+  }
+  return std::string();
+}
+
 #elif defined(__FreeBSD__)
 
 const char *BlkDev::sysfsdir() const {

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -24,9 +24,7 @@ extern int get_device_by_path(const char *path, char* partition, char* device, s
 extern std::string get_device_id(const std::string& devname,
 				 std::string *err=0);
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
-extern int block_device_run_smartctl(const char *device, int timeout,
-				     std::string *result);
-extern int block_device_get_metrics(const char *device, int timeout,
+extern int block_device_get_metrics(const string& devname, int timeout,
 				    json_spirit::mValue *result);
 
 // do everything to translate a device to the raw physical devices that

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -21,7 +21,8 @@ enum blkdev_prop_t {
 extern int get_device_by_path(const char *path, char* partition, char* device, size_t max);
 
 
-extern std::string get_device_id(const std::string& devname);
+extern std::string get_device_id(const std::string& devname,
+				 std::string *err=0);
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
 extern int block_device_run_smartctl(const char *device, int timeout,
 				     std::string *result);

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -29,6 +29,11 @@ extern int block_device_run_smartctl(const char *device, int timeout,
 extern int block_device_get_metrics(const char *device, int timeout,
 				    json_spirit::mValue *result);
 
+// do everything to translate a device to the raw physical devices that
+// back it, including partitions -> wholedisks and dm -> constituent devices.
+extern void get_raw_devices(const std::string& in,
+			    std::set<std::string> *ls);
+
 // for VDO
 /// return an op fd for the sysfs stats dir, if this is a VDO device
 extern int get_vdo_stats_handle(const char *devname, std::string *vdo_name);
@@ -59,6 +64,15 @@ public:
   /* virtual for testing purposes */
   virtual const char *sysfsdir() const;
   virtual int wholedisk(char* device, size_t max) const;
+  int wholedisk(std::string *s) const {
+    char out[PATH_MAX] = {0};
+    int r = wholedisk(out, sizeof(out));
+    if (r < 0) {
+      return r;
+    }
+    *s = out;
+    return r;
+  }
 
 protected:
   int64_t get_int_property(blkdev_prop_t prop) const;

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -1,8 +1,12 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #ifndef __CEPH_COMMON_BLKDEV_H
 #define __CEPH_COMMON_BLKDEV_H
 
 #include <set>
 #include <string>
+#include "json_spirit/json_spirit_value.h"
 
 enum blkdev_prop_t {
   BLKDEV_PROP_DEV,
@@ -21,6 +25,8 @@ extern std::string get_device_id(const std::string& devname);
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
 extern int block_device_run_smartctl(const char *device, int timeout,
 				     std::string *result);
+extern int block_device_get_metrics(const char *device, int timeout,
+				    json_spirit::mValue *result);
 
 // for VDO
 /// return an op fd for the sysfs stats dir, if this is a VDO device

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3646,17 +3646,9 @@ void Monitor::handle_command(MonOpRequestRef op)
 	"mon_smart_report_timeout");
       json_spirit::mObject json_map;
       json_spirit::mValue smart_json;
-      std::string result;
-      if (block_device_run_smartctl(("/dev/" + dev).c_str(), smart_timeout,
-				    &result)) {
-	dout(10) << "probe_smart_device failed for /dev/" << dev << dendl;
-	result = "{\"error\": \"smartctl failed\", \"dev\": \"" + dev +
-	  "\", \"smartctl_error\": \"" + result + "\"}";
-      }
-
-      if (!json_spirit::read(result, smart_json)) {
-	derr << "smartctl JSON output of /dev/" + dev + " is invalid"
-	     << dendl;
+      if (block_device_get_metrics(("/dev/" + dev).c_str(), smart_timeout,
+				    &smart_json)) {
+	dout(10) << "block_device_get_metrics failed for /dev/" << dev << dendl;
       } else {
 	json_map[devid] = smart_json;
       }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3660,7 +3660,7 @@ void Monitor::handle_command(MonOpRequestRef op)
 	continue;
       }
       json_spirit::mValue smart_json;
-      if (block_device_get_metrics(("/dev/" + devname).c_str(), smart_timeout,
+      if (block_device_get_metrics(devname, smart_timeout,
 				   &smart_json)) {
 	dout(10) << "block_device_get_metrics failed for /dev/" << devname
 		 << dendl;

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -218,10 +218,7 @@ int KernelDevice::get_devices(std::set<std::string> *ls)
   if (devname.empty()) {
     return 0;
   }
-  ls->insert(devname);
-  if (devname.find("dm-") == 0) {
-    get_dm_parents(devname, ls);
-  }
+  get_raw_devices(devname, ls);
   return 0;
 }
 

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -2186,15 +2186,12 @@ off64_t FileJournal::get_journal_size_estimate()
 
 void FileJournal::get_devices(set<string> *ls)
 {
-  char dev_node[PATH_MAX];
+  string dev_node;
   BlkDev blkdev(fd);
-  if (int rc = blkdev.wholedisk(dev_node, PATH_MAX); rc) {
+  if (int rc = blkdev.wholedisk(&dev_node); rc) {
     return;
   }
-  ls->insert(dev_node);
-  if (strncmp(dev_node, "dm-", 3) == 0) {
-    get_dm_parents(dev_node, ls);
-  }
+  get_raw_devices(dev_node, ls);
 }
 
 void FileJournal::collect_metadata(map<string,string> *pm)

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -716,15 +716,12 @@ void FileStore::collect_metadata(map<string,string> *pm)
 
 int FileStore::get_devices(set<string> *ls)
 {
-  char dev_node[PATH_MAX];
+  string dev_node;
   BlkDev blkdev(fsid_fd);
-  if (int rc = blkdev.wholedisk(dev_node, PATH_MAX); rc) {
+  if (int rc = blkdev.wholedisk(&dev_node); rc) {
     return rc;
   }
-  ls->insert(dev_node);
-  if (strncmp(dev_node, "dm-", 3) == 0) {
-    get_dm_parents(dev_node, ls);
-  }
+  get_raw_devices(dev_node, ls);
   if (journal) {
     journal->get_devices(ls);
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5753,14 +5753,16 @@ void OSD::_collect_metadata(map<string,string> *pm)
   (*pm)["devices"] = stringify(devnames);
   string devids;
   for (auto& dev : devnames) {
-    if (!devids.empty()) {
-      devids += ",";
-    }
-    string id = get_device_id(dev);
+    string err;
+    string id = get_device_id(dev, &err);
     if (id.size()) {
+      if (!devids.empty()) {
+	devids += ",";
+      }
       devids += dev + "=" + id;
     } else {
-      dout(10) << __func__ << " no unique device id for " << dev << dendl;
+      dout(10) << __func__ << " no unique device id for " << dev << ": "
+	       << err << dendl;
     }
   }
   (*pm)["device_ids"] = devids;
@@ -6621,10 +6623,11 @@ void OSD::probe_smart(const string& only_devid, ostream& ss)
       continue;
     }
 
-    string devid = get_device_id(dev);
+    string err;
+    string devid = get_device_id(dev, &err);
     if (devid.size() == 0) {
-      dout(10) << __func__ << " no unique id for dev " << dev << ", skipping"
-	       << dendl;
+      dout(10) << __func__ << " no unique id for dev " << dev << " ("
+	       << err << "), skipping" << dendl;
       continue;
     }
     if (only_devid.size() && devid != only_devid) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6635,7 +6635,7 @@ void OSD::probe_smart(const string& only_devid, ostream& ss)
     }
 
     json_spirit::mValue smart_json;
-    if (block_device_get_metrics(("/dev/" + dev).c_str(), smart_timeout,
+    if (block_device_get_metrics(dev, smart_timeout,
 				 &smart_json)) {
       dout(10) << "block_device_get_metrics failed for /dev/" << dev << dendl;
       continue;

--- a/sudoers.d/ceph-osd-smartctl
+++ b/sudoers.d/ceph-osd-smartctl
@@ -1,3 +1,4 @@
 ## allow ceph-osd (which runs as user ceph) to collect device health metrics
 
 ceph ALL=NOPASSWD: /usr/sbin/smartctl -a --json /dev/*
+ceph ALL=NOPASSWD: /usr/sbin/nvme * smart-log-add --json /dev/*


### PR DESCRIPTION
- map to raw devices when LVM is consuming a parititon
- use a new get_raw_devices() that does everything
- report get_device_id errors
- fix mon to use the new helpers

Fixes http://tracker.ceph.com/issues/37542