### PR TITLE
mgr/rook: remove init_rook

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -270,11 +270,6 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
             self._k8s,
             cluster_name)
 
-
-        # In case Rook isn't already clued in to this ceph
-        # cluster's existence, initialize it.
-        # self._rook_cluster.init_rook()
-
         self._initialized.set()
 
         while not self._shutdown.is_set():

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -46,32 +46,6 @@ class RookCluster(object):
         #  be formalized at some point)
         return self.cluster_name
 
-    def init_rook(self):
-        """
-        Create a passive Rook configuration for this Ceph cluster.  This
-        will prompt Rook to start watching for other resources within
-        the cluster (e.g. Filesystem CRDs), but no other action will happen.
-        """
-
-        # TODO: complete or remove this functionality: if Rook wasn't
-        # already running, then we would need to supply it with
-        # keys and ceph.conf as well as creating the cluster CRD
-
-        cluster_crd = {
-            "apiVersion": ROOK_API_NAME,
-            "kind": "CephCluster",
-            "metadata": {
-                "name": self.cluster_name,
-                "namespace": self.cluster_name
-            },
-            "spec": {
-                "backend": "ceph",
-                "hostNetwork": True
-            }
-        }
-
-        self.rook_api_post("cephclusters", body=cluster_crd)
-
     def rook_url(self, path):
         prefix = "/apis/ceph.rook.io/%s/namespaces/%s/" % (
             ROOK_API_VERSION, self.rook_namespace)


### PR DESCRIPTION
John evidently added this code early on in development, when we figured
we might be taking over a cluster that is already running under k8s.

I don't see how we'd ever make that work, so just remove this function
for now, and the commented-out callsite.

Reported-by: Sebastian Wagner <sebastian.wagner@suse.com>
Signed-off-by: Jeff Layton <jlayton@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

