### PR TITLE
doc/rados/configuration: refresh osdmap section

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -855,30 +855,14 @@ Ceph performs well as the OSD map grows larger.
 
 :Description: The number of OSD maps to keep cached.
 :Type: 32-bit Integer
-:Default: ``500``
-
-
-``osd map cache bl size``
-
-:Description: The size of the in-memory OSD map cache in OSD daemons.
-:Type: 32-bit Integer
 :Default: ``50``
-
-
-``osd map cache bl inc size``
-
-:Description: The size of the in-memory OSD map cache incrementals in
-              OSD daemons.
-
-:Type: 32-bit Integer
-:Default: ``100``
 
 
 ``osd map message max``
 
 :Description: The maximum map entries allowed per MOSDMap message.
 :Type: 32-bit Integer
-:Default: ``100``
+:Default: ``40``
 
 
 


### PR DESCRIPTION
"osd map cache size" and "osd map message max" were reduced in commit
855955e58e63 ("osd: reduce size of osdmap cache, messages").

"osd map cache bl size" and "osd map cache bl inc size" were removed
six years ago.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>