### PR TITLE
os/bluestore: Fix 38176. Way out from critically full devices.

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -57,6 +57,10 @@ Commands
 
    Instruct BlueFS to check the size of its block devices and, if they have expanded, make use of the additional space.
 
+:command:`bluefs-bdev-emergency-expand` --path *osd path*
+
+   Instruct BlueFS to check the size of its block devices and, if they have expanded, make use of the additional space. This differs from `bluefs-bdev-expand` in that it can be done in cases when bluefs is critically out of space and BlueStore cannot start. If expansion process is started but terminated, device cannot be used until expansion is restarted and finished.
+
 :command:`bluefs-bdev-new-wal` --path *osd path* --dev-target *new-device*
 
    Adds WAL device to BlueFS, fails if WAL device already exists.

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2190,7 +2190,7 @@ private:
   * opens both DB and dependant super_meta, FreelistManager and allocator
   * in the proper order
   */
-  int _open_db_and_around(bool read_only);
+  int _open_db_and_around(bool read_only, bool do_bdev_expand = false);
   void _close_db_and_around();
 
   // updates legacy bluefs related recs in DB to a state valid for
@@ -2207,7 +2207,7 @@ private:
   void _close_db();
   int _open_fm(KeyValueDB::Transaction t);
   void _close_fm();
-  int _open_alloc();
+  int _open_alloc(bool do_bdev_expand = false);
   void _close_alloc();
   int _open_collections(int *errors=0);
   void _close_collections();
@@ -2395,7 +2395,7 @@ public:
   bool test_mount_in_use() override;
 
 private:
-  int _mount(bool kv_only, bool open_db=true);
+  int _mount(bool kv_only, bool open_db = true, bool do_bdev_expand = false);
 public:
   int mount() override {
     return _mount(false);
@@ -2470,7 +2470,8 @@ public:
   int migrate_to_new_bluefs_device(const set<int>& devs_source,
     int id,
     const string& path);
-  int expand_devices(ostream& out);
+  int expand_devices(ostream& out, bool recovery_from_enospc = false);
+  int check_during_expand();
   string get_device_path(unsigned id);
 
 public:

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -242,7 +242,7 @@ int main(int argc, char **argv)
     ;
   po::options_description po_positional("Positional options");
   po_positional.add_options()
-    ("command", po::value<string>(&action), "fsck, repair, bluefs-export, bluefs-bdev-sizes, bluefs-bdev-expand, bluefs-bdev-new-db, bluefs-bdev-new-wal, bluefs-bdev-migrate, show-label, set-label-key, rm-label-key, prime-osd-dir, bluefs-log-dump")
+    ("command", po::value<string>(&action), "fsck, repair, bluefs-export, bluefs-bdev-sizes, bluefs-bdev-expand, bluefs-bdev-emergency-expand, bluefs-bdev-new-db, bluefs-bdev-new-wal, bluefs-bdev-migrate, show-label, set-label-key, rm-label-key, prime-osd-dir, bluefs-log-dump")
     ;
   po::options_description po_all("All options");
   po_all.add(po_options).add(po_positional);
@@ -325,7 +325,7 @@ int main(int argc, char **argv)
     }
     inferring_bluefs_devices(devs, path);
   }
-  if (action == "bluefs-bdev-sizes" || action == "bluefs-bdev-expand") {
+  if (action == "bluefs-bdev-sizes" || action == "bluefs-bdev-expand" || action == "bluefs-bdev-emergency-expand") {
     if (path.empty()) {
       cerr << "must specify bluestore path" << std::endl;
       exit(EXIT_FAILURE);
@@ -532,6 +532,15 @@ int main(int argc, char **argv)
     if (r <0) {
       cerr << "failed to expand bluestore devices: "
 	   << cpp_strerror(r) << std::endl;
+      exit(EXIT_FAILURE);
+    }
+  }
+  else if (action == "bluefs-bdev-emergency-expand") {
+    BlueStore bluestore(cct.get(), path);
+    auto r = bluestore.expand_devices(cout, true);
+    if (r <0) {
+      cerr << "failed to expand bluestore devices: "
+           << cpp_strerror(r) << std::endl;
       exit(EXIT_FAILURE);
     }
   }


### PR DESCRIPTION
Created solution to expand bdev even when device is critically full and bluestore cannot start.
Fixes: https://tracker.ceph.com/issues/38176
Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>
