### PR TITLE
Cancel ops in messenger when ops are redirected.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -626,7 +626,7 @@ using namespace ceph;
       buffer::raw *tr = _raw;
       _raw = tr->clone();
       _raw->nref = 1;
-      if (unlikely(--tr->nref == 0)) {
+      if (likely(--tr->nref == 0)) {
         ANNOTATE_HAPPENS_AFTER(&tr->nref);
         ANNOTATE_HAPPENS_BEFORE_FORGET_ALL(&tr->nref);
         delete tr;

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1269,7 +1269,7 @@ using namespace ceph;
     }
   }
 
-  void buffer::list::clone_replace(const unsigned o, const unsigned l)
+  void buffer::list::clone_replace(unsigned o, unsigned l)
   {
     ceph_assert(o+l <= _len);
     unsigned p = 0;

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -1095,12 +1095,8 @@ namespace buffer CEPH_BUFFER_API {
 
     void zero();
     void zero(unsigned o, unsigned l);
-    // allocate a new buffer, clone the old content, then replace old buffer.
-    // this is used when the old buffer may be already be freed but we still need to reference it.
-    // for example, when a write message to an osd is resent to an new osd when crushmap changes
-    // the new osd returned the response and the data buffer of the write message is freed by client
-    // but the write message may still be in the osd's outcoming_bl, then we can use a new buffer
-    // to replace the old freed buffer to avoid segfault.
+    // clone the old buffers to new buffers, then replace old buffers with the
+    // new buffers so the old buffers are not referenced by this bufferlist
     void clone_replace(unsigned o, unsigned l);
 
     bool is_contiguous() const;

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -281,7 +281,7 @@ namespace buffer CEPH_BUFFER_API {
     raw *clone();
     void swap(ptr& other) noexcept;
     ptr& make_shareable();
-    void clone_replace();
+    void make_owner();
 
     iterator begin(size_t offset=0) {
       return iterator(this, offset, false);
@@ -1095,9 +1095,9 @@ namespace buffer CEPH_BUFFER_API {
 
     void zero();
     void zero(unsigned o, unsigned l);
-    // clone the old buffers to new buffers, then replace old buffers with the
-    // new buffers so the old buffers are not referenced by this bufferlist
-    void clone_replace(unsigned o, unsigned l);
+    // make this the owner of the buffers when manage buffer from outside ceph, such as
+    // buffers created by buffer::create_static.
+    void make_owner(unsigned o, unsigned l);
 
     bool is_contiguous() const;
     void rebuild();

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -281,6 +281,7 @@ namespace buffer CEPH_BUFFER_API {
     raw *clone();
     void swap(ptr& other) noexcept;
     ptr& make_shareable();
+    void clone_replace();
 
     iterator begin(size_t offset=0) {
       return iterator(this, offset, false);
@@ -1094,6 +1095,13 @@ namespace buffer CEPH_BUFFER_API {
 
     void zero();
     void zero(unsigned o, unsigned l);
+    // allocate a new buffer, clone the old content, then replace old buffer.
+    // this is used when the old buffer may be already be freed but we still need to reference it.
+    // for example, when a write message to an osd is resent to an new osd when crushmap changes
+    // the new osd returned the response and the data buffer of the write message is freed by client
+    // but the write message may still be in the osd's outcoming_bl, then we can use a new buffer
+    // to replace the old freed buffer to avoid segfault.
+    void clone_replace(unsigned o, unsigned l);
 
     bool is_contiguous() const;
     void rebuild();

--- a/src/include/buffer_raw.h
+++ b/src/include/buffer_raw.h
@@ -76,6 +76,10 @@ namespace ceph::buffer {
       }
     }
 
+    virtual raw *own() {
+      return this;
+    }
+
 private:
     // no copying.
     // cppcheck-suppress noExplicitConstructor

--- a/src/msg/Connection.h
+++ b/src/msg/Connection.h
@@ -97,7 +97,7 @@ public:
    * @return true if ready to send, or false otherwise
    */
   virtual bool is_connected() = 0;
-
+  virtual void cancel_ops(const boost::container::flat_set<ceph_tid_t> &ops) {}
   Messenger *get_messenger() {
     return msgr;
   }

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -299,7 +299,6 @@ ssize_t AsyncConnection::write(bufferlist &bl,
 // else return < 0 means error
 ssize_t AsyncConnection::_try_send(bool more)
 {
-  ssize_t remaining;
   if (async_msgr->cct->_conf->ms_inject_socket_failures && cs) {
     if (rand() % async_msgr->cct->_conf->ms_inject_socket_failures == 0) {
       ldout(async_msgr->cct, 0) << __func__ << " injecting socket failure" << dendl;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -130,10 +130,12 @@ class AsyncConnection : public Connection {
     policy.lossy = true;
   }
 
- entity_addr_t get_peer_socket_addr() const override {
-   return target_addr;
- }
+  entity_addr_t get_peer_socket_addr() const override {
+    return target_addr;
+  }
 
+  void cancel_ops(const boost::container::flat_set<ceph_tid_t> &ops) override;
+ 
  private:
   enum {
     STATE_NONE,
@@ -170,6 +172,7 @@ class AsyncConnection : public Connection {
   bool open_write = false;
 
   std::mutex write_lock;
+  std::mutex send_lock;
 
   std::mutex lock;
   EventCallbackRef read_handler;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -172,7 +172,7 @@ class AsyncConnection : public Connection {
   bool open_write = false;
   // lock order: lock -> write_lock -> send_lock
   std::mutex write_lock;
-  std::mutex send_lock;
+  mutable std::mutex send_lock;
 
   std::mutex lock;
   EventCallbackRef read_handler;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -170,7 +170,7 @@ class AsyncConnection : public Connection {
   // lockfree, only used in own thread
   bufferlist outcoming_bl;
   bool open_write = false;
-  // lock order: write_lock -> send_lock
+  // lock order: lock -> write_lock -> send_lock
   std::mutex write_lock;
   std::mutex send_lock;
 

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -172,7 +172,7 @@ class AsyncConnection : public Connection {
   bool open_write = false;
   // lock order: lock -> write_lock -> send_lock
   std::mutex write_lock;
-  mutable std::mutex send_lock;
+  std::mutex send_lock;
 
   std::mutex lock;
   EventCallbackRef read_handler;

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -170,7 +170,7 @@ class AsyncConnection : public Connection {
   // lockfree, only used in own thread
   bufferlist outcoming_bl;
   bool open_write = false;
-
+  // lock order: write_lock -> send_lock
   std::mutex write_lock;
   std::mutex send_lock;
 

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -167,7 +167,7 @@ class AsyncConnection : public Connection {
 
   DispatchQueue *dispatch_queue;
 
-  // lockfree, only used in own thread
+  // must be protected with send_lock
   bufferlist outcoming_bl;
   bool open_write = false;
   // lock order: lock -> write_lock -> send_lock

--- a/src/msg/async/Protocol.cc
+++ b/src/msg/async/Protocol.cc
@@ -466,7 +466,7 @@ void ProtocolV1::cancel_ops(const boost::container::flat_set<ceph_tid_t> &ops)
         len = (*it)->len;
       }
       if (len > 0) {
-        connection->outcoming_bl.clone_replace(o, len);
+        connection->outcoming_bl.make_owner(o, len);
       }
     }
   }

--- a/src/msg/async/Protocol.cc
+++ b/src/msg/async/Protocol.cc
@@ -460,8 +460,6 @@ void ProtocolV1::cancel_ops(const boost::container::flat_set<ceph_tid_t> &ops)
         len = (*it)->len;
       }
       if (len > 0) {
-        // this will modify the inner buffer of outcoming_bl, and only _try_send will touch inner buffer of outcoming_bl,
-        // other places just append to outcoming_bl, and both _try_send and this are made exclusive by send_lock, so it is safe.
         connection->outcoming_bl.clone_replace(o, len);
       }
     }

--- a/src/msg/async/Protocol.cc
+++ b/src/msg/async/Protocol.cc
@@ -338,7 +338,6 @@ void ProtocolV1::write_event() {
         m->get();
       }
       more = !out_q.empty();
-      connection->send_lock.lock();
       connection->write_lock.unlock();
 
       // send_message or requeue messages may not encode message
@@ -348,7 +347,9 @@ void ProtocolV1::write_event() {
 
       r = write_message(m, data, more);
 
+      connection->send_lock.unlock();
       connection->write_lock.lock();
+      connection->send_lock.lock();
       if (r == 0) {
         ;
       } else if (r < 0) {

--- a/src/msg/async/Protocol.cc
+++ b/src/msg/async/Protocol.cc
@@ -454,7 +454,7 @@ void ProtocolV1::cancel_ops(const boost::container::flat_set<ceph_tid_t> &ops)
       unsigned o, len;
       if ((*it)->start < sent_pos) {
         o = 0;
-        len -= ((*it)->start - sent_pos);
+        len -= (sent_pos - (*it)->start);
       } else {
         o = (*it)->start - sent_pos;
         len = (*it)->len;

--- a/src/msg/simple/Pipe.h
+++ b/src/msg/simple/Pipe.h
@@ -122,6 +122,7 @@ static const int SM_IOV_MAX = (IOV_MAX >= 1024 ? IOV_MAX / 4 : IOV_MAX);
     Messenger::Policy policy;
     
     Mutex pipe_lock;
+    Mutex send_lock;
     int state;
     std::atomic<bool> state_closed = { false }; // true iff state = STATE_CLOSED
 
@@ -308,7 +309,7 @@ static const int SM_IOV_MAX = (IOV_MAX >= 1024 ? IOV_MAX / 4 : IOV_MAX);
      * @return 0 for success, or -1 on error
      */
     int tcp_write(const char *buf, unsigned len);
-
+    void cancel_ops(const boost::container::flat_set<ceph_tid_t> &ops);
   };
 
 

--- a/src/msg/simple/Pipe.h
+++ b/src/msg/simple/Pipe.h
@@ -15,7 +15,6 @@
 #ifndef CEPH_MSGR_PIPE_H
 #define CEPH_MSGR_PIPE_H
 
-#include "include/memory.h"
 #include "auth/AuthSessionHandler.h"
 
 #include "msg/msg_types.h"
@@ -131,7 +130,7 @@ static const int SM_IOV_MAX = (IOV_MAX >= 1024 ? IOV_MAX / 4 : IOV_MAX);
 
     // session_security handles any signatures or encryptions required for this pipe's msgs. PLR
 
-    ceph::shared_ptr<AuthSessionHandler> session_security;
+    std::shared_ptr<AuthSessionHandler> session_security;
 
   protected:
     friend class SimpleMessenger;
@@ -165,7 +164,7 @@ static const int SM_IOV_MAX = (IOV_MAX >= 1024 ? IOV_MAX / 4 : IOV_MAX);
     void writer();
     void unlock_maybe_reap();
 
-    int randomize_out_seq();
+    void randomize_out_seq();
 
     int read_message(Message **pm,
 		     AuthSessionHandler *session_security_copy);
@@ -232,17 +231,17 @@ static const int SM_IOV_MAX = (IOV_MAX >= 1024 ? IOV_MAX / 4 : IOV_MAX);
     void stop_and_wait();
 
     void _send(Message *m) {
-      assert(pipe_lock.is_locked());
+      ceph_assert(pipe_lock.is_locked());
       out_q[m->get_priority()].push_back(m);
       cond.Signal();
     }
     void _send_keepalive() {
-      assert(pipe_lock.is_locked());
+      ceph_assert(pipe_lock.is_locked());
       send_keepalive = true;
       cond.Signal();
     }
     Message *_get_next_outgoing() {
-      assert(pipe_lock.is_locked());
+      ceph_assert(pipe_lock.is_locked());
       Message *m = 0;
       while (!m && !out_q.empty()) {
         map<int, list<Message*> >::reverse_iterator p = out_q.rbegin();
@@ -312,6 +311,7 @@ static const int SM_IOV_MAX = (IOV_MAX >= 1024 ? IOV_MAX / 4 : IOV_MAX);
      * @return 0 for success, or -1 on error
      */
     int tcp_write(const char *buf, unsigned len);
+
   };
 
 

--- a/src/msg/simple/Pipe.h
+++ b/src/msg/simple/Pipe.h
@@ -123,7 +123,7 @@ static const int SM_IOV_MAX = (IOV_MAX >= 1024 ? IOV_MAX / 4 : IOV_MAX);
     Messenger::Policy policy;
     
     Mutex pipe_lock;
-    std::mutex send_lock;
+    Mutex send_lock;
 
     int state;
     std::atomic<bool> state_closed = { false }; // true iff state = STATE_CLOSED

--- a/src/msg/simple/PipeConnection.cc
+++ b/src/msg/simple/PipeConnection.cc
@@ -94,3 +94,10 @@ void PipeConnection::mark_disposable()
   if (msgr)
     static_cast<SimpleMessenger*>(msgr)->mark_disposable(this);
 }
+
+void PipeConnection::cancel_ops(const boost::container::flat_set<ceph_tid_t> &ops)
+{
+  if (pipe) {
+    pipe->cancel_ops(ops);
+  }
+}

--- a/src/msg/simple/PipeConnection.h
+++ b/src/msg/simple/PipeConnection.h
@@ -47,6 +47,7 @@ public:
   void send_keepalive() override;
   void mark_down() override;
   void mark_disposable() override;
+  void cancel_ops(const boost::container::flat_set<ceph_tid_t> &ops) override;
 
   entity_addr_t get_peer_socket_addr() const override {
     return peer_addrs.front();

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -85,7 +85,9 @@ class ObjectCacher {
     OSDWrite(const SnapContext& sc, const bufferlist& b, ceph::real_time mt,
 	     int f, ceph_tid_t _journal_tid)
       : snapc(sc), bl(b), mtime(mt), fadvise_flags(f),
-	journal_tid(_journal_tid) {}
+	journal_tid(_journal_tid) {
+          bl.make_owner(0, bl.length());
+        }
   };
 
   OSDWrite *prepare_write(const SnapContext& sc,


### PR DESCRIPTION
Separated from https://github.com/ceph/ceph/pull/24943 , some backgrounds are at https://github.com/ceph/ceph/pull/12216 .

* Cancel ops to the old osd when ops are redirected, so buffer will not be used after it has been freed.
* To cancel ops already in outcoming_bl, we deep copy data part of the message so it will not reference the buffer which may have been freed.
* out_seq is only updated for new messages, and messages from sent queue are sent using their original sequence. So even when we remove ops from sent queue, the out_seq is correct.
