### PR TITLE
ceph-volume: functional tests, add libvirt customization

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/functional/.gitignore
+++ b/src/ceph-volume/ceph_volume/tests/functional/.gitignore
@@ -2,3 +2,4 @@
 .vagrant/
 vagrant_ssh_config
 fetch/
+global_vagrant_variables.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/README.md
+++ b/src/ceph-volume/ceph_volume/tests/functional/README.md
@@ -1,0 +1,24 @@
+# ceph-volume functional test suite
+
+This test suite is based on vagrant and is normally run via Jenkins on github
+PRs. With a functioning Vagrant installation these test can also be run locally
+(tested with vagrant's libvirt provider).
+
+## Vagrant with libvirt
+By default the tests make assumption on the network segments to use (public and
+cluster network), as well as the libvirt storage pool and uri. In an unused
+vagrant setup these defaults should be fine.
+If you prefer to explicitly configure the storage pool and libvirt
+uri, create a file
+`$ceph_repo/src/ceph-volume/ceph_volume/tests/functional/global_vagrant_variables.yml`
+with content as follows:
+``` yaml
+libvirt_uri: qemu:///system
+libvirt_storage_pool: 'vagrant-ceph-nvme'
+```
+Adjust the values as needed.
+
+After this descend into a test directory (e.g.
+`$ceph_repo/src/ceph-volume/ceph_volume/tests/functional/lvm` and run `tox -vre
+centos7-bluestore-create -- --provider=libvirt` to execute the tests in
+`$ceph_repo/src/ceph-volume/ceph_volume/tests/functional/lvm/centos7/bluestore/create/`

--- a/src/ceph-volume/ceph_volume/tests/functional/Vagrantfile
+++ b/src/ceph-volume/ceph_volume/tests/functional/Vagrantfile
@@ -7,6 +7,21 @@ VAGRANTFILE_API_VERSION = '2'
 
 DEBUG = false
 
+global_settings = {}
+if File.symlink?(__FILE__)
+  global_config =  File.expand_path(
+    File.join(
+      File.dirname(File.readlink(__FILE__)),
+      'global_vagrant_variables.yml')
+  )
+  if File.exist?(global_config)
+    global_settings = YAML.load_file(global_config)
+  end
+end
+
+LIBVIRT_URI = global_settings.fetch('libvirt_uri', '')
+LIBVIRT_STORAGE_POOL = global_settings.fetch('libvirt_storage_pool', '')
+
 config_file=File.expand_path(File.join(File.dirname(__FILE__), 'vagrant_variables.yml'))
 settings=YAML.load_file(config_file)
 
@@ -46,10 +61,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.ssh.private_key_path = settings['ssh_private_key_path']
   config.ssh.username = USER
 
-  # When using libvirt, avoid errors like:
-  # "CPU feature cmt not found"
   config.vm.provider :libvirt do |lv|
+    # When using libvirt, avoid errors like:
+    # "CPU feature cmt not found"
     lv.cpu_mode = 'host-passthrough'
+    # set libvirt uri if present
+    if not LIBVIRT_URI.empty?
+      lv.uri = LIBVIRT_URI
+    end
+    # set libvirt storage pool if present
+    if not LIBVIRT_STORAGE_POOL.empty?
+      lv.storage_pool_name = LIBVIRT_STORAGE_POOL
+    end
   end
 
   # Faster bootup. Disables mounting the sync folder for libvirt and virtualbox


### PR DESCRIPTION
Signed-off-by: Jan Fajerski <jfajerski@suse.com>

This PR adds two customization options to make running the functional tests a little more comfortable for existing vagrant setups. Existing setups continue to work as before.