### PR TITLE
mgr/dashboard: use the orchestrator_cli backend setting

### DIFF
--- a/doc/mgr/ansible.rst
+++ b/doc/mgr/ansible.rst
@@ -34,7 +34,6 @@ Enable the Ansible orchestrator module and use it with the :ref:`CLI <orchestrat
 
 ::
 
-    ceph mgr module enable orchestrator_cli
     ceph mgr module enable ansible
     ceph orchestrator set backend ansible
 

--- a/doc/mgr/orchestrator_cli.rst
+++ b/doc/mgr/orchestrator_cli.rst
@@ -55,7 +55,6 @@ You can select the orchestrator module to use with the ``set backend`` command::
 
 For example, to enable the Rook orchestrator module and use it with the CLI::
 
-    ceph mgr module enable orchestrator_cli
     ceph mgr module enable rook
     ceph orchestrator set backend rook
 

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -47,6 +47,7 @@ const static std::map<uint32_t, std::set<std::string>> always_on_modules = {
       "progress",
       "balancer",
       "devicehealth",
+      "orchestrator_cli",
       "volumes",
     }
   }

--- a/src/pybind/mgr/dashboard/services/orchestrator.py
+++ b/src/pybind/mgr/dashboard/services/orchestrator.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import time
 
 from .. import mgr, logger
-from ..settings import Settings
 
 
 class NoOrchesrtatorConfiguredException(Exception):
@@ -21,10 +20,10 @@ class OrchClient(object):
         return cls._instance
 
     def _call(self, method, *args, **kwargs):
-        if not Settings.ORCHESTRATOR_BACKEND:
+        _backend = mgr.get_module_option_ex("orchestrator_cli", "orchestrator")
+        if not _backend:
             raise NoOrchesrtatorConfiguredException()
-        return mgr.remote(Settings.ORCHESTRATOR_BACKEND, method, *args,
-                          **kwargs)
+        return mgr.remote(_backend, method, *args, **kwargs)
 
     def _wait(self, completions):
         while not self._call("wait", completions):
@@ -39,7 +38,8 @@ class OrchClient(object):
         return completion.result
 
     def available(self):
-        if not Settings.ORCHESTRATOR_BACKEND:
+        _backend = mgr.get_module_option_ex("orchestrator_cli", "orchestrator")
+        if not _backend:
             return False
         status, desc = self._call("available")
         logger.info("[ORCH] is orchestrator available: %s, %s", status, desc)

--- a/src/pybind/mgr/dashboard/settings.py
+++ b/src/pybind/mgr/dashboard/settings.py
@@ -43,9 +43,6 @@ class Options(object):
     # NFS Ganesha settings
     GANESHA_CLUSTERS_RADOS_POOL_NAMESPACE = ('', str)
 
-    # Orchestrator settings
-    ORCHESTRATOR_BACKEND = ('', str)
-
     # Prometheus settings
     PROMETHEUS_API_HOST = ('', str)  # Not in use ATM
     ALERTMANAGER_API_HOST = ('', str)

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -18,6 +18,10 @@ except ImportError:
 import time
 import fnmatch
 
+class NoOrchestrator(Exception):
+    def __init__(self):
+        super(NoOrchestrator, self).__init__("No orchestrator configured (try "
+                                             "`ceph orchestrator set backend`)")
 
 class _Completion(G):
     @property

--- a/src/pybind/mgr/orchestrator.py
+++ b/src/pybind/mgr/orchestrator.py
@@ -812,6 +812,10 @@ class OrchestratorClientMixin(Orchestrator):
             o = self._select_orchestrator()
         except AttributeError:
             o = self.remote('orchestrator_cli', '_select_orchestrator')
+
+        if o is None:
+            raise NoOrchestrator()
+
         self.log.debug("_oremote {} -> {}.{}(*{}, **{})".format(self.module_name, o, meth, args, kwargs))
         return self.remote(o, meth, *args, **kwargs)
 

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -30,11 +30,7 @@ class OrchestratorCli(orchestrator.OrchestratorClientMixin, MgrModule):
     ]
 
     def _select_orchestrator(self):
-        o = self.get_module_option("orchestrator")
-        if o is None:
-            raise NoOrchestrator()
-
-        return o
+        return self.get_module_option("orchestrator")
 
     @CLIReadCommand('orchestrator device ls',
                     "name=host,type=CephString,n=N,req=false "
@@ -319,14 +315,16 @@ Usage:
                     desc='Report configured backend and its status')
     @handle_exceptions
     def _status(self):
-        avail, why = self.available()
+        o = self._select_orchestrator()
+        if o is None:
+            raise orchestrator.NoOrchestrator()
 
+        avail, why = self.available()
         if avail is None:
             # The module does not report its availability
-            return HandleCommandResult(stdout="Backend: {0}".format(self._select_orchestrator()))
+            return HandleCommandResult(stdout="Backend: {0}".format(o))
         else:
             return HandleCommandResult(stdout="Backend: {0}\nAvailable: {1}{2}".format(
-                                           self._select_orchestrator(),
-                                           avail,
+                                           o, avail,
                                            " ({0})".format(why) if not avail else ""
                                        ))

--- a/src/pybind/mgr/orchestrator_cli/module.py
+++ b/src/pybind/mgr/orchestrator_cli/module.py
@@ -13,19 +13,13 @@ from mgr_module import MgrModule, HandleCommandResult, CLIWriteCommand, CLIReadC
 import orchestrator
 
 
-class NoOrchestrator(Exception):
-    def __init__(self):
-        super(NoOrchestrator, self).__init__("No orchestrator configured (try "
-                                             "`ceph orchestrator set backend`)")
-
-
 def handle_exceptions(func):
 
     @wraps(func)
     def inner(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except (NoOrchestrator, ImportError) as e:
+        except (orchestrator.NoOrchestrator, ImportError) as e:
             return HandleCommandResult(-errno.ENOENT, stderr=str(e))
     return inner
 

--- a/src/pybind/mgr/volumes/module.py
+++ b/src/pybind/mgr/volumes/module.py
@@ -168,7 +168,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         try:
             completion = self.add_stateless_service("mds", spec)
             self._orchestrator_wait([completion])
-        except ImportError:
+        except (ImportError, orchestrator.NoOrchestrator):
             return 0, "", "Volume created successfully (no MDS daemons created)"
         except Exception as e:
             # Don't let detailed orchestrator exceptions (python backtraces)
@@ -249,7 +249,7 @@ class Module(orchestrator.OrchestratorClientMixin, MgrModule):
         try:
             completion = self.remove_stateless_service("mds", vol_name)
             self._orchestrator_wait([completion])
-        except ImportError:
+        except (ImportError, orchestrator.NoOrchestrator):
             self.log.warning("No orchestrator, not tearing down MDS daemons")
         except Exception as e:
             # Don't let detailed orchestrator exceptions (python backtraces)


### PR DESCRIPTION
The impetus for this patch is to eliminate the dashboard-specific setting for the orchestrator backend. We currently have to set it in two places:
```
ceph orchestrator set backend foo
ceph dashboard set-orchestrator-backend foo
```
Which is counterintuitive and could end up with ensuing hilarity if they are not set compatibly. This PR deprecates the dashboard-specific setting and just has it use the orchestrator_cli's setting instead.

This means that we need to make the orchestrator_cli be always-on, which I think we probably want to do anyway -- the volumes module is always-on and it has at least some dependency on the backend setting there.