### PR TITLE
lumious: mds: SimpleLock::dump() add dump state name

### DIFF
--- a/src/mds/SimpleLock.cc
+++ b/src/mds/SimpleLock.cc
@@ -22,6 +22,8 @@ void SimpleLock::dump(Formatter *f) const {
     return;
   }
 
+  f->dump_string("state", get_state_name(get_state()));
+
   f->open_array_section("gather_set");
   if (have_more()) {
     for(const auto &i : more()->gather_set) {


### PR DESCRIPTION
for debug purpose, should get lock state name when using mds command dump cache

Signed-off-by: Min Chen <chenmin@sangfor.com.cn>