### PR TITLE
ceph-volume: open dmcrypt plain devices

### DIFF
--- a/src/ceph-volume/ceph_volume/util/encryption.py
+++ b/src/ceph-volume/ceph_volume/util/encryption.py
@@ -65,6 +65,7 @@ def plain_open(key, device, mapping):
         device,
         mapping,
         '--type', 'plain',
+        '--hash', 'plain',
         '--key-size', '256',
     ]
 


### PR DESCRIPTION
if ceph-volume needs to open a plain cryptsetup volume the key is read and base64 decoded from the ceph key-value store.
The key will be transmit to cryptsetup via cryptsetup --key-file -  ... (read from stdin)
though cryptsetup hashes the key read from stdin with some hash algorithm. 
Now If I try to import old keys from /etc/ceph/dmcrypt-keys/ to the key-value store and handle the disks via ceph-volume instead of ceph-disk it is impossible to open the crypt volumes.

This patch fix this problem by adding --hash plain as option to cryptsetup. This should restore the old behavior used in ceph-disk

Fixes: http://tracker.ceph.com/issues/38166
Signed-off-by: Manuel Lausch <manuel.lausch@1und1.de>