### PR TITLE
mimic: common: fix missing include boost/noncopyable.hpp

### DIFF
--- a/src/common/inline_variant.h
+++ b/src/common/inline_variant.h
@@ -14,6 +14,7 @@
 #include <boost/mpl/map.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/mpl/range_c.hpp>
+#include <boost/noncopyable.hpp>
 
 #include "function_signature.h"
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38179