### PR TITLE
Luminous: both mds and client need dumpcache  for inode

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -541,8 +541,8 @@ protected:
   void _invalidate_kernel_dcache();
   void _trim_negative_child_dentries(InodeRef& in);
   
-  void dump_inode(Formatter *f, Inode *in, set<Inode*>& did, bool disconnected);
-  void dump_cache(Formatter *f);  // debug
+  void dump_inode(Formatter *f, Inode *in, set<Inode*>& did, bool disconnected, bool recursive = true);
+  void dump_cache(Formatter *f, inodeno_t ino = 0);  // debug
 
   // force read-only
   void force_session_readonly(MetaSession *s);

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1174,11 +1174,12 @@ public:
 protected:
   int dump_cache(boost::string_view fn, Formatter *f,
 		  boost::string_view dump_root = "",
+		  inodeno_t ino = 0,
 		  int depth = -1);
 public:
-  int dump_cache() { return dump_cache(NULL, NULL); }
-  int dump_cache(boost::string_view filename);
-  int dump_cache(Formatter *f);
+  int dump_cache() { return dump_cache(boost::string_view(""),  (Formatter *)NULL); }
+  int dump_cache(boost::string_view filename, inodeno_t ino = 0);
+  int dump_cache(Formatter *f, inodeno_t ino = 0);
   int dump_cache(boost::string_view dump_root, int depth, Formatter *f);
 
   void cache_status(Formatter *f);

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -242,9 +242,11 @@ void MDSDaemon::set_up_admin_socket()
                                      "migrate a subtree to named MDS");
   assert(r == 0);
   r = admin_socket->register_command("dump cache",
-                                     "dump cache name=path,type=CephString,req=false",
+                                     "dump cache "
+                                     "name=ino,type=CephInt,req=false "
+                                     "name=path,type=CephString,req=false",
                                      asok_hook,
-                                     "dump metadata cache (optionally to a file)");
+                                     "dump metadata cache (optionally dump an inode by ino or/and write to a file with path)");
   assert(r == 0);
   r = admin_socket->register_command("cache status",
                                      "cache status",

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2384,11 +2384,20 @@ bool MDSRankDispatcher::handle_asok_command(
   } else if (command == "dump cache") {
     Mutex::Locker l(mds_lock);
     string path;
+    int64_t ino = 0;
     int r;
+
+    if (!cmd_getval(g_ceph_context, cmdmap, "ino", ino)) {
+      ino = 0;
+    } else if (ino <= 0) {
+      ss << "invalid ino";
+      return true;
+    }
+
     if(!cmd_getval(g_ceph_context, cmdmap, "path", path)) {
-      r = mdcache->dump_cache(f);
+      r = mdcache->dump_cache(f, (inodeno_t)ino);
     } else {
-      r = mdcache->dump_cache(path);
+      r = mdcache->dump_cache(path, (inodeno_t)ino);
     }
 
     if (r != 0) {


### PR DESCRIPTION
currently, mds and client just dump cache for whole cached namespace, and
it is not convinent for debuging, just support dump cache by inode number(dec),
only print head version (not snapped) inode

Signed-off-by: Junhui Tang <tangjunhui@sangfor.com.cn>