### PR TITLE
Luminous: mds backport lookup_snap_ino and fix it

### DIFF
--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -549,6 +549,12 @@ union ceph_mds_request_args {
 		__le64 length; /* num bytes to lock from start */
 		__u8 wait; /* will caller wait for lock to become available? */
 	} __attribute__ ((packed)) filelock_change;
+	struct {
+		__le32 mask;                 /* CEPH_CAP_* */
+		__le64 snapid;
+		__le64 parent;
+		__le32 hash;
+	} __attribute__ ((packed)) lookupino;
 } __attribute__ ((packed));
 
 #define CEPH_MDS_REQUEST_HEAD_VERSION	1

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2561,6 +2561,24 @@ void CInode::pre_cow_old_inode()
     cow_old_inode(follows, true);
 }
 
+bool CInode::has_snap_data(snapid_t snapid)
+{
+  bool found = snapid >= first && snapid <= last;
+  if (!found && is_multiversion()) {
+    auto p = old_inodes.lower_bound(snapid);
+    if (p != old_inodes.end()) {
+      if (p->second.first > snapid) {
+	if  (p != old_inodes.begin())
+	  --p;
+      }
+      if (p->second.first <= snapid && snapid <= p->first) {
+	found = true;
+      }
+    }
+  }
+  return found;
+}
+
 void CInode::purge_stale_snap_data(const set<snapid_t>& snaps)
 {
   dout(10) << "purge_stale_snap_data " << snaps << dendl;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -2563,17 +2563,31 @@ void CInode::pre_cow_old_inode()
 
 const set<snapid_t> CInode::get_valid_snaps()
 {
-  open_snaprealm();
-  if (!snaprealm->is_open())
-    snaprealm->_open_parents(NULL);
-  SnapRealm *realm = find_snaprealm();
-  assert(realm);
+  SnapRealm *realm = NULL;
+  set<snapid_t> snaps;
+
+  dout(10) << __func__ << ": find snaprealm for "
+           << ((is_dir()) ? "dir" : "file")
+           << " inode " << *this
+           << dendl;
+
+  realm = find_snaprealm();
+  if (!realm) {
+    dout(10) << __func__ << ": find NO snaprealm for inode "
+             << *this << dendl;
+    return snaps;
+  }
+
+  dout(10) << __func__ << ": found snaprealm addr = " << realm
+           << ", realm = " << *realm << dendl;
+
+  if (!realm->is_open())
+    realm->_open_parents(NULL);
 
   map<snapid_t, SnapInfo *> infomap;
   realm->get_snap_info(infomap, get_oldest_snap());
   dout(10) << __func__ << ": infomap.size() = " << infomap.size() << dendl;
 
-  set<snapid_t> snaps;
   for (auto p : infomap) {
     dout(15) << __func__ << ": infomap.first = " << p.first << dendl;
     snaps.insert(p.first);

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -500,6 +500,7 @@ public:
   void split_old_inode(snapid_t snap);
   mempool_old_inode *pick_old_inode(snapid_t last);
   void pre_cow_old_inode();
+  bool has_snap_data(snapid_t s);
   void purge_stale_snap_data(const std::set<snapid_t>& snaps);
 
   // -- cache infrastructure --

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -500,6 +500,9 @@ public:
   void split_old_inode(snapid_t snap);
   mempool_old_inode *pick_old_inode(snapid_t last);
   void pre_cow_old_inode();
+  const set<snapid_t> get_valid_snaps();
+  bool is_valid_snap(const set<snapid_t>& snaps, snapid_t s);
+  bool is_valid_snap(snapid_t s);
   bool has_snap_data(snapid_t s);
   void purge_stale_snap_data(const std::set<snapid_t>& snaps);
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -799,6 +799,13 @@ public:
   CInode* get_inode(inodeno_t ino, snapid_t s=CEPH_NOSNAP) {
     return get_inode(vinodeno_t(ino, s));
   }
+  CInode* lookup_snap_inode(vinodeno_t vino) {
+    auto p = snap_inode_map.lower_bound(vino);
+    if (p != snap_inode_map.end() &&
+	p->second->ino() == vino.ino && p->second->first <= vino.snapid)
+      return p->second;
+    return NULL;
+  }
 
   CDir* get_dirfrag(dirfrag_t df) {
     CInode *in = get_inode(df.ino);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3182,6 +3182,9 @@ void Server::handle_client_lookup_ino(MDRequestRef& mdr,
 {
   MClientRequest *req = mdr->client_request;
 
+  if ((uint64_t)req->head.args.lookupino.snapid > 0)
+    return _lookup_snap_ino(mdr);
+
   inodeno_t ino = req->get_filepath().get_ino();
   CInode *in = mdcache->get_inode(ino);
   if (in && in->state_test(CInode::STATE_PURGING)) {
@@ -3212,7 +3215,7 @@ void Server::handle_client_lookup_ino(MDRequestRef& mdr,
     rdlocks.insert(&dn->lock);
   }
 
-  unsigned mask = req->head.args.getattr.mask;
+  unsigned mask = req->head.args.lookupino.mask;
   if (mask) {
     Capability *cap = in->get_client_cap(mdr->get_client());
     int issued = 0;
@@ -3266,6 +3269,81 @@ void Server::handle_client_lookup_ino(MDRequestRef& mdr,
     if (want_dentry)
       mdr->tracedn = dn;
     respond_to_request(mdr, 0);
+  }
+}
+
+void Server::_lookup_snap_ino(MDRequestRef& mdr)
+{
+  MClientRequest *req = mdr->client_request;
+
+  vinodeno_t vino;
+  vino.ino = req->get_filepath().get_ino();
+  vino.snapid = (__u64)req->head.args.lookupino.snapid;
+  inodeno_t parent_ino = (__u64)req->head.args.lookupino.parent;
+  __u32 hash = req->head.args.lookupino.hash;
+
+  dout(7) << "lookup_snap_ino " << vino << " parent " << parent_ino << " hash " << hash << dendl;
+
+  CInode *in = mdcache->lookup_snap_inode(vino);
+  if (!in) {
+    in = mdcache->get_inode(vino.ino);
+    if (in) {
+      if (in->state_test(CInode::STATE_PURGING) ||
+	  !in->has_snap_data(vino.snapid)) {
+	if (in->is_dir() || !parent_ino) {
+	  respond_to_request(mdr, -ESTALE);
+	  return;
+	}
+	in = NULL;
+      }
+    }
+  }
+
+  if (in) {
+    dout(10) << "reply to lookup_snap_ino " << *in << dendl;
+    mdr->snapid = vino.snapid;
+    mdr->tracei = in;
+    respond_to_request(mdr, 0);
+    return;
+  }
+
+  CInode *diri = NULL;
+  if (parent_ino) {
+    diri = mdcache->get_inode(parent_ino);
+    if (!diri) {
+      mdcache->open_ino(parent_ino, mds->mdsmap->get_metadata_pool(), new C_MDS_LookupIno2(this, mdr));
+      return;
+    }
+
+    if (!diri->is_dir()) {
+      respond_to_request(mdr, -EINVAL);
+      return;
+    }
+
+    set<SimpleLock*> rdlocks, wrlocks, xlocks;
+    rdlocks.insert(&diri->dirfragtreelock);
+    if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
+      return;
+
+    frag_t frag = diri->dirfragtree[hash];
+    CDir *dir = try_open_auth_dirfrag(diri, frag, mdr);
+    if (!dir)
+      return;
+
+    if (!dir->is_complete()) {
+      if (dir->is_frozen()) {
+	mds->locker->drop_locks(mdr.get());
+	mdr->drop_local_auth_pins();
+	dir->add_waiter(CDir::WAIT_UNFREEZE, new C_MDS_RetryRequest(mdcache, mdr));
+	return;
+      }
+      dir->fetch(new C_MDS_RetryRequest(mdcache, mdr), true);
+      return;
+    }
+
+    respond_to_request(mdr, -ESTALE);
+  } else {
+    mdcache->open_ino(vino.ino, mds->mdsmap->get_metadata_pool(), new C_MDS_LookupIno2(this, mdr), false);
   }
 }
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3288,7 +3288,7 @@ void Server::_lookup_snap_ino(MDRequestRef& mdr)
 
   const snapid_t min_snap = 2;
 
-  if (vino.snapid < min_snap || vino.snapid > CEPH_MAXSNAP) {
+  if (vino.snapid < min_snap) {
     respond_to_request(mdr, -EINVAL);
     return;
   }
@@ -3333,7 +3333,7 @@ void Server::_lookup_snap_ino(MDRequestRef& mdr)
       } else {
        dout(7) << __func__ << ": head is dir "  << dendl;
        lookup_hardlink = false;
-       if (!in->has_snap_data(vino.snapid)) {
+       if (!in->has_snap_data(vino.snapid) && vino.snapid != CEPH_SNAPDIR) {
        dout(1) << __func__ << ": head dir invalid snap "
                << vino.snapid << dendl;
        respond_to_request(mdr, -ESTALE);
@@ -3369,7 +3369,7 @@ void Server::_lookup_snap_ino(MDRequestRef& mdr)
        respond_to_request(mdr, -ESTALE);
        return;
       }
-    } else if (!in->has_snap_data(vino.snapid)) {
+    } else if (!in->has_snap_data(vino.snapid) && vino.snapid != CEPH_SNAPDIR) {
       dout(1) << __func__ << ": found snap dir but invalid snap "
        << vino.snapid << dendl;
       respond_to_request(mdr, -ESTALE);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -201,6 +201,7 @@ public:
   void handle_client_getattr(MDRequestRef& mdr, bool is_lookup);
   void handle_client_lookup_ino(MDRequestRef& mdr,
 				bool want_parent, bool want_dentry);
+  void _lookup_snap_ino(MDRequestRef& mdr);
   void _lookup_ino_2(MDRequestRef& mdr, int r);
   void handle_client_readdir(MDRequestRef& mdr);
   void handle_client_file_setlock(MDRequestRef& mdr);


### PR DESCRIPTION
1. backport lookup snapped inode commit from mimic by Yan, Zheng
2. fix lookup snap ino logic, mainly on hardlink across different subdirs
    under the same snapped directory, removed snapshot, and subdirs nested snapshot
3. we have tested this mainly on nfs-ganesha + libcephfs

Signed-off-by: Min Chen <chenmin@sangfor.com.cn>