### PR TITLE
mgr/dashboard: Changed background colors for UI views, panel headers, panel footers, table headers

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/app.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.component.html
@@ -1,5 +1,5 @@
 <cd-navigation *ngIf="!isLoginActive()"></cd-navigation>
-<div class="container-fluid"
+<div class="container-fluid view-background-color"
      [ngClass]="{'full-height':isLoginActive(), 'dashboard':isDashboardPage()} ">
   <cd-breadcrumbs></cd-breadcrumbs>
   <router-outlet></router-outlet>

--- a/src/pybind/mgr/dashboard/frontend/src/app/app.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/app.component.scss
@@ -1,7 +1,6 @@
 @import '../defaults';
 
 .dashboard {
-  background-color: $color-whitesmoke-gray;
   margin: 0;
   padding: 0;
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/datatable/table/table.component.scss
@@ -183,6 +183,9 @@
         border-left: none;
       }
     }
+    .datatable-header-inner {
+      background-color: $color-table-header-bg;
+    }
   }
   .datatable-body {
     .empty-row {

--- a/src/pybind/mgr/dashboard/frontend/src/defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/defaults.scss
@@ -36,6 +36,7 @@ $color-whitesmoke-gray: #f5f5f5;
 $color-solid-white: #ffffff;
 $color-transparent: rgba(0, 0, 0, 0.09);
 $color-brand-gray: #374249;
+$color-light-white: #fcfcfc;
 
 $color-app-bg: $color-solid-white;
 $color-bg-darken: $color-dark-gray;
@@ -103,7 +104,7 @@ $color-helper-bg: $color-blue;
 $color-table-seperator-border: $color-transparent;
 $color-table-input-border: $color-transparent;
 $color-table-dropdown-bg: $color-whitesmoke-gray;
-$color-table-header-bg: $color-whitesmoke-gray;
+$color-table-header-bg: $color-light-white;
 $color-table-header-border: $color-light-gray;
 $color-table-active-row: $color-sky-blue;
 $color-table-active-row-hover: $color-light-blue;
@@ -115,7 +116,7 @@ $color-table-sort: $color-blue;
 $color-table-empty-row: $color-light-yellow;
 $color-table-hover-row: $color-white-gray;
 $color-table-even-row-bg: $color-solid-white;
-$color-table-odd-row-bg: $color-whitesmoke-gray;
+$color-table-odd-row-bg: $color-light-white;
 $color-table-datatable-header: $color-whitesmoke-gray;
 
 /*Chart tooltip*/
@@ -129,6 +130,10 @@ $color-popover-seperator-bg: $color-white-gray;
 $color-popover-message-text: $color-dark-gray;
 $color-popover-table-text: $color-dark-gray;
 $color-popover-date: $color-solid-gray;
+
+/*Horizontal Form*/
+$color-form-panel-header: $color-light-white;
+$color-form-panel-footer: $color-light-white;
 
 /*RGW user form*/
 $color-rgw-icon: $color-blue-gray;

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -287,6 +287,17 @@ uib-accordion .panel-title,
   padding-left: 4px;
   vertical-align: text-top;
 }
+
+/*Overwriting form panel's background color */
+.form-horizontal > .panel.panel-default {
+  & > .panel-heading {
+    background-color: $color-form-panel-header;
+  }
+  & > .panel-footer {
+    background-color: $color-form-panel-footer;
+  }
+}
+
 /* Panel */
 .panel-footer button.btn:not(:first-child) {
   margin-left: 5px;
@@ -300,4 +311,17 @@ uib-accordion .panel-title,
 }
 .nav-tabs {
   margin-bottom: 15px;
+}
+
+/* Background color */
+.view-background-color {
+  background-color: $color-whitesmoke-gray;
+  height: 100%;
+}
+
+/* Overwriting active tab background color */
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:hover,
+.nav-tabs > li.active > a:focus {
+  background-color: $color-whitesmoke-gray;
 }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/35692


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

Before -
![background-color-before](https://user-images.githubusercontent.com/5517376/50819167-9e9d1080-136c-11e9-8f95-9a76d60fb9a8.png)
![panel-header-footer-before](https://user-images.githubusercontent.com/5517376/50819168-9e9d1080-136c-11e9-8daf-6293065e1446.png)
![table-header-before](https://user-images.githubusercontent.com/5517376/50819169-9e9d1080-136c-11e9-85ce-a7ac2249fb33.png)

After -
![background-color-after](https://user-images.githubusercontent.com/5517376/50819188-aceb2c80-136c-11e9-9c42-992fec8950e8.png)
![panel-header-footer-after](https://user-images.githubusercontent.com/5517376/50819191-aceb2c80-136c-11e9-9ed7-ba5d7711c494.png)
![table-header-after](https://user-images.githubusercontent.com/5517376/50819192-aceb2c80-136c-11e9-8d69-bfd248b6c850.png)

