### PR TITLE
mgr/diskprediction_cloud: fix divide by zero when total_size is 0

### DIFF
--- a/src/pybind/mgr/diskprediction_cloud/common/clusterdata.py
+++ b/src/pybind/mgr/diskprediction_cloud/common/clusterdata.py
@@ -261,7 +261,10 @@ class ClusterAPI(object):
         total_size = round(float(ceph_stats.get('total_bytes', 0)) / GB)
         avail_size = round(float(ceph_stats.get('total_avail_bytes', 0)) / GB, 2)
         raw_used_size = round(float(ceph_stats.get('total_used_bytes', 0)) / GB, 2)
-        raw_used_percent = round(float(raw_used_size) / float(total_size) * 100, 2)
+        if total_size != 0:
+            raw_used_percent = round(float(raw_used_size) / float(total_size) * 100, 2)
+        else:
+            raw_used_percent = 0
         return {'total_size': total_size, 'avail_size': avail_size, 'raw_used_size': raw_used_size,
                 'used_percent': raw_used_percent}
 


### PR DESCRIPTION
Fix float division by zero issue. Execute module self-test with not device configure.
Ref: [25983](https://github.com/ceph/ceph/pull/25983)

Fixes: https://tracker.ceph.com/issues/37736
Signed-off-by: Rick Chen <rick.chen@prophetstor.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug
