### PR TITLE
doc: updated rgw multitenancy link

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -349,7 +349,7 @@ Request Parameters
 :Required: Yes
 
 A tenant name may also specified as a part of ``uid``, by following the syntax
-``tenant$user``, refer to `Multitenancy`_ for more details.
+``tenant$user``, refer to :ref:`Multitenancy <rgw-multitenancy>` for more details.
 
 ``display-name``
 
@@ -1978,7 +1978,6 @@ Binding libraries
 
 .. _Admin Guide: ../admin
 .. _Quota Management: ../admin#quota-management
-.. _Multitenancy: ./multitenancy
 .. _QuentinPerez/go-radosgw: https://github.com/QuentinPerez/go-radosgw
 .. _twonote/radosgw-admin4j: https://github.com/twonote/radosgw-admin4j
 .. _UMIACS/rgwadmin: https://github.com/UMIACS/rgwadmin

--- a/doc/radosgw/multitenancy.rst
+++ b/doc/radosgw/multitenancy.rst
@@ -1,3 +1,5 @@
+.. _rgw-multitenancy:
+
 =================
 RGW Multi-tenancy
 =================


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

Fixes include:

- Adding ``:ref:`` label to rgw multitenancy page
(http://docs.ceph.com/docs/master/radosgw/multitenancy/)
- Updating Multitenancy link for reference
(http://docs.ceph.com/docs/master/radosgw/adminops/#id9)

Fixes: https://tracker.ceph.com/issues/37880
Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>