### PR TITLE
mimic: osd: force-backfill sets forced_recovery instead of forced_backfill in 13.2.1

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2333,18 +2333,18 @@ bool PG::set_force_backfill(bool b)
 {
   bool did = false;
   if (b) {
-    if (!(state & PG_STATE_FORCED_RECOVERY) &&
+    if (!(state & PG_STATE_FORCED_BACKFILL) &&
 	(state & (PG_STATE_DEGRADED |
 		  PG_STATE_BACKFILL_WAIT |
 		  PG_STATE_BACKFILLING))) {
       dout(10) << __func__ << " set" << dendl;
-      state_set(PG_STATE_FORCED_RECOVERY);
+      state_set(PG_STATE_FORCED_BACKFILL);
       publish_stats_to_osd();
       did = true;
     }
-  } else if (state & PG_STATE_FORCED_RECOVERY) {
+  } else if (state & PG_STATE_FORCED_BACKFILL) {
     dout(10) << __func__ << " clear" << dendl;
-    state_clear(PG_STATE_FORCED_RECOVERY);
+    state_clear(PG_STATE_FORCED_BACKFILL);
     publish_stats_to_osd();
     did = true;
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/38111