### PR TITLE
mimic: doc: pin the version for "breathe" to 4.1.11

### DIFF
--- a/admin/doc-requirements.txt
+++ b/admin/doc-requirements.txt
@@ -1,3 +1,3 @@
 Sphinx == 1.6.3
 -e git+https://github.com/ceph/sphinx-ditaa.git@py3#egg=sphinx-ditaa
--e git+https://github.com/michaeljones/breathe#egg=breathe
+breathe == 4.11.1


### PR DESCRIPTION
It has the compatibility needed for Sphinx version 1.6.3

Fixes: http://tracker.ceph.com/issues/38229