### PR TITLE
rpm,debian: package librados2-compat

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -561,6 +561,18 @@ developed as part of the Ceph distributed storage system. This is a
 shared library allowing applications to access the distributed object
 store using a simple file-like interface.
 
+%package -n librados2-compat
+Summary:	Compatibility package for librados2 clients
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
+Obsoletes:	librados2
+Requires:   librados3 = %{_epoch_prefix}%{version}-%{release}
+Provides:   librados2:%{_libdir}/librados.so.2
+%description -n librados2-compat
+This package includes compatibility symlink to allow some librados2
+clients to continue working along with librados3.
+
 %package -n librados-devel
 Summary:	RADOS headers
 %if 0%{?suse_version}
@@ -702,6 +714,7 @@ Summary:	RADOS block device client library
 %if 0%{?suse_version}
 Group:		System/Libraries
 %endif
+Requires:	librados2-compat = %{_epoch_prefix}%{version}-%{release}
 Requires:	librados3 = %{_epoch_prefix}%{version}-%{release}
 Requires:	libradospp1 = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?suse_version}
@@ -1127,6 +1140,9 @@ install -m 0644 -D udev/50-rbd.rules %{buildroot}%{_udevrulesdir}/50-rbd.rules
 
 # sudoers.d
 install -m 0600 -D sudoers.d/ceph-osd-smartctl %{buildroot}%{_sysconfdir}/sudoers.d/ceph-osd-smartctl
+
+# librados2-compat link
+ln -sf librados.so.3 %{buildroot}/%{_libdir}/librados.so.2
 
 #set up placeholder directories
 mkdir -p %{buildroot}%{_sysconfdir}/ceph
@@ -1716,6 +1732,13 @@ fi
 %post -n librados3 -p /sbin/ldconfig
 
 %postun -n librados3 -p /sbin/ldconfig
+
+%files -n librados2-compat
+%{_libdir}/librados.so.2
+
+%post -n librados2-compat -p /sbin/ldconfig
+
+%postun -n librados2-compat -p /sbin/ldconfig
 
 %files -n librados-devel
 %dir %{_includedir}/rados

--- a/debian/control
+++ b/debian/control
@@ -461,6 +461,21 @@ Description: OCF-compliant resource agents for Ceph
  Ceph with OCF-compliant cluster resource managers,
  such as Pacemaker.
 
+Package: librados2-compat
+Architecture: any
+Depends: librados3 (= ${binary:Version})
+Conflicts: librados2
+Provides: librados2
+Breaks: librados2
+Replaces: librados2
+Description: librados2 compatibility symlinks
+ Ceph is a massively scalable, open-source, distributed
+ storage system that runs on commodity hardware and delivers object,
+ block and file system storage.
+ .
+ This package includes compatibility symlinks to allow some librados2
+ clients to continue working along with librados3.
+
 Package: librados3
 Conflicts: librados
 Replaces: librados
@@ -588,7 +603,8 @@ Description: RADOS striping interface (development files)
 Package: librbd1
 Architecture: linux-any
 Section: libs
-Depends: librados3 (= ${binary:Version}),
+Depends: librados2-compat (= ${binary:Version}),
+         librados3 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},
 Description: RADOS block device client library

--- a/debian/librados2-compat.links
+++ b/debian/librados2-compat.links
@@ -1,0 +1,2 @@
+#!/usr/bin/dh-exec
+usr/lib/${DEB_HOST_MULTIARCH}/librados.so.3 usr/lib/${DEB_HOST_MULTIARCH}/librados.so.2


### PR DESCRIPTION
create a symlink from librados.so.2 to librados.so.3 to allow some
librados2 clients to link against librados3. this is an upgrade path for
existing librados2 and/or librbd1 clients to migrate to librados3 and
librbd1 of nautilus release.