### PR TITLE
mgr/dashboard: Fix /api/grafana/validation

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/grafana.py
+++ b/src/pybind/mgr/dashboard/controllers/grafana.py
@@ -32,6 +32,7 @@ class Grafana(BaseController):
     def validation(self, params):
         grafana = GrafanaRestClient()
         method = 'GET'
-        url = Settings.GRAFANA_API_URL + '/api/dashboards/uid/' + params
+        url = Settings.GRAFANA_API_URL.rstrip('/') + \
+            '/api/dashboards/uid/' + params
         response = grafana.url_validation(method, url)
         return response


### PR DESCRIPTION
If the Grafana URL contains a trailing slash, this endpoint ends up
returning a 404, disabling the integration entirely. Fix that.

Signed-off-by: Zack Cerza <zack@redhat.com>