### PR TITLE
mgr/orchestrator: Disable teuthology test executes ceph-volume

### DIFF
--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -24,9 +24,10 @@ class TestOrchestratorCli(MgrTestCase):
         ret = self._orch_cmd("status")
         self.assertIn("test_orchestrator", ret)
 
-    def test_device_ls(self):
-        ret = self._orch_cmd("device", "ls")
-        self.assertIn("localhost:", ret)
+    # TODO: This fails, cause ceph-volume is not found at runtime.
+    # def test_device_ls(self):
+    #    ret = self._orch_cmd("device", "ls")
+    #    self.assertIn("localhost:", ret)
 
     def test_service_ls(self):
         ret = self._orch_cmd("service", "ls")


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

Fixes http://tracker.ceph.com/issues/37773


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

