### PR TITLE
DNM: bluestore: FreeBSD make `ceph-osd mkfs` use AIO.

### DIFF
--- a/src/os/bluestore/BlockDevice.cc
+++ b/src/os/bluestore/BlockDevice.cc
@@ -93,9 +93,11 @@ BlockDevice *BlockDevice::create(CephContext* cct, const string& path,
   int r = ::readlink(path.c_str(), buf, sizeof(buf) - 1);
   if (r >= 0) {
     buf[r] = '\0';
+#if defined(HAVE_SPDK)
     char *bname = ::basename(buf);
     if (strncmp(bname, SPDK_PREFIX, sizeof(SPDK_PREFIX)-1) == 0)
       type = "ust-nvme";
+#endif
   }
 
 #if defined(HAVE_BLUESTORE_PMEM)

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2283,7 +2283,7 @@ void BlueFS::_rewrite_log_and_layout_sync(bool allocate_with_fallback,
   log_writer->append(bl);
   r = _flush(log_writer, true);
   ceph_assert(r == 0);
-#ifdef HAVE_LIBAIO
+#if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(log_writer, &completed_ios);
@@ -2863,7 +2863,7 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
   return 0;
 }
 
-#ifdef HAVE_LIBAIO
+#if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
 // we need to retire old completed aios so they don't stick around in
 // memory indefinitely (along with their bufferlist refs).
 void BlueFS::_claim_completed_aios(FileWriter *h, list<aio_t> *ls)
@@ -2983,7 +2983,7 @@ void BlueFS::_flush_bdev_safely(FileWriter *h)
 {
   std::array<bool, MAX_BDEV> flush_devs = h->dirty_devs;
   h->dirty_devs.fill(false);
-#ifdef HAVE_LIBAIO
+#if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
   if (!cct->_conf->bluefs_sync_write) {
     list<aio_t> completed_ios;
     _claim_completed_aios(h, &completed_ios);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1944,7 +1944,7 @@ int BlueFS::_read_random(
       memcpy(out, buf->bl.c_str() + off - buf->bl_off, r);
       out += r;
 
-      dout(30) << __func__ << " result chunk (0x"
+      dout(40) << __func__ << " result chunk (0x"
 	       << std::hex << r << std::dec << " bytes):\n";
       bufferlist t;
       t.substr_of(buf->bl, off - buf->bl_off, r);
@@ -2049,7 +2049,7 @@ int BlueFS::_read(
       out += r;
     }
 
-    dout(30) << __func__ << " result chunk (0x"
+    dout(40) << __func__ << " result chunk (0x"
              << std::hex << r << std::dec << " bytes):\n";
     bufferlist t;
     t.substr_of(buf->bl, off - buf->bl_off, r);
@@ -2824,7 +2824,7 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     break;
   }
 
-  dout(30) << "dump:\n";
+  dout(40) << "dump:\n";
   bl.hexdump(*_dout);
   *_dout << dendl;
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -359,7 +359,7 @@ private:
   int _flush(FileWriter *h, bool force);
   int _fsync(FileWriter *h, std::unique_lock<ceph::mutex>& l);
 
-#ifdef HAVE_LIBAIO
+#if defined(HAVE_LIBAIO) || defined(HAVE_POSIXAIO)
   void _claim_completed_aios(FileWriter *h, std::list<aio_t> *ls);
   void wait_for_aio(FileWriter *h);  // safe to call without a lock
 #endif

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2843,7 +2843,7 @@ bool BlueStore::ExtentMap::encode_some(
     }
   }
   /*derr << __func__ << bl << dendl;
-  derr << __func__ << ":";
+  derr << __func__ << ":\n";
   bl.hexdump(*_dout);
   *_dout << dendl;
   */
@@ -2853,7 +2853,7 @@ bool BlueStore::ExtentMap::encode_some(
 unsigned BlueStore::ExtentMap::decode_some(bufferlist& bl)
 {
   /*
-  derr << __func__ << ":";
+  derr << __func__ << ":\n";
   bl.hexdump(*_dout);
   *_dout << dendl;
   */

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -38,7 +38,7 @@
 #define dout_context cct
 #define dout_subsys ceph_subsys_bdev
 #undef dout_prefix
-#define dout_prefix *_dout << "bdev(" << this << " " << path << ") "
+#define dout_prefix *_dout << "bdev:kd:" << __LINE__ << "(" << this << " " << path << ") "
 
 using std::list;
 using std::map;
@@ -227,7 +227,7 @@ int KernelDevice::open(const string& p)
 	  << " block_size " << block_size
 	  << " (" << byte_u_t(block_size) << ")"
 	  << " " << (rotational ? "rotational" : "non-rotational")
-       << " discard " << (support_discard ? "supported" : "not supported")
+      << " discard " << (support_discard ? "supported" : "not supported")
 	  << dendl;
   return 0;
 
@@ -874,7 +874,7 @@ int KernelDevice::write(
       bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
-  dout(40) << "data: ";
+  dout(40) << "data: \n";
   bl.hexdump(*_dout);
   *_dout << dendl;
 
@@ -903,7 +903,7 @@ int KernelDevice::aio_write(
       bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
-  dout(40) << "data: ";
+  dout(40) << "data: \n";
   bl.hexdump(*_dout);
   *_dout << dendl;
 
@@ -1029,7 +1029,7 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   ceph_assert((uint64_t)r == len);
   pbl->push_back(std::move(p));
 
-  dout(40) << "data: ";
+  dout(40) << "data: \n";
   pbl->hexdump(*_dout);
   *_dout << dendl;
 
@@ -1099,7 +1099,7 @@ int KernelDevice::direct_read_unaligned(uint64_t off, uint64_t len, char *buf)
   ceph_assert((uint64_t)r == aligned_len);
   memcpy(buf, p.c_str() + (off - aligned_off), len);
 
-  dout(40) << __func__ << " data: ";
+  dout(40) << __func__ << " data: \n";
   bufferlist bl;
   bl.append(buf, len);
   bl.hexdump(*_dout);
@@ -1172,7 +1172,7 @@ int KernelDevice::read_random(uint64_t off, uint64_t len, char *buf,
     ceph_assert((uint64_t)r == len);
   }
 
-  dout(40) << __func__ << " data: ";
+  dout(40) << __func__ << " data: \n";
   bufferlist bl;
   bl.append(buf, len);
   bl.hexdump(*_dout);

--- a/src/os/bluestore/aio.cc
+++ b/src/os/bluestore/aio.cc
@@ -2,7 +2,17 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <algorithm>
+
+#include "acconfig.h"
+#include "include/compat.h"
 #include "ceph_aio.h"
+#include "common/errno.h"
+#include "common/debug.h"
+
+#define dout_context cct
+#define dout_subsys ceph_subsys_bdev
+#undef dout_prefix
+#define dout_prefix *_dout << "bdev:aio:" << __LINE__ << " "
 
 std::ostream& operator<<(std::ostream& os, const aio_t& aio)
 {
@@ -15,6 +25,25 @@ std::ostream& operator<<(std::ostream& os, const aio_t& aio)
   return os;
 }
 
+#if defined(HAVE_POSIXAIO)
+std::ostream& operator<<(std::ostream& os, const struct aiocb *cb)
+{
+  os << "aiocb @ "    << &cb << "(";
+  os << "fildes = "   << cb->aio_fildes;
+  os << ", offset = " << cb->aio_offset;
+  os << ", nbytes = " << cb->aio_nbytes;
+  os << ", buf = 0x"    << std::hex << (size_t)cb->aio_buf << std::dec;
+  os << ", lio_opcode = " << cb->aio_lio_opcode;
+  os << ", priv.status = " << cb->_aiocb_private.status;
+  os << ", priv.error = " << cb->_aiocb_private.error;
+  os << ", priv.sigevent.notify = " << cb->aio_sigevent.sigev_notify;
+  os << ", priv.sigevent.notify_kqueue = " << cb->aio_sigevent.sigev_notify_kqueue;
+  os << ", priv.sigevent.kevent_flags = " << cb->aio_sigevent.sigev_notify_kevent_flags;
+  os << ")";
+  return os;
+}
+#endif
+
 int aio_queue_t::submit_batch(aio_iter begin, aio_iter end, 
 			      uint16_t aios_size, void *priv, 
 			      int *retries)
@@ -23,6 +52,11 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
   int attempts = 16;
   int delay = 125;
   int r;
+
+  dout(20) << __func__
+           << " aios_size = " << aios_size
+           << " retries = " << (*retries)
+           << dendl;
 
   aio_iter cur = begin;
   struct aio_t *piocb[aios_size];
@@ -39,18 +73,58 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
 #if defined(HAVE_LIBAIO)
     r = io_submit(ctx, std::min(left, max_iodepth), (struct iocb**)(piocb + done));
 #elif defined(HAVE_POSIXAIO)
+    dout(20) << __func__
+        << " left = " << left
+        << " aio " << &(piocb[done]->aio)
+        << dendl;
     if (piocb[done]->n_aiocb == 1) {
+      dout(25) << __func__
+          << "  n_aiocb == 1 "
+          << " &piocb[done]->aio.aiocbp[0] = " << &(piocb[done]->aio.aiocbp[0])
+          << " on kqueue = " << ctx
+          << " for (fd, off, len) = ("
+            << piocb[done]->aio.aiocbp[0].aio_fildes << ","
+            << piocb[done]->aio.aiocbp[0].aio_offset << ","
+            << piocb[done]->aio.aiocbp[0].aio_nbytes
+          << ")"
+          << dendl;
+      ceph_assert( 0 < piocb[done]->aio.aiocbp[0].aio_fildes
+                   && piocb[done]->aio.aiocbp[0].aio_fildes < 4096 );
       // TODO: consider batching multiple reads together with lio_listio
-      piocb[done]->aio.aiocb.aio_sigevent.sigev_notify = SIGEV_KEVENT;
-      piocb[done]->aio.aiocb.aio_sigevent.sigev_notify_kqueue = ctx;
-      piocb[done]->aio.aiocb.aio_sigevent.sigev_value.sival_ptr = piocb[done];
-      r = aio_read(&piocb[done]->aio.aiocb);
+      piocb[done]->aio.aiocbp[0].aio_sigevent.sigev_notify = SIGEV_KEVENT;
+      piocb[done]->aio.aiocbp[0].aio_sigevent.sigev_notify_kqueue = ctx;
+      piocb[done]->aio.aiocbp[0].aio_sigevent.sigev_notify_kevent_flags =
+                                                                EV_ONESHOT;
+      // make that kevent can read back this piocb
+      piocb[done]->aio.aiocbp[0].aio_sigevent.sigev_value.sival_ptr =
+                                                    (void*)&(piocb[done]->aio);
+      r = 0;
+      switch (piocb[done]->aio.aiocbp[0].aio_lio_opcode) {
+        case LIO_WRITE:
+          r = aio_write(&(piocb[done]->aio.aiocbp[0]));
+          break;
+        case LIO_READ:
+          r = aio_read(&(piocb[done]->aio.aiocbp[0]));
+          break;
+        case LIO_NOP:
+          break;
+        default:
+          ;;
+      }
+      if (r < 0 )
+        r = -errno;
+      else
+        r = 1;
     } else {
+      dout(30) << __func__
+               << "  using lio_listio"
+               << dendl;
       struct sigevent sev;
       sev.sigev_notify = SIGEV_KEVENT;
       sev.sigev_notify_kqueue = ctx;
       sev.sigev_value.sival_ptr = piocb[done];
-      r = lio_listio(LIO_NOWAIT, &piocb[done]->aio.aiocbp, piocb[done]->n_aiocb, &sev);
+      r = lio_listio(LIO_NOWAIT, &piocb[done]->aio.aiocbp,
+                     piocb[done]->n_aiocb, &sev);
     }
 #endif
     if (r < 0) {
@@ -71,13 +145,10 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
   return done;
 }
 
+#if defined(HAVE_LIBAIO)
 int aio_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max)
 {
-#if defined(HAVE_LIBAIO)
   io_event events[max];
-#elif defined(HAVE_POSIXAIO)
-  struct kevent events[max];
-#endif
   struct timespec t = {
     timeout_ms / 1000,
     (timeout_ms % 1000) * 1000 * 1000
@@ -85,40 +156,121 @@ int aio_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max)
 
   int r = 0;
   do {
-#if defined(HAVE_LIBAIO)
     r = io_getevents(ctx, 1, max, events, &t);
-#elif defined(HAVE_POSIXAIO)
-    r = kevent(ctx, NULL, 0, events, max, &t);
-    if (r < 0)
-      r = -errno;
-#endif
   } while (r == -EINTR);
 
   for (int i=0; i<r; ++i) {
-#if defined(HAVE_LIBAIO)
     paio[i] = (aio_t *)events[i].obj;
     paio[i]->rval = events[i].res;
-#else
-    paio[i] = (aio_t*)events[i].udata;
-    if (paio[i]->n_aiocb == 1) {
-      paio[i]->rval = aio_return(&paio[i]->aio.aiocb);
-    } else {
-      // Emulate the return value of pwritev.  I can't find any documentation
-      // for what the value of io_event.res is supposed to be.  I'm going to
-      // assume that it's just like pwritev/preadv/pwrite/pread.
-      paio[i]->rval = 0;
-      for (int j = 0; j < paio[i]->n_aiocb; j++) {
-	int res = aio_return(&paio[i]->aio.aiocbp[j]);
-	if (res < 0) {
-	  paio[i]->rval = res;
-	  break;
-	} else {
-	  paio[i]->rval += res;
-	}
-      }
-      free(paio[i]->aio.aiocbp);
-    }
-#endif
   }
   return r;
 }
+#elif defined(HAVE_POSIXAIO)
+// return value: the number of completed AIOs.
+//        paio:  the completed AIOs
+//        paio->rval: the number of bytes read/written
+// or            zero if a timeout has occurred
+// or            any negative return will result in a assert upon return
+
+int aio_queue_t::get_next_completed(int fd, int timeout_ms, aio_t **paio, int max)
+{
+  struct timespec t = {
+    timeout_ms / 1000,
+    (timeout_ms % 1000) * 1000 * 1000
+  };
+
+  struct kevent events[max];
+  struct kevent ev;
+  dout(21) << __func__ << " kqueue registration"
+      << " on fd = " << fd
+      << " , with kqueue handle ctx = " << ctx
+      << dendl;
+
+  EV_SET(&ev, fd, 0, EV_ADD | EV_CLEAR, 0, 0, 0);
+  int rev = kevent(ctx, &ev, 1, NULL, 0, 0 );
+  if (rev < 0) {
+    dout(1) << __func__ << " kqueue registration error "
+        << " kevent return(" << errno << ") "
+        << cpp_strerror(errno)
+        << dendl;
+    return -errno;
+  }
+  do {
+    dout(21) << __func__ << " running POSIX AIO" << dendl;
+    memset(&events, 0, sizeof(events));
+    rev = kevent(ctx, NULL, 0, events, max, &t);
+    dout(25) << __func__
+        << " on kqueue handle = " << ctx
+        << " kevent return = " << rev
+        << " max = " << max
+        << dendl;
+    if (rev < 0) {
+        dout(5) << __func__
+            << " error event " << cpp_strerror(errno)
+            << dendl;
+        return -errno;
+    } else if (rev == 0) {
+        // Got a timeout
+        timeouts++;
+        dout(30) << __func__ << " return"
+            << " timeouts " << timeouts
+            << " rev = 0"
+            << dendl;
+        return rev;
+      } else {
+        dout(25) << __func__ << " process " << rev << " events"
+            << dendl;
+        // Process all the events posted
+        // Emulate the return value of pwritev. I can't find any documentation
+        // for what the value of io_event.res is supposed to be. I'm going to
+        // assume that it's just like pwritev/preadv/pwrite/pread.
+        for(int i = 0; i < rev; i++) {
+            struct aio_t* aio = (struct aio_t*)events[i].udata;
+            struct aiocb* slot = &(aio->aio.aiocbp[i]);
+            dout(10) << __func__ << " slot = " << &slot << dendl;
+            int ree = aio_error(slot);
+            if (ree < 0) {
+                dout(10) << __func__ << " aio_error" << cpp_strerror(errno)
+                    << dendl;
+            }
+            int res = aio_return(slot);
+            if (res < 0) {
+                // Most common error to be returned here is 22: Invalid argument
+                // Meaning that there was a problem submitting the aio in
+                // aio_{read/write}. Usually a coding problem in submit_batch
+                dout(1) << __func__
+                    << " error in processing event i = " << i
+                    << " aio_return"
+                    << cpp_strerror(errno)
+                    << dendl;
+                return -errno;
+            } else {
+                dout(10) << __func__ << " aio completed: "
+                    << res << " bytes."
+                    << dendl;
+                paio[i]         = aio;
+                paio[i]->rval   = res;
+                paio[i]->fd     = slot->aio_fildes;
+                paio[i]->offset = slot->aio_offset;
+                paio[i]->length = slot->aio_nbytes;
+                paio[i]->cct    = cct;
+                paio[i]->priv   = aio->priv;
+                dout(25) << __func__
+                         << " processing event i = " << i
+                         << " ident = "  << events[i].ident
+                         << " flags = "  << events[i].flags
+                         << " fflags = " << events[i].fflags
+                         << " udata = "  << aio
+                         << " aiocbp = " << slot
+                         << dendl;
+           }
+        }
+    }
+  } while (rev == 0);
+
+  dout(21) << __func__
+           << " finished return = " << rev
+           << dendl;
+  return rev;
+}
+#endif

--- a/src/os/bluestore/aio.cc
+++ b/src/os/bluestore/aio.cc
@@ -17,7 +17,7 @@
 std::ostream& operator<<(std::ostream& os, const aio_t& aio)
 {
   unsigned i = 0;
-  os << "aio: ";
+  os << "aio@ " << &aio << ": ";
   for (auto& iov : aio.iov) {
     os << "\n [" << i++ << "] 0x"
        << std::hex << iov.iov_base << "~" << iov.iov_len << std::dec;

--- a/src/os/bluestore/ceph_aio.h
+++ b/src/os/bluestore/ceph_aio.h
@@ -105,7 +105,7 @@ struct io_queue_t {
   virtual void shutdown() = 0;
   virtual int submit_batch(aio_iter begin, aio_iter end, uint16_t aios_size,
 			   void *priv, int *retries) = 0;
-  virtual int get_next_completed(int timeout_ms, aio_t **paio, int max) = 0;
+  virtual int get_next_completed(int timeout_ms, aio_t **paio, int max, int fd = 0) = 0;
 };
 
 struct aio_queue_t final : public io_queue_t {
@@ -117,12 +117,19 @@ struct aio_queue_t final : public io_queue_t {
   int timeouts;
   int fd;
 #endif
-  CephContext *cct;
+//  CephContext *cct;
+
+  typedef list<aio_t>::iterator aio_iter;
 
   explicit aio_queue_t(unsigned max_iodepth)
     : max_iodepth(max_iodepth),
       ctx(0) {
   }
+//XXXAIO  explicit aio_queue_t(unsigned max_iodepth, CephContext *cct)
+//    : max_iodepth(max_iodepth),
+//      ctx(0),
+//      cct(cct) {
+//  }
   ~aio_queue_t() final {
     ceph_assert(ctx == 0);
   }
@@ -161,5 +168,5 @@ struct aio_queue_t final : public io_queue_t {
 
   int submit_batch(aio_iter begin, aio_iter end, uint16_t aios_size,
 		   void *priv, int *retries) final;
-  int get_next_completed(int timeout_ms, aio_t **paio, int max) final;
+  int get_next_completed(int timeout_ms, aio_t **paio, int max, int fd = 0) final;
 };

--- a/src/os/bluestore/ceph_io_uring.h
+++ b/src/os/bluestore/ceph_io_uring.h
@@ -27,5 +27,5 @@ struct ioring_queue_t final : public io_queue_t {
 
   int submit_batch(aio_iter begin, aio_iter end, uint16_t aios_size,
                    void *priv, int *retries) final;
-  int get_next_completed(int timeout_ms, aio_t **paio, int max) final;
+  int get_next_completed(int timeout_ms, aio_t **paio, int max, int fd = 0) final;
 };

--- a/src/os/bluestore/io_uring.cc
+++ b/src/os/bluestore/io_uring.cc
@@ -189,7 +189,7 @@ int ioring_queue_t::submit_batch(aio_iter beg, aio_iter end,
   return rc;
 }
 
-int ioring_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max)
+int ioring_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max, inf fd)
 {
 get_cqe:
   pthread_mutex_lock(&d->cq_mutex);
@@ -254,7 +254,7 @@ int ioring_queue_t::submit_batch(aio_iter beg, aio_iter end,
   ceph_assert(0);
 }
 
-int ioring_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max)
+int ioring_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max, int fd)
 {
   ceph_assert(0);
 }


### PR DESCRIPTION
- build the correct aio blocks
 - make kevent return completed events and pass
   the original aio struct as priv pointer

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug