### PR TITLE
mimic: osd-backfill-stats.sh fails in rados/standalone/osd.yaml

### DIFF
--- a/qa/standalone/osd/osd-backfill-stats.sh
+++ b/qa/standalone/osd/osd-backfill-stats.sh
@@ -70,13 +70,17 @@ function check() {
     local misplaced_end=$8
     local primary_start=${9:-}
     local primary_end=${10:-}
+    local check_setup=${11:-true}
 
     local log=$(grep -l +backfilling $dir/osd.$primary.log)
-    test -n "$log" || return 1
-    if [ "$(echo "$log" | wc -w)" != "1" ];
+    if [ $check_setup = "true" ];
     then
-      echo "Test setup failure, a single OSD should have performed backfill"
-      return 1
+      local alllogs=$(grep -l +backfilling $dir/osd.*.log)
+      if [ "$(echo "$alllogs" | wc -w)" != "1" ];
+      then
+        echo "Test setup failure, a single OSD should have performed backfill"
+        return 1
+      fi
     fi
 
     local addp=" "
@@ -478,7 +482,7 @@ function TEST_backfill_remapped() {
 
     local misplaced=$(expr $objects \* 2)
 
-    check $dir $PG $primary replicated 0 0 $misplaced $objects || return 1
+    check $dir $PG $primary replicated 0 0 $misplaced $objects "" "" false || return 1
 
     delete_pool $poolname
     kill_daemons $dir || return 1

--- a/qa/standalone/osd/osd-backfill-stats.sh
+++ b/qa/standalone/osd/osd-backfill-stats.sh
@@ -71,7 +71,7 @@ function check() {
     local primary_start=${9:-}
     local primary_end=${10:-}
 
-    local log=$(grep -l +backfilling $dir/osd.*.log)
+    local log=$(grep -l +backfilling $dir/osd.$primary.log)
     test -n "$log" || return 1
 
     local addp=" "
@@ -453,15 +453,21 @@ function TEST_backfill_remapped() {
     ceph osd out osd.${primary}
     ceph osd pool set $poolname size 2
     sleep 2
+
+    # primary may change due to invalidating the old pg_temp, which was [1,2,0],
+    # but up_primary (3) chooses [0,1] for acting.
+    local new_primary=$(get_primary $poolname obj1)
+
     ceph osd unset nobackfill
     ceph tell osd.$(get_primary $poolname obj1) debug kick_recovery_wq 0
+
     sleep 2
 
     wait_for_clean || return 1
 
     local misplaced=$(expr $objects \* 2)
 
-    check $dir $PG $primary replicated 0 0 $misplaced $objects || return 1
+    check $dir $PG $new_primary replicated 0 0 $misplaced $objects || return 1
 
     delete_pool $poolname
     kill_daemons $dir || return 1

--- a/qa/standalone/osd/osd-backfill-stats.sh
+++ b/qa/standalone/osd/osd-backfill-stats.sh
@@ -73,6 +73,11 @@ function check() {
 
     local log=$(grep -l +backfilling $dir/osd.$primary.log)
     test -n "$log" || return 1
+    if [ "$(echo "$log" | wc -w)" != "1" ];
+    then
+      echo "Test setup failure, a single OSD should have performed backfill"
+      return 1
+    fi
 
     local addp=" "
     if [ "$type" = "erasure" ];

--- a/qa/standalone/osd/osd-backfill-stats.sh
+++ b/qa/standalone/osd/osd-backfill-stats.sh
@@ -340,8 +340,11 @@ function TEST_backfill_out2() {
     ceph osd pool set $poolname size 3
     ceph osd out osd.${otherosd}
     ceph osd out osd.${primary}
+    # Primary might change before backfill starts
+    sleep 2
+    primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
-    ceph tell osd.$(get_primary $poolname obj1) debug kick_recovery_wq 0
+    ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 
     wait_for_clean || return 1
@@ -394,8 +397,11 @@ function TEST_backfill_sizeup4_allout() {
     ceph osd out osd.$otherosd
     ceph osd out osd.$primary
     ceph osd pool set $poolname size 4
+    # Primary might change before backfill starts
+    sleep 2
+    primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
-    ceph tell osd.$(get_primary $poolname obj1) debug kick_recovery_wq 0
+    ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 
     wait_for_clean || return 1
@@ -456,10 +462,10 @@ function TEST_backfill_remapped() {
 
     # primary may change due to invalidating the old pg_temp, which was [1,2,0],
     # but up_primary (3) chooses [0,1] for acting.
-    local new_primary=$(get_primary $poolname obj1)
+    primary=$(get_primary $poolname obj1)
 
     ceph osd unset nobackfill
-    ceph tell osd.$(get_primary $poolname obj1) debug kick_recovery_wq 0
+    ceph tell osd.$primary debug kick_recovery_wq 0
 
     sleep 2
 
@@ -467,7 +473,7 @@ function TEST_backfill_remapped() {
 
     local misplaced=$(expr $objects \* 2)
 
-    check $dir $PG $new_primary replicated 0 0 $misplaced $objects || return 1
+    check $dir $PG $primary replicated 0 0 $misplaced $objects || return 1
 
     delete_pool $poolname
     kill_daemons $dir || return 1
@@ -515,8 +521,11 @@ function TEST_backfill_ec_all_out() {
     do
         ceph osd out osd.$o
     done
+    # Primary might change before backfill starts
+    sleep 2
+    primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
-    ceph tell osd.$(get_primary $poolname obj1) debug kick_recovery_wq 0
+    ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 
     wait_for_clean || return 1
@@ -562,8 +571,11 @@ function TEST_backfill_ec_prim_out() {
 
     ceph osd set nobackfill
     ceph osd out osd.$primary
+    # Primary might change before backfill starts
+    sleep 2
+    primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
-    ceph tell osd.$(get_primary $poolname obj1) debug kick_recovery_wq 0
+    ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 
     wait_for_clean || return 1
@@ -617,8 +629,11 @@ function TEST_backfill_ec_down_all_out() {
     do
         ceph osd out osd.$o
     done
+    # Primary might change before backfill starts
+    sleep 2
+    primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
-    ceph tell osd.$(get_primary $poolname obj1) debug kick_recovery_wq 0
+    ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
     flush_pg_stats
 
@@ -698,8 +713,11 @@ function TEST_backfill_ec_down_out() {
     kill $(cat $dir/osd.${otherosd}.pid)
     ceph osd down osd.${otherosd}
     ceph osd out osd.${otherosd}
+    # Primary might change before backfill starts
+    sleep 2
+    primary=$(get_primary $poolname obj1)
     ceph osd unset nobackfill
-    ceph tell osd.$(get_primary $poolname obj1) debug kick_recovery_wq 0
+    ceph tell osd.$primary debug kick_recovery_wq 0
     sleep 2
 
     wait_for_clean || return 1


### PR DESCRIPTION
Backport of some test changes to fix http://tracker.ceph.com/issues/37393