### PR TITLE
luminous: examples: fix link order in librados example Makefile

### DIFF
--- a/examples/librados/Makefile
+++ b/examples/librados/Makefile
@@ -3,13 +3,13 @@ CXX?=g++
 CXX_FLAGS?=-std=c++11 -Wall -Wextra -Werror -g
 CXX_LIBS?=-lrados -lradosstriper
 CXX_INC?=$(LOCAL_LIBRADOS_INC)
-CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS) $(CXX_LIBS)
+CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS)
 
 CC?=gcc
 CC_FLAGS=-Wall -Wextra -Werror -g
 CC_INC=$(LOCAL_LIBRADOS_INC)
 CC_LIBS?=-lrados
-CC_CC=$(CC) $(CC_FLAGS) $(CC_INC) $(LOCAL_LIBRADOS) $(CC_LIBS)
+CC_CC=$(CC) $(CC_FLAGS) $(CC_INC) $(LOCAL_LIBRADOS)
 
 # Relative path to the Ceph source:
 CEPH_SRC_HOME?=../../src
@@ -26,13 +26,13 @@ all-system: LOCAL_LIBRADOS_INC=
 all-system: all
 
 hello_world_cpp: hello_world.cc
-	$(CXX_CC) -o hello_world_cpp hello_world.cc
+	$(CXX_CC) -o hello_world_cpp hello_world.cc $(CXX_LIBS)
 
 hello_radosstriper_cpp: hello_radosstriper.cc
-	$(CXX_CC) -o hello_radosstriper_cpp hello_radosstriper.cc
+	$(CXX_CC) -o hello_radosstriper_cpp hello_radosstriper.cc $(CXX_LIBS)
 
 hello_world_c: hello_world_c.c
-	$(CC_CC) -o hello_world_c hello_world_c.c
+	$(CC_CC) -o hello_world_c hello_world_c.c $(CC_LIBS)
 
 clean:
 	rm -f hello_world_cpp hello_radosstriper_cpp hello_world_c

--- a/examples/librados/hello_world.readme
+++ b/examples/librados/hello_world.readme
@@ -6,7 +6,7 @@ build tree (ie. using relative paths). If you would like to build the examples a
 your system librados and headers, use "make all-system".
 
 And executed using
-./librados_hello_world -c ../../src/ceph.conf
+./hello_world_cpp -c ../../src/ceph.conf
 (or whatever path to a ceph.conf is appropriate to you, or
 by explicitly specifying monitors, user id, and keys).
 


### PR DESCRIPTION
The library link order in librados example Makefile is incorrect
and as a result 'make' throws an error. This change fixes the order.

Fixes: http://tracker.ceph.com/issues/37795

Signed-off-by: Mahati Chamarthy <mahati.chamarthy@intel.com>
(cherry picked from commit 5b027155b41d15c9e9e26b81340a76673f483890)

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
