### PR TITLE
ceph.spec.in: added missing Python dependency in manager

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -432,14 +432,16 @@ Group:          System/Filesystems
 Requires:       ceph-base = %{_epoch_prefix}%{version}-%{release}
 Requires:       python%{_python_buildid}-pecan
 Requires:       python%{_python_buildid}-six
+Requires:       python%{_python_buildid}-requests
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       python%{_python_buildid}-cherrypy
 Requires:       python%{_python_buildid}-jwt
 Requires:       python%{_python_buildid}-jinja2
 Requires:       python%{_python_buildid}-routes
 Requires:       python%{_python_buildid}-werkzeug
-Requires:       pyOpenSSL%{_python_buildid}
-Requires:	python%{_python_buildid}-bcrypt
+Requires:       python%{_python_buildid}-pyopenssl
+Requires:       python%{_python_buildid}-bcrypt
+
 %endif
 %if 0%{?suse_version}
 Requires:       python%{_python_buildid}-CherryPy


### PR DESCRIPTION
- Added python OpenSSL  (fedora/rhel) dependency
- Added python Requests (all) dependency

Fixes: https://tracker.ceph.com/issues/37584
Signed-off-by: Juan Miguel Olmo Martínez <jolmomar@redhat.com>

