### PR TITLE
mon/MonClient: make mon hunt more aggressive

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2057,7 +2057,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_client_hunt_parallel", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(2)
+    .set_default(3)
     .set_description(""),
 
     Option("mon_client_hunt_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
@@ -2073,7 +2073,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_client_hunt_interval_backoff", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(2.0)
+    .set_default(1.5)
     .set_description(""),
 
     Option("mon_client_hunt_interval_min_multiple", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
With v2 and v1 addresses, it helps to be a bit more aggressive
searching for mons since the v1 or v2 ports may not be in use.

- try 3 parallel connection attempts, not 2
- increase the timeout interval more slowly

Signed-off-by: Sage Weil <sage@redhat.com>


I observed a MGR_DOWN in the multimon suite that occurred because 3 attempts in a row the mgr picked 2 mons that weren't part of the quorum, pushing it past the 60s needed to mark the MGR down.  The 3 parallel attempts and shorter timeout will make this more unlikely.

It's unrelated to the v1/v2 thing, but that expansion of mon candidates during the initial mon search phase can cause similar problems with clients (even when all mons are up).