### PR TITLE
librbd: properly filter out trashed non-user images on purge

### DIFF
--- a/src/librbd/api/Trash.cc
+++ b/src/librbd/api/Trash.cc
@@ -284,11 +284,12 @@ int Trash<I>::purge(IoCtx& io_ctx, time_t expire_ts,
     return r;
   }
 
-  std::remove_if(trash_entries.begin(), trash_entries.end(),
-      [](librbd::trash_image_info_t info) {
-        return info.source != RBD_TRASH_IMAGE_SOURCE_USER;
-      }
-  );
+  trash_entries.erase(
+      std::remove_if(trash_entries.begin(), trash_entries.end(),
+                     [](librbd::trash_image_info_t info) {
+                       return info.source != RBD_TRASH_IMAGE_SOURCE_USER;
+                     }),
+      trash_entries.end());
 
   std::set<std::string> to_be_removed;
   if (threshold != -1) {


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/38006
Signed-off-by: Mykola Golub <mgolub@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

