### PR TITLE
common/blkdev.h: use std::string

### DIFF
--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -24,7 +24,7 @@ extern int get_device_by_path(const char *path, char* partition, char* device, s
 extern std::string get_device_id(const std::string& devname,
 				 std::string *err=0);
 extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
-extern int block_device_get_metrics(const string& devname, int timeout,
+extern int block_device_get_metrics(const std::string& devname, int timeout,
 				    json_spirit::mValue *result);
 
 // do everything to translate a device to the raw physical devices that


### PR DESCRIPTION
Minor fix in https://github.com/ceph/ceph/pull/25672

Signed-off-by: Neha Ojha <nojha@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

