### PR TITLE
mgr/dashboard: added command to tox.ini

### DIFF
--- a/src/pybind/mgr/dashboard/HACKING.rst
+++ b/src/pybind/mgr/dashboard/HACKING.rst
@@ -394,9 +394,26 @@ Alternatively, you can use Python's native package installation method::
   $ pip install coverage
 
 To run the tests, run ``run-tox.sh`` in the dashboard directory (where
-``tox.ini`` is located).
+``tox.ini`` is located)::
 
-We also collect coverage information from the backend code. You can check the
+  ## Run Python 2+3 tests+lint commands:
+  $ ./run-tox.sh
+
+  ## Run Python 3 tests+lint commands:
+  $ WITH_PYTHON2=OFF ./run-tox.sh
+
+  ## Run Python 3 arbitrary command (e.g. 1 single test):
+  $ WITH_PYTHON2=OFF ./run-tox.sh pytest tests/test_rgw_client.py::RgwClientTest::test_ssl_verify
+
+You can also run tox instead of ``run-tox.sh``::
+
+  ## Run Python 3 tests command:
+  $ CEPH_BUILD_DIR=.tox tox -e py3-cov
+
+  ## Run Python 3 arbitrary command (e.g. 1 single test):
+  $ CEPH_BUILD_DIR=.tox tox -e py3-run pytest tests/test_rgw_client.py::RgwClientTest::test_ssl_verify
+
+We also collect coverage information from the backend code when you run tests. You can check the
 coverage information provided by the tox output, or by running the following
 command after tox has finished successfully::
 
@@ -404,11 +421,6 @@ command after tox has finished successfully::
 
 This command will create a directory ``htmlcov`` with an HTML representation of
 the code coverage of the backend.
-
-You can also run a single step of the tox script (aka tox environment), for
-instance if you only want to run the linting tools, do::
-
-  $ tox -e lint
 
 API tests based on Teuthology
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/pybind/mgr/dashboard/run-tox.sh
+++ b/src/pybind/mgr/dashboard/run-tox.sh
@@ -20,10 +20,18 @@ export CEPH_BUILD_DIR=$CEPH_BUILD_DIR
 source ${MGR_DASHBOARD_VIRTUALENV}/bin/activate
 
 if [ "$WITH_PYTHON2" = "ON" ]; then
-  ENV_LIST+="py27-cov,py27-lint,"
+  if [[ -n "$@" ]]; then
+    ENV_LIST+="py27-run,"
+  else
+    ENV_LIST+="py27-cov,py27-lint,"
+  fi
 fi
 if [ "$WITH_PYTHON3" = "ON" ]; then
-  ENV_LIST+="py3-cov,py3-lint"
+  if [[ -n "$@" ]]; then
+    ENV_LIST+="py3-run"
+  else
+    ENV_LIST+="py3-cov,py3-lint"
+  fi
 fi
 
-tox -c ${TOX_PATH} -e $ENV_LIST
+tox -c ${TOX_PATH} -e "$ENV_LIST" "$@"

--- a/src/pybind/mgr/dashboard/tox.ini
+++ b/src/pybind/mgr/dashboard/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py3}-cov,{py27,py3}-lint
+envlist = py27-{cov,lint,run},py3-{cov,lint,run}
 skipsdist = true
 toxworkdir = {env:CEPH_BUILD_DIR}/dashboard
 minversion = 2.8.1
@@ -27,3 +27,4 @@ commands=
     cov: coverage xml
     lint: pylint --rcfile=.pylintrc --jobs=5 . module.py tools.py controllers tests services exceptions.py
     lint: pycodestyle --max-line-length=100 --exclude=.tox,venv,frontend,.vscode --ignore=E402,E121,E123,E126,E226,E24,E704,W503,E741 .
+    run: {posargs}


### PR DESCRIPTION
* Added 'run' command to run arbitrary commands so
  you don't have to run the whole test/lint suite.
  Use case examples:
  - Run only 1 test:
  tox -e py3-run pytest tests/test_rgw_client.py::RgwClientTest::test_ssl_verify
  - Run pycodestyle for only 1 file:
  tox -e py3-run pycodestyle tests/test_rgw_client.py

Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

