### PR TITLE
mon: implement hiding commands in ceph tool

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -43,6 +43,7 @@ FLAG_NOFORWARD = (1 << 0)
 FLAG_OBSOLETE = (1 << 1)
 FLAG_DEPRECATED = (1 << 2)
 FLAG_POLL = (1 << 4)
+FLAG_HIDDEN = (1 << 5)
 
 # priorities from src/common/perf_counters.h
 PRIO_CRITICAL = 10
@@ -477,7 +478,7 @@ def format_help(cmddict, partial=None):
         if not cmd['help']:
             continue
         flags = cmd.get('flags', 0)
-        if flags & (FLAG_OBSOLETE | FLAG_DEPRECATED):
+        if flags & (FLAG_OBSOLETE | FLAG_DEPRECATED | FLAG_HIDDEN):
             continue
         concise = concise_sig(cmd['sig'])
         if partial and not concise.startswith(partial):

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3112,9 +3112,7 @@ void Monitor::handle_command(MonOpRequestRef op)
         paxos_service[PAXOS_MGR].get())->get_command_descs();
 
     for (auto& c : leader_mon_commands) {
-      if (!c.is_hidden()) {
-	commands.push_back(c);
-      }
+      commands.push_back(c);
     }
 
     auto features = m->get_connection()->get_features();


### PR DESCRIPTION
Otherwise ceph.in doing get_command_descriptions sees the command does not
exist and will print an error.

Fixes: https://tracker.ceph.com/issues/37956

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

