### PR TITLE
crush: fix memory leak

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -2440,6 +2440,7 @@ int CrushWrapper::bucket_remove_item(crush_bucket *bucket, int item)
 	weight_set->weights = (__u32*)realloc(weight_set->weights,
 					      new_size * sizeof(__u32));
       } else {
+        free(weight_set->weights);
 	weight_set->weights = NULL;
       }
       weight_set->size = new_size;
@@ -2451,6 +2452,7 @@ int CrushWrapper::bucket_remove_item(crush_bucket *bucket, int item)
       if (new_size) {
 	arg->ids = (__s32 *)realloc(arg->ids, new_size * sizeof(__s32));
       } else {
+        free(arg->ids);
 	arg->ids = NULL;
       }
       arg->ids_size = new_size;


### PR DESCRIPTION
If we remove the last item of bucket, there should still be
one final entry in the __weights__ field of __weight_set__.
Free the corresponding memory before we __null__ the pointer.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

