### PR TITLE
test/rgw: add ifdef for HAVE_BOOST_CONTEXT

### DIFF
--- a/src/test/rgw/test_rgw_reshard_wait.cc
+++ b/src/test/rgw/test_rgw_reshard_wait.cc
@@ -56,6 +56,7 @@ TEST(ReshardWait, stop_block)
   short_waiter.stop();
 }
 
+#ifdef HAVE_BOOST_CONTEXT
 TEST(ReshardWait, wait_yield)
 {
   constexpr ceph::timespan wait_duration = 10ms;
@@ -159,3 +160,4 @@ TEST(ReshardWait, stop_multiple)
   EXPECT_GT(long_duration, elapsed); // waited less than 10s
   short_waiter.stop();
 }
+#endif // HAVE_BOOST_CONTEXT


### PR DESCRIPTION
only run the ReshardWait coroutine tests if HAVE_BOOST_CONTEXT is defined