### PR TITLE
Wip githubmap

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -40,7 +40,6 @@ jan--f Jan Fajerski <jfajerski@suse.com>
 jcsp John Spray <john.spray@redhat.com>
 jdurgin Josh Durgin <jdurgin@redhat.com>
 jecluis João Eduardo Luís <joao@suse.de>
-jlayton Jeff Layton <jlayton@redhat.com>
 joscollin Jos Collin <jcollin@redhat.com>
 jtlayton Jeff Layton <jlayton@redhat.com>
 ktdreyer Ken Dreyer <kdreyer@redhat.com>

--- a/.githubmap
+++ b/.githubmap
@@ -32,7 +32,7 @@ Exotelis Sebastian Krah <skrah@suse.com>
 emmericp Paul Emmerich <paul.emmerich@croit.io>
 epuertat Ernesto Puerta <epuertat@redhat.com>
 fullerdj Douglas Fuller <dfuller@redhat.com>
-gregsfortytwo Gregory Farnum <gfarnum@redhat.com>
+gregsfortytwo Greg Farnum <gfarnum@redhat.com>
 idryomov Ilya Dryomov <idryomov@redhat.com>
 ifed01 Igor Fedotov <ifedotov@suse.com>
 ivancich J. Eric Ivancich <ivancich@redhat.com>


### PR DESCRIPTION
Patrick requested this change for the ptl-tool mapping to work correctly.
Then we noticed a bad "jlayton" entry as his irc and GitHub nicks don't match.