### PR TITLE
mgr/balancer: blame if upmap won't actually work

### DIFF
--- a/qa/suites/rados/thrash/d-balancer/upmap.yaml
+++ b/qa/suites/rados/thrash/d-balancer/upmap.yaml
@@ -2,5 +2,6 @@ tasks:
 - exec:
     mon.a:
       - while ! ceph balancer status ; do sleep 1 ; done
+      - ceph osd set-require-min-compat-client luminous
       - ceph balancer mode upmap
       - ceph balancer on

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -374,6 +374,14 @@ class Module(MgrModule):
             }
             return (0, json.dumps(s, indent=4), '')
         elif command['prefix'] == 'balancer mode':
+            if command['mode'] == 'upmap':
+                min_compat_client = self.get_osdmap().dump().get('require_min_compat_client', '')
+                if min_compat_client < 'luminous': # works well because version is alphabetized..
+                    warn = 'min_compat_client "%s" ' \
+                           '< "luminous", which is required for pg-upmap. ' \
+                           'Try "ceph osd set-require-min-compat-client luminous" ' \
+                           'before enabling this mode' % min_compat_client
+                    return (-errno.EPERM, '', warn)
             self.set_module_option('mode', command['mode'])
             return (0, '', '')
         elif command['prefix'] == 'balancer on':


### PR DESCRIPTION
With automatic balancing on, and if mode is set to upmap,
balancer will fail silently if min_compat_client is lower than
luminous.
You can't figure out that unless you take a closer look at the
mgr log, which is super annoying..

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

