### PR TITLE
vstart.sh: fix params generation for monmaptool

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -680,7 +680,7 @@ start_mon() {
 		    "$keyring_fn"
 
 		# build a fresh fs monmap, mon fs
-		local str=""
+		local params=()
 		local count=0
 		local mon_host=""
 		for f in $MONS
@@ -694,7 +694,7 @@ start_mon() {
 		    if [ $msgr -eq 21 ]; then
 			A="[v2:$IP:$(($CEPH_PORT+$count)),v1:$IP:$(($CEPH_PORT+$count+1))]"
 		    fi
-		    str="$str --addv $f $A"
+		    params+=("--addv" "$f" "$A")
 		    mon_host="$mon_host $A"
 		    wconf <<EOF
 [mon.$f]
@@ -707,7 +707,7 @@ EOF
 [global]
         mon host = $mon_host
 EOF
-		prun "$CEPH_BIN/monmaptool" --create --clobber $str --print "$monmap_fn"
+		prun "$CEPH_BIN/monmaptool" --create --clobber "${params[@]}" --print "$monmap_fn"
 
 		for f in $MONS
 		do


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/38174

This broke in the msgr21 case, due to bash globbing in cases where
the generated string somehow matched names of certain files in local
directory. Also need to pass params to the prun function separately,
otherwise everything is quoted together.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

