### PR TITLE
luminous ceph-volume zap devices associated with an OSD ID and/or OSD FSID

### DIFF
--- a/doc/ceph-volume/lvm/zap.rst
+++ b/doc/ceph-volume/lvm/zap.rst
@@ -15,18 +15,51 @@ on the given lv or partition will be removed and all data will be purged.
 
 Zapping a logical volume::
 
-      ceph-volume lvm zap {vg name/lv name}
+    ceph-volume lvm zap {vg name/lv name}
 
 Zapping a partition::
 
-      ceph-volume lvm zap /dev/sdc1
+    ceph-volume lvm zap /dev/sdc1
 
-If you are zapping a raw device or partition and would like any vgs or lvs created
-from that device removed use the ``--destroy`` flag. A common use case is to simply
-deploy OSDs using a whole raw device. If you do so and then wish to reuse that device for
-another OSD you must use the ``--destroy`` flag when zapping so that the vgs and lvs that
-ceph-volume created on the raw device will be removed.
+Removing Devices
+----------------
+When zapping, and looking for full removal of the device (lv, vg, or partition)
+use the ``--destroy`` flag. A common use case is to simply deploy OSDs using
+a whole raw device. If you do so and then wish to reuse that device for another
+OSD you must use the ``--destroy`` flag when zapping so that the vgs and lvs
+that ceph-volume created on the raw device will be removed.
+
+.. note:: Multiple devices can be accepted at once, to zap them all
 
 Zapping a raw device and destroying any vgs or lvs present::
 
-      ceph-volume lvm zap /dev/sdc --destroy
+    ceph-volume lvm zap /dev/sdc --destroy
+
+
+This action can be performed on partitions, and logical volumes as well::
+
+    ceph-volume lvm zap /dev/sdc1 --destroy
+    ceph-volume lvm zap osd-vg/data-lv --destroy
+
+
+Finally, multiple devices can be detected if filtering by OSD ID and/or OSD
+FSID. Either identifier can be used or both can be used at the same time. This
+is useful in situations where multiple devices associated with a specific ID
+need to be purged. When using the FSID, the filtering is stricter, and might
+not match other (possibly invalid) devices associated to an ID.
+
+By ID only::
+
+    ceph-volume lvm zap --destroy --osd-id 1
+
+By FSID::
+
+    ceph-volume lvm zap --destroy --osd-fsid 2E8FBE58-0328-4E3B-BFB7-3CACE4E9A6CE
+
+By both::
+
+    ceph-volume lvm zap --destroy --osd-fsid 2E8FBE58-0328-4E3B-BFB7-3CACE4E9A6CE --osd-id 1
+
+
+.. warning:: If the systemd unit associated with the OSD ID to be zapped is
+             detected as running, the tool will refuse to zap until the daemon is stopped.

--- a/doc/man/8/ceph-volume.rst
+++ b/doc/man/8/ceph-volume.rst
@@ -226,6 +226,17 @@ Usage, for logical partitions::
 
       ceph-volume lvm zap /dev/sdc1
 
+For full removal of the device use the ``--destroy`` flag (allowed for all
+device types)::
+
+      ceph-volume lvm zap --destroy /dev/sdc1
+
+Multiple devices can be removed by specifying the OSD ID and/or the OSD FSID::
+
+      ceph-volume lvm zap --destroy --osd-id 1
+      ceph-volume lvm zap --destroy --osd-id 1 --osd-fsid C9605912-8395-4D76-AFC0-7DFDAC315D59
+
+
 Positional arguments:
 
 * <DEVICE>  Either in the form of ``vg/lv`` for logical volumes,

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -8,6 +8,7 @@ from ceph_volume import decorators, terminal, process
 from ceph_volume.api import lvm as api
 from ceph_volume.util import system, encryption, disk, arg_validators
 from ceph_volume.util.device import Device
+from ceph_volume.systemd import systemctl
 
 logger = logging.getLogger(__name__)
 mlogger = terminal.MultiLogger(__name__)
@@ -39,6 +40,79 @@ def zap_data(path):
         'bs=1M',
         'count=10',
     ])
+
+
+def find_associated_devices(osd_id=None, osd_fsid=None):
+    """
+    From an ``osd_id`` and/or an ``osd_fsid``, filter out all the LVs in the
+    system that match those tag values, further detect if any partitions are
+    part of the OSD, and then return the set of LVs and partitions (if any).
+    """
+    lv_tags = {}
+    if osd_id:
+        lv_tags['ceph.osd_id'] = osd_id
+    if osd_fsid:
+        lv_tags['ceph.osd_fsid'] = osd_fsid
+    lvs = api.Volumes()
+    lvs.filter(lv_tags=lv_tags)
+    if not lvs:
+        raise RuntimeError('Unable to find any LV for zapping OSD: %s' % osd_id or osd_fsid)
+
+    devices_to_zap = ensure_associated_lvs(lvs)
+
+    return [Device(path) for path in set(devices_to_zap) if path]
+
+
+def ensure_associated_lvs(lvs):
+    """
+    Go through each LV and ensure if backing devices (journal, wal, block)
+    are LVs or partitions, so that they can be accurately reported.
+    """
+    # look for many LVs for each backing type, because it is possible to
+    # recieve a filtering for osd.1, and have multiple failed deployments
+    # leaving many journals with osd.1 - usually, only a single LV will be
+    # returned
+    journal_lvs = lvs._filter(lv_tags={'ceph.type': 'journal'})
+    db_lvs = lvs._filter(lv_tags={'ceph.type': 'db'})
+    wal_lvs = lvs._filter(lv_tags={'ceph.type': 'wal'})
+    backing_devices = [
+        (journal_lvs, 'journal'),
+        (db_lvs, 'block'),
+        (wal_lvs, 'wal')
+    ]
+
+    verified_devices = []
+
+    for lv in lvs:
+        # go through each lv and append it, otherwise query `blkid` to find
+        # a physical device. Do this for each type (journal,db,wal) regardless
+        # if they have been processed in the previous LV, so that bad devices
+        # with the same ID can be caught
+        for ceph_lvs, _type in backing_devices:
+            if ceph_lvs:
+                verified_devices.extend([l.lv_path for l in ceph_lvs])
+                continue
+
+            # must be a disk partition, by querying blkid by the uuid we are
+            # ensuring that the device path is always correct
+            try:
+                device_uuid = lv.tags['ceph.%s_uuid' % _type]
+            except KeyError:
+                # Bluestore will not have ceph.journal_uuid, and Filestore
+                # will not not have ceph.db_uuid
+                continue
+
+            osd_device = disk.get_device_from_partuuid(device_uuid)
+            if not osd_device:
+                # if the osd_device is not found by the partuuid, then it is
+                # not possible to ensure this device exists anymore, so skip it
+                continue
+            verified_devices.append(osd_device)
+
+        verified_devices.append(lv.lv_path)
+
+    # reduce the list from all the duplicates that were added
+    return list(set(verified_devices))
 
 
 class Zap(object):
@@ -147,8 +221,10 @@ class Zap(object):
         zap_data(device.abspath)
 
     @decorators.needs_root
-    def zap(self):
-        for device in self.args.devices:
+    def zap(self, devices=None):
+        devices = devices or self.args.devices
+
+        for device in devices:
             mlogger.info("Zapping: %s", device.abspath)
             if device.is_mapper:
                 terminal.error("Refusing to zap the mapper device: {}".format(device))
@@ -163,6 +239,17 @@ class Zap(object):
                 self.zap_raw_device(device)
 
         terminal.success("Zapping successful for: %s" % ", ".join([str(d) for d in self.args.devices]))
+
+    @decorators.needs_root
+    def zap_osd(self):
+        if self.args.osd_id:
+            osd_is_running = systemctl.osd_is_active(self.args.osd_id)
+            if osd_is_running:
+                mlogger.error("OSD ID %s is running, stop it with:" % self.args.osd_id)
+                mlogger.error("systemctl stop ceph-osd@%s" % self.args.osd_id)
+                raise SystemExit("Unable to zap devices associated with OSD ID: %s" % self.args.osd_id)
+        devices = find_associated_devices(self.args.osd_id, self.args.osd_fsid)
+        self.zap(devices)
 
     def dmcrypt_close(self, dmcrypt_uuid):
         dmcrypt_path = "/dev/mapper/{}".format(dmcrypt_uuid)
@@ -195,6 +282,14 @@ class Zap(object):
 
               ceph-volume lvm zap /dev/sda /dev/sdb /db/sdc
 
+          Zapping devices associated with an OSD ID:
+
+              ceph-volume lvm zap --osd-id 1
+
+            Optionally include the OSD FSID
+
+              ceph-volume lvm zap --osd-id 1 --osd-fsid 55BD4219-16A7-4037-BC20-0F158EFCC83D
+
         If the --destroy flag is given and you are zapping a raw device or partition
         then all vgs and lvs that exist on that raw device or partition will be destroyed.
 
@@ -223,14 +318,31 @@ class Zap(object):
             default=[],
             help='Path to one or many lv (as vg/lv), partition (as /dev/sda1) or device (as /dev/sda)'
         )
+
         parser.add_argument(
             '--destroy',
             action='store_true',
             default=False,
             help='Destroy all volume groups and logical volumes if you are zapping a raw device or partition',
         )
+
+        parser.add_argument(
+            '--osd-id',
+            help='Specify an OSD ID to detect associated devices for zapping',
+        )
+
+        parser.add_argument(
+            '--osd-fsid',
+            help='Specify an OSD FSID to detect associated devices for zapping',
+        )
+
         if len(self.argv) == 0:
             print(sub_command_help)
             return
+
         self.args = parser.parse_args(self.argv)
-        self.zap()
+
+        if self.args.osd_id or self.args.osd_fsid:
+            self.zap_osd()
+        else:
+            self.zap()

--- a/src/ceph-volume/ceph_volume/devices/lvm/zap.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/zap.py
@@ -69,7 +69,7 @@ def ensure_associated_lvs(lvs):
     are LVs or partitions, so that they can be accurately reported.
     """
     # look for many LVs for each backing type, because it is possible to
-    # recieve a filtering for osd.1, and have multiple failed deployments
+    # receive a filtering for osd.1, and have multiple failed deployments
     # leaving many journals with osd.1 - usually, only a single LV will be
     # returned
     journal_lvs = lvs._filter(lv_tags={'ceph.type': 'journal'})
@@ -238,7 +238,14 @@ class Zap(object):
             if device.is_device:
                 self.zap_raw_device(device)
 
-        terminal.success("Zapping successful for: %s" % ", ".join([str(d) for d in self.args.devices]))
+        if self.args.devices:
+            terminal.success(
+                "Zapping successful for: %s" % ", ".join([str(d) for d in self.args.devices])
+            )
+        else:
+            terminal.success(
+                "Zapping successful for OSD: %s" % self.args.osd_id or self.args.osd_fsid
+            )
 
     @decorators.needs_root
     def zap_osd(self):

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_zap.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_zap.py
@@ -1,0 +1,153 @@
+import pytest
+from ceph_volume.api import lvm as api
+from ceph_volume.devices.lvm import zap
+
+
+class TestFindAssociatedDevices(object):
+
+    def test_no_lvs_found_that_match_id(self, volumes, monkeypatch, device_info):
+        monkeypatch.setattr(zap.api, 'Volumes', lambda: volumes)
+        tags = 'ceph.osd_id=9,ceph.journal_uuid=x,ceph.type=data'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', vg_name='vg', lv_tags=tags)
+        volumes.append(osd)
+        with pytest.raises(RuntimeError):
+            zap.find_associated_devices(osd_id=10)
+
+    def test_no_lvs_found_that_match_fsid(self, volumes, monkeypatch, device_info):
+        monkeypatch.setattr(zap.api, 'Volumes', lambda: volumes)
+        tags = 'ceph.osd_id=9,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=data'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', vg_name='vg', lv_tags=tags)
+        volumes.append(osd)
+        with pytest.raises(RuntimeError):
+            zap.find_associated_devices(osd_fsid='aaaa-lkjh')
+
+    def test_no_lvs_found_that_match_id_fsid(self, volumes, monkeypatch, device_info):
+        monkeypatch.setattr(zap.api, 'Volumes', lambda: volumes)
+        tags = 'ceph.osd_id=9,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=data'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', vg_name='vg', lv_tags=tags)
+        volumes.append(osd)
+        with pytest.raises(RuntimeError):
+            zap.find_associated_devices(osd_id='9', osd_fsid='aaaa-lkjh')
+
+    def test_no_ceph_lvs_found(self, volumes, monkeypatch):
+        monkeypatch.setattr(zap.api, 'Volumes', lambda: volumes)
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', lv_tags='')
+        volumes.append(osd)
+        with pytest.raises(RuntimeError):
+            zap.find_associated_devices(osd_id=100)
+
+    def test_lv_is_matched_id(self, volumes, monkeypatch):
+        monkeypatch.setattr(zap.api, 'Volumes', lambda: volumes)
+        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        volumes.append(osd)
+        result = zap.find_associated_devices(osd_id='0')
+        assert result[0].abspath == '/dev/VolGroup/lv'
+
+    def test_lv_is_matched_fsid(self, volumes, monkeypatch):
+        monkeypatch.setattr(zap.api, 'Volumes', lambda: volumes)
+        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=data'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        volumes.append(osd)
+        result = zap.find_associated_devices(osd_fsid='asdf-lkjh')
+        assert result[0].abspath == '/dev/VolGroup/lv'
+
+    def test_lv_is_matched_id_fsid(self, volumes, monkeypatch):
+        monkeypatch.setattr(zap.api, 'Volumes', lambda: volumes)
+        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=data'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        volumes.append(osd)
+        result = zap.find_associated_devices(osd_id='0', osd_fsid='asdf-lkjh')
+        assert result[0].abspath == '/dev/VolGroup/lv'
+
+
+class TestEnsureAssociatedLVs(object):
+
+    def test_nothing_is_found(self, volumes):
+        result = zap.ensure_associated_lvs(volumes)
+        assert result == []
+
+    def test_data_is_found(self, volumes):
+        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=data'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/data', lv_tags=tags)
+        volumes.append(osd)
+        result = zap.ensure_associated_lvs(volumes)
+        assert result == ['/dev/VolGroup/data']
+
+    def test_block_is_found(self, volumes):
+        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=block'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/block', lv_tags=tags)
+        volumes.append(osd)
+        result = zap.ensure_associated_lvs(volumes)
+        assert result == ['/dev/VolGroup/block']
+
+    def test_block_and_partition_are_found(self, volumes, monkeypatch):
+        monkeypatch.setattr(zap.disk, 'get_device_from_partuuid', lambda x: '/dev/sdb1')
+        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=block'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/block', lv_tags=tags)
+        volumes.append(osd)
+        result = zap.ensure_associated_lvs(volumes)
+        assert '/dev/sdb1' in result
+        assert '/dev/VolGroup/block' in result
+
+    def test_journal_is_found(self, volumes):
+        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=journal'
+        osd = api.Volume(
+            lv_name='volume1', lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        volumes.append(osd)
+        result = zap.ensure_associated_lvs(volumes)
+        assert result == ['/dev/VolGroup/lv']
+
+    def test_multiple_journals_are_found(self, volumes):
+        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=journal'
+        for i in range(3):
+            osd = api.Volume(
+                lv_name='volume%s' % i, lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/lv%s' % i, lv_tags=tags)
+            volumes.append(osd)
+        result = zap.ensure_associated_lvs(volumes)
+        assert '/dev/VolGroup/lv0' in result
+        assert '/dev/VolGroup/lv1' in result
+        assert '/dev/VolGroup/lv2' in result
+
+    def test_multiple_dbs_are_found(self, volumes):
+        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.journal_uuid=x,ceph.type=db'
+        for i in range(3):
+            osd = api.Volume(
+                lv_name='volume%s' % i, lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/lv%s' % i, lv_tags=tags)
+            volumes.append(osd)
+        result = zap.ensure_associated_lvs(volumes)
+        assert '/dev/VolGroup/lv0' in result
+        assert '/dev/VolGroup/lv1' in result
+        assert '/dev/VolGroup/lv2' in result
+
+    def test_multiple_wals_are_found(self, volumes):
+        tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.wal_uuid=x,ceph.type=wal'
+        for i in range(3):
+            osd = api.Volume(
+                lv_name='volume%s' % i, lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/lv%s' % i, lv_tags=tags)
+            volumes.append(osd)
+        result = zap.ensure_associated_lvs(volumes)
+        assert '/dev/VolGroup/lv0' in result
+        assert '/dev/VolGroup/lv1' in result
+        assert '/dev/VolGroup/lv2' in result
+
+    def test_multiple_backing_devs_are_found(self, volumes):
+        for _type in ['journal', 'db', 'wal']:
+            tags = 'ceph.osd_id=0,ceph.osd_fsid=asdf-lkjh,ceph.wal_uuid=x,ceph.type=%s' % _type
+            osd = api.Volume(
+                lv_name='volume%s' % _type, lv_uuid='y', vg_name='', lv_path='/dev/VolGroup/lv%s' % _type, lv_tags=tags)
+            volumes.append(osd)
+        result = zap.ensure_associated_lvs(volumes)
+        assert '/dev/VolGroup/lvjournal' in result
+        assert '/dev/VolGroup/lvwal' in result
+        assert '/dev/VolGroup/lvdb' in result

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type-dmcrypt/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type-dmcrypt/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/mixed-type/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/single-type-dmcrypt/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/single-type-dmcrypt/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/single-type/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/bluestore/single-type/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type-dmcrypt/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type-dmcrypt/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/mixed-type/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/single-type-dmcrypt/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/single-type-dmcrypt/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/single-type/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/centos7/filestore/single-type/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/playbooks/test_zap.yml
@@ -1,0 +1,31 @@
+
+- hosts: osds
+  become: yes
+  tasks:
+
+    - name: stop ceph-osd daemons
+      service:
+        name: "ceph-osd@{{ item }}"
+        state: stopped
+      with_items: "{{ osd_ids }}"
+
+
+- hosts: mons
+  become: yes
+  tasks:
+
+    - name: purge osds
+      command: "ceph --cluster {{ cluster }} osd purge osd.{{ item }} --yes-i-really-mean-it"
+      with_items: "{{ osd_ids }}"
+
+
+- hosts: osds
+  become: yes
+  tasks:
+
+    - name: zap devices used for OSDs
+      command: "ceph-volume --cluster {{ cluster }} lvm zap --osd-id {{ item }} --destroy"
+      with_items: "{{ osd_ids }}"
+      environment:
+        CEPH_VOLUME_DEBUG: 1
+

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/tox.ini
@@ -63,4 +63,7 @@ commands=
   # retest to ensure cluster came back up correctly
   testinfra -n 4 --sudo -v --connection=ansible --ansible-inventory={changedir}/hosts {envdir}/tmp/ceph-ansible/tests/functional/tests
 
+  # test zap OSDs by ID
+  ansible-playbook -vv -i {changedir}/hosts {changedir}/test_zap.yml
+
   vagrant destroy {env:VAGRANT_DESTROY_FLAGS:"--force"}

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/bluestore/single-type-dmcrypt/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/bluestore/single-type-dmcrypt/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/bluestore/single-type/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/bluestore/single-type/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/filestore/single-type-dmcrypt/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/filestore/single-type-dmcrypt/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml

--- a/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/filestore/single-type/test_zap.yml
+++ b/src/ceph-volume/ceph_volume/tests/functional/batch/xenial/filestore/single-type/test_zap.yml
@@ -1,0 +1,1 @@
+../../../playbooks/test_zap.yml


### PR DESCRIPTION
Enhance zapping by allowing a combination of OSD ID and OSD FSID. Full removal of the underlying LV and VG (if only the LV is the last one), including partitions if specified.

Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1644847
Backport of: https://github.com/ceph/ceph/pull/25429