### PR TITLE
qa: don't use notcmalloc flavor unless we need it

### DIFF
--- a/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
+++ b/qa/suites/rgw/tempest/tasks/rgw_tempest.yaml
@@ -1,7 +1,6 @@
 # see http://tracker.ceph.com/issues/20360 and http://tracker.ceph.com/issues/18126
 tasks:
 - install:
-    flavor: notcmalloc
 - ceph:
 - tox: [ client.0 ]
 - keystone:

--- a/qa/tasks/keystone.py
+++ b/qa/tasks/keystone.py
@@ -333,7 +333,6 @@ def task(ctx, config):
     Example of configuration:
 
       - install:
-          flavor: notcmalloc
       - ceph:
       - tox: [ client.0 ]
       - keystone:


### PR DESCRIPTION
If we drop these uses of notcmalloc, we can stop doing notcmalloc builds for everything but centos7 (reducing shaman build load by 33%!)