### PR TITLE
mgr/zabbix: drop "total_objects" field

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -171,7 +171,6 @@ class Module(MgrModule):
 
         df = self.get('df')
         data['num_pools'] = len(df['pools'])
-        data['total_objects'] = df['stats']['total_objects']
         data['total_used_bytes'] = df['stats']['total_used_bytes']
         data['total_bytes'] = df['stats']['total_bytes']
         data['total_avail_bytes'] = df['stats']['total_avail_bytes']


### PR DESCRIPTION
This field was removed from df output a while back in
342f309

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

