### PR TITLE
luminous: client: session flush does not cause cap release message flush

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2106,6 +2106,14 @@ void Client::handle_client_session(MClientSession *m)
     break;
 
   case CEPH_SESSION_FLUSHMSG:
+    /* flush cap release */
+    {
+      auto& m = session->release;
+      if (m) {
+        session->con->send_message(std::move(m));
+        m = nullptr;
+      }
+    }
     session->con->send_message(new MClientSession(CEPH_SESSION_FLUSHMSG_ACK, m->get_seq()));
     break;
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38104