### PR TITLE
pybind/mgr/prometheus: improve 'rbd_stats_pools' param parsing

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -555,7 +555,7 @@ class Module(MgrModule):
         # stats are collected for every namespace in the pool.
         pools_string = self.get_localized_module_option('rbd_stats_pools', '')
         pools = {}
-        for p in re.split('[\s,]+', pools_string):
+        for p in [x for x in re.split('[\s,]+', pools_string) if x]:
             s = p.split('/', 2)
             pool_name = s[0]
             if len(s) == 1:


### PR DESCRIPTION
re.split can still produce a list with empty string elements (e.g. if
'rbd_stats_pools' is just an empty string) and we want to filter out
those.

Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

