### PR TITLE
vstart: make parameter '-m ip::port" work.

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -868,6 +868,8 @@ if [ -n "$MON_ADDR" ]; then
 	CMON_ARGS=" -m "$MON_ADDR
 	COSD_ARGS=" -m "$MON_ADDR
 	CMDS_ARGS=" -m "$MON_ADDR
+	ip="$(echo $MON_ADDR|awk -F':' '{print $1}')"
+	CEPH_PORT="$(echo $MON_ADDR|awk -F':' '{print $2}')"
 fi
 
 if [ -z "$CEPH_PORT" ]


### PR DESCRIPTION
If vstart.sh choose other ip::port, but we asign other ip:port using -m.
vstart.sh can't work well. Because  the assigned ip:port can't into
monmap. So no mon listen this address.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

