### PR TITLE
mimic: librbd: properly filter out trashed non-user images on purge

### DIFF
--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -393,11 +393,12 @@ int execute_purge (const po::variables_map &vm,
     return r;
   }
 
-  std::remove_if(trash_entries.begin(), trash_entries.end(),
-    [](librbd::trash_image_info_t info) {
-      return info.source != RBD_TRASH_IMAGE_SOURCE_USER;
-    }
-  );
+  trash_entries.erase(
+      std::remove_if(trash_entries.begin(), trash_entries.end(),
+                     [](librbd::trash_image_info_t info) {
+                       return info.source != RBD_TRASH_IMAGE_SOURCE_USER;
+                     }),
+  trash_entries.end());
 
   std::vector<const char *> to_be_removed;
 


### PR DESCRIPTION
https://tracker.ceph.com/issues/38032