### PR TITLE
mds: associate socket peer addr with Session

### DIFF
--- a/src/common/StackStringStream.h
+++ b/src/common/StackStringStream.h
@@ -157,6 +157,13 @@ public:
     return osp.get();
   }
 
+  sss const* get() const {
+    return osp.get();
+  }
+  sss* get() {
+    return osp.get();
+  }
+
 private:
   static constexpr std::size_t max_elems = 8;
 

--- a/src/mds/MDSAuthCaps.h
+++ b/src/mds/MDSAuthCaps.h
@@ -52,7 +52,8 @@ struct MDSCapSpec {
   static const unsigned RWS		= (READ|WRITE|SNAPSHOT);
   static const unsigned RWPS		= (READ|WRITE|SET_VXATTR|SNAPSHOT);
 
-  MDSCapSpec(unsigned _caps=0) : caps(_caps) {
+  MDSCapSpec() = default;
+  MDSCapSpec(unsigned _caps) : caps(_caps) {
     if (caps & ALL)
       caps |= RWPS;
   }
@@ -84,7 +85,7 @@ struct MDSCapSpec {
     return (caps & SET_VXATTR);
   }
 private:
-  unsigned caps;
+  unsigned caps = 0;
 };
 
 // conditions before we are allowed to do it
@@ -153,16 +154,19 @@ struct MDSCapGrant {
 
 class MDSAuthCaps
 {
-  CephContext *cct;
+  CephContext *cct = nullptr;
   std::vector<MDSCapGrant> grants;
 
 public:
-  explicit MDSAuthCaps(CephContext *cct_=NULL)
-    : cct(cct_) { }
+  MDSAuthCaps() = default;
+  explicit MDSAuthCaps(CephContext *cct_) : cct(cct_) {}
 
   // this ctor is used by spirit/phoenix; doesn't need cct.
-  explicit MDSAuthCaps(const std::vector<MDSCapGrant> &grants_)
-    : cct(NULL), grants(grants_) { }
+  explicit MDSAuthCaps(const std::vector<MDSCapGrant>& grants_) : grants(grants_) {}
+
+  void clear() {
+    grants.clear();
+  }
 
   void set_allow_all();
   bool parse(CephContext *cct, std::string_view str, std::ostream *err);

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -178,6 +178,8 @@ private:
 
   static const std::vector<MDSCommand>& get_commands();
 
+  bool parse_caps(const AuthCapsInfo&, MDSAuthCaps&);
+
   mono_time starttime = mono_clock::zero();
 };
 

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -207,7 +207,7 @@ bool Messenger::ms_deliver_verify_authorizer(
 	connection_secret,
 	challenge);
       if (isvalid) {
-	dis->ms_handle_authentication(con);
+	return dis->ms_handle_authentication(con)>=0;
       }
       return true;
     }


### PR DESCRIPTION
The recent messenger changes caused the peer address to be ANY?

Fixes: http://tracker.ceph.com/issues/38087
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

