### PR TITLE
qa/tasks/radosbench: default to 64k writes

### DIFF
--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -76,12 +76,12 @@ def task(ctx, config):
             else:
                 pool = manager.create_pool_with_unique_name(erasure_code_profile_name=profile_name)
 
-        osize = config.get('objectsize', 0)
+        osize = config.get('objectsize', 65536)
         if osize is 0:
             objectsize = []
         else:
             objectsize = ['-o', str(osize)]
-        size = ['-b', str(config.get('size', 4<<20))]
+        size = ['-b', str(config.get('size', 65536))]
         # If doing a reading run then populate data
         if runtype != "write":
             proc = remote.run(


### PR DESCRIPTION
The default rados bench is 4MB writes, but this tends to fill up our
tiny test clusters.  Use 64KB instead.

Signed-off-by: Sage Weil <sage@redhat.com>