### PR TITLE
mimic: os/bluestore: fixup access a destroy cond cause deadlock or undefine

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -77,13 +77,13 @@ public:
   uint64_t get_num_ios() const;
 
   void try_aio_wake() {
+    std::lock_guard l(lock);
     if (num_running == 1) {
 
       // we might have some pending IOs submitted after the check
       // as there is no lock protection for aio_submit.
       // Hence we might have false conditional trigger.
       // aio_wait has to handle that hence do not care here.
-      std::lock_guard<std::mutex> l(lock);
       cond.notify_all();
       --num_running;
       ceph_assert(num_running >= 0);


### PR DESCRIPTION
http://tracker.ceph.com/issues/38143