### PR TITLE
osd: OSD device smart data include additional nvme data

### DIFF
--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -18,10 +18,12 @@ extern int get_device_by_path(const char *path, char* partition, char* device, s
 
 
 extern std::string get_device_id(const std::string& devname);
+extern std::string get_device_vendor(const std::string& devname);
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
 extern int block_device_run_smartctl(const char *device, int timeout,
 				     std::string *result);
-
+extern int block_device_run_nvme(const char *device, const char *vendor, int timeout,
+             std::string *result);
 // for VDO
 /// return an op fd for the sysfs stats dir, if this is a VDO device
 extern int get_vdo_stats_handle(const char *devname, std::string *vdo_name);

--- a/sudoers.d/ceph-osd-smartctl
+++ b/sudoers.d/ceph-osd-smartctl
@@ -1,3 +1,4 @@
 ## allow ceph-osd (which runs as user ceph) to collect device health metrics
 
 ceph ALL=NOPASSWD: /usr/sbin/smartctl -a --json /dev/*
+ceph ALL=NOPASSWD: /usr/sbin/nvme *


### PR DESCRIPTION
Add nvme addition data into the deveh health data. That use nvme tool
and command syntax "nvme \<vendor\> smart-log-add \<dev\> -json". The nvme
json output append in the dev smart "nvme_smart_health_information_add_log".

Signed-off-by: Rick Chen <rick.chen@prophetstor.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

