### PR TITLE
mgr/dashboard: Fix summary refresh call stack

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.spec.ts
@@ -47,6 +47,7 @@ describe('SummaryService', () => {
   });
 
   it('should call refresh', fakeAsync(() => {
+    summaryService.enablePolling();
     authStorageService.set('foobar', undefined, undefined);
     const calledWith = [];
     summaryService.subscribe((data) => {
@@ -57,10 +58,9 @@ describe('SummaryService', () => {
     expect(calledWith).toEqual([summary, summary]);
     tick(10000);
     expect(calledWith.length).toEqual(4);
-    // In order to not trigger setTimeout again,
+    // In order to not trigger setInterval again,
     // which would raise 'Error: 1 timer(s) still in the queue.'
-    spyOn(summaryService, 'refresh').and.callFake(() => true);
-    tick(5000);
+    window.clearInterval(summaryService.polling);
   }));
 
   describe('Should test methods after first refresh', () => {

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/services/summary.service.ts
@@ -18,8 +18,22 @@ export class SummaryService {
   // Observable streams
   summaryData$ = this.summaryDataSource.asObservable();
 
+  polling: number;
+
   constructor(private http: HttpClient, private router: Router, private ngZone: NgZone) {
+    this.enablePolling();
+  }
+
+  enablePolling() {
     this.refresh();
+
+    this.ngZone.runOutsideAngular(() => {
+      this.polling = window.setInterval(() => {
+        this.ngZone.run(() => {
+          this.refresh();
+        });
+      }, 5000);
+    });
   }
 
   refresh() {
@@ -28,14 +42,6 @@ export class SummaryService {
         this.summaryDataSource.next(data);
       });
     }
-
-    this.ngZone.runOutsideAngular(() => {
-      setTimeout(() => {
-        this.ngZone.run(() => {
-          this.refresh();
-        });
-      }, 5000);
-    });
   }
 
   /**


### PR DESCRIPTION
Currently each time we created a task it would call the summary refresh method.
Since that method was a recursive method, overtime we would get N calls to the
refresh each 5 seconds.

`Signed-off-by: Tiago Melo <tmelo@suse.com>`