### PR TITLE
mon,osd,bluestore: expose object store suboptimal behavior warnings

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1075,6 +1075,7 @@ OPTION(bluestore_debug_random_read_err, OPT_DOUBLE)
 OPTION(bluestore_debug_inject_bug21040, OPT_BOOL)
 OPTION(bluestore_debug_inject_csum_err_probability, OPT_FLOAT)
 OPTION(bluestore_no_per_pool_stats_tolerance, OPT_STR)
+OPTION(bluestore_warn_on_bluefs_spillover, OPT_BOOL)
 
 OPTION(kstore_max_ops, OPT_U64)
 OPTION(kstore_max_bytes, OPT_U64)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4600,6 +4600,10 @@ std::vector<Option> get_global_options() {
       "'until_fsck' will tolerate the case for regular ops and fail on fsck or repair, the latter will fix the issue, "
       "'until_repair' will tolerate for regular ops and fsck. Repair indicates and fixes the issue, "
       "'enforce' will unconditionally use global stats mode."),
+
+    Option("bluestore_warn_on_bluefs_spillover", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("Enable health indication on bluefs slow device usage"),
     // -----------------------------------------
     // kstore
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2939,6 +2939,50 @@ void PGMap::get_health_checks(
     }
   }
 
+  // OBJECT_STORE_WARN
+  if (osd_sum.os_alerts.size()) {
+    map<string, pair<size_t, list<string>>> os_alerts_sum;
+
+    for (auto& a : osd_sum.os_alerts) {
+      int left = max;
+      string s0 = " osd:";
+      s0 += stringify(a.first);
+      for (auto& aa : a.second) {
+        string s(s0);
+        s += " ";
+        s += aa.second;
+        auto it = os_alerts_sum.find(aa.first);
+        if (it == os_alerts_sum.end()) {
+          list<string> d;
+          d.emplace_back(s);
+          os_alerts_sum.emplace(aa.first, std::make_pair(1, d));
+        } else {
+          auto& p = it->second;
+          ++p.first;
+          p.second.emplace_back(s);
+        }
+	if (--left == 0) {
+	  break;
+	}
+      }
+    }
+
+    for (auto& asum : os_alerts_sum) {
+      string summary;
+      if (asum.first == "BLUEFS_SPILLOVER") {
+	summary = "BlueFS spillover detected";
+      } else if (asum.first == "BLUESTORE_NO_COMPRESSION") {
+	summary = "BlueStore compression broken";
+      }
+      summary += " on ";
+      summary += stringify(asum.second.first);
+      summary += " OSD(s)";
+      auto& d = checks->add(asum.first, HEALTH_WARN, summary);
+      for (auto& s : asum.second.second) {
+        d.detail.push_back(s);
+      }
+    }
+  }
   // PG_NOT_SCRUBBED
   // PG_NOT_DEEP_SCRUBBED
   {

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1558,7 +1558,8 @@ public:
     return false;   // assume a backend cannot, unless it says otherwise
   }
 
-  virtual int statfs(struct store_statfs_t *buf) = 0;
+  virtual int statfs(struct store_statfs_t *buf,
+		     osd_alert_list_t* alerts = nullptr) = 0;
   virtual int pool_statfs(uint64_t pool_id, struct store_statfs_t *buf) = 0;
 
   virtual void collect_metadata(map<string,string> *pm) { }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -13612,7 +13612,8 @@ void BlueStore::_log_alerts(osd_alert_list_t& alerts)
 {
   std::lock_guard l(qlock);
 
-  if (!spillover_alert.empty()) {
+  if (!spillover_alert.empty() &&
+      cct->_conf->bluestore_warn_on_bluefs_spillover) {
     alerts.emplace(
       "BLUEFS_SPILLOVER",
       spillover_alert);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4361,7 +4361,6 @@ void BlueStore::_init_logger()
 int BlueStore::_reload_logger()
 {
   struct store_statfs_t store_statfs;
-
   int r = statfs(&store_statfs);
   if (r >= 0) {
     logger->set(l_bluestore_allocated, store_statfs.allocated);
@@ -7987,8 +7986,12 @@ void BlueStore::_get_statfs_overall(struct store_statfs_t *buf)
   buf->available = bfree;
 }
 
-int BlueStore::statfs(struct store_statfs_t *buf)
+int BlueStore::statfs(struct store_statfs_t *buf,
+		      osd_alert_list_t* alerts)
 {
+  if (alerts) {
+    alerts->clear();
+  }
   _get_statfs_overall(buf);
   {
     std::lock_guard l(vstatfs_lock);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2474,7 +2474,8 @@ public:
   string get_device_path(unsigned id);
 
 public:
-  int statfs(struct store_statfs_t *buf) override;
+  int statfs(struct store_statfs_t *buf,
+             osd_alert_list_t* alerts = nullptr) override;
   int pool_statfs(uint64_t pool_id, struct store_statfs_t *buf) override;
 
   void collect_metadata(map<string,string> *pm) override;
@@ -2676,7 +2677,6 @@ private:
       debug_mdata_error_objects.erase(o);
     }
   }
-
 private:
 
   // --------------------------------------------------------

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -728,10 +728,13 @@ int FileStore::get_devices(set<string> *ls)
   return 0;
 }
 
-int FileStore::statfs(struct store_statfs_t *buf0)
+int FileStore::statfs(struct store_statfs_t *buf0, osd_alert_list_t* alerts)
 {
   struct statfs buf;
   buf0->reset();
+  if (alerts) {
+    alerts->clear(); // returns nothing for now
+  }
   if (::statfs(basedir.c_str(), &buf) < 0) {
     int r = -errno;
     ceph_assert(!m_filestore_fail_eio || r != -EIO);

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -517,7 +517,8 @@ public:
   void collect_metadata(map<string,string> *pm) override;
   int get_devices(set<string> *ls) override;
 
-  int statfs(struct store_statfs_t *buf) override;
+  int statfs(struct store_statfs_t *buf,
+             osd_alert_list_t* alerts = nullptr) override;
   int pool_statfs(uint64_t pool_id, struct store_statfs_t *buf) override;
 
   int _do_transactions(

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1083,10 +1083,13 @@ void KStore::_sync()
   dout(10) << __func__ << " done" << dendl;
 }
 
-int KStore::statfs(struct store_statfs_t* buf0)
+int KStore::statfs(struct store_statfs_t* buf0, osd_alert_list_t* alerts)
 {
   struct statfs buf;
   buf0->reset();
+  if (alerts) {
+    alerts->clear(); // returns nothing for now
+  }
   if (::statfs(basedir.c_str(), &buf) < 0) {
     int r = -errno;
     ceph_assert(r != -ENOENT);

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -439,7 +439,8 @@ public:
   void get_db_statistics(Formatter *f) override {
     db->get_statistics(f);
   }
-  int statfs(struct store_statfs_t *buf) override;
+  int statfs(struct store_statfs_t *buf,
+             osd_alert_list_t* alerts = nullptr) override;
   int pool_statfs(uint64_t pool_id, struct store_statfs_t *buf) override;
 
   CollectionHandle open_collection(const coll_t& c) override;

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -220,9 +220,12 @@ int MemStore::mkfs()
   return 0;
 }
 
-int MemStore::statfs(struct store_statfs_t *st)
+int MemStore::statfs(struct store_statfs_t *st, osd_alert_list_t* alerts)
 {
-   dout(10) << __func__ << dendl;
+  dout(10) << __func__ << dendl;
+  if (alerts) {
+    alerts->clear(); // returns nothing for now
+  }
   st->reset();
   st->total = cct->_conf->memstore_device_bytes;
   st->available = std::max<int64_t>(st->total - used_bytes, 0);

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -290,7 +290,8 @@ public:
     return 0;
   }
 
-  int statfs(struct store_statfs_t *buf) override;
+  int statfs(struct store_statfs_t *buf,
+             osd_alert_list_t* alerts = nullptr) override;
   int pool_statfs(uint64_t pool_id, struct store_statfs_t *buf) override;
 
   bool exists(CollectionHandle &c, const ghobject_t& oid) override;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2993,7 +2993,8 @@ int OSD::init()
   // prime osd stats
   {
     struct store_statfs_t stbuf;
-    int r = store->statfs(&stbuf);
+    osd_alert_list_t alerts;
+    int r = store->statfs(&stbuf, &alerts);
     ceph_assert(r == 0);
     service.set_statfs(stbuf);
   }
@@ -3937,7 +3938,8 @@ int OSD::update_crush_location()
     snprintf(weight, sizeof(weight), "%.4lf", cct->_conf->osd_crush_initial_weight);
   } else {
     struct store_statfs_t st;
-    int r = store->statfs(&st);
+    osd_alert_list_t alerts;
+    int r = store->statfs(&st, &alerts);
     if (r < 0) {
       derr << "statfs: " << cpp_strerror(r) << dendl;
       return r;
@@ -5279,7 +5281,8 @@ void OSD::tick_without_osd_lock()
 
   // refresh osd stats
   struct store_statfs_t stbuf;
-  int r = store->statfs(&stbuf);
+  osd_alert_list_t alerts;
+  int r = store->statfs(&stbuf, &alerts);
   ceph_assert(r == 0);
   service.set_statfs(stbuf);
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -893,7 +893,8 @@ void OSDService::set_injectfull(s_names type, int64_t count)
   injectfull = count;
 }
 
-void OSDService::set_statfs(const struct store_statfs_t &stbuf)
+void OSDService::set_statfs(const struct store_statfs_t &stbuf,
+			    osd_alert_list_t& alerts)
 {
   uint64_t bytes = stbuf.total;
   uint64_t avail = stbuf.available;
@@ -925,6 +926,8 @@ void OSDService::set_statfs(const struct store_statfs_t &stbuf)
 
   std::lock_guard l(stat_lock);
   osd_stat.statfs = stbuf;
+  osd_stat.os_alerts.clear();
+  osd_stat.os_alerts[whoami].swap(alerts);
   if (cct->_conf->fake_statfs_for_testing) {
     osd_stat.statfs.total = bytes;
     osd_stat.statfs.available = avail;
@@ -2996,7 +2999,7 @@ int OSD::init()
     osd_alert_list_t alerts;
     int r = store->statfs(&stbuf, &alerts);
     ceph_assert(r == 0);
-    service.set_statfs(stbuf);
+    service.set_statfs(stbuf, alerts);
   }
 
   // i'm ready!
@@ -5284,7 +5287,7 @@ void OSD::tick_without_osd_lock()
   osd_alert_list_t alerts;
   int r = store->statfs(&stbuf, &alerts);
   ceph_assert(r == 0);
-  service.set_statfs(stbuf);
+  service.set_statfs(stbuf, alerts);
 
   // osd_lock is not being held, which means the OSD state
   // might change when doing the monitor report

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -903,7 +903,8 @@ public:
   osd_stat_t osd_stat;
   uint32_t seq = 0;
 
-  void set_statfs(const struct store_statfs_t &stbuf);
+  void set_statfs(const struct store_statfs_t &stbuf,
+    osd_alert_list_t& alerts);
   osd_stat_t set_osd_stat(vector<int>& hb_peers, int num_pgs);
   float compute_adjusted_ratio(osd_stat_t new_stat, float *pratio, uint64_t adjust_used = 0);
   osd_stat_t get_osd_stat() {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -112,6 +112,7 @@ string ceph_osd_op_flag_string(unsigned flags);
 /// conver CEPH_OSD_ALLOC_HINT_FLAG_* op flags to a string
 string ceph_osd_alloc_hint_flag_string(unsigned flags);
 
+typedef map<string,string> osd_alert_list_t;
 
 /**
  * osd request identifier

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -113,6 +113,9 @@ string ceph_osd_op_flag_string(unsigned flags);
 string ceph_osd_alloc_hint_flag_string(unsigned flags);
 
 typedef map<string,string> osd_alert_list_t;
+/// map osd id -> alert_list_t
+typedef map<int, osd_alert_list_t> osd_alerts_t;
+void dump(Formatter* f, const osd_alerts_t& alerts);
 
 /**
  * osd request identifier
@@ -2270,6 +2273,7 @@ struct osd_stat_t {
   pow2_hist_t op_queue_age_hist;
 
   objectstore_perf_stat_t os_perf_stat;
+  osd_alerts_t os_alerts;
 
   epoch_t up_from = 0;
   uint64_t seq = 0;
@@ -2278,13 +2282,19 @@ struct osd_stat_t {
 
   osd_stat_t() : snap_trim_queue_len(0), num_snap_trimming(0) {}
 
-  void add(const osd_stat_t& o) {
+ void add(const osd_stat_t& o) {
     statfs.add(o.statfs);
     snap_trim_queue_len += o.snap_trim_queue_len;
     num_snap_trimming += o.num_snap_trimming;
     op_queue_age_hist.add(o.op_queue_age_hist);
     os_perf_stat.add(o.os_perf_stat);
     num_pgs += o.num_pgs;
+    for (const auto& a : o.os_alerts) {
+      auto& target = os_alerts[a.first];
+      for (auto& i : a.second) {
+	target.emplace(i.first, i.second);
+      }
+    }
   }
   void sub(const osd_stat_t& o) {
     statfs.sub(o.statfs);
@@ -2293,8 +2303,16 @@ struct osd_stat_t {
     op_queue_age_hist.sub(o.op_queue_age_hist);
     os_perf_stat.sub(o.os_perf_stat);
     num_pgs -= o.num_pgs;
+    for (const auto& a : o.os_alerts) {
+      auto& target = os_alerts[a.first];
+      for (auto& i : a.second) {
+        target.erase(i.first);
+      }
+      if (target.empty()) {
+	os_alerts.erase(a.first);
+      }
+    }
   }
-
   void dump(Formatter *f) const;
   void encode(bufferlist &bl, uint64_t features) const;
   void decode(bufferlist::const_iterator &bl);


### PR DESCRIPTION
Now one can see bluefs spillover or lacking compressor plugin warnings via 'ceph health' report.
Sample 'ceph health detail' output:

HEALTH_WARN BlueFS spillover detected at 2 OSD(s); BlueStore compression broken at 1 OSD(s); Module 'restful' has failed dependency: No module named 'OpenSSL'
BLUEFS_SPILLOVER BlueFS spillover detected at 2 OSD(s)
     osd:0 spilled over to slow device: 3 MiB
     osd:1 spilled over to slow device: 3 MiB
BLUESTORE_NO_COMPRESSION BlueStore compression broken at 1 OSD(s)
     osd:2 unable to load:lz4
MGR_MODULE_DEPENDENCY Module 'restful' has failed dependency: No module named 'OpenSSL'

Signed-off-by: Igor Fedotov <ifedotov@suse.com>

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

Here is samle 'ceph health detail' output for new alerts:
HEALTH_WARN BlueFS spillover detected at 2 OSD(s); BlueStore compression broken at 1 OSD(s); Module 'restful' has failed dependency: No module named 'OpenSSL'
BLUEFS_SPILLOVER BlueFS spillover detected at 2 OSD(s)
     osd:0 spilled over to slow device: 3 MiB
     osd:1 spilled over to slow device: 3 MiB
BLUESTORE_NO_COMPRESSION BlueStore compression broken at 1 OSD(s)
     osd:2 unable to load:lz4
MGR_MODULE_DEPENDENCY Module 'restful' has failed dependency: No module named 'OpenSSL'

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

