### PR TITLE
common: make CEPH_BUFFER_ALLOC_UNIT known at compile-time.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -41,7 +41,7 @@
 
 using namespace ceph;
 
-#define CEPH_BUFFER_ALLOC_UNIT  (std::min(CEPH_PAGE_SIZE, 4096u))
+#define CEPH_BUFFER_ALLOC_UNIT  4096u
 #define CEPH_BUFFER_APPEND_SIZE (CEPH_BUFFER_ALLOC_UNIT - sizeof(raw_combined))
 
 #ifdef BUFFER_DEBUG


### PR DESCRIPTION
It sounds extremely unlikely that any platform Ceph targets can have `PAGE_SIZE` lower than 4k. However, to handle these corner cases, `bufferlist` was rounding to `CEPH_PAGE_SIZE` known at run-time only. As a result, compilers were enforced to generate pretty inefficient code like in `:refill_append_space` (self is 1,10%):

```
       │         min(const _Tp& __a, const _Tp& __b)
       │         {
       │           // concept requirements
       │           __glibcxx_function_requires(_LessThanComparableConcept<_Tp>)
       │           //return __b < __a ? __b : __a;
       │           if (__b < __a)
  5,44 │       mov    _DYNAMIC+0x14a0,%rax
       │     _Z11round_up_toImjENSt13make_unsignedINSt11common_typeIJT_T0_EE4typeEE4typeES2_S3_():
       │       mov    $0x1000,%ecx
       │     _ZN4ceph6buffer4list19refill_append_spaceEj():
       │         size_t alen = round_up_to(need, CEPH_BUFFER_ALLOC_UNIT) -
       │           sizeof(raw_combined);
       │         buffer::hangable_ptr& new_back = \
       │           hangable_ptr::create(raw_combined::create(alen, 0, get_mempool()));
       │       mov    %rbp,%rdi
       │     _Z11round_up_toImjENSt13make_unsignedINSt11common_typeIJT_T0_EE4typeEE4typeES2_S3_():
  6,21 │       cmpl   $0x1000,(%rax)
  0,78 │       cmovbe (%rax),%ecx
       │       mov    %r12,%rax
       │       xor    %edx,%edx
  0,78 │       mov    %ecx,%ecx
 45,59 │       div    %rcx
```

Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>
