### PR TITLE
mimic: tests: krbd discard no longer guarantees zeroing

### DIFF
--- a/qa/rbd/krbd_whole_object_zeroout.t
+++ b/qa/rbd/krbd_whole_object_zeroout.t
@@ -21,7 +21,7 @@ cloneimg1:
   0000000 cdcd cdcd cdcd cdcd cdcd cdcd cdcd cdcd
   *
   c800000
-  $ blkdiscard -l 100M $DEV
+  $ fallocate -z -l 100M $DEV
   $ hexdump $DEV
   0000000 0000 0000 0000 0000 0000 0000 0000 0000
   *
@@ -50,7 +50,7 @@ min((100M % 28M) / 512K, 7) = 7 objects in the last object set
   0000000 cdcd cdcd cdcd cdcd cdcd cdcd cdcd cdcd
   *
   c800000
-  $ blkdiscard -l 100M $DEV
+  $ fallocate -z -l 100M $DEV
   $ hexdump $DEV
   0000000 0000 0000 0000 0000 0000 0000 0000 0000
   *
@@ -79,7 +79,7 @@ min((100M % 92M) / 512K, 23) = 16 objects in the last object set
   0000000 cdcd cdcd cdcd cdcd cdcd cdcd cdcd cdcd
   *
   c800000
-  $ blkdiscard -l 100M $DEV
+  $ fallocate -z -l 100M $DEV
   $ hexdump $DEV
   0000000 0000 0000 0000 0000 0000 0000 0000 0000
   *
@@ -108,7 +108,7 @@ min((100M % 260M) / 512K, 65) = 65 objects in the last object set
   0000000 cdcd cdcd cdcd cdcd cdcd cdcd cdcd cdcd
   *
   c800000
-  $ blkdiscard -l 100M $DEV
+  $ fallocate -z -l 100M $DEV
   $ hexdump $DEV
   0000000 0000 0000 0000 0000 0000 0000 0000 0000
   *

--- a/qa/suites/krbd/basic/tasks/krbd_whole_object_zeroout.yaml
+++ b/qa/suites/krbd/basic/tasks/krbd_whole_object_zeroout.yaml
@@ -2,4 +2,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - qa/rbd/krbd_whole_object_discard.t
+      - qa/rbd/krbd_whole_object_zeroout.t

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -1094,7 +1094,7 @@ krbd_discard(struct rbd_ctx *ctx, uint64_t off, uint64_t len)
 	int ret;
 
 	/*
-	 * BLKDISCARD goes straight to disk and doesn't do anything
+	 * BLKZEROOUT goes straight to disk and doesn't do anything
 	 * about dirty buffers.  This means we need to flush so that
 	 *
 	 *   write 0..3M
@@ -1108,19 +1108,22 @@ krbd_discard(struct rbd_ctx *ctx, uint64_t off, uint64_t len)
 	 *
 	 * returns "data 0000 data" rather than "data data data" in
 	 * case 1..2M was cached.
+	 *
+         * Note: These cache coherency issues are supposed to be fixed
+         * in recent kernels.
 	 */
 	ret = __krbd_flush(ctx, true);
 	if (ret < 0)
 		return ret;
 
 	/*
-	 * off and len must be 512-byte aligned, otherwise BLKDISCARD
+	 * off and len must be 512-byte aligned, otherwise BLKZEROOUT
 	 * will fail with -EINVAL.  This means that -K (enable krbd
 	 * mode) requires -h 512 or similar.
 	 */
-	if (ioctl(ctx->krbd_fd, BLKDISCARD, &range) < 0) {
+	if (ioctl(ctx->krbd_fd, BLKZEROOUT, &range) < 0) {
 		ret = -errno;
-		prt("BLKDISCARD(%llu, %llu) failed\n", off, len);
+		prt("BLKZEROOUT(%llu, %llu) failed\n", off, len);
 		return ret;
 	}
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/38185