### PR TITLE
mgr/dashboard: Group buttons together into one menu on OSD page

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.html
@@ -14,23 +14,35 @@
                           [tableActions]="tableActions">
         </cd-table-actions>
 
-        <button class="btn btn-sm btn-default btn-label tc_configureCluster"
-                type="button"
-                (click)="configureClusterAction()">
-          <i class="fa fa-fw fa-cog"
-             aria-hidden="true">
-          </i>
-          <ng-container i18n>Set Cluster-wide Flags</ng-container>
-        </button>
-
-        <button class="btn btn-sm btn-default btn-label tc_configureCluster"
-                type="button"
-                (click)="configureQosParamsAction()">
-          <i class="fa fa-fw fa-cog"
-             aria-hidden="true">
-          </i>
-          <ng-container i18n>Set Cluster-wide Recovery Priority</ng-container>
-        </button>
+        <div class="btn-group"
+             dropdown>
+          <button type="button"
+                  class="btn btn-sm btn-default btn-label tc_configureCluster"
+                  (click)="configureClusterAction()">
+            <i class="fa fa-fw fa-cog"
+               aria-hidden="true">
+            </i>
+            <ng-container i18n>Set Cluster-wide Flags</ng-container>
+          </button>
+          <button type="button"
+                  dropdownToggle
+                  class="btn btn-sm btn-default dropdown-toggle dropdown-toggle-split">
+            <span class="caret caret-black"></span>
+          </button>
+          <ul *dropdownMenu
+              class="dropdown-menu"
+              role="menu">
+            <li role="menuitem">
+              <a class="dropdown-item"
+                 (click)="configureQosParamsAction()">
+                <i class="fa fa-fw fa-cog"
+                   aria-hidden="true">
+                </i>
+                <ng-container i18n>Set Cluster-wide Recovery Priority</ng-container>
+              </a>
+            </li>
+          </ul>
+        </div>
       </div>
 
       <cd-osd-details cdTableDetail

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.scss
@@ -1,0 +1,3 @@
+.caret.caret-black {
+  color: #000000;
+}

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
@@ -669,7 +669,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/osd/osd-list/osd-list.component.html</context>
-          <context context-type="linenumber">59</context>
+          <context context-type="linenumber">71</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/pool/pool-list/pool-list.component.html</context>
@@ -1062,13 +1062,13 @@
         <source>Set Cluster-wide Flags</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/osd/osd-list/osd-list.component.html</context>
-          <context context-type="linenumber">23</context>
+          <context context-type="linenumber">25</context>
         </context-group>
       </trans-unit><trans-unit id="9617df8e0504d997d0ff45b6c206a12becd13c37" datatype="html">
         <source>Set Cluster-wide Recovery Priority</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/osd/osd-list/osd-list.component.html</context>
-          <context context-type="linenumber">32</context>
+          <context context-type="linenumber">41</context>
         </context-group>
       </trans-unit><trans-unit id="b49d7877d24112d4bdfce9256edf61a007fae888" datatype="html">
         <source>OSDs List</source>
@@ -1081,20 +1081,20 @@
   <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/><x id="INTERPOLATION_1" equiv-text="{{ markActionDescription }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> if you proceed.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/osd/osd-list/osd-list.component.html</context>
-          <context context-type="linenumber">69</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit><trans-unit id="2d3a73f6440a7d896d74356fe0a725d731e71cbb" datatype="html">
         <source>The OSD is not safe to destroy!</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/osd/osd-list/osd-list.component.html</context>
-          <context context-type="linenumber">78</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit><trans-unit id="9d08116242443953ebbfe10bc2092e0a694b4adf" datatype="html">
         <source><x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/>OSD <x id="INTERPOLATION" equiv-text="{{ selection.first().id }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> will be
   <x id="START_TAG_STRONG" ctype="x-strong" equiv-text="&lt;strong&gt;"/><x id="INTERPOLATION_1" equiv-text="{{ actionDescription }}"/><x id="CLOSE_TAG_STRONG" ctype="x-strong" equiv-text="&lt;/strong&gt;"/> if you proceed.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/cluster/osd/osd-list/osd-list.component.html</context>
-          <context context-type="linenumber">80</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit><trans-unit id="d2bcd3296d2850de762fb943060b7e086a893181" datatype="html">
         <source>Health</source>

--- a/src/pybind/mgr/dashboard/frontend/src/styles.scss
+++ b/src/pybind/mgr/dashboard/frontend/src/styles.scss
@@ -155,6 +155,9 @@ button.btn.btn-label > i.fa {
   /** Add space between icon and text */
   padding-right: 5px;
 }
+.btn-toolbar .btn-group {
+  float: none;
+}
 
 /* Dropdown */
 .dropdown-menu {


### PR DESCRIPTION
Group the two buttons 'Set Cluster-wide Flags' and 'Set Cluster-wide Recovery Priority' together into one button menu.

Fixes: http://tracker.ceph.com/issues/37380
Signed-off-by: Tatjana Dehler <tdehler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

