### PR TITLE
msg/async: fix IP inference

### DIFF
--- a/src/msg/async/ProtocolV1.cc
+++ b/src/msg/async/ProtocolV1.cc
@@ -1794,7 +1794,7 @@ CtPtr ProtocolV1::handle_client_banner(char *buffer, int r) {
   if (peer_addr.is_blank_ip()) {
     // peer apparently doesn't know what ip they have; figure it out for them.
     int port = peer_addr.get_port();
-    peer_addr.u = connection->socket_addr.u;
+    peer_addr.set_sockaddr(connection->target_addr.get_sockaddr());
     peer_addr.set_port(port);
 
     ldout(cct, 0) << __func__ << " accept peer addr is really " << peer_addr

--- a/src/msg/async/ProtocolV2.cc
+++ b/src/msg/async/ProtocolV2.cc
@@ -1837,10 +1837,10 @@ CtPtr ProtocolV2::handle_client_addrvec(char *buffer, int r) {
     if (peer_addr.is_blank_ip()) {
       // peer apparently doesn't know what ip they have; figure it out for them.
       int port = peer_addr.get_port();
-      peer_addr.u = connection->socket_addr.u;
+      peer_addr.set_sockaddr(connection->target_addr.get_sockaddr());
       peer_addr.set_port(port);
       ldout(cct, 0) << __func__ << " accept peer addr is really " << peer_addr
-                    << " (socket is " << connection->socket_addr << ")"
+                    << " (target is " << connection->target_addr << ")"
                     << dendl;
       peer_addr_p = &peer_addr;
     }

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -322,6 +322,9 @@ struct entity_addr_t {
       memset(&u, 0, sizeof(u));
       memcpy(&u.sin6, sa, sizeof(u.sin6));
       break;
+    case AF_UNSPEC:
+      memset(&u, 0, sizeof(u));
+      break;
     default:
       return false;
     }

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -313,9 +313,13 @@ struct entity_addr_t {
   {
     switch (sa->sa_family) {
     case AF_INET:
+      // pre-zero, since we're only copying a portion of the source
+      memset(&u, 0, sizeof(u));
       memcpy(&u.sin, sa, sizeof(u.sin));
       break;
     case AF_INET6:
+      // pre-zero, since we're only copying a portion of the source
+      memset(&u, 0, sizeof(u));
       memcpy(&u.sin6, sa, sizeof(u.sin6));
       break;
     default:

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -440,11 +440,15 @@ struct entity_addr_t {
     __u16 rest;
     decode(marker, bl);
     decode(rest, bl);
-    type = TYPE_LEGACY;
     decode(nonce, bl);
     sockaddr_storage ss;
     decode(ss, bl);
     set_sockaddr((sockaddr*)&ss);
+    if (get_family() == AF_UNSPEC) {
+      type = TYPE_NONE;
+    } else {
+      type = TYPE_LEGACY;
+    }
   }
 
   // Right now, these only deal with sockaddr_storage that have only family and content.

--- a/src/test/test_addrs.cc
+++ b/src/test/test_addrs.cc
@@ -131,7 +131,7 @@ TEST(Msgr, TestEmptyAddrvecEncodeAddrDecode)
   addrvec.encode(bl, 0);
   auto bli = bl.cbegin();
   addr.decode(bli);
-  ASSERT_EQ(addr, entity_addr_t(1, 0));
+  ASSERT_EQ(addr, entity_addr_t());
 }
 
 const char *addrvec_checks[][4] = {
@@ -237,9 +237,11 @@ TEST(Msgr, TestAddrvecEncodeAddrDecode3)
   auto bli = bl.cbegin();
 
   addr.decode(bli);
+  //cout << addrvec << " (legacy " << addrvec.legacy_addr()
+  //<< ") -> " << addr << std::endl;
 
   ASSERT_NE(addr, addrvec.v[0]); // it's not the first addr(which is non-legacy)
-  ASSERT_NE(addr, entity_addr_t(1, 0)); // it's not a blank addr either
+  ASSERT_EQ(addr, entity_addr_t()); // it's not a blank addr either
 }
 
 const char *addrvec_parse_checks[][3] = {


### PR DESCRIPTION
socket_addr is *our* socket address; target_addr is the remote peer's
socket address.  We are inferring the remote's IP address here.

Fixes: http://tracker.ceph.com/issues/37882
Signed-off-by: Sage Weil <sage@redhat.com>