### PR TITLE
luminous ceph-volume: Adapt code to support Python3

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_util.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_util.py
@@ -95,22 +95,22 @@ class TestPromptBool(object):
     def test_trueish(self, response):
         fake_input = lambda x: response
         qx = 'what the what?'
-        assert util.prompt_bool(qx, _raw_input=fake_input) is True
+        assert util.prompt_bool(qx, input_=fake_input) is True
 
     @pytest.mark.parametrize('response', false_responses())
     def test_falseish(self, response):
         fake_input = lambda x: response
         qx = 'what the what?'
-        assert util.prompt_bool(qx, _raw_input=fake_input) is False
+        assert util.prompt_bool(qx, input_=fake_input) is False
 
     def test_try_again_true(self):
         responses = ['g', 'h', 'y']
         fake_input = lambda x: responses.pop(0)
         qx = 'what the what?'
-        assert util.prompt_bool(qx, _raw_input=fake_input) is True
+        assert util.prompt_bool(qx, input_=fake_input) is True
 
     def test_try_again_false(self):
         responses = ['g', 'h', 'n']
         fake_input = lambda x: responses.pop(0)
         qx = 'what the what?'
-        assert util.prompt_bool(qx, _raw_input=fake_input) is False
+        assert util.prompt_bool(qx, input_=fake_input) is False

--- a/src/ceph-volume/ceph_volume/util/__init__.py
+++ b/src/ceph-volume/ceph_volume/util/__init__.py
@@ -2,6 +2,10 @@ import logging
 from math import floor
 from ceph_volume import terminal
 
+try:
+    input = raw_input  # pylint: disable=redefined-builtin
+except NameError:
+    pass
 
 logger = logging.getLogger(__name__)
 
@@ -79,12 +83,12 @@ def str_to_bool(val):
         raise ValueError("Invalid input value: %s" % val)
 
 
-def prompt_bool(question, _raw_input=None):
+def prompt_bool(question, input_=None):
     """
     Interface to prompt a boolean (or boolean-like) response from a user.
     Usually a confirmation.
     """
-    input_prompt = _raw_input or raw_input
+    input_prompt = input_ or input
     prompt_format = '--> {question} '.format(question=question)
     response = input_prompt(prompt_format)
     try:
@@ -93,4 +97,4 @@ def prompt_bool(question, _raw_input=None):
         terminal.error('Valid true responses are: y, yes, <Enter>')
         terminal.error('Valid false responses are: n, no')
         terminal.error('That response was invalid, please try again')
-        return prompt_bool(question, _raw_input=input_prompt)
+        return prompt_bool(question, input_=input_prompt)


### PR DESCRIPTION
The following changes are done:
- Adapt code because raw_input() has been renamed to input() in Python3
- Changed signature of prompt_bool. Variables that are named like built-ins must be named like xxx_ and not _xxx

Fixes: https://tracker.ceph.com/issues/37470

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug


Backport of: https://github.com/ceph/ceph/pull/25324