### PR TITLE
luminous: bluestore: add bluestore_ignore_data_csum option

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1026,6 +1026,7 @@ OPTION(bluestore_block_wal_path, OPT_STR)
 OPTION(bluestore_block_wal_size, OPT_U64) // rocksdb wal
 OPTION(bluestore_block_wal_create, OPT_BOOL)
 OPTION(bluestore_block_preallocate_file, OPT_BOOL) //whether preallocate space if block/db_path/wal_path is file rather that block device.
+OPTION(bluestore_ignore_data_csum, OPT_BOOL)
 OPTION(bluestore_csum_type, OPT_STR) // none|xxhash32|xxhash64|crc32c|crc32c_16|crc32c_8
 OPTION(bluestore_csum_min_block, OPT_U32)
 OPTION(bluestore_csum_max_block, OPT_U32)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3371,6 +3371,10 @@ std::vector<Option> get_global_options() {
     .add_tag("mkfs")
     .set_description("Preallocate file created via bluestore_block*_create"),
 
+    Option("bluestore_ignore_data_csum", Option::TYPE_BOOL, Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("Ignore checksum errors on read and do not generate an EIO error"),
+
     Option("bluestore_csum_type", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("crc32c")
     .set_enum_allowed({"none", "crc32c", "crc32c_16", "crc32c_8", "xxhash32", "xxhash64"})

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6822,6 +6822,9 @@ int BlueStore::_verify_csum(OnodeRef& o,
     }
   }
   logger->tinc(l_bluestore_csum_lat, ceph_clock_now() - start);
+  if (cct->_conf->bluestore_ignore_data_csum) {
+    return 0;
+  }
   return r;
 }
 


### PR DESCRIPTION
This option just suppresses the EIO errors.  We still get the messages
in the logs, though.  This can be useful when you are in dire straights
and prefer some data to no data.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit b7b78809f1e9790b08a2f5a49de96be1131e5010)

- remove RUNTIME flag in options.cc (not in luminous)
- trivial conflict due to adjacnet ceph_clock_now()