### PR TITLE
msg: fix includes for ostringstream

### DIFF
--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -15,6 +15,8 @@
 #ifndef CEPH_MSG_TYPES_H
 #define CEPH_MSG_TYPES_H
 
+#include <sstream>
+
 #include <netinet/in.h>
 
 #include "include/ceph_features.h"


### PR DESCRIPTION
Clang complains...

```
/home/jenkins/workspace/ceph-master/src/msg/msg_types.h:420:19: error: implicit instantiation of undefined template 'std::__1::basic_os
tringstream<char, std::__1::char_traits<char>, std::__1::allocator<char> >'
    ostringstream ss;
                  ^
/usr/include/c++/v1/iosfwd:123:32: note: template is declared here
    class _LIBCPP_TEMPLATE_VIS basic_ostringstream;
                               ^
1 error generated.
```

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug