### PR TITLE
mon: adjust mon sync, extra_probe_peers to use addrvec

### DIFF
--- a/doc/dev/mon-bootstrap.rst
+++ b/doc/dev/mon-bootstrap.rst
@@ -172,12 +172,25 @@ example::
 
      ceph-mon --mkfs -i <myid> --fsid <fsid> --keyring <mon secret key> --public-addr <ip>
 
-Once the daemon starts, you can give it one or more peer addresses to join with::
+Once the daemon starts, you can give it one or more peer addresses (preferably a bare IP address with no port; the mon will set the addr types and ports for you) to join with::
 
      ceph daemon mon.<id> add_bootstrap_peer_hint <peer ip>
 
-This monitor will never participate in cluster creation; it can only join an existing
-cluster.
+Alternatively, you can explicitly specify the addrvec_t with::
+
+     ceph daemon mon.<id> add_bootstrap_peer_hintv <peer addrvec>
+
+For example,::
+
+     ceph daemon mon.new add_bootstrap_peer_hintv v2:1.2.3.4:3300,v1:1.2.3.4:6789
+
+This monitor will never participate in cluster creation; it can only
+join an existing cluster.
+
+Note that the address(es) specified should match exactly the addresses
+the new monitor is binding too.  If, for example, the new mon binds to
+only a v2 address but a v2 and v1 address are provided, there is some
+possibility of confusion in the mons.
 
 Expanding with initial members
 ------------------------------

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -468,7 +468,7 @@ void MonMap::set_initial_members(CephContext *cct,
 				 list<std::string>& initial_members,
 				 string my_name,
 				 const entity_addrvec_t& my_addrs,
-				 set<entity_addr_t> *removed)
+				 set<entity_addrvec_t> *removed)
 {
   // remove non-initial members
   unsigned i = 0;
@@ -484,9 +484,7 @@ void MonMap::set_initial_members(CephContext *cct,
     lgeneric_dout(cct, 1) << " removing " << get_name(i) << " " << get_addrs(i)
 			  << dendl;
     if (removed) {
-      for (auto& j : get_addrs(i).v) {
-	removed->insert(j);
-      }
+      removed->insert(get_addrs(i));
     }
     remove(n);
     ceph_assert(!contains(n));

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -403,7 +403,7 @@ public:
 			   list<std::string>& initial_members,
 			   string my_name,
 			   const entity_addrvec_t& my_addrs,
-			   set<entity_addr_t> *removed);
+			   set<entity_addrvec_t> *removed);
 
   void print(ostream& out) const;
   void print_summary(ostream& out) const;

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -149,7 +149,7 @@ public:
   MonMap *monmap;
   uuid_d fingerprint;
 
-  set<entity_addr_t> extra_probe_peers;
+  set<entity_addrvec_t> extra_probe_peers;
 
   LogClient log_client;
   LogChannelRef clog;
@@ -302,7 +302,7 @@ private:
    * @} // provider state
    */
   struct SyncProvider {
-    entity_inst_t entity;  ///< who
+    entity_addrvec_t addrs;
     uint64_t cookie;       ///< unique cookie for this sync attempt
     utime_t timeout;       ///< when we give up and expire this attempt
     version_t last_committed; ///< last paxos version on peer
@@ -324,7 +324,7 @@ private:
   /**
    * @} // requester state
    */
-  entity_inst_t sync_provider;   ///< who we are syncing from
+  entity_addrvec_t sync_provider;  ///< who we are syncing from
   uint64_t sync_cookie;          ///< 0 if we are starting, non-zero otherwise
   bool sync_full;                ///< true if we are a full sync, false for recent catch-up
   version_t sync_start_version;  ///< last_committed at sync start
@@ -398,7 +398,7 @@ private:
    * @param entity where to pull committed state from
    * @param full whether to do a full sync or just catch up on recent paxos
    */
-  void sync_start(entity_inst_t &entity, bool full);
+  void sync_start(entity_addrvec_t &addrs, bool full);
 
 public:
   /**

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -355,7 +355,7 @@ int main(int argc, const char **argv)
     get_str_list(g_conf()->mon_initial_members, initial_members);
     if (!initial_members.empty()) {
       cout << "initial_members " << initial_members << ", filtering seed monmap" << std::endl;
-      set<entity_addr_t> removed;
+      set<entity_addrvec_t> removed;
       monmap.set_initial_members(g_ceph_context, initial_members,
 				 string(), entity_addrvec_t(),
 				 &removed);


### PR DESCRIPTION
The peer addr stuff via asok is a bit fragile because the user must
provide an exact addrvec matching the mon to avoid some weirdness, but
it's rarely used, and the fix would be some robustness/tolerance in the
messenger that is a bigger project than this.

Signed-off-by: Sage Weil <sage@redhat.com>