### PR TITLE
librbd: workaround an ICE of GCC

### DIFF
--- a/src/crimson/common/config_proxy.h
+++ b/src/crimson/common/config_proxy.h
@@ -71,8 +71,8 @@ class ConfigProxy : public seastar::peering_sharded_service<ConfigProxy>
                                                      const std::string &key) {
                                             rev_obs[obs].insert(key);
                                           }, nullptr);
-            for (auto& [obs, keys] : rev_obs) {
-              obs->handle_conf_change(proxy, keys);
+            for (auto& obs_keys : rev_obs) {
+              obs_keys.first->handle_conf_change(proxy, obs_keys.second);
             }
           });
         }).finally([new_values] {

--- a/src/test/librbd/managed_lock/test_mock_GetLockerRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_GetLockerRequest.cc
@@ -62,9 +62,9 @@ public:
 
       cls_lock_get_info_reply reply;
       if (r != -ENOENT) {
-        reply.lockers = decltype(reply.lockers){
-          {rados::cls::lock::locker_id_t(entity, locker_cookie),
-           rados::cls::lock::locker_info_t(utime_t(), entity_addr, "")}};
+        reply.lockers.emplace(
+          rados::cls::lock::locker_id_t(entity, locker_cookie),
+          rados::cls::lock::locker_info_t(utime_t(), entity_addr, ""));
         reply.tag = lock_tag;
         reply.lock_type = lock_type;
       }


### PR DESCRIPTION
GCC is somehow annoyed at seeing the combination of decltype and
initializer_list in this place. i tried to remove the `if` clause, and
only left the `else` block, GCC was happy with that change. so
there are multiple factors taking effect in this problem. but we cannot
have a minimal reproducer for this issue here without more efforts. and
`reply.lockers` is empty after `reply` is constructed, so it would be
simpler if we just add the locker info to it instead of assigning a
newly constructed `map` to it.

Fixes: http://tracker.ceph.com/issues/37719
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

