### PR TITLE
rgw: check lc objs not empty after fetching

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -466,8 +466,10 @@ public:
       if (ret < 0) {
         ldout(store->ctx(), 0) << "ERROR: list_op returned ret=" << ret << dendl;
         return ret;
-      } else {
-        obj_iter = objs.begin();
+      } 
+      obj_iter = objs.begin();
+      if (obj_iter == objs.end()) {
+        return false;
       }
       delay();
     }


### PR DESCRIPTION
During lifecycle processing, the bucket's objects
may be deleted by other clients, so we need to
check objs not empty after each fetch.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

