### PR TITLE
librbd: multiple cache writeback threads.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6769,6 +6769,10 @@ static std::vector<Option> get_rbd_options() {
     .set_description("whether to make writeback caching writethrough until "
                      "flush is called, to be sure the user of librbd will send "
                      "flushes so that writeback is safe"),
+    
+    Option("rbd_cache_writeback_threads", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(1)
+    .set_description("number of threads to writeback"),
 
     Option("rbd_cache_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(32_M)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6769,10 +6769,6 @@ static std::vector<Option> get_rbd_options() {
     .set_description("whether to make writeback caching writethrough until "
                      "flush is called, to be sure the user of librbd will send "
                      "flushes so that writeback is safe"),
-    
-    Option("rbd_cache_writeback_threads", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1)
-    .set_description("number of threads to writeback"),
 
     Option("rbd_cache_size", Option::TYPE_SIZE, Option::LEVEL_ADVANCED)
     .set_default(32_M)

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -38,7 +38,8 @@ public:
 
   explicit ThreadPoolSingleton(CephContext *cct)
     : ThreadPool(cct, "librbd::writeback_thread_pool", "tp_writeback",
-                 cct->_conf->get_val<uint64_t>("rbd_cache_writeback_threads"), "rbd_cache_writeback_threads") {
+                 g_conf().get_val<uint64_t>("rbd_cache_writeback_threads"),
+                 "rbd_cache_writeback_threads") {
     start();
   }
   ~ThreadPoolSingleton() override {
@@ -128,7 +129,7 @@ public:
     ictx->cct->lookup_or_create_singleton_object<ThreadPoolSingleton>(
       thread_pool_singleton, "librbd::writeback_thread_pool");
     writeback_queue = new WritebackQueue(this, ictx, "librbd::writeback_work_queue",
-                                  m_ictx->cct->_conf->get_val<int64_t>("rbd_op_thread_timeout"),
+                                  g_conf().get_val<int64_t>("rbd_op_thread_timeout"),
                                   thread_pool_singleton);
     thread_pool_singleton->writeback_queue = writeback_queue;
   }


### PR DESCRIPTION
With rbd cache on, the flusher threads and tp_librbd threads are mutually exclusive by the cache lock, limiting librbd performance. According to cpu flames, most of the time is spent in LibrbdWriteback::write. By further analysis, LibrbdWriteback::write can run with cache lock unlocked and run concurrently using multiple threads.

According to one of my tests (4k randwrite), using default configuration, the iops is 22.7k(with avg latency 8.6ms, p99 latency 13.5ms), while with 4 writeback threads, the iops is 38.8k(avg/p99 latency=4.8ms/54.8ms), the improvement is 71%. In another test, 4 tp_librbd (with this pr https://github.com/ceph/ceph/pull/24483) with rbd cache off, the iops is 41.5k(avg/p99 latency=5.1ms/42.7ms), and 4 tp_librbd + 4 writeback threads the iops is 42.5k(avg/p99 latency=3.7ms/58.5ms), catching the rbd cache off case.