### PR TITLE
mgr/telemetry: fix total_objects

### DIFF
--- a/src/pybind/mgr/telemetry/module.py
+++ b/src/pybind/mgr/telemetry/module.py
@@ -281,7 +281,6 @@ class Module(MgrModule):
         report['usage'] = {
             'pools': len(df['pools']),
             'pg_num:': num_pg,
-            'total_objects': df['stats']['total_objects'],
             'total_used_bytes': df['stats']['total_used_bytes'],
             'total_bytes': df['stats']['total_bytes'],
             'total_avail_bytes': df['stats']['total_avail_bytes']


### PR DESCRIPTION
This field was removed from df output a while back in
342f309645df886fb96eb401634e38376553e6d9

Fixes: http://tracker.ceph.com/issues/37976
Signed-off-by: Sage Weil <sage@redhat.com>