### PR TITLE
rbd device commands are deprecated

### DIFF
--- a/src/ocf/rbd.in
+++ b/src/ocf/rbd.in
@@ -138,7 +138,7 @@ find_rbd_dev() {
 
     # Run "rbd device list", filter out the header line, then try to
     # extract the device name
-    rbd device list | tail -n +2 | sed -n -e "s,$sedpat,\1,p"
+    rbd showmapped | tail -n +2 | sed -n -e "s,$sedpat,\1,p"
 }
 
 rbd_validate_all() {
@@ -211,7 +211,7 @@ rbd_start() {
         rbd_name="$rbd_name@${OCF_RESKEY_snap}"
     fi
 
-    do_rbd device map $rbd_name $rbd_map_options || exit $OCF_ERR_GENERIC
+    do_rbd map $rbd_name $rbd_map_options || exit $OCF_ERR_GENERIC
 
     # After the resource has been started, check whether it started up
     # correctly. If the resource starts asynchronously, the agent may
@@ -249,7 +249,7 @@ rbd_stop() {
     # exit with an $OCF_ERR_ error code if anything goes seriously
     # wrong)
     rbd_dev=`find_rbd_dev`
-    do_rbd device unmap $rbd_dev || exit $OCF_ERR_GENERIC
+    do_rbd unmap $rbd_dev || exit $OCF_ERR_GENERIC
 
     # After the resource has been stopped, check whether it shut down
     # correctly. If the resource stops asynchronously, the agent may


### PR DESCRIPTION
rbd device list, rbd device map and rdb device unmap commands are no longer used. This needs to be replaced with rbd showmapped, rbd map and rbd unmap.


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

