### PR TITLE
qa/suites/upgrade/mimic-x: fix rhel runs

### DIFF
--- a/qa/suites/upgrade/mimic-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/mimic-x/parallel/0-cluster/start.yaml
@@ -4,6 +4,9 @@ meta:
    with a separate client 0,1,2 third node.
    Use xfs beneath the osds.
    CephFS tests running on client 2,3
+   #Note-To enable RHEL runs on ovh nodes, add the following to overrides
+   #ansible.cephlab:
+   # skip_tags: entitlements,packages,repos
 roles:
 - - mon.a
   - mgr.x
@@ -38,6 +41,3 @@ overrides:
         osd_class_default_list: "cephfs hello journal lock log numops rbd refcount 
                                  rgw sdk timeindex user version"
     fs: xfs
-  #enable RHEL runs on ovh nodes
-  ansible.cephlab:
-    skip_tags: entitlements,packages,repos

--- a/qa/suites/upgrade/mimic-x/stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/mimic-x/stress-split/0-cluster/start.yaml
@@ -3,6 +3,9 @@ meta:
    Run ceph on two nodes,
    with a separate client-only node.
    Use xfs beneath the osds.
+   #Note-To enable RHEL runs on ovh nodes, add the following to overrides
+   #ansible.cephlab:
+   # skip_tags: entitlements,packages,repos
 overrides:
   ceph:
     fs: xfs
@@ -15,9 +18,6 @@ overrides:
         enable experimental unrecoverable data corrupting features: "*"
       mon:
         mon warn on osd down out interval zero: false
-  #enable RHEL runs on ovh nodes
-  ansible.cephlab:
-    skip_tags: entitlements,packages,repos
 roles:
 - - mon.a
   - mon.b


### PR DESCRIPTION
This should fix the upgrade/mimic-x suite failures on rhel.

The following fragment was required for rhel on ovh
<pre>overrides:
    ansible.cephlab:
        skip_tags: entitlements,packages,repos
</pre>

Since, this suite runs on smithi in our nightlies, we should not need
this.

Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

