### PR TITLE
ceph-objectstore-tool: fix split check on import

### DIFF
--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1711,7 +1711,8 @@ int ObjectStoreTool::do_import(ObjectStore *store, OSDSuperblock& sb,
 	auto p = pg_num_history.pg_nums.find(pgid.pgid.m_pool);
 	if (p != pg_num_history.pg_nums.end() &&
 	    !p->second.empty()) {
-	  unsigned pg_num = ms.osdmap.get_pg_num(pgid.pgid.pool());
+	  unsigned start_pg_num = ms.osdmap.get_pg_num(pgid.pgid.pool());
+	  unsigned pg_num = start_pg_num;
 	  for (auto q = p->second.lower_bound(ms.map_epoch);
 	       q != p->second.end();
 	       ++q) {
@@ -1734,7 +1735,8 @@ int ObjectStoreTool::do_import(ObjectStore *store, OSDSuperblock& sb,
 
 	    // check for split children
 	    set<spg_t> children;
-	    if (pgid.is_split(pg_num, new_pg_num, &children)) {
+	    if (pgid.is_split(start_pg_num, new_pg_num, &children)) {
+	      cerr << " children are " << children << std::endl;
 	      for (auto child : children) {
 		coll_t coll(child);
 		if (store->collection_exists(coll)) {


### PR DESCRIPTION
Consider pg 1.3:
- in epoch A it splits to 1.b
- in epoch B 1.b splits to 1.1b

We export 1.3 before A, and import into another OSD that already has 1.b.
The existing check looks for whether 1.3 splits into 1.1b from B-1 to B,
but it should really look look at whether 1.3 splits into 1.1b over the
*entire* range (the export epoch, which is something < A).

Fixes: http://tracker.ceph.com/issues/37671
Signed-off-by: Sage Weil <sage@redhat.com>