### PR TITLE
test: switch to GNU sed

### DIFF
--- a/src/test/crush/crush_weights.sh
+++ b/src/test/crush/crush_weights.sh
@@ -2,6 +2,12 @@
 
 source $(dirname $0)/../detect-build-env-vars.sh
 
+if [ `uname` = FreeBSD ]; then
+    SED=gsed
+else
+    SED=sed
+fi
+
 read -r -d '' cm <<'EOF'
 # devices
 device 0 device0
@@ -39,7 +45,7 @@ EOF
 
 three=($(echo "$cm" | crushtool -c /dev/fd/0 --test --show-utilization \
                               --min-x 1 --max-x 1000000 --num-rep 3 | \
-  grep "device \(0\|4\)" | sed -e 's/^.*stored : \([0-9]\+\).*$/\1/'))
+  grep "device \(0\|4\)" | $SED -e 's/^.*stored : \([0-9]\+\).*$/\1/'))
 
 if test $(echo "scale=5; (10 - ${three[0]}/${three[1]}) < .75" | bc) = 1; then
     echo 3 replicas weights better distributed than they should be. 1>&2
@@ -48,7 +54,7 @@ fi
 
 one=($(echo "$cm" | crushtool -c /dev/fd/0 --test --show-utilization \
                               --min-x 1 --max-x 1000000 --num-rep 1 | \
-  grep "device \(0\|4\)" | sed -e 's/^.*stored : \([0-9]\+\).*$/\1/'))
+  grep "device \(0\|4\)" | $SED -e 's/^.*stored : \([0-9]\+\).*$/\1/'))
 
 if test $(echo "scale=5; (10 - ${one[0]}/${one[1]}) > .1 || (10 - ${one[0]}/${one[1]}) < -.1" | bc) = 1; then
     echo 1 replica not distributed as they should be. 1>&2


### PR DESCRIPTION
BSD sed and GNU sed have migrated too far apart in RE evaluation
So switch for this test also to gsed.




<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->

- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug