### PR TITLE
mimic: ceph-volume: mark a device not available if it belongs to ceph-disk

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_device.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_device.py
@@ -92,6 +92,14 @@ class TestDevice(object):
         disk = device.Device("/dev/sda")
         assert disk.is_ceph_disk_member
 
+    def test_is_ceph_disk_member_not_available(self, device_info):
+        lsblk = {"PARTLABEL": "ceph data"}
+        device_info(lsblk=lsblk)
+        disk = device.Device("/dev/sda")
+        assert disk.is_ceph_disk_member
+        assert not disk.available
+        assert "Used by ceph-disk" in disk.rejected_reasons
+
     def test_is_not_ceph_disk_member_lsblk(self, device_info):
         lsblk = {"PARTLABEL": "gluster partition"}
         device_info(lsblk=lsblk)


### PR DESCRIPTION
The `ceph-volume inventory` command will now show if a device is being
used by ceph-disk and mark it not available if so.

Fixes: https://tracker.ceph.com/issues/24871

Signed-off-by: Andrew Schoen <aschoen@redhat.com>
(cherry picked from commit d14a6b284c44a3f61c0dd8c60ccc474203003653)

backport of: #26084
