### PR TITLE
luminous: os/bluestore: KernelDevice::read() does the EIO mapping now.

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -697,7 +697,11 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   int r = ::pread(buffered ? fd_buffered : fd_direct,
 		  p.c_str(), len, off);
   if (r < 0) {
-    r = -errno;
+    if (ioc->allow_eio && is_expected_ioerr(r)) {
+      r = -EIO;
+    } else {
+      r = -errno;
+    }
     goto out;
   }
   assert((uint64_t)r == len);


### PR DESCRIPTION
https://tracker.ceph.com/issues/37825