### PR TITLE
Fix rook spec and have service_describe provide rados_config_location field for nfs services

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -355,6 +355,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                 sd.daemon_name = p['labels']["mgr"]
             elif sd.service_type == "nfs":
                 sd.daemon_name = p['labels']["ceph_nfs"]
+                sd.rados_config_location = self.rook_cluster.get_nfs_conf_url(sd.daemon_name, p['labels']['instance'])
             else:
                 # Unknown type -- skip it
                 continue

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -245,7 +245,7 @@ class RookCluster(object):
                 "namespace": self.rook_namespace
             },
             "spec": {
-                "RADOS": {
+                "rados": {
                     "pool": spec.extended["pool"]
                 },
                 "server": {
@@ -255,7 +255,7 @@ class RookCluster(object):
         }
 
         if "namespace" in spec.extended:
-            rook_nfsgw["spec"]["RADOS"]["namespace"] = spec.extended["namespace"]
+            rook_nfsgw["spec"]["rados"]["namespace"] = spec.extended["namespace"]
 
         with self.ignore_409("NFS cluster '{0}' already exists".format(spec.name)):
             self.rook_api_post("cephnfses/", body=rook_nfsgw)

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -129,6 +129,22 @@ class RookCluster(object):
 
         return nodename_to_devices
 
+    def get_nfs_conf_url(self, nfs_cluster, instance):
+        #
+        # Fetch cephnfs object for "nfs_cluster" and then return a rados://
+        # URL for the instance within that cluster.
+        #
+        ceph_nfs = self.rook_api_get("cephnfses/{0}".format(nfs_cluster))
+        pool = ceph_nfs['spec']['rados']['pool']
+        namespace = ceph_nfs['spec']['rados'].get('namespace', None)
+
+        if namespace == None:
+            url = "rados://{0}/conf-{1}.{2}".format(pool, nfs_cluster, instance)
+        else:
+            url = "rados://{0}/{1}/conf-{2}.{3}".format(pool, namespace, nfs_cluster, instance)
+        return url
+
+
     def describe_pods(self, service_type, service_id, nodename):
         # Go query the k8s API about deployment, containers related to this
         # filesystem


### PR DESCRIPTION
The patch fixes the rook backend to account for a recent change to the ganesha CRD. The second one teaches it how to display the rados_config_location field for nfs services. This is necessary for @rjfd's dashboard integration work.