### PR TITLE
mgr/dashboard: Confusing tilted time stamps in the CephFS performance graph

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-chart/cephfs-chart.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cephfs/cephfs-chart/cephfs-chart.component.ts
@@ -85,6 +85,9 @@ export class CephfsChartComponent implements OnChanges, OnInit {
                 displayFormats: {
                   quarter: 'MMM YYYY'
                 }
+              },
+              ticks: {
+                maxRotation: 0
               }
             }
           ],


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/37862

Signed-off-by: Volker Theile <vtheile@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

