### PR TITLE
rgw: verisoning: bugfix in concurrent, list and get will have consistency issue

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7317,6 +7317,11 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGW
   op.cmpxattr(RGW_ATTR_OLH_ID_TAG, CEPH_OSD_CMPXATTR_OP_EQ, olh_tag);
   op.cmpxattr(RGW_ATTR_OLH_VER, CEPH_OSD_CMPXATTR_OP_GT, last_ver);
 
+  bufferlist ver_bl;
+  string last_ver_s = to_string(last_ver);
+  ver_bl.append(last_ver_s.c_str(), last_ver_s.size());
+  op.setxattr(RGW_ATTR_OLH_VER, ver_bl);
+
   struct timespec mtime_ts = real_clock::to_timespec(state.mtime);
   op.mtime2(&mtime_ts);
 


### PR DESCRIPTION
when rgw1 and rgw2 concurrent put same key object, if rgw1 read the old olh_log, then halt. rgw2 do the all put phases, set olh.info in data pool to newest version object. Finally, rgw1 set the olh.info to an old verison based on the olh_log he read before.

Fixes: http://tracker.ceph.com/issues/38060