### PR TITLE
mgr/dashboard: Implement OSD purge

### DIFF
--- a/qa/tasks/mgr/dashboard/test_osd.py
+++ b/qa/tasks/mgr/dashboard/test_osd.py
@@ -93,8 +93,8 @@ class OsdTest(DashboardTestCase):
         # Destroy
         self._post('/api/osd/5/destroy')
         self.assertStatus(200)
-        # Remove
-        self._post('/api/osd/5/remove')
+        # Purge
+        self._post('/api/osd/5/purge')
         self.assertStatus(200)
 
     def test_safe_to_destroy(self):

--- a/src/pybind/mgr/dashboard/controllers/osd.py
+++ b/src/pybind/mgr/dashboard/controllers/osd.py
@@ -141,11 +141,12 @@ class Osd(RESTController):
         }
 
     @RESTController.Resource('POST')
-    def remove(self, svc_id):
+    def purge(self, svc_id):
         """
         Note: osd must be marked `down` before removal.
         """
-        CephService.send_command('mon', 'osd rm', ids=[svc_id])
+        CephService.send_command('mon', 'osd purge-actual', id=int(svc_id),
+                                 yes_i_really_mean_it=True)
 
     @RESTController.Resource('POST')
     def destroy(self, svc_id):

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.spec.ts
@@ -181,7 +181,7 @@ describe('OsdListComponent', () => {
       const modalClass = CriticalConfirmationModalComponent;
       mockSafeToDestroy();
       expectOpensModal('Mark Lost', modalClass);
-      expectOpensModal('Remove', modalClass);
+      expectOpensModal('Purge', modalClass);
       expectOpensModal('Destroy', modalClass);
     });
   });
@@ -216,7 +216,7 @@ describe('OsdListComponent', () => {
     it('calls the corresponding service methods in critical confirmation modals', () => {
       mockSafeToDestroy();
       expectOsdServiceMethodCalled('Mark Lost', 'markLost');
-      expectOsdServiceMethodCalled('Remove', 'remove');
+      expectOsdServiceMethodCalled('Purge', 'purge');
       expectOsdServiceMethodCalled('Destroy', 'destroy');
     });
   });

--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/cluster/osd/osd-list/osd-list.component.ts
@@ -118,17 +118,17 @@ export class OsdListComponent implements OnInit {
         icon: 'fa-unlink'
       },
       {
-        name: this.i18n('Remove'),
+        name: this.i18n('Purge'),
         permission: 'delete',
         click: () =>
           this.showCriticalConfirmationModal(
-            this.i18n('Remove'),
+            this.i18n('Purge'),
             this.i18n('OSD'),
-            this.i18n('removed'),
-            this.osdService.remove
+            this.i18n('purged'),
+            this.osdService.purge
           ),
         disable: () => this.isNotSelectedOrInState('up'),
-        icon: 'fa-remove'
+        icon: 'fa-eraser'
       },
       {
         name: this.i18n('Destroy'),
@@ -141,7 +141,7 @@ export class OsdListComponent implements OnInit {
             this.osdService.destroy
           ),
         disable: () => this.isNotSelectedOrInState('up'),
-        icon: 'fa-eraser'
+        icon: 'fa-remove'
       }
     ];
   }

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.spec.ts
@@ -94,9 +94,9 @@ describe('OsdService', () => {
     expect(req.request.method).toBe('POST');
   });
 
-  it('should remove an OSD', () => {
-    service.remove(1).subscribe();
-    const req = httpTesting.expectOne('api/osd/1/remove');
+  it('should purge an OSD', () => {
+    service.purge(1).subscribe();
+    const req = httpTesting.expectOne('api/osd/1/purge');
     expect(req.request.method).toBe('POST');
   });
 

--- a/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
+++ b/src/pybind/mgr/dashboard/frontend/src/app/shared/api/osd.service.ts
@@ -98,8 +98,8 @@ export class OsdService {
     return this.http.post(`${this.path}/${id}/mark_lost`, null);
   }
 
-  remove(id: number) {
-    return this.http.post(`${this.path}/${id}/remove`, null);
+  purge(id: number) {
+    return this.http.post(`${this.path}/${id}/purge`, null);
   }
 
   destroy(id: number) {

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
@@ -5064,8 +5064,8 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="019d4bd6a5690f0cfa0ecf346a4e6bf7f0d8debb" datatype="html">
-        <source>Remove</source>
+      <trans-unit id="40fedc157ad899a18ec40573f770d18b040959d2" datatype="html">
+        <source>Purge</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/osd/osd-list/osd-list.component.ts</context>
           <context context-type="linenumber">1</context>
@@ -5086,8 +5086,8 @@
           <context context-type="linenumber">1</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="c640261f80e6afd42cac3f4b63594012f198e0e8" datatype="html">
-        <source>removed</source>
+      <trans-unit id="4f3cff08c7033b63bbccfe66006b1bcaea48ddd8" datatype="html">
+        <source>purged</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/ceph/cluster/osd/osd-list/osd-list.component.ts</context>
           <context context-type="linenumber">1</context>


### PR DESCRIPTION
Implements OSD purge and removes the `OSD remove` functionality from the UI, ~~but keeps it in the API.~~

Fixes: http://tracker.ceph.com/issues/35811

Signed-off-by: Patrick Nawracay <pnawracay@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

