### PR TITLE
cmake: use $CMAKE_BINARY_DIR for default $CEPH_BUILD_VIRTUALENV

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -392,6 +392,17 @@ function test_kill_daemons() {
     teardown $dir || return 1
 }
 
+#
+# return a random TCP port which is not used yet
+#
+# please note, there could be racing if we use this function for
+# a free port, and then try to bind on this port.
+#
+function get_unused_port() {
+    local ip=127.0.0.1
+    python3 -c "import socket; s=socket.socket(); s.bind(('$ip', 0)); print(s.getsockname()[1]); s.close()"
+}
+
 #######################################################################
 
 ##

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -459,7 +459,7 @@ install(TARGETS librados-config DESTINATION bin)
 # virtualenv base directory for ceph-disk and ceph-detect-init
 set(CEPH_BUILD_VIRTUALENV $ENV{TMPDIR})
 if(NOT CEPH_BUILD_VIRTUALENV)
-  set(CEPH_BUILD_VIRTUALENV /tmp)
+  set(CEPH_BUILD_VIRTUALENV ${CMAKE_BINARY_DIR})
 endif()
 
 add_subdirectory(pybind)

--- a/src/pybind/mgr/ansible/run-tox.sh
+++ b/src/pybind/mgr/ansible/run-tox.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run from ./ or from ../
-: ${MGR_ANSIBLE_VIRTUALENV:=/tmp/mgr-ansible-virtualenv}
+: ${MGR_ANSIBLE_VIRTUALENV:=$CEPH_BUILD_DIR/mgr-ansible-virtualenv}
 : ${WITH_PYTHON2:=ON}
 : ${WITH_PYTHON3:=ON}
 : ${CEPH_BUILD_DIR:=$PWD/.tox}

--- a/src/pybind/mgr/dashboard/run-tox.sh
+++ b/src/pybind/mgr/dashboard/run-tox.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run from ./ or from ../
-: ${MGR_DASHBOARD_VIRTUALENV:=/tmp/mgr-dashboard-virtualenv}
+: ${MGR_DASHBOARD_VIRTUALENV:=$CEPH_BUILD_DIR/mgr-dashboard-virtualenv}
 : ${WITH_PYTHON2:=ON}
 : ${WITH_PYTHON3:=ON}
 : ${CEPH_BUILD_DIR:=$PWD/.tox}

--- a/src/pybind/mgr/insights/run-tox.sh
+++ b/src/pybind/mgr/insights/run-tox.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run from ./ or from ../
-: ${MGR_INSIGHTS_VIRTUALENV:=/tmp/mgr-insights-virtualenv}
+: ${MGR_INSIGHTS_VIRTUALENV:=$CEPH_BUILD_DIR/mgr-insights-virtualenv}
 : ${WITH_PYTHON2:=ON}
 : ${WITH_PYTHON3:=ON}
 : ${CEPH_BUILD_DIR:=$PWD/.tox}

--- a/src/pybind/mgr/orchestrator_cli/run-tox.sh
+++ b/src/pybind/mgr/orchestrator_cli/run-tox.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # run from ./ or from ../
-: ${MGR_ORCHESTRATOR_CLI_VIRTUALENV:=/tmp/mgr-orchestrator_cli-virtualenv}
+: ${MGR_ORCHESTRATOR_CLI_VIRTUALENV:=$CEPH_BUILD_DIR/mgr-orchestrator_cli-virtualenv}
 : ${WITH_PYTHON2:=ON}
 : ${WITH_PYTHON3:=ON}
 : ${CEPH_BUILD_DIR:=$PWD/.tox}

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -1,5 +1,6 @@
 import json
 import re
+import os
 import threading
 import functools
 import uuid
@@ -196,9 +197,9 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
             c_v_out = check_output(['ceph-volume', 'inventory', '--format', 'json'])
         except OSError:
             cmd = """
-            . /tmp/ceph-volume-virtualenv/bin/activate
+            . {}/ceph-volume-virtualenv/bin/activate
             ceph-volume inventory --format json
-            """
+            """.format(tmpdir=os.environ.get('TMPDIR', '/tmp'))
             c_v_out = check_output(cmd, shell=True)
 
         for out in c_v_out.splitlines():

--- a/src/test/osd/safe-to-destroy.sh
+++ b/src/test/osd/safe-to-destroy.sh
@@ -8,7 +8,7 @@ function run() {
     local dir=$1
     shift
 
-    export CEPH_MON="127.0.0.1:7227" # git grep '\<7227\>' : there must be only one
+    export CEPH_MON="127.0.0.1:$(get_unused_port)"
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "

--- a/src/test/smoke.sh
+++ b/src/test/smoke.sh
@@ -2,11 +2,13 @@
 
 source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
 
+mon_port=$(get_unused_port)
+
 function run() {
     local dir=$1
     shift
 
-    export CEPH_MON="127.0.0.1:7224" # git grep '\<7224\>' : there must be only one
+    export CEPH_MON="127.0.0.1:$mon_port"
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
@@ -34,10 +36,9 @@ function TEST_minimal() {
 
 function TEST_multimon() {
     local dir=$1
-
-    MONA="127.0.0.1:7224" # git grep '\<7224\>' : there must be only one
-    MONB="127.0.0.1:7225" # git grep '\<7225\>' : there must be only one
-    MONC="127.0.0.1:7226" # git grep '\<7226\>' : there must be only one
+    MONA="127.0.0.1:$((mon_port++))"
+    MONB="127.0.0.1:$((mon_port++))"
+    MONC="127.0.0.1:$((mon_port++))"
 
     run_mon $dir a --public-addr $MONA
     run_mon $dir b --public-addr $MONB


### PR DESCRIPTION
to avoid conflict with other `make check` runs in the same host

See-also: http://tracker.ceph.com/issues/36737
Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

