### PR TITLE
mgr/dashboard/run-backend-api-tests: fix orchestrator use case

### DIFF
--- a/src/pybind/mgr/dashboard/run-backend-api-tests.sh
+++ b/src/pybind/mgr/dashboard/run-backend-api-tests.sh
@@ -102,10 +102,12 @@ run_teuthology_tests() {
 
     OPTIONS=''
     TEST_CASES=''
-    if [[ "$@" == '' || "$@" == '--create-cluster-only' ]]; then
-      TEST_CASES=`for i in \`ls $BUILD_DIR/../qa/tasks/mgr/dashboard/test_*\`; do F=$(basename $i); M="${F%.*}"; echo -n " tasks.mgr.dashboard.$M"; done`
-      TEST_CASES="tasks.mgr.test_dashboard $TEST_CASES"
-      if [[ "$@" == '--create-cluster-only' ]]; then
+    if [ "$@" = '' -o "$@" = '--create-cluster-only' ]; then
+      if [ "$(basename "$PWD")" = "dashboard" ]; then
+        TEST_CASES=`for i in \`ls $BUILD_DIR/../qa/tasks/mgr/dashboard/test_*\`; do F=$(basename $i); M="${F%.*}"; echo -n " tasks.mgr.dashboard.$M"; done`
+        TEST_CASES="tasks.mgr.test_dashboard $TEST_CASES"
+      fi
+      if [ "$@" = '--create-cluster-only' ]; then
         OPTIONS="$@"
       fi
     else
@@ -117,7 +119,7 @@ run_teuthology_tests() {
     export PATH=$BUILD_DIR/bin:$PATH
     export LD_LIBRARY_PATH=$BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/:$BUILD_DIR/lib
     export PYTHONPATH=$TEMP_DIR/teuthology:$BUILD_DIR/../qa:$BUILD_DIR/lib/cython_modules/lib.${CEPH_PY_VERSION_MAJOR}/:$BUILD_DIR/../src/pybind
-    if [[ -z "$RGW" ]]; then
+    if [ -z "$RGW" ]; then
         export RGW=1
     fi
 


### PR DESCRIPTION
* Add `if [ "$(basename "$PWD")" = "dashboard" ]; then` when selecting tests when creating the cluster.
* Fix sourcing when sourced from zsh.

Signed-off-by: Sebastian Wagner <sebastian.wagner@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

