### PR TITLE
os/bluestore: Only use WRITE_LIFE_ when available

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -37,11 +37,11 @@
 #include "include/interval_set.h"
 #define SPDK_PREFIX "spdk:"
 
+#if defined(__linux__)
 #if !defined(F_SET_FILE_RW_HINT)
 #define F_LINUX_SPECIFIC_BASE 1024
 #define F_SET_FILE_RW_HINT         (F_LINUX_SPECIFIC_BASE + 14)
 #endif
-
 // These values match Linux definition
 // https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/include/uapi/linux/fcntl.h#n56
 #define  WRITE_LIFE_NOT_SET  	0 	// No hint information set
@@ -51,6 +51,17 @@
 #define  WRITE_LIFE_LONG  	4       // Data written has a long life time
 #define  WRITE_LIFE_EXTREME  	5     	// Data written has an extremely long life time
 #define  WRITE_LIFE_MAX  	6
+#else
+// On systems don't have WRITE_LIFE_* only use one FD 
+// And all files are created equal
+#define  WRITE_LIFE_NOT_SET  	0 	// No hint information set
+#define  WRITE_LIFE_NONE  	0       // No hints about write life time
+#define  WRITE_LIFE_SHORT  	0       // Data written has a short life time
+#define  WRITE_LIFE_MEDIUM  	0    	// Data written has a medium life time
+#define  WRITE_LIFE_LONG  	0       // Data written has a long life time
+#define  WRITE_LIFE_EXTREME  	0    	// Data written has an extremely long life time
+#define  WRITE_LIFE_MAX  	1
+#endif
 
 class CephContext;
 


### PR DESCRIPTION
When WRITE_LIFE is not available this will reduce to using only 2 files:
 - direct
 - buffered



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug