### PR TITLE
luminous ceph-volume tests/functional declare ceph-ansible roles instead of importing them

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/playbooks/deploy.yml
@@ -74,27 +74,12 @@
   gather_facts: false
   become: True
   any_errors_fatal: true
+  roles:
+    - ceph-defaults
+    - ceph-facts
+    - ceph-handler
+    - ceph-common
   tasks:
-    - name: run ceph-defaults role
-      import_role:
-        name: ceph-defaults
-
-    # mimic and luminous are tested with the ceph-ansible branch
-    # stable-3.2 and this role is not available there
-    - name: run ceph-facts role
-      import_role:
-        name: ceph-facts
-      when:
-        - ceph_dev_branch not in ["mimic", "lumious"]
-
-    - name: run ceph-handler role
-      import_role:
-        name: ceph-handler
-
-    - name: run ceph-common role
-      import_role:
-        name: ceph-common
-
     - name: rsync ceph-volume to test nodes on centos
       synchronize:
         src: "{{ toxinidir}}/../../../../ceph_volume"


### PR DESCRIPTION
Necessary mostly for Mimic and Luminous branches, caused by the change in this ceph-ansible PR: https://github.com/ceph/ceph-ansible/pull/3435

Tests will fail against master until ceph-ansible PR https://github.com/ceph/ceph-ansible/pull/3480 gets merged

Fixes: http://tracker.ceph.com/issues/37805
Backport of: https://github.com/ceph/ceph/pull/25820