### PR TITLE
qa:rbd/workunits : Replace `rbd bench-write` with `rbd bench --io-typ…

### DIFF
--- a/qa/workunits/rbd/diff.sh
+++ b/qa/workunits/rbd/diff.sh
@@ -14,14 +14,14 @@ function cleanup() {
 cleanup
 
 rbd create foo --size 1000
-rbd bench-write foo --io-size 4096 --io-threads 5 --io-total 4096000 --io-pattern rand
+rbd bench --io-type write foo --io-size 4096 --io-threads 5 --io-total 4096000 --io-pattern rand
 
 #rbd cp foo foo.copy
 rbd create foo.copy --size 1000
 rbd export-diff foo - | rbd import-diff - foo.copy
 
 rbd snap create foo --snap=two
-rbd bench-write foo --io-size 4096 --io-threads 5 --io-total 4096000 --io-pattern rand
+rbd bench --io-type write foo --io-size 4096 --io-threads 5 --io-total 4096000 --io-pattern rand
 rbd snap create foo --snap=three
 rbd snap create foo.copy --snap=two
 

--- a/qa/workunits/rbd/diff_continuous.sh
+++ b/qa/workunits/rbd/diff_continuous.sh
@@ -25,7 +25,7 @@ trap cleanup EXIT
 
 # start from a clone
 rbd create $parent --size $size --image-format 2 --stripe-count 8 --stripe-unit 65536
-rbd bench-write $parent --io-size $iosize --io-threads $iothreads --io-total $iototal --io-pattern rand 
+rbd bench --io-type write $parent --io-size $iosize --io-threads $iothreads --io-total $iototal --io-pattern rand
 rbd snap create $parent --snap parent
 rbd snap protect $parent --snap parent
 rbd clone $parent@parent $src --stripe-count 4 --stripe-unit 262144
@@ -35,7 +35,7 @@ rbd create $dst --size $size --image-format 2 --order 19
 for s in `seq 1 $max`; do
     rbd snap create $src --snap=snap$s
     rbd export-diff $src@snap$s - $lastsnap | rbd import-diff - $dst  &
-    rbd bench-write $src --io-size $iosize --io-threads $iothreads --io-total $iototal --io-pattern rand  &
+    rbd bench --io-type write $src --io-size $iosize --io-threads $iothreads --io-total $iototal --io-pattern rand  &
     wait
     lastsnap="--from-snap snap$s"
 done

--- a/qa/workunits/rbd/journal.sh
+++ b/qa/workunits/rbd/journal.sh
@@ -70,7 +70,7 @@ test_rbd_journal()
 
     local count=10
     save_commit_position ${journal}
-    rbd bench-write ${image} --io-size 4096 --io-threads 1 \
+    rbd bench --io-type write ${image} --io-size 4096 --io-threads 1 \
 	--io-total $((4096 * count)) --io-pattern seq
     rbd journal status --image ${image} | fgrep "tid=$((count - 1))"
     restore_commit_position ${journal}


### PR DESCRIPTION
…e write`
Should fix warnings like:
```
2019-01-25T13:49:00.971 INFO:tasks.workunit.client.0.target192168000038.stderr:+ rbd bench-write testrbdjournal66808 --io-size 4096 --io-threads 1 --io-total 40960 --io-pattern seq
2019-01-25T13:49:01.029 INFO:tasks.workunit.client.0.target192168000038.stderr:rbd: bench-write is deprecated, use rbd bench --io-type write
```

Signed-off-by: Shyukri Shyukriev <shshyukriev@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

