### PR TITLE
ceph: cleanup mds ceph status output

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -15,6 +15,8 @@
 
 #include "FSMap.h"
 
+#include "common/StackStringStream.h"
+
 #include <sstream>
 #ifdef WITH_SEASTAR
 #include "crimson/common/config_proxy.h"
@@ -100,8 +102,8 @@ void FSMap::print(ostream& out) const
     out << "No filesystems configured" << std::endl;
   }
 
-  for (const auto &fs : filesystems) {
-    fs.second->print(out);
+  for (const auto& p : filesystems) {
+    p.second->print(out);
     out << " " << std::endl << " " << std::endl;  // Space out a bit
   }
 
@@ -119,23 +121,53 @@ void FSMap::print(ostream& out) const
 
 void FSMap::print_summary(Formatter *f, ostream *out) const
 {
-  map<mds_role_t,string> by_rank;
-  map<string,int> by_state;
-
   if (f) {
     f->dump_unsigned("epoch", get_epoch());
-    for (auto i : filesystems) {
-      auto fs = i.second;
+    for (const auto &p : filesystems) {
+      auto& fs = p.second;
       f->dump_unsigned("id", fs->fscid);
       f->dump_unsigned("up", fs->mds_map.up.size());
       f->dump_unsigned("in", fs->mds_map.in.size());
       f->dump_unsigned("max", fs->mds_map.max_mds);
     }
   } else {
-    for (auto i : filesystems) {
-      auto fs = i.second;
-      *out << fs->mds_map.fs_name << "-" << fs->mds_map.up.size() << "/"
-	   << fs->mds_map.in.size() << "/" << fs->mds_map.max_mds << " up ";
+    auto count = filesystems.size();
+    if (count <= 3) {
+      bool first = true;
+      for (const auto& p : filesystems) {
+        const auto& fs = p.second;
+        if (!first) {
+          *out << " ";
+        }
+        if (fs->mds_map.is_degraded()) {
+          *out << fs->mds_map.fs_name << ":" << fs->mds_map.up.size() << "/" << fs->mds_map.in.size();
+        } else {
+          *out << fs->mds_map.fs_name << ":" << fs->mds_map.in.size();
+        }
+        first = false;
+      }
+    } else {
+      *out << count << " fs";
+      unsigned degraded = 0;
+      CachedStackStringStream css;
+      *css << " (degraded: ";
+      for (const auto& p : filesystems) {
+        const auto& fs = p.second;
+        if (fs->mds_map.is_degraded()) {
+          degraded++;
+          if (degraded <= 3) {
+            *css << fs->mds_map.fs_name << ":" << fs->mds_map.up.size() << "/" << fs->mds_map.in.size();
+          }
+        }
+      }
+      if (degraded > 0) {
+        if (degraded <= 3) {
+          *css << ")";
+          *out << css->strv();
+        } else {
+          *out << " (degraded: " << degraded << " fs)";
+        }
+      }
     }
   }
 
@@ -143,70 +175,77 @@ void FSMap::print_summary(Formatter *f, ostream *out) const
     f->open_array_section("by_rank");
   }
 
-  const auto all_info = get_mds_info();
-  for (const auto &p : all_info) {
-    const auto &info = p.second;
-    string s = ceph_mds_state_name(info.state);
+  std::map<MDSMap::DaemonState,unsigned> by_state;
+  std::map<mds_role_t, std::string> by_rank;
+  for (const auto& [gid, fscid] : mds_roles) {
+    if (fscid == FS_CLUSTER_ID_NONE)
+      continue;
+
+    const auto& info = filesystems.at(fscid)->mds_map.get_info_gid(gid);
+    auto s = std::string(ceph_mds_state_name(info.state));
     if (info.laggy()) {
       s += "(laggy or crashed)";
     }
 
-    const fs_cluster_id_t fscid = mds_roles.at(info.global_id);
-
-    if (info.rank != MDS_RANK_NONE &&
-        info.state != MDSMap::STATE_STANDBY_REPLAY) {
-      if (f) {
-        f->open_object_section("mds");
-        f->dump_unsigned("filesystem_id", fscid);
-        f->dump_unsigned("rank", info.rank);
-        f->dump_string("name", info.name);
-        f->dump_string("status", s);
-        f->close_section();
-      } else {
-        by_rank[mds_role_t(fscid, info.rank)] = info.name + "=" + s;
-      }
+    if (f) {
+      f->open_object_section("mds");
+      f->dump_unsigned("filesystem_id", fscid);
+      f->dump_unsigned("rank", info.rank);
+      f->dump_string("name", info.name);
+      f->dump_string("status", s);
+      f->dump_unsigned("gid", gid);
+      f->close_section();
     } else {
-      by_state[s]++;
+      by_rank[mds_role_t(fscid, info.rank)] = info.name + "=" + s;
     }
+    by_state[info.state]++;
   }
 
   if (f) {
     f->close_section();
   } else {
-    if (!by_rank.empty()) {
+    if (0 < by_rank.size() && by_rank.size() < 5) {
       if (filesystems.size() > 1) {
         // Disambiguate filesystems
         std::map<std::string, std::string> pretty;
-        for (auto i : by_rank) {
-          const auto &fs_name = filesystems.at(i.first.fscid)->mds_map.fs_name;
-          std::ostringstream o;
-          o << "[" << fs_name << ":" << i.first.rank << "]";
-          pretty[o.str()] = i.second;
+        for (const auto& [role,status] : by_rank) {
+          const auto &fs_name = filesystems.at(role.fscid)->mds_map.fs_name;
+          CachedStackStringStream css;
+          *css << fs_name << ":" << role.rank;
+          pretty.emplace(std::piecewise_construct, std::forward_as_tuple(css->strv()), std::forward_as_tuple(status));
         }
         *out << " " << pretty;
       } else {
         // Omit FSCID in output when only one filesystem exists
         std::map<mds_rank_t, std::string> shortened;
-        for (auto i : by_rank) {
-          shortened[i.first.rank] = i.second;
+        for (const auto& [role,status] : by_rank) {
+          shortened[role.rank] = status;
         }
         *out << " " << shortened;
+      }
+    } else {
+      for (const auto& [state, count] : by_state) {
+        auto s = std::string_view(ceph_mds_state_name(state));
+        *out << " " << count << " " << s;
       }
     }
   }
 
-  for (map<string,int>::reverse_iterator p = by_state.rbegin(); p != by_state.rend(); ++p) {
+  {
+    auto state = MDSMap::DaemonState::STATE_STANDBY;
+    auto name = ceph_mds_state_name(state);
+    auto count = standby_daemons.size();
     if (f) {
-      f->dump_unsigned(p->first.c_str(), p->second);
+      f->dump_unsigned(name, count);
     } else {
-      *out << ", " << p->second << " " << p->first;
+      *out << ", " << count << " " << name;
     }
   }
 
   size_t failed = 0;
   size_t damaged = 0;
-  for (auto i : filesystems) {
-    auto fs = i.second;
+  for (const auto& p : filesystems) {
+    auto& fs = p.second;
     failed += fs->mds_map.failed.size();
     damaged += fs->mds_map.damaged.size();
   }


### PR DESCRIPTION
This is primarily to make the CephFS line more readable with lots of file
systems with more understandable output.

From something like:

    mds: a-2/2/2 up  {0=c=up:active,1=b=up:active}, 1 up:standby

Now with 1 FS and 1 active:

    mds: a:1 {0=p=up:active}, 15 up:standby

2 FS, 2 actives:

    mds: a:1 b:1 {a:0=o=up:active,b:0=n=up:active}, 14 up:standby

2 FS, 3 actives:

    mds: a:1 b:2 {a:0=o=up:active,b:0=n=up:active,b:1=p=up:active}, 13 up:standby

3 FS and 2 active and 1 reconnect:

    mds: a:1/1 b:1 c:1 {a:0=n=up:reconnect,b:0=p=up:active,c:0=o=up:active}, 13 up:standby

3 FS and 1 failed rank:

    mds: a:0/1 b:1 c:1 {b:0=p=up:active,c:0=o=up:active}, 14 up:standby, 1 failed

3 FS, 4 actives:

    mds: a:1 b:2 c:1 {a:0=o=up:active,b:0=n=up:active,b:1=p=up:active,c:0=l=up:active}, 12 up:standby

3 FS, 3 actives, 1 FS failed:

    mds: a:1 b:2 c:0/1 {a:0=o=up:active,b:0=n=up:active,b:1=p=up:active}, 13 up:standby, 1 failed

3 FS, 5 actives:

    mds: a:1 b:2 c:2 5 up:active, 11 up:standby

4 FS:

    mds: 4 fs {a:0=o=up:active,b:0=n=up:active,c:0=l=up:active,d:0=p=up:active}, 12 up:standby

5 FS:

    mds: 5 fs 5 up:active, 11 up:standby

5 FS, 1 degraded:

    mds: 5 fs (degraded: c:0/1) {a:0=o=up:active,b:0=n=up:active,d:0=p=up:active,e:0=m=up:active}, 12 up:standby, 1 failed

8 FS, 1 degraded:

    mds: 8 fs (degraded: c:0/1) 7 up:active, 9 up:standby, 1 failed

Fixes: http://tracker.ceph.com/issues/37954
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

