### PR TITLE
changes to address FTBFS on fc30

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif(WITH_CCACHE)
 option(WITH_MANPAGE "Build man pages." ON)
 if(WITH_MANPAGE)
   find_program(SPHINX_BUILD
-    sphinx-build)
+    NAMES sphinx-build sphinx-build-3)
   if(NOT SPHINX_BUILD)
     message(FATAL_ERROR "Can't find sphinx-build.")
   endif(NOT SPHINX_BUILD)

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1341,6 +1341,8 @@ namespace {
 template<typename Size>
 struct get_size_visitor : public boost::static_visitor<Size>
 {
+  get_size_visitor() {}
+
   template<typename T>
   Size operator()(const T&) const {
     return -1;


### PR DESCRIPTION
in C++17, the base class subobject itself is an element of the
aggregation. by calling `get_size_visitor<T>{}`, we are using
aggregation-initialization of the derived class of
`boost::static_visitor` which defines its ctor and dtor as protected
member methods. and for aggregation-initialization, the base class
subobjects are treated exactly the same as member variables. so, we are
calling the protected member methods of `boost::static_visitor` via
`get_size_visitor<T>{}`. one way to do this, is to explicitly define the
ctor of `get_size_visitor`. or avoid using aggregation-initialization.

as list initialization is encouraged under most circumstances, for
instance,

- it does not allow narrowing.
- it is not ambiguous in the sense that it cannot be parsed as a
function declaration.

so, in this change, an empty constructor is added.

Signed-off-by: Kefu Chai <kchai@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

