### PR TITLE
client: directory size always is zero lead to is_quota_bytes_approaching lose efficacy

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -14011,16 +14011,16 @@ bool Client::is_quota_bytes_exceeded(Inode *in, int64_t new_bytes,
 
 bool Client::is_quota_bytes_approaching(Inode *in, const UserPerm& perms)
 {
+  ceph_assert(in->size >= in->reported_size);
+  const uint64_t size = in->size - in->reported_size;
   return check_quota_condition(in, perms,
-      [](const Inode &in) {
+      [&size](const Inode &in) {
         if (in.quota.max_bytes) {
           if (in.rstat.rbytes >= in.quota.max_bytes) {
             return true;
           }
 
-          ceph_assert(in.size >= in.reported_size);
           const uint64_t space = in.quota.max_bytes - in.rstat.rbytes;
-          const uint64_t size = in.size - in.reported_size;
           return (space >> 4) < size;
         } else {
           return false;


### PR DESCRIPTION
Dear all,
Problem: set 100M for testdir quota, but we can write more than 300M data under this testdir.

Reason: the directory inode size always is zero, so that is_quota_bytes_approaching can't work 
correctly, the client always use delay message to notify mds update testdir used space statistic, 
and cause client update testdir used space statistic more delays, so client can write more data.

Solution: in client did not record current new added space in directory level, so i want to use current 
write file new added size replace directory size.
Looking forward to a better solution,thanks!

Fixes: 
Signed-off-by: guoyong guo.yong33@zte.com.cn

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

