### PR TITLE
mgr/dashboard: Fix summary refresh call stack

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
@@ -20,6 +20,14 @@ export class SummaryService {
 
   constructor(private http: HttpClient, private router: Router, private ngZone: NgZone) {
     this.refresh();
+
+    this.ngZone.runOutsideAngular(() => {
+      setInterval(() => {
+        this.ngZone.run(() => {
+          this.refresh();
+        });
+      }, 5000);
+    });
   }
 
   refresh() {
@@ -28,14 +36,6 @@ export class SummaryService {
         this.summaryDataSource.next(data);
       });
     }
-
-    this.ngZone.runOutsideAngular(() => {
-      setTimeout(() => {
-        this.ngZone.run(() => {
-          this.refresh();
-        });
-      }, 5000);
-    });
   }
 
   /**


### PR DESCRIPTION
Currently each time we created a task it would call the summary refresh method.
Since that method was a recursive method, overtime we would get N calls to the
refresh each 5 seconds.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`