### PR TITLE
make-dist: set version number only once

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 if [ ! -d .git ]; then
     echo "no .git present.  run this from the base dir of the git checkout."
@@ -6,9 +6,16 @@ if [ ! -d .git ]; then
 fi
 
 version=$1
-[ -z "$version" ] && version=`git describe --match 'v*' | sed 's/^v//'`
-outfile="ceph-$version"
+[ -z "$version" ] && version=$(git describe --long --match 'v*' | sed 's/^v//')
+if expr index $version '-' > /dev/null; then
+    rpm_version=$(echo $version | cut -d - -f 1-1)
+    rpm_release=$(echo $version | cut -d - -f 2- | sed 's/-/./')
+else
+    rpm_version=$version
+    rpm_release=0
+fi
 
+outfile="ceph-$version"
 echo "version $version"
 
 # update submodules
@@ -105,20 +112,7 @@ bin/git-archive-all.sh --prefix ceph-$version/ \
 # populate files with version strings
 echo "including src/.git_version, ceph.spec"
 
-(git rev-parse HEAD ; git describe) 2> /dev/null > src/.git_version
-
-# if the version has '-' in it, it has a 'release' part,
-# like vX.Y.Z-N-g<shortsha1>.  If it doesn't, it's just
-# vX.Y.Z.  Handle both, and translate - to . for rpm
-# naming rules (the - separates version and release).
-
-if expr index $version '-' > /dev/null; then
-	rpm_version=`echo $version | cut -d - -f 1-1`
-	rpm_release=`echo $version | cut -d - -f 2- | sed 's/-/./'`
-else
-	rpm_version=$version
-	rpm_release=0
-fi
+(git rev-parse HEAD ; echo $version) 2> /dev/null > src/.git_version
 
 for spec in ceph.spec.in alpine/APKBUILD.in; do
     cat $spec |

--- a/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/version-number-sanity.yaml
@@ -1,0 +1,13 @@
+roles:
+- [mon.a, mds.a, mgr.x, osd.0, osd.1, client.0]
+overrides:
+  ceph:
+    log-whitelist:
+      - \(POOL_APP_NOT_ENABLED\)
+tasks:
+- install:
+- ceph:
+- workunit:
+    clients:
+      all:
+        - rados/version_number_sanity.sh

--- a/qa/workunits/rados/version_number_sanity.sh
+++ b/qa/workunits/rados/version_number_sanity.sh
@@ -1,0 +1,30 @@
+#!/bin/bash -ex
+#
+# test that ceph RPM/DEB package version matches "ceph --version"
+# (for a loose definition of "matches")
+#
+source /etc/os-release
+case $ID in
+debian|ubuntu)
+    RPMDEB='DEB'
+    dpkg-query --show ceph-common
+    PKG_NAME_AND_VERSION=$(dpkg-query --show ceph-common)
+    ;;
+centos|fedora|rhel|opensuse*|suse|sles)
+    RPMDEB='RPM'
+    rpm -q ceph
+    PKG_NAME_AND_VERSION=$(rpm -q ceph)
+    ;;
+*)
+    echo "Unsupported distro ->$ID<-! Bailing out."
+    exit 1
+esac
+PKG_CEPH_VERSION=$(perl -e '"'"$PKG_NAME_AND_VERSION"'" =~ m/(\d+(\.\d+)+)/; print "$1\n";')
+echo "According to $RPMDEB package, the ceph version under test is ->$PKG_CEPH_VERSION<-"
+test -n "$PKG_CEPH_VERSION"
+ceph --version
+BUFFER=$(ceph --version)
+CEPH_CEPH_VERSION=$(perl -e '"'"$BUFFER"'" =~ m/ceph version (\d+(\.\d+)+)/; print "$1\n";')
+echo "According to \"ceph --version\", the ceph version under test is ->$CEPH_CEPH_VERSION<-"
+test -n "$CEPH_CEPH_VERSION"
+test "$PKG_CEPH_VERSION" = "$CEPH_CEPH_VERSION"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -188,8 +188,6 @@ if(${ENABLE_GIT_VERSION})
     list(GET CEPH_GIT_SHA_AND_TAG 0 CEPH_GIT_VER)
     list(GET CEPH_GIT_SHA_AND_TAG 1 CEPH_GIT_NICE_VER)
   endif(${CEPH_GIT_VER} STREQUAL "GITDIR-NOTFOUND")
-  # remove 'v' prefix from raw git version
-  string(SUBSTRING ${CEPH_GIT_NICE_VER} 1 -1 CEPH_GIT_NICE_VER)
 else(${ENABLE_GIT_VERSION})
   set(CEPH_GIT_VER "no_version")
   set(CEPH_GIT_NICE_VER "Development")


### PR DESCRIPTION
Before this commit, "git describe" was being run *twice* - once
at the beginning to initialize the version variable, and another
time further down to populate the .git_version file.

Refactor so the command is run only once, and include the --long
option to eliminate the undesirable behavior of producing just
the tag when HEAD points to a tag.

Also, since .git_version is now populated without the leading "v",
the cmake code for stripping off that leading "v" is no longer
needed.

Signed-off-by: Nathan Cutler <ncutler@suse.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [x] Includes tests for new functionality or reproducer for bug

