### PR TITLE
rgw: fix bug, get -90(msg is too long) when delete too many files at once

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9073,21 +9073,41 @@ int RGWRados::remove_objs_from_index(RGWBucketInfo& bucket_info, list<rgw_obj_in
   if (r < 0)
     return r;
 
-  bufferlist updates;
+  // if the count of files ,need to be deleted, is too big.
+  // Objecter will get error -90(msg is too long)
+  // so we should send 1000 files at one time
+  r = 0;
+  int cnt = 1000;     // the num of files at one time
+  list<rgw_obj_index_key>::iterator begin,end;
+  begin = end = oid_list.begin();
+  for (unsigned int begin_offset = 0; cnt > 0 && begin_offset < oid_list.size(); begin_offset += cnt){
+    dout(2) << "RGWRados::remove_objs_from_index bucket=" << bucket_info.bucket << " objs=" << oid_list.size() << " " << begin_offset << "/" << cnt << dendl;
+    bufferlist updates;
 
-  for (auto iter = oid_list.begin(); iter != oid_list.end(); ++iter) {
-    rgw_bucket_dir_entry entry;
-    entry.key = *iter;
-    dout(2) << "RGWRados::remove_objs_from_index bucket=" << bucket_info.bucket << " obj=" << entry.key.name << ":" << entry.key.instance << dendl;
-    entry.ver.epoch = (uint64_t)-1; // ULLONG_MAX, needed to that objclass doesn't skip out request
-    updates.append(CEPH_RGW_REMOVE | suggest_flag);
-    encode(entry, updates);
+    // calc the begin of files
+    advance(begin, cnt);
+
+    // calc the end of files
+    if (cnt > 0 && oid_list.size() > begin_offset + cnt) {
+      advance(end, cnt);
+    }else
+      end = oid_list.end();
+    
+    // send files begin begin and end
+    for (auto iter = begin; iter != end; ++iter) {
+
+      rgw_bucket_dir_entry entry;
+      entry.key = *iter;
+      dout(2) << "RGWRados::remove_objs_from_index bucket=" << bucket_info.bucket << " obj=" << entry.key.name << ":" << entry.key.instance << dendl;
+      entry.ver.epoch = (uint64_t)-1; // ULLONG_MAX, needed to that objclass doesn't skip out request
+      updates.append(CEPH_RGW_REMOVE | suggest_flag);
+      ::encode(entry, updates);
+    }
+    bufferlist out;
+    r = index_ctx.exec(dir_oid, RGW_CLASS, RGW_DIR_SUGGEST_CHANGES, updates, out);
+    if(r < 0)
+      break;
   }
-
-  bufferlist out;
-
-  r = index_ctx.exec(dir_oid, RGW_CLASS, RGW_DIR_SUGGEST_CHANGES, updates, out);
-
   return r;
 }
 


### PR DESCRIPTION
in the case, we remove a lot of objs at a time, we will get a errno, -90 (msg is too long). change to remove 1000 files per time.

Signed-off-by: simon gao <simon29rock@gmail.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

