### PR TITLE
osd/OSDMonitor: renaming ceph server names support

### DIFF
--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -554,6 +554,8 @@ public:
   void count_metadata(const string& field, map<string,int> *out);
 protected:
   int get_osd_objectstore_type(int osd, std::string *type);
+  int get_osd_hostname(int osd, string* hostname);
+  int update_osd_hostname(int osd, const string& hostname);
   bool is_pool_currently_all_bluestore(int64_t pool_id, const pg_pool_t &pool,
 				       ostream *err);
 


### PR DESCRIPTION
As a part of the infrastructure change we are planning to rename
the servers running ceph-osd, ceph-mon and rbd services. The
IP addresses will be the same, it's only the server names which
will need to change.

This patch adds the core crush-related part for that purpose.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

