### PR TITLE
ceph-volume normalize comma to dot for string to int conversions 

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_util.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_util.py
@@ -15,6 +15,14 @@ class TestAsBytes(object):
 
 class TestStrToInt(object):
 
+    def test_passing_a_float_str_comma(self):
+        result = util.str_to_int("1,99")
+        assert result == 1
+
+    def test_passing_a_float_does_not_round_comma(self):
+        result = util.str_to_int("1,99", round_down=False)
+        assert result == 2
+
     def test_passing_a_float_str(self):
         result = util.str_to_int("1.99")
         assert result == 1

--- a/src/ceph-volume/ceph_volume/tests/util/test_util.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_util.py
@@ -23,18 +23,30 @@ class TestStrToInt(object):
         result = util.str_to_int("1,99", round_down=False)
         assert result == 2
 
-    def test_passing_a_float_str(self):
-        result = util.str_to_int("1.99")
+    @pytest.mark.parametrize("value", ['2', 2])
+    def test_passing_an_int(self, value):
+        result = util.str_to_int(value)
+        assert result == 2
+
+    @pytest.mark.parametrize("value", ['1.99', 1.99])
+    def test_passing_a_float(self, value):
+        result = util.str_to_int(value)
         assert result == 1
 
-    def test_passing_a_float_does_not_round(self):
-        result = util.str_to_int("1.99", round_down=False)
+    @pytest.mark.parametrize("value", ['1.99', 1.99])
+    def test_passing_a_float_does_not_round(self, value):
+        result = util.str_to_int(value, round_down=False)
         assert result == 2
 
     def test_text_is_not_an_integer_like(self):
         with pytest.raises(RuntimeError) as error:
             util.str_to_int("1.4GB")
         assert str(error.value) == "Unable to convert to integer: '1.4GB'"
+
+    def test_input_is_not_string(self):
+        with pytest.raises(RuntimeError) as error:
+            util.str_to_int(None)
+        assert str(error.value) == "Unable to convert to integer: 'None'"
 
 
 def true_responses(upper_casing=False):

--- a/src/ceph-volume/ceph_volume/util/__init__.py
+++ b/src/ceph-volume/ceph_volume/util/__init__.py
@@ -30,10 +30,21 @@ def str_to_int(string, round_down=True):
     """
     Parses a string number into an integer, optionally converting to a float
     and rounding down.
+
+    Some LVM values may come with a comma instead of a dot to define decimals.
+    This function normalizes a comma into a dot
     """
     error_msg = "Unable to convert to integer: '%s'" % str(string)
     try:
-        integer = float(string)
+        integer = float(string.replace(',', '.'))
+    except AttributeError:
+        # this might be a integer already, so try to use it, otherwise raise
+        # the original exception
+        if isinstance(string, (int, float)):
+            integer = string
+        else:
+            logger.exception(error_msg)
+            raise RuntimeError(error_msg)
     except (TypeError, ValueError):
         logger.exception(error_msg)
         raise RuntimeError(error_msg)


### PR DESCRIPTION
Sometimes, LVM may return a string with a comma instead with a dot. This normalizes to a dot, so that integer conversion works.

Fixes: http://tracker.ceph.com/issues/37442