### PR TITLE
mgr: update daemon_state when necessary

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -553,7 +553,7 @@ bool DaemonServer::handle_report(MMgrReport *m)
 
     // issue metadata request in background
     if (!daemon_state.is_updating(key) && 
-	(key.first == "osd" || key.first == "mds")) {
+	(key.first == "osd" || key.first == "mds" || key.first == "mon")) {
 
       std::ostringstream oss;
       auto c = new MetadataUpdate(daemon_state, key);
@@ -566,6 +566,9 @@ bool DaemonServer::handle_report(MMgrReport *m)
         oss << "{\"prefix\": \"mds metadata\", \"who\": \""
             << key.second << "\"}";
  
+      } else if (key.first == "mon") {
+        oss << "{\"prefix\": \"mon metadata\", \"id\": \""
+            << key.second << "\"}";
       } else {
 	ceph_abort();
       }

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -85,6 +85,13 @@ void MetadataUpdate::finish(int r)
 
       json_spirit::mObject daemon_meta = json_result.get_obj();
 
+      // Skip daemon who doesn't have hostname yet
+      if (daemon_meta.count("hostname") == 0) {
+        dout(1) << "Skipping incomplete metadata entry for "
+                << key.first << "." << key.second << dendl;
+        return;
+      }
+
       // Apply any defaults
       for (const auto &i : defaults) {
         if (daemon_meta.find(i.first) == daemon_meta.end()) {

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -85,6 +85,7 @@ public:
   void handle_osd_map();
   void handle_log(MLog *m);
   void handle_service_map(MServiceMap *m);
+  void handle_mon_map();
 
   bool got_mgr_map(const MgrMap& m);
 

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -161,6 +161,11 @@ int MgrStandby::init()
     client_messenger->wait();
     return r;
   }
+  // only forward monmap updates after authentication finishes, otherwise
+  // monc.authenticate() will be waiting for MgrStandy::ms_dispatch()
+  // to acquire the lock forever, as it is already locked in the beginning of
+  // this method.
+  monc.set_passthrough_monmap();
 
   client_t whoami = monc.get_global_id();
   client_messenger->set_myname(entity_name_t::MGR(whoami.v));


### PR DESCRIPTION
Currently, mgr will refuse monitor's connection request if it doesn't have information about that monitor in its deamon_state. This will lead to a situation that the earlier started mgr cannot communicate well with the later added monitor.

Fixes: http://tracker.ceph.com/issues/37753
Signed-off-by: Xinyin Song <songxinying@sensetime.com>