### PR TITLE
mgr/dashboard: Fix navbar focused color

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/defaults.scss
@@ -36,6 +36,7 @@ $color-whitesmoke-gray: #f5f5f5;
 $color-solid-white: #ffffff;
 $color-transparent: rgba(0, 0, 0, 0.09);
 $color-brand-gray: #374249;
+$color-brand-green: #2b99a8;
 
 $color-app-bg: $color-solid-white;
 $color-bg-darken: $color-dark-gray;
@@ -86,13 +87,13 @@ $color-info-card-border: $color-soft-gray;
 $color-navbar-bg: $color-brand-gray;
 $color-navbar-brand: $color-white-gray;
 $color-nav-top-bar: $color-blue;
-$color-nav-bottom-bar: $color-blue;
+$color-nav-bottom-bar: $color-brand-green;
 $color-nav-toggle-bar: $color-white-gray;
 $color-nav-toggle-shadow: $color-solid-white;
 $color-nav-collapse-border: $color-white-gray;
-$color-nav-open-bg: $color-gray;
+$color-nav-open-bg: $color-brand-green;
 $color-nav-links: $color-white-gray;
-$color-nav-links-hover: $color-gray;
+$color-nav-links-hover: $color-brand-green;
 $color-nav-active-link-bg: $color-blue;
 $color-nav-border-top-collapse: $color-white-gray;
 


### PR DESCRIPTION
The previous gray does not match the new branding color. Now use the green from https://ceph.com.

Before:
![before](https://user-images.githubusercontent.com/1897962/50639735-ce11de80-0f62-11e9-87dd-793dad290500.png)

After:
![after](https://user-images.githubusercontent.com/1897962/50830891-76e88100-1349-11e9-8c8c-44d59c98a547.png)

Signed-off-by: Volker Theile <vtheile@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

