### PR TITLE
crimson/osd: add heartbeat support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -295,7 +295,7 @@ if(WITH_SEASTAR)
   endmacro ()
   set(Seastar_HWLOC OFF CACHE BOOL "" FORCE)
   set(Seastar_STD_OPTIONAL_VARIANT_STRINGVIEW ON CACHE BOOL "" FORCE)
-  set(Seastar_CXX_FLAGS "-Wno-sign-compare;-Wno-attributes" CACHE STRING "" FORCE)
+  set(Seastar_CXX_FLAGS "-Wno-sign-compare;-Wno-attributes;-Wno-pessimizing-move;-Wno-address-of-packed-member" CACHE STRING "" FORCE)
   add_subdirectory(seastar)
   # create the directory so cmake won't complain when looking at the imported
   # target: Seastar exports this directory created at build-time

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -17,6 +17,7 @@
 #include "include/str_list.h"
 #include "common/ceph_context.h"
 #ifndef WITH_SEASTAR
+#include "common/config.h"
 #include "common/config_obs.h"
 #endif
 #include "common/debug.h"

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -16,7 +16,9 @@
 #include "include/ipaddr.h"
 #include "include/str_list.h"
 #include "common/ceph_context.h"
+#ifndef WITH_SEASTAR
 #include "common/config_obs.h"
+#endif
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/numa.h"
@@ -115,6 +117,7 @@ const struct sockaddr *find_ip_in_subnet_list(
   return r;
 }
 
+#ifndef WITH_SEASTAR
 // observe this change
 struct Observer : public md_config_obs_t {
   const char *keys[2];
@@ -219,6 +222,7 @@ void pick_addresses(CephContext *cct, int needs)
 
   freeifaddrs(ifa);
 }
+#endif	// !WITH_SEASTAR
 
 static int fill_in_one_address(
   CephContext *cct,

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -3,9 +3,11 @@
 #ifndef CEPH_PICK_ADDRESS_H
 #define CEPH_PICK_ADDRESS_H
 
-#include "common/config.h"
+#include <string>
+#include <list>
 
 class CephContext;
+struct entity_addr_t;
 class entity_addrvec_t;
 
 
@@ -63,8 +65,7 @@ std::string pick_iface(CephContext *cct, const struct sockaddr_storage &network)
  * @param ls list of addresses
  * @param match [out] pointer to match, if an item in @a ls is found configured locally.
  */
-bool have_local_addr(CephContext *cct, const list<entity_addr_t>& ls, entity_addr_t *match);
-
+bool have_local_addr(CephContext *cct, const std::list<entity_addr_t>& ls, entity_addr_t *match);
 
 const struct sockaddr *find_ip_in_subnet_list(
   CephContext *cct,

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -18,6 +18,7 @@ class entity_addrvec_t;
 #define CEPH_PICK_ADDRESS_PREFER_IPV4 0x40
 #define CEPH_PICK_ADDRESS_DEFAULT_MON_PORTS  0x80
 
+#ifndef WITH_SEASTAR
 /*
   Pick addresses based on subnets if needed.
 
@@ -38,6 +39,8 @@ class entity_addrvec_t;
   This function will exit on error.
  */
 void pick_addresses(CephContext *cct, int needs);
+
+#endif	// !WITH_SEASTAR
 
 int pick_addresses(CephContext *cct, unsigned flags, entity_addrvec_t *addrs,
 		   int preferred_numa_node = -1);

--- a/src/crimson/CMakeLists.txt
+++ b/src/crimson/CMakeLists.txt
@@ -47,6 +47,7 @@ add_library(crimson-common STATIC
   ${PROJECT_SOURCE_DIR}/src/common/perf_counters.cc
   ${PROJECT_SOURCE_DIR}/src/common/perf_histogram.cc
   ${PROJECT_SOURCE_DIR}/src/common/page.cc
+  ${PROJECT_SOURCE_DIR}/src/common/pick_address.cc
   ${PROJECT_SOURCE_DIR}/src/common/snap_types.cc
   ${PROJECT_SOURCE_DIR}/src/common/signal.cc
   ${PROJECT_SOURCE_DIR}/src/common/str_list.cc

--- a/src/crimson/mon/MonClient.h
+++ b/src/crimson/mon/MonClient.h
@@ -71,6 +71,9 @@ public:
   seastar::future<> start();
   seastar::future<> stop();
 
+  const uuid_d& get_fsid() const {
+    return monmap.fsid;
+  }
   get_version_t get_version(const std::string& map);
   command_result_t run_command(const std::vector<std::string>& cmd,
 			       const bufferlist& bl);

--- a/src/crimson/net/Messenger.h
+++ b/src/crimson/net/Messenger.h
@@ -44,6 +44,10 @@ class Messenger {
   /// bind to the given address
   virtual void bind(const entity_addrvec_t& addr) = 0;
 
+  /// try to bind to the first unused port of given address
+  virtual void try_bind(const entity_addrvec_t& addr,
+			uint32_t min_port, uint32_t max_port) = 0;
+
   /// start the messenger
   virtual seastar::future<> start(Dispatcher *dispatcher) = 0;
 

--- a/src/crimson/net/SocketMessenger.h
+++ b/src/crimson/net/SocketMessenger.h
@@ -52,6 +52,9 @@ class SocketMessenger final : public Messenger {
 
   void bind(const entity_addrvec_t& addr) override;
 
+  void try_bind(const entity_addrvec_t& addr,
+		uint32_t min_port, uint32_t max_port) override;
+
   seastar::future<> start(Dispatcher *dispatcher) override;
 
   ConnectionRef connect(const entity_addr_t& peer_addr,

--- a/src/crimson/osd/CMakeLists.txt
+++ b/src/crimson/osd/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(crimson-osd
   chained_dispatchers.cc
+  heartbeat.cc
   main.cc
   osd.cc
   osd_meta.cc

--- a/src/crimson/osd/heartbeat.cc
+++ b/src/crimson/osd/heartbeat.cc
@@ -1,0 +1,300 @@
+#include "heartbeat.h"
+
+#include <boost/range/join.hpp>
+
+#include "messages/MOSDPing.h"
+#include "messages/MOSDFailure.h"
+
+#include "crimson/common/config_proxy.h"
+#include "crimson/net/Connection.h"
+#include "crimson/net/SocketMessenger.h"
+#include "crimson/osd/osdmap_service.h"
+#include "crimson/mon/MonClient.h"
+
+#include "osd/OSDMap.h"
+
+using ceph::common::local_conf;
+
+namespace {
+  seastar::logger& logger() {
+    return ceph::get_logger(ceph_subsys_osd);
+  }
+
+  template<typename Message, typename... Args>
+  Ref<Message> make_message(Args&&... args)
+  {
+    return {new Message{std::forward<Args>(args)...}, false};
+  }
+}
+
+Heartbeat::Heartbeat(int whoami,
+                     uint32_t nonce,
+                     const OSDMapService& service,
+                     ceph::mon::Client& monc)
+  : front_msgr{new ceph::net::SocketMessenger{entity_name_t::OSD(whoami),
+                                              "hb_front", nonce}},
+    back_msgr{new ceph::net::SocketMessenger{entity_name_t::OSD(whoami),
+                                             "hb_back", nonce}},
+    service{service},
+    monc{monc},
+    timer{[this] {send_heartbeats();}}
+{}
+
+seastar::future<> Heartbeat::start(entity_addrvec_t front_addrs,
+                                   entity_addrvec_t back_addrs)
+{
+  logger().info("heartbeat: start");
+  // i only care about the address, so any unused port would work
+  for (auto& addr : boost::join(front_addrs.v, back_addrs.v)) {
+    addr.set_port(0);
+  }
+  front_msgr->try_bind(front_addrs,
+                       local_conf()->ms_bind_port_min,
+                       local_conf()->ms_bind_port_max);
+  back_msgr->try_bind(front_addrs,
+                      local_conf()->ms_bind_port_min,
+                      local_conf()->ms_bind_port_max);
+  return seastar::when_all_succeed(front_msgr->start(this),
+                                   back_msgr->start(this)).then([this] {
+    timer.arm_periodic(
+      std::chrono::seconds(local_conf()->osd_heartbeat_interval));
+  });
+}
+
+seastar::future<> Heartbeat::stop()
+{
+  return seastar::when_all_succeed(front_msgr->shutdown(),
+                                   back_msgr->shutdown());
+}
+
+const entity_addrvec_t& Heartbeat::get_front_addrs() const
+{
+  return front_msgr->get_myaddrs();
+}
+
+const entity_addrvec_t& Heartbeat::get_back_addrs() const
+{
+  return back_msgr->get_myaddrs();
+}
+
+void Heartbeat::add_peer(osd_id_t peer)
+{
+  auto found = peers.find(peer);
+  if (found == peers.end()) {
+    logger().info("add_peer({})", peer);
+    PeerInfo info;
+    auto osdmap = service.get_map();
+    // TODO: msgr v2
+    info.con_front =
+      front_msgr->connect(osdmap->get_hb_front_addrs(peer).legacy_addr(),
+                          CEPH_ENTITY_TYPE_OSD);
+    info.con_back =
+      back_msgr->connect(osdmap->get_hb_back_addrs(peer).legacy_addr(),
+                         CEPH_ENTITY_TYPE_OSD);
+    peers.emplace(peer, std::move(info));
+  }
+}
+
+seastar::future<> Heartbeat::remove_peer(osd_id_t peer)
+{
+  auto found = peers.find(peer);
+  assert(found != peers.end());
+  logger().info("remove_peer({})", peer);
+  return seastar::when_all_succeed(found->second.con_front->close(),
+                                   found->second.con_back->close()).then(
+    [this, peer] {
+      peers.erase(peer);
+      return seastar::now();
+    });
+}
+
+seastar::future<> Heartbeat::ms_dispatch(ceph::net::ConnectionRef conn,
+                                         MessageRef m)
+{
+  logger().info("heartbeat: ms_dispatch {}", *m);
+  switch (m->get_type()) {
+  case CEPH_MSG_PING:
+    return handle_osd_ping(conn, boost::static_pointer_cast<MOSDPing>(m));
+  default:
+    return seastar::now();
+  }
+}
+
+seastar::future<> Heartbeat::handle_osd_ping(ceph::net::ConnectionRef conn,
+                                             Ref<MOSDPing> m)
+{
+  switch (m->op) {
+  case MOSDPing::PING:
+    return handle_ping(conn, m);
+  case MOSDPing::PING_REPLY:
+    return handle_reply(conn, m);
+  case MOSDPing::YOU_DIED:
+    return handle_you_died();
+  default:
+    return seastar::now();
+  }
+}
+
+seastar::future<> Heartbeat::handle_ping(ceph::net::ConnectionRef conn,
+                                         Ref<MOSDPing> m)
+{
+  auto min_message = static_cast<uint32_t>(
+    local_conf()->osd_heartbeat_min_size);
+  auto reply =
+    make_message<MOSDPing>(m->fsid,
+                           service.get_map()->get_epoch(),
+                           MOSDPing::PING_REPLY,
+                           m->stamp,
+                           min_message);
+  return conn->send(reply);
+}
+
+seastar::future<> Heartbeat::handle_reply(ceph::net::ConnectionRef conn,
+                                          Ref<MOSDPing> m)
+{
+  const osd_id_t from = m->get_source().num();
+  auto found = peers.find(from);
+  if (found == peers.end()) {
+    // stale reply
+    return seastar::now();
+  }
+  auto& peer = found->second;
+  auto ping = peer.ping_history.find(m->stamp);
+  if (ping == peer.ping_history.end()) {
+    // old replies, deprecated by newly sent pings.
+    return seastar::now();
+  }
+  const auto now = clock::now();
+  auto& unacked = ping->second.unacknowledged;
+  if (conn == peer.con_back) {
+    peer.last_rx_back = now;
+    unacked--;
+  } else if (conn == peer.con_front) {
+    peer.last_rx_front = now;
+    unacked--;
+  }
+  if (unacked == 0) {
+    peer.ping_history.erase(peer.ping_history.begin(), ++ping);
+  }
+  if (peer.is_healthy(now)) {
+    // cancel false reports
+    failure_queue.erase(from);
+    if (auto pending = failure_pending.find(from);
+        pending != failure_pending.end()) {
+      return send_still_alive(from, pending->second.addrs);
+    }
+  }
+  return seastar::now();
+}
+
+seastar::future<> Heartbeat::handle_you_died()
+{
+  // TODO: ask for newer osdmap
+  return seastar::now();
+}
+
+seastar::future<> Heartbeat::send_heartbeats()
+{
+  using peers_item_t = typename peers_map_t::value_type;
+  return seastar::parallel_for_each(peers,
+    [this](peers_item_t& item) {
+      const auto now = clock::now();
+      const auto deadline =
+        now + std::chrono::seconds(local_conf()->osd_heartbeat_grace);
+      auto& [peer, info] = item;
+      info.last_tx = now;
+      if (clock::is_zero(info.first_tx)) {
+        info.first_tx = now;
+      }
+      const utime_t sent_stamp{now};
+      auto [reply, added] = info.ping_history.emplace(sent_stamp,
+                                                      reply_t{deadline, 0});
+      std::vector<ceph::net::ConnectionRef> conns{info.con_front,
+                                                  info.con_back};
+      return seastar::parallel_for_each(std::move(conns),
+        [=] (auto con) {
+          if (con) {
+            auto min_message = static_cast<uint32_t>(
+              local_conf()->osd_heartbeat_min_size);
+            auto ping = make_message<MOSDPing>(monc.get_fsid(),
+                                               service.get_map()->get_epoch(),
+                                               MOSDPing::PING,
+                                               sent_stamp,
+                                               min_message);
+            return con->send(ping).then([&reply] {
+              reply->second.unacknowledged++;
+              return seastar::now();
+            });
+          } else {
+            return seastar::now();
+          }
+        });
+    });
+}
+
+seastar::future<> Heartbeat::send_failures()
+{
+  using failure_item_t = typename failure_queue_t::value_type;
+  return seastar::parallel_for_each(failure_queue,
+    [this](failure_item_t& failure_item) {
+      auto [osd, failed_since] = failure_item;
+      if (failure_pending.count(osd)) {
+        return seastar::now();
+      }
+      auto failed_for = chrono::duration_cast<chrono::seconds>(
+        clock::now() - failed_since).count();
+      auto osdmap = service.get_map();
+      auto failure_report =
+        make_message<MOSDFailure>(monc.get_fsid(),
+                                  osd,
+                                  osdmap->get_addrs(osd),
+                                  static_cast<int>(failed_for),
+                                  osdmap->get_epoch());
+      failure_pending.emplace(osd, failure_info_t{failed_since,
+                                                  osdmap->get_addrs(osd)});
+      return monc.send_message(failure_report);
+    }).then([this] {
+      failure_queue.clear();
+      return seastar::now();
+    });
+}
+
+seastar::future<> Heartbeat::send_still_alive(osd_id_t osd,
+                                              const entity_addrvec_t& addrs)
+{
+  auto still_alive = make_message<MOSDFailure>(monc.get_fsid(),
+                                               osd,
+                                               addrs,
+                                               0,
+                                               service.get_map()->get_epoch(),
+                                               MOSDFailure::FLAG_ALIVE);
+  return monc.send_message(still_alive).then([=] {
+    failure_pending.erase(osd);
+    return seastar::now();
+  });
+}
+
+bool Heartbeat::PeerInfo::is_unhealthy(clock::time_point now) const
+{
+  if (ping_history.empty()) {
+    // we haven't sent a ping yet or we have got all replies,
+    // in either way we are safe and healthy for now
+    return false;
+  } else {
+    auto oldest_ping = ping_history.begin();
+    return now > oldest_ping->second.deadline;
+  }
+}
+
+bool Heartbeat::PeerInfo::is_healthy(clock::time_point now) const
+{
+  if (con_front && clock::is_zero(last_rx_front)) {
+    return false;
+  }
+  if (con_back && clock::is_zero(last_rx_back)) {
+    return false;
+  }
+  // only declare to be healthy until we have received the first
+  // replies from both front/back connections
+  return !is_unhealthy(now);
+}

--- a/src/crimson/osd/heartbeat.h
+++ b/src/crimson/osd/heartbeat.h
@@ -1,0 +1,107 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <cstdint>
+#include <seastar/core/future.hh>
+#include "common/ceph_time.h"
+#include "crimson/net/Dispatcher.h"
+#include "crimson/net/Fwd.h"
+
+class MOSDPing;
+class OSDMapService;
+
+namespace ceph::mon {
+  class Client;
+}
+
+template<typename Message> using Ref = boost::intrusive_ptr<Message>;
+
+class Heartbeat : public ceph::net::Dispatcher {
+public:
+  using osd_id_t = int;
+
+  Heartbeat(int whoami,
+	    uint32_t nonce,
+	    const OSDMapService& service,
+	    ceph::mon::Client& monc);
+
+  seastar::future<> start(entity_addrvec_t front,
+			  entity_addrvec_t back);
+  seastar::future<> stop();
+
+  void add_peer(osd_id_t peer);
+  seastar::future<> remove_peer(osd_id_t peer);
+
+  seastar::future<> send_heartbeats();
+  seastar::future<> send_failures();
+
+  const entity_addrvec_t& get_front_addrs() const;
+  const entity_addrvec_t& get_back_addrs() const;
+
+  // Dispatcher methods
+  seastar::future<> ms_dispatch(ceph::net::ConnectionRef conn,
+				MessageRef m) override;
+
+private:
+  seastar::future<> handle_osd_ping(ceph::net::ConnectionRef conn,
+				    Ref<MOSDPing> m);
+  seastar::future<> handle_ping(ceph::net::ConnectionRef conn,
+				Ref<MOSDPing> m);
+  seastar::future<> handle_reply(ceph::net::ConnectionRef conn,
+				 Ref<MOSDPing> m);
+  seastar::future<> handle_you_died();
+
+  seastar::future<> send_still_alive(osd_id_t, const entity_addrvec_t&);
+
+private:
+  std::unique_ptr<ceph::net::Messenger> front_msgr;
+  std::unique_ptr<ceph::net::Messenger> back_msgr;
+  const OSDMapService& service;
+  ceph::mon::Client& monc;
+
+  seastar::timer<seastar::lowres_clock> timer;
+  // use real_clock so it can be converted to utime_t
+  using clock = ceph::coarse_real_clock;
+
+  struct reply_t {
+    clock::time_point deadline;
+    // one sent over front conn, another sent over back conn
+    uint8_t unacknowledged = 0;
+  };
+  struct PeerInfo {
+    /// peer connection (front)
+    ceph::net::ConnectionRef con_front;
+    /// peer connection (back)
+    ceph::net::ConnectionRef con_back;
+    /// time we sent our first ping request
+    clock::time_point first_tx;
+    /// last time we sent a ping request
+    clock::time_point last_tx;
+    /// last time we got a ping reply on the front side
+    clock::time_point last_rx_front;
+    /// last time we got a ping reply on the back side
+    clock::time_point last_rx_back;
+    /// history of inflight pings, arranging by timestamp we sent
+    std::map<utime_t, reply_t> ping_history;
+
+    bool is_unhealthy(clock::time_point now) const;
+    bool is_healthy(clock::time_point now) const;
+  };
+  using peers_map_t = std::map<osd_id_t, PeerInfo>;
+  peers_map_t peers;
+
+  // osds which are considered failed
+  // osd_id => when was the last time that both front and back pings were acked
+  //           use for calculating how long the OSD has been unresponsive
+  using failure_queue_t = std::map<osd_id_t, clock::time_point>;
+  failure_queue_t failure_queue;
+  struct failure_info_t {
+    clock::time_point failed_since;
+    entity_addrvec_t addrs;
+  };
+  // osds we've reported to monior as failed ones, but they are not marked down
+  // yet
+  std::map<osd_id_t, failure_info_t> failure_pending;
+};

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -170,6 +170,7 @@ seastar::future<> OSD::start_boot()
 
 seastar::future<> OSD::_preboot(version_t newest, version_t oldest)
 {
+  logger().info("osd.{}: _preboot", whoami);
   if (osdmap->get_epoch() == 0) {
     logger().warn("waiting for initial osdmap");
   } else if (osdmap->is_destroyed(whoami)) {
@@ -512,7 +513,6 @@ seastar::future<> OSD::committed_osd_maps(version_t first,
       logger().info("osd.{}: now preboot", whoami);
 
       if (m->get_source().is_mon()) {
-        logger().info("osd.{}: _preboot", whoami);
         return _preboot(m->oldest_map, m->newest_map);
       } else {
         logger().info("osd.{}: start_boot", whoami);

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -549,8 +549,3 @@ seastar::future<> OSD::send_beacon()
                                     min_last_epoch_clean);
   return monc.send_message(m);
 }
-
-ghobject_t OSD::get_osdmap_pobject_name(epoch_t epoch) {
-  string name = fmt::format("osdmap.{}", epoch);
-  return ghobject_t(hobject_t(sobject_t(object_t(name), 0)));
-}

--- a/src/crimson/osd/osd.cc
+++ b/src/crimson/osd/osd.cc
@@ -296,6 +296,11 @@ seastar::future<> OSD::ms_handle_remote_reset(ceph::net::ConnectionRef conn)
   return seastar::now();
 }
 
+seastar::lw_shared_ptr<OSDMap> OSD::get_map() const
+{
+  return osdmap;
+}
+
 seastar::future<seastar::lw_shared_ptr<OSDMap>> OSD::get_map(epoch_t e)
 {
   // TODO: use LRU cache for managing osdmap, fallback to disk if we have to

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -78,8 +78,6 @@ public:
   seastar::future<> start();
   seastar::future<> stop();
 
-  static ghobject_t get_osdmap_pobject_name(epoch_t epoch);
-
 private:
   seastar::future<> start_boot();
   seastar::future<> _preboot(version_t newest_osdmap, version_t oldest_osdmap);

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -12,6 +12,7 @@
 #include "crimson/mon/MonClient.h"
 #include "crimson/net/Dispatcher.h"
 #include "crimson/osd/chained_dispatchers.h"
+#include "crimson/osd/osdmap_service.h"
 #include "crimson/osd/state.h"
 
 #include "osd/OSDMap.h"
@@ -33,7 +34,8 @@ namespace ceph::os {
 
 template<typename T> using Ref = boost::intrusive_ptr<T>;
 
-class OSD : public ceph::net::Dispatcher {
+class OSD : public ceph::net::Dispatcher,
+	    private OSDMapService {
   seastar::gate gate;
   seastar::timer<seastar::lowres_clock> beacon_timer;
   const int whoami;
@@ -74,7 +76,7 @@ class OSD : public ceph::net::Dispatcher {
 
 public:
   OSD(int id, uint32_t nonce);
-  ~OSD();
+  ~OSD() override;
 
   seastar::future<> mkfs(uuid_d fsid);
 
@@ -89,7 +91,10 @@ private:
   seastar::future<Ref<PG>> load_pg(spg_t pgid);
   seastar::future<> load_pgs();
 
-  seastar::future<seastar::lw_shared_ptr<OSDMap>> get_map(epoch_t e);
+  // OSDMapService methods
+  seastar::future<seastar::lw_shared_ptr<OSDMap>> get_map(epoch_t e) override;
+  seastar::lw_shared_ptr<OSDMap> get_map() const override;
+
   seastar::future<bufferlist> load_map_bl(epoch_t e);
   void store_map_bl(ceph::os::Transaction& t,
                     epoch_t e, bufferlist&& bl);

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -41,8 +41,8 @@ class OSD : public ceph::net::Dispatcher,
   const int whoami;
   // talk with osd
   std::unique_ptr<ceph::net::Messenger> cluster_msgr;
-  // talk with mon/mgr
-  std::unique_ptr<ceph::net::Messenger> client_msgr;
+  // talk with client/mon/mgr
+  std::unique_ptr<ceph::net::Messenger> public_msgr;
   ChainedDispatchers dispatchers;
   ceph::mon::Client monc;
 

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -1,3 +1,6 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
 #pragma once
 
 #include <map>

--- a/src/crimson/osd/osd.h
+++ b/src/crimson/osd/osd.h
@@ -21,6 +21,7 @@ class MOSDMap;
 class OSDMap;
 class OSDMeta;
 class PG;
+class Heartbeat;
 
 namespace ceph::net {
   class Messenger;
@@ -45,6 +46,9 @@ class OSD : public ceph::net::Dispatcher,
   std::unique_ptr<ceph::net::Messenger> public_msgr;
   ChainedDispatchers dispatchers;
   ceph::mon::Client monc;
+
+  std::unique_ptr<Heartbeat> heartbeat;
+  seastar::timer<seastar::lowres_clock> heartbeat_timer;
 
   // TODO: use LRU cache
   std::map<epoch_t, seastar::lw_shared_ptr<OSDMap>> osdmaps;
@@ -115,4 +119,5 @@ private:
   seastar::future<> shutdown();
 
   seastar::future<> send_beacon();
+  void update_heartbeat_peers();
 };

--- a/src/crimson/osd/osdmap_service.h
+++ b/src/crimson/osd/osdmap_service.h
@@ -1,0 +1,19 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <seastar/core/shared_ptr.hh>
+
+#include "include/types.h"
+
+class OSDMap;
+
+class OSDMapService {
+public:
+  virtual ~OSDMapService() = default;
+  virtual seastar::future<seastar::lw_shared_ptr<OSDMap>>
+  get_map(epoch_t e) = 0;
+  /// get the latest map
+  virtual seastar::lw_shared_ptr<OSDMap> get_map() const = 0;
+};


### PR DESCRIPTION
- allow crimson-osd to pick an unused port if the port is not specified
- add heartbeat support: it helps to prevent crimson-osd from being marked down by its ceph-osd peers. we could adjust the grace period, but this feature helps us to be prepared for the read/write i/o path. where crimson should also 1) listen on a (random) port and 2) report this listening port to monitor.