### PR TITLE
luminous: mds: fix bug of PurgeQueue.journal open hits shutdown cause damaged

### DIFF
--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -175,6 +175,10 @@ void PurgeQueue::open(Context *completion)
       journaler.set_writeable();
       recovered = true;
       finish_contexts(g_ceph_context, waiting_for_recovery);
+    } else if (r == -ESHUTDOWN) { // journal open hits shutdown by signal ...
+      derr << "PurgeQueue.journaler is shutdown,"
+        << ", ignore error " << r
+        << " and return" << dendl;
     } else {
       derr << "Error " << r << " loading Journaler" << dendl;
       on_error->complete(r);


### PR DESCRIPTION
when test node reboot, when mds is booting but received signal shutdown before open journal,
then journal error_handler will take shutdown as damaged error

Signed-off-by: Min Chen <chenmin@sangfor.com.cn>