### PR TITLE
crimson/net: fix crimson msgr error leaks to caller

### DIFF
--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -864,7 +864,6 @@ SocketConnection::start_accept(seastar::connected_socket&& fd,
           peer_addr.set_type(addr.get_type());
           peer_addr.set_port(addr.get_port());
           peer_addr.set_nonce(addr.get_nonce());
-        }).then([this] {
           return seastar::repeat([this] {
             return repeat_handle_connect();
           });

--- a/src/crimson/net/SocketConnection.cc
+++ b/src/crimson/net/SocketConnection.cc
@@ -75,9 +75,6 @@ void SocketConnection::read_tags_until_next_message()
       // read the next tag
       return socket->read_exactly(1)
         .then([this] (auto buf) {
-          if (buf.empty()) {
-            throw std::system_error(make_error_code(error::read_eof));
-          }
           switch (buf[0]) {
           case CEPH_MSGR_TAG_MSG:
             // stop looping and notify read_header()

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -165,6 +165,9 @@ class SocketConnection : public Connection {
 
   void execute_open();
 
+  seastar::future<> do_send(MessageRef msg);
+  seastar::future<> do_keepalive();
+
  public:
   SocketConnection(SocketMessenger& messenger,
                    Dispatcher& dispatcher);

--- a/src/crimson/net/SocketConnection.h
+++ b/src/crimson/net/SocketConnection.h
@@ -108,13 +108,9 @@ class SocketConnection : public Connection {
     bufferlist data;
   } m;
 
-  /// satisfied when a CEPH_MSGR_TAG_MSG is read, indicating that a message
-  /// header will follow
-  seastar::promise<> on_message;
-
   seastar::future<> maybe_throttle();
-  void read_tags_until_next_message();
-  seastar::future<stop_t> handle_ack();
+  seastar::future<> handle_tags();
+  seastar::future<> handle_ack();
 
   /// becomes available when handshake completes, and when all previous messages
   /// have been sent to the output stream. send() chains new messages as
@@ -139,7 +135,7 @@ class SocketConnection : public Connection {
   ///          false otherwise.
   bool update_rx_seq(seq_num_t seq);
 
-  seastar::future<MessageRef> do_read_message();
+  seastar::future<> read_message();
 
   std::unique_ptr<AuthSessionHandler> session_security;
 
@@ -198,9 +194,6 @@ class SocketConnection : public Connection {
   /// only call when SocketConnection first construct
   void start_accept(seastar::connected_socket&& socket,
                     const entity_addr_t& peer_addr);
-
-  /// read a message from a connection that has completed its handshake
-  seastar::future<MessageRef> read_message();
 
   /// the number of connections initiated in this session, increment when a
   /// new connection is established


### PR DESCRIPTION
@tchaikov @rzarzynski 
This should fix the issue that crimson-messenger could leak internal exceptions to the callers unexpectedly and fall into unknown states. Please check.

Depends on PR #25580 