### PR TITLE
rgw: lifcycle: don't reject compound rules with empty prefix

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -90,8 +90,14 @@ bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
   if (rule->get_filter().has_tags()){
     op.obj_tags = rule->get_filter().get_tags();
   }
-  auto ret = prefix_map.emplace(std::move(prefix), std::move(op));
-  return ret.second;
+
+  /* prefix is optional, update prefix map only if prefix...exists */
+  if (!prefix.empty()) {
+    auto ret = prefix_map.emplace(std::move(prefix), std::move(op));
+    return ret.second;
+  }
+
+  return true;
 }
 
 int RGWLifecycleConfiguration::check_and_add_rule(LCRule *rule)


### PR DESCRIPTION

    rgw: lifcycle: don't reject compound rules with empty prefix
    
    A rule containing a tag filter but no constraining prefix is
    legal, as is a sequence of >1 such rules.
    
    Fixes: http://tracker.ceph.com/issues/37879
    

- [ x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

