### PR TITLE
mgr/dashboard: Fix typo in pools management

### DIFF
--- a/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
+++ b/src/pybind/mgr/dashboard/frontend/src/app/ceph/pool/pool-form/pool-form.component.html
@@ -111,7 +111,7 @@
               <span class="help-block"
                     *ngIf="externalPgChange"
                     i18n>The current PGs settings were calculated for you, you
-                    should make sure the values suite your needs before submit.</span>
+                    should make sure the values suit your needs before submit.</span>
             </div>
           </div>
 

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.de-DE.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.de-DE.xlf
@@ -1386,9 +1386,9 @@
         </context-group>
       </trans-unit><trans-unit datatype="html" id="909411b5c8155bb36baa02f1a0bf28ab2ac41acb">
         <source>The current PGs settings were calculated for you, you
-                    should make sure the values suite your needs before submit.</source>
+                    should make sure the values suit your needs before submit.</source>
         <target state="translated">The current PGs settings were calculated for you, you
-                    should make sure the values suite your needs before submit.</target>
+                    should make sure the values suit your needs before submit.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
           <context context-type="linenumber">113</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.pt-PT.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.pt-PT.xlf
@@ -1386,9 +1386,9 @@
         </context-group>
       </trans-unit><trans-unit datatype="html" id="909411b5c8155bb36baa02f1a0bf28ab2ac41acb">
         <source>The current PGs settings were calculated for you, you
-                    should make sure the values suite your needs before submit.</source>
+                    should make sure the values suit your needs before submit.</source>
         <target state="translated">The current PGs settings were calculated for you, you
-                    should make sure the values suite your needs before submit.</target>
+                    should make sure the values suit your needs before submit.</target>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
           <context context-type="linenumber">113</context>

--- a/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
+++ b/src/pybind/mgr/dashboard/frontend/src/locale/messages.xlf
@@ -1729,9 +1729,9 @@
           <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
           <context context-type="linenumber">109</context>
         </context-group>
-      </trans-unit><trans-unit id="909411b5c8155bb36baa02f1a0bf28ab2ac41acb" datatype="html">
+      </trans-unit><trans-unit id="37dd747f97e873d4280500da71b0076805f530a1" datatype="html">
         <source>The current PGs settings were calculated for you, you
-                    should make sure the values suite your needs before submit.</source>
+                    should make sure the values suit your needs before submit.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">app/ceph/pool/pool-form/pool-form.component.html</context>
           <context context-type="linenumber">113</context>


### PR DESCRIPTION

Typo fix: "suite your needs" -> "suit your needs"

Signed-off-by: Lenz Grimmer <lgrimmer@suse.com>