### PR TITLE
mon/ConfigMonitor: add --force flag to 'config set', fix vstart.sh

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1131,7 +1131,8 @@ COMMAND("mgr versions", \
 COMMAND("config set" \
 	" name=who,type=CephString" \
 	" name=name,type=CephString" \
-	" name=value,type=CephString", \
+	" name=value,type=CephString" \
+	" name=force,type=CephBool,req=false",
 	"Set a configuration option for one or more entities",
 	"config", "rw")
 COMMAND("config rm"						\

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -743,7 +743,7 @@ start_mgr() {
 EOF
 
             if $with_mgr_dashboard ; then
-                ceph_adm config set mgr mgr/dashboard/$name/server_port $MGR_PORT
+                ceph_adm config set mgr mgr/dashboard/$name/server_port $MGR_PORT --force
                 if [ $mgr -eq 1 ]; then
                     DASH_URLS="https://$IP:$MGR_PORT"
                 else
@@ -752,7 +752,7 @@ EOF
             fi
 	    MGR_PORT=$(($MGR_PORT + 1000))
 
-	    ceph_adm config set mgr mgr/restful/$name/server_port $MGR_PORT
+	    ceph_adm config set mgr mgr/restful/$name/server_port $MGR_PORT --force
             if [ $mgr -eq 1 ]; then
                 RESTFUL_URLS="https://$IP:$MGR_PORT"
             else


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

