### PR TITLE
rpm: package crypto libraries for all archs

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1180,10 +1180,8 @@ rm -rf %{buildroot}
 %dir %{_libdir}/ceph/compressor
 %{_libdir}/ceph/compressor/libceph_*.so*
 %{_unitdir}/ceph-crash.service
-%ifarch x86_64
 %dir %{_libdir}/ceph/crypto
 %{_libdir}/ceph/crypto/libceph_*.so*
-%endif
 %if %{with lttng}
 %{_libdir}/libos_tp.so*
 %{_libdir}/libosd_tp.so*


### PR DESCRIPTION
Since 318a8e3c079c937d4e006a9eb4f47c5349648360 we are now building at least the
openssl crypto plugin on all architectures, not just x86_64.
    
This fixes the non-x86_64 builds for master.

Fixes: 318a8e3c079c937d4e006a9eb4f47c5349648360
Signed-off-by: Nathan Cutler <ncutler@suse.com>
