### PR TITLE
luminous: os/bluestore: fixup access a destroy cond cause deadlock or undefine

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -64,13 +64,13 @@ public:
   void aio_wait();
 
   void try_aio_wake() {
+    std::lock_guard<std::mutex> l(lock);
     if (num_running == 1) {
 
       // we might have some pending IOs submitted after the check
       // as there is no lock protection for aio_submit.
       // Hence we might have false conditional trigger.
       // aio_wait has to handle that hence do not care here.
-      std::lock_guard<std::mutex> l(lock);
       cond.notify_all();
       --num_running;
       assert(num_running >= 0);


### PR DESCRIPTION
http://tracker.ceph.com/issues/38142