### PR TITLE
common/buffer: fix compiler bug when enable DEBUG_BUFFER.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -45,7 +45,8 @@ using namespace ceph;
 #define CEPH_BUFFER_APPEND_SIZE (CEPH_BUFFER_ALLOC_UNIT - sizeof(raw_combined))
 
 #ifdef BUFFER_DEBUG
-# define bdout { std::lock_guard lg(ceph::spinlock()); std::cout
+static ceph::spinlock debug_lock;
+# define bdout { std::lock_guard<ceph::spinlock> lg(debug_lock); std::cout
 # define bendl std::endl; }
 #else
 # define bdout if (0) { std::cout


### PR DESCRIPTION
When enable DEBUG_BUFFER, met the following bug:

    /home/ceph/jp-ceph/src/common/buffer.cc: In constructor ‘ceph::buffer::raw_malloc::raw_malloc(unsigned int)’:
    /home/ceph/jp-ceph/src/common/buffer.cc:49:34: error: deduced class type ‘lock_guard’ in function return type
     # define bdout { std::lock_guard lg(ceph::spinlock()); std::cout
                                  ^
    /home/ceph/jp-ceph/src/common/buffer.cc:49:34: note: in definition of macro ‘bdout’
     # define bdout { std::lock_guard lg(ceph::spinlock()); std::cout