### PR TITLE
cls/lock: always store v1 addr in locker_info_t

### DIFF
--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -216,6 +216,13 @@ static int lock_obj(cls_method_context_t hctx,
     expiration += duration;
 
   }
+  // make all addrs of type legacy, because v2 clients speak v2 or v1,
+  // even depending on which OSD they are talking to, and the type
+  // isn't what uniquely identifies them.  also, storing a v1 addr
+  // here means that old clients who get this locker_info won't see an
+  // old "msgr2:" prefix.
+  inst.addr.set_type(entity_addr_t::TYPE_LEGACY);
+
   struct locker_info_t info(expiration, inst.addr, description);
 
   linfo.lockers[id] = info;

--- a/src/cls/lock/cls_lock_ops.cc
+++ b/src/cls/lock/cls_lock_ops.cc
@@ -121,7 +121,7 @@ void cls_lock_get_info_reply::dump(Formatter *f) const
     f->dump_string("description", info.description);
     f->dump_string("cookie", id.cookie);
     f->dump_stream("expiration") << info.expiration;
-    f->dump_stream("addr") << info.addr;
+    f->dump_string("addr", info.addr.get_legacy_str());
     f->close_section();
   }
   f->close_section();

--- a/src/cls/lock/cls_lock_types.cc
+++ b/src/cls/lock/cls_lock_types.cc
@@ -41,7 +41,7 @@ void locker_id_t::generate_test_instances(list<locker_id_t*>& o)
 void locker_info_t::dump(Formatter *f) const
 {
   f->dump_stream("expiration") << expiration;
-  f->dump_stream("addr") << addr;
+  f->dump_string("addr", addr.get_legacy_str());
   f->dump_string("description", description);
 }
 


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>