### PR TITLE
librbd/api: misc fix migration

### DIFF
--- a/src/librbd/api/Migration.cc
+++ b/src/librbd/api/Migration.cc
@@ -14,6 +14,7 @@
 #include "librbd/Utils.h"
 #include "librbd/api/Config.h"
 #include "librbd/api/Group.h"
+#include "librbd/api/Image.h"
 #include "librbd/api/Snapshot.h"
 #include "librbd/api/Trash.h"
 #include "librbd/deep_copy/MetadataCopyRequest.h"
@@ -991,6 +992,25 @@ int Migration<I>::list_snaps(std::vector<librbd::snap_info_t> *snapsptr) {
       }
       if (is_protected) {
         lderr(m_cct) << "image has protected snapshot '" << snap.name << "'"
+                     << dendl;
+        return -EBUSY;
+      }
+
+      RWLock::RLocker l(m_src_image_ctx->snap_lock);
+      cls::rbd::ParentImageSpec parent_spec{m_src_image_ctx->md_ctx.get_id(),
+                                            m_src_image_ctx->md_ctx.get_namespace(),
+                                            m_src_image_ctx->id, snap.id};
+      std::vector<librbd::linked_image_spec_t> child_images;
+      r = api::Image<I>::list_children(m_src_image_ctx, parent_spec, &child_images);
+      if (r < 0) {
+        lderr(m_cct) << "failed listing children: " << cpp_strerror(r)
+                     << dendl;
+        return r;
+      }
+
+      size_t size = child_images.size();
+      if (size > 0) {
+        lderr(m_cct) << "image has snapshot '" << snap.name << "' with linked clones"
                      << dendl;
         return -EBUSY;
       }


### PR DESCRIPTION
This commit [d02c1f](https://github.com/ceph/ceph/commit/d02c1f5e3ee97f77f91569e9267cf756b2f7e19f) disallow preparing migration if image has snapshot with linked clones.
I think there is another solution: pass a flag for snap_remove() (`int r = snap_remove(m_src_image_ctx, snap.name.c_str(), 2, prog_ctx);` [L1430](https://github.com/ceph/ceph/blob/master/src/librbd/api/Migration.cc#L1430) ) and it will automatic flatten all the children before removing snap in migration commit step.

@dillaman  @trociny  Does these fixes make sense for you or are there better ways? Please have a look, thanks.  

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

