### PR TITLE
mgr: ceph-mgr crashing due to "recursive lock of PyModuleRegistry::lock"

### DIFF
--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -125,8 +125,7 @@ public:
   bool module_exists(const std::string &module_name) const
   {
     std::lock_guard l(lock);
-    auto mod_iter = modules.find(module_name);
-    return mod_iter != modules.end();
+    return modules.count(module_name) > 0;
   }
 
   /**


### PR DESCRIPTION
The issue was introduced by https://github.com/ceph/ceph/commit/030e85bb9c6c3571fec514f457010efea8f49296 (https://tracker.ceph.com/issues/37722).

- Improve PyModuleRegistry::module_exists()
- Revert changes at ceph_get_module_option() in BaseMgrModule.cc. This is necessary to prevent a dead-lock in some situations. The old code does not use methods from PyModuleRegistry in it's path which finally was the reason for the dead-lock.

Fixes: http://tracker.ceph.com/issues/37997

Signed-off-by: Volker Theile <vtheile@suse.com>

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

