### PR TITLE
osd, mgr, mds: make timeout of updating rotating keys configurable

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2014,7 +2014,15 @@ std::vector<Option> get_global_options() {
 
     Option("max_rotating_auth_attempts", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(10)
-    .set_description(""),
+    .set_description("number of attempts to initialize rotating keys before giving up"),
+
+    Option("rotating_keys_bootstrap_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(30)
+    .set_description("timeout for obtaining rotating keys during bootstrap phase (seconds)"),
+
+    Option("rotating_keys_renewal_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(10)
+    .set_description("timeout for updating rotating keys (seconds)"),
 
     Option("cephx_require_signatures", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -507,7 +507,9 @@ int MDSDaemon::init()
   }
 
   int rotating_auth_attempts = 0;
-  while (monc->wait_auth_rotating(30.0) < 0) {
+  auto rotating_auth_timeout =
+    g_conf().get_val<int64_t>("rotating_keys_bootstrap_timeout");
+  while (monc->wait_auth_rotating(rotating_auth_timeout) < 0) {
     if (++rotating_auth_attempts <= g_conf()->max_rotating_auth_attempts) {
       derr << "unable to obtain rotating service keys; retrying" << dendl;
       continue;
@@ -1177,7 +1179,8 @@ bool MDSDaemon::ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer, bo
     return true;
 
   if (force_new) {
-    if (monc->wait_auth_rotating(10) < 0)
+    auto timeout = g_conf().get_val<int64_t>("rotating_keys_renewal_timeout");
+    if (monc->wait_auth_rotating(timeout) < 0)
       return false;
   }
 

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -227,7 +227,8 @@ bool DaemonServer::ms_get_authorizer(int dest_type,
   }
 
   if (force_new) {
-    if (monc->wait_auth_rotating(10) < 0)
+    auto timeout = g_conf().get_val<int64_t>("rotating_keys_renewal_timeout");
+    if (monc->wait_auth_rotating(timeout) < 0)
       return false;
   }
 

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -436,7 +436,8 @@ bool MgrStandby::ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer,
     return true;
 
   if (force_new) {
-    if (monc.wait_auth_rotating(10) < 0)
+    auto timeout = cct->_conf.get_val<int64_t>("rotating_keys_renewal_timeout");
+    if (monc.wait_auth_rotating(timeout) < 0)
       return false;
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2677,6 +2677,8 @@ int OSD::init()
   }
 
   int rotating_auth_attempts = 0;
+  auto rotating_auth_timeout =
+    g_conf().get_val<int64_t>("rotating_keys_bootstrap_timeout");
 
   // sanity check long object name handling
   {
@@ -2923,7 +2925,7 @@ int OSD::init()
     exit(1);
   }
 
-  while (monc->wait_auth_rotating(30.0) < 0) {
+  while (monc->wait_auth_rotating(rotating_auth_timeout) < 0) {
     derr << "unable to obtain rotating service keys; retrying" << dendl;
     ++rotating_auth_attempts;
     if (rotating_auth_attempts > g_conf()->max_rotating_auth_attempts) {
@@ -6935,7 +6937,8 @@ bool OSD::ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer, bool for
   if (force_new) {
     /* the MonClient checks keys every tick(), so we should just wait for that cycle
        to get through */
-    if (monc->wait_auth_rotating(10) < 0) {
+    auto timeout = g_conf().get_val<int64_t>("rotating_keys_renewal_timeout");
+    if (monc->wait_auth_rotating(timeout) < 0) {
       derr << "OSD::ms_get_authorizer wait_auth_rotating failed" << dendl;
       return false;
     }

--- a/src/tools/cephfs/MDSUtility.cc
+++ b/src/tools/cephfs/MDSUtility.cc
@@ -163,7 +163,9 @@ bool MDSUtility::ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer,
     return true;
 
   if (force_new) {
-    if (monc->wait_auth_rotating(10) < 0)
+    auto timeout =
+      g_ceph_context->_conf.get_val<int64_t>("rotating_keys_renewal_timeout");
+    if (monc->wait_auth_rotating(timeout) < 0)
       return false;
   }
 


### PR DESCRIPTION
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

