### PR TITLE
mgr: Improve ActivePyModules::get_typed_config implementation

### DIFF
--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -529,15 +529,15 @@ PyObject *ActivePyModules::get_typed_config(
   const std::string &module_name,
   const std::string &key) const
 {
-  if (!py_module_registry.module_exists(module_name)) {
-    derr << "Module '" << module_name << "' is not available" << dendl;
-    Py_RETURN_NONE;
-  }
-
   std::string value;
   bool found = get_config(module_name, key, &value);
   if (found) {
     PyModuleRef module = py_module_registry.get_module(module_name);
+    if (!module) {
+        derr << "Module '" << module_name << "' is not available" << dendl;
+        Py_RETURN_NONE;
+    }
+
     dout(10) << __func__ << " " << key << " found: " << value << dendl;
     return module->get_typed_option_value(key, value);
   }

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2082,6 +2082,7 @@ bool DaemonServer::_handle_command(
 
     // Validate that the module is enabled
     PyModuleRef module = py_modules.get_module(handler_name);
+    ceph_assert(module);
     if (!module->is_enabled()) {
       ss << "Module '" << handler_name << "' is not enabled (required by "
             "command '" << prefix << "'): use `ceph mgr module enable "

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -113,20 +113,19 @@ public:
   std::vector<ModuleCommand> get_py_commands() const;
 
   /**
-   * module_name **must** exist, but does not have to be loaded
-   * or runnable.
+   * Get the specified module. The module does not have to be
+   * loaded or runnable.
+   *
+   * Returns an empty reference if it does not exist.
    */
   PyModuleRef get_module(const std::string &module_name)
   {
     std::lock_guard l(lock);
-    return modules.at(module_name);
-  }
-
-  bool module_exists(const std::string &module_name) const
-  {
-    std::lock_guard l(lock);
-    auto mod_iter = modules.find(module_name);
-    return mod_iter != modules.end();
+    auto module_iter = modules.find(module_name);
+    if (module_iter == modules.end()) {
+        return {};
+    }
+    return module_iter->second;
   }
 
   /**


### PR DESCRIPTION
- Remove PyModuleRegistry::module_exists method
- Rafctor PyModuleRegistry::get_module method

Signed-off-by: Volker Theile <vtheile@suse.com>

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

