### PR TITLE
msg/async: fix mark_down vs accept race

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1933,6 +1933,13 @@ CtPtr ProtocolV1::handle_connect_message_2() {
           need_challenge ? &authorizer_challenge : nullptr) ||
       !authorizer_valid) {
     connection->lock.lock();
+    if (state != ACCEPTING_WAIT_CONNECT_MSG_AUTH) {
+      ldout(cct, 1) << __func__
+		    << " state changed while accept, it must be mark_down"
+		    << dendl;
+      ceph_assert(state == CLOSED);
+      return _fault();
+    }
 
     if (need_challenge && !had_challenge && authorizer_challenge) {
       ldout(cct, 10) << __func__ << ": challenging authorizer" << dendl;

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1980,6 +1980,13 @@ CtPtr ProtocolV2::handle_connect_message_2() {
           need_challenge ? &authorizer_challenge : nullptr) ||
       !authorizer_valid) {
     connection->lock.lock();
+    if (state != ACCEPTING_WAIT_CONNECT_MSG_AUTH) {
+      ldout(cct, 1) << __func__
+		    << " state changed while accept, it must be mark_down"
+		    << dendl;
+      ceph_assert(state == CLOSED);
+      return _fault();
+    }
 
     if (need_challenge && !had_challenge && authorizer_challenge) {
       ldout(cct, 10) << __func__ << ": challenging authorizer" << dendl;


### PR DESCRIPTION
If we mark_down a connection while it is accepting and reading the
connect message, we fail to see the CLOSED state before setting the
next state (ACCEPTING_WAIT_CONNECT_MSG_AUTH), and as a result we later
crash because the can_write bool isn't in the right state.

Fixes: http://tracker.ceph.com/issues/36497
Signed-off-by: Sage Weil <sage@redhat.com>