### PR TITLE
rgw: http_client: propagate send_data_hint differently

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -472,7 +472,7 @@ int RGWHTTPClient::get_req_retcode()
 /*
  * init request, will be used later with RGWHTTPManager
  */
-int RGWHTTPClient::init_request(rgw_http_req_data *_req_data, bool send_data_hint)
+int RGWHTTPClient::init_request(rgw_http_req_data *_req_data)
 {
   ceph_assert(!req_data);
   _req_data->get();
@@ -930,11 +930,11 @@ void RGWHTTPManager::manage_pending_requests()
   }
 }
 
-int RGWHTTPManager::add_request(RGWHTTPClient *client, bool send_data_hint)
+int RGWHTTPManager::add_request(RGWHTTPClient *client)
 {
   rgw_http_req_data *req_data = new rgw_http_req_data;
 
-  int ret = client->init_request(req_data, send_data_hint);
+  int ret = client->init_request(req_data);
   if (ret < 0) {
     req_data->put();
     req_data = NULL;

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -76,6 +76,7 @@ class RGWHTTPClient : public RGWIOProvider
   bufferlist::iterator send_iter;
   bool has_send_len;
   long http_status;
+  bool send_data_hint{false};
   size_t receive_pause_skip{0}; /* how many bytes to skip next time receive_data is called
                                    due to being paused */
 
@@ -86,6 +87,7 @@ class RGWHTTPClient : public RGWIOProvider
   bool verify_ssl; // Do not validate self signed certificates, default to false
 
   std::atomic<unsigned> stopped { 0 };
+
 
 protected:
   CephContext *cct;
@@ -99,8 +101,7 @@ protected:
 
   RGWHTTPManager *get_manager();
 
-  int init_request(rgw_http_req_data *req_data,
-                   bool send_data_hint = false);
+  int init_request(rgw_http_req_data *req_data);
 
   virtual int receive_header(void *ptr, size_t len) {
     return 0;
@@ -165,6 +166,9 @@ public:
     has_send_len = true;
   }
 
+  void set_send_data_hint(bool hint) {
+    send_data_hint = hint;
+  }
 
   long get_http_status() const {
     return http_status;
@@ -347,7 +351,7 @@ public:
   int start();
   void stop();
 
-  int add_request(RGWHTTPClient *client, bool send_data_hint = false);
+  int add_request(RGWHTTPClient *client);
   int remove_request(RGWHTTPClient *client);
   int set_request_state(RGWHTTPClient *client, RGWHTTPRequestSetState state);
 };

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -761,7 +761,7 @@ int RGWRESTStreamRWRequest::do_send_prepare(RGWAccessKey *key, map<string, strin
   if (send_data) {
     set_send_length(send_data->length());
     set_outbl(*send_data);
-    send_data_hint = true;
+    set_send_data_hint(true);
   }
   
 
@@ -789,7 +789,7 @@ int RGWRESTStreamRWRequest::send(RGWHTTPManager *mgr)
     return RGWHTTP::send(this);
   }
 
-  int r = mgr->add_request(this, send_data_hint);
+  int r = mgr->add_request(this);
   if (r < 0)
     return r;
 

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -161,7 +161,6 @@ public:
 };
 
 class RGWRESTStreamRWRequest : public RGWHTTPStreamRWRequest {
-  bool send_data_hint{false};
 protected:
   HostStyle host_style;
 public:


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/36092

send_data_hint is passed so that the lower http client layer
to know in in cases where it's an http request that usually doesn't
send data (e.g., GET) that the request will actually send data,
and initialize the curl client correctly. In a case that was
used by the elasticsearch mechanism it wasn't passed correctly.
Now made it a data member in RGWHTTPClient, which also cleans
the interface a bit.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

