### PR TITLE
mgr/orchestrator: Unify `osd create` and `osd add`

### DIFF
--- a/src/pybind/mgr/ansible/module.py
+++ b/src/pybind/mgr/ansible/module.py
@@ -290,7 +290,7 @@ class Module(MgrModule, orchestrator.Orchestrator):
 
         return ansible_operation
 
-    def create_osds(self, drive_group, all_hosts=None):
+    def create_osds(self, drive_group, all_hosts):
         """Create one or more OSDs within a single Drive Group.
         If no host provided the operation affects all the host in the OSDS role
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1158,6 +1158,13 @@ class MgrModule(ceph_module.BaseMgrModule):
         Invoke a method on another module.  All arguments, and the return
         value from the other module must be serializable.
 
+        Limitation: Do not import any modules within the called method.
+        Otherwise you will get an error in Python 2::
+
+            RuntimeError('cannot unmarshal code objects in restricted execution mode',)
+
+
+
         :param module_name: Name of other module.  If module isn't loaded,
                             an ImportError exception is raised.
         :param method_name: Method name.  If it does not exist, a NameError

--- a/src/pybind/mgr/orchestrator_cli/test_orchestrator.py
+++ b/src/pybind/mgr/orchestrator_cli/test_orchestrator.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import pytest
 
 
-from orchestrator import DriveGroupSpec, DeviceSelection
+from orchestrator import DriveGroupSpec, DeviceSelection, DriveGroupValidationError
 
 
 def test_DriveGroup():
@@ -31,6 +31,6 @@ def test_drive_selection():
     spec = DriveGroupSpec('node_name', data_devices=devs)
     assert spec.data_devices.paths == ['/dev/sda']
 
-    with pytest.raises(TypeError, match='exclusive'):
+    with pytest.raises(DriveGroupValidationError, match='exclusive'):
         DeviceSelection(paths=['/dev/sda'], rotates=False)
 

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -26,6 +26,10 @@ class TestReadCompletion(orchestrator.ReadCompletion):
         global all_completions
         all_completions.append(self)
 
+    def __str__(self):
+        return "TestReadCompletion(result={} message={})".format(self.result, self.message)
+
+
     @property
     def result(self):
         return self._result
@@ -40,10 +44,9 @@ class TestReadCompletion(orchestrator.ReadCompletion):
 
 
 class TestWriteCompletion(orchestrator.WriteCompletion):
-    def __init__(self, execute_cb, complete_cb, message):
+    def __init__(self, execute_cb, message):
         super(TestWriteCompletion, self).__init__()
         self.execute_cb = execute_cb
-        self.complete_cb = complete_cb
 
         # Executed means I executed my API call, it may or may
         # not have succeeded
@@ -63,6 +66,13 @@ class TestWriteCompletion(orchestrator.WriteCompletion):
         global all_completions
         all_completions.append(self)
 
+    def __str__(self):
+        return "TestWriteCompletion(executed={} result={} id={} message={} error={})".format(self.executed, self._result, self.id, self.message,  self.error)
+
+    @property
+    def result(self):
+        return self._result
+
     @property
     def is_persistent(self):
         return (not self.is_errored) and self.executed
@@ -79,13 +89,18 @@ class TestWriteCompletion(orchestrator.WriteCompletion):
         if not self.executed:
             self._result = self.execute_cb()
             self.executed = True
+            self.effective = True
 
-        if not self.effective:
-            # TODO: check self.result for API errors
-            if self.complete_cb is None:
-                self.effective = True
-            else:
-                self.effective = self.complete_cb()
+
+def deferred_write(message):
+    def wrapper(f):
+        @functools.wraps(f)
+        def inner(*args, **kwargs):
+            args[0].log.warning('message' + message)
+            return TestWriteCompletion(lambda: f(*args, **kwargs),
+                                       '{}, args={}, kwargs={}'.format(message, args, kwargs))
+        return inner
+    return wrapper
 
 
 def deferred_read(f):
@@ -246,12 +261,12 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     def add_stateless_service(self, service_type, spec):
         raise NotImplementedError(service_type)
 
+    @deferred_write("create_osds")
     def create_osds(self, drive_group, all_hosts):
-        raise NotImplementedError(str(drive_group))
+        drive_group.validate(all_hosts)
 
+
+    @deferred_write("service_action")
     def service_action(self, action, service_type, service_name=None, service_id=None):
-        return TestWriteCompletion(
-            lambda: True, None,
-            "Pretending to {} service {} (name={}, id={})".format(
-                action, service_type, service_name, service_id))
+        pass
 


### PR DESCRIPTION
Also:

* Added some more tests
* Better validation of drive Groups
* Simplified `TestWriteCompletion`

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

