### PR TITLE
mimic: mgr/dashboard: Set mirror_mode to None

### DIFF
--- a/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
+++ b/src/pybind/mgr/dashboard/controllers/rbd_mirroring.py
@@ -94,6 +94,7 @@ def get_daemons_and_pools():  # pylint: disable=R0915
                 mirror_mode = rbdctx.mirror_mode_get(ioctx)
             except:  # noqa pylint: disable=W0702
                 logger.exception("Failed to query mirror mode %s", pool_name)
+                mirror_mode = None
 
             stats = {}
             if mirror_mode == rbd.RBD_MIRROR_MODE_DISABLED:


### PR DESCRIPTION
Fixes http://tracker.ceph.com/issues/37870
Fixes https://github.com/rook/rook/issues/2404

Used existing fix from dc616c7d724a2580927ff8fb1fbc070d83dd67ef

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

