### PR TITLE
ceph-osd: fix warning

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -475,7 +475,7 @@ flushjournal_out:
   }
 
   if (require_osd_release > 0 &&
-      require_osd_release + 2 < ceph_release()) {
+      require_osd_release + 2 < (int)ceph_release()) {
     derr << "OSD's recorded require_osd_release " << require_osd_release
 	 << " + 2 < this release " << ceph_release()
 	 << "; you can only upgrade 2 releases at a time" << dendl;


### PR DESCRIPTION
/home/sage/src/ceph/src/ceph_osd.cc: In function ‘int main(int, const char**)’:
/home/sage/src/ceph/src/ceph_osd.cc:478:31: warning: comparison of integer expressions of different signedness: ‘int’ and ‘unsigned int’ [-Wsign-compare]
       require_osd_release + 2 < ceph_release()) {
       ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~

Signed-off-by: Sage Weil <sage@redhat.com>