### PR TITLE
mgr/dashboard: config option type names update

### DIFF
--- a/qa/tasks/mgr/dashboard/test_cluster_configuration.py
+++ b/qa/tasks/mgr/dashboard/test_cluster_configuration.py
@@ -173,6 +173,8 @@ class ClusterConfigurationTest(DashboardTestCase):
         self.assertIn('services', data)
         self.assertIn('type', data)
         self.assertIn('desc', data)
+        self.assertIn(data['type'], ['str', 'bool', 'float', 'int', 'size', 'uint', 'addr', 'uuid',
+                                     'secs'])
 
         if 'value' in data:
             self.assertIn('source', data)

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.spec.ts
@@ -42,10 +42,10 @@ describe('ConfigurationFormComponent', () => {
   });
 
   describe('getType', () => {
-    it('should return uint64_t type', () => {
-      const ret = component.getType('uint64_t');
+    it('should return uint type', () => {
+      const ret = component.getType('uint');
       expect(ret).toBeTruthy();
-      expect(ret.name).toBe('uint64_t');
+      expect(ret.name).toBe('uint');
       expect(ret.inputType).toBe('number');
       expect(ret.humanReadable).toBe('Positive integer value');
       expect(ret.defaultMin).toBe(0);
@@ -54,10 +54,10 @@ describe('ConfigurationFormComponent', () => {
       expect(ret.allowsNegative).toBe(false);
     });
 
-    it('should return int64_t type', () => {
-      const ret = component.getType('int64_t');
+    it('should return int type', () => {
+      const ret = component.getType('int');
       expect(ret).toBeTruthy();
-      expect(ret.name).toBe('int64_t');
+      expect(ret.name).toBe('int');
       expect(ret.inputType).toBe('number');
       expect(ret.humanReadable).toBe('Integer value');
       expect(ret.defaultMin).toBeUndefined();
@@ -66,10 +66,10 @@ describe('ConfigurationFormComponent', () => {
       expect(ret.allowsNegative).toBe(true);
     });
 
-    it('should return size_t type', () => {
-      const ret = component.getType('size_t');
+    it('should return size type', () => {
+      const ret = component.getType('size');
       expect(ret).toBeTruthy();
-      expect(ret.name).toBe('size_t');
+      expect(ret.name).toBe('size');
       expect(ret.inputType).toBe('number');
       expect(ret.humanReadable).toBe('Positive integer value (size)');
       expect(ret.defaultMin).toBe(0);
@@ -90,10 +90,10 @@ describe('ConfigurationFormComponent', () => {
       expect(ret.allowsNegative).toBe(false);
     });
 
-    it('should return double type', () => {
-      const ret = component.getType('double');
+    it('should return float type', () => {
+      const ret = component.getType('float');
       expect(ret).toBeTruthy();
-      expect(ret.name).toBe('double');
+      expect(ret.name).toBe('float');
       expect(ret.inputType).toBe('number');
       expect(ret.humanReadable).toBe('Decimal value');
       expect(ret.defaultMin).toBeUndefined();
@@ -102,10 +102,10 @@ describe('ConfigurationFormComponent', () => {
       expect(ret.allowsNegative).toBe(true);
     });
 
-    it('should return std::string type', () => {
-      const ret = component.getType('std::string');
+    it('should return str type', () => {
+      const ret = component.getType('str');
       expect(ret).toBeTruthy();
-      expect(ret.name).toBe('std::string');
+      expect(ret.name).toBe('str');
       expect(ret.inputType).toBe('text');
       expect(ret.humanReadable).toBe('Text');
       expect(ret.defaultMin).toBeUndefined();
@@ -114,10 +114,10 @@ describe('ConfigurationFormComponent', () => {
       expect(ret.allowsNegative).toBeUndefined();
     });
 
-    it('should return entity_addr_t type', () => {
-      const ret = component.getType('entity_addr_t');
+    it('should return addr type', () => {
+      const ret = component.getType('addr');
       expect(ret).toBeTruthy();
-      expect(ret.name).toBe('entity_addr_t');
+      expect(ret.name).toBe('addr');
       expect(ret.inputType).toBe('text');
       expect(ret.humanReadable).toBe('IPv4 or IPv6 address');
       expect(ret.defaultMin).toBeUndefined();
@@ -126,10 +126,10 @@ describe('ConfigurationFormComponent', () => {
       expect(ret.allowsNegative).toBeUndefined();
     });
 
-    it('should return uuid_d type', () => {
-      const ret = component.getType('uuid_d');
+    it('should return uuid type', () => {
+      const ret = component.getType('uuid');
       expect(ret).toBeTruthy();
-      expect(ret.name).toBe('uuid_d');
+      expect(ret.name).toBe('uuid');
       expect(ret.inputType).toBe('text');
       expect(ret.humanReadable).toBe('UUID');
       expect(ret.defaultMin).toBeUndefined();
@@ -160,8 +160,8 @@ describe('ConfigurationFormComponent', () => {
   });
 
   describe('getValidators', () => {
-    it('should return a validator for types double, entity_addr_t and uuid_d', () => {
-      const types = ['double', 'entity_addr_t', 'uuid_d'];
+    it('should return a validator for types float, addr and uuid', () => {
+      const types = ['float', 'addr', 'uuid'];
 
       types.forEach((valType) => {
         const configOption = new ConfigFormModel();
@@ -173,8 +173,8 @@ describe('ConfigurationFormComponent', () => {
       });
     });
 
-    it('should not return a validator for types std::string and bool', () => {
-      const types = ['std::string', 'bool'];
+    it('should not return a validator for types str and bool', () => {
+      const types = ['str', 'bool'];
 
       types.forEach((valType) => {
         const configOption = new ConfigFormModel();
@@ -187,7 +187,7 @@ describe('ConfigurationFormComponent', () => {
 
     it('should return a pattern and a min validator', () => {
       const configOption = new ConfigFormModel();
-      configOption.type = 'int64_t';
+      configOption.type = 'int';
       configOption.min = 2;
 
       const ret = component.getValidators(configOption);
@@ -199,7 +199,7 @@ describe('ConfigurationFormComponent', () => {
 
     it('should return a pattern and a max validator', () => {
       const configOption = new ConfigFormModel();
-      configOption.type = 'int64_t';
+      configOption.type = 'int';
       configOption.max = 5;
 
       const ret = component.getValidators(configOption);
@@ -211,7 +211,7 @@ describe('ConfigurationFormComponent', () => {
 
     it('should return multiple validators', () => {
       const configOption = new ConfigFormModel();
-      configOption.type = 'double';
+      configOption.type = 'float';
       configOption.max = 5.2;
       configOption.min = 1.5;
 
@@ -224,23 +224,23 @@ describe('ConfigurationFormComponent', () => {
   });
 
   describe('getStep', () => {
-    it('should return the correct step for type uint64_t and value 0', () => {
-      const ret = component.getStep('uint64_t', 0);
+    it('should return the correct step for type uint and value 0', () => {
+      const ret = component.getStep('uint', 0);
       expect(ret).toBe(1);
     });
 
-    it('should return the correct step for type int64_t and value 1', () => {
-      const ret = component.getStep('int64_t', 1);
+    it('should return the correct step for type int and value 1', () => {
+      const ret = component.getStep('int', 1);
       expect(ret).toBe(1);
     });
 
-    it('should return the correct step for type int64_t and value null', () => {
-      const ret = component.getStep('int64_t', null);
+    it('should return the correct step for type int and value null', () => {
+      const ret = component.getStep('int', null);
       expect(ret).toBe(1);
     });
 
-    it('should return the correct step for type size_t and value 2', () => {
-      const ret = component.getStep('size_t', 2);
+    it('should return the correct step for type size and value 2', () => {
+      const ret = component.getStep('size', 2);
       expect(ret).toBe(1);
     });
 
@@ -249,28 +249,28 @@ describe('ConfigurationFormComponent', () => {
       expect(ret).toBe(1);
     });
 
-    it('should return the correct step for type double and value 1', () => {
-      const ret = component.getStep('double', 1);
+    it('should return the correct step for type float and value 1', () => {
+      const ret = component.getStep('float', 1);
       expect(ret).toBe(0.1);
     });
 
-    it('should return the correct step for type double and value 0.1', () => {
-      const ret = component.getStep('double', 0.1);
+    it('should return the correct step for type float and value 0.1', () => {
+      const ret = component.getStep('float', 0.1);
       expect(ret).toBe(0.1);
     });
 
-    it('should return the correct step for type double and value 0.02', () => {
-      const ret = component.getStep('double', 0.02);
+    it('should return the correct step for type float and value 0.02', () => {
+      const ret = component.getStep('float', 0.02);
       expect(ret).toBe(0.01);
     });
 
-    it('should return the correct step for type double and value 0.003', () => {
-      const ret = component.getStep('double', 0.003);
+    it('should return the correct step for type float and value 0.003', () => {
+      const ret = component.getStep('float', 0.003);
       expect(ret).toBe(0.001);
     });
 
-    it('should return the correct step for type double and value null', () => {
-      const ret = component.getStep('double', null);
+    it('should return the correct step for type float and value null', () => {
+      const ret = component.getStep('float', null);
       expect(ret).toBe(0.1);
     });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/configuration/configuration-form/configuration-form.component.ts
@@ -69,7 +69,7 @@ export class ConfigurationFormComponent implements OnInit {
   getType(type: string): any {
     const knownTypes = [
       {
-        name: 'uint64_t',
+        name: 'uint',
         inputType: 'number',
         humanReadable: this.i18n('Positive integer value'),
         defaultMin: 0,
@@ -78,7 +78,7 @@ export class ConfigurationFormComponent implements OnInit {
         allowsNegative: false
       },
       {
-        name: 'int64_t',
+        name: 'int',
         inputType: 'number',
         humanReadable: this.i18n('Integer value'),
         patternHelpText: this.i18n('The entered value needs to be a number.'),
@@ -86,7 +86,7 @@ export class ConfigurationFormComponent implements OnInit {
         allowsNegative: true
       },
       {
-        name: 'size_t',
+        name: 'size',
         inputType: 'number',
         humanReadable: this.i18n('Positive integer value (size)'),
         defaultMin: 0,
@@ -104,7 +104,7 @@ export class ConfigurationFormComponent implements OnInit {
         allowsNegative: false
       },
       {
-        name: 'double',
+        name: 'float',
         inputType: 'number',
         humanReadable: this.i18n('Decimal value'),
         patternHelpText: this.i18n('The entered value needs to be a number or decimal.'),
@@ -112,20 +112,20 @@ export class ConfigurationFormComponent implements OnInit {
         allowsNegative: true
       },
       {
-        name: 'std::string',
+        name: 'str',
         inputType: 'text',
         humanReadable: this.i18n('Text'),
         isNumberType: false
       },
       {
-        name: 'entity_addr_t',
+        name: 'addr',
         inputType: 'text',
         humanReadable: this.i18n('IPv4 or IPv6 address'),
         patternHelpText: this.i18n('The entered value needs to be a valid IP address.'),
         isNumberType: false
       },
       {
-        name: 'uuid_d',
+        name: 'uuid',
         inputType: 'text',
         humanReadable: this.i18n('UUID'),
         patternHelpText: this.i18n(
@@ -176,32 +176,32 @@ export class ConfigurationFormComponent implements OnInit {
         validators.push(Validators.min(typeParams.defaultMin));
       }
 
-      if (configOption.type === 'double') {
+      if (configOption.type === 'float') {
         validators.push(CdValidators.decimalNumber());
       } else {
         validators.push(CdValidators.number(typeParams.allowsNegative));
       }
 
       return validators;
-    } else if (configOption.type === 'entity_addr_t') {
+    } else if (configOption.type === 'addr') {
       return [CdValidators.ip()];
-    } else if (configOption.type === 'uuid_d') {
+    } else if (configOption.type === 'uuid') {
       return [CdValidators.uuid()];
     }
   }
 
   getStep(type: string, value: number): number | undefined {
-    const numberTypes = ['uint64_t', 'int64_t', 'size_t', 'secs'];
+    const numberTypes = ['uint', 'int', 'size', 'secs'];
 
     if (numberTypes.includes(type)) {
       return 1;
     }
 
-    if (type === 'double') {
+    if (type === 'float') {
       if (value !== null) {
         const stringVal = value.toString();
         if (stringVal.indexOf('.') !== -1) {
-          // Value type double and contains decimal characters
+          // Value type float and contains decimal characters
           const decimal = value.toString().split('.');
           return Math.pow(10, -decimal[1].length);
         }


### PR DESCRIPTION
Use the new config option type names (given by the cluster) in the dashboard.

Fixes: http://tracker.ceph.com/issues/37843
Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

