### PR TITLE
rgw: RGWAsyncRemoveObj uses bucket versioning status

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -701,9 +701,7 @@ int RGWAsyncRemoveObj::_send_request()
   if (del_if_older) {
     del_op.params.unmod_since = timestamp;
   }
-  if (versioned) {
-    del_op.params.versioning_status = BUCKET_VERSIONED;
-  }
+  del_op.params.versioning_status = bucket_info.versioning_status();
   del_op.params.olh_epoch = versioned_epoch;
   del_op.params.marker_version_id = marker_version_id;
   del_op.params.obj_owner.set_id(owner);


### PR DESCRIPTION
the 'bool versioned' flag does not carry information about suspended versioning. when syncing delete markers in versioning-suspended buckets, lack of the BUCKET_VERSIONS_SUSPENDED flag causes us to generate a new random version id instead of using the empty one