### PR TITLE
pybind/rgw: pass the flags to callback function

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -154,6 +154,9 @@
 * librados::IoCtx::nobjects_begin() and librados::NObjectIterator now communicate
   errors by throwing a std::system_error exception instead of std::runtime_error.
 
+* the callback function passed to LibRGWFS.readdir() now accepts a ``flags``
+  parameter. it will be the last parameter passed to  ``readdir()` method.
+
 >=13.1.0
 --------
 

--- a/src/pybind/rgw/rgw.pyx
+++ b/src/pybind/rgw/rgw.pyx
@@ -144,7 +144,7 @@ cdef extern from "rados/rgw_file.h" nogil:
 
     int rgw_readdir(rgw_fs *fs,
                     rgw_file_handle *parent_fh, uint64_t *offset,
-                    bool (*cb)(const char *name, void *arg, uint64_t offset) nogil except? -9000,
+                    bool (*cb)(const char *name, void *arg, uint64_t offset, uint32_t flags) nogil except? -9000,
                     void *cb_arg, bool *eof, uint32_t flags) except? -9000
 
     int rgw_getattr(rgw_fs *fs,
@@ -314,11 +314,11 @@ cdef make_ex(ret, msg):
         return Error(msg + (": error code %d" % ret))
 
 
-cdef bool readdir_cb(const char *name, void *arg, uint64_t offset) \
+cdef bool readdir_cb(const char *name, void *arg, uint64_t offset, uint32_t flags) \
 except? -9000 with gil:
     if exc.PyErr_Occurred():
         return False
-    (<object>arg)(name, offset)
+    (<object>arg)(name, offset, flags)
     return True
 
 

--- a/src/test/pybind/test_rgwfs.py
+++ b/src/test/pybind/test_rgwfs.py
@@ -29,7 +29,7 @@ def setup_test():
     except Exception:
         root_dir_handler = rgwfs.mkdir(root_handler, b"bucket", 0)
 
-    def cb(name, offset):
+    def cb(name, offset, flags):
         names.append(name)
     rgwfs.readdir(root_dir_handler, cb, 0, 0)
     for name in names:


### PR DESCRIPTION
before this change, the `flags` parameter passed to `LibRGWFS.readdir()`
will be dropped on the floor and ignored.
after this change, it will be passed to the specified callback function.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

