### PR TITLE
msg/async: do not force updating rotating keys inline

### DIFF
--- a/src/msg/async/ProtocolV1.h
+++ b/src/msg/async/ProtocolV1.h
@@ -226,7 +226,6 @@ public:
   // Client Protocol
 private:
   int global_seq;
-  bool got_bad_auth;
   AuthAuthorizer *authorizer;
 
   CONTINUATION_DECL(ProtocolV1, send_client_banner);

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -74,7 +74,6 @@ ProtocolV2::ProtocolV2(AsyncConnection *connection)
       once_ready(false),
       state(NONE),
       global_seq(0),
-      got_bad_auth(false),
       authorizer(nullptr),
       wait_for_seq(false) {
   temp_buffer = new char[4096];
@@ -95,7 +94,6 @@ void ProtocolV2::connect() {
   this->state = START_CONNECT;
 
   // reset connect state variables
-  got_bad_auth = false;
   if (authorizer) {
     delete authorizer;
     authorizer = nullptr;
@@ -1235,7 +1233,6 @@ void ProtocolV2::reset_recv_state() {
       delete authorizer;
     }
     authorizer = nullptr;
-    got_bad_auth = false;
   }
 
   // clean read and write callbacks
@@ -1595,14 +1592,7 @@ CtPtr ProtocolV2::handle_connect_reply_2() {
 
   if (connect_reply.tag == CEPH_MSGR_TAG_BADAUTHORIZER) {
     ldout(cct, 0) << __func__ << " connect got BADAUTHORIZER" << dendl;
-    if (got_bad_auth) {
-      return _fault();
-    }
-    got_bad_auth = true;
-    delete authorizer;
-    authorizer = messenger->ms_deliver_get_authorizer(connection->peer_type,
-                                                      true);  // try harder
-    return CONTINUE(send_connect_message);
+    return _fault();
   }
 
   if (connect_reply.tag == CEPH_MSGR_TAG_RESETSESSION) {

--- a/src/msg/async/ProtocolV2.h
+++ b/src/msg/async/ProtocolV2.h
@@ -181,7 +181,6 @@ public:
   // Client Protocol
 private:
   int global_seq;
-  bool got_bad_auth;
   AuthAuthorizer *authorizer;
 
   CONTINUATION_DECL(ProtocolV2, send_client_banner);


### PR DESCRIPTION
We found quite a few OSDs were unable to re-join the cluster
after the updation of the core switch was done.
The symptoms are similar - all these OSDs are complaining about not
being able to renew rotating keys, which are necessary
for authorized entities to talk with each other.

The root cause is that a specific OSD would keep hunting a reachable Mon,
and if unavailable, the hunting process would reboot every __timeout__ seconds,
causing the async-connection in progress torn down and re-created.

However the underlying thread in charge of the hunting process could be
blocked if there were hundreds of async-connections which were also waiting
for new rotating keys, e.g.:
```
2018-12-29 16:35:19.210884 7f416d6ee700  0 -- 172.18.35.6:6808/1036230 >> 172.18.35.4:6810/1037600 conn(0x7f41d9e3c000 :6808 s=STATE_CONNECTING_WAIT_CONNECT_REPLY_AUTH
 pgs=293 cs=25 l=0).handle_connect_reply connect got BADAUTHORIZER
2018-12-29 16:35:19.210891 7f416d6ee700 10 monclient(hunting): wait_auth_rotating waiting (until 2018-12-29 16:35:29.210889)
2018-12-29 16:35:29.210947 7f416d6ee700  0 monclient(hunting): wait_auth_rotating timed out after 10
2018-12-29 16:35:29.211101 7f416d6ee700  0 -- 172.18.35.6:6808/1036230 >> 172.18.35.4:6824/1028882 conn(0x7f418195d000 :-1 s=STATE_CONNECTING_WAIT_CONNECT_REPLY_AUTH p
gs=1433 cs=8 l=0).handle_connect_reply connect got BADAUTHORIZER
2018-12-29 16:35:29.211108 7f416d6ee700 10 monclient(hunting): wait_auth_rotating waiting (until 2018-12-29 16:35:39.211108)
2018-12-29 16:35:39.211167 7f416d6ee700  0 monclient(hunting): wait_auth_rotating timed out after 10
```
which as a result causes the corresponding OSD being stuck at hunting forever.

Fix by avoiding updating rotating keys on the messenger level and
make monclient do it instead. On detecting a bad or an outdated
rotating key, we could simply backoff and restart the connecting
procedure.

Signed-off-by: yanjun <yan.jun8@zte.com.cn>
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

