### PR TITLE
Luminous: fix bug of read snapped file hang when it has no enough caps

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -366,6 +366,7 @@ OPTION(client_readahead_max_bytes, OPT_LONGLONG)  // default unlimited
 OPTION(client_readahead_max_periods, OPT_LONGLONG)  // as multiple of file layout period (object size * num stripes)
 OPTION(client_reconnect_stale, OPT_BOOL)  // automatically reconnect stale session
 OPTION(client_snapdir, OPT_STR)
+OPTION(client_snap_read_caps_retry, OPT_INT) // max times of request read caps of snap file to mds
 OPTION(client_mountpoint, OPT_STR)
 OPTION(client_mount_uid, OPT_INT)
 OPTION(client_mount_gid, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6588,6 +6588,10 @@ std::vector<Option> get_mds_client_options() {
     .set_default(".snap")
     .set_description("pseudo directory for snapshot access to a directory"),
 
+    Option("client_snap_read_caps_retry", Option::TYPE_INT, Option::LEVEL_BASIC)
+    .set_default(3)
+    .set_description("max times of request read caps of snap file to mds"),
+
     Option("client_mountpoint", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("/")
     .set_description("default mount-point"),


### PR DESCRIPTION
When snapped file inode is expired by lru at client, 
it need to request new read caps for read snapped file,
unfortunately,  if CInode on mds is stay at lock state with no read caps,
then, mds will not send broadcast caps to client, and client will hang at Client::get_caps(),

to fix  this case:
1. mds need to grant more snapped file read caps for loner client
2. client should not wait for unreachable read caps for ever, but to _renew_caps() 
    to trigger mds eval to nudge lock state for get read caps,
    if _renew_caps() more than eg 3 times, then client should give up and return ERROR

Signed-off-by: Min Chen chenmin@sangfor.com.cn