### PR TITLE
msg/async: identify client using any: addr

### DIFF
--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -194,8 +194,10 @@ class AsyncConnection : public Connection {
   // Accepting state
   bool msgr2 = false;
   entity_addr_t socket_addr;  ///< local socket addr
-  entity_addr_t target_addr;  ///< which of the peer_addrs we're using
+  entity_addr_t target_addr;  ///< which of the peer_addrs we're connecting to (as clienet) or should reconnect to (as peer)
 
+  entity_addr_t _infer_target_addr(const entity_addrvec_t& av);
+  
   // used only by "read_until"
   uint64_t state_offset;
   Worker *worker;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -889,6 +889,7 @@ bool AsyncMessenger::learned_addr(const entity_addr_t &peer_addr_for_me)
   if (need_addr) {
     if (my_addrs->empty()) {
       auto a = peer_addr_for_me;
+      a.set_type(entity_addr_t::TYPE_ANY);
       a.set_nonce(nonce);
       if (!did_bind) {
 	a.set_port(0);


### PR DESCRIPTION
The client can speak v1 or v2, so it is misleading to identify it with a v1 or v2
address (it is either).  This avoid some kludgey workarounds.

We also are a bit more precise about what target_addr means.  It is only used by
the client to indicate which of the peer_addrs we are connecting to, or by a
peer to identify which the peer_addrs we *would* reconnect to.

Signed-off-by: Sage Weil <sage@redhat.com>