### PR TITLE
luminous: qa: test_damage needs to silence MDS_READ_ONLY

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/damage.yaml
+++ b/qa/suites/fs/basic_functional/tasks/damage.yaml
@@ -17,6 +17,8 @@ overrides:
       - Corrupt dentry
       - Scrub error on inode
       - Metadata damage detected
+      - MDS_READ_ONLY
+      - force file system read-only
 
 tasks:
   - cephfs_test_runner:

--- a/qa/suites/kcephfs/recovery/tasks/damage.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/damage.yaml
@@ -17,6 +17,8 @@ overrides:
       - Corrupt dentry
       - Scrub error on inode
       - Metadata damage detected
+      - MDS_READ_ONLY
+      - force file system read-only
 
 tasks:
   - cephfs_test_runner:


### PR DESCRIPTION
http://tracker.ceph.com/issues/37953