### PR TITLE
mon,mgr: include progress events in 'ceph -s'

### DIFF
--- a/qa/tasks/mgr/test_progress.py
+++ b/qa/tasks/mgr/test_progress.py
@@ -101,7 +101,7 @@ class TestProgress(MgrTestCase):
                               timeout=self.EVENT_CREATION_PERIOD)
         ev = self._all_events()[0]
         log.info(json.dumps(ev, indent=1))
-        self.assertIn("Rebalancing after OSD 0 marked out", ev['message'])
+        self.assertIn("Rebalancing after osd.0 marked out", ev['message'])
 
         return ev
 

--- a/src/mgr/ActivePyModules.cc
+++ b/src/mgr/ActivePyModules.cc
@@ -911,6 +911,35 @@ void ActivePyModules::get_health_checks(health_check_map_t *checks)
   }
 }
 
+void ActivePyModules::update_progress_event(
+  const std::string& evid,
+  const std::string& desc,
+  float progress)
+{
+  std::lock_guard l(lock);
+  auto& pe = progress_events[evid];
+  pe.message = desc;
+  pe.progress = progress;
+}
+
+void ActivePyModules::complete_progress_event(const std::string& evid)
+{
+  std::lock_guard l(lock);
+  progress_events.erase(evid);
+}
+
+void ActivePyModules::clear_all_progress_events()
+{
+  std::lock_guard l(lock);
+  progress_events.clear();
+}
+
+void ActivePyModules::get_progress_events(std::map<std::string,ProgressEvent> *events)
+{
+  std::lock_guard l(lock);
+  *events = progress_events;
+}
+
 void ActivePyModules::config_notify()
 {
   std::lock_guard l(lock);

--- a/src/mgr/ActivePyModules.h
+++ b/src/mgr/ActivePyModules.h
@@ -25,6 +25,7 @@
 #include "common/LogClient.h"
 #include "mon/MgrMap.h"
 #include "mon/MonCommand.h"
+#include "mon/mon_types.h"
 
 #include "DaemonState.h"
 #include "ClusterState.h"
@@ -49,6 +50,7 @@ class ActivePyModules
   DaemonServer &server;
   PyModuleRegistry &py_module_registry;
 
+  map<std::string,ProgressEvent> progress_events;
 
   mutable Mutex lock{"ActivePyModules::lock"};
 
@@ -118,6 +120,13 @@ public:
   void set_health_checks(const std::string& module_name,
 			 health_check_map_t&& checks);
   void get_health_checks(health_check_map_t *checks);
+
+  void update_progress_event(const std::string& evid,
+			     const std::string& desc,
+			     float progress);
+  void complete_progress_event(const std::string& evid);
+  void clear_all_progress_events();
+  void get_progress_events(std::map<std::string,ProgressEvent>* events);
 
   void config_notify();
 

--- a/src/mgr/BaseMgrModule.cc
+++ b/src/mgr/BaseMgrModule.cc
@@ -658,6 +658,52 @@ ceph_have_mon_connection(BaseMgrModule *self, PyObject *args)
   }
 }
 
+static PyObject*
+ceph_update_progress_event(BaseMgrModule *self, PyObject *args)
+{
+  char *evid = nullptr;
+  char *desc = nullptr;
+  float progress = 0.0;
+  if (!PyArg_ParseTuple(args, "ssf:ceph_update_progress_event",
+			&evid, &desc, &progress)) {
+    return nullptr;
+  }
+
+  PyThreadState *tstate = PyEval_SaveThread();
+  self->py_modules->update_progress_event(evid, desc, progress);
+  PyEval_RestoreThread(tstate);
+
+  Py_RETURN_NONE;
+}
+
+static PyObject*
+ceph_complete_progress_event(BaseMgrModule *self, PyObject *args)
+{
+  char *evid = nullptr;
+  if (!PyArg_ParseTuple(args, "s:ceph_complete_progress_event",
+			&evid)) {
+    return nullptr;
+  }
+
+  PyThreadState *tstate = PyEval_SaveThread();
+  self->py_modules->complete_progress_event(evid);
+  PyEval_RestoreThread(tstate);
+
+  Py_RETURN_NONE;
+}
+
+static PyObject*
+ceph_clear_all_progress_events(BaseMgrModule *self, PyObject *args)
+{
+  PyThreadState *tstate = PyEval_SaveThread();
+  self->py_modules->clear_all_progress_events();
+  PyEval_RestoreThread(tstate);
+
+  Py_RETURN_NONE;
+}
+
+
+
 static PyObject *
 ceph_dispatch_remote(BaseMgrModule *self, PyObject *args)
 {
@@ -1046,6 +1092,13 @@ PyMethodDef BaseMgrModule_methods[] = {
   {"_ceph_have_mon_connection", (PyCFunction)ceph_have_mon_connection,
     METH_NOARGS, "Find out whether this mgr daemon currently has "
                  "a connection to a monitor"},
+
+  {"_ceph_update_progress_event", (PyCFunction)ceph_update_progress_event,
+   METH_VARARGS, "Update status of a progress event"},
+  {"_ceph_complete_progress_event", (PyCFunction)ceph_complete_progress_event,
+   METH_VARARGS, "Complete a progress event"},
+  {"_ceph_clear_all_progress_events", (PyCFunction)ceph_clear_all_progress_events,
+   METH_NOARGS, "Clear all progress events"},
 
   {"_ceph_dispatch_remote", (PyCFunction)ceph_dispatch_remote,
     METH_VARARGS, "Dispatch a call to another module"},

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -2192,6 +2192,7 @@ void DaemonServer::send_report()
 
   auto m = new MMonMgrReport();
   py_modules.get_health_checks(&m->health_checks);
+  py_modules.get_progress_events(&m->progress_events);
 
   cluster_state.with_mutable_pgmap([&](PGMap& pg_map) {
       cluster_state.update_delta_stats();

--- a/src/mgr/PyModuleRegistry.h
+++ b/src/mgr/PyModuleRegistry.h
@@ -151,6 +151,10 @@ public:
    */
   void get_health_checks(health_check_map_t *checks);
 
+  void get_progress_events(map<std::string,ProgressEvent> *events) {
+    return active_modules->get_progress_events(events);
+  }
+
   // FIXME: breaking interface so that I don't have to go rewrite all
   // the places that call into these (for now)
   // >>>

--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -13,10 +13,12 @@ class MgrStatMonitor : public PaxosService {
   version_t version = 0;
   PGMapDigest digest;
   ServiceMap service_map;
+  std::map<std::string,ProgressEvent> progress_events;
 
   // pending commit
   PGMapDigest pending_digest;
   health_check_map_t pending_health_checks;
+  std::map<std::string,ProgressEvent> pending_progress_events;
   bufferlist pending_service_map_bl;
 
 public:
@@ -62,6 +64,10 @@ public:
 
   const ServiceMap& get_service_map() const {
     return service_map;
+  }
+
+  const std::map<std::string,ProgressEvent>& get_progress_events() {
+    return progress_events;
   }
 
   // pg stat access

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2897,6 +2897,13 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     f->close_section();
 
     f->dump_object("servicemap", mgrstatmon()->get_service_map());
+
+    f->open_object_section("progress_events");
+    for (auto& i : mgrstatmon()->get_progress_events()) {
+      f->dump_object(i.first.c_str(), i.second);
+    }
+    f->close_section();
+
     f->close_section();
   } else {
     ss << "  cluster:\n";
@@ -2949,6 +2956,23 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
 
     ss << "\n \n  data:\n";
     mgrstatmon()->print_summary(NULL, &ss);
+
+    auto& pem = mgrstatmon()->get_progress_events();
+    if (!pem.empty()) {
+      ss << "\n \n  progress:\n";
+      for (auto& i : pem) {
+	ss << "    " << i.second.message << "\n";
+	ss << "      [";
+	unsigned j;
+	for (j=0; j < i.second.progress * 30; ++j) {
+	  ss << '=';
+	}
+	for (; j < 30; ++j) {
+	  ss << '.';
+	}
+	ss << "]\n";
+      }
+    }
     ss << "\n ";
   }
 }

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -591,4 +591,28 @@ inline ostream& operator<<(ostream& out, const mon_feature_t& f) {
   return out;
 }
 
+
+struct ProgressEvent {
+  string message;                  ///< event description
+  float progress;                  ///< [0..1]
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    encode(message, bl);
+    encode(progress, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::const_iterator& p) {
+    DECODE_START(1, p);
+    decode(message, p);
+    decode(progress, p);
+    DECODE_FINISH(p);
+  }
+  void dump(Formatter *f) const {
+    f->dump_string("message", message);
+    f->dump_float("progress", progress);
+  }
+};
+WRITE_CLASS_ENCODER(ProgressEvent)
+
 #endif

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -1122,6 +1122,15 @@ class MgrModule(ceph_module.BaseMgrModule):
 
         return self._ceph_have_mon_connection()
 
+    def update_progress_event(self, evid, desc, progress):
+        return self._ceph_update_progress_event(str(evid), str(desc), float(progress))
+
+    def complete_progress_event(self, evid):
+        return self._ceph_complete_progress_event(str(evid))
+
+    def clear_all_progress_events(self):
+        return self._ceph_clear_all_progress_events()
+
     @property
     def rados(self):
         """

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -348,7 +348,7 @@ class Module(MgrModule):
 
         # TODO: reconcile with existing events referring to this OSD going out
         ev = PgRecoveryEvent(
-            "Rebalancing after OSD {0} marked out".format(osd_id),
+            "Rebalancing after osd.{0} marked out".format(osd_id),
             refs=[("osd", osd_id)],
             which_pgs=affected_pgs,
             evactuate_osds=[osd_id]
@@ -359,7 +359,7 @@ class Module(MgrModule):
     def _osd_in(self, osd_id):
         for ev_id, ev in self._events.items():
             if isinstance(ev, PgRecoveryEvent) and osd_id in ev.evacuating_osds:
-                self.log.info("OSD {0} came back in, cancelling event".format(
+                self.log.info("osd.{0} came back in, cancelling event".format(
                     osd_id
                 ))
                 self._complete(ev)

--- a/src/pybind/mgr/progress/module.py
+++ b/src/pybind/mgr/progress/module.py
@@ -6,10 +6,6 @@ import uuid
 import json
 
 
-# How often to potentially write back any dirty events (event history
-# persistence is best effort!
-PERSIST_PERIOD = 5
-
 ENCODING_VERSION = 1
 
 
@@ -250,6 +246,13 @@ class Module(MgrModule):
             'desc': 'number of past completed events to remember',
             'runtime': True,
         },
+        {
+            'name': 'persist_interval',
+            'default': 5,
+            'type': 'secs',
+            'desc': 'how frequently to persist completed events',
+            'runtime': True,
+        },
     ]
 
     def __init__(self, *args, **kwargs):
@@ -442,7 +445,7 @@ class Module(MgrModule):
                 self._save()
                 self._dirty = False
 
-            self._shutdown.wait(timeout=PERSIST_PERIOD)
+            self._shutdown.wait(timeout=self.persist_interval)
 
         self._shutdown.wait()
 


### PR DESCRIPTION
```
  cluster:
    id:     42750cd6-fe50-4432-a99e-0feda7f26b1a
    health: HEALTH_WARN
            Degraded data redundancy: 546/12405 objects degraded (4.401%), 1 pg degraded
            application not enabled on 1 pool(s)

  services:
    mon: 3 daemons, quorum a,b,c (age 7m)
    mgr: x(active, since 7m)
    osd: 4 osds: 4 up (since 6m), 3 in (since 20s); 2 remapped pgs

  data:
    pools:   1 pools, 8 pgs
    objects: 4.13k objects, 16 KiB
    usage:   4.5 GiB used, 36 GiB / 40 GiB avail
    pgs:     546/12405 objects degraded (4.401%)
             401/12405 objects misplaced (3.233%)
             6 active+clean
             1 active+recovering+undersized+remapped
             1 active+recovery_wait+undersized+degraded+remapped

  progress:
    Rebalancing after OSD 1 marked out
      [=====.........................]


```
or in json,
```
    "progress_events": {
        "35fa5840-aed5-434a-b229-368dbf100462": {
            "message": "Rebalancing after OSD 3 marked out",
            "progress": 0.059829059988260269
        }
    }
```
There is a ton of improvement and cleanup we can do on the progress event infrastructure, including moving parts of the progress module into mgr_module itself, adding timestamps and estimated completion etc., but this sets up the mgr->mon pipeline and gets the basics in place.  Other cleanup and improvements can follow, once this is easily visible!




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug