### PR TITLE
qa/tasks/ceph: stop any split/merge activity before scrubbing

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1932,6 +1932,10 @@ def task(ctx, config):
 
             yield
         finally:
+            # set pg_num_targets back to actual pg_num, so we don't have to
+            # wait for pending merges (which can take a while!)
+            ctx.managers[config['cluster']].stop_pg_num_changes()
+
             if config.get('wait-for-scrub', True):
                 osd_scrub_pgs(ctx, config)
 

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1796,6 +1796,21 @@ class CephManager:
             self.pools[pool_name] = new_pg_num
             return True
 
+    def stop_pg_num_changes(self):
+        """
+        Reset all pg_num_targets back to pg_num, canceling splits and merges
+        """
+        self.log('Canceling any pending splits or merges...')
+        osd_dump = self.get_osd_dump_json()
+        for pool in osd_dump['pools']:
+            if pool['pg_num'] != pool['pg_num_target']:
+                self.log('Setting pool %s (%d) pg_num %d -> %d' %
+                         (pool['pool_name'], pool['pool'],
+                          pool['pg_num_target'],
+                          pool['pg_num']))
+                self.raw_cluster_cmd('osd', 'pool', 'set', pool['pool_name'],
+                                     'pg_num', str(pool['pg_num']))
+
     def set_pool_pgpnum(self, pool_name, force):
         """
         Set pgpnum property of pool_name pool.


### PR DESCRIPTION
If there are leftover merges at the end of the run they can take a long
time to get through, blowing our timeout for (waiting for pgs to become
active and to stop splitting/merge) and scrubbing pgs.  Stop all of that
at the end of the run so that we don't have to wait so long.

This resolves some of the 'Scrubbing terminated -- not all pgs were active and clean.' failures in the rados suite.