### PR TITLE
mgr/orchestrator: Fix up rook osd create dispatcher

### DIFF
--- a/src/pybind/mgr/rook/module.py
+++ b/src/pybind/mgr/rook/module.py
@@ -78,7 +78,7 @@ class RookWriteCompletion(orchestrator.WriteCompletion):
         self.executed = False
 
         # Result of k8s API call, this is set if executed==True
-        self.k8s_result = None
+        self._result = None
 
         self.effective = False
 
@@ -91,6 +91,10 @@ class RookWriteCompletion(orchestrator.WriteCompletion):
         # XXX hacky global
         global all_completions
         all_completions.append(self)
+
+    @property
+    def result(self):
+        return self._result
 
     @property
     def is_persistent(self):
@@ -106,7 +110,7 @@ class RookWriteCompletion(orchestrator.WriteCompletion):
 
     def execute(self):
         if not self.executed:
-            self.k8s_result = self.execute_cb()
+            self._result = self.execute_cb()
             self.executed = True
 
         if not self.effective:
@@ -403,7 +407,7 @@ class RookOrchestrator(MgrModule, orchestrator.Orchestrator):
                                "support OSD creation.")
 
         def execute():
-            self.rook_cluster.add_osds(drive_group, all_hosts)
+            return self.rook_cluster.add_osds(drive_group, all_hosts)
 
         def is_complete():
             # Find OSD pods on this host

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -404,8 +404,7 @@ class RookCluster(object):
                 })
 
         if len(patch) == 0:
-            log.warning("No-op adding stateful service")
-            return
+            return "No change"
 
         try:
             self.rook_api_patch(
@@ -416,3 +415,5 @@ class RookCluster(object):
             raise ApplyException(
                 "Failed to create OSD entries in Cluster CRD: {0}".format(
                     e))
+
+        return "Success"

--- a/src/pybind/mgr/rook/rook_cluster.py
+++ b/src/pybind/mgr/rook/rook_cluster.py
@@ -343,7 +343,7 @@ class RookCluster(object):
         Rook currently (0.8) can only do single-drive OSDs, so we
         treat all drive groups as just a list of individual OSDs.
         """
-        block_devices = drive_group.data_devices
+        block_devices = drive_group.data_devices.paths
 
         assert drive_group.objectstore in ("bluestore", "filestore")
 


### PR DESCRIPTION
I noticed that trying to "ceph orchestrator osd create" on rook didn't work properly. This patchset fixes that and an unrelated typo in orchestrator.py.