### PR TITLE
luminous: Object can still be deleted even if s3:DeleteObject policy is set

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4240,7 +4240,7 @@ int RGWDeleteObj::verify_permission()
     if (r == Effect::Allow)
       return true;
     else if (r == Effect::Deny)
-      return false;
+      return -EACCES;
   }
 
   if (!verify_bucket_permission_no_policy(s, RGW_PERM_WRITE)) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4238,7 +4238,7 @@ int RGWDeleteObj::verify_permission()
 				 rgw::IAM::s3DeleteObjectVersion,
 				 ARN(s->bucket, s->object.name));
     if (r == Effect::Allow)
-      return true;
+      return 0;
     else if (r == Effect::Deny)
       return -EACCES;
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/38193