### PR TITLE
test/crimson: fix build failure of test_alien_echo.

### DIFF
--- a/src/test/crimson/test_alien_echo.cc
+++ b/src/test/crimson/test_alien_echo.cc
@@ -28,7 +28,7 @@ struct DummyAuthAuthorizer : public AuthAuthorizer {
   DummyAuthAuthorizer()
     : AuthAuthorizer(CEPH_AUTH_CEPHX)
   {}
-  bool verify_reply(bufferlist::const_iterator&) override {
+  bool verify_reply(bufferlist::const_iterator&, CryptoKey*) override {
     return true;
   }
   bool add_challenge(CephContext*, bufferlist&) override {


### PR DESCRIPTION
Signed-off-by: chunmei Liu <chunmei.liu@intel.com>

virtual fun define and its implementation don't match.
see below.
ceph/src/test/crimson/test_alien_echo.cc:31:8: error: ‘bool seastar_pingpong::DummyAuthAuthorizer::verify_reply(ceph::buffer::list::const_iterator&)’ marked ‘override’, but does not override
   bool verify_reply(bufferlist::const_iterator&) override {


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

