### PR TITLE
mgr/dashboard: Add guideline how to brand the UI and update the color scheme

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -260,7 +260,7 @@ or
     $ npm run build -- --prod
 
 Unfortunately it's currently not possible to use multiple configurations when
-serving or buildung the ui at the same time. That means a configuration just
+serving or building the ui at the same time. That means a configuration just
 for the branding ``fileReplacements`` it not an option, because you want to use
 the production configuration anyway
 (https://github.com/angular/angular-cli/issues/10612).

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -234,7 +234,7 @@ Frontend branding
 ~~~~~~~~~~~~~~~~~
 
 Every vendor can customize the 'Ceph dashboard' to his needs. No matter if
-Logo, HTML-Template or Typescript, every file inside the frontend folder can be
+logo, HTML-Template or TypeScript, every file inside the frontend folder can be
 replaced.
 
 To replace files, open ``./frontend/angular.json`` and scroll to the section
@@ -260,17 +260,23 @@ or
     $ npm run build -- --prod
 
 Unfortunately it's currently not possible to use multiple configurations when
-serving or building the ui at the same time. That means a configuration just
-for the branding ``fileReplacements`` it not an option, because you want to use
+serving or building the UI at the same time. That means a configuration just
+for the branding ``fileReplacements`` is not an option, because you want to use
 the production configuration anyway
 (https://github.com/angular/angular-cli/issues/10612).
 Furthermore it's also not possible to use glob expressions for
-``fileReplacements``. As long as the feature hasn't been implemented, the
-vendor has to add the file replacements manually to the angular.json
+``fileReplacements``. As long as the feature hasn't been implemented, you have
+to add the file replacements manually to the angular.json file
 (https://github.com/angular/angular-cli/issues/12354).
 
-Nethertheless you should stick to the suggested naming scheme because it makes
+Nevertheless you should stick to the suggested naming scheme because it makes
 it easier for you to use glob expressions once it's supported in the future.
+
+To change the variable defaults you can overwrite them in the file
+``./frontend/src/vendor.variables.scss``. Just reassign the variable you want
+to change, for example ``$color-primary: teal;``
+To overwrite or extend the default CSS, you can add your own styles in
+``./frontend/src/vendor.overrides.scss``.
 
 I18N
 ----

--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -230,6 +230,48 @@ Example:
       Some <strong>helper</strong> html text
     </cd-helper>
 
+Frontend branding
+~~~~~~~~~~~~~~~~~
+
+Every vendor can customize the 'Ceph dashboard' to his needs. No matter if
+Logo, HTML-Template or Typescript, every file inside the frontend folder can be
+replaced.
+
+To replace files, open ``./frontend/angular.json`` and scroll to the section
+``fileReplacements`` inside the production configuration. Here you can add the
+files you wish to brand. We recommend to place the branded version of a file in
+the same directory as the original one and to add a ``.brand`` to the file
+name, right in front of the file extension. A ``fileReplacement`` could for
+example look like this:
+
+.. code:: javascript
+
+    {
+      "replace": "src/app/core/auth/login/login.component.html",
+      "with": "src/app/core/auth/login/login.component.brand.html"
+    }
+
+To serve or build the branded user interface run:
+
+    $ npm run start -- --prod
+
+or
+
+    $ npm run build -- --prod
+
+Unfortunately it's currently not possible to use multiple configurations when
+serving or buildung the ui at the same time. That means a configuration just
+for the branding ``fileReplacements`` it not an option, because you want to use
+the production configuration anyway
+(https://github.com/angular/angular-cli/issues/10612).
+Furthermore it's also not possible to use glob expressions for
+``fileReplacements``. As long as the feature hasn't been implemented, the
+vendor has to add the file replacements manually to the angular.json
+(https://github.com/angular/angular-cli/issues/12354).
+
+Nethertheless you should stick to the suggested naming scheme because it makes
+it easier for you to use glob expressions once it's supported in the future.
+
 I18N
 ----
 

--- a/src/pybind/mgr/dashboard/frontend/angular.json
+++ b/src/pybind/mgr/dashboard/frontend/angular.json
@@ -27,6 +27,7 @@
               "node_modules/awesome-bootstrap-checkbox/awesome-bootstrap-checkbox.css",
               "node_modules/ngx-bootstrap/datepicker/bs-datepicker.css",
               "src/styles.scss",
+              "src/vendor.overrides.scss",
               "node_modules/ng2-tree/styles.css"
             ],
             "scripts": [

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-list/pool-list.component.scss
@@ -5,7 +5,7 @@
 }
 
 ::ng-deep .pg-working {
-  color: $color-blue;
+  color: $color-primary;
 }
 
 ::ng-deep .pg-warning {

--- a/src/pybind/mgr/dashboard/frontend/src/defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/defaults.scss
@@ -12,8 +12,6 @@ $color-light-yellow: #fff3cd;
 $color-bright-green: #00bb00;
 $color-green: #71843f;
 
-$color-darker-blue: #2172bf;
-$color-dark-blue: #2582d9;
 $color-blue: #288cea;
 $color-light-blue: #d9edf7;
 $color-sky-blue: #afd9ee;
@@ -35,25 +33,29 @@ $color-light-shade-gray: #f3f3f3;
 $color-whitesmoke-gray: #f5f5f5;
 $color-solid-white: #ffffff;
 $color-transparent: rgba(0, 0, 0, 0.09);
+$color-brand-teal: #2b99a8;
 $color-brand-gray: #374249;
-$color-brand-green: #2b99a8;
+
+$color-primary: #2b99a8; //$color-blue - ceph=$color-brand-teal - suse=#00C081
+$color-secondary: #0d2c40; //$color-dark-gray - ceph=$color-brand-gray - suse=#0D2C40
+$color-accent: #00b2e2; // ceph=#ef5c55 - suse=#00b2e2
 
 $color-app-bg: $color-solid-white;
 $color-bg-darken: $color-dark-gray;
-$color-links: $color-blue;
+$color-links: $color-primary;
 $color-links-focus: $color-dark-gray;
 $color-breadcrumb: $color-dark-gray;
 $color-button-text: $color-white-gray;
-$color-button: $color-blue;
-$color-button-hover: $color-dark-blue;
-$color-button-border: $color-darker-blue;
+$color-button: $color-primary;
+$color-button-hover: darken($color-primary, 3);
+$color-button-border: darken($color-primary, 6);
 $color-button-badge: $color-white-gray;
 $color-button-caret: $color-white-gray;
 $color-dropdown-menu: $color-dark-gray;
 $color-dropdown-active-text: $color-white-gray;
-$color-dropdown-active-bg: $color-blue;
+$color-dropdown-active-bg: $color-primary;
 $color-caret-text: $color-solid-white;
-$color-progress-bar-info-bg: $color-blue;
+$color-progress-bar-info-bg: $color-primary;
 $color-progress-bar-freespace-bg: $color-light-gray;
 $color-oaprogress-text: $color-black;
 $color-tags-border: $color-light-gray;
@@ -68,9 +70,9 @@ $color-login-row-text: $color-solid-white;
 $color-login-row-bg: $color-dark-gray;
 $color-password-toggle-text: $color-solid-white;
 $color-password-toggle-bg: $color-solid-gray;
-$color-password-toggle-focus: $color-blue;
-$color-login-checkbox-bg: $color-blue;
-$color-login-checkbox-border: $color-blue;
+$color-password-toggle-focus: $color-primary;
+$color-login-checkbox-bg: $color-primary;
+$color-login-checkbox-border: $color-primary;
 $color-login-active-row-bg: $color-light-yellow;
 $color-login-active-row-text: $color-black;
 
@@ -84,21 +86,21 @@ $color-info-card-background: $color-whitesmoke-gray;
 $color-info-card-border: $color-soft-gray;
 
 /*Navigation*/
-$color-navbar-bg: $color-brand-gray;
+$color-navbar-bg: $color-secondary;
 $color-navbar-brand: $color-white-gray;
-$color-nav-top-bar: $color-blue;
-$color-nav-bottom-bar: $color-brand-green;
+$color-nav-top-bar: $color-primary;
+$color-nav-bottom-bar: $color-primary;
 $color-nav-toggle-bar: $color-white-gray;
 $color-nav-toggle-shadow: $color-solid-white;
 $color-nav-collapse-border: $color-white-gray;
-$color-nav-open-bg: $color-brand-green;
+$color-nav-open-bg: $color-primary;
 $color-nav-links: $color-white-gray;
-$color-nav-links-hover: $color-brand-green;
-$color-nav-active-link-bg: $color-blue;
+$color-nav-links-hover: $color-primary;
+$color-nav-active-link-bg: $color-primary;
 $color-nav-border-top-collapse: $color-white-gray;
 
 /*Helper*/
-$color-helper-bg: $color-blue;
+$color-helper-bg: $color-primary;
 
 /*Table*/
 $color-table-seperator-border: $color-transparent;
@@ -109,10 +111,10 @@ $color-table-header-border: $color-light-gray;
 $color-table-active-row: $color-sky-blue;
 $color-table-active-row-hover: $color-light-blue;
 $color-table-progress-bar-bg: $color-sky-blue;
-$color-table-progress-bar-active: $color-blue;
+$color-table-progress-bar-active: $color-primary;
 $color-table-gradient-1: $color-whitesmoke-gray;
 $color-table-gradient-2: $color-grad-gray;
-$color-table-sort: $color-blue;
+$color-table-sort: $color-primary;
 $color-table-empty-row: $color-light-yellow;
 $color-table-hover-row: $color-white-gray;
 $color-table-even-row-bg: $color-solid-white;

--- a/src/pybind/mgr/dashboard/frontend/src/defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/defaults.scss
@@ -1,143 +1,145 @@
 /*The file suppose to contain all variables, mixins and extends*/
 
-$color-solid-red: #ff0000;
-$color-pink: #a94442;
-$color-light-red: #f2dede;
+@import 'vendor.variables';
 
-$color-orange: #ff6600;
+$color-solid-red: #ff0000 !default;
+$color-pink: #a94442 !default;
+$color-light-red: #f2dede !default;
 
-$color-bright-yellow: #ffc200;
-$color-light-yellow: #fff3cd;
+$color-orange: #ff6600 !default;
 
-$color-bright-green: #00bb00;
-$color-green: #71843f;
+$color-bright-yellow: #ffc200 !default;
+$color-light-yellow: #fff3cd !default;
 
-$color-blue: #288cea;
-$color-light-blue: #d9edf7;
-$color-sky-blue: #afd9ee;
+$color-bright-green: #00bb00 !default;
+$color-green: #71843f !default;
 
-$color-black: #000;
-$color-transparent-black: rgba(0, 0, 0, 0.7);
-$color-solid-gray: #555555;
-$color-dark-gray: #474544;
-$color-gray: #505050;
-$color-mild-gray: #777777;
-$color-blue-gray: #90949c;
-$color-grad-gray: #ededed;
-$color-shadow-gray: rgba(3, 3, 3, 0.175);
-$color-light-gray: #d1d1d1;
-$color-soft-gray: #ddd;
-$color-white-gray: #eee;
-$color-shade-gray: #efefef;
-$color-light-shade-gray: #f3f3f3;
-$color-whitesmoke-gray: #f5f5f5;
-$color-solid-white: #ffffff;
-$color-transparent: rgba(0, 0, 0, 0.09);
-$color-brand-teal: #2b99a8;
-$color-brand-gray: #374249;
+$color-blue: #288cea !default;
+$color-light-blue: #d9edf7 !default;
+$color-sky-blue: #afd9ee !default;
 
-$color-primary: $color-brand-teal;
-$color-secondary: $color-brand-gray;
-$color-accent: #ef5c55;
+$color-black: #000 !default;
+$color-transparent-black: rgba(0, 0, 0, 0.7) !default;
+$color-solid-gray: #555555 !default;
+$color-dark-gray: #474544 !default;
+$color-gray: #505050 !default;
+$color-mild-gray: #777777 !default;
+$color-blue-gray: #90949c !default;
+$color-grad-gray: #ededed !default;
+$color-shadow-gray: rgba(3, 3, 3, 0.175) !default;
+$color-light-gray: #d1d1d1 !default;
+$color-soft-gray: #ddd !default;
+$color-white-gray: #eee !default;
+$color-shade-gray: #efefef !default;
+$color-light-shade-gray: #f3f3f3 !default;
+$color-whitesmoke-gray: #f5f5f5 !default;
+$color-solid-white: #ffffff !default;
+$color-transparent: rgba(0, 0, 0, 0.09) !default;
+$color-brand-teal: #2b99a8 !default;
+$color-brand-gray: #374249 !default;
 
-$color-app-bg: $color-solid-white;
-$color-bg-darken: $color-dark-gray;
-$color-links: $color-primary;
-$color-links-focus: $color-dark-gray;
-$color-breadcrumb: $color-dark-gray;
-$color-button-text: $color-white-gray;
-$color-button: $color-primary;
-$color-button-hover: darken($color-primary, 3);
-$color-button-border: darken($color-primary, 6);
-$color-button-badge: $color-white-gray;
-$color-button-caret: $color-white-gray;
-$color-dropdown-menu: $color-dark-gray;
-$color-dropdown-active-text: $color-white-gray;
-$color-dropdown-active-bg: $color-primary;
-$color-caret-text: $color-solid-white;
-$color-progress-bar-info-bg: $color-primary;
-$color-progress-bar-freespace-bg: $color-light-gray;
-$color-oaprogress-text: $color-black;
-$color-tags-border: $color-light-gray;
-$color-tags-box-shadow: $color-transparent;
-$color-error-btn-bg: $color-light-red;
-$color-error-btn-border: $color-pink;
-$color-noscript-text: $color-mild-gray;
-$color-required-text: $color-pink;
+$color-primary: $color-brand-teal !default;
+$color-secondary: $color-brand-gray !default;
+$color-accent: #ef5c55 !default;
+
+$color-app-bg: $color-solid-white !default;
+$color-bg-darken: $color-dark-gray !default;
+$color-links: $color-primary !default;
+$color-links-focus: $color-dark-gray !default;
+$color-breadcrumb: $color-dark-gray !default;
+$color-button-text: $color-white-gray !default;
+$color-button: $color-primary !default;
+$color-button-hover: darken($color-primary, 3) !default;
+$color-button-border: darken($color-primary, 6) !default;
+$color-button-badge: $color-white-gray !default;
+$color-button-caret: $color-white-gray !default;
+$color-dropdown-menu: $color-dark-gray !default;
+$color-dropdown-active-text: $color-white-gray !default;
+$color-dropdown-active-bg: $color-primary !default;
+$color-caret-text: $color-solid-white !default;
+$color-progress-bar-info-bg: $color-primary !default;
+$color-progress-bar-freespace-bg: $color-light-gray !default;
+$color-oaprogress-text: $color-black !default;
+$color-tags-border: $color-light-gray !default;
+$color-tags-box-shadow: $color-transparent !default;
+$color-error-btn-bg: $color-light-red !default;
+$color-error-btn-border: $color-pink !default;
+$color-noscript-text: $color-mild-gray !default;
+$color-required-text: $color-pink !default;
 
 /*Button*/
-$button-radius: 1.875rem;
+$button-radius: 1.875rem !default;
 
 /*Login*/
-$color-login-row-text: $color-solid-white;
-$color-login-row-bg: $color-secondary;
-$color-password-toggle-text: $color-solid-white;
-$color-password-toggle-bg: $color-solid-gray;
-$color-password-toggle-focus: $color-primary;
-$color-login-checkbox-bg: $color-primary;
-$color-login-checkbox-border: $color-primary;
-$color-login-active-row-bg: $color-light-yellow;
-$color-login-active-row-text: $color-black;
+$color-login-row-text: $color-solid-white !default;
+$color-login-row-bg: $color-secondary !default;
+$color-password-toggle-text: $color-solid-white !default;
+$color-password-toggle-bg: $color-solid-gray !default;
+$color-password-toggle-focus: $color-primary !default;
+$color-login-checkbox-bg: $color-primary !default;
+$color-login-checkbox-border: $color-primary !default;
+$color-login-active-row-bg: $color-light-yellow !default;
+$color-login-active-row-text: $color-black !default;
 
 /*Landing Page*/
 
 /*InfoGroup*/
-$color-info-group-underline: $color-whitesmoke-gray;
+$color-info-group-underline: $color-whitesmoke-gray !default;
 
 /*InfoCard*/
-$color-info-card-background: $color-whitesmoke-gray;
-$color-info-card-border: $color-soft-gray;
+$color-info-card-background: $color-whitesmoke-gray !default;
+$color-info-card-border: $color-soft-gray !default;
 
 /*Navigation*/
-$color-navbar-bg: $color-secondary;
-$color-navbar-brand: $color-white-gray;
-$color-nav-top-bar: $color-primary;
-$color-nav-bottom-bar: $color-primary;
-$color-nav-toggle-bar: $color-white-gray;
-$color-nav-toggle-shadow: $color-solid-white;
-$color-nav-collapse-border: $color-white-gray;
-$color-nav-open-bg: $color-primary;
-$color-nav-links: $color-white-gray;
-$color-nav-links-hover: $color-primary;
-$color-nav-active-link-bg: $color-primary;
-$color-nav-border-top-collapse: $color-white-gray;
+$color-navbar-bg: $color-secondary !default;
+$color-navbar-brand: $color-white-gray !default;
+$color-nav-top-bar: $color-primary !default;
+$color-nav-bottom-bar: $color-primary !default;
+$color-nav-toggle-bar: $color-white-gray !default;
+$color-nav-toggle-shadow: $color-solid-white !default;
+$color-nav-collapse-border: $color-white-gray !default;
+$color-nav-open-bg: $color-primary !default;
+$color-nav-links: $color-white-gray !default;
+$color-nav-links-hover: $color-primary !default;
+$color-nav-active-link-bg: $color-primary !default;
+$color-nav-border-top-collapse: $color-white-gray !default;
 
 /*Helper*/
-$color-helper-bg: $color-primary;
+$color-helper-bg: $color-primary !default;
 
 /*Table*/
-$color-table-seperator-border: $color-transparent;
-$color-table-input-border: $color-transparent;
-$color-table-dropdown-bg: $color-whitesmoke-gray;
-$color-table-header-bg: $color-whitesmoke-gray;
-$color-table-header-border: $color-light-gray;
-$color-table-active-row: $color-sky-blue;
-$color-table-active-row-hover: $color-light-blue;
-$color-table-progress-bar-bg: $color-sky-blue;
-$color-table-progress-bar-active: $color-primary;
-$color-table-gradient-1: $color-whitesmoke-gray;
-$color-table-gradient-2: $color-grad-gray;
-$color-table-sort: $color-primary;
-$color-table-empty-row: $color-light-yellow;
-$color-table-hover-row: $color-white-gray;
-$color-table-even-row-bg: $color-solid-white;
-$color-table-odd-row-bg: $color-whitesmoke-gray;
-$color-table-datatable-header: $color-whitesmoke-gray;
+$color-table-seperator-border: $color-transparent !default;
+$color-table-input-border: $color-transparent !default;
+$color-table-dropdown-bg: $color-whitesmoke-gray !default;
+$color-table-header-bg: $color-whitesmoke-gray !default;
+$color-table-header-border: $color-light-gray !default;
+$color-table-active-row: $color-sky-blue !default;
+$color-table-active-row-hover: $color-light-blue !default;
+$color-table-progress-bar-bg: $color-sky-blue !default;
+$color-table-progress-bar-active: $color-primary !default;
+$color-table-gradient-1: $color-whitesmoke-gray !default;
+$color-table-gradient-2: $color-grad-gray !default;
+$color-table-sort: $color-primary !default;
+$color-table-empty-row: $color-light-yellow !default;
+$color-table-hover-row: $color-white-gray !default;
+$color-table-even-row-bg: $color-solid-white !default;
+$color-table-odd-row-bg: $color-whitesmoke-gray !default;
+$color-table-datatable-header: $color-whitesmoke-gray !default;
 
 /*Chart tooltip*/
-$color-chart-tooltip-bg: $color-transparent-black;
-$color-chat-tooltip-text: $color-solid-white;
-$color-chart-tooltip-border: $color-black;
+$color-chart-tooltip-bg: $color-transparent-black !default;
+$color-chat-tooltip-text: $color-solid-white !default;
+$color-chart-tooltip-border: $color-black !default;
 
 /*Popover*/
-$color-popover-seperator-text: $color-blue-gray;
-$color-popover-seperator-bg: $color-white-gray;
-$color-popover-message-text: $color-dark-gray;
-$color-popover-table-text: $color-dark-gray;
-$color-popover-date: $color-solid-gray;
+$color-popover-seperator-text: $color-blue-gray !default;
+$color-popover-seperator-bg: $color-white-gray !default;
+$color-popover-message-text: $color-dark-gray !default;
+$color-popover-table-text: $color-dark-gray !default;
+$color-popover-date: $color-solid-gray !default;
 
 /*RGW user form*/
-$color-rgw-icon: $color-blue-gray;
+$color-rgw-icon: $color-blue-gray !default;
 
 @mixin table-cell {
   padding: 5px;

--- a/src/pybind/mgr/dashboard/frontend/src/defaults.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/defaults.scss
@@ -36,9 +36,9 @@ $color-transparent: rgba(0, 0, 0, 0.09);
 $color-brand-teal: #2b99a8;
 $color-brand-gray: #374249;
 
-$color-primary: #2b99a8; //$color-blue - ceph=$color-brand-teal - suse=#00C081
-$color-secondary: #0d2c40; //$color-dark-gray - ceph=$color-brand-gray - suse=#0D2C40
-$color-accent: #00b2e2; // ceph=#ef5c55 - suse=#00b2e2
+$color-primary: $color-brand-teal;
+$color-secondary: $color-brand-gray;
+$color-accent: #ef5c55;
 
 $color-app-bg: $color-solid-white;
 $color-bg-darken: $color-dark-gray;
@@ -65,9 +65,12 @@ $color-error-btn-border: $color-pink;
 $color-noscript-text: $color-mild-gray;
 $color-required-text: $color-pink;
 
+/*Button*/
+$button-radius: 1.875rem;
+
 /*Login*/
 $color-login-row-text: $color-solid-white;
-$color-login-row-bg: $color-dark-gray;
+$color-login-row-bg: $color-secondary;
 $color-password-toggle-text: $color-solid-white;
 $color-password-toggle-bg: $color-solid-gray;
 $color-password-toggle-focus: $color-primary;

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -117,11 +117,11 @@ fieldset[disabled] .btn-primary:active,
 .btn-primary.disabled.active,
 .btn-primary[disabled].active,
 fieldset[disabled] .btn-primary.active {
-  background-color: $color-blue;
+  background-color: $color-primary;
   border-color: $color-button-border;
 }
 .btn-primary .badge {
-  color: $color-blue;
+  color: $color-primary;
   background-color: $color-button-badge;
 }
 .btn-primary .caret {
@@ -286,6 +286,15 @@ uib-accordion .panel-title,
   font-size: 6px;
   padding-left: 4px;
   vertical-align: text-top;
+}
+.form-control {
+  display: table-cell;
+
+  &:focus {
+    border-color: rgba($color-primary, 0.8);
+    outline: 0;
+    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px 2px rgba($color-primary, 0.5);
+  }
 }
 /* Panel */
 .panel-footer button.btn:not(:first-child) {

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -83,10 +83,21 @@ option {
 }
 
 /* Buttons */
+.btn {
+  &,
+  &:active,
+  &.active {
+    &:focus,
+    &.focus {
+      outline: 0;
+    }
+  }
+}
 .btn-primary {
   color: $color-button-text;
-  background-color: $color-button;
-  border-color: $color-button-border;
+  background-color: $color-accent;
+  border-color: $color-accent;
+  border-radius: $button-radius;
 }
 .btn-primary:hover,
 .btn-primary:focus,
@@ -94,13 +105,19 @@ option {
 .btn-primary.active,
 .open .dropdown-toggle.btn-primary {
   color: $color-button-text;
-  background-color: $color-button-hover;
-  border-color: $color-button-border;
+  background-color: lighten($color-accent, 10);
+  border-color: lighten($color-accent, 10);
 }
 .btn-primary:active,
 .btn-primary.active,
 .open .dropdown-toggle.btn-primary {
   background-image: none;
+
+  &:hover,
+  &:focus{
+    background-color: lighten($color-accent, 10);
+    border-color: lighten($color-accent, 10);
+  }
 }
 .btn-primary.disabled,
 .btn-primary[disabled],
@@ -117,8 +134,8 @@ fieldset[disabled] .btn-primary:active,
 .btn-primary.disabled.active,
 .btn-primary[disabled].active,
 fieldset[disabled] .btn-primary.active {
-  background-color: $color-primary;
-  border-color: $color-button-border;
+  background-color: $color-accent;
+  border-color: $color-accent;
 }
 .btn-primary .badge {
   color: $color-primary;
@@ -126,6 +143,12 @@ fieldset[disabled] .btn-primary.active {
 }
 .btn-primary .caret {
   color: $color-button-caret;
+}
+.btn-default {
+  border-radius: $button-radius;
+}
+.form-group .btn-default {
+  border-radius: 4px;
 }
 .btn-group > .btn > i.fa,
 button.btn.btn-label > i.fa {
@@ -148,6 +171,12 @@ button.btn.btn-label > i.fa {
 .dropdown-menu > .active > a {
   color: $color-dropdown-active-text;
   background-color: $color-dropdown-active-bg;
+
+  &,
+  &:hover,
+  &:focus {
+    background-color: darken($color-dropdown-active-bg, 10);
+  }
 }
 .dataTables_wrapper .dropdown-menu > li.divider {
   cursor: auto;

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -114,7 +114,7 @@ option {
   background-image: none;
 
   &:hover,
-  &:focus{
+  &:focus {
     background-color: lighten($color-accent, 10);
     border-color: lighten($color-accent, 10);
   }
@@ -322,7 +322,7 @@ uib-accordion .panel-title,
   &:focus {
     border-color: rgba($color-primary, 0.8);
     outline: 0;
-    box-shadow: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px 2px rgba($color-primary, 0.5);
+    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075), 0 0 8px 2px rgba($color-primary, 0.5);
   }
 }
 /* Panel */

--- a/src/pybind/mgr/dashboard/frontend/src/vendor.overrides.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/vendor.overrides.scss
@@ -1,0 +1,3 @@
+/* Vendor specific scss */
+
+@import 'defaults';

--- a/src/pybind/mgr/dashboard/frontend/src/vendor.variables.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/vendor.variables.scss
@@ -1,2 +1,1 @@
 /* Vendor specific variables */
-

--- a/src/pybind/mgr/dashboard/frontend/src/vendor.variables.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/vendor.variables.scss
@@ -1,0 +1,2 @@
+/* Vendor specific variables */
+


### PR DESCRIPTION
Add guidelines for the vendors how to brand the frontend of the ceph dashboard.

I also updated the color scheme of the UI to match the branding of ceph.com

![ceph-dashboard-ui-branded-01](https://user-images.githubusercontent.com/7863239/51253322-3ff41a00-199e-11e9-9e6f-6e3cdcf98d1f.jpg)

As you can see in the screenshot I changed the layout of the buttons as well as the hyperlink text color. The idea was to use as less different colors as possible to keep the color scheme consistent and clean. That's why I added the scss variables `$color-primary`, `$color-secondary` and `$color-accent` which are assigned to the most important and eye-catching elements.

- [ ] References tracker ticket
- [x] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

