### PR TITLE
cmake: boost fixes for ARM 32 bit

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -163,6 +163,7 @@ function(do_build_boost version)
   include(ExternalProject)
   ExternalProject_Add(Boost
     ${source_dir}
+    PATCH_COMMAND patch -p1 < ${CMAKE_CURRENT_SOURCE_DIR}/patches/boost_context_asm_arm_syntax_unified.patch
     CONFIGURE_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${configure_command}
     BUILD_COMMAND CC=${CMAKE_C_COMPILER} CXX=${CMAKE_CXX_COMPILER} ${build_command}
     BUILD_IN_SOURCE 1

--- a/patches/boost_context_asm_arm_syntax_unified.patch
+++ b/patches/boost_context_asm_arm_syntax_unified.patch
@@ -1,0 +1,36 @@
+diff --git a/libs/context/src/asm/jump_arm_aapcs_elf_gas.S b/src/Boost/libs/context/src/asm/jump_arm_aapcs_elf_gas.S
+index d0f7fa2..58d11b0 100644
+--- a/libs/context/src/asm/jump_arm_aapcs_elf_gas.S
++++ b/libs/context/src/asm/jump_arm_aapcs_elf_gas.S
+@@ -42,6 +42,7 @@
+ .globl jump_fcontext
+ .align 2
+ .type jump_fcontext,%function
++.syntax unified
+ jump_fcontext:
+     @ save LR as PC
+     push {lr}
+diff --git a/libs/context/src/asm/make_arm_aapcs_elf_gas.S b/src/Boost/libs/context/src/asm/make_arm_aapcs_elf_gas.S
+index 98819a2..b88ff68 100644
+--- a/libs/context/src/asm/make_arm_aapcs_elf_gas.S
++++ b/libs/context/src/asm/make_arm_aapcs_elf_gas.S
+@@ -42,6 +42,7 @@
+ .globl make_fcontext
+ .align 2
+ .type make_fcontext,%function
++.syntax unified
+ make_fcontext:
+     @ shift address in A1 to lower 16 byte boundary
+     bic  a1, a1, #15
+diff --git a/libs/context/src/asm/ontop_arm_aapcs_elf_gas.S b/src/Boost/libs/context/src/asm/ontop_arm_aapcs_elf_gas.S
+index 9d9198f..2efebbb 100644
+--- a/libs/context/src/asm/ontop_arm_aapcs_elf_gas.S
++++ b/libs/context/src/asm/ontop_arm_aapcs_elf_gas.S
+@@ -42,6 +42,7 @@
+ .globl ontop_fcontext
+ .align 2
+ .type ontop_fcontext,%function
++.syntax unified
+ ontop_fcontext:
+     @ save LR as PC
+     push {lr}


### PR DESCRIPTION
Code fixes for cmake build: Cmake build files and ASM fixes in boost to get 32-bit ARM compiling

These are some necessary fixes to get ceph compiling for/on ARM 32-bit platforms. It is a follow-up on my fixes to luminous to fix master branch. It should not influence other platforms. Since it hard-sets some of the cmake options, that are vital to compile on 32-bit, I decided to add a wrapper script for arm32 instead of heavily changing the original do_cmake.sh. Nevertheless, it was necessary to make the build type a bit more configurable... After that, I try to fix the make-debs.sh build for arm32.

Fixes: https://tracker.ceph.com/issues/23387
Signed-off-by: Daniel Glaser <me@the78mole.de>