### PR TITLE
mon: don't add pg_temp when acting == next_acting

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -984,6 +984,9 @@ void OSDMonitor::prime_pg_temp(
     return;  // can be no worse off than before
 
   if (next_up == next_acting) {
+    if (acting == next_acting) {
+      return;
+    }
     acting.clear();
     dout(20) << __func__ << " next_up == next_acting now, clear pg_temp"
 	     << dendl;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -974,7 +974,8 @@ void OSDMonitor::prime_pg_temp(
   int next_up_primary, next_acting_primary;
   next.pg_to_up_acting_osds(pgid, &next_up, &next_up_primary,
 			    &next_acting, &next_acting_primary);
-  if (acting == next_acting && next_up != next_acting)
+  if (acting == next_acting &&
+      !(up != acting && next_up == next_acting))
     return;  // no change since last epoch
 
   if (acting.empty())
@@ -984,9 +985,6 @@ void OSDMonitor::prime_pg_temp(
     return;  // can be no worse off than before
 
   if (next_up == next_acting) {
-    if (acting == next_acting) {
-      return;
-    }
     acting.clear();
     dout(20) << __func__ << " next_up == next_acting now, clear pg_temp"
 	     << dendl;


### PR DESCRIPTION
Due to commit ea723fbb88c69bd00fefd32a3ee94bf5ce53569c
pg_temp with clean acting set are added to inc map.
It happens even if up == next up == acting == next acting.
This results in huge amount of pg_temps and traffic spikes
when epoch is incremented on a large cluster.
This behavior could be reproduced by reweighting osd
to it's actual weight.

This patch allows not to add pg_temp
when acting set == next acting set == next up set.

If this patch looks ok, i'll create an issue for backporting it to luminous branch.
If you need any info, please ask for details.