### PR TITLE
mgr/restful: updated string formatting to str.format()

### DIFF
--- a/src/pybind/mgr/restful/api/config.py
+++ b/src/pybind/mgr/restful/api/config.py
@@ -33,7 +33,7 @@ class ConfigOsd(RestController):
         valid_flags = set(args.keys()) & set(common.OSD_FLAGS)
         invalid_flags = list(set(args.keys()) - valid_flags)
         if invalid_flags:
-            context.instance.log.warn("%s not valid to set/unset" % invalid_flags)
+            context.instance.log.warn("%s not valid to set/unset", invalid_flags)
 
         for flag in list(valid_flags):
             if args[flag]:

--- a/src/pybind/mgr/restful/api/mon.py
+++ b/src/pybind/mgr/restful/api/mon.py
@@ -23,7 +23,7 @@ class MonName(RestController):
 
         if len(mon) != 1:
             response.status = 500
-            return {'message': 'Failed to identify the monitor node "%s"' % self.name}
+            return {'message': 'Failed to identify the monitor node "{}"'.format(self.name)}
 
         return mon[0]
 

--- a/src/pybind/mgr/restful/api/osd.py
+++ b/src/pybind/mgr/restful/api/osd.py
@@ -20,7 +20,7 @@ class OsdIdCommand(RestController):
 
         if not osd:
             response.status = 500
-            return {'message': 'Failed to identify the OSD id "%d"' % self.osd_id}
+            return {'message': 'Failed to identify the OSD id "{}"'.format(self.osd_id)}
 
         if osd['up']:
             return common.OSD_IMPLEMENTED_COMMANDS
@@ -40,11 +40,11 @@ class OsdIdCommand(RestController):
 
         if not osd:
             response.status = 500
-            return {'message': 'Failed to identify the OSD id "%d"' % self.osd_id}
+            return {'message': 'Failed to identify the OSD id "{}"'.format(self.osd_id)}
 
         if not osd['up'] or command not in common.OSD_IMPLEMENTED_COMMANDS:
             response.status = 500
-            return {'message': 'Command "%s" not available' % command}
+            return {'message': 'Command "{}" not available'.format(command)}
 
         return context.instance.submit_request([[{
             'prefix': 'osd ' + command,
@@ -68,7 +68,7 @@ class OsdId(RestController):
         osd = context.instance.get_osds(ids=[str(self.osd_id)])
         if len(osd) != 1:
             response.status = 500
-            return {'message': 'Failed to identify the OSD id "%d"' % self.osd_id}
+            return {'message': 'Failed to identify the OSD id "{}"'.format(self.osd_id)}
 
         return osd[0]
 

--- a/src/pybind/mgr/restful/api/pool.py
+++ b/src/pybind/mgr/restful/api/pool.py
@@ -20,7 +20,7 @@ class PoolId(RestController):
 
         if not pool:
             response.status = 500
-            return {'message': 'Failed to identify the pool id "%d"' % self.pool_id}
+            return {'message': 'Failed to identify the pool id "{}"'.format(self.pool_id)}
 
         # pgp_num is called pg_placement_num, deal with that
         if 'pg_placement_num' in pool:
@@ -44,13 +44,13 @@ class PoolId(RestController):
         pool = context.instance.get_pool_by_id(self.pool_id)
         if not pool:
             response.status = 500
-            return {'message': 'Failed to identify the pool id "%d"' % self.pool_id}
+            return {'message': 'Failed to identify the pool id "{}"'.format(self.pool_id)}
 
         # Check for invalid pool args
         invalid = common.invalid_pool_args(args)
         if invalid:
             response.status = 500
-            return {'message': 'Invalid arguments found: "%s"' % str(invalid)}
+            return {'message': 'Invalid arguments found: "{}"'.format(invalid)}
 
         # Schedule the update request
         return context.instance.submit_request(common.pool_update_commands(pool['pool_name'], args), **kwargs)
@@ -66,7 +66,7 @@ class PoolId(RestController):
 
         if not pool:
             response.status = 500
-            return {'message': 'Failed to identify the pool id "%d"' % self.pool_id}
+            return {'message': 'Failed to identify the pool id "{}"'.format(self.pool_id)}
 
         return context.instance.submit_request([[{
             'prefix': 'osd pool delete',
@@ -125,7 +125,7 @@ class Pool(RestController):
         invalid = common.invalid_pool_args(args)
         if invalid:
             response.status = 500
-            return {'message': 'Invalid arguments found: "%s"' % str(invalid)}
+            return {'message': 'Invalid arguments found: "{}"'.format(invalid)}
 
         # Schedule the creation and update requests
         return context.instance.submit_request(

--- a/src/pybind/mgr/restful/api/request.py
+++ b/src/pybind/mgr/restful/api/request.py
@@ -23,7 +23,7 @@ class RequestId(RestController):
 
         if len(request) != 1:
             response.status = 500
-            return {'message': 'Unknown request id "%s"' % str(self.request_id)}
+            return {'message': 'Unknown request id "{}"'.format(self.request_id)}
 
         request = request[0]
         return request


### PR DESCRIPTION
<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

Updated string formatting to Python3-style ``str.format()``. Removed older string formatting (``%`` operator).

Signed-off-by: James McClune <jmcclune@mcclunetechnologies.net>