### PR TITLE
os/objectstore: add new op OP_CREATE for create a new object.

### DIFF
--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -56,6 +56,16 @@ void Transaction::dump(ceph::Formatter *f)
     case Transaction::OP_NOP:
       f->dump_string("op_name", "nop");
       break;
+    case Transaction::OP_CREATE:
+      {
+	coll_t cid = i.get_cid(op->cid);
+	ghobject_t oid = i.get_oid(op->oid);
+	f->dump_string("op_name", "create");
+	f->dump_stream("collection") << cid;
+	f->dump_stream("oid") << oid;
+      }
+      break;
+
     case Transaction::OP_TOUCH:
       {
         coll_t cid = i.get_cid(op->cid);

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -106,6 +106,7 @@ class Transaction {
 public:
   enum {
     OP_NOP =          0,
+    OP_CREATE =       7,   // cid, oid
     OP_TOUCH =        9,   // cid, oid
     OP_WRITE =        10,  // cid, oid, offset, len, bl
     OP_ZERO =         11,  // cid, oid, offset, len
@@ -400,6 +401,7 @@ public:
     case OP_NOP:
       break;
 
+    case OP_CREATE:
     case OP_TOUCH:
     case OP_REMOVE:
     case OP_SETATTR:
@@ -789,6 +791,19 @@ public:
   void nop() {
     Op* _op = _get_next_op();
     _op->op = OP_NOP;
+    data.ops++;
+  }
+  /**
+   * create
+   *
+   * create an object that does not yet exist
+   * (behavior is undefined if the object already exists)
+   */
+  void create(const coll_t& cid, const ghobject_t& oid) {
+    Op* _op = _get_next_op();
+    _op->op = OP_CREATE;
+    _op->cid = _get_coll_id(cid);
+    _op->oid = _get_object_id(oid);
     data.ops++;
   }
   /**

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3504,7 +3504,8 @@ uint64_t BlueStore::Collection::make_blob_unshared(SharedBlob *sb)
 
 BlueStore::OnodeRef BlueStore::Collection::get_onode(
   const ghobject_t& oid,
-  bool create)
+  bool create,
+  bool is_createop)
 {
   ceph_assert(create ? lock.is_wlocked() : lock.is_locked());
 
@@ -3528,9 +3529,12 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
 			<< pretty_binary_string(key) << dendl;
 
   bufferlist v;
-  int r = store->db->get(PREFIX_OBJ, key.c_str(), key.size(), &v);
-  ldout(store->cct, 20) << " r " << r << " v.len " << v.length() << dendl;
+  int r = -ENOENT;
   Onode *on;
+  if (!is_createop) {
+    r = store->db->get(PREFIX_OBJ, key.c_str(), key.size(), &v);
+    ldout(store->cct, 20) << " r " << r << " v.len " << v.length() << dendl;
+  }
   if (v.length() == 0) {
     ceph_assert(r == -ENOENT);
     if (!store->cct->_conf->bluestore_debug_misc &&
@@ -11186,6 +11190,7 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
     // these operations implicity create the object
     bool create = false;
     if (op->op == Transaction::OP_TOUCH ||
+	op->op == Transaction::OP_CREATE ||
 	op->op == Transaction::OP_WRITE ||
 	op->op == Transaction::OP_ZERO) {
       create = true;
@@ -11196,7 +11201,7 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
     OnodeRef &o = ovec[op->oid];
     if (!o) {
       ghobject_t oid = i.get_oid(op->oid);
-      o = c->get_onode(oid, create);
+      o = c->get_onode(oid, create, op->op == Transaction::OP_CREATE);
     }
     if (!create && (!o || !o->exists)) {
       dout(10) << __func__ << " op " << op->op << " got ENOENT on "
@@ -11206,6 +11211,7 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
     }
 
     switch (op->op) {
+    case Transaction::OP_CREATE:
     case Transaction::OP_TOUCH:
       r = _touch(txc, c, o);
       break;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1396,7 +1396,7 @@ public:
     pool_opts_t pool_opts;
     ContextQueue *commit_queue;
 
-    OnodeRef get_onode(const ghobject_t& oid, bool create);
+    OnodeRef get_onode(const ghobject_t& oid, bool create, bool is_createop=false);
 
     // the terminology is confusing here, sorry!
     //

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2788,6 +2788,7 @@ void FileStore::_do_transaction(
     case Transaction::OP_NOP:
       break;
     case Transaction::OP_TOUCH:
+    case Transaction::OP_CREATE:
       {
         const coll_t &_cid = i.get_cid(op->cid);
         const ghobject_t &oid = i.get_oid(op->oid);

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -2315,6 +2315,7 @@ void KStore::_txc_add_transaction(TransContext *txc, Transaction *t)
       // these operations implicity create the object
       bool create = false;
       if (op->op == Transaction::OP_TOUCH ||
+	  op->op == Transaction::OP_CREATE ||
 	  op->op == Transaction::OP_WRITE ||
 	  op->op == Transaction::OP_ZERO) {
 	create = true;
@@ -2333,6 +2334,7 @@ void KStore::_txc_add_transaction(TransContext *txc, Transaction *t)
 
     switch (op->op) {
     case Transaction::OP_TOUCH:
+    case Transaction::OP_CREATE:
 	r = _touch(txc, c, o);
       break;
 

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -670,6 +670,7 @@ void MemStore::_do_transaction(Transaction& t)
     case Transaction::OP_NOP:
       break;
     case Transaction::OP_TOUCH:
+    case Transaction::OP_CREATE:
       {
         coll_t cid = i.get_cid(op->cid);
         ghobject_t oid = i.get_oid(op->oid);

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1980,7 +1980,8 @@ bool ECBackend::try_reads_to_commit()
       &trans,
       &(op->temp_added),
       &(op->temp_cleared),
-      get_parent()->get_dpp());
+      get_parent()->get_dpp(),
+      get_osdmap()->require_osd_release);
   }
 
   dout(20) << __func__ << ": " << cache << dendl;

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -105,7 +105,8 @@ void ECTransaction::generate_transactions(
   map<shard_id_t, ObjectStore::Transaction> *transactions,
   set<hobject_t> *temp_added,
   set<hobject_t> *temp_removed,
-  DoutPrefixProvider *dpp)
+  DoutPrefixProvider *dpp,
+  const ceph_release_t require_osd_release)
 {
   ceph_assert(written_map);
   ceph_assert(transactions);
@@ -264,9 +265,15 @@ void ECTransaction::generate_transactions(
 	[&](const PGTransaction::ObjectOperation::Init::None &) {},
 	[&](const PGTransaction::ObjectOperation::Init::Create &op) {
 	  for (auto &&st: *transactions) {
-	    st.second.touch(
-	      coll_t(spg_t(pgid, st.first)),
-	      ghobject_t(oid, ghobject_t::NO_GEN, st.first));
+	    if (require_osd_release >= ceph_release_t::nautilus) {
+	      st.second.create(
+		coll_t(spg_t(pgid, st.first)),
+		ghobject_t(oid, ghobject_t::NO_GEN, st.first));
+	    } else {
+	      st.second.touch(
+		coll_t(spg_t(pgid, st.first)),
+		ghobject_t(oid, ghobject_t::NO_GEN, st.first));
+	    }
 	  }
 	},
 	[&](const PGTransaction::ObjectOperation::Init::Clone &op) {

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -193,7 +193,8 @@ namespace ECTransaction {
     map<shard_id_t, ObjectStore::Transaction> *transactions,
     set<hobject_t> *temp_added,
     set<hobject_t> *temp_removed,
-    DoutPrefixProvider *dpp);
+    DoutPrefixProvider *dpp,
+    const ceph_release_t require_osd_release = ceph_release_t::unknown);
 };
 
 #endif

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -282,7 +282,8 @@ void generate_transaction(
   vector<pg_log_entry_t> &log_entries,
   ObjectStore::Transaction *t,
   set<hobject_t> *added,
-  set<hobject_t> *removed)
+  set<hobject_t> *removed,
+  const ceph_release_t require_osd_release = ceph_release_t::unknown )
 {
   ceph_assert(t);
   ceph_assert(added);
@@ -323,7 +324,11 @@ void generate_transaction(
 	[&](const PGTransaction::ObjectOperation::Init::None &) {
 	},
 	[&](const PGTransaction::ObjectOperation::Init::Create &op) {
-	  t->touch(coll, goid);
+	  if (require_osd_release >= ceph_release_t::nautilus) {
+	    t->create(coll, goid);
+	  } else {
+	    t->touch(coll, goid);
+	  }
 	},
 	[&](const PGTransaction::ObjectOperation::Init::Clone &op) {
 	  t->clone(
@@ -449,7 +454,8 @@ void ReplicatedBackend::submit_transaction(
     log_entries,
     &op_t,
     &added,
-    &removed);
+    &removed,
+    get_osdmap()->require_osd_release);
   ceph_assert(added.size() <= 1);
   ceph_assert(removed.size() <= 1);
 


### PR DESCRIPTION
For OP_CREATE in bluestore mean node didn't exist, so skip search form kvdb.

This function merged  in 22f73ba62eb1fe. But because compatible problem,
it revert in 491c2545f3b0942c9f33.
This commit fix the compatible problem

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

