### PR TITLE
mgr/dashboard: Updated colors in PG Status chart

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie-color.enum.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie-color.enum.ts
@@ -1,8 +1,7 @@
 export enum HealthPieColor {
-  // Names inspired by https://encycolorpedia.com
-  MEDIUM_LIGHT_SHADE_PINK_RED = '#ff7592',
-  MEDIUM_DARK_SHADE_CYAN_BLUE = '#1d699d',
-  LIGHT_SHADE_BROWN = '#fcd0a1',
-  MEDIUM_DARK_SHADE_BLUE_MAGENTA = '#564d65',
-  SHADE_GREEN_CYAN = '#2cda9d'
+  DEFAULT_RED = '#ff7592',
+  DEFAULT_BLUE = '#1d699d',
+  DEFAULT_ORANGE = '#ffa500',
+  DEFAULT_MAGENTA = '#564d65',
+  DEFAULT_GREEN = '#00bb00'
 }

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health-pie/health-pie.component.ts
@@ -126,11 +126,11 @@ export class HealthPieComponent implements OnChanges, OnInit {
     this.chartConfig.colors = [
       {
         backgroundColor: [
-          HealthPieColor.MEDIUM_LIGHT_SHADE_PINK_RED,
-          HealthPieColor.MEDIUM_DARK_SHADE_CYAN_BLUE,
-          HealthPieColor.LIGHT_SHADE_BROWN,
-          HealthPieColor.SHADE_GREEN_CYAN,
-          HealthPieColor.MEDIUM_DARK_SHADE_BLUE_MAGENTA
+          HealthPieColor.DEFAULT_RED,
+          HealthPieColor.DEFAULT_BLUE,
+          HealthPieColor.DEFAULT_ORANGE,
+          HealthPieColor.DEFAULT_GREEN,
+          HealthPieColor.DEFAULT_MAGENTA
         ]
       }
     ];

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.spec.ts
@@ -214,10 +214,10 @@ describe('HealthComponent', () => {
       colors: [
         {
           backgroundColor: [
-            HealthPieColor.SHADE_GREEN_CYAN,
-            HealthPieColor.MEDIUM_DARK_SHADE_CYAN_BLUE,
-            HealthPieColor.LIGHT_SHADE_BROWN,
-            HealthPieColor.MEDIUM_LIGHT_SHADE_PINK_RED
+            HealthPieColor.DEFAULT_GREEN,
+            HealthPieColor.DEFAULT_BLUE,
+            HealthPieColor.DEFAULT_ORANGE,
+            HealthPieColor.DEFAULT_RED
           ]
         }
       ],

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/dashboard/health/health.component.ts
@@ -90,10 +90,10 @@ export class HealthComponent implements OnInit, OnDestroy {
     chart.colors = [
       {
         backgroundColor: [
-          HealthPieColor.SHADE_GREEN_CYAN,
-          HealthPieColor.MEDIUM_DARK_SHADE_CYAN_BLUE,
-          HealthPieColor.LIGHT_SHADE_BROWN,
-          HealthPieColor.MEDIUM_LIGHT_SHADE_PINK_RED
+          HealthPieColor.DEFAULT_GREEN,
+          HealthPieColor.DEFAULT_BLUE,
+          HealthPieColor.DEFAULT_ORANGE,
+          HealthPieColor.DEFAULT_RED
         ]
       }
     ];


### PR DESCRIPTION
* For consistency:
  Set 'Clean' status color to 'HEALTH_OK' color
  (Cluster Status card).

  Set 'Warning' status color to 'HEALTH_WARN' color.

  'Working' (blue) & 'Unknown' (red) are kept due to
  previous consensus about these complementary colors
  in doughnut/pie charts.

* Renamed Health Pie colors for the sake of clarity.

Signed-off-by: Alfonso Martínez <almartin@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

