### PR TITLE
SubmittingPatches: added inline markup to important references

### DIFF
--- a/SubmittingPatches.rst
+++ b/SubmittingPatches.rst
@@ -152,7 +152,7 @@ have been included in the discussion
 --------------------------------------------------------------
 
 If this patch fixes a problem reported by somebody else, consider adding a
-Reported-by: tag to credit the reporter for their contribution. This tag should
+``Reported-by:`` tag to credit the reporter for their contribution. This tag should
 not be added without the reporter's permission, especially if the problem was
 not reported in a public forum. That said, if we diligently credit our bug
 reporters, they will, hopefully, be inspired to help us again in the future.
@@ -254,7 +254,7 @@ email list to ensure your submission is noticed.
 When addressing review comments, can should either add additional patches to
 your branch or (better yet) squash those changes into the relevant commits so
 that the sequence of changes is "clean" and gets things right the first time.
-The 'git rebase -i' command is very helpful in this process. Once you have
+The ``git rebase -i`` command is very helpful in this process. Once you have
 updated your local branch, you can simply force-push to the existing branch
 in your public repository that is referenced by the pull request with
 


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>