### PR TITLE
ceph-volume: add space between words

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/batch.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/batch.py
@@ -174,7 +174,7 @@ class Batch(object):
         parser.add_argument(
             '--no-auto',
             action='store_true',
-            help=('deploy standalone OSDs if rotational and non-rotational drives'
+            help=('deploy standalone OSDs if rotational and non-rotational drives '
                   'are passed in DEVICES'),
         )
         parser.add_argument(


### PR DESCRIPTION
The current help of batch was showing:

rotational drivesare passed in DEVICES

This commit fixes it and now we have:

rotational drives are passed in DEVICES

Tremendous fix, I know.

Signed-off-by: Sébastien Han <seb@redhat.com>

