### PR TITLE
rgw: when exclusive lock fails due existing lock, log add'l info

### DIFF
--- a/src/test/cls_lock/test_cls_lock.cc
+++ b/src/test/cls_lock/test_cls_lock.cc
@@ -85,6 +85,9 @@ TEST(ClsLock, TestMultiLocking) {
   ASSERT_EQ(0, ioctx.write(oid, bl, bl.length(), 0));
 
   Lock l(lock_name);
+  // we set the duration, so the log output contains a locker with a
+  // non-zero expiration time
+  l.set_duration(utime_t(120, 0));
 
   /* test lock object */
 


### PR DESCRIPTION
This is being added to better understand lock-contention issues in
running systems. Here are two sample log output lines:

>   2019-02-04 14:22:31.228 7f06abb59700 20 <cls>
>   /somedir/ceph/src/cls/lock/cls_lock.cc:221: could not exclusive-lock
>   object, already locked by [{name:client.4139,
>   addr:v1:127.0.0.1:0/2034495868, exp:2019-02-04 14:24:31.0.22272s}]

>   2019-02-04 14:22:37.219 7f06abb59700 20 <cls>
>   /somedir/ceph/src/cls/lock/cls_lock.cc:221: could not exclusive-lock
>   object, already locked by [{name:client.4147,
>   addr:v1:127.0.0.1:0/141966515, exp:never}]

Fixes: http://tracker.ceph.com/issues/38171
Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>