### PR TITLE
msg/async/Protocol: unregister con from accept vs mark_down race

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -199,6 +199,7 @@ void ProtocolV1::fault() {
         backoff.set_from_double(cct->_conf->ms_max_backoff);
     }
 
+    global_seq = messenger->get_global_seq();
     state = START_CONNECT;
     connection->state = AsyncConnection::STATE_CONNECTING;
     ldout(cct, 10) << __func__ << " waiting " << backoff << dendl;
@@ -214,6 +215,7 @@ void ProtocolV1::fault() {
     } else {
       ldout(cct, 0) << __func__ << " initiating reconnect" << dendl;
       connect_seq++;
+      global_seq = messenger->get_global_seq();
       state = START_CONNECT;
       connection->state = AsyncConnection::STATE_CONNECTING;
     }

--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -2387,6 +2387,7 @@ CtPtr ProtocolV1::open(ceph_msg_connect_reply &reply,
                   << dendl;
     ceph_assert(state == CLOSED || state == NONE);
     ldout(cct, 10) << "accept fault after register" << dendl;
+    messenger->unregister_conn(connection);
     connection->inject_delay();
     return _fault();
   }

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -2426,6 +2426,7 @@ CtPtr ProtocolV2::open(ceph_msg_connect_reply &reply,
                   << dendl;
     ceph_assert(state == CLOSED || state == NONE);
     ldout(cct, 10) << "accept fault after register" << dendl;
+    messenger->unregister_conn(connection);
     connection->inject_delay();
     return _fault();
   }

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -196,6 +196,7 @@ void ProtocolV2::fault() {
         backoff.set_from_double(cct->_conf->ms_max_backoff);
     }
 
+    global_seq = messenger->get_global_seq();
     state = START_CONNECT;
     connection->state = AsyncConnection::STATE_CONNECTING;
     ldout(cct, 10) << __func__ << " waiting " << backoff << dendl;
@@ -211,6 +212,7 @@ void ProtocolV2::fault() {
     } else {
       ldout(cct, 0) << __func__ << " initiating reconnect" << dendl;
       connect_seq++;
+      global_seq = messenger->get_global_seq();
       state = START_CONNECT;
       connection->state = AsyncConnection::STATE_CONNECTING;
     }


### PR DESCRIPTION
If we are accepting a connection and it gets marked down while we are
working on it, unregister it. Otherwise, we leave teh connection CLOSED
and registered and it interferes with the ability to open a new connection.

Fixes: http://tracker.ceph.com/issues/37778
Signed-off-by: Sage Weil <sage@redhat.com>