### PR TITLE
luminous ceph-volume: fix JSON output in `inventory`

### DIFF
--- a/src/ceph-volume/ceph_volume/inventory/main.py
+++ b/src/ceph-volume/ceph_volume/inventory/main.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
-import pprint
+import json
 
 from ceph_volume.util.device import Devices, Device
 
@@ -39,8 +39,8 @@ class Inventory(object):
 
     def format_report(self, inventory):
         if self.args.format == 'json':
-            print(inventory.json_report())
+            print(json.dumps(inventory.json_report()))
         elif self.args.format == 'json-pretty':
-            pprint.pprint(inventory.json_report())
+            print(json.dumps(inventory.json_report(), indent=4, sort_keys=True))
         else:
             print(inventory.pretty_report())


### PR DESCRIPTION
Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>

`print()` uses single-quotes by default, which is invalid JSON. 

Fixes http://tracker.ceph.com/issues/37390
Backport of: https://github.com/ceph/ceph/pull/25224