### PR TITLE
luminous ceph-volume fix TypeError on dmcrypt when using Python3

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_encryption.py
@@ -33,3 +33,21 @@ class TestDmcryptClose(object):
         file_name = '/path/does/not/exist'
         encryption.dmcrypt_close(file_name)
         assert fake_run.calls == []
+
+
+class TestDmcryptKey(object):
+
+    def test_dmcrypt_with_default_size(self, conf_ceph_stub):
+        conf_ceph_stub('[global]\nfsid=asdf-lkjh')
+        result = encryption.create_dmcrypt_key()
+        assert len(result) == 172
+
+    def test_dmcrypt_with_custom_size(self, conf_ceph_stub):
+        conf_ceph_stub('''
+        [global]
+        fsid=asdf
+        [osd]
+        osd_dmcrypt_size=8
+        ''')
+        result = encryption.create_dmcrypt_key()
+        assert len(result) == 172

--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -23,7 +23,7 @@ def create_dmcrypt_key():
     )
     # The size of the key is defined in bits, so we must transform that
     # value to bytes (dividing by 8) because we read in bytes, not bits
-    random_string = os.urandom(dmcrypt_key_size / 8)
+    random_string = os.urandom(int(dmcrypt_key_size / 8))
     key = base64.b64encode(random_string).decode('utf-8')
     return key
 


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/37963
Backport of: https://github.com/ceph/ceph/pull/26034