### PR TITLE
common/Formatter: escape printed buffer in XMLFormatter::dump_format_va()

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -487,7 +487,7 @@ void XMLFormatter::dump_format_va(const char* name, const char *ns, bool quoted,
 
   print_spaces();
   if (ns) {
-    m_ss << "<" << e << " xmlns=\"" << ns << "\">" << buf << "</" << e << ">";
+    m_ss << "<" << e << " xmlns=\"" << ns << "\">" << escape_xml_str(buf) << "</" << e << ">";
   } else {
     m_ss << "<" << e << ">" << escape_xml_str(buf) << "</" << e << ">";
   }


### PR DESCRIPTION
Formatter: escape characters in XMLFormatter::dump_format_va

Signed-off-by: ashitakasam <694240887@qq.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

