### PR TITLE
osd: unmount store after service.shutdown()

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3859,11 +3859,6 @@ int OSD::shutdown()
     store->flush_journal();
   }
 
-  store->umount();
-  delete store;
-  store = 0;
-  dout(10) << "Store synced" << dendl;
-
   monc->shutdown();
   osd_lock.Unlock();
 
@@ -3873,6 +3868,13 @@ int OSD::shutdown()
     s->shard_osdmap = OSDMapRef();
   }
   service.shutdown();
+
+  std::lock_guard lock(osd_lock);
+  store->umount();
+  delete store;
+  store = nullptr;
+  dout(10) << "Store synced" << dendl;
+
   op_tracker.on_shutdown();
 
   class_handler->shutdown();


### PR DESCRIPTION
in service.shutdown(), the store's cache is accessed, so we need to
destroy the store after service.shutdown()

Fixes: http://tracker.ceph.com/issues/37975
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

