### PR TITLE
luminous: osd: keep using cache even if op will invalid cache

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1836,13 +1836,12 @@ bool ECBackend::try_state_to_reads()
     return false;
   }
 
+  op->using_cache = pipeline_state.caching_enabled();
+
   if (op->invalidates_cache()) {
     dout(20) << __func__ << ": invalidating cache after this op"
 	     << dendl;
     pipeline_state.invalidate();
-    op->using_cache = false;
-  } else {
-    op->using_cache = pipeline_state.caching_enabled();
   }
 
   waiting_state.pop_front();


### PR DESCRIPTION
https://tracker.ceph.com/issues/37993