### PR TITLE
qa/suites/rados/thrash: prime some other pool pgs with data

### DIFF
--- a/qa/suites/rados/thrash/ceph.yaml
+++ b/qa/suites/rados/thrash/ceph.yaml
@@ -1,3 +1,10 @@
 tasks:
 - install:
 - ceph:
+
+# prime some random pool data, in the hopes of reproducing
+# http://tracker.ceph.com/issues/21142
+- exec:
+    mon.a:
+      - ceph osd pool create xyz 16
+      - rados -p xyz bench 5 write -b 1 --no-cleanup


### PR DESCRIPTION
We're having a hard time root causing http://tracker.ceph.com/issues/21142
and some evidence suggests that it affects pgs that are mostly inactive or
idle.  Create some pools that have data but aren't being used in the hopes
that we can reproduce it.

Signed-off-by: Sage Weil <sage@redhat.com>