### PR TITLE
qa/suites/rados/multimon/tasks/mon_recovery: whitelist PG_AVAILABILITY

### DIFF
--- a/qa/suites/rados/multimon/tasks/mon_recovery.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_recovery.yaml
@@ -4,4 +4,5 @@ tasks:
     log-whitelist:
       - overall HEALTH_
       - \(MON_DOWN\)
+      - \(PG_AVAILABILITY\)
 - mon_recovery:


### PR DESCRIPTION
The mgr creates a pool for device health, and mons may be thrashing and
make peering slow.

Signed-off-by: Sage Weil <sage@redhat.com>