### PR TITLE
mgr/dashboard: Add table of contents

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -1,6 +1,8 @@
 Dashboard Developer Documentation
 ====================================
 
+.. contents:: Table of Contents
+
 Frontend Development
 --------------------
 


### PR DESCRIPTION
Adds a table of contents to the HACKING.rst to make the navigation easier.

I just used the directive 'contents'
