### PR TITLE
doc: updated Ceph documentation links

### DIFF
--- a/doc/dev/documenting.rst
+++ b/doc/dev/documenting.rst
@@ -30,7 +30,7 @@ Code Documentation
 C and C++ can be documented with Doxygen_, using the subset of Doxygen
 markup supported by Breathe_.
 
-.. _Doxygen: http://www.stack.nl/~dimitri/doxygen/
+.. _Doxygen: http://www.doxygen.nl/
 .. _Breathe: https://github.com/michaeljones/breathe
 
 The general format for function documentation is::

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -1,3 +1,5 @@
+.. _user-management:
+
 =================
  User Management
 =================

--- a/doc/rbd/rbd-snapshot.rst
+++ b/doc/rbd/rbd-snapshot.rst
@@ -37,7 +37,7 @@ Cephx Notes
 
 When `cephx`_ is enabled (it is by default), you must specify a user name or ID
 and a path to the keyring containing the corresponding key for the user. See
-`User Management`_ for details. You may also add the ``CEPH_ARGS`` environment
+:ref:`User Management <user-management>` for details. You may also add the ``CEPH_ARGS`` environment
 variable to avoid re-entry of the following parameters. ::
 
 	rbd --id {user-ID} --keyring=/path/to/secret [commands]
@@ -302,7 +302,6 @@ For example::
 
 
 .. _cephx: ../../rados/configuration/auth-config-ref/
-.. _User Management: ../../operations/user-management
 .. _QEMU: ../qemu-rbd/
 .. _OpenStack: ../rbd-openstack/
 .. _CloudStack: ../rbd-cloudstack/


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

Fixes include:

- Updating Doxygen link for reference (http://docs.ceph.com/docs/master/dev/documenting/)
- Adding ``:ref:`` label for User Management page (http://docs.ceph.com/docs/master/rados/operations/user-management/)
- Update User Management link for reference (http://docs.ceph.com/docs/master/rbd/rbd-snapshot/)

Fixes: https://tracker.ceph.com/issues/37793
Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>