### PR TITLE
Clean up field names in ServiceDescription and add a service field

### DIFF
--- a/src/pybind/mgr/deepsea/module.py
+++ b/src/pybind/mgr/deepsea/module.py
@@ -183,10 +183,10 @@ class DeepSeaOrchestrator(MgrModule, orchestrator.Orchestrator):
             result = []
             if event_data['success']:
                 for node_name, service_info in event_data["return"].items():
-                    for service_type, daemon_name in service_info.items():
+                    for service_type, service_instance in service_info.items():
                         desc = orchestrator.ServiceDescription()
                         desc.nodename = node_name
-                        desc.daemon_name = daemon_name
+                        desc.service_instance = service_instance
                         desc.service_type = service_type
                         result.append(desc)
             return result

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -406,6 +406,17 @@ class ServiceDescription(object):
         # justify having this field here.
         self.container_id = None
 
+        # Some services can be deployed in groups. For example, mds's can
+        # have an active and standby daemons, and nfs-ganesha can run daemons
+        # in parallel. This tag refers to a group of daemons as a whole.
+        #
+        # For instance, a cluster of mds' all service the same fs, and they
+        # will all have the same service_group (which may be the
+        # Filesystem name in the FSMap).
+        #
+        # Single-instance services should leave this set to None
+        self.service = None
+
         # The orchestrator will have picked some names for daemons,
         # typically either based on hostnames or on pod names.
         # This is the <foo> in mds.<foo>, the ID that will appear
@@ -436,6 +447,7 @@ class ServiceDescription(object):
         out = {
             'nodename': self.nodename,
             'container_id': self.container_id,
+            'service': self.service,
             'service_instance': self.service_instance,
             'service_type': self.service_type,
             'version': self.version,

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -411,7 +411,7 @@ class ServiceDescription(object):
         # in parallel. This tag refers to a group of daemons as a whole.
         #
         # For instance, a cluster of mds' all service the same fs, and they
-        # will all have the same service_group (which may be the
+        # will all have the same service value (which may be the
         # Filesystem name in the FSMap).
         #
         # Single-instance services should leave this set to None

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -410,7 +410,7 @@ class ServiceDescription(object):
         # typically either based on hostnames or on pod names.
         # This is the <foo> in mds.<foo>, the ID that will appear
         # in the FSMap/ServiceMap.
-        self.daemon_name = None
+        self.service_instance = None
 
         # The type of service (osd, mon, mgr, etc.)
         self.service_type = None
@@ -436,7 +436,7 @@ class ServiceDescription(object):
         out = {
             'nodename': self.nodename,
             'container_id': self.container_id,
-            'daemon_name': self.daemon_name,
+            'service_instance': self.service_instance,
             'service_type': self.service_type,
             'version': self.version,
             'rados_config_location': self.rados_config_location,

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -191,7 +191,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         services = completion.result
 
         # Sort the list for display
-        services.sort(key=lambda s: (s.service_type, s.nodename, s.daemon_name))
+        services.sort(key=lambda s: (s.service_type, s.nodename, s.service_instance))
 
         if len(services) == 0:
             return HandleCommandResult(stdout="No services reported")
@@ -203,7 +203,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
             for s in services:
                 lines.append("{0}.{1} {2} {3} {4} {5}".format(
                     s.service_type,
-                    s.daemon_name,
+                    s.service_instance,
                     s.nodename,
                     s.container_id,
                     s.version,

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -201,9 +201,14 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         else:
             lines = []
             for s in services:
-                lines.append("{0}.{1} {2} {3} {4} {5}".format(
+                if s.service == None:
+                    service_id = s.service_instance
+                else:
+                    service_id = "{0}.{1}".format(s.service, s.service_instance)
+
+                lines.append("{0} {1} {2} {3} {4} {5}".format(
                     s.service_type,
-                    s.service_instance,
+                    service_id,
                     s.nodename,
                     s.container_id,
                     s.version,

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -346,16 +346,16 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             sd.service_type = p['labels']['app'].replace('rook-ceph-', '')
 
             if sd.service_type == "osd":
-                sd.daemon_name = "%s" % p['labels']["ceph-osd-id"]
+                sd.service_instance = "%s" % p['labels']["ceph-osd-id"]
             elif sd.service_type == "mds":
-                sd.daemon_name = p['labels']["rook_file_system"]
+                sd.service_instance = p['labels']["rook_file_system"]
             elif sd.service_type == "mon":
-                sd.daemon_name = p['labels']["mon"]
+                sd.service_instance = p['labels']["mon"]
             elif sd.service_type == "mgr":
-                sd.daemon_name = p['labels']["mgr"]
+                sd.service_instance = p['labels']["mgr"]
             elif sd.service_type == "nfs":
-                sd.daemon_name = p['labels']["ceph_nfs"]
-                sd.rados_config_location = self.rook_cluster.get_nfs_conf_url(sd.daemon_name, p['labels']['instance'])
+                sd.service_instance = p['labels']["ceph_nfs"]
+                sd.rados_config_location = self.rook_cluster.get_nfs_conf_url(sd.service_instance, p['labels']['instance'])
             else:
                 # Unknown type -- skip it
                 continue

--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -348,14 +348,17 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             if sd.service_type == "osd":
                 sd.service_instance = "%s" % p['labels']["ceph-osd-id"]
             elif sd.service_type == "mds":
-                sd.service_instance = p['labels']["rook_file_system"]
+                sd.service = p['labels']['rook_file_system']
+                pfx = "{0}-".format(sd.service)
+                sd.service_instance = p['labels']['ceph_daemon_id'].replace(pfx, '', 1)
             elif sd.service_type == "mon":
                 sd.service_instance = p['labels']["mon"]
             elif sd.service_type == "mgr":
                 sd.service_instance = p['labels']["mgr"]
             elif sd.service_type == "nfs":
-                sd.service_instance = p['labels']["ceph_nfs"]
-                sd.rados_config_location = self.rook_cluster.get_nfs_conf_url(sd.service_instance, p['labels']['instance'])
+                sd.service = p['labels']['ceph_nfs']
+                sd.service_instance = p['labels']['instance']
+                sd.rados_config_location = self.rook_cluster.get_nfs_conf_url(sd.service, sd.service_instance)
             else:
                 # Unknown type -- skip it
                 continue

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -238,7 +238,7 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
         for p in processes:
             sd = orchestrator.ServiceDescription()
             sd.nodename = 'localhost'
-            sd.daemon_name = re.search('ceph-[^ ]+', p).group()
+            sd.service_instance = re.search('ceph-[^ ]+', p).group()
             result.append(sd)
 
         return result


### PR DESCRIPTION
This brings the naming of fields in ServiceDescription closer in line to the document here:

https://docs.google.com/document/d/17DIs_NCMBsTG3jbrhsG0Ot5y40TC9ADDZgEhmtF6Yks/edit

It does two things:

- rename daemon_name field to service_instance
- add a new service_group field that indicates a group or cluster of service_instances