### PR TITLE
mimic: mds: remove wrong assertion in Locker::snapflush_nudge

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2587,7 +2587,11 @@ void Locker::snapflush_nudge(CInode *in)
     return;
 
   CInode *head = mdcache->get_inode(in->ino());
-  assert(head);
+  // head inode gets unpinned when snapflush starts. It might get trimmed
+  // before snapflush finishes.
+  if (!head)
+    return;
+
   assert(head->is_auth());
   if (head->client_need_snapflush.empty())
     return;


### PR DESCRIPTION
http://tracker.ceph.com/issues/37818