### PR TITLE
mgr/ansible: Replace Ansible playbook used to retrieve storage devices data

### DIFF
--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -647,7 +647,10 @@ class InventoryDevice(object):
         self.type = None  # 'ssd', 'hdd', 'nvme'
         self.id = None  # unique within a node (or globally if you like).
         self.size = None  # byte integer.
-        self.extended = None  # arbitrary JSON-serializable object
+        self.rotates = False # indicates if it is a spinning disk
+        self.available = False # can be used to create a new OSD?
+        self.dev_id = None  # vendor/model
+        self.extended = {}  # arbitrary JSON-serializable object
 
         # If this drive is not empty, but is suitable for appending
         # additional journals, wals, or bluestore dbs, then report
@@ -655,7 +658,29 @@ class InventoryDevice(object):
         self.metadata_space_free = None
 
     def to_json(self):
-        return dict(type=self.type, blank=self.blank, id=self.id, size=self.size, **self.extended)
+        return dict(type=self.type, blank=self.blank, id=self.id,
+                    size=self.size, rotates=self.rotates,
+                    available=self.available, dev_id=self.dev_id,
+                    **self.extended)
+
+    def pretty_print(self, only_header=False):
+        """Print a human friendly line with the information of the device
+
+        :param only_header: Print only the name of the device attributes
+
+        Ex:
+        >  Device Path           Type       Size    Rotates  Available Model
+        >     /dev/sdc            hdd   50.00 GB       True       True ATA/QEMU
+
+        """
+        row_format = "  {0:<15} {1:>10} {2:>10} {3:>10} {4:>10} {5:<15}\n"
+        if only_header:
+            return row_format.format("Device Path", "Type", "Size", "Rotates",
+                                     "Available", "Model")
+        else:
+            return row_format.format(self.id, self.type, self.size,
+                                     str(self.rotates), str(self.available),
+                                     self.dev_id)
 
 
 class InventoryNode(object):

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -13,10 +13,11 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
     MODULE_OPTIONS = [
         {'name': 'orchestrator'}
     ]
+
     COMMANDS = [
         {
             'cmd': "orchestrator device ls "
-                   "name=host,type=CephString,req=false"
+                   "name=host,type=CephString,req=false "
                    "name=format,type=CephChoices,strings=json|plain,req=false ",
             "desc": "List devices on a node",
             "perm": "r"
@@ -141,23 +142,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
 
     def _list_devices(self, cmd):
         """
-        This (all lines starting with ">") is how it is supposed to work. As of
-        now, it's not yet implemented:
-        > :returns: Either JSON:
-        >     [
-        >       {
-        >         "name": "sda",
-        >         "host": "foo",
-        >         ... lots of stuff from ceph-volume ...
-        >         "stamp": when this state was refreshed
-        >       },
-        >     ]
-        >
-        > or human readable:
-        >
-        >     HOST  DEV  SIZE  DEVID(vendor\\_model\\_serial)   IN-USE  TIMESTAMP
-        >
-        > Note: needs ceph-volume on the host.
+        Provide information about storage devices present in cluster hosts
 
         Note: this does not have to be completely synchronous. Slightly out of
         date hardware inventory is fine as long as hardware ultimately appears
@@ -181,11 +166,17 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
         else:
             # Return a human readable version
             result = ""
+
             for inventory_node in completion.result:
-                result += "{0}:\n".format(inventory_node.name)
+                result += "Host {0}:\n".format(inventory_node.name)
+
+                if inventory_node.devices:
+                    result += inventory_node.devices[0].pretty_print(only_header=True)
+                else:
+                    result += "No storage devices found"
+
                 for d in inventory_node.devices:
-                    result += "  {0} ({1}, {2}b)\n".format(
-                        d.id, d.type, d.size)
+                    result += d.pretty_print()
                 result += "\n"
 
             return HandleCommandResult(stdout=result)


### PR DESCRIPTION
A new Ansible playbook allows to retrieve the storage devices information produced by ceph-volume. 
(The previous playbook was used while the official one was developed).

The output format has been adjusted to the specifications agreed in  "Orchestrator Cli", 
[https://docs.google.com/document/d/17DIs_NCMBsTG3jbrhsG0Ot5y40TC9ADDZgEhmtF6Yks/edit?usp=sharing]()

This has implied to add new attributes in the Orchestrator "InventoryDevice" class and also in order to  avoid different "outputs" of the storage device attributes, a "pretty_print" method has been added.

Note: The "timestamp" attribute has not been included. I do not know what was exactly the function/use of this attribute. 
(If it is intended to be used to create a cache, maybe this attribute should go in the "InventoryNode" class and not here. In any case if it is needed i will include it asap.)

Other issues:
It seems that Ceph-volume does not return information to differentiate between SDD and NVMe devices. 
It will be needed to add this information in order to provide the user with the right information to decide how to distribute OSD's components (e.g. bluestore wal)


Example:

```
[vagrant@mon0 ~]$ ceph orchestrator device ls
Host 192.168.121.212:
  Device Path           Type       Size    Rotates  Available Model          
  /dev/sdc               hdd   50.00 GB       True       True ATA/QEMU HARDDISK
  /dev/sda               hdd   50.00 GB       True      False ATA/QEMU HARDDISK
  /dev/sdb               hdd   50.00 GB       True      False ATA/QEMU HARDDISK
  /dev/vda               hdd   41.00 GB       True      False 0x1af4/        
Host 192.168.121.213:
  Device Path           Type       Size    Rotates  Available Model          
  /dev/sdc               hdd   50.00 GB       True       True ATA/QEMU HARDDISK
  /dev/sda               hdd   50.00 GB       True      False ATA/QEMU HARDDISK
  /dev/sdb               hdd   50.00 GB       True      False ATA/QEMU HARDDISK
  /dev/vda               hdd   41.00 GB       True      False 0x1af4/        
```

```json
[vagrant@mon0 ~]$ ceph orchestrator device ls -f json | jq .
[
  {
    "name": "192.168.121.212",
    "devices": [
      {
        "available": true,
        "dev_id": "ATA/QEMU HARDDISK",
        "blank": false,
        "rotates": true,
        "type": "hdd",
        "id": "/dev/sdc",
        "size": "50.00 GB"
      },
      {
        "available": false,
        "dev_id": "ATA/QEMU HARDDISK",
        "blank": false,
        "rotates": true,
        "type": "hdd",
        "id": "/dev/sda",
        "size": "50.00 GB"
      },
      {
        "available": false,
        "dev_id": "ATA/QEMU HARDDISK",
        "blank": false,
        "rotates": true,
        "type": "hdd",
        "id": "/dev/sdb",
        "size": "50.00 GB"
      },
      {
        "available": false,
        "dev_id": "0x1af4/",
        "blank": false,
        "rotates": true,
        "type": "hdd",
        "id": "/dev/vda",
        "size": "41.00 GB"
      }
    ]
  },
  {
    "name": "192.168.121.213",
    "devices": [
      {
        "available": true,
        "dev_id": "ATA/QEMU HARDDISK",
        "blank": false,
        "rotates": true,
        "type": "hdd",
        "id": "/dev/sdc",
        "size": "50.00 GB"
      },
      {
        "available": false,
        "dev_id": "ATA/QEMU HARDDISK",
        "blank": false,
        "rotates": true,
        "type": "hdd",
        "id": "/dev/sda",
        "size": "50.00 GB"
      },
      {
        "available": false,
        "dev_id": "ATA/QEMU HARDDISK",
        "blank": false,
        "rotates": true,
        "type": "hdd",
        "id": "/dev/sdb",
        "size": "50.00 GB"
      },
      {
        "available": false,
        "dev_id": "0x1af4/",
        "blank": false,
        "rotates": true,
        "type": "hdd",
        "id": "/dev/vda",
        "size": "41.00 GB"
      }
    ]
  }
]
````

Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>