### PR TITLE
test: write log file to current directory

### DIFF
--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -30,7 +30,7 @@ TEST(Log, Simple)
   Log log(&subs);
   log.start();
  
-  log.set_log_file("/tmp/foo");
+  log.set_log_file("foo");
   log.reopen_log_file();
 
   log.set_stderr_level(5, -1);
@@ -59,7 +59,7 @@ TEST(Log, ReuseBad)
   subs.set_gather_level(1, 1);
   Log log(&subs);
   log.start();
-  log.set_log_file("/tmp/foo");
+  log.set_log_file("foo");
   log.reopen_log_file();
 
   const int l = 0;
@@ -91,7 +91,7 @@ TEST(Log, ManyNoGather)
   subs.set_gather_level(1, 1);
   Log log(&subs);
   log.start();
-  log.set_log_file("/tmp/big");
+  log.set_log_file("big");
   log.reopen_log_file();
   for (int i=0; i<many; i++) {
     int l = 10;
@@ -110,7 +110,7 @@ TEST(Log, ManyGatherLog)
   subs.set_gather_level(1, 10);
   Log log(&subs);
   log.start();
-  log.set_log_file("/tmp/big");
+  log.set_log_file("big");
   log.reopen_log_file();
   for (int i=0; i<many; i++) {
     int l = 10;
@@ -131,7 +131,7 @@ TEST(Log, ManyGatherLogStackSpillover)
   subs.set_gather_level(1, 10);
   Log log(&subs);
   log.start();
-  log.set_log_file("/tmp/big");
+  log.set_log_file("big");
   log.reopen_log_file();
   for (int i=0; i<many; i++) {
     int l = 10;
@@ -154,7 +154,7 @@ TEST(Log, ManyGather)
   subs.set_gather_level(1, 1);
   Log log(&subs);
   log.start();
-  log.set_log_file("/tmp/big");
+  log.set_log_file("big");
   log.reopen_log_file();
   for (int i=0; i<many; i++) {
     int l = 10;
@@ -172,7 +172,7 @@ void do_segv()
   subs.set_gather_level(1, 1);
   Log log(&subs);
   log.start();
-  log.set_log_file("/tmp/big");
+  log.set_log_file("big");
   log.reopen_log_file();
 
   log.inject_segv();
@@ -198,7 +198,7 @@ TEST(Log, LargeLog)
   subs.set_gather_level(1, 10);
   Log log(&subs);
   log.start();
-  log.set_log_file("/tmp/big");
+  log.set_log_file("big");
   log.reopen_log_file();
   int l = 10;
   {
@@ -218,7 +218,7 @@ TEST(Log, LargeFromSmallLog)
   subs.set_gather_level(1, 10);
   Log log(&subs);
   log.start();
-  log.set_log_file("/tmp/big");
+  log.set_log_file("big");
   log.reopen_log_file();
   int l = 10;
   {
@@ -242,7 +242,7 @@ TEST(Log, TimeSwitch)
   subs.set_gather_level(1, 10);
   Log log(&subs);
   log.start();
-  log.set_log_file("/tmp/time_switch_log");
+  log.set_log_file("time_switch_log");
   log.reopen_log_file();
   int l = 10;
   bool coarse = true;
@@ -343,7 +343,7 @@ TEST(Log, Speed_nogather)
 
 TEST(Log, GarbleRecovery)
 {
-  static const char* test_file="/tmp/log_for_moment";
+  static const char* test_file="log_for_moment";
 
   Log* saved = g_ceph_context->_log;
   Log log(&g_ceph_context->_conf->subsys);


### PR DESCRIPTION
instead of writing log files to '/tmp', write them to current directory.

by default, ctest runs the tests in ${CMAKE_CURRENT_BINARY_DIR}, so, in
this case, the log files are located in build/src/test/. this ensure
that current user has enough previledge to remove the log files.

this also allows multiple instances of 'unittest_log' to run in parallel.

See-also: http://tracker.ceph.com/issues/36737
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

