### PR TITLE
mgr/dashboard: RbdMirroringService test suite fails in dev mode

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/rbd-mirroring.service.spec.ts
@@ -19,10 +19,13 @@ describe('RbdMirroringService', () => {
     }
   };
 
-  configureTestBed({
-    providers: [RbdMirroringService],
-    imports: [HttpClientTestingModule]
-  });
+  configureTestBed(
+    {
+      providers: [RbdMirroringService],
+      imports: [HttpClientTestingModule]
+    },
+    true
+  );
 
   beforeEach(() => {
     service = TestBed.get(RbdMirroringService);


### PR DESCRIPTION
If you have set **DEV** in **unit-test-configuration.ts** to true, in order to
run all unit tests much faster, the unit test suite of RBD mirroring
service fails.

The reason is, that it's expecting a call, that is triggered inside the
constructor, which is only done once in for the copy used in the fast
testing mode (if it would be done on within **ngOnInit** this wouldn't be a
problem).

Fixes: http://tracker.ceph.com/issues/37841
Signed-off-by: Stephan Müller <smueller@suse.com>