### PR TITLE
luminous:  qa: remove single mds yaml for cephfs multifs test

### DIFF
--- a/qa/suites/fs/multifs/clusters/1-mds-2-client-coloc.yaml
+++ b/qa/suites/fs/multifs/clusters/1-mds-2-client-coloc.yaml
@@ -1,1 +1,0 @@
-.qa/cephfs/clusters/1-mds-2-client-coloc.yaml


### PR DESCRIPTION
this is luminous only -- commit b98c982 (which backports 3b7233a) missed the yaml file deletion.

http://tracker.ceph.com/issues/24912