### PR TITLE
pybind/rados: fix application metadata list

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -3870,10 +3870,10 @@ returned %d, but should return zero on success." % (self.name, ret))
                                                           c_vals, &val_length)
                 if ret == 0:
                     keys = [decode_cstr(key) for key in
-                                c_keys[:key_length].split(b'\0') if key]
+                                c_keys[:key_length].split(b'\0')]
                     vals = [decode_cstr(val) for val in
-                                c_vals[:val_length].split(b'\0') if val]
-                    return zip(keys, vals)
+                                c_vals[:val_length].split(b'\0')]
+                    return zip(keys, vals)[:-1]
                 elif ret == -errno.ERANGE:
                     pass
                 else:


### PR DESCRIPTION
otherwise if we set metadata to `[('k1', 'v1'), ('k2', ''), ('k3', 'v3')]`,
we will get the following:

`[('k1', 'v1'), ('k2', 'v3')]`

Signed-off-by: runsisi <luo.runbing@zte.com.cn>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

