### PR TITLE
ceph_argparse: fix --verbose

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1138,7 +1138,7 @@ def validate_command(sigdict, args, verbose=False):
         if matched < best_match_cnt:
             continue
         if verbose:
-            print("better match: {0} > {1}: {3} ".format(
+            print("better match: {0} > {1}: {2} ".format(
                 matched, best_match_cnt, concise_sig(sig)
             ), file=sys.stderr)
         if matched > best_match_cnt:


### PR DESCRIPTION
Fixes traceback when issuing `ceph --verbose osd purge <id>` (and likely other commands).

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

