### PR TITLE
mon/ConfigMonitor: add --force flag to 'config set', fix vstart.sh

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1131,7 +1131,8 @@ COMMAND("mgr versions", \
 COMMAND("config set" \
 	" name=who,type=CephString" \
 	" name=name,type=CephString" \
-	" name=value,type=CephString", \
+	" name=value,type=CephString" \
+	" name=force,type=CephBool,req=false",
 	"Set a configuration option for one or more entities",
 	"config", "rw")
 COMMAND("config rm"						\

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -743,7 +743,7 @@ start_mgr() {
 EOF
 
             if $with_mgr_dashboard ; then
-                ceph_adm config set mgr mgr/dashboard/$name/server_port $MGR_PORT
+                ceph_adm config set mgr mgr/dashboard/$name/server_port $MGR_PORT --force
                 if [ $mgr -eq 1 ]; then
                     DASH_URLS="https://$IP:$MGR_PORT"
                 else
@@ -752,7 +752,7 @@ EOF
             fi
 	    MGR_PORT=$(($MGR_PORT + 1000))
 
-	    ceph_adm config set mgr mgr/restful/$name/server_port $MGR_PORT
+	    ceph_adm config set mgr mgr/restful/$name/server_port $MGR_PORT --force
             if [ $mgr -eq 1 ]; then
                 RESTFUL_URLS="https://$IP:$MGR_PORT"
             else


### PR DESCRIPTION
vstart.sh needs to set the dashboard config options before the module loads and its options are known