### PR TITLE
rados: return legacy address in 'lock info'

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1261,7 +1261,7 @@ static int do_lock_cmd(std::vector<const char*> &nargs,
       formatter->dump_string("cookie", id.cookie);
       formatter->dump_string("description", info.description);
       formatter->dump_stream("expiration") << info.expiration;
-      formatter->dump_stream("addr") << info.addr;
+      formatter->dump_stream("addr") << info.addr.get_legacy_str();
       formatter->close_section();
     }
     formatter->close_section();


### PR DESCRIPTION
There is no need to differentiate v1 vs v2 addresses and we should
avoid breaking backwards compatibility in the output.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

