### PR TITLE
rgw: sync: stat remote obj sets default content type

### DIFF
--- a/src/rgw/rgw_sync_module.cc
+++ b/src/rgw/rgw_sync_module.cc
@@ -50,6 +50,11 @@ int RGWCallStatRemoteObjCR::operate() {
       ldout(sync_env->cct, 0) << "RGWStatRemoteObjCR() returned " << retcode << dendl;
       return set_cr_error(retcode);
     }
+    if (attrs.find(RGW_ATTR_CONTENT_TYPE) == attrs.end()) {
+      bufferlist bl;
+      bl.append("binary/octet-stream");
+      attrs.emplace(RGW_ATTR_CONTENT_TYPE, std::move(bl));
+    }
     ldout(sync_env->cct, 20) << "stat of remote obj: z=" << sync_env->source_zone
                              << " b=" << bucket_info.bucket << " k=" << key
                              << " size=" << size << " mtime=" << mtime << dendl;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/38197

We don't always store content type, and need to use default content
type in those cases. We now pass the default content type to
sync modules that only do work based on object metadata.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [x] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

