### PR TITLE
mgr/orchestrator: Add host mon mgr management to interface

### DIFF
--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -89,23 +89,17 @@ to talk to it)
 
 Also show any in-progress actions.
 
-..
-    Host Management
-    ~ ~~~~~~~~~~~~~~
+Host Management
+~~~~~~~~~~~~~~~
 
-    List hosts associated with the cluster: :
+List hosts associated with the cluster::
 
-        ceph orchestrator host ls
+    ceph orchestrator host ls
 
-    Add and remove hosts: :
+Add and remove hosts::
 
-      ceph orchestrator host add <host>
-      ceph orchestrator host rm <host>
-
-    . . note: :
-
-    Removing a host only succeeds, if the host is unused.
-
+    ceph orchestrator host add <host>
+    ceph orchestrator host rm <host>
 
 OSD Management
 ~~~~~~~~~~~~~~
@@ -163,18 +157,23 @@ Removes one or more OSDs from the cluster and the host, if the OSDs are marked a
     bluestore and ``all`` stands for all devices associated with the osd
 
 
+Monitor and manager management
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Creates or removes MONs or MGRs from the cluster. Orchestrator may return an
+error if it doesn't know how to do this transition.
+
+Update the number of monitor nodes::
+
+    ceph orchestrator mon update <num> [host, host:network...]
+
+Each host can optionally specificy a network for the monitor to listen on.
+
+Update the number of manager nodes::
+
+    ceph orchestrator mgr update <num> [host...]
+
 ..
-    Monitor and manager management
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-    ::
-
-        ceph orchestrator mon update <num> [host...]
-        ceph orchestrator mgr update <num> [host...]
-
-    Creates or removes MONs or MGRs from the cluster. Orchestrator may return an
-    error if it doesn't know how to do this transition.
-
     .. note::
 
         The host lists are the new full list of mon/mgr hosts

--- a/qa/tasks/mgr/test_orchestrator_cli.py
+++ b/qa/tasks/mgr/test_orchestrator_cli.py
@@ -104,3 +104,21 @@ class TestOrchestratorCli(MgrTestCase):
 
     def test_nfs_rm(self):
         self._orch_cmd("nfs", "rm", "service_name")
+
+    def test_host_ls(self):
+        out = self._orch_cmd("host", "ls")
+        self.assertEqual(out, "localhost\n")
+
+    def test_host_add(self):
+        self._orch_cmd("host", "add", "hostname")
+
+    def test_host_rm(self):
+        self._orch_cmd("host", "rm", "hostname")
+
+    def test_mon_update(self):
+        self._orch_cmd("mon", "update", "3")
+        self._orch_cmd("mon", "update", "3", "host1", "host2", "host3")
+        self._orch_cmd("mon", "update", "3", "host1:network", "host2:network", "host3:network")
+
+    def test_mgr_update(self):
+        self._orch_cmd("mgr", "update", "3")

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -308,12 +308,12 @@ class Orchestrator(object):
         raise NotImplementedError()
 
     def update_mons(self, num, hosts):
-        # type: (int, List[List[str,str]]) -> WriteCompletion
+        # type: (int, List[Tuple[str,str]]) -> WriteCompletion
         """
         Update the number of cluster monitors.
 
         :param num: requested number of monitors.
-        :param hosts: list of hosts (optional)
+        :param hosts: list of hosts + network (optional)
         """
         raise NotImplementedError()
 
@@ -796,9 +796,10 @@ class InventoryNode(object):
     InventoryNode.
     """
     def __init__(self, name, devices):
+        # type: (str, List[InventoryDevice]) -> None
         assert isinstance(devices, list)
         self.name = name  # unique within cluster.  For example a hostname.
-        self.devices = devices  # type: List[InventoryDevice]
+        self.devices = devices
 
     def to_json(self):
         return {'name': self.name, 'devices': [d.to_json() for d in self.devices]}

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -197,7 +197,7 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
-    def remote_host(self, host):
+    def remove_host(self, host):
         # type: (str) -> WriteCompletion
         """
         Remove a host from the orchestrator inventory.

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -297,6 +297,26 @@ class Orchestrator(object):
         """
         raise NotImplementedError()
 
+    def update_mgrs(self, num, hosts):
+        # type: (int, List[str]) -> WriteCompletion
+        """
+        Update the number of cluster managers.
+
+        :param num: requested number of managers.
+        :param hosts: list of hosts (optional)
+        """
+        raise NotImplementedError()
+
+    def update_mons(self, num, hosts):
+        # type: (int, List[List[str,str]]) -> WriteCompletion
+        """
+        Update the number of cluster monitors.
+
+        :param num: requested number of monitors.
+        :param hosts: list of hosts (optional)
+        """
+        raise NotImplementedError()
+
     def add_stateless_service(self, service_type, spec):
         # type: (str, StatelessServiceSpec) -> WriteCompletion
         """

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -196,7 +196,7 @@ Usage:
         try:
             drive_group.validate(all_hosts)
         except orchestrator.DriveGroupValidationError as e:
-                return HandleCommandResult(-errno.EINVAL, stderr=str(e))
+            return HandleCommandResult(-errno.EINVAL, stderr=str(e))
 
         completion = self.create_osds(drive_group, all_hosts)
         self._orchestrator_wait([completion])

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -42,6 +42,35 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
 
         return o
 
+    @CLIWriteCommand('orchestrator host add',
+                     "name=host,type=CephString,req=true",
+                     'Add a host')
+    @handle_exceptions
+    def _add_host(self, host):
+        completion = self.add_host(host)
+        self._orchestrator_wait([completion])
+        result = "\n".join(map(lambda r: str(r), completion.result))
+        return HandleCommandResult(stdout=result)
+
+    @CLIWriteCommand('orchestrator host rm',
+                     "name=host,type=CephString,req=true",
+                     'Remove a host')
+    @handle_exceptions
+    def _remove_host(self, host):
+        completion = self.remove_host(host)
+        self._orchestrator_wait([completion])
+        result = "\n".join(map(lambda r: str(r), completion.result))
+        return HandleCommandResult(stdout=result)
+
+    @CLIReadCommand('orchestrator host ls',
+                    desc='List hosts')
+    @handle_exceptions
+    def _get_hosts(self):
+        completion = self.get_hosts()
+        self._orchestrator_wait([completion])
+        result = "\n".join(map(lambda node: node.name, completion.result))
+        return HandleCommandResult(stdout=result)
+
     @CLIReadCommand('orchestrator device ls',
                     "name=host,type=CephString,n=N,req=false "
                     "name=format,type=CephChoices,strings=json|plain,req=false",
@@ -271,6 +300,59 @@ Usage:
         completion = self.service_action(action, svc_type, service_id=svc_id)
         self._orchestrator_wait([completion])
         return HandleCommandResult()
+
+    @CLIWriteCommand('orchestrator mgr update',
+                     "name=num,type=CephInt,req=true "
+                     "name=hosts,type=CephString,n=N,req=false",
+                     'Update the number of manager instances')
+    @handle_exceptions
+    def _update_mgrs(self, num, hosts):
+        hosts = hosts if hosts is not None else []
+
+        if num <= 0:
+            return HandleCommandResult(-errno.EINVAL,
+                    stderr="Invalid number of mgrs: require {} > 0".format(num))
+
+        completion = self.update_mgrs(num, hosts)
+        self._orchestrator_wait([completion])
+        result = "\n".join(map(lambda r: str(r), completion.result))
+        return HandleCommandResult(stdout=result)
+
+    @CLIWriteCommand('orchestrator mon update',
+                     "name=num,type=CephInt,req=true "
+                     "name=hosts,type=CephString,n=N,req=false",
+                     'Update the number of monitor instances')
+    @handle_exceptions
+    def _update_mons(self, num, hosts):
+        hosts = hosts if hosts is not None else []
+
+        if num <= 0:
+            return HandleCommandResult(-errno.EINVAL,
+                    stderr="Invalid number of mons: require {} > 0".format(num))
+
+        def split_host(host):
+            """Split host into host and network parts"""
+            # TODO: stricter validation
+            parts = host.split(":")
+            if len(parts) == 1:
+                return (parts[0], None)
+            elif len(parts) == 2:
+                return (parts[0], parts[1])
+            else:
+                raise RuntimeError("Invalid host specification: "
+                        "'{}'".format(host))
+
+        if hosts:
+            try:
+                hosts = list(map(split_host, hosts))
+            except Exception as e:
+                msg = "Failed to parse host list: '{}': {}".format(hosts, e)
+                return HandleCommandResult(-errno.EINVAL, stderr=msg)
+
+        completion = self.update_mons(num, hosts)
+        self._orchestrator_wait([completion])
+        result = "\n".join(map(lambda r: str(r), completion.result))
+        return HandleCommandResult(stdout=result)
 
     @CLIWriteCommand('orchestrator set backend',
                      "name=module_name,type=CephString,req=true",

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -49,8 +49,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
     def _add_host(self, host):
         completion = self.add_host(host)
         self._orchestrator_wait([completion])
-        result = "\n".join(map(lambda r: str(r), completion.result))
-        return HandleCommandResult(stdout=result)
+        return HandleCommandResult(stdout=str(completion.result))
 
     @CLIWriteCommand('orchestrator host rm',
                      "name=host,type=CephString,req=true",
@@ -59,8 +58,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
     def _remove_host(self, host):
         completion = self.remove_host(host)
         self._orchestrator_wait([completion])
-        result = "\n".join(map(lambda r: str(r), completion.result))
-        return HandleCommandResult(stdout=result)
+        return HandleCommandResult(stdout=str(completion.result))
 
     @CLIReadCommand('orchestrator host ls',
                     desc='List hosts')
@@ -306,7 +304,7 @@ Usage:
                      "name=hosts,type=CephString,n=N,req=false",
                      'Update the number of manager instances')
     @handle_exceptions
-    def _update_mgrs(self, num, hosts):
+    def _update_mgrs(self, num, hosts=None):
         hosts = hosts if hosts is not None else []
 
         if num <= 0:
@@ -315,15 +313,14 @@ Usage:
 
         completion = self.update_mgrs(num, hosts)
         self._orchestrator_wait([completion])
-        result = "\n".join(map(lambda r: str(r), completion.result))
-        return HandleCommandResult(stdout=result)
+        return HandleCommandResult(stdout=str(completion.result))
 
     @CLIWriteCommand('orchestrator mon update',
                      "name=num,type=CephInt,req=true "
                      "name=hosts,type=CephString,n=N,req=false",
                      'Update the number of monitor instances')
     @handle_exceptions
-    def _update_mons(self, num, hosts):
+    def _update_mons(self, num, hosts=None):
         hosts = hosts if hosts is not None else []
 
         if num <= 0:
@@ -351,8 +348,7 @@ Usage:
 
         completion = self.update_mons(num, hosts)
         self._orchestrator_wait([completion])
-        result = "\n".join(map(lambda r: str(r), completion.result))
-        return HandleCommandResult(stdout=result)
+        return HandleCommandResult(stdout=str(completion.result))
 
     @CLIWriteCommand('orchestrator set backend',
                      "name=module_name,type=CephString,req=true",

--- a/src/pybind/mgr/test_orchestrator/module.py
+++ b/src/pybind/mgr/test_orchestrator/module.py
@@ -125,7 +125,6 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
 
     The implementation is similar to the Rook orchestrator, but simpler.
     """
-
     def _progress(self, *args, **kwargs):
         try:
             self.remote("progress", *args, **kwargs)
@@ -270,3 +269,26 @@ class TestOrchestrator(MgrModule, orchestrator.Orchestrator):
     @deferred_write("remove_stateless_service")
     def remove_stateless_service(self, service_type, id_):
         pass
+
+    @deferred_read
+    def get_hosts(self):
+        return [orchestrator.InventoryNode('localhost', [])]
+
+    @deferred_write("add_host")
+    def add_host(self, host):
+        assert isinstance(host, str)
+
+    @deferred_write("remove_host")
+    def remove_host(self, host):
+        assert isinstance(host, str)
+
+    @deferred_write("update_mgrs")
+    def update_mgrs(self, num, hosts):
+        assert not hosts or len(hosts) == num
+        assert all([isinstance(h, str) for h in hosts])
+
+    @deferred_write("update_mons")
+    def update_mons(self, num, hosts):
+        assert not hosts or len(hosts) == num
+        assert all([isinstance(h[0], str) for h in hosts])
+        assert all([isinstance(h[1], str) or h[1] is None for h in hosts])


### PR DESCRIPTION
As the SSH orchestrator still needs some minor tweaks, I'd like to merge the host management interface.

1. Changed the interface methods to return strings in order to make the result more generic and less error prone. 
2. Add tests. 
3. Some minor documentation tweaks. 
4. removed label form `add host`

<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

